### PR TITLE
fix: print warning instead of fail during moon new

### DIFF
--- a/crates/moonbuild/src/new.rs
+++ b/crates/moonbuild/src/new.rs
@@ -216,14 +216,24 @@ fn common(target_dir: &Path, cake_full_name: &str) -> anyhow::Result<i32> {
 
         #[cfg(unix)]
         {
-            std::os::unix::fs::symlink("README.mbt.md", &readme_file)
-                .context("failed to create symbolic link to README.mbt.md")?;
+            if let Err(e) = std::os::unix::fs::symlink("README.mbt.md", &readme_file) {
+                eprintln!(
+                    "{} failed to create symbolic link to README.mbt.md. {}",
+                    "Warning:".bold().yellow(),
+                    e
+                );
+            }
         }
 
         #[cfg(windows)]
         {
-            std::os::windows::fs::symlink_file("README.mbt.md", &readme_file)
-                .context("failed to create symbolic link to README.mbt.md")?;
+            if let Err(e) = std::os::windows::fs::symlink_file("README.mbt.md", &readme_file) {
+                eprintln!(
+                    "{} failed to create symbolic link to README.mbt.md. You may need to enable developer mode or have administrator privileges. {}",
+                    "Warning:".bold().yellow(),
+                    e
+                );
+            }
         }
     }
     // Agents.md


### PR DESCRIPTION
## Related Issues

- [x] Related issues: #975

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - When symbolic creation failed, it will only print error message instead of crash
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
