### PR TITLE
fix `moon check` where can_dirty_on_output flag was set incorrectly

### DIFF
--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -6318,7 +6318,13 @@ fn test_moon_check_json_output() {
         check(
             get_stderr(&dir, ["check", "--output-json"]),
             expect![[r#"
-                Finished. moon: no work to do
+                Finished. moon: ran 1 task, now up to date
+            "#]],
+        );
+        check(
+            get_stderr(&dir, ["check", "--output-json"]),
+            expect![[r#"
+                Finished. moon: ran 1 task, now up to date
             "#]],
         );
     }
@@ -6339,7 +6345,13 @@ fn test_moon_check_json_output() {
         check(
             get_stderr(&dir, ["check", "--output-json"]),
             expect![[r#"
-                Finished. moon: no work to do
+                Finished. moon: ran 1 task, now up to date
+            "#]],
+        );
+        check(
+            get_stderr(&dir, ["check", "--output-json"]),
+            expect![[r#"
+                Finished. moon: ran 1 task, now up to date
             "#]],
         );
     }

--- a/crates/moonbuild/src/gen/gen_check.rs
+++ b/crates/moonbuild/src/gen/gen_check.rs
@@ -443,7 +443,7 @@ pub fn gen_check_command(
         "check: {}",
         get_desc_name(&item.package_full_name, &item.mi_out)
     ));
-    build.can_dirty_on_output = false;
+    build.can_dirty_on_output = true;
     build
 }
 


### PR DESCRIPTION
## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - ____
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
