### PR TITLE
refactor: remove unused registry config plumbing

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -24,7 +24,6 @@ use moonutil::common::RunMode;
 use moonutil::common::WATCH_MODE_DIR;
 use moonutil::common::{BUILD_DIR, lower_surface_targets};
 use moonutil::common::{FileLock, TargetBackend};
-use moonutil::mooncakes::RegistryConfig;
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
@@ -199,7 +198,6 @@ fn run_check_for_single_file_rr(
     // Manually synthesize and resolve single file project
     let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
         cmd.auto_sync_flags.clone(),
-        RegistryConfig::load(),
         false,
         cmd.build_flags.enable_coverage,
     );

--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -157,14 +157,7 @@ pub(crate) fn remove_cli(cli: UniversalFlags, cmd: RemoveSubcommand) -> anyhow::
     }
     let username = parts[0];
     let pkgname = parts[1];
-    let registry_config = RegistryConfig::load();
-    mooncake::pkg::remove::remove(
-        project_root,
-        module_dir,
-        username,
-        pkgname,
-        &registry_config,
-    )
+    mooncake::pkg::remove::remove(project_root, module_dir, username, pkgname)
 }
 
 pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result<i32> {

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -25,7 +25,6 @@ use moonutil::common::{
     BUILD_DIR, FileLock, RunMode, TargetBackend, TestArtifacts, is_moon_pkg_exist,
 };
 use moonutil::dirs::PackageDirs;
-use moonutil::mooncakes::RegistryConfig;
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use tracing::{Level, instrument};
 
@@ -271,7 +270,6 @@ fn run_single_file_rr(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resul
     // Resolve single-file project (synthesized package around the file)
     let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
         cmd.auto_sync_flags.clone(),
-        RegistryConfig::load(),
         false,
         cmd.build_flags.enable_coverage,
     );

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -41,7 +41,6 @@ use moonutil::common::BUILD_DIR;
 use moonutil::common::{
     FileLock, RunMode, TargetBackend, TestArtifacts, TestIndexRange, lower_surface_targets,
 };
-use moonutil::mooncakes::RegistryConfig;
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use std::path::{Path, PathBuf};
 use tracing::{Level, debug, info, instrument, trace, warn};
@@ -318,7 +317,6 @@ fn run_test_in_single_file_rr(cli: &UniversalFlags, cmd: &TestSubcommand) -> any
     // Resolve synthesized single-file project
     let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
         cmd.auto_sync_flags.clone(),
-        RegistryConfig::load(),
         false,
         cmd.build_flags.enable_coverage,
     );

--- a/crates/moonbuild-rupes-recta/src/lib.rs
+++ b/crates/moonbuild-rupes-recta/src/lib.rs
@@ -53,8 +53,9 @@
 
     The rough steps (with Rupes Recta) of building a MoonBit program are:
 
