### PR TITLE
fix(rr): When bundling core, `packages.json` should refer to `bundle` dir

### DIFF
--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -145,7 +145,7 @@ pub fn run_bundle_internal_rr(
         let _lock = FileLock::lock(target_dir)?;
 
         // Generate metadata for IDE & bundler
-        rr_build::generate_metadata(source_dir, target_dir, &_build_meta)?;
+        rr_build::generate_metadata(source_dir, target_dir, &_build_meta, RunMode::Bundle)?;
 
         let result = rr_build::execute_build(
             &BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature),

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -318,7 +318,7 @@ fn run_check_normal_internal_rr(
         let _lock = FileLock::lock(target_dir)?;
 
         // Generate metadata for IDE
-        rr_build::generate_metadata(source_dir, target_dir, &build_meta)?;
+        rr_build::generate_metadata(source_dir, target_dir, &build_meta, RunMode::Check)?;
 
         let mut cfg = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature);
         cfg.patch_file = cmd.patch_file.clone();

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -102,7 +102,7 @@ pub fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Result<i32
 
     // Generate metadata for `moondoc`
     let _lock = FileLock::lock(&target_dir)?;
-    rr_build::generate_metadata(&source_dir, &target_dir, &_build_meta)?;
+    rr_build::generate_metadata(&source_dir, &target_dir, &_build_meta, RunMode::Check)?;
 
     // Execute the build
     let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature);

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -535,11 +535,15 @@ fn check_tcc_availability(
 }
 
 /// Generate metadata file `packages.json` in the target directory.
+///
+/// To ensure the correct paths are generated, `mode` should match your
+/// corresponding `preconfig` used in [`plan_build`].
 #[instrument(level = Level::DEBUG, skip_all)]
 pub fn generate_metadata(
     source_dir: &Path,
     target_dir: &Path,
     build_meta: &BuildMeta,
+    mode: RunMode,
 ) -> anyhow::Result<()> {
     let metadata_file = target_dir.join("packages.json");
     let metadata = moonbuild_rupes_recta::metadata::gen_metadata_json(
@@ -548,6 +552,7 @@ pub fn generate_metadata(
         target_dir,
         build_meta.opt_level,
         build_meta.target_backend.into(),
+        mode,
     );
     let orig_meta = std::fs::read_to_string(&metadata_file);
     let meta = serde_json::to_string_pretty(&metadata).context("Failed to serialize metadata")?;

--- a/crates/moonbuild-rupes-recta/src/metadata.rs
+++ b/crates/moonbuild-rupes-recta/src/metadata.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 
 use indexmap::IndexMap;
 use moonutil::{
-    common::TargetBackend,
+    common::{RunMode, TargetBackend},
     cond_expr::{CompileCondition, OptLevel},
     module::ModuleDBJSON,
     moon_dir::core,
@@ -45,6 +45,7 @@ pub fn gen_metadata_json(
     target_dir: &Path,
     opt_level: OptLevel,
     backend: TargetBackend,
+    mode: RunMode,
 ) -> ModuleDBJSON {
     // Get the main module info
     let &[main_module_id] = ctx.local_modules() else {
@@ -57,7 +58,7 @@ pub fn gen_metadata_json(
         .main_module(Some(main_module.clone()))
         .opt_level(opt_level)
         .stdlib_dir(Some(core()))
-        .run_mode(moonutil::common::RunMode::Check)
+        .run_mode(mode)
         .target_base_dir(target_dir.to_owned())
         .build()
         .expect("Failed to build legacy layout");


### PR DESCRIPTION


- Related issues: None <!-- write issue numbers here -->
- PR kind: Bugfix <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

Output metadata `pacakge.json` generated by `moon bundle` should have its artifacts in `target/.../bundle` instead of `check`.

<!-- A brief summary of what the PR does -->

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
