### PR TITLE
internal: add -Fo`path` for cl

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -16,5 +16,10 @@
 #
 # For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-[default.extend-identifiers]
+[default.extend-words]
 Fo = "Fo"
+
+[files]
+extend-exclude = [
+    "crates/moonutil/resources/error_codes/"
+]


### PR DESCRIPTION
Generate intermediate compilation products (.obj) in the corresponding target directory; if not specified, they will be generated in the current working directory by default, which may cause `fatal error C1083: Cannot open compiler generated file: 'D:\a\core\core\sorted_map.blackbox_test.obj': Permission denied` (./sorted_map & ./immut/sorted_map)