### PR TITLE
support `async test` without arguments directly

### DIFF
--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -248,8 +248,16 @@ fn generate_driver(
     //   only no_arg tests are present -> no_arg_test
     //   otherwise -> no_arg_test and with_arg_test
 
-    let no_async_tests = data.async_tests.iter().all(|x| x.1.is_empty());
-    let only_no_arg_tests = data.with_args_tests.iter().all(|x| x.1.is_empty()) && no_async_tests;
+    let no_async_tests = data
+        .async_tests
+        .iter()
+        .chain(data.async_tests_with_args.iter())
+        .all(|x| x.1.is_empty());
+    let only_no_arg_tests = data
+        .with_args_tests
+        .iter()
+        .chain(data.async_tests_with_args.iter())
+        .all(|x| x.1.is_empty());
 
     let template = if enable_bench {
         BENCH_DRIVER_TEMPLATE
@@ -310,10 +318,15 @@ fn generate_driver(
         if no_async_tests {
             template
         } else {
-            template.replace(
-                "let moonbit_test_driver_internal_async_tests : Moonbit_Test_Driver_Internal_TestDriver_Async_Map = { }  // WILL BE REPLACED",
-                &MooncGenTestInfo::section_to_mbt("moonbit_test_driver_internal_async_tests", &data.async_tests),
-            )
+            template
+                .replace(
+                    "let moonbit_test_driver_internal_async_tests : Moonbit_Test_Driver_Internal_TestDriver_Async_Map = { }  // WILL BE REPLACED",
+                    &MooncGenTestInfo::section_to_mbt("moonbit_test_driver_internal_async_tests", &data.async_tests),
+                )
+                .replace(
+                    "let moonbit_test_driver_internal_async_tests_with_args : Moonbit_Test_Driver_Internal_TestDriver_Async_With_Args_Map = { }  // WILL BE REPLACED",
+                    &MooncGenTestInfo::section_to_mbt("moonbit_test_driver_internal_async_tests_with_args", &data.async_tests_with_args),
+                )
         }
     };
 
@@ -345,6 +358,10 @@ fn generate_driver(
         .replace(
             "let moonbit_test_driver_internal_async_tests =",
             "let moonbit_test_driver_internal_async_tests : Moonbit_Test_Driver_Internal_TestDriver_Async_Map =",
+        )
+        .replace(
+            "let moonbit_test_driver_internal_async_tests_with_args =",
+            "let moonbit_test_driver_internal_async_tests_with_args : Moonbit_Test_Driver_Internal_TestDriver_Async_With_Args_Map =",
         )
         .replace("{PACKAGE}", pkgname)
         .replace("{BEGIN_MOONTEST}", MOON_TEST_DELIMITER_BEGIN)

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -495,6 +495,7 @@ fn parse_test_results(
         meta.with_args_tests,
         meta.with_bench_args_tests,
         meta.async_tests,
+        meta.async_tests_with_args,
     ]
     .into_iter()
     .flatten()

--- a/crates/moon/src/run/runtest/filter.rs
+++ b/crates/moon/src/run/runtest/filter.rs
@@ -230,6 +230,7 @@ pub fn apply_filter(
             &meta.no_args_tests,
             &meta.with_args_tests,
             &meta.async_tests,
+            &meta.async_tests_with_args,
         ]
     };
 
@@ -383,6 +384,7 @@ mod test {
             .collect(),
             with_bench_args_tests: Default::default(),
             async_tests: Default::default(),
+            async_tests_with_args: Default::default(),
         }
     }
 

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -2923,7 +2923,7 @@ fn moon_test_target_js_panic_with_sourcemap() {
             [username/hello] test lib/hello_test.mbt:1 ("hello") failed: Error
                 at $panic ($ROOT/_build/js/debug/test/lib/lib.blackbox_test.js:3:9)
                 at username$hello$lib_blackbox_test$$__test_68656c6c6f5f746573742e6d6274_0 ($ROOT/src/lib/hello_test.mbt:3:5)
-                at username$hello$lib_blackbox_test$$moonbit_test_driver_internal_js_catch ($ROOT/src/lib/__generated_driver_for_blackbox_test.mbt:414:11)
+                at username$hello$lib_blackbox_test$$moonbit_test_driver_internal_js_catch ($ROOT/src/lib/__generated_driver_for_blackbox_test.mbt:443:11)
             Total tests: 1, passed: 0, failed: 1."#]],
     );
 }

