### PR TITLE
ci: move cargo clippy after cargo test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,25 +89,8 @@ jobs:
       - name: check for typos
         run: typos
 
-  code-style:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.77.0
-        with:
-          components: rustfmt, clippy
-      - name: Cargo cache
-        uses: actions/cache@v4
-        with:
-            key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-            path: ~/.cargo/registry
-      - name: Check formatting
-        run: cargo fmt -- --check
-      - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
   test:
-    needs: [code-style, typo-check, license-header-check]
+    needs: [typo-check, license-header-check]
     strategy:
       fail-fast: false
       matrix:
@@ -130,6 +113,8 @@ jobs:
           cp moonc-version-dont-delete/moonc-version .
 
       - uses: dtolnay/rust-toolchain@1.77.0
+        with:
+          components: rustfmt, clippy
       - name: Cargo cache
         uses: actions/cache@v4
         with:
@@ -161,6 +146,13 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+      - name: Check format
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo fmt -- --check
+      - name: Clippy
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       # - name: Test core (Unix)
       #   if: ${{ matrix.os != 'windows-latest' }}


### PR DESCRIPTION
move cargo clippy after cargo test to save CI time cc @Young-Flash 

Before
<img width="828" alt="before" src="https://github.com/user-attachments/assets/bd81887e-5f5b-42c5-8e1e-0508b48254fe">


After

<img width="833" alt="after" src="https://github.com/user-attachments/assets/7afb64d2-616d-4dc2-9059-8d631466213e">

