### PR TITLE
feat: Print dependency cycle with an arrow when meeting cyclic depedency

### DIFF
--- a/crates/moonbuild/src/gen/util.rs
+++ b/crates/moonbuild/src/gen/util.rs
@@ -40,7 +40,8 @@ pub fn toposort(m: &ModuleDB) -> anyhow::Result<Vec<String>> {
                 .into_iter()
                 .map(|n| m.get_package_by_index(n.index()).full_name())
                 .collect::<Vec<_>>();
-            bail!("cyclic dependency detected: {:?}", cycle);
+            let cycle_str = cycle.join(" -> ");
+            bail!("cyclic dependency detected: {}", cycle_str);
         }
     };
     Ok(topo)

--- a/crates/moonutil/src/scan.rs
+++ b/crates/moonutil/src/scan.rs
@@ -735,7 +735,8 @@ pub fn scan(
                 .into_iter()
                 .map(|n| idx_to_name[&n].clone())
                 .collect::<Vec<_>>();
-            bail!("cyclic dependency detected: {:?}", cycle);
+            let cycle_str = cycle.join(" -> ");
+            bail!("cyclic dependency detected: {}", cycle_str);
         }
     }
 


### PR DESCRIPTION

## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [ ] Bug fix
- [x] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - Previously cyclic dependency was printed like `[A, B, C, A]`, now it's `A -> B -> C -> A`
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS

cc @peter-jerry-ye 