### PR TITLE
internal: add raw_target_dir in MoonbuildOpt

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -115,7 +115,7 @@ fn run_build_internal(
         cli.quiet,
     )?;
 
-    let original_target_dir = target_dir;
+    let raw_target_dir = target_dir;
     let mut moonc_opt = super::get_compiler_flags(source_dir, &cmd.build_flags)?;
     moonc_opt.build_opt.deny_warn = cmd.build_flags.deny_warn;
     let run_mode = RunMode::Build;
@@ -125,6 +125,7 @@ fn run_build_internal(
 
     let moonbuild_opt = MoonbuildOpt {
         source_dir: source_dir.to_path_buf(),
+        raw_target_dir: raw_target_dir.to_path_buf(),
         target_dir,
         sort_input,
         run_mode,
@@ -172,7 +173,7 @@ fn run_build_internal(
             &moonbuild_opt,
             &reg_cfg,
             &module,
-            original_target_dir,
+            raw_target_dir,
         )
     } else {
         entry::run_build(&moonc_opt, &moonbuild_opt, &module)

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -131,7 +131,11 @@ fn run_build_internal(
         quiet: cli.quiet,
         verbose: cli.verbose,
         build_graph: cli.build_graph,
-        ..Default::default()
+        test_opt: None,
+        fmt_opt: None,
+        args: vec![],
+        output_json: false,
+        no_parallelize: false,
     };
 
     let module = moonutil::scan::scan(

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -123,11 +123,13 @@ fn run_bundle_internal(
     let run_mode = RunMode::Bundle;
     let sort_input = cmd.build_flags.sort_input;
 
+    let raw_target_dir = target_dir.to_path_buf();
     let target_dir = mk_arch_mode_dir(source_dir, target_dir, &moonc_opt, run_mode)?;
     let _lock = FileLock::lock(&target_dir)?;
 
     let moonbuild_opt = MoonbuildOpt {
         source_dir: source_dir.to_path_buf(),
+        raw_target_dir,
         target_dir,
         sort_input,
         run_mode,

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -131,7 +131,14 @@ fn run_bundle_internal(
         target_dir,
         sort_input,
         run_mode,
-        ..Default::default()
+        test_opt: None,
+        fmt_opt: None,
+        args: vec![],
+        verbose: cli.verbose,
+        quiet: cli.quiet,
+        output_json: false,
+        no_parallelize: false,
+        build_graph: false,
     };
     let module = moonutil::scan::scan(
         false,

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -150,7 +150,10 @@ fn run_check_internal(
         verbose: cli.verbose,
         output_json: cmd.output_json,
         build_graph: cli.build_graph,
-        ..Default::default()
+        test_opt: None,
+        fmt_opt: None,
+        args: vec![],
+        no_parallelize: false,
     };
 
     let module = moonutil::scan::scan(

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -132,7 +132,7 @@ fn run_check_internal(
         cli.quiet,
     )?;
 
-    let original_target_dir = target_dir;
+    let raw_target_dir = target_dir;
     let mut moonc_opt = get_compiler_flags(source_dir, &cmd.build_flags)?;
     moonc_opt.build_opt.deny_warn = cmd.build_flags.deny_warn;
     let run_mode = RunMode::Check;
@@ -143,6 +143,7 @@ fn run_check_internal(
 
     let moonbuild_opt = MoonbuildOpt {
         source_dir: source_dir.to_path_buf(),
+        raw_target_dir: raw_target_dir.to_path_buf(),
         target_dir: target_dir.clone(),
         sort_input,
         run_mode,
@@ -190,7 +191,7 @@ fn run_check_internal(
             &moonbuild_opt,
             &reg_cfg,
             &module,
-            original_target_dir,
+            raw_target_dir,
         )
     } else {
         let pid_path = target_dir.join(MOON_PID_NAME);

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -82,9 +82,11 @@ pub fn run_doc(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Result<i32> {
     )?;
 
     let run_mode = RunMode::Check;
+    let raw_target_dir = target_dir.to_path_buf();
     let target_dir = mk_arch_mode_dir(&source_dir, &target_dir, &moonc_opt, run_mode)?;
     let moonbuild_opt = MoonbuildOpt {
         source_dir: source_dir.clone(),
+        raw_target_dir,
         target_dir,
         sort_input: true,
         run_mode,

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -88,7 +88,14 @@ pub fn run_doc(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Result<i32> {
         target_dir,
         sort_input: true,
         run_mode,
-        ..Default::default()
+        test_opt: None,
+        fmt_opt: None,
+        args: vec![],
+        verbose: cli.verbose,
+        quiet: cli.quiet,
+        output_json: false,
+        no_parallelize: false,
+        build_graph: false,
     };
 
     let module = moonutil::scan::scan(

--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -46,6 +46,7 @@ pub fn run_fmt(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> 
 
     let moonc_opt = MooncOpt::default();
     let run_mode = RunMode::Format;
+    let raw_target_dir = target_dir.to_path_buf();
     let target_dir = mk_arch_mode_dir(&source_dir, &target_dir, &moonc_opt, run_mode)?;
     let _lock = FileLock::lock(&target_dir)?;
 
@@ -59,6 +60,7 @@ pub fn run_fmt(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> 
 
     let moonbuild_opt = MoonbuildOpt {
         source_dir,
+        raw_target_dir,
         target_dir: target_dir.clone(),
         sort_input: cmd.sort_input,
         run_mode,

--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -64,7 +64,12 @@ pub fn run_fmt(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> 
         run_mode,
         fmt_opt: Some(FmtOpt { check: cmd.check }),
         build_graph: cli.build_graph,
-        ..Default::default()
+        test_opt: None,
+        args: vec![],
+        verbose: cli.verbose,
+        quiet: cli.quiet,
+        output_json: false,
+        no_parallelize: false,
     };
 
     let module = moonutil::scan::scan(

--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -130,9 +130,11 @@ pub fn generate_test_driver(
         &RegistryConfig::load(),
         cli.quiet,
     )?;
+    let raw_target_dir = target_dir.to_path_buf();
 
     let moonbuild_opt = MoonbuildOpt {
         source_dir,
+        raw_target_dir,
         target_dir: target_dir.clone(),
         test_opt: Some(TestOpt {
             filter_package: filter_package.clone(),

--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -145,7 +145,12 @@ pub fn generate_test_driver(
         fmt_opt: None,
         sort_input,
         run_mode,
-        ..Default::default()
+        args: vec![],
+        verbose: cli.verbose,
+        quiet: cli.quiet,
+        output_json: false,
+        no_parallelize: false,
+        build_graph: false,
     };
 
     let module = moonutil::scan::scan(

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -69,6 +69,7 @@ pub fn run_info(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32>
     })?;
     let module_name = &mod_desc.name;
     let mut moonc_opt = MooncOpt::default();
+    let raw_target_dir = target_dir.to_path_buf();
     let target_dir = mk_arch_mode_dir(
         source_dir.as_path(),
         target_dir.as_path(),
@@ -82,6 +83,7 @@ pub fn run_info(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32>
     }
     let moonbuild_opt = MoonbuildOpt {
         source_dir: source_dir.clone(),
+        raw_target_dir,
         target_dir: target_dir.clone(),
         sort_input: false,
         run_mode: RunMode::Check,
@@ -114,20 +116,7 @@ pub fn run_info(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32>
         &resolved_env,
         &dir_sync_result,
         &moonc_opt,
-        &MoonbuildOpt {
-            source_dir: source_dir.clone(),
-            target_dir,
-            sort_input: false,
-            run_mode: RunMode::Check,
-            test_opt: None,
-            fmt_opt: None,
-            args: vec![],
-            verbose: cli.verbose,
-            quiet: cli.quiet,
-            output_json: false,
-            no_parallelize: false,
-            build_graph: false,
-        },
+        &moonbuild_opt,
     )?;
 
     let runtime = tokio::runtime::Runtime::new()?;

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -85,7 +85,14 @@ pub fn run_info(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32>
         target_dir: target_dir.clone(),
         sort_input: false,
         run_mode: RunMode::Check,
-        ..Default::default()
+        test_opt: None,
+        fmt_opt: None,
+        args: vec![],
+        verbose: cli.verbose,
+        quiet: cli.quiet,
+        output_json: false,
+        no_parallelize: false,
+        build_graph: false,
     };
 
     let module = moonutil::scan::scan(
@@ -110,7 +117,16 @@ pub fn run_info(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32>
         &MoonbuildOpt {
             source_dir: source_dir.clone(),
             target_dir,
-            ..Default::default()
+            sort_input: false,
+            run_mode: RunMode::Check,
+            test_opt: None,
+            fmt_opt: None,
+            args: vec![],
+            verbose: cli.verbose,
+            quiet: cli.quiet,
+            output_json: false,
+            no_parallelize: false,
+            build_graph: false,
         },
     )?;
 

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -226,6 +226,7 @@ pub fn run_run_internal(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Res
 
     let mut moonc_opt = super::get_compiler_flags(&source_dir, &cmd.build_flags)?;
     let run_mode = RunMode::Run;
+    let raw_target_dir = target_dir.to_path_buf();
     let target_dir = mk_arch_mode_dir(&source_dir, &target_dir, &moonc_opt, run_mode)?;
     let _lock = FileLock::lock(&target_dir)?;
 
@@ -260,6 +261,7 @@ pub fn run_run_internal(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Res
     }
     let moonbuild_opt = MoonbuildOpt {
         source_dir,
+        raw_target_dir,
         target_dir,
         sort_input,
         run_mode,

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -267,7 +267,10 @@ pub fn run_run_internal(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Res
         quiet: true,
         verbose: cli.verbose,
         build_graph: cli.build_graph,
-        ..Default::default()
+        test_opt: None,
+        fmt_opt: None,
+        output_json: false,
+        no_parallelize: false,
     };
 
     let module = moonutil::scan::scan(

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -162,6 +162,7 @@ fn run_test_internal(
     moonc_opt.link_opt.debug_flag = !cmd.release;
 
     let run_mode = RunMode::Test;
+    let raw_target_dir = target_dir.to_path_buf();
     let target_dir = mk_arch_mode_dir(source_dir, target_dir, &moonc_opt, run_mode)?;
     let _lock = FileLock::lock(&target_dir)?;
 
@@ -180,6 +181,7 @@ fn run_test_internal(
     let filter_index = cmd.index;
     let moonbuild_opt = MoonbuildOpt {
         source_dir: source_dir.to_path_buf(),
+        raw_target_dir,
         target_dir: target_dir.clone(),
         test_opt: Some(TestOpt {
             filter_package: filter_package.clone(),

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -195,7 +195,9 @@ fn run_test_internal(
         verbose: cli.verbose,
         no_parallelize: cmd.no_parallelize,
         build_graph: cli.build_graph,
-        ..Default::default()
+        fmt_opt: None,
+        args: vec![],
+        output_json: false,
     };
 
     let mut module = moonutil::scan::scan(

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -343,7 +343,7 @@ impl LinkCoreFlags {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct MoonbuildOpt {
     pub source_dir: PathBuf,
     pub target_dir: PathBuf,

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -346,6 +346,7 @@ impl LinkCoreFlags {
 #[derive(Debug, Clone)]
 pub struct MoonbuildOpt {
     pub source_dir: PathBuf,
+    pub raw_target_dir: PathBuf,
     pub target_dir: PathBuf,
     pub test_opt: Option<TestOpt>,
     pub sort_input: bool,


### PR DESCRIPTION
This PR:

1. remove `Default` trait for `MoonbuildOpt`. We need to construct `MoonbuildOpt` carefully without implicit operations.

2. add `raw_target_dir` to `MoonbuildOpt`, which corresponds exactly to the `xxx` in `--target xxx` command.

3. prepare for https://github.com/moonbitlang/moon/pull/294, in `moon generate` all modes share the same state. It's better to record the raw target directory, instead of inferring it by some hacks.


## Type of Pull Request

- [ ] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [x] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [x] Other (please describe):

## Does this PR change existing behavior?

- [] Yes (please describe the changes below)
  - ____
- [x] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
