### PR TITLE
fix js test args for debug

### DIFF
--- a/crates/moonbuild/src/entry.rs
+++ b/crates/moonbuild/src/entry.rs
@@ -629,6 +629,14 @@ pub fn run_test(
                 .replace(
                     "origin_js_path",
                     &artifact_path.display().to_string().replace("\\", "/"),
+                )
+                .replace(
+                    "let testParams = []",
+                    &format!("let testParams = {}", test_args.to_args()),
+                )
+                .replace(
+                    "let packageName = \"\"",
+                    &format!("let packageName = {:?}", test_args.package),
                 );
 
                 std::fs::write(&wrapper_js_driver_path, js_driver)?;
@@ -749,6 +757,17 @@ impl TestArgs {
             .iter()
             .map(|(_, range)| range.end - range.start)
             .sum()
+    }
+
+    fn to_args(&self) -> String {
+        let file_and_index = &self.file_and_index;
+        let mut test_params: Vec<[String; 2]> = vec![];
+        for (file, index) in file_and_index {
+            for i in index.clone() {
+                test_params.push([file.clone(), i.to_string()]);
+            }
+        }
+        format!("{:?}", test_params)
     }
 }
 

--- a/crates/moonbuild/template/js_driver.js
+++ b/crates/moonbuild/template/js_driver.js
@@ -1,17 +1,22 @@
 const { moonbit_test_driver_internal_execute } = require("origin_js_path");
 
-let testArgs;
+let packageName = "";
+let testParams = [];
+
 try {
-  testArgs = JSON.parse(process.argv[2]);
+  // check if there is command line argument
+  if (process.argv.length > 2) {
+    const testArgs = JSON.parse(process.argv[2]);
+    packageName = testArgs.package;
+    testParams = testArgs.file_and_index.flatMap(([file, range]) =>
+      Array.from({ length: range.end - range.start }, (_, i) => [file, (range.start + i).toString()])
+    );
+  }
 } catch (error) {
-  console.error("failed to parse args:", error.message);
+  console.error("failed to parse args: ", error.message);
   process.exit(1);
 }
 
-const packageName = testArgs.package;
-const testParams = testArgs.file_and_index.flatMap(([file, range]) => 
-  Array.from({length: range.end - range.start}, (_, i) => [file, (range.start + i).toString()])
-);
 
 for (param of testParams) {
     try {


### PR DESCRIPTION
this PR enable running test artifact without cli args for js backend, so ide could use `node` to run `xx.cjs` directly

cc @hackwaly 