### PR TITLE
test: move target backend dry-run coverage to planner

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -135,27 +135,18 @@ fn run_build_rr(
     _watch: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<WatchOutput> {
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
-        cli,
-        &cmd.build_flags,
-        selected_target_backend,
-        target_dir,
-        RunMode::Build,
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
+        cmd.auto_sync_flags.clone(),
+        !cmd.build_flags.std(),
+        cmd.build_flags.enable_coverage,
     );
-    let (build_meta, build_graph) = rr_build::plan_build(
-        preconfig,
-        &cli.unstable_feature,
-        source_dir,
+    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir)?;
+    let (build_meta, build_graph) = plan_build_rr_from_resolved(
+        cli,
+        cmd,
         target_dir,
-        Box::new(|resolve_output, target_backend| {
-            calc_user_intent(
-                cmd.path.as_deref(),
-                cmd.package.as_deref(),
-                resolve_output,
-                target_backend,
-            )
-        }),
+        selected_target_backend,
+        resolve_output,
     )?;
 
     // Prepare for `watch` mode
@@ -195,6 +186,38 @@ fn run_build_rr(
         additional_ignored_paths: prebuild_list.ignored_paths,
         additional_watched_paths: prebuild_list.watched_paths,
     })
+}
+
+pub(crate) fn plan_build_rr_from_resolved(
+    cli: &UniversalFlags,
+    cmd: &BuildSubcommand,
+    target_dir: &Path,
+    selected_target_backend: Option<TargetBackend>,
+    resolve_output: moonbuild_rupes_recta::ResolveOutput,
+) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
+    let preconfig = preconfig_compile(
+        &cmd.auto_sync_flags,
+        cli,
+        &cmd.build_flags,
+        selected_target_backend,
+        target_dir,
+        RunMode::Build,
+    );
+
+    rr_build::plan_build_from_resolved(
+        preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        Box::new(|resolved, target_backend| {
+            calc_user_intent(
+                cmd.path.as_deref(),
+                cmd.package.as_deref(),
+                resolved,
+                target_backend,
+            )
+        }),
+        resolve_output,
+    )
 }
 
 /// Generate user intent

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -330,31 +330,20 @@ fn run_check_normal_internal_rr(
     _watch: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<WatchOutput> {
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
-        cli,
-        &cmd.build_flags,
-        selected_target_backend,
-        target_dir,
-        RunMode::Check,
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
+        cmd.auto_sync_flags.clone(),
+        !cmd.build_flags.std(),
+        cmd.build_flags.enable_coverage,
     );
-
-    let (build_meta, build_graph) = rr_build::plan_build(
-        preconfig,
-        &cli.unstable_feature,
+    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir)
+        .context("Failed to calculate build plan")?;
+    let (build_meta, build_graph) = plan_check_rr_from_resolved(
+        cli,
+        cmd,
         source_dir,
         target_dir,
-        Box::new(|r, tb| {
-            calc_user_intent(
-                r,
-                source_dir,
-                cmd.package_path.as_deref(),
-                cmd.path.as_deref(),
-                tb,
-                cmd.no_mi,
-                cmd.patch_file.as_deref(),
-            )
-        }),
+        selected_target_backend,
+        resolve_output,
     )
     .context("Failed to calculate build plan")?;
 
@@ -397,6 +386,42 @@ fn run_check_normal_internal_rr(
             additional_watched_paths: prebuild_list.watched_paths,
         })
     }
+}
+
+pub(crate) fn plan_check_rr_from_resolved(
+    cli: &UniversalFlags,
+    cmd: &CheckSubcommand,
+    source_dir: &Path,
+    target_dir: &Path,
+    selected_target_backend: Option<TargetBackend>,
+    resolve_output: moonbuild_rupes_recta::ResolveOutput,
+) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
+    let preconfig = preconfig_compile(
+        &cmd.auto_sync_flags,
+        cli,
+        &cmd.build_flags,
+        selected_target_backend,
+        target_dir,
+        RunMode::Check,
+    );
+
+    rr_build::plan_build_from_resolved(
+        preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        Box::new(|resolved, target_backend| {
+            calc_user_intent(
+                resolved,
+                source_dir,
+                cmd.package_path.as_deref(),
+                cmd.path.as_deref(),
+                target_backend,
+                cmd.no_mi,
+                cmd.patch_file.as_deref(),
+            )
+        }),
+        resolve_output,
+    )
 }
 
 /// Generate user intent of checking all packages in the current workspace.

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -160,24 +160,19 @@ fn run_run_rr(
         target_dir,
     } = cli.source_tgt_dir.try_into_package_dirs()?;
 
