### PR TITLE
fix: change `moon.pkg.json` to `moon.pkg` in error message

### DIFF
--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -27,7 +27,7 @@ use std::{
 
 use anyhow::Context;
 use moonbuild_rupes_recta::{ResolveOutput, fmt::FmtResolveOutput, model::PackageId};
-use moonutil::common::TargetBackend;
+use moonutil::common::{MOON_PKG, TargetBackend};
 use moonutil::mooncakes::{DirSyncResult, result::ResolvedEnv};
 
 /// Canonicalize the given path, returning the directory it's referencing, and
@@ -404,8 +404,9 @@ pub(crate) fn filter_pkg_by_dir_for_fmt(
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "Cannot find package to format at path `{}`.\n\
-                 Hint: Make sure the path points to a package directory containing moon.pkg.json.",
-                dir.display()
+                 Hint: Make sure the path points to a package directory containing `{}`.",
+                dir.display(),
+                MOON_PKG
             )
         })
 }

--- a/crates/moonbuild-rupes-recta/src/discover/model.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/model.rs
@@ -285,7 +285,7 @@ pub enum DiscoverError {
     },
 
     #[error(
-        "Unable to read `moon.pkg.json` for module '{module}' package '{package}' \
+        "Unable to read `moon.pkg` for module '{module}' package '{package}' \
         at path '{path}', error: {inner}"
     )]
     CantReadPackageFile {

--- a/crates/moonutil/src/package.rs
+++ b/crates/moonutil/src/package.rs
@@ -858,7 +858,7 @@ pub fn convert_pkg_json_to_package_with_supported_targets_decl(
         is_main = true;
         eprintln!(
                 "{}",
-                "Warning: The `name` field in `moon.pkg.json` is now deprecated. For the main package, please use `\"is-main\": true` instead. Refer to the latest documentation at https://www.moonbitlang.com/docs/build-system-tutorial for more information.".yellow()
+                "Warning: The `name` field in `moon.pkg` is now deprecated. For the main package, please use `\"is-main\": true` instead. Refer to the latest documentation at https://www.moonbitlang.com/docs/build-system-tutorial for more information.".yellow()
                     .bold()
             );
     }


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

## Summary

change `moon.pkg.json` to `moon.pkg` in error message

