### PR TITLE
fix(rr): not count task in core

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -637,11 +637,20 @@ pub fn execute_build(
     input: BuildInput,
     target_dir: &Path,
 ) -> anyhow::Result<N2RunStats> {
+    // Get start nodes (leaf outputs) before moving the graph
+    let start_nodes = input.graph.get_start_nodes();
+
     execute_build_partial(
         cfg,
         input,
         target_dir,
-        Box::new(|work| work.want_every_file(None)),
+        Box::new(|work| {
+            // Want only the leaf output files, not all files including stdlib
+            for file_id in start_nodes {
+                work.want_file(file_id)?;
+            }
+            Ok(())
+        }),
     )
 }
 


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

Summary

New moon task count differs from old moon when `moon check`. The reason can be seen in the following debug output.

```
> ┌[kiwish-4.2]-(warns/warn_list)-[git:main*]-
└> NEW_MOON=1 moon check --sort-input --no-render
=== RUPES-RECTA BACKEND DEBUG ===
Total files in graph: 13

All files in graph (all will be wanted by want_every_file):
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/lib1/hello.mbt
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/lib1/lib1.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/lib1/lib1.blackbox_test.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/lib/hello.mbt
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/lib/lib.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/lib/hello_test.mbt
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/lib/lib.blackbox_test.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/main/main.mbt
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/main/main.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/main/main.blackbox_test.mi
  /Users/whitepie/.moon/lib/core/abort/abort.mbt
  /Users/whitepie/.moon/lib/core/target/wasm-gc/release/bundle/abort/abort.mi
  /Users/whitepie/.moon/lib/core/abort/pkg.mbti
=== END DEBUG ===

Finished. moon: ran 6 tasks, now up to date
┌[kiwish-4.2]-(warns/warn_list)-[git:main*]-
└> moon check --sort-input --no-render
=== LEGACY BACKEND DEBUG ===
Total files in graph: 10
Files in state.default: 3

All files in graph:
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/lib/lib.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/lib/hello.mbt
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/lib/lib.blackbox_test.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/lib/hello_test.mbt
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/lib1/lib1.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/lib1/hello.mbt
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/lib1/lib1.blackbox_test.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/main/main.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/main/main.mbt
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/main/main.blackbox_test.mi

Files in state.default (wanted by legacy):
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/main/main.blackbox_test.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/lib/lib.blackbox_test.mi
  /Users/whitepie/playground/moonbuild/crates/moon/tests/test_cases/warns/warn_list/target/wasm-gc/release/check/lib1/lib1.blackbox_test.mi
=== END DEBUG ===
```

The new moon Task wants every file in the graph, which includes the abort.mi (I don't actually know why it's in the graph though). In this PR, I changed it to only want the start node in the graph, which matches the old moon's behavior.

The number of RR-failed-tests decreases from 98 to 93 when I test it locally.

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
