### PR TITLE
feat: add LLVM experimental warning to RR backend

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -36,6 +36,7 @@ use std::{
 };
 
 use anyhow::Context;
+use colored::Colorize;
 use indexmap::IndexMap;
 use moonbuild::entry::{N2RunStats, ResultCatcher, create_progress_console};
 use moonbuild_rupes_recta::{
@@ -432,6 +433,14 @@ pub fn plan_build_from_resolved<'a>(
         .target_backend
         .or(preferred_backend)
         .unwrap_or_default();
+
+    // TODO: remove this once LLVM backend is well supported
+    if target_backend == TargetBackend::LLVM {
+        eprintln!(
+            "{}: LLVM backend is experimental and only supported on nightly moonbit toolchain for now",
+            "Warning".yellow()
+        );
+    }
 
     info!("Calculating user intent");
     let intent = calc_user_intent(&resolve_output, target_backend)?;


### PR DESCRIPTION
## Summary

Add the same LLVM backend warning that exists in the legacy backend to the Rupes Recta backend. The warning is shown when users use `--target llvm` to inform them that LLVM is experimental.

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
