### PR TITLE
internal: use cc -O2 for native --release

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -117,9 +117,9 @@ fn run_build_internal(
     )?;
 
     let raw_target_dir = target_dir;
-    let mut moonc_opt = super::get_compiler_flags(source_dir, &cmd.build_flags)?;
-    moonc_opt.build_opt.deny_warn = cmd.build_flags.deny_warn;
     let run_mode = RunMode::Build;
+    let mut moonc_opt = super::get_compiler_flags(source_dir, &cmd.build_flags, run_mode)?;
+    moonc_opt.build_opt.deny_warn = cmd.build_flags.deny_warn;
     let target_dir = mk_arch_mode_dir(source_dir, target_dir, &moonc_opt, run_mode)?;
     let _lock = FileLock::lock(&target_dir)?;
     let sort_input = cmd.build_flags.sort_input;

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -126,8 +126,8 @@ fn run_bundle_internal(
         cli.quiet,
     )?;
 
-    let mut moonc_opt = super::get_compiler_flags(source_dir, &cmd.build_flags)?;
     let run_mode = RunMode::Bundle;
+    let mut moonc_opt = super::get_compiler_flags(source_dir, &cmd.build_flags, run_mode)?;
     let sort_input = cmd.build_flags.sort_input;
 
     let raw_target_dir = target_dir.to_path_buf();

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -134,9 +134,9 @@ fn run_check_internal(
     )?;
 
     let raw_target_dir = target_dir;
-    let mut moonc_opt = get_compiler_flags(source_dir, &cmd.build_flags)?;
-    moonc_opt.build_opt.deny_warn = cmd.build_flags.deny_warn;
     let run_mode = RunMode::Check;
+    let mut moonc_opt = get_compiler_flags(source_dir, &cmd.build_flags, run_mode)?;
+    moonc_opt.build_opt.deny_warn = cmd.build_flags.deny_warn;
     let target_dir = mk_arch_mode_dir(source_dir, target_dir, &moonc_opt, run_mode)?;
     let _lock = FileLock::lock(&target_dir)?;
 

--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -124,9 +124,9 @@ pub fn generate_test_driver(
     });
     cmd.build_flags.target_backend = target_backend;
 
-    let moonc_opt = super::get_compiler_flags(&source_dir, &cmd.build_flags)?;
-
     let run_mode = RunMode::Test;
+    let moonc_opt = super::get_compiler_flags(&source_dir, &cmd.build_flags, run_mode)?;
+
     let sort_input = cmd.build_flags.sort_input;
     let filter_package = cmd.package.map(|it| it.into_iter().collect());
 

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -227,8 +227,9 @@ pub fn run_run_internal(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Res
         cli.quiet,
     )?;
 
-    let mut moonc_opt = super::get_compiler_flags(&source_dir, &cmd.build_flags)?;
     let run_mode = RunMode::Run;
+    let mut moonc_opt = super::get_compiler_flags(&source_dir, &cmd.build_flags, run_mode)?;
+
     let raw_target_dir = target_dir.to_path_buf();
     let target_dir = mk_arch_mode_dir(&source_dir, &target_dir, &moonc_opt, run_mode)?;
     let _lock = FileLock::lock(&target_dir)?;

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -151,13 +151,13 @@ fn run_test_internal(
         cli.quiet,
     )?;
 
-    let mut moonc_opt = super::get_compiler_flags(source_dir, &cmd.build_flags)?;
+    let run_mode = RunMode::Test;
+    let mut moonc_opt = super::get_compiler_flags(source_dir, &cmd.build_flags, run_mode)?;
     // release is 'false' by default, so we will run test at debug mode(to gain more detailed stack trace info), unless `--release` is specified
     // however, other command like build, check, run, etc, will run at release mode by default
     moonc_opt.build_opt.debug_flag = !cmd.build_flags.release;
     moonc_opt.link_opt.debug_flag = !cmd.build_flags.release;
 
