### PR TITLE
fix update expect test

### DIFF
--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -6306,7 +6306,7 @@ fn test_snapshot_test_target_js() {
 
             test "test inspect 2" {
               inspect!("c", content="c")
-              inspect!("d")
+              inspect!("d", content="d")
             }
 
             test "test snapshot 2" (it : @test.T) {

--- a/crates/moonbuild/template/js_driver.js
+++ b/crates/moonbuild/template/js_driver.js
@@ -1,7 +1,17 @@
 const { moonbit_test_driver_internal_execute } = require("origin_js_path");
 
-const packageName = "";
-const testParams = [];
+let testArgs;
+try {
+  testArgs = JSON.parse(process.argv[2]);
+} catch (error) {
+  console.error("failed to parse args:", error.message);
+  process.exit(1);
+}
+
+const packageName = testArgs.package;
+const testParams = testArgs.file_and_index.flatMap(([file, range]) => 
+  Array.from({length: range.end - range.start}, (_, i) => [file, (range.start + i).toString()])
+);
 
 for (param of testParams) {
     try {


### PR DESCRIPTION
- when updating expect test, if rerun test success, we should update the test resut directly and `continue` to process the next test result in the `for` loop
- `TestArgs` should be passing to `js_driver.js` instead of hardcoding into it