### PR TITLE
add test for `moon bench`

### DIFF
--- a/crates/moon/tests/test_cases/moon_bench/lib/hello_bench.mbt
+++ b/crates/moon/tests/test_cases/moon_bench/lib/hello_bench.mbt
@@ -1,24 +1,24 @@
 // bench w/o BenchError raised
 ///|
-test "bench" (it : @test.T) {
+test "bench" (it : @bench.T) {
   ignore(it)
 }
 
 // non-bench with BenchError raised
 ///|
-test "non-bench" (it : @test.T) {
-  it.bench!(fn() { ignore(42) })
+test "non-bench" (it : @bench.T) {
+  it.bench(fn() { ignore(42) })
 }
 
 // bench with BenchError raised
 ///|
-test "bench" (it : @test.T) {
-  it.bench!(fn() {  })
+test "bench" (it : @bench.T) {
+  it.bench(fn() {  })
 }
 
 // fib bench
 ///|
-test "bench: naive fib" (it : @test.T) {
+test "bench: naive fib" (it : @bench.T) {
   let n = 20
   fn f(n : Int) {
     if n < 2 {
@@ -27,7 +27,7 @@ test "bench: naive fib" (it : @test.T) {
     f(n - 1) + f(n - 2)
   }
 
-  it.bench!(fn() { f(n) |> ignore })
+  it.bench(fn() { f(n) |> ignore })
 }
 
 // non-bench w/o BenchError raised

--- a/crates/moon/tests/test_cases/moon_bench/mod.rs
+++ b/crates/moon/tests/test_cases/moon_bench/mod.rs
@@ -1,1 +1,7 @@
+use super::*;
 
+#[test]
+fn test_bench_driver_build() {
+    let dir = TestDir::new("moon_bench");
+    check(get_stderr(&dir, ["bench", "--build-only"]), expect![""]);
+}


### PR DESCRIPTION
Add test for `moon bench --build-only`, so that we can detect build failure and warnings in the benchmark driver. This PR only tests `--build-only` because the result of actually running `moon bench` is unstable, so testing that part may require some clever post processing on the output.