### PR TITLE
Fix `--watch` change list

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -117,7 +117,7 @@ fn run_build_internal(
     };
 
     if cmd.watch {
-        watching(f, source_dir, target_dir, target_dir)
+        watching(f, source_dir, source_dir, target_dir)
     } else {
         f()
     }

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -240,7 +240,7 @@ fn run_check_normal_internal(
                 actual_target.display()
             )
         })?;
-        watching(f, source_dir, &actual_target, target_dir)
+        watching(f, source_dir, source_dir, &actual_target)
     } else {
         f()
     }


### PR DESCRIPTION
- Related issues: #1155  <!-- write issue numbers here -->
- PR kind: Bugfix <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

Caused by `.mooncakes` syncing involving a lockfile to avoid racing condition, but that triggers a filesystem change.

<!-- A brief summary of what the PR does -->

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
