### PR TITLE
feat: accept multiple package paths for build and check

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -30,8 +30,8 @@ use std::path::PathBuf;
 use tracing::{Level, instrument};
 
 use crate::filter::{
-    canonicalize_with_filename, ensure_package_supports_backend, ensure_packages_support_backend,
-    filter_pkg_by_dir, match_packages_by_name_rr, package_supports_backend,
+    ensure_packages_support_backend, match_packages_by_name_rr, package_supports_backend,
+    select_supported_packages,
 };
 use crate::rr_build;
 use crate::rr_build::BuildConfig;
@@ -46,9 +46,9 @@ use super::{BuildFlags, UniversalFlags};
 /// Build the current package
 #[derive(Debug, clap::Parser)]
 pub(crate) struct BuildSubcommand {
-    /// The path to the package that should be built.
+    /// Paths to the packages that should be built.
     #[clap(name = "PATH", conflicts_with("package"))]
-    pub path: Option<PathBuf>,
+    pub path: Vec<PathBuf>,
 
     #[clap(flatten)]
     pub build_flags: BuildFlags,
@@ -71,17 +71,35 @@ pub(crate) fn run_build(cli: &UniversalFlags, cmd: BuildSubcommand) -> anyhow::R
         source_dir,
         target_dir,
     } = cli.source_tgt_dir.try_into_package_dirs()?;
+    let current_work_root = cli.source_tgt_dir.try_into_workspace_module_dirs()?;
+    let current_work_root = current_work_root
+        .module_dir
+        .unwrap_or(current_work_root.project_root);
 
     if cmd.build_flags.target.is_empty() {
-        return run_build_internal(cli, &cmd, &source_dir, &target_dir, None);
+        return run_build_internal(
+            cli,
+            &cmd,
+            &source_dir,
+            &target_dir,
+            &current_work_root,
+            None,
+        );
     }
     let surface_targets = cmd.build_flags.target.clone();
     let targets = lower_surface_targets(&surface_targets);
 
     let mut ret_value = 0;
     for t in targets {
-        let x = run_build_internal(cli, &cmd, &source_dir, &target_dir, Some(t))
-            .context(format!("failed to run build for target {t:?}"))?;
+        let x = run_build_internal(
+            cli,
+            &cmd,
+            &source_dir,
+            &target_dir,
+            &current_work_root,
+            Some(t),
+        )
+        .context(format!("failed to run build for target {t:?}"))?;
         ret_value = ret_value.max(x);
     }
     Ok(ret_value)
