### PR TITLE
Improve parallelism for 'moon test'

### DIFF
--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -254,11 +254,11 @@ fn run_test_internal(
     }
 
     let res = do_run_test(
-        &moonc_opt,
-        &moonbuild_opt,
+        moonc_opt,
+        moonbuild_opt,
         build_only,
         auto_update,
-        &module,
+        module,
         verbose,
     );
 
@@ -270,13 +270,20 @@ fn run_test_internal(
 }
 
 fn do_run_test(
-    moonc_opt: &MooncOpt,
-    moonbuild_opt: &MoonbuildOpt,
+    moonc_opt: MooncOpt,
+    moonbuild_opt: MoonbuildOpt,
     build_only: bool,
     auto_update: bool,
-    module: &ModuleDB,
+    module: ModuleDB,
     verbose: bool,
 ) -> anyhow::Result<i32> {
+    let backend_hint = moonbuild_opt
+        .test_opt
+        .as_ref()
+        .and_then(|opt| opt.display_backend_hint.as_ref())
+        .map(|_| format!(" [{}]", moonc_opt.build_opt.target_backend.to_backend_ext()))
+        .unwrap_or_default();
+
     let test_res = entry::run_test(
         moonc_opt,
         moonbuild_opt,
@@ -295,13 +302,6 @@ fn do_run_test(
     let passed = test_res.iter().filter(|r| r.is_ok()).count();
 
     let failed = total - passed;
-    let backend_hint = moonbuild_opt
-        .test_opt
-        .as_ref()
-        .and_then(|opt| opt.display_backend_hint.as_ref())
-        .map(|_| format!(" [{}]", moonc_opt.build_opt.target_backend.to_backend_ext()))
-        .unwrap_or_default();
-
     println!(
         "Total tests: {}, passed: {}, failed: {}.{}",
         if total > 0 {


### PR DESCRIPTION
Currently, when using the command `moon test`, `moon` will create 16 threads by using the `tokio` library. But these 16 threads will never be used after creating. And these 16 threads become more strange when combining with the argument `--no-parallel`. It is a misuse of the library `tokio`.

This patch, which want to fix the issue, contains the following features:
- When the `--no-parallel` is not provided, run the tests parallelly
  - the thread count is equal to the logic cores (not the constant 16)
  - spawn the test tasks to the `tokio` runtime scheduler (use the threads `tokio` created to run the test)
- When the `--no-parallel` is provided,  run the tests sequentially
  - don't create new thread
  - run the test one by one in current thread

Thanks for your review.

## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe): Improve performance

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
