### PR TITLE
fix(rr): `moonc check` with 3rd party packages. Unused stale field.

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/build_common.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/build_common.rs
@@ -241,7 +241,7 @@ impl<'a> BuildCommonConfig<'a> {
     }
 
     /// Add warning/alert deny all arguments (combined)
-    pub fn add_warn_alert_deny_all_combined(&self, args: &mut Vec<String>) {
+    pub fn add_deny_all(&self, args: &mut Vec<String>) {
         if self.deny_warn {
             args.extend([
                 "-w".to_string(),

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/build_package.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/build_package.rs
@@ -55,7 +55,7 @@ impl<'a> MooncBuildPackage<'a> {
         self.defaults.add_error_format(args);
 
         // Warning and alert handling
-        self.defaults.add_warn_alert_deny_all_combined(args);
+        self.defaults.add_deny_all(args);
 
         // Input files
         self.required.add_mbt_sources(args);

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/check.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/check.rs
@@ -37,7 +37,6 @@ pub struct MooncCheck<'a> {
     pub defaults: BuildCommonConfig<'a>,
     pub mi_out: Cow<'a, Path>,
 
-    pub is_third_party: bool,
     pub single_file: bool,
 }
 
@@ -57,7 +56,7 @@ impl<'a> MooncCheck<'a> {
         self.defaults.add_error_format(args);
 
         // Warning and alert handling (deny all combined)
-        self.defaults.add_warn_alert_deny_all_combined(args);
+        self.defaults.add_deny_all(args);
 
         // MBT source files
         self.required.add_mbt_sources(args);
@@ -70,16 +69,7 @@ impl<'a> MooncCheck<'a> {
 
         // Custom warning/alert lists
         self.defaults.add_custom_warn_alert_lists(args);
-
-        // Third-party package handling
-        if self.is_third_party {
-            args.extend([
-                "-w".to_string(),
-                "-a".to_string(),
-                "-alert".to_string(),
-                "-all".to_string(),
-            ]);
-        }
+        self.defaults.add_warn_alert_allow_all(args);
 
         // Output
         args.extend(["-o".to_string(), self.mi_out.display().to_string()]);

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -213,7 +213,6 @@ impl<'a> BuildPlanLowerContext<'a> {
             ),
             defaults: self.set_build_commons(package, info, is_main),
             mi_out: mi_output.into(),
-            is_third_party: false,
             single_file: false,
         };
 


### PR DESCRIPTION
This is a blind spot of the initial LLM-based commandline abstraction.

Closes #1087 