@@ -93,6 +111,7 @@ fn run_build_internal(
     cmd: &BuildSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    current_work_root: &Path,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     let f = |watch: bool| {
@@ -101,6 +120,7 @@ fn run_build_internal(
             cmd,
             source_dir,
             target_dir,
+            current_work_root,
             watch,
             selected_target_backend,
         )
@@ -122,6 +142,7 @@ fn run_build_rr(
     cmd: &BuildSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    current_work_root: &Path,
     _watch: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<WatchOutput> {
@@ -134,6 +155,7 @@ fn run_build_rr(
     let (build_meta, build_graph) = plan_build_rr_from_resolved(
         cli,
         cmd,
+        current_work_root,
         target_dir,
         selected_target_backend,
         resolve_output,
@@ -181,6 +203,7 @@ fn run_build_rr(
 pub(crate) fn plan_build_rr_from_resolved(
     cli: &UniversalFlags,
     cmd: &BuildSubcommand,
+    current_work_root: &Path,
     target_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
@@ -200,10 +223,12 @@ pub(crate) fn plan_build_rr_from_resolved(
         target_dir,
         Box::new(|resolved, target_backend| {
             calc_user_intent(
-                cmd.path.as_deref(),
+                current_work_root,
+                &cmd.path,
                 cmd.package.as_deref(),
                 resolved,
                 target_backend,
+                cli.verbose,
             )
         }),
         resolve_output,
@@ -215,16 +240,26 @@ pub(crate) fn plan_build_rr_from_resolved(
 /// to core.
 #[instrument(level = Level::DEBUG, skip_all)]
 fn calc_user_intent(
-    path_filter: Option<&Path>,
+    current_work_root: &Path,
+    path_filters: &[PathBuf],
     package_filter: Option<&str>,
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     target_backend: TargetBackend,
+    verbose: bool,
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
-    if let Some(path) = path_filter {
-        let (dir, _) = canonicalize_with_filename(path)?;
-        let pkg = filter_pkg_by_dir(resolve_output, &dir)?;
-        ensure_package_supports_backend(resolve_output, pkg, target_backend)?;
-        Ok(vec![UserIntent::Build(pkg)].into())
+    if !path_filters.is_empty() {
+        let selected = select_supported_packages(
+            current_work_root,
+            resolve_output,
+            path_filters,
+            target_backend,
+            verbose,
+        )?;
+        Ok(selected
+            .into_iter()
+            .map(UserIntent::Build)
+            .collect::<Vec<_>>()
+            .into())
     } else if let Some(package_filter) = package_filter {
         let pkgs = match_packages_by_name_rr(
             resolve_output,

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -30,7 +30,7 @@ use tracing::{Level, instrument};
 
 use crate::filter::{
     canonicalize_with_filename, ensure_package_supports_backend, filter_pkg_by_dir,
-    package_supports_backend,
+    package_supports_backend, resolve_selected_package_dir, select_supported_packages,
 };
 use crate::rr_build::{self, BuildConfig, CalcUserIntentOutput, preconfig_compile};
 use crate::watch::prebuild_output::{PrebuildWatchPaths, rr_get_prebuild_watch_paths};
@@ -80,7 +80,7 @@ pub(crate) struct CheckSubcommand {
 
     /// Filesystem path to a package directory or `.mbt` / `.mbt.md` file
     #[clap(conflicts_with = "watch", name = "PATH", group = "package_selector")]
-    pub path: Option<PathBuf>,
+    pub path: Vec<PathBuf>,
 
     /// Check whether the code is properly formatted
     #[clap(long)]
@@ -92,38 +92,72 @@ pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::
     if cmd.fmt {
         let mut cli_for_fmt = cli.clone();
         cli_for_fmt.quiet = true;
-        let fmt_exit_code = crate::cli::fmt::run_fmt(
-            &cli_for_fmt,
-            crate::cli::FmtSubcommand {
-                check: false,
-                sort_input: false,
-                block_style: None,
-                warn: true,
-                path: cmd.path.clone(),
-                args: vec![],
-            },
-        )?;
+        let current_root = cli
+            .source_tgt_dir
+            .try_into_workspace_module_dirs()
+            .ok()
+            .map(|dirs| dirs.module_dir.unwrap_or(dirs.project_root));
+        let fmt_targets = match (current_root.as_deref(), cmd.path.is_empty()) {
+            (_, true) => vec![None],
+            (Some(current_root), false) => cmd
+                .path
+                .iter()
+                .filter_map(|path| {
+                    resolve_selected_package_dir(current_root, path, cli.verbose).transpose()
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?
+                .into_iter()
+                .map(Some)
+                .collect::<Vec<_>>(),
+            (None, false) => cmd.path.iter().cloned().map(Some).collect::<Vec<_>>(),
+        };
+        let mut fmt_exit_code = 0;
+        for path in fmt_targets {
+            let exit_code = crate::cli::fmt::run_fmt(
+                &cli_for_fmt,
+                crate::cli::FmtSubcommand {
+                    check: false,
+                    sort_input: false,
+                    block_style: None,
+                    warn: true,
+                    path,
+                    args: vec![],
+                },
+            )?;
+            fmt_exit_code = fmt_exit_code.max(exit_code);
+        }
         if fmt_exit_code != 0 {
             eprintln!("{}: formatting code failed", "Warning".yellow().bold());
         }
     }
+
+    let current_work_root = cli
+        .source_tgt_dir
+        .try_into_workspace_module_dirs()
+        .ok()
+        .map(|dirs| dirs.module_dir.unwrap_or(dirs.project_root));
 
     // Check if we're running within a project
     let (source_dir, target_dir, single_file) = match cli.source_tgt_dir.try_into_package_dirs() {
         Ok(dirs) => (dirs.source_dir, dirs.target_dir, false),
         Err(e @ moonutil::dirs::PackageDirsError::NotInProject(_)) => {
             // Now we're talking about real single-file scenario.
-            if let Some(path) = cmd.path.as_deref() {
-                let single_file_path = dunce::canonicalize(path)
-                    .with_context(|| format!("failed to resolve file path `{}`", path.display()))?;
-                let source_dir = single_file_path
-                    .parent()
-                    .context("file path must have a parent directory")?
-                    .to_path_buf();
-                let target_dir = source_dir.join(BUILD_DIR);
-                (source_dir, target_dir, true)
-            } else {
-                return Err(e.into());
+            match cmd.path.as_slice() {
+                [path] => {
+                    let single_file_path = dunce::canonicalize(path).with_context(|| {
+                        format!("failed to resolve file path `{}`", path.display())
+                    })?;
+                    let source_dir = single_file_path
+                        .parent()
+                        .context("file path must have a parent directory")?
+                        .to_path_buf();
+                    let target_dir = source_dir.join(BUILD_DIR);
+                    (source_dir, target_dir, true)
+                }
+                [] => return Err(e.into()),
+                _ => {
+                    anyhow::bail!("standalone single-file `moon check` expects exactly one `PATH`");
+                }
             }
         }
         Err(e) => {
@@ -132,15 +166,31 @@ pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::
     };
 
     if cmd.build_flags.target.is_empty() {
-        return run_check_internal(cli, cmd, &source_dir, &target_dir, single_file, None);
+        return run_check_internal(
+            cli,
+            cmd,
+            &source_dir,
+            &target_dir,
+            current_work_root.as_deref(),
+            single_file,
+            None,
+        );
     }
 
     let surface_targets = cmd.build_flags.target.clone();
     let targets = lower_surface_targets(&surface_targets);
     let mut ret_value = 0;
     for t in targets {
-        let x = run_check_internal(cli, cmd, &source_dir, &target_dir, single_file, Some(t))
-            .context(format!("failed to run check for target {t:?}"))?;
+        let x = run_check_internal(
+            cli,
+            cmd,
+            &source_dir,
+            &target_dir,
+            current_work_root.as_deref(),
+            single_file,
+            Some(t),
+        )
+        .context(format!("failed to run check for target {t:?}"))?;
         ret_value = ret_value.max(x);
     }
     Ok(ret_value)
@@ -152,13 +202,21 @@ fn run_check_internal(
     cmd: &CheckSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    current_work_root: Option<&Path>,
     single_file: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     if single_file {
         run_check_for_single_file(cli, cmd, selected_target_backend)
     } else {
-        run_check_normal_internal(cli, cmd, source_dir, target_dir, selected_target_backend)
+        run_check_normal_internal(
+            cli,
+            cmd,
+            source_dir,
+            target_dir,
+            current_work_root.expect("project checks should have a work root"),
+            selected_target_backend,
+        )
     }
 }
 
@@ -184,7 +242,7 @@ fn run_check_for_single_file_rr(
 
     let path = cmd
         .path
-        .as_ref()
+        .first()
         .expect("path should be set in single-file mode");
     let single_file_path = dunce::canonicalize(path)
         .with_context(|| format!("failed to resolve file path `{}`", path.display()))?;
@@ -289,6 +347,7 @@ fn run_check_normal_internal(
     cmd: &CheckSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    current_work_root: &Path,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     let run_once = |watch: bool, target_dir: &Path| -> anyhow::Result<WatchOutput> {
@@ -297,6 +356,7 @@ fn run_check_normal_internal(
             cmd,
             source_dir,
             target_dir,
+            current_work_root,
             watch,
             selected_target_backend,
         )
@@ -327,6 +387,7 @@ fn run_check_normal_internal_rr(
     cmd: &CheckSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    current_work_root: &Path,
     _watch: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<WatchOutput> {
@@ -342,6 +403,7 @@ fn run_check_normal_internal_rr(
         cmd,
         source_dir,
         target_dir,
+        current_work_root,
         selected_target_backend,
         resolve_output,
     )
@@ -393,6 +455,7 @@ pub(crate) fn plan_check_rr_from_resolved(
     cmd: &CheckSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    current_work_root: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
@@ -410,14 +473,25 @@ pub(crate) fn plan_check_rr_from_resolved(
         &cli.unstable_feature,
         target_dir,
         Box::new(|resolved, target_backend| {
+            if let Some(filter_path) = cmd.package_path.as_deref() {
+                return calc_user_intent_from_package_path(
+                    resolved,
+                    source_dir,
+                    filter_path,
+                    target_backend,
+                    cmd.no_mi,
+                    cmd.patch_file.as_deref(),
+                );
+            }
+
             calc_user_intent(
                 resolved,
-                source_dir,
-                cmd.package_path.as_deref(),
-                cmd.path.as_deref(),
+                current_work_root,
+                &cmd.path,
                 target_backend,
                 cmd.no_mi,
                 cmd.patch_file.as_deref(),
+                cli.verbose,
             )
         }),
         resolve_output,
@@ -426,53 +500,84 @@ pub(crate) fn plan_check_rr_from_resolved(
 
 /// Generate user intent of checking all packages in the current workspace.
 ///
-/// Two paths are supported:
-/// - `package_path`: The legacy `-p` flag, specifying the path from the source
-///   dir to the package to check.
-/// - `path`: The new positional argument, specifying a relative path from the
-///   working directory to a package directory.
-/// Only one of them can be specified at a time.
 #[instrument(level = Level::DEBUG, skip_all)]
-fn calc_user_intent(
+fn calc_user_intent_from_package_path(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     source_dir: &Path,
-    package_path: Option<&Path>,
-    path: Option<&Path>,
+    filter_path: &Path,
     target_backend: TargetBackend,
     no_mi: bool,
     patch_file: Option<&Path>,
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
-    if package_path.is_some() && path.is_some() {
-        anyhow::bail!(
-            "Only one of `-p/--package-path` and positional `PATH` can be specified at a time"
-        );
-    }
+    let (dir, _) = canonicalize_with_filename(&source_dir.join(filter_path))?;
+    let pkg = filter_pkg_by_dir(resolve_output, &dir)?;
+    ensure_package_supports_backend(resolve_output, pkg, target_backend)?;
+    let directive =
+        rr_build::build_patch_directive_for_package(pkg, no_mi, None, patch_file, false)?;
+    Ok((vec![UserIntent::Check(pkg)], directive).into())
+}
 
-    if let Some(filter_path) = package_path {
-        let (dir, _) = canonicalize_with_filename(&source_dir.join(filter_path))?;
-        let pkg = filter_pkg_by_dir(resolve_output, &dir)?;
-        ensure_package_supports_backend(resolve_output, pkg, target_backend)?;
-
-        // Apply --no-mi and --patch-file to specific packages
-        let directive =
-            rr_build::build_patch_directive_for_package(pkg, no_mi, None, patch_file, false)?;
-
-        Ok((vec![UserIntent::Check(pkg)], directive).into())
-    } else if let Some(check_path) = path {
-        let (dir, _) = canonicalize_with_filename(check_path)?;
-        let pkg = filter_pkg_by_dir(resolve_output, &dir)?;
-        ensure_package_supports_backend(resolve_output, pkg, target_backend)?;
-
-        // Apply --no-mi and --patch-file to specific packages
-        let directive =
-            rr_build::build_patch_directive_for_package(pkg, no_mi, None, patch_file, false)?;
-
-        Ok((vec![UserIntent::Check(pkg)], directive).into())
+#[instrument(level = Level::DEBUG, skip_all)]
+fn calc_user_intent(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    current_work_root: &Path,
+    paths: &[PathBuf],
+    target_backend: TargetBackend,
+    no_mi: bool,
+    patch_file: Option<&Path>,
+    verbose: bool,
+) -> Result<CalcUserIntentOutput, anyhow::Error> {
+    if !paths.is_empty() {
+        let selected = select_supported_packages(
+            current_work_root,
+            resolve_output,
+            paths,
+            target_backend,
+            verbose,
+        )?;
+        let directive = build_directive_for_selected_packages(&selected, no_mi, patch_file)?;
+        Ok((
+            selected.into_iter().map(UserIntent::Check).collect(),
+            directive,
+        )
+            .into())
     } else {
         let intents: Vec<_> = rr_build::local_packages(resolve_output)
             .filter(|&pkg| package_supports_backend(resolve_output, pkg, target_backend))
             .map(UserIntent::Check)
             .collect();
         Ok(intents.into())
+    }
+}
+
+fn build_directive_for_selected_packages(
+    selected: &[moonbuild_rupes_recta::model::PackageId],
+    no_mi: bool,
+    patch_file: Option<&Path>,
+) -> anyhow::Result<moonbuild_rupes_recta::build_plan::InputDirective> {
+    match selected {
+        [pkg] => rr_build::build_patch_directive_for_package(*pkg, no_mi, None, patch_file, false),
+        [] => {
+            if no_mi {
+                anyhow::bail!("`--no-mi` requires the selector to resolve to a single package");
+            }
+            if patch_file.is_some() {
+                anyhow::bail!(
+                    "`--patch-file` requires the selector to resolve to a single package"
+                );
+            }
+            Ok(Default::default())
+        }
+        _ => {
+            if no_mi {
+                anyhow::bail!("`--no-mi` requires the selector to resolve to a single package");
+            }
+            if patch_file.is_some() {
+                anyhow::bail!(
+                    "`--patch-file` requires the selector to resolve to a single package"
+                );
+            }
+            Ok(Default::default())
+        }
     }
 }

--- a/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
@@ -516,7 +516,7 @@ _moon() {
             return 0
             ;;
         moon__build)
-            opts="-g -d -j -w -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --frozen --watch --package --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]"
+            opts="-g -d -j -w -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --frozen --watch --package --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -604,7 +604,7 @@ _moon() {
             return 0
             ;;
         moon__check)
-            opts="-g -d -j -w -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --frozen --watch --package-path --patch-file --no-mi --explain --fmt --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]"
+            opts="-g -d -j -w -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --frozen --watch --package-path --patch-file --no-mi --explain --fmt --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -132,7 +132,7 @@ _arguments "${_arguments_options[@]}" : \
 '(--dry-run)--build-graph[]' \
 '-h[Print help]' \
 '--help[Print help]' \
-'::PATH -- The path to the package that should be built:_files' \
+'*::PATH -- Paths to the packages that should be built:_files' \
 && ret=0
 ;;
 (check)
@@ -177,7 +177,7 @@ _arguments "${_arguments_options[@]}" : \
 '(--dry-run)--build-graph[]' \
 '-h[Print help]' \
 '--help[Print help]' \
-'::PATH -- Filesystem path to a package directory or `.mbt` / `.mbt.md` file:_files' \
+'*::PATH -- Filesystem path to a package directory or `.mbt` / `.mbt.md` file:_files' \
 && ret=0
 ;;
 (prove)

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -28,6 +28,7 @@ use std::{
 use anyhow::Context;
 use moonbuild_rupes_recta::{ResolveOutput, fmt::FmtResolveOutput, model::PackageId};
 use moonutil::common::{MOON_PKG, MOON_PKG_JSON, TargetBackend, is_moon_pkg_exist};
+use moonutil::dirs::{check_moon_work_exists, find_ancestor_with_mod, find_ancestor_with_work};
 use moonutil::mooncakes::{DirSyncResult, result::ResolvedEnv};
 
 /// Canonicalize the given path, returning the directory it's referencing, and
@@ -336,6 +337,90 @@ where
         target_backend,
         details
     );
+}
+
+pub(crate) fn resolve_selected_package_dir(
+    current_root: &Path,
+    path: &Path,
+    verbose: bool,
+) -> anyhow::Result<Option<PathBuf>> {
+    let (dir, _) = canonicalize_with_filename(path)?;
+    let path_root = if check_moon_work_exists(current_root) {
+        find_ancestor_with_work(&dir)?
+    } else {
+        find_ancestor_with_mod(&dir)
+    };
+
+    if !is_moon_pkg_exist(&dir) || path_root.as_deref() != Some(current_root) {
+        if verbose {
+            tracing::warn!(
+                "skipping path `{}` because it is not a package in the current work context.",
+                path.display()
+            );
+        }
+        return Ok(None);
+    }
+    Ok(Some(dir))
+}
+
+pub(crate) fn select_supported_packages<I>(
+    current_root: &Path,
+    resolve_output: &ResolveOutput,
+    paths: I,
+    target_backend: TargetBackend,
+    verbose: bool,
+) -> anyhow::Result<Vec<PackageId>>
+where
+    I: IntoIterator,
+    I::Item: AsRef<Path>,
+{
+    let mut selected = Vec::new();
+    let mut unsupported = Vec::new();
+    let mut seen = HashSet::new();
+
+    for path in paths {
+        let path = path.as_ref();
+        let Some(dir) = resolve_selected_package_dir(current_root, path, verbose)? else {
+            continue;
+        };
+        let pkg_id = filter_pkg_by_dir(resolve_output, &dir)?;
+        if !seen.insert(pkg_id) {
+            continue;
+        }
+
+        if package_supports_backend(resolve_output, pkg_id, target_backend) {
+            selected.push(pkg_id);
+        } else {
+            unsupported.push((path.to_path_buf(), pkg_id));
+        }
+    }
+
+    if selected.is_empty() && !unsupported.is_empty() {
+        if let [(_, pkg_id)] = unsupported.as_slice() {
+            ensure_package_supports_backend(resolve_output, *pkg_id, target_backend)?;
+        } else {
+            ensure_packages_support_backend(
+                resolve_output,
+                unsupported.iter().map(|(_, pkg_id)| *pkg_id),
+                target_backend,
+            )?;
+        }
+    }
+
+    if verbose {
+        for (path, pkg_id) in &unsupported {
+            let pkg = resolve_output.pkg_dirs.get_package(*pkg_id);
+            tracing::warn!(
+                "skipping path `{}` because package `{}` does not support target backend `{}`. Supported backends: {}",
+                path.display(),
+                pkg.fqn,
+                target_backend,
+                format_supported_backends(resolve_output, *pkg_id),
+            );
+        }
+    }
+
+    Ok(selected)
 }
 
 #[derive(Debug)]

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -88,6 +88,7 @@ impl PlanningFixture {
         let (build_meta, build_graph) = crate::cli::build::plan_build_rr_from_resolved(
             cli,
             cmd,
+            &self.source_dir,
             &self.source_dir.join("_build"),
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
@@ -105,6 +106,7 @@ impl PlanningFixture {
             cmd,
             &self.source_dir,
             &self.source_dir.join("_build"),
+            &self.source_dir,
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;

--- a/crates/moon/tests/test_cases/check_fmt/mod.rs
+++ b/crates/moon/tests/test_cases/check_fmt/mod.rs
@@ -16,3 +16,23 @@ fn test_check_fmt() {
     assert!(output.contains("File not formatted: $ROOT/check_fmt.mbt"));
     assert!(output.contains("File not formatted: $ROOT/cmd/main/main.mbt"));
 }
+
+#[test]
+fn test_check_fmt_skips_filtered_paths() {
+    let dir = TestDir::new("check_fmt.in");
+    std::fs::create_dir_all(dir.join("notes")).unwrap();
+    std::fs::write(dir.join("notes/README.txt"), "not a package").unwrap();
+
+    let output = get_stdout(&dir, ["check", "cmd/main", "notes", "--fmt"]);
+    assert!(
+        output.contains("File not formatted: $ROOT/cmd/main/main.mbt"),
+        "stdout: {output}"
+    );
+    assert!(
+        !output.contains("File not formatted: $ROOT/check_fmt.mbt"),
+        "stdout: {output}"
+    );
+
+    let stderr = get_stderr(&dir, ["check", "cmd/main", "notes", "--fmt", "--verbose"]);
+    assert!(stderr.contains("skipping path `notes`"), "stderr: {stderr}");
+}

--- a/crates/moon/tests/test_cases/debug_flag_test/mod.rs
+++ b/crates/moon/tests/test_cases/debug_flag_test/mod.rs
@@ -37,7 +37,7 @@ fn profile_flags_conflict_in_cli() {
         expect![[r#"
             error: the argument '--debug' cannot be used with '--release'
 
-            Usage: moon build --debug [PATH]
+            Usage: moon build --debug [PATH]...
 
             For more information, try '--help'.
         "#]],
@@ -48,7 +48,7 @@ fn profile_flags_conflict_in_cli() {
         expect![[r#"
             error: the argument '--release' cannot be used with '--debug'
 
-            Usage: moon check --release [PATH]
+            Usage: moon check --release [PATH]...
 
             For more information, try '--help'.
         "#]],
@@ -71,7 +71,7 @@ fn profile_flags_conflict_in_cli() {
 fn cli_reports_selector_conflicts_before_planning() {
     let dir = TestDir::new("debug_flag_test");
 
-    let check_stderr = get_err_stderr(&dir, ["check", "-p", "lib", "lib", "--dry-run"]);
+    let check_stderr = get_err_stderr(&dir, ["check", "-p", "lib", "--dry-run", "lib"]);
     assert!(
         check_stderr.contains("cannot be used with"),
         "stderr: {check_stderr}"
@@ -148,6 +148,30 @@ fn check_path_selector_smoke() {
         check_with_path_selector.contains("moonc check"),
         "stdout: {check_with_path_selector}"
     );
+
+    #[cfg(unix)]
+    {
+        let stderr = get_err_stderr(&dir, ["check", "lib", "main", "--no-mi", "--dry-run"]);
+        assert!(
+            stderr.contains("`--no-mi` requires the selector to resolve to a single package"),
+            "stderr: {stderr}"
+        );
+
+        let stderr = get_err_stderr(&dir, ["check", "notes", "--no-mi", "--dry-run"]);
+        assert!(
+            stderr.contains("`--no-mi` requires the selector to resolve to a single package"),
+            "stderr: {stderr}"
+        );
+
+        let stderr = get_err_stderr(
+            &dir,
+            ["check", "notes", "--patch-file", "patch.json", "--dry-run"],
+        );
+        assert!(
+            stderr.contains("`--patch-file` requires the selector to resolve to a single package"),
+            "stderr: {stderr}"
+        );
+    }
 }
 
 fn assert_moonrun_line(output: &str, release: bool) {

--- a/crates/moon/tests/test_cases/debug_flag_test/notes/README.txt
+++ b/crates/moon/tests/test_cases/debug_flag_test/notes/README.txt
@@ -1,0 +1,1 @@
+not a package

--- a/crates/moon/tests/test_cases/filter_by_path/mod.rs
+++ b/crates/moon/tests/test_cases/filter_by_path/mod.rs
@@ -1,5 +1,38 @@
 use super::*;
 use expect_test::expect_file;
+use std::{ffi::OsString, path::PathBuf};
+
+fn assert_contains_and_absent(output: &str, present: &[&str], absent: &[&str]) {
+    for needle in present {
+        assert!(
+            output.contains(needle),
+            "expected output to contain `{needle}`, got:\n{output}"
+        );
+    }
+    for needle in absent {
+        assert!(
+            !output.contains(needle),
+            "expected output to not contain `{needle}`, got:\n{output}"
+        );
+    }
+}
+
+fn create_outside_work_context_dir(dir: &TestDir, name: &str) -> PathBuf {
+    let outside = dir.as_ref().parent().unwrap().join(name);
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(outside.join("README.txt"), "outside work context").unwrap();
+    outside
+}
+
+fn create_other_project_pkg(dir: &TestDir, name: &str) -> PathBuf {
+    let root = dir.as_ref().parent().unwrap().join(name);
+    let pkg = root.join("pkg");
+    std::fs::create_dir_all(&pkg).unwrap();
+    std::fs::write(root.join("moon.mod.json"), "{}").unwrap();
+    std::fs::write(pkg.join("moon.pkg.json"), "{}").unwrap();
+    std::fs::write(pkg.join("hello.mbt"), "fn init { () }\n").unwrap();
+    pkg
+}
 
 fn run_info_and_clear(
     base_dir: &TestDir,
@@ -208,7 +241,7 @@ fn test_moon_build_filter_by_path_success() {
 }
 
 #[test]
-fn test_moon_build_filter_by_path_failure() {
+fn test_moon_build_filter_by_multiple_paths_success() {
     let dir = TestDir::new("test_filter/test_filter");
 
     // Test error handling for non-existent paths
@@ -225,8 +258,87 @@ fn test_moon_build_filter_by_path_failure() {
         .assert()
         .failure();
 
-    // Multiple folders should be rejected
-    let _stderr = get_err_stderr(&dir, ["build", "A", "lib", "--dry-run", "--sort-input"]);
+    let stdout = get_stdout(&dir, ["build", "A", "lib", "--dry-run", "--sort-input"]);
+    assert_contains_and_absent(
+        &stdout,
+        &["./A/hello.mbt", "./lib/hello.mbt"],
+        &["./main/main.mbt"],
+    );
+}
+
+#[test]
+fn test_moon_build_filter_by_multiple_paths_skips_outside_current_root() {
+    let dir = TestDir::new("test_filter/test_filter");
+    let outside = create_outside_work_context_dir(&dir, "outside_build_skip");
+    let other_pkg = create_other_project_pkg(&dir, "other_build_project");
+    let outside_display = outside.display().to_string().replace('\\', "/");
+    let other_pkg_display = other_pkg.display().to_string().replace('\\', "/");
+
+    let stdout = get_stdout(
+        &dir,
+        [
+            OsString::from("build"),
+            OsString::from("A"),
+            outside.as_os_str().to_os_string(),
+            other_pkg.as_os_str().to_os_string(),
+            OsString::from("--dry-run"),
+            OsString::from("--sort-input"),
+        ],
+    );
+    assert_contains_and_absent(
+        &stdout,
+        &["./A/hello.mbt"],
+        &["./lib/hello.mbt", "./main/main.mbt"],
+    );
+
+    let stderr = get_stderr(
+        &dir,
+        [
+            OsString::from("build"),
+            OsString::from("A"),
+            outside.as_os_str().to_os_string(),
+            other_pkg.as_os_str().to_os_string(),
+            OsString::from("--dry-run"),
+            OsString::from("--sort-input"),
+            OsString::from("--verbose"),
+        ],
+    );
+    assert!(
+        stderr.contains(&format!("skipping path `{outside_display}`")),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("skipping path `{other_pkg_display}`")),
+        "stderr: {stderr}"
+    );
+
+    let stderr = get_stderr(
+        &dir,
+        [
+            OsString::from("build"),
+            OsString::from("A"),
+            outside.as_os_str().to_os_string(),
+            other_pkg.as_os_str().to_os_string(),
+            OsString::from("--dry-run"),
+            OsString::from("--sort-input"),
+        ],
+    );
+    assert!(!stderr.contains("skipping path"), "stderr: {stderr}");
+}
+
+#[test]
+fn test_moon_build_filter_by_multiple_paths_skips_same_root_non_packages() {
+    let dir = TestDir::new("test_filter/test_filter");
+
+    let stdout = get_stdout(&dir, ["build", "A", "notes", "--dry-run", "--sort-input"]);
+    assert_contains_and_absent(
+        &stdout,
+        &["./A/hello.mbt"],
+        &["./lib/hello.mbt", "./main/main.mbt"],
+    );
+
+    let stderr = get_stderr(&dir, ["build", "A", "notes", "--dry-run", "--verbose"]);
+    assert!(stderr.contains("skipping path `notes`"), "stderr: {stderr}");
 }
 
 // ===== moon check command tests =====
@@ -279,7 +391,7 @@ fn test_moon_check_filter_by_path_success() {
 }
 
 #[test]
-fn test_moon_check_filter_by_path_failure() {
+fn test_moon_check_filter_by_multiple_paths_success() {
     let dir = TestDir::new("test_filter/test_filter");
 
     // Test error handling for non-existent paths
@@ -303,6 +415,85 @@ fn test_moon_check_filter_by_path_failure() {
         .assert()
         .failure();
 
-    // Multiple folders should be rejected
-    let _stderr = get_err_stderr(&dir, ["check", "A", "lib", "--dry-run", "--sort-input"]);
+    let stdout = get_stdout(&dir, ["check", "A", "lib", "--dry-run", "--sort-input"]);
+    assert_contains_and_absent(
+        &stdout,
+        &["./A/hello.mbt", "./lib/hello.mbt"],
+        &["./main/main.mbt"],
+    );
+}
+
+#[test]
+fn test_moon_check_filter_by_multiple_paths_skips_outside_current_root() {
+    let dir = TestDir::new("test_filter/test_filter");
+    let outside = create_outside_work_context_dir(&dir, "outside_check_skip");
+    let other_pkg = create_other_project_pkg(&dir, "other_check_project");
+    let outside_display = outside.display().to_string().replace('\\', "/");
+    let other_pkg_display = other_pkg.display().to_string().replace('\\', "/");
+
+    let stdout = get_stdout(
+        &dir,
+        [
+            OsString::from("check"),
+            OsString::from("A"),
+            outside.as_os_str().to_os_string(),
+            other_pkg.as_os_str().to_os_string(),
+            OsString::from("--dry-run"),
+            OsString::from("--sort-input"),
+        ],
+    );
+    assert_contains_and_absent(
+        &stdout,
+        &["./A/hello.mbt"],
+        &["./lib/hello.mbt", "./main/main.mbt"],
+    );
+
+    let stderr = get_stderr(
+        &dir,
+        [
+            OsString::from("check"),
+            OsString::from("A"),
+            outside.as_os_str().to_os_string(),
+            other_pkg.as_os_str().to_os_string(),
+            OsString::from("--dry-run"),
+            OsString::from("--sort-input"),
+            OsString::from("--verbose"),
+        ],
+    );
+    assert!(
+        stderr.contains(&format!("skipping path `{outside_display}`")),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("skipping path `{other_pkg_display}`")),
+        "stderr: {stderr}"
+    );
+
+    let stderr = get_stderr(
+        &dir,
+        [
+            OsString::from("check"),
+            OsString::from("A"),
+            outside.as_os_str().to_os_string(),
+            other_pkg.as_os_str().to_os_string(),
+            OsString::from("--dry-run"),
+            OsString::from("--sort-input"),
+        ],
+    );
+    assert!(!stderr.contains("skipping path"), "stderr: {stderr}");
+}
+
+#[test]
+fn test_moon_check_filter_by_multiple_paths_skips_same_root_non_packages() {
+    let dir = TestDir::new("test_filter/test_filter");
+
+    let stdout = get_stdout(&dir, ["check", "A", "notes", "--dry-run", "--sort-input"]);
+    assert_contains_and_absent(
+        &stdout,
+        &["./A/hello.mbt"],
+        &["./lib/hello.mbt", "./main/main.mbt"],
+    );
+
+    let stderr = get_stderr(&dir, ["check", "A", "notes", "--dry-run", "--verbose"]);
+    assert!(stderr.contains("skipping path `notes`"), "stderr: {stderr}");
 }

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -52,6 +52,87 @@ fn test_mixed_backend_explicit_selection_rejects_unsupported_backend() {
 }
 
 #[test]
+fn test_mixed_backend_explicit_multi_path_selection_filters_unsupported_packages() {
+    let dir = TestDir::new("mixed_backend_local_dep.in");
+
+    let check_out = get_stdout(
+        &dir,
+        [
+            "check",
+            "web",
+            "server",
+            "--target",
+            "js",
+            "--dry-run",
+            "--sort-input",
+        ],
+    );
+    assert_contains_and_absent(
+        &check_out,
+        &[
+            "./shared/shared.mbt",
+            "./web/main.mbt",
+            "./deps/jsdep/lib/lib.mbt",
+        ],
+        &["./server/main.mbt", "./deps/nativedep/lib/lib.mbt"],
+    );
+
+    let build_out = get_stdout(
+        &dir,
+        [
+            "build",
+            "web",
+            "server",
+            "--target",
+            "js",
+            "--dry-run",
+            "--sort-input",
+        ],
+    );
+    assert_contains_and_absent(
+        &build_out,
+        &[
+            "./shared/shared.mbt",
+            "./web/main.mbt",
+            "./deps/jsdep/lib/lib.mbt",
+        ],
+        &["./server/main.mbt", "./deps/nativedep/lib/lib.mbt"],
+    );
+}
+
+#[test]
+fn test_mixed_backend_explicit_multi_path_selection_warns_only_in_verbose_mode() {
+    let dir = TestDir::new("mixed_backend_local_dep.in");
+
+    let stderr = get_stderr(
+        &dir,
+        [
+            "check",
+            "web",
+            "server",
+            "--target",
+            "js",
+            "--dry-run",
+            "--verbose",
+        ],
+    );
+    assert!(
+        stderr.contains("skipping path `server`"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("mixed/localdep/server"), "stderr: {stderr}");
+
+    let stderr = get_stderr(
+        &dir,
+        ["check", "web", "server", "--target", "js", "--dry-run"],
+    );
+    assert!(
+        !stderr.contains("skipping path `server`"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn test_mixed_backend_run_info_bundle_are_target_aware() {
     let dir = TestDir::new("mixed_backend_local_dep.in");
 

--- a/crates/moon/tests/test_cases/test_filter/test_filter/notes/README.txt
+++ b/crates/moon/tests/test_cases/test_filter/test_filter/notes/README.txt
@@ -1,0 +1,1 @@
+not a package

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -155,6 +155,134 @@ fn test_workspace_commands() {
 }
 
 #[test]
+fn test_workspace_root_path_selector_is_skipped() {
+    let dir = TestDir::new("workspace_basic.in");
+
+    check(
+        get_stdout(&dir, ["build", ".", "--dry-run"]),
+        expect![[r#""#]],
+    );
+    check(
+        get_stdout(&dir, ["check", ".", "--dry-run"]),
+        expect![[r#""#]],
+    );
+
+    let build_stderr = get_stderr(&dir, ["build", ".", "--dry-run"]);
+    assert!(
+        !build_stderr.contains("skipping path"),
+        "stderr: {build_stderr}"
+    );
+
+    let check_stderr = get_stderr(&dir, ["check", ".", "--dry-run"]);
+    assert!(
+        !check_stderr.contains("skipping path"),
+        "stderr: {check_stderr}"
+    );
+
+    let build_stderr = get_stderr(&dir, ["build", ".", "--dry-run", "--verbose"]);
+    assert!(
+        build_stderr.contains("skipping path `.`"),
+        "stderr: {build_stderr}"
+    );
+
+    let check_stderr = get_stderr(&dir, ["check", ".", "--dry-run", "--verbose"]);
+    assert!(
+        check_stderr.contains("skipping path `.`"),
+        "stderr: {check_stderr}"
+    );
+}
+
+#[test]
+fn test_workspace_module_root_path_selector_is_skipped() {
+    let dir = TestDir::new("workspace_basic.in");
+
+    check(
+        get_stdout(&dir, ["build", "app", "--dry-run"]),
+        expect![[r#""#]],
+    );
+    check(
+        get_stdout(&dir, ["check", "app", "--dry-run"]),
+        expect![[r#""#]],
+    );
+    check(
+        get_stdout(&dir, ["build", "liba", "--dry-run"]),
+        expect![[r#""#]],
+    );
+    check(
+        get_stdout(&dir, ["check", "liba", "--dry-run"]),
+        expect![[r#""#]],
+    );
+
+    let build_app = get_stderr(&dir, ["build", "app", "--dry-run", "--verbose"]);
+    assert!(
+        build_app.contains("skipping path `app`"),
+        "stderr: {build_app}"
+    );
+
+    let check_app = get_stderr(&dir, ["check", "app", "--dry-run", "--verbose"]);
+    assert!(
+        check_app.contains("skipping path `app`"),
+        "stderr: {check_app}"
+    );
+
+    let build_liba = get_stderr(&dir, ["build", "liba", "--dry-run", "--verbose"]);
+    assert!(
+        build_liba.contains("skipping path `liba`"),
+        "stderr: {build_liba}"
+    );
+
+    let check_liba = get_stderr(&dir, ["check", "liba", "--dry-run", "--verbose"]);
+    assert!(
+        check_liba.contains("skipping path `liba`"),
+        "stderr: {check_liba}"
+    );
+}
+
+#[test]
+fn test_workspace_member_path_selector_uses_module_context() {
+    let dir = TestDir::new("workspace_basic.in");
+
+    let build_stderr = get_stderr(
+        &dir,
+        [
+            "-C",
+            "app",
+            "build",
+            "src/main",
+            "../liba/src/lib",
+            "--dry-run",
+            "--verbose",
+        ],
+    );
+    assert!(
+        build_stderr.contains("skipping path `../liba/src/lib`"),
+        "stderr: {build_stderr}"
+    );
+
+    let check_stderr = get_stderr(
+        &dir,
+        [
+            "-C",
+            "app",
+            "check",
+            "src/main",
+            "../liba/src/lib",
+            "--no-mi",
+            "--dry-run",
+            "--verbose",
+        ],
+    );
+    assert!(
+        check_stderr.contains("skipping path `../liba/src/lib`"),
+        "stderr: {check_stderr}"
+    );
+    assert!(
+        !check_stderr.contains("`--no-mi` requires the selector to resolve to a single package"),
+        "stderr: {check_stderr}"
+    );
+}
+
+#[test]
 fn test_work_init_creates_empty_workspace() {
     let dir = TestDir::new("hello");
 

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -98,11 +98,11 @@ Create a new MoonBit module
 
 Build the current package
 
-**Usage:** `moon build [OPTIONS] [PATH]`
+**Usage:** `moon build [OPTIONS] [PATH]...`
 
 ###### **Arguments:**
 
-* `<PATH>` — The path to the package that should be built
+* `<PATH>` — Paths to the packages that should be built
 
 ###### **Options:**
 
@@ -137,7 +137,7 @@ Build the current package
 
 Check the current package, but don't build object files
 
-**Usage:** `moon check [OPTIONS] [PATH]`
+**Usage:** `moon check [OPTIONS] [PATH]...`
 
 ###### **Arguments:**
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -98,11 +98,11 @@ Create a new MoonBit module
 
 Build the current package
 
-**Usage:** `moon build [OPTIONS] [PATH]`
+**Usage:** `moon build [OPTIONS] [PATH]...`
 
 ###### **Arguments:**
 
-* `<PATH>` — The path to the package that should be built
+* `<PATH>` — Paths to the packages that should be built
 
 ###### **Options:**
 
@@ -137,7 +137,7 @@ Build the current package
 
 Check the current package, but don't build object files
 
-**Usage:** `moon check [OPTIONS] [PATH]`
+**Usage:** `moon check [OPTIONS] [PATH]...`
 
 ###### **Arguments:**
 


### PR DESCRIPTION
## Summary
- accept multiple positional package paths for `moon build` and `moon check`
- keep selection scoped to the current work context and skip invalid/out-of-context package directories, warning only in verbose mode
- add regressions for multi-path selection, workspace path filtering, backend filtering, and single-path selector behavior

## Verification
- cargo fmt --all
- cargo test -p moon workspace_basic -- --nocapture
- cargo test -p moon filter_by_path -- --nocapture
- cargo test -p moon target_backend -- --nocapture
- cargo test -p moon debug_flag_test -- --nocapture
- cargo test -p moon single_file -- --nocapture
- cargo clippy -p moon --tests -- -D warnings