### PR TITLE
simplify async test driver

### DIFF
--- a/crates/moon/tests/test_cases/moon_test/dummy_async_impl/async.mbt
+++ b/crates/moon/tests/test_cases/moon_test/dummy_async_impl/async.mbt
@@ -1,10 +1,8 @@
 ///|
 struct TaskGroup[X] {
   mut result : X?
+  mut err : Error?
 }
-
-///|
-suberror AlreadyTerminated
 
 ///|
 suberror Unfinished
@@ -13,29 +11,25 @@ suberror Unfinished
 pub fn[X] TaskGroup::spawn_bg(
   self : TaskGroup[X],
   f : async () -> Unit,
-) -> Unit raise {
-  if self.result is Some(_) {
-    raise AlreadyTerminated
-  }
+) -> Unit {
+  guard not(self.result is Some(_))
   let mut done = false
-  let mut err = None
   run_async(fn() {
-    f() catch { e => err = Some(e) } 
+    f() catch { e => self.err = Some(e) } 
     done = true
   })
-  if err is Some(err) {
-    raise err
-  } else if not(done) {
-    raise Unfinished
-  }
+  guard done
 }
 
 ///|
 pub async fn[X] with_task_group(
   f : async (TaskGroup[X]) -> X,
 ) -> X raise {
-  let group = { result: None }
+  let group = { result: None, err: None }
   group.result = Some(f(group))
+  if group.err is Some(err) {
+    raise err
+  }
   guard group.result is Some(result)
   result
 }

--- a/crates/moonbuild/template/test_driver/async.mbt
+++ b/crates/moonbuild/template/test_driver/async.mbt
@@ -4,20 +4,9 @@ fn moonbit_test_driver_internal_run_async_test(
   ctx : Moonbit_Test_Driver_Internal_Async_Context,
   name : String,
   f : async (Moonbit_Test_Driver_Internal_Test_Arg) -> Unit raise,
-  on_err~ : (Error) -> Unit
 ) -> Unit {
   let it = moonbit_test_driver_internal_new_test_arg(name)
-  try {
-    // Currently, `spawn_bg` may raise error in `moonbitlang/async`.
-    // However, this error is intended to be removed.
-    // So we need to make sure the code here is compatible with
-    // both the old version and new version.
-    if true {
-      ctx.spawn_bg(() => f(it))
-    } else {
-      raise Failure("")
-    }
-  } catch { err => on_err(err) }
+  ctx.spawn_bg(() => f(it))
 }
 
 fn moonbit_test_driver_internal_run_async_main(

--- a/crates/moonbuild/template/test_driver/no_async.mbt
+++ b/crates/moonbuild/template/test_driver/no_async.mbt
@@ -4,9 +4,7 @@ fn moonbit_test_driver_internal_run_async_test(
   _ctx : Moonbit_Test_Driver_Internal_Async_Context,
   _name : String,
   _f : async (Moonbit_Test_Driver_Internal_Test_Arg) -> Unit raise,
-  on_err~ : (Error) -> Unit,
 ) -> Unit {
-  ignore(on_err)
   panic()
 }
 

--- a/crates/moonbuild/template/test_driver/test_driver_template.mbt
+++ b/crates/moonbuild/template/test_driver/test_driver_template.mbt
@@ -187,7 +187,6 @@ pub fn moonbit_test_driver_internal_do_execute(
           moonbit_test_driver_internal_run_async_test(
             async_ctx,
             name,
-            on_err~,
             fn(arg) {
               try f(arg) catch {
                 err => on_err(err)


### PR DESCRIPTION
In the latest release of `moonbitlang/async`, with https://github.com/moonbitlang/async/pull/130 merged, the `TaskGroup::spawn_bg` method no longer raises error. This PR migrates the async test driver to adapt for this change, removing the `try` block around `spawn_bg`.