### PR TITLE
chore: add metadata in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a bug report for moon.
 title: ''
 assignees: ''
-
+labels: bug
 ---
 
 # Bug Report

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature Request
 about: Create a feature request for moon.
 title: ''
 assignees: ''
-
+labels: feature request
 ---
 
 


### PR DESCRIPTION
Selecting a different issue template automatically adds tags so that no more than one prefix is required

e.g. `[Feature Request]` , `[Bug]`