### PR TITLE
Flush and close trace file normally when using `moon check --watch --trace`

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -180,7 +180,7 @@ fn run_check_internal(
 
     let watch_mode = cmd.watch;
 
-    if watch_mode {
+    let res = if watch_mode {
         let reg_cfg = RegistryConfig::load();
         watching(
             &moonc_opt,
@@ -202,11 +202,13 @@ fn run_check_internal(
             }
             Ok(if output.is_empty() { 0 } else { 1 })
         } else {
-            let result = entry::run_check(&moonc_opt, &moonbuild_opt, &module);
-            if cli.trace {
-                trace::close();
-            }
-            result
+            entry::run_check(&moonc_opt, &moonbuild_opt, &module)
         }
+    };
+
+    if cli.trace {
+        trace::close();
     }
+
+    res
 }


### PR DESCRIPTION
Currently, when using the command `moon check --watch --trace`, the final buffer can't be flushed to the trace file and the last entry, named `main`, is not printed. This patch fixes it.

## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
