### PR TITLE
make `moon test` compatible with both new and old source loc format

### DIFF
--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -1495,7 +1495,8 @@ fn rr_test_from_plan(
             // Promote test results
             let promotion_source = last_test_result.as_ref().unwrap_or(&test_result);
             let (rerun_count, rerun_filter_raw) =
-                perform_promotion(promotion_source).expect("Failed to promote tests");
+                perform_promotion(&build_meta.resolve_output.pkg_dirs, promotion_source)
+                    .expect("Failed to promote tests");
             debug!(
                 rerun_count,
                 pending_targets = rerun_filter_raw.0.len(),

--- a/crates/moonbuild-rupes-recta/src/discover/model.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/model.rs
@@ -23,6 +23,7 @@ use std::{
     path::PathBuf,
 };
 
+use moonbuild::expect::PackageSrcResolver;
 use moonutil::common::{MOON_PKG_JSON, TargetBackend};
 use moonutil::mooncakes::{ModuleId, ModuleSource};
 use moonutil::package::MoonPkg;
@@ -225,6 +226,13 @@ impl DiscoverResult {
 
     pub fn abort_pkg(&self) -> Option<PackageId> {
         self.abort_pkg
+    }
+}
+
+impl PackageSrcResolver for DiscoverResult {
+    fn resolve_pkg_src(&self, pkg_path: &str) -> PathBuf {
+        let pkg_id = self.packages_rev_map[pkg_path];
+        self.packages[pkg_id].root_path.clone()
     }
 }
 


### PR DESCRIPTION
`moonc` will migrate the format of source location to relative path soon (absolute path file name => package + file path relative to package root). After the migration, the output of `moon test` on `inspect` mismatch will change from a plain file name string to a more structured format (a JSON object with fields `pkg`, `filename`, `start_line`, etc.).

`moonbitlang/core` is already compatible with both new and old formats of source location. If `moonc` provides source location in old format, `inspect` will output the source location in the old format too (a plain string). If the source location is in new format, `inspect` will output the aforementioned structured JSON format of source location.

This PR makes `moon` compatible with the two formats of source location as well when handling output of `inspect` etc. After this PR, the whole tool chain will be compatible with relative source location, and we can actually perform the migration in `moonc`. After a new round of release, legacy code for handling old format can be removed.

The main code change in this PR is:

- make expect test handling compatible with both formats of source location (via `#[serde(untagged)]`)
- in the new format, `inspect` no longer provide absolute path. To update test diff, `moon` must manually resolve the file path using package name + relative path. Since legacy `moonbuild` and the new RR backend has different representation of project meta data, a new trait `PackageSrcResolver` is introduced, and expect test handling API now accept a `PackageSrcResolver` as parameter to handle file path resolution

CI could check that this PR is compatible with the old format. Compatibility with the new format is tested locally using a `moonc` branch with relative source location. After this PR landed in `moon`, the `moonc ` branch would be merged, and we can observe compatibility with the new format via nightly CI.