### PR TITLE
refactor: moonrun backtrace runtime and simplify path/color behavior

### DIFF
--- a/crates/moonrun/src/backtrace_api.rs
+++ b/crates/moonrun/src/backtrace_api.rs
@@ -1,0 +1,101 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::v8_builder::{ArgsExt, ObjectExt, ScopeExt};
+use std::io::IsTerminal;
+use std::path::Path;
+
+fn resolve_source_map_path_impl(wasm_path: &str, source_map_path: &str) -> String {
+    if source_map_path.is_empty() {
+        return String::new();
+    }
+    if Path::new(source_map_path).is_absolute() {
+        return source_map_path.to_string();
+    }
+
+    let base_dir = Path::new(wasm_path)
+        .parent()
+        .unwrap_or_else(|| Path::new("."));
+    let joined = base_dir.join(source_map_path);
+    joined.to_string_lossy().into_owned()
+}
+
+fn should_use_stacktrace_color() -> bool {
+    if !std::env::var("NO_COLOR").unwrap_or_default().is_empty() {
+        return false;
+    }
+    std::io::stderr().is_terminal()
+}
+
+fn resolve_source_map_path(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut ret: v8::ReturnValue,
+) {
+    let wasm_path = args.string_lossy(scope, 0);
+    let source_map_path = args.string_lossy(scope, 1);
+    let resolved = resolve_source_map_path_impl(&wasm_path, &source_map_path);
+    ret.set(scope.string(&resolved).into());
+}
+
+const BACKTRACE_RUNTIME_NAMESPACE: &str = "__moonbit_backtrace_runtime";
+
+pub fn init(scope: &mut v8::HandleScope) {
+    let global_proxy = scope.get_current_context().global(scope);
+    let backtrace_obj = global_proxy.child(scope, BACKTRACE_RUNTIME_NAMESPACE);
+
+    let stacktrace_color_enabled_key = scope.string("stacktrace_color_enabled").into();
+    let stacktrace_color_enabled = v8::Boolean::new(scope, should_use_stacktrace_color()).into();
+    backtrace_obj.set(
+        scope,
+        stacktrace_color_enabled_key,
+        stacktrace_color_enabled,
+    );
+    backtrace_obj.set_func(scope, "resolve_source_map_path", resolve_source_map_path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(windows))]
+    #[test]
+    fn resolve_source_map_path_handles_relative_and_absolute_paths_unix() {
+        assert_eq!(
+            resolve_source_map_path_impl("/repo/main.wasm", "main.wasm.map"),
+            "/repo/main.wasm.map"
+        );
+        assert_eq!(
+            resolve_source_map_path_impl("/repo/main.wasm", "/tmp/main.wasm.map"),
+            "/tmp/main.wasm.map"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_source_map_path_handles_windows_paths() {
+        assert_eq!(
+            resolve_source_map_path_impl(r"C:\repo\main.wasm", r"maps\main.wasm.map"),
+            r"C:\repo\maps\main.wasm.map"
+        );
+        assert_eq!(
+            resolve_source_map_path_impl(r"C:\repo\main.wasm", r"C:\tmp\main.wasm.map"),
+            r"C:\tmp\main.wasm.map"
+        );
+    }
+}

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 use std::{cell::Cell, io::Read, path::PathBuf, time::Instant};
 use v8::V8::set_flags_from_string;
 
+mod backtrace_api;
 mod fs_api_temp;
 mod sys_api;
 mod util;
@@ -380,6 +381,7 @@ fn init_env(
         sys_api::init_env(obj, scope, wasm_file_name, args);
         fs_api_temp::init_fs(obj, scope);
     }
+    backtrace_api::init(scope);
 
     {
         global_proxy.set_func(scope, "read_file_to_bytes", read_file_to_bytes);

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -76,30 +76,6 @@ fn check(actual: &str, expect: Expect) {
     expect.assert_eq(actual)
 }
 
-fn strip_ansi(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let bytes = text.as_bytes();
-    let mut i = 0;
-
-    while i < bytes.len() {
-        if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
-            i += 2;
-            while i < bytes.len() {
-                let b = bytes[i];
-                if b.is_ascii_alphabetic() {
-                    i += 1;
-                    break;
-                }
-                i += 1;
-            }
-            continue;
-        }
-        out.push(bytes[i] as char);
-        i += 1;
-    }
-    out
-}
-
 fn normalize_source_token(token: &str) -> String {
     let Some(line_sep) = token.rfind(':') else {
         return token.to_string();
@@ -236,7 +212,6 @@ fn test_moonrun_wasm_stack_trace() {
     //          at wasm://wasm/d858b7fa:wasm-function[17]:0x72b
     //          at wasm://wasm/d858b7fa:wasm-function[24]:0x7a3
     let s = std::str::from_utf8(&out).unwrap().to_string();
-    let s = strip_ansi(&s);
     // need normalization because the source loc (absolute path now) string in
     // encoded in data section and makes the hash of the .wasm file flaky
     // because the absolute path contains temp dir path
@@ -260,7 +235,6 @@ fn test_moonrun_wasm_stack_trace() {
         .stderr
         .to_owned();
     let s = std::str::from_utf8(&out).unwrap().to_string();
-    let s = strip_ansi(&s);
     check(
         &s,
         expect![[r#"


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind: refactor <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

There was some hack in the JS to make the output of backtrace path stable, which was unnecessary and error prone.

This PR also moves a lot of host specific logic from js to rust.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
