### PR TITLE
test: move more dry-run coverage to planner

### DIFF
--- a/crates/moon/src/tests/planner/dummy_core_planning.rs
+++ b/crates/moon/src/tests/planner/dummy_core_planning.rs
@@ -1,0 +1,130 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use expect_test::expect_file;
+
+use super::fixture::{
+    PlanningFixture, parse_build_command, parse_check_command, parse_test_command,
+};
+
+// Phase 3: `dummy_core` is mostly a dry-run matrix over one fixture, so planner
+// tests can resolve it once and snapshot the resulting graph directly.
+
+#[test]
+fn dummy_core_check_graph_matches_snapshots() {
+    let fixture = PlanningFixture::new("dummy_core").expect("fixture should resolve");
+
+    let (cli, cmd) = parse_check_command(&["check", "--dry-run", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/check_default.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_check_with_cli(&cli, &cmd)
+            .expect("default check graph should plan"),
+    );
+
+    let (cli, cmd) =
+        parse_check_command(&["check", "--dry-run", "--target", "wasm", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/check_wasm.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_check_with_cli(&cli, &cmd)
+            .expect("wasm check graph should plan"),
+    );
+
+    let (cli, cmd) =
+        parse_check_command(&["check", "--dry-run", "--target", "wasm-gc", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/check_wasm_gc.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_check_with_cli(&cli, &cmd)
+            .expect("wasm-gc check graph should plan"),
+    );
+
+    let (cli, cmd) = parse_check_command(&["check", "--dry-run", "--target", "js", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/check_js.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_check_with_cli(&cli, &cmd)
+            .expect("js check graph should plan"),
+    );
+}
+
+#[test]
+fn dummy_core_build_graph_matches_snapshots() {
+    let fixture = PlanningFixture::new("dummy_core").expect("fixture should resolve");
+
+    let (cli, cmd) = parse_build_command(&["build", "--dry-run", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/build_default.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_build_with_cli(&cli, &cmd)
+            .expect("default build graph should plan"),
+    );
+
+    let (cli, cmd) =
+        parse_build_command(&["build", "--dry-run", "--target", "wasm", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/build_wasm.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_build_with_cli(&cli, &cmd)
+            .expect("wasm build graph should plan"),
+    );
+
+    let (cli, cmd) =
+        parse_build_command(&["build", "--dry-run", "--target", "wasm-gc", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/build_wasm_gc.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_build_with_cli(&cli, &cmd)
+            .expect("wasm-gc build graph should plan"),
+    );
+
+    let (cli, cmd) = parse_build_command(&["build", "--dry-run", "--target", "js", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/build_js.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_build_with_cli(&cli, &cmd)
+            .expect("js build graph should plan"),
+    );
+}
+
+#[test]
+fn dummy_core_test_graph_matches_snapshots() {
+    let fixture = PlanningFixture::new("dummy_core").expect("fixture should resolve");
+
+    let (cli, cmd) = parse_test_command(&["test", "--dry-run", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/test_default.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_test_with_cli(&cli, &cmd)
+            .expect("default test graph should plan"),
+    );
+
+    let (cli, cmd) = parse_test_command(&["test", "--dry-run", "--target", "wasm", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/test_wasm.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_test_with_cli(&cli, &cmd)
+            .expect("wasm test graph should plan"),
+    );
+
+    let (cli, cmd) =
+        parse_test_command(&["test", "--dry-run", "--target", "wasm-gc", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/test_wasm_gc.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_test_with_cli(&cli, &cmd)
+            .expect("wasm-gc test graph should plan"),
+    );
+
+    let (cli, cmd) = parse_test_command(&["test", "--dry-run", "--target", "js", "--sort-input"]);
+    expect_file!["../../../tests/test_cases/dummy_core/test_js.jsonl.snap"].assert_eq(
+        &fixture
+            .plan_test_with_cli(&cli, &cmd)
+            .expect("js test graph should plan"),
+    );
+}

--- a/crates/moon/src/tests/planner/mod.rs
+++ b/crates/moon/src/tests/planner/mod.rs
@@ -18,6 +18,7 @@
 
 mod backend_selection;
 mod cli_to_planner;
+mod dummy_core_planning;
 mod fixture;
 mod package_filter_planning;
 mod profile_planning;

--- a/crates/moon/src/tests/planner/profile_planning.rs
+++ b/crates/moon/src/tests/planner/profile_planning.rs
@@ -18,10 +18,85 @@
 
 use expect_test::expect_file;
 
-use super::fixture::{PlanningFixture, parse_bench_command, parse_test_command};
+use super::fixture::{
+    PlanningFixture, parse_bench_command, parse_build_command, parse_check_command,
+    parse_run_command, parse_test_command,
+};
 
 // Phase 3: these tests start from an already chosen command configuration and
 // assert how the planner lowers that intent into the dry-run graph.
+
+fn line_with<'a>(graph: &'a str, command: &str, filter: &[&str]) -> &'a str {
+    graph
+        .lines()
+        .find(|line| line.contains(command) && filter.iter().all(|needle| line.contains(needle)))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected graph line containing `{command}` and {:?}\n{graph}",
+                filter
+            )
+        })
+}
+
+fn command_tokens(graph: &str, command: &str, filter: &[&str]) -> Vec<String> {
+    let line = line_with(graph, command, filter);
+    let line_json: serde_json::Value =
+        serde_json::from_str(line).expect("planner dump line should be valid JSON");
+    let command = line_json["command"]
+        .as_str()
+        .expect("planner dump line should contain a command");
+    shlex::split(command).expect("planner command should tokenize")
+}
+
+fn assert_command_uses_profile(
+    graph: &str,
+    command: &str,
+    filter: &[&str],
+    profile: &str,
+    expect_debug_flags: bool,
+) {
+    let tokens = command_tokens(graph, command, filter);
+    let expected_prefix = format!("./_build/wasm-gc/{profile}/");
+    let other_prefix = if profile == "debug" {
+        "./_build/wasm-gc/release/"
+    } else {
+        "./_build/wasm-gc/debug/"
+    };
+
+    assert!(
+        tokens
+            .iter()
+            .filter(|token| token.contains("./_build/wasm-gc/"))
+            .all(|token| token.contains(&expected_prefix)),
+        "expected `{command}` with {:?} to use `{expected_prefix}`, got:\n{:?}",
+        filter,
+        tokens,
+    );
+    assert!(
+        tokens
+            .iter()
+            .filter(|token| token.contains("./_build/wasm-gc/"))
+            .all(|token| !token.contains(other_prefix)),
+        "expected `{command}` with {:?} to avoid `{other_prefix}`, got:\n{:?}",
+        filter,
+        tokens,
+    );
+
+    for flag in ["-g", "-O0", "-source-map"] {
+        assert_eq!(
+            tokens.iter().any(|token| token == flag),
+            expect_debug_flags,
+            "expected `{command}` with {:?} to {} `{flag}`, got:\n{:?}",
+            filter,
+            if expect_debug_flags {
+                "include"
+            } else {
+                "omit"
+            },
+            tokens,
+        );
+    }
+}
 
 #[test]
 fn bench_graph_uses_selected_codegen_profile() {
@@ -73,4 +148,215 @@ fn release_test_graph_matches_snapshot() {
             .plan_test_with_cli(&cli, &cmd)
             .expect("release test graph should plan"),
     );
+}
+
+#[test]
+fn check_graph_uses_debug_profile_without_codegen_flags() {
+    let fixture = PlanningFixture::new("debug_flag_test").expect("fixture should resolve");
+
+    for (label, args) in [
+        (
+            "default check",
+            ["check", "--dry-run", "--nostd", "--sort-input"].as_slice(),
+        ),
+        (
+            "explicit debug check",
+            ["check", "--dry-run", "--debug", "--nostd", "--sort-input"].as_slice(),
+        ),
+    ] {
+        let (cli, cmd) = parse_check_command(args);
+        let graph = fixture
+            .plan_check_with_cli(&cli, &cmd)
+            .unwrap_or_else(|err| panic!("{label} should plan: {err:#}"));
+
+        assert_command_uses_profile(&graph, "moonc check", &["./lib/hello.mbt"], "debug", false);
+        assert_command_uses_profile(&graph, "moonc check", &["./main/main.mbt"], "debug", false);
+    }
+}
+
+#[test]
+fn build_graph_uses_selected_profile() {
+    let fixture = PlanningFixture::new("debug_flag_test").expect("fixture should resolve");
+
+    for (label, args, profile) in [
+        (
+            "default build",
+            ["build", "--dry-run", "--nostd", "--sort-input"].as_slice(),
+            "debug",
+        ),
+        (
+            "release build",
+            ["build", "--dry-run", "--release", "--nostd", "--sort-input"].as_slice(),
+            "release",
+        ),
+        (
+            "debug build",
+            ["build", "--dry-run", "--debug", "--nostd", "--sort-input"].as_slice(),
+            "debug",
+        ),
+        (
+            "default build with explicit target",
+            [
+                "build",
+                "--target",
+                "wasm-gc",
+                "--dry-run",
+                "--nostd",
+                "--sort-input",
+            ]
+            .as_slice(),
+            "debug",
+        ),
+        (
+            "release build with explicit target",
+            [
+                "build",
+                "--target",
+                "wasm-gc",
+                "--dry-run",
+                "--release",
+                "--nostd",
+                "--sort-input",
+            ]
+            .as_slice(),
+            "release",
+        ),
+        (
+            "debug build with explicit target",
+            [
+                "build",
+                "--target",
+                "wasm-gc",
+                "--dry-run",
+                "--debug",
+                "--nostd",
+                "--sort-input",
+            ]
+            .as_slice(),
+            "debug",
+        ),
+    ] {
+        let (cli, cmd) = parse_build_command(args);
+        let graph = fixture
+            .plan_build_with_cli(&cli, &cmd)
+            .unwrap_or_else(|err| panic!("{label} should plan: {err:#}"));
+
+        assert_command_uses_profile(
+            &graph,
+            "moonc build-package",
+            &["./lib/hello.mbt"],
+            profile,
+            profile == "debug",
+        );
+        assert_command_uses_profile(
+            &graph,
+            "moonc link-core",
+            &["-main", "hello/main"],
+            profile,
+            profile == "debug",
+        );
+    }
+}
+
+#[test]
+fn run_graph_uses_selected_profile() {
+    let fixture = PlanningFixture::new("debug_flag_test").expect("fixture should resolve");
+
+    for (label, args, profile) in [
+        (
+            "default run",
+            ["run", "main", "--dry-run", "--nostd", "--sort-input"].as_slice(),
+            "debug",
+        ),
+        (
+            "release run",
+            [
+                "run",
+                "main",
+                "--dry-run",
+                "--release",
+                "--nostd",
+                "--sort-input",
+            ]
+            .as_slice(),
+            "release",
+        ),
+        (
+            "debug run",
+            [
+                "run",
+                "main",
+                "--dry-run",
+                "--debug",
+                "--nostd",
+                "--sort-input",
+            ]
+            .as_slice(),
+            "debug",
+        ),
+        (
+            "default run with explicit target",
+            [
+                "run",
+                "main",
+                "--target",
+                "wasm-gc",
+                "--dry-run",
+                "--nostd",
+                "--sort-input",
+            ]
+            .as_slice(),
+            "debug",
+        ),
+        (
+            "release run with explicit target",
+            [
+                "run",
+                "main",
+                "--target",
+                "wasm-gc",
+                "--dry-run",
+                "--release",
+                "--nostd",
+                "--sort-input",
+            ]
+            .as_slice(),
+            "release",
+        ),
+        (
+            "debug run with explicit target",
+            [
+                "run",
+                "main",
+                "--target",
+                "wasm-gc",
+                "--dry-run",
+                "--debug",
+                "--nostd",
+                "--sort-input",
+            ]
+            .as_slice(),
+            "debug",
+        ),
+    ] {
+        let (cli, cmd) = parse_run_command(args);
+        let graph = fixture
+            .plan_run_with_cli(&cli, &cmd)
+            .unwrap_or_else(|err| panic!("{label} should plan: {err:#}"));
+
+        assert_command_uses_profile(
+            &graph,
+            "moonc build-package",
+            &["./lib/hello.mbt"],
+            profile,
+            profile == "debug",
+        );
+        assert_command_uses_profile(
+            &graph,
+            "moonc link-core",
+            &["-main", "hello/main"],
+            profile,
+            profile == "debug",
+        );
+    }
 }

--- a/crates/moon/src/tests/planner/profile_policy.rs
+++ b/crates/moon/src/tests/planner/profile_policy.rs
@@ -24,49 +24,59 @@ use crate::build_flags::BuildFlags;
 // tested without involving any planner graph.
 
 #[test]
-fn bench_profile_selection_matches_flags() {
-    assert_eq!(
-        BuildFlags::default().effective_profile(RunMode::Bench),
-        OptLevel::Release
-    );
-    assert_eq!(
-        BuildFlags {
-            release: true,
-            ..Default::default()
-        }
-        .effective_profile(RunMode::Bench),
-        OptLevel::Release
-    );
-    assert_eq!(
-        BuildFlags {
-            debug: true,
-            ..Default::default()
-        }
-        .effective_profile(RunMode::Bench),
-        OptLevel::Debug
-    );
+fn release_by_default_modes_match_flags() {
+    for run_mode in [RunMode::Bench, RunMode::Bundle] {
+        assert_eq!(
+            BuildFlags::default().effective_profile(run_mode),
+            OptLevel::Release
+        );
+    }
 }
 
 #[test]
-fn test_profile_selection_matches_flags() {
-    assert_eq!(
-        BuildFlags::default().effective_profile(RunMode::Test),
-        OptLevel::Debug
-    );
-    assert_eq!(
-        BuildFlags {
-            release: true,
-            ..Default::default()
-        }
-        .effective_profile(RunMode::Test),
-        OptLevel::Release
-    );
-    assert_eq!(
-        BuildFlags {
-            debug: true,
-            ..Default::default()
-        }
-        .effective_profile(RunMode::Test),
-        OptLevel::Debug
-    );
+fn debug_by_default_modes_match_flags() {
+    for run_mode in [RunMode::Build, RunMode::Run, RunMode::Test, RunMode::Check] {
+        assert_eq!(
+            BuildFlags::default().effective_profile(run_mode),
+            OptLevel::Debug
+        );
+    }
+}
+
+#[test]
+fn explicit_release_overrides_every_mode() {
+    let flags = BuildFlags {
+        release: true,
+        ..Default::default()
+    };
+
+    for run_mode in [
+        RunMode::Build,
+        RunMode::Run,
+        RunMode::Test,
+        RunMode::Check,
+        RunMode::Bench,
+        RunMode::Bundle,
+    ] {
+        assert_eq!(flags.effective_profile(run_mode), OptLevel::Release);
+    }
+}
+
+#[test]
+fn explicit_debug_overrides_every_mode() {
+    let flags = BuildFlags {
+        debug: true,
+        ..Default::default()
+    };
+
+    for run_mode in [
+        RunMode::Build,
+        RunMode::Run,
+        RunMode::Test,
+        RunMode::Check,
+        RunMode::Bench,
+        RunMode::Bundle,
+    ] {
+        assert_eq!(flags.effective_profile(run_mode), OptLevel::Debug);
+    }
 }

--- a/crates/moon/tests/support/dry_run_utils.rs
+++ b/crates/moon/tests/support/dry_run_utils.rs
@@ -39,16 +39,6 @@ pub(crate) fn line_with<T: AsRef<str> + Debug>(
     );
 }
 
-/// Return the shlex-split tokens of a command line from a dry-run output.
-pub(crate) fn command_tokens<T: AsRef<str> + Debug>(
-    input: impl AsRef<str>,
-    command: impl AsRef<str>,
-    filter: &[T],
-) -> Vec<String> {
-    let line = line_with(input, command, filter);
-    shlex::split(&line).unwrap_or_default()
-}
-
 /// Ensures the expected lines appear in order within the actual output, allowing
 /// unrelated lines to exist between matches.
 pub(crate) fn assert_lines_in_order(actual: impl AsRef<str>, expect: impl AsRef<str>) {

--- a/crates/moon/tests/test_cases/debug_flag_test/mod.rs
+++ b/crates/moon/tests/test_cases/debug_flag_test/mod.rs
@@ -1,475 +1,74 @@
 use expect_test::expect;
 
-use crate::{
-    TestDir,
-    dry_run_utils::{command_tokens, line_with},
-    get_stdout,
-    util::{check, moon_bin},
-};
+use crate::{TestDir, dry_run_utils::line_with, get_stdout, util::check};
 
 #[cfg(unix)]
 use crate::get_err_stderr;
 
 #[test]
-fn debug_flag_test() {
+fn run_dry_run_uses_selected_profile_for_runtime_artifact() {
     let dir = TestDir::new("debug_flag_test");
-    snapbox::cmd::Command::new(moon_bin())
-        .current_dir(&dir)
-        .args(["clean"])
-        .assert()
-        .success();
 
-    let check_default = get_stdout(&dir, ["check", "--dry-run", "--nostd"]);
-    let check_debug = get_stdout(&dir, ["check", "--dry-run", "--debug", "--nostd"]);
-    // Default `check` uses debug artifacts without adding codegen flags.
-    assert_moonc_line(
-        &check_default,
-        "moonc check",
-        &["./lib/hello.mbt"],
-        false,
-        Some(false),
-    );
-    // Same expectation for the main package check invocation.
-    assert_moonc_line(
-        &check_default,
-        "moonc check",
-        &["./main/main.mbt"],
-        false,
-        Some(false),
-    );
-    // Explicit debug keeps the same debug-only check behavior.
-    assert_moonc_line(
-        &check_debug,
-        "moonc check",
-        &["./lib/hello.mbt"],
-        false,
-        Some(false),
-    );
-    // Same expectation for the main package check invocation.
-    assert_moonc_line(
-        &check_debug,
-        "moonc check",
-        &["./main/main.mbt"],
-        false,
-        Some(false),
-    );
+    let default_run = get_stdout(&dir, ["run", "main", "--dry-run", "--nostd"]);
+    assert_moonrun_line(&default_run, false);
 
-    let build_default = get_stdout(&dir, ["build", "--dry-run", "--nostd"]);
-    let build_release = get_stdout(&dir, ["build", "--dry-run", "--release", "--nostd"]);
-    let build_debug = get_stdout(&dir, ["build", "--dry-run", "--debug", "--nostd"]);
-    // Default build uses debug artifacts for the library.
-    assert_moonc_line(
-        &build_default,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        false,
-        None,
-    );
-    // Default build for the main package also uses debug paths.
-    assert_moonc_line(
-        &build_default,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        false,
-        None,
-    );
-    // Default build link step targets the debug artifact.
-    assert_moonc_line(
-        &build_default,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        false,
-        None,
-    );
-    // Release build keeps release-only artifact paths for the library.
-    assert_moonc_line(
-        &build_release,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        true,
-        None,
-    );
-    // Release build for the main package also uses release paths.
-    assert_moonc_line(
-        &build_release,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        true,
-        None,
-    );
-    // Release build link step targets the release artifact.
-    assert_moonc_line(
-        &build_release,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        true,
-        None,
-    );
-    // Debug build toggles the library compilation into the debug directory with debug flags.
-    assert_moonc_line(
-        &build_debug,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        false,
-        None,
-    );
-    // Debug build toggles the main package compilation likewise.
-    assert_moonc_line(
-        &build_debug,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        false,
-        None,
-    );
-    // Debug build link step consumes debug artifacts with debug flags.
-    assert_moonc_line(
-        &build_debug,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        false,
-        None,
-    );
-
-    let run_default = get_stdout(&dir, ["run", "main", "--dry-run", "--nostd"]);
-    let run_release = get_stdout(&dir, ["run", "main", "--dry-run", "--release", "--nostd"]);
-    let run_debug = get_stdout(&dir, ["run", "main", "--dry-run", "--debug", "--nostd"]);
-    // Default run recompiles the library in debug mode.
-    assert_moonc_line(
-        &run_default,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        false,
-        None,
-    );
-    // Default run recompiles the main package in debug mode.
-    assert_moonc_line(
-        &run_default,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        false,
-        None,
-    );
-    // Default run links debug artifacts.
-    assert_moonc_line(
-        &run_default,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        false,
-        None,
-    );
-    // Default run executes the debug Wasm.
-    assert_moonrun_line(&run_default, false);
-    // Running in release mode recompiles the library using release settings.
-    assert_moonc_line(
-        &run_release,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        true,
-        None,
-    );
-    // Running in release mode recompiles the main package using release settings.
-    assert_moonc_line(
-        &run_release,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        true,
-        None,
-    );
-    // Release run links the release artifacts.
-    assert_moonc_line(
-        &run_release,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        true,
-        None,
-    );
-    // Release run executes the release Wasm.
-    assert_moonrun_line(&run_release, true);
-    // Debug run recompiles the library in debug mode with flags.
-    assert_moonc_line(
-        &run_debug,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        false,
-        None,
-    );
-    // Debug run recompiles the main package in debug mode with flags.
-    assert_moonc_line(
-        &run_debug,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        false,
-        None,
-    );
-    // Debug run links debug artifacts with flags.
-    assert_moonc_line(
-        &run_debug,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        false,
-        None,
-    );
-    // Debug run executes the debug Wasm.
-    assert_moonrun_line(&run_debug, false);
-
-    let build_target_default = get_stdout(
-        &dir,
-        ["build", "--target", "wasm-gc", "--dry-run", "--nostd"],
-    );
-    let build_target_release = get_stdout(
-        &dir,
-        [
-            "build",
-            "--target",
-            "wasm-gc",
-            "--dry-run",
-            "--release",
-            "--nostd",
-        ],
-    );
-    let build_target_debug = get_stdout(
-        &dir,
-        [
-            "build",
-            "--dry-run",
-            "--target",
-            "wasm-gc",
-            "--debug",
-            "--nostd",
-        ],
-    );
-    // Default target build uses debug artifacts for the library.
-    assert_moonc_line(
-        &build_target_default,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        false,
-        None,
-    );
-    // Default target build uses debug artifacts for the main package.
-    assert_moonc_line(
-        &build_target_default,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        false,
-        None,
-    );
-    // Default target build links debug outputs.
-    assert_moonc_line(
-        &build_target_default,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        false,
-        None,
-    );
-    // Explicit release target keeps release artifacts for the library.
-    assert_moonc_line(
-        &build_target_release,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        true,
-        None,
-    );
-    // Explicit release target keeps release artifacts for the main package.
-    assert_moonc_line(
-        &build_target_release,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        true,
-        None,
-    );
-    // Explicit release target link references release outputs.
-    assert_moonc_line(
-        &build_target_release,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        true,
-        None,
-    );
-    // Debug build with explicit target uses debug artifacts for the library.
-    assert_moonc_line(
-        &build_target_debug,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        false,
-        None,
-    );
-    // Debug build with explicit target uses debug artifacts for the main package.
-    assert_moonc_line(
-        &build_target_debug,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        false,
-        None,
-    );
-    // Debug build with explicit target links debug outputs with flags.
-    assert_moonc_line(
-        &build_target_debug,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        false,
-        None,
-    );
-
-    let run_target_default = get_stdout(
-        &dir,
-        ["run", "main", "--target", "wasm-gc", "--dry-run", "--nostd"],
-    );
-    let run_target_release = get_stdout(
-        &dir,
-        [
-            "run",
-            "main",
-            "--target",
-            "wasm-gc",
-            "--dry-run",
-            "--release",
-            "--nostd",
-        ],
-    );
-    let run_target_debug = get_stdout(
-        &dir,
-        [
-            "run",
-            "main",
-            "--target",
-            "wasm-gc",
-            "--dry-run",
-            "--debug",
-            "--nostd",
-        ],
-    );
-    // Default run with explicit target rebuilds the library in debug mode.
-    assert_moonc_line(
-        &run_target_default,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        false,
-        None,
-    );
-    // Default run with explicit target rebuilds the main package in debug mode.
-    assert_moonc_line(
-        &run_target_default,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        false,
-        None,
-    );
-    // Default run with explicit target links debug outputs.
-    assert_moonc_line(
-        &run_target_default,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        false,
-        None,
-    );
-    // Default run with explicit target executes the debug artifact.
-    assert_moonrun_line(&run_target_default, false);
-    // Release run with explicit target rebuilds the library in release mode.
-    assert_moonc_line(
-        &run_target_release,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        true,
-        None,
-    );
-    // Release run with explicit target rebuilds the main package in release mode.
-    assert_moonc_line(
-        &run_target_release,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        true,
-        None,
-    );
-    // Release run with explicit target links release outputs.
-    assert_moonc_line(
-        &run_target_release,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        true,
-        None,
-    );
-    // Release run with explicit target executes the release artifact.
-    assert_moonrun_line(&run_target_release, true);
-    // Debug run with explicit target rebuilds the library with debug flags.
-    assert_moonc_line(
-        &run_target_debug,
-        "moonc build-package",
-        &["./lib/hello.mbt"],
-        false,
-        None,
-    );
-    // Debug run with explicit target rebuilds the main package with debug flags.
-    assert_moonc_line(
-        &run_target_debug,
-        "moonc build-package",
-        &["./main/main.mbt"],
-        false,
-        None,
-    );
-    // Debug run with explicit target links debug outputs.
-    assert_moonc_line(
-        &run_target_debug,
-        "moonc link-core",
-        &["-main", "hello/main"],
-        false,
-        None,
-    );
-    // Debug run with explicit target executes the debug artifact.
-    assert_moonrun_line(&run_target_debug, false);
-
-    // release should conflict with debug
-    #[cfg(unix)]
-    {
-        check(
-            get_err_stderr(&dir, ["test", "--release", "--debug"]),
-            expect![[r#"
-                error: the argument '--release' cannot be used with '--debug'
-
-                Usage: moon test --release [PATH]
-
-                For more information, try '--help'.
-            "#]],
-        );
-
-        check(
-            get_err_stderr(&dir, ["build", "--debug", "--release"]),
-            expect![[r#"
-                error: the argument '--debug' cannot be used with '--release'
-
-                Usage: moon build --debug [PATH]
-
-                For more information, try '--help'.
-            "#]],
-        );
-
-        check(
-            get_err_stderr(&dir, ["check", "--release", "--debug"]),
-            expect![[r#"
-                error: the argument '--release' cannot be used with '--debug'
-
-                Usage: moon check --release [PATH]
-
-                For more information, try '--help'.
-            "#]],
-        );
-
-        check(
-            get_err_stderr(&dir, ["run", "main", "--debug", "--release"]),
-            expect![[r#"
-                error: the argument '--debug' cannot be used with '--release'
-
-                Usage: moon run --debug <PACKAGE_OR_MBT_FILE> [ARGS]...
-
-                For more information, try '--help'.
-            "#]],
-        );
-    }
+    let release_run = get_stdout(&dir, ["run", "main", "--dry-run", "--release", "--nostd"]);
+    assert_moonrun_line(&release_run, true);
 }
 
 #[cfg(unix)]
 #[test]
-fn cli_requires_conflicts_and_path_kinds_are_enforced() {
+fn profile_flags_conflict_in_cli() {
+    let dir = TestDir::new("debug_flag_test");
+
+    check(
+        get_err_stderr(&dir, ["test", "--release", "--debug"]),
+        expect![[r#"
+            error: the argument '--release' cannot be used with '--debug'
+
+            Usage: moon test --release [PATH]
+
+            For more information, try '--help'.
+        "#]],
+    );
+
+    check(
+        get_err_stderr(&dir, ["build", "--debug", "--release"]),
+        expect![[r#"
+            error: the argument '--debug' cannot be used with '--release'
+
+            Usage: moon build --debug [PATH]
+
+            For more information, try '--help'.
+        "#]],
+    );
+
+    check(
+        get_err_stderr(&dir, ["check", "--release", "--debug"]),
+        expect![[r#"
+            error: the argument '--release' cannot be used with '--debug'
+
+            Usage: moon check --release [PATH]
+
+            For more information, try '--help'.
+        "#]],
+    );
+
+    check(
+        get_err_stderr(&dir, ["run", "main", "--debug", "--release"]),
+        expect![[r#"
+            error: the argument '--debug' cannot be used with '--release'
+
+            Usage: moon run --debug <PACKAGE_OR_MBT_FILE> [ARGS]...
+
+            For more information, try '--help'.
+        "#]],
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn cli_reports_selector_conflicts_before_planning() {
     let dir = TestDir::new("debug_flag_test");
 
     let check_stderr = get_err_stderr(&dir, ["check", "-p", "lib", "lib", "--dry-run"]);
@@ -539,80 +138,16 @@ fn cli_requires_conflicts_and_path_kinds_are_enforced() {
         build_binary_dep_stderr.contains("cannot be used with"),
         "stderr: {build_binary_dep_stderr}"
     );
+}
 
+#[test]
+fn check_path_selector_smoke() {
+    let dir = TestDir::new("debug_flag_test");
     let check_with_path_selector = get_stdout(&dir, ["check", "lib", "--no-mi", "--dry-run"]);
     assert!(
         check_with_path_selector.contains("moonc check"),
         "stdout: {check_with_path_selector}"
     );
-}
-
-fn assert_moonc_line(
-    output: &str,
-    command: &str,
-    filter: &[&str],
-    release: bool,
-    debug_flags: Option<bool>,
-) {
-    let tokens = command_tokens(output, command, filter);
-    assert_tokens_follow_mode(&tokens, release, command, filter, debug_flags);
-}
-
-fn assert_tokens_follow_mode(
-    tokens: &[String],
-    release: bool,
-    command: &str,
-    filter: &[&str],
-    debug_flags: Option<bool>,
-) {
-    let target_prefix = if release {
-        "./_build/wasm-gc/release/"
-    } else {
-        "./_build/wasm-gc/debug/"
-    };
-
-    for token in tokens {
-        if token.contains("./_build/wasm-gc/") {
-            assert!(
-                token.contains(target_prefix),
-                "expected `{}` command with filter {:?} to use `{}` artifacts, saw `{}`",
-                command,
-                filter,
-                target_prefix,
-                token
-            );
-        }
-    }
-
-    let has_flag = |flag: &str| tokens.iter().any(|t| t == flag);
-    let expect_debug_flags = match debug_flags {
-        Some(value) => value,
-        None => !release,
-    };
-
-    if expect_debug_flags {
-        for flag in ["-g", "-O0", "-source-map"] {
-            assert!(
-                has_flag(flag),
-                "expected debug `{}` command with filter {:?} to include `{}`, tokens: {:?}",
-                command,
-                filter,
-                flag,
-                tokens
-            );
-        }
-    } else {
-        for flag in ["-g", "-O0", "-source-map"] {
-            assert!(
-                !has_flag(flag),
-                "expected release `{}` command with filter {:?} to omit `{}`, tokens: {:?}",
-                command,
-                filter,
-                flag,
-                tokens
-            );
-        }
-    }
 }
 
 fn assert_moonrun_line(output: &str, release: bool) {

--- a/crates/moon/tests/test_cases/dummy_core/mod.rs
+++ b/crates/moon/tests/test_cases/dummy_core/mod.rs
@@ -5,7 +5,7 @@ use expect_test::expect_file;
 use moonbuild_debug::graph::ENV_VAR;
 
 #[test]
-fn test_dummy_core() {
+fn dummy_core_writes_packages_json_for_selected_target() {
     let test_dir = TestDir::new("dummy_core");
     let dir = dunce::canonicalize(test_dir.as_ref()).unwrap();
 
@@ -33,136 +33,13 @@ fn test_dummy_core() {
         expect_file!["./packages_js.json.snap"]
             .assert_eq(&replace_dir(&std::fs::read_to_string(p).unwrap(), &dir))
     };
+}
 
-    let check_dry_run_dump_file = test_dir.join("check.jsonl");
+#[test]
+fn dummy_core_bundle_dry_run_matches_snapshots() {
+    let test_dir = TestDir::new("dummy_core");
+    let dir = dunce::canonicalize(test_dir.as_ref()).unwrap();
 
-    let _dry_run = get_stdout_with_envs(
-        &dir,
-        ["check", "--dry-run", "--sort-input"],
-        [(ENV_VAR, &check_dry_run_dump_file)],
-    );
-    compare_graphs(
-        &check_dry_run_dump_file,
-        expect_file!["./check_default.jsonl.snap"],
-    );
-
-    let check_wasm_dump_file = test_dir.join("check_wasm.jsonl");
-    get_stdout_with_envs(
-        &dir,
-        ["check", "--dry-run", "--target", "wasm", "--sort-input"],
-        [(ENV_VAR, &check_wasm_dump_file)],
-    );
-    compare_graphs(
-        &check_wasm_dump_file,
-        expect_file!["./check_wasm.jsonl.snap"],
-    );
-
-    let check_wasm_gc_dry_run_dump_file = test_dir.join("check_wasm_gc.jsonl");
-    get_stdout_with_envs(
-        &dir,
-        ["check", "--dry-run", "--target", "wasm-gc", "--sort-input"],
-        [(ENV_VAR, &check_wasm_gc_dry_run_dump_file)],
-    );
-
-    compare_graphs(
-        &check_wasm_gc_dry_run_dump_file,
-        expect_file!["./check_wasm_gc.jsonl.snap"],
-    );
-
-    let check_js_dry_run_dump_file = test_dir.join("check_js.jsonl");
-    get_stdout_with_envs(
-        &dir,
-        ["check", "--dry-run", "--target", "js", "--sort-input"],
-        [(ENV_VAR, &check_js_dry_run_dump_file)],
-    );
-    compare_graphs(
-        &check_js_dry_run_dump_file,
-        expect_file!["./check_js.jsonl.snap"],
-    );
-
-    let build_dump_file = test_dir.join("build.jsonl");
-    get_stdout_with_envs(
-        &dir,
-        ["build", "--dry-run", "--sort-input"],
-        [(ENV_VAR, &build_dump_file)],
-    );
-    compare_graphs(&build_dump_file, expect_file!["./build_default.jsonl.snap"]);
-
-    let wasm_build_dump_file = test_dir.join("build_wasm.jsonl");
-    get_stdout_with_envs(
-        &dir,
-        ["build", "--dry-run", "--target", "wasm", "--sort-input"],
-        [(ENV_VAR, &wasm_build_dump_file)],
-    );
-    compare_graphs(
-        &wasm_build_dump_file,
-        expect_file!["./build_wasm.jsonl.snap"],
-    );
-
-    let wasm_gc_build_dump_file = test_dir.join("build_wasm_gc.jsonl");
-    get_stdout_with_envs(
-        &dir,
-        ["build", "--dry-run", "--target", "wasm-gc", "--sort-input"],
-        [(ENV_VAR, &wasm_gc_build_dump_file)],
-    );
-    compare_graphs(
-        &wasm_gc_build_dump_file,
-        expect_file!["./build_wasm_gc.jsonl.snap"],
-    );
-
-    let js_build_dump_file = test_dir.join("build_js.jsonl");
-    get_stdout_with_envs(
-        &dir,
-        ["build", "--dry-run", "--target", "js", "--sort-input"],
-        [(ENV_VAR, &js_build_dump_file)],
-    );
-    compare_graphs(&js_build_dump_file, expect_file!["./build_js.jsonl.snap"]);
-
-    let test_dry_run_dump_file = test_dir.join("test.jsonl");
-    get_stdout_with_envs(
-        &dir,
-        ["test", "--dry-run", "--sort-input"],
-        [(ENV_VAR, &test_dry_run_dump_file)],
-    );
-    compare_graphs(
-        &test_dry_run_dump_file,
-        expect_file!["./test_default.jsonl.snap"],
-    );
-
-    let test_wasm_dry_run_dump_file = test_dir.join("test_wasm.jsonl");
-    get_stdout_with_envs(
-        &dir,
-        ["test", "--dry-run", "--target", "wasm", "--sort-input"],
-        [(ENV_VAR, &test_wasm_dry_run_dump_file)],
-    );
-    compare_graphs(
-        &test_wasm_dry_run_dump_file,
-        expect_file!["./test_wasm.jsonl.snap"],
-    );
-
-    let test_wasm_gc_dry_run_dump_file = test_dir.join("test_wasm_gc.jsonl");
-    get_stdout_with_envs(
-        &dir,
-        ["test", "--dry-run", "--target", "wasm-gc", "--sort-input"],
-        [(ENV_VAR, &test_wasm_gc_dry_run_dump_file)],
-    );
-    compare_graphs(
-        &test_wasm_gc_dry_run_dump_file,
-        expect_file!["./test_wasm_gc.jsonl.snap"],
-    );
-
-    let test_js_dry_run_dump_file = test_dir.join("test_js.jsonl");
-    get_stdout_with_envs(
-        &dir,
-        ["test", "--dry-run", "--target", "js", "--sort-input"],
-        [(ENV_VAR, &test_js_dry_run_dump_file)],
-    );
-    compare_graphs(
-        &test_js_dry_run_dump_file,
-        expect_file!["./test_js.jsonl.snap"],
-    );
-
-    // test with coverage
     let test_coverage_dry_run_dump_file = test_dir.join("test_coverage.jsonl");
     get_stdout_with_envs(
         &dir,
@@ -174,7 +51,6 @@ fn test_dummy_core() {
         expect_file!["./coverage.jsonl.snap"],
     );
 
-    // bundle dry-run tests
     let bundle_dry_run_dump_file = test_dir.join("bundle_dry_run.jsonl");
     get_stdout_with_envs(
         &dir,


### PR DESCRIPTION
## Summary
- move most `debug_flag_test` dry-run profile coverage into planner tests
- move `dummy_core` check/build/test dry-run snapshot coverage into planner tests
- keep only the CLI wiring, runtime smoke, coverage, bundle, and `packages.json` cases in e2e

## Testing
- cargo test -p moon 'tests::planner::profile_'
- cargo test -p moon --test mod debug_flag_test
- cargo test -p moon 'tests::planner::dummy_core_'
- cargo test -p moon --test mod dummy_core
- cargo clippy -p moon --tests -- -D warnings