### PR TITLE
Enable block style by default

### DIFF
--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -19,7 +19,7 @@
 use moonbuild::dry_run;
 use mooncake::pkg::sync::auto_sync;
 use moonutil::{
-    common::{FileLock, FmtOpt, MoonbuildOpt, MooncOpt, RunMode},
+    common::{BlockStyle, FileLock, FmtOpt, MoonbuildOpt, MooncOpt, RunMode},
     dirs::{mk_arch_mode_dir, PackageDirs},
     mooncakes::{sync::AutoSyncFlags, RegistryConfig},
 };
@@ -38,9 +38,8 @@ pub struct FmtSubcommand {
     pub sort_input: bool,
 
     /// Add separator between each segments
-    #[clap(long)]
-    pub block_style: bool,
-
+    #[clap(long, value_enum, num_args=0..=1, default_missing_value = "true")]
+    pub block_style: Option<BlockStyle>,
     pub args: Vec<String>,
 }
 
@@ -72,7 +71,7 @@ pub fn run_fmt(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> 
         run_mode,
         fmt_opt: Some(FmtOpt {
             check: cmd.check,
-            block_style: cmd.block_style,
+            block_style: cmd.block_style.unwrap_or_default(),
             extra_args: cmd.args,
         }),
         build_graph: cli.build_graph,

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -3937,18 +3937,20 @@ fn test_moon_fmt() {
     check(
         read(dir.join("lib").join("hello.mbt")),
         expect![[r#"
-                pub fn hello() -> String {
-                  "Hello, world!"
-                }
-            "#]],
+            ///|
+            pub fn hello() -> String {
+              "Hello, world!"
+            }
+        "#]],
     );
     check(
         read(dir.join("main").join("main.mbt")),
         expect![[r#"
-                fn main {
-                  println(@lib.hello())
-                }
-            "#]],
+            ///|
+            fn main {
+              println(@lib.hello())
+            }
+        "#]],
     );
 }
 
@@ -3985,6 +3987,7 @@ fn test_moon_fmt_002() {
                 .join("hello.mbt"),
         ),
         expect![[r#"
+            ///|
             pub fn hello() -> String {
               "Hello, world!"
             }
@@ -4000,6 +4003,7 @@ fn test_moon_fmt_002() {
                 .join("main.mbt"),
         ),
         expect![[r#"
+            ///|
             fn main {
               println(@lib.hello())
             }
@@ -4013,25 +4017,25 @@ fn test_moon_fmt_extra_args() {
     check(
         get_stdout(&dir, ["fmt", "--dry-run", "--sort-input"]),
         expect![[r#"
-        moonfmt ./lib/hello.mbt -w -o ./target/wasm-gc/release/format/lib/hello.mbt
-        moonfmt ./lib/hello_wbtest.mbt -w -o ./target/wasm-gc/release/format/lib/hello_wbtest.mbt
-        moonfmt ./main/main.mbt -w -o ./target/wasm-gc/release/format/main/main.mbt
-    "#]],
+            moonfmt ./lib/hello.mbt -w -o ./target/wasm-gc/release/format/lib/hello.mbt -block-style
+            moonfmt ./lib/hello_wbtest.mbt -w -o ./target/wasm-gc/release/format/lib/hello_wbtest.mbt -block-style
+            moonfmt ./main/main.mbt -w -o ./target/wasm-gc/release/format/main/main.mbt -block-style
+        "#]],
     );
     check(
         get_stdout(&dir, ["fmt", "--dry-run", "--sort-input", "--", "a", "b"]),
         expect![[r#"
-            moonfmt ./lib/hello.mbt -w -o ./target/wasm-gc/release/format/lib/hello.mbt a b
-            moonfmt ./lib/hello_wbtest.mbt -w -o ./target/wasm-gc/release/format/lib/hello_wbtest.mbt a b
-            moonfmt ./main/main.mbt -w -o ./target/wasm-gc/release/format/main/main.mbt a b
+            moonfmt ./lib/hello.mbt -w -o ./target/wasm-gc/release/format/lib/hello.mbt a b -block-style
+            moonfmt ./lib/hello_wbtest.mbt -w -o ./target/wasm-gc/release/format/lib/hello_wbtest.mbt a b -block-style
+            moonfmt ./main/main.mbt -w -o ./target/wasm-gc/release/format/main/main.mbt a b -block-style
         "#]],
     );
     check(
         get_stdout(&dir, ["fmt", "--check", "--sort-input", "--dry-run"]),
         expect![[r#"
-            moon tool format-and-diff --old ./lib/hello.mbt --new ./target/wasm-gc/release/format/lib/hello.mbt
-            moon tool format-and-diff --old ./lib/hello_wbtest.mbt --new ./target/wasm-gc/release/format/lib/hello_wbtest.mbt
-            moon tool format-and-diff --old ./main/main.mbt --new ./target/wasm-gc/release/format/main/main.mbt
+            moon tool format-and-diff --old ./lib/hello.mbt --new ./target/wasm-gc/release/format/lib/hello.mbt --block-style
+            moon tool format-and-diff --old ./lib/hello_wbtest.mbt --new ./target/wasm-gc/release/format/lib/hello_wbtest.mbt --block-style
+            moon tool format-and-diff --old ./main/main.mbt --new ./target/wasm-gc/release/format/main/main.mbt --block-style
         "#]],
     );
     check(
@@ -4048,9 +4052,9 @@ fn test_moon_fmt_extra_args() {
             ],
         ),
         expect![[r#"
-            moon tool format-and-diff --old ./lib/hello.mbt --new ./target/wasm-gc/release/format/lib/hello.mbt c d
-            moon tool format-and-diff --old ./lib/hello_wbtest.mbt --new ./target/wasm-gc/release/format/lib/hello_wbtest.mbt c d
-            moon tool format-and-diff --old ./main/main.mbt --new ./target/wasm-gc/release/format/main/main.mbt c d
+            moon tool format-and-diff --old ./lib/hello.mbt --new ./target/wasm-gc/release/format/lib/hello.mbt --block-style c d
+            moon tool format-and-diff --old ./lib/hello_wbtest.mbt --new ./target/wasm-gc/release/format/lib/hello_wbtest.mbt --block-style c d
+            moon tool format-and-diff --old ./main/main.mbt --new ./target/wasm-gc/release/format/main/main.mbt --block-style c d
         "#]],
     );
 }
@@ -4064,6 +4068,30 @@ fn test_moon_fmt_block_style() {
             moonfmt ./lib/hello.mbt -w -o ./target/wasm-gc/release/format/lib/hello.mbt -block-style
             moonfmt ./lib/hello_wbtest.mbt -w -o ./target/wasm-gc/release/format/lib/hello_wbtest.mbt -block-style
             moonfmt ./main/main.mbt -w -o ./target/wasm-gc/release/format/main/main.mbt -block-style
+        "#]],
+    );
+
+    check(
+        get_stdout(
+            &dir,
+            ["fmt", "--block-style=true", "--sort-input", "--dry-run"],
+        ),
+        expect![[r#"
+            moonfmt ./lib/hello.mbt -w -o ./target/wasm-gc/release/format/lib/hello.mbt -block-style
+            moonfmt ./lib/hello_wbtest.mbt -w -o ./target/wasm-gc/release/format/lib/hello_wbtest.mbt -block-style
+            moonfmt ./main/main.mbt -w -o ./target/wasm-gc/release/format/main/main.mbt -block-style
+        "#]],
+    );
+
+    check(
+        get_stdout(
+            &dir,
+            ["fmt", "--block-style=false", "--sort-input", "--dry-run"],
+        ),
+        expect![[r#"
+            moonfmt ./lib/hello.mbt -w -o ./target/wasm-gc/release/format/lib/hello.mbt
+            moonfmt ./lib/hello_wbtest.mbt -w -o ./target/wasm-gc/release/format/lib/hello_wbtest.mbt
+            moonfmt ./main/main.mbt -w -o ./target/wasm-gc/release/format/main/main.mbt
         "#]],
     );
 

--- a/crates/moonbuild/src/fmt.rs
+++ b/crates/moonbuild/src/fmt.rs
@@ -129,7 +129,12 @@ fn gen_inplace_fmt_command(
         .arg(&item.phony_out)
         .args(&moonbuild_opt.fmt_opt.as_ref().unwrap().extra_args)
         .arg_with_cond(
-            moonbuild_opt.fmt_opt.as_ref().unwrap().block_style,
+            moonbuild_opt
+                .fmt_opt
+                .as_ref()
+                .unwrap()
+                .block_style
+                .is_line(),
             "-block-style",
         )
         .build();
@@ -238,7 +243,12 @@ fn gen_fmt_to_command(
     .arg("--new")
     .arg(&item.output)
     .arg_with_cond(
-        moonbuild_opt.fmt_opt.as_ref().unwrap().block_style,
+        moonbuild_opt
+            .fmt_opt
+            .as_ref()
+            .unwrap()
+            .block_style
+            .is_line(),
         "--block-style",
     )
     .args(&moonbuild_opt.fmt_opt.as_ref().unwrap().extra_args)

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -389,10 +389,23 @@ pub struct TestArtifacts {
     pub artifacts_path: Vec<PathBuf>,
 }
 
+#[derive(Debug, Clone, Default, ValueEnum)]
+pub enum BlockStyle {
+    False,
+    #[default]
+    True,
+}
+
+impl BlockStyle {
+    pub fn is_line(&self) -> bool {
+        matches!(self, Self::True)
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct FmtOpt {
     pub check: bool,
-    pub block_style: bool,
+    pub block_style: BlockStyle,
     pub extra_args: Vec<String>,
 }
 

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -238,7 +238,10 @@ Format source code
 
 * `--check` — Check only and don't change the source code
 * `--sort-input` — Sort input files
-* `--block-style` — Add separator between each segments
+* `--block-style <BLOCK_STYLE>` — Add separator between each segments
+
+  Possible values: `false`, `true`
+
 
 
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -238,7 +238,10 @@ Format source code
 
 * `--check` — Check only and don't change the source code
 * `--sort-input` — Sort input files
-* `--block-style` — Add separator between each segments
+* `--block-style <BLOCK_STYLE>` — Add separator between each segments
+
+  Possible values: `false`, `true`
+
 
 
 


### PR DESCRIPTION
cc @Yoorkin 

```
moon fmt                      => moon fmt --block-style=true
moon fmt --block-style        => moon fmt --block-style=true
moon fmt --block-style=true   => moon fmt --block-style=true
moon fmt --block-style=false  => moon fmt --block-style=false
```