### PR TITLE
chore: Bump dependency to `moonbitlang/x` to `0.4.29` for tests to pass

### DIFF
--- a/crates/moon/tests/test_cases/moon_test_single_file.in/111.mbt.md
+++ b/crates/moon/tests/test_cases/moon_test_single_file.in/111.mbt.md
@@ -1,7 +1,7 @@
 ---
 moonbit:
   deps:
-    moonbitlang/x: 0.4.23
+    moonbitlang/x: 0.4.29
     # moonbitlang/x:
     #   path: "/Users/flash/projects/x"
   backend:

--- a/crates/moon/tests/test_cases/test_moonbitlang_x.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/test_moonbitlang_x.in/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "username/hello",
   "version": "0.1.0",
   "deps": {
-    "moonbitlang/x": "0.4.22"
+    "moonbitlang/x": "0.4.29"
   },
   "readme": "README.md",
   "repository": "",


### PR DESCRIPTION
Update `moonbitlang/x` so that tests pass again

## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [ ] Yes (please describe the changes below)
  - ____
- [x] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
