### PR TITLE
Add docs and human-readable descriptions to build plan nodes

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -176,6 +176,7 @@ impl<'a> BuildPlanLowerContext<'a> {
             outs,
         );
         build.cmdline = Some(cmd.commandline.to_n2_string());
+        build.desc = Some(node.human_desc(self.modules, self.packages));
         // n2 can't capture and replay command outputs. this is a workaround to
         // avoid losing warnings from `moonc`. According to legacy code, this
         // only triggers for `Check` nodes.


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind: <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

This PR improves documentation for build plan nodes.

It also adds a human-readable description on these nodes so they are more readable during build.

<img width="850" height="338" alt="2025-12-01_16-43" src="https://github.com/user-attachments/assets/e40f230e-4315-4b21-b099-0c63f79b0fb7" />


<!-- A brief summary of what the PR does -->

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
