### PR TITLE
[Rupes Recta] Revert `moon fmt` behavior back to cached

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
@@ -239,8 +239,12 @@ impl LegacyLayout {
         result
     }
 
-    /// The *artifact* of the format operation. This should be only for the
-    /// temporary output of a format-diff operation.
+    /// The *artifact* of the format operation.
+    ///
+    /// At the time of writing, it should only be used as a stamp file to
+    /// indicate that formatting has been done. However, due to the way
+    /// `moonfmt` works, it actually produces a formatted copy of the input file
+    /// at this path.
     pub fn format_artifact_path(&self, pkg: &PackageFQN, filename: &OsStr) -> PathBuf {
         let mut result = self.target_base_dir.clone();
         self.push_package_dir_no_backend(&mut result, pkg);

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -45,7 +45,7 @@ mod lower_aux;
 mod lower_build;
 mod utils;
 
-pub use utils::{build_ins, build_n2_fileloc, build_phony_out};
+pub use utils::{build_ins, build_n2_fileloc, build_outs};
 
 use crate::build_lower::artifact::LegacyLayoutBuilder;
 use context::BuildPlanLowerContext;

--- a/crates/moonbuild-rupes-recta/src/build_lower/utils.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/utils.rs
@@ -59,20 +59,6 @@ pub fn build_outs(
     }
 }
 
-pub fn build_phony_out(
-    graph: &mut N2Graph,
-    paths: impl IntoIterator<Item = impl AsRef<Path>>,
-) -> BuildOuts {
-    let file_ids: Vec<_> = paths
-        .into_iter()
-        .map(|x| register_file(graph, x.as_ref()))
-        .collect();
-    BuildOuts {
-        explicit: 0,
-        ids: file_ids,
-    }
-}
-
 /// Create a dummy [`FileLoc`] for the given file name. This is a little bit
 /// wasteful in terms of memory usage, but should do the job.
 pub fn build_n2_fileloc(name: impl Into<PathBuf>) -> FileLoc {


### PR DESCRIPTION
Closes #1063 

Previously `moon fmt` was designed to run the formatter for every file; this has become a bottleneck in perf, so we revert it back to the legacy behavior.


## Related Issues

- [x] Related issues: #1063


## Type of Pull Request

- [x] Bug fix
- [ ] New feature
    - [ ] I have already discussed this feature with the maintainers.
- [ ] Refactor
- [ ] Performance optimization
- [ ] Documentation
- [ ] Other (please describe):

## Does this PR change existing behavior?

- [x] Yes (please describe the changes below)
  - ____
- [ ] No

## Does this PR introduce new dependencies?

- [x] No
- [ ] Yes (please check binary size changes)

## Checklist:

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
