### PR TITLE
refactor: remove target_backend from build_flags

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -172,9 +172,6 @@ pub struct BuildFlags {
     #[clap(long, value_delimiter = ',')]
     pub target: Vec<SurfaceTarget>,
 
-    #[clap(skip)]
-    pub target_backend: Option<TargetBackend>,
-
     /// [Deprecated] Handle the selected targets sequentially
     ///
     /// This flag is deprecated, because all targets are handled sequentially
@@ -240,7 +237,6 @@ impl Default for BuildFlags {
             strip: false,
             no_strip: false,
             target: Vec::new(),
-            target_backend: None,
             serial: false,
             enable_coverage: false,
             sort_input: false,
@@ -258,14 +254,6 @@ impl Default for BuildFlags {
 }
 
 impl BuildFlags {
-    /// Set the target backend if not already set
-    pub fn with_default_target_backend(mut self, backend: Option<TargetBackend>) -> Self {
-        if self.target_backend.is_none() {
-            self.target_backend = backend;
-        }
-        self
-    }
-
     pub fn resolve_single_target_backend(&self) -> anyhow::Result<Option<TargetBackend>> {
         if self.target.is_empty() {
             return Ok(None);

--- a/crates/moon/src/cli/bench.rs
+++ b/crates/moon/src/cli/bench.rs
@@ -18,7 +18,7 @@
 
 use anyhow::Context;
 use moonutil::{
-    common::{TestIndexRange, lower_surface_targets},
+    common::{TargetBackend, TestIndexRange, lower_surface_targets},
     dirs::PackageDirs,
     mooncakes::sync::AutoSyncFlags,
 };
@@ -66,7 +66,7 @@ pub fn run_bench(cli: UniversalFlags, cmd: BenchSubcommand) -> anyhow::Result<i3
     } = cli.source_tgt_dir.try_into_package_dirs()?;
 
     if cmd.build_flags.target.is_empty() {
-        return run_bench_internal(&cli, &cmd, &source_dir, &target_dir, None);
+        return run_bench_internal(&cli, &cmd, &source_dir, &target_dir, None, None);
     }
     let surface_targets = cmd.build_flags.target.clone();
     let targets = lower_surface_targets(&surface_targets);
@@ -74,10 +74,15 @@ pub fn run_bench(cli: UniversalFlags, cmd: BenchSubcommand) -> anyhow::Result<i3
 
     let mut ret_value = 0;
     for t in targets {
-        let mut cmd = cmd.clone();
-        cmd.build_flags.target_backend = Some(t);
-        let x = run_bench_internal(&cli, &cmd, &source_dir, &target_dir, display_backend_hint)
-            .context(format!("failed to run bench for target {t:?}"))?;
+        let x = run_bench_internal(
+            &cli,
+            &cmd,
+            &source_dir,
+            &target_dir,
+            display_backend_hint,
+            Some(t),
+        )
+        .context(format!("failed to run bench for target {t:?}"))?;
         ret_value = ret_value.max(x);
     }
     Ok(ret_value)
@@ -90,6 +95,7 @@ fn run_bench_internal(
     source_dir: &Path,
     target_dir: &Path,
     display_backend_hint: Option<()>,
+    selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     super::run_test_or_bench_internal(
         cli,
@@ -97,5 +103,6 @@ fn run_bench_internal(
         source_dir,
         target_dir,
         display_backend_hint,
+        selected_target_backend,
     )
 }

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -87,6 +87,7 @@ pub fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Result<i32
         &cmd.auto_sync_flags,
         &cli,
         &BuildFlags::default(),
+        None,
         &target_dir,
         RunMode::Check,
     );

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -147,10 +147,8 @@ pub fn run_info_rr_internal(
     let mut preconfig = rr_build::preconfig_compile(
         &cmd.auto_sync_flags,
         cli,
-        &BuildFlags {
-            target_backend: target,
-            ..BuildFlags::default()
-        },
+        &BuildFlags::default(),
+        target,
         &target_dir,
         RunMode::Check,
     );

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -467,13 +467,13 @@ fn build_and_install_packages(
         let build_flags = BuildFlags {
             release: true,
             warn_list: Some("-a".to_string()),
-            target_backend: Some(TargetBackend::Native),
             ..BuildFlags::default()
         };
         let preconfig = preconfig_compile(
             &moonutil::mooncakes::sync::AutoSyncFlags { frozen: false },
             cli,
             &build_flags,
+            Some(TargetBackend::Native),
             &target_dir,
             RunMode::Build,
         );

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -129,9 +129,9 @@ pub fn run_build_binary_dep(cli: &UniversalFlags, cmd: &BuildBinaryDepArgs) -> a
             cli,
             &BuildFlags {
                 release: true,
-                target_backend: Some(target),
                 ..BuildFlags::default()
             },
+            Some(target),
             &target_dir,
             RunMode::Build,
         );

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -298,6 +298,7 @@ impl CompilePreConfig {
 /// - `auto_sync_flags`: The flags to control module download & sync behavior.
 /// - `cli`: The universal CLI flags.
 /// - `build_flags`: The build-specific flags.
+/// - `selected_target_backend`: The backend selected for this invocation, if explicit.
 /// - `target_dir`: The target directory for the build.
 /// - `action`: The run mode (build, test, bench, etc.). This also affects the
 ///   default build profile (bench/check/bundle default to release; others default to debug).
@@ -306,6 +307,7 @@ pub fn preconfig_compile(
     auto_sync_flags: &AutoSyncFlags,
     cli: &UniversalFlags,
     build_flags: &BuildFlags,
+    selected_target_backend: Option<TargetBackend>,
     target_dir: &Path,
     action: RunMode,
 ) -> CompilePreConfig {
@@ -314,7 +316,7 @@ pub fn preconfig_compile(
     CompilePreConfig {
         frozen: auto_sync_flags.frozen,
         target_dir: target_dir.to_owned(),
-        target_backend: build_flags.target_backend,
+        target_backend: selected_target_backend,
         opt_level,
         action,
         debug_symbols: build_flags.debug_symbols_for(action),


### PR DESCRIPTION
refactor to separate parsed targets from selected backend and remove the cmd.clone() mutation pattern.