### PR TITLE
make test driver compatible with future API change in `moonbitlang/async`

### DIFF
--- a/crates/moonbuild/template/test_driver/async.mbt
+++ b/crates/moonbuild/template/test_driver/async.mbt
@@ -8,7 +8,17 @@ fn moonbit_test_driver_internal_run_async_test(
   on_err~ : (Error) -> Unit
 ) -> Unit {
   let it = moonbit_test_driver_internal_new_test_arg(name)
-  ctx.spawn_bg(() => f(it)) catch { err => on_err(err) }
+  try {
+    // Currently, `spawn_bg` may raise error in `moonbitlang/async`.
+    // However, this error is intended to be removed.
+    // So we need to make sure the code here is compatible with
+    // both the old version and new version.
+    if true {
+      ctx.spawn_bg(() => f(it))
+    } else {
+      raise Failure("")
+    }
+  } catch { err => on_err(err) }
 }
 
 fn moonbit_test_driver_internal_run_async_main(


### PR DESCRIPTION
related: https://github.com/moonbitlang/async/pull/130

The above planned API change in `moonbitlang/async` will break test driver with "the body of this try expression never raise any error" warning, because the `spawn_bg` API no longer raises error. This PR modifies the async test driver, so that the compiler doesn't report any warning no matter `spawn_bg` raise error or not. We may remove the hack in this PR after the `moonbitlang/async` PR is merged and released.

Since the change in this PR concerns two specific version of `moonbitlang/async`, it is hard to test it in CI. I tested this PR locally with both versions of `moonbitlang/async` and it works without problem.