### PR TITLE
fix: respect explicit manifest selection for workspace logic

### DIFF
--- a/crates/moon/src/cli/bench.rs
+++ b/crates/moon/src/cli/bench.rs
@@ -63,10 +63,19 @@ pub(crate) fn run_bench(cli: UniversalFlags, cmd: BenchSubcommand) -> anyhow::Re
     let PackageDirs {
         source_dir,
         target_dir,
+        project_manifest_path,
     } = cli.source_tgt_dir.try_into_package_dirs()?;
 
     if cmd.build_flags.target.is_empty() {
-        return run_bench_internal(&cli, &cmd, &source_dir, &target_dir, None, None);
+        return run_bench_internal(
+            &cli,
+            &cmd,
+            &source_dir,
+            &target_dir,
+            Some(project_manifest_path.as_path()),
+            None,
+            None,
+        );
     }
     let surface_targets = cmd.build_flags.target.clone();
     let targets = lower_surface_targets(&surface_targets);
@@ -79,6 +88,7 @@ pub(crate) fn run_bench(cli: UniversalFlags, cmd: BenchSubcommand) -> anyhow::Re
             &cmd,
             &source_dir,
             &target_dir,
+            Some(project_manifest_path.as_path()),
             display_backend_hint,
             Some(t),
         )
