### PR TITLE
docs: update documentation for Rupes Recta being default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,20 +27,28 @@ If you are working from mainland China, using the `.cn` domain may result in a s
 
 - `crates/`
   - `moon/`: The entry point to the `moon` utility.
-    - `test/`
-      - `test_cases/`: Integration snapshot tests, the majority of tests.
-      - other files: Test utilities to use.
-  - `moonbuild/`: The legacy build graph generation engine. Will be removed soon, avoid modifying except for bugfixes.
+    - `src/rr_build/`: Integration with Rupes Recta build engine.
+    - `tests/test_cases/`: Integration snapshot tests, the majority of tests.
+  - `moonbuild-rupes-recta/`: The new build graph generation engine (**now default**).
+  - `moonbuild/`: The legacy build graph generation engine. Set `NEW_MOON=0` to use it if you encounter issues with Rupes Recta.
   - `moonbuild-debug/`: Debugging utilities, mainly around dry-run printing and snapshotting.
-  - `moonbuild-rupes-recta/`: The new build graph generation engine.
   - `mooncake/`: Library to resolve and download dependencies.
   - `moonrun/`: The runtime of WASM MoonBit programs.
-  - `moonutil/`: Misc utilities.
+  - `moonutil/`: Misc utilities including feature flags (`src/features.rs`).
 - `docs/`: Documentation site
   - `manual/`, `manual-zh/`: User-facing documentation
   - `dev/`: Developer-facing documentation
     - `reference/`: Reference behaviors and models of the build system. Keep in sync with code.
 - `xtask/`: Development utilities
+
+### Build system transition
+
+The project has transitioned from the legacy `moonbuild` to the new `moonbuild-rupes-recta` ("Rupes Recta") build engine:
+
+- **Rupes Recta is now enabled by default**
+- To use the legacy build system: set `NEW_MOON=0`
+- Unstable features can be enabled via `-Z` flags (e.g., `-Z rr_export_module_graph`)
+- See `crates/moonutil/src/features.rs` for all feature flags
 
 ## Coding guidelines
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -67,30 +67,32 @@ cargo install --path ./crates/moon --debug --offline
 
 ## Source Code Overview
 
-The following content is based on [a28d2f1a](https://github.com/moonbitlang/moon/commit/a28d2f1a1bb47bdaf428fd150e0f6d2b4c959bb0), which may outdated as the project develops.
-
 - `crates/moon`
   - `src/cli`: the command line interface of `moon`
     - `src/cli/mooncake_adapter.rs`: forwards to the `mooncake`
       binary
     - `src/cli/generate_test_driver.rs`: as the name suggests
+  - `src/rr_build`: integration with the Rupes Recta build engine
   - `tests/test_cases/mod.rs`: all end-to-end tests are located in
     this file
 
-- `crates/moonbuild`
+- `crates/moonbuild-rupes-recta`: the new build graph generation engine (now default)
+  - `src/build_lower`: lowers resolved modules to n2 build commands
+  - `src/fmt.rs`: formatting support
+  - `src/metadata.rs`: metadata generation for IDE/tooling
+  - See `docs/dev/reference/compiler-cmd-ref.md` for compiler command reference
+
+- `crates/moonbuild`: the legacy build graph generation engine
+  - Being phased out in favor of `moonbuild-rupes-recta`
+  - Set `NEW_MOON=0` to use the legacy engine if needed
   - `src/{check, gen, build, bundle, entry, runtest}`: generate
     commands and n2 state according to `moon.mod.json` and `moon.pkg.json`
   - `src/bundle.rs`: only for `moonbitlang/core`, not visible
     to users
-  - `src/bench.rs`: generates a project for benchmarking, will
-    be moved to `moon new`
   - `src/dry_run.rs`: prints commands without executing them,
     mainly used by end-to-end tests.
   - `src/expect.rs`: the implementation of expect tests in
     `moon`
-  - `src/upgrade.rs`: for `moon upgrade`. We hope to move it to
-    another binary crate, not mooncake, since depending on network in moonbuild
-    does not make sense.
 
 - `crates/mooncake`: package manager
   - `src/pkg/add`: `moon add`
@@ -102,13 +104,18 @@ The following content is based on [a28d2f1a](https://github.com/moonbitlang/moon
   - `src/resolver/mvs.rs`: Go-like minimal version selection
     algorithm.
 
-- `crates/moonutil`: currently not well organized, needs cleanup
+- `crates/moonutil`: shared utilities
   - `src/common.rs`: common definitions shared by other crates
   - `src/scan.rs`: scans the project directory to gather all
     structural information
   - `src/moon_dir.rs`: gets the `.moon`, `core`, etc. directory
     paths and handles related environment variables
+  - `src/features.rs`: feature flags including `rupes_recta`
   - `src/build.rs`: for `moon version`
+
+- `crates/moonrun`: runtime for executing WASM MoonBit programs
+
+- `crates/moonbuild-debug`: debugging utilities for dry-run printing and snapshotting
 
 
 ## Before PR


### PR DESCRIPTION
- Update docs/dev/README.md to reflect current architecture:
  - Remove outdated commit reference
  - Add moonbuild-rupes-recta as the default build engine
  - Add moonrun and moonbuild-debug crate descriptions
  - Document features.rs for feature flags

- Update AGENTS.md with build system transition info:
  - Mark moonbuild-rupes-recta as now default
  - Add section explaining NEW_MOON env var for fallback
  - Document -Z flags for unstable features
