### PR TITLE
fix(mooncake): pass through moon override

### DIFF
--- a/crates/moon/src/cli/mooncake_adapter.rs
+++ b/crates/moon/src/cli/mooncake_adapter.rs
@@ -35,8 +35,10 @@ pub(crate) fn execute_cli<T: Serialize>(
     args: &[&str],
     display_name: &str,
 ) -> anyhow::Result<i32> {
+    let current_moon = std::env::current_exe()?;
     let mut child = Command::new(&*moonutil::BINARIES.mooncake)
         .args(args)
+        .env("MOON_OVERRIDE", current_moon)
         .stdout(Stdio::inherit())
         .stdin(Stdio::piped())
         .stderr(Stdio::inherit())
@@ -66,9 +68,11 @@ pub(crate) fn execute_cli_with_inherit_stdin<T: Serialize>(
     args: &[&str],
     display_name: &str,
 ) -> anyhow::Result<i32> {
+    let current_moon = std::env::current_exe()?;
     let mut child = Command::new(&*moonutil::BINARIES.mooncake)
         .args(args)
         .env("MOONCAKE_ALLOW_DIRECT", "1")
+        .env("MOON_OVERRIDE", current_moon)
         .stdout(Stdio::inherit())
         .stdin(Stdio::inherit())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

## Summary

Pass `MOON_OVERRIDE` from `moon` to the `mooncake` subprocess so any later `moon` invocation inside `mooncake` resolves back to the same `moon` binary that launched it.

Focused verification:
- `cargo test -p moon single_module_mooncake_cli_does_not_emit_legacy_workspace_file -- --nocapture`
- `cargo test -p moon test_manifest_path_targets_workspace_member_for_single_module_commands -- --nocapture`
- `cargo test -p moon test_package_targets_workspace_member_from_member_dir -- --nocapture`

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS