### PR TITLE
fix: node error when root package.json set `"type":"module"`

### DIFF
--- a/crates/moon/src/run/runtime.rs
+++ b/crates/moon/src/run/runtime.rs
@@ -139,5 +139,12 @@ fn create_js_driver(js_path: &Path, test_args: &TestArgs) -> anyhow::Result<(Tem
     std::fs::write(package_json, "{}")
         .expect("Failed to write temporary package.json for JS testing script");
 
+    // Also write package.json to the directory of the .js file being required
+    // to prevent node from finding the user's package.json with "type": "module"
+    if let Some(js_parent) = js_path.parent() {
+        let js_dir_package_json = js_parent.join("package.json");
+        let _ = std::fs::write(js_dir_package_json, "{}");
+    }
+
     Ok((dir, js_file))
 }

--- a/crates/moonbuild/src/entry.rs
+++ b/crates/moonbuild/src/entry.rs
@@ -864,6 +864,10 @@ pub fn run_test(
                 std::fs::write(&wrapper_js_driver_path, js_driver)?;
                 // prevent node use the outer layer package.json with `"type": "module"`
                 std::fs::write(moonbuild_opt.target_dir.join("package.json"), "{}")?;
+                // Also write package.json to the directory of the .js file being required
+                if let Some(artifact_parent) = artifact_path.parent() {
+                    let _ = std::fs::write(artifact_parent.join("package.json"), "{}");
+                }
                 test_artifacts
                     .artifacts_path
                     .push(wrapper_js_driver_path.clone());


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind: <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

<!-- A brief summary of what the PR does -->

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
