### PR TITLE
fix: exclude third-party packages from coverage analysis

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -184,7 +184,7 @@ fn run_build_rr(
     } else {
         let _lock = FileLock::lock(target_dir)?;
         // Generate all_pkgs.json for indirect dependency resolution
-        rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Build)?;
+        rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Build, false)?;
 
         let result = rr_build::execute_build(
             &BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose),

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -154,7 +154,7 @@ pub fn run_bundle_internal_rr(
     } else {
         let _lock = FileLock::lock(target_dir)?;
         // Generate all_pkgs.json for indirect dependency resolution
-        rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Bundle)?;
+        rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Bundle, false)?;
         // Generate metadata for IDE & bundler
         rr_build::generate_metadata(source_dir, target_dir, &build_meta, RunMode::Bundle, None)?;
 

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -235,7 +235,7 @@ fn run_check_for_single_file_rr(
     let _lock = FileLock::lock(&raw_target_dir)?;
 
     // Generate all_pkgs.json for indirect dependency resolution
-    rr_build::generate_all_pkgs_json(&raw_target_dir, &build_meta, RunMode::Check)?;
+    rr_build::generate_all_pkgs_json(&raw_target_dir, &build_meta, RunMode::Check, false)?;
     let filename = single_file_path
         .file_name()
         .and_then(|n| n.to_str())
@@ -469,7 +469,7 @@ fn run_check_normal_internal_rr(
     } else {
         let _lock = FileLock::lock(target_dir)?;
         // Generate all_pkgs.json for indirect dependency resolution
-        rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Check)?;
+        rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Check, false)?;
         // Generate metadata for IDE
         rr_build::generate_metadata(source_dir, target_dir, &build_meta, RunMode::Check, None)?;
 

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -128,7 +128,7 @@ pub fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Result<i32
     let _lock = FileLock::lock(&target_dir)?;
     // Generate the all_pkgs.json for indirect dependency resolution
     // before executing the build
-    rr_build::generate_all_pkgs_json(&target_dir, &build_meta, RunMode::Check)?;
+    rr_build::generate_all_pkgs_json(&target_dir, &build_meta, RunMode::Check, false)?;
     // Generate metadata for `moondoc`
     rr_build::generate_metadata(&source_dir, &target_dir, &build_meta, RunMode::Check, None)?;
 

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -189,7 +189,7 @@ pub fn run_info_rr_internal(
     )?;
     // Generate the all_pkgs.json for indirect dependency resolution
     // before executing the build
