### PR TITLE
fix(rr): `mooninfo` condition wrong

### DIFF
--- a/crates/moonbuild-rupes-recta/src/intent.rs
+++ b/crates/moonbuild-rupes-recta/src/intent.rs
@@ -142,7 +142,7 @@ impl UserIntent {
             }
             UserIntent::Info(pkg) => {
                 let pkg_info = resolved.pkg_dirs.get_package(pkg);
-                if !pkg_info.is_virtual_impl() || pkg_info.is_virtual() {
+                if !(pkg_info.is_virtual_impl() || pkg_info.is_virtual()) {
                     out.push(BuildPlanNode::GenerateMbti(
                         pkg.build_target(TargetKind::Source),
                     ));


### PR DESCRIPTION
- Related issues: #1144  <!-- write issue numbers here -->
- PR kind: Bugfix <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

A wrong condition was put into `moon info` that accidentally enabled virtual packages' `.mbti` files

<!-- A brief summary of what the PR does -->

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
