### PR TITLE
ci: Run CI nightly to match the nightly compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 20 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
We don't have commits in this repo everyday, so it's hard to know when a compiler change breaks the toolchain. Running CI every day after the nightly compiler release would help with the observability. This is currently set to 4am Beijing Time, please suggest otherwise.

## Related Issues

- [ ] Related issues: #____

## Type of Pull Request

- [ ] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [x] Other (please describe): CI

## Does this PR change existing behavior?

- [ ] Yes (please describe the changes below)
  - ____
- [x] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [ ] ~Tests added/updated for bug fixes or new features~
- [ ] ~Compatible with Windows/Linux/macOS~