-    1. Read the `mooncakes.io` registry and resolve the *module* dependency
-       graph (via `mooncake`'s internal resolver).
+    1. Read the local registry index (usually populated from `mooncakes.io`
+       by `moon update`) and resolve the *module* dependency graph
+       (via `mooncake`'s internal resolver).
     2. Download the required dependency to local cache folders
        ([`mooncake::pkg::install`]).
     3. Discover packages within modules ([`crate::discover`]). This is different

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -35,9 +35,7 @@ use mooncake::pkg::sync::{auto_sync, auto_sync_for_single_file_rr};
 use moonutil::{
     common::{MOONBITLANG_CORE, MbtMdHeader, TargetBackend, parse_front_matter_config},
     dependency::{SourceDependencyInfo, SourceDependencyInfoJson},
-    mooncakes::{
-        DirSyncResult, ModuleId, RegistryConfig, result::ResolvedEnv, sync::AutoSyncFlags,
-    },
+    mooncakes::{DirSyncResult, ModuleId, result::ResolvedEnv, sync::AutoSyncFlags},
     package::{Import, PkgJSONImport, pkg_json_imports_to_imports},
 };
 use tracing::instrument;
@@ -79,7 +77,6 @@ impl ResolveOutput {
 #[derive(Debug)]
 pub struct ResolveConfig {
     sync_flags: AutoSyncFlags,
-    registry_config: RegistryConfig,
     no_std: bool,
     /// Gate coverage injection in pkg_solve
     pub enable_coverage: bool,
@@ -252,28 +249,19 @@ mod tests {
 
 impl ResolveConfig {
     /// Creates a new `ResolveConfig` with whether to freeze package resolving,
-    /// and other flags populated from the environment with a sensible default.
-    ///
-    /// This method performs IO to load the registry configuration,
+    /// and other flags populated with sensible defaults.
     pub fn new_with_load_defaults(frozen: bool, no_std: bool, enable_coverage: bool) -> Self {
         Self {
             sync_flags: AutoSyncFlags { frozen },
-            registry_config: RegistryConfig::load(),
             no_std,
             enable_coverage,
         }
     }
 
-    /// Creates a new `ResolveConfig` with the given flags and registry
-    pub fn new(
-        sync_flags: AutoSyncFlags,
-        registry_config: RegistryConfig,
-        no_std: bool,
-        enable_coverage: bool,
-    ) -> Self {
+    /// Creates a new `ResolveConfig` with the given sync and build flags.
+    pub fn new(sync_flags: AutoSyncFlags, no_std: bool, enable_coverage: bool) -> Self {
         Self {
             sync_flags,
-            registry_config,
             no_std,
             enable_coverage,
         }
@@ -305,14 +293,9 @@ pub fn resolve(cfg: &ResolveConfig, source_dir: &Path) -> Result<ResolveOutput, 
     );
     debug!("Resolve config: sync_flags={:?}", cfg.sync_flags);
 
-    let (resolved_env, dir_sync_result, workspace) = auto_sync(
-        source_dir,
-        &cfg.sync_flags,
-        &cfg.registry_config,
-        false,
-        cfg.no_std,
-    )
-    .map_err(ResolveError::SyncModulesError)?;
+    let (resolved_env, dir_sync_result, workspace) =
+        auto_sync(source_dir, &cfg.sync_flags, false, cfg.no_std)
+            .map_err(ResolveError::SyncModulesError)?;
 
     info!("Module dependency resolution completed successfully");
     debug!("Resolved {} modules", resolved_env.module_count());

--- a/crates/mooncake/src/pkg/remove.rs
+++ b/crates/mooncake/src/pkg/remove.rs
@@ -22,7 +22,6 @@ use std::{path::Path, sync::Arc};
 use moonutil::{
     common::{read_module_desc_file_in_dir, write_module_json_to_file},
     module::convert_module_to_mod_json,
-    mooncakes::RegistryConfig,
 };
 
 use crate::{
@@ -44,7 +43,6 @@ pub fn remove(
     module_dir: &Path,
     username: &str,
     pkgname: &str,
-    _registry_config: &RegistryConfig,
 ) -> anyhow::Result<i32> {
     let mut m = read_module_desc_file_in_dir(module_dir)?;
     let removed = m.deps.shift_remove(&format!("{username}/{pkgname}"));

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -25,7 +25,7 @@ use moonutil::{
     common::{MbtMdHeader, MoonbuildOpt, MooncOpt, read_module_desc_file_in_dir},
     module::MoonMod,
     mooncakes::{
-        DirSyncResult, ModuleSource, RegistryConfig,
+        DirSyncResult, ModuleSource,
         result::{ResolvedEnv, ResolvedModule, ResolvedRootModules},
         sync::AutoSyncFlags,
     },
@@ -35,10 +35,11 @@ use semver::Version;
 
 /// Given the specified source directory, resolve the module dependency relation
 /// and their directories
+///
+/// TODO: support registry config
 pub fn auto_sync(
     source_dir: &Path,
     cli: &AutoSyncFlags,
-    _registry_config: &RegistryConfig,
     quiet: bool,
     no_std: bool,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult, Option<MoonWork>)> {

--- a/crates/mooncake/src/update.rs
+++ b/crates/mooncake/src/update.rs
@@ -192,10 +192,7 @@ enum PullLatestRegistryIndexErrorKind {
     NonZeroExitCode(std::process::ExitStatus),
 }
 
-fn pull_latest_registry_index(
-    _registry_config: &RegistryConfig,
-    target_dir: &Path,
-) -> Result<(), PullLatestRegistryIndexError> {
+fn pull_latest_registry_index(target_dir: &Path) -> Result<(), PullLatestRegistryIndexError> {
     let mut child = moonutil::git::git_command(
         &["-C", target_dir.to_str().unwrap(), "pull", "origin", "main"],
         Stdios::npp(),
@@ -340,7 +337,7 @@ pub fn update(target_dir: &Path, registry_config: &RegistryConfig) -> anyhow::Re
             source: UpdateErrorKind::GetRemoteUrlError(e),
         })?;
         if url == registry_config.index {
-            let result = pull_latest_registry_index(registry_config, target_dir);
+            let result = pull_latest_registry_index(target_dir);
             match result {
                 Err(_) => {
                     eprintln!(

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -190,7 +190,9 @@ There are two types of dependencies in a module.
 
 There are two kinds of sources that dependencies come from:
 
-- A **registry dependency** is downloaded from the `mooncakes.io` package registry.
+- A **registry dependency** is resolved from the local registry index under
+  `~/.moon/registry/index`, which is typically populated from `mooncakes.io`
+  by `moon update`.
   It is declared with a version range (written as a version number)
   and later resolved to a concrete version.
 - A **local dependency** is fetched from a local path.
@@ -202,6 +204,18 @@ MVS resolves each module dependency to the lowest version that satisfies all req
 Since MoonBit packages follows [SemVer][],
 only the caret version range (all compatible versions) is supported when specifying version requirements.
 See details in [Modules and packages][mod-pkg].
+
+Current registry configuration behavior today is:
+
+- `RegistryConfig` currently affects how `moon update` populates the local
+  registry index.
+- MVS itself resolves against the local on-disk index and does not consume
+  `RegistryConfig` directly.
+- Package artifact downloads and symbols download are still tied to the default
+  Mooncakes endpoints.
+
+Future custom/private registry work may configure these pieces together,
+rather than reintroducing unused registry parameters into resolve entry points.
 
 [semver]: https://semver.org/
 [mvs]: https://go.dev/ref/mod#minimal-version-selection


### PR DESCRIPTION
## Summary
- remove unused RegistryConfig plumbing from RR resolve and sync entry points
- keep registry configuration limited to index update paths and document the current split between update, MVS resolution, and downloads
- clean up stale resolver comments after the API simplification

## Testing
- cargo test -p moon --test add_updates_index
- cargo test -p mooncake resolver::mvs --lib