### PR TITLE
feat: add supported-targets to packages.json

### DIFF
--- a/crates/moon/tests/test_cases/blackbox/test_blackbox_success_packages.json.snap
+++ b/crates/moon/tests/test_cases/blackbox/test_blackbox_success_packages.json.snap
@@ -90,7 +90,14 @@
           "fspath": "$ROOT/C"
         }
       ],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/A/A.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/A/A.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -137,7 +144,14 @@
           "fspath": "$MOON_HOME/lib/core/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/B/B.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/B/B.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -184,7 +198,14 @@
           "fspath": "$MOON_HOME/lib/core/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/C/C.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/C/C.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -231,7 +252,14 @@
           "fspath": "$MOON_HOME/lib/core/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/D/D.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/D/D.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": true,
@@ -278,7 +306,14 @@
           "fspath": "$MOON_HOME/lib/core/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/main/main.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/main/main.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     }
   ],
   "deps": [],

--- a/crates/moon/tests/test_cases/cond_comp.in/moon.test
+++ b/crates/moon/tests/test_cases/cond_comp.in/moon.test
@@ -259,7 +259,14 @@
             "fspath": "[MOON_HOME]/lib/core/prelude"
           }
         ],
-        "artifact": "[WORK_DIR]/_build/wasm-gc/debug/check/lib/lib.mi"
+        "artifact": "[WORK_DIR]/_build/wasm-gc/debug/check/lib/lib.mi",
+        "supported-targets": [
+          "Wasm",
+          "WasmGC",
+          "Js",
+          "Native",
+          "LLVM"
+        ]
       },
       {
         "is-main": true,
@@ -311,7 +318,14 @@
             "fspath": "[MOON_HOME]/lib/core/prelude"
           }
         ],
-        "artifact": "[WORK_DIR]/_build/wasm-gc/debug/check/main/main.mi"
+        "artifact": "[WORK_DIR]/_build/wasm-gc/debug/check/main/main.mi",
+        "supported-targets": [
+          "Wasm",
+          "WasmGC",
+          "Js",
+          "Native",
+          "LLVM"
+        ]
       }
     ],
     "deps": [],

--- a/crates/moon/tests/test_cases/dummy_core/packages_js.json.snap
+++ b/crates/moon/tests/test_cases/dummy_core/packages_js.json.snap
@@ -103,7 +103,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/js/debug/check/0/0.mi"
+      "artifact": "$ROOT/_build/js/debug/check/0/0.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -175,7 +182,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/js/debug/check/1/1.mi"
+      "artifact": "$ROOT/_build/js/debug/check/1/1.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -216,7 +230,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/js/debug/check/2/2.mi"
+      "artifact": "$ROOT/_build/js/debug/check/2/2.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -243,7 +264,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/js/debug/check/char/char.mi"
+      "artifact": "$ROOT/_build/js/debug/check/char/char.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -264,7 +292,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/js/debug/check/coverage/coverage.mi"
+      "artifact": "$ROOT/_build/js/debug/check/coverage/coverage.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -297,7 +332,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/js/debug/check/iter/iter.mi"
+      "artifact": "$ROOT/_build/js/debug/check/iter/iter.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -312,7 +354,14 @@
       "deps": [],
       "wbtest-deps": [],
       "test-deps": [],
-      "artifact": "$ROOT/_build/js/debug/check/prelude/prelude.mi"
+      "artifact": "$ROOT/_build/js/debug/check/prelude/prelude.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     }
   ],
   "deps": [],

--- a/crates/moon/tests/test_cases/dummy_core/packages_wasm_gc.json.snap
+++ b/crates/moon/tests/test_cases/dummy_core/packages_wasm_gc.json.snap
@@ -103,7 +103,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/0/0.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/0/0.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -175,7 +182,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/1/1.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/1/1.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -216,7 +230,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/2/2.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/2/2.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -243,7 +264,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/char/char.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/char/char.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -264,7 +292,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/coverage/coverage.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/coverage/coverage.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -297,7 +332,14 @@
           "fspath": "$ROOT/prelude"
         }
       ],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/iter/iter.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/iter/iter.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     },
     {
       "is-main": false,
@@ -312,7 +354,14 @@
       "deps": [],
       "wbtest-deps": [],
       "test-deps": [],
-      "artifact": "$ROOT/_build/wasm-gc/debug/check/prelude/prelude.mi"
+      "artifact": "$ROOT/_build/wasm-gc/debug/check/prelude/prelude.mi",
+      "supported-targets": [
+        "Wasm",
+        "WasmGC",
+        "Js",
+        "Native",
+        "LLVM"
+      ]
     }
   ],
   "deps": [],