-    let input_path = cmd.package_or_mbt_file.clone();
-    let mut preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
-        cli,
-        &cmd.build_flags,
-        selected_target_backend,
-        &target_dir,
-        RunMode::Run,
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
+        cmd.auto_sync_flags.clone(),
+        !cmd.build_flags.std(),
+        cmd.build_flags.enable_coverage,
     );
-    preconfig.try_tcc_run = !cli.dry_run;
-
-    let value_tracing = cmd.build_flags.enable_value_tracing;
-    let (build_meta, build_graph) = rr_build::plan_build(
-        preconfig,
-        &cli.unstable_feature,
+    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir)?;
+    let (build_meta, build_graph) = plan_run_rr_from_resolved(
+        cli,
+        &cmd,
         &source_dir,
         &target_dir,
-        Box::new(|r, tb| calc_user_intent(&input_path, &source_dir, r, value_tracing, tb)),
+        selected_target_backend,
+        resolve_output,
     )?;
     rr_run_from_plan(
         cli,
@@ -186,6 +181,43 @@ fn run_run_rr(
         &target_dir,
         &build_meta,
         build_graph,
+    )
+}
+
+pub(crate) fn plan_run_rr_from_resolved(
+    cli: &UniversalFlags,
+    cmd: &RunSubcommand,
+    source_dir: &Path,
+    target_dir: &Path,
+    selected_target_backend: Option<TargetBackend>,
+    resolve_output: moonbuild_rupes_recta::ResolveOutput,
+) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
+    let mut preconfig = preconfig_compile(
+        &cmd.auto_sync_flags,
+        cli,
+        &cmd.build_flags,
+        selected_target_backend,
+        target_dir,
+        RunMode::Run,
+    );
+    preconfig.try_tcc_run = !cli.dry_run;
+
+    let input_path = cmd.package_or_mbt_file.clone();
+    let value_tracing = cmd.build_flags.enable_value_tracing;
+    rr_build::plan_build_from_resolved(
+        preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        Box::new(|resolved, target_backend| {
+            calc_user_intent(
+                &input_path,
+                source_dir,
+                resolved,
+                value_tracing,
+                target_backend,
+            )
+        }),
+        resolve_output,
     )
 }
 

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -21,10 +21,11 @@ use moonbuild_debug::graph::debug_dump_build_graph;
 use std::path::PathBuf;
 
 use moonbuild_rupes_recta::ResolveOutput;
