### PR TITLE
Rollup (1) of misc pre-merge changes for Rupes Recta prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "argh"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +1515,7 @@ name = "mooncake"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arcstr",
  "bytes",
  "clap",
  "colored",
@@ -1556,6 +1566,7 @@ name = "moonutil"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arcstr",
  "ariadne",
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ edition = "2021"
 
 [workspace.dependencies]
 n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "dbd9c7921f8f2f388b85f375ea7a30575310b35d" }
+arcstr = { version = "1.2", features = ["serde"] }
 moonbuild = { path = "./crates/moonbuild", version = "*" }
 mooncake = { path = "./crates/mooncake", version = "*" }
 moonutil = { path = "./crates/moonutil", version = "*" }

--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -74,7 +74,7 @@ pub fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result<i32> {
     let pkgname = author_pkg[1];
     let pkg_name = ModuleName {
         username: username.to_string(),
-        pkgname: pkgname.to_string(),
+        unqual: pkgname.to_string(),
     };
 
     if parts.len() == 2 {

--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -73,8 +73,8 @@ pub fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result<i32> {
     let username = author_pkg[0];
     let pkgname = author_pkg[1];
     let pkg_name = ModuleName {
-        username: username.to_string(),
-        unqual: pkgname.to_string(),
+        username: username.into(),
+        unqual: pkgname.into(),
     };
 
     if parts.len() == 2 {

--- a/crates/moonbuild/src/build_script.rs
+++ b/crates/moonbuild/src/build_script.rs
@@ -64,8 +64,8 @@ pub fn run_prebuild_config(
 
             let output = run_build_script_for_module(module, dir, input, prebuild)?;
             pkg_outputs.insert(
-                PathComponent::from_str(&module.name.to_string()).with_context(|| {
-                    format!("Name of module `{}` cannot be parsed", &module.name)
+                PathComponent::from_str(&module.name().to_string()).with_context(|| {
+                    format!("Name of module `{}` cannot be parsed", &module.name())
                 })?,
                 output,
             );
@@ -217,7 +217,7 @@ fn run_build_script_for_module(
         "Running external prebuild config at `{}`. The script can execute arbitrary code.",
         prebuild
     );
-    let mut cmd = run_script_cmd(prebuild, &module.name)?
+    let mut cmd = run_script_cmd(prebuild, module.name())?
         .current_dir(dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/crates/mooncake/Cargo.toml
+++ b/crates/mooncake/Cargo.toml
@@ -25,6 +25,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arcstr.workspace = true
 moonutil.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mooncake/src/dep_dir.rs
+++ b/crates/mooncake/src/dep_dir.rs
@@ -108,7 +108,7 @@ fn pkg_list_to_dep_dir_state<'a>(
             ModuleSourceKind::Git(_) => continue, // TODO: git registries are resolved differently
         }
         let user = &pkg.name.username;
-        let pkg_name = &pkg.name.pkgname;
+        let pkg_name = &pkg.name.unqual;
         let pkg_list: &mut HashMap<String, _> = user_list.entry(user.to_owned()).or_default();
         pkg_list.insert(pkg_name.to_owned(), pkg);
     }
@@ -264,7 +264,7 @@ fn pkg_to_dir(dep_dir: &DepDir, username: &str, pkgname: &str) -> PathBuf {
 fn map_source_to_dir(dep_dir: &DepDir, module: &ModuleSource) -> PathBuf {
     match &module.source {
         ModuleSourceKind::Registry(_) => {
-            pkg_to_dir(dep_dir, &module.name.username, &module.name.pkgname)
+            pkg_to_dir(dep_dir, &module.name.username, &module.name.unqual)
         }
         ModuleSourceKind::Local(path) => path.clone(),
         ModuleSourceKind::Git(url) => {
@@ -325,7 +325,7 @@ mod test {
                         let res = ModuleSource {
                             name: ModuleName {
                                 username: user.clone(),
-                                pkgname: module.clone(),
+                                unqual: module.clone(),
                             },
                             version,
                             source: ModuleSourceKind::Registry(None),
@@ -352,7 +352,7 @@ mod test {
                         let res = ModuleSource {
                             name: ModuleName {
                                 username: user.to_owned(),
-                                pkgname: pkg.to_owned(),
+                                unqual: pkg.to_owned(),
                             },
                             version,
                             source: ModuleSourceKind::Registry(None),

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -53,7 +53,7 @@ impl OnlineRegistry {
         self.index
             .join("user")
             .join(&name.username)
-            .join(format!("{}.index", name.pkgname))
+            .join(format!("{}.index", name.unqual))
     }
 }
 
@@ -193,7 +193,7 @@ impl OnlineRegistry {
             println!("Downloading {name}");
         }
         let filepath = form_urlencoded::Serializer::new(String::new())
-            .append_key_only(&format!("{}/{}/{}", name.username, name.pkgname, version))
+            .append_key_only(&format!("{}/{}/{}", name.username, name.unqual, version))
             .finish();
         let url = format!("{}/{}.zip", self.url_base, filepath);
         let data = reqwest::blocking::get(url)?.error_for_status()?.bytes()?;
@@ -255,7 +255,7 @@ fn cache_of(name: &ModuleName, version: &Version) -> std::path::PathBuf {
 
     cache_dir
         .join(&name.username)
-        .join(&name.pkgname)
+        .join(&name.unqual)
         .join(format!("{version}.zip"))
 }
 

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -52,7 +52,7 @@ impl OnlineRegistry {
     fn index_file_of(&self, name: &ModuleName) -> std::path::PathBuf {
         self.index
             .join("user")
-            .join(&name.username)
+            .join(name.username.as_str())
             .join(format!("{}.index", name.unqual))
     }
 }
@@ -254,8 +254,8 @@ fn cache_of(name: &ModuleName, version: &Version) -> std::path::PathBuf {
     let cache_dir = moonutil::moon_dir::cache();
 
     cache_dir
-        .join(&name.username)
-        .join(&name.unqual)
+        .join(name.username.as_str())
+        .join(name.unqual.as_str())
         .join(format!("{version}.zip"))
 }
 

--- a/crates/mooncake/src/resolver.rs
+++ b/crates/mooncake/src/resolver.rs
@@ -89,9 +89,9 @@ fn assert_no_duplicate_module_names(result: &result::ResolvedEnv) -> Result<(), 
     let mut module_name_versions: HashMap<_, Vec<_>> = HashMap::new();
     for it in result.all_modules() {
         module_name_versions
-            .entry(&it.name)
+            .entry(it.name())
             .or_default()
-            .push(&it.version);
+            .push(it.version());
     }
     let mut errs = vec![];
     for (name, versions) in module_name_versions {

--- a/crates/mooncake/src/resolver/env.rs
+++ b/crates/mooncake/src/resolver/env.rs
@@ -83,9 +83,9 @@ impl<'a> ResolverEnv<'a> {
     }
 
     pub fn get(&mut self, ms: &ModuleSource) -> Option<Arc<MoonMod>> {
-        match &ms.source {
+        match ms.source() {
             ModuleSourceKind::Registry(reg) => {
-                self.get_module_version(&ms.name, &ms.version, reg.as_deref())
+                self.get_module_version(ms.name(), ms.version(), reg.as_deref())
             }
             ModuleSourceKind::Git(_) => todo!("Resolve git module"),
             ModuleSourceKind::Local(path) => self.resolve_local_module(path).ok(),

--- a/crates/mooncake/src/resolver/mvs.rs
+++ b/crates/mooncake/src/resolver/mvs.rs
@@ -313,6 +313,7 @@ fn mvs_resolve(
         log::debug!("---- {} -> {:?}", ms, id);
         working_list.push((Arc::clone(module), ms.clone()));
         visited.insert(ms, id);
+        builder.push_root_module(id);
     }
 
     log::debug!("-- Inserting dependencies");

--- a/crates/moonutil/Cargo.toml
+++ b/crates/moonutil/Cargo.toml
@@ -25,6 +25,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arcstr.workspace = true
 home.workspace = true
 anyhow.workspace = true
 colored.workspace = true

--- a/crates/moonutil/Cargo.toml
+++ b/crates/moonutil/Cargo.toml
@@ -30,7 +30,7 @@ home.workspace = true
 anyhow.workspace = true
 colored.workspace = true
 indexmap.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["rc"] }
 serde_json_lenient.workspace = true
 walkdir.workspace = true
 clap.workspace = true

--- a/crates/moonutil/src/mooncakes.rs
+++ b/crates/moonutil/src/mooncakes.rs
@@ -23,6 +23,7 @@ use std::{
     str::FromStr,
 };
 
+use arcstr::ArcStr;
 use clap::Subcommand;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -38,9 +39,9 @@ pub type DirSyncResult = SecondaryMap<ModuleId, PathBuf>;
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ModuleName {
     /// The username part of the module name
-    pub username: String,
+    pub username: ArcStr,
     /// The unqualified name part of the module name
-    pub unqual: String,
+    pub unqual: ArcStr,
 }
 
 impl ModuleName {
@@ -83,12 +84,12 @@ impl FromStr for ModuleName {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.split_once('/') {
             Some((username, pkgname)) => Ok(ModuleName {
-                username: username.to_string(),
-                unqual: pkgname.to_string(),
+                username: username.into(),
+                unqual: pkgname.into(),
             }),
             None => Ok(ModuleName {
-                username: String::new(),
-                unqual: s.to_string(),
+                username: ArcStr::new(),
+                unqual: s.into(),
             }),
         }
     }

--- a/crates/moonutil/src/mooncakes.rs
+++ b/crates/moonutil/src/mooncakes.rs
@@ -37,16 +37,32 @@ pub type DirSyncResult = SecondaryMap<ModuleId, PathBuf>;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ModuleName {
+    /// The username part of the module name
     pub username: String,
-    pub pkgname: String,
+    /// The unqualified name part of the module name
+    pub unqual: String,
+}
+
+impl ModuleName {
+    /// Returns whether the module's name is in legacy format, either having
+    /// empty username or containing multiple segments in the unqualified name.
+    pub fn is_legacy(&self) -> bool {
+        if self.username.is_empty() {
+            return true;
+        }
+        if self.unqual.contains('/') {
+            return true;
+        }
+        false
+    }
 }
 
 impl std::fmt::Debug for ModuleName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.username.is_empty() {
-            f.write_fmt(format_args!("{}", self.pkgname))
+            f.write_fmt(format_args!("{}", self.unqual))
         } else {
-            f.write_fmt(format_args!("{}/{}", self.username, self.pkgname))
+            f.write_fmt(format_args!("{}/{}", self.username, self.unqual))
         }
     }
 }
@@ -54,9 +70,9 @@ impl std::fmt::Debug for ModuleName {
 impl std::fmt::Display for ModuleName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.username.is_empty() {
-            f.write_fmt(format_args!("{}", self.pkgname))
+            f.write_fmt(format_args!("{}", self.unqual))
         } else {
-            f.write_fmt(format_args!("{}/{}", self.username, self.pkgname))
+            f.write_fmt(format_args!("{}/{}", self.username, self.unqual))
         }
     }
 }
@@ -68,11 +84,11 @@ impl FromStr for ModuleName {
         match s.split_once('/') {
             Some((username, pkgname)) => Ok(ModuleName {
                 username: username.to_string(),
-                pkgname: pkgname.to_string(),
+                unqual: pkgname.to_string(),
             }),
             None => Ok(ModuleName {
                 username: String::new(),
-                pkgname: s.to_string(),
+                unqual: s.to_string(),
             }),
         }
     }

--- a/crates/moonutil/src/scan.rs
+++ b/crates/moonutil/src/scan.rs
@@ -625,7 +625,7 @@ fn adapt_modules_into_scan_paths(
         let path = module_paths
             .get(id)
             .expect("All modules should be resolved");
-        let module_name = module.name.to_string();
+        let module_name = module.name().to_string();
         result.insert(module_name, path.clone());
     }
     result


### PR DESCRIPTION
- **refactor: Rename pkgname to unqual in ModuleName for consistency**
- **refactor: Update dependencies to use ArcStr for improved performance and memory efficiency**
- **refactor: Make `ModuleSource` cheaply clonable**
- **refactor: Allow resolved alias to still be optional, and move alias dedup check backwards**
- **refactor: Add reverse mapping and root modules info for module resolver**

## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [ ] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [x] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [ ] Yes (please describe the changes below)
  - ____
- [x] No

## Does this PR introduce new dependencies?

- [ ] No
- [x] Yes (please check binary size changes)

## Checklist:

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
