### PR TITLE
refactor: cleanup unnecessary clone

### DIFF
--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -498,7 +498,7 @@ pub(crate) fn collect_test_outline(
 /// Gather tests executables from the build metadata.
 #[instrument(level = "trace", skip(build_meta))]
 fn gather_tests(build_meta: &BuildMeta) -> Vec<TestExecutableToRun<'_>> {
-    let mut pending = HashMap::new();
+    let mut pending = HashMap::with_capacity(build_meta.artifacts.len());
     let mut results = vec![];
 
     for (node, artifacts) in &build_meta.artifacts {

--- a/crates/moonbuild-debug/src/graph.rs
+++ b/crates/moonbuild-debug/src/graph.rs
@@ -184,9 +184,9 @@ impl PathNormalizer {
         let replace_table = moonutil::BINARIES
             .all_moon_bins()
             .iter()
-            .map(|(name, path)| (path.to_string_lossy().to_string(), name.to_string()))
+            .map(|(name, path)| (path.to_string_lossy().into_owned(), name.to_string()))
             .collect();
-        let moon_home = home().to_string_lossy().to_string();
+        let moon_home = home().to_string_lossy().into_owned();
 
         let canonical = dunce::canonicalize(source_dir).ok();
         PathNormalizer {

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/mod.rs
@@ -209,7 +209,7 @@ pub(super) trait CmdlineAbstraction {
 
     /// Build the full command with executable and arguments.
     fn build_command(&self, executable: impl AsRef<OsStr>) -> Vec<String> {
-        let mut args = vec![executable.as_ref().to_string_lossy().to_string()];
+        let mut args = vec![executable.as_ref().to_string_lossy().into_owned()];
         self.to_args(&mut args);
         args
     }

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -159,7 +159,7 @@ impl<'a> super::BuildPlanLowerContext<'a> {
             }
         };
 
-        let resolved_cc = resolve_cc(CC::default(), None);
+        let resolved_cc = resolve_cc(&CC::default(), None);
         let libbacktrace_path = runtime_c_path
             .parent()
             .expect("runtime_c_path should have a parent")

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -701,7 +701,7 @@ impl<'a> BuildPlanLowerContext<'a> {
             .expect("runtime dylib should have a parent directory");
 
         // Resolve CC: prefer stub_cc if provided, otherwise use default.
-        let cc = resolve_cc(self.opt.default_cc.clone(), info.stub_cc.clone());
+        let cc = resolve_cc(&self.opt.default_cc, info.stub_cc.as_ref());
 
         // Build linker config: shared lib, no libmoonbitrun, and link shared runtime dir
         let lcfg = LinkerConfigBuilder::<&Path>::default()
@@ -837,7 +837,7 @@ impl<'a> BuildPlanLowerContext<'a> {
         }
 
         let cc_cmd = make_cc_command_pure(
-            resolve_cc(self.opt.default_cc.clone(), info.cc.clone()), // TODO: no clone
+            resolve_cc(&self.opt.default_cc, info.cc.as_ref()),
             config,
             &c_flags.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
             sources.iter().map(|x| x.display().to_string()),

--- a/crates/moonbuild/src/dry_run.rs
+++ b/crates/moonbuild/src/dry_run.rs
@@ -58,7 +58,7 @@ pub fn print_build_commands(
 /// Note: This is specifically for stable dry-run output in tests and CI.
 /// Absolute stability across all possible edge cases is not a goal.
 fn create_file_sorting_cache(graph: &Graph) -> HashMap<FileId, (String, usize)> {
-    let mut key_cache = HashMap::new();
+    let mut key_cache = HashMap::with_capacity(graph.files.all_ids().size_hint().0);
     for id in graph.files.all_ids() {
         let name = &graph.file(id).name;
         let normalized = name.replace('\\', "/");

--- a/crates/moonbuild/src/expect.rs
+++ b/crates/moonbuild/src/expect.rs
@@ -419,16 +419,10 @@ fn collect<'a>(
         let json_str = &msg[EXPECT_FAILED.len()..];
         let rep = parse_expect_failed_message(pkg_src, json_str)?;
 
-        match targets.get_mut(&rep.loc.filename) {
-            Some(st) => {
-                st.insert(rep.guess_target()?);
-            }
-            None => {
-                let mut newst = BTreeSet::new();
-                newst.insert(rep.guess_target()?);
-                targets.insert(rep.loc.filename.clone(), newst);
-            }
-        }
+        targets
+            .entry(rep.loc.filename.clone())
+            .or_default()
+            .insert(rep.guess_target()?);
     }
     Ok(targets)
 }

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -51,7 +51,8 @@ pub fn add_latest(
     quiet: bool,
     index_updated: bool,
 ) -> anyhow::Result<i32> {
-    if pkg_name.to_string() == MOONBITLANG_CORE {
+    let pkg_name_str = pkg_name.to_string();
+    if pkg_name_str == MOONBITLANG_CORE {
         eprintln!(
             "{}: no need to add `{}` as dependency",
             "Warning".yellow().bold(),
@@ -65,11 +66,11 @@ pub fn add_latest(
         .get_latest_version(pkg_name)
         .ok_or_else(|| {
             if index_updated {
-                anyhow::anyhow!("could not find the latest version of {}", pkg_name.to_string())
+                anyhow::anyhow!("could not find the latest version of {}", pkg_name_str)
             } else {
             anyhow::anyhow!(
                 "could not find the latest version of {}. Please consider running `moon update` to update the index.",
-                pkg_name.to_string()
+                pkg_name_str
             )
             }
         })?
@@ -102,7 +103,8 @@ pub fn add(
 ) -> anyhow::Result<i32> {
     let mut m = read_module_desc_file_in_dir(source_dir)?;
 
-    if pkg_name.to_string() == MOONBITLANG_CORE {
+    let pkg_name_str = pkg_name.to_string();
+    if pkg_name_str == MOONBITLANG_CORE {
         eprintln!(
             "{}: no need to add `{}` as dependency",
             "Warning".yellow().bold(),
@@ -114,7 +116,7 @@ pub fn add(
     if bin {
         let bin_deps = m.bin_deps.get_or_insert_with(indexmap::IndexMap::new);
         bin_deps.insert(
-            pkg_name.to_string(),
+            pkg_name_str,
             BinaryDependencyInfo {
                 common: SourceDependencyInfo {
                     version: moonutil::version::as_caret_version_req(version.clone()),
@@ -125,7 +127,7 @@ pub fn add(
         );
     } else {
         m.deps.insert(
-            pkg_name.to_string(),
+            pkg_name_str,
             SourceDependencyInfo {
                 version: moonutil::version::as_caret_version_req(version.clone()),
                 ..Default::default()

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -63,7 +63,7 @@ pub fn auto_sync_for_single_mbt_md(
         front_matter_config.and_then(|config| config.moonbit.unwrap_or_default().deps)
     {
         for (k, v) in deps_map.iter() {
-            deps.insert(k.to_string(), v.clone().into());
+            deps.insert(k.clone(), v.clone().into());
         }
     }
 
@@ -99,7 +99,7 @@ pub fn auto_sync_for_single_file_rr(
     let mut synth_deps = IndexMap::new();
     if let Some(deps_map) = front_matter_deps {
         for (k, v) in deps_map.iter() {
-            synth_deps.insert(k.to_string(), v.clone().into());
+            synth_deps.insert(k.clone(), v.clone().into());
         }
     }
 

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -98,7 +98,7 @@ impl RegistryList {
     }
 
     pub fn with_registry(registry: Box<dyn Registry>) -> Self {
-        let mut registries = HashMap::new();
+        let mut registries = HashMap::with_capacity(1);
         let default_registry_name = "default";
         registries.insert(default_registry_name.to_owned(), registry);
 

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -141,9 +141,10 @@ impl OnlineRegistry {
         let reader = std::io::BufReader::new(file);
 
         let lines = reader.lines().collect::<std::io::Result<Vec<String>>>()?;
+        let version_str = version.to_string();
         for line in lines.iter().rev() {
             let j: MoonModJSON = serde_json_lenient::from_str(line)?;
-            if j.version.as_ref() == Some(&version.to_string()) {
+            if j.version.as_ref() == Some(&version_str) {
                 if let Some(checksum) = j.checksum {
                     return Ok(checksum);
                 } else {

--- a/crates/mooncake/src/resolver/mvs.rs
+++ b/crates/mooncake/src/resolver/mvs.rs
@@ -225,16 +225,14 @@ fn mvs_resolve(
     // Do a DFS in the graph
     while let Some((source, module)) = working_list.pop() {
         log::debug!("-- Solving for {}", source);
-        let mut all_deps = module.deps.clone();
-        all_deps.extend(
+        let all_deps = module.deps.iter().chain(
             module
                 .bin_deps
-                .clone()
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(k, v)| (k, v.into())),
+                .iter()
+                .flat_map(|m| m.iter())
+                .map(|(k, v)| (k, &v.common)),
         );
-        for (name, req) in &all_deps {
+        for (name, req) in all_deps {
             let pkg_name = match name.parse() {
                 Ok(v) => v,
                 Err(_) => {

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -339,7 +339,7 @@ pub struct ArchiverConfig {
 }
 
 /// Resolve the C compiler to use from global state
-pub fn resolve_cc(cc: CC, user_cc: Option<CC>) -> CC {
+pub fn resolve_cc(cc: &CC, user_cc: Option<&CC>) -> CC {
     if ENV_CC.is_some() && user_cc.is_some() {
         eprintln!(
             "{}: Both MOON_CC environment variable and user-specified CC are provided. \
@@ -347,7 +347,9 @@ pub fn resolve_cc(cc: CC, user_cc: Option<CC>) -> CC {
             "Warning".yellow().bold(),
         );
     }
-    ENV_CC.clone().unwrap_or_else(|| user_cc.unwrap_or(cc))
+    ENV_CC
+        .clone()
+        .unwrap_or_else(|| user_cc.cloned().unwrap_or_else(|| cc.clone()))
 }
 
 // Struct to hold path configuration for commands
@@ -417,7 +419,7 @@ pub fn make_archiver_command<S>(
 where
     S: AsRef<str>,
 {
-    let resolved_cc = resolve_cc(cc, user_cc);
+    let resolved_cc = resolve_cc(&cc, user_cc.as_ref());
     make_archiver_command_pure(resolved_cc, config, src, dest)
 }
 
@@ -581,7 +583,7 @@ where
     S: AsRef<str>,
     P: AsRef<Path>,
 {
-    let resolved_cc = resolve_cc(cc, user_cc);
+    let resolved_cc = resolve_cc(&cc, user_cc.as_ref());
     let lib_path = &MOON_DIRS.moon_lib_path.display().to_string();
     make_linker_command_pure(
         resolved_cc,
@@ -848,7 +850,7 @@ pub fn make_cc_command<S>(
 where
     S: AsRef<str>,
 {
-    let resolved_cc = resolve_cc(cc, user_cc);
+    let resolved_cc = resolve_cc(&cc, user_cc.as_ref());
     let paths = CompilerPaths::from_moon_dirs();
     make_cc_command_pure(
         resolved_cc,

--- a/crates/moonutil/src/module.rs
+++ b/crates/moonutil/src/module.rs
@@ -143,7 +143,9 @@ impl ModuleDB {
                 .chain(pkg.test_imports.iter());
 
             let mut paths = Vec::new();
-            let has_deps = all_deps.clone().count() > 0;
+            let has_deps = !pkg.imports.is_empty()
+                || !pkg.wbtest_imports.is_empty()
+                || !pkg.test_imports.is_empty();
 
             for dep in all_deps {
                 let dep_name = dep.path.make_full_path();

--- a/crates/moonutil/src/scan.rs
+++ b/crates/moonutil/src/scan.rs
@@ -429,26 +429,42 @@ fn scan_one_package(
     }
 
     // append warn_list & alert_list in current moon.pkg.json into the one in moon.mod.json
-    let warn_list = mod_desc
-        .warn_list
-        .as_ref()
-        .map_or(pkg.warn_list.clone(), |x| {
-            Some(x.clone() + &pkg.warn_list.unwrap_or_default())
-        })
-        .map_or(moonc_opt.build_opt.warn_list.clone(), |x| {
-            Some(x.clone() + &moonc_opt.build_opt.warn_list.clone().unwrap_or_default())
-        })
-        .filter(|s| !s.is_empty());
-    let alert_list = mod_desc
-        .alert_list
-        .as_ref()
-        .map_or(pkg.alert_list.clone(), |x| {
-            Some(x.clone() + &pkg.alert_list.unwrap_or_default())
-        })
-        .map_or(moonc_opt.build_opt.alert_list.clone(), |x| {
-            Some(x.clone() + &moonc_opt.build_opt.alert_list.clone().unwrap_or_default())
-        })
-        .filter(|s| !s.is_empty());
+    let warn_list = {
+        let mut parts = Vec::new();
+        if let Some(w) = &mod_desc.warn_list {
+            parts.push(w.as_str());
+        }
+        if let Some(w) = &pkg.warn_list {
+            parts.push(w.as_str());
+        }
+        if let Some(w) = &moonc_opt.build_opt.warn_list {
+            parts.push(w.as_str());
+        }
+        let combined: String = parts.concat();
+        if combined.is_empty() {
+            None
+        } else {
+            Some(combined)
+        }
+    };
+    let alert_list = {
+        let mut parts = Vec::new();
+        if let Some(a) = &mod_desc.alert_list {
+            parts.push(a.as_str());
+        }
+        if let Some(a) = &pkg.alert_list {
+            parts.push(a.as_str());
+        }
+        if let Some(a) = &moonc_opt.build_opt.alert_list {
+            parts.push(a.as_str());
+        }
+        let combined: String = parts.concat();
+        if combined.is_empty() {
+            None
+        } else {
+            Some(combined)
+        }
+    };
 
     let artifact: PathBuf = target_dir.into();
 


### PR DESCRIPTION
- Replace HashMap double-lookups with .entry() API
- Add with_capacity() to HashMaps where size is known
- Replace indexed loops with .enumerate()
- Eliminate chained String clones in scan.rs warn_list/alert_list
- Avoid HashMap clone in MVS resolver by iterating with .chain()
- Replace iterator clone for emptiness check with direct .is_empty()
- Change resolve_cc to accept references, removing clones at call sites
- Use .to_string_lossy().into_owned() instead of .to_string_lossy().to_string()
- Replace split(" ") with split_whitespace()
- Hoist version.to_string() out of loop in registry lookup
- Use format!() instead of String + concatenation
- Use .clone() instead of .to_string() on &String in sync.rs
- Hoist pkg_name.to_string() to local variable in add.rs

