### PR TITLE
Hotfix: don't push empty string on empty exports list

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/link_core.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/link_core.rs
@@ -157,13 +157,10 @@ impl<'a> MooncLinkCore<'a> {
         }
 
         // WebAssembly exports
-        if let Some(exports) = self.exports {
-            if exports.is_empty() {
-                // Empty exports case - legacy adds empty string
-                args.push("".to_string());
-            } else {
-                args.push(format!("-exported_functions={}", exports.join(",")));
-            }
+        if let Some(exports) = self.exports
+            && !exports.is_empty()
+        {
+            args.push(format!("-exported_functions={}", exports.join(",")));
         }
 
         // WASM-specific config

--- a/crates/moonbuild/src/gen/gen_build.rs
+++ b/crates/moonbuild/src/gen/gen_build.rs
@@ -711,7 +711,7 @@ pub fn gen_link_command(
         .lazy_args_with_cond(exports.is_some(), || {
             let es = exports.unwrap();
             if es.is_empty() {
-                vec!["".to_string()]
+                vec![]
             } else {
                 vec![format!(
                     "-exported_functions={}",


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind: Bugfix <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

On `moonc link-core`, if the JS/WASM exports list is empty, the build system will erroneously push an empty string to the args list. This empty string will be recognized as an import by the compiler, and crash because the file with empty path does not exist, causing an ICE.

This PR fixes the issue by removing the empty string.

cc @peter-jerry-ye @hackwaly 

<!-- A brief summary of what the PR does -->

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
