### PR TITLE
fix: not produce abort.mi when build abort.core

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -347,7 +347,7 @@ impl<'a> BuildPlanLowerContext<'a> {
         // Propagate debug/coverage flags and common settings
         (cmd.flags.enable_coverage, cmd.flags.self_coverage) =
             self.get_coverage_flags(target, &package.fqn, true);
-        cmd.defaults.no_mi |= target.kind.is_test();
+        cmd.defaults.no_mi |= target.kind.is_test() | (cmd.defaults.check_mi.is_some());
 
         // Include doctest-only files as inputs to track dependency correctly
         // Note: This is the *extra* inputs, trivial dependencies are already


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

## Summary

When running `moonc build-package` on the virtual package `abort` to produce `abort.core`, it has a byproduct `abort.mi`. This will overwrite the `abort.mi` produced by `moonc build-interface` on `abort.mbti` and thus mark it as dirty so `abort.mbti` will be rebuilt all the time. This PR fixed this problem by passing `-no-mi` when building `abort.core`.


