### PR TITLE
Reduce blast radius of builtin FQN stripping to `builtin` itself

### DIFF
--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -19,8 +19,8 @@
 use anyhow::{bail, Context};
 use moonutil::cli::UniversalFlags;
 use moonutil::common::{
-    DriverKind, MooncGenTestInfo, TargetBackend, MOONBITLANG_CORE, MOON_TEST_DELIMITER_BEGIN,
-    MOON_TEST_DELIMITER_END,
+    DriverKind, MooncGenTestInfo, TargetBackend, MOONBITLANG_CORE_BUILTIN,
+    MOON_TEST_DELIMITER_BEGIN, MOON_TEST_DELIMITER_END,
 };
 use std::ffi::OsStr;
 use std::io::{Read, Write};
@@ -335,8 +335,8 @@ fn generate_driver(
         .replace("{END_MOONTEST}", MOON_TEST_DELIMITER_END)
         .replace("// {COVERAGE_END}", &coverage_end_template);
 
-    if pkgname.starts_with(MOONBITLANG_CORE) {
-        template.replace(&format!("@{MOONBITLANG_CORE}/builtin."), "")
+    if pkgname == MOONBITLANG_CORE_BUILTIN {
+        template.replace(&format!("@{MOONBITLANG_CORE_BUILTIN}."), "")
     } else {
         template
     }

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -40,6 +40,7 @@ pub const MBTI_GENERATED: &str = "pkg.generated.mbti";
 pub const MBTI_USER_WRITTEN: &str = "pkg.mbti";
 pub const MOON_PID_NAME: &str = ".moon.pid";
 pub const MOONBITLANG_CORE: &str = "moonbitlang/core";
+pub const MOONBITLANG_CORE_BUILTIN: &str = "moonbitlang/core/builtin";
 pub const MOONBITLANG_COVERAGE: &str = "moonbitlang/core/coverage";
 pub const MOONBITLANG_ABORT: &str = "moonbitlang/core/abort";
 


### PR DESCRIPTION
Fixes #988 

The test driver needs to use a number of standard library types. It uses their fully-qualified names (like `@moonbitlang/core/builtin.Map`) to prevent clashing with local type names. However, the test driver generator explicitly excludes the standard library itself for FQN-ing. This behavior has caused troubles when standard library types shadows builtin types with the same name. See #988 for more info.

This PR reduces the no-FQN behavior to just `@moonbitlang/core/builtin` itself, so that in other standard library packages, types can use the same type name as `builtin`, like `@moonbitlang/core/immut/hashmap.Map`.

## Note

I have tried an alternative approach of completely removing the type annotation. However, since test drivers may encounter cases where zero test are included, the type checker cannot deduce the type in this case and will result in a compilation error.

## Related Issues

- [x] Related issues: #988

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - Non-`moonbitlang/core/builtin` packages will not strip out the `@moonbitlang/core/builtin` qualification of types.
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
