### PR TITLE
chore: warning for username and print final cakename

### DIFF
--- a/crates/moon/tests/test_cases/moon_new/mod.rs
+++ b/crates/moon/tests/test_cases/moon_new/mod.rs
@@ -161,7 +161,7 @@ fn test_moon_new_exist() {
         ["new", "hello", "--user", "moonbitlang", "--name", "hello"],
     );
 
-    assert!(res.contains("Created hello"));
+    assert!(res.contains("Created moonbitlang/hello at hello"));
     assert!(res.contains("Initialized empty Git repository"));
 
     snapbox::cmd::Command::new(moon_bin())

--- a/crates/moonbuild/src/new.rs
+++ b/crates/moonbuild/src/new.rs
@@ -61,7 +61,7 @@ pub fn moon_new_default(target_dir: &Path, user: String, name: String) -> anyhow
             is_main: Some(true),
             import: Some(moonutil::package::PkgJSONImport::List(vec![
                 PkgJSONImportItem::Object {
-                    path: cake_full_name,
+                    path: cake_full_name.clone(),
                     alias: Some("lib".to_string()),
                     sub_package: None,
                     value: None,
@@ -146,7 +146,12 @@ pub fn moon_new_default(target_dir: &Path, user: String, name: String) -> anyhow
         moonutil::common::write_package_json_to_file(&j, &lib_moon_pkg)?;
     }
 
-    println!("{} {}", "Created".bold().green(), target_dir.display());
+    println!(
+        "{} {} at {}",
+        "Created".bold().green(),
+        cake_full_name,
+        target_dir.display()
+    );
 
     Ok(0)
 }


### PR DESCRIPTION
## Related Issues

- [x] Related issues: #975

## Type of Pull Request

- [ ] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [x] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - The message after `moon new` is changed to show the generated mooncake name
  - The warning messages are printed if username is missing
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
