### PR TITLE
fix incorrect implementation of virtual package

### DIFF
--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -60,6 +60,7 @@ mod test_driver_dependencies;
 mod test_error_report;
 mod test_expect_test;
 mod test_filter;
+mod virtual_pkg_dep;
 mod warns;
 
 #[test]

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/.gitignore
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/.gitignore
@@ -1,0 +1,3 @@
+target/
+.mooncakes/
+.DS_Store

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/LICENSE
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/README.md
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/README.md
@@ -1,0 +1,1 @@
+# username/hello

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/moon.mod.json
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/moon.mod.json
@@ -1,0 +1,10 @@
+{
+  "name": "indirect_depend_virtual",
+  "version": "0.1.0",
+  "readme": "README.md",
+  "repository": "",
+  "license": "Apache-2.0",
+  "keywords": [],
+  "description": "",
+  "source": "src"
+}

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/impl/moon.pkg.json
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/impl/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "implement": "indirect_depend_virtual/virtual"
+}

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/impl/p.mbt
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/impl/p.mbt
@@ -1,0 +1,4 @@
+///|
+pub fn f(x : Int) -> Int {
+  x + 1
+}

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/main/main.mbt
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/main/main.mbt
@@ -1,0 +1,5 @@
+///|
+fn main {
+  println(@middle.f())
+  println(@virtual.f(44))
+}

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/main/moon.pkg.json
@@ -1,0 +1,10 @@
+{
+  "is-main": true,
+  "import": [
+    "indirect_depend_virtual/middle",
+    "indirect_depend_virtual/virtual"
+  ],
+  "overrides": [
+    "indirect_depend_virtual/impl"
+  ]
+}

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/middle/moon.pkg.json
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/middle/moon.pkg.json
@@ -1,0 +1,4 @@
+{
+  "import": [ "indirect_depend_virtual/virtual" ]
+}
+

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/middle/p.mbt
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/middle/p.mbt
@@ -1,0 +1,4 @@
+///|
+pub fn f() -> Int {
+  @virtual.f(42)
+}

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/virtual/moon.pkg.json
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/virtual/moon.pkg.json
@@ -1,0 +1,5 @@
+{
+  "virtual": {
+    "has-default": false
+  }
+}

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/virtual/pkg.mbti
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/indirect_depend_virtual/src/virtual/pkg.mbti
@@ -1,0 +1,3 @@
+package "indirect_depend_virtual/virtual" 
+
+fn f(Int) -> Int

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/mod.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+#[test]
+fn test_indirect_depend_virtual() {
+    let dir = TestDir::new("virtual_pkg_dep/indirect_depend_virtual");
+
+    check(
+        get_stdout(&dir, ["run", "src/main", "--target", "native", "--dry-run"]),
+        expect![[r#"
+            moonc build-interface ./src/virtual/pkg.mbti -o ./target/native/release/build/virtual/virtual.mi -pkg indirect_depend_virtual/virtual -pkg-sources indirect_depend_virtual/virtual:./src/virtual -virtual -std-path $MOON_HOME/lib/core/target/native/release/bundle -error-format=json
+            moonc build-package ./src/middle/p.mbt -o ./target/native/release/build/middle/middle.core -pkg indirect_depend_virtual/middle -std-path $MOON_HOME/lib/core/target/native/release/bundle -i ./target/native/release/build/virtual/virtual.mi:virtual -pkg-sources indirect_depend_virtual/middle:./src/middle -target native
+            moonc build-package ./src/impl/p.mbt -o ./target/native/release/build/impl/impl.core -pkg indirect_depend_virtual/impl -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources indirect_depend_virtual/impl:./src/impl -target native -check-mi ./target/native/release/build/virtual/virtual.mi -impl-virtual -no-mi -pkg-sources indirect_depend_virtual/virtual:./src/virtual
+            moonc build-package ./src/main/main.mbt -o ./target/native/release/build/main/main.core -pkg indirect_depend_virtual/main -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -i ./target/native/release/build/middle/middle.mi:middle -i ./target/native/release/build/virtual/virtual.mi:virtual -pkg-sources indirect_depend_virtual/main:./src/main -target native
+            moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/abort/abort.core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/release/build/impl/impl.core ./target/native/release/build/middle/middle.core ./target/native/release/build/main/main.core -main indirect_depend_virtual/main -o ./target/native/release/build/main/main.c -pkg-config-path ./src/main/moon.pkg.json -pkg-sources indirect_depend_virtual/impl:./src/impl -pkg-sources indirect_depend_virtual/middle:./src/middle -pkg-sources indirect_depend_virtual/main:./src/main -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -target native
+            cc -o ./target/native/release/build/runtime.o -I$MOON_HOME/include -L$MOON_HOME/lib -g -c -fwrapv -fno-strict-aliasing -O2 $MOON_HOME/lib/runtime.c
+            cc -o ./target/native/release/build/main/main.exe -I$MOON_HOME/include -L$MOON_HOME/lib -fwrapv -fno-strict-aliasing -O2 $MOON_HOME/lib/libmoonbitrun.o ./target/native/release/build/main/main.c ./target/native/release/build/runtime.o -lm
+            ./target/native/release/build/main/main.exe
+        "#]],
+    );
+    check(
+        get_stdout(&dir, ["run", "src/main", "--target", "native"]),
+        expect![[r#"
+            43
+            45
+        "#]],
+    );
+}

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/mod.rs
@@ -3,19 +3,18 @@ use super::*;
 #[test]
 fn test_indirect_depend_virtual() {
     let dir = TestDir::new("virtual_pkg_dep/indirect_depend_virtual");
-
+    // need to omit the command generated for cc, because it's platform dependent
     check(
-        get_stdout(&dir, ["run", "src/main", "--target", "native", "--dry-run"]),
+        get_stdout(&dir, ["run", "src/main", "--target", "native", "--dry-run"])
+            .lines()
+            .collect::<Vec<_>>()[0..5]
+            .join("\n"),
         expect![[r#"
             moonc build-interface ./src/virtual/pkg.mbti -o ./target/native/release/build/virtual/virtual.mi -pkg indirect_depend_virtual/virtual -pkg-sources indirect_depend_virtual/virtual:./src/virtual -virtual -std-path $MOON_HOME/lib/core/target/native/release/bundle -error-format=json
             moonc build-package ./src/middle/p.mbt -o ./target/native/release/build/middle/middle.core -pkg indirect_depend_virtual/middle -std-path $MOON_HOME/lib/core/target/native/release/bundle -i ./target/native/release/build/virtual/virtual.mi:virtual -pkg-sources indirect_depend_virtual/middle:./src/middle -target native
             moonc build-package ./src/impl/p.mbt -o ./target/native/release/build/impl/impl.core -pkg indirect_depend_virtual/impl -std-path $MOON_HOME/lib/core/target/native/release/bundle -pkg-sources indirect_depend_virtual/impl:./src/impl -target native -check-mi ./target/native/release/build/virtual/virtual.mi -impl-virtual -no-mi -pkg-sources indirect_depend_virtual/virtual:./src/virtual
             moonc build-package ./src/main/main.mbt -o ./target/native/release/build/main/main.core -pkg indirect_depend_virtual/main -is-main -std-path $MOON_HOME/lib/core/target/native/release/bundle -i ./target/native/release/build/middle/middle.mi:middle -i ./target/native/release/build/virtual/virtual.mi:virtual -pkg-sources indirect_depend_virtual/main:./src/main -target native
-            moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/abort/abort.core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/release/build/impl/impl.core ./target/native/release/build/middle/middle.core ./target/native/release/build/main/main.core -main indirect_depend_virtual/main -o ./target/native/release/build/main/main.c -pkg-config-path ./src/main/moon.pkg.json -pkg-sources indirect_depend_virtual/impl:./src/impl -pkg-sources indirect_depend_virtual/middle:./src/middle -pkg-sources indirect_depend_virtual/main:./src/main -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -target native
-            cc -o ./target/native/release/build/runtime.o -I$MOON_HOME/include -L$MOON_HOME/lib -g -c -fwrapv -fno-strict-aliasing -O2 $MOON_HOME/lib/runtime.c
-            cc -o ./target/native/release/build/main/main.exe -I$MOON_HOME/include -L$MOON_HOME/lib -fwrapv -fno-strict-aliasing -O2 $MOON_HOME/lib/libmoonbitrun.o ./target/native/release/build/main/main.c ./target/native/release/build/runtime.o -lm
-            ./target/native/release/build/main/main.exe
-        "#]],
+            moonc link-core $MOON_HOME/lib/core/target/native/release/bundle/abort/abort.core $MOON_HOME/lib/core/target/native/release/bundle/core.core ./target/native/release/build/impl/impl.core ./target/native/release/build/middle/middle.core ./target/native/release/build/main/main.core -main indirect_depend_virtual/main -o ./target/native/release/build/main/main.c -pkg-config-path ./src/main/moon.pkg.json -pkg-sources indirect_depend_virtual/impl:./src/impl -pkg-sources indirect_depend_virtual/middle:./src/middle -pkg-sources indirect_depend_virtual/main:./src/main -pkg-sources moonbitlang/core:$MOON_HOME/lib/core -target native"#]],
     );
     check(
         get_stdout(&dir, ["run", "src/main", "--target", "native"]),

--- a/crates/moonbuild/src/gen/util.rs
+++ b/crates/moonbuild/src/gen/util.rs
@@ -93,15 +93,13 @@ pub fn topo_from_node(m: &ModuleDB, pkg: &Package) -> anyhow::Result<Vec<String>
                 // if neighbor is a virtual package, we should find its implementation
                 if let Some(impl_pkg) = virtual_impl.get(&neighbor_full_name) {
                     impl_pkg.to_string()
+                } else if virtual_info.has_default {
+                    neighbor_full_name
                 } else {
-                    if virtual_info.has_default {
+                    bail!(
+                        "Virtual package {} has no implementation",
                         neighbor_full_name
-                    } else {
-                        bail!(
-                            "Virtual package {} has no implementation",
-                            neighbor_full_name
-                        );
-                    }
+                    );
                 }
             } else {
                 neighbor_full_name

--- a/crates/moonbuild/src/gen/util.rs
+++ b/crates/moonbuild/src/gen/util.rs
@@ -23,7 +23,7 @@ use moonutil::{graph::get_example_cycle, package::Link};
 use std::fmt::Write;
 
 #[allow(unused)]
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use petgraph::dot::{Config, Dot};
 
@@ -51,30 +51,64 @@ pub fn topo_from_node(m: &ModuleDB, pkg: &Package) -> anyhow::Result<Vec<String>
     let pkg_full_name = pkg.full_name();
     let mut stk: Vec<String> = Vec::new();
     let mut visited: HashSet<String> = HashSet::new();
+    /* mapping from virtual package to its implementation */
+    let mut virtual_impl: HashMap<String, String> = HashMap::new();
 
     fn dfs(
         m: &ModuleDB,
         pkg_full_name: &str,
         stk: &mut Vec<String>,
         visited: &mut HashSet<String>,
+        virtual_impl: &mut HashMap<String, String>,
     ) -> anyhow::Result<()> {
         visited.insert(pkg_full_name.to_string());
 
         let pkg = m.get_package_by_name(pkg_full_name);
-        for neighbor in pkg.imports.iter() {
-            let mut neighbor_full_name = neighbor.path.make_full_path();
-            // if there is a pkg which overrides the `neighbor_full_name`, we should use the overrid pkg
-            if let Some(overrides) = pkg.overrides.as_ref() {
-                for over_ride in overrides.iter() {
-                    let override_pkg = m.get_package_by_name(over_ride);
-                    let implement = override_pkg.implement.as_ref().unwrap().clone();
-                    if implement == neighbor_full_name {
-                        neighbor_full_name = override_pkg.full_name();
+        // record the virtual package and its implementation
+        if let Some(overrides) = pkg.overrides.as_ref() {
+            for implement in overrides.iter() {
+                let implement_pkg = m.get_package_by_name(implement);
+                let virtual_pkg = implement_pkg.implement.as_ref().unwrap().clone();
+                if let Some(impl_pkg) = virtual_impl.get(&virtual_pkg) {
+                    if *impl_pkg == implement_pkg.full_name() {
+                        continue;
+                    } else {
+                        bail!(
+                            "Virtual package {} has multiple implementations: {} and {}",
+                            virtual_pkg,
+                            impl_pkg,
+                            implement_pkg.full_name()
+                        );
                     }
+                } else {
+                    virtual_impl.insert(virtual_pkg, implement_pkg.full_name());
                 }
             }
-            if !visited.contains(&neighbor_full_name) {
-                dfs(m, &neighbor_full_name, stk, visited)?;
+        }
+
+        for neighbor in pkg.imports.iter() {
+            let neighbor_full_name = neighbor.path.make_full_path();
+            let neighbor_pkg = m.get_package_by_name(&neighbor_full_name);
+            let neighbor_no_virtual = if let Some(virtual_info) = &neighbor_pkg.virtual_pkg {
+                // if neighbor is a virtual package, we should find its implementation
+                if let Some(impl_pkg) = virtual_impl.get(&neighbor_full_name) {
+                    impl_pkg.to_string()
+                } else {
+                    if virtual_info.has_default {
+                        neighbor_full_name
+                    } else {
+                        bail!(
+                            "Virtual package {} has no implementation",
+                            neighbor_full_name
+                        );
+                    }
+                }
+            } else {
+                neighbor_full_name
+            };
+
+            if !visited.contains(&neighbor_no_virtual) {
+                dfs(m, &neighbor_no_virtual, stk, visited, virtual_impl)?;
             }
         }
 
@@ -82,7 +116,7 @@ pub fn topo_from_node(m: &ModuleDB, pkg: &Package) -> anyhow::Result<Vec<String>
         Ok(())
     }
 
-    dfs(m, &pkg_full_name, &mut stk, &mut visited)?;
+    dfs(m, &pkg_full_name, &mut stk, &mut visited, &mut virtual_impl)?;
     Ok(stk)
 }
 


### PR DESCRIPTION
## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
 
Consider the scenario:
```
virtual --> middle --> main
   |                     ^
   |                     |
   +---------------------+
```
In `moon.pkg.json` of main, it claims an implementation package `impl` is used as the implementation of `virtual`.

Previous behavior will insert `impl.core` to twice for some intricate reasons:
* When it visits `main`, `virtual` is added as a dependency. Because `moon.pkg.json` of `main` says use `impl` for `virtual`, it will add `impl.core` to the worklist.
* When it visits `middle`, `virtual` is added as a dependency. But this time it doesn't know which implementation should be used. So it add `virtual.core` to the worklist.
So the generated `link-core` command will contain a `virtual.core` and a `impl.core`. Before the command is issued, it run another pass to replace `virtual.core` with `impl.core` and this causes the bug.

This PR changes the behavior. When it analyzes the dependency, it will create a table to keep track of which implementation package implements which virtual package. So when it visits `main` and `middle`, it will consistently replace `virtual` with `impl` to avoid this problem. 

- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [x] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
