### PR TITLE
fix: rename does not work across mount point

### DIFF
--- a/crates/moonbuild/src/upgrade.rs
+++ b/crates/moonbuild/src/upgrade.rs
@@ -22,7 +22,7 @@ use console::Term;
 use dialoguer::Confirm;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use moonutil::common::{CargoPathExt, MOONBITLANG_CORE};
-use moonutil::moon_dir;
+use moonutil::moon_dir::{self, moon_tmp_dir};
 use reqwest;
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
@@ -177,7 +177,7 @@ pub fn do_upgrade(root: &'static str) -> Result<i32> {
             })
             .collect::<Vec<String>>();
 
-        let temp_dir = tempfile::tempdir()?;
+        let temp_dir = tempfile::tempdir_in(moon_tmp_dir()?)?;
         let temp_dir_path = temp_dir.path();
 
         let progress_map = Arc::new(Mutex::new(indexmap::map::IndexMap::new()));

--- a/crates/moonutil/src/moon_dir.rs
+++ b/crates/moonutil/src/moon_dir.rs
@@ -18,6 +18,8 @@
 
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
+
 use crate::common::TargetBackend;
 
 pub fn home() -> PathBuf {
@@ -112,6 +114,15 @@ pub fn config_json() -> PathBuf {
     home().join("config.json")
 }
 
+pub fn moon_tmp_dir() -> anyhow::Result<PathBuf> {
+    let p = home().join("tmp");
+    if !p.exists() {
+        std::fs::create_dir_all(&p)
+            .with_context(|| format!("failed to create tmp directory `{}`", p.display()))?;
+    }
+    Ok(p)
+}
+
 #[test]
 fn test_moon_dir() {
     use expect_test::expect;
@@ -123,6 +134,7 @@ fn test_moon_dir() {
         index(),
         credentials_json(),
         config_json(),
+        moon_tmp_dir().unwrap(),
     ];
     dbg!(&dirs);
     let dirs = dirs
@@ -143,6 +155,7 @@ fn test_moon_dir() {
             "registry|index",
             "credentials.json",
             "config.json",
+            "tmp",
         ]
     "#]]
     .assert_debug_eq(&dirs);


### PR DESCRIPTION
## Related Issues

- [ ] Related issues: Close https://github.com/moonbitlang/moon/issues/85

## Type of Pull Request

- [x] Bug fix


Just a workaround. It is also possible that `$MOON_HOME/bin` and `$MOON_HOME/tmp` are not in the same mount point.
