### PR TITLE
generate debug info when using MSVC

### DIFF
--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -831,8 +831,12 @@ fn add_cc_intermediate_dir_flags(
 }
 
 fn add_cc_debug_flags(cc: &CC, buf: &mut Vec<String>, config: &CCConfig) {
-    if config.debug_info && cc.is_gcc_like() {
-        buf.push("-g".to_string());
+    if config.debug_info {
+        if cc.is_gcc_like() {
+            buf.push("-g".to_string());
+        } else if cc.is_msvc() {
+            buf.push("/Z7".to_string());
+        }
     }
 }
 


### PR DESCRIPTION
Currently, when using MSVC on native backend, no debug symbol is ever generated, making stack trace etc. unreadable. This PR pass the `/Z7` flag to MSVC when debug symbol is desirable (i.e. debug mode or `--no-strip` is passed), which cause MSVC to emit debug symbol directly in the resulting executable file. Local test reveal that with this PR, stack trace now work out of the box on Windows for native backend.