### PR TITLE
[Rupes Recta] Basic native backend support

### DIFF
--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -193,7 +193,7 @@ fn run_single_mbt_file(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resu
         ];
         Some(tcc_run_command)
     } else if target_backend == TargetBackend::Native || target_backend == TargetBackend::LLVM {
-        let cc_cmd = moonutil::compiler_flags::make_cc_command(
+        let cc_cmd = moonutil::compiler_flags::make_cc_command::<&'static str>(
             cc_default,
             None,
             moonutil::compiler_flags::CCConfigBuilder::default()

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -162,6 +162,7 @@ pub fn compile(
         if let Some(plan) = compile_output.build_plan {
             moonbuild_rupes_recta::util::print_build_plan_dot(
                 &plan,
+                &resolve_output.module_rel,
                 &resolve_output.pkg_dirs,
                 &mut std::fs::File::create(target_dir.join("build_plan.dot"))?,
             )?;

--- a/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
@@ -27,7 +27,7 @@ use moonutil::{common::TargetBackend, mooncakes::ModuleSource};
 
 use crate::{
     discover::DiscoverResult,
-    model::{BuildTarget, TargetKind},
+    model::{BuildTarget, OperatingSystem, TargetKind},
     pkg_name::PackageFQN,
 };
 
@@ -141,7 +141,7 @@ impl LegacyLayout {
         pkg_list: &DiscoverResult,
         target: &BuildTarget,
         backend: TargetBackend,
-        os: &str,
+        os: OperatingSystem,
     ) -> PathBuf {
         let pkg_fqn = &pkg_list.get_package(target.package).fqn;
         let mut base_dir = self.package_dir(pkg_fqn, backend);
@@ -159,7 +159,7 @@ impl LegacyLayout {
         pkg_list: &DiscoverResult,
         target: &BuildTarget,
         backend: TargetBackend,
-        os: &str,
+        os: OperatingSystem,
         legacy_behavior: bool,
     ) -> PathBuf {
         let pkg_fqn = &pkg_list.get_package(target.package).fqn;
@@ -218,7 +218,7 @@ fn build_kind_suffix(kind: TargetKind) -> &'static str {
     }
 }
 
-fn linked_core_artifact_ext(backend: TargetBackend, os: &str) -> &'static str {
+fn linked_core_artifact_ext(backend: TargetBackend, os: OperatingSystem) -> &'static str {
     match backend {
         TargetBackend::Wasm | TargetBackend::WasmGC => ".wasm",
         TargetBackend::Js => ".js",
@@ -229,7 +229,7 @@ fn linked_core_artifact_ext(backend: TargetBackend, os: &str) -> &'static str {
 
 fn make_executable_artifact_ext(
     backend: TargetBackend,
-    os: &str,
+    os: OperatingSystem,
     legacy_behavior: bool,
 ) -> &'static str {
     match backend {
@@ -240,45 +240,45 @@ fn make_executable_artifact_ext(
 }
 
 /// The extension for executables. The legacy behavior forces everything into an `.exe`.
-fn executable_ext(os: &str, legacy_behavior: bool) -> &'static str {
+fn executable_ext(os: OperatingSystem, legacy_behavior: bool) -> &'static str {
     if legacy_behavior {
         ".exe"
     } else {
         match os {
-            "windows" => ".exe",
-            "linux" | "macos" => "",
-            _ => panic!("Unsupported OS {os}"),
+            OperatingSystem::Windows => ".exe",
+            OperatingSystem::Linux | OperatingSystem::MacOS => "",
+            OperatingSystem::None => panic!("No executable extension for no-OS targets"),
         }
     }
 }
 
 /// Returns the file extension for static libraries on the given OS
 #[allow(unused)]
-fn static_library_ext(os: &str) -> &'static str {
+fn static_library_ext(os: OperatingSystem) -> &'static str {
     match os {
-        "windows" => ".lib",
-        "linux" | "macos" => ".a",
-        _ => panic!("Unsupported OS {os}"),
+        OperatingSystem::Windows => ".lib",
+        OperatingSystem::Linux | OperatingSystem::MacOS => ".a",
+        OperatingSystem::None => panic!("No static library extension for no-OS targets"),
     }
 }
 
 /// Returns the file extension for dynamic libraries on the given OS
 #[allow(unused)]
-fn dynamic_library_ext(os: &str) -> &'static str {
+fn dynamic_library_ext(os: OperatingSystem) -> &'static str {
     match os {
-        "windows" => ".dll",
-        "linux" => ".so",
-        "macos" => ".dylib",
-        _ => panic!("Unsupported OS {os}"),
+        OperatingSystem::Windows => ".dll",
+        OperatingSystem::Linux => ".so",
+        OperatingSystem::MacOS => ".dylib",
+        OperatingSystem::None => panic!("No dynamic library extension for no-OS targets"),
     }
 }
 
 /// Returns the file extension for object files on the given OS
-fn object_file_ext(os: &str) -> &'static str {
+fn object_file_ext(os: OperatingSystem) -> &'static str {
     match os {
-        "windows" => ".obj",
-        "linux" | "macos" => ".o",
-        _ => panic!("Unsupported OS {os}"),
+        OperatingSystem::Windows => ".obj",
+        OperatingSystem::Linux | OperatingSystem::MacOS => ".o",
+        OperatingSystem::None => panic!("No object file extension for no-OS targets"),
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
@@ -202,6 +202,13 @@ impl LegacyLayout {
         ));
         base_dir
     }
+
+    pub fn runtime_output_path(&self, backend: TargetBackend, os: OperatingSystem) -> PathBuf {
+        let mut result = self.target_base_dir.clone();
+        push_backend(&mut result, backend);
+        result.push(format!("runtime{}", object_file_ext(os)));
+        result
+    }
 }
 
 fn push_backend(path: &mut PathBuf, backend: TargetBackend) {

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/mod.rs
@@ -102,9 +102,11 @@ impl<'a> std::fmt::Display for CompiledPackageName<'a> {
             // original name + "_blackbox_test", in order to support importing
             // all public declaration in the original package. This is an
             // implicit behavior that should be documented and fixed later.
-            TargetKind::WhiteboxTest => "_whitebox_test",
             TargetKind::BlackboxTest => "_blackbox_test",
-            TargetKind::InlineTest => "_inline_test",
+            // All other target kinds should not have suffixes, or else the
+            // tests in `moonbitlang/core` will not have the correct imports.
+            TargetKind::WhiteboxTest => "",
+            TargetKind::InlineTest => "",
             TargetKind::SubPackage => "",
         };
         write!(f, "{}{}", self.fqn, suffix)

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     },
     build_plan::{BuildPlan, BuildTargetInfo, LinkCoreInfo},
     discover::{DiscoverResult, DiscoveredPackage},
-    model::{Artifacts, BuildPlanNode, TargetKind},
+    model::{Artifacts, BuildPlanNode, OperatingSystem, TargetKind},
     pkg_name::PackageFQNWithSource,
     pkg_solve::DepRelationship,
 };
