### PR TITLE
test: bump snapshots for indirect_dep and source location reports

### DIFF
--- a/crates/moon/tests/test_cases/indirect_dep/build_all_pkgs.json
+++ b/crates/moon/tests/test_cases/indirect_dep/build_all_pkgs.json
@@ -212,6 +212,11 @@
     },
     {
       "root": "moonbitlang/core",
+      "rel": "internal/strconv",
+      "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/internal/strconv/strconv.mi"
+    },
+    {
+      "root": "moonbitlang/core",
       "rel": "json",
       "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/json/json.mi"
     },

--- a/crates/moon/tests/test_cases/indirect_dep/bundle_all_pkgs.json
+++ b/crates/moon/tests/test_cases/indirect_dep/bundle_all_pkgs.json
@@ -212,6 +212,11 @@
     },
     {
       "root": "moonbitlang/core",
+      "rel": "internal/strconv",
+      "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/internal/strconv/strconv.mi"
+    },
+    {
+      "root": "moonbitlang/core",
       "rel": "json",
       "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/json/json.mi"
     },

--- a/crates/moon/tests/test_cases/indirect_dep/check_all_pkgs.json
+++ b/crates/moon/tests/test_cases/indirect_dep/check_all_pkgs.json
@@ -212,6 +212,11 @@
     },
     {
       "root": "moonbitlang/core",
+      "rel": "internal/strconv",
+      "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/internal/strconv/strconv.mi"
+    },
+    {
+      "root": "moonbitlang/core",
       "rel": "json",
       "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/json/json.mi"
     },

--- a/crates/moon/tests/test_cases/indirect_dep/info_all_pkgs.json
+++ b/crates/moon/tests/test_cases/indirect_dep/info_all_pkgs.json
@@ -212,6 +212,11 @@
     },
     {
       "root": "moonbitlang/core",
+      "rel": "internal/strconv",
+      "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/internal/strconv/strconv.mi"
+    },
+    {
+      "root": "moonbitlang/core",
       "rel": "json",
       "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/json/json.mi"
     },

--- a/crates/moon/tests/test_cases/indirect_dep/run_all_pkgs.json
+++ b/crates/moon/tests/test_cases/indirect_dep/run_all_pkgs.json
@@ -212,6 +212,11 @@
     },
     {
       "root": "moonbitlang/core",
+      "rel": "internal/strconv",
+      "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/internal/strconv/strconv.mi"
+    },
+    {
+      "root": "moonbitlang/core",
       "rel": "json",
       "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/json/json.mi"
     },

