### PR TITLE
fix: block SIGCHLD only on macOS

### DIFF
--- a/crates/moon/src/run/child.rs
+++ b/crates/moon/src/run/child.rs
@@ -22,7 +22,7 @@ use std::process::{ExitStatus, Stdio};
 
 use anyhow::Context;
 use moonbuild::section_capture::{SectionCapture, handle_stdout_async};
-use moonutil::platform::unix_with_sigchild_blocked;
+use moonutil::platform::macos_with_sigchild_blocked;
 use tokio::process::Command;
 
 /// Run a command under the governing of `moon run`.
@@ -63,7 +63,7 @@ pub async fn run<'a>(
     cmd.kill_on_drop(true); // to prevent zombie processes;
 
     // Preventing race conditions with SIGCHLD handlers, see definition for info
-    let mut child = unix_with_sigchild_blocked(|| {
+    let mut child = macos_with_sigchild_blocked(|| {
         cmd.spawn()
             .with_context(|| format!("Failed to spawn command {:?}", cmd))
     })?;

--- a/crates/moonbuild/src/runtest.rs
+++ b/crates/moonbuild/src/runtest.rs
@@ -29,7 +29,7 @@ use moonutil::common::{
 };
 use moonutil::module::ModuleDB;
 use moonutil::moon_dir::MOON_DIRS;
-use moonutil::platform::unix_with_sigchild_blocked;
+use moonutil::platform::macos_with_sigchild_blocked;
 use n2::load::State;
 use serde::{Deserialize, Serialize};
 use std::{path::Path, process::Stdio};
@@ -154,7 +154,7 @@ async fn run(
         eprintln!("{:?}", subprocess.as_std());
     }
 
-    let mut execution = unix_with_sigchild_blocked(|| {
+    let mut execution = macos_with_sigchild_blocked(|| {
         subprocess
             .stdin(Stdio::null())
             .stdout(Stdio::piped())

--- a/crates/moonutil/src/platform.rs
+++ b/crates/moonutil/src/platform.rs
@@ -24,8 +24,8 @@
 /// Related tokio issue:
 /// - https://github.com/tokio-rs/tokio/issues/6770
 /// - https://github.com/tokio-rs/tokio/pull/6953
-#[cfg(unix)]
-pub fn unix_with_sigchild_blocked<T>(f: impl FnOnce() -> T) -> T {
+#[cfg(target_os = "macos")]
+pub fn macos_with_sigchild_blocked<T>(f: impl FnOnce() -> T) -> T {
     // block SIGCHLD to avoid race condition with spawn and signal handler registration
     unsafe {
         let mut mask: libc::sigset_t = std::mem::zeroed();
@@ -43,7 +43,7 @@ pub fn unix_with_sigchild_blocked<T>(f: impl FnOnce() -> T) -> T {
     res
 }
 
-#[cfg(not(unix))]
-pub fn unix_with_sigchild_blocked<T>(f: impl FnOnce() -> T) -> T {
+#[cfg(not(target_os = "macos"))]
+pub fn macos_with_sigchild_blocked<T>(f: impl FnOnce() -> T) -> T {
     f()
 }


### PR DESCRIPTION
- Related issues:
  - https://github.com/moonbitlang/maria/issues/255
  - https://github.com/moonbitlang/moon/pull/1156
- PR kind: Bugfix

## Summary

We should only block sigchild on macOS - blocking it on Linux will cause moon test hangs when the test spawns child processes.

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