@@ -272,7 +272,7 @@ impl<'a> BuildPlanLowerContext<'a> {
                     self.packages,
                     &target,
                     self.opt.target_backend,
-                    "todo: no native yet",
+                    OperatingSystem::None,
                 ));
             }
             BuildPlanNode::GenerateTestInfo(target) => {
@@ -462,7 +462,7 @@ impl<'a> BuildPlanLowerContext<'a> {
             self.packages,
             &target,
             self.opt.target_backend,
-            "todo: os not supported yet",
+            OperatingSystem::None,
         );
 
         let package_sources = info

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -184,13 +184,13 @@ impl<'a> BuildPlanLowerContext<'a> {
                 package,
                 info,
             ),
-            BuildActionSpec::BuildMbt(info) => self.lower_build_mbt(
+            BuildActionSpec::BuildCore(info) => self.lower_build_mbt(
                 node,
                 target.expect("BuildMbt nodes must have a target"),
                 package,
                 info,
             ),
-            BuildActionSpec::BuildC(_path_bufs) => todo!(),
+            BuildActionSpec::BuildCStubs(_path_bufs) => todo!(),
             BuildActionSpec::LinkCore(info) => self.lower_link_core(
                 node,
                 target.expect("LinkCore nodes must have a target"),
@@ -203,12 +203,14 @@ impl<'a> BuildPlanLowerContext<'a> {
             }
             BuildActionSpec::GenerateMbti => todo!(),
             BuildActionSpec::Bundle => todo!(),
-            BuildActionSpec::GenerateTestDriver(info) => self.lower_gen_test_driver(
+            BuildActionSpec::GenerateTestInfo(info) => self.lower_gen_test_driver(
                 node,
                 target.expect("GenerateTestDriver nodes must have a target"),
                 package,
                 info,
             ),
+            BuildActionSpec::Format(_info) => todo!(),
+            BuildActionSpec::BuildRuntimeLib => todo!(),
         };
 
         // Collect n2 inputs and outputs.
@@ -291,13 +293,12 @@ impl<'a> BuildPlanLowerContext<'a> {
                 // TODO: Implement if needed
             }
             BuildPlanNode::Bundle(_module_id) => {
-                // Bundle nodes produce different artifacts
-                // TODO: Implement bundle artifact handling
+                todo!()
             }
             BuildPlanNode::BuildRuntimeLib => {
-                // Runtime lib artifacts
-                // TODO: Implement runtime lib artifact handling
+                todo!()
             }
+            BuildPlanNode::GenerateMbti(_target) => todo!(),
         }
     }
 

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -636,6 +636,8 @@ impl<'a> BuildPlanConstructor<'a> {
     }
 
     fn build_runtime_lib(&mut self, _node: BuildPlanNode) -> Result<(), BuildPlanConstructError> {
-        todo!()
+        // Nothing specific to do here ;)
+        self.resolved_node(_node);
+        Ok(())
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -172,50 +172,6 @@ pub struct MakeExecutableInfo {
     pub link_c_stubs: Vec<BuildTarget>,
 }
 
-/// The specification of the specific build target, e.g. its files.
-#[derive(Debug)]
-#[deprecated]
-pub enum BuildActionSpec {
-    /// Check the given list of MoonBit source files.
-    ///
-    /// Outgoing edges of this node represents the direct dependencies.
-    Check(BuildTargetInfo),
-
-    /// Build the given list of MoonBit source files.
-    ///
-    /// Outgoing edges of this node represents the direct dependencies.
-    BuildCore(BuildTargetInfo),
-
-    /// Build the given list of C source files.
-    BuildCStubs(Vec<PathBuf>),
-
-    /// Link the core files from the given list of targets, **in order**.
-    ///
-    /// Outgoing edges of this node represents the build targets it depends on,
-    /// but there's another copy of it, **ordered**, in the value's payloads,
-    /// since the build command will need to use it.
-    LinkCore(LinkCoreInfo),
-
-    /// Make executable; link with the C artifacts of the given list of targets,
-    /// if any.
-    MakeExecutable { link_c_stubs: Vec<BuildTarget> },
-
-    /// Generates the test driver for the given target
-    GenerateTestInfo(BuildTargetInfo),
-
-    /// Format the given target's source files.
-    Format(BuildTargetInfo),
-
-    /// Generate the MBTI file for the given package.
-    GenerateMbti,
-
-    /// Bundle the packages specified by the outgoing edges.
-    Bundle,
-
-    /// Build the runtime library for the speific target
-    BuildRuntimeLib,
-}
-
 /// Represents the environment in which the build is being performed.
 pub struct BuildEnvironment {
     // FIXME: Target backend should go into the solver, not here

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -202,9 +202,9 @@ pub fn build_plan(
     packages: &DiscoverResult,
     build_deps: &DepRelationship,
     build_env: &BuildEnvironment,
-    input: &[BuildPlanNode],
+    input: impl Iterator<Item = BuildPlanNode>,
 ) -> Result<BuildPlan, BuildPlanConstructError> {
-    info!("Constructing build plan with {} input nodes", input.len());
+    info!("Constructing build plan");
     debug!(
         "Build environment: backend={:?}, opt_level={:?}",
         build_env.target_backend, build_env.opt_level
@@ -257,7 +257,10 @@ impl<'a> BuildPlanConstructor<'a> {
         self.res
     }
 
-    fn build(&mut self, input: &[BuildPlanNode]) -> Result<(), BuildPlanConstructError> {
+    fn build(
+        &mut self,
+        input: impl Iterator<Item = BuildPlanNode>,
+    ) -> Result<(), BuildPlanConstructError> {
         assert!(
             self.pending.is_empty(),
             "Pending nodes should be empty before starting the build"
@@ -265,9 +268,9 @@ impl<'a> BuildPlanConstructor<'a> {
 
         // Add the input node to the pending list
         for i in input {
-            self.need_node(*i);
+            self.need_node(i);
+            self.res.input_nodes.push(i);
         }
-        self.res.input_nodes.extend_from_slice(input);
 
         while let Some(node) = self.pending.pop() {
             // check if the node is already resolved

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -608,6 +608,12 @@ impl<'a> BuildPlanConstructor<'a> {
             },
         );
 
+        // Native backends also needs a runtime library
+        if self.build_env.target_backend.is_native() {
+            let rt_node = self.need_node(BuildPlanNode::BuildRuntimeLib);
+            self.add_edge(make_exec_node, rt_node);
+        }
+
         self.resolved_node(make_exec_node);
 
         Ok(())

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -41,13 +41,14 @@ use log::{debug, info, trace};
 use moonutil::{
     common::TargetBackend,
     cond_expr::{OptLevel, ParseCondExprError},
+    mooncakes::ModuleId,
 };
 use petgraph::{prelude::DiGraphMap, visit::DfsPostOrder};
 
 use crate::{
     cond_comp::{self, CompileCondition},
     discover::DiscoverResult,
-    model::{BuildPlanNode, BuildTarget, TargetAction, TargetKind},
+    model::{BuildPlanNode, BuildTarget, TargetKind},
     pkg_solve::DepRelationship,
 };
 
@@ -182,9 +183,9 @@ pub struct BuildEnvironment {
 #[derive(Debug, thiserror::Error)]
 pub enum BuildPlanConstructError {
     // TODO: This parsing should be moved earlier into the pipeline
-    #[error("Error when parsing conditional compilation expression of {node:?}: {err}")]
+    #[error("Error when parsing conditional compilation expression of {target:?}: {err}")]
     ParseCondExprError {
-        node: BuildPlanNode,
+        target: BuildTarget,
         err: ParseCondExprError,
     },
 }
@@ -275,18 +276,11 @@ impl<'a> BuildPlanConstructor<'a> {
     /// new node. To deduplicate pending nodes, this should be called before
     /// adding relevant edges to the graph (since the latter will also add the
     /// node into the graph).
-    fn need_node(&mut self, node: BuildPlanNode) {
+    fn need_node(&mut self, node: BuildPlanNode) -> BuildPlanNode {
         if !self.res.spec.contains_key(&node) {
             self.pending.push(node);
             self.res.graph.add_node(node);
         }
-    }
-
-    /// Tell the build graph that we need to calculate the graph portion of a
-    /// new node, and return that node for later usage. See [`Self::need_node`].
-    fn need(&mut self, target: BuildTarget, action: TargetAction) -> BuildPlanNode {
-        let node = BuildPlanNode { target, action };
-        self.need_node(node);
         node
     }
 
@@ -317,28 +311,31 @@ impl<'a> BuildPlanConstructor<'a> {
         &mut self,
         node: BuildPlanNode,
     ) -> Result<(), BuildPlanConstructError> {
-        match node.action {
-            TargetAction::Check => self.build_check(node),
-            TargetAction::Build => self.build_build(node),
-            TargetAction::BuildCStubs => self.build_build_c_stubs(node),
-            TargetAction::LinkCore => {
+        match node {
+            BuildPlanNode::Check(target) => self.build_check(node, target),
+            BuildPlanNode::BuildCore(target) => self.build_build(node, target),
+            BuildPlanNode::BuildCStubs(target) => self.build_build_c_stubs(node, target),
+            BuildPlanNode::LinkCore(_) => {
                 panic!(
                     "Link core should not appear in the wild without \
                     accompanied by MakeExecutable. Anytime it is met in the \
                     pending list, it should be already resolved."
                 )
             }
-            TargetAction::MakeExecutable => self.build_make_exec_link_core(node),
-            TargetAction::GenerateTestInfo => self.build_gen_test_info(node),
+            BuildPlanNode::MakeExecutable(target) => self.build_make_exec_link_core(node, target),
+            BuildPlanNode::GenerateTestInfo(target) => self.build_gen_test_info(node, target),
+            BuildPlanNode::Format(target) => self.build_format(node, target),
+            BuildPlanNode::Bundle(module_id) => self.build_bundle(node, module_id),
+            BuildPlanNode::BuildRuntimeLib => self.build_runtime_lib(node),
         }
     }
 
     fn target_info_of(
         &self,
-        node: BuildPlanNode,
+        target: BuildTarget,
     ) -> Result<BuildTargetInfo, BuildPlanConstructError> {
         // Resolve the source files
-        let source_files = self.resolve_mbt_files_for_node(node)?;
+        let source_files = self.resolve_mbt_files_for_node(target)?;
         Ok(BuildTargetInfo {
             files: source_files,
             // is_main: pkg.raw.is_main,
@@ -346,24 +343,32 @@ impl<'a> BuildPlanConstructor<'a> {
         })
     }
 
-    fn build_check(&mut self, node: BuildPlanNode) -> Result<(), BuildPlanConstructError> {
+    fn build_check(
+        &mut self,
+        node: BuildPlanNode,
+        target: BuildTarget,
+    ) -> Result<(), BuildPlanConstructError> {
         // Check depends on `.mi` of all dependencies, which practically
         // means the Check of all dependencies.
         for dep in self
             .build_deps
             .dep_graph
-            .neighbors_directed(node.target, petgraph::Direction::Outgoing)
+            .neighbors_directed(target, petgraph::Direction::Outgoing)
         {
-            let dep_node = self.need(dep, TargetAction::Check);
+            let dep_node = self.need_node(BuildPlanNode::Check(dep));
             self.add_edge(node, dep_node);
         }
 
-        self.resolved_node(node, BuildActionSpec::Check(self.target_info_of(node)?));
+        self.resolved_node(node, BuildActionSpec::Check(self.target_info_of(target)?));
 
         Ok(())
     }
 
-    fn build_build(&mut self, node: BuildPlanNode) -> Result<(), BuildPlanConstructError> {
+    fn build_build(
+        &mut self,
+        node: BuildPlanNode,
+        target: BuildTarget,
+    ) -> Result<(), BuildPlanConstructError> {
         // Build depends on `.mi`` of all dependencies. Although Check can
         // also emit `.mi` files, since we're building, this action actually
         // means we need to build all dependencies.
@@ -371,63 +376,71 @@ impl<'a> BuildPlanConstructor<'a> {
         for dep in self
             .build_deps
             .dep_graph
-            .neighbors_directed(node.target, petgraph::Direction::Outgoing)
+            .neighbors_directed(target, petgraph::Direction::Outgoing)
         {
-            let dep_node = self.need(dep, TargetAction::Build);
+            let dep_node = self.need_node(BuildPlanNode::BuildCore(dep));
             self.add_edge(node, dep_node);
         }
 
         // If the given target is a test, we will also need to generate the test driver.
-        if node.target.kind.is_test() {
-            let gen_test_info = BuildPlanNode {
-                action: TargetAction::GenerateTestInfo,
-                ..node
-            };
+        if target.kind.is_test() {
+            let gen_test_info = BuildPlanNode::GenerateTestInfo(target);
             self.need_node(gen_test_info);
             self.add_edge(node, gen_test_info);
         }
 
-        self.resolved_node(node, BuildActionSpec::BuildMbt(self.target_info_of(node)?));
+        self.resolved_node(
+            node,
+            BuildActionSpec::BuildMbt(self.target_info_of(target)?),
+        );
 
         Ok(())
     }
 
-    fn build_gen_test_info(&mut self, node: BuildPlanNode) -> Result<(), BuildPlanConstructError> {
+    fn build_gen_test_info(
+        &mut self,
+        node: BuildPlanNode,
+        target: BuildTarget,
+    ) -> Result<(), BuildPlanConstructError> {
         self.need_node(node);
-        let target_info = self.target_info_of(node)?; // FIXME: cache this
+        let target_info = self.target_info_of(target)?; // FIXME: cache this
         self.resolved_node(node, BuildActionSpec::GenerateTestDriver(target_info));
         Ok(())
     }
 
     fn resolve_mbt_files_for_node(
         &self,
-        node: BuildPlanNode,
+        target: BuildTarget,
     ) -> Result<Vec<PathBuf>, BuildPlanConstructError> {
         // FIXME: Should we resolve test drivers' paths, or should we leave it
         // in the lowering phase? The path to the test driver depends on the
         // artifact layout, so we might not be able to do that here, unless we
         // add some kind of `SpecialFile::TestDriver` or something.
-        let pkg = self.packages.get_package(node.target.package);
+        let pkg = self.packages.get_package(target.package);
         let source_files = cond_comp::filter_files(
             &pkg.raw,
             &pkg.root_path,
             pkg.source_files.iter().map(|x| x.as_path()),
             &CompileCondition {
                 optlevel: self.build_env.opt_level,
-                test_kind: node.target.kind.into(),
+                test_kind: target.kind.into(),
                 backend: self.build_env.target_backend,
             },
         )
-        .map_err(|err| BuildPlanConstructError::ParseCondExprError { node, err })?;
+        .map_err(|err| BuildPlanConstructError::ParseCondExprError { target, err })?;
         Ok(source_files)
     }
 
-    fn build_build_c_stubs(&mut self, node: BuildPlanNode) -> Result<(), BuildPlanConstructError> {
+    fn build_build_c_stubs(
+        &mut self,
+        node: BuildPlanNode,
+        target: BuildTarget,
+    ) -> Result<(), BuildPlanConstructError> {
         // Depends on nothing, but anyway needs to be inserted into the graph.
         self.need_node(node);
 
         // Resolve the C stub files
-        let pkg = self.packages.get_package(node.target.package);
+        let pkg = self.packages.get_package(target.package);
         let c_source = pkg.c_stub_files.clone();
         self.resolved_node(node, BuildActionSpec::BuildC(c_source));
 
@@ -445,6 +458,7 @@ impl<'a> BuildPlanConstructor<'a> {
     fn build_make_exec_link_core(
         &mut self,
         make_exec_node: BuildPlanNode,
+        target: BuildTarget,
     ) -> Result<(), BuildPlanConstructError> {
         /*
             Link-core requires traversing all output of the current package's
@@ -461,13 +475,10 @@ impl<'a> BuildPlanConstructor<'a> {
                 TODO: virtual packages are not yet implemented here.
         */
 
-        debug!(
-            "Building MakeExecutable for target: {:?}",
-            make_exec_node.target
-        );
+        debug!("Building MakeExecutable for target: {:?}", target);
         debug!("Performing DFS post-order traversal to collect dependencies");
         // This DFS is shared by both LinkCore and MakeExecutable actions.
-        let mut dfs = DfsPostOrder::new(&self.build_deps.dep_graph, make_exec_node.target);
+        let mut dfs = DfsPostOrder::new(&self.build_deps.dep_graph, target);
         // This is the link core sources
         let mut link_core_deps = IndexSet::new();
         // This is the C stub sources
@@ -498,15 +509,12 @@ impl<'a> BuildPlanConstructor<'a> {
             }
         }
 
-        let link_core_node = self.need(make_exec_node.target, TargetAction::LinkCore);
+        let link_core_node = self.need_node(BuildPlanNode::LinkCore(target));
 
         // Add edges to all dependencies
         // Note that we have already replaced unnecessary dependencies
         for target in &link_core_deps {
-            let dep_node = BuildPlanNode {
-                target: *target,
-                action: TargetAction::Build,
-            };
+            let dep_node = BuildPlanNode::BuildCore(*target);
             self.need_node(dep_node);
             self.add_edge(link_core_node, dep_node);
         }
@@ -523,7 +531,7 @@ impl<'a> BuildPlanConstructor<'a> {
 
         // Add dependencies of make exec
         for target in &c_stub_deps {
-            let dep_node = self.need(*target, TargetAction::BuildCStubs);
+            let dep_node = self.need_node(BuildPlanNode::BuildCStubs(*target));
             self.add_edge(make_exec_node, dep_node);
         }
         self.resolved_node(
@@ -534,5 +542,25 @@ impl<'a> BuildPlanConstructor<'a> {
         );
 
         Ok(())
+    }
+
+    fn build_format(
+        &mut self,
+        _node: BuildPlanNode,
+        _target: BuildTarget,
+    ) -> Result<(), BuildPlanConstructError> {
+        todo!("Handle formatting node")
+    }
+
+    fn build_bundle(
+        &mut self,
+        _node: BuildPlanNode,
+        _module_id: ModuleId,
+    ) -> Result<(), BuildPlanConstructError> {
+        todo!()
+    }
+
+    fn build_runtime_lib(&mut self, _node: BuildPlanNode) -> Result<(), BuildPlanConstructError> {
+        todo!()
     }
 }

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -16,15 +16,17 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 
 use log::{debug, info};
-use moonutil::{common::TargetBackend, cond_expr::OptLevel};
+use moonutil::{
+    common::TargetBackend, compiler_flags::CompilerPaths, cond_expr::OptLevel, moon_dir::MOON_DIRS,
+};
 
 use crate::{
     build_lower,
     build_plan::{self, BuildEnvironment},
-    model::{Artifacts, BuildPlanNode},
+    model::{Artifacts, BuildPlanNode, OperatingSystem},
     resolve::ResolveOutput,
 };
 
@@ -114,6 +116,9 @@ pub fn compile(
         opt_level: cx.opt_level,
         debug_symbols: cx.debug_symbols,
         stdlib_path: cx.stdlib_path.clone(),
+        compiler_paths: CompilerPaths::from_moon_dirs(), // change to external
+        os: OperatingSystem::from_str(std::env::consts::OS).expect("Unknown"),
+        runtime_dot_c_path: MOON_DIRS.moon_lib_path.join("runtime.c"), // FIXME: don't calculate here
     };
     let res = build_lower::lower_build_plan(
         &cx.resolve_output.pkg_dirs,

--- a/crates/moonbuild-rupes-recta/src/cond_comp.rs
+++ b/crates/moonbuild-rupes-recta/src/cond_comp.rs
@@ -149,6 +149,7 @@ fn check_test_suffix(stripped: &str, test_kind: Option<TestKind>) -> bool {
     #[allow(clippy::match_like_matches_macro)] // This is more readable
     match (test_kind, file_test_spec) {
         (None, NoTest) => true,
+        (Some(TestKind::Inline), NoTest) => true,
         (Some(TestKind::Whitebox), NoTest | Whitebox) => true,
         (Some(TestKind::Blackbox), Blackbox) => true,
         _ => false,

--- a/crates/moonbuild-rupes-recta/src/lib.rs
+++ b/crates/moonbuild-rupes-recta/src/lib.rs
@@ -106,6 +106,7 @@ pub mod compile;
 pub mod resolve;
 
 // Random utilities
+mod special_cases;
 pub mod util;
 
 // Reexports

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -94,6 +94,7 @@ pub enum BuildPlanNode {
     MakeExecutable(BuildTarget),
     GenerateTestInfo(BuildTarget),
     Format(BuildTarget),
+    GenerateMbti(BuildTarget),
     Bundle(ModuleId),
     BuildRuntimeLib,
 }
@@ -132,7 +133,8 @@ impl BuildPlanNode {
             | BuildPlanNode::LinkCore(target)
             | BuildPlanNode::MakeExecutable(target)
             | BuildPlanNode::GenerateTestInfo(target)
-            | BuildPlanNode::Format(target) => Some(target),
+            | BuildPlanNode::Format(target)
+            | BuildPlanNode::GenerateMbti(target) => Some(target),
             BuildPlanNode::Bundle(_) | BuildPlanNode::BuildRuntimeLib => None,
         }
     }

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -34,18 +34,6 @@ pub enum RunAction {
     Test,
 }
 
-/// Represents the actions performed on a single build target.
-#[deprecated]
-#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum TargetAction {
-    Check,
-    Build,
-    BuildCStubs,
-    LinkCore,
-    MakeExecutable,
-    GenerateTestInfo,
-}
-
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum TargetKind {
     Source,

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -146,3 +146,39 @@ pub struct Artifacts {
     pub node: BuildPlanNode,
     pub artifacts: Vec<PathBuf>,
 }
+
+/// Supported operating systems for artifact generation
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperatingSystem {
+    Windows,
+    Linux,
+    MacOS,
+    /// No operating system (e.g., WASM/JS targets)
+    None,
+}
+
+impl std::fmt::Display for OperatingSystem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            OperatingSystem::Windows => "windows",
+            OperatingSystem::Linux => "linux",
+            OperatingSystem::MacOS => "macos",
+            OperatingSystem::None => "none",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl std::str::FromStr for OperatingSystem {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "windows" => Ok(OperatingSystem::Windows),
+            "linux" => Ok(OperatingSystem::Linux),
+            "macos" => Ok(OperatingSystem::MacOS),
+            "none" => Ok(OperatingSystem::None),
+            _ => Err(format!("Unsupported OS: {}", s)),
+        }
+    }
+}

--- a/crates/moonbuild-rupes-recta/src/pkg_name.rs
+++ b/crates/moonbuild-rupes-recta/src/pkg_name.rs
@@ -69,6 +69,15 @@ impl std::fmt::Display for PackageFQN {
     }
 }
 
+/// Compare a package FQN to a tuple of (username, module, package)
+impl<'a> PartialEq<(&'a str, &'a str, &'a str)> for PackageFQN {
+    fn eq(&self, &(user, module, package): &(&'a str, &'a str, &'a str)) -> bool {
+        self.module.name().username == user
+            && self.module.name().unqual == module
+            && self.package.as_str() == package
+    }
+}
+
 /// Write a package FQN to a formatter given module and package parts
 pub fn write_package_fqn_to<W: std::fmt::Write>(
     f: &mut W,

--- a/crates/moonbuild-rupes-recta/src/pkg_name.rs
+++ b/crates/moonbuild-rupes-recta/src/pkg_name.rs
@@ -131,6 +131,52 @@ impl From<PackageFQN> for PackageFQNWithSource {
     }
 }
 
+/// An optional wrapper around [`PackageFQNWithSource`] that displays "unknown" when None.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OptionalPackageFQNWithSource {
+    inner: Option<PackageFQNWithSource>,
+}
+
+impl OptionalPackageFQNWithSource {
+    /// Create a new optional package FQN with source from an Option.
+    pub fn new(inner: Option<PackageFQNWithSource>) -> Self {
+        Self { inner }
+    }
+
+    /// Create from an optional PackageFQN.
+    pub fn from_optional_fqn(fqn: Option<PackageFQN>) -> Self {
+        Self {
+            inner: fqn.map(PackageFQNWithSource::from_fqn),
+        }
+    }
+
+    /// Get the inner optional PackageFQNWithSource.
+    pub fn inner(&self) -> &Option<PackageFQNWithSource> {
+        &self.inner
+    }
+}
+
+impl std::fmt::Display for OptionalPackageFQNWithSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.inner {
+            Some(fqn) => write!(f, "{}", fqn),
+            None => write!(f, "unknown"),
+        }
+    }
+}
+
+impl From<Option<PackageFQNWithSource>> for OptionalPackageFQNWithSource {
+    fn from(inner: Option<PackageFQNWithSource>) -> Self {
+        Self::new(inner)
+    }
+}
+
+impl From<Option<PackageFQN>> for OptionalPackageFQNWithSource {
+    fn from(fqn: Option<PackageFQN>) -> Self {
+        Self::from_optional_fqn(fqn)
+    }
+}
+
 /// An unqualified package path, representing the non-module portion of the
 /// package. For example, the `builtin` in `moonbitlang/core/builtin`.
 /// This path may contain multiple segments (like `immut/linked_list`), or zero

--- a/crates/moonbuild-rupes-recta/src/special_cases.rs
+++ b/crates/moonbuild-rupes-recta/src/special_cases.rs
@@ -1,0 +1,73 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! A place **dedicated** for identifying special cases in building.
+//!
+//! Although the special case handlers themselves are better living in the
+//! relevant modules, we should keep alls special case identifiers here to
+//! keep them in one place for easier maintenance.
+#![allow(unused)]
+
+use crate::{model::PackageId, ResolveOutput};
+
+// string segments
+const MOONBIT: &str = "moonbitlang";
+const CORE: &str = "core";
+const ABORT: &str = "abort";
+const BUILTIN: &str = "builtin";
+const COVERAGE: &str = "coverage";
+
+/// Libraries that should not be tested
+const SKIP_TEST_LIBS: &[(&str, &str, &str)] = &[(MOONBIT, CORE, ABORT)];
+/// Libraries that should not be covered
+const SKIP_COVERAGE_LIBS: &[(&str, &str, &str)] = &[(MOONBIT, CORE, ABORT)];
+/// Libraries that should use themselves for coverage
+const SELF_COVERAGE_LIBS: &[(&str, &str, &str)] =
+    &[(MOONBIT, CORE, BUILTIN), (MOONBIT, CORE, COVERAGE)];
+
+fn name_matches(
+    package_id: PackageId,
+    resolve_output: &ResolveOutput,
+    target: (&str, &str, &str),
+) -> bool {
+    let pkg = resolve_output.pkg_dirs.get_package(package_id);
+    let fqn = &pkg.fqn;
+    *fqn == target
+}
+
+pub fn should_skip_tests(package_id: PackageId, resolve_output: &ResolveOutput) -> bool {
+    SKIP_TEST_LIBS
+        .iter()
+        .any(|&target| name_matches(package_id, resolve_output, target))
+}
+
+pub fn should_skip_coverage(package_id: PackageId, resolve_output: &ResolveOutput) -> bool {
+    SKIP_COVERAGE_LIBS
+        .iter()
+        .any(|&target| name_matches(package_id, resolve_output, target))
+}
+
+pub fn is_self_coverage_lib(package_id: PackageId, resolve_output: &ResolveOutput) -> bool {
+    SELF_COVERAGE_LIBS
+        .iter()
+        .any(|&target| name_matches(package_id, resolve_output, target))
+}
+
+pub fn is_builtin_lib(package_id: PackageId, resolve_output: &ResolveOutput) -> bool {
+    name_matches(package_id, resolve_output, (MOONBIT, CORE, BUILTIN))
+}

--- a/crates/moonbuild-rupes-recta/src/special_cases.rs
+++ b/crates/moonbuild-rupes-recta/src/special_cases.rs
@@ -18,10 +18,15 @@
 
 //! A place **dedicated** for identifying special cases in building.
 //!
-//! Although the special case handlers themselves are better living in the
-//! relevant modules, we should keep alls special case identifiers here to
-//! keep them in one place for easier maintenance.
+//! Although the special case handlers themselves may be better living in the
+//! relevant modules, we should at least keep all special case identifiers here
+//! to keep them in one place for easier maintenance.
+//!
+//! Most, if not all, of the special cases are related to `moonbitlang/core`,
+//! the standard library of MoonBit.
 #![allow(unused)]
+
+use moonutil::package::MoonPkg;
 
 use crate::{model::PackageId, ResolveOutput};
 
@@ -31,6 +36,8 @@ const CORE: &str = "core";
 const ABORT: &str = "abort";
 const BUILTIN: &str = "builtin";
 const COVERAGE: &str = "coverage";
+const PRELUDE: &str = "prelude";
+pub const CORE_MODULE: &str = "moonbitlang/core";
 
 /// Libraries that should not be tested
 const SKIP_TEST_LIBS: &[(&str, &str, &str)] = &[(MOONBIT, CORE, ABORT)];
@@ -39,6 +46,23 @@ const SKIP_COVERAGE_LIBS: &[(&str, &str, &str)] = &[(MOONBIT, CORE, ABORT)];
 /// Libraries that should use themselves for coverage
 const SELF_COVERAGE_LIBS: &[(&str, &str, &str)] =
     &[(MOONBIT, CORE, BUILTIN), (MOONBIT, CORE, COVERAGE)];
+
+pub fn module_name_is_core(name: &str) -> bool {
+    name == CORE_MODULE
+}
+
+/// Core packages require importing `prelude` in test imports, or the test will
+/// not be able to run.
+pub fn add_prelude_as_import_for_core(mut pkg_json: MoonPkg) -> MoonPkg {
+    pkg_json
+        .test_imports
+        .push(moonutil::package::Import::Alias {
+            path: "moonbitlang/core/prelude".into(),
+            alias: Some("prelude".into()),
+            sub_package: false,
+        });
+    pkg_json
+}
 
 fn name_matches(
     package_id: PackageId,

--- a/crates/moonbuild-rupes-recta/src/util.rs
+++ b/crates/moonbuild-rupes-recta/src/util.rs
@@ -168,6 +168,7 @@ impl BuildPlanNode {
             BuildPlanNode::GenerateTestInfo(target) => format!("{:?}@GenerateTestInfo", target),
             BuildPlanNode::Format(target) => format!("{:?}@Format", target),
             BuildPlanNode::Bundle(module_id) => format!("{:?}@Bundle", module_id),
+            BuildPlanNode::GenerateMbti(target) => format!("{:?}@GenerateMbti", target),
             BuildPlanNode::BuildRuntimeLib => "BuildRuntimeLib".to_string(),
         }
     }
@@ -206,6 +207,10 @@ impl BuildPlanNode {
                 let src = env.mod_name_from_id(*module_id);
                 format!("{}\\nBundle", src)
             }
+            BuildPlanNode::GenerateMbti(build_target) => {
+                let fqn = packages.fqn(build_target.package);
+                format!("{}\\nGenerateMbti", fqn)
+            }
             BuildPlanNode::BuildRuntimeLib => "BuildRuntimeLib".to_string(),
         }
     }
@@ -220,6 +225,7 @@ impl BuildPlanNode {
             BuildPlanNode::GenerateTestInfo(_) => "lightgray",
             BuildPlanNode::Format(_) => "lavender",
             BuildPlanNode::Bundle(_) => "wheat",
+            BuildPlanNode::GenerateMbti(_) => "lightcyan",
             BuildPlanNode::BuildRuntimeLib => "orange",
         }
     }

--- a/crates/moonbuild-rupes-recta/src/util.rs
+++ b/crates/moonbuild-rupes-recta/src/util.rs
@@ -18,9 +18,9 @@
 
 //! A number of random utilities useful for debugging the project
 
-use crate::build_plan::BuildPlan;
 use crate::discover::DiscoverResult;
 use crate::pkg_solve::DepRelationship;
+use crate::{build_plan::BuildPlan, model::BuildPlanNode};
 use moonutil::mooncakes::result::ResolvedEnv;
 use petgraph::Direction;
 use std::io::{self, Write};
@@ -157,9 +157,78 @@ pub fn print_dep_relationship_dot(
     Ok(())
 }
 
+impl BuildPlanNode {
+    fn gen_node_id(&self) -> String {
+        match self {
+            BuildPlanNode::Check(target) => format!("{:?}@Check", target),
+            BuildPlanNode::BuildCore(target) => format!("{:?}@BuildCore", target),
+            BuildPlanNode::BuildCStubs(target) => format!("{:?}@BuildCStubs", target),
+            BuildPlanNode::LinkCore(target) => format!("{:?}@LinkCore", target),
+            BuildPlanNode::MakeExecutable(target) => format!("{:?}@MakeExecutable", target),
+            BuildPlanNode::GenerateTestInfo(target) => format!("{:?}@GenerateTestInfo", target),
+            BuildPlanNode::Format(target) => format!("{:?}@Format", target),
+            BuildPlanNode::Bundle(module_id) => format!("{:?}@Bundle", module_id),
+            BuildPlanNode::BuildRuntimeLib => "BuildRuntimeLib".to_string(),
+        }
+    }
+
+    fn gen_label(&self, env: &ResolvedEnv, packages: &DiscoverResult) -> String {
+        match self {
+            BuildPlanNode::Check(target) => {
+                let fqn = packages.fqn(target.package);
+                format!("{}\\nCheck", fqn)
+            }
+            BuildPlanNode::BuildCore(target) => {
+                let fqn = packages.fqn(target.package);
+                format!("{}\\nBuildCore", fqn)
+            }
+            BuildPlanNode::BuildCStubs(target) => {
+                let fqn = packages.fqn(target.package);
+                format!("{}\\nBuildCStubs", fqn)
+            }
+            BuildPlanNode::LinkCore(target) => {
+                let fqn = packages.fqn(target.package);
+                format!("{}\\nLinkCore", fqn)
+            }
+            BuildPlanNode::MakeExecutable(target) => {
+                let fqn = packages.fqn(target.package);
+                format!("{}\\nMakeExecutable", fqn)
+            }
+            BuildPlanNode::GenerateTestInfo(target) => {
+                let fqn = packages.fqn(target.package);
+                format!("{}\\nGenerateTestInfo", fqn)
+            }
+            BuildPlanNode::Format(target) => {
+                let fqn = packages.fqn(target.package);
+                format!("{}\\nFormat", fqn)
+            }
+            BuildPlanNode::Bundle(module_id) => {
+                let src = env.mod_name_from_id(*module_id);
+                format!("{}\\nBundle", src)
+            }
+            BuildPlanNode::BuildRuntimeLib => "BuildRuntimeLib".to_string(),
+        }
+    }
+
+    fn gen_color(&self) -> &'static str {
+        match self {
+            BuildPlanNode::Check(_) => "lightblue",
+            BuildPlanNode::BuildCore(_) => "lightgreen",
+            BuildPlanNode::BuildCStubs(_) => "lightyellow",
+            BuildPlanNode::LinkCore(_) => "lightcoral",
+            BuildPlanNode::MakeExecutable(_) => "lightpink",
+            BuildPlanNode::GenerateTestInfo(_) => "lightgray",
+            BuildPlanNode::Format(_) => "lavender",
+            BuildPlanNode::Bundle(_) => "wheat",
+            BuildPlanNode::BuildRuntimeLib => "orange",
+        }
+    }
+}
+
 /// Print a build plan as a DOT graph, showing build nodes and their dependencies
 pub fn print_build_plan_dot(
     build_plan: &BuildPlan,
+    env: &ResolvedEnv,
     packages: &DiscoverResult,
     writer: &mut dyn Write,
 ) -> io::Result<()> {
@@ -169,22 +238,9 @@ pub fn print_build_plan_dot(
 
     // Nodes: use BuildPlanNode debug as ID, label with package FQN, target kind, and action
     for node in build_plan.all_nodes() {
-        let node_id = format!(
-            "{:?}@{:?}@{:?}",
-            node.target.package, node.target.kind, node.action
-        );
-        let fqn = packages.fqn(node.target.package);
-        let label = format!("{}\\n{:?}\\n{:?}", fqn, node.target.kind, node.action);
-
-        // Color nodes based on action type
-        let color = match node.action {
-            crate::model::TargetAction::Check => "lightblue",
-            crate::model::TargetAction::Build => "lightgreen",
-            crate::model::TargetAction::BuildCStubs => "lightyellow",
-            crate::model::TargetAction::LinkCore => "lightcoral",
-            crate::model::TargetAction::MakeExecutable => "lightpink",
-            crate::model::TargetAction::GenerateTestInfo => "lightgray",
-        };
+        let node_id = node.gen_node_id();
+        let label = node.gen_label(env, packages);
+        let color = node.gen_color();
 
         writeln!(
             writer,
@@ -196,14 +252,8 @@ pub fn print_build_plan_dot(
     // Edges: dependencies between build plan nodes
     for node in build_plan.all_nodes() {
         for dep in build_plan.dependency_nodes(node) {
-            let node_id = format!(
-                "{:?}@{:?}@{:?}",
-                node.target.package, node.target.kind, node.action
-            );
-            let dep_id = format!(
-                "{:?}@{:?}@{:?}",
-                dep.target.package, dep.target.kind, dep.action
-            );
+            let node_id = node.gen_node_id();
+            let dep_id = dep.gen_node_id();
             writeln!(writer, "    \"{}\" -> \"{}\";\n", node_id, dep_id)?;
         }
     }

--- a/crates/moonbuild/src/gen/gen_build.rs
+++ b/crates/moonbuild/src/gen/gen_build.rs
@@ -784,7 +784,7 @@ pub fn gen_compile_runtime_command(
         line: 0,
     };
 
-    let cc_cmd = make_cc_command(
+    let cc_cmd = make_cc_command::<&'static str>(
         CC::default(),
         None,
         CCConfigBuilder::default()
@@ -798,7 +798,7 @@ pub fn gen_compile_runtime_command(
             .build()
             .unwrap(),
         &[],
-        &[&runtime_dot_c_path.display().to_string()],
+        &[runtime_dot_c_path.display().to_string()],
         &target_dir.display().to_string(),
         &artifact_output_path.display().to_string(),
     );
@@ -843,7 +843,7 @@ pub fn gen_compile_shared_runtime_command(
         line: 0,
     };
 
-    let cc_cmd = make_cc_command(
+    let cc_cmd = make_cc_command::<&'static str>(
         CC::default(),
         None,
         CCConfigBuilder::default()
@@ -857,7 +857,7 @@ pub fn gen_compile_shared_runtime_command(
             .build()
             .unwrap(),
         &[],
-        &[&runtime_dot_c_path],
+        [runtime_dot_c_path],
         &target_dir.display().to_string(),
         &artifact_output_path.display().to_string(),
     );
@@ -974,7 +974,7 @@ pub fn gen_compile_exe_command(
             .build()
             .unwrap(),
         &native_flags,
-        &sources,
+        sources,
         &target_dir.display().to_string(),
         &artifact_output_path.display().to_string(),
     );
@@ -1248,7 +1248,7 @@ pub fn gen_compile_stub_command(
                 .build()
                 .unwrap(),
             &native_stub_cc_flags,
-            &sources,
+            sources,
             &MOON_DIRS.moon_lib_path.display().to_string(),
             &artifact_output_path,
         );
@@ -1359,7 +1359,7 @@ pub fn gen_link_exe_command(
             .build()
             .unwrap(),
         &native_flags,
-        &sources,
+        sources,
         &PathBuf::from(&item.out)
             .parent()
             .unwrap()

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -805,7 +805,7 @@ pub fn make_cc_command<S>(
     user_cc: Option<CC>,
     config: CCConfig,
     user_cc_flags: &[S],
-    src: &[S],
+    src: impl IntoIterator<Item = impl Into<String>>,
     dest_dir: &str,
     dest: &str,
 ) -> Vec<String>
@@ -829,7 +829,7 @@ pub fn make_cc_command_pure<S>(
     cc: CC,
     config: CCConfig,
     user_cc_flags: &[S],
-    src: &[S],
+    src: impl IntoIterator<Item = impl Into<String>>,
     dest_dir: &str,
     dest: &str,
     paths: &CompilerPaths,
@@ -860,7 +860,7 @@ where
     add_cc_shared_runtime_flags(&cc, &mut buf, &config);
     add_cc_moonbitrun_with_warnings(&cc, &mut buf, &config);
 
-    buf.extend(src.iter().map(|s| s.as_ref().to_string()));
+    buf.extend(src.into_iter().map(|s| s.into()));
 
     add_cc_common_libraries(&cc, &mut buf, &config);
     buf.extend(user_cc_flags.iter().map(|s| s.as_ref().to_string()));


### PR DESCRIPTION
This PR adds build system support for native backend, and fixes a couple issues in test execution.

In order to support native backend, a couple new build plan node types need to be added, in particular `BuildRuntimeLibrary` which has no imports. In return, a refactor around the node type was made to make this change easy. Subsequent refactors remove duplicated build metadata, so different nodes can share the same data.

This PR might still contain some issues related to test execution. In particular, the number of tests executed in `core` is not right -- expected 5290 vs executed 4409. Nevertheless, I think it's about the time to merge a milestone of it to trunk. Next up, it might be time to add integration tests.

## Related Issues

- [x] Related issues: #802

## Type of Pull Request

- [ ] Bug fix
- [x] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - ____
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
