### PR TITLE
Skip .mi output when compiling test

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -224,7 +224,8 @@ impl<'a> BuildPlanLowerContext<'a> {
                     FileDependencyKind::BuildCore { mi, core } => (mi, core),
                     _ => (true, true),
                 };
-                if mi && !(info.check_mi_against.is_some() || info.no_mi()) {
+                if mi && info.check_mi_against.is_none() && !info.no_mi() && !target.kind.is_test()
+                {
                     out.push(self.layout.mi_of_build_target(
                         self.packages,
                         &target,


### PR DESCRIPTION
- Related issues: #1154  <!-- write issue numbers here -->
- PR kind: Bugfix <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

Closes #1154 

The issue was caused by tests announcing their `.mi` as output without actually generating them.

<!-- A brief summary of what the PR does -->

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