-use moonutil::{cli::UniversalFlags, common::TargetBackend};
+use moonutil::cli::UniversalFlags;
 
 use crate::cli::{
-    BenchSubcommand, MoonBuildCli, MoonBuildSubcommands, TestLikeSubcommand, TestSubcommand,
+    BenchSubcommand, BuildSubcommand, CheckSubcommand, MoonBuildCli, MoonBuildSubcommands,
+    RunSubcommand, TestLikeSubcommand, TestSubcommand,
 };
 
 pub(super) struct PlanningFixture {
@@ -53,11 +54,14 @@ impl PlanningFixture {
         cmd: &TestSubcommand,
     ) -> anyhow::Result<String> {
         let borrowed: TestLikeSubcommand<'_> = cmd.into();
-        self.plan(
+        let (build_meta, build_graph, _) = crate::cli::test::plan_test_or_bench_rr_from_resolved(
             cli,
             &borrowed,
+            &self.source_dir.join("_build"),
             cmd.build_flags.resolve_single_target_backend()?,
-        )
+            self.resolve_output.clone(),
+        )?;
+        self.dump_plan(build_meta, build_graph)
     }
 
     pub(super) fn plan_bench_with_cli(
@@ -66,26 +70,72 @@ impl PlanningFixture {
         cmd: &BenchSubcommand,
     ) -> anyhow::Result<String> {
         let borrowed: TestLikeSubcommand<'_> = cmd.into();
-        self.plan(
+        let (build_meta, build_graph, _) = crate::cli::test::plan_test_or_bench_rr_from_resolved(
             cli,
             &borrowed,
+            &self.source_dir.join("_build"),
             cmd.build_flags.resolve_single_target_backend()?,
-        )
+            self.resolve_output.clone(),
+        )?;
+        self.dump_plan(build_meta, build_graph)
     }
 
-    fn plan(
+    pub(super) fn plan_build_with_cli(
         &self,
         cli: &UniversalFlags,
-        cmd: &TestLikeSubcommand<'_>,
-        selected_target_backend: Option<TargetBackend>,
+        cmd: &BuildSubcommand,
     ) -> anyhow::Result<String> {
-        let (build_meta, build_graph, _) = crate::cli::test::plan_test_or_bench_rr_from_resolved(
+        let (build_meta, build_graph) = crate::cli::build::plan_build_rr_from_resolved(
             cli,
             cmd,
             &self.source_dir.join("_build"),
-            selected_target_backend,
+            cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
+        self.dump_plan(build_meta, build_graph)
+    }
+
+    pub(super) fn plan_check_with_cli(
+        &self,
+        cli: &UniversalFlags,
+        cmd: &CheckSubcommand,
+    ) -> anyhow::Result<String> {
+        let (build_meta, build_graph) = crate::cli::check::plan_check_rr_from_resolved(
+            cli,
+            cmd,
+            &self.source_dir,
+            &self.source_dir.join("_build"),
+            cmd.build_flags.resolve_single_target_backend()?,
+            self.resolve_output.clone(),
+        )?;
+        self.dump_plan(build_meta, build_graph)
+    }
+
+    pub(super) fn plan_run_with_cli(
+        &self,
+        cli: &UniversalFlags,
+        cmd: &RunSubcommand,
+    ) -> anyhow::Result<String> {
+        let (build_meta, build_graph) = crate::cli::run::plan_run_rr_from_resolved(
+            cli,
+            cmd,
+            &self.source_dir,
+            &self.source_dir.join("_build"),
+            cmd.build_flags.resolve_single_target_backend()?,
+            self.resolve_output.clone(),
+        )?;
+        self.dump_plan(build_meta, build_graph)
+    }
+
+    pub(super) fn case_dir(&self) -> &std::path::Path {
+        &self.source_dir
+    }
+
+    fn dump_plan(
+        &self,
+        build_meta: crate::rr_build::BuildMeta,
+        build_graph: crate::rr_build::BuildInput,
+    ) -> anyhow::Result<String> {
         let graph = build_graph.graph_for_test();
         let default_files = build_meta
             .artifacts
@@ -101,6 +151,33 @@ impl PlanningFixture {
         dump.dump_to(&mut out).expect("graph dump should serialize");
         Ok(String::from_utf8(out).expect("graph dump should be valid UTF-8"))
     }
+}
+
+pub(super) fn parse_build_command(args: &[&str]) -> (UniversalFlags, BuildSubcommand) {
+    let parsed = MoonBuildCli::try_parse_from(std::iter::once("moon").chain(args.iter().copied()))
+        .expect("build command should parse");
+    let MoonBuildSubcommands::Build(cmd) = parsed.subcommand else {
+        panic!("expected `moon build` to parse as the build subcommand");
+    };
+    (parsed.flags, cmd)
+}
+
+pub(super) fn parse_check_command(args: &[&str]) -> (UniversalFlags, CheckSubcommand) {
+    let parsed = MoonBuildCli::try_parse_from(std::iter::once("moon").chain(args.iter().copied()))
+        .expect("check command should parse");
+    let MoonBuildSubcommands::Check(cmd) = parsed.subcommand else {
+        panic!("expected `moon check` to parse as the check subcommand");
+    };
+    (parsed.flags, cmd)
+}
+
+pub(super) fn parse_run_command(args: &[&str]) -> (UniversalFlags, RunSubcommand) {
+    let parsed = MoonBuildCli::try_parse_from(std::iter::once("moon").chain(args.iter().copied()))
+        .expect("run command should parse");
+    let MoonBuildSubcommands::Run(cmd) = parsed.subcommand else {
+        panic!("expected `moon run` to parse as the run subcommand");
+    };
+    (parsed.flags, cmd)
 }
 
 pub(super) fn parse_test_command(args: &[&str]) -> (UniversalFlags, TestSubcommand) {

--- a/crates/moon/src/tests/planner/mod.rs
+++ b/crates/moon/src/tests/planner/mod.rs
@@ -22,3 +22,4 @@ mod fixture;
 mod package_filter_planning;
 mod profile_planning;
 mod profile_policy;
+mod target_backend_planning;

--- a/crates/moon/src/tests/planner/target_backend_planning.rs
+++ b/crates/moon/src/tests/planner/target_backend_planning.rs
@@ -1,0 +1,265 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use super::fixture::{
+    PlanningFixture, parse_build_command, parse_check_command, parse_run_command,
+};
+
+// Phase 3: these tests already know the selected backend and only need to
+// verify that planning keeps the right packages and commands in the graph.
+
+fn assert_contains_and_absent(graph: &str, present: &[&str], absent: &[&str]) {
+    for needle in present {
+        assert!(
+            graph.contains(needle),
+            "expected graph to contain `{needle}`, got:\n{graph}"
+        );
+    }
+    for needle in absent {
+        assert!(
+            !graph.contains(needle),
+            "expected graph to not contain `{needle}`, got:\n{graph}"
+        );
+    }
+}
+
+#[test]
+fn target_backend_build_planning_respects_default_and_explicit_backend() {
+    let fixture = PlanningFixture::new("target_backend").expect("fixture should resolve");
+
+    let (cli, cmd) = parse_build_command(&["build", "--dry-run", "--nostd", "--sort-input"]);
+    let default_graph = fixture
+        .plan_build_with_cli(&cli, &cmd)
+        .expect("default build graph should plan");
+    assert_contains_and_absent(
+        &default_graph,
+        &[
+            "./_build/wasm-gc/debug/build/main/main.wasm",
+            "-target wasm-gc",
+        ],
+        &["./_build/js/debug/build/main/main.js", "-target js"],
+    );
+
+    let (cli, cmd) = parse_build_command(&[
+        "build",
+        "--dry-run",
+        "--target",
+        "js",
+        "--nostd",
+        "--sort-input",
+    ]);
+    let js_graph = fixture
+        .plan_build_with_cli(&cli, &cmd)
+        .expect("js build graph should plan");
+    assert_contains_and_absent(
+        &js_graph,
+        &["./_build/js/debug/build/main/main.js", "-target js"],
+        &[
+            "./_build/wasm-gc/debug/build/main/main.wasm",
+            "-target wasm-gc",
+        ],
+    );
+}
+
+#[test]
+fn mixed_backend_build_and_check_planning_are_target_aware() {
+    let fixture =
+        PlanningFixture::new("mixed_backend_local_dep.in").expect("fixture should resolve");
+
+    let (cli, cmd) = parse_check_command(&["check", "--target", "js", "--dry-run", "--sort-input"]);
+    let check_js = fixture
+        .plan_check_with_cli(&cli, &cmd)
+        .expect("js check graph should plan");
+    assert_contains_and_absent(
+        &check_js,
+        &[
+            "./shared/shared.mbt",
+            "./web/main.mbt",
+            "./deps/jsdep/lib/lib.mbt",
+        ],
+        &[
+            "./server/main.mbt",
+            "./deps/nativedep/lib/lib.mbt",
+            "./deps/unuseddep/lib/lib.mbt",
+        ],
+    );
+
+    let (cli, cmd) = parse_build_command(&["build", "--target", "js", "--dry-run", "--sort-input"]);
+    let build_js = fixture
+        .plan_build_with_cli(&cli, &cmd)
+        .expect("js build graph should plan");
+    assert_contains_and_absent(
+        &build_js,
+        &[
+            "./shared/shared.mbt",
+            "./web/main.mbt",
+            "./deps/jsdep/lib/lib.mbt",
+        ],
+        &["./server/main.mbt", "./deps/nativedep/lib/lib.mbt"],
+    );
+
+    let (cli, cmd) =
+        parse_check_command(&["check", "--target", "native", "--dry-run", "--sort-input"]);
+    let check_native = fixture
+        .plan_check_with_cli(&cli, &cmd)
+        .expect("native check graph should plan");
+    assert_contains_and_absent(
+        &check_native,
+        &[
+            "./shared/shared.mbt",
+            "./server/main.mbt",
+            "./deps/nativedep/lib/lib.mbt",
+        ],
+        &[
+            "./web/main.mbt",
+            "./deps/jsdep/lib/lib.mbt",
+            "./deps/unuseddep/lib/lib.mbt",
+        ],
+    );
+
+    let (cli, cmd) =
+        parse_build_command(&["build", "--target", "native", "--dry-run", "--sort-input"]);
+    let build_native = fixture
+        .plan_build_with_cli(&cli, &cmd)
+        .expect("native build graph should plan");
+    assert_contains_and_absent(
+        &build_native,
+        &[
+            "./shared/shared.mbt",
+            "./server/main.mbt",
+            "./deps/nativedep/lib/lib.mbt",
+        ],
+        &["./web/main.mbt", "./deps/jsdep/lib/lib.mbt"],
+    );
+}
+
+#[test]
+fn mixed_backend_run_planning_is_target_aware() {
+    let fixture =
+        PlanningFixture::new("mixed_backend_local_dep.in").expect("fixture should resolve");
+
+    let (cli, cmd) =
+        parse_run_command(&["run", "web", "--target", "js", "--dry-run", "--sort-input"]);
+    let run_js = fixture
+        .plan_run_with_cli(&cli, &cmd)
+        .expect("js run graph should plan");
+    assert_contains_and_absent(
+        &run_js,
+        &[
+            "./shared/shared.mbt",
+            "./web/main.mbt",
+            "./deps/jsdep/lib/lib.mbt",
+        ],
+        &["./server/main.mbt", "./deps/nativedep/lib/lib.mbt"],
+    );
+
+    let (cli, cmd) = parse_run_command(&[
+        "run",
+        "server",
+        "--target",
+        "native",
+        "--dry-run",
+        "--sort-input",
+    ]);
+    let run_native = fixture
+        .plan_run_with_cli(&cli, &cmd)
+        .expect("native run graph should plan");
+    assert_contains_and_absent(
+        &run_native,
+        &[
+            "./shared/shared.mbt",
+            "./server/main.mbt",
+            "./deps/nativedep/lib/lib.mbt",
+        ],
+        &["./web/main.mbt", "./deps/jsdep/lib/lib.mbt"],
+    );
+}
+
+#[test]
+fn supported_targets_empty_packages_are_skipped_in_check_planning() {
+    let fixture =
+        PlanningFixture::new("supported_targets_empty.in").expect("fixture should resolve");
+
+    let (cli, cmd) = parse_check_command(&["check", "--target", "js", "--dry-run", "--sort-input"]);
+    let check_js = fixture
+        .plan_check_with_cli(&cli, &cmd)
+        .expect("js check graph should plan");
+    assert_contains_and_absent(
+        &check_js,
+        &["./main/main.mbt", "./lib/lib.mbt"],
+        &["./never/never.mbt"],
+    );
+
+    let (cli, cmd) =
+        parse_check_command(&["check", "--target", "native", "--dry-run", "--sort-input"]);
+    let check_native = fixture
+        .plan_check_with_cli(&cli, &cmd)
+        .expect("native check graph should plan");
+    assert_contains_and_absent(
+        &check_native,
+        &["./main/main.mbt", "./lib/lib.mbt"],
+        &["./never/never.mbt"],
+    );
+}
+
+#[test]
+fn module_supported_targets_intersection_filters_check_planning() {
+    let fixture = PlanningFixture::new("supported_targets_module_intersection.in")
+        .expect("fixture should resolve");
+    let lib_path = fixture.case_dir().join("lib");
+    let lib_path = lib_path.to_str().expect("fixture path should be UTF-8");
+
+    let (cli, cmd) = parse_check_command(&[
+        "check",
+        lib_path,
+        "--target",
+        "wasm-gc",
+        "--dry-run",
+        "--sort-input",
+    ]);
+    let check_wasm_gc = fixture
+        .plan_check_with_cli(&cli, &cmd)
+        .expect("wasm-gc check graph should plan");
+    assert_contains_and_absent(&check_wasm_gc, &["./lib/lib.mbt"], &["./main/main.mbt"]);
+
+    let (cli, cmd) = parse_check_command(&[
+        "check",
+        lib_path,
+        "--target",
+        "native",
+        "--dry-run",
+        "--sort-input",
+    ]);
+    let check_native = fixture
+        .plan_check_with_cli(&cli, &cmd)
+        .expect("native check graph should plan");
+    assert_contains_and_absent(&check_native, &["./lib/lib.mbt"], &["./main/main.mbt"]);
+
+    let (cli, cmd) = parse_check_command(&[
+        "check",
+        lib_path,
+        "--target",
+        "llvm",
+        "--dry-run",
+        "--sort-input",
+    ]);
+    let check_llvm = fixture
+        .plan_check_with_cli(&cli, &cmd)
+        .expect("llvm check graph should plan");
+    assert_contains_and_absent(&check_llvm, &["./lib/lib.mbt"], &["./main/main.mbt"]);
+}

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn test_target_backend() {
+fn test_target_backend_cli_wiring_smoke() {
     let dir = TestDir::new("target_backend");
     check(
         get_stdout(&dir, ["build", "--dry-run", "--nostd"]),
@@ -9,54 +9,6 @@ fn test_target_backend() {
             moonc build-package ./lib/hello.mbt -o ./_build/wasm-gc/debug/build/lib/lib.core -pkg hello/lib -pkg-sources hello/lib:./lib -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
             moonc build-package ./main/main.mbt -o ./_build/wasm-gc/debug/build/main/main.core -pkg hello/main -is-main -i ./_build/wasm-gc/debug/build/lib/lib.mi:lib -pkg-sources hello/main:./main -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
             moonc link-core ./_build/wasm-gc/debug/build/lib/lib.core ./_build/wasm-gc/debug/build/main/main.core -main hello/main -o ./_build/wasm-gc/debug/build/main/main.wasm -pkg-config-path ./main/moon.pkg.json -pkg-sources hello/lib:./lib -pkg-sources hello/main:./main -target wasm-gc -g -O0 -source-map
-        "#]],
-    );
-    check(
-        get_stdout(
-            &dir,
-            ["build", "--dry-run", "--target", "wasm-gc", "--nostd"],
-        ),
-        expect![[r#"
-            moonc build-package ./lib/hello.mbt -o ./_build/wasm-gc/debug/build/lib/lib.core -pkg hello/lib -pkg-sources hello/lib:./lib -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
-            moonc build-package ./main/main.mbt -o ./_build/wasm-gc/debug/build/main/main.core -pkg hello/main -is-main -i ./_build/wasm-gc/debug/build/lib/lib.mi:lib -pkg-sources hello/main:./main -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
-            moonc link-core ./_build/wasm-gc/debug/build/lib/lib.core ./_build/wasm-gc/debug/build/main/main.core -main hello/main -o ./_build/wasm-gc/debug/build/main/main.wasm -pkg-config-path ./main/moon.pkg.json -pkg-sources hello/lib:./lib -pkg-sources hello/main:./main -target wasm-gc -g -O0 -source-map
-        "#]],
-    );
-    check(
-        get_stdout(&dir, ["build", "--dry-run", "--target", "js", "--nostd"]),
-        expect![[r#"
-            moonc build-package ./lib/hello.mbt -o ./_build/js/debug/build/lib/lib.core -pkg hello/lib -pkg-sources hello/lib:./lib -target js -g -O0 -source-map -workspace-path . -all-pkgs ./_build/js/debug/build/all_pkgs.json
-            moonc build-package ./main/main.mbt -o ./_build/js/debug/build/main/main.core -pkg hello/main -is-main -i ./_build/js/debug/build/lib/lib.mi:lib -pkg-sources hello/main:./main -target js -g -O0 -source-map -workspace-path . -all-pkgs ./_build/js/debug/build/all_pkgs.json
-            moonc link-core ./_build/js/debug/build/lib/lib.core ./_build/js/debug/build/main/main.core -main hello/main -o ./_build/js/debug/build/main/main.js -pkg-config-path ./main/moon.pkg.json -pkg-sources hello/lib:./lib -pkg-sources hello/main:./main -target js -g -O0 -source-map
-        "#]],
-    );
-    check(
-        get_stdout(&dir, ["build", "--dry-run", "--nostd"]),
-        expect![[r#"
-            moonc build-package ./lib/hello.mbt -o ./_build/wasm-gc/debug/build/lib/lib.core -pkg hello/lib -pkg-sources hello/lib:./lib -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
-            moonc build-package ./main/main.mbt -o ./_build/wasm-gc/debug/build/main/main.core -pkg hello/main -is-main -i ./_build/wasm-gc/debug/build/lib/lib.mi:lib -pkg-sources hello/main:./main -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
-            moonc link-core ./_build/wasm-gc/debug/build/lib/lib.core ./_build/wasm-gc/debug/build/main/main.core -main hello/main -o ./_build/wasm-gc/debug/build/main/main.wasm -pkg-config-path ./main/moon.pkg.json -pkg-sources hello/lib:./lib -pkg-sources hello/main:./main -target wasm-gc -g -O0 -source-map
-        "#]],
-    );
-    check(
-        get_stdout(&dir, ["run", "main", "--dry-run", "--nostd"]),
-        expect![[r#"
-            moonc build-package ./lib/hello.mbt -o ./_build/wasm-gc/debug/build/lib/lib.core -pkg hello/lib -pkg-sources hello/lib:./lib -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
-            moonc build-package ./main/main.mbt -o ./_build/wasm-gc/debug/build/main/main.core -pkg hello/main -is-main -i ./_build/wasm-gc/debug/build/lib/lib.mi:lib -pkg-sources hello/main:./main -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
-            moonc link-core ./_build/wasm-gc/debug/build/lib/lib.core ./_build/wasm-gc/debug/build/main/main.core -main hello/main -o ./_build/wasm-gc/debug/build/main/main.wasm -pkg-config-path ./main/moon.pkg.json -pkg-sources hello/lib:./lib -pkg-sources hello/main:./main -target wasm-gc -g -O0 -source-map
-            moonrun ./_build/wasm-gc/debug/build/main/main.wasm --
-        "#]],
-    );
-    check(
-        get_stdout(
-            &dir,
-            ["run", "main", "--dry-run", "--target", "wasm-gc", "--nostd"],
-        ),
-        expect![[r#"
-            moonc build-package ./lib/hello.mbt -o ./_build/wasm-gc/debug/build/lib/lib.core -pkg hello/lib -pkg-sources hello/lib:./lib -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
-            moonc build-package ./main/main.mbt -o ./_build/wasm-gc/debug/build/main/main.core -pkg hello/main -is-main -i ./_build/wasm-gc/debug/build/lib/lib.mi:lib -pkg-sources hello/main:./main -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
-            moonc link-core ./_build/wasm-gc/debug/build/lib/lib.core ./_build/wasm-gc/debug/build/main/main.core -main hello/main -o ./_build/wasm-gc/debug/build/main/main.wasm -pkg-config-path ./main/moon.pkg.json -pkg-sources hello/lib:./lib -pkg-sources hello/main:./main -target wasm-gc -g -O0 -source-map
-            moonrun ./_build/wasm-gc/debug/build/main/main.wasm --
         "#]],
     );
     check(
@@ -89,75 +41,6 @@ fn assert_contains_and_absent(output: &str, present: &[&str], absent: &[&str]) {
 }
 
 #[test]
-fn test_mixed_backend_build_and_check_are_target_aware() {
-    let dir = TestDir::new("mixed_backend_local_dep.in");
-
-    let check_js = get_stdout(
-        &dir,
-        ["check", "--target", "js", "--dry-run", "--sort-input"],
-    );
-    assert_contains_and_absent(
-        &check_js,
-        &[
-            "./shared/shared.mbt",
-            "./web/main.mbt",
-            "./deps/jsdep/lib/lib.mbt",
-        ],
-        &[
-            "./server/main.mbt",
-            "./deps/nativedep/lib/lib.mbt",
-            "./deps/unuseddep/lib/lib.mbt",
-        ],
-    );
-
-    let build_js = get_stdout(
-        &dir,
-        ["build", "--target", "js", "--dry-run", "--sort-input"],
-    );
-    assert_contains_and_absent(
-        &build_js,
-        &[
-            "./shared/shared.mbt",
-            "./web/main.mbt",
-            "./deps/jsdep/lib/lib.mbt",
-        ],
-        &["./server/main.mbt", "./deps/nativedep/lib/lib.mbt"],
-    );
-
-    let check_native = get_stdout(
-        &dir,
-        ["check", "--target", "native", "--dry-run", "--sort-input"],
-    );
-    assert_contains_and_absent(
-        &check_native,
-        &[
-            "./shared/shared.mbt",
-            "./server/main.mbt",
-            "./deps/nativedep/lib/lib.mbt",
-        ],
-        &[
-            "./web/main.mbt",
-            "./deps/jsdep/lib/lib.mbt",
-            "./deps/unuseddep/lib/lib.mbt",
-        ],
-    );
-
-    let build_native = get_stdout(
-        &dir,
-        ["build", "--target", "native", "--dry-run", "--sort-input"],
-    );
-    assert_contains_and_absent(
-        &build_native,
-        &[
-            "./shared/shared.mbt",
-            "./server/main.mbt",
-            "./deps/nativedep/lib/lib.mbt",
-        ],
-        &["./web/main.mbt", "./deps/jsdep/lib/lib.mbt"],
-    );
-}
-
-#[test]
 fn test_mixed_backend_explicit_selection_rejects_unsupported_backend() {
     let dir = TestDir::new("mixed_backend_local_dep.in");
 
@@ -166,58 +49,11 @@ fn test_mixed_backend_explicit_selection_rejects_unsupported_backend() {
         check_err.contains("Package 'mixed/localdep/server' does not support target backend 'js'")
     );
     assert!(check_err.contains("Supported backends: [native]"));
-
-    let build_err = get_err_stderr(&dir, ["build", "server", "--target", "js", "--dry-run"]);
-    assert!(
-        build_err.contains("Package 'mixed/localdep/server' does not support target backend 'js'")
-    );
-    assert!(build_err.contains("Supported backends: [native]"));
-
-    let run_err = get_err_stderr(&dir, ["run", "server", "--target", "js", "--dry-run"]);
-    assert!(
-        run_err.contains("Package 'mixed/localdep/server' does not support target backend 'js'")
-    );
-    assert!(run_err.contains("Supported backends: [native]"));
 }
 
 #[test]
 fn test_mixed_backend_run_info_bundle_are_target_aware() {
     let dir = TestDir::new("mixed_backend_local_dep.in");
-
-    let run_js = get_stdout(
-        &dir,
-        ["run", "web", "--target", "js", "--dry-run", "--sort-input"],
-    );
-    assert_contains_and_absent(
-        &run_js,
-        &[
-            "./shared/shared.mbt",
-            "./web/main.mbt",
-            "./deps/jsdep/lib/lib.mbt",
-        ],
-        &["./server/main.mbt", "./deps/nativedep/lib/lib.mbt"],
-    );
-
-    let run_native = get_stdout(
-        &dir,
-        [
-            "run",
-            "server",
-            "--target",
-            "native",
-            "--dry-run",
-            "--sort-input",
-        ],
-    );
-    assert_contains_and_absent(
-        &run_native,
-        &[
-            "./shared/shared.mbt",
-            "./server/main.mbt",
-            "./deps/nativedep/lib/lib.mbt",
-        ],
-        &["./web/main.mbt", "./deps/jsdep/lib/lib.mbt"],
-    );
 
     get_stdout(&dir, ["info", "--target", "js"]);
     assert!(dir.join("shared").join(MBTI_GENERATED).exists());
@@ -289,26 +125,6 @@ fn test_mixed_backend_run_info_bundle_are_target_aware() {
 fn test_supported_targets_empty_list_is_never_selected() {
     let dir = TestDir::new("supported_targets_empty.in");
 
-    let check_js = get_stdout(
-        &dir,
-        ["check", "--target", "js", "--dry-run", "--sort-input"],
-    );
-    assert_contains_and_absent(
-        &check_js,
-        &["./main/main.mbt", "./lib/lib.mbt"],
-        &["./never/never.mbt"],
-    );
-
-    let check_native = get_stdout(
-        &dir,
-        ["check", "--target", "native", "--dry-run", "--sort-input"],
-    );
-    assert_contains_and_absent(
-        &check_native,
-        &["./main/main.mbt", "./lib/lib.mbt"],
-        &["./never/never.mbt"],
-    );
-
     let explicit_err = get_err_stderr(&dir, ["check", "never", "--target", "js", "--dry-run"]);
     assert!(
         explicit_err
@@ -320,45 +136,6 @@ fn test_supported_targets_empty_list_is_never_selected() {
 #[test]
 fn test_module_supported_targets_intersects_package_supported_targets() {
     let dir = TestDir::new("supported_targets_module_intersection.in");
-
-    let check_wasm_gc = get_stdout(
-        &dir,
-        [
-            "check",
-            "lib",
-            "--target",
-            "wasm-gc",
-            "--dry-run",
-            "--sort-input",
-        ],
-    );
-    assert_contains_and_absent(&check_wasm_gc, &["./lib/lib.mbt"], &["./main/main.mbt"]);
-
-    let check_native = get_stdout(
-        &dir,
-        [
-            "check",
-            "lib",
-            "--target",
-            "native",
-            "--dry-run",
-            "--sort-input",
-        ],
-    );
-    assert_contains_and_absent(&check_native, &["./lib/lib.mbt"], &["./main/main.mbt"]);
-
-    let check_llvm = get_stdout(
-        &dir,
-        [
-            "check",
-            "lib",
-            "--target",
-            "llvm",
-            "--dry-run",
-            "--sort-input",
-        ],
-    );
-    assert_contains_and_absent(&check_llvm, &["./lib/lib.mbt"], &["./main/main.mbt"]);
 
     let js_err = get_err_stderr(&dir, ["check", "lib", "--target", "js", "--dry-run"]);
     assert!(


### PR DESCRIPTION
## Summary
- add small build/check/run planning seams that can reuse an already resolved fixture
- move target_backend dry-run graph coverage into planner tests
- keep CLI wiring, explicit errors, info/bundle, and metadata checks in the e2e suite

## Verification
- cargo fmt
- cargo test -p moon 'tests::planner::'
- cargo test -p moon --test mod target_backend
- cargo clippy -p moon --tests -- -D warnings