### PR TITLE
Simplify issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,43 +3,36 @@ name: Bug report
 about: Create a bug report for moon.
 title: ''
 assignees: ''
-labels: bug
+labels:
+  - bug
+  - pending-triage
 ---
 
-# Bug Report
+<!-- A brief summary if possible -->
 
-## Environment
+## Actual behavior
 
-### OS
-
-Operating System: ____
-
-<!--
-e.g. Linux, Windows, macOS
--->
-
-### MoonBit CLI Tools Version
-
-<!--
-Please copy and paste the output of `moon version --all` below.
--->
-
-```
-
-```
-
-## Steps to Reproduce
-
-<!-- Provide the steps to reproduce the bug.
--->
+<!-- What has happened? What's going wrong?
+Paste logs and/or screenshots here -->
 
 ## Expected Behavior
 
-<!-- Describe what you expected to happen. -->
+<!-- What should happen instead? -->
 
-## Actual Behavior
+## Steps to Reproduce
 
-<!-- Describe what actually happened. Include screenshots or logs if applicable. -->
+<!-- How to trigger it? Does it happen every time? -->
+
+## Environment
+
+Operating System: <!-- Linux/Windows/Mac/(specify) -->
+
+<!-- Please copy and paste the output of `moon version --all` below. -->
+
+```
+
+```
 
 ## Checklist
+
 - [ ] (Optional) My case is minimal enough to be reproducible.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,20 +6,25 @@ assignees: ''
 labels: feature request
 ---
 
+<!--
+    NOTE
 
-# Feature Request
+    While we appreciate all feature requests, please understand that not all
+    requests can be accepted. Providing detailed information will help us better
+    evaluate your suggestion.
+-->
 
-**Note:** While we appreciate all feature requests, please understand that not all requests can be accepted. Providing detailed information will help us better evaluate your suggestion.
-
-## Summary
+<!-- A brief summary of what you want to add. -->
 
 ## Motivation
 
-<!-- Describe the problem or use case that this feature would address. Why is this feature important to you or your team? -->
+<!-- Describe the problem or use case that this feature would address. Why is
+this feature important to you or your team? -->
 
 ## Detailed Description
 
-<!-- Provide a detailed description of the feature. Include any relevant details, diagrams, or examples to help illustrate the feature. -->
+<!-- Provide a detailed description of the feature. Include any relevant
+details, diagrams, or examples to help illustrate the feature. -->
 
 ## Related Issues
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,11 @@
-## Related Issues
+- Related issues: None <!-- write issue numbers here -->
+- PR kind: <!-- Bugfix, feature, refactor, optimization, ... -->
 
-- [ ] Related issues: #____
+## Summary
 
-## Type of Pull Request
+<!-- A brief summary of what the PR does -->
 
-- [ ] Bug fix
-- [ ] New feature
-    - [ ] I have already discussed this feature with the maintainers.
-- [ ] Refactor
-- [ ] Performance optimization
-- [ ] Documentation
-- [ ] Other (please describe):
-
-## Does this PR change existing behavior?
-
-- [x] Yes (please describe the changes below)
-  - ____
-- [ ] No
-
-## Does this PR introduce new dependencies?
-
-- [x] No
-- [ ] Yes (please check binary size changes)
-
-## Checklist:
+## Metadata
 
 - [ ] Tests added/updated for bug fixes or new features
 - [ ] Compatible with Windows/Linux/macOS


### PR DESCRIPTION
Nobody writes them cleanly so we're better off just use simpler templates.

TODO: maybe use the github form variant?