### PR TITLE
remove unqualified call to prelude definition in test driver

### DIFF
--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -2927,7 +2927,7 @@ fn moon_test_target_js_panic_with_sourcemap() {
             [username/hello] test lib/hello_test.mbt:1 ("hello") failed: Error
                 at $panic ($ROOT/_build/js/debug/test/lib/lib.blackbox_test.js:3:9)
                 at username$hello$lib_blackbox_test$$__test_68656c6c6f5f746573742e6d6274_0 ($ROOT/src/lib/hello_test.mbt:3:5)
-                at username$hello$lib_blackbox_test$$moonbit_test_driver_internal_js_catch ($ROOT/src/lib/__generated_driver_for_blackbox_test.mbt:483:11)
+                at username$hello$lib_blackbox_test$$moonbit_test_driver_internal_js_catch ($ROOT/src/lib/__generated_driver_for_blackbox_test.mbt:484:11)
             Total tests: 1, passed: 0, failed: 1."#]],
     );
 }

--- a/crates/moonbuild/template/test_driver/no_bench_arg_template.mbt
+++ b/crates/moonbuild/template/test_driver/no_bench_arg_template.mbt
@@ -7,6 +7,6 @@ fn moonbit_test_driver_internal_new_bench_arg() -> Moonbit_Test_Driver_Internal_
 fn moonbit_test_driver_internal_get_bench_summary(
   bench : Moonbit_Test_Driver_Internal_Bench_Arg,
 ) -> String {
-  ignore(bench)
+  let _ = bench
   ""
 }

--- a/crates/moonbuild/template/test_driver/test_driver_template.mbt
+++ b/crates/moonbuild/template/test_driver/test_driver_template.mbt
@@ -172,9 +172,10 @@ pub fn moonbit_test_driver_internal_do_execute(
       raise MoonBitTestDriverInternalSkipTest(name="")
     }
   } catch {
-    MoonBitTestDriverInternalSkipTest(name~) =>
+    err => {
+      guard err is MoonBitTestDriverInternalSkipTest(name~)
       handle_result(name, "skipped test", true)
-    _err => panic()
+    }
   }
 }
 


### PR DESCRIPTION
We should not call definitions in `moonbitlang/core/prelude` directly, unqualified in the test driver, because there may be local definitions shadowing those in `@prelude` in the package being tested. This PR removes unqualified call to definitions in `@prelude` in the test driver.