### PR TITLE
fix: update deny warn list

### DIFF
--- a/crates/moon/tests/test_cases/warns/mod.rs
+++ b/crates/moon/tests/test_cases/warns/mod.rs
@@ -226,7 +226,7 @@ fn test_deny_warn() {
     check(
         get_err_stdout(&dir, ["check", "--deny-warn", "--sort-input"]),
         expect![[r#"
-            failed: moonc check -error-format json -w @a-31-32 -alert @all-raise-throw-unsafe+deprecated $ROOT/lib/hello.mbt -o $ROOT/target/wasm-gc/release/check/lib/lib.mi -pkg username/hello/lib -std-path $MOON_HOME/lib/core/target/wasm-gc/release/bundle -pkg-sources username/hello/lib:$ROOT/lib -target wasm-gc
+            failed: moonc check -error-format json -w @a-31-32 -alert @all-raise-throw-unsafe-test_import_all+deprecated $ROOT/lib/hello.mbt -o $ROOT/target/wasm-gc/release/check/lib/lib.mi -pkg username/hello/lib -std-path $MOON_HOME/lib/core/target/wasm-gc/release/bundle -pkg-sources username/hello/lib:$ROOT/lib -target wasm-gc
         "#]],
     );
 
@@ -268,7 +268,7 @@ fn test_deny_warn() {
     check(
         get_err_stdout(&dir, ["build", "--deny-warn", "--sort-input"]),
         expect![[r#"
-            failed: moonc build-package -error-format json -w @a-31-32 -alert @all-raise-throw-unsafe+deprecated $ROOT/lib/hello.mbt -o $ROOT/target/wasm-gc/release/build/lib/lib.core -pkg username/hello/lib -std-path $MOON_HOME/lib/core/target/wasm-gc/release/bundle -pkg-sources username/hello/lib:$ROOT/lib -target wasm-gc
+            failed: moonc build-package -error-format json -w @a-31-32 -alert @all-raise-throw-unsafe-test_import_all+deprecated $ROOT/lib/hello.mbt -o $ROOT/target/wasm-gc/release/build/lib/lib.core -pkg username/hello/lib -std-path $MOON_HOME/lib/core/target/wasm-gc/release/bundle -pkg-sources username/hello/lib:$ROOT/lib -target wasm-gc
         "#]],
     );
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/mod.rs
@@ -177,6 +177,6 @@ pub(crate) const MOONC_REGULAR_WARNING_SET: &str = "+a-31-32";
 pub(crate) const MOONC_REGULAR_ALERT_SET: &str = "+all-raise-throw-unsafe+deprecated";
 
 pub(crate) const MOONC_DENY_WARNING_SET: &str = "@a-31-32";
-pub(crate) const MOONC_DENY_ALERT_SET: &str = "@all-raise-throw-unsafe+deprecated";
+pub(crate) const MOONC_DENY_ALERT_SET: &str = "@all-raise-throw-unsafe-test_import_all+deprecated";
 pub(crate) const MOONC_ALLOW_WARNING_SET: &str = "-a";
 pub(crate) const MOONC_ALLOW_ALERT_SET: &str = "-all";

--- a/crates/moonbuild/src/gen/gen_build.rs
+++ b/crates/moonbuild/src/gen/gen_build.rs
@@ -516,7 +516,7 @@ pub fn gen_build_command(
                 "-w",
                 "@a-31-32",
                 "-alert",
-                "@all-raise-throw-unsafe+deprecated",
+                "@all-raise-throw-unsafe-test_import_all+deprecated",
             ],
         )
         .args(&item.mbt_deps)

--- a/crates/moonbuild/src/gen/gen_check.rs
+++ b/crates/moonbuild/src/gen/gen_check.rs
@@ -544,7 +544,7 @@ pub fn gen_check_command(
                 "-w",
                 "@a-31-32",
                 "-alert",
-                "@all-raise-throw-unsafe+deprecated",
+                "@all-raise-throw-unsafe-test_import_all+deprecated",
             ],
         )
         .args(&item.mbt_deps)


### PR DESCRIPTION
Update deny warn list to latest moonc.

This is a temporary solution; we will need to add a "deny all open warnings" option in moonc.

# Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [ ] Yes (please describe the changes below)
  - ____
- [x] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [x] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
