### PR TITLE
[RR] Fix regression in single-file builds' packages.json filename

### DIFF
--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -154,7 +154,7 @@ pub fn run_bundle_internal_rr(
         let _lock = FileLock::lock(target_dir)?;
 
         // Generate metadata for IDE & bundler
-        rr_build::generate_metadata(source_dir, target_dir, &_build_meta, RunMode::Bundle)?;
+        rr_build::generate_metadata(source_dir, target_dir, &_build_meta, RunMode::Bundle, None)?;
 
         let result = rr_build::execute_build(
             &BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose),

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -197,7 +197,17 @@ fn run_check_for_single_file_rr(
     }
 
     let _lock = FileLock::lock(&raw_target_dir)?;
-    rr_build::generate_metadata(&source_dir, &raw_target_dir, &build_meta, RunMode::Check)?;
+    let filename = single_file_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(String::from);
+    rr_build::generate_metadata(
+        &source_dir,
+        &raw_target_dir,
+        &build_meta,
+        RunMode::Check,
+        filename.as_deref(),
+    )?;
 
     let mut cfg = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose);
     cfg.patch_file = cmd.patch_file.clone();
@@ -413,7 +423,7 @@ fn run_check_normal_internal_rr(
         let _lock = FileLock::lock(target_dir)?;
 
         // Generate metadata for IDE
-        rr_build::generate_metadata(source_dir, target_dir, &build_meta, RunMode::Check)?;
+        rr_build::generate_metadata(source_dir, target_dir, &build_meta, RunMode::Check, None)?;
 
         let mut cfg = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose);
         cfg.patch_file = cmd.patch_file.clone();

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -127,7 +127,7 @@ pub fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Result<i32
 
     // Generate metadata for `moondoc`
     let _lock = FileLock::lock(&target_dir)?;
-    rr_build::generate_metadata(&source_dir, &target_dir, &_build_meta, RunMode::Check)?;
+    rr_build::generate_metadata(&source_dir, &target_dir, &_build_meta, RunMode::Check, None)?;
 
     // Execute the build
     let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature, cli.verbose);

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -581,14 +581,23 @@ fn check_tcc_availability(
 ///
 /// To ensure the correct paths are generated, `mode` should match your
 /// corresponding `preconfig` used in [`plan_build`].
+///
+/// If the caller is from a single-file build, `single_file_filename` should
+/// be set to the filename (with extension) of the single file being built.
 #[instrument(level = Level::DEBUG, skip_all)]
 pub fn generate_metadata(
     source_dir: &Path,
     target_dir: &Path,
     build_meta: &BuildMeta,
     mode: RunMode,
+    single_file_filename: Option<&str>,
 ) -> anyhow::Result<()> {
-    let metadata_file = target_dir.join("packages.json");
+    let metadata_file = if let Some(filename) = single_file_filename {
+        target_dir.join(format!("{}.packages.json", filename))
+    } else {
+        target_dir.join("packages.json")
+    };
+
     let metadata = moonbuild_rupes_recta::metadata::gen_metadata_json(
         &build_meta.resolve_output,
         source_dir,


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind: Bugfix <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

Found by @bzy-debug .

Single file projects have a different `packages.json` filename schema compared to regular files. This PR corrects the behavior so that they now output `<filename>.packages.json`.

<!-- A brief summary of what the PR does -->

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