-    rr_build::generate_all_pkgs_json(&target_dir, &build_meta, RunMode::Check)?;
+    rr_build::generate_all_pkgs_json(&target_dir, &build_meta, RunMode::Check, false)?;
 
     // TODO: UX: Consider mirroring flags from `moon check`?
     let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature, cli.verbose);

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -715,7 +715,7 @@ fn rr_run_from_plan(
 
     let _lock = FileLock::lock(target_dir)?;
     // Generate all_pkgs.json for indirect dependency resolution
-    rr_build::generate_all_pkgs_json(target_dir, build_meta, RunMode::Run)?;
+    rr_build::generate_all_pkgs_json(target_dir, build_meta, RunMode::Run, false)?;
 
     let build_config =
         BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose);

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -1485,7 +1485,12 @@ fn rr_test_from_plan(
     let _lock = FileLock::lock(target_dir)?;
     // Generate the all_pkgs.json for indirect dependency resolution
     // before executing the build
-    rr_build::generate_all_pkgs_json(target_dir, build_meta, cmd.run_mode)?;
+    rr_build::generate_all_pkgs_json(
+        target_dir,
+        build_meta,
+        cmd.run_mode,
+        cmd.build_flags.enable_coverage,
+    )?;
 
     let build_config = BuildConfig::from_flags(cmd.build_flags, &cli.unstable_feature, cli.verbose);
 

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -145,7 +145,7 @@ pub fn run_build_binary_dep(cli: &UniversalFlags, cmd: &BuildBinaryDepArgs) -> a
 
         let _lock = FileLock::lock(&target_dir)?;
         // Generate all_pkgs.json for indirect dependency resolution
-        rr_build::generate_all_pkgs_json(&target_dir, &build_meta, RunMode::Build)?;
+        rr_build::generate_all_pkgs_json(&target_dir, &build_meta, RunMode::Build, false)?;
 
         let result = rr_build::execute_build(&BuildConfig::default(), build_graph, &target_dir)?;
         result.print_info(cli.quiet, "building")?;

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -629,10 +629,13 @@ pub fn generate_metadata(
     Ok(())
 }
 
+/// Generate the `all_pkgs.json` metadata file for indirect dependency resolution.
+/// If `exclude_third_party` is true, only packages in the local workspace will be included.
 pub fn generate_all_pkgs_json(
     target_dir: &Path,
     build_meta: &BuildMeta,
     mode: RunMode,
+    exclude_third_party: bool,
 ) -> anyhow::Result<()> {
     let resolve_output = &build_meta.resolve_output;
     let &[main_module_id] = resolve_output.local_modules() else {
@@ -655,6 +658,7 @@ pub fn generate_all_pkgs_json(
         &build_meta.resolve_output,
         &layout,
         build_meta.target_backend.into(),
+        exclude_third_party,
     );
     let orig_all_pkgs = std::fs::read_to_string(&all_pkgs_path);
     let all_pkgs_str =

--- a/crates/moonbuild-rupes-recta/src/all_pkgs.rs
+++ b/crates/moonbuild-rupes-recta/src/all_pkgs.rs
@@ -55,10 +55,20 @@ pub fn gen_all_pkgs_json(
     resolve_output: &ResolveOutput,
     layout: &crate::build_lower::artifact::LegacyLayout,
     backend: TargetBackend,
+    exclude_third_party: bool,
 ) -> AllPkgsJSON {
+    let local_modules = resolve_output.local_modules();
     let mut packages: Vec<PackageArtifactJSON> = resolve_output
         .pkg_dirs
         .all_packages(false)
+        // Skip third-party packages if requested
+        .filter(|(_id, pkg)| {
+            if !exclude_third_party {
+                return true;
+            }
+            // Keep only packages whose module is in the local modules
+            local_modules.contains(&pkg.module)
+        })
         // Skip the `moonbitlang/core/abort` package to match the behavior of the legacy metadata JSON
         .filter(|(id, _)| {
             resolve_output


### PR DESCRIPTION
## Summary

This fix prevents third-party packages from being included in `moon coverage analyze` command output.

## Problem

When executing `moon coverage analyze`, third-party packages were also being checked for test coverage, which is typically not desired behavior. Users typically want to see coverage only for their own code, not for external dependencies.

## Root Cause

The issue was in the `gen_all_pkgs_json` function in `crates/moonbuild-rupes-recta/src/all_pkgs.rs`. This function generates an `all_pkgs.json` file that is used by the MoonBit compiler during test execution with coverage instrumentation. The function was calling `all_packages(false)`, which includes all packages (both first-party and third-party), causing third-party packages to be instrumented for coverage analysis.

## Solution

1. **Modified `gen_all_pkgs_json`** (`crates/moonbuild-rupes-recta/src/all_pkgs.rs`):
   - Added an `exclude_third_party: bool` parameter
   - Added filtering logic to exclude packages whose modules are not in the local workspace when this parameter is `true`

2. **Updated `generate_all_pkgs_json`** (`crates/moon/src/rr_build/mod.rs`):
   - Added the `exclude_third_party` parameter and passed it through to `gen_all_pkgs_json`

3. **Modified test execution** (`crates/moon/src/cli/test.rs`):
   - When coverage mode is enabled (`cmd.build_flags.enable_coverage`), pass `true` for `exclude_third_party`

4. **Updated all other call sites** to pass `false` for `exclude_third_party`, maintaining existing behavior for non-coverage commands:
   - `crates/moon/src/cli/build.rs`
   - `crates/moon/src/cli/bundle.rs`
   - `crates/moon/src/cli/check.rs`
   - `crates/moon/src/cli/doc.rs`
   - `crates/moon/src/cli/info.rs`
   - `crates/moon/src/cli/run.rs`
   - `crates/moon/src/cli/tool/build_binary_dep.rs`

## Files Changed

- `crates/moonbuild-rupes-recta/src/all_pkgs.rs` - Added filtering logic for third-party packages
- `crates/moon/src/rr_build/mod.rs` - Added parameter to pass through exclusion flag
- `crates/moon/src/cli/test.rs` - Pass `true` for exclude_third_party when coverage is enabled
- `crates/moon/src/cli/build.rs` - Updated call (pass `false`)
- `crates/moon/src/cli/bundle.rs` - Updated call (pass `false`)
- `crates/moon/src/cli/check.rs` - Updated calls (pass `false`)
- `crates/moon/src/cli/doc.rs` - Updated call (pass `false`)
- `crates/moon/src/cli/info.rs` - Updated call (pass `false`)
- `crates/moon/src/cli/run.rs` - Updated call (pass `false`)
- `crates/moon/src/cli/tool/build_binary_dep.rs` - Updated call (pass `false`)

## Testing

- All existing tests pass (271 passed, 10 ignored)
- Code quality verified with `cargo clippy` and `cargo fmt`
- No warnings or errors on modified crates

## Backward Compatibility

This change maintains full backward compatibility. The `exclude_third_party` parameter defaults to `false` for all existing commands, so only the coverage analysis behavior is affected.