### PR TITLE
fix bench driver for JS backend & add tests

### DIFF
--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -2924,7 +2924,7 @@ fn moon_test_target_js_panic_with_sourcemap() {
             [username/hello] test lib/hello_test.mbt:1 ("hello") failed: Error
                 at $panic ($ROOT/target/js/debug/test/lib/lib.blackbox_test.js:3:9)
                 at username$hello$lib_blackbox_test$$__test_68656c6c6f5f746573742e6d6274_0 ($ROOT/src/lib/hello_test.mbt:3:5)
-                at username$hello$lib_blackbox_test$$moonbit_test_driver_internal_js_catch ($ROOT/src/lib/__generated_driver_for_blackbox_test.mbt:223:11)
+                at username$hello$lib_blackbox_test$$moonbit_test_driver_internal_js_catch ($ROOT/src/lib/__generated_driver_for_blackbox_test.mbt:479:11)
             Total tests: 1, passed: 0, failed: 1."#]],
     );
 }

--- a/crates/moon/tests/test_cases/moon_bench/mod.rs
+++ b/crates/moon/tests/test_cases/moon_bench/mod.rs
@@ -7,6 +7,25 @@ fn test_bench_driver_build() {
 }
 
 #[test]
+fn test_bench_driver_build_js() {
+    let dir = TestDir::new("moon_bench");
+    check(
+        get_stderr(&dir, ["bench", "--build-only", "--target", "js"]),
+        expect![""],
+    );
+}
+
+#[test]
+#[cfg(not(windows))]
+fn test_bench_driver_build_native() {
+    let dir = TestDir::new("moon_bench");
+    check(
+        get_stderr(&dir, ["bench", "--build-only", "--target", "native"]),
+        expect![""],
+    );
+}
+
+#[test]
 fn test_bench_uses_release_mode_by_default() {
     let dir = TestDir::new("moon_bench");
 

--- a/crates/moonbuild/template/test_driver/bench_driver_template.mbt
+++ b/crates/moonbuild/template/test_driver/bench_driver_template.mbt
@@ -78,19 +78,28 @@ pub fn moonbit_test_driver_internal_do_execute(filename : String, index : Int) -
         return
       }
       test_name = name
-      try {
-        let bench_out = @moonbitlang/core/bench.new()
-        item.f.0(bench_out)
-        let s = bench_out.dump_summaries()
-        message = "@BATCH_BENCH { \"summaries\": \{s} }"
-      } catch {
-        @moonbitlang/core/builtin.Failure(e) | @moonbitlang/core/builtin.InspectError(e) | @moonbitlang/core/builtin.SnapshotError(e) | @moonbitlang/core/builtin.BenchError(e) => {
-          message = e
-        }
-        e => {
-          message = moonbit_test_driver_internal_error_to_string(e)
-        }
-      }
+      let bench_out = @moonbitlang/core/bench.new()
+      moonbit_test_driver_internal_catch_error(
+        () => item.f.0(bench_out),
+        on_ok=() => {
+          let s = bench_out.dump_summaries()
+          message = "@BATCH_BENCH { \"summaries\": \{s} }"
+        },
+        on_err=(err) => {
+          match err {
+            @moonbitlang/core/builtin.Failure(e)
+            | @moonbitlang/core/builtin.InspectError(e)
+            | @moonbitlang/core/builtin.SnapshotError(e)
+            | @moonbitlang/core/builtin.BenchError(e)
+            | MoonBitTestDriverInternalJsError(e) => {
+              message = e
+            }
+            e => {
+              message = moonbit_test_driver_internal_error_to_string(e)
+            }
+          }
+        },
+      )
     }
     _ => { message = "skipped test" }
   }
@@ -120,8 +129,13 @@ fn main {
 }
 
 #cfg(target="js")
