### PR TITLE
fix coverage on JavaScript backend for async test

### DIFF
--- a/crates/moonbuild/template/test_driver_project/template_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_async.mbt
@@ -7,16 +7,19 @@ impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with run_async
   tests,
 ) {
   let moonbit_test_driver_internal_max_concurrent_tests : Int = 0 // REPLACE ME: moonbit_test_driver_internal_max_concurrent_tests
-  @moonbitlang/async.run_async_main(() => @moonbitlang/async.with_task_group(group => {
-    let mut i = 0
-    for _ in 0..<moonbit_test_driver_internal_max_concurrent_tests {
-      group.spawn_bg(() => while i < tests.length() {
-        let f = tests[i]
-        i += 1
-        f()
-      })
-    }
-  }))
+  @moonbitlang/async.run_async_main(() => {
+    @moonbitlang/async.with_task_group(group => {
+      let mut i = 0
+      for _ in 0..<moonbit_test_driver_internal_max_concurrent_tests {
+        group.spawn_bg(() => while i < tests.length() {
+          let f = tests[i]
+          i += 1
+          f()
+        })
+      }
+    })
+    // {COVERAGE_END}
+  })
 }
 
 ///|


### PR DESCRIPTION
Coverage is not working properly on JavaScript backend when `async test` is present. `@coverage.end()` should be called after all tests are run to properly collect coverage data. Previously, the JS test driver call `@coverage.end()` at the end of the entry script `js_driver.js`. However, if `async test` is present, there may be promises created by `async test` running in the background at this point, and coverage data for those tests would be missing.

This PR fixes the problem by always calling `@coverage.end()` after all `async test` completed. Note that `@coverage.end()` will reset the global counter and can be safely invoked multiple times, so no need to change other parts of code.

Duplicated call to `@coverage.end()` may be avoidable , but that's out of the scope of this PR.

I've tested locally and this PR can indeed produce correct coverage data on `moonbitlang/async`.