### PR TITLE
Delegate writing `mbti` files to `mooninfo` instead of capturing stdout

### DIFF
--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -247,8 +247,14 @@ pub fn run_info_internal(
             if !mi.exists() {
                 bail!("cannot find mi file for package {}", name);
             }
+            let filepath = mi.with_extension("mbti");
+            let filename = filepath.file_name().unwrap().to_str().unwrap();
 
-            let mut args = vec!["-format=text".into(), mi.display().to_string()];
+            let mut args = vec![
+                "-format=text".into(),
+                mi.display().to_string(),
+                format!("-o={}", filepath.display()),
+            ];
             if cmd.no_alias {
                 args.push("-no-alias".into());
             }
@@ -257,13 +263,6 @@ pub fn run_info_internal(
             let out = mooninfo.output().await?;
 
             if out.status.success() {
-                let filename = format!("{}.mbti", pkg.last_name());
-                let filepath = mi.with_extension("mbti");
-
-                tokio::fs::write(&filepath, out.stdout)
-                    .await
-                    .context(format!("failed to write {}", filename))?;
-
                 if
                 // no target specified, default to wasmgc
                 cmd.target.is_none()
@@ -277,7 +276,7 @@ pub fn run_info_internal(
                         &filepath,
                         &module_source_dir
                             .join(pkg.rel.fs_full_name())
-                            .join(&filename),
+                            .join(filename),
                     )
                     .await?;
                 }


### PR DESCRIPTION

## Related Issues

- [x] Related issues: https://github.com/moonbitlang/moonbit-docs/issues/420

closes https://github.com/moonbitlang/moonbit-docs/issues/420

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
    - To ensure a consistent line ending between platforms, `moon info` writing is delegated to `mooninfo` which writes in a consistent line ending.
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
