### PR TITLE
fix: use full path moonc

### DIFF
--- a/crates/moonutil/src/binaries.rs
+++ b/crates/moonutil/src/binaries.rs
@@ -47,6 +47,12 @@ fn moon_bin(binary_name: &str, env_var: &str) -> PathBuf {
         return in_moon_home;
     }
 
+    // Try to resolve from PATH. This gives graph inputs a stable absolute path
+    // when we need to track tool binaries as dependencies.
+    if let Ok(in_path) = which::which(binary_name) {
+        return in_path;
+    }
+
     // Fallback: just rely on PATH
     PathBuf::from(binary_name)
 }


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

## Summary

#1495 added the binary `moonc` to the dependency graph. However, in some situations the n2 doesn't see the full path of `moonc` making it fail to find it. This PR fixed the problem by resolving its full path.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
