### PR TITLE
fix: `mdbook` 0.5.0 removed unused `multilingual` field

### DIFF
--- a/docs/manual-zh/book.toml
+++ b/docs/manual-zh/book.toml
@@ -18,7 +18,6 @@
 
 [book]
 language = "zh"
-multilingual = false
 src = "src"
 title = "Moon 手册"
 

--- a/docs/manual/book.toml
+++ b/docs/manual/book.toml
@@ -18,7 +18,6 @@
 
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Moon Manual"
 


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind: Bugfix <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

`rust-lang/mdbook` released 0.5.0 just 5 hours ago, and it's breaking our CI. This PR migrates the project to support mdbook 0.5.0. Mainly, just:

- Removed the `book.multilingual` field. This was never used. https://github.com/rust-lang/mdBook/pull/2775

https://github.com/rust-lang/mdBook/releases/tag/v0.5.0 

<!-- A brief summary of what the PR does -->

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
