### PR TITLE
chore: remove invalid Instant

### DIFF
--- a/crates/moonrun/src/template/js_glue.js
+++ b/crates/moonrun/src/template/js_glue.js
@@ -8,14 +8,6 @@ const spectest = {
         print_char: (x) => print(x),
         read_char: () => read_char(),
     },
-    Instant: {
-        now() {
-            return instant_now();
-        },
-        elapsed_as_secs_f64(instant) {
-            return instant_elapsed_as_secs_f64(instant);
-        }
-    },
     __moonbit_fs_unstable: __moonbit_fs_unstable,
     __moonbit_rand_unstable: __moonbit_rand_unstable,
     __moonbit_io_unstable: __moonbit_io_unstable,


### PR DESCRIPTION
I would like to remove Instant from the glue code for the following reasons:

- Instant is no binding on the Rust side, instead __moonbit_time_unstable has.

- From a consistency perspective, __moonbit_time_unstable is the one that should be retained.