### PR TITLE
refactor: not put js test driver in tmp file

### DIFF
--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -208,9 +208,9 @@ fn install_build_rr(
         .context("RR build should yield exactly one artifact file")?;
 
     // Build command using existing runtime mapping, then shlex-join
-    let guard = crate::run::command_for(meta.target_backend, artifact, None)?;
-    let parts = std::iter::once(guard.command.as_std().get_program())
-        .chain(guard.command.as_std().get_args())
+    let cmd = crate::run::command_for(meta.target_backend, artifact, None)?;
+    let parts = std::iter::once(cmd.as_std().get_program())
+        .chain(cmd.as_std().get_args())
         .map(|x| x.to_string_lossy().to_string())
         .collect::<Vec<_>>();
     let line = shlex::try_join(parts.iter().map(|s| &**s))

--- a/crates/moon/src/run/mod.rs
+++ b/crates/moon/src/run/mod.rs
@@ -24,7 +24,7 @@ mod runtime;
 
 pub use child::run;
 pub use runtest::{TestFilter, TestIndex, perform_promotion, run_tests};
-pub use runtime::{CommandGuard, command_for};
+pub use runtime::command_for;
 
 use std::sync::OnceLock;
 

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -482,7 +482,7 @@ fn run_one_test_executable(
     let mut cov_cap = mk_coverage_capture();
     let mut test_cap = make_test_capture();
     if ctx.verbose {
-        crate::rr_build::dry_print_command(cmd.command.as_std(), ctx.source_dir, true);
+        crate::rr_build::dry_print_command(cmd.as_std(), ctx.source_dir, true);
     }
     info!(package = %test_args.package, executable = %test.executable.display(), "launching test executable");
 
@@ -491,7 +491,7 @@ fn run_one_test_executable(
         .block_on(crate::run::run(
             &mut [&mut cov_cap, &mut test_cap],
             true,
-            cmd.command,
+            cmd,
         ))
         .with_context(|| format!("Failed to run test for {fqn} {:?}", test.target.kind))?;
     debug!(?exit_status, "test process finished");

--- a/docs/dev/reference/tests.md
+++ b/docs/dev/reference/tests.md
@@ -71,8 +71,7 @@ rendered via `render_expect_fail` / `render_snapshot_fail` to provide context wh
 
 ## Commands per backend (and how to specify test cases)
 
-`command_for` (in `runtime.rs`) hides the differences between target backends. The
-runner always records a `CommandGuard` that cleans up temporary drivers when necessary.
+`command_for` (in `runtime.rs`) hides the differences between target backends.
 
 ### Wasm and WasmGC
 
@@ -84,13 +83,14 @@ runner always records a `CommandGuard` that cleans up temporary drivers when nec
 ### JavaScript
 
 - For plain `moon run`, Node reads the emitted `.js`. For tests, the runner synthesizes
-  a temporary CommonJS driver next to the compiled `.cjs` file.
-- The driver imports the original artifact, sets `testParams` and `packageName`, and
-  then invokes the generated test harness.
-- Execution command: `node --enable-source-maps <temp_dir>/driver.cjs '<TestArgs JSON>'`.
-  The temporary directory also contains a throwaway `package.json` so Node does not try
-  to interpret surrounding workspace settings (`type: module`). The directory is deleted
-  once the command finishes.
+  a CommonJS driver alongside the compiled `.js` file.
+- The driver (e.g. `foo.cjs` next to `foo.js`) imports the original artifact, sets
+  `testParams` and `packageName`, and then invokes the generated test harness.
+- Execution command: `node --enable-source-maps <artifact>.cjs '<TestArgs JSON>'`.
+  A `package.json` is also written to the artifact directory so Node does not try
+  to interpret surrounding workspace settings (`type: module`).
+- The driver file persists after test runs, allowing users to manually re-run or debug
+  tests by invoking the driver directly.
 
 ### Native and LLVM
 


### PR DESCRIPTION
- Related issues: #1359
- PR kind: refactor

## Summary

The new backend generates the `driver.cjs` into a temporary dir so that the `driver.cjs` is properly cleaned up when the test finishes. But this making debug with the driver hard. So this PR changes it to store the driver in the build target dir.


