### PR TITLE
Fix ineffective attribute clap with next_help_heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 The build system and package manager for MoonBit.
 
 ```bash
-$ moon              
+$ moon help
 The build system and package manager for MoonBit.
 
 Usage: moon [OPTIONS] <COMMAND>
@@ -37,6 +37,9 @@ Commands:
   help                   Print this message or the help of the given subcommand(s)
 
 Options:
+  -h, --help  Print help
+
+Common Options:
   -C, --directory <SOURCE_DIR>   The source code directory. Defaults to the current directory
       --target-dir <TARGET_DIR>  The target directory. Defaults to `source_dir/target`
   -q, --quiet                    Suppress output
@@ -44,7 +47,6 @@ Options:
       --trace                    Trace the execution of the program
       --dry-run                  Do not actually run the command
       --build-graph              generate build graph
-  -h, --help                     Print help
 ```
 
 See tutorials at

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -431,6 +431,9 @@ fn test_moon_help() {
               help                   Print this message or the help of the given subcommand(s)
 
             Options:
+              -h, --help  Print help
+
+            Common Options:
               -C, --directory <SOURCE_DIR>   The source code directory. Defaults to the current directory
                   --target-dir <TARGET_DIR>  The target directory. Defaults to `source_dir/target`
               -q, --quiet                    Suppress output
@@ -438,7 +441,6 @@ fn test_moon_help() {
                   --trace                    Trace the execution of the program
                   --dry-run                  Do not actually run the command
                   --build-graph              generate build graph
-              -h, --help                     Print help
         "#]],
     );
 }

--- a/crates/moonutil/src/cli.rs
+++ b/crates/moonutil/src/cli.rs
@@ -29,6 +29,7 @@ use crate::dirs::SourceTargetDirs;
 // }
 
 #[derive(Debug, clap::Parser, Serialize, Deserialize, Clone)]
