### PR TITLE
refactor: add Toolchain abstraction with source tracking

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -27,8 +27,8 @@ use moonutil::{
     common::RunMode,
     compiler_flags::{
         ArchiverConfigBuilder, CC, CCConfigBuilder, LinkerConfigBuilder, OptLevel as CCOptLevel,
-        OutputType as CCOutputType, make_archiver_command, make_cc_command, make_cc_command_pure,
-        make_linker_command_pure, resolve_cc,
+        OutputType as CCOutputType, make_archiver_command_pure, make_cc_command_pure,
+        make_linker_command_pure,
     },
     cond_expr::OptLevel,
     mooncakes::{CORE_MODULE, ModuleId},
@@ -817,14 +817,15 @@ impl<'a> BuildPlanLowerContext<'a> {
             .display()
             .to_string();
 
-        let cc_cmd = make_cc_command(
-            self.opt.default_cc.clone(),
-            info.stub_cc.clone(),
+        let cc = info.effective_native_toolchain.cc().clone();
+        let cc_cmd = make_cc_command_pure(
+            cc,
             config,
             &info.cc_flags,
             [input_file.display().to_string()],
             &intermediate_dir,
-            &output_file.display().to_string(),
+            Some(&output_file.display().to_string()),
+            &self.opt.compiler_paths,
         );
 
         BuildCommand {
@@ -887,9 +888,9 @@ impl<'a> BuildPlanLowerContext<'a> {
             .build()
             .expect("Failed to build archiver configuration");
 
-        let archiver_cmd = make_archiver_command(
-            self.opt.default_cc.clone(),
-            info.stub_cc.clone(), // TODO: no clone
+        let cc = info.effective_native_toolchain.cc().clone();
+        let archiver_cmd = make_archiver_command_pure(
+            cc,
             config,
             &object_files
                 .iter()
@@ -932,8 +933,8 @@ impl<'a> BuildPlanLowerContext<'a> {
             .parent()
             .expect("runtime dylib should have a parent directory");
 
-        // Resolve CC: prefer stub_cc if provided, otherwise use default.
-        let cc = resolve_cc(&self.opt.default_cc, info.stub_cc.as_ref());
+        // Use the effective toolchain (already resolved at planning time)
+        let cc = info.effective_native_toolchain.cc().clone();
 
         // Build linker config: shared lib, no libmoonbitrun, and link shared runtime dir
         let lcfg = LinkerConfigBuilder::<&Path>::default()
@@ -1068,8 +1069,9 @@ impl<'a> BuildPlanLowerContext<'a> {
             c_flags.push(libbacktrace_path.display().to_string());
         }
 
+        let cc = info.effective_native_toolchain.cc().clone();
         let cc_cmd = make_cc_command_pure(
-            resolve_cc(&self.opt.default_cc, info.cc.as_ref()),
+            cc,
             config,
             &c_flags.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
             sources.iter().map(|x| x.display().to_string()),

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -24,7 +24,7 @@ use indexmap::IndexMap;
 use log::{debug, info};
 use moonutil::{
     common::RunMode,
-    compiler_flags::{CC, CompilerPaths},
+    compiler_flags::{CompilerPaths, Toolchain},
     cond_expr::OptLevel,
     mooncakes::ModuleSource,
 };
@@ -75,8 +75,8 @@ pub struct BuildOptions {
     pub stdlib_path: Option<PathBuf>,
     pub runtime_dot_c_path: PathBuf,
     pub compiler_paths: CompilerPaths,
-    /// Preferred default C/C++ toolchain to use (overrides CC::default()).
-    pub default_cc: CC,
+    /// Selected native toolchain for this invocation.
+    pub selected_native_toolchain: Toolchain,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -32,7 +32,7 @@ use moonutil::{
         DOT_MBT_DOT_MD, IgnoredMoonScript, MOD_DIR, MOON_BIN_DIR, MOON_MOD_JSON, MOONCAKE_BIN,
         PKG_DIR, TargetBackend, is_moon_pkg, is_moon_script_ignored,
     },
-    compiler_flags::{CC, DETECTED_CC},
+    compiler_flags::{CC, Toolchain},
     mooncakes::ModuleId,
     package::SupportedTargetsDeclKind,
 };
@@ -725,10 +725,19 @@ impl<'a> BuildPlanConstructor<'a> {
             .transpose()?
             .unwrap_or_default();
 
-        self.propagate_link_config(stub_cc.as_ref(), std::iter::once(target), &mut link_flags);
+        let effective_native_toolchain = self
+            .build_env
+            .selected_native_toolchain
+            .with_package_override(stub_cc.as_ref());
+
+        self.propagate_link_config(
+            &effective_native_toolchain,
+            std::iter::once(target),
+            &mut link_flags,
+        );
 
         let c_info = BuildCStubsInfo {
-            stub_cc,
+            effective_native_toolchain,
             cc_flags,
             link_flags,
         };
@@ -854,11 +863,21 @@ impl<'a> BuildPlanConstructor<'a> {
         if !link_pkgs.contains(&target.package) {
             link_pkgs.push(target.package);
         }
-        self.propagate_link_config(cc.as_ref(), link_pkgs.into_iter(), &mut c_flags);
+
+        let effective_native_toolchain = self
+            .build_env
+            .selected_native_toolchain
+            .with_package_override(cc.as_ref());
+
+        self.propagate_link_config(
+            &effective_native_toolchain,
+            link_pkgs.into_iter(),
+            &mut c_flags,
+        );
 
         let v = MakeExecutableInfo {
             link_c_stubs: c_stub_deps.clone(),
-            cc,
+            effective_native_toolchain,
             c_flags,
         };
         self.res.make_executable_info.insert(target, v);
@@ -1035,14 +1054,14 @@ impl<'a> BuildPlanConstructor<'a> {
     /// Propagate the link configuration of the packages in dependency to the output list
     fn propagate_link_config(
         &self,
-        cc: Option<&CC>,
+        toolchain: &Toolchain,
         pkgs: impl Iterator<Item = PackageId>,
         out: &mut Vec<String>,
     ) {
         let Some(prebuild) = self.prebuild_config else {
             return;
         };
-        let is_msvc_like = cc.unwrap_or(&*DETECTED_CC).is_msvc();
+        let is_msvc_like = toolchain.cc().is_msvc();
         for pkg in pkgs {
             let Some(link_config) = prebuild.package_configs.get(&pkg) else {
                 continue;

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -52,7 +52,7 @@ use std::{
 use log::{debug, info};
 use moonutil::{
     common::{RunMode, TargetBackend},
-    compiler_flags::CC,
+    compiler_flags::Toolchain,
     cond_expr::OptLevel,
     mooncakes::ModuleId,
 };
@@ -289,8 +289,8 @@ pub struct LinkCoreInfo {
 }
 
 pub struct BuildCStubsInfo {
-    /// The C compiler to compile the C stubs
-    pub(crate) stub_cc: Option<CC>,
+    /// The effective native toolchain for compiling the C stubs
+    pub(crate) effective_native_toolchain: Toolchain,
     /// Additional flags to pass to the C compiler when compiling the C stubs
     pub(crate) cc_flags: Vec<String>,
     /// Additional flags to pass to the linker (TCC only)
@@ -299,8 +299,8 @@ pub struct BuildCStubsInfo {
 }
 
 pub struct MakeExecutableInfo {
-    /// The C compiler to use to compile the package itself
-    pub(crate) cc: Option<CC>,
+    /// The effective native toolchain for this executable step
+    pub(crate) effective_native_toolchain: Toolchain,
     /// The flags to pass to the C compiler when compiling the package itself
     pub(crate) c_flags: Vec<String>,
     /// The C stub targets to link with.
@@ -332,7 +332,8 @@ pub struct BuildEnvironment {
     pub std: bool,
     /// Commandline_level warnings to enable/disable
     pub warn_list: Option<String>,
-    // Can have more, e.g. cross compile
+    /// Selected native toolchain for this invocation.
+    pub selected_native_toolchain: Toolchain,
 }
 
 /// Directives provided along the input actions.

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -22,7 +22,7 @@ use indexmap::IndexMap;
 use log::{debug, info};
 use moonutil::{
     common::RunMode,
-    compiler_flags::{CC, CompilerPaths},
+    compiler_flags::{CC, CompilerPaths, Toolchain},
     cond_expr::OptLevel,
     moon_dir::MOON_DIRS,
 };
@@ -126,6 +126,7 @@ pub fn compile(
         action: cx.action,
         std: cx.stdlib_path.is_some(),
         warn_list: cx.warn_list.clone(),
+        selected_native_toolchain: Toolchain::from_cc(cx.default_cc.clone()),
     };
     let (plan, user_warnings) = build_plan::build_plan(
         resolve_output,
@@ -159,7 +160,7 @@ pub fn compile(
 
         stdlib_path: cx.stdlib_path.clone(),
         compiler_paths: CompilerPaths::from_moon_dirs(), // change to external
-        default_cc: cx.default_cc.clone(),
+        selected_native_toolchain: Toolchain::from_cc(cx.default_cc.clone()),
         os: OperatingSystem::from_str(std::env::consts::OS).expect("Unknown"),
         runtime_dot_c_path: MOON_DIRS.moon_lib_path.join("runtime.c"), // FIXME: don't calculate here
     };

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -30,7 +30,7 @@ use std::{
 const ENV_MOON_CC: &str = "MOON_CC";
 const ENV_MOON_AR: &str = "MOON_AR";
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum CCKind {
     Msvc,     // cl.exe
     SystemCC, // cc
@@ -39,7 +39,7 @@ pub enum CCKind {
     Tcc,      // tcc
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum ARKind {
     MsvcLib, // lib.exe
     GnuAr,   // ar
@@ -47,7 +47,7 @@ pub enum ARKind {
     TccAr,   // tcc -ar
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CC {
     pub cc_kind: CCKind,
     pub cc_path: String,
@@ -60,6 +60,76 @@ pub struct CC {
 impl Default for CC {
     fn default() -> Self {
         NATIVE_CC().clone()
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ToolchainSource {
+    EnvOverride,
+    PathProbe,
+    PackageOverride,
+}
+
+#[derive(Clone, Debug)]
+pub struct Toolchain {
+    cc: CC,
+    source: ToolchainSource,
+}
+
+impl Toolchain {
+    pub fn from_env_override(cc: CC) -> Self {
+        Self {
+            cc,
+            source: ToolchainSource::EnvOverride,
+        }
+    }
+
+    pub fn from_path_probe(cc: CC) -> Self {
+        Self {
+            cc,
+            source: ToolchainSource::PathProbe,
+        }
+    }
+
+    pub fn from_package_override(cc: CC) -> Self {
+        Self {
+            cc,
+            source: ToolchainSource::PackageOverride,
+        }
+    }
+
+    pub fn from_cc(cc: CC) -> Self {
+        if cc.is_env_override {
+            Toolchain::from_env_override(cc)
+        } else {
+            Toolchain::from_path_probe(cc)
+        }
+    }
+
+    pub fn cc(&self) -> &CC {
+        &self.cc
+    }
+
+    pub fn source(&self) -> ToolchainSource {
+        self.source
+    }
+
+    pub fn with_package_override(&self, package_cc: Option<&CC>) -> Toolchain {
+        match (self.source, package_cc) {
+            (ToolchainSource::EnvOverride, Some(_)) => {
+                static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+                WARN_ONCE.call_once(|| {
+                    eprintln!(
+                        "{}: Both MOON_CC environment variable and user-specified CC are provided. \
+                        MOON_CC takes precedence.",
+                        "Warning".yellow().bold(),
+                    );
+                });
+                self.clone()
+            }
+            (ToolchainSource::EnvOverride, None) | (_, None) => self.clone(),
+            (_, Some(package_cc)) => Toolchain::from_package_override(package_cc.clone()),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Introduces a `Toolchain` struct that wraps `CC` with source tracking (`EnvOverride`, `PathProbe`, `PackageOverride`)
- Toolchain is now resolved at build planning time rather than at lowering time
- This is a preparatory change for adding MSVC environment discovery using `find-msvc-tools`, which will require storing environment variables in the Toolchain to properly execute the compiler

## Changes

- **compiler_flags.rs**: Added `Toolchain`, `ToolchainSource`, and `from_default()` constructor
- **build_plan/mod.rs**: Added `selected_native_toolchain` to `BuildEnvironment` and updated struct types
- **build_plan/builders.rs**: Use `Toolchain` throughout; resolve at planning time
- **build_lower/mod.rs**: Changed from `default_cc: CC` to `selected_native_toolchain: Toolchain`
- **build_lower/lower_build.rs**: Use stored toolchain instead of calling `resolve_cc()` at lowering time
- **compile/mod.rs**: Create and pass `Toolchain` through the system

## Testing

- `cargo check --workspace` passes
- `cargo test --package moonbuild-rupes-recta --lib` passes (27 tests)

## Notes for reviewers

This is a minimal refactor to establish the `Toolchain` abstraction. The next step will add:
- `env_vars: HashMap<String, String>` field to store MSVC environment variables
- New `ToolchainSource::ActiveSearch` variant for actively discovered MSVC
- Integration with `find-msvc-tools` library