### PR TITLE
feat(moon): support external subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,7 @@ dependencies = [
  "tokio",
  "walkdir",
  "which 6.0.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3042,6 +3043,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -57,6 +57,10 @@ petgraph.workspace = true
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10.66", features = ["vendored"] }
 
+[target."cfg(windows)".dependencies.windows-sys]
+features = ["Win32_Foundation", "Win32_System_Console"]
+version = "0.59.0"
+
 [dev-dependencies]
 tempfile = "3.6.0"
 snapbox = "0.4.15"

--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -25,6 +25,7 @@ pub mod clean;
 pub mod coverage;
 pub mod deps;
 pub mod doc;
+pub mod external;
 pub mod fmt;
 pub mod generate_test_driver;
 pub mod info;
@@ -49,6 +50,7 @@ pub use clean::*;
 pub use coverage::*;
 pub use deps::*;
 pub use doc::*;
+pub use external::*;
 pub use fmt::*;
 pub use generate_test_driver::*;
 pub use info::*;
@@ -134,6 +136,10 @@ pub enum MoonBuildSubcommands {
     Version(VersionSubcommand),
     #[clap(hide = true)]
     Tool(ToolSubcommand),
+
+    // External subcommands
+    #[clap(external_subcommand)]
+    External(Vec<String>),
 }
 
 #[derive(Debug, clap::Parser, Clone)]

--- a/crates/moon/src/cli/external.rs
+++ b/crates/moon/src/cli/external.rs
@@ -1,0 +1,59 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use anyhow::{bail, Context as _};
+use std::process::{Command, ExitStatus};
+use which::which_global;
+
+pub fn run_external(mut args: Vec<String>) -> anyhow::Result<i32> {
+    if args.is_empty() {
+        bail!("no external subcommand provided");
+    };
+    let subcmd = args.remove(0);
+    let bin = &format!("moon-{subcmd}");
+    let resolved = which_global(bin).context(anyhow::format_err!(
+        "no such subcommand: `{subcmd}`, is `{bin}` a valid executable accessible via your `PATH`?"
+    ))?;
+    Ok(exec(Command::new(resolved).args(args))?.code().unwrap_or(0))
+}
+
+#[cfg(unix)]
+fn exec(cmd: &mut Command) -> anyhow::Result<ExitStatus> {
+    use std::os::unix::prelude::*;
+
+    Err(cmd.exec().into())
+}
+
+#[cfg(windows)]
+fn exec(cmd: &mut Command) -> anyhow::Result<ExitStatus> {
+    use windows_sys::Win32::Foundation::{BOOL, FALSE, TRUE};
+    use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
+
+    unsafe extern "system" fn ctrlc_handler(_: u32) -> BOOL {
+        // Do nothing. Let the child process handle it.
+        TRUE
+    }
+
+    unsafe {
+        if SetConsoleCtrlHandler(Some(ctrlc_handler), TRUE) == FALSE {
+            bail!("could not set Ctrl-C handler")
+        }
+    }
+
+    Ok(cmd.status()?)
+}

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -92,5 +92,6 @@ fn main1() -> anyhow::Result<i32> {
         ShellCompletion(gs) => cli::gen_shellcomp(&flags, gs),
         Version(v) => cli::run_version(v),
         Tool(v) => cli::run_tool(v),
+        External(args) => cli::run_external(args),
     }
 }


### PR DESCRIPTION
This PR brings `moon` closer to `git` and `cargo`'s behavior WRT external subcommands, that is, `moon <subcmd>` will fall back to calling `moon-{name}` if such a binary is found in `PATH`.

This encourages exploration of tooling ideas without relying on `moon`'s codebase itself while keeping a unified user experience. Famous examples include [`git-branchless`](https://github.com/arxanas/git-branchless), [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall), [`cargo-chef`](https://github.com/LukeMathWalker/cargo-chef) and [`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild).

See https://doc.rust-lang.org/cargo/reference/external-tools.html#custom-subcommands for more discussion on the rationale of this feature.