### PR TITLE
use `ReadOnlyArray` for the big map in test driver

### DIFF
--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -2965,7 +2965,7 @@ fn moon_test_target_js_panic_with_sourcemap() {
             [username/hello] test lib/hello_test.mbt:1 ("hello") failed: Error
                 at $panic ($ROOT/_build/js/debug/test/lib/lib.blackbox_test.js:6:9)
                 at _M0FP38username5hello19lib__blackbox__test41____test__68656c6c6f5f746573742e6d6274__0 ($ROOT/src/lib/hello_test.mbt:3:5)
-                at _M0FP38username5hello19lib__blackbox__test42moonbit__test__driver__internal__js__catch ($ROOT/src/lib/__generated_driver_for_blackbox_test.mbt:351:15)
+                at _M0FP38username5hello19lib__blackbox__test42moonbit__test__driver__internal__js__catch ($ROOT/src/lib/__generated_driver_for_blackbox_test.mbt:348:15)
             Total tests: 1, passed: 0, failed: 1."#]],
     );
 }

--- a/crates/moonbuild/template/test_driver_project/types.mbt
+++ b/crates/moonbuild/template/test_driver_project/types.mbt
@@ -84,10 +84,7 @@ impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl
 priv struct MoonBitTestDriverInternalTestMap[F](
   @moonbitlang/core/prelude.Map[
     String,
-    @moonbitlang/core/prelude.Map[
-      Int,
-      (F, @moonbitlang/core/prelude.Array[String]),
-    ],
+    @moonbitlang/core/prelude.Map[Int, (F, ReadOnlyArray[String])],
   ]
 )
 


### PR DESCRIPTION
This PR uses `ReadOnlyArray` instead of `Array` for test attributes in the big test map in the test driver, since the array is never mutated anyway. This helps lifting the test map constant to toplevel in some backends and can significantly improve compile speed for packages with a lot of tests (actually lift the big map to toplevel require some `moonc` improvement, too. But this PR is also necessary).