-pub fn moonbit_test_driver_internal_execute(filename : String, index : Int) -> Unit {
-  moonbit_test_driver_internal_do_execute(filename, index)
+pub fn moonbit_test_driver_internal_execute(
+  tests : Array[MoonBitTestDriverInternalTestEntry],
+) -> Unit {
+  for i in 0..<tests.length() {
+    let entry = tests[i]
+    moonbit_test_driver_internal_do_execute(entry.filename(), entry.index())
+  }
 }
 
 #cfg(any(target="wasm", target="wasm-gc"))

--- a/crates/moonbuild/template/test_driver/common.mbt
+++ b/crates/moonbuild/template/test_driver/common.mbt
@@ -170,3 +170,77 @@ fn moonbit_test_driver_internal_get_cli_args_ffi() -> FixedArray[Bytes] = "$moon
 // =========================================================
 // ================== END NATIVE SPECIFIC ==================
 // =========================================================
+
+// =========================================================
+// -================== BEGIN JS SPECIFIC ===================
+// =========================================================
+
+///|
+#cfg(target="js")
+#external
+type MoonBitTestDriverInternalTestEntry
+
+///|
+#cfg(target="js")
+extern "js" fn MoonBitTestDriverInternalTestEntry::filename(self : Self) -> String =
+  #| (entry) => entry[0]
+
+///|
+#cfg(target="js")
+extern "js" fn MoonBitTestDriverInternalTestEntry::index(self : Self) -> Int =
+  #| (entry) => entry[1]
+
+///|
+pub(all) suberror MoonBitTestDriverInternalJsError String
+
+///|
+#cfg(target="js")
+fn moonbit_test_driver_internal_catch_error(
+  f : () -> Unit raise,
+  on_ok~ : () -> Unit,
+  on_err~ : (Error) -> Unit,
+) -> Unit {
+  moonbit_test_driver_internal_js_catch(
+    on_err=(err_str) => on_err(MoonBitTestDriverInternalJsError(err_str)),
+    () => {
+      try f() catch {
+        err => on_err(err)
+      } noraise {
+        _ => on_ok()
+      }
+    }
+  )
+}
+
+///|
+#cfg(target="js")
+extern "js" fn moonbit_test_driver_internal_js_catch(
+  f : () -> Unit,
+  on_err~ : (String) -> Unit,
+) =
+  #| (f, on_err) => {
+  #|   try {
+  #|     f()
+  #|   } catch (err) {
+  #|     const msg = err.stack.toString()
+  #|     on_err(msg)
+  #|   }
+  #| }
+
+///|
+#cfg(not(target="js"))
+fn moonbit_test_driver_internal_catch_error(
+  f : () -> Unit raise,
+  on_ok~ : () -> Unit,
+  on_err~ : (Error) -> Unit,
+) -> Unit {
+  try f() catch {
+    err => on_err(err)
+  } noraise {
+    _ => on_ok()
+  }
+}
+
+// =========================================================
+// -=================== END JS SPECIFIC ====================
+// =========================================================

--- a/crates/moonbuild/template/test_driver/test_driver_template.mbt
+++ b/crates/moonbuild/template/test_driver/test_driver_template.mbt
@@ -202,57 +202,6 @@ pub fn moonbit_test_driver_internal_do_execute(
 }
 
 ///|
-pub(all) suberror MoonBitTestDriverInternalJsError String
-
-///|
-#cfg(target="js")
-fn moonbit_test_driver_internal_catch_error(
-  f : () -> Unit raise,
-  on_ok~ : () -> Unit,
-  on_err~ : (Error) -> Unit,
-) -> Unit {
-  moonbit_test_driver_internal_js_catch(
-    on_err=(err_str) => on_err(MoonBitTestDriverInternalJsError(err_str)),
-    () => {
-      try f() catch {
-        err => on_err(err)
-      } noraise {
-        _ => on_ok()
-      }
-    }
-  )
-}
-
-///|
-#cfg(target="js")
-extern "js" fn moonbit_test_driver_internal_js_catch(
-  f : () -> Unit,
-  on_err~ : (String) -> Unit,
-) =
-  #| (f, on_err) => {
-  #|   try {
-  #|     f()
-  #|   } catch (err) {
-  #|     const msg = err.stack.toString()
-  #|     on_err(msg)
-  #|   }
-  #| }
-
-///|
-#cfg(not(target="js"))
-fn moonbit_test_driver_internal_catch_error(
-  f : () -> Unit raise,
-  on_ok~ : () -> Unit,
-  on_err~ : (Error) -> Unit,
-) -> Unit {
-  try f() catch {
-    err => on_err(err)
-  } noraise {
-    _ => on_ok()
-  }
-}
-
-///|
 let moonbit_test_driver_internal_max_concurrent_tests : Int = 10
 
 #cfg(target="native")
@@ -270,18 +219,6 @@ fn main {
 fn main {
   ()
 }
-
-#cfg(target="js")
-#external
-type MoonBitTestDriverInternalTestEntry
-
-#cfg(target="js")
-extern "js" fn MoonBitTestDriverInternalTestEntry::filename(self : Self) -> String =
-  #| (entry) => entry[0]
-
-#cfg(target="js")
-extern "js" fn MoonBitTestDriverInternalTestEntry::index(self : Self) -> Int =
-  #| (entry) => entry[1]
 
 #cfg(target="js")
 pub fn moonbit_test_driver_internal_execute(


### PR DESCRIPTION
#1252 forgot to update bench driver for JS backend, making `moon bench --target js` failing. This PR fixes the issue, and add tests for `moon bench` in js/native backends, which were previously missing.