### PR TITLE
test: not depend on transitive module dep

### DIFF
--- a/crates/moon/tests/test_cases/native_stub.in/native_3.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/native_stub.in/native_3.in/moon.mod.json
@@ -4,6 +4,9 @@
   "deps": {
     "native_2": {
       "path": "../native_2.in"
+    },
+    "native_1": {
+      "path": "../native_1.in"
     }
   }
 }


### PR DESCRIPTION
- Related issues: None

## Summary

Avoid using the transitive dependency feature in tests, so that the following test is fixed for RR backnd
```
test_cases::test_native_stub_in_pkg_json
```

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
