### PR TITLE
internal: use moonbitlang/core in test driver explicitly

### DIFF
--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -4,7 +4,8 @@ use colored::Colorize;
 use mooncake::pkg::sync::auto_sync;
 use moonutil::cli::UniversalFlags;
 use moonutil::common::{
-    MoonbuildOpt, RunMode, TestOpt, MOON_TEST_DELIMITER_BEGIN, MOON_TEST_DELIMITER_END,
+    MoonbuildOpt, RunMode, TestOpt, MOONBITLANG_CORE, MOON_TEST_DELIMITER_BEGIN,
+    MOON_TEST_DELIMITER_END,
 };
 use moonutil::dirs::PackageDirs;
 use moonutil::mooncakes::sync::AutoSyncFlags;
@@ -202,10 +203,18 @@ pub fn generate_test_driver(
 }
 
 fn generate_driver(lines: &[String], pkgname: &str) -> String {
-    let test_driver_template = include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../moonbuild/template/test_driver_template.mbt"
-    ));
+    let test_driver_template = {
+        let template = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../moonbuild/template/test_driver_template.mbt"
+        ));
+        if pkgname.starts_with(MOONBITLANG_CORE) {
+            template.replace(&format!("@{}/builtin.", MOONBITLANG_CORE), "")
+        } else {
+            template.to_string()
+        }
+    };
+
     test_driver_template
         .replace("// test identifiers", &lines.join("\n    "))
         .replace("{package}", pkgname)

--- a/crates/moonbuild/template/test_driver_template.mbt
+++ b/crates/moonbuild/template/test_driver_template.mbt
@@ -22,13 +22,13 @@ fn startswith_panic(s : String) -> Bool {
 }
 
 fn main {
-  let tests : Array[(String, String, () -> Unit!String)] = [
+  let tests : @moonbitlang/core/builtin.Array[(String, String, () -> Unit!String)] = [
     // test identifiers
   ]
   let total = tests.length()
-  let test_names = Array::make(total, "")
-  let filenames = Array::make(total, "")
-  let messages = Array::make(total, "")
+  let test_names = @moonbitlang/core/builtin.Array::make(total, "")
+  let filenames = @moonbitlang/core/builtin.Array::make(total, "")
+  let messages = @moonbitlang/core/builtin.Array::make(total, "")
   let mut succ_idx = total
   let mut fail_idx = 0
   for k = 0; k < tests.length(); k = k + 1 {
@@ -50,8 +50,8 @@ fn main {
       }
     }
   }
-  fn repr(obj : Array[String]) -> String {
-    let buf = Buffer::new(size_hint=16)
+  fn repr(obj : @moonbitlang/core/builtin.Array[String]) -> String {
+    let buf = @moonbitlang/core/builtin.Buffer::new(size_hint=16)
     obj.debug_write(buf)
     buf.to_string()
   }


### PR DESCRIPTION
to avoid `Array` and `Buffer` override by user's code