--- a/crates/moon/tests/test_cases/indirect_dep/test_all_pkgs.json
+++ b/crates/moon/tests/test_cases/indirect_dep/test_all_pkgs.json
@@ -212,6 +212,11 @@
     },
     {
       "root": "moonbitlang/core",
+      "rel": "internal/strconv",
+      "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/internal/strconv/strconv.mi"
+    },
+    {
+      "root": "moonbitlang/core",
       "rel": "json",
       "artifact": "$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/json/json.mi"
     },

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -1068,7 +1068,7 @@ fn moon_test_with_failure_json() {
         &output,
         // should keep in this format, it's used in ide test explorer
         expect![[r#"
-            {"package":"username/hello/lib1","filename":"hello.mbt","index":"0","test_name":"test_1","message":"lib1/hello.mbt:7:3-7:24@username/hello FAILED: test_1 failed"}
+            {"package":"username/hello/lib1","filename":"hello.mbt","index":"0","test_name":"test_1","message":"src/lib1/hello.mbt:7:3-7:24@username/hello FAILED: test_1 failed"}
             Total tests: 2, passed: 1, failed: 1.
         "#]],
     );

--- a/crates/moon/tests/test_cases/run_doc_test/mod.rs
+++ b/crates/moon/tests/test_cases/run_doc_test/mod.rs
@@ -28,7 +28,7 @@ fn test_run_doc_test() {
             +1256
             ----
 
-            [username/hello] test lib/hello.mbt:19 (#2) failed: lib_blackbox_test/hello.mbt:22:5-22:30@username/hello FAILED: this is a failure
+            [username/hello] test lib/hello.mbt:19 (#2) failed: src/lib/hello.mbt:22:5-22:30@username/hello FAILED: this is a failure
             [username/hello] test lib/greet.mbt:18 (#2) failed
             expect test failed at $ROOT/src/lib/greet.mbt:23:7-23:20
             Diff: (- expected, + actual)
@@ -36,7 +36,7 @@ fn test_run_doc_test() {
             +1256
             ----
 
-            [username/hello] test lib/greet.mbt:30 (#3) failed: lib_blackbox_test/greet.mbt:34:7-34:30@username/hello FAILED: another failure
+            [username/hello] test lib/greet.mbt:30 (#3) failed: src/lib/greet.mbt:34:7-34:30@username/hello FAILED: another failure
             [username/hello] test lib/greet.mbt:95 (#8) failed
             expect test failed at $ROOT/src/lib/greet.mbt:99:5-99:40
             Diff: (- expected, + actual)
@@ -90,8 +90,8 @@ fn test_run_doc_test() {
             test block 4
             test block 5
             doc_test 5 from greet.mbt
-            [username/hello] test lib/hello.mbt:21 (#2) failed: lib_blackbox_test/hello.mbt:24:5-24:30@username/hello FAILED: this is a failure
-            [username/hello] test lib/greet.mbt:32 (#3) failed: lib_blackbox_test/greet.mbt:36:7-36:30@username/hello FAILED: another failure
+            [username/hello] test lib/hello.mbt:21 (#2) failed: src/lib/hello.mbt:24:5-24:30@username/hello FAILED: this is a failure
+            [username/hello] test lib/greet.mbt:32 (#3) failed: src/lib/greet.mbt:36:7-36:30@username/hello FAILED: another failure
             Total tests: 16, passed: 14, failed: 2.
         "#]],
     );


### PR DESCRIPTION
## Summary
- bump snapshots for:
  - `test_cases::indirect_dep::test_all_pkgs`
  - `test_cases::indirect_dep::test_indirect_dep_bundle`
  - `test_cases::moon_test_with_failure_json`
  - `test_cases::run_doc_test::test_run_doc_test`
- update failure location strings to report `src/...` paths instead of `lib_blackbox_test/...` / `lib1/...`
- refresh `indirect_dep/*_all_pkgs.json` snapshots

## Verification
I checked whether the updates are only source-location changes:
- `moon_test_with_failure_json` and `run_doc_test` are source-location/reporting path changes (`lib_blackbox_test/...` or `lib1/...` -> `src/...`).
- `indirect_dep` snapshots include one additional dependency entry, `moonbitlang/core/internal/strconv`, in all `*_all_pkgs.json` snapshots, so those are not only location changes.

## Test Commands
- `UPDATE_EXPECT=1 cargo test -p moon test_cases::indirect_dep::test_all_pkgs -- --exact`
- `UPDATE_EXPECT=1 cargo test -p moon test_cases::indirect_dep::test_indirect_dep_bundle -- --exact`
- `UPDATE_EXPECT=1 cargo test -p moon test_cases::moon_test_with_failure_json -- --exact`
- `UPDATE_EXPECT=1 cargo test -p moon test_cases::run_doc_test::test_run_doc_test -- --exact`
- `cargo test -p moon test_cases::indirect_dep::test_all_pkgs -- --exact`
- `cargo test -p moon test_cases::indirect_dep::test_indirect_dep_bundle -- --exact`
- `cargo test -p moon test_cases::moon_test_with_failure_json -- --exact`
- `cargo test -p moon test_cases::run_doc_test::test_run_doc_test -- --exact`
