### PR TITLE
Use kqueue watcher on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ expect-test = "1.5.0"
 snapbox = "0.6.23"
 futures = { version = "0.3.29", features = ["std"], default-features = false }
 indexmap = { version = "2.2.6", features = ["serde"] }
-notify = "6.1.1"
 reqwest = { version = "0.12.24", default-features = false, features = [
     "multipart",
     "blocking",

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -61,7 +61,6 @@ derive_builder.workspace = true
 sha2.workspace = true
 similar.workspace = true
 
-notify.workspace = true
 ignore.workspace = true
 
 tracing.workspace = true
@@ -77,6 +76,12 @@ features = [
     "Win32_System_Threading",
 ]
 version = "0.59.0"
+
+[target."cfg(not(target_os = \"macos\"))".dependencies]
+notify = "6.1.1"
+
+[target."cfg(target_os = \"macos\")".dependencies]
+notify = { version = "6.1.1", default-features = false, features = ["crossbeam-channel", "macos_kqueue"] }
 
 [target."cfg(windows)".dependencies]
 junction = "1"


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

## Summary

On macOS, `moon build --watch` was using `notify`'s `RecommendedWatcher`, which resolves to `FSEvents` by default. On this machine that backend could silently miss normal `.mbt` edits, so watch mode could stay on "waiting for filesystem changes..." even when source files changed.

This PR keeps the code path unchanged and only changes the dependency configuration:

- on macOS, `moon` builds `notify` with `macos_kqueue`
- on non-macOS targets, `moon` keeps using the default `notify` configuration

I intentionally did not include polling fallback logic in this PR, to keep the change small and isolated to backend selection.

## Problem Observed

The issue was reproduced locally in two steps:

1. `moon build --watch` on macOS stayed alive but missed ordinary `.mbt` file edits.
2. A standalone `notify 6.1.1` probe showed the same pattern:
   - `FSEvents` missed the edits
   - forcing `kqueue` immediately delivered the same edits

That was enough to narrow the problem to `notify`'s macOS `FSEvents` path for this development workflow, not Moon's file filtering logic.

## Why Not FSEvents On macOS

Relevant background and upstream discussions:

- Apple FSEvents overview: https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/FSEvents_ProgGuide/TechnologyOverview/TechnologyOverview.html
- Apple FSEvents security model: https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/FSEvents_ProgGuide/FileSystemEventSecurity/FileSystemEventSecurity.html
- `notify-rs` issue #387: https://github.com/notify-rs/notify/issues/387
- `notify-rs` issue #412: https://github.com/notify-rs/notify/issues/412
- `notify-rs` issue #465: https://github.com/notify-rs/notify/issues/465
- `notify-rs` issue #554: https://github.com/notify-rs/notify/issues/554
- `notify-rs` PR #733: https://github.com/notify-rs/notify/pull/733
- `notify-rs` PR #769: https://github.com/notify-rs/notify/pull/769
- `notify-rs` PR #790: https://github.com/notify-rs/notify/pull/790
- Watchexec note on macOS FSEvents limitations: https://watchexec.github.io/docs/macos-fsevents.html
- `fsnotify` repository: https://github.com/fsnotify/fsnotify

The practical conclusion here is narrow: for Moon's dev-watch usage on macOS, `kqueue` is a better default than `FSEvents`.

## kqueue Limitations

`kqueue` is not perfect, and this PR does not try to hide that:

- recursive watching is implemented by registering many individual filesystem entries, so large trees or low `ulimit -n` values can fail
- directories like `node_modules` or generated output can increase that cost significantly
- directory topology changes are more expensive than with tree-level watcher backends

That tradeoff is still acceptable here because the failure mode is more explicit than silently missing source edits.

## Verification

- `cargo test -p moon watch`
- `cargo build -p moon`

## Metadata

- [ ] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
