### PR TITLE
fix: adapt doctest format

### DIFF
--- a/crates/moon/tests/test_cases/all_kind_test.in/lib/README.mbt.md
+++ b/crates/moon/tests/test_cases/all_kind_test.in/lib/README.mbt.md
@@ -1,9 +1,9 @@
 
 
-```mbt
-test {
+```mbt test
+
     let unused_in_lib_md_test = 1
     println("md test in lib pkg")
     inspect("update in md test")
-}
+
 ```

--- a/crates/moon/tests/test_cases/all_kind_test.in/lib/hello.mbt
+++ b/crates/moon/tests/test_cases/all_kind_test.in/lib/hello.mbt
@@ -1,5 +1,5 @@
 
-/// ```mbt
+/// ```mbt test
 ///   let unused_in_lib_doc_test = 1
 ///   println("doc test 1")
 ///   inspect("update in doc test")
@@ -9,7 +9,7 @@ pub fn hello() -> String {
  "Hello, world!"
 }
 
-/// ```mbt
+/// ```mbt test
 ///   println("doc test 2")
 /// ```
 ///

--- a/crates/moon/tests/test_cases/all_kind_test.in/main/main.mbt
+++ b/crates/moon/tests/test_cases/all_kind_test.in/main/main.mbt
@@ -5,7 +5,7 @@ fn main {
   T::{} |> ignore
 }
 
-/// ```mbt
+/// ```mbt test
 ///   println("doc test in main pkg")
 /// ```
 struct T {}

