### PR TITLE
Skip merge commit checking if not triggered by a PR

### DIFF
--- a/.github/workflows/check-merge-commit.yml
+++ b/.github/workflows/check-merge-commit.yml
@@ -36,17 +36,21 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const prNumber = context.payload.pull_request.number;
-          const commits = await github.rest.pulls.listCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-              per_page: 100
-          });
-          const commitMessages = commits.data.map(commit => commit.commit.message);
-          const hasMergeCommit = commitMessages.some(message => message.startsWith('Merge branch') || message.startsWith('Merge pull request'));
-          if (hasMergeCommit) {
-              core.setFailed('Pull request contains merge commit(s).');
+          // If this commit is not part of a PR (e.g. in merge queue check),
+          // skip the rest
+          if (context && context.payload && context.payload.pull_request) {
+            const prNumber = context.payload.pull_request.number;
+            const commits = await github.rest.pulls.listCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100
+            });
+            const commitMessages = commits.data.map(commit => commit.commit.message);
+            const hasMergeCommit = commitMessages.some(message => message.startsWith('Merge branch') || message.startsWith('Merge pull request'));
+            if (hasMergeCommit) {
+                core.setFailed('Pull request contains merge commit(s).');
+            }
           }
 
     - name: Check for merge commits


### PR DESCRIPTION
Fixes merge queue failures caused by this, e.g. https://github.com/moonbitlang/moon/actions/runs/12926229402/job/36048803053