### PR TITLE
fix: Obey env var `MOON_HOME` when looking for dirs

### DIFF
--- a/crates/moonutil/src/moon_dir.rs
+++ b/crates/moonutil/src/moon_dir.rs
@@ -31,10 +31,7 @@ pub struct MoonDirs {
 }
 
 pub static MOON_DIRS: std::sync::LazyLock<MoonDirs> = std::sync::LazyLock::new(|| {
-    let moonc_path = which::which("moonc")
-        .context("moonc not found in PATH")
-        .unwrap();
-    let moon_home = moonc_path.parent().unwrap().parent().unwrap().to_path_buf();
+    let moon_home = home();
     let moon_include_path = moon_home.join("include");
     let moon_lib_path = moon_home.join("lib");
     let moon_bin_path = moon_home.join("bin");


### PR DESCRIPTION
Previously, `MOON_DIRS` does not obey the `MOON_HOME` env var set, but looks for `moonc` in PATH. 

This behavior is problematic if `moonc` is set as a shim or symbolic link, using the already-existing `home()` is a more robust option. For development cases where you need to find the files beside `moonc`, it might be better to just manually link them into `MOON_HOME`.