@@ -94,6 +104,7 @@ fn run_bench_internal(
     cmd: &BenchSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    project_manifest_path: Option<&Path>,
     display_backend_hint: Option<()>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
@@ -102,6 +113,7 @@ fn run_bench_internal(
         cmd.into(),
         source_dir,
         target_dir,
+        project_manifest_path,
         display_backend_hint,
         selected_target_backend,
     )

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -70,18 +70,33 @@ pub(crate) fn run_build(cli: &UniversalFlags, cmd: BuildSubcommand) -> anyhow::R
     let PackageDirs {
         source_dir,
         target_dir,
+        project_manifest_path,
     } = cli.source_tgt_dir.try_into_package_dirs()?;
 
     if cmd.build_flags.target.is_empty() {
-        return run_build_internal(cli, &cmd, &source_dir, &target_dir, None);
+        return run_build_internal(
+            cli,
+            &cmd,
+            &source_dir,
+            &target_dir,
+            Some(project_manifest_path.as_path()),
+            None,
+        );
     }
     let surface_targets = cmd.build_flags.target.clone();
     let targets = lower_surface_targets(&surface_targets);
 
     let mut ret_value = 0;
     for t in targets {
-        let x = run_build_internal(cli, &cmd, &source_dir, &target_dir, Some(t))
-            .context(format!("failed to run build for target {t:?}"))?;
+        let x = run_build_internal(
+            cli,
+            &cmd,
+            &source_dir,
+            &target_dir,
+            Some(project_manifest_path.as_path()),
+            Some(t),
+        )
+        .context(format!("failed to run build for target {t:?}"))?;
         ret_value = ret_value.max(x);
     }
     Ok(ret_value)
@@ -93,6 +108,7 @@ fn run_build_internal(
     cmd: &BuildSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    project_manifest_path: Option<&Path>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     let f = |watch: bool| {
@@ -101,6 +117,7 @@ fn run_build_internal(
             cmd,
             source_dir,
             target_dir,
+            project_manifest_path,
             watch,
             selected_target_backend,
         )
@@ -122,6 +139,7 @@ fn run_build_rr(
     cmd: &BuildSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    project_manifest_path: Option<&Path>,
     _watch: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<WatchOutput> {
@@ -129,7 +147,8 @@ fn run_build_rr(
         cmd.auto_sync_flags.clone(),
         !cmd.build_flags.std(),
         cmd.build_flags.enable_coverage,
-    );
+    )
+    .with_project_manifest_path(project_manifest_path);
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir)?;
     let (build_meta, build_graph) = plan_build_rr_from_resolved(
         cli,

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -52,6 +52,7 @@ pub(crate) fn run_bundle(cli: UniversalFlags, cmd: BundleSubcommand) -> anyhow::
     let PackageDirs {
         source_dir,
         target_dir,
+        project_manifest_path,
     } = cli.source_tgt_dir.try_into_package_dirs()?;
 
     let mut surface_targets = cmd.build_flags.target.clone();
@@ -60,15 +61,29 @@ pub(crate) fn run_bundle(cli: UniversalFlags, cmd: BundleSubcommand) -> anyhow::
     }
 
     if surface_targets.is_empty() {
-        return run_bundle_internal(&cli, &cmd, &source_dir, &target_dir, None);
+        return run_bundle_internal(
+            &cli,
+            &cmd,
+            &source_dir,
+            &target_dir,
+            Some(project_manifest_path.as_path()),
+            None,
+        );
     }
 
     let targets = lower_surface_targets(&surface_targets);
 
     let mut ret_value = 0;
     for t in targets {
-        let x = run_bundle_internal(&cli, &cmd, &source_dir, &target_dir, Some(t))
-            .context(format!("failed to run bundle for target {t:?}"))?;
+        let x = run_bundle_internal(
+            &cli,
+            &cmd,
+            &source_dir,
+            &target_dir,
+            Some(project_manifest_path.as_path()),
+            Some(t),
+        )
+        .context(format!("failed to run bundle for target {t:?}"))?;
         ret_value = ret_value.max(x);
     }
     Ok(ret_value)
@@ -80,9 +95,17 @@ pub(crate) fn run_bundle_internal(
     cmd: &BundleSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    project_manifest_path: Option<&Path>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
-    run_bundle_internal_rr(cli, cmd, source_dir, target_dir, selected_target_backend)
+    run_bundle_internal_rr(
+        cli,
+        cmd,
+        source_dir,
+        target_dir,
+        project_manifest_path,
+        selected_target_backend,
+    )
 }
 
 #[instrument(skip_all)]
@@ -91,6 +114,7 @@ pub(crate) fn run_bundle_internal_rr(
     cmd: &BundleSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    project_manifest_path: Option<&Path>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     let mut preconfig = rr_build::preconfig_compile(
@@ -116,6 +140,7 @@ pub(crate) fn run_bundle_internal_rr(
         source_dir,
         target_dir,
         UserDiagnostics::from_flags(cli),
+        project_manifest_path,
         Box::new(|r, _tb| {
             Ok(r.local_modules()
                 .iter()

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -110,9 +110,17 @@ pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::
     }
 
     // Check if we're running within a project
-    let (source_dir, target_dir, single_file) = match cli.source_tgt_dir.try_into_package_dirs() {
-        Ok(dirs) => (dirs.source_dir, dirs.target_dir, false),
-        Err(e @ moonutil::dirs::PackageDirsError::NotInProject(_)) => {
+    let (source_dir, target_dir, single_file, project_manifest_path) = match cli
+        .source_tgt_dir
+        .try_into_package_dirs()
+    {
+        Ok(dirs) => (
+            dirs.source_dir,
+            dirs.target_dir,
+            false,
+            Some(dirs.project_manifest_path),
+        ),
+        Err(e) if e.allows_single_file_fallback() => {
             // Now we're talking about real single-file scenario.
             match cmd.path.as_slice() {
                 [path] => {
@@ -124,7 +132,7 @@ pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::
                         .context("file path must have a parent directory")?
                         .to_path_buf();
                     let target_dir = source_dir.join(BUILD_DIR);
-                    (source_dir, target_dir, true)
+                    (source_dir, target_dir, true, None)
                 }
                 [] => return Err(e.into()),
                 _ => {
@@ -138,15 +146,31 @@ pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::
     };
 
     if cmd.build_flags.target.is_empty() {
-        return run_check_internal(cli, cmd, &source_dir, &target_dir, single_file, None);
+        return run_check_internal(
+            cli,
+            cmd,
+            &source_dir,
+            &target_dir,
+            single_file,
+            project_manifest_path.as_deref(),
+            None,
+        );
     }
 
     let surface_targets = cmd.build_flags.target.clone();
     let targets = lower_surface_targets(&surface_targets);
     let mut ret_value = 0;
     for t in targets {
-        let x = run_check_internal(cli, cmd, &source_dir, &target_dir, single_file, Some(t))
-            .context(format!("failed to run check for target {t:?}"))?;
+        let x = run_check_internal(
+            cli,
+            cmd,
+            &source_dir,
+            &target_dir,
+            single_file,
+            project_manifest_path.as_deref(),
+            Some(t),
+        )
+        .context(format!("failed to run check for target {t:?}"))?;
         ret_value = ret_value.max(x);
     }
     Ok(ret_value)
@@ -159,12 +183,20 @@ fn run_check_internal(
     source_dir: &Path,
     target_dir: &Path,
     single_file: bool,
+    project_manifest_path: Option<&Path>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     if single_file {
         run_check_for_single_file(cli, cmd, selected_target_backend)
     } else {
-        run_check_normal_internal(cli, cmd, source_dir, target_dir, selected_target_backend)
+        run_check_normal_internal(
+            cli,
+            cmd,
+            source_dir,
+            target_dir,
+            project_manifest_path,
+            selected_target_backend,
+        )
     }
 }
 
@@ -302,6 +334,7 @@ fn run_check_normal_internal(
     cmd: &CheckSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    project_manifest_path: Option<&Path>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     let run_once = |watch: bool, target_dir: &Path| -> anyhow::Result<WatchOutput> {
@@ -310,6 +343,7 @@ fn run_check_normal_internal(
             cmd,
             source_dir,
             target_dir,
+            project_manifest_path,
             watch,
             selected_target_backend,
         )
@@ -340,6 +374,7 @@ fn run_check_normal_internal_rr(
     cmd: &CheckSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    project_manifest_path: Option<&Path>,
     _watch: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<WatchOutput> {
@@ -347,7 +382,8 @@ fn run_check_normal_internal_rr(
         cmd.auto_sync_flags.clone(),
         !cmd.build_flags.std(),
         cmd.build_flags.enable_coverage,
-    );
+    )
+    .with_project_manifest_path(project_manifest_path);
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir)
         .context("Failed to calculate build plan")?;
     let (build_meta, build_graph) = plan_check_rr_from_resolved(

--- a/crates/moon/src/cli/coverage.rs
+++ b/crates/moon/src/cli/coverage.rs
@@ -115,6 +115,7 @@ fn run_coverage_clean(cli: UniversalFlags) -> Result<i32, anyhow::Error> {
     let PackageDirs {
         source_dir: src,
         target_dir: tgt,
+        ..
     } = cli.source_tgt_dir.try_into_package_dirs()?;
     clean_coverage_artifacts(&src, &tgt)?;
     Ok(0)
@@ -136,6 +137,7 @@ fn run_coverage_report(cli: UniversalFlags, args: CoverageReportSubcommand) -> a
     let PackageDirs {
         source_dir: src,
         target_dir: _tgt,
+        ..
     } = cli.source_tgt_dir.try_into_package_dirs()?;
 
     let res = run_coverage_report_command(args.args, &src, cli.dry_run);

--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -63,6 +63,7 @@ pub(crate) fn install_cli(cli: UniversalFlags, cmd: InstallSubcommand) -> anyhow
         let PackageDirs {
             source_dir,
             target_dir,
+            ..
         } = cli.source_tgt_dir.try_into_package_dirs()?;
         return mooncake::pkg::install::install(
             &source_dir,
@@ -157,7 +158,13 @@ pub(crate) fn remove_cli(cli: UniversalFlags, cmd: RemoveSubcommand) -> anyhow::
     }
     let username = parts[0];
     let pkgname = parts[1];
-    mooncake::pkg::remove::remove(project_root, module_dir, username, pkgname)
+    mooncake::pkg::remove::remove(
+        project_root,
+        module_dir,
+        Some(dirs.project_manifest_path.as_path()),
+        username,
+        pkgname,
+    )
 }
 
 pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result<i32> {
@@ -210,6 +217,7 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
         mooncake::pkg::add::add(
             project_root,
             module_dir,
+            Some(dirs.project_manifest_path.as_path()),
             &pkg_name,
             cmd.bin,
             &version,
@@ -219,6 +227,7 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
         mooncake::pkg::add::add_latest(
             project_root,
             module_dir,
+            Some(dirs.project_manifest_path.as_path()),
             &pkg_name,
             cmd.bin,
             cli.quiet,

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -92,6 +92,7 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
     let doc_source_dir = dirs.require_module_dir("doc")?.clone();
     let source_dir = dirs.project_root;
     let target_dir = dirs.target_dir;
+    let project_manifest_path = dirs.project_manifest_path;
 
     // FIXME: This is copied from `moon check`'s code. Share code if possible.
     let mut preconfig = preconfig_compile(
@@ -111,6 +112,7 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
         &source_dir,
         &target_dir,
         UserDiagnostics::from_flags(&cli),
+        Some(project_manifest_path.as_path()),
         Box::new(move |resolve_output, _| {
             let module_id = selected_doc_module_id(resolve_output, &doc_source_dir_for_intent)?;
             Ok(vec![UserIntent::Doc(module_id)].into())

--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -64,10 +64,14 @@ fn run_fmt_rr(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> {
     let PackageDirs {
         source_dir,
         target_dir,
+        project_manifest_path,
     } = cli.source_tgt_dir.try_into_package_dirs()?;
 
-    let resolved = moonbuild_rupes_recta::fmt::resolve_for_fmt(&source_dir)
-        .context("Failed to resolve environment")?;
+    let resolved = moonbuild_rupes_recta::fmt::resolve_for_fmt(
+        &source_dir,
+        Some(project_manifest_path.as_path()),
+    )
+    .context("Failed to resolve environment")?;
 
     let mut selected_packages = Vec::new();
     let output = UserDiagnostics::from_flags(cli);
@@ -96,6 +100,7 @@ fn run_fmt_rr(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> {
         &source_dir,
         &target_dir,
         &selected_packages,
+        Some(project_manifest_path.as_path()),
     )?;
 
     if cli.dry_run {

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -139,6 +139,7 @@ pub(crate) fn run_info_rr_internal(
     let PackageDirs {
         source_dir,
         target_dir,
+        project_manifest_path,
     } = cli.source_tgt_dir.try_into_package_dirs()?;
 
     let mut preconfig = rr_build::preconfig_compile(
@@ -159,6 +160,7 @@ pub(crate) fn run_info_rr_internal(
         &source_dir,
         &target_dir,
         output,
+        Some(project_manifest_path.as_path()),
         Box::new(move |resolve_output, tb| {
             calc_user_intent(
                 package_filter.as_deref(),

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -97,6 +97,7 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
     };
     let project_root = dirs.project_root;
     let target_dir = dirs.target_dir;
+    let project_manifest_path = dirs.project_manifest_path;
     let build_flags = cmd.to_build_flags();
     let verif_dir = target_dir.join("verif");
     let why3_config_path = verif_dir.join("why3.conf");
@@ -121,6 +122,7 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
         &project_root,
         &target_dir,
         UserDiagnostics::from_flags(cli),
+        Some(project_manifest_path.as_path()),
         Box::new(move |resolve_output, target_backend| {
             calc_user_intent(
                 path_filter,

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -119,7 +119,7 @@ pub(crate) fn run_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resul
                 }
             }
         }
-        Err(e @ moonutil::dirs::PackageDirsError::NotInProject(_)) => {
+        Err(e) if e.allows_single_file_fallback() => {
             if is_mbt || is_mbtx {
                 return run_single_file_rr(cli, cmd);
             }
@@ -159,13 +159,15 @@ fn run_run_rr(
     let PackageDirs {
         source_dir,
         target_dir,
+        project_manifest_path,
     } = cli.source_tgt_dir.try_into_package_dirs()?;
 
     let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
         cmd.auto_sync_flags.clone(),
         !cmd.build_flags.std(),
         cmd.build_flags.enable_coverage,
-    );
+    )
+    .with_project_manifest_path(Some(project_manifest_path.as_path()));
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir)?;
     let (build_meta, build_graph) = plan_run_rr_from_resolved(
         cli,

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -211,7 +211,7 @@ fn run_test_impl(cli: &UniversalFlags, cmd: &TestSubcommand) -> anyhow::Result<i
     // Check if we're running within a project
     let dirs = match cli.source_tgt_dir.try_into_package_dirs() {
         Ok(dirs) => dirs,
-        Err(e @ moonutil::dirs::PackageDirsError::NotInProject(_)) => {
+        Err(e) if e.allows_single_file_fallback() => {
             // Now we're talking about real single-file scenario.
             match cmd.path.as_slice() {
                 [_] => {
@@ -239,7 +239,15 @@ fn run_test_impl(cli: &UniversalFlags, cmd: &TestSubcommand) -> anyhow::Result<i
 
     if cmd.build_flags.target.is_empty() {
         debug!("no explicit backend target provided; using defaults");
-        return run_test_internal(cli, cmd, &dirs.source_dir, &dirs.target_dir, None, None);
+        return run_test_internal(
+            cli,
+            cmd,
+            &dirs.source_dir,
+            &dirs.target_dir,
+            Some(dirs.project_manifest_path.as_path()),
+            None,
+            None,
+        );
     }
     let surface_targets = &cmd.build_flags.target;
     let targets = lower_surface_targets(surface_targets);
@@ -256,6 +264,7 @@ fn run_test_impl(cli: &UniversalFlags, cmd: &TestSubcommand) -> anyhow::Result<i
             cmd,
             &dirs.source_dir,
             &dirs.target_dir,
+            Some(dirs.project_manifest_path.as_path()),
             display_backend_hint,
             Some(t),
         )
@@ -272,6 +281,7 @@ fn run_test_internal(
     cmd: &TestSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    project_manifest_path: Option<&Path>,
     display_backend_hint: Option<()>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
@@ -285,6 +295,7 @@ fn run_test_internal(
         cmd.into(),
         source_dir,
         target_dir,
+        project_manifest_path,
         display_backend_hint,
         selected_target_backend,
     )?;
@@ -481,13 +492,15 @@ pub(crate) fn plan_test_or_bench_rr(
     cmd: &TestLikeSubcommand<'_>,
     source_dir: &Path,
     target_dir: &Path,
+    project_manifest_path: Option<&Path>,
     selected_target_backend: Option<TargetBackend>,
 ) -> Result<(rr_build::BuildMeta, rr_build::BuildInput, TestFilter), anyhow::Error> {
     let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
         cmd.auto_sync_flags.frozen,
         !cmd.build_flags.std(),
         cmd.build_flags.enable_coverage,
-    );
+    )
+    .with_project_manifest_path(project_manifest_path);
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir)?;
     plan_test_or_bench_rr_from_resolved(
         cli,
@@ -560,6 +573,7 @@ pub(crate) fn run_test_or_bench_internal(
     cmd: TestLikeSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    project_manifest_path: Option<&Path>,
     display_backend_hint: Option<()>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
@@ -607,6 +621,7 @@ pub(crate) fn run_test_or_bench_internal(
         &cmd,
         source_dir,
         target_dir,
+        project_manifest_path,
         display_backend_hint,
         selected_target_backend,
     )
@@ -618,12 +633,19 @@ fn run_test_rr(
     cmd: &TestLikeSubcommand<'_>,
     source_dir: &Path,
     target_dir: &Path,
+    project_manifest_path: Option<&Path>,
     display_backend_hint: Option<()>, // FIXME: unsure why it's option but as-is for now
     selected_target_backend: Option<TargetBackend>,
 ) -> Result<i32, anyhow::Error> {
     info!(run_mode = ?cmd.run_mode, update = cmd.update, build_only = cmd.build_only, "starting rupes-recta test run");
-    let (build_meta, build_graph, filter) =
-        plan_test_or_bench_rr(cli, cmd, source_dir, target_dir, selected_target_backend)?;
+    let (build_meta, build_graph, filter) = plan_test_or_bench_rr(
+        cli,
+        cmd,
+        source_dir,
+        target_dir,
+        project_manifest_path,
+        selected_target_backend,
+    )?;
     debug!(
         artifact_count = build_meta.artifacts.len(),
         "planned rupes-recta build graph"

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -74,6 +74,7 @@ pub(crate) fn run_build_binary_dep(
     let PackageDirs {
         source_dir,
         target_dir,
+        project_manifest_path,
     } = cli.source_tgt_dir.try_into_package_dirs()?;
     if cli.dry_run {
         anyhow::bail!("--dry-run is not supported for `moon tool build-binary-dep`");
@@ -82,7 +83,8 @@ pub(crate) fn run_build_binary_dep(
     // bin-deps have their build target determined in `moon.pkg.json`, so we
     // must resolve the packages before settling on the build config and then
     // running the build plan.
-    let resolve_cfg = ResolveConfig::new_with_load_defaults(false, false, false);
+    let resolve_cfg = ResolveConfig::new_with_load_defaults(false, false, false)
+        .with_project_manifest_path(Some(project_manifest_path.as_path()));
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir)?;
 
     // Note: There's a cyclic dependency!

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -419,6 +419,7 @@ pub(crate) fn plan_build<'a>(
     source_dir: &'a Path,
     target_dir: &'a Path,
     output: UserDiagnostics,
+    project_manifest_path: Option<&'a Path>,
     calc_user_intent: Box<CalcUserIntentFn<'a>>,
 ) -> anyhow::Result<(BuildMeta, BuildInput)> {
     info!("Starting build planning");
@@ -427,7 +428,8 @@ pub(crate) fn plan_build<'a>(
         preconfig.frozen,
         !preconfig.use_std,
         preconfig.enable_coverage,
-    );
+    )
+    .with_project_manifest_path(project_manifest_path);
     let resolve_output = moonbuild_rupes_recta::resolve(&cfg, source_dir)?;
 
     info!("Resolve completed");
@@ -586,6 +588,7 @@ pub fn plan_fmt(
     source_dir: &Path,
     target_dir: &Path,
     selected_packages: &[PackageId],
+    project_manifest_path: Option<&Path>,
 ) -> anyhow::Result<BuildInput> {
     let graph = moonbuild_rupes_recta::fmt::build_graph_for_fmt(
         resolved,
@@ -593,6 +596,7 @@ pub fn plan_fmt(
         source_dir,
         target_dir,
         selected_packages,
+        project_manifest_path,
     )?;
     let db_path = n2_db_path(
         target_dir,

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -28,6 +28,7 @@ use moonutil::{
         BUILD_DIR, CargoPathExt, DEP_PATH, MBTI_GENERATED, MOON_MOD_JSON, StringExt, TargetBackend,
         get_cargo_pkg_version,
     },
+    dirs::MOON_NO_WORKSPACE,
     module::MoonModJSON,
 };
 use walkdir::WalkDir;
@@ -2652,6 +2653,59 @@ fn test_single_file_nonexistent_path_error() {
         run_result.get_output().status.code(),
         Some(101),
         "moon run should not panic for non-existent file"
+    );
+}
+
+#[test]
+fn test_single_file_commands_work_with_workspace_disabled() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    std::fs::write(
+        dir.join("hello.mbt"),
+        r#"fn main {
+  println("hello")
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("test.mbt"),
+        r#"test "x" {
+  assert_true(true)
+}
+"#,
+    )
+    .unwrap();
+
+    let check_result = snapbox::cmd::Command::new(moon_bin())
+        .current_dir(dir)
+        .env(MOON_NO_WORKSPACE, "1")
+        .args(["check", "hello.mbt"])
+        .assert()
+        .success()
+        .get_output()
+        .stderr
+        .clone();
+    check(
+        String::from_utf8(check_result).unwrap(),
+        expect![[r#"
+            Finished. moon: ran 2 tasks, now up to date
+        "#]],
+    );
+
+    check(
+        get_stdout_with_envs(&dir, ["test", "test.mbt"], [(MOON_NO_WORKSPACE, "1")]),
+        expect![[r#"
+            Total tests: 1, passed: 1, failed: 0.
+        "#]],
+    );
+
+    check(
+        get_stdout_with_envs(&dir, ["run", "hello.mbt"], [(MOON_NO_WORKSPACE, "1")]),
+        expect![[r#"
+            hello
+        "#]],
     );
 }
 

--- a/crates/moon/tests/test_cases/warns/mod.rs
+++ b/crates/moon/tests/test_cases/warns/mod.rs
@@ -149,9 +149,10 @@ fn test_warn_list_alerts() {
             ],
         ),
         expect![[r#"
-            moonc check $ROOT/b/hello.mbt -w -a -o ./_build/wasm-gc/debug/check/.mooncakes/username/b/b.mi -pkg username/b -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/b:$ROOT/b -target wasm-gc -workspace-path $ROOT/b -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
-            moonc check ./main.mbt -o ./_build/wasm-gc/debug/check/a.mi -pkg username/a -is-main -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/.mooncakes/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/a:. -target wasm-gc -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
-            moonc check -doctest-only ./main.mbt -include-doctests -o ./_build/wasm-gc/debug/check/a.blackbox_test.mi -pkg username/a_blackbox_test -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/a.mi:a -i ./_build/wasm-gc/debug/check/.mooncakes/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/a_blackbox_test:. -target wasm-gc -blackbox-test -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
+            moonc check ./b/hello.mbt -o ./_build/wasm-gc/debug/check/username/b/b.mi -pkg username/b -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/b:./b -target wasm-gc -workspace-path ./b -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
+            moonc check -doctest-only ./b/hello.mbt -include-doctests -o ./_build/wasm-gc/debug/check/username/b/b.blackbox_test.mi -pkg username/b_blackbox_test -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/b_blackbox_test:./b -target wasm-gc -blackbox-test -workspace-path ./b -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
+            moonc check ./a/main.mbt -o ./_build/wasm-gc/debug/check/username/a/a.mi -pkg username/a -is-main -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/a:./a -target wasm-gc -workspace-path ./a -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
+            moonc check -doctest-only ./a/main.mbt -include-doctests -o ./_build/wasm-gc/debug/check/username/a/a.blackbox_test.mi -pkg username/a_blackbox_test -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/username/a/a.mi:a -i ./_build/wasm-gc/debug/check/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/a_blackbox_test:./a -target wasm-gc -blackbox-test -workspace-path ./a -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
         "#]],
     );
 
@@ -180,7 +181,7 @@ fn test_warn_list_alerts() {
                │   ───────┬───────  
                │          ╰───────── Warning (alert_two): two
             ───╯
-            Finished. moon: ran 3 tasks, now up to date (2 warnings, 0 errors)
+            Finished. moon: ran 4 tasks, now up to date (2 warnings, 0 errors)
         "#]],
     );
 
@@ -190,7 +191,7 @@ fn test_warn_list_alerts() {
             ["test", "--manifest-path", "a/moon.mod.json", "--sort-input"],
         ),
         expect![[r#"
-            Total tests: 0, passed: 0, failed: 0.
+            Total tests: 1, passed: 1, failed: 0.
         "#]],
     );
 }
@@ -211,9 +212,10 @@ fn test_mod_level_warn_list_alerts() {
             ],
         ),
         expect![[r#"
-            moonc check $ROOT/b/hello.mbt -w -a -o ./_build/wasm-gc/debug/check/.mooncakes/username/b/b.mi -pkg username/b -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/b:$ROOT/b -target wasm-gc -workspace-path $ROOT/b -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
-            moonc check ./main.mbt -w -alert_one-alert_two -o ./_build/wasm-gc/debug/check/a.mi -pkg username/a -is-main -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/.mooncakes/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/a:. -target wasm-gc -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
-            moonc check -doctest-only ./main.mbt -include-doctests -w -alert_one-alert_two -o ./_build/wasm-gc/debug/check/a.blackbox_test.mi -pkg username/a_blackbox_test -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/a.mi:a -i ./_build/wasm-gc/debug/check/.mooncakes/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/a_blackbox_test:. -target wasm-gc -blackbox-test -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
+            moonc check ./b/hello.mbt -o ./_build/wasm-gc/debug/check/username/b/b.mi -pkg username/b -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/b:./b -target wasm-gc -workspace-path ./b -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
+            moonc check -doctest-only ./b/hello.mbt -include-doctests -o ./_build/wasm-gc/debug/check/username/b/b.blackbox_test.mi -pkg username/b_blackbox_test -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/b_blackbox_test:./b -target wasm-gc -blackbox-test -workspace-path ./b -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
+            moonc check ./a/main.mbt -w -alert_one-alert_two -o ./_build/wasm-gc/debug/check/username/a/a.mi -pkg username/a -is-main -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/a:./a -target wasm-gc -workspace-path ./a -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
+            moonc check -doctest-only ./a/main.mbt -include-doctests -w -alert_one-alert_two -o ./_build/wasm-gc/debug/check/username/a/a.blackbox_test.mi -pkg username/a_blackbox_test -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/username/a/a.mi:a -i ./_build/wasm-gc/debug/check/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/a_blackbox_test:./a -target wasm-gc -blackbox-test -workspace-path ./a -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
         "#]],
     );
 }

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use moonutil::{common::MBTI_GENERATED, dirs::MOON_NO_WORKSPACE};
+use std::path::Path;
 
 fn assert_requires_target_module(stderr: &str, command: &str) {
     assert!(
@@ -16,6 +17,138 @@ fn assert_registry_resolution_failure(stderr: &str) {
             .contains("Failed to resolve registry dependency `alice/liba` for module `alice/app`"),
         "expected registry dependency resolution failure, got:\n{stderr}"
     );
+}
+
+fn assert_workspace_disabled_without_module(stderr: &str) {
+    assert!(
+        stderr.contains("workspace mode is disabled by MOON_NO_WORKSPACE"),
+        "expected workspace-disabled error, got:\n{stderr}"
+    );
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, content).unwrap();
+}
+
+fn same_root_workspace_dir() -> TestDir {
+    let dir = TestDir::new_empty();
+
+    write_file(
+        &dir.join("moon.work"),
+        r#"members = [
+  ".",
+  "./dep",
+]
+preferred_target = "wasm-gc"
+"#,
+    );
+    write_file(
+        &dir.join("moon.mod.json"),
+        r#"{
+  "name": "alice/app",
+  "version": "0.1.0",
+  "source": "src",
+  "deps": {
+    "alice/liba": "0.1.0"
+  }
+}
+"#,
+    );
+    write_file(
+        &dir.join("src/main/moon.pkg.json"),
+        r#"{
+  "is-main": true,
+  "import": [
+    "alice/liba/lib"
+  ]
+}
+"#,
+    );
+    write_file(
+        &dir.join("src/main/main.mbt"),
+        r#"fn main {
+  println(@lib.hello())
+}
+"#,
+    );
+    write_file(
+        &dir.join("dep/moon.mod.json"),
+        r#"{
+  "name": "alice/liba",
+  "version": "0.1.1",
+  "source": "src"
+}
+"#,
+    );
+    write_file(&dir.join("dep/src/lib/moon.pkg.json"), "{}\n");
+    write_file(
+        &dir.join("dep/src/lib/lib.mbt"),
+        r#"pub fn hello() -> String {
+  "workspace"
+}
+"#,
+    );
+
+    dir
+}
+
+fn nested_workspace_under_unrelated_module_dir() -> TestDir {
+    let dir = TestDir::new_empty();
+
+    write_file(
+        &dir.join("outer/moon.mod.json"),
+        r#"{
+  "name": "alice/outer",
+  "version": "0.1.0",
+  "source": "src"
+}
+"#,
+    );
+    write_file(&dir.join("outer/src/outer/moon.pkg.json"), "{}\n");
+    write_file(
+        &dir.join("outer/src/outer/outer.mbt"),
+        r#"pub fn outer() -> Int {
+  0
+}
+"#,
+    );
+
+    write_file(
+        &dir.join("outer/ws/moon.work"),
+        r#"members = [
+  "./app",
+]
+preferred_target = "wasm-gc"
+"#,
+    );
+    write_file(
+        &dir.join("outer/ws/app/moon.mod.json"),
+        r#"{
+  "name": "alice/app",
+  "version": "0.1.0",
+  "source": "src"
+}
+"#,
+    );
+    write_file(
+        &dir.join("outer/ws/app/src/main/moon.pkg.json"),
+        r#"{
+  "is-main": true
+}
+"#,
+    );
+    write_file(
+        &dir.join("outer/ws/app/src/main/main.mbt"),
+        r#"fn main {
+  println("app")
+}
+"#,
+    );
+
+    dir
 }
 
 #[test]
@@ -667,21 +800,92 @@ fn test_manifest_path_can_disable_implicit_workspace_mode() {
 }
 
 #[test]
-fn test_workspace_root_keeps_workspace_mode_with_env_override() {
+fn test_workspace_root_cannot_use_workspace_with_env_override() {
     let dir = TestDir::new("workspace_basic.in");
 
-    let stdout = get_stdout_with_envs(
+    let stderr = get_err_stderr_with_envs(
         &dir,
         ["build", "--dry-run", "--sort-input"],
         [(MOON_NO_WORKSPACE, "1")],
     );
+    assert_workspace_disabled_without_module(&stderr);
+}
+
+#[test]
+fn test_same_root_module_can_disable_implicit_workspace_mode() {
+    let dir = same_root_workspace_dir();
+
+    let stderr = get_err_stderr_with_envs(&dir, ["build", "--dry-run"], [(MOON_NO_WORKSPACE, "1")]);
+    assert_registry_resolution_failure(&stderr);
+}
+
+#[test]
+fn test_same_root_manifest_path_can_disable_implicit_workspace_mode() {
+    let dir = same_root_workspace_dir();
+
+    let stderr = get_err_stderr_with_envs(
+        &dir,
+        ["--manifest-path", "moon.mod.json", "build", "--dry-run"],
+        [(MOON_NO_WORKSPACE, "1")],
+    );
+    assert_registry_resolution_failure(&stderr);
+}
+
+#[test]
+fn test_same_root_workspace_manifest_can_disable_workspace_mode_with_env_override() {
+    let dir = same_root_workspace_dir();
+
+    let stderr = get_err_stderr_with_envs(
+        &dir,
+        [
+            "--manifest-path",
+            "moon.work",
+            "build",
+            "--dry-run",
+            "--sort-input",
+        ],
+        [(MOON_NO_WORKSPACE, "1")],
+    );
+    assert_registry_resolution_failure(&stderr);
+}
+
+#[test]
+fn test_workspace_manifest_path_cannot_use_workspace_with_env_override() {
+    let dir = TestDir::new("workspace_basic.in");
+
+    let stderr = get_err_stderr_with_envs(
+        &dir,
+        [
+            "--manifest-path",
+            "moon.work",
+            "build",
+            "--dry-run",
+            "--sort-input",
+        ],
+        [(MOON_NO_WORKSPACE, "1")],
+    );
+    assert_workspace_disabled_without_module(&stderr);
+}
+
+#[test]
+fn test_workspace_root_beats_unrelated_outer_module_boundary() {
+    let dir = nested_workspace_under_unrelated_module_dir();
+
+    let stdout = get_stdout(
+        &dir,
+        ["-C", "outer/ws", "build", "--dry-run", "--sort-input"],
+    );
     assert!(
-        stdout.contains("./liba/src/lib/lib.mbt"),
-        "expected workspace-root build to keep the workspace member graph, got:\n{stdout}"
+        stdout.contains("alice/app/main"),
+        "expected workspace-root build to select the nearer workspace member, got:\n{stdout}"
     );
     assert!(
         stdout.contains("-workspace-path ./app"),
         "expected workspace-root build to keep workspace-aware package layout, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("alice/outer/outer"),
+        "expected workspace-root build to ignore the unrelated outer module, got:\n{stdout}"
     );
 }
 

--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -53,7 +53,7 @@ use moonutil::{
     },
     mooncakes::ModuleSourceKind,
     package::resolve_supported_targets,
-    workspace::{canonical_workspace_module_dirs, read_workspace},
+    workspace::{canonical_workspace_module_dirs, read_workspace, read_workspace_file},
 };
 use relative_path::{PathExt, RelativePath};
 use tracing::{Level, instrument, warn};
@@ -106,21 +106,37 @@ pub fn discover_packages(
 /// This supports either a single local module rooted at `source_dir` or a
 /// workspace rooted there via `moon.work` or legacy `moon.work.json`.
 #[instrument(skip_all)]
-pub fn discover_local_project(source_dir: &Path) -> Result<DiscoveredLocalProject, DiscoverError> {
+pub fn discover_local_project(
+    source_dir: &Path,
+    project_manifest_path: Option<&Path>,
+) -> Result<DiscoveredLocalProject, DiscoverError> {
     info!(
         "Starting local project discovery for {}",
         source_dir.display()
     );
 
-    let workspace =
+    let selected_workspace_manifest_path = project_manifest_path
+        .filter(|path| path.file_name().and_then(|name| name.to_str()) != Some(MOON_MOD_JSON));
+    let workspace = if let Some(workspace_manifest_path) = selected_workspace_manifest_path {
+        read_workspace_file(workspace_manifest_path)
+            .map(Some)
+            .map_err(|inner| DiscoverError::CantReadLocalWorkspace {
+                path: workspace_manifest_path.to_owned(),
+                inner,
+            })?
+    } else {
         read_workspace(source_dir).map_err(|inner| DiscoverError::CantReadLocalWorkspace {
             path: source_dir.to_owned(),
             inner,
-        })?;
+        })?
+    };
+    let workspace_root = selected_workspace_manifest_path
+        .and_then(Path::parent)
+        .unwrap_or(source_dir);
     let module_dirs = if let Some(workspace) = workspace.as_ref() {
-        canonical_workspace_module_dirs(source_dir, workspace).map_err(|inner| {
+        canonical_workspace_module_dirs(workspace_root, workspace).map_err(|inner| {
             DiscoverError::CantReadLocalWorkspace {
-                path: source_dir.to_owned(),
+                path: workspace_root.to_owned(),
                 inner,
             }
         })?

--- a/crates/moonbuild-rupes-recta/src/fmt.rs
+++ b/crates/moonbuild-rupes-recta/src/fmt.rs
@@ -33,7 +33,9 @@
 use log::*;
 use std::{collections::HashSet, path::Path};
 
-use moonutil::common::{MOON_PKG, MOON_PKG_JSON, MOON_WORK, MOON_WORK_JSON};
+use anyhow::Context;
+use moonutil::common::{MOON_MOD_JSON, MOON_PKG, MOON_PKG_JSON, MOON_WORK, MOON_WORK_JSON};
+use moonutil::workspace::workspace_manifest_path;
 use n2::graph::Build;
 
 use crate::{
@@ -52,12 +54,15 @@ pub type FmtResolveOutput = DiscoveredLocalProject;
 ///
 /// This supports either a single module rooted at `source_dir` or a workspace
 /// rooted there via `moon.work` or legacy `moon.work.json`.
-pub fn resolve_for_fmt(source_dir: &Path) -> Result<FmtResolveOutput, ResolveError> {
+pub fn resolve_for_fmt(
+    source_dir: &Path,
+    project_manifest_path: Option<&Path>,
+) -> Result<FmtResolveOutput, ResolveError> {
     info!(
         "Resolving formatter environment for {}",
         source_dir.display()
     );
-    discover_local_project(source_dir).map_err(ResolveError::from)
+    discover_local_project(source_dir, project_manifest_path).map_err(ResolveError::from)
 }
 
 pub struct FmtConfig {
@@ -90,6 +95,7 @@ pub fn build_graph_for_fmt(
     source_dir: &Path,
     target_dir: &Path,
     selected_packages: &[PackageId],
+    project_manifest_path: Option<&Path>,
 ) -> anyhow::Result<n2::graph::Graph> {
     info!(
         "Building format graph for {} root modules",
@@ -115,8 +121,8 @@ pub fn build_graph_for_fmt(
     let mut package_count = 0;
     let selected_packages = (!selected_packages.is_empty())
         .then(|| selected_packages.iter().copied().collect::<HashSet<_>>());
-    let has_workspace_manifest =
-        selected_packages.is_none() && format_workspace_node(&mut graph, cfg, &layout, source_dir)?;
+    let has_workspace_manifest = selected_packages.is_none()
+        && format_workspace_node(&mut graph, cfg, &layout, source_dir, project_manifest_path)?;
 
     for &module_id in &resolved.root_module_ids {
         let Some(packages) = resolved.pkg_dirs.packages_for_module(module_id) else {
@@ -149,53 +155,62 @@ fn format_workspace_node(
     cfg: &FmtConfig,
     layout: &LegacyLayout,
     source_dir: &Path,
+    project_manifest_path: Option<&Path>,
 ) -> anyhow::Result<bool> {
-    let moon_work = source_dir.join(MOON_WORK);
-    let moon_work_json = source_dir.join(MOON_WORK_JSON);
-
-    let has_dsl = moon_work.exists();
-    let has_json = moon_work_json.exists();
-
-    if !has_dsl && !has_json {
-        debug!(
-            "Skipping moon.work formatting for {} - no workspace file exists",
-            source_dir.display()
-        );
+    let workspace_manifest_path = project_manifest_path
+        .map(Path::to_path_buf)
+        .or_else(|| workspace_manifest_path(source_dir));
+    let Some(workspace_manifest_path) = workspace_manifest_path else {
+        return Ok(false);
+    };
+    let file_name = workspace_manifest_path
+        .file_name()
+        .and_then(|name| name.to_str());
+    if file_name == Some(MOON_MOD_JSON) {
         return Ok(false);
     }
+    let source_dir = workspace_manifest_path
+        .parent()
+        .context("workspace manifest path has no parent directory")?;
 
     let target_moon_work = layout.format_root_artifact_path(std::ffi::OsStr::new(MOON_WORK));
-
-    if has_dsl && has_json {
-        warn!(
-            "Both {} and {} exist at workspace root '{}', using the new format {}. Please remove the deprecated {}.",
-            MOON_WORK_JSON,
-            MOON_WORK,
-            source_dir.display(),
-            MOON_WORK,
-            MOON_WORK_JSON
-        );
-        format_moon_work_dsl(graph, cfg, &moon_work, &target_moon_work)?;
-    } else if has_dsl {
-        format_moon_work_dsl(graph, cfg, &moon_work, &target_moon_work)?;
-    } else if cfg.migrate_moon_work_json {
-        format_moon_work_json_migrate(
-            graph,
-            cfg,
-            &moon_work_json,
-            &target_moon_work,
-            &moon_work,
-            source_dir,
-        )?;
-    } else {
-        debug!(
-            "Skipping moon.work.json migration for {} - feature disabled",
-            source_dir.display()
-        );
-        return Ok(false);
+    match file_name {
+        Some(MOON_WORK) => {
+            let moon_work_json = source_dir.join(MOON_WORK_JSON);
+            if moon_work_json.exists() {
+                warn!(
+                    "Both {} and {} exist at workspace root '{}', using the new format {}. Please remove the deprecated {}.",
+                    MOON_WORK_JSON,
+                    MOON_WORK,
+                    source_dir.display(),
+                    MOON_WORK,
+                    MOON_WORK_JSON
+                );
+            }
+            format_moon_work_dsl(graph, cfg, &workspace_manifest_path, &target_moon_work)?;
+            Ok(true)
+        }
+        Some(MOON_WORK_JSON) if cfg.migrate_moon_work_json => {
+            let moon_work = source_dir.join(MOON_WORK);
+            format_moon_work_json_migrate(
+                graph,
+                cfg,
+                &workspace_manifest_path,
+                &target_moon_work,
+                &moon_work,
+                source_dir,
+            )?;
+            Ok(true)
+        }
+        Some(MOON_WORK_JSON) => {
+            debug!(
+                "Skipping moon.work.json migration for {} - feature disabled",
+                source_dir.display()
+            );
+            Ok(false)
+        }
+        _ => Ok(false),
     }
-
-    Ok(true)
 }
 
 fn build_for_package(

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -83,6 +83,7 @@ pub struct ResolveConfig {
     no_std: bool,
     /// Gate coverage injection in pkg_solve
     pub enable_coverage: bool,
+    project_manifest_path: Option<std::path::PathBuf>,
 }
 
 struct FrontMatterImports {
@@ -258,6 +259,7 @@ impl ResolveConfig {
             sync_flags: AutoSyncFlags { frozen },
             no_std,
             enable_coverage,
+            project_manifest_path: None,
         }
     }
 
@@ -267,7 +269,13 @@ impl ResolveConfig {
             sync_flags,
             no_std,
             enable_coverage,
+            project_manifest_path: None,
         }
+    }
+
+    pub fn with_project_manifest_path(mut self, project_manifest_path: Option<&Path>) -> Self {
+        self.project_manifest_path = project_manifest_path.map(Path::to_path_buf);
+        self
     }
 }
 
@@ -296,9 +304,14 @@ pub fn resolve(cfg: &ResolveConfig, source_dir: &Path) -> Result<ResolveOutput, 
     );
     debug!("Resolve config: sync_flags={:?}", cfg.sync_flags);
 
-    let (resolved_env, dir_sync_result, workspace) =
-        auto_sync(source_dir, &cfg.sync_flags, false, cfg.no_std)
-            .map_err(ResolveError::SyncModulesError)?;
+    let (resolved_env, dir_sync_result, workspace) = auto_sync(
+        source_dir,
+        &cfg.sync_flags,
+        false,
+        cfg.no_std,
+        cfg.project_manifest_path.as_deref(),
+    )
+    .map_err(ResolveError::SyncModulesError)?;
 
     info!("Module dependency resolution completed successfully");
     debug!("Resolved {} modules", resolved_env.module_count());

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -47,6 +47,7 @@ pub struct AddSubcommand {
 pub fn add_latest(
     project_root: &Path,
     module_dir: &Path,
+    project_manifest_path: Option<&Path>,
     pkg_name: &ModuleName,
     bin: bool,
     quiet: bool,
@@ -84,6 +85,7 @@ pub fn add_latest(
     add(
         project_root,
         module_dir,
+        project_manifest_path,
         pkg_name,
         bin,
         &latest_version,
@@ -100,6 +102,7 @@ fn test_module_name() {
 pub fn add(
     project_root: &Path,
     module_dir: &Path,
+    project_manifest_path: Option<&Path>,
     pkg_name: &ModuleName,
     bin: bool,
     version: &Version,
@@ -140,7 +143,12 @@ pub fn add(
     }
 
     let m = Arc::new(m);
-    let roots = roots_for_selected_module(project_root, module_dir, Arc::clone(&m))?;
+    let roots = roots_for_selected_module(
+        project_root,
+        module_dir,
+        Arc::clone(&m),
+        project_manifest_path,
+    )?;
     install_impl(project_root, roots, quiet, false, false, true)?;
 
     let new_j = convert_module_to_mod_json(Arc::unwrap_or_clone(m));

--- a/crates/mooncake/src/pkg/mod.rs
+++ b/crates/mooncake/src/pkg/mod.rs
@@ -18,14 +18,15 @@
 
 use std::{path::Path, sync::Arc};
 
+use anyhow::Context;
 use moonutil::{
-    common::read_module_desc_file_in_dir,
+    common::{MOON_MOD_JSON, read_module_desc_file_in_dir},
     module::MoonMod,
     mooncakes::{
         ModuleSource,
         result::{ResolvedModule, ResolvedRootModules},
     },
-    workspace::{canonical_workspace_module_dirs, read_workspace},
+    workspace::{canonical_workspace_module_dirs, read_workspace, read_workspace_file},
 };
 
 pub mod add;
@@ -41,8 +42,31 @@ pub(crate) fn roots_for_selected_module(
     project_root: &Path,
     module_dir: &Path,
     module: Arc<MoonMod>,
+    project_manifest_path: Option<&Path>,
 ) -> anyhow::Result<ResolvedRootModules> {
-    if let Some(workspace) = read_workspace(project_root)? {
+    if let Some(project_manifest_path) = project_manifest_path {
+        if project_manifest_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            != Some(MOON_MOD_JSON)
+        {
+            let workspace_root = project_manifest_path
+                .parent()
+                .context("workspace manifest path has no parent directory")?;
+            let workspace = read_workspace_file(project_manifest_path)?;
+            let mut roots = ResolvedRootModules::with_key();
+            for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {
+                let member = if member_dir == module_dir {
+                    Arc::clone(&module)
+                } else {
+                    Arc::new(read_module_desc_file_in_dir(&member_dir)?)
+                };
+                let source = ModuleSource::from_local_module(&member, &member_dir);
+                roots.insert(ResolvedModule::new(source, member));
+            }
+            return Ok(roots);
+        }
+    } else if let Some(workspace) = read_workspace(project_root)? {
         let mut roots = ResolvedRootModules::with_key();
         for member_dir in canonical_workspace_module_dirs(project_root, &workspace)? {
             let member = if member_dir == module_dir {
@@ -53,10 +77,10 @@ pub(crate) fn roots_for_selected_module(
             let source = ModuleSource::from_local_module(&member, &member_dir);
             roots.insert(ResolvedModule::new(source, member));
         }
-        Ok(roots)
-    } else {
-        let source = ModuleSource::from_local_module(&module, module_dir);
-        let (roots, _) = ResolvedModule::only_one_module(source, module);
-        Ok(roots)
+        return Ok(roots);
     }
+
+    let source = ModuleSource::from_local_module(&module, module_dir);
+    let (roots, _) = ResolvedModule::only_one_module(source, module);
+    Ok(roots)
 }

--- a/crates/mooncake/src/pkg/remove.rs
+++ b/crates/mooncake/src/pkg/remove.rs
@@ -41,6 +41,7 @@ pub struct RemoveSubcommand {
 pub fn remove(
     project_root: &Path,
     module_dir: &Path,
+    project_manifest_path: Option<&Path>,
     username: &str,
     pkgname: &str,
 ) -> anyhow::Result<i32> {
@@ -54,7 +55,12 @@ pub fn remove(
         )
     }
     let m = Arc::new(m);
-    let roots = roots_for_selected_module(project_root, module_dir, Arc::clone(&m))?;
+    let roots = roots_for_selected_module(
+        project_root,
+        module_dir,
+        Arc::clone(&m),
+        project_manifest_path,
+    )?;
 
     let resolve_cfg = ResolveConfig {
         registry: registry::default_registry(),

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -20,16 +20,17 @@
 
 use std::{path::Path, sync::Arc};
 
+use anyhow::Context;
 use indexmap::IndexMap;
 use moonutil::{
-    common::{MbtMdHeader, MoonbuildOpt, MooncOpt, read_module_desc_file_in_dir},
+    common::{MOON_MOD_JSON, MbtMdHeader, MoonbuildOpt, MooncOpt, read_module_desc_file_in_dir},
     module::MoonMod,
     mooncakes::{
         DirSyncResult, ModuleSource,
         result::{ResolvedEnv, ResolvedModule, ResolvedRootModules},
         sync::AutoSyncFlags,
     },
-    workspace::{MoonWork, canonical_workspace_module_dirs, read_workspace},
+    workspace::{MoonWork, canonical_workspace_module_dirs, read_workspace, read_workspace_file},
 };
 use semver::Version;
 
@@ -42,8 +43,37 @@ pub fn auto_sync(
     cli: &AutoSyncFlags,
     quiet: bool,
     no_std: bool,
+    project_manifest_path: Option<&Path>,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult, Option<MoonWork>)> {
-    if let Some(workspace) = read_workspace(source_dir)? {
+    if let Some(project_manifest_path) = project_manifest_path {
+        if project_manifest_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            != Some(MOON_MOD_JSON)
+        {
+            let workspace_root = project_manifest_path
+                .parent()
+                .context("workspace manifest path has no parent directory")?;
+            let workspace = read_workspace_file(project_manifest_path)?;
+            let mut roots = ResolvedRootModules::with_key();
+            for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {
+                let module = Arc::new(read_module_desc_file_in_dir(&member_dir)?);
+                let source = ModuleSource::from_local_module(&module, &member_dir);
+                roots.insert(ResolvedModule::new(source, module));
+            }
+
+            let (resolved_env, sync_result) = super::install::install_impl(
+                workspace_root,
+                roots,
+                quiet,
+                false,
+                cli.dont_sync(),
+                no_std,
+            )?;
+            log::debug!("Dir sync result: {:?}", sync_result);
+            return Ok((resolved_env, sync_result, Some(workspace)));
+        }
+    } else if let Some(workspace) = read_workspace(source_dir)? {
         let mut roots = ResolvedRootModules::with_key();
         for member_dir in canonical_workspace_module_dirs(source_dir, &workspace)? {
             let module = Arc::new(read_module_desc_file_in_dir(&member_dir)?);

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -23,10 +23,11 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::common::{BUILD_DIR, MOON_MOD_JSON, MOON_WORK, MOON_WORK_JSON};
-use crate::workspace::{canonical_workspace_module_dirs, read_workspace, workspace_manifest_path};
+use crate::workspace::{
+    canonical_workspace_module_dirs, read_workspace_file, workspace_manifest_path,
+};
 
-/// Set to a non-`0` value to keep commands started from inside a module in
-/// single-module mode instead of promoting them into an ancestor workspace.
+/// Set to a non-`0` value to disable workspace mode entirely.
 pub const MOON_NO_WORKSPACE: &str = "MOON_NO_WORKSPACE";
 
 #[derive(Debug, Error)]
@@ -35,8 +36,21 @@ pub enum PackageDirsError {
         "not in a Moon project (no moon.mod.json, moon.work, or moon.work.json found starting from {0} or its ancestors)"
     )]
     NotInProject(PathBuf),
+    #[error(
+        "not in a Moon module (workspace mode is disabled by MOON_NO_WORKSPACE and no moon.mod.json was found starting from {0} or its ancestors)"
+    )]
+    WorkspaceDisabledNotInModule(PathBuf),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+impl PackageDirsError {
+    pub fn allows_single_file_fallback(&self) -> bool {
+        matches!(
+            self,
+            Self::NotInProject(_) | Self::WorkspaceDisabledNotInModule(_)
+        )
+    }
 }
 
 #[derive(Debug, clap::Parser, Serialize, Deserialize, Clone)]
@@ -62,89 +76,149 @@ pub struct SourceTargetDirs {
 
 impl SourceTargetDirs {
     pub fn try_into_package_dirs(&self) -> Result<PackageDirs, PackageDirsError> {
-        let project_root = if let Some(manifest_path) = &self.manifest_path {
-            resolve_manifest_root(manifest_path).map_err(PackageDirsError::from)?
-        } else {
-            let start_dir = Self::current_dir()?;
-            let project_root = find_ancestor_with_work(&start_dir)
-                .map_err(PackageDirsError::from)?
-                .or_else(|| find_ancestor_with_mod(&start_dir));
-            project_root.ok_or_else(|| PackageDirsError::NotInProject(start_dir.clone()))?
-        };
+        let project = self.resolve_project_selection()?;
 
-        let target_dir = self.resolve_target_dir(&project_root)?;
+        let target_dir = self.resolve_target_dir(&project.project_root)?;
 
         Ok(PackageDirs {
-            source_dir: project_root,
+            source_dir: project.project_root,
             target_dir,
+            project_manifest_path: project.project_manifest_path,
         })
     }
 
     pub fn try_into_workspace_module_dirs(&self) -> Result<WorkspaceModuleDirs, PackageDirsError> {
-        let (project_root, module_dir) = if let Some(manifest_path) = &self.manifest_path {
-            let manifest_path = dunce::canonicalize(manifest_path)
-                .with_context(|| {
-                    format!(
-                        "failed to resolve manifest path `{}`",
-                        manifest_path.display()
-                    )
-                })
-                .map_err(PackageDirsError::from)?;
+        let project = self.resolve_project_selection()?;
 
-            if manifest_path.is_dir() {
-                return Err(PackageDirsError::from(anyhow::anyhow!(
-                    "`--manifest-path` must point to `{}`, `{}`, or `{}` (got directory `{}`)",
+        let target_dir = self.resolve_target_dir(&project.project_root)?;
+
+        Ok(WorkspaceModuleDirs {
+            project_root: project.project_root,
+            module_dir: project.module_dir,
+            target_dir,
+            project_manifest_path: project.project_manifest_path,
+        })
+    }
+
+    fn resolve_project_selection(&self) -> Result<ProjectSelection, PackageDirsError> {
+        if let Some(manifest_path) = &self.manifest_path {
+            return Self::resolve_project_selection_from_manifest_path(manifest_path);
+        }
+
+        let start_dir = Self::current_dir()?;
+        if disable_workspace_from_env() {
+            return project_selection_with_workspace_disabled(start_dir);
+        }
+
+        let module_dir = find_ancestor_with_mod(&start_dir);
+
+        if let Some(project_manifest_path) =
+            find_applicable_workspace_manifest_path(&start_dir).map_err(PackageDirsError::from)?
+        {
+            let project_root =
+                manifest_root(&project_manifest_path).map_err(PackageDirsError::from)?;
+            return Ok(ProjectSelection {
+                project_root,
+                module_dir,
+                project_manifest_path,
+            });
+        }
+
+        if let Some(module_dir) = module_dir {
+            let project_manifest_path = module_dir.join(MOON_MOD_JSON);
+            return Ok(ProjectSelection {
+                project_root: module_dir.clone(),
+                module_dir: Some(module_dir),
+                project_manifest_path,
+            });
+        }
+
+        Err(PackageDirsError::NotInProject(start_dir))
+    }
+
+    fn resolve_project_selection_from_manifest_path(
+        manifest_path: &Path,
+    ) -> Result<ProjectSelection, PackageDirsError> {
+        let manifest_path = dunce::canonicalize(manifest_path)
+            .with_context(|| {
+                format!(
+                    "failed to resolve manifest path `{}`",
+                    manifest_path.display()
+                )
+            })
+            .map_err(PackageDirsError::from)?;
+
+        if manifest_path.is_dir() {
+            return Err(PackageDirsError::from(anyhow::anyhow!(
+                "`--manifest-path` must point to `{}`, `{}`, or `{}` (got directory `{}`)",
+                MOON_MOD_JSON,
+                MOON_WORK,
+                MOON_WORK_JSON,
+                manifest_path.display()
+            )));
+        }
+
+        let file_name = manifest_path.file_name().and_then(|s| s.to_str());
+        let manifest_dir = manifest_path
+            .parent()
+            .context("manifest path has no parent directory")
+            .map(Path::to_path_buf)
+            .map_err(PackageDirsError::from)?;
+
+        if disable_workspace_from_env() {
+            return match file_name {
+                Some(MOON_MOD_JSON) => Ok(ProjectSelection {
+                    project_root: manifest_dir.clone(),
+                    module_dir: Some(manifest_dir),
+                    project_manifest_path: manifest_path,
+                }),
+                Some(MOON_WORK) | Some(MOON_WORK_JSON) => {
+                    project_selection_with_workspace_disabled(manifest_dir)
+                }
+                _ => Err(PackageDirsError::from(anyhow::anyhow!(
+                    "`--manifest-path` must point to `{}`, `{}`, or `{}` (got `{}`)",
                     MOON_MOD_JSON,
                     MOON_WORK,
                     MOON_WORK_JSON,
                     manifest_path.display()
-                )));
-            }
+                ))),
+            };
+        }
 
-            let file_name = manifest_path.file_name().and_then(|s| s.to_str());
-            let manifest_root = manifest_path
-                .parent()
-                .context("manifest path has no parent directory")
-                .map(Path::to_path_buf)
-                .map_err(PackageDirsError::from)?;
-
-            match file_name {
-                Some(MOON_MOD_JSON) => {
-                    let module_dir = manifest_root;
-                    let project_root = find_ancestor_with_work(&module_dir)
+        match file_name {
+            Some(MOON_MOD_JSON) => {
+                if let Some(project_manifest_path) =
+                    find_applicable_workspace_manifest_path(&manifest_dir)
                         .map_err(PackageDirsError::from)?
-                        .unwrap_or_else(|| module_dir.clone());
-                    (project_root, Some(module_dir))
-                }
-                Some(MOON_WORK) => (manifest_root, None),
-                Some(MOON_WORK_JSON) => (manifest_root, None),
-                _ => {
-                    return Err(PackageDirsError::from(anyhow::anyhow!(
-                        "`--manifest-path` must point to `{}`, `{}`, or `{}` (got `{}`)",
-                        MOON_MOD_JSON,
-                        MOON_WORK,
-                        MOON_WORK_JSON,
-                        manifest_path.display()
-                    )));
+                {
+                    let project_root =
+                        manifest_root(&project_manifest_path).map_err(PackageDirsError::from)?;
+                    Ok(ProjectSelection {
+                        project_root,
+                        module_dir: Some(manifest_dir),
+                        project_manifest_path,
+                    })
+                } else {
+                    Ok(ProjectSelection {
+                        project_root: manifest_dir.clone(),
+                        module_dir: Some(manifest_dir),
+                        project_manifest_path: manifest_path,
+                    })
                 }
             }
-        } else {
-            let start_dir = Self::current_dir()?;
-            let project_root = find_ancestor_with_work(&start_dir)
-                .map_err(PackageDirsError::from)?
-                .or_else(|| find_ancestor_with_mod(&start_dir))
-                .ok_or_else(|| PackageDirsError::NotInProject(start_dir.clone()))?;
-            let module_dir = find_ancestor_with_mod(&start_dir);
-            (project_root, module_dir)
-        };
-
-        let target_dir = self.resolve_target_dir(&project_root)?;
-
-        Ok(WorkspaceModuleDirs {
-            project_root,
-            module_dir,
-            target_dir,
-        })
+            Some(MOON_WORK) | Some(MOON_WORK_JSON) => Ok(ProjectSelection {
+                project_root: manifest_dir,
+                module_dir: None,
+                project_manifest_path: manifest_path,
+            }),
+            _ => Err(PackageDirsError::from(anyhow::anyhow!(
+                "`--manifest-path` must point to `{}`, `{}`, or `{}` (got `{}`)",
+                MOON_MOD_JSON,
+                MOON_WORK,
+                MOON_WORK_JSON,
+                manifest_path.display()
+            ))),
+        }
     }
 
     fn current_dir() -> Result<PathBuf, PackageDirsError> {
@@ -175,6 +249,7 @@ impl SourceTargetDirs {
 pub struct PackageDirs {
     pub source_dir: PathBuf,
     pub target_dir: PathBuf,
+    pub project_manifest_path: PathBuf,
 }
 
 pub struct WorkspaceModuleDirs {
@@ -183,6 +258,7 @@ pub struct WorkspaceModuleDirs {
     /// Selected module root, if the command was invoked from within a module.
     pub module_dir: Option<PathBuf>,
     pub target_dir: PathBuf,
+    pub project_manifest_path: PathBuf,
 }
 
 impl WorkspaceModuleDirs {
@@ -213,47 +289,75 @@ pub fn find_ancestor_with_mod(source_dir: &Path) -> Option<PathBuf> {
 }
 
 pub fn find_ancestor_with_work(source_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
+    if disable_workspace_from_env() {
+        return Ok(None);
+    }
+
+    find_applicable_workspace_manifest_path(source_dir)?
+        .map(|path| manifest_root(&path))
+        .transpose()
+}
+
+fn disable_workspace_from_env() -> bool {
+    match std::env::var(MOON_NO_WORKSPACE) {
+        Ok(value) => value != "0",
+        Err(std::env::VarError::NotPresent) => false,
+        Err(std::env::VarError::NotUnicode(_)) => true,
+    }
+}
+
+fn project_selection_with_workspace_disabled(
+    start_dir: PathBuf,
+) -> Result<ProjectSelection, PackageDirsError> {
+    let Some(module_dir) = find_ancestor_with_mod(&start_dir) else {
+        return Err(PackageDirsError::WorkspaceDisabledNotInModule(start_dir));
+    };
+
+    let project_manifest_path = module_dir.join(MOON_MOD_JSON);
+    Ok(ProjectSelection {
+        project_root: module_dir.clone(),
+        module_dir: Some(module_dir),
+        project_manifest_path,
+    })
+}
+
+struct ProjectSelection {
+    project_root: PathBuf,
+    module_dir: Option<PathBuf>,
+    project_manifest_path: PathBuf,
+}
+
+fn find_applicable_workspace_manifest_path(source_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
     let mut module_root = None;
-    let disable_workspace_from_module = disable_workspace_from_module_env();
 
     for dir in source_dir.ancestors() {
-        if let Some(workspace_path) = workspace_manifest_path(dir) {
-            let Some(module_root) = module_root else {
-                // A workspace still applies from nested non-module directories.
-                return Ok(Some(dir.to_path_buf()));
-            };
-
-            if disable_workspace_from_module {
-                return Ok(None);
+        let Some(workspace_path) = workspace_manifest_path(dir) else {
+            if module_root.is_none() && check_moon_mod_exists(dir) {
+                module_root = Some(dir);
             }
+            continue;
+        };
 
-            // After we have entered a module, only ancestor workspaces that
-            // explicitly list that module still apply.
-            let workspace = read_workspace(dir)?.context(format!(
-                "failed to parse workspace file `{}`",
-                workspace_path.display()
-            ))?;
-            for member_dir in canonical_workspace_module_dirs(dir, &workspace)? {
-                if member_dir == module_root {
-                    return Ok(Some(dir.to_path_buf()));
-                }
+        let Some(module_root) = module_root else {
+            return Ok(Some(workspace_path));
+        };
+
+        let workspace = read_workspace_file(&workspace_path)?;
+        for member_dir in canonical_workspace_module_dirs(dir, &workspace)? {
+            if member_dir == module_root {
+                return Ok(Some(workspace_path));
             }
-        }
-
-        if module_root.is_none() && check_moon_mod_exists(dir) {
-            module_root = Some(dir);
         }
     }
 
     Ok(None)
 }
 
-fn disable_workspace_from_module_env() -> bool {
-    match std::env::var(MOON_NO_WORKSPACE) {
-        Ok(value) => value != "0",
-        Err(std::env::VarError::NotPresent) => false,
-        Err(std::env::VarError::NotUnicode(_)) => true,
-    }
+fn manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {
+    manifest_path
+        .parent()
+        .context("manifest path has no parent directory")
+        .map(Path::to_path_buf)
 }
 
 pub fn resolve_manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {

--- a/docs/dev/reference/readme.md
+++ b/docs/dev/reference/readme.md
@@ -6,6 +6,7 @@ This is a reference documentation of the current MoonBuild behavior.
 
 * [Architecture and overview](./arch.md)
 * [Modules and packages](./modules-packages.md)
+* [Workspace](./workspace.md)
 * [Package build process](./build.md)
 * [How binaries are found](./binaries.md)
 * [Indirect dependency support for compiler](./indirect-dep.md)

--- a/docs/dev/reference/workspace.md
+++ b/docs/dev/reference/workspace.md
@@ -1,0 +1,345 @@
+# Workspace Design
+
+This document describes Moon's current workspace model: manifest formats,
+project selection, command categories, and the boundaries of what workspace
+mode does and does not support.
+
+The implementation lives mainly in:
+
+- `crates/moonutil/src/dirs.rs`
+- `crates/moonutil/src/workspace.rs`
+- `crates/mooncake/src/pkg/mod.rs`
+- `crates/mooncake/src/pkg/sync.rs`
+- `crates/moon/src/cli/mooncake_adapter.rs`
+- `crates/moonbuild-rupes-recta/src/discover/mod.rs`
+- `crates/moonbuild-rupes-recta/src/fmt.rs`
+
+## Goals
+
+Workspace support is meant to provide one consistent model for:
+
+1. selecting the effective project for a command
+2. deciding whether that project is a single module or a workspace
+3. deciding whether the command needs one selected member module or the whole
+   selected project
+
+The design intentionally avoids a separate enum like "project mode". The source
+of truth is the selected manifest path itself.
+
+## Manifest Model
+
+Moon accepts two workspace manifest formats:
+
+- `moon.work`
+  - the current DSL form
+- `moon.work.json`
+  - the legacy JSON form
+
+If both exist in the same directory, `moon.work` wins.
+
+New workspace writes go to `moon.work`.
+Legacy `moon.work.json` is read for compatibility, but it is not the preferred
+output format anymore.
+
+A workspace manifest defines:
+
+- `members` / legacy `use`
+  - the module directories contained by the workspace
+- `preferred_target` / legacy `preferred-target`
+  - an optional default backend for the workspace
+
+Workspace members are canonicalized relative to the workspace root and deduped.
+
+The workspace root may or may not also contain a `moon.mod.json`.
+
+## Selection Result
+
+`SourceTargetDirs` resolves command input into:
+
+- `project_manifest_path`
+  - one of `moon.mod.json`, `moon.work`, or `moon.work.json`
+- `project_root`
+  - the parent directory of `project_manifest_path`
+- `module_dir`
+  - `Some(member_dir)` when a command selected a module inside a workspace
+  - `None` when a command selected a workspace root directly
+
+The intended interpretation is simple:
+
+- `project_manifest_path = moon.mod.json`
+  - single-module behavior
+- `project_manifest_path = moon.work` or `moon.work.json`
+  - workspace behavior
+
+`module_dir` is orthogonal:
+
+- it does not decide whether workspace mode is enabled
+- it only tells member-scoped commands which member they should act on
+
+## Command Model
+
+Workspace behavior is easier to understand if commands are split into three
+categories.
+
+The list below focuses on the current workspace-specific command split. Other
+commands still use the same project-selection layer, but are less important to
+the workspace model itself.
+
+### Project-Scoped Commands
+
+These commands operate on the selected project as a whole.
+
+Representative examples:
+
+- `moon build`
+- `moon check`
+- `moon test`
+- `moon fmt`
+- `moon info`
+
+When the selected manifest is a workspace manifest, these commands operate on
+the whole workspace. They can be run from:
+
+- the workspace root
+- a workspace member directory
+- a nested non-module directory under the workspace
+- `--manifest-path <member>/moon.mod.json`
+- `--manifest-path moon.work`
+
+They do not need an implicit default member.
+
+### Member-Scoped Commands
+
+These commands need one concrete module even when the selected project is a
+workspace.
+
+Current examples:
+
+- `moon add`
+- `moon remove`
+- `moon tree`
+- `moon package`
+- `moon publish`
+- `moon doc`
+- `moon prove`
+
+These commands are still workspace-aware:
+
+- they keep workspace-local dependency resolution
+- they keep workspace-local build layout
+- they use the selected member as the operation target
+
+But they are not workspace-wide commands.
+
+At a workspace root, they fail unless Moon can determine a member module from
+context. In practice, that means:
+
+- running them directly at the workspace root is not supported
+- running them from a member directory is supported
+- passing `--manifest-path <member>/moon.mod.json` is supported
+
+This is why `publish`, `package`, `doc`, and `prove` only work for one selected
+module at a time today. There is no "publish the whole workspace" or "generate
+docs for the whole workspace" mode in the current design.
+
+### Workspace Maintenance Commands
+
+These commands manage the workspace manifest itself:
+
+- `moon work init`
+- `moon work use`
+- `moon work sync`
+
+Their model is different from normal project commands:
+
+- `work init`
+  - creates a `moon.work`
+- `work use`
+  - updates an existing applicable workspace if one already applies
+  - otherwise stays local and creates/updates a workspace rooted at the current
+    module or directory
+- `work sync`
+  - requires a workspace manifest
+  - syncs workspace-local dependency versions into member manifests
+
+`work sync` is workspace-only. It is not meaningful in plain single-module mode.
+
+## Supported And Unsupported Behaviors
+
+The current design supports:
+
+- workspace roots that contain only `moon.work` / `moon.work.json`
+- workspace roots that also contain `moon.mod.json`
+- selecting a member module from inside the member directory
+- selecting a member module with `--manifest-path <member>/moon.mod.json`
+- whole-workspace `build` / `check` / `test` / `fmt` / `info`
+- member-scoped `package` / `publish` / `doc` / `prove` while still using
+  workspace-local dependency resolution
+- nested discovery from non-module directories inside a workspace
+- legacy `moon.work.json`
+
+The current design does not support:
+
+- an implicit default member at workspace root for member-scoped commands
+- workspace-wide `publish`
+- workspace-wide `package`
+- workspace-wide `doc`
+- workspace-wide `prove`
+- workspace-wide `add` / `remove` / `tree`
+
+Those commands need a selected member and will fail at workspace root with the
+"cannot infer a target module in workspace" error.
+
+## Selection Inputs
+
+Project selection depends on:
+
+- the working directory after `-C`
+- `--manifest-path`
+- `MOON_NO_WORKSPACE`
+
+`--manifest-path` pins manifest resolution, but does not change the process
+working directory.
+
+## `MOON_NO_WORKSPACE`
+
+`MOON_NO_WORKSPACE` is Moon's "workspace off" switch.
+
+If it is set to a non-`0` value:
+
+- implicit workspace discovery is disabled
+- explicit `--manifest-path moon.work` / `moon.work.json` is also disabled
+- commands behave as if workspace mode does not exist
+
+This is intentionally close to `GO_WORK=off` in Go.
+
+The resulting behavior is:
+
+- if a `moon.mod.json` can be found from the selected start directory upward,
+  Moon uses that module
+- otherwise the command behaves as "not in a Moon module"
+
+This applies even when:
+
+- `moon.work` and `moon.mod.json` are colocated at the same root
+- `--manifest-path` explicitly points to a workspace manifest
+
+So `MOON_NO_WORKSPACE` does not mean "disable only implicit promotion into a
+workspace". It disables workspace behavior completely.
+
+## Selection Without `--manifest-path`
+
+Without `--manifest-path`, Moon starts from the current directory after `-C`.
+
+The algorithm is:
+
+1. Canonicalize the current directory.
+2. If `MOON_NO_WORKSPACE` is enabled:
+   - find the nearest ancestor containing `moon.mod.json`
+   - if found, select that module manifest
+   - otherwise, fail because workspace mode is disabled and no module exists
+3. Otherwise, walk ancestors from nearest to farthest and look for applicable
+   workspace manifests.
+4. If an applicable workspace manifest is found, select that workspace
+   manifest.
+5. If no applicable workspace is found, fall back to the nearest ancestor
+   `moon.mod.json`.
+6. If neither exists, fail with "not in a Moon project".
+
+## Selection With `--manifest-path`
+
+`--manifest-path` accepts exactly:
+
+- `moon.mod.json`
+- `moon.work`
+- `moon.work.json`
+
+The selected manifest path is canonicalized first.
+
+### `--manifest-path <...>/moon.mod.json`
+
+This means "start from this module".
+
+- if `MOON_NO_WORKSPACE` is enabled, the command stays in single-module mode
+- otherwise, Moon may still promote to an enclosing applicable workspace
+
+This is important: `--manifest-path moon.mod.json` does not mean "force
+single-module mode". It means "select this module as the starting point".
+
+If an enclosing workspace applies, the command keeps:
+
+- `project_manifest_path = workspace manifest`
+- `project_root = workspace root`
+- `module_dir = selected module`
+
+That is how member-scoped commands can act on one member while still using the
+workspace's local dependency graph.
+
+### `--manifest-path <...>/moon.work` or `moon.work.json`
+
+This means "start from this workspace root", but only when workspace mode is
+enabled.
+
+If `MOON_NO_WORKSPACE` is enabled:
+
+- Moon ignores the workspace manifest
+- Moon falls back to the nearest ancestor `moon.mod.json`, if any
+- otherwise the command fails because workspace mode is disabled and no module
+  is available
+
+## How Moon Decides Whether A Workspace Applies
+
+Workspace applicability is order-sensitive.
+
+Moon walks ancestors from nearest to farthest. While walking, it derives the
+current module boundary from the same ancestor order instead of precomputing one
+outer module root before the walk.
+
+This preserves the intended precedence:
+
+- a nearer applicable workspace should win
+- a farther workspace may still apply later if it explicitly lists the selected
+  module as a member
+- an unrelated outer `moon.mod.json` must not make Moon skip a nearer workspace
+  that should still apply
+
+This matters for layouts like:
+
+```text
+outer/
+  moon.mod.json
+  ws/
+    moon.work
+    app/
+      moon.mod.json
+```
+
+From `outer/ws`, the nearer workspace should win while workspace mode is
+enabled.
+
+With `MOON_NO_WORKSPACE=1`, the workspace is ignored and selection falls back to
+the nearest ancestor module, which is `outer/moon.mod.json`.
+
+## Colocated `moon.work` And `moon.mod.json`
+
+If a directory contains both:
+
+- with workspace mode enabled, Moon may select the workspace manifest
+- with `MOON_NO_WORKSPACE=1`, Moon must select `moon.mod.json` instead
+
+This was the bug shape that motivated the recent cleanup of workspace
+selection.
+
+## Examples
+
+| Start point / flags | Result |
+| --- | --- |
+| workspace root + `build` / `check` / `test` / `fmt` / `info` | operate on the whole workspace |
+| workspace root + `add` / `remove` / `tree` / `package` / `publish` / `doc` / `prove` | error: no target member can be inferred |
+| member directory + member-scoped command | target that member and keep workspace context |
+| `--manifest-path app/moon.mod.json` | start from `app`, then allow workspace promotion |
+| `--manifest-path app/moon.mod.json` + member-scoped command | act on `app`, but keep workspace-local deps/layout if a workspace applies |
+| `--manifest-path moon.work` | select the workspace manifest |
+| inside workspace member + `MOON_NO_WORKSPACE=1` | ignore the workspace and use the nearest ancestor `moon.mod.json` |
+| workspace root with no module + `MOON_NO_WORKSPACE=1` | error: workspace mode is disabled and no module is available |
+| `moon work sync` outside a workspace | error: requires `moon.work` or `moon.work.json` |


### PR DESCRIPTION
## Summary
- replace `ProjectMode` with the selected project manifest path
- make `MOON_NO_WORKSPACE=1` disable workspace mode completely
- fixed manifest path resolution

## Testing
- `cargo check -p moon --quiet`
- `cargo test -p moon same_root -- --nocapture`
- `cargo test -p moon implicit_workspace_mode -- --nocapture`
- `cargo test -p moon workspace_mode_with_env_override -- --nocapture`