### PR TITLE
Revert "chore: deprecate String::substring"

### DIFF
--- a/crates/moonbuild/template/test_driver/no_args_driver_template_native.mbt
+++ b/crates/moonbuild/template/test_driver/no_args_driver_template_native.mbt
@@ -145,13 +145,13 @@ fn main {
     let mut start = 0
     while i < s.length() {
       if moonbit_unsafe_char_from_int(s.charcode_at(i)) == sep {
-        res.push(s.charcodes(start = start, end = i).to_string())
+        res.push(s.substring(start = start, end = i))
         start = i + 1
       }
       i += 1
     }
     if start < s.length() {
-      res.push(s.charcodes(start = start, end = s.length()).to_string())
+      res.push(s.substring(start = start, end = s.length()))
     }
     res
   }

--- a/crates/moonbuild/template/test_driver/with_args_bench_driver_template_native.mbt
+++ b/crates/moonbuild/template/test_driver/with_args_bench_driver_template_native.mbt
@@ -180,13 +180,13 @@ fn main {
     let mut start = 0
     while i < s.length() {
       if moonbit_unsafe_char_from_int(s.charcode_at(i)) == sep {
-        res.push(s.charcodes(start = start, end = i).to_string())
+        res.push(s.substring(start = start, end = i))
         start = i + 1
       }
       i += 1
     }
     if start < s.length() {
-      res.push(s.charcodes(start = start, end = s.length()).to_string())
+      res.push(s.substring(start = start, end = s.length()))
     }
     res
   }

--- a/crates/moonbuild/template/test_driver/with_args_driver_template_native.mbt
+++ b/crates/moonbuild/template/test_driver/with_args_driver_template_native.mbt
@@ -227,13 +227,13 @@ fn main {
     let mut start = 0
     while i < s.length() {
       if moonbit_unsafe_char_from_int(s.charcode_at(i)) == sep {
-        res.push(s.charcodes(start = start, end = i).to_string())
+        res.push(s.substring(start = start, end = i))
         start = i + 1
       }
       i += 1
     }
     if start < s.length() {
-      res.push(s.charcodes(start = start, end = s.length()).to_string())
+      res.push(s.substring(start = start, end = s.length()))
     }
     res
   }


### PR DESCRIPTION
Reverts moonbitlang/moon#905

native backend relies on substring; and if we use charcode instead, everything in core will rely on package string