### PR TITLE
feat: add --disable-source-maps option for JS target

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -224,6 +224,10 @@ pub struct BuildFlags {
     /// Render no-location diagnostics starting from a certain level
     #[clap(long, value_name = "MIN_LEVEL", default_value = "error")]
     pub render_no_loc: DiagnosticLevel,
+
+    /// Disable source maps support in Node.js runtime (JS backend only)
+    #[clap(long)]
+    pub disable_source_maps: bool,
 }
 
 impl Default for BuildFlags {
@@ -249,6 +253,7 @@ impl Default for BuildFlags {
             enable_value_tracing: false,
             jobs: None,
             render_no_loc: DiagnosticLevel::Error,
+            disable_source_maps: false,
         }
     }
 }

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -149,7 +149,11 @@ fn run_run_rr(
 }
 
 #[instrument(level = Level::DEBUG, skip_all)]
-fn get_run_cmd(build_meta: &rr_build::BuildMeta, argv: &[String]) -> tokio::process::Command {
+fn get_run_cmd(
+    build_meta: &rr_build::BuildMeta,
+    argv: &[String],
+    disable_source_maps: bool,
+) -> tokio::process::Command {
     let (_, artifact) = build_meta
         .artifacts
         .first()
@@ -158,7 +162,12 @@ fn get_run_cmd(build_meta: &rr_build::BuildMeta, argv: &[String]) -> tokio::proc
         .artifacts
         .first()
         .expect("Expected exactly one executable as the output of the build node");
-    let mut cmd = crate::run::command_for(build_meta.target_backend, executable, None);
+    let mut cmd = crate::run::command_for(
+        build_meta.target_backend,
+        executable,
+        None,
+        !disable_source_maps,
+    );
     cmd.args(argv);
     cmd
 }
@@ -304,7 +313,7 @@ fn rr_run_from_plan(
             target_dir,
         );
 
-        let run_cmd = get_run_cmd(build_meta, &cmd.args);
+        let run_cmd = get_run_cmd(build_meta, &cmd.args, cmd.build_flags.disable_source_maps);
         rr_build::dry_print_command(run_cmd.as_std(), source_dir, false);
         return Ok(0);
     }
@@ -320,7 +329,7 @@ fn rr_run_from_plan(
     if !build_result.successful() {
         return Ok(build_result.return_code_for_success());
     }
-    let run_cmd = get_run_cmd(build_meta, &cmd.args);
+    let run_cmd = get_run_cmd(build_meta, &cmd.args, cmd.build_flags.disable_source_maps);
     if cli.verbose {
         rr_build::dry_print_command(run_cmd.as_std(), source_dir, true);
     }

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -869,6 +869,7 @@ fn rr_test_from_plan(
         cli.verbose,
         cmd.no_parallelize,
         cmd.build_flags.jobs,
+        cmd.build_flags.disable_source_maps,
     )?;
     let _initial_summary = test_result.summary();
 
@@ -962,6 +963,7 @@ fn rr_test_from_plan(
                 cli.verbose,
                 cmd.no_parallelize,
                 cmd.build_flags.jobs,
+                cmd.build_flags.disable_source_maps,
             )?;
             let _rerun_summary = new_test_result.summary();
 

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -213,7 +213,7 @@ fn install_build_rr(
         .context("RR build should yield exactly one artifact file")?;
 
     // Build command using existing runtime mapping, then shlex-join
-    let guard = crate::run::command_for(meta.target_backend, artifact, None);
+    let guard = crate::run::command_for(meta.target_backend, artifact, None, true);
     let parts = std::iter::once(guard.as_std().get_program())
         .chain(guard.as_std().get_args())
         .map(|x| x.to_string_lossy().to_string())

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -156,6 +156,7 @@ pub(crate) fn run_tests(
     verbose: bool,
     no_parallelize: bool,
     parallelism: Option<usize>,
+    disable_source_maps: bool,
 ) -> anyhow::Result<ReplaceableTestResults> {
     // Gathering artifacts
     let executables = gather_tests(build_meta);
@@ -183,6 +184,7 @@ pub(crate) fn run_tests(
             include_skipped,
             bench,
             verbose,
+            disable_source_maps,
         };
         for r in executables {
             debug!(target = ?r.target, executable = %r.executable.display(), "running test executable");
@@ -222,6 +224,7 @@ pub(crate) fn run_tests(
                         include_skipped,
                         bench,
                         verbose,
+                        disable_source_maps,
                     };
 
                     loop {
@@ -286,6 +289,8 @@ struct TestRunCtx<'a> {
     bench: bool,
     /// Enable verbose printing
     verbose: bool,
+    /// Disable source maps in Node.js runtime
+    disable_source_maps: bool,
 }
 
 /// A container of test results corresponding to each test artifact, and
@@ -619,6 +624,7 @@ fn run_one_test_executable(
         ctx.build_meta.target_backend,
         test.executable,
         Some(&test_args),
+        !ctx.disable_source_maps,
     );
     let mut cov_cap = mk_coverage_capture();
     let mut test_cap = make_test_capture();

--- a/crates/moon/src/run/runtime.rs
+++ b/crates/moon/src/run/runtime.rs
@@ -37,6 +37,9 @@ use tokio::process::Command;
 /// file in WASM or WASM-GC backends, a `.js` file in JS backend, or a native
 /// executable in Native or LLVM backends.
 ///
+/// `enable_source_maps` controls whether to add `--enable-source-maps` flag
+/// to the Node.js runtime for JS backend.
+///
 /// ### Note
 ///
 /// Currently there's no support for using `tcc` to execute the target program.
@@ -44,6 +47,7 @@ pub(crate) fn command_for(
     backend: RunBackend,
     mbt_executable: &Path,
     test: Option<&TestArgs>,
+    enable_source_maps: bool,
 ) -> Command {
     match backend {
         RunBackend::Wasm | RunBackend::WasmGC => {
@@ -66,7 +70,9 @@ pub(crate) fn command_for(
                 }
             }
             let mut cmd = Command::new(moonutil::BINARIES.node_or_default());
-            cmd.arg("--enable-source-maps");
+            if enable_source_maps {
+                cmd.arg("--enable-source-maps");
+            }
             cmd.arg(mbt_executable);
             if let Some(t) = test {
                 cmd.arg(serde_json::to_string(t).expect("Failed to serialize test args"));


### PR DESCRIPTION
Add a new --disable-source-maps CLI flag to control whether --enable-source-maps is passed to the Node.js runtime when running moon test/run with --target js.

Changes:
- Add disable_source_maps field to BuildFlags in cli.rs
- Update command_for() to accept enable_source_maps parameter
- Thread the flag through test and run command execution paths
- Default behavior unchanged: source maps remain enabled

- Related issues: None <!-- write issue numbers here -->
- PR kind: <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

<!-- A brief summary of what the PR does -->

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [ ] Compatible with Windows/Linux/macOS
