### PR TITLE
feat: Add system api to get single environment variable and check whether it is exists

### DIFF
--- a/crates/moonrun/src/sys_api.rs
+++ b/crates/moonrun/src/sys_api.rs
@@ -92,6 +92,30 @@ fn unset_env_var(
     ret.set_undefined()
 }
 
+fn get_env_var(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut ret: v8::ReturnValue,
+) {
+    let key = args.get(0);
+    let key = key.to_string(scope).unwrap();
+    let key = key.to_rust_string_lossy(scope);
+    let value = std::env::var(&key).unwrap_or_default();
+    let value = v8::String::new(scope, &value).unwrap();
+    ret.set(value.into());
+}
+
+fn get_env_var_exists(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut ret: v8::ReturnValue,
+) {
+    let key = args.get(0);
+    let key = key.to_string(scope).unwrap();
+    let key = key.to_rust_string_lossy(scope);
+    ret.set_bool(std::env::var(key).is_ok());
+}
+
 fn get_env_vars(
     scope: &mut v8::HandleScope,
     _args: v8::FunctionCallbackArguments,
@@ -147,6 +171,16 @@ pub fn init_env<'s>(
     let get_env_vars = get_env_vars.get_function(scope).unwrap();
     let ident = v8::String::new(scope, "get_env_vars").unwrap();
     obj.set(scope, ident.into(), get_env_vars.into());
+
+    let get_env_var = v8::FunctionTemplate::new(scope, get_env_var);
+    let get_env_var = get_env_var.get_function(scope).unwrap();
+    let ident = v8::String::new(scope, "get_env_var").unwrap();
+    obj.set(scope, ident.into(), get_env_var.into());
+
+    let get_env_var_exists = v8::FunctionTemplate::new(scope, get_env_var_exists);
+    let get_env_var_exists = get_env_var_exists.get_function(scope).unwrap();
+    let ident = v8::String::new(scope, "get_env_var_exists").unwrap();
+    obj.set(scope, ident.into(), get_env_var_exists.into());
 
     obj
 }


### PR DESCRIPTION
- Related issues: moonbitlang/x#127
- PR kind: Feature <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

This is the fundamental feature in order to fix/optimize moonbitlang/x#127 when targeting WASM platform, which provides system api to get a single environmental variable and check whether the environmental variable is exists. There's also a PR related to this at moonbitlang/x#201.

Already tested with test code above:
```
❯ moon test -p moonbitlang/x/sys -f sys_test.mbt -i 0 --target js
Warning: [0029]
   ╭─[ /Users/stevexmh/Documents/programs/x/sys/internal/ffi/moon.pkg.json:4:19 ]
   │
 4 │           "path": "moonbitlang/x/internal/ffi",
   │                   ──────────────┬─────────────  
   │                                 ╰─────────────── Warning: Unused package 'moonbitlang/x/internal/ffi'
───╯
Warning: [0029]
   ╭─[ /Users/stevexmh/Documents/programs/x/sys/internal/ffi/moon.pkg.json:5:20 ]
   │
 5 │           "alias": "common_ffi"
   │                    ──────┬─────  
   │                          ╰─────── Warning: Unused package alias 'common_ffi'
───╯
Total tests: 1, passed: 1, failed: 0.
❯ moon test -p moonbitlang/x/sys -f sys_test.mbt -i 0 --target wasm
Total tests: 1, passed: 1, failed: 0.
❯ moon test -p moonbitlang/x/sys -f sys_test.mbt -i 0 --target wasm-gc
Total tests: 1, passed: 1, failed: 0.
❯ moon test -p moonbitlang/x/sys -f sys_test.mbt -i 0 --target native
Total tests: 1, passed: 1, failed: 0.
```

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
