### PR TITLE
update moon.pkg syntax to deprecate 'as' aliasing

### DIFF
--- a/crates/moonutil/src/moon_pkg/parser.rs
+++ b/crates/moonutil/src/moon_pkg/parser.rs
@@ -271,12 +271,18 @@ impl Parser {
                 let path = s.parse_string()?;
                 let alias = match s.peek() {
                     Token::AS(_) => {
+                        // deprecated syntax: "path/to/pkg" as @alias
                         s.skip();
                         let Token::PACKAGENAME((_, alias)) = s.peek() else {
                             return Err(ParseError::UnexpectedToken(s.peek().clone()));
                         };
                         s.skip();
                         Some(alias.clone())
+                    }
+                    Token::PACKAGENAME((_, alias)) => {
+                        let alias = alias.clone();
+                        s.skip();
+                        Some(alias)
                     }
                     _ => None,
                 };
@@ -354,6 +360,7 @@ fn parse_test() {
 import {
   "path/to/pkg1",
   "path/to/pkg2" as @alias,
+  "path/to/pkg3" @alias3,
 }
 
 import {
@@ -400,6 +407,10 @@ f(
                 Object {
                     "path": String("path/to/pkg2"),
                     "alias": String("alias"),
+                },
+                Object {
+                    "path": String("path/to/pkg3"),
+                    "alias": String("alias3"),
                 },
             ],
             "test-import": Array [

--- a/crates/moonutil/tests/expect_moon_pkg.rs
+++ b/crates/moonutil/tests/expect_moon_pkg.rs
@@ -28,7 +28,7 @@ fn expect_import() {
     let actual = run(r#"
       import {
         "path/to/pkg1",
-        "path/to/another1" as @another1,
+        "path/to/another1" @another1,
       }
 
       import {
@@ -38,7 +38,7 @@ fn expect_import() {
 
       import {
         "path/to/pkg3",
-        "path/to/another3" as @another3,
+        "path/to/another3" @another3,
       } for "wbtest"
     "#);
     expect_test::expect![[r#"


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind: <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

use `"xxx" @alias` instead of `"xxx" as @alias`

cc @myfreess 

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
