### PR TITLE
refactor: add redact for line numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,6 +1601,7 @@ dependencies = [
  "dunce",
  "home",
  "ignore",
+ "regex",
  "snapbox",
  "tempfile",
  "which 6.0.2",
@@ -2209,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2221,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2666,6 +2667,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "normalize-line-endings",
+ "regex",
  "similar",
  "snapbox-macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ ariadne = { version = "0.5.1", features = ["auto-color"] }
 clap_complete = { version = "4.5.4" }
 schemars = "0.8"
 nucleo-matcher = "0.3.1"
-regex = { version = "1.10.3", default-features = false, features = ["std"] }
+regex = { version = "1.11.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 base64 = "0.22.1"
 derive_builder = "0.20.2"

--- a/crates/moon-test-util/Cargo.toml
+++ b/crates/moon-test-util/Cargo.toml
@@ -26,7 +26,8 @@ rust-version.workspace = true
 anyhow.workspace = true
 dunce.workspace = true
 ignore.workspace = true
-snapbox.workspace = true
+snapbox = { workspace = true, features = ["regex"] }
 tempfile.workspace = true
 which.workspace = true
 home.workspace = true
+regex.workspace = true

--- a/crates/moon-test-util/src/lib.rs
+++ b/crates/moon-test-util/src/lib.rs
@@ -17,4 +17,5 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 pub mod cmdtest;
+pub mod stack_trace;
 pub mod test_dir;

--- a/crates/moon-test-util/src/stack_trace.rs
+++ b/crates/moon-test-util/src/stack_trace.rs
@@ -1,0 +1,45 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::path::Path;
+
+fn stack_trace_line_number_regex() -> regex::Regex {
+    regex::Regex::new(r"(?<redacted>:[0-9]+)(?:[ \t]+(?:at|by)|\n|$)")
+        .expect("valid stack trace line number regex")
+}
+
+pub fn redaction_regex(pattern: &str) -> regex::Regex {
+    regex::Regex::new(pattern).expect("valid redaction regex")
+}
+
+pub fn stack_trace_redactions(_src_dir: &Path) -> snapbox::Redactions {
+    let mut redactions = snapbox::Redactions::new();
+    redactions
+        .insert("[LINE_NUMBER]", stack_trace_line_number_regex())
+        .expect("valid stack trace line number redaction");
+    redactions
+        .insert(
+            "[CORE_PATH]",
+            regex::Regex::new(
+                r"(?<redacted>(?:\$MOON_HOME|(?:[A-Za-z]:)?/[^ \t\r\n]*\.moon)/lib/core)",
+            )
+            .expect("valid moon core path regex"),
+        )
+        .expect("valid moon core path redaction");
+    redactions
+}


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind: optimization <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

Previously the test was extremely unstable due to the fact that stack trace was snapshot. Whenever the core has file change, the line number gets updated, and the test result is changed.

This PR adds redaction for the line numbers.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
