### PR TITLE
Improve error messages of `moon test`

### DIFF
--- a/crates/moonbuild/src/entry.rs
+++ b/crates/moonbuild/src/entry.rs
@@ -586,6 +586,9 @@ pub fn run_test(
                     Err(e) => {
                         // when spawn process failed, this can still make the total test count to be correct
                         // but this is not a good way to handle it
+                        for _ in 0..test_args.get_test_cnt() {
+                            eprintln!("{:?}\n", &e);
+                        }
                         return Ok(vec![
                             Err(TestFailedStatus::Others(e.to_string()));
                             test_args.get_test_cnt() as usize

--- a/crates/moonbuild/src/entry.rs
+++ b/crates/moonbuild/src/entry.rs
@@ -584,11 +584,9 @@ pub fn run_test(
                         .await?;
                     }
                     Err(e) => {
+                        eprintln!("{:?}\n", &e);
                         // when spawn process failed, this can still make the total test count to be correct
                         // but this is not a good way to handle it
-                        for _ in 0..test_args.get_test_cnt() {
-                            eprintln!("{:?}\n", &e);
-                        }
                         return Ok(vec![
                             Err(TestFailedStatus::Others(e.to_string()));
                             test_args.get_test_cnt() as usize


### PR DESCRIPTION
When the command `node` is not installed locally and I use the following command to run test about backend `js`. The test fails, but the concrete cause is not printed, which is hard for user to debug.


```
$ cargo test --package moon --test mod test_cases::test_js -- --exact

---- test_cases::test_js stdout ----
thread 'test_cases::test_js' panicked at crates/moon/tests/test_cases/mod.rs:6028:18:
Expected success, was 2
stdout:

Total tests: 3, passed: 0, failed: 3.

```

This patch improves the error message. After this patch, the output of the same command is shown below.

```
$ cargo test --package moon --test mod test_cases::test_js -- --exact

---- test_cases::test_js stdout ----
thread 'test_cases::test_js' panicked at crates/moon/tests/test_cases/mod.rs:6028:18:
Expected success, was 2
stdout:

Total tests: 3, passed: 0, failed: 3.


stderr:

failed to execute 'node /tmp/.tmpZK4XGm/target/js/debug/test/lib/lib.internal_test.cjs'

Caused by:
    No such file or directory (os error 2)

failed to execute 'node /tmp/.tmpZK4XGm/target/js/debug/test/lib/lib.whitebox_test.cjs'

Caused by:
    No such file or directory (os error 2)

failed to execute 'node /tmp/.tmpZK4XGm/target/js/debug/test/lib/lib.whitebox_test.cjs'

Caused by:
    No such file or directory (os error 2)
```

## Type of Pull Request

- [ ] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - print more error message
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
