### PR TITLE
[codex] fix install diagnostics rendering

### DIFF
--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -579,7 +579,16 @@ fn build_and_install_packages(
         let _lock = FileLock::lock(&target_dir)?;
         rr_build::generate_all_pkgs_json(&target_dir, &build_meta, RunMode::Build)?;
 
-        let result = rr_build::execute_build(&BuildConfig::default(), build_graph, &target_dir)?;
+        let result = rr_build::execute_build(
+            &BuildConfig::from_flags(
+                &build_flags,
+                &cli.unstable_feature,
+                cli.verbose,
+                UserDiagnostics::from_flags(cli),
+            ),
+            build_graph,
+            &target_dir,
+        )?;
         if !result.successful() {
             result.print_info(quiet, "building").ok();
             output.error(format!("Failed to build `{}`", pkg.full_pkg_name));

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -139,13 +139,14 @@ pub(crate) fn run_build_binary_dep(
         let package = &*resolve_output.pkg_dirs.get_package(pkg).raw;
         let bin_name = package.bin_name.as_deref();
 
+        let build_flags = BuildFlags {
+            release: true,
+            ..BuildFlags::default()
+        };
         let preconfig = preconfig_compile(
             &AutoSyncFlags { frozen: false },
             cli,
-            &BuildFlags {
-                release: true,
-                ..BuildFlags::default()
-            },
+            &build_flags,
             Some(target),
             &target_dir,
             RunMode::Build,
@@ -165,7 +166,16 @@ pub(crate) fn run_build_binary_dep(
         // Generate all_pkgs.json for indirect dependency resolution
         rr_build::generate_all_pkgs_json(&target_dir, &build_meta, RunMode::Build)?;
 
-        let result = rr_build::execute_build(&BuildConfig::default(), build_graph, &target_dir)?;
+        let result = rr_build::execute_build(
+            &BuildConfig::from_flags(
+                &build_flags,
+                &cli.unstable_feature,
+                cli.verbose,
+                UserDiagnostics::from_flags(cli),
+            ),
+            build_graph,
+            &target_dir,
+        )?;
         result.print_info(cli.quiet, "building")?;
 
         install_build_rr(&build_meta, &cmd.install_path, bin_name)?;

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -3230,6 +3230,41 @@ fn test_moon_install_global_local_path() {
 }
 
 #[test]
+fn test_moon_install_global_local_path_renders_build_errors() {
+    let dir = TestDir::new("moon_install_global_error.in");
+    let install_dir = dir.join("test_bin");
+    std::fs::create_dir_all(&install_dir).unwrap();
+
+    let stderr = get_err_stderr(
+        &dir,
+        [
+            "install",
+            "--path",
+            "src/main",
+            "--bin",
+            install_dir.to_str().unwrap(),
+        ],
+    );
+
+    assert!(
+        stderr.contains("Error: ["),
+        "Expected rendered diagnostic in stderr, got: {stderr}",
+    );
+    assert!(
+        stderr.contains("$ROOT/src/main/main.mbt"),
+        "Expected source location in stderr, got: {stderr}",
+    );
+    assert!(
+        stderr.contains("Expr Type Mismatch"),
+        "Expected compile error message in stderr, got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("\"$message_type\":\"diagnostic\""),
+        "Expected rendered diagnostics instead of raw JSON, got: {stderr}",
+    );
+}
+
+#[test]
 fn test_moon_install_global_defaults_to_moon_home_bin() {
     let dir = TestDir::new("moon_install_global.in");
     let moon_home = tempfile::tempdir().unwrap();

--- a/crates/moon/tests/test_cases/moon_install_global_error.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/moon_install_global_error.in/moon.mod.json
@@ -1,0 +1,5 @@
+{
+  "name": "test/install_global_error",
+  "version": "0.1.0",
+  "source": "src"
+}

--- a/crates/moon/tests/test_cases/moon_install_global_error.in/src/main/main.mbt
+++ b/crates/moon/tests/test_cases/moon_install_global_error.in/src/main/main.mbt
@@ -1,0 +1,4 @@
+fn main {
+  let message: String = 1
+  println(message)
+}

--- a/crates/moon/tests/test_cases/moon_install_global_error.in/src/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/moon_install_global_error.in/src/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}


### PR DESCRIPTION
## Summary

Fix `moon install` so compiler failures are rendered as user-facing diagnostics instead of dumping raw diagnostic JSON.

## What Changed

- switched the `moon install` build execution path to use `BuildConfig::from_flags(...)` instead of `BuildConfig::default()`
- applied the same diagnostic configuration fix to `moon tool build-binary-dep`
- added a regression test and a minimal failing fixture covering a local install that hits a compile error

## Why

The install flow already configured `moonc` to emit JSON diagnostics for rendered output, but the actual build execution still used the default raw build config. That mismatch caused the executor to print the JSON lines directly instead of rendering them.

## Impact

Users installing a package with build errors now see normal rendered compiler diagnostics, including source locations and messages, rather than raw JSON payloads.

## Validation

- `cargo test -p moon test_moon_install_global_local_path_renders_build_errors -- --nocapture`
- `cargo test -p moon test_cases::test_moon_install_global_local_path -- --exact --nocapture`