### PR TITLE
Trace correct test time

### DIFF
--- a/crates/moonbuild/src/entry.rs
+++ b/crates/moonbuild/src/entry.rs
@@ -551,16 +551,16 @@ pub fn run_test(
 
             let printed = Arc::clone(&printed);
             handlers.push(async move {
-                let mut result = trace::scope("test", || async {
+                let mut result = trace::async_scope(
+                    "test",
                     execute_test(
                         moonc_opt.build_opt.target_backend,
                         &artifact_path,
                         target_dir,
                         &test_args,
                         &file_test_info_map,
-                    )
-                    .await
-                })
+                    ),
+                )
                 .await;
                 match result {
                     Ok(ref mut test_res_for_cur_pkg) => {


### PR DESCRIPTION
Currently, when using the command `moon test --trace` to record the test time, the output in `trace.json` is not right. The duration is always `0` (shown below).

```
,{"pid":0, "name":"test", "ts":7753866, "tid": 0, "ph":"X", "dur":0}
,{"pid":0, "name":"test", "ts":7758979, "tid": 0, "ph":"X", "dur":0}
```

It is because the code in [entry.rs](https://github.com/moonbitlang/moon/blob/1caf7785baf1f436f21697f1d5993fb53aa6347e/crates/moonbuild/src/entry.rs#L559..L569) just records the time to construct a `Future` instead of the time to run the test.

This PR relies on https://github.com/moonbitlang/n2/pull/2 and can't be integrated before it. After merging these two PRs, the output should be right (as shown below).

```
,{"pid":0, "name":"test", "ts":9205546, "tid": 0, "ph":"X", "dur":401710}
,{"pid":0, "name":"test", "ts":9196616, "tid": 0, "ph":"X", "dur":414907}
```


## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - record the right test time
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
