### PR TITLE
chore: Ignore generated files in test dir

### DIFF
--- a/crates/moon/tests/test_cases/pre_build.in/.gitignore
+++ b/crates/moon/tests/test_cases/pre_build.in/.gitignore
@@ -1,2 +1,5 @@
 target/
 .mooncakes/
+src/lib/a.mbt
+src/lib/b.mbt
+src/lib/c.mbt

--- a/crates/moon/tests/test_cases/prebuild/moonlex/.gitignore
+++ b/crates/moon/tests/test_cases/prebuild/moonlex/.gitignore
@@ -1,2 +1,3 @@
 target/
 .mooncakes/
+src/main/fortytwolexer.mbt


### PR DESCRIPTION
This PR is a spinoff of #802's main progress.

This PR ignores the files that might be created during `moon check`ing of the test case projects. The `moon check` might be triggered by AI coding tools, causing clutter in the repo that should not be comitted.
