### PR TITLE
Fix `moon bundle` logic in RR

### DIFF
--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -144,6 +144,9 @@ pub fn run_bundle_internal_rr(
     } else {
         let _lock = FileLock::lock(target_dir)?;
 
+        // Generate metadata for IDE & bundler
+        rr_build::generate_metadata(source_dir, target_dir, &_build_meta)?;
+
         let result = rr_build::execute_build(
             &BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature),
             build_graph,


### PR DESCRIPTION
- `moon bundle --all` didn't work
- `moon bundle` should generate metadata to feed to the IDE & tools

Atop #1096, #1097.