+#[clap(next_help_heading = "Common Options")]
 pub struct UniversalFlags {
     #[clap(flatten)]
     pub source_tgt_dir: SourceTargetDirs,

--- a/crates/moonutil/src/cli.rs
+++ b/crates/moonutil/src/cli.rs
@@ -29,7 +29,6 @@ use crate::dirs::SourceTargetDirs;
 // }
 
 #[derive(Debug, clap::Parser, Serialize, Deserialize, Clone)]
-#[clap(next_display_order(2000), next_help_heading("Common options"))]
 pub struct UniversalFlags {
     #[clap(flatten)]
     pub source_tgt_dir: SourceTargetDirs,

--- a/docs/manual-zh/src/tutorial.md
+++ b/docs/manual-zh/src/tutorial.md
@@ -17,39 +17,41 @@
     Usage: moon [OPTIONS] <COMMAND>
 
     Commands:
-    new                    Create a new MoonBit module
-    build                  Build the current package
-    check                  Check the current package, but don't build object files
-    run                    Run a main package
-    test                   Test the current package
-    clean                  Remove the target directory
-    fmt                    Format source code
-    doc                    Generate documentation
-    info                   Generate public interface (`.mbti`) files for all packages in the module
-    add                    Add a dependency
-    remove                 Remove a dependency
-    install                Install dependencies
-    tree                   Display the dependency tree
-    login                  Log in to your account
-    register               Register an account at mooncakes.io
-    publish                Publish the current package
-    update                 Update the package registry index
-    coverage               Code coverage utilities
-    generate-build-matrix  Generate build matrix for benchmarking (legacy feature)
-    upgrade                Upgrade toolchains
-    shell-completion       Generate shell completion for bash/elvish/fish/pwsh/zsh to stdout
-    version                Print version info and exit
-    help                   Print this message or the help of the given subcommand(s)
+      new                    Create a new MoonBit module
+      build                  Build the current package
+      check                  Check the current package, but don't build object files
+      run                    Run a main package
+      test                   Test the current package
+      clean                  Remove the target directory
+      fmt                    Format source code
+      doc                    Generate documentation
+      info                   Generate public interface (`.mbti`) files for all packages in the module
+      add                    Add a dependency
+      remove                 Remove a dependency
+      install                Install dependencies
+      tree                   Display the dependency tree
+      login                  Log in to your account
+      register               Register an account at mooncakes.io
+      publish                Publish the current package
+      update                 Update the package registry index
+      coverage               Code coverage utilities
+      generate-build-matrix  Generate build matrix for benchmarking (legacy feature)
+      upgrade                Upgrade toolchains
+      shell-completion       Generate shell completion for bash/elvish/fish/pwsh/zsh to stdout
+      version                Print version info and exit
+      help                   Print this message or the help of the given subcommand(s)
 
     Options:
-    -C, --directory <SOURCE_DIR>   The source code directory. Defaults to the current directory
-        --target-dir <TARGET_DIR>  The target directory. Defaults to `source_dir/target`
-    -q, --quiet                    Suppress output
-    -v, --verbose                  Increase verbosity
-        --trace                    Trace the execution of the program
-        --dry-run                  Do not actually run the command
-        --build-graph              generate build graph
-    -h, --help                     Print help
+      -h, --help  Print help
+
+    Common Options:
+      -C, --directory <SOURCE_DIR>   The source code directory. Defaults to the current directory
+          --target-dir <TARGET_DIR>  The target directory. Defaults to `source_dir/target`
+      -q, --quiet                    Suppress output
+      -v, --verbose                  Increase verbosity
+          --trace                    Trace the execution of the program
+          --dry-run                  Do not actually run the command
+          --build-graph              generate build graph
     ```
 
 2. **Moonbit Language** Visual Studio Code 插件: 可以从 VS Code 市场安装。该插件为 MoonBit 提供了丰富的开发环境，包括语法高亮、代码补全、交互式除错和测试等功能。

--- a/docs/manual/src/tutorial.md
+++ b/docs/manual/src/tutorial.md
@@ -17,39 +17,41 @@ Before you begin with this tutorial, make sure you have installed the following:
     Usage: moon [OPTIONS] <COMMAND>
 
     Commands:
-    new                    Create a new MoonBit module
-    build                  Build the current package
-    check                  Check the current package, but don't build object files
-    run                    Run a main package
-    test                   Test the current package
-    clean                  Remove the target directory
-    fmt                    Format source code
-    doc                    Generate documentation
-    info                   Generate public interface (`.mbti`) files for all packages in the module
-    add                    Add a dependency
-    remove                 Remove a dependency
-    install                Install dependencies
-    tree                   Display the dependency tree
-    login                  Log in to your account
-    register               Register an account at mooncakes.io
-    publish                Publish the current package
-    update                 Update the package registry index
-    coverage               Code coverage utilities
-    generate-build-matrix  Generate build matrix for benchmarking (legacy feature)
-    upgrade                Upgrade toolchains
-    shell-completion       Generate shell completion for bash/elvish/fish/pwsh/zsh to stdout
-    version                Print version info and exit
-    help                   Print this message or the help of the given subcommand(s)
+      new                    Create a new MoonBit module
+      build                  Build the current package
+      check                  Check the current package, but don't build object files
+      run                    Run a main package
+      test                   Test the current package
+      clean                  Remove the target directory
+      fmt                    Format source code
+      doc                    Generate documentation
+      info                   Generate public interface (`.mbti`) files for all packages in the module
+      add                    Add a dependency
+      remove                 Remove a dependency
+      install                Install dependencies
+      tree                   Display the dependency tree
+      login                  Log in to your account
+      register               Register an account at mooncakes.io
+      publish                Publish the current package
+      update                 Update the package registry index
+      coverage               Code coverage utilities
+      generate-build-matrix  Generate build matrix for benchmarking (legacy feature)
+      upgrade                Upgrade toolchains
+      shell-completion       Generate shell completion for bash/elvish/fish/pwsh/zsh to stdout
+      version                Print version info and exit
+      help                   Print this message or the help of the given subcommand(s)
 
     Options:
-    -C, --directory <SOURCE_DIR>   The source code directory. Defaults to the current directory
-        --target-dir <TARGET_DIR>  The target directory. Defaults to `source_dir/target`
-    -q, --quiet                    Suppress output
-    -v, --verbose                  Increase verbosity
-        --trace                    Trace the execution of the program
-        --dry-run                  Do not actually run the command
-        --build-graph              generate build graph
-    -h, --help                     Print help
+      -h, --help  Print help
+
+    Common Options:
+      -C, --directory <SOURCE_DIR>   The source code directory. Defaults to the current directory
+          --target-dir <TARGET_DIR>  The target directory. Defaults to `source_dir/target`
+      -q, --quiet                    Suppress output
+      -v, --verbose                  Increase verbosity
+          --trace                    Trace the execution of the program
+          --dry-run                  Do not actually run the command
+          --build-graph              generate build graph
     ```
 
 2. **MoonBit Language** plugin in Visual Studio Code: You can install it from the VS Code marketplace. This plugin provides a rich development environment for MoonBit, including functionalities like syntax highlighting, code completion, and more.


### PR DESCRIPTION
The code shown below is ineffective and can't generate the `Common options` heading.

```
// ineffective
#[clap(next_display_order(2000), next_help_heading("Common options"))]
```

We can use an assignment instead of the method invocation to fix this issue.

```
// effective 
#[clap(next_help_heading = "Common options")]
```

But when using the assignment, the output is not good(shown below).

```
$ moon help

The build system and package manager for MoonBit.

Usage: moon [OPTIONS] <COMMAND>

Commands:
// skip

Options:
  -h, --help  Print help

Common Options:
  -C, --directory <SOURCE_DIR>   The source code directory. Defaults to the current directory
      --target-dir <TARGET_DIR>  The target directory. Defaults to `source_dir/target`
  -q, --quiet                    Suppress output
  -v, --verbose                  Increase verbosity
      --trace                    Trace the execution of the program
      --dry-run                  Do not actually run the command
      --build-graph              generate build graph
```

So I just remove this ineffective code.

## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [ ] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe): Remove ineffective code

## Does this PR change existing behavior?

- [ ] Yes (please describe the changes below)
- [x] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
