### PR TITLE
FEAT: Add Shell Completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "8f6b81fb3c84f5563d509c59b5a48d935f689e993afa90fe39047f05adef9142"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "5ca6706fd5224857d9ac5eb9355f6683563cc0541c7cd9d014043b57cbec78ac"
 dependencies = [
  "anstream",
  "anstyle",
@@ -265,10 +265,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.5.4"
+name = "clap_complete"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "faa2032320fd6f50d22af510d204b2994eef49600dfbd0e771a166213844e4cd"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1167,6 +1176,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "ctrlc",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ thiserror = "1.0"
 test-log = "0.2"
 fs4 = { version = "0.8.3", features = ["sync"] }
 ariadne = { version = "0.4.1", features = ["auto-color"] }
+clap_complete = { version = "4.5.4" }
 
 [profile.release]
 debug = false

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -49,6 +49,7 @@ log.workspace = true
 walkdir.workspace = true
 tokio.workspace = true
 futures.workspace = true
+clap_complete.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10.66", features = ["vendored"] }

--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -30,6 +30,7 @@ pub mod info;
 pub mod mooncake_adapter;
 pub mod new;
 pub mod run;
+pub mod shell_completion;
 pub mod test;
 pub mod update;
 pub mod upgrade;
@@ -48,12 +49,11 @@ pub use generate_test_driver::*;
 pub use info::*;
 pub use new::*;
 pub use run::*;
+pub use shell_completion::*;
 pub use test::*;
 pub use update::*;
 pub use upgrade::*;
 pub use version::*;
-
-use std::path::Path;
 
 use anyhow::bail;
 use moonutil::{
@@ -64,6 +64,7 @@ use moonutil::{
     },
     mooncakes::{LoginSubcommand, PublishSubcommand, RegisterSubcommand},
 };
+use std::path::Path;
 
 #[derive(Debug, clap::Parser)]
 #[clap(
@@ -113,6 +114,7 @@ pub enum MoonBuildSubcommands {
     GenerateBuildMatrix(GenerateBuildMatrix),
     /// Upgrade toolchains
     Upgrade,
+    ShellCompletion(ShellCompSubCommand),
     Version(VersionSubcommand),
 }
 

--- a/crates/moon/src/cli/shell_completion.rs
+++ b/crates/moon/src/cli/shell_completion.rs
@@ -1,0 +1,40 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use super::MoonBuildCli;
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+use moonutil::cli::UniversalFlags;
+use std::io;
+
+/// Generate shell completion for bash/elvish/fish/pwsh/zsh to stdout
+#[derive(Debug, clap::Parser)]
+pub struct ShellCompSubCommand {
+    /// The shell to generate completion for
+    #[clap(value_enum, long, ignore_case = true, value_parser = clap::builder::EnumValueParser::<Shell>::new(), default_value_t = Shell::from_env().unwrap_or(Shell::Bash), value_name = "SHELL")]
+    pub shell: Shell,
+}
+
+pub fn gen_shellcomp(_cli: &UniversalFlags, cmd: ShellCompSubCommand) -> anyhow::Result<i32> {
+    if _cli.dry_run {
+        anyhow::bail!("this command has no side effects, dry run is not needed.")
+    }
+    let mut _moon = MoonBuildCli::command();
+    generate(cmd.shell, &mut _moon, "moon", &mut io::stdout());
+    Ok(0)
+}

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -84,6 +84,7 @@ fn main1() -> anyhow::Result<i32> {
         Tree(t) => cli::tree_cli(flags, t),
         Update(u) => cli::update_cli(flags, u),
         Upgrade => cli::run_upgrade(flags),
+        ShellCompletion(gs) => cli::gen_shellcomp(&flags, gs),
         Version(v) => cli::run_version(v),
     }
 }

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -380,6 +380,7 @@ fn test_moon_help() {
               coverage               Code coverage utilities
               generate-build-matrix  Generate build matrix for benchmarking (legacy feature)
               upgrade                Upgrade toolchains
+              shell-completion       Generate shell completion for bash/elvish/fish/pwsh/zsh to stdout
               version                Print version info and exit
               help                   Print this message or the help of the given subcommand(s)
 


### PR DESCRIPTION
adds go-like shell completion for bash/elvish/fish/pwsh/zsh.
### example
```bash
moon shell-completion --shell={SHELL}
```
Generates shell completion script at runtime. By default it reads from `$SHELL` to determine the type of shell.

<img width="917" alt="image" src="https://github.com/user-attachments/assets/48fb4adf-b655-4f0e-9b8e-920e250956f1">

![record](https://github.com/user-attachments/assets/10a738bd-fdbc-49f5-a10e-44c239766f7d)

### Usage

```bash
moon shell-completion --shell={SHELL}
```

The `shell-completion` subcommand generates shell completion scripts for bash/elvish/fish/powershell/zsh.

Use `moon shell-cimpletion` to output a completion script. By default if `--shell` isn't provided explicitly, `moon` will read from `$SHELL` to determine the correct shell type. Providing any of `{bash,elvish,fish,powershell,zsh}` to `--shell` would override this.

Here's how one may use it w/ Zsh:

Zsh autoloads function from `$FPATH`, we could add `$ZSH/completions` to it, and using
```bash
moon shell-completion --shell=zsh > $ZSH/completions/_moon
```
will enable `moon` completions for Zsh.
