### PR TITLE
internal: don't auto wrap doc test block

### DIFF
--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -3942,24 +3942,24 @@ fn test_run_doc_test() {
             test block 4
             test block 5
             doc_test 5 from greet.mbt
-            test username/hello/lib/hello.mbt::doc_test hello.mbt 9 4 failed
-            expect test failed at $ROOT/src/lib/hello.mbt:12:5-12:18
+            test username/hello/lib/hello.mbt::1 failed
+            expect test failed at $ROOT/src/lib/hello.mbt:15:7-15:20
             Diff:
             ----
             1256
             ----
 
-            test username/hello/lib/hello.mbt::doc_test hello.mbt 19 4 failed: FAILED: $ROOT/src/lib/hello.mbt:22:5-22:30 this is a failure
+            test username/hello/lib/hello.mbt::2 failed: FAILED: $ROOT/src/lib/hello.mbt:27:7-27:32 this is a failure
             test username/hello/lib/greet.mbt::2 failed
-            expect test failed at $ROOT/src/lib/greet.mbt:22:7-22:20
+            expect test failed at $ROOT/src/lib/greet.mbt:24:7-24:20
             Diff:
             ----
             1256
             ----
 
-            test username/hello/lib/greet.mbt::3 failed: FAILED: $ROOT/src/lib/greet.mbt:31:7-31:30 another failure
-            test username/hello/lib/greet.mbt::doc_test greet.mbt 92 38 failed
-            expect test failed at $ROOT/src/lib/greet.mbt:96:5-96:40
+            test username/hello/lib/greet.mbt::3 failed: FAILED: $ROOT/src/lib/greet.mbt:33:7-33:30 another failure
+            test username/hello/lib/greet.mbt::8 failed
+            expect test failed at $ROOT/src/lib/greet.mbt:104:7-104:42
             Diff:
             ----
             b"/x54/x00/x65/x00/x73/x00/x74/x00"
@@ -3990,10 +3990,10 @@ fn test_run_doc_test() {
 
             doc_test 2 from hello.mbt
             doc_test 2 from hello.mbt
-            test username/hello/lib/hello.mbt::doc_test hello.mbt 19 4 failed: FAILED: $ROOT/src/lib/hello.mbt:22:5-22:30 this is a failure
+            test username/hello/lib/hello.mbt::2 failed: FAILED: $ROOT/src/lib/hello.mbt:27:7-27:32 this is a failure
             test block 2
             test block 2
-            test username/hello/lib/greet.mbt::3 failed: FAILED: $ROOT/src/lib/greet.mbt:31:7-31:30 another failure
+            test username/hello/lib/greet.mbt::3 failed: FAILED: $ROOT/src/lib/greet.mbt:33:7-33:30 another failure
             Total tests: 16, passed: 14, failed: 2.
         "#]],
     );

--- a/crates/moon/tests/test_cases/run_doc_test.in/src/lib/greet.mbt
+++ b/crates/moon/tests/test_cases/run_doc_test.in/src/lib/greet.mbt
@@ -1,5 +1,7 @@
-/// ```
-/// println("doc_test 1 from greet.mbt")
+/// ```moonbit
+/// test {
+///   println("doc_test 1 from greet.mbt")
+/// }
 /// ```
 pub fn greet1() -> String {
   "greet, world!"
@@ -38,8 +40,11 @@ pub fn greet2() -> String {
 
 /// ```moonbit
 /// 
-/// println("doc_test 3 from greet.mbt")
 /// 
+/// 
+/// test {
+///   println("doc_test 3 from greet.mbt")
+/// }
 /// 
 /// 
 /// ```
@@ -63,7 +68,7 @@ pub fn greet() -> String {
 }
 
 
-/// ```
+/// ```mbt
 /// test {
 /// 
 ///   println("test block 5")
@@ -79,8 +84,10 @@ pub fn greet4() -> String {
 }
 
 
-/// ```
+/// ```moonbit
+/// test {
 ///   println("doc_test 5 from greet.mbt")
+/// }
 /// 
 /// 
 /// 
@@ -89,45 +96,47 @@ pub fn greet5() -> String {
   "greet, wor1ld!"
 }
 
-/// ```
-/// let buf = @buffer.new(size_hint=100)
-/// buf.write_string("Tes")
-/// buf.write_char('t')
-/// inspect(buf.contents(), content="")
-/// inspect(buf.contents())
+/// ```moonbit
+/// test {
+///   let buf = @buffer.new(size_hint=100)
+///   buf.write_string("Tes")
+///   buf.write_char('t')
+///   inspect(buf.contents(), content="")
+///   inspect(buf.contents())
 /// 
-///  let multi_line_string_1 = 
+///   let multi_line_string_1 = 
+///      #|1
+///      #|2
+///      #|3
+///      #|4
+///      #|5
+///      #|
+/// 
+///   inspect(multi_line_string_1)
+///   inspect(multi_line_string_1, content="")
+/// 
+///   let multi_line_string_2 = 
 ///     #|1
 ///     #|2
 ///     #|3
-///     #|4
-///     #|5
-///     #|
 /// 
-///  inspect(multi_line_string_1)
-///  inspect(multi_line_string_1, content="")
+///   inspect(multi_line_string_2)
+///   inspect(multi_line_string_2, content="")
 /// 
-///  let multi_line_string_2 = 
-///     #|1
-///     #|2
-///     #|3
-/// 
-///  inspect(multi_line_string_2)
-///  inspect(multi_line_string_2, content="")
-/// 
-///  let multi_line_string_3 = 
+///   let multi_line_string_3 = 
 ///     #|1
 ///     #|2
 /// 
-///  inspect(multi_line_string_3)
-///  inspect(multi_line_string_3, content="")
+///   inspect(multi_line_string_3)
+///   inspect(multi_line_string_3, content="")
 /// 
-///  let multi_line_string_4 = 
+///   let multi_line_string_4 = 
 ///     #|1
 /// 
-///  inspect(multi_line_string_4)
-///  inspect(multi_line_string_4, content="")
+///   inspect(multi_line_string_4)
+///   inspect(multi_line_string_4, content="")
 /// 
+/// }
 /// ```
 pub fn greet6() -> String {
   "greet, wor1ld!"

--- a/crates/moon/tests/test_cases/run_doc_test.in/src/lib/hello.mbt
+++ b/crates/moon/tests/test_cases/run_doc_test.in/src/lib/hello.mbt
@@ -1,39 +1,48 @@
-/// ```
-/// println("doc_test 1 from hello.mbt")
+/// ```moonbit
+/// test {
+///   println("doc_test 1 from hello.mbt")
+/// }
 /// ```
 pub fn hello1() -> String {
   "Hello, world!"
 }
 
 
-/// ```mbt
-/// println("doc_test 2 from hello.mbt")
+/// ```moonbit
+/// test {
+///   println("doc_test 2 from hello.mbt")
 /// 
-/// inspect(1256)
+///   inspect(1256)
+/// }
 /// 
 /// ```
 pub fn hello2() -> String {
   "Hello, world!"
 }
 
-/// ```
-/// println("doc_test 3 from hello.mbt")
+/// ```moonbit
+/// test {
+///   println("doc_test 3 from hello.mbt")
 /// 
-/// fail("this is a failure")
+///   fail("this is a failure")
+/// 
+/// }
 /// 
 /// ```
 pub fn hello3() -> String {
   "Hello, wor1ld!"
 }
 
-/// ```
-/// println("doc_test")
+/// ```moonbit
+/// test {
+///   println("doc_test")
 /// 
 /// 
 /// 
 /// 
 /// 
-/// assert_true(true)
+///   assert_true(true)
+/// }
 /// ```
 pub fn hello() -> String {
   "Hello, wor1ld!"
@@ -56,17 +65,19 @@ pub fn hello() -> String {
 /// 
 /// 
 /// 
-/// ```
-/// 
-/// assert_true(true)
+/// ```mbt
+/// test {
+///   assert_true(true)
+/// }
 /// ```
 /// 
 /// this is comment
 /// 
 /// 
-/// ```
-/// 
-/// assert_true(true)
+/// ```mbt
+/// test {
+///   assert_true(true)
+/// }
 /// ```
 pub fn fasd() -> String {
   "Hello, wor1ld!"

--- a/crates/moonutil/src/doc_test.rs
+++ b/crates/moonutil/src/doc_test.rs
@@ -50,7 +50,7 @@ impl DocTestExtractor {
         for cap in pattern.captures_iter(&content) {
             if let Some(test_match) = cap.get(0) {
                 let lang = cap.get(1).map(|m| m.as_str().trim()).unwrap_or("");
-                if lang.is_empty() || lang == "mbt" || lang == "moonbit" {
+                if lang == "mbt" || lang == "moonbit" {
                     let line_number = content[..test_match.start()]
                         .chars()
                         .filter(|&c| c == '\n')
@@ -137,30 +137,16 @@ impl PatchJSON {
             let mut current_line = 1;
             let mut content = String::new();
             for doc_test in doc_tests_in_mbt_file {
-                let test_name = format!(
-                    "{} {} {} {}",
-                    "doc_test", doc_test.file_name, doc_test.line_number, doc_test.line_count
-                );
-
-                let already_wrapped = doc_test
-                    .content
-                    .lines()
-                    .any(|line| line.replacen("///", "", 1).trim_start().starts_with("test"));
-
                 let processed_content = doc_test
                     .content
                     .as_str()
                     .lines()
                     .map(|line| {
-                        if already_wrapped {
-                            let remove_slash = line.replacen("///", "", 1).trim_start().to_string();
-                            if remove_slash.starts_with("test") || remove_slash.starts_with("}") {
-                                remove_slash
-                            } else {
-                                line.to_string().replacen("///", "   ", 1)
-                            }
+                        let remove_slash = line.replacen("///", "", 1).trim_start().to_string();
+                        if remove_slash.starts_with("test") || remove_slash.starts_with("}") {
+                            remove_slash
                         } else {
-                            format!("   {}", line.trim_start_matches("///")).to_string()
+                            line.to_string().replacen("///", "   ", 1)
                         }
                     })
                     .collect::<Vec<_>>()
@@ -169,14 +155,7 @@ impl PatchJSON {
                 let start_line_number = doc_test.line_number;
                 let empty_lines = "\n".repeat(start_line_number - current_line);
 
-                if already_wrapped {
-                    content.push_str(&format!("\n{}{}\n", empty_lines, processed_content));
-                } else {
-                    content.push_str(&format!(
-                        "{}test \"{}\" {{\n{}\n}}",
-                        empty_lines, test_name, processed_content
-                    ));
-                }
+                content.push_str(&format!("\n{}{}\n", empty_lines, processed_content));
 
                 // +1 for the }
                 current_line = start_line_number + doc_test.line_count + 1;


### PR DESCRIPTION
- don't auto wrap doc test block
- ignore ''' code, just support '''mbt | moonbit

cc @bzy-debug 