### PR TITLE
refactor: route user-facing warnings through user diagnostics

### DIFF
--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -94,7 +94,7 @@ fn run_fmt_rr(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> {
         migrate_moon_pkg_json: cli.unstable_feature.rr_moon_pkg,
         migrate_moon_work_json: cli.unstable_feature.rr_moon_pkg,
     };
-    let graph = plan_fmt(
+    let (graph, user_warnings) = plan_fmt(
         &resolved,
         &fmt_config,
         &source_dir,
@@ -102,6 +102,9 @@ fn run_fmt_rr(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> {
         &selected_packages,
         Some(project_manifest_path.as_path()),
     )?;
+    for message in &user_warnings {
+        output.user_message(message);
+    }
 
     if cli.dry_run {
         rr_build::print_dry_run_all(&graph, &source_dir, &target_dir);

--- a/crates/moon/src/cli/tool/format_and_diff.rs
+++ b/crates/moon/src/cli/tool/format_and_diff.rs
@@ -69,7 +69,7 @@ pub(crate) fn run_format_and_diff(cmd: FormatAndDiffSubcommand) -> anyhow::Resul
     if cmd.warn {
         // This command is executed by n2, so colored message using with
         // `eprintln!` is not displayed correctly.
-        tracing::warn!("File not formatted: {}", cmd.old.display());
+        println!("File not formatted: {}", cmd.old.display());
         return Ok(0);
     }
 

--- a/crates/moon/src/cli/tool/format_workspace.rs
+++ b/crates/moon/src/cli/tool/format_workspace.rs
@@ -67,7 +67,7 @@ pub(crate) fn run_format_workspace(cmd: FormatWorkspaceSubcommand) -> anyhow::Re
     }
 
     if cmd.warn {
-        tracing::warn!("File not formatted: {}", cmd.old.display());
+        println!("File not formatted: {}", cmd.old.display());
         return Ok(0);
     }
 

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -107,6 +107,20 @@ fn init_tracing(trace_flag: bool) -> Box<dyn Any> {
     Box::new(chrome_guard)
 }
 
+fn emit_resolve_warnings_from_error_chain(output: UserDiagnostics, err: &anyhow::Error) {
+    for cause in err.chain() {
+        let Some(resolve_err) =
+            cause.downcast_ref::<moonbuild_rupes_recta::resolve::ResolveError>()
+        else {
+            continue;
+        };
+        for warning in resolve_err.user_warnings() {
+            output.user_message(warning);
+        }
+        break;
+    }
+}
+
 pub fn main() {
     panic::setup_panic_hook();
 
@@ -174,6 +188,7 @@ pub fn main() {
     match res {
         Ok(code) => std::process::exit(code),
         Err(e) => {
+            emit_resolve_warnings_from_error_chain(output, &e);
             output.error(format!("{:?}", e));
             std::process::exit(-1);
         }

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -45,6 +45,7 @@ use moonbuild_rupes_recta::{
     intent::UserIntent,
     model::{Artifacts, BuildPlanNode, PackageId, RunBackend, TargetKind},
     prebuild::run_prebuild_config,
+    user_warning::UserWarning,
 };
 use moonutil::{
     cli::UniversalFlags,
@@ -457,8 +458,8 @@ pub(crate) fn plan_build_from_resolved<'a>(
     calc_user_intent: Box<CalcUserIntentFn<'a>>,
     resolve_output: ResolveOutput,
 ) -> anyhow::Result<(BuildMeta, BuildInput)> {
-    for warning in &resolve_output.user_warnings {
-        output.warn(warning);
+    for message in &resolve_output.user_warnings {
+        output.user_message(message);
     }
 
     // A couple of debug things:
@@ -520,13 +521,18 @@ pub(crate) fn plan_build_from_resolved<'a>(
     // Expand user intents to concrete BuildPlanNode inputs
     info!("Expanding user intents to build plan nodes");
     let mut input_nodes: Vec<BuildPlanNode> = Vec::new();
+    let mut intent_messages = Vec::new();
     for i in &intent.intents {
         i.append_nodes(
             &resolve_output,
             &mut input_nodes,
+            &mut intent_messages,
             &intent.directive,
             target_backend,
         );
+    }
+    for message in &intent_messages {
+        output.user_message(message);
     }
     let cx = preconfig.into_compile_config(
         target_backend,
@@ -543,8 +549,8 @@ pub(crate) fn plan_build_from_resolved<'a>(
         &intent.directive,
         prebuild_config.as_ref(),
     )?;
-    for warning in &compile_output.user_warnings {
-        output.warn(warning);
+    for message in &compile_output.user_warnings {
+        output.user_message(message);
     }
 
     if unstable_features.rr_export_build_plan
@@ -589,8 +595,8 @@ pub fn plan_fmt(
     target_dir: &Path,
     selected_packages: &[PackageId],
     project_manifest_path: Option<&Path>,
-) -> anyhow::Result<BuildInput> {
-    let graph = moonbuild_rupes_recta::fmt::build_graph_for_fmt(
+) -> anyhow::Result<(BuildInput, Vec<UserWarning>)> {
+    let (graph, user_warnings) = moonbuild_rupes_recta::fmt::build_graph_for_fmt(
         resolved,
         cfg,
         source_dir,
@@ -605,7 +611,7 @@ pub fn plan_fmt(
         RunMode::Format,
     );
     let input = BuildInput { graph, db_path };
-    Ok(input)
+    Ok((input, user_warnings))
 }
 
 /// Check if we can actually run `tcc -run`.

--- a/crates/moon/src/user_diagnostics.rs
+++ b/crates/moon/src/user_diagnostics.rs
@@ -20,6 +20,7 @@ use std::fmt::Display;
 
 use colored::{ColoredString, Colorize};
 use moonutil::cli::UniversalFlags;
+use moonutil::user_warning::{UserMessageLevel, UserWarning};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum UserThreshold {
@@ -68,6 +69,13 @@ impl UserDiagnostics {
 
     pub(crate) fn info(self, message: impl Display) {
         self.emit(UserMessageKind::Info, message);
+    }
+
+    pub(crate) fn user_message(self, message: &UserWarning) {
+        match message.level() {
+            UserMessageLevel::Warn => self.warn(message),
+            UserMessageLevel::Info => self.info(message),
+        }
     }
 
     #[allow(dead_code)]

--- a/crates/moon/tests/test_cases/fmt_moon_pkg/mod.rs
+++ b/crates/moon/tests/test_cases/fmt_moon_pkg/mod.rs
@@ -24,7 +24,9 @@ fn test_fmt_moon_pkg_json_migration_dry_run() {
                 "--sort-input",
             ],
         ),
-        expect![""],
+        expect![[r#"
+            Warning: Migrating to moon.pkg in package 'test/fmt_moon_pkg/lib', deprecated moon.pkg.json is removed.
+        "#]],
     );
 
     let output = get_stdout(
@@ -111,7 +113,10 @@ fn test_fmt_moon_pkg_both_exist() {
                 "--sort-input",
             ],
         ),
-        expect![""],
+        expect![[r#"
+            Warning: Migrating to moon.pkg in package 'test/fmt_moon_pkg_both', deprecated moon.pkg.json is removed.
+            Warning: Both moon.pkg.json and moon.pkg exist in package 'test/fmt_moon_pkg_both/both', using the new format moon.pkg. Please remove the deprecated moon.pkg.json.
+        "#]],
     );
 
     let output = get_stdout(

--- a/crates/moon/tests/test_cases/fmt_moon_work/mod.rs
+++ b/crates/moon/tests/test_cases/fmt_moon_work/mod.rs
@@ -49,7 +49,9 @@ fn test_fmt_moon_work_json_migration_dry_run() {
                 "--sort-input",
             ],
         ),
-        expect![""],
+        expect![[r#"
+            Warning: Migrating to moon.work at workspace root '$ROOT', deprecated moon.work.json is removed.
+        "#]],
     );
 
     let output = get_stdout(

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -355,6 +355,19 @@ fn test_test_warns_when_test_target_is_never_realizable() {
 }
 
 #[test]
+fn test_check_skips_backend_mismatched_tests_as_info() {
+    let dir = TestDir::new("supported_targets_test_target_mismatch.in");
+
+    let stderr = get_stderr(&dir, ["check", "--target", "js", "--dry-run"]);
+    assert!(!stderr.contains("target is not realizable for this backend"));
+
+    let verbose_stderr = get_stderr(&dir, ["check", "--target", "js", "--dry-run", "-v"]);
+    assert!(verbose_stderr.contains("Skipping whitebox tests for package"));
+    assert!(verbose_stderr.contains("Skipping blackbox tests for package"));
+    assert!(verbose_stderr.contains("target is not realizable for this backend"));
+}
+
+#[test]
 fn test_missing_supported_targets_root_warns_when_dep_declares() {
     let dir = TestDir::new("supported_targets_missing_root_warning.in");
     let stderr = get_stderr(&dir, ["check", "--target", "js", "--dry-run"]);

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -138,10 +138,10 @@ impl<'a> BuildPlanConstructor<'a> {
                 .warned_missing_supported_targets
                 .insert(importer_target.package)
         {
-            warn!(
+            self.user_warnings.push(UserWarning::new(format!(
                 "Package `{}` does not declare `supported_targets`, but depends on `{}` which declares it. Consider declaring `supported_targets` explicitly",
                 importer_pkg.fqn, dependency_pkg.fqn
-            );
+            )));
         }
 
         let dependency_realizable = self

--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -56,7 +56,7 @@ use moonutil::{
     workspace::{canonical_workspace_module_dirs, read_workspace, read_workspace_file},
 };
 use relative_path::{PathExt, RelativePath};
-use tracing::{Level, instrument, warn};
+use tracing::{Level, instrument};
 use walkdir::WalkDir;
 
 use crate::{
@@ -460,11 +460,6 @@ fn discover_virtual_mbti(
         if has_new_mbti {
             Some(new_mbti)
         } else if has_old_mbti {
-            warn!(
-                "Using package name in MBTI file is deprecated. Please rename {} to {}",
-                old_mbti.display(),
-                MBTI_USER_WRITTEN
-            );
             Some(old_mbti)
         } else {
             return Err(DiscoverError::MissingVirtualMbtiFile(fqn.clone().into()));

--- a/crates/moonbuild-rupes-recta/src/fmt.rs
+++ b/crates/moonbuild-rupes-recta/src/fmt.rs
@@ -46,6 +46,7 @@ use crate::{
     discover::{DiscoveredLocalProject, DiscoveredPackage, discover_local_project},
     model::PackageId,
     resolve::ResolveError,
+    user_warning::UserWarning,
 };
 
 pub type FmtResolveOutput = DiscoveredLocalProject;
@@ -96,7 +97,7 @@ pub fn build_graph_for_fmt(
     target_dir: &Path,
     selected_packages: &[PackageId],
     project_manifest_path: Option<&Path>,
-) -> anyhow::Result<n2::graph::Graph> {
+) -> anyhow::Result<(n2::graph::Graph, Vec<UserWarning>)> {
     info!(
         "Building format graph for {} root modules",
         resolved.root_module_ids.len()
@@ -118,11 +119,19 @@ pub fn build_graph_for_fmt(
     debug!("Layout built for formatting");
 
     let mut graph = n2::graph::Graph::default();
+    let mut user_warnings = Vec::new();
     let mut package_count = 0;
     let selected_packages = (!selected_packages.is_empty())
         .then(|| selected_packages.iter().copied().collect::<HashSet<_>>());
     let has_workspace_manifest = selected_packages.is_none()
-        && format_workspace_node(&mut graph, cfg, &layout, source_dir, project_manifest_path)?;
+        && format_workspace_node(
+            &mut graph,
+            cfg,
+            &layout,
+            source_dir,
+            project_manifest_path,
+            &mut user_warnings,
+        )?;
 
     for &module_id in &resolved.root_module_ids {
         let Some(packages) = resolved.pkg_dirs.packages_for_module(module_id) else {
@@ -138,7 +147,7 @@ pub fn build_graph_for_fmt(
 
             let pkg = resolved.pkg_dirs.get_package(id);
             info!("Processing package {}", pkg.fqn);
-            build_for_package(&mut graph, cfg, &layout, pkg)?;
+            build_for_package(&mut graph, cfg, &layout, pkg, &mut user_warnings)?;
             package_count += 1;
         }
     }
@@ -147,7 +156,7 @@ pub fn build_graph_for_fmt(
         anyhow::bail!("No packages found in workspace to format");
     }
 
-    Ok(graph)
+    Ok((graph, user_warnings))
 }
 
 fn format_workspace_node(
@@ -156,6 +165,7 @@ fn format_workspace_node(
     layout: &LegacyLayout,
     source_dir: &Path,
     project_manifest_path: Option<&Path>,
+    user_warnings: &mut Vec<UserWarning>,
 ) -> anyhow::Result<bool> {
     let workspace_manifest_path = project_manifest_path
         .map(Path::to_path_buf)
@@ -178,14 +188,14 @@ fn format_workspace_node(
         Some(MOON_WORK) => {
             let moon_work_json = source_dir.join(MOON_WORK_JSON);
             if moon_work_json.exists() {
-                warn!(
+                user_warnings.push(UserWarning::new(format!(
                     "Both {} and {} exist at workspace root '{}', using the new format {}. Please remove the deprecated {}.",
                     MOON_WORK_JSON,
                     MOON_WORK,
                     source_dir.display(),
                     MOON_WORK,
                     MOON_WORK_JSON
-                );
+                )));
             }
             format_moon_work_dsl(graph, cfg, &workspace_manifest_path, &target_moon_work)?;
             Ok(true)
@@ -199,6 +209,7 @@ fn format_workspace_node(
                 &target_moon_work,
                 &moon_work,
                 source_dir,
+                user_warnings,
             )?;
             Ok(true)
         }
@@ -218,6 +229,7 @@ fn build_for_package(
     cfg: &FmtConfig,
     layout: &LegacyLayout,
     pkg: &DiscoveredPackage,
+    user_warnings: &mut Vec<UserWarning>,
 ) -> anyhow::Result<()> {
     let ignore_set = &pkg.raw.formatter.ignore;
     let prebuild_outputs = pkg
@@ -261,7 +273,7 @@ fn build_for_package(
     }
 
     // Always format moon.pkg when present; migration from moon.pkg.json is gated.
-    format_moon_pkg_node(graph, cfg, layout, pkg)?;
+    format_moon_pkg_node(graph, cfg, layout, pkg, user_warnings)?;
 
     Ok(())
 }
@@ -389,13 +401,14 @@ fn format_moon_work_json_migrate(
     target_moon_work: &std::path::Path,
     moon_work: &std::path::Path,
     source_dir: &Path,
+    user_warnings: &mut Vec<UserWarning>,
 ) -> anyhow::Result<()> {
-    warn!(
+    user_warnings.push(UserWarning::new(format!(
         "Migrating to {} at workspace root '{}', deprecated {} is removed.",
         MOON_WORK,
         source_dir.display(),
         MOON_WORK_JSON
-    );
+    )));
 
     if cfg.check_only || cfg.warn_only {
         let mut cmd = vec![
@@ -503,6 +516,7 @@ fn format_moon_pkg_node(
     cfg: &FmtConfig,
     layout: &LegacyLayout,
     pkg: &DiscoveredPackage,
+    user_warnings: &mut Vec<UserWarning>,
 ) -> anyhow::Result<()> {
     use moonutil::common::{MOON_PKG, MOON_PKG_JSON};
 
@@ -525,10 +539,10 @@ fn format_moon_pkg_node(
 
     if has_dsl && has_json {
         // Both files exist: prefer moon.pkg (new format), warn about duplicate
-        warn!(
+        user_warnings.push(UserWarning::new(format!(
             "Both {} and {} exist in package '{}', using the new format {}. Please remove the deprecated {}.",
             MOON_PKG_JSON, MOON_PKG, pkg.fqn, MOON_PKG, MOON_PKG_JSON
-        );
+        )));
         // Format moon.pkg (new format)
         format_moon_pkg_dsl(graph, cfg, &moon_pkg_dsl, &target_moon_pkg, pkg)
     } else if has_dsl {
@@ -543,6 +557,7 @@ fn format_moon_pkg_node(
             &target_moon_pkg,
             &moon_pkg_dsl,
             pkg,
+            user_warnings,
         )
     } else {
         debug!(
@@ -633,12 +648,13 @@ fn format_moon_pkg_json_migrate(
     target_moon_pkg: &std::path::Path,
     moon_pkg: &std::path::Path,
     pkg: &DiscoveredPackage,
+    user_warnings: &mut Vec<UserWarning>,
 ) -> anyhow::Result<()> {
     // Warn the user about migration and prompt to remove the old config
-    warn!(
+    user_warnings.push(UserWarning::new(format!(
         "Migrating to {} in package '{}', deprecated {} is removed.",
         MOON_PKG, pkg.fqn, MOON_PKG_JSON
-    );
+    )));
 
     if cfg.check_only || cfg.warn_only {
         // In check/warn mode, use format-and-diff to compare

--- a/crates/moonbuild-rupes-recta/src/intent.rs
+++ b/crates/moonbuild-rupes-recta/src/intent.rs
@@ -24,7 +24,6 @@
 //! node generation logic.
 
 use moonutil::{common::TargetBackend, mooncakes::ModuleId};
-use tracing::warn;
 
 use crate::{
     build_plan::InputDirective,
@@ -32,6 +31,7 @@ use crate::{
     discover::DiscoveredPackage,
     model::{BuildPlanNode, BuildTarget, PackageId, TargetKind},
     resolve::ResolveOutput,
+    user_warning::UserWarning,
 };
 
 /// A concise set of user actions that expand into concrete BuildPlanNode groups.
@@ -65,6 +65,7 @@ impl UserIntent {
         self,
         resolved: &ResolveOutput,
         out: &mut Vec<BuildPlanNode>,
+        user_messages: &mut Vec<UserWarning>,
         directive: &InputDirective,
         target_backend: TargetBackend,
     ) {
@@ -122,6 +123,7 @@ impl UserIntent {
                                 source_supports_backend,
                                 whitebox_target,
                                 target_backend,
+                                user_messages,
                             ) {
                                 out.push(BuildPlanNode::check(whitebox_target));
                             }
@@ -132,6 +134,7 @@ impl UserIntent {
                             source_supports_backend,
                             blackbox_target,
                             target_backend,
+                            user_messages,
                         ) {
                             out.push(BuildPlanNode::check(blackbox_target));
                         }
@@ -174,6 +177,7 @@ impl UserIntent {
                                 source_supports_backend,
                                 t,
                                 target_backend,
+                                user_messages,
                             )
                         {
                             continue;
@@ -235,12 +239,13 @@ fn should_skip_test_target(
     source_supports_backend: bool,
     target: BuildTarget,
     target_backend: TargetBackend,
+    user_messages: &mut Vec<UserWarning>,
 ) -> bool {
     if !source_supports_backend || target_realizes_backend(resolved, target, target_backend) {
         return false;
     }
 
-    warn_if_test_target_is_never_realizable(resolved, target);
+    warn_or_info_test_target_skip(resolved, target, target_backend, user_messages);
     true
 }
 
@@ -249,6 +254,13 @@ fn target_realizes_backend(
     target: BuildTarget,
     target_backend: TargetBackend,
 ) -> bool {
+    realizable_supported_backends(resolved, target).contains(&target_backend)
+}
+
+fn realizable_supported_backends(
+    resolved: &ResolveOutput,
+    target: BuildTarget,
+) -> &indexmap::IndexSet<TargetBackend> {
     resolved
         .pkg_rel
         .realizable_supported_targets
@@ -261,16 +273,15 @@ fn target_realizes_backend(
                 .get_package(target.package)
                 .effective_supported_targets,
         )
-        .contains(&target_backend)
 }
 
-fn warn_if_test_target_is_never_realizable(resolved: &ResolveOutput, target: BuildTarget) {
-    let Some(realizable) = resolved.pkg_rel.realizable_supported_targets.get(&target) else {
-        return;
-    };
-    if !realizable.is_empty() {
-        return;
-    }
+fn warn_or_info_test_target_skip(
+    resolved: &ResolveOutput,
+    target: BuildTarget,
+    target_backend: TargetBackend,
+    user_messages: &mut Vec<UserWarning>,
+) {
+    let realizable = realizable_supported_backends(resolved, target);
 
     let pkg = resolved.pkg_dirs.get_package(target.package);
     let test_kind = match target.kind {
@@ -278,8 +289,24 @@ fn warn_if_test_target_is_never_realizable(resolved: &ResolveOutput, target: Bui
         TargetKind::BlackboxTest => "blackbox",
         _ => return,
     };
-    warn!(
-        "Skipping {test_kind} tests for package `{}`: the test target is unrealizable on every backend because its dependency graph has no supported backend intersection",
-        pkg.fqn
-    );
+
+    if realizable.is_empty() {
+        user_messages.push(UserWarning::warn(format!(
+            "Skipping {test_kind} tests for package `{}`: the test target is unrealizable on every backend because its dependency graph has no supported backend intersection",
+            pkg.fqn
+        )));
+        return;
+    }
+
+    let mut supported_backends = realizable
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    supported_backends.sort();
+    user_messages.push(UserWarning::info(format!(
+        "Skipping {test_kind} tests for package `{}` on backend `{}`: target is not realizable for this backend. Realizable backends: [{}]",
+        pkg.fqn,
+        target_backend,
+        supported_backends.join(", ")
+    )));
 }

--- a/crates/moonbuild-rupes-recta/src/lib.rs
+++ b/crates/moonbuild-rupes-recta/src/lib.rs
@@ -127,4 +127,4 @@ pub mod util;
 // Reexports
 pub use compile::{CompileConfig, CompileOutput, compile};
 pub use resolve::{ResolveConfig, ResolveOutput, resolve};
-pub use user_warning::UserWarning;
+pub use user_warning::{UserMessageLevel, UserWarning};

--- a/crates/moonbuild-rupes-recta/src/pkg_solve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/pkg_solve/mod.rs
@@ -41,13 +41,15 @@ pub fn solve(
     modules: &ResolvedEnv,
     packages: &DiscoverResult,
     enable_coverage: bool,
-) -> Result<(DepRelationship, Vec<UserWarning>), SolveError> {
+    user_warnings: &mut Vec<UserWarning>,
+) -> Result<DepRelationship, SolveError> {
     info!("Starting dependency resolution");
 
-    let (mut res, user_warnings) = solve_only(modules, packages, enable_coverage)?;
-    verify(&res, packages)?;
+    let (mut res, mut solve_warnings) = solve_only(modules, packages, enable_coverage)?;
+    user_warnings.append(&mut solve_warnings);
+    verify(&res, packages, user_warnings)?;
     res.realizable_supported_targets = compute_realizable_supported_targets(&res, packages);
 
     info!("Dependency resolution completed successfully");
-    Ok((res, user_warnings))
+    Ok(res)
 }

--- a/crates/moonbuild-rupes-recta/src/pkg_solve/verify.rs
+++ b/crates/moonbuild-rupes-recta/src/pkg_solve/verify.rs
@@ -32,6 +32,7 @@ use crate::{
         DepEdge,
         model::{DepRelationship, ImportLoop, SolveError},
     },
+    user_warning::UserWarning,
 };
 
 use super::model::MultipleError;
@@ -41,7 +42,11 @@ use super::model::MultipleError;
 /// This function checks the following:
 /// - No loops (except test imports, which don't currently have a workaround)
 /// - Aliases are unique within one package
-pub(super) fn verify(dep: &DepRelationship, packages: &DiscoverResult) -> Result<(), SolveError> {
+pub(super) fn verify(
+    dep: &DepRelationship,
+    packages: &DiscoverResult,
+    user_warnings: &mut Vec<UserWarning>,
+) -> Result<(), SolveError> {
     debug!("Verifying package dependency graph integrity");
 
     let mut errs = vec![];
@@ -55,7 +60,7 @@ pub(super) fn verify(dep: &DepRelationship, packages: &DiscoverResult) -> Result
     debug!("Done uniqueness verification");
     verify_no_forbidden_internal_imports(dep, packages, &mut errs);
     debug!("Done internal import verification");
-    warn_main_package_dependencies(dep, packages);
+    warn_main_package_dependencies(dep, packages, user_warnings);
     debug!("Done main package deprecation warnings");
 
     debug!("Package dependency graph verification completed successfully");
@@ -259,7 +264,11 @@ fn verify_no_forbidden_internal_imports(
     }
 }
 
-fn warn_main_package_dependencies(dep: &DepRelationship, packages: &DiscoverResult) {
+fn warn_main_package_dependencies(
+    dep: &DepRelationship,
+    packages: &DiscoverResult,
+    user_warnings: &mut Vec<UserWarning>,
+) {
     let mut seen: HashSet<(PackageId, PackageId, TargetKind)> = HashSet::new();
 
     for node in dep.dep_graph.node_identifiers() {
@@ -295,7 +304,7 @@ fn warn_main_package_dependencies(dep: &DepRelationship, packages: &DiscoverResu
                 _ => unreachable!("only package import fields should reach this warning"),
             };
 
-            tracing::warn!(
+            user_warnings.push(UserWarning::new(format!(
                 "Package `{}` depends on main package `{}` via `{}` in package directory \"{}\". \
 This dependency will become an error in a future release. \
 Move reusable APIs into a non-main package and keep main packages as entrypoints.",
@@ -303,7 +312,7 @@ Move reusable APIs into a non-main package and keep main packages as entrypoints
                 dependency_pkg.fqn,
                 import_field,
                 importer_pkg.root_path.display(),
-            );
+            )));
         }
     }
 }

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -33,7 +33,9 @@ use std::str::FromStr;
 
 use mooncake::pkg::sync::{auto_sync, auto_sync_for_single_file_rr};
 use moonutil::{
-    common::{MOONBITLANG_CORE, MbtMdHeader, TargetBackend, parse_front_matter_config},
+    common::{
+        MBTI_USER_WRITTEN, MOONBITLANG_CORE, MbtMdHeader, TargetBackend, parse_front_matter_config,
+    },
     dependency::{SourceDependencyInfo, SourceDependencyInfoJson},
     mooncakes::{DirSyncResult, ModuleId, result::ResolvedEnv, sync::AutoSyncFlags},
     package::{Import, PkgJSONImport, pkg_json_imports_to_imports},
@@ -125,6 +127,23 @@ fn extract_front_matter_config(header: Option<&MbtMdHeader>) -> anyhow::Result<F
     }
 
     Ok(config)
+}
+
+fn collect_virtual_mbti_deprecation_warnings(packages: &DiscoverResult) -> Vec<UserWarning> {
+    packages
+        .all_packages(false)
+        .filter_map(|(_pkg_id, pkg)| {
+            let virtual_mbti = pkg.virtual_mbti.as_ref()?;
+            if virtual_mbti.file_name().and_then(|name| name.to_str()) == Some(MBTI_USER_WRITTEN) {
+                return None;
+            }
+            Some(UserWarning::new(format!(
+                "Using package name in MBTI file is deprecated. Please rename {} to {}",
+                virtual_mbti.display(),
+                MBTI_USER_WRITTEN
+            )))
+        })
+        .collect()
 }
 
 fn parse_front_matter_imports(
@@ -288,10 +307,23 @@ pub enum ResolveError {
     DiscoverError(#[from] DiscoverError),
 
     #[error("Failed to solve package relationship")]
-    SolveError(#[from] pkg_solve::SolveError),
+    SolveError {
+        #[source]
+        source: Box<pkg_solve::SolveError>,
+        user_warnings: Vec<UserWarning>,
+    },
 
     #[error("Failed to parse single file front matter configuration")]
     SingleFileParseError(#[source] anyhow::Error),
+}
+
+impl ResolveError {
+    pub fn user_warnings(&self) -> &[UserWarning] {
+        match self {
+            ResolveError::SolveError { user_warnings, .. } => user_warnings,
+            _ => &[],
+        }
+    }
 }
 
 /// Performs the resolving process from a raw working directory, until all of
@@ -331,8 +363,21 @@ pub fn resolve(cfg: &ResolveConfig, source_dir: &Path) -> Result<ResolveOutput, 
         discover_result.package_count()
     );
 
-    let (dep_relationship, user_warnings) =
-        pkg_solve::solve(&resolved_env, &discover_result, cfg.enable_coverage)?;
+    let mut user_warnings = collect_virtual_mbti_deprecation_warnings(&discover_result);
+    let dep_relationship = match pkg_solve::solve(
+        &resolved_env,
+        &discover_result,
+        cfg.enable_coverage,
+        &mut user_warnings,
+    ) {
+        Ok(ok) => ok,
+        Err(source) => {
+            return Err(ResolveError::SolveError {
+                source: Box::new(source),
+                user_warnings,
+            });
+        }
+    };
 
     info!("Package dependency resolution completed successfully");
     debug!(
@@ -419,6 +464,7 @@ Use moonbit.import with 'username/module@version[/package]' entries to opt in to
 
     // Discover all packages in resolved modules
     let mut discover_result = discover_packages(&resolved_env, &dir_sync_result)?;
+    user_warnings.extend(collect_virtual_mbti_deprecation_warnings(&discover_result));
 
     // Synthesize the single-file package that imports everything from discovered modules
     crate::discover::synth::build_synth_single_file_package(
@@ -430,9 +476,20 @@ Use moonbit.import with 'username/module@version[/package]' entries to opt in to
     )?;
 
     // Solve package dependency relationship
-    let (dep_relationship, mut solve_warnings) =
-        pkg_solve::solve(&resolved_env, &discover_result, cfg.enable_coverage)?;
-    user_warnings.append(&mut solve_warnings);
+    let dep_relationship = match pkg_solve::solve(
+        &resolved_env,
+        &discover_result,
+        cfg.enable_coverage,
+        &mut user_warnings,
+    ) {
+        Ok(ok) => ok,
+        Err(source) => {
+            return Err(ResolveError::SolveError {
+                source: Box::new(source),
+                user_warnings,
+            });
+        }
+    };
 
     let res = ResolveOutput {
         module_rel: resolved_env,

--- a/crates/moonbuild-rupes-recta/src/user_warning.rs
+++ b/crates/moonbuild-rupes-recta/src/user_warning.rs
@@ -16,19 +16,4 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::fmt::{self, Display, Formatter};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UserWarning(String);
-
-impl UserWarning {
-    pub fn new(message: impl Into<String>) -> Self {
-        Self(message.into())
-    }
-}
-
-impl Display for UserWarning {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
+pub use moonutil::user_warning::{UserMessageLevel, UserWarning};

--- a/crates/moonutil/src/lib.rs
+++ b/crates/moonutil/src/lib.rs
@@ -42,6 +42,7 @@ pub mod platform;
 pub mod render;
 pub mod shlex;
 pub mod supported_targets;
+pub mod user_warning;
 pub mod version;
 pub mod workspace;
 

--- a/crates/moonutil/src/user_warning.rs
+++ b/crates/moonutil/src/user_warning.rs
@@ -1,0 +1,61 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserMessageLevel {
+    Warn,
+    Info,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserWarning {
+    level: UserMessageLevel,
+    message: String,
+}
+
+impl UserWarning {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self::warn(message)
+    }
+
+    pub fn warn(message: impl Into<String>) -> Self {
+        Self {
+            level: UserMessageLevel::Warn,
+            message: message.into(),
+        }
+    }
+
+    pub fn info(message: impl Into<String>) -> Self {
+        Self {
+            level: UserMessageLevel::Info,
+            message: message.into(),
+        }
+    }
+
+    pub fn level(&self) -> UserMessageLevel {
+        self.level
+    }
+}
+
+impl Display for UserWarning {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a shared user-facing diagnostics payload in `moonutil`:
  - `UserWarning`
  - `UserMessageLevel::{Warn, Info}`
- route RR user-facing messages through this payload instead of ad-hoc `tracing::warn!` / `eprintln!` in core planning paths (`resolve`, `pkg_solve`, `intent`, `fmt`, and build-plan warnings).
- centralize CLI emission with `UserDiagnostics`:
  - default threshold: show `Warning`/`Error`
  - `--verbose`: also show `Info`
  - `--quiet`: suppress `Info` but keep `Warning`/`Error`
- keep formatter migration messaging in formatter command/tool paths where that flow does not go through RR build execution.
- fix a correctness gap where resolve-time user warnings could be lost if `verify` failed:
  - `pkg_solve::solve` now appends warnings into caller-owned storage before returning verify errors.
  - `ResolveError::SolveError` carries accumulated `user_warnings`.
  - `main` emits carried warnings from the error chain before printing the final error.

## Why
- separate user-facing UX diagnostics from developer logging/tracing.
- make warning/info behavior consistent across commands.
- ensure actionable warnings are not dropped on failing resolve paths.

## Validation
- `cargo fmt --all`
- `cargo check -p moonutil -p moonbuild-rupes-recta -p moon`
- `cargo test -p moonbuild-rupes-recta resolve::tests -- --nocapture`
- `cargo test -p moon test_cases::test_validate_import -- --nocapture`
- `cargo test -p moon test_cases::virtual_pkg::test_virtual_pkg_err -- --nocapture`
