### PR TITLE
Avoid closing trace file prematurely when using `moon test --trace`

### DIFF
--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -247,18 +247,20 @@ fn run_test_internal(
         return dry_run::print_commands(&module, &moonc_opt, &moonbuild_opt).map(From::from);
     }
 
-    if cli.trace {
-        trace::close();
-    }
-
-    do_run_test(
+    let res = do_run_test(
         &moonc_opt,
         &moonbuild_opt,
         build_only,
         auto_update,
         &module,
         verbose,
-    )
+    );
+
+    if cli.trace {
+        trace::close();
+    }
+
+    res
 }
 
 fn do_run_test(


### PR DESCRIPTION
When using the command `moon test --trace`, the trace file is closed prematurely. The wrong output is shown below.

```
[
{"pid":0, "name":"main", "ts":0, "tid": 0, "ph":"X", "dur":7517}
]
,{"pid":0, "name":"<skip>", "ts":69065, "tid": 4, "ph":"X", "dur":61929}
// skip other information
```

This patch fixes it and the newly right output is shown below.

```
[
{"pid":0, "name":"<skip>", "ts":69065, "tid": 4, "ph":"X", "dur":61929}
// skip other information
]
```


## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
