### PR TITLE
perf: avoid using serde from_reader

### DIFF
--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -450,8 +450,9 @@ fn run_one_test_executable(
     let pkgname = fqn.to_string();
 
     // Parse test metadata
-    let meta = std::fs::File::open(test.meta).context("Failed to open test metadata")?;
-    let meta: MooncGenTestInfo = serde_json_lenient::from_reader(meta)
+    let meta_bytes = std::fs::read(test.meta)
+        .with_context(|| format!("Failed to read test metadata at {}", test.meta.display()))?;
+    let meta: MooncGenTestInfo = serde_json_lenient::from_slice(&meta_bytes)
         .with_context(|| format!("Failed to parse test metadata at {}", test.meta.display()))?;
     trace!(path = %test.meta.display(), "loaded test metadata");
 


### PR DESCRIPTION
- Related issues: None
- PR kind: Optimization

## Summary

serde_json_lenient::from_reader() (and serde_json::from_reader()) is known to be slow because it reads byte-by-byte from the reader. The typical fix is to read the entire file into memory first, then parse