### PR TITLE
Add option to control max build concurrency

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -202,6 +202,10 @@ pub struct BuildFlags {
     /// Enable value tracing
     #[clap(long, hide = true)]
     pub enable_value_tracing: bool,
+
+    /// Set the max number of jobs to run in parallel
+    #[clap(short = 'j', long)]
+    pub jobs: Option<usize>,
 }
 
 impl BuildFlags {

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -159,6 +159,7 @@ fn run_build_internal(
         args: vec![],
         output_json: false,
         no_parallelize: false,
+        parallelism: cmd.build_flags.jobs,
     };
 
     let mut module = scan_with_pre_build(

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -150,6 +150,7 @@ fn run_bundle_internal(
         output_json: false,
         no_parallelize: false,
         build_graph: false,
+        parallelism: cmd.build_flags.jobs,
     };
     let module = scan_with_pre_build(
         false,

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -173,6 +173,7 @@ fn run_check_internal(
         fmt_opt: None,
         args: vec![],
         no_parallelize: false,
+        parallelism: cmd.build_flags.jobs,
     };
 
     let mut module = scan_with_pre_build(

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -101,6 +101,7 @@ pub fn run_doc(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Result<i32> {
         output_json: false,
         no_parallelize: false,
         build_graph: false,
+        parallelism: None,
     };
 
     let module = scan_with_pre_build(

--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -83,6 +83,7 @@ pub fn run_fmt(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> 
         quiet: cli.quiet,
         output_json: false,
         no_parallelize: false,
+        parallelism: None,
     };
 
     let module = scan_with_pre_build(

--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -185,6 +185,7 @@ pub fn generate_test_driver(
         output_json: false,
         no_parallelize: false,
         build_graph: false,
+        parallelism: None,
     };
 
     let module = scan_with_pre_build(

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -201,6 +201,7 @@ pub fn run_info_internal(
         output_json: false,
         no_parallelize: false,
         build_graph: false,
+        parallelism: None,
     };
 
     let module = scan_with_pre_build(

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -305,6 +305,7 @@ pub fn run_run_internal(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Res
         fmt_opt: None,
         output_json: false,
         no_parallelize: false,
+        parallelism: cmd.build_flags.jobs,
     };
 
     let mut module = scan_with_pre_build(

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -215,6 +215,7 @@ fn run_test_internal(
         fmt_opt: None,
         args: vec![],
         output_json: false,
+        parallelism: cmd.build_flags.jobs,
     };
 
     let mut module = moonutil::scan::scan(

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -1362,6 +1362,166 @@ fn test_moon_test_filter_package_with_test_imports() {
 }
 
 #[test]
+fn test_moon_parallelism() {
+    let dir = TestDir::new("test_filter_pkg_with_test_imports.in");
+
+    check(
+        get_stdout(
+            &dir,
+            [
+                "test",
+                "-j1",
+                "-p",
+                "username/hello/lib",
+                "--sort-input",
+                "--no-parallelize",
+            ],
+        ),
+        expect![[r#"
+            Hello from lib1
+
+            Hello from lib2
+
+            Hello from lib7
+            Total tests: 2, passed: 2, failed: 0.
+        "#]],
+    );
+
+    check(
+        get_stdout(
+            &dir,
+            [
+                "test",
+                "-j1",
+                "-p",
+                "username/hello/lib1",
+                "--sort-input",
+                "--no-parallelize",
+            ],
+        ),
+        expect![[r#"
+            Hello from lib3
+
+            Total tests: 1, passed: 1, failed: 0.
+        "#]],
+    );
+
+    check(
+        get_stdout(
+            &dir,
+            [
+                "test",
+                "-j1",
+                "-p",
+                "username/hello/lib2",
+                "--sort-input",
+                "--no-parallelize",
+            ],
+        ),
+        expect![[r#"
+            Hello from lib4
+            Total tests: 1, passed: 1, failed: 0.
+        "#]],
+    );
+
+    check(
+        get_stdout(
+            &dir,
+            [
+                "test",
+                "-j1",
+                "-p",
+                "username/hello/lib3",
+                "--sort-input",
+                "--no-parallelize",
+            ],
+        ),
+        expect![[r#"
+            Hello from lib3
+
+            Hello from lib7
+            Hello from lib6
+            Total tests: 3, passed: 3, failed: 0.
+        "#]],
+    );
+
+    check(
+        get_stdout(
+            &dir,
+            [
+                "test",
+                "-j1",
+                "-p",
+                "username/hello/lib4",
+                "--sort-input",
+                "--no-parallelize",
+            ],
+        ),
+        expect![[r#"
+            Hello from lib5
+            Hello from lib5
+            Hello from lib7
+            Total tests: 3, passed: 3, failed: 0.
+        "#]],
+    );
+
+    check(
+        get_stdout(
+            &dir,
+            [
+                "test",
+                "-j1",
+                "-p",
+                "username/hello/lib5",
+                "--sort-input",
+                "--no-parallelize",
+            ],
+        ),
+        expect![[r#"
+            Hello from lib5
+            Total tests: 1, passed: 1, failed: 0.
+        "#]],
+    );
+
+    check(
+        get_stdout(
+            &dir,
+            [
+                "test",
+                "-j1",
+                "-p",
+                "username/hello/lib6",
+                "--sort-input",
+                "--no-parallelize",
+            ],
+        ),
+        expect![[r#"
+            Hello from lib6
+            Total tests: 1, passed: 1, failed: 0.
+        "#]],
+    );
+
+    check(
+        get_stdout(
+            &dir,
+            [
+                "test",
+                "-j1",
+                "-p",
+                "username/hello/lib7",
+                "--sort-input",
+                "--no-parallelize",
+            ],
+        ),
+        expect![[r#"
+            Hello from lib7
+            Hello from lib6
+            Total tests: 2, passed: 2, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
 fn test_moon_test_filter_package_dry_run() {
     let dir = TestDir::new("test_filter.in");
 

--- a/crates/moonbuild/src/entry.rs
+++ b/crates/moonbuild/src/entry.rs
@@ -153,6 +153,13 @@ pub fn n2_simple_run_interface(
     Ok(res)
 }
 
+pub fn get_parallelism() -> usize {
+    std::env::var("MOON_MAX_CONCURRENCY")
+        .ok()
+        .and_then(|it| it.parse().ok())
+        .unwrap_or_else(|| default_parallelism().unwrap_or(1))
+}
+
 pub fn n2_run_interface(
     state: n2::load::State,
     moonbuild_opt: &MoonbuildOpt,
@@ -188,7 +195,7 @@ pub fn n2_run_interface(
     let mut progress =
         create_progress_console(Some(Box::new(render_and_catch)), moonbuild_opt.verbose);
     let options = work::Options {
-        parallelism: default_parallelism()?,
+        parallelism: get_parallelism(),
         failures_left: Some(10),
         explain: false,
         adopt: false,

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -182,6 +182,7 @@ fn get_module_db(
         fmt_opt: None,
         args: vec![],
         output_json: false,
+        parallelism: None, // we don't care about parallelism here
     };
     let module_db = scan(
         false,

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -383,6 +383,8 @@ pub struct MoonbuildOpt {
     pub output_json: bool,
     pub no_parallelize: bool,
     pub build_graph: bool,
+    /// Max parallel tasks to run in n2; `None` to use default
+    pub parallelism: Option<usize>,
 }
 
 impl MoonbuildOpt {

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -112,6 +112,7 @@ Build the current package
 * `--no-render` — Don't render diagnostics from moonc (don't pass '-error-format json' to moonc)
 * `--warn-list <WARN_LIST>` — Warn list config
 * `--alert-list <ALERT_LIST>` — Alert list config
+* `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `-w`, `--watch` — Monitor the file system and automatically build artifacts
 
@@ -147,6 +148,7 @@ Check the current package, but don't build object files
 * `--no-render` — Don't render diagnostics from moonc (don't pass '-error-format json' to moonc)
 * `--warn-list <WARN_LIST>` — Warn list config
 * `--alert-list <ALERT_LIST>` — Alert list config
+* `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `--output-json` — Output in json format
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `-w`, `--watch` — Monitor the file system and automatically check files
@@ -186,6 +188,7 @@ Run a main package
 * `--no-render` — Don't render diagnostics from moonc (don't pass '-error-format json' to moonc)
 * `--warn-list <WARN_LIST>` — Warn list config
 * `--alert-list <ALERT_LIST>` — Alert list config
+* `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not run the code
 
@@ -217,6 +220,7 @@ Test the current package
 * `--no-render` — Don't render diagnostics from moonc (don't pass '-error-format json' to moonc)
 * `--warn-list <WARN_LIST>` — Warn list config
 * `--alert-list <ALERT_LIST>` — Alert list config
+* `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `-p`, `--package <PACKAGE>` — Run test in the specified package
 * `-f`, `--file <FILE>` — Run test in the specified file. Only valid when `--package` is also specified
 * `-i`, `--index <INDEX>` — Run only the index-th test in the file. Only valid when `--file` is also specified

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -112,6 +112,7 @@ Build the current package
 * `--no-render` — Don't render diagnostics from moonc (don't pass '-error-format json' to moonc)
 * `--warn-list <WARN_LIST>` — Warn list config
 * `--alert-list <ALERT_LIST>` — Alert list config
+* `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `-w`, `--watch` — Monitor the file system and automatically build artifacts
 
@@ -147,6 +148,7 @@ Check the current package, but don't build object files
 * `--no-render` — Don't render diagnostics from moonc (don't pass '-error-format json' to moonc)
 * `--warn-list <WARN_LIST>` — Warn list config
 * `--alert-list <ALERT_LIST>` — Alert list config
+* `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `--output-json` — Output in json format
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `-w`, `--watch` — Monitor the file system and automatically check files
@@ -186,6 +188,7 @@ Run a main package
 * `--no-render` — Don't render diagnostics from moonc (don't pass '-error-format json' to moonc)
 * `--warn-list <WARN_LIST>` — Warn list config
 * `--alert-list <ALERT_LIST>` — Alert list config
+* `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not run the code
 
@@ -217,6 +220,7 @@ Test the current package
 * `--no-render` — Don't render diagnostics from moonc (don't pass '-error-format json' to moonc)
 * `--warn-list <WARN_LIST>` — Warn list config
 * `--alert-list <ALERT_LIST>` — Alert list config
+* `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `-p`, `--package <PACKAGE>` — Run test in the specified package
 * `-f`, `--file <FILE>` — Run test in the specified file. Only valid when `--package` is also specified
 * `-i`, `--index <INDEX>` — Run only the index-th test in the file. Only valid when `--file` is also specified


### PR DESCRIPTION
## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [ ] Bug fix
- [x] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - Add `-j<N>` commandline arg to control parallelism
  - Add an environment variable `MOON_MAX_PAR_TASKS` to limit the maximum tasks building in parallel
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