-    let run_mode = RunMode::Test;
     let raw_target_dir = target_dir.to_path_buf();
     let target_dir = mk_arch_mode_dir(source_dir, target_dir, &moonc_opt, run_mode)?;
     let _lock = FileLock::lock(&target_dir)?;

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -6994,3 +6994,170 @@ fn test_moonfmt() {
 "#]],
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn test_use_cc_for_native_release() {
+    let dir = TestDir::new("moon_test_hello_exec_fntest.in");
+    // build
+    {
+        check(
+            get_stdout(
+                &dir,
+                [
+                    "build",
+                    "--target",
+                    "native",
+                    "--release",
+                    "--sort-input",
+                    "--dry-run",
+                ],
+            ),
+            expect![[r#"
+            moonc build-package ./lib/hello.mbt -o ./target/native/release/build/lib/lib.core -pkg moonbitlang/hello/lib -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moonbitlang/hello/lib:./lib -target native
+            moonc build-package ./main/main.mbt -o ./target/native/release/build/main/main.core -pkg moonbitlang/hello/main -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -i ./target/native/release/build/lib/lib.mi:lib -pkg-sources moonbitlang/hello/main:./main -target native
+            moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/release/build/lib/lib.core ./target/native/release/build/main/main.core -main moonbitlang/hello/main -o ./target/native/release/build/main/main.exe -pkg-sources moonbitlang/hello/lib:./lib -pkg-sources moonbitlang/hello/main:./main -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -target native -cc "cc -O2"
+        "#]],
+        );
+        // if --release is not specified, it should not use cc
+        check(
+            get_stdout(
+                &dir,
+                ["build", "--target", "native", "--sort-input", "--dry-run"],
+            ),
+            expect![[r#"
+            moonc build-package ./lib/hello.mbt -o ./target/native/release/build/lib/lib.core -pkg moonbitlang/hello/lib -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moonbitlang/hello/lib:./lib -target native
+            moonc build-package ./main/main.mbt -o ./target/native/release/build/main/main.core -pkg moonbitlang/hello/main -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -i ./target/native/release/build/lib/lib.mi:lib -pkg-sources moonbitlang/hello/main:./main -target native
+            moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/release/build/lib/lib.core ./target/native/release/build/main/main.core -main moonbitlang/hello/main -o ./target/native/release/build/main/main.exe -pkg-sources moonbitlang/hello/lib:./lib -pkg-sources moonbitlang/hello/main:./main -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -target native
+        "#]],
+        );
+        check(
+            get_stdout(
+                &dir,
+                [
+                    "build",
+                    "--target",
+                    "native",
+                    "--debug",
+                    "--sort-input",
+                    "--dry-run",
+                ],
+            ),
+            expect![[r#"
+            moonc build-package ./lib/hello.mbt -o ./target/native/debug/build/lib/lib.core -pkg moonbitlang/hello/lib -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moonbitlang/hello/lib:./lib -target native -g
+            moonc build-package ./main/main.mbt -o ./target/native/debug/build/main/main.core -pkg moonbitlang/hello/main -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -i ./target/native/debug/build/lib/lib.mi:lib -pkg-sources moonbitlang/hello/main:./main -target native -g
+            moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/debug/build/lib/lib.core ./target/native/debug/build/main/main.core -main moonbitlang/hello/main -o ./target/native/debug/build/main/main.exe -pkg-sources moonbitlang/hello/lib:./lib -pkg-sources moonbitlang/hello/main:./main -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -target native -g
+        "#]],
+        );
+    }
+
+    // run
+    {
+        check(
+            get_stdout(
+                &dir,
+                [
+                    "run",
+                    "main",
+                    "--target",
+                    "native",
+                    "--release",
+                    "--sort-input",
+                    "--dry-run",
+                ],
+            ),
+            expect![[r#"
+                moonc build-package ./lib/hello.mbt -o ./target/native/release/build/lib/lib.core -pkg moonbitlang/hello/lib -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moonbitlang/hello/lib:./lib -target native
+                moonc build-package ./main/main.mbt -o ./target/native/release/build/main/main.core -pkg moonbitlang/hello/main -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -i ./target/native/release/build/lib/lib.mi:lib -pkg-sources moonbitlang/hello/main:./main -target native
+                moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/release/build/lib/lib.core ./target/native/release/build/main/main.core -main moonbitlang/hello/main -o ./target/native/release/build/main/main.exe -pkg-sources moonbitlang/hello/lib:./lib -pkg-sources moonbitlang/hello/main:./main -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -target native -cc "cc -O2"
+                 ./target/native/release/build/main/main.exe
+            "#]],
+        );
+        // if --release is not specified, it should not use cc
+        check(
+            get_stdout(
+                &dir,
+                [
+                    "run",
+                    "main",
+                    "--target",
+                    "native",
+                    "--sort-input",
+                    "--dry-run",
+                ],
+            ),
+            expect![[r#"
+                moonc build-package ./lib/hello.mbt -o ./target/native/release/build/lib/lib.core -pkg moonbitlang/hello/lib -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moonbitlang/hello/lib:./lib -target native
+                moonc build-package ./main/main.mbt -o ./target/native/release/build/main/main.core -pkg moonbitlang/hello/main -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -i ./target/native/release/build/lib/lib.mi:lib -pkg-sources moonbitlang/hello/main:./main -target native
+                moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/release/build/lib/lib.core ./target/native/release/build/main/main.core -main moonbitlang/hello/main -o ./target/native/release/build/main/main.exe -pkg-sources moonbitlang/hello/lib:./lib -pkg-sources moonbitlang/hello/main:./main -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -target native
+                 ./target/native/release/build/main/main.exe
+            "#]],
+        );
+        check(
+            get_stdout(
+                &dir,
+                [
+                    "run",
+                    "main",
+                    "--target",
+                    "native",
+                    "--debug",
+                    "--sort-input",
+                    "--dry-run",
+                ],
+            ),
+            expect![[r#"
+                moonc build-package ./lib/hello.mbt -o ./target/native/debug/build/lib/lib.core -pkg moonbitlang/hello/lib -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moonbitlang/hello/lib:./lib -target native -g
+                moonc build-package ./main/main.mbt -o ./target/native/debug/build/main/main.core -pkg moonbitlang/hello/main -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -i ./target/native/debug/build/lib/lib.mi:lib -pkg-sources moonbitlang/hello/main:./main -target native -g
+                moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/debug/build/lib/lib.core ./target/native/debug/build/main/main.core -main moonbitlang/hello/main -o ./target/native/debug/build/main/main.exe -pkg-sources moonbitlang/hello/lib:./lib -pkg-sources moonbitlang/hello/main:./main -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -target native -g
+                 ./target/native/debug/build/main/main.exe
+            "#]],
+        );
+    }
+
+    // test
+    {
+        check(
+            get_stdout(
+                &dir,
+                [
+                    "test",
+                    "--target",
+                    "native",
+                    "--release",
+                    "--sort-input",
+                    "--dry-run",
+                ],
+            ),
+            expect![[r#"
+                moon generate-test-driver --source-dir . --target-dir ./target/native/release/test --package moonbitlang/hello/lib --sort-input --target native --driver-kind whitebox
+                moonc build-package ./lib/hello.mbt ./lib/hello_wbtest.mbt ./target/native/release/test/lib/__generated_driver_for_whitebox_test.mbt -o ./target/native/release/test/lib/lib.whitebox_test.core -pkg moonbitlang/hello/lib -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moonbitlang/hello/lib:./lib -target native
+                moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/release/test/lib/lib.whitebox_test.core -main moonbitlang/hello/lib -o ./target/native/release/test/lib/lib.whitebox_test.exe -test-mode -pkg-sources moonbitlang/hello/lib:./lib -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -exported_functions moonbit_test_driver_internal_execute -target native -cc "cc -O2"
+                moon generate-test-driver --source-dir . --target-dir ./target/native/release/test --package moonbitlang/hello/lib --sort-input --target native --driver-kind internal
+                moonc build-package ./lib/hello.mbt ./target/native/release/test/lib/__generated_driver_for_internal_test.mbt -o ./target/native/release/test/lib/lib.internal_test.core -pkg moonbitlang/hello/lib -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moonbitlang/hello/lib:./lib -target native
+                moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/release/test/lib/lib.internal_test.core -main moonbitlang/hello/lib -o ./target/native/release/test/lib/lib.internal_test.exe -test-mode -pkg-sources moonbitlang/hello/lib:./lib -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -exported_functions moonbit_test_driver_internal_execute -target native -cc "cc -O2"
+            "#]],
+        );
+        check(
+            get_stdout(
+                &dir,
+                [
+                    "test",
+                    "--target",
+                    "native",
+                    "--debug",
+                    "--sort-input",
+                    "--dry-run",
+                ],
+            ),
+            expect![[r#"
+                moon generate-test-driver --source-dir . --target-dir ./target/native/debug/test --package moonbitlang/hello/lib --sort-input --target native --driver-kind whitebox
+                moonc build-package ./lib/hello.mbt ./lib/hello_wbtest.mbt ./target/native/debug/test/lib/__generated_driver_for_whitebox_test.mbt -o ./target/native/debug/test/lib/lib.whitebox_test.core -pkg moonbitlang/hello/lib -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moonbitlang/hello/lib:./lib -target native -g
+                moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/debug/test/lib/lib.whitebox_test.core -main moonbitlang/hello/lib -o ./target/native/debug/test/lib/lib.whitebox_test.exe -test-mode -pkg-sources moonbitlang/hello/lib:./lib -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -exported_functions moonbit_test_driver_internal_execute -target native -g
+                moon generate-test-driver --source-dir . --target-dir ./target/native/debug/test --package moonbitlang/hello/lib --sort-input --target native --driver-kind internal
+                moonc build-package ./lib/hello.mbt ./target/native/debug/test/lib/__generated_driver_for_internal_test.mbt -o ./target/native/debug/test/lib/lib.internal_test.core -pkg moonbitlang/hello/lib -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moonbitlang/hello/lib:./lib -target native -g
+                moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/debug/test/lib/lib.internal_test.core -main moonbitlang/hello/lib -o ./target/native/debug/test/lib/lib.internal_test.exe -test-mode -pkg-sources moonbitlang/hello/lib:./lib -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -exported_functions moonbit_test_driver_internal_execute -target native -g
+            "#]],
+        );
+    }
+}


### PR DESCRIPTION
for `run | build | test` (which need link-core), use `cc -O2` if --release is provided for native backend