### PR TITLE
Use `-fPIC` when compiling stubs to object files when `tcc -run` mode enabled

### DIFF
--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -8036,7 +8036,7 @@ fn test_native_backend_tcc_run() {
         expect![[r#"
             stubcc -o ./target/native/debug/test/lib/stub.o -I$MOON_HOME/include -L$MOON_HOME/lib -g -c -fPIC -DMOONBIT_USE_SHARED_RUNTIME ./lib/stub.c stubccflags
             cc -o ./target/native/debug/test/libruntime.so -I$MOON_HOME/include -L$MOON_HOME/lib -g -shared -fPIC -fwrapv -fno-strict-aliasing -O2 $MOON_HOME/lib/runtime.c -lm
-            stubcc -o ./target/native/debug/test/lib/liblib.so -L$MOON_HOME/lib -L./target/native/debug/test ./target/native/debug/test/lib/stub.o -lm -lruntime stubcclinkflags
+            stubcc -o ./target/native/debug/test/lib/liblib.so -L$MOON_HOME/lib -L./target/native/debug/test -shared -fPIC ./target/native/debug/test/lib/stub.o -lm -lruntime stubcclinkflags
             moon generate-test-driver --source-dir . --target-dir ./target --package moon_new/lib --sort-input --target native --driver-kind internal
             moonc build-package ./lib/hello.mbt ./target/native/debug/test/lib/__generated_driver_for_internal_test.mbt -o ./target/native/debug/test/lib/lib.internal_test.core -pkg moon_new/lib -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moon_new/lib:./lib -target native -g -O0 -no-mi
             moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/debug/test/lib/lib.internal_test.core -main moon_new/lib -o ./target/native/debug/test/lib/lib.internal_test.c -test-mode -pkg-config-path ./lib/moon.pkg.json -pkg-sources moon_new/lib:./lib -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -exported_functions moonbit_test_driver_internal_execute,moonbit_test_driver_finish -target native -g -O0

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -8016,7 +8016,7 @@ fn test_native_backend_tcc_run() {
             ["test", "--target", "native", "--dry-run", "--sort-input"],
         ),
         expect![[r#"
-            stubcc -o ./target/native/debug/test/lib/stub.o -I$MOON_HOME/include -L$MOON_HOME/lib -g -c -DMOONBIT_USE_SHARED_RUNTIME ./lib/stub.c stubccflags
+            stubcc -o ./target/native/debug/test/lib/stub.o -I$MOON_HOME/include -L$MOON_HOME/lib -g -c -fPIC -DMOONBIT_USE_SHARED_RUNTIME ./lib/stub.c stubccflags
             cc -o ./target/native/debug/test/libruntime.dylib -I$MOON_HOME/include -L$MOON_HOME/lib -g -shared -fPIC -fwrapv -fno-strict-aliasing -O2 $MOON_HOME/lib/runtime.c -lm
             stubcc -o ./target/native/debug/test/lib/liblib.dylib -L$MOON_HOME/lib -L./target/native/debug/test ./target/native/debug/test/lib/stub.o -lm -lruntime stubcclinkflags
             moon generate-test-driver --source-dir . --target-dir ./target --package moon_new/lib --sort-input --target native --driver-kind internal
@@ -8032,7 +8032,7 @@ fn test_native_backend_tcc_run() {
             ["test", "--target", "native", "--dry-run", "--sort-input"],
         ),
         expect![[r#"
-            stubcc -o ./target/native/debug/test/lib/stub.o -I$MOON_HOME/include -L$MOON_HOME/lib -g -c -DMOONBIT_USE_SHARED_RUNTIME ./lib/stub.c stubccflags
+            stubcc -o ./target/native/debug/test/lib/stub.o -I$MOON_HOME/include -L$MOON_HOME/lib -g -c -fPIC -DMOONBIT_USE_SHARED_RUNTIME ./lib/stub.c stubccflags
             cc -o ./target/native/debug/test/libruntime.so -I$MOON_HOME/include -L$MOON_HOME/lib -g -shared -fPIC -fwrapv -fno-strict-aliasing -O2 $MOON_HOME/lib/runtime.c -lm
             stubcc -o ./target/native/debug/test/lib/liblib.so -L$MOON_HOME/lib -L./target/native/debug/test ./target/native/debug/test/lib/stub.o -lm -lruntime stubcclinkflags
             moon generate-test-driver --source-dir . --target-dir ./target --package moon_new/lib --sort-input --target native --driver-kind internal

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -2558,9 +2558,11 @@ fn test_mbti() {
     let _ = get_stdout(&dir, ["info"]);
     let lib_mi_out = &std::fs::read_to_string(dir.join("lib").join("lib.mbti")).unwrap();
     expect![[r#"
-        package username/hello/lib
+        package "username/hello/lib"
 
-        alias @moonbitlang/core/immut/list as @list
+        import(
+          "moonbitlang/core/immut/list"
+        )
 
         // Values
         fn hello() -> String
@@ -2578,7 +2580,7 @@ fn test_mbti() {
 
     let main_mi_out = &std::fs::read_to_string(dir.join("main").join("main.mbti")).unwrap();
     expect![[r#"
-        package username/hello/main
+        package "username/hello/main"
 
         // Values
 
@@ -2599,7 +2601,7 @@ fn test_mbti_no_alias() {
     let _ = get_stdout(&dir, ["info", "--no-alias"]);
     let lib_mi_out = &std::fs::read_to_string(dir.join("lib").join("lib.mbti")).unwrap();
     expect![[r#"
-        package username/hello/lib
+        package "username/hello/lib"
 
         // Values
         fn hello() -> String
@@ -2617,7 +2619,7 @@ fn test_mbti_no_alias() {
 
     let main_mi_out = &std::fs::read_to_string(dir.join("main").join("main.mbti")).unwrap();
     expect![[r#"
-        package username/hello/main
+        package "username/hello/main"
 
         // Values
 
@@ -8018,7 +8020,7 @@ fn test_native_backend_tcc_run() {
         expect![[r#"
             stubcc -o ./target/native/debug/test/lib/stub.o -I$MOON_HOME/include -L$MOON_HOME/lib -g -c -fPIC -DMOONBIT_USE_SHARED_RUNTIME ./lib/stub.c stubccflags
             cc -o ./target/native/debug/test/libruntime.dylib -I$MOON_HOME/include -L$MOON_HOME/lib -g -shared -fPIC -fwrapv -fno-strict-aliasing -O2 $MOON_HOME/lib/runtime.c -lm
-            stubcc -o ./target/native/debug/test/lib/liblib.dylib -L$MOON_HOME/lib -L./target/native/debug/test ./target/native/debug/test/lib/stub.o -lm -lruntime stubcclinkflags
+            stubcc -o ./target/native/debug/test/lib/liblib.dylib -L$MOON_HOME/lib -L./target/native/debug/test -shared -fPIC ./target/native/debug/test/lib/stub.o -lm -lruntime stubcclinkflags
             moon generate-test-driver --source-dir . --target-dir ./target --package moon_new/lib --sort-input --target native --driver-kind internal
             moonc build-package ./lib/hello.mbt ./target/native/debug/test/lib/__generated_driver_for_internal_test.mbt -o ./target/native/debug/test/lib/lib.internal_test.core -pkg moon_new/lib -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources moon_new/lib:./lib -target native -g -O0 -no-mi
             moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/debug/test/lib/lib.internal_test.core -main moon_new/lib -o ./target/native/debug/test/lib/lib.internal_test.c -test-mode -pkg-config-path ./lib/moon.pkg.json -pkg-sources moon_new/lib:./lib -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -exported_functions moonbit_test_driver_internal_execute,moonbit_test_driver_finish -target native -g -O0

--- a/crates/moon/tests/test_cases/moon_info_001.in/moon.test
+++ b/crates/moon/tests/test_cases/moon_info_001.in/moon.test
@@ -3,7 +3,7 @@
   Finished. moon: ran 2 tasks, now up to date
   
   $ xcat src/lib/lib.mbti
-  package username/hello/lib
+  package "username/hello/lib"
   
   // Values
   fn hello() -> String

--- a/crates/moon/tests/test_cases/moon_info_002.in/moon.test
+++ b/crates/moon/tests/test_cases/moon_info_002.in/moon.test
@@ -3,7 +3,7 @@
   Finished. moon: ran 1 task, now up to date
   
   $ xcat lib/lib.mbti
-  package username/hello/lib
+  package "username/hello/lib"
   
   // Values
   fn hello() -> String

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -540,6 +540,7 @@ where
         if cc.is_msvc() {
             buf.push("/DMOONBIT_USE_SHARED_RUNTIME".to_string());
         } else if cc.is_gcc_like() {
+            buf.push("-fPIC".to_string());
             buf.push("-DMOONBIT_USE_SHARED_RUNTIME".to_string());
         }
     }

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -342,7 +342,7 @@ where
     }
 
     // Build shared library
-    if config.output_ty == OutputType::SharedLib && !has_user_flags {
+    if config.output_ty == OutputType::SharedLib {
         if cc.is_msvc() {
             buf.push("/LD".to_string());
         } else if cc.is_gcc_like() {
@@ -523,7 +523,7 @@ where
         }
     }
 
-    if cc.is_tcc() && !has_user_flags {
+    if cc.is_tcc() {
         if config.no_sys_header {
             buf.push("-DMOONBIT_NATIVE_NO_SYS_HEADER".to_string());
         } else {


### PR DESCRIPTION
## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [ ] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - ____
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
