### PR TITLE
Add footer for unstable feature flags enabled in `moon version`

### DIFF
--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -118,7 +118,7 @@ pub fn main() {
         Update(u) => cli::update_cli(flags, u),
         Upgrade(u) => cli::run_upgrade(flags, u),
         ShellCompletion(gs) => cli::gen_shellcomp(&flags, gs),
-        Version(v) => cli::run_version(v),
+        Version(v) => cli::run_version(&flags, v),
         Tool(v) => cli::run_tool(v),
         External(args) => cli::run_external(args),
     };


### PR DESCRIPTION
Added footer so that people will know what feature flags they have enabled. If no  were enabled, the output is the same as the current one.

```console
$ moon version --all
moon 0.1.20251014 (8194e6c5 2025-10-14) ~/.moon/bin/moon
moonc v0.6.28+9cc043db5-nightly (2025-10-12) ~/.moon/bin/moonc
moonrun 0.1.20251011 (cc4f4e7 2025-10-11) ~/.moon/bin/moonrun
moon-pilot 0.0.1-81125f2 (2025-10-12) ~/.moon/bin/moon-pilot

$ NEW_MOON=1 moon version --all
moon 0.1.20251014 (8194e6c5 2025-10-14) ~/.moon/bin/moon
moonc v0.6.28+9cc043db5-nightly (2025-10-12) ~/.moon/bin/moonc
moonrun 0.1.20251011 (cc4f4e7 2025-10-11) ~/.moon/bin/moonrun
moon-pilot 0.0.1-81125f2 (2025-10-12) ~/.moon/bin/moon-pilot

Feature flags enabled: rupes_recta
-> You're currently using the experimental build graph generator "Rupes Recta" (`-Z rupes_recta` or `NEW_MOON=1` set). If you encounter a problem, please verify whether it also reproduces with the legacy build.

$ NEW_MOON=1 moon version
moon 0.1.20251014 (8194e6c5 2025-10-14)

Feature flags enabled: rupes_recta
-> You're currently using the experimental build graph generator "Rupes Recta" (`-Z rupes_recta` or `NEW_MOON=1` set). If you encounter a problem, please verify whether it also reproduces with the legacy build.
```