### PR TITLE
Use kqueue on macOS watch mode with poll fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ expect-test = "1.5.0"
 snapbox = "0.6.23"
 futures = { version = "0.3.29", features = ["std"], default-features = false }
 indexmap = { version = "2.2.6", features = ["serde"] }
-notify = "6.1.1"
 reqwest = { version = "0.12.24", default-features = false, features = [
     "multipart",
     "blocking",

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -61,7 +61,6 @@ derive_builder.workspace = true
 sha2.workspace = true
 similar.workspace = true
 
-notify.workspace = true
 ignore.workspace = true
 
 tracing.workspace = true
@@ -77,6 +76,12 @@ features = [
     "Win32_System_Threading",
 ]
 version = "0.59.0"
+
+[target."cfg(not(target_os = \"macos\"))".dependencies]
+notify = "6.1.1"
+
+[target."cfg(target_os = \"macos\")".dependencies]
+notify = { version = "6.1.1", default-features = false, features = ["crossbeam-channel", "macos_kqueue"] }
 
 [target."cfg(windows)".dependencies]
 junction = "1"

--- a/crates/moon/src/watch/mod.rs
+++ b/crates/moon/src/watch/mod.rs
@@ -22,6 +22,8 @@ pub(crate) mod prebuild_output;
 use anyhow::Context;
 use colored::*;
 use moonutil::common::is_watch_relevant_project_file;
+#[cfg(target_os = "macos")]
+use notify::PollWatcher;
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
 use std::collections::HashSet;
@@ -48,6 +50,39 @@ struct AdditionalWatchPaths {
     watched_paths: HashSet<PathBuf>,
 }
 
+type WatchEventSender = std::sync::mpsc::Sender<notify::Result<notify::Event>>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WatchBackend {
+    #[cfg(target_os = "macos")]
+    Kqueue,
+    #[cfg(target_os = "macos")]
+    Poll,
+    #[cfg(not(target_os = "macos"))]
+    Recommended,
+}
+
+impl WatchBackend {
+    fn label(self) -> &'static str {
+        match self {
+            #[cfg(target_os = "macos")]
+            WatchBackend::Kqueue => "kqueue",
+            #[cfg(target_os = "macos")]
+            WatchBackend::Poll => "poll",
+            #[cfg(not(target_os = "macos"))]
+            WatchBackend::Recommended => "recommended",
+        }
+    }
+}
+
+struct ActiveWatcher {
+    backend: WatchBackend,
+    _watcher: Box<dyn Watcher>,
+}
+
+#[cfg(target_os = "macos")]
+const POLL_WATCHER_INTERVAL: Duration = Duration::from_secs(1);
+
 /// Run a watcher that watches on `watch_dir`, and calls `run` when a file
 /// changes. The watcher ignores changes in `original_target_dir`, and will
 /// repopulate `target_dir` if it is deleted.
@@ -67,9 +102,6 @@ pub(crate) fn watching(
 
     // Setup watcher
     let (tx, rx) = std::sync::mpsc::channel();
-    debug!("Creating file watcher with default config");
-    let mut watcher = RecommendedWatcher::new(tx, Config::default())
-        .context("Failed to create a directory watcher")?;
 
     // Setup Ctrl-C handler
     {
@@ -93,16 +125,14 @@ pub(crate) fn watching(
             "Starting to watch directory '{}' recursively",
             watch_dir.display()
         );
-        watcher
-            .watch(watch_dir, RecursiveMode::Recursive)
-            .with_context(|| format!("Failed to watch directory: '{}'", watch_dir.display()))?;
+        let mut watcher = create_active_watcher(tx.clone(), watch_dir)?;
 
         // in watch mode, moon is a long-running process that should handle errors as much as possible rather than throwing them up and then exiting.
         const DEBOUNCE_TIME: Duration = Duration::from_millis(300);
         debug!("Watcher loop started (debounce = {:?})", DEBOUNCE_TIME);
         while let Ok(res) = rx.recv() {
             let Ok(evt) = res else {
-                warn!(?res, "Watcher event channel returned an error");
+                handle_watcher_error(&mut watcher, tx.clone(), watch_dir, res.unwrap_err());
                 continue;
             };
 
@@ -110,9 +140,11 @@ pub(crate) fn watching(
             let mut evt_list = vec![evt];
             let start = std::time::Instant::now();
             while start.elapsed() < DEBOUNCE_TIME {
-                if let Ok(Ok(evt)) = rx.recv_timeout(DEBOUNCE_TIME.saturating_sub(start.elapsed()))
-                {
-                    evt_list.push(evt);
+                match rx.recv_timeout(DEBOUNCE_TIME.saturating_sub(start.elapsed())) {
+                    Ok(Ok(evt)) => evt_list.push(evt),
+                    Ok(Err(err)) => handle_watcher_error(&mut watcher, tx.clone(), watch_dir, err),
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
                 }
             }
 
@@ -141,9 +173,192 @@ pub(crate) fn watching(
     Ok(0)
 }
 
+fn create_active_watcher(
+    event_tx: WatchEventSender,
+    watch_dir: &Path,
+) -> anyhow::Result<ActiveWatcher> {
+    #[cfg(target_os = "macos")]
+    {
+        let kqueue_tx = event_tx.clone();
+        let poll_tx = event_tx.clone();
+        let (watcher, backend_label) = try_with_fallback(
+            WatchBackend::Kqueue.label(),
+            || create_kqueue_watcher(kqueue_tx, watch_dir),
+            WatchBackend::Poll.label(),
+            || create_poll_watcher(poll_tx, watch_dir),
+        )?;
+        info!(backend = backend_label, "Using file watcher backend");
+        return Ok(watcher);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let watcher = create_recommended_watcher(event_tx, watch_dir)?;
+        info!(
+            backend = watcher.backend.label(),
+            "Using file watcher backend"
+        );
+        Ok(watcher)
+    }
+}
+
+fn start_watcher<W>(
+    backend: WatchBackend,
+    event_tx: WatchEventSender,
+    config: Config,
+    watch_dir: &Path,
+) -> anyhow::Result<ActiveWatcher>
+where
+    W: Watcher + 'static,
+{
+    debug!(backend = backend.label(), "Creating file watcher");
+    let mut watcher = W::new(event_tx, config)
+        .with_context(|| format!("Failed to create {} file watcher", backend.label()))?;
+    watcher
+        .watch(watch_dir, RecursiveMode::Recursive)
+        .with_context(|| {
+            format!(
+                "Failed to watch directory '{}' with {} watcher",
+                watch_dir.display(),
+                backend.label()
+            )
+        })?;
+
+    Ok(ActiveWatcher {
+        backend,
+        _watcher: Box::new(watcher),
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn create_recommended_watcher(
+    event_tx: WatchEventSender,
+    watch_dir: &Path,
+) -> anyhow::Result<ActiveWatcher> {
+    start_watcher::<RecommendedWatcher>(
+        WatchBackend::Recommended,
+        event_tx,
+        Config::default(),
+        watch_dir,
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn create_kqueue_watcher(
+    event_tx: WatchEventSender,
+    watch_dir: &Path,
+) -> anyhow::Result<ActiveWatcher> {
+    start_watcher::<RecommendedWatcher>(
+        WatchBackend::Kqueue,
+        event_tx,
+        Config::default(),
+        watch_dir,
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn create_poll_watcher(
+    event_tx: WatchEventSender,
+    watch_dir: &Path,
+) -> anyhow::Result<ActiveWatcher> {
+    start_watcher::<PollWatcher>(
+        WatchBackend::Poll,
+        event_tx,
+        Config::default().with_poll_interval(POLL_WATCHER_INTERVAL),
+        watch_dir,
+    )
+}
+
+fn try_with_fallback<T>(
+    primary_label: &'static str,
+    primary: impl FnOnce() -> anyhow::Result<T>,
+    fallback_label: &'static str,
+    fallback: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<(T, &'static str)> {
+    match primary() {
+        Ok(value) => Ok((value, primary_label)),
+        Err(primary_error) => {
+            warn!(
+                backend = primary_label,
+                fallback_backend = fallback_label,
+                error = ?primary_error,
+                "Primary file watcher backend failed; trying fallback",
+            );
+            match fallback() {
+                Ok(value) => Ok((value, fallback_label)),
+                Err(fallback_error) => Err(anyhow::anyhow!(
+                    "Failed to initialize {} watcher: {:#}\nFallback {} watcher also failed: {:#}",
+                    primary_label,
+                    primary_error,
+                    fallback_label,
+                    fallback_error
+                )),
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn handle_watcher_error(
+    watcher: &mut ActiveWatcher,
+    event_tx: WatchEventSender,
+    watch_dir: &Path,
+    error: notify::Error,
+) {
+    if watcher.backend != WatchBackend::Kqueue {
+        warn!(
+            backend = watcher.backend.label(),
+            error = ?error,
+            "Watcher event channel returned an error",
+        );
+        return;
+    }
+
+    warn!(
+        backend = watcher.backend.label(),
+        fallback_backend = WatchBackend::Poll.label(),
+        error = ?error,
+        "Watcher backend reported an error; switching to polling fallback",
+    );
+
+    match create_poll_watcher(event_tx, watch_dir) {
+        Ok(poll_watcher) => {
+            *watcher = poll_watcher;
+            warn!(
+                backend = watcher.backend.label(),
+                poll_interval_ms = POLL_WATCHER_INTERVAL.as_millis() as u64,
+                "Polling fallback enabled after watcher error",
+            );
+        }
+        Err(fallback_error) => {
+            warn!(
+                error = ?fallback_error,
+                "Polling fallback failed after watcher error",
+            );
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn handle_watcher_error(
+    watcher: &mut ActiveWatcher,
+    _event_tx: WatchEventSender,
+    _watch_dir: &Path,
+    error: notify::Error,
+) {
+    warn!(
+        backend = watcher.backend.label(),
+        error = ?error,
+        "Watcher event channel returned an error",
+    );
+}
+
 /// Check if the event kind is relevant for a rebuild/rerun.
 fn is_event_relevant(event: &notify::Event) -> bool {
     match event.kind {
+        EventKind::Modify(notify::event::ModifyKind::Metadata(
+            notify::event::MetadataKind::WriteTime,
+        )) if event.paths.iter().all(|path| path.is_file()) => (),
         EventKind::Modify(notify::event::ModifyKind::Metadata(_)) => {
             trace!("Ignoring metadata-only modify event: {:?}", event);
             return false;
@@ -347,12 +562,21 @@ fn run_and_print(run: impl FnOnce() -> anyhow::Result<WatchOutput>) -> Additiona
 mod tests {
     use super::*;
 
+    use anyhow::anyhow;
     use moonutil::common::{BUILD_DIR, MOON_WORK, MOON_WORK_JSON};
-    use notify::event::{CreateKind, Event, EventKind};
+    use notify::event::{CreateKind, Event, EventKind, MetadataKind, ModifyKind};
 
     fn build_event(path: &Path) -> notify::Event {
         Event {
             kind: EventKind::Create(CreateKind::File),
+            paths: vec![path.to_path_buf()],
+            attrs: Default::default(),
+        }
+    }
+
+    fn metadata_write_time_event(path: &Path) -> notify::Event {
+        Event {
+            kind: EventKind::Modify(ModifyKind::Metadata(MetadataKind::WriteTime)),
             paths: vec![path.to_path_buf()],
             attrs: Default::default(),
         }
@@ -685,5 +909,62 @@ mod tests {
 
         assert!(result);
         assert!(target_dir.exists());
+    }
+
+    #[test]
+    fn fallback_helper_prefers_primary_result() {
+        let (value, backend) =
+            try_with_fallback("primary", || Ok(7), "fallback", || Ok(9)).unwrap();
+
+        assert_eq!(value, 7);
+        assert_eq!(backend, "primary");
+    }
+
+    #[test]
+    fn fallback_helper_uses_fallback_after_primary_error() {
+        let (value, backend) = try_with_fallback(
+            "primary",
+            || Err(anyhow!("primary failed")),
+            "fallback",
+            || Ok(9),
+        )
+        .unwrap();
+
+        assert_eq!(value, 9);
+        assert_eq!(backend, "fallback");
+    }
+
+    #[test]
+    fn fallback_helper_reports_both_errors() {
+        let error = try_with_fallback::<i32>(
+            "primary",
+            || Err(anyhow!("primary failed")),
+            "fallback",
+            || Err(anyhow!("fallback failed")),
+        )
+        .unwrap_err();
+
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("primary failed"));
+        assert!(rendered.contains("fallback failed"));
+    }
+
+    #[test]
+    fn metadata_write_time_on_file_is_relevant() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file = temp_dir.path().join("src/main.mbt");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, "stuff").unwrap();
+
+        assert!(is_event_relevant(&metadata_write_time_event(&file)));
+    }
+
+    #[test]
+    fn metadata_write_time_on_directory_is_ignored() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dir = temp_dir.path().join("src");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        assert!(!is_event_relevant(&metadata_write_time_event(&dir)));
     }
 }


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

## Summary

On macOS, `moon build --watch` was using `notify`'s `RecommendedWatcher`, which resolves to `FSEvents` by default. On this machine that backend was silently missing normal `.mbt` edits, so watch mode could sit on "waiting for filesystem changes..." even when source files changed.

This PR changes `moon` to:

- use `notify` with `macos_kqueue` on macOS
- keep the default `notify` configuration on non-macOS targets
- fall back to `PollWatcher` if macOS `kqueue` fails during watcher setup
- fall back to `PollWatcher` if the active `kqueue` watcher later reports an error
- treat file `Modify(Metadata(WriteTime))` events as relevant so the polling fallback can actually trigger rebuilds

I also added unit coverage for the fallback helper and for the `Metadata(WriteTime)` event filtering.

## Background

This came from a real macOS failure where `moon build --watch` stayed alive but never saw `.mbt` edits. The behavior reproduced in a standalone `notify 6.1.1` probe:

- `FSEvents` missed edits in the watched tree
- forcing `kqueue` immediately delivered the same edits

After this change I re-validated both paths locally:

- normal macOS watch path: `kqueue` receives `client.mbt` changes and rebuilds
- forced failure path: lowering `ulimit -n` to `32` makes `kqueue` fail with `Too many open files`, Moon logs the fallback to `poll`, and a subsequent `client.mbt` edit triggers a rebuild via `Modify(Metadata(WriteTime))`

## Why Not FSEvents On macOS

The motivation here is not just theory; we reproduced a real failure locally with `notify`'s FSEvents backend. Related background and upstream discussions:

- Apple FSEvents overview: https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/FSEvents_ProgGuide/TechnologyOverview/TechnologyOverview.html
- Apple FSEvents security model: https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/FSEvents_ProgGuide/FileSystemEventSecurity/FileSystemEventSecurity.html
- `notify-rs` issue #387: https://github.com/notify-rs/notify/issues/387
- `notify-rs` issue #412: https://github.com/notify-rs/notify/issues/412
- `notify-rs` issue #465: https://github.com/notify-rs/notify/issues/465
- `notify-rs` issue #554: https://github.com/notify-rs/notify/issues/554
- `notify-rs` PR #733: https://github.com/notify-rs/notify/pull/733
- `notify-rs` PR #769: https://github.com/notify-rs/notify/pull/769
- `notify-rs` PR #790: https://github.com/notify-rs/notify/pull/790
- Watchexec note on macOS FSEvents limitations: https://watchexec.github.io/docs/macos-fsevents.html
- `fsnotify` repository: https://github.com/fsnotify/fsnotify

The practical conclusion for Moon watch mode is:

- `FSEvents` can fail silently for dev-watch usage
- `kqueue` is a better default for this macOS workflow because it fails more explicitly
- `poll` is still needed as a last-resort escape hatch when `kqueue` cannot be installed

## kqueue Limitations

`kqueue` is better for this case, but it is not free of tradeoffs:

- recursive watching is implemented by registering each file and directory, so large trees or low `ulimit -n` values can fail with `EMFILE` / `ENFILE`
- directory topology changes are more expensive because the watcher may need to remove and re-add whole subtrees
- delete / rename / unmount / revoke scenarios can remove active watches, which is why this PR also switches to polling if the live `kqueue` watcher reports an error

That is why this PR does not stop at "switch to kqueue"; it also adds a polling fallback.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
