### PR TITLE
refactor: use Arc<Mutex<...>> for SectionCapture

### DIFF
--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -738,7 +738,7 @@ fn rr_run_from_plan(
 
     let res = default_rt()
         .context("Failed to create runtime")?
-        .block_on(crate::run::run(&mut [], false, run_cmd.command))
+        .block_on(crate::run::run(&[], false, run_cmd.command))
         .context("failed to run command")?;
 
     if let Some(code) = res.code() {

--- a/crates/moon/src/run/child.rs
+++ b/crates/moon/src/run/child.rs
@@ -18,12 +18,15 @@
 
 //! Handles spawning of a child process under the govern of `moon run`
 
-use std::process::{ExitStatus, Stdio};
+use std::{
+    process::{ExitStatus, Stdio},
+    sync::Arc,
+};
 
 use anyhow::Context;
 use moonbuild::section_capture::{SectionCapture, handle_stdout_async};
 use moonutil::platform::macos_with_sigchild_blocked;
-use tokio::process::Command;
+use tokio::{process::Command, sync::Mutex};
 
 /// Run a command under the governing of `moon run`.
 ///
@@ -39,7 +42,7 @@ use tokio::process::Command;
 /// output since the running process might not have any other method to interact
 /// with the host `moon` process.
 pub async fn run<'a>(
-    captures: &mut [&mut SectionCapture<'a>],
+    captures: &[Arc<Mutex<SectionCapture<'a>>>],
     capture: bool,
     mut cmd: Command,
 ) -> anyhow::Result<ExitStatus> {


### PR DESCRIPTION
- Related issues: None
- PR kind: refactor

## Summary

This PR refactor the `SectionCapture` passing logic to use `Arc<Mutex<...>>`, so that it is possible to move the stdout capturing task into a standalone coroutine/thread.

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
