### PR TITLE
feat: warn when both MOON_CC and user CC are provided

### DIFF
--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -340,6 +340,13 @@ pub struct ArchiverConfig {
 
 /// Resolve the C compiler to use from global state
 pub fn resolve_cc(cc: CC, user_cc: Option<CC>) -> CC {
+    if ENV_CC.is_some() && user_cc.is_some() {
+        eprintln!(
+            "{}: Both MOON_CC environment variable and user-specified CC are provided. \
+            MOON_CC takes precedence.",
+            "Warning".yellow().bold(),
+        );
+    }
     ENV_CC.clone().unwrap_or_else(|| user_cc.unwrap_or(cc))
 }
 


### PR DESCRIPTION
## Summary

Add a warning when both the MOON_CC environment variable and a user-specified CC (from moon.pkg.json) are provided, since MOON_CC takes precedence and the user-specified CC will be ignored.

