### PR TITLE
Integrate moonlex & moonyacc

### DIFF
--- a/crates/moon/tests/test_cases/hello/mod.rs
+++ b/crates/moon/tests/test_cases/hello/mod.rs
@@ -15,7 +15,7 @@ fn test_hello() {
             .join(".moon-lock")
             .exists()
             .to_string(),
-        expect!["false"],
+        expect!["true"],
     );
 }
 

--- a/crates/moon/tests/test_cases/hello/mod.rs
+++ b/crates/moon/tests/test_cases/hello/mod.rs
@@ -15,7 +15,7 @@ fn test_hello() {
             .join(".moon-lock")
             .exists()
             .to_string(),
-        expect!["true"],
+        expect!["false"],
     );
 }
 

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -60,6 +60,7 @@ pub const MOON_DOC_TEST_POSTFIX: &str = "__moonbit_internal_doc_test";
 pub const MOON_MD_TEST_POSTFIX: &str = "__moonbit_internal_md_test";
 
 pub const DOT_MBT_DOT_MD: &str = ".mbt.md";
+pub const DOT_MBT_DOT_X: &str = ".mbt.x";
 
 pub const MOON_BIN_DIR: &str = "__moonbin__";
 

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -60,7 +60,8 @@ pub const MOON_DOC_TEST_POSTFIX: &str = "__moonbit_internal_doc_test";
 pub const MOON_MD_TEST_POSTFIX: &str = "__moonbit_internal_md_test";
 
 pub const DOT_MBT_DOT_MD: &str = ".mbt.md";
-pub const DOT_MBT_DOT_X: &str = ".mbt.x";
+pub const DOT_MBL: &str = ".mbl";
+pub const DOT_MBY: &str = ".mby";
 
 pub const MOON_BIN_DIR: &str = "__moonbin__";
 

--- a/crates/moonutil/src/scan.rs
+++ b/crates/moonutil/src/scan.rs
@@ -426,8 +426,6 @@ fn scan_one_package(
 
     let mut prebuild = pkg.pre_build.unwrap_or(vec![]);
     for mbl_file in mbl_files {
-        // mbl_file is a file with extension .mbl
-        // mbt_file is the same file with extension .mbt
         let mbt_file = mbl_file.with_extension("mbt");
         let generate = MoonPkgGenerate {
             input: crate::package::StringOrArray::String(mbl_file.display().to_string()),
@@ -441,8 +439,6 @@ fn scan_one_package(
         prebuild.push(generate);
     }
     for mby_file in mby_files {
-        // mby_file is a file with extension .mby
-        // mbt_file is the same file with extension .mbt
         let mbt_file = mby_file.with_extension("mbt");
         let generate = MoonPkgGenerate {
             input: crate::package::StringOrArray::String(mby_file.display().to_string()),

--- a/crates/moonutil/src/scan.rs
+++ b/crates/moonutil/src/scan.rs
@@ -424,6 +424,7 @@ fn scan_one_package(
         }))
     };
 
+    let pkg_prebuild_is_none = pkg.pre_build.is_none();
     let mut prebuild = pkg.pre_build.unwrap_or(vec![]);
     for mbl_file in mbl_files {
         let mbt_file = mbl_file.with_extension("mbt");
@@ -473,7 +474,11 @@ fn scan_one_package(
         warn_list,
         alert_list,
         targets: cond_targets,
-        pre_build: Some(prebuild),
+        pre_build: if pkg_prebuild_is_none && prebuild.is_empty() {
+            None
+        } else {
+            Some(prebuild)
+        },
         patch_file: None,
         no_mi: false,
         doc_test_patch_file: None,


### PR DESCRIPTION
## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [ ] Bug fix
- [x] New feature
    - [x] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - Moon now discovers `.mbt.x` files and add user-invisible prebuild rules to use `moonlex` to compile them to `.mbt` files.
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] This feature requires `moonlex.wasm` to be distributed in `$MOON_HOME/bin` 
- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
