### PR TITLE
fix: make bin-deps non-transitive and sync docs

### DIFF
--- a/crates/mooncake/src/resolver/mvs.rs
+++ b/crates/mooncake/src/resolver/mvs.rs
@@ -213,6 +213,11 @@ fn mvs_resolve(
     res: &mut ResolvedEnv,
     root: &[(ModuleSource, Arc<MoonMod>)],
 ) -> bool {
+    let root_sources = root
+        .iter()
+        .map(|(source, _)| source.clone())
+        .collect::<HashSet<_>>();
+
     // Ordered set used to ensure they are iterated in order later.
     let mut gathered_versions = HashMap::<ModuleName, BTreeSet<ModuleSourceOrdWrapper>>::new();
 
@@ -233,13 +238,14 @@ fn mvs_resolve(
     // Do a DFS in the graph
     while let Some((source, module)) = working_list.pop() {
         log::debug!("-- Solving for {}", source);
-        let all_deps = module.deps.iter().chain(
+        let bin_deps = root_sources.contains(&source).then(|| {
             module
                 .bin_deps
                 .iter()
                 .flat_map(|m| m.iter())
-                .map(|(k, v)| (k, &v.common)),
-        );
+                .map(|(k, v)| (k, &v.common))
+        });
+        let all_deps = module.deps.iter().chain(bin_deps.into_iter().flatten());
         for (name, req) in all_deps {
             let pkg_name = match name.parse() {
                 Ok(v) => v,
@@ -343,12 +349,14 @@ fn mvs_resolve(
             .iter()
             .map(|(k, v)| (k, v, DependencyKind::Regular));
 
-        let bin_deps = module.bin_deps.iter().flat_map(|map| {
-            map.iter()
-                .map(|(k, v)| (k, &v.common, DependencyKind::Binary))
+        let bin_deps = root_sources.contains(&pkg).then(|| {
+            module.bin_deps.iter().flat_map(|map| {
+                map.iter()
+                    .map(|(k, v)| (k, &v.common, DependencyKind::Binary))
+            })
         });
 
-        let all_deps = regular_deps.chain(bin_deps);
+        let all_deps = regular_deps.chain(bin_deps.into_iter().flatten());
         for (dep_name, req, kind) in all_deps {
             let dep_name = dep_name.parse().unwrap();
             // If any malformed name, it should be reported in the previous round
@@ -481,6 +489,7 @@ mod test {
     use moonutil::mooncakes::ModuleId;
     use moonutil::mooncakes::result::DependencyEdge;
     use petgraph::dot::{Config, Dot};
+    use semver::VersionReq;
     use test_log::test;
 
     use super::*;
@@ -711,6 +720,47 @@ mod test {
         assert!(status, "Resolve failed");
         let result = result_env;
         assert_depends_on(&result, "root/module@0.1.0", "dep/one@0.1.1");
+    }
+
+    #[test]
+    fn test_bin_deps_are_not_transitive() {
+        let mut registry = MockRegistry::new();
+        registry.add_module_full("dep/bin", "0.1.0", []);
+
+        let mut dep = create_mock_module("dep/regular", "0.1.0", []);
+        dep.bin_deps = Some(
+            [(
+                "dep/bin".to_string(),
+                moonutil::dependency::BinaryDependencyInfo {
+                    common: moonutil::dependency::SourceDependencyInfo {
+                        version: VersionReq::parse("0.1.0").unwrap(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+        );
+        registry.add_module(dep);
+
+        let registry = RegistryList::with_registry(Box::new(registry));
+        let mut env = ResolverEnv::new(&registry);
+        let mut resolver = MvsSolver;
+        let root = create_mock_module("root/module", "0.1.0", [("dep/regular", "0.1.0")]);
+        let roots = create_mock_root(root);
+        let mut result_env = ResolvedEnv::new();
+        let status = resolver.resolve(&mut env, &mut result_env, &roots);
+        assert!(status, "Resolve failed");
+        let result = result_env;
+
+        assert_depends_on(&result, "root/module@0.1.0", "dep/regular@0.1.0");
+        assert_no_depends_on(&result, "dep/regular@0.1.0", "dep/bin@0.1.0");
+        assert_no_depends_on(&result, "root/module@0.1.0", "dep/bin@0.1.0");
+        assert!(
+            id_from_mod_name(&result, &"dep/bin@0.1.0".parse().unwrap()).is_none(),
+            "transitive bin-dep should not be resolved at all"
+        );
     }
 
     #[test]

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -162,7 +162,12 @@ There are two types of dependencies in a module.
 
 - A regular dependency is a dependency that can be accessed from code.
 - A **binary dependency** (bin-dep) is a dependency that is used for its executable.
-  The implementation of binary dependencies is complex. Please check (TBD) for details.
+  Bin-deps are declared in `moon.mod.json` under `bin-deps`.
+  They are resolved only for the input/root module itself: bin-deps of regular
+  dependencies are not propagated transitively.
+  After dependency sync, direct bin-deps of the input module are built and
+  installed by invoking `moon tool build-binary-dep` inside the dependency
+  module.
 
 There are two kinds of sources that dependencies come from:
 

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -49,7 +49,7 @@ The detailed semantics of tests are in [the corresponding section](#building-tes
 
 ### Imports
 
-The imported packages are specified in the `imports` field in `moon.mod.json`,
+The imported packages are specified in the `import` field in `moon.pkg.json`,
 and are available to all three build targets.
 Test targets (whitebox and blackbox) can also have imports that are not used in regular targets,
 specified in an additional import field named `wbtest-import` and `test-import`.

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -2,8 +2,8 @@
 
 Prebuild tasks let a package generate source files (typically `.mbt`) from other assets before compilation, via declarative rules in `moon.pkg.json`.
 
-- Scope: Applies only to non-third-party packages in the current module.
-- Bypass: If `MOON_IGNORE_PREBUILD` is set in the environment, prebuild tasks are skipped.
+- Scope: Applies only to packages in the input module being built.
+  Third-party dependencies are expected to already contain their generated outputs.
 
 ## Package Configuration
 
@@ -29,7 +29,8 @@ Notes:
 
 - `input`/`output` paths are package-relative in config and expand to absolute paths inside the command.
 - When arrays are used, placeholders expand to space-separated lists in declaration order.
-- Generated outputs are treated as regular package sources in the current build and categorized by filename rules.
+- All declared outputs are tracked as build outputs.
+- Only `.mbt` and `.mbt.md` outputs are added back to the package's MoonBit source set.
 
 ## Path Resolution
 
@@ -37,6 +38,8 @@ Notes:
 - `$input`/`$output` expand to absolute file paths.
 - `$pkg_dir`/`$mod_dir` expand to absolute directories.
 - `$mooncake_bin` expands to `<module-root>/.mooncakes/__moonbin__`.
+  This directory contains launchers installed for the current module's direct
+  `bin-deps`.
 
 ## Placeholder Substitution
 
@@ -56,6 +59,8 @@ Only the `command` field is substituted. The following placeholders are recogniz
 
 - `$mooncake_bin`  
   Expands to the absolute path `<module-root>/.mooncakes/__moonbin__`.
+  This currently refers to launchers installed from the current module's direct
+  `bin-deps`.
 
 Substitution semantics:
 
@@ -66,7 +71,9 @@ Substitution semantics:
 
 ## :embed Shorthand
 
-If the command starts with `:embed` (no leading whitespace), it denotes the built-in embed tool. Conceptually this is equivalent to invoking the Moon tool "embed" subcommand with the remaining arguments and substituted placeholders.
+If the command starts with the exact prefix `:embed `, it denotes the built-in embed tool.
+Conceptually this is equivalent to invoking the Moon tool `embed` subcommand with
+the remaining arguments and substituted placeholders.
 
 - Form: `:embed [FLAGS...] -i $input -o $output [--name IDENT]`
 - Purpose: Generate output file(s) that embed the content of input file(s) as MoonBit code.
@@ -84,8 +91,13 @@ Behavior:
 
 ## Ordering and Inclusion
 
-- Tasks are processed in the order they appear in `pre-build`.
-- All declared outputs are expected to be produced. Outputs are included as regular sources and categorized by filename.
+- Each `pre-build` entry becomes its own prebuild node in the build graph.
+- There is no explicit build-graph edge between two prebuild tasks solely because one is
+  written earlier in `pre-build`.
+- If one prebuild task consumes another task's declared output, the dependency is currently
+  expected to be handled by the underlying file-level tracking in `n2`.
+- Only declared outputs ending in `.mbt` or `.mbt.md` are included as MoonBit sources for
+  compilation, and only when they live in the package directory itself.
 
 ## Failure Conditions
 
@@ -97,9 +109,13 @@ A task is considered failed (for the build) if any of the following holds after 
 
 ## Compatibility and Caveats
 
-- `:embed` detection is prefix-based and requires `:embed` as the first token.
+- `:embed` detection is prefix-based and requires the literal prefix `:embed `.
 - Substitution does not add quoting. Quote `$input`, `$output`, or directories inside `command` if paths may contain spaces.
 - Using arrays for `output` expands to a space-separated list; ensure your tool’s CLI accepts the intended arity.
+- On Unix-like platforms, the final prebuild command string is executed through `sh -c`.
+- On Windows, the final prebuild command string is passed directly to `CreateProcessA`.
+- On Unix-like platforms, if the first word of the command looks like a relative path,
+  it is currently resolved against the module root directory.
 - Windows (PowerShell):  
   On Windows only, if the first word of the `command` (before any spaces) corresponds to a `.ps1` file that exists in the module root directory, the command is rewritten to execute that script via PowerShell using its absolute path. Example: if the command is `generate-assets $input $output` and `generate-assets.ps1` exists in the module root, the effective command becomes `powershell <absolute-path-to-module-root>/generate-assets.ps1 $input $output`. Detection examines the first word before placeholder substitution.
 


### PR DESCRIPTION
## Summary
- stop resolving `bin-deps` transitively by limiting them to root/input modules in MVS
- add a regression test that asserts transitive `bin-deps` are not resolved into downstream builds
- sync developer docs for bin-deps and pre-build behavior with the current implementation

## Notes
- the resolver keeps a `root_sources` set so it can distinguish direct input modules from ordinary dependencies in both the version-gathering pass and the final graph construction pass
- this preserves current direct `bin-deps` behavior while removing the surprising transitive propagation path

## Testing
- not run in this step