### PR TITLE
internal: tweak --build-only

### DIFF
--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -343,6 +343,12 @@ fn do_run_test(
         auto_update,
         module,
     )?;
+
+    // don't print test summary if build_only
+    if build_only {
+        return Ok(0);
+    }
+
     let total = test_res.len();
     let passed = test_res.iter().filter(|r| r.is_ok()).count();
 

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -68,6 +68,7 @@ fn test_design() {
         "#]],
     );
 
+    get_stdout_with_args(&dir, ["clean"]);
     check(
         &get_stdout_with_args_and_replace_dir(
             &dir,
@@ -77,6 +78,7 @@ fn test_design() {
             {"artifacts_path":["$ROOT/target/js/release/build/main2/main2.js"]}
         "#]],
     );
+    assert!(dir.join("target/js/release/build/main2/main2.js").exists());
 }
 
 #[test]
@@ -5233,6 +5235,7 @@ fn test_moon_run_single_mbt_file() {
             {"artifacts_path":["$ROOT/a/b/target/single.js"]}
         "#]],
     );
+    assert!(dir.join("a/b/target/single.js").exists());
 
     let output = get_stdout_with_args_and_replace_dir(&dir, ["run", "a/b/single.mbt", "--dry-run"]);
     check(
@@ -5594,6 +5597,7 @@ fn test_specify_source_dir_004() {
         "#]],
     );
 
+    get_stdout_with_args(&dir, ["clean"]);
     check(
         &get_stdout_with_args_and_replace_dir(
             &dir,
@@ -5603,6 +5607,7 @@ fn test_specify_source_dir_004() {
             {"artifacts_path":["$ROOT/target/js/release/build/main/main.js"]}
         "#]],
     );
+    assert!(dir.join("target/js/release/build/main/main.js").exists());
 
     check(
         &get_stdout_with_args_and_replace_dir(&dir, ["run", "nes/t/ed/src/main"]),

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -67,6 +67,16 @@ fn test_design() {
             main2
         "#]],
     );
+
+    check(
+        &get_stdout_with_args_and_replace_dir(
+            &dir,
+            ["run", "main2", "--target", "js", "--build-only"],
+        ),
+        expect![[r#"
+            {"artifacts_path":["$ROOT/target/js/release/build/main2/main2.js"]}
+        "#]],
+    );
 }
 
 #[test]
@@ -5213,6 +5223,17 @@ fn test_moon_run_single_mbt_file() {
         "#]],
     );
 
+    let output = get_stdout_with_args_and_replace_dir(
+        &dir,
+        ["run", "a/b/single.mbt", "--target", "js", "--build-only"],
+    );
+    check(
+        &output,
+        expect![[r#"
+            {"artifacts_path":["$ROOT/a/b/target/single.js"]}
+        "#]],
+    );
+
     let output = get_stdout_with_args_and_replace_dir(&dir, ["run", "a/b/single.mbt", "--dry-run"]);
     check(
         &output,
@@ -5572,6 +5593,17 @@ fn test_specify_source_dir_004() {
             Finished. moon: ran 3 tasks, now up to date
         "#]],
     );
+
+    check(
+        &get_stdout_with_args_and_replace_dir(
+            &dir,
+            ["run", "nes/t/ed/src/main", "--target", "js", "--build-only"],
+        ),
+        expect![[r#"
+            {"artifacts_path":["$ROOT/target/js/release/build/main/main.js"]}
+        "#]],
+    );
+
     check(
         &get_stdout_with_args_and_replace_dir(&dir, ["run", "nes/t/ed/src/main"]),
         expect![[r#"

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -385,6 +385,11 @@ impl TestOpt {
     }
 }
 
+#[derive(serde::Serialize, Clone)]
+pub struct TestArtifacts {
+    pub artifacts_path: Vec<PathBuf>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct FmtOpt {
     pub check: bool,


### PR DESCRIPTION
this PR tweak the `--build-only` flag for `moon run` and `moon test`, with the flag, `moon` will build all the artifacts without   running them, and give a json which indicates the path of artifacts.

cc @hackwaly 