--- a/crates/moonbuild/template/test_driver/test_driver_template.mbt
+++ b/crates/moonbuild/template/test_driver/test_driver_template.mbt
@@ -24,6 +24,17 @@ type Moonbit_Test_Driver_Internal_TestDriver_Async_Map = @moonbitlang/core/built
   @moonbitlang/core/builtin.Map[
     Int,
     (
+      async () -> Unit raise,
+      @moonbitlang/core/builtin.Array[String],
+    ),
+  ],
+]
+
+type Moonbit_Test_Driver_Internal_TestDriver_Async_With_Args_Map = @moonbitlang/core/builtin.Map[
+  String,
+  @moonbitlang/core/builtin.Map[
+    Int,
+    (
       async (Moonbit_Test_Driver_Internal_Test_Arg) -> Unit raise,
       @moonbitlang/core/builtin.Array[String],
     ),
@@ -33,6 +44,7 @@ type Moonbit_Test_Driver_Internal_TestDriver_Async_Map = @moonbitlang/core/built
 let moonbit_test_driver_internal_no_args_tests : Moonbit_Test_Driver_Internal_No_Args_Map = { }  // WILL BE REPLACED
 let moonbit_test_driver_internal_with_args_tests : Moonbit_Test_Driver_Internal_TestDriver_With_Args_Map = { }  // WILL BE REPLACED
 let moonbit_test_driver_internal_async_tests : Moonbit_Test_Driver_Internal_TestDriver_Async_Map = { }  // WILL BE REPLACED
+let moonbit_test_driver_internal_async_tests_with_args : Moonbit_Test_Driver_Internal_TestDriver_Async_With_Args_Map = { }  // WILL BE REPLACED
 
 ///|
 pub fn moonbit_test_driver_internal_do_execute(
@@ -118,6 +130,23 @@ pub fn moonbit_test_driver_internal_do_execute(
 
   if (
     moonbit_test_driver_internal_async_tests.get(filename) is Some(index_map) &&
+    index_map.get(index) is Some((f, attrs))
+  ) {
+    let name = if attrs is [name, ..] { name } else { "" }
+    guard !test_should_be_skipped(name, attrs) else {}
+    async_tests.push(() => {
+      try f() catch {
+        err if moonbit_test_driver_internal_is_being_cancelled() => raise err
+        err => on_err(name, err)
+      } noraise {
+        _ => handle_result(name, "", false)
+      }
+    })
+    return
+  }
+
+  if (
+    moonbit_test_driver_internal_async_tests_with_args.get(filename) is Some(index_map) &&
     index_map.get(index) is Some((f, attrs))
   ) {
     let name = if attrs is [name, ..] { name } else { "" }

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -983,6 +983,8 @@ pub struct MooncGenTestInfo {
     pub with_bench_args_tests: IndexMap<FileName, Vec<MbtTestInfo>>,
     #[serde(default)]
     pub async_tests: IndexMap<FileName, Vec<MbtTestInfo>>,
+    #[serde(default)]
+    pub async_tests_with_args: IndexMap<FileName, Vec<MbtTestInfo>>,
 }
 
 impl MbtTestInfo {


### PR DESCRIPTION
Previously, it was assumed that all `async test` has a `@test.Test` argument in the test driver. For `async test` without argument, `moonc` will automatically fill a dummy parameter. However, in the future, we plan to require explicit import for packages in `moonbitlang/core`, including `@test.Test`. So `@test.Test` is no longer universally available.

This PR add support for `async test` without arguments directly in the test driver. To avoid making the test driver too complex, the code for test driver is first refactored and simplified.

This PR can only be merged after the compiler counterpart of this PR is merged and released to the nightly channel.