### PR TITLE
fix: pass cli options to publish

### DIFF
--- a/crates/moon/src/cli/mooncake_adapter.rs
+++ b/crates/moon/src/cli/mooncake_adapter.rs
@@ -86,7 +86,11 @@ pub fn register_cli(cli: UniversalFlags, cmd: RegisterSubcommand) -> anyhow::Res
 }
 
 pub fn publish_cli(cli: UniversalFlags, cmd: PublishSubcommand) -> anyhow::Result<i32> {
-    execute_cli_with_inherit_stdin(cli, MooncakeSubcommands::Publish(cmd), &["publish"])
+    execute_cli(
+        cli,
+        MooncakeSubcommands::Publish(cmd),
+        &["--read-args-from-stdin"],
+    )
 }
 
 pub fn package_cli(cli: UniversalFlags, cmd: PackageSubcommand) -> anyhow::Result<i32> {


### PR DESCRIPTION
## Related Issues

- [x] Related issues: #641

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - Currently, the flags for `moon publish` are not passed correctly to mooncake. This PR fixes the issue
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [x] Manually tested
- [x] Compatible with Windows/Linux/macOS
