### PR TITLE
fix(install): remove implicit install-all defaults

### DIFF
--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -26,16 +26,34 @@ use moonutil::{
     moon_dir,
     mooncakes::{ModuleName, RegistryConfig},
 };
+use std::path::{Path, PathBuf};
 
 use super::UniversalFlags;
 use super::install_binary::{
     GitRef, install_binary, install_from_git, install_from_local, is_git_url, is_local_path,
-    parse_package_spec,
+    parse_package_spec, strip_wildcard_suffix,
 };
+
+/// Returns the local filesystem path used for wildcard local install.
+fn local_wildcard_path(source: &str) -> Option<PathBuf> {
+    let base = strip_wildcard_suffix(source)?;
+    if base.is_empty() {
+        if source.starts_with('/') {
+            Some(PathBuf::from("/"))
+        } else {
+            Some(PathBuf::from("."))
+        }
+    } else if base.ends_with(':') && source.ends_with("/...") {
+        // `C:/...` should resolve to `C:/` instead of drive-relative `C:`.
+        Some(PathBuf::from(format!("{base}/")))
+    } else {
+        Some(PathBuf::from(base))
+    }
+}
 
 pub(crate) fn install_cli(cli: UniversalFlags, cmd: InstallSubcommand) -> anyhow::Result<i32> {
     // If no package path and no local path, use legacy behavior
-    if cmd.package_path.is_none() && cmd.path.is_none() {
+    if cmd.source.is_none() && cmd.path.is_none() {
         eprintln!(
             "{}: `moon install` without arguments is deprecated and will be removed in a future version. \
              Use `moon install <package>` to install binaries globally, or use `moon build` to build your project.",
@@ -59,26 +77,44 @@ pub(crate) fn install_cli(cli: UniversalFlags, cmd: InstallSubcommand) -> anyhow
 
     // Explicit --path takes priority
     if let Some(local_path) = cmd.path {
-        return install_from_local(&cli, &local_path, &install_dir);
+        let local_path_str = local_path.to_string_lossy();
+        if strip_wildcard_suffix(local_path_str.as_ref()).is_some() {
+            eprintln!(
+                "{}: `--path` does not support wildcard selectors like `{}`",
+                "Warning".yellow().bold(),
+                local_path_str
+            );
+            anyhow::bail!(
+                "Use positional SOURCE for wildcard install: `moon install {}`",
+                local_path_str
+            );
+        }
+        return install_from_local(&cli, &local_path, &install_dir, false);
     }
 
-    let package_path = cmd.package_path.unwrap();
+    let source = cmd.source.unwrap();
 
     // Local path install
-    // These checks can't be done in clap because we need to inspect the value of package_path
+    // These checks can't be done in clap because we need to inspect the value of source
     // to determine whether it's a local path, git URL, or registry path.
-    if is_local_path(&package_path) {
+    if is_local_path(&source) {
         if has_git_ref {
             anyhow::bail!("--rev, --branch, and --tag can only be used with git URLs");
         }
-        if cmd.package_path_in_repo.is_some() {
-            anyhow::bail!("Package path in repo can only be used with git URLs");
+        if cmd.path_in_repo.is_some() {
+            anyhow::bail!("Path in repo can only be used with git URLs");
         }
-        return install_from_local(&cli, package_path.as_ref(), &install_dir);
+        let (local_path, install_all) = local_wildcard_path(&source)
+            .map_or((PathBuf::from(source.as_str()), false), |base| (base, true));
+        return install_from_local(&cli, Path::new(&local_path), &install_dir, install_all);
     }
 
     // Git URL install
-    if is_git_url(&package_path) {
+    if is_git_url(&source) {
+        let install_all = cmd
+            .path_in_repo
+            .as_deref()
+            .is_some_and(|s| strip_wildcard_suffix(s).is_some());
         let git_ref = if let Some(rev) = cmd.rev.as_deref() {
             GitRef::Rev(rev)
         } else if let Some(branch) = cmd.branch.as_deref() {
@@ -90,10 +126,11 @@ pub(crate) fn install_cli(cli: UniversalFlags, cmd: InstallSubcommand) -> anyhow
         };
         return install_from_git(
             &cli,
-            &package_path,
+            &source,
             git_ref,
-            cmd.package_path_in_repo.as_deref(),
+            cmd.path_in_repo.as_deref(),
             &install_dir,
+            install_all,
         );
     }
 
@@ -101,11 +138,12 @@ pub(crate) fn install_cli(cli: UniversalFlags, cmd: InstallSubcommand) -> anyhow
     if has_git_ref {
         anyhow::bail!("--rev, --branch, and --tag can only be used with git URLs");
     }
-    if cmd.package_path_in_repo.is_some() {
-        anyhow::bail!("Package path in repo can only be used with git URLs");
+    if cmd.path_in_repo.is_some() {
+        anyhow::bail!("Path in repo can only be used with git URLs");
     }
-    let spec = parse_package_spec(&package_path)?;
-    install_binary(&cli, &spec, &install_dir)
+    let spec = parse_package_spec(&source)?;
+    let install_all = spec.is_wildcard;
+    install_binary(&cli, &spec, &install_dir, install_all)
 }
 
 pub(crate) fn remove_cli(cli: UniversalFlags, cmd: RemoveSubcommand) -> anyhow::Result<i32> {
@@ -204,4 +242,27 @@ pub(crate) fn tree_cli(cli: UniversalFlags, _cmd: TreeSubcommand) -> anyhow::Res
         target_dir,
     } = cli.source_tgt_dir.try_into_package_dirs()?;
     mooncake::pkg::tree::tree(&source_dir, &target_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_local_wildcard_path_unix_root() {
+        let got = local_wildcard_path("/...").unwrap();
+        assert_eq!(got, PathBuf::from("/"));
+    }
+
+    #[test]
+    fn test_local_wildcard_path_relative_current() {
+        let got = local_wildcard_path("./...").unwrap();
+        assert_eq!(got, PathBuf::from("."));
+    }
+
+    #[test]
+    fn test_local_wildcard_path_windows_drive_root() {
+        let got = local_wildcard_path("C:/...").unwrap();
+        assert_eq!(got, PathBuf::from("C:/"));
+    }
 }

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -47,16 +47,124 @@ pub(super) struct PackageSpec {
 }
 
 /// How to filter packages for installation.
-enum PackageFilter {
-    /// Match by filesystem path (for local/git install pointing to specific package)
-    ByPath(PathBuf),
-    /// Match all main packages, optionally with a prefix (for wildcard patterns)
-    Wildcard { prefix: String },
-    /// Match by package path string (for registry install)
-    ByPackagePath(String),
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MatchKind {
+    /// Match only the selected target.
+    Exact,
+    /// Match the selected target and all descendants under that target.
+    Prefix,
+}
+
+/// The namespace where a package selector is interpreted.
+#[derive(Debug, Clone)]
+enum FilterTarget {
+    /// Physical package root path on disk (local/git modes).
+    FileSystem(PathBuf),
+    /// Logical package path relative to module source root (registry mode).
+    PackagePath(String),
+}
+
+/// Package selection rule used by binary installation.
+///
+/// The filter is intentionally split into target namespace (`FilterTarget`)
+/// and matching strategy (`MatchKind`) so callers can compose selectors
+/// explicitly instead of relying on ad-hoc enum variants.
+#[derive(Debug, Clone)]
+struct PackageFilter {
+    target: FilterTarget,
+    kind: MatchKind,
+}
+
+impl PackageFilter {
+    /// Build a filesystem-based filter.
+    fn filesystem(path: PathBuf, install_all: bool) -> Self {
+        Self {
+            target: FilterTarget::FileSystem(path),
+            kind: if install_all {
+                MatchKind::Prefix
+            } else {
+                MatchKind::Exact
+            },
+        }
+    }
+
+    /// Build a logical package-path filter.
+    fn package_path(path: String, install_all: bool) -> Self {
+        Self {
+            target: FilterTarget::PackagePath(path),
+            kind: if install_all {
+                MatchKind::Prefix
+            } else {
+                MatchKind::Exact
+            },
+        }
+    }
+
+    /// Returns true if a discovered package matches this filter.
+    fn matches(&self, pkg_root_path: &Path, pkg_path_str: &str) -> bool {
+        match (&self.target, self.kind) {
+            (FilterTarget::FileSystem(path), MatchKind::Exact) => pkg_root_path == *path,
+            (FilterTarget::FileSystem(prefix_path), MatchKind::Prefix) => {
+                pkg_root_path.starts_with(prefix_path)
+            }
+            (FilterTarget::PackagePath(target), MatchKind::Exact) => pkg_path_str == *target,
+            (FilterTarget::PackagePath(prefix), MatchKind::Prefix) => {
+                prefix.is_empty()
+                    || pkg_path_str.starts_with(&format!("{}/", prefix))
+                    || pkg_path_str == *prefix
+            }
+        }
+    }
+
+    /// Build a mode-appropriate "no package selected" error.
+    fn no_match_error(&self, module_name: &ModuleName, module_dir: &Path) -> anyhow::Error {
+        match (&self.target, self.kind) {
+            (FilterTarget::FileSystem(path), MatchKind::Exact) => anyhow::anyhow!(
+                "Path `{}` is not a main package (is-main: true required)",
+                path.display()
+            ),
+            (FilterTarget::FileSystem(prefix_path), MatchKind::Prefix) => {
+                if prefix_path == module_dir {
+                    anyhow::anyhow!("No main packages found in module `{}`", module_name)
+                } else {
+                    anyhow::anyhow!(
+                        "No main packages found under path `{}`",
+                        prefix_path.display()
+                    )
+                }
+            }
+            (FilterTarget::PackagePath(prefix), MatchKind::Prefix) => {
+                if prefix.is_empty() {
+                    anyhow::anyhow!("No main packages found in module `{}`", module_name)
+                } else {
+                    anyhow::anyhow!(
+                        "No main packages found matching pattern `{}/{}/...`",
+                        module_name,
+                        prefix
+                    )
+                }
+            }
+            (FilterTarget::PackagePath(target), MatchKind::Exact) => {
+                let full_name = if target.is_empty() {
+                    module_name.to_string()
+                } else {
+                    format!("{}/{}", module_name, target)
+                };
+                anyhow::anyhow!(
+                    "Package `{}` not found or is not a main package (is-main: true required)",
+                    full_name
+                )
+            }
+        }
+    }
 }
 
 const GIT_URL_PREFIXES: &[&str] = &["https://", "http://", "git://", "ssh://", "git@"];
+
+/// Returns the non-wildcard prefix for inputs ending with `/...` or `...`.
+pub(super) fn strip_wildcard_suffix(s: &str) -> Option<&str> {
+    s.strip_suffix("...").map(|base| base.trim_end_matches('/'))
+}
 
 /// Check if a string looks like a git URL.
 pub(super) fn is_git_url(s: &str) -> bool {
@@ -84,9 +192,7 @@ pub(super) fn parse_package_spec(input: &str) -> anyhow::Result<PackageSpec> {
         (input, None)
     };
 
-    let (path_part, is_wildcard) = if let Some(stripped) = path_part.strip_suffix("/...") {
-        (stripped, true)
-    } else if let Some(stripped) = path_part.strip_suffix("...") {
+    let (path_part, is_wildcard) = if let Some(stripped) = strip_wildcard_suffix(path_part) {
         (stripped, true)
     } else {
         (path_part, false)
@@ -126,6 +232,7 @@ pub(super) fn install_binary(
     cli: &UniversalFlags,
     spec: &PackageSpec,
     install_dir: &Path,
+    install_all: bool,
 ) -> anyhow::Result<i32> {
     let quiet = cli.quiet;
 
@@ -182,13 +289,8 @@ pub(super) fn install_binary(
 
     registry.install_to(&spec.module_name, &version, module_dir, quiet)?;
 
-    let filter = if spec.is_wildcard {
-        PackageFilter::Wildcard {
-            prefix: spec.package_path.clone().unwrap_or_default(),
-        }
-    } else {
-        PackageFilter::ByPackagePath(spec.package_path.clone().unwrap_or_default())
-    };
+    let filter =
+        PackageFilter::package_path(spec.package_path.clone().unwrap_or_default(), install_all);
 
     build_and_install_packages(cli, &spec.module_name, module_dir, install_dir, filter)
 }
@@ -198,6 +300,7 @@ pub(super) fn install_from_local(
     cli: &UniversalFlags,
     local_path: &Path,
     install_dir: &Path,
+    install_all: bool,
 ) -> anyhow::Result<i32> {
     let input_path = dunce::canonicalize(local_path).with_context(|| {
         format!(
@@ -216,14 +319,7 @@ pub(super) fn install_from_local(
 
     let module = moonutil::common::read_module_desc_file_in_dir(&module_root)?;
     let module_name: ModuleName = module.name.parse().map_err(|e| anyhow::anyhow!("{}", e))?;
-
-    let filter = if input_path == module_root {
-        PackageFilter::Wildcard {
-            prefix: String::new(),
-        }
-    } else {
-        PackageFilter::ByPath(input_path)
-    };
+    let filter = PackageFilter::filesystem(input_path, install_all);
 
     build_and_install_packages(cli, &module_name, &module_root, install_dir, filter)
 }
@@ -245,8 +341,9 @@ pub(super) fn install_from_git(
     cli: &UniversalFlags,
     git_url: &str,
     git_ref: GitRef<'_>,
-    package_path: Option<&str>,
+    path_in_repo: Option<&str>,
     install_dir: &Path,
+    install_all: bool,
 ) -> anyhow::Result<i32> {
     let quiet = cli.quiet;
 
@@ -298,12 +395,13 @@ pub(super) fn install_from_git(
     }
 
     // Determine the target path within the cloned repo
-    let target_path = if let Some(pkg_path) = package_path {
-        let pkg_path = pkg_path.trim_matches('/');
-        if pkg_path.is_empty() {
+    let target_path = if let Some(repo_path) = path_in_repo {
+        let repo_path = repo_path.trim_matches('/');
+        let repo_path = repo_path.trim_end_matches("/...").trim_end_matches("...");
+        if repo_path.is_empty() {
             clone_dir.to_path_buf()
         } else {
-            clone_dir.join(pkg_path.trim_end_matches("/..."))
+            clone_dir.join(repo_path)
         }
     } else {
         clone_dir.to_path_buf()
@@ -313,7 +411,22 @@ pub(super) fn install_from_git(
     if !target_path.exists() {
         bail!(
             "Path `{}` does not exist in the repository",
-            package_path.unwrap_or("")
+            path_in_repo.unwrap_or("")
+        );
+    }
+
+    let target_path = dunce::canonicalize(&target_path).with_context(|| {
+        format!(
+            "Path `{}` cannot be resolved in the repository",
+            path_in_repo.unwrap_or("")
+        )
+    })?;
+    let clone_dir =
+        dunce::canonicalize(clone_dir).context("Failed to resolve cloned repository")?;
+    if !target_path.starts_with(&clone_dir) {
+        bail!(
+            "Path `{}` escapes repository root",
+            path_in_repo.unwrap_or("")
         );
     }
 
@@ -324,27 +437,7 @@ pub(super) fn install_from_git(
 
     let module = moonutil::common::read_module_desc_file_in_dir(&module_root)?;
     let module_name: ModuleName = module.name.parse().map_err(|e| anyhow::anyhow!("{}", e))?;
-
-    let is_module_root = target_path == module_root;
-    let is_wildcard = package_path
-        .map(|p| p.ends_with("/...") || p == "...")
-        .unwrap_or(is_module_root);
-
-    let filter = if is_wildcard || is_module_root {
-        PackageFilter::Wildcard {
-            prefix: package_path
-                .map(|p| p.trim_end_matches("/...").trim_end_matches("..."))
-                .unwrap_or("")
-                .to_string(),
-        }
-    } else {
-        // Use ByPackagePath for git install (string comparison, not filesystem path)
-        PackageFilter::ByPackagePath(
-            package_path
-                .map(|p| p.trim_matches('/').to_string())
-                .unwrap_or_default(),
-        )
-    };
+    let filter = PackageFilter::filesystem(target_path, install_all);
 
     build_and_install_packages(cli, &module_name, &module_root, install_dir, filter)
 }
@@ -359,13 +452,6 @@ fn build_and_install_packages(
 ) -> anyhow::Result<i32> {
     let quiet = cli.quiet;
 
-    std::fs::create_dir_all(install_dir).with_context(|| {
-        format!(
-            "Failed to create install directory `{}`",
-            install_dir.display()
-        )
-    })?;
-
     let resolve_cfg = ResolveConfig::new_with_load_defaults(false, false, false);
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, module_dir)?;
 
@@ -377,7 +463,13 @@ fn build_and_install_packages(
         );
     };
 
-    let mut packages_to_build: Vec<(PackageId, String)> = Vec::new();
+    struct SelectedPackage {
+        pkg_id: PackageId,
+        full_pkg_name: String,
+        binary_name: String,
+    }
+
+    let mut selected_packages: Vec<SelectedPackage> = Vec::new();
 
     for (pkg_path, &pkg_id) in all_pkgs {
         let pkg = resolve_output.pkg_dirs.get_package(pkg_id);
@@ -387,84 +479,88 @@ fn build_and_install_packages(
 
         let pkg_path_str = pkg_path.to_string();
 
-        let matched = match &filter {
-            PackageFilter::ByPath(path) => pkg.root_path == *path,
-            PackageFilter::Wildcard { prefix } => {
-                prefix.is_empty()
-                    || pkg_path_str.starts_with(&format!("{}/", prefix))
-                    || pkg_path_str == *prefix
-            }
-            PackageFilter::ByPackagePath(target) => pkg_path_str == *target,
-        };
+        let matched = filter.matches(&pkg.root_path, &pkg_path_str);
 
         if matched {
-            packages_to_build.push((pkg_id, pkg_path_str));
+            let binary_name = pkg_path_str
+                .rsplit('/')
+                .next()
+                .filter(|s| !s.is_empty())
+                .unwrap_or(&module_name.unqual)
+                .to_string();
+            let full_pkg_name = if pkg_path_str.is_empty() {
+                module_name.to_string()
+            } else {
+                format!("{}/{}", module_name, pkg_path_str)
+            };
+            selected_packages.push(SelectedPackage {
+                pkg_id,
+                full_pkg_name,
+                binary_name,
+            });
         }
     }
 
-    if packages_to_build.is_empty() {
-        match &filter {
-            PackageFilter::ByPath(path) => {
-                bail!(
-                    "Path `{}` is not a main package (is-main: true required)",
-                    path.display()
-                );
-            }
-            PackageFilter::Wildcard { prefix } => {
-                if prefix.is_empty() {
-                    bail!("No main packages found in module `{}`", module_name);
-                } else {
-                    bail!(
-                        "No main packages found matching pattern `{}/{}/...`",
-                        module_name,
-                        prefix
-                    );
-                }
-            }
-            PackageFilter::ByPackagePath(target) => {
-                let full_name = if target.is_empty() {
-                    module_name.to_string()
-                } else {
-                    format!("{}/{}", module_name, target)
-                };
-                bail!(
-                    "Package `{}` not found or is not a main package (is-main: true required)",
-                    full_name
-                );
-            }
-        }
+    if selected_packages.is_empty() {
+        return Err(filter.no_match_error(module_name, module_dir));
     }
+
+    if cli.dry_run {
+        let mut dry_run_count = 0;
+        for pkg in &selected_packages {
+            if moonutil::moon_dir::RESERVED_BIN_NAMES.contains(&pkg.binary_name.as_str()) {
+                eprintln!(
+                    "{}: Cannot install `{}` - name conflicts with MoonBit toolchain binary",
+                    "Error".red().bold(),
+                    pkg.binary_name
+                );
+                continue;
+            }
+            let dst_name = if cfg!(windows) {
+                format!("{}.exe", pkg.binary_name)
+            } else {
+                pkg.binary_name.clone()
+            };
+            let binary_dst = install_dir.join(dst_name);
+            eprintln!("{}: Would build `{}`", "Dry-run".cyan(), pkg.full_pkg_name);
+            eprintln!(
+                "{}: Would install `{}` to `{}`",
+                "Dry-run".cyan(),
+                pkg.binary_name,
+                binary_dst.display()
+            );
+            dry_run_count += 1;
+        }
+        if dry_run_count == 0 {
+            bail!("No packages would be installed");
+        }
+        return Ok(0);
+    }
+
+    std::fs::create_dir_all(install_dir).with_context(|| {
+        format!(
+            "Failed to create install directory `{}`",
+            install_dir.display()
+        )
+    })?;
 
     let target_dir = module_dir.join(moonutil::common::BUILD_DIR);
     std::fs::create_dir_all(&target_dir).context("Failed to create build directory")?;
     let mut installed_count = 0;
 
-    for (pkg_id, pkg_path) in packages_to_build {
-        let binary_name = pkg_path
-            .rsplit('/')
-            .next()
-            .filter(|s| !s.is_empty())
-            .unwrap_or(&module_name.unqual)
-            .to_string();
-
+    for pkg in selected_packages {
         // Check if binary name would overwrite a reserved toolchain binary
-        if moonutil::moon_dir::RESERVED_BIN_NAMES.contains(&binary_name.as_str()) {
+        if moonutil::moon_dir::RESERVED_BIN_NAMES.contains(&pkg.binary_name.as_str()) {
             eprintln!(
                 "{}: Cannot install `{}` - name conflicts with MoonBit toolchain binary",
                 "Error".red().bold(),
-                binary_name
+                pkg.binary_name
             );
             continue;
         }
 
-        let full_pkg_name = if pkg_path.is_empty() {
-            module_name.to_string()
-        } else {
-            format!("{}/{}", module_name, pkg_path)
-        };
-
         if !quiet {
-            eprintln!("{}: Building `{}`...", "Info".cyan(), full_pkg_name);
+            eprintln!("{}: Building `{}`...", "Info".cyan(), pkg.full_pkg_name);
         }
 
         let build_flags = BuildFlags {
@@ -485,7 +581,7 @@ fn build_and_install_packages(
             preconfig,
             &cli.unstable_feature,
             &target_dir,
-            Box::new(move |_, _| Ok(vec![UserIntent::Build(pkg_id)].into())),
+            Box::new(move |_, _| Ok(vec![UserIntent::Build(pkg.pkg_id)].into())),
             resolve_output.clone(),
         )?;
 
@@ -498,22 +594,22 @@ fn build_and_install_packages(
             eprintln!(
                 "{}: Failed to build `{}`",
                 "Error".red().bold(),
-                full_pkg_name
+                pkg.full_pkg_name
             );
             continue;
         }
         result.print_info(quiet, "building").ok();
 
         let target = BuildTarget {
-            package: pkg_id,
+            package: pkg.pkg_id,
             kind: TargetKind::Source,
         };
         let binary_src =
             build_meta.artifacts[&BuildPlanNode::MakeExecutable(target)].artifacts[0].clone();
         let dst_name = if cfg!(windows) {
-            format!("{}.exe", binary_name)
+            format!("{}.exe", pkg.binary_name)
         } else {
-            binary_name.clone()
+            pkg.binary_name.clone()
         };
         let binary_dst = install_dir.join(dst_name);
 
@@ -537,7 +633,7 @@ fn build_and_install_packages(
             eprintln!(
                 "{}: Installed `{}` to `{}`",
                 "Success".green().bold(),
-                binary_name,
+                pkg.binary_name,
                 binary_dst.display()
             );
         }
@@ -555,6 +651,14 @@ fn build_and_install_packages(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_path(parts: &[&str]) -> PathBuf {
+        let mut path = PathBuf::new();
+        for part in parts {
+            path.push(part);
+        }
+        path
+    }
 
     #[test]
     fn test_is_git_url() {
@@ -663,5 +767,42 @@ mod tests {
 
         // Invalid version
         assert!(parse_package_spec("user/module@invalid").is_err());
+    }
+
+    #[test]
+    fn test_package_filter_matches_by_path() {
+        let path = test_path(&["repo", "examples", "native", "pixeladventure"]);
+        let filter = PackageFilter::filesystem(path.clone(), false);
+
+        assert!(filter.matches(&path, "native/pixeladventure"));
+        assert!(!filter.matches(
+            &test_path(&["repo", "examples", "native", "cards"]),
+            "native/cards"
+        ));
+    }
+
+    #[test]
+    fn test_package_filter_matches_by_path_prefix() {
+        let filter = PackageFilter::filesystem(test_path(&["repo", "examples", "native"]), true);
+
+        assert!(filter.matches(
+            &test_path(&["repo", "examples", "native", "pixeladventure"]),
+            "native/pixeladventure",
+        ));
+        assert!(filter.matches(
+            &test_path(&["repo", "examples", "native", "cards"]),
+            "native/cards",
+        ));
+        assert!(!filter.matches(&test_path(&["repo", "examples", "web", "demo"]), "web/demo"));
+    }
+
+    #[test]
+    fn test_package_filter_matches_by_package_prefix() {
+        let filter = PackageFilter::package_path("native".to_string(), true);
+        assert!(filter.matches(
+            &test_path(&["repo", "examples", "native", "pixeladventure"]),
+            "native/pixeladventure",
+        ));
+        assert!(!filter.matches(&test_path(&["repo", "examples", "web", "demo"]), "web/demo",));
     }
 }

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -1862,63 +1862,66 @@ fn test_moon_query() {
 #[test]
 #[allow(clippy::just_underscores_and_digits)]
 fn test_moon_install_bin() {
+    struct BinFileCleanup(Vec<std::path::PathBuf>);
+
+    impl Drop for BinFileCleanup {
+        fn drop(&mut self) {
+            for path in &self.0 {
+                let _ = std::fs::remove_file(path);
+            }
+        }
+    }
+
     let top_dir = TestDir::new("moon_install_bin.in");
     let dir = top_dir.join("user.in");
 
-    let _1;
-    let _2;
-    let _3;
-    let _4;
-    let _5;
+    let installed_bins;
 
     #[cfg(unix)]
     {
-        _1 = top_dir.join("author2.in").join("author2-native");
-        _2 = top_dir.join("author2.in").join("author2-js");
-        _3 = top_dir.join("author2.in").join("author2-wasm");
-        _4 = top_dir.join("author1.in").join("this-is-wasm");
-        _5 = top_dir.join("author1.in").join("main-js");
+        installed_bins = vec![
+            top_dir.join("author2.in").join("author2-native"),
+            top_dir.join("author2.in").join("author2-js"),
+            top_dir.join("author2.in").join("author2-wasm"),
+            top_dir.join("author1.in").join("this-is-wasm"),
+            top_dir.join("author1.in").join("main-js"),
+        ];
     }
 
     #[cfg(target_os = "windows")]
     {
-        _1 = top_dir.join("author2.in").join("author2-native.ps1");
-        _2 = top_dir.join("author2.in").join("author2-js.ps1");
-        _3 = top_dir.join("author2.in").join("author2-wasm.ps1");
-        _4 = top_dir.join("author1.in").join("this-is-wasm.ps1");
-        _5 = top_dir.join("author1.in").join("main-js.ps1");
+        installed_bins = vec![
+            top_dir.join("author2.in").join("author2-native.ps1"),
+            top_dir.join("author2.in").join("author2-js.ps1"),
+            top_dir.join("author2.in").join("author2-wasm.ps1"),
+            top_dir.join("author1.in").join("this-is-wasm.ps1"),
+            top_dir.join("author1.in").join("main-js.ps1"),
+        ];
     }
+    let _cleanup = BinFileCleanup(installed_bins.clone());
 
     // moon check should auto install bin deps
     get_stdout(&dir, ["check"]);
-    assert!(_1.exists());
-    assert!(_2.exists());
-    assert!(_3.exists());
-    assert!(_4.exists());
-    assert!(_5.exists());
+    for bin in &installed_bins {
+        assert!(bin.exists());
+    }
 
     {
         // delete all bin files
-        std::fs::remove_file(&_1).unwrap();
-        std::fs::remove_file(&_2).unwrap();
-        std::fs::remove_file(&_3).unwrap();
-        std::fs::remove_file(&_4).unwrap();
-        std::fs::remove_file(&_5).unwrap();
-        assert!(!_1.exists());
-        assert!(!_2.exists());
-        assert!(!_3.exists());
-        assert!(!_4.exists());
-        assert!(!_5.exists());
+        for bin in &installed_bins {
+            std::fs::remove_file(bin).unwrap();
+        }
+        for bin in &installed_bins {
+            assert!(!bin.exists());
+        }
     }
 
     // moon install should install bin deps
     get_stdout(&dir, ["install"]);
 
-    assert!(_1.exists());
-    assert!(_2.exists());
-    assert!(_3.exists());
-    assert!(_4.exists());
-    assert!(_5.exists());
+    for bin in &installed_bins {
+        assert!(bin.exists());
+    }
 
     let content = get_stderr(&dir, ["build", "--sort-input"]);
 
@@ -3019,13 +3022,66 @@ fn test_moon_install_global_local_path() {
 }
 
 #[test]
-fn test_moon_install_global_git_url() {
-    // Test installing from git URL
+fn test_moon_install_global_local_path_module_root_is_exact_path() {
+    let dir = TestDir::new("moon_install_global.in");
+
+    let stderr = get_err_stderr(&dir, ["install", "--path", "."]);
+    assert!(
+        stderr.contains("is not a main package"),
+        "Expected exact local path behavior in stderr, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_moon_install_global_local_source_wildcard_from_module_root() {
+    let dir = TestDir::new("moon_install_global.in");
+    let install_dir = dir.join("test_bin_wildcard_root");
+    std::fs::create_dir_all(&install_dir).unwrap();
+
+    let _output = get_stdout(
+        &dir,
+        ["install", "./...", "--bin", install_dir.to_str().unwrap()],
+    );
+
+    #[cfg(unix)]
+    let binary_path = install_dir.join("main");
+    #[cfg(target_os = "windows")]
+    let binary_path = install_dir.join("main.exe");
+
+    assert!(
+        binary_path.exists(),
+        "Expected binary at {:?} to exist",
+        binary_path
+    );
+}
+
+#[test]
+fn test_moon_install_global_local_path_wildcard_with_path_flag_warns() {
+    let dir = TestDir::new("moon_install_global.in");
+
+    let stderr = get_err_stderr(&dir, ["install", "--path", "src/..."]);
+    assert!(
+        stderr.contains("does not support wildcard selectors like `src/...`"),
+        "Expected wildcard warning in stderr, got: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("Use positional SOURCE for wildcard install: `moon install src/...`"),
+        "Expected guidance for positional SOURCE in stderr, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_moon_install_global_git_url_default_root_package() {
+    // Test installing from git URL without PATH_IN_REPO.
+    // Default behavior installs the module root package only.
     let install_dir = tempfile::tempdir().unwrap();
     let install_path = install_dir.path();
     let work_dir = tempfile::tempdir().unwrap();
 
-    // Install all packages from git repo
+    // Install root package only
     get_stdout(
         &work_dir,
         [
@@ -3036,20 +3092,20 @@ fn test_moon_install_global_git_url() {
         ],
     );
 
-    // Check that all 4 binaries were created
+    // Check that only root package binary was created
     #[cfg(unix)]
     {
         assert!(install_path.join("install-test").exists());
-        assert!(install_path.join("hello").exists());
-        assert!(install_path.join("tool1").exists());
-        assert!(install_path.join("tool2").exists());
+        assert!(!install_path.join("hello").exists());
+        assert!(!install_path.join("tool1").exists());
+        assert!(!install_path.join("tool2").exists());
     }
     #[cfg(target_os = "windows")]
     {
         assert!(install_path.join("install-test.exe").exists());
-        assert!(install_path.join("hello.exe").exists());
-        assert!(install_path.join("tool1.exe").exists());
-        assert!(install_path.join("tool2.exe").exists());
+        assert!(!install_path.join("hello.exe").exists());
+        assert!(!install_path.join("tool1.exe").exists());
+        assert!(!install_path.join("tool2.exe").exists());
     }
 }
 
@@ -3122,5 +3178,39 @@ fn test_moon_install_global_git_url_wildcard() {
         assert!(install_path.join("tool2.exe").exists());
         assert!(!install_path.join("hello.exe").exists());
         assert!(!install_path.join("install-test.exe").exists());
+    }
+}
+
+#[test]
+fn test_moon_install_global_git_url_root_wildcard() {
+    // Test installing all packages from git URL using /...
+    let install_dir = tempfile::tempdir().unwrap();
+    let install_path = install_dir.path();
+    let work_dir = tempfile::tempdir().unwrap();
+
+    get_stdout(
+        &work_dir,
+        [
+            "install",
+            "https://github.com/moonbitlang/moon-install-git-test-cases.git",
+            "/...",
+            "--bin",
+            install_path.to_str().unwrap(),
+        ],
+    );
+
+    #[cfg(unix)]
+    {
+        assert!(install_path.join("install-test").exists());
+        assert!(install_path.join("hello").exists());
+        assert!(install_path.join("tool1").exists());
+        assert!(install_path.join("tool2").exists());
+    }
+    #[cfg(target_os = "windows")]
+    {
+        assert!(install_path.join("install-test.exe").exists());
+        assert!(install_path.join("hello.exe").exists());
+        assert!(install_path.join("tool1.exe").exists());
+        assert!(install_path.join("tool2.exe").exists());
     }
 }

--- a/crates/moon/tests/test_cases/moon_commands/shell_completion_bash.stdout
+++ b/crates/moon/tests/test_cases/moon_commands/shell_completion_bash.stdout
@@ -1931,7 +1931,7 @@ _moon() {
             return 0
             ;;
         moon__install)
-            opts="-q -v -h --bin --path --rev --branch --tag --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PACKAGE_PATH] [PACKAGE_PATH_IN_REPO]"
+            opts="-q -v -h --bin --path --rev --branch --tag --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [SOURCE] [PATH_IN_REPO]"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/moon/tests/test_cases/moon_commands/shell_completion_elvish.stdout
+++ b/crates/moon/tests/test_cases/moon_commands/shell_completion_elvish.stdout
@@ -473,8 +473,8 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --trace 'Trace the execution of the program'
             cand --dry-run 'Do not actually run the command'
             cand --build-graph 'build-graph'
-            cand -h 'Print help'
-            cand --help 'Print help'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
         }
         &'moon;tree'= {
             cand --manifest-path 'Path to `moon.mod.json` to use as the project manifest (does not change the working directory)'

--- a/crates/moon/tests/test_cases/moon_commands/shell_completion_fish.stdout
+++ b/crates/moon/tests/test_cases/moon_commands/shell_completion_fish.stdout
@@ -368,7 +368,7 @@ complete -c moon -n "__fish_moon_using_subcommand install" -s v -l verbose -d 'I
 complete -c moon -n "__fish_moon_using_subcommand install" -l trace -d 'Trace the execution of the program'
 complete -c moon -n "__fish_moon_using_subcommand install" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand install" -l build-graph
-complete -c moon -n "__fish_moon_using_subcommand install" -s h -l help -d 'Print help'
+complete -c moon -n "__fish_moon_using_subcommand install" -s h -l help -d 'Print help (see more with /'--help/')'
 complete -c moon -n "__fish_moon_using_subcommand tree" -l manifest-path -d 'Path to `moon.mod.json` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tree" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tree" -s q -l quiet -d 'Suppress output'

--- a/crates/moon/tests/test_cases/moon_commands/shell_completion_powershell.stdout
+++ b/crates/moon/tests/test_cases/moon_commands/shell_completion_powershell.stdout
@@ -491,8 +491,8 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--trace', 'trace', [CompletionResultType]::ParameterName, 'Trace the execution of the program')
             [CompletionResult]::new('--dry-run', 'dry-run', [CompletionResultType]::ParameterName, 'Do not actually run the command')
             [CompletionResult]::new('--build-graph', 'build-graph', [CompletionResultType]::ParameterName, 'build-graph')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             break
         }
         'moon;tree' {

--- a/crates/moon/tests/test_cases/moon_commands/shell_completion_zsh.stdout
+++ b/crates/moon/tests/test_cases/moon_commands/shell_completion_zsh.stdout
@@ -475,7 +475,7 @@ _arguments "${_arguments_options[@]}" : /
 ;;
 (install)
 _arguments "${_arguments_options[@]}" : /
-'--bin=[Specify installation directory (default/: ~/.moon/bin/)]:BIN:_files' /
+'--bin=[Specify installation directory (default/: ~/.moon/bin/)]:DIR:_files' /
 '(--rev --branch --tag)--path=[Install from local path instead of registry]:PATH:_files' /
 '--rev=[Git revision to checkout (commit hash, requires git URL)]:REV: ' /
 '--branch=[Git branch to checkout (requires git URL)]:BRANCH: ' /
@@ -489,10 +489,10 @@ _arguments "${_arguments_options[@]}" : /
 '--trace[Trace the execution of the program]' /
 '--dry-run[Do not actually run the command]' /
 '(--dry-run)--build-graph[]' /
-'-h[Print help]' /
-'--help[Print help]' /
-'::package_path -- Package path to install (e.g., user/pkg/main or user/pkg/cmd/...) Supports @version suffix (e.g., user/pkg/main@1.0.0) Git URLs are auto-detected (any URL format git supports) Local paths are auto-detected/: ./, ../, / (Unix), or drive letter (Windows) If not provided, falls back to legacy behavior (install project dependencies):' /
-'::package_path_in_repo -- Package path within a git repository (e.g., src/main or cmd/...) Only used with git URLs. Supports /... suffix for wildcard matching:' /
+'-h[Print help (see more with '/''--help'/'')]' /
+'--help[Print help (see more with '/''--help'/'')]' /
+'::source -- Package path, local path, or git URL:' /
+'::path_in_repo -- Filesystem path inside git repo (git SOURCE only):' /
 && ret=0
 ;;
 (tree)

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -37,42 +37,48 @@ use std::{
 
 /// Install a binary package globally or install project dependencies (deprecated without args)
 #[derive(Debug, clap::Parser)]
-#[clap(group = clap::ArgGroup::new("git_ref").multiple(false))]
+#[clap(
+    group = clap::ArgGroup::new("git_ref").multiple(false),
+    verbatim_doc_comment
+)]
 pub struct InstallSubcommand {
-    /// Package path to install (e.g., user/pkg/main or user/pkg/cmd/...)
-    /// Supports @version suffix (e.g., user/pkg/main@1.0.0)
-    /// Git URLs are auto-detected (any URL format git supports)
-    /// Local paths are auto-detected: ./, ../, / (Unix), or drive letter (Windows)
-    /// If not provided, falls back to legacy behavior (install project dependencies)
-    pub package_path: Option<String>,
+    #[clap(
+        value_name = "SOURCE",
+        help = "Package path, local path, or git URL",
+        long_help = "Install source.\n\nInterpretation order:\n  1. local path (`./`, `../`, `/`, Windows drive)\n  2. git URL\n  3. registry package path (`user/module/pkg[@version]`)\n\nUse `/...` suffix to install all matching main packages."
+    )]
+    pub source: Option<String>,
 
-    /// Package path within a git repository (e.g., src/main or cmd/...)
-    /// Only used with git URLs. Supports /... suffix for wildcard matching.
-    pub package_path_in_repo: Option<String>,
+    #[clap(
+        value_name = "PATH_IN_REPO",
+        help = "Filesystem path inside git repo (git SOURCE only)",
+        long_help = "Filesystem path inside the cloned git repository.\nUsed only when SOURCE is a git URL.\n\nUse `/...` suffix to install all matching main packages under this path prefix."
+    )]
+    pub path_in_repo: Option<String>,
 
     /// Specify installation directory (default: ~/.moon/bin/)
-    #[clap(long)]
+    #[clap(long, value_name = "DIR")]
     pub bin: Option<PathBuf>,
 
     /// Install from local path instead of registry
     #[clap(
         long,
-        conflicts_with = "package_path",
+        conflicts_with = "source",
         conflicts_with = "git_ref",
-        conflicts_with = "package_path_in_repo"
+        conflicts_with = "path_in_repo"
     )]
     pub path: Option<PathBuf>,
 
     /// Git revision to checkout (commit hash, requires git URL)
-    #[clap(long, group = "git_ref", requires = "package_path")]
+    #[clap(long, group = "git_ref", requires = "source")]
     pub rev: Option<String>,
 
     /// Git branch to checkout (requires git URL)
-    #[clap(long, group = "git_ref", requires = "package_path")]
+    #[clap(long, group = "git_ref", requires = "source")]
     pub branch: Option<String>,
 
     /// Git tag to checkout (requires git URL)
-    #[clap(long, group = "git_ref", requires = "package_path")]
+    #[clap(long, group = "git_ref", requires = "source")]
     pub tag: Option<String>,
 }
 

--- a/docs/dev/reference/moon-install-binary.md
+++ b/docs/dev/reference/moon-install-binary.md
@@ -1,0 +1,168 @@
+# Behavior of `moon install` (binary installer)
+
+> This page documents the binary-install mode of `moon install`.
+> It does not describe the legacy no-arg dependency-sync behavior.
+>
+> Status: expected behavior in this branch as of March 2, 2026.
+
+## Scope
+
+`moon install` has two modes:
+
+1. `moon install` with no package arguments:
+   legacy dependency install/sync for the current project (deprecated).
+2. `moon install <package-selector> ...`:
+   binary installer mode (this document).
+
+## Selector model
+
+Binary installer mode resolves a target source first, then selects package(s) in that source.
+
+### Terminology: filesystem path vs package path
+
+This document uses two different path notions:
+
+1. **Filesystem path** (physical path):
+   path on disk, e.g. `/repo/examples/pixeladventure` or `./cmd/tool`.
+2. **Package path** (logical package identity inside a module):
+   `module_name + "/" + package_relative_path`.
+
+Important details for package paths:
+
+- `package_relative_path` is relative to the module's `source` root, not necessarily module root.
+- When `source` is set in `moon.mod.json`, the `source` directory name is not part of the package path.
+
+Example:
+
+- module root: `/repo`
+- `moon.mod.json`: `{ "name": "user/proj", "source": "src" }`
+- package directory on disk: `/repo/src/tools/fmt`
+- package path: `user/proj/tools/fmt` (not `user/proj/src/tools/fmt`)
+
+### Source resolution
+
+Given `SOURCE`:
+
+1. If `--path <PATH>` is set, use local path mode.
+2. Else if `SOURCE` looks like a local path (`./`, `../`, `/`, or Windows drive), use local path mode.
+3. Else if `SOURCE` looks like a git URL, use git mode.
+4. Else, use registry mode.
+
+Practical caveat:
+
+- Bare relative strings like `foo/bar` are treated as registry package paths, not filesystem paths.
+  Use `./foo/bar` (or `../foo/bar`) to force local path mode.
+
+### Package selection
+
+Default rule: install an exact package.
+
+Wildcard rule: if selector ends with `/...` (or `...`), install all main packages under that prefix.
+
+When matching packages after discovery:
+
+- registry selectors are matched by **package path**,
+- local/git selectors are matched by **filesystem path** (then converted to discovered packages).
+
+## Expected behavior by mode
+
+### Registry mode
+
+Input form:
+
+- `moon install user/module/pkg`
+- `moon install user/module/...`
+- optional `@version`, e.g. `user/module/pkg@1.2.3`
+
+Rules:
+
+- No wildcard: exact package path in the resolved registry module.
+- With wildcard: all `is-main: true` packages under the wildcard prefix.
+
+### Local path mode
+
+Input form:
+
+- `moon install --path ./some/pkg`
+- `moon install ./some/pkg`
+- wildcard via positional arg: `moon install ./some/prefix/...`
+
+Rules:
+
+- Input selector is a filesystem path.
+- No wildcard: exact package at that filesystem path.
+- If the exact filesystem path is module root, install that module's root package only
+  (root package path is empty string relative to `source` root).
+- With wildcard suffix: all `is-main: true` packages under the matched filesystem path prefix.
+
+### Git mode
+
+Input form:
+
+- `moon install <git-url> [PATH_IN_REPO] [--rev|--branch|--tag]`
+- wildcard in repo selector: `PATH_IN_REPO=some/prefix/...`
+
+Rules:
+
+- Clone repo, optionally checkout ref.
+- `PATH_IN_REPO` is interpreted as a filesystem path inside the cloned repository.
+- Resolve selected filesystem path and find nearest ancestor containing `moon.mod.json` as module root.
+- No wildcard:
+  - no `PATH_IN_REPO`: install root package of detected module.
+  - with `PATH_IN_REPO`: install exact package at the selected filesystem path.
+- With wildcard in `PATH_IN_REPO`: install all `is-main: true` packages under that filesystem prefix.
+- Path escape (`..` resolving outside cloned repo) is rejected.
+
+Practical caveat:
+
+- If `PATH_IN_REPO` is omitted, the repository root must itself be a module root
+  (contain `moon.mod.json`) for installation to proceed.
+  For nested-module repositories, pass `PATH_IN_REPO` explicitly.
+
+## Shared behavior
+
+These rules apply in all binary installer modes:
+
+- Only packages with `is-main: true` are installable.
+- Build target is native executable in release mode.
+- Output directory defaults to `~/.moon/bin` and can be overridden by `--bin`.
+- Binary name:
+  - last segment of package path for non-root packages
+  - module unqualified name for root package
+- Reserved Moon toolchain binary names are not overwritten.
+- Name collisions between selected packages are allowed; later installs overwrite earlier files.
+- `--dry-run` does not write binaries; it prints what would be built/installed.
+
+## Cross-tool structural reference (verified 2026-03-04)
+
+This table compares how `moon install` (binary mode), `go install`, and `cargo install`
+identify source, intent, and target.
+
+| Dimension | `moon install` (binary mode) | `go install` | `cargo install` |
+| --- | --- | --- | --- |
+| Source identification | Resolution order: `--path` local override, then local-path-looking `SOURCE` (`./`, `../`, `/`, drive), then git URL, else registry package path. | Package args are import paths/patterns by default. Rooted paths or args beginning with `.`/`..` are interpreted as filesystem paths. With `@version`, args must be package paths/patterns (not relative/absolute paths). | Default source is crates.io. Source is switched explicitly via `--git`, `--path`, `--registry`, or `--index`. |
+| Intent identification | Default intent: exact package install. Wildcard intent: `/...` suffix means install all matching `is-main: true` packages under prefix. | Default intent: exact package/import path(s). Wildcard intent: `...` package patterns expand to all matches; `x/...` includes `x` and descendants because wildcard can match empty string. | Exact crate install (no package-pattern wildcard like `...`). For a selected crate package, Cargo installs all binary targets by default (`--bins` behavior), or one via `--bin <name>`. |
+| Target identification | Registry mode matches logical package path. Local/git mode matches filesystem path, then maps discovered package(s) under the module. | Target is package/import path (or package in a directory when filesystem path form is used). | Target is crate identity. If source contains multiple crates (registry/git), crate argument disambiguates. `--path` points to a local crate directory. |
+| Relative path handling | Bare `foo/bar` is treated as registry package path. Use `./foo/bar` / `../foo/bar` for local filesystem semantics. | Rooted / `.` / `..`-prefixed args are filesystem paths; otherwise import-path semantics. | Relative filesystem path is only interpreted through `--path`; positional args are crate names. |
+| Version / revision selection | Registry: `user/module/pkg@version`. Git: `--rev`, `--branch`, `--tag`. | `pkg@version` installs in module-aware mode and ignores current-module `go.mod` (subject to `go install` constraints). | Registry versions via `crate@version` or `--version`; git refs via `--branch`, `--tag`, `--rev`. |
+| Build argument surface | Installer does not expose a broad package-manager-level build argument passthrough; it builds/installs selected native executables (with shared command flags like `--dry-run` and verbosity controls). | Accepts shared Go build flags: `go install [build flags] [packages]`. | Rich install/build controls: features (`--features`, `--all-features`, `--no-default-features`), target/profile (`--target`, `--profile`), jobs, lock/offline, etc. |
+| Collision / overwrite behavior | Name collisions between selected packages are allowed; later installs overwrite (reserved Moon tool names are blocked). | Official help does not document a dedicated collision guard in install destination; binaries are installed by command name in one bin directory (inference). | Overwrite protection by default; `--force` is required to overwrite existing crates/binaries. |
+| Dry-run / preview | `--dry-run` prints plan and does not write binaries. | `-n` (shared build flag) prints commands without executing. | `--dry-run` exists but is unstable. |
+| Interactive prompting | No interactive package/binary selection prompt. | No interactive package selection prompt. | No interactive package/binary selection prompt. If source has multiple packages and target is ambiguous, Cargo errors and requires explicit package selection. |
+| Install destination | `~/.moon/bin` by default, override with `--bin`. | `GOBIN`, else `$GOPATH/bin` (or `$HOME/go/bin` when `GOPATH` unset). | Install root `bin` directory; precedence: `--root`, `CARGO_INSTALL_ROOT`, config, `CARGO_HOME`, `$HOME/.cargo`. |
+
+References:
+
+- Go command docs (`install`, package lists/patterns): <https://pkg.go.dev/cmd/go>
+- Go module reference (`go install pkg@version`): <https://go.dev/ref/mod#go-install>
+- Cargo install reference: <https://doc.rust-lang.org/cargo/commands/cargo-install.html>
+
+## Historical behavior before this clarification
+
+The implementation previously had several surprising behaviors that caused confusion:
+
+1. Selecting a module root in local/git mode could install all main packages implicitly.
+2. Git path selection used string-based matching and could select the wrong package in nested-module repos.
+3. `moon install --dry-run` still performed real build/install side effects.
+
+This reference defines the expected behavior used to align code, tests, and user documentation.

--- a/docs/dev/reference/readme.md
+++ b/docs/dev/reference/readme.md
@@ -18,6 +18,7 @@ This is a reference documentation of the current MoonBuild behavior.
 - [Virtual packages](./virtual-pkg.md)
 - [`tcc -run` mode](./tcc-run.md)
 - [`moon bundle`](./bundle.md)
+- [`moon install` binary installer behavior](./moon-install-binary.md)
 - [Rupes Recta special cases](./rr-special-cases.md)
 - [`moon test` execution flow](./tests.md)
 - [`supported-targets` behavior](./supported-targets.md)

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -426,16 +426,26 @@ Remove a dependency
 
 Install a binary package globally or install project dependencies (deprecated without args)
 
-**Usage:** `moon install [OPTIONS] [PACKAGE_PATH] [PACKAGE_PATH_IN_REPO]`
+**Usage:** `moon install [OPTIONS] [SOURCE] [PATH_IN_REPO]`
 
 ###### **Arguments:**
 
-* `<PACKAGE_PATH>` — Package path to install (e.g., user/pkg/main or user/pkg/cmd/...) Supports @version suffix (e.g., user/pkg/main@1.0.0) Git URLs are auto-detected (any URL format git supports) Local paths are auto-detected: ./, ../, / (Unix), or drive letter (Windows) If not provided, falls back to legacy behavior (install project dependencies)
-* `<PACKAGE_PATH_IN_REPO>` — Package path within a git repository (e.g., src/main or cmd/...) Only used with git URLs. Supports /... suffix for wildcard matching
+* `<SOURCE>` — Install source.
+
+   Interpretation order:
+     1. local path (`./`, `../`, `/`, Windows drive)
+     2. git URL
+     3. registry package path (`user/module/pkg[@version]`)
+
+   Use `/...` suffix to install all matching main packages.
+* `<PATH_IN_REPO>` — Filesystem path inside the cloned git repository.
+   Used only when SOURCE is a git URL.
+
+   Use `/...` suffix to install all matching main packages under this path prefix.
 
 ###### **Options:**
 
-* `--bin <BIN>` — Specify installation directory (default: ~/.moon/bin/)
+* `--bin <DIR>` — Specify installation directory (default: ~/.moon/bin/)
 * `--path <PATH>` — Install from local path instead of registry
 * `--rev <REV>` — Git revision to checkout (commit hash, requires git URL)
 * `--branch <BRANCH>` — Git branch to checkout (requires git URL)

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -426,16 +426,26 @@ Remove a dependency
 
 Install a binary package globally or install project dependencies (deprecated without args)
 
-**Usage:** `moon install [OPTIONS] [PACKAGE_PATH] [PACKAGE_PATH_IN_REPO]`
+**Usage:** `moon install [OPTIONS] [SOURCE] [PATH_IN_REPO]`
 
 ###### **Arguments:**
 
-* `<PACKAGE_PATH>` — Package path to install (e.g., user/pkg/main or user/pkg/cmd/...) Supports @version suffix (e.g., user/pkg/main@1.0.0) Git URLs are auto-detected (any URL format git supports) Local paths are auto-detected: ./, ../, / (Unix), or drive letter (Windows) If not provided, falls back to legacy behavior (install project dependencies)
-* `<PACKAGE_PATH_IN_REPO>` — Package path within a git repository (e.g., src/main or cmd/...) Only used with git URLs. Supports /... suffix for wildcard matching
+* `<SOURCE>` — Install source.
+
+   Interpretation order:
+     1. local path (`./`, `../`, `/`, Windows drive)
+     2. git URL
+     3. registry package path (`user/module/pkg[@version]`)
+
+   Use `/...` suffix to install all matching main packages.
+* `<PATH_IN_REPO>` — Filesystem path inside the cloned git repository.
+   Used only when SOURCE is a git URL.
+
+   Use `/...` suffix to install all matching main packages under this path prefix.
 
 ###### **Options:**
 
-* `--bin <BIN>` — Specify installation directory (default: ~/.moon/bin/)
+* `--bin <DIR>` — Specify installation directory (default: ~/.moon/bin/)
 * `--path <PATH>` — Install from local path instead of registry
 * `--rev <REV>` — Git revision to checkout (commit hash, requires git URL)
 * `--branch <BRANCH>` — Git branch to checkout (requires git URL)


### PR DESCRIPTION
## Summary
- make moon install default to exact-package install across local, git, and registry selectors
- keep install-all behavior only behind explicit wildcard selectors such as /...
- preserve absolute wildcard root handling so /... stays rooted at filesystem /
- align install tests and generated help/completion snapshots with clarified behavior
- document source resolution and path semantics for binary install mode

## Why
Users reported surprising installs where selecting module or repo roots installed multiple binaries unintentionally. This change makes default behavior exact and requires explicit wildcard intent for fan-out.

## Testing
- cargo test -p moon install_binary
- cargo test -p moon deps::tests
- cargo test -p moon test_cases::moon_commands
- cargo test -p moon gen_docs_for_moon_help_page
