### PR TITLE
Add directory '.idea' to '.gitignore'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/target
 .vscode/
 .DS_store
+.idea/


### PR DESCRIPTION
This patch adds the project files of the IDE RustRover (directory `.idea`) to the file `.gitignore`.

## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [ ] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe):

## Does this PR change existing behavior?

- [ ] Yes (please describe the changes below)
- [x] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