--- a/crates/moon/tests/test_cases/moon_test/doctest_without_bbtest/lib/hello.mbt
+++ b/crates/moon/tests/test_cases/moon_test/doctest_without_bbtest/lib/hello.mbt
@@ -1,4 +1,4 @@
-/// ```
+/// ```mbt test
 /// inspect!(add(1, 2), content="3")
 /// ```
 pub fn add(a: Int, b: Int) -> Int {

--- a/crates/moon/tests/test_cases/moon_test_single_file.in/111.mbt.md
+++ b/crates/moon/tests/test_cases/moon_test_single_file.in/111.mbt.md
@@ -16,15 +16,15 @@ fn _hello() -> Unit {
 }
 ```
 
-```moonbit
-test {
+```mbt test
+
     println("111")
-}
+
 ```
 
 
-```moonbit
-test {
+
+```mbt test
     let single_mbt_md = 1
     let path = "1.txt"
     let content = "Hello, MoonBit"
@@ -33,5 +33,4 @@ test {
     inspect(res, content=content)
     inspect(234523)
     println("222")
-}
 ```

--- a/crates/moon/tests/test_cases/moon_test_single_file.in/222.mbt.md
+++ b/crates/moon/tests/test_cases/moon_test_single_file.in/222.mbt.md
@@ -5,9 +5,6 @@ k: v
 # 1
 
 
-```moonbit
-test {
-    println("222")
-}
+```mbt test
+  println("222")
 ```
-

--- a/crates/moon/tests/test_cases/run_doc_test.in/src/lib/greet.mbt
+++ b/crates/moon/tests/test_cases/run_doc_test.in/src/lib/greet.mbt
@@ -1,4 +1,4 @@
-/// ```
+/// ```mbt test
 /// println("doc_test 1 from greet.mbt")
 /// ```
 pub fn greet1() -> String {
@@ -7,7 +7,7 @@ pub fn greet1() -> String {
 
 
 ///|
-/// ```mbt
+/// ```mbt test
 /// 
 /// 
 ///
@@ -15,7 +15,7 @@ pub fn greet1() -> String {
 ///
 /// ```
 /// 
-/// ```mbt
+/// ```mbt test
 ///
 /// 
 ///   println("test block 2")
@@ -27,7 +27,7 @@ pub fn greet1() -> String {
 ///
 /// ```
 /// 
-/// ```mbt
+/// ```mbt test
 ///
 ///   println("test block 3")
 /// 
@@ -39,7 +39,7 @@ pub fn greet2() -> String {
   "greet, world!"
 }
 
-/// ```moonbit
+/// ```mbt test
 /// 
 /// println("doc_test 3 from greet.mbt")
 /// 
@@ -50,7 +50,7 @@ pub fn greet3() -> String {
   "greet, wor1ld!"
 }
 
-/// ```moonbit
+/// ```mbt test
 ///
 /// 
 /// 
@@ -66,7 +66,7 @@ pub fn greet() -> String {
 }
 
 
-/// ```
+/// ```mbt test
 ///
 /// 
 ///   println("test block 5")
@@ -82,7 +82,7 @@ pub fn greet4() -> String {
 }
 
 
-/// ```
+/// ```mbt test
 ///   println("doc_test 5 from greet.mbt")
 /// 
 /// 
@@ -92,7 +92,7 @@ pub fn greet5() -> String {
   "greet, wor1ld!"
 }
 
-/// ```
+/// ```mbt test
 /// let buf = @buffer.new(size_hint=100)
 /// buf.write_string("Tes")
 /// buf.write_char('t')

--- a/crates/moon/tests/test_cases/run_doc_test.in/src/lib/hello.mbt
+++ b/crates/moon/tests/test_cases/run_doc_test.in/src/lib/hello.mbt
@@ -1,4 +1,4 @@
-/// ```
+/// ```mbt test
 /// println("doc_test 1 from hello.mbt")
 /// ```
 pub fn hello1() -> String {
@@ -6,7 +6,7 @@ pub fn hello1() -> String {
 }
 
 
-/// ```mbt
+/// ```mbt test
 /// println("doc_test 2 from hello.mbt")
 /// 
 /// inspect(1256)
@@ -16,7 +16,7 @@ pub fn hello2() -> String {
   "Hello, world!"
 }
 
-/// ```
+/// ```mbt test
 /// println("doc_test 3 from hello.mbt")
 /// 
 /// fail("this is a failure")
@@ -26,7 +26,7 @@ pub fn hello3() -> String {
   "Hello, wor1ld!"
 }
 
-/// ```
+/// ```mbt test
 /// println("doc_test")
 /// 
 /// 
@@ -56,7 +56,7 @@ pub fn hello() -> String {
 /// 
 /// 
 /// 
-/// ```
+/// ```mbt test
 /// 
 /// assert_true(true)
 /// ```
@@ -64,7 +64,7 @@ pub fn hello() -> String {
 /// this is comment
 /// 
 /// 
-/// ```
+/// ```mbt test 
 /// 
 /// assert_true(true)
 /// ```

--- a/crates/moon/tests/test_cases/run_md_test.in/src/lib/1.mbt.md
+++ b/crates/moon/tests/test_cases/run_md_test.in/src/lib/1.mbt.md
@@ -2,34 +2,31 @@
 
 # 1
 
-```mbt
-fn fn_in_md_test() -> Unit {
-    println("fn in md test")
-}
-```
 
-```mbt
-test {
+
+
+```mbt test
+
     println(@lib.hello1())
-}
+
 ``` 
 
 ## 1.1
 
 - 1.1.1 
 
-```mbt
-test {
+```mbt test
+
     println(@lib.hello3())
-}
+
 ```   
 
 - 1.1.2 
 
-```mbt
+```mbt test
 
 
-test {
+
     let input =
         #|```moonbit
         #|fn main {
@@ -42,15 +39,15 @@ test {
     let a = 1
     println(@lib.hello2())
     inspect("4234")
-}
+
 ```  
 
 ## 1.2
 
 - 1.2.1
 
-````moonbit
-test {
+````mbt test
+
     let a = #| all
             #| wishes
             #|
@@ -59,6 +56,6 @@ test {
             #|
 
     inspect(a)
-}
+
 ````
 

--- a/crates/moon/tests/test_cases/run_md_test.in/src/lib/2.mbt.md
+++ b/crates/moon/tests/test_cases/run_md_test.in/src/lib/2.mbt.md
@@ -1,8 +1,8 @@
 
 # 1
-```mbt
-test {
+```mbt test
+
     println(test_hello())
     assert_eq(@lib.hello3(), "Hello, world 3!")
-}
+
 ``` 

--- a/crates/moon/tests/test_cases/run_md_test.in/src/lib/hello_test.mbt
+++ b/crates/moon/tests/test_cases/run_md_test.in/src/lib/hello_test.mbt
@@ -8,6 +8,9 @@ fn test_hello() -> String {
 
 
 test "inspect in bbtest" {
+  fn fn_in_md_test() -> Unit {
+    println("fn in md test")
+  }
   fn_in_md_test()
   inspect("inspect in bbtest")
   let a = #| all

--- a/crates/moon/tests/test_cases/run_md_test/mod.rs
+++ b/crates/moon/tests/test_cases/run_md_test/mod.rs
@@ -8,9 +8,9 @@ fn test_run_md_test() {
         get_stderr(&dir, ["check", "--sort-input"]),
         expect![[r#"
             Warning: [0002]
-                ╭─[ $ROOT/src/lib/1.mbt.md:42:9 ]
+                ╭─[ $ROOT/src/lib/1.mbt.md:39:9 ]
                 │
-             42 │     let a = 1
+             39 │     let a = 1
                 │         ┬  
                 │         ╰── Warning: Unused variable 'a'
             ────╯
@@ -33,21 +33,21 @@ fn test_run_md_test() {
             ```
             Hello, world 2!
             [username/hello] test lib/hello_test.mbt:10 ("inspect in bbtest") failed
-            expect test failed at $ROOT/src/lib/hello_test.mbt:12:3-12:31
+            expect test failed at $ROOT/src/lib/hello_test.mbt:15:3-15:31
             Diff: (- expected, + actual)
             ----
             +inspect in bbtest
             ----
 
-            [username/hello] test lib/1.mbt.md:32 (#2) failed
-            expect test failed at $ROOT/src/lib/1.mbt.md:44:5-44:20
+            [username/hello] test lib/1.mbt.md:26 (#2) failed
+            expect test failed at $ROOT/src/lib/1.mbt.md:41:5-41:20
             Diff: (- expected, + actual)
             ----
             +4234
             ----
 
-            [username/hello] test lib/1.mbt.md:53 (#3) failed
-            expect test failed at $ROOT/src/lib/1.mbt.md:61:5-61:15
+            [username/hello] test lib/1.mbt.md:49 (#3) failed
+            expect test failed at $ROOT/src/lib/1.mbt.md:58:5-58:15
             Diff: (- expected, + actual)
             ----
             + all


### PR DESCRIPTION
- Related issues: None

## Summary

`moonc` requires doc test to start with `mbt test` in the markdown header. This PR adapts tests to that style.


## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
