### PR TITLE
Fix: virtual package should not generate mbti

### DIFF
--- a/crates/moonbuild-rupes-recta/src/intent.rs
+++ b/crates/moonbuild-rupes-recta/src/intent.rs
@@ -142,7 +142,7 @@ impl UserIntent {
             }
             UserIntent::Info(pkg) => {
                 let pkg_info = resolved.pkg_dirs.get_package(pkg);
-                if !pkg_info.is_virtual_impl() {
+                if !pkg_info.is_virtual_impl() || pkg_info.is_virtual() {
                     out.push(BuildPlanNode::GenerateMbti(
                         pkg.build_target(TargetKind::Source),
                     ));


### PR DESCRIPTION
- Related issues: #1172  <!-- write issue numbers here -->
- PR kind: Bugfix <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

Closes #1172 

RR accidentally generates mbti for virtual packages due to a missing condition.

<!-- A brief summary of what the PR does -->

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
