### PR TITLE
Add build statistics display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,6 +1470,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arcstr",
+ "ariadne",
  "base64 0.22.1",
  "chrono",
  "clap",

--- a/crates/moon/tests/test_cases/cond_comp.in/moon.test
+++ b/crates/moon/tests/test_cases/cond_comp.in/moon.test
@@ -72,7 +72,7 @@
      │     ──────────┬─────────  
      │               ╰─────────── Warning: Unused package 'username/hello/lib'
   ───╯
-  Finished. moon: ran 3 tasks, now up to date
+  Finished. moon: ran 3 tasks, now up to date (2 warnings, 0 errors)
   
   $ xcat target/packages.json
   {

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -1433,7 +1433,8 @@ fn test_blackbox_dedup_alias() {
                │     ────────────┬───────────  
                │                 ╰───────────── Warning: Unused package 'username/hello/dir/lib'
             ───╯
-            error: failed when testing
+            Failed with 1 warnings, 1 errors.
+            error: failed when testing project
         "#]],
     );
 }
@@ -2671,7 +2672,7 @@ fn test_pre_build() {
                │     ────┬───  
                │         ╰───── Warning: Unused toplevel variable 'resource'. Note if the body contains side effect, it will not happen. Use `fn init { .. }` to wrap the effect.
             ───╯
-            Finished. moon: ran 2 tasks, now up to date
+            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
     check(
@@ -2684,7 +2685,7 @@ fn test_pre_build() {
                │     ────┬───  
                │         ╰───── Warning: Unused toplevel variable 'resource'. Note if the body contains side effect, it will not happen. Use `fn init { .. }` to wrap the effect.
             ───╯
-            Finished. moon: ran 3 tasks, now up to date
+            Finished. moon: ran 3 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 
@@ -3852,7 +3853,7 @@ fn test_render_diagnostic_in_patch_file() {
                │      ────────────┬────────────  
                │                  ╰────────────── Warning: Unused variable 'unused_in_patch_test_json'
             ───╯
-            Finished. moon: ran 3 tasks, now up to date
+            Finished. moon: ran 3 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
     check(
@@ -3868,7 +3869,7 @@ fn test_render_diagnostic_in_patch_file() {
                │      ─────────────┬─────────────  
                │                   ╰─────────────── Warning: Unused variable 'unused_in_patch_wbtest_json'
             ───╯
-            Finished. moon: ran 2 tasks, now up to date
+            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
     check(
@@ -3881,7 +3882,7 @@ fn test_render_diagnostic_in_patch_file() {
                │      ──────────┬─────────  
                │                ╰─────────── Warning: Unused variable 'unused_in_patch_json'
             ───╯
-            Finished. moon: ran 2 tasks, now up to date
+            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 
@@ -3980,7 +3981,7 @@ fn test_render_diagnostic_in_patch_file() {
                │       }
                │       ```
             ───╯
-            Finished. moon: ran 2 tasks, now up to date
+            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 }
@@ -4563,7 +4564,8 @@ fn test_diag_loc_map() {
                     has type : String
                     wanted   : Int
             ─────╯
-            error: failed when checking
+            Failed with 0 warnings, 1 errors.
+            error: failed when checking project
         "#]],
     );
 }
@@ -4747,7 +4749,7 @@ fn test_run_md_test() {
                 │         ┬  
                 │         ╰── Warning: Unused variable 'a'
             ────╯
-            Finished. moon: ran 3 tasks, now up to date
+            Finished. moon: ran 3 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 
@@ -5335,7 +5337,8 @@ fn test_virtual_pkg() {
                │ ──────────┬──────────  
                │           ╰──────────── Missing implementation for function f2.
             ───╯
-            error: failed when building
+            Failed with 0 warnings, 1 errors.
+            error: failed when building project
         "#]],
     );
 }
@@ -5398,7 +5401,7 @@ fn moon_check_and_test_single_file() {
                    │       ─────┬────  
                    │            ╰────── Warning: Unused variable 'single_mbt'
                 ───╯
-                Finished. moon: ran 2 tasks, now up to date
+                Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
             "#]],
         );
         // abs path
@@ -5412,7 +5415,7 @@ fn moon_check_and_test_single_file() {
                    │       ─────┬────  
                    │            ╰────── Warning: Unused variable 'single_mbt'
                 ───╯
-                Finished. moon: ran 1 task, now up to date
+                Finished. moon: ran 1 task, now up to date (1 warnings, 0 errors)
             "#]],
         );
     }
@@ -5496,7 +5499,7 @@ fn moon_check_and_test_single_file() {
                    │       ────┬────  
                    │           ╰────── Warning: Unused variable 'with_main'
                 ───╯
-                Finished. moon: ran 1 task, now up to date
+                Finished. moon: ran 1 task, now up to date (1 warnings, 0 errors)
             "#]],
         );
         let without_main = dir.join("without_main.mbt").display().to_string();
@@ -5517,7 +5520,7 @@ fn moon_check_and_test_single_file() {
                    │       ──────┬─────  
                    │             ╰─────── Warning: Unused variable 'without_main'
                 ───╯
-                Finished. moon: ran 1 task, now up to date
+                Finished. moon: ran 1 task, now up to date (2 warnings, 0 errors)
             "#]],
         );
     }
@@ -5619,7 +5622,7 @@ fn test_in_main_pkg() {
                │       ┬  
                │       ╰── Warning: Unused variable 'a'
             ───╯
-            Finished. moon: ran 6 tasks, now up to date
+            Finished. moon: ran 6 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 
@@ -5676,7 +5679,7 @@ fn merge_doc_test_and_md_test() {
                │           ───────────┬──────────  
                │                      ╰──────────── Warning: Unused variable 'unused_in_lib_doc_test'
             ───╯
-            Finished. moon: ran 3 tasks, now up to date
+            Finished. moon: ran 3 tasks, now up to date (2 warnings, 0 errors)
         "#]],
     );
 

--- a/crates/moon/tests/test_cases/warns/mod.rs
+++ b/crates/moon/tests/test_cases/warns/mod.rs
@@ -219,7 +219,7 @@ fn test_deny_warn() {
                │       ┬  
                │       ╰── Warning: Unused variable 'a'
             ───╯
-            Finished. moon: ran 2 tasks, now up to date
+            Finished. moon: ran 2 tasks, now up to date (4 warnings, 0 errors)
         "#]],
     );
 
@@ -261,7 +261,7 @@ fn test_deny_warn() {
                │       ┬  
                │       ╰── Warning: Unused variable 'a'
             ───╯
-            Finished. moon: ran 3 tasks, now up to date
+            Finished. moon: ran 3 tasks, now up to date (4 warnings, 0 errors)
         "#]],
     );
 

--- a/crates/moonbuild/Cargo.toml
+++ b/crates/moonbuild/Cargo.toml
@@ -68,6 +68,7 @@ base64.workspace = true
 shlex.workspace = true
 serde_json.workspace = true
 regex.workspace = true
+ariadne.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true


### PR DESCRIPTION
Upon build process finish, `moon` will report the statistic of warnings & errors

```
Finished. moon: ran 1 task, now up to date (1 warnings, 0 errors)
```
```
Finished. moon: no work to do (1 warnings, 0 errors)
```
```
Failed with 5 warnings, 100 errors.
error: failed to build project
```

If the result has no warning AND no error, the message will not be displayed, like

```
Finished. moon: no work to do
```

## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [ ] Bug fix
- [x] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - see above
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
