### PR TITLE
feat: use env vars to ignore prebuild and postadd scripts

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -655,7 +655,7 @@ pub fn plan_build_from_resolved<'a>(
 
     // Run prebuild config if any
     info!("Running prebuild configuration");
-    let prebuild_config = run_prebuild_config(&resolve_output)?;
+    let prebuild_config = Some(run_prebuild_config(&resolve_output)?);
 
     // Expand user intents to concrete BuildPlanNode inputs
     info!("Expanding user intents to build plan nodes");
@@ -677,7 +677,7 @@ pub fn plan_build_from_resolved<'a>(
         &resolve_output,
         &input_nodes,
         &intent.directive,
-        Some(&prebuild_config),
+        prebuild_config.as_ref(),
     )?;
 
     if unstable_features.rr_export_build_plan

--- a/crates/moon/tests/mod.rs
+++ b/crates/moon/tests/mod.rs
@@ -190,3 +190,13 @@ pub fn get_err_stderr(
     let s = get_err_stderr_without_replace(dir, args, [] as [(&str, &str); 0]);
     replace_dir(&s, dir)
 }
+
+#[track_caller]
+pub fn get_err_stderr_with_envs(
+    dir: &impl AsRef<std::path::Path>,
+    args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
+    envs: impl IntoIterator<Item = (impl AsRef<std::ffi::OsStr>, impl AsRef<std::ffi::OsStr>)>,
+) -> String {
+    let s = get_err_stderr_without_replace(dir, args, envs);
+    replace_dir(&s, dir)
+}

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -1357,6 +1357,31 @@ fn test_pre_build() {
 }
 
 #[test]
+fn test_pre_build_ignore_prebuild_env() {
+    let dir = TestDir::new("pre_build.in");
+
+    // replace CRLF with LF on Windows
+    let b_txt_path = dir.join("src/lib/b.txt");
+    std::fs::write(&b_txt_path, read(&b_txt_path)).unwrap();
+
+    assert!(
+        !dir.join("src/lib/a.mbt").exists(),
+        "Prebuilt file should not exist before execution"
+    );
+
+    let stderr = get_err_stderr_with_envs(&dir, ["check"], [("MOON_IGNORE_PREBUILD", "1")]);
+
+    assert!(
+        stderr.contains("a.mbt"),
+        "expected missing generated source in stderr, got:\n{stderr}"
+    );
+    assert!(
+        !dir.join("src/lib/a.mbt").exists(),
+        "`MOON_IGNORE_PREBUILD` should not generate prebuild outputs"
+    );
+}
+
+#[test]
 fn test_bad_version() {
     let dir = TestDir::new("general.in");
     let content = std::fs::read_to_string(dir.join("moon.mod.json")).unwrap();

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -29,8 +29,8 @@ use std::{
 use indexmap::{IndexSet, set::MutableValues};
 use moonutil::{
     common::{
-        DEP_PATH, DOT_MBT_DOT_MD, MOD_DIR, MOON_BIN_DIR, MOON_MOD_JSON, MOONCAKE_BIN, PKG_DIR,
-        is_moon_pkg,
+        DEP_PATH, DOT_MBT_DOT_MD, IgnoredMoonScript, MOD_DIR, MOON_BIN_DIR, MOON_MOD_JSON,
+        MOONCAKE_BIN, PKG_DIR, is_moon_pkg, is_moon_script_ignored,
     },
     compiler_flags::{CC, DETECTED_CC},
     mooncakes::ModuleId,
@@ -101,7 +101,9 @@ impl<'a> BuildPlanConstructor<'a> {
             return;
         }
 
-        if let Some(prebuild) = &pkg.raw.pre_build {
+        if !is_moon_script_ignored(IgnoredMoonScript::Prebuild)
+            && let Some(prebuild) = &pkg.raw.pre_build
+        {
             for i in 0..prebuild.len() {
                 let prebuild_node = self.need_node(BuildPlanNode::RunPrebuild(pkg_id, i as u32));
                 self.add_edge(node, prebuild_node);

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -1224,8 +1224,27 @@ impl PrePostBuild {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum IgnoredMoonScript {
+    Prebuild,
+    Postadd,
+}
+
+impl IgnoredMoonScript {
+    pub fn env_var(self) -> &'static str {
+        match self {
+            IgnoredMoonScript::Prebuild => "MOON_IGNORE_PREBUILD",
+            IgnoredMoonScript::Postadd => "MOON_IGNORE_POSTADD",
+        }
+    }
+}
+
+pub fn is_moon_script_ignored(script: IgnoredMoonScript) -> bool {
+    std::env::var_os(script.env_var()).is_some()
+}
+
 pub fn execute_postadd_script(dir: &Path) -> anyhow::Result<()> {
-    if std::env::var("MOON_IGNORE_POSTADD").is_ok() {
+    if is_moon_script_ignored(IgnoredMoonScript::Postadd) {
         return Ok(());
     }
     let m = read_module_desc_file_in_dir(dir)?;


### PR DESCRIPTION
## Motivation

What we expect is that when user upload the project, the project is complete on its own. i.e. all the prebuild script have already been executed and the generated files are included in the uploaded project. But, the current check of publish only performs a simple moon check, which is not strict enough as it will trigger prebuild script, and if people excluded those generated files, they would not know. Therefore, we add this environment variable to disable the prebuild script for testing.

## Summary
- add shared env-var helpers for ignoring Moon scripts via `MOON_IGNORE_PREBUILD` and `MOON_IGNORE_POSTADD`
- skip package `moon.pkg.json` `pre_build` tasks when `MOON_IGNORE_PREBUILD` is set, without affecting module-level prebuild config
- add regression coverage for checking a package without generating missing prebuild outputs

## Testing
- cargo test -p moon --test mod test_pre_build -- --nocapture
- cargo test -p moon --test mod prebuild_config_script -- --nocapture
- cargo test -p moon --test mod test_postadd_script -- --nocapture