### PR TITLE
support `moon info -v`

### DIFF
--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -192,7 +192,8 @@ pub fn run_info_rr_internal(
     rr_build::generate_all_pkgs_json(&target_dir, &build_meta, RunMode::Check)?;
 
     // TODO: UX: Consider mirroring flags from `moon check`?
-    let result = rr_build::execute_build(&BuildConfig::default(), build_graph, &target_dir)?;
+    let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature, cli.verbose);
+    let result = rr_build::execute_build(&cfg, build_graph, &target_dir)?;
     result.print_info(cli.quiet, "generating mbti files")?;
 
     Ok((result.successful(), build_meta))


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

## Summary

Simply passing the verbose flag to n2.

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