--- a/crates/moon/tests/test_cases/run_md_test/mod.rs
+++ b/crates/moon/tests/test_cases/run_md_test/mod.rs
@@ -199,7 +199,14 @@ fn test_run_md_test() {
                           "fspath": "$MOON_HOME/lib/core/prelude"
                         }
                       ],
-                      "artifact": "$ROOT/_build/wasm-gc/debug/check/lib/lib.mi"
+                      "artifact": "$ROOT/_build/wasm-gc/debug/check/lib/lib.mi",
+                      "supported-targets": [
+                        "Wasm",
+                        "WasmGC",
+                        "Js",
+                        "Native",
+                        "LLVM"
+                      ]
                     },
                     {
                       "is-main": true,
@@ -251,7 +258,14 @@ fn test_run_md_test() {
                           "fspath": "$MOON_HOME/lib/core/prelude"
                         }
                       ],
-                      "artifact": "$ROOT/_build/wasm-gc/debug/check/main/main.mi"
+                      "artifact": "$ROOT/_build/wasm-gc/debug/check/main/main.mi",
+                      "supported-targets": [
+                        "Wasm",
+                        "WasmGC",
+                        "Js",
+                        "Native",
+                        "LLVM"
+                      ]
                     }
                   ],
                   "deps": [],

--- a/crates/moon/tests/test_cases/specify_source_dir_001/mod.rs
+++ b/crates/moon/tests/test_cases/specify_source_dir_001/mod.rs
@@ -89,7 +89,14 @@ fn test_specify_source_dir_001() {
                           "fspath": "$MOON_HOME/lib/core/prelude"
                         }
                       ],
-                      "artifact": "$ROOT/_build/wasm-gc/debug/check/lib/lib.mi"
+                      "artifact": "$ROOT/_build/wasm-gc/debug/check/lib/lib.mi",
+                      "supported-targets": [
+                        "Wasm",
+                        "WasmGC",
+                        "Js",
+                        "Native",
+                        "LLVM"
+                      ]
                     },
                     {
                       "is-main": true,
@@ -141,7 +148,14 @@ fn test_specify_source_dir_001() {
                           "fspath": "$MOON_HOME/lib/core/prelude"
                         }
                       ],
-                      "artifact": "$ROOT/_build/wasm-gc/debug/check/main/main.mi"
+                      "artifact": "$ROOT/_build/wasm-gc/debug/check/main/main.mi",
+                      "supported-targets": [
+                        "Wasm",
+                        "WasmGC",
+                        "Js",
+                        "Native",
+                        "LLVM"
+                      ]
                     }
                   ],
                   "deps": [],

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -433,6 +433,34 @@ fn test_module_supported_targets_intersects_package_supported_targets() {
 }
 
 #[test]
+fn test_packages_json_contains_computed_supported_targets() {
+    let dir = TestDir::new("supported_targets_module_intersection.in");
+
+    snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .args(["check", "--sort-input"])
+        .assert()
+        .success();
+
+    let packages_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dir.join("_build/packages.json")).unwrap())
+            .unwrap();
+    let packages = packages_json["packages"].as_array().unwrap();
+
+    let lib = packages.iter().find(|pkg| pkg["rel"] == "lib").unwrap();
+    assert_eq!(
+        lib["supported-targets"],
+        serde_json::json!(["WasmGC", "Native", "LLVM"])
+    );
+
+    let main = packages.iter().find(|pkg| pkg["rel"] == "main").unwrap();
+    assert_eq!(
+        main["supported-targets"],
+        serde_json::json!(["Wasm", "WasmGC", "Native", "LLVM"])
+    );
+}
+
+#[test]
 fn test_supported_targets_transitive_mismatch_fails_fast() {
     let dir = TestDir::new("supported_targets_transitive_mismatch.in");
 

--- a/crates/moonbuild-rupes-recta/src/metadata.rs
+++ b/crates/moonbuild-rupes-recta/src/metadata.rs
@@ -168,6 +168,7 @@ fn gen_package_json(
             )
             .to_string_lossy()
             .into_owned(),
+        supported_targets: pkg.raw.supported_targets.iter().copied().collect(),
     }
 }
 

--- a/crates/moonutil/src/package.rs
+++ b/crates/moonutil/src/package.rs
@@ -50,6 +50,7 @@ pub struct PackageJSON {
     pub wbtest_deps: Vec<AliasJSON>,
     pub test_deps: Vec<AliasJSON>,
     pub artifact: String,
+    pub supported_targets: Vec<TargetBackend>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
- Related issues: None
- PR kind: feature

## Summary

- add `supported-targets` to each `packages.json` package entry using the already computed resolved target set
- add a regression test for computed supported-target intersections in `packages.json`
- update existing `packages.json` snapshots and inline expectations to include the new field

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
