### PR TITLE
test: query symbol on windows

### DIFF
--- a/crates/moon/tests/test_cases/query_symbol/mod.rs
+++ b/crates/moon/tests/test_cases/query_symbol/mod.rs
@@ -1,7 +1,6 @@
 use super::*;
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn test_query_not_in_project() {
     let dir = TestDir::new("query_symbol.in/empty");
 
@@ -39,7 +38,6 @@ fn test_query_not_in_project() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn test_query_in_project() {
     let dir = TestDir::new("query_symbol.in/proj");
 


### PR DESCRIPTION
Test whether nightly moonc has fixed the issue with query symbol.

