### PR TITLE
Add preferred target configuration for modules

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -247,7 +247,10 @@ pub fn get_compiler_flags(src_dir: &Path, build_flags: &BuildFlags) -> anyhow::R
         OutputFormat::Wasm
     };
 
-    let target_backend = build_flags.target_backend.unwrap_or_default();
+    let target_backend = build_flags
+        .target_backend
+        .or(moon_mod.preferred_target) // if we have specified in module config
+        .unwrap_or_default();
 
     if target_backend == TargetBackend::Js && output_format == OutputFormat::Wat {
         bail!("--output-wat is not supported for --target js");

--- a/crates/moon/tests/test_cases/hello/main/main.mbt
+++ b/crates/moon/tests/test_cases/hello/main/main.mbt
@@ -1,3 +1,7 @@
 fn main {
   println("Hello, world!")
 }
+
+test {
+
+}

--- a/crates/moonbuild/src/bench.rs
+++ b/crates/moonbuild/src/bench.rs
@@ -156,6 +156,7 @@ pub fn write(config: &Config, base_dir: &Path) {
         exclude: None,
 
         scripts: None,
+        preferred_target: None,
 
         __moonbit_unstable_prebuild: None,
     };

--- a/crates/moonbuild/src/new.rs
+++ b/crates/moonbuild/src/new.rs
@@ -182,6 +182,7 @@ fn common(
             exclude: None,
 
             scripts: None,
+            preferred_target: None,
 
             __moonbit_unstable_prebuild: None,
         };

--- a/crates/moonbuild/template/mod.schema.json
+++ b/crates/moonbuild/template/mod.schema.json
@@ -89,6 +89,13 @@
       "description": "name of the module",
       "type": "string"
     },
+    "preferred-target": {
+      "description": "The preferred target backend of this module.\n\nToolchains are recommended to use this target as the default target when the user is not specifying or overriding in any other ways. However, this is merely a recommendation, and tools may deviate from this value at any time.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "readme": {
       "description": "path to module's README file",
       "type": [

--- a/crates/mooncake/src/resolver/mvs.rs
+++ b/crates/mooncake/src/resolver/mvs.rs
@@ -499,6 +499,7 @@ mod test {
                 alert_list: None,
                 include: None,
                 exclude: None,
+                preferred_target: None,
                 scripts: None,
                 __moonbit_unstable_prebuild: None,
             }

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -22,7 +22,7 @@ use crate::module::{MoonMod, MoonModJSON};
 use crate::package::{convert_pkg_json_to_package, MoonPkg, MoonPkgJSON, Package, VirtualPkg};
 use crate::path::PathComponent;
 use anyhow::{bail, Context};
-use clap::ValueEnum;
+use clap::{error, ValueEnum};
 use fs4::fs_std::FileExt;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -146,6 +146,8 @@ pub enum MoonModJSONFormatErrorKind {
     Source(#[from] SourceError),
     #[error("`version` bad format")]
     Version(#[from] semver::Error),
+    #[error("`preferred-backend` is not a valid backend")]
+    PreferredBackend(anyhow::Error),
 }
 
 pub fn read_module_from_json(path: &Path) -> Result<MoonMod, MoonModJSONFormatError> {

--- a/docs/manual-zh/src/source/mod_json_schema.html
+++ b/docs/manual-zh/src/source/mod_json_schema.html
@@ -127,6 +127,13 @@
       "description": "name of the module",
       "type": "string"
     },
+    "preferred-target": {
+      "description": "The preferred target backend of this module.\n\nToolchains are recommended to use this target as the default target when the user is not specifying or overriding in any other ways. However, this is merely a recommendation, and tools may deviate from this value at any time.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "readme": {
       "description": "path to module's README file",
       "type": [

--- a/docs/manual/src/source/mod_json_schema.html
+++ b/docs/manual/src/source/mod_json_schema.html
@@ -127,6 +127,13 @@
       "description": "name of the module",
       "type": "string"
     },
+    "preferred-target": {
+      "description": "The preferred target backend of this module.\n\nToolchains are recommended to use this target as the default target when the user is not specifying or overriding in any other ways. However, this is merely a recommendation, and tools may deviate from this value at any time.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "readme": {
       "description": "path to module's README file",
       "type": [


### PR DESCRIPTION
## Related Issues

- [x] Related issues: #865 

closes #865 

## Type of Pull Request

- [ ] Bug fix
- [x] New feature
    - [x] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - A new field `preferred-target` is added to `moon.mod.json`. Setting this field will cause all `moon ____` build commands to use this target as the default target to run, when no other overrides are provided.
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
