### PR TITLE
feat: add env var to disable implicit workspace mode

### DIFF
--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use moonutil::common::MBTI_GENERATED;
+use moonutil::{common::MBTI_GENERATED, dirs::MOON_NO_WORKSPACE};
 
 fn assert_requires_target_module(stderr: &str, command: &str) {
     assert!(
@@ -567,6 +567,18 @@ fn test_single_module_commands_from_member_dir_target_member_manifest() {
 }
 
 #[test]
+fn test_member_dir_can_disable_implicit_workspace_mode() {
+    let dir = TestDir::new("workspace_basic.in");
+
+    let stderr = get_err_stderr_with_envs(
+        &dir,
+        ["-C", "app", "build", "--dry-run"],
+        [(MOON_NO_WORKSPACE, "1")],
+    );
+    assert_registry_resolution_failure(&stderr);
+}
+
+#[test]
 fn test_manifest_path_targets_workspace_member_for_single_module_commands() {
     let dir = TestDir::new("workspace_basic.in");
 
@@ -628,6 +640,37 @@ fn test_manifest_path_targets_workspace_member_for_single_module_commands() {
               "deps": {},
               "source": "src"
             }"#]],
+    );
+}
+
+#[test]
+fn test_manifest_path_can_disable_implicit_workspace_mode() {
+    let dir = TestDir::new("workspace_basic.in");
+
+    let stderr = get_err_stderr_with_envs(
+        &dir,
+        ["--manifest-path", "app/moon.mod.json", "build", "--dry-run"],
+        [(MOON_NO_WORKSPACE, "1")],
+    );
+    assert_registry_resolution_failure(&stderr);
+}
+
+#[test]
+fn test_workspace_root_keeps_workspace_mode_with_env_override() {
+    let dir = TestDir::new("workspace_basic.in");
+
+    let stdout = get_stdout_with_envs(
+        &dir,
+        ["build", "--dry-run", "--sort-input"],
+        [(MOON_NO_WORKSPACE, "1")],
+    );
+    assert!(
+        stdout.contains("./liba/src/lib/lib.mbt"),
+        "expected workspace-root build to keep the workspace member graph, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("-workspace-path ./app"),
+        "expected workspace-root build to keep workspace-aware package layout, got:\n{stdout}"
     );
 }
 

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -25,6 +25,10 @@ use thiserror::Error;
 use crate::common::{BUILD_DIR, MOON_MOD_JSON, MOON_WORK, MOON_WORK_JSON};
 use crate::workspace::{canonical_workspace_module_dirs, read_workspace, workspace_manifest_path};
 
+/// Set to a non-`0` value to keep commands started from inside a module in
+/// single-module mode instead of promoting them into an ancestor workspace.
+pub const MOON_NO_WORKSPACE: &str = "MOON_NO_WORKSPACE";
+
 #[derive(Debug, Error)]
 pub enum PackageDirsError {
     #[error(
@@ -210,6 +214,7 @@ pub fn find_ancestor_with_mod(source_dir: &Path) -> Option<PathBuf> {
 
 pub fn find_ancestor_with_work(source_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
     let mut module_root = None;
+    let disable_workspace_from_module = disable_workspace_from_module_env();
 
     for dir in source_dir.ancestors() {
         if let Some(workspace_path) = workspace_manifest_path(dir) {
@@ -217,6 +222,10 @@ pub fn find_ancestor_with_work(source_dir: &Path) -> anyhow::Result<Option<PathB
                 // A workspace still applies from nested non-module directories.
                 return Ok(Some(dir.to_path_buf()));
             };
+
+            if disable_workspace_from_module {
+                return Ok(None);
+            }
 
             // After we have entered a module, only ancestor workspaces that
             // explicitly list that module still apply.
@@ -237,6 +246,14 @@ pub fn find_ancestor_with_work(source_dir: &Path) -> anyhow::Result<Option<PathB
     }
 
     Ok(None)
+}
+
+fn disable_workspace_from_module_env() -> bool {
+    match std::env::var(MOON_NO_WORKSPACE) {
+        Ok(value) => value != "0",
+        Err(std::env::VarError::NotPresent) => false,
+        Err(std::env::VarError::NotUnicode(_)) => true,
+    }
 }
 
 pub fn resolve_manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {


### PR DESCRIPTION
## Summary
- add `MOON_NO_WORKSPACE` to keep commands started inside a module in single-module mode
- keep explicit workspace manifests and workspace-root invocation behavior unchanged
- add regression coverage for member-dir, manifest-path, and workspace-root resolution

## Testing
- cargo test -p moon workspace_basic
- cargo test -p moonutil