### PR TITLE
Flush and close trace file normally when using `moon build --trace`

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -161,16 +161,23 @@ fn run_build_internal(
         trace::open("trace.json").context("failed to open `trace.json`")?;
     }
 
+    let res;
     if cmd.watch {
         let reg_cfg = RegistryConfig::load();
-        watching(
+        res = watching(
             &moonc_opt,
             &moonbuild_opt,
             &reg_cfg,
             &module,
             original_target_dir,
-        )
+        );
     } else {
-        entry::run_build(&moonc_opt, &moonbuild_opt, &module)
+        res = entry::run_build(&moonc_opt, &moonbuild_opt, &module);
     }
+
+    if trace_flag {
+        trace::close();
+    }
+
+    res
 }

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -161,19 +161,18 @@ fn run_build_internal(
         trace::open("trace.json").context("failed to open `trace.json`")?;
     }
 
-    let res;
-    if cmd.watch {
+    let res = if cmd.watch {
         let reg_cfg = RegistryConfig::load();
-        res = watching(
+        watching(
             &moonc_opt,
             &moonbuild_opt,
             &reg_cfg,
             &module,
             original_target_dir,
-        );
+        )
     } else {
-        res = entry::run_build(&moonc_opt, &moonbuild_opt, &module);
-    }
+        entry::run_build(&moonc_opt, &moonbuild_opt, &module)
+    };
 
     if trace_flag {
         trace::close();


### PR DESCRIPTION
Currently, when using the command `moon build --trace`, the final buffer can't be flushed to the trace file and the last entry, named `main`, is not printed. This patch fixes it.


## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
