### PR TITLE
fix 'moon run' compiles multi packages issue

### DIFF
--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -38,7 +38,7 @@ use moonutil::mooncakes::sync::AutoSyncFlags;
 use moonutil::mooncakes::RegistryConfig;
 use n2::trace;
 
-use super::pre_build::scan_with_x_build;
+use super::pre_build::scan_with_x_build_single_package;
 use super::{BuildFlags, UniversalFlags};
 
 /// Run a main package
@@ -388,13 +388,14 @@ pub fn run_run_internal(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Res
         dynamic_stub_libs: None,
     };
 
-    let mut module = scan_with_x_build(
+    let mut module = scan_with_x_build_single_package(
         false,
         &moonc_opt,
         &moonbuild_opt,
         &resolved_env,
         &dir_sync_result,
         &PrePostBuild::PreBuild,
+        &package,
     )?;
 
     let pkg = module.get_package_by_path_mut(&package).unwrap();

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -380,6 +380,7 @@ pub fn get_module_for_single_file_test(
 
     let mut module = moonutil::scan::scan(
         false,
+        None,
         Some(moon_mod),
         &resolved_env,
         &dir_sync_result,

--- a/crates/moonbuild/src/watch.rs
+++ b/crates/moonbuild/src/watch.rs
@@ -172,6 +172,7 @@ fn handle_file_change(
         let module = match moonutil::scan::scan(
             false,
             None,
+            None,
             &resolved_env,
             &dir_sync_result,
             moonc_opt,

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -188,6 +188,7 @@ fn get_module_db(
     let module_db = scan(
         false,
         None,
+        None,
         resolved_env,
         &dir_sync_result,
         &moonutil::common::MooncOpt::default(),


### PR DESCRIPTION
## Related Issues

- [ ] Related issues: #790

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - Originally, the' moon run src/foo' command would compile all packages under the module, even though it was specified.
    - That is the reason the defect mentioned in the issue occurred.
  - New changes: The run command will only compile the package indicated by the command.
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [x] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
