### PR TITLE
feat: add git source and add path recognition for moon install

### DIFF
--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -339,7 +339,12 @@ pub(super) fn install_from_git(
                 .to_string(),
         }
     } else {
-        PackageFilter::ByPath(target_path)
+        // Use ByPackagePath for git install (string comparison, not filesystem path)
+        PackageFilter::ByPackagePath(
+            package_path
+                .map(|p| p.trim_matches('/').to_string())
+                .unwrap_or_default(),
+        )
     };
 
     build_and_install_packages(cli, &module_name, &module_root, install_dir, filter)

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -46,12 +46,21 @@ pub struct InstallSubcommand {
     /// If not provided, falls back to legacy behavior (install project dependencies)
     pub package_path: Option<String>,
 
+    /// Package path within a git repository (e.g., src/main or cmd/...)
+    /// Only used with git URLs. Supports /... suffix for wildcard matching.
+    pub package_path_in_repo: Option<String>,
+
     /// Specify installation directory (default: ~/.moon/bin/)
     #[clap(long)]
     pub bin: Option<PathBuf>,
 
     /// Install from local path instead of registry
-    #[clap(long, conflicts_with = "package_path", conflicts_with = "git_ref")]
+    #[clap(
+        long,
+        conflicts_with = "package_path",
+        conflicts_with = "git_ref",
+        conflicts_with = "package_path_in_repo"
+    )]
     pub path: Option<PathBuf>,
 
     /// Git revision to checkout (commit hash, requires git URL)

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -426,11 +426,12 @@ Remove a dependency
 
 Install a binary package globally or install project dependencies (deprecated without args)
 
-**Usage:** `moon install [OPTIONS] [PACKAGE_PATH]`
+**Usage:** `moon install [OPTIONS] [PACKAGE_PATH] [PACKAGE_PATH_IN_REPO]`
 
 ###### **Arguments:**
 
 * `<PACKAGE_PATH>` — Package path to install (e.g., user/pkg/main or user/pkg/cmd/...) Supports @version suffix (e.g., user/pkg/main@1.0.0) Git URLs are auto-detected (any URL format git supports) Local paths are auto-detected: ./, ../, / (Unix), or drive letter (Windows) If not provided, falls back to legacy behavior (install project dependencies)
+* `<PACKAGE_PATH_IN_REPO>` — Package path within a git repository (e.g., src/main or cmd/...) Only used with git URLs. Supports /... suffix for wildcard matching
 
 ###### **Options:**
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -426,11 +426,12 @@ Remove a dependency
 
 Install a binary package globally or install project dependencies (deprecated without args)
 
-**Usage:** `moon install [OPTIONS] [PACKAGE_PATH]`
+**Usage:** `moon install [OPTIONS] [PACKAGE_PATH] [PACKAGE_PATH_IN_REPO]`
 
 ###### **Arguments:**
 
 * `<PACKAGE_PATH>` — Package path to install (e.g., user/pkg/main or user/pkg/cmd/...) Supports @version suffix (e.g., user/pkg/main@1.0.0) Git URLs are auto-detected (any URL format git supports) Local paths are auto-detected: ./, ../, / (Unix), or drive letter (Windows) If not provided, falls back to legacy behavior (install project dependencies)
+* `<PACKAGE_PATH_IN_REPO>` — Package path within a git repository (e.g., src/main or cmd/...) Only used with git URLs. Supports /... suffix for wildcard matching
 
 ###### **Options:**
 


### PR DESCRIPTION
This PR adds `--git` support to `moon install`, allowing users to install packages directly from remote git repositories. Usage includes `moon install --git <url>` for installing root packages, `moon install --git <url> cmd/main` for specific packages, and `moon install --git <url> cmd/...` for wildcard patterns. Optional `--branch`, `--tag`, or `--rev` flags allow specifying the checkout target.