### PR TITLE
fix(rr): Correct behavior of gen-test-driver

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/gen_test_driver.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/gen_test_driver.rs
@@ -65,32 +65,6 @@ pub struct MoonGenTestDriver<'a> {
     pub patch_file: Option<Cow<'a, Path>>,
 }
 
-impl<'a> MoonGenTestDriver<'a> {
-    /// Create a new instance with only necessary fields populated, others as default
-    pub fn new(
-        files: &'a [PathBuf],
-        output_driver: impl Into<Cow<'a, Path>>,
-        output_metadata: impl Into<Cow<'a, Path>>,
-        target_backend: TargetBackend,
-        pkg_name: &'a str,
-        driver_kind: DriverKind,
-    ) -> Self {
-        Self {
-            files,
-            doctest_only_files: &[],
-            output_driver: output_driver.into(),
-            output_metadata: output_metadata.into(),
-            target_backend,
-            pkg_name,
-            bench: false,
-            enable_coverage: false,
-            coverage_package_override: None,
-            driver_kind,
-            patch_file: None,
-        }
-    }
-}
-
 impl<'a> CmdlineAbstraction for MoonGenTestDriver<'a> {
     fn to_args(&self, args: &mut Vec<String>) {
         args.push("generate-test-driver".into());

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -66,15 +66,21 @@ impl<'a> super::BuildPlanLowerContext<'a> {
         } else {
             info.files().map(|x| x.to_owned()).collect::<Vec<_>>()
         };
+        let patch_file = info.patch_file.as_deref().map(|x| x.into());
 
-        let cmd = compiler::MoonGenTestDriver::new(
-            &files_vec,
-            output_driver,
-            output_metadata,
-            self.opt.target_backend,
-            &pkg_full_name,
+        let cmd = compiler::MoonGenTestDriver {
+            files: &files_vec,
+            doctest_only_files: &info.doctest_files,
+            output_driver: output_driver.into(),
+            output_metadata: output_metadata.into(),
+            bench: false, // TODO
+            enable_coverage: self.opt.enable_coverage,
+            coverage_package_override: None, // TODO,
             driver_kind,
-        );
+            target_backend: self.opt.target_backend,
+            patch_file,
+            pkg_name: &pkg_full_name,
+        };
 
         BuildCommand {
             commandline: cmd.build_command("moon"),


### PR DESCRIPTION
The previous implementation used a constructor and forgot to initialize a number of important fields, which caused this problem.

Fixes https://github.com/moonbitlang/moon/issues/1104

The result behavior is correct as of now.

```
Running `target/debug/moon -Z rupes_recta -C /home/rynco/Projects/core test`
Total tests: 5736, passed: 5736, failed: 0.
```
