### PR TITLE
internal: enable --release flag for build | check | run | bundle

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -139,6 +139,10 @@ pub struct BuildFlags {
     #[clap(long, short = 'g')]
     pub debug: bool,
 
+    /// Compile in release mode
+    #[clap(long)]
+    pub release: bool,
+
     /// Select output target
     #[clap(long, value_delimiter = ',')]
     pub target: Option<Vec<SurfaceTarget>>,

--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -140,7 +140,7 @@ pub struct BuildFlags {
     pub debug: bool,
 
     /// Compile in release mode
-    #[clap(long)]
+    #[clap(long, conflicts_with = "debug")]
     pub release: bool,
 
     /// Select output target

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -46,10 +46,6 @@ pub struct TestSubcommand {
     #[clap(flatten)]
     pub build_flags: BuildFlags,
 
-    /// run test at release compiled mode
-    #[clap(long)]
-    pub release: bool,
-
     /// Run test in the specified package
     #[clap(short, long, num_args(0..))]
     pub package: Option<Vec<String>>,
@@ -158,8 +154,8 @@ fn run_test_internal(
     let mut moonc_opt = super::get_compiler_flags(source_dir, &cmd.build_flags)?;
     // release is 'false' by default, so we will run test at debug mode(to gain more detailed stack trace info), unless `--release` is specified
     // however, other command like build, check, run, etc, will run at release mode by default
-    moonc_opt.build_opt.debug_flag = !cmd.release;
-    moonc_opt.link_opt.debug_flag = !cmd.release;
+    moonc_opt.build_opt.debug_flag = !cmd.build_flags.release;
+    moonc_opt.link_opt.debug_flag = !cmd.build_flags.release;
 
     let run_mode = RunMode::Test;
     let raw_target_dir = target_dir.to_path_buf();

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -4607,6 +4607,54 @@ fn debug_flag_test() {
             moonrun ./target/wasm-gc/debug/build/main/main.wasm
         "#]],
     );
+
+    // release should conflict with debug
+    #[cfg(unix)]
+    {
+        check(
+            get_err_stderr(&dir, ["test", "--release", "--debug"]),
+            expect![[r#"
+                error: the argument '--release' cannot be used with '--debug'
+
+                Usage: moon test --release
+
+                For more information, try '--help'.
+            "#]],
+        );
+
+        check(
+            get_err_stderr(&dir, ["build", "--debug", "--release"]),
+            expect![[r#"
+                error: the argument '--debug' cannot be used with '--release'
+
+                Usage: moon build --debug
+
+                For more information, try '--help'.
+            "#]],
+        );
+
+        check(
+            get_err_stderr(&dir, ["check", "--release", "--debug"]),
+            expect![[r#"
+                error: the argument '--release' cannot be used with '--debug'
+
+                Usage: moon check --release
+
+                For more information, try '--help'.
+            "#]],
+        );
+
+        check(
+            get_err_stderr(&dir, ["run", "main", "--debug", "--release"]),
+            expect![[r#"
+                error: the argument '--debug' cannot be used with '--release'
+
+                Usage: moon run --debug <PACKAGE_OR_MBT_FILE> [ARGS]...
+
+                For more information, try '--help'.
+            "#]],
+        );
+    }
 }
 
 #[test]

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -95,6 +95,7 @@ Build the current package
 * `--std` — Enable the standard library (default)
 * `--nostd` — Disable the standard library
 * `-g`, `--debug` — Emit debug information
+* `--release` — Compile in release mode
 * `--target <TARGET>` — Select output target
 
   Possible values: `wasm`, `wasm-gc`, `js`, `native`, `all`
@@ -121,6 +122,7 @@ Check the current package, but don't build object files
 * `--std` — Enable the standard library (default)
 * `--nostd` — Disable the standard library
 * `-g`, `--debug` — Emit debug information
+* `--release` — Compile in release mode
 * `--target <TARGET>` — Select output target
 
   Possible values: `wasm`, `wasm-gc`, `js`, `native`, `all`
@@ -153,6 +155,7 @@ Run a main package
 * `--std` — Enable the standard library (default)
 * `--nostd` — Disable the standard library
 * `-g`, `--debug` — Emit debug information
+* `--release` — Compile in release mode
 * `--target <TARGET>` — Select output target
 
   Possible values: `wasm`, `wasm-gc`, `js`, `native`, `all`
@@ -179,6 +182,7 @@ Test the current package
 * `--std` — Enable the standard library (default)
 * `--nostd` — Disable the standard library
 * `-g`, `--debug` — Emit debug information
+* `--release` — Compile in release mode
 * `--target <TARGET>` — Select output target
 
   Possible values: `wasm`, `wasm-gc`, `js`, `native`, `all`
@@ -189,7 +193,6 @@ Test the current package
 * `--output-wat` — Output WAT instead of WASM
 * `-d`, `--deny-warn` — Treat all warnings as errors
 * `--no-render` — Don't render diagnostics from moonc (don't pass '-error-format json' to moonc)
-* `--release` — run test at release compiled mode
 * `-p`, `--package <PACKAGE>` — Run test in the specified package
 * `-f`, `--file <FILE>` — Run test in the specified file. Only valid when `--package` is also specified
 * `-i`, `--index <INDEX>` — Run only the index-th test in the file. Only valid when `--file` is also specified

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -95,6 +95,7 @@ Build the current package
 * `--std` — Enable the standard library (default)
 * `--nostd` — Disable the standard library
 * `-g`, `--debug` — Emit debug information
+* `--release` — Compile in release mode
 * `--target <TARGET>` — Select output target
 
   Possible values: `wasm`, `wasm-gc`, `js`, `native`, `all`
@@ -121,6 +122,7 @@ Check the current package, but don't build object files
 * `--std` — Enable the standard library (default)
 * `--nostd` — Disable the standard library
 * `-g`, `--debug` — Emit debug information
+* `--release` — Compile in release mode
 * `--target <TARGET>` — Select output target
 
   Possible values: `wasm`, `wasm-gc`, `js`, `native`, `all`
@@ -153,6 +155,7 @@ Run a main package
 * `--std` — Enable the standard library (default)
 * `--nostd` — Disable the standard library
 * `-g`, `--debug` — Emit debug information
+* `--release` — Compile in release mode
 * `--target <TARGET>` — Select output target
 
   Possible values: `wasm`, `wasm-gc`, `js`, `native`, `all`
@@ -179,6 +182,7 @@ Test the current package
 * `--std` — Enable the standard library (default)
 * `--nostd` — Disable the standard library
 * `-g`, `--debug` — Emit debug information
+* `--release` — Compile in release mode
 * `--target <TARGET>` — Select output target
 
   Possible values: `wasm`, `wasm-gc`, `js`, `native`, `all`
@@ -189,7 +193,6 @@ Test the current package
 * `--output-wat` — Output WAT instead of WASM
 * `-d`, `--deny-warn` — Treat all warnings as errors
 * `--no-render` — Don't render diagnostics from moonc (don't pass '-error-format json' to moonc)
-* `--release` — run test at release compiled mode
 * `-p`, `--package <PACKAGE>` — Run test in the specified package
 * `-f`, `--file <FILE>` — Run test in the specified file. Only valid when `--package` is also specified
 * `-i`, `--index <INDEX>` — Run only the index-th test in the file. Only valid when `--file` is also specified


### PR DESCRIPTION
`build | check | run | bundle` is already in release mode by default (moonc run in release mode if no debug flag provided), this PR just remove the cli parsing error for --release flag for them