### PR TITLE
fix(rr): Topo sort packages in moonc bundle

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -98,19 +98,19 @@ impl<'a> super::BuildPlanLowerContext<'a> {
         let output = self
             .layout
             .bundle_result_path(self.opt.target_backend, module.name());
+        let info = self
+            .build_plan
+            .bundle_info(module_id)
+            .expect("Bundle info should be present when lowering bundle node");
 
         let mut inputs = vec![];
-        for dep in self.build_plan.dependency_nodes(node) {
-            let BuildPlanNode::BuildCore(package) = dep else {
-                panic!("Bundle node can only depend on BuildCore nodes");
-            };
+        for dep in info.bundle_targets.iter() {
             inputs.push(self.layout.core_of_build_target(
                 self.packages,
-                &package,
+                dep,
                 self.opt.target_backend,
             ));
         }
-        inputs.sort();
 
         let cmd = compiler::MooncBundleCore::new(&inputs, output);
 

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -301,7 +301,14 @@ impl<'a> BuildPlanConstructor<'a> {
                 );
             }
             BuildPlanNode::GenerateMbti(_build_target) => (),
-            BuildPlanNode::Bundle(_module_id) => (),
+            BuildPlanNode::Bundle(module_id) => {
+                assert!(
+                    self.res.bundle_info.contains_key(&module_id),
+                    "Bundle info for module {:?} should be present when resolving node {:?}",
+                    module_id,
+                    node
+                );
+            }
             BuildPlanNode::BuildRuntimeLib => (),
             BuildPlanNode::BuildDocs => (),
             BuildPlanNode::RunPrebuild(pkg, idx) => {


### PR DESCRIPTION
- Related issues: #1164  <!-- write issue numbers here -->
- PR kind: Bugfix <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

`moonc bundle-core` requires the input in topo order, while the RR backend previously just sorted by name. This PR fixes the issue.


Closes #1164

<!-- A brief summary of what the PR does -->

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
