### PR TITLE
feat: Support mixed workspace preferred targets

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -459,10 +459,7 @@ fn resolve_build_groups(
             package_filter,
             output,
         );
-        return Ok(group_packages_by_default_target(
-            resolve_output,
-            pkgs.into_iter(),
-        ));
+        return Ok(group_packages_by_default_target(resolve_output, pkgs));
     }
 
     Ok(

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -17,6 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use anyhow::Context;
+use moonbuild::entry::N2RunStats;
 use moonbuild_rupes_recta::intent::UserIntent;
 use moonbuild_rupes_recta::model::PackageId;
 use moonutil::common::FileLock;
@@ -24,13 +25,14 @@ use moonutil::common::RunMode;
 use moonutil::common::TargetBackend;
 use moonutil::common::lower_surface_targets;
 use moonutil::dirs::PackageDirs;
+use moonutil::mooncakes::ModuleId;
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
 
 use crate::filter::{
     ensure_packages_support_backend, match_packages_by_name_rr, package_supports_backend,
-    select_supported_packages,
+    select_packages, select_supported_packages,
 };
 use crate::rr_build;
 use crate::rr_build::BuildConfig;
@@ -42,6 +44,16 @@ use crate::watch::prebuild_output::{PrebuildWatchPaths, rr_get_prebuild_watch_pa
 use crate::watch::watching;
 
 use super::{BuildFlags, UniversalFlags};
+
+enum BuildScope {
+    Modules(Vec<ModuleId>),
+    Packages(Vec<PackageId>),
+}
+
+struct BuildGroup {
+    target_backend: TargetBackend,
+    scope: BuildScope,
+}
 
 /// Build the current package
 #[derive(Debug, clap::Parser)]
@@ -157,50 +169,137 @@ fn run_build_rr(
     )
     .with_project_manifest_path(project_manifest_path);
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir, mooncakes_dir)?;
-    let (build_meta, build_graph) = plan_build_rr_from_resolved(
-        cli,
-        cmd,
-        target_dir,
-        selected_target_backend,
-        resolve_output,
-    )?;
+    if let Some(target_backend) = selected_target_backend {
+        let (build_meta, build_graph) = plan_build_rr_from_resolved(
+            cli,
+            cmd,
+            target_dir,
+            Some(target_backend),
+            None,
+            None,
+            resolve_output,
+        )?;
 
-    // Prepare for `watch` mode
-    let prebuild_list = if _watch {
-        rr_get_prebuild_watch_paths(&build_meta.resolve_output)
-    } else {
-        PrebuildWatchPaths {
-            ignored_paths: Vec::new(),
-            watched_paths: Vec::new(),
-        }
+        let prebuild_list = if _watch {
+            rr_get_prebuild_watch_paths(&build_meta.resolve_output)
+        } else {
+            PrebuildWatchPaths {
+                ignored_paths: Vec::new(),
+                watched_paths: Vec::new(),
+            }
+        };
+
+        let ok = if cli.dry_run {
+            rr_build::print_dry_run(
+                &build_graph,
+                build_meta.artifacts.values(),
+                source_dir,
+                target_dir,
+            );
+            true
+        } else {
+            let _lock = FileLock::lock(target_dir)?;
+            rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Build)?;
+            let result = rr_build::execute_build(
+                &BuildConfig::from_flags(
+                    &cmd.build_flags,
+                    &cli.unstable_feature,
+                    cli.verbose,
+                    UserDiagnostics::from_flags(cli),
+                ),
+                build_graph,
+                target_dir,
+            )?;
+            result.print_info(cli.quiet, "building")?;
+            result.successful()
+        };
+        return Ok(WatchOutput {
+            ok,
+            additional_ignored_paths: prebuild_list.ignored_paths,
+            additional_watched_paths: prebuild_list.watched_paths,
+        });
+    }
+
+    let groups = resolve_build_groups(&resolve_output, cmd, UserDiagnostics::from_flags(cli))?;
+
+    let mut prebuild_list = PrebuildWatchPaths {
+        ignored_paths: Vec::new(),
+        watched_paths: Vec::new(),
     };
+    let mut planned = Vec::new();
+
+    for group in groups {
+        let module_scope = match &group.scope {
+            BuildScope::Modules(modules) => Some(modules.as_slice()),
+            BuildScope::Packages(_) => None,
+        };
+        let selected_packages = match &group.scope {
+            BuildScope::Modules(_) => None,
+            BuildScope::Packages(packages) => Some(packages.as_slice()),
+        };
+        let (build_meta, build_graph) = plan_build_rr_from_resolved(
+            cli,
+            cmd,
+            target_dir,
+            Some(group.target_backend),
+            module_scope,
+            selected_packages,
+            resolve_output.clone(),
+        )?;
+        if _watch {
+            let group_paths = rr_get_prebuild_watch_paths(&build_meta.resolve_output);
+            prebuild_list
+                .ignored_paths
+                .extend(group_paths.ignored_paths);
+            prebuild_list
+                .watched_paths
+                .extend(group_paths.watched_paths);
+        }
+        planned.push((build_meta, build_graph));
+    }
+
+    if planned.is_empty() {
+        if !cli.dry_run {
+            N2RunStats {
+                n_tasks_executed: Some(0),
+                n_errors: 0,
+                n_warnings: 0,
+            }
+            .print_info(cli.quiet, "building")?;
+        }
+        return Ok(WatchOutput {
+            ok: true,
+            additional_ignored_paths: prebuild_list.ignored_paths,
+            additional_watched_paths: prebuild_list.watched_paths,
+        });
+    }
 
     let ok = if cli.dry_run {
-        rr_build::print_dry_run(
-            &build_graph,
-            build_meta.artifacts.values(),
-            source_dir,
-            target_dir,
-        );
+        for (build_meta, build_graph) in &planned {
+            rr_build::print_dry_run(
+                build_graph,
+                build_meta.artifacts.values(),
+                source_dir,
+                target_dir,
+            );
+        }
         true
     } else {
         let _lock = FileLock::lock(target_dir)?;
-        // Generate all_pkgs.json for indirect dependency resolution
-        rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Build)?;
-
-        let result = rr_build::execute_build(
-            &BuildConfig::from_flags(
-                &cmd.build_flags,
-                &cli.unstable_feature,
-                cli.verbose,
-                UserDiagnostics::from_flags(cli),
-            ),
-            build_graph,
-            target_dir,
-        )?;
-        result.print_info(cli.quiet, "building")?;
-
-        result.successful()
+        let build_config = BuildConfig::from_flags(
+            &cmd.build_flags,
+            &cli.unstable_feature,
+            cli.verbose,
+            UserDiagnostics::from_flags(cli),
+        );
+        let mut ok = true;
+        for (build_meta, build_graph) in planned {
+            rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Build)?;
+            let result = rr_build::execute_build(&build_config, build_graph, target_dir)?;
+            result.print_info(cli.quiet, "building")?;
+            ok &= result.successful();
+        }
+        ok
     };
     Ok(WatchOutput {
         ok,
@@ -214,6 +313,8 @@ pub(crate) fn plan_build_rr_from_resolved(
     cmd: &BuildSubcommand,
     target_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
+    module_scope: Option<&[ModuleId]>,
+    selected_packages: Option<&[PackageId]>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
     let preconfig = preconfig_compile(
@@ -235,6 +336,8 @@ pub(crate) fn plan_build_rr_from_resolved(
             calc_user_intent(
                 &cmd.path,
                 cmd.package.as_deref(),
+                module_scope.unwrap_or(resolved.local_modules()),
+                selected_packages,
                 resolved,
                 target_backend,
                 output,
@@ -251,11 +354,25 @@ pub(crate) fn plan_build_rr_from_resolved(
 fn calc_user_intent(
     path_filters: &[PathBuf],
     package_filter: Option<&str>,
+    module_scope: &[ModuleId],
+    selected_packages: Option<&[PackageId]>,
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     target_backend: TargetBackend,
     output: UserDiagnostics,
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
-    if !path_filters.is_empty() {
+    if let Some(selected_packages) = selected_packages {
+        ensure_packages_support_backend(
+            resolve_output,
+            selected_packages.iter().copied(),
+            target_backend,
+        )?;
+        Ok(selected_packages
+            .iter()
+            .copied()
+            .map(UserIntent::Build)
+            .collect::<Vec<_>>()
+            .into())
+    } else if !path_filters.is_empty() {
         let selected =
             select_supported_packages(resolve_output, path_filters, target_backend, output)?;
         Ok(selected
@@ -264,12 +381,7 @@ fn calc_user_intent(
             .collect::<Vec<_>>()
             .into())
     } else if let Some(package_filter) = package_filter {
-        let pkgs = match_packages_by_name_rr(
-            resolve_output,
-            resolve_output.local_modules(),
-            package_filter,
-            output,
-        );
+        let pkgs = match_packages_by_name_rr(resolve_output, module_scope, package_filter, output);
         ensure_packages_support_backend(resolve_output, pkgs.iter().copied(), target_backend)?;
         Ok(pkgs
             .into_iter()
@@ -277,7 +389,7 @@ fn calc_user_intent(
             .collect::<Vec<_>>()
             .into())
     } else {
-        let supported_packages = rr_build::local_packages(resolve_output)
+        let supported_packages = rr_build::local_packages_in_modules(resolve_output, module_scope)
             .filter(|&pkg_id| package_supports_backend(resolve_output, pkg_id, target_backend))
             .collect::<Vec<_>>();
         let linkable_pkgs = get_linkable_pkgs(
@@ -323,4 +435,67 @@ fn get_linkable_pkgs(
         }
     }
     linkable_pkgs
+}
+
+fn resolve_build_groups(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    cmd: &BuildSubcommand,
+    output: UserDiagnostics,
+) -> anyhow::Result<Vec<BuildGroup>> {
+    if !cmd.path.is_empty() {
+        let selected = select_packages(&cmd.path, output, |dir| {
+            crate::filter::filter_pkg_by_dir(resolve_output, dir)
+        })?;
+        return Ok(group_packages_by_default_target(
+            resolve_output,
+            selected.into_iter().map(|(_, pkg_id)| pkg_id),
+        ));
+    }
+
+    if let Some(package_filter) = cmd.package.as_deref() {
+        let pkgs = match_packages_by_name_rr(
+            resolve_output,
+            resolve_output.local_modules(),
+            package_filter,
+            output,
+        );
+        return Ok(group_packages_by_default_target(
+            resolve_output,
+            pkgs.into_iter(),
+        ));
+    }
+
+    Ok(
+        rr_build::group_modules_by_default_target(resolve_output, resolve_output.local_modules())
+            .into_iter()
+            .map(|(target_backend, modules)| BuildGroup {
+                target_backend,
+                scope: BuildScope::Modules(modules),
+            })
+            .collect(),
+    )
+}
+
+fn group_packages_by_default_target(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    packages: impl IntoIterator<Item = PackageId>,
+) -> Vec<BuildGroup> {
+    let mut grouped = std::collections::BTreeMap::<TargetBackend, Vec<PackageId>>::new();
+    for pkg_id in packages {
+        let module_id = resolve_output.pkg_dirs.get_package(pkg_id).module;
+        grouped
+            .entry(rr_build::default_target_for_module(
+                resolve_output,
+                module_id,
+            ))
+            .or_default()
+            .push(pkg_id);
+    }
+    grouped
+        .into_iter()
+        .map(|(target_backend, packages)| BuildGroup {
+            target_backend,
+            scope: BuildScope::Packages(packages),
+        })
+        .collect()
 }

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -123,66 +123,84 @@ pub(crate) fn run_bundle_internal_rr(
     project_manifest_path: Option<&Path>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
-    let mut preconfig = rr_build::preconfig_compile(
-        &cmd.auto_sync_flags,
-        cli,
-        &cmd.build_flags,
-        selected_target_backend,
-        target_dir,
-        RunMode::Bundle,
-    );
-
-    // Allow warn in `moon bundle`, different from other run modes, to reduce
-    // commandline clutter on installation
-    preconfig.warning_condition = if cmd.build_flags.deny_warn {
-        WarningCondition::Deny
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
+        cmd.auto_sync_flags.frozen,
+        !cmd.build_flags.std(),
+        cmd.build_flags.enable_coverage,
+    )
+    .with_project_manifest_path(project_manifest_path);
+    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir, mooncakes_dir)?;
+    let groups = if let Some(target_backend) = selected_target_backend {
+        vec![(target_backend, resolve_output.local_modules().to_vec())]
     } else {
-        WarningCondition::Allow
+        rr_build::group_modules_by_default_target(&resolve_output, resolve_output.local_modules())
     };
 
-    let (build_meta, build_graph) = rr_build::plan_build(
-        preconfig,
-        &cli.unstable_feature,
-        source_dir,
-        target_dir,
-        mooncakes_dir,
-        UserDiagnostics::from_flags(cli),
-        project_manifest_path,
-        Box::new(|r, _tb| {
-            Ok(r.local_modules()
-                .iter()
-                .map(|&mid| UserIntent::Bundle(mid))
-                .collect::<Vec<_>>()
-                .into())
-        }),
-    )?;
+    let mut planned = Vec::new();
+    for (target_backend, module_scope) in groups {
+        let mut preconfig = rr_build::preconfig_compile(
+            &cmd.auto_sync_flags,
+            cli,
+            &cmd.build_flags,
+            Some(target_backend),
+            target_dir,
+            RunMode::Bundle,
+        );
+        preconfig.warning_condition = if cmd.build_flags.deny_warn {
+            WarningCondition::Deny
+        } else {
+            WarningCondition::Allow
+        };
+
+        let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
+            preconfig,
+            &cli.unstable_feature,
+            target_dir,
+            UserDiagnostics::from_flags(cli),
+            Box::new(move |_, _tb| {
+                Ok(module_scope
+                    .iter()
+                    .map(|&mid| UserIntent::Bundle(mid))
+                    .collect::<Vec<_>>()
+                    .into())
+            }),
+            resolve_output.clone(),
+        )?;
+        planned.push((build_meta, build_graph));
+    }
 
     if cli.dry_run {
-        rr_build::print_dry_run(
-            &build_graph,
-            build_meta.artifacts.values(),
-            source_dir,
-            target_dir,
-        );
+        for (build_meta, build_graph) in &planned {
+            rr_build::print_dry_run(
+                build_graph,
+                build_meta.artifacts.values(),
+                source_dir,
+                target_dir,
+            );
+        }
         Ok(0)
     } else {
         let _lock = FileLock::lock(target_dir)?;
-        // Generate all_pkgs.json for indirect dependency resolution
-        rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Bundle)?;
-        // Generate metadata for IDE & bundler
-        rr_build::generate_metadata(source_dir, target_dir, &build_meta, RunMode::Bundle, None)?;
-
-        let result = rr_build::execute_build(
-            &BuildConfig::from_flags(
-                &cmd.build_flags,
-                &cli.unstable_feature,
-                cli.verbose,
-                UserDiagnostics::from_flags(cli),
-            ),
-            build_graph,
-            target_dir,
-        )?;
-        result.print_info(cli.quiet, "bundling")?;
-        Ok(result.return_code_for_success())
+        let build_config = BuildConfig::from_flags(
+            &cmd.build_flags,
+            &cli.unstable_feature,
+            cli.verbose,
+            UserDiagnostics::from_flags(cli),
+        );
+        let mut ret = 0;
+        for (build_meta, build_graph) in planned {
+            rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Bundle)?;
+            rr_build::generate_metadata(
+                source_dir,
+                target_dir,
+                &build_meta,
+                RunMode::Bundle,
+                None,
+            )?;
+            let result = rr_build::execute_build(&build_config, build_graph, target_dir)?;
+            result.print_info(cli.quiet, "bundling")?;
+            ret = ret.max(result.return_code_for_success());
+        }
+        Ok(ret)
     }
 }

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -779,9 +779,18 @@ fn resolve_check_groups(
         let selected = select_packages(&cmd.path, output, |dir| {
             filter_pkg_by_dir(resolve_output, dir)
         })?;
+        let selected_packages = selected
+            .into_iter()
+            .map(|(_, pkg_id)| pkg_id)
+            .collect::<Vec<_>>();
+        build_directive_for_selected_packages(
+            &selected_packages,
+            cmd.no_mi,
+            cmd.patch_file.as_deref(),
+        )?;
         return Ok(group_check_packages_by_default_target(
             resolve_output,
-            selected.into_iter().map(|(_, pkg_id)| pkg_id),
+            selected_packages,
         ));
     }
 

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -17,19 +17,22 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use anyhow::Context;
+use moonbuild::entry::N2RunStats;
 use moonbuild_rupes_recta::intent::UserIntent;
+use moonbuild_rupes_recta::model::PackageId;
 use moonutil::cli::UniversalFlags;
 use moonutil::common::RunMode;
 use moonutil::common::WATCH_MODE_DIR;
 use moonutil::common::lower_surface_targets;
 use moonutil::common::{FileLock, TargetBackend};
+use moonutil::mooncakes::ModuleId;
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
 
 use crate::filter::{
-    canonicalize_with_filename, ensure_package_supports_backend, filter_pkg_by_dir,
-    package_supports_backend, select_supported_packages,
+    canonicalize_with_filename, ensure_package_supports_backend, ensure_packages_support_backend,
+    filter_pkg_by_dir, package_supports_backend, select_packages, select_supported_packages,
 };
 use crate::rr_build::{self, BuildConfig, CalcUserIntentOutput, preconfig_compile};
 use crate::user_diagnostics::UserDiagnostics;
@@ -37,6 +40,16 @@ use crate::watch::prebuild_output::{PrebuildWatchPaths, rr_get_prebuild_watch_pa
 use crate::watch::{WatchOutput, watching};
 
 use super::BuildFlags;
+
+enum CheckScope {
+    Modules(Vec<ModuleId>),
+    Packages(Vec<PackageId>),
+}
+
+struct CheckGroup {
+    target_backend: TargetBackend,
+    scope: CheckScope,
+}
 
 /// Check the current package, but don't build object files
 #[derive(Debug, clap::Parser)]
@@ -421,42 +434,44 @@ fn run_check_normal_internal_rr(
     .with_project_manifest_path(project_manifest_path);
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir, mooncakes_dir)
         .context("Failed to calculate build plan")?;
-    let (build_meta, build_graph) = plan_check_rr_from_resolved(
-        cli,
-        cmd,
-        source_dir,
-        target_dir,
-        selected_target_backend,
-        resolve_output,
-    )
-    .context("Failed to calculate build plan")?;
-
-    let prebuild_list = if _watch {
-        rr_get_prebuild_watch_paths(&build_meta.resolve_output)
-    } else {
-        PrebuildWatchPaths {
-            ignored_paths: Vec::new(),
-            watched_paths: Vec::new(),
-        }
-    };
-
-    if cli.dry_run {
-        rr_build::print_dry_run(
-            &build_graph,
-            build_meta.artifacts.values(),
+    if let Some(target_backend) = selected_target_backend {
+        let (build_meta, build_graph) = plan_check_rr_from_resolved(
+            cli,
+            cmd,
             source_dir,
             target_dir,
-        );
-        Ok(WatchOutput {
-            ok: true,
-            additional_ignored_paths: prebuild_list.ignored_paths,
-            additional_watched_paths: prebuild_list.watched_paths,
-        })
-    } else {
+            Some(target_backend),
+            None,
+            None,
+            resolve_output,
+        )
+        .context("Failed to calculate build plan")?;
+
+        let prebuild_list = if _watch {
+            rr_get_prebuild_watch_paths(&build_meta.resolve_output)
+        } else {
+            PrebuildWatchPaths {
+                ignored_paths: Vec::new(),
+                watched_paths: Vec::new(),
+            }
+        };
+
+        if cli.dry_run {
+            rr_build::print_dry_run(
+                &build_graph,
+                build_meta.artifacts.values(),
+                source_dir,
+                target_dir,
+            );
+            return Ok(WatchOutput {
+                ok: true,
+                additional_ignored_paths: prebuild_list.ignored_paths,
+                additional_watched_paths: prebuild_list.watched_paths,
+            });
+        }
+
         let _lock = FileLock::lock(target_dir)?;
-        // Generate all_pkgs.json for indirect dependency resolution
         rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Check)?;
-        // Generate metadata for IDE
         rr_build::generate_metadata(source_dir, target_dir, &build_meta, RunMode::Check, None)?;
 
         let mut cfg = BuildConfig::from_flags(
@@ -469,8 +484,110 @@ fn run_check_normal_internal_rr(
         cfg.explain_errors |= cmd.explain;
         let result = rr_build::execute_build(&cfg, build_graph, target_dir)?;
         result.print_info(cli.quiet, "checking")?;
-        Ok(WatchOutput {
+        return Ok(WatchOutput {
             ok: result.successful(),
+            additional_ignored_paths: prebuild_list.ignored_paths,
+            additional_watched_paths: prebuild_list.watched_paths,
+        });
+    }
+
+    let groups = resolve_check_groups(
+        &resolve_output,
+        source_dir,
+        cmd,
+        UserDiagnostics::from_flags(cli),
+    )
+    .context("Failed to determine default target groups")?;
+
+    let mut planned = Vec::new();
+    let mut prebuild_list = PrebuildWatchPaths {
+        ignored_paths: Vec::new(),
+        watched_paths: Vec::new(),
+    };
+
+    for group in groups {
+        let module_scope = match &group.scope {
+            CheckScope::Modules(modules) => Some(modules.as_slice()),
+            CheckScope::Packages(_) => None,
+        };
+        let selected_packages = match &group.scope {
+            CheckScope::Modules(_) => None,
+            CheckScope::Packages(packages) => Some(packages.as_slice()),
+        };
+        let (build_meta, build_graph) = plan_check_rr_from_resolved(
+            cli,
+            cmd,
+            source_dir,
+            target_dir,
+            Some(group.target_backend),
+            module_scope,
+            selected_packages,
+            resolve_output.clone(),
+        )
+        .context("Failed to calculate build plan")?;
+        if _watch {
+            let group_paths = rr_get_prebuild_watch_paths(&build_meta.resolve_output);
+            prebuild_list
+                .ignored_paths
+                .extend(group_paths.ignored_paths);
+            prebuild_list
+                .watched_paths
+                .extend(group_paths.watched_paths);
+        }
+        planned.push((build_meta, build_graph));
+    }
+
+    if planned.is_empty() {
+        if !cli.dry_run {
+            N2RunStats {
+                n_tasks_executed: Some(0),
+                n_errors: 0,
+                n_warnings: 0,
+            }
+            .print_info(cli.quiet, "checking")?;
+        }
+        return Ok(WatchOutput {
+            ok: true,
+            additional_ignored_paths: prebuild_list.ignored_paths,
+            additional_watched_paths: prebuild_list.watched_paths,
+        });
+    }
+
+    if cli.dry_run {
+        for (build_meta, build_graph) in &planned {
+            rr_build::print_dry_run(
+                build_graph,
+                build_meta.artifacts.values(),
+                source_dir,
+                target_dir,
+            );
+        }
+        Ok(WatchOutput {
+            ok: true,
+            additional_ignored_paths: prebuild_list.ignored_paths,
+            additional_watched_paths: prebuild_list.watched_paths,
+        })
+    } else {
+        let _lock = FileLock::lock(target_dir)?;
+        let mut cfg = BuildConfig::from_flags(
+            &cmd.build_flags,
+            &cli.unstable_feature,
+            cli.verbose,
+            UserDiagnostics::from_flags(cli),
+        );
+        cfg.patch_file = cmd.patch_file.clone();
+        cfg.explain_errors |= cmd.explain;
+
+        let mut ok = true;
+        for (build_meta, build_graph) in planned {
+            rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Check)?;
+            rr_build::generate_metadata(source_dir, target_dir, &build_meta, RunMode::Check, None)?;
+            let result = rr_build::execute_build(&cfg, build_graph, target_dir)?;
+            result.print_info(cli.quiet, "checking")?;
+            ok &= result.successful();
+        }
+        Ok(WatchOutput {
+            ok,
             additional_ignored_paths: prebuild_list.ignored_paths,
             additional_watched_paths: prebuild_list.watched_paths,
         })
@@ -483,6 +600,8 @@ pub(crate) fn plan_check_rr_from_resolved(
     source_dir: &Path,
     target_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
+    module_scope: Option<&[ModuleId]>,
+    selected_packages: Option<&[PackageId]>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
     let preconfig = preconfig_compile(
@@ -501,6 +620,18 @@ pub(crate) fn plan_check_rr_from_resolved(
         target_dir,
         output,
         Box::new(|resolved, target_backend| {
+            if let Some(selected_packages) = selected_packages {
+                return calc_user_intent(
+                    resolved,
+                    &cmd.path,
+                    module_scope.unwrap_or(resolved.local_modules()),
+                    Some(selected_packages),
+                    target_backend,
+                    cmd.no_mi,
+                    cmd.patch_file.as_deref(),
+                    output,
+                );
+            }
             if let Some(filter_path) = cmd.package_path.as_deref() {
                 return calc_user_intent_from_package_path(
                     resolved,
@@ -515,6 +646,8 @@ pub(crate) fn plan_check_rr_from_resolved(
             calc_user_intent(
                 resolved,
                 &cmd.path,
+                module_scope.unwrap_or(resolved.local_modules()),
+                None,
                 target_backend,
                 cmd.no_mi,
                 cmd.patch_file.as_deref(),
@@ -548,12 +681,31 @@ fn calc_user_intent_from_package_path(
 fn calc_user_intent(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     paths: &[PathBuf],
+    module_scope: &[ModuleId],
+    selected_packages: Option<&[PackageId]>,
     target_backend: TargetBackend,
     no_mi: bool,
     patch_file: Option<&Path>,
     output: UserDiagnostics,
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
-    if !paths.is_empty() {
+    if let Some(selected_packages) = selected_packages {
+        ensure_packages_support_backend(
+            resolve_output,
+            selected_packages.iter().copied(),
+            target_backend,
+        )?;
+        let directive =
+            build_directive_for_selected_packages(selected_packages, no_mi, patch_file)?;
+        Ok((
+            selected_packages
+                .iter()
+                .copied()
+                .map(UserIntent::Check)
+                .collect(),
+            directive,
+        )
+            .into())
+    } else if !paths.is_empty() {
         let selected = select_supported_packages(resolve_output, paths, target_backend, output)?;
         let directive = build_directive_for_selected_packages(&selected, no_mi, patch_file)?;
         Ok((
@@ -562,7 +714,7 @@ fn calc_user_intent(
         )
             .into())
     } else {
-        let intents: Vec<_> = rr_build::local_packages(resolve_output)
+        let intents: Vec<_> = rr_build::local_packages_in_modules(resolve_output, module_scope)
             .filter(|&pkg| package_supports_backend(resolve_output, pkg, target_backend))
             .map(UserIntent::Check)
             .collect();
@@ -600,4 +752,64 @@ fn build_directive_for_selected_packages(
             Ok(Default::default())
         }
     }
+}
+
+fn resolve_check_groups(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    source_dir: &Path,
+    cmd: &CheckSubcommand,
+    output: UserDiagnostics,
+) -> anyhow::Result<Vec<CheckGroup>> {
+    if let Some(filter_path) = cmd.package_path.as_deref() {
+        let (dir, _) = canonicalize_with_filename(&source_dir.join(filter_path))?;
+        let pkg = filter_pkg_by_dir(resolve_output, &dir)?;
+        return Ok(group_check_packages_by_default_target(
+            resolve_output,
+            [pkg],
+        ));
+    }
+
+    if !cmd.path.is_empty() {
+        let selected = select_packages(&cmd.path, output, |dir| {
+            filter_pkg_by_dir(resolve_output, dir)
+        })?;
+        return Ok(group_check_packages_by_default_target(
+            resolve_output,
+            selected.into_iter().map(|(_, pkg_id)| pkg_id),
+        ));
+    }
+
+    Ok(
+        rr_build::group_modules_by_default_target(resolve_output, resolve_output.local_modules())
+            .into_iter()
+            .map(|(target_backend, modules)| CheckGroup {
+                target_backend,
+                scope: CheckScope::Modules(modules),
+            })
+            .collect(),
+    )
+}
+
+fn group_check_packages_by_default_target(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    packages: impl IntoIterator<Item = PackageId>,
+) -> Vec<CheckGroup> {
+    let mut grouped = std::collections::BTreeMap::<TargetBackend, Vec<PackageId>>::new();
+    for pkg_id in packages {
+        let module_id = resolve_output.pkg_dirs.get_package(pkg_id).module;
+        grouped
+            .entry(rr_build::default_target_for_module(
+                resolve_output,
+                module_id,
+            ))
+            .or_default()
+            .push(pkg_id);
+    }
+    grouped
+        .into_iter()
+        .map(|(target_backend, packages)| CheckGroup {
+            target_backend,
+            scope: CheckScope::Packages(packages),
+        })
+        .collect()
 }

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -598,6 +598,7 @@ fn run_check_normal_internal_rr(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn plan_check_rr_from_resolved(
     cli: &UniversalFlags,
     cmd: &CheckSubcommand,
@@ -682,6 +683,7 @@ fn calc_user_intent_from_package_path(
 }
 
 #[instrument(level = Level::DEBUG, skip_all)]
+#[allow(clippy::too_many_arguments)]
 fn calc_user_intent(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     paths: &[PathBuf],

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -499,6 +499,10 @@ fn run_check_normal_internal_rr(
     )
     .context("Failed to determine default target groups")?;
 
+    if groups.is_empty() {
+        build_directive_for_selected_packages(&[], cmd.no_mi, cmd.patch_file.as_deref())?;
+    }
+
     let mut planned = Vec::new();
     let mut prebuild_list = PrebuildWatchPaths {
         ignored_paths: Vec::new(),

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -94,31 +94,38 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
     let source_dir = dirs.project_root;
     let target_dir = dirs.target_dir;
     let project_manifest_path = dirs.project_manifest_path;
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
+        cmd.auto_sync_flags.frozen,
+        false,
+        false,
+    )
+    .with_project_manifest_path(project_manifest_path.as_deref());
+    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+    let module_id = selected_doc_module_id(&resolve_output, &doc_source_dir)?;
+    let target_backend = rr_build::default_target_for_module(&resolve_output, module_id);
 
     // FIXME: This is copied from `moon check`'s code. Share code if possible.
     let mut preconfig = preconfig_compile(
         &cmd.auto_sync_flags,
         &cli,
         &BuildFlags::default(),
-        None,
+        Some(target_backend),
         &target_dir,
         RunMode::Check,
     );
     preconfig.docs_serve = cmd.serve;
 
     let doc_source_dir_for_intent = doc_source_dir.clone();
-    let (build_meta, build_graph) = rr_build::plan_build(
+    let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
         preconfig,
         &cli.unstable_feature,
-        &source_dir,
         &target_dir,
-        &mooncakes_dir,
         UserDiagnostics::from_flags(&cli),
-        project_manifest_path.as_deref(),
         Box::new(move |resolve_output, _| {
             let module_id = selected_doc_module_id(resolve_output, &doc_source_dir_for_intent)?;
             Ok(vec![UserIntent::Doc(module_id)].into())
         }),
+        resolve_output,
     )?;
 
     // Early exit for dry-run
@@ -170,7 +177,6 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
                 static_dir.display()
             );
         }
-        let module_id = selected_doc_module_id(&build_meta.resolve_output, &doc_source_dir)?;
         let full_name = build_meta
             .resolve_output
             .module_rel

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -47,9 +47,15 @@ enum InfoScope {
     Packages(Vec<PackageId>),
 }
 
+#[derive(Clone, Debug, Default)]
+struct InfoPlanOverrides {
+    module_scope: Option<Vec<ModuleId>>,
+    selected_packages: Option<Vec<PackageId>>,
+}
+
 struct InfoGroup {
     target_backend: TargetBackend,
-    scope: InfoScope,
+    overrides: InfoPlanOverrides,
 }
 
 /// Generate public interface (`.mbti`) files for all packages in the module or workspace
@@ -107,7 +113,7 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
     // If there's zero or one target, just run normally and promote the results
     if lowered_targets.len() <= 1 {
         let target_backend = lowered_targets.first().cloned();
-        let (success, meta) = run_info_rr_internal(&cli, &cmd, target_backend, None, None)?;
+        let (success, meta) = run_info_rr_internal(&cli, &cmd, target_backend)?;
         if success {
             imp::promote_info_results(&meta);
             return Ok(0);
@@ -128,7 +134,7 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
 
     let mut all_meta = vec![];
     for &tgt in &lowered_targets {
-        let (success, meta) = run_info_rr_internal(&cli, &cmd, Some(tgt), None, None)?;
+        let (success, meta) = run_info_rr_internal(&cli, &cmd, Some(tgt))?;
         if !success {
             bail!("moon info failed for target {:?}", tgt);
         }
@@ -161,20 +167,12 @@ fn run_info_rr_grouped_default(cli: UniversalFlags, cmd: InfoSubcommand) -> anyh
 
     let mut ok = true;
     for group in groups {
-        let module_scope = match &group.scope {
-            InfoScope::Modules(modules) => Some(modules.as_slice()),
-            InfoScope::Packages(_) => None,
-        };
-        let selected_packages = match &group.scope {
-            InfoScope::Modules(_) => None,
-            InfoScope::Packages(packages) => Some(packages.as_slice()),
-        };
-        let (success, meta) = run_info_rr_internal(
+        let (success, meta) = run_info_rr_from_resolved(
             &cli,
             &cmd,
             Some(group.target_backend),
-            module_scope,
-            selected_packages,
+            &group.overrides,
+            resolve_output.clone(),
         )?;
         ok &= success;
         if success {
@@ -192,16 +190,38 @@ pub(crate) fn run_info_rr_internal(
     cli: &UniversalFlags,
     cmd: &InfoSubcommand,
     target: Option<TargetBackend>,
-    module_scope: Option<&[ModuleId]>,
-    selected_packages: Option<&[PackageId]>,
 ) -> anyhow::Result<(bool, BuildMeta)> {
     let PackageDirs {
         source_dir,
-        target_dir,
         mooncakes_dir,
         project_manifest_path,
+        ..
     } = cli.source_tgt_dir.try_into_package_dirs()?;
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
+        cmd.auto_sync_flags.frozen,
+        false,
+        false,
+    )
+    .with_project_manifest_path(project_manifest_path.as_deref());
+    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
 
+    run_info_rr_from_resolved(
+        cli,
+        cmd,
+        target,
+        &InfoPlanOverrides::default(),
+        resolve_output,
+    )
+}
+
+fn run_info_rr_from_resolved(
+    cli: &UniversalFlags,
+    cmd: &InfoSubcommand,
+    target: Option<TargetBackend>,
+    overrides: &InfoPlanOverrides,
+    resolve_output: moonbuild_rupes_recta::ResolveOutput,
+) -> anyhow::Result<(bool, BuildMeta)> {
+    let PackageDirs { target_dir, .. } = cli.source_tgt_dir.try_into_package_dirs()?;
     let mut preconfig = rr_build::preconfig_compile(
         &cmd.auto_sync_flags,
         cli,
@@ -213,14 +233,8 @@ pub(crate) fn run_info_rr_internal(
     preconfig.info_no_alias = cmd.no_alias;
     let package_filter = cmd.package.clone();
     let path_filter = cmd.path.clone();
+    let overrides = overrides.clone();
     let output = UserDiagnostics::from_flags(cli);
-    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
-        cmd.auto_sync_flags.frozen,
-        false,
-        false,
-    )
-    .with_project_manifest_path(project_manifest_path.as_deref());
-    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
     let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
         preconfig,
         &cli.unstable_feature,
@@ -230,8 +244,11 @@ pub(crate) fn run_info_rr_internal(
             calc_user_intent(
                 package_filter.as_deref(),
                 &path_filter,
-                module_scope.unwrap_or(resolve_output.local_modules()),
-                selected_packages,
+                overrides
+                    .module_scope
+                    .as_deref()
+                    .unwrap_or(resolve_output.local_modules()),
+                overrides.selected_packages.as_deref(),
                 resolve_output,
                 tb,
                 output,
@@ -421,9 +438,8 @@ fn resolve_info_groups(
     Ok(
         rr_build::group_modules_by_default_target(resolve_output, resolve_output.local_modules())
             .into_iter()
-            .map(|(target_backend, modules)| InfoGroup {
-                target_backend,
-                scope: InfoScope::Modules(modules),
+            .map(|(target_backend, scope)| {
+                info_group_from_scope(target_backend, InfoScope::Modules(scope))
             })
             .collect(),
     )
@@ -446,9 +462,25 @@ fn group_info_packages_by_default_target(
     }
     grouped
         .into_iter()
-        .map(|(target_backend, packages)| InfoGroup {
-            target_backend,
-            scope: InfoScope::Packages(packages),
+        .map(|(target_backend, scope)| {
+            info_group_from_scope(target_backend, InfoScope::Packages(scope))
         })
         .collect()
+}
+
+fn info_group_from_scope(target_backend: TargetBackend, scope: InfoScope) -> InfoGroup {
+    let overrides = match scope {
+        InfoScope::Modules(module_scope) => InfoPlanOverrides {
+            module_scope: Some(module_scope),
+            selected_packages: None,
+        },
+        InfoScope::Packages(selected_packages) => InfoPlanOverrides {
+            module_scope: None,
+            selected_packages: Some(selected_packages),
+        },
+    };
+    InfoGroup {
+        target_backend,
+        overrides,
+    }
 }

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -22,9 +22,11 @@ use std::path::PathBuf;
 
 use anyhow::bail;
 use moonbuild_rupes_recta::intent::UserIntent;
+use moonbuild_rupes_recta::model::PackageId;
 use moonutil::{
     common::{RunMode, SurfaceTarget, TargetBackend, lower_surface_targets},
     dirs::PackageDirs,
+    mooncakes::ModuleId,
     mooncakes::sync::AutoSyncFlags,
 };
 
@@ -39,6 +41,16 @@ use crate::{
 };
 
 use super::UniversalFlags;
+
+enum InfoScope {
+    Modules(Vec<ModuleId>),
+    Packages(Vec<PackageId>),
+}
+
+struct InfoGroup {
+    target_backend: TargetBackend,
+    scope: InfoScope,
+}
 
 /// Generate public interface (`.mbti`) files for all packages in the module or workspace
 #[derive(Debug, clap::Parser)]
@@ -81,6 +93,10 @@ pub(crate) fn run_info(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Resu
 }
 
 pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32> {
+    if cmd.target.is_none() {
+        return run_info_rr_grouped_default(cli, cmd);
+    }
+
     // Determine which target to use
     let target = &cmd.target;
     let mut lowered_targets = vec![];
@@ -91,7 +107,7 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
     // If there's zero or one target, just run normally and promote the results
     if lowered_targets.len() <= 1 {
         let target_backend = lowered_targets.first().cloned();
-        let (success, meta) = run_info_rr_internal(&cli, &cmd, target_backend)?;
+        let (success, meta) = run_info_rr_internal(&cli, &cmd, target_backend, None, None)?;
         if success {
             imp::promote_info_results(&meta);
             return Ok(0);
@@ -112,7 +128,7 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
 
     let mut all_meta = vec![];
     for &tgt in &lowered_targets {
-        let (success, meta) = run_info_rr_internal(&cli, &cmd, Some(tgt))?;
+        let (success, meta) = run_info_rr_internal(&cli, &cmd, Some(tgt), None, None)?;
         if !success {
             bail!("moon info failed for target {:?}", tgt);
         }
@@ -128,6 +144,47 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
     if identical { Ok(0) } else { Ok(1) }
 }
 
+fn run_info_rr_grouped_default(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32> {
+    let package_dirs = cli.source_tgt_dir.try_into_package_dirs()?;
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
+        cmd.auto_sync_flags.frozen,
+        false,
+        false,
+    )
+    .with_project_manifest_path(package_dirs.project_manifest_path.as_deref());
+    let resolve_output = moonbuild_rupes_recta::resolve(
+        &resolve_cfg,
+        &package_dirs.source_dir,
+        &package_dirs.mooncakes_dir,
+    )?;
+    let groups = resolve_info_groups(&resolve_output, &cmd, UserDiagnostics::from_flags(&cli))?;
+
+    let mut ok = true;
+    for group in groups {
+        let module_scope = match &group.scope {
+            InfoScope::Modules(modules) => Some(modules.as_slice()),
+            InfoScope::Packages(_) => None,
+        };
+        let selected_packages = match &group.scope {
+            InfoScope::Modules(_) => None,
+            InfoScope::Packages(packages) => Some(packages.as_slice()),
+        };
+        let (success, meta) = run_info_rr_internal(
+            &cli,
+            &cmd,
+            Some(group.target_backend),
+            module_scope,
+            selected_packages,
+        )?;
+        ok &= success;
+        if success {
+            imp::promote_info_results(&meta);
+        }
+    }
+
+    Ok(if ok { 0 } else { 1 })
+}
+
 /// Run `moon info` for the given target (`None` for default target)
 ///
 /// Returns `(success, build metadata if not dry-run)`.
@@ -135,6 +192,8 @@ pub(crate) fn run_info_rr_internal(
     cli: &UniversalFlags,
     cmd: &InfoSubcommand,
     target: Option<TargetBackend>,
+    module_scope: Option<&[ModuleId]>,
+    selected_packages: Option<&[PackageId]>,
 ) -> anyhow::Result<(bool, BuildMeta)> {
     let PackageDirs {
         source_dir,
@@ -155,23 +214,30 @@ pub(crate) fn run_info_rr_internal(
     let package_filter = cmd.package.clone();
     let path_filter = cmd.path.clone();
     let output = UserDiagnostics::from_flags(cli);
-    let (build_meta, build_graph) = rr_build::plan_build(
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
+        cmd.auto_sync_flags.frozen,
+        false,
+        false,
+    )
+    .with_project_manifest_path(project_manifest_path.as_deref());
+    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+    let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
         preconfig,
         &cli.unstable_feature,
-        &source_dir,
         &target_dir,
-        &mooncakes_dir,
         output,
-        project_manifest_path.as_deref(),
         Box::new(move |resolve_output, tb| {
             calc_user_intent(
                 package_filter.as_deref(),
                 &path_filter,
+                module_scope.unwrap_or(resolve_output.local_modules()),
+                selected_packages,
                 resolve_output,
                 tb,
                 output,
             )
         }),
+        resolve_output,
     )?;
     // Generate the all_pkgs.json for indirect dependency resolution
     // before executing the build
@@ -193,23 +259,32 @@ pub(crate) fn run_info_rr_internal(
 fn calc_user_intent(
     package_filter: Option<&str>,
     path_filter: &[PathBuf],
+    module_scope: &[ModuleId],
+    selected_packages: Option<&[PackageId]>,
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     target_backend: TargetBackend,
     output: UserDiagnostics,
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
-    let package_ids: Vec<_> = resolve_output
-        .local_modules()
-        .iter()
-        .flat_map(|&module_id| {
-            resolve_output
-                .pkg_dirs
-                .packages_for_module(module_id)
-                .into_iter()
-                .flat_map(|packages| packages.values().copied())
-        })
-        .collect();
+    let package_ids: Vec<_> =
+        rr_build::local_packages_in_modules(resolve_output, module_scope).collect();
 
-    let intents = if let [path] = path_filter {
+    let intents = if let Some(selected_packages) = selected_packages {
+        let filtered = selected_packages
+            .iter()
+            .copied()
+            .filter(|&pkg_id| package_supports_backend(resolve_output, pkg_id, target_backend))
+            .collect::<Vec<_>>();
+        if filtered.is_empty() && !selected_packages.is_empty() {
+            output.warn(format!(
+                "No selected package supports target backend `{}` for `moon info`",
+                target_backend
+            ));
+        }
+        filtered
+            .into_iter()
+            .map(UserIntent::Info)
+            .collect::<Vec<_>>()
+    } else if let [path] = path_filter {
         // Preserve the old single-path behavior exactly.
         let (dir, _) = canonicalize_with_filename(path)?;
         let pkg = filter_pkg_by_dir(resolve_output, &dir)?;
@@ -300,4 +375,80 @@ fn calc_user_intent(
     };
 
     Ok(intents.into())
+}
+
+fn resolve_info_groups(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    cmd: &InfoSubcommand,
+    output: UserDiagnostics,
+) -> anyhow::Result<Vec<InfoGroup>> {
+    if !cmd.path.is_empty() {
+        let selected = select_packages(&cmd.path, output, |dir| {
+            filter_pkg_by_dir(resolve_output, dir)
+        })?;
+        return Ok(group_info_packages_by_default_target(
+            resolve_output,
+            selected.into_iter().map(|(_, pkg_id)| pkg_id),
+        ));
+    }
+
+    if let Some(filter) = cmd.package.as_deref() {
+        let package_ids: Vec<_> =
+            rr_build::local_packages_in_modules(resolve_output, resolve_output.local_modules())
+                .collect();
+        let matches = match_packages_with_fuzzy(
+            resolve_output,
+            package_ids.iter().copied(),
+            std::iter::once(filter),
+        );
+        if matches.matched.is_empty() {
+            bail!(
+                "package `{}` not found, make sure you have spelled it correctly, e.g. `moonbitlang/core/hashmap`(exact match) or `hashmap`(fuzzy match)",
+                filter
+            );
+        }
+        if !matches.missing.is_empty() {
+            for missing in matches.missing {
+                output.warn(format!("Input `{}` did not match any package", missing));
+            }
+        }
+        return Ok(group_info_packages_by_default_target(
+            resolve_output,
+            matches.matched,
+        ));
+    }
+
+    Ok(
+        rr_build::group_modules_by_default_target(resolve_output, resolve_output.local_modules())
+            .into_iter()
+            .map(|(target_backend, modules)| InfoGroup {
+                target_backend,
+                scope: InfoScope::Modules(modules),
+            })
+            .collect(),
+    )
+}
+
+fn group_info_packages_by_default_target(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    packages: impl IntoIterator<Item = PackageId>,
+) -> Vec<InfoGroup> {
+    let mut grouped = std::collections::BTreeMap::<TargetBackend, Vec<PackageId>>::new();
+    for pkg_id in packages {
+        let module_id = resolve_output.pkg_dirs.get_package(pkg_id).module;
+        grouped
+            .entry(rr_build::default_target_for_module(
+                resolve_output,
+                module_id,
+            ))
+            .or_default()
+            .push(pkg_id);
+    }
+    grouped
+        .into_iter()
+        .map(|(target_backend, packages)| InfoGroup {
+            target_backend,
+            scope: InfoScope::Packages(packages),
+        })
+        .collect()
 }

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -122,25 +122,45 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
         ensure_why3_config(&generated_why3_config_path)?;
     }
 
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
+        cmd.auto_sync_flags.frozen,
+        false,
+        false,
+    )
+    .with_project_manifest_path(project_manifest_path.as_deref());
+    let resolve_output =
+        moonbuild_rupes_recta::resolve(&resolve_cfg, &project_root, &mooncakes_dir)?;
+    let selected_target_backend = if let Some(path) = cmd.path.as_deref() {
+        let (dir, _) = canonicalize_with_filename(path)?;
+        let pkg = filter_pkg_by_dir(&resolve_output, &dir)?;
+        Some(rr_build::default_target_for_module(
+            &resolve_output,
+            resolve_output.pkg_dirs.get_package(pkg).module,
+        ))
+    } else {
+        let main_module_id = selected_main_module_id(&resolve_output, module_dir.as_deref())?;
+        Some(rr_build::default_target_for_module(
+            &resolve_output,
+            main_module_id,
+        ))
+    };
+
     let preconfig = preconfig_compile(
         &cmd.auto_sync_flags,
         cli,
         &build_flags,
-        None,
+        selected_target_backend,
         &target_dir,
         RunMode::Prove,
     );
     let path_filter = cmd.path.as_deref();
     let prove_why3_config = why3_config_path.clone();
 
-    let (build_meta, build_graph) = rr_build::plan_build(
+    let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
         preconfig,
         &cli.unstable_feature,
-        &project_root,
         &target_dir,
-        &mooncakes_dir,
         UserDiagnostics::from_flags(cli),
-        project_manifest_path.as_deref(),
         Box::new(move |resolve_output, target_backend| {
             calc_user_intent(
                 path_filter,
@@ -150,6 +170,7 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
                 prove_why3_config.as_deref(),
             )
         }),
+        resolve_output,
     )?;
     let proof_reports = planned_proof_reports(&build_meta);
 

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -168,6 +168,11 @@ fn run_run_rr(
     )
     .with_project_manifest_path(project_manifest_path.as_deref());
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+    let selected_target_backend = selected_target_backend.or_else(|| {
+        selected_module_for_run_input(&cmd.package_or_mbt_file, &source_dir, &resolve_output)
+            .ok()
+            .map(|module_id| rr_build::default_target_for_module(&resolve_output, module_id))
+    });
     let (build_meta, build_graph) = plan_run_rr_from_resolved(
         cli,
         &cmd,
@@ -184,6 +189,22 @@ fn run_run_rr(
         &build_meta,
         build_graph,
     )
+}
+
+fn selected_module_for_run_input(
+    input_path: &str,
+    source_dir: &Path,
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+) -> anyhow::Result<moonutil::mooncakes::ModuleId> {
+    let (dir, _) = match crate::filter::canonicalize_with_filename(Path::new(input_path)) {
+        Ok((dir, filename)) => (dir, filename),
+        Err(_) => {
+            let backup_path = source_dir.join(input_path);
+            crate::filter::canonicalize_with_filename(&backup_path)?
+        }
+    };
+    let pkg = crate::filter::filter_pkg_by_dir(resolve_output, &dir)?;
+    Ok(resolve_output.pkg_dirs.get_package(pkg).module)
 }
 
 pub(crate) fn plan_run_rr_from_resolved(

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -1109,6 +1109,23 @@ fn resolve_test_target_groups(
     output: UserDiagnostics,
 ) -> anyhow::Result<Vec<TestTargetGroup>> {
     if !cmd.explicit_path_filters.is_empty() {
+        if let [path] = cmd.explicit_path_filters {
+            let (dir, filename) = canonicalize_with_filename(path)?;
+            let pkg = filter_pkg_by_dir(resolve_output, &dir)?;
+            let module_id = resolve_output.pkg_dirs.get_package(pkg).module;
+            return Ok(vec![TestTargetGroup {
+                target_backend: rr_build::default_target_for_module(resolve_output, module_id),
+                overrides: TestPlanOverrides {
+                    resolved_paths: Some(vec![ResolvedTestPathFilter {
+                        path: path.clone(),
+                        package: pkg,
+                        filename,
+                    }]),
+                    ..Default::default()
+                },
+            }]);
+        }
+
         let mut grouped =
             std::collections::BTreeMap::<TargetBackend, Vec<ResolvedTestPathFilter>>::new();
         for path in cmd.explicit_path_filters {
@@ -1154,11 +1171,6 @@ fn resolve_test_target_groups(
             all_affected_packages.iter().copied(),
             package_filter,
         );
-        if !package_matches.missing.is_empty() {
-            for missing in package_matches.missing {
-                output.warn(format!("Input `{}` did not match any package", missing));
-            }
-        }
         if package_matches.matched.is_empty() {
             output.warn(format!(
                 "package `{}` not found, make sure you have spelled it correctly, e.g. `moonbitlang/core/hashmap`(exact match) or `hashmap`(fuzzy match)",

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -466,6 +466,7 @@ fn run_test_in_single_file_rr(
         &build_meta,
         build_graph,
         filter,
+        true,
     )
 }
 
@@ -706,7 +707,12 @@ pub(crate) fn run_test_or_bench_internal(
             anyhow::bail!("cannot update test on multiple targets");
         }
         let display_backend_hint = if groups.len() > 1 { Some(()) } else { None };
+        let aggregate_build_only_output = cmd.build_only && groups.len() > 1 && !cli.dry_run;
         let mut ret = 0;
+        let mut build_only_artifacts = TestArtifacts {
+            artifacts_path: Vec::new(),
+            test_filter_args: Vec::new(),
+        };
         for group in groups {
             let (build_meta, build_graph, filter) = plan_test_or_bench_rr_from_resolved(
                 cli,
@@ -716,7 +722,8 @@ pub(crate) fn run_test_or_bench_internal(
                 Some(&group.overrides),
                 resolve_output.clone(),
             )?;
-            ret = ret.max(rr_test_from_plan(
+            let filter_for_build_only = aggregate_build_only_output.then(|| filter.clone());
+            let code = rr_test_from_plan(
                 cli,
                 &cmd,
                 source_dir,
@@ -725,7 +732,29 @@ pub(crate) fn run_test_or_bench_internal(
                 &build_meta,
                 build_graph,
                 filter,
-            )?);
+                !aggregate_build_only_output,
+            )?;
+            ret = ret.max(code);
+            if let Some(filter) = filter_for_build_only.as_ref()
+                && code == 0
+            {
+                let group_artifacts = collect_test_artifacts_for_build_only(
+                    &build_meta,
+                    target_dir,
+                    filter,
+                    cmd.include_skipped,
+                    cmd.run_mode == RunMode::Bench,
+                )?;
+                build_only_artifacts
+                    .artifacts_path
+                    .extend(group_artifacts.artifacts_path);
+                build_only_artifacts
+                    .test_filter_args
+                    .extend(group_artifacts.test_filter_args);
+            }
+        }
+        if aggregate_build_only_output && ret == 0 {
+            println!("{}", serde_json_lenient::to_string(&build_only_artifacts)?);
         }
         return Ok(ret);
     }
@@ -779,6 +808,7 @@ fn run_test_rr(
         &build_meta,
         build_graph,
         filter,
+        true,
     )
 }
 
@@ -1258,6 +1288,7 @@ fn rr_test_from_plan(
     build_meta: &rr_build::BuildMeta,
     build_graph: rr_build::BuildInput,
     filter: TestFilter,
+    print_build_only_json: bool,
 ) -> Result<i32, anyhow::Error> {
     // Dry-run: share the same routine
     if cli.dry_run {
@@ -1317,7 +1348,9 @@ fn rr_test_from_plan(
             cmd.include_skipped,
             cmd.run_mode == RunMode::Bench,
         )?;
-        println!("{}", serde_json_lenient::to_string(&test_artifacts)?);
+        if print_build_only_json {
+            println!("{}", serde_json_lenient::to_string(&test_artifacts)?);
+        }
         return Ok(0);
     }
 

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -41,12 +41,32 @@ use moonbuild_rupes_recta::model::PackageId;
 use moonutil::common::{
     FileLock, RunMode, TargetBackend, TestArtifacts, TestIndexRange, lower_surface_targets,
 };
+use moonutil::mooncakes::ModuleId;
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use std::path::{Path, PathBuf};
 use tracing::{Level, debug, info, instrument, trace};
 
 use super::BenchSubcommand;
 use super::{BuildFlags, UniversalFlags};
+
+#[derive(Clone, Debug)]
+struct ResolvedTestPathFilter {
+    path: PathBuf,
+    package: PackageId,
+    filename: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TestPlanOverrides {
+    module_scope: Option<Vec<ModuleId>>,
+    selected_packages: Option<Vec<PackageId>>,
+    resolved_paths: Option<Vec<ResolvedTestPathFilter>>,
+}
+
+struct TestTargetGroup {
+    target_backend: TargetBackend,
+    overrides: TestPlanOverrides,
+}
 
 /// Print test summary statistics in the legacy format
 fn print_test_summary(
@@ -544,6 +564,7 @@ pub(crate) fn plan_test_or_bench_rr(
         cmd,
         target_dir,
         selected_target_backend,
+        None,
         resolve_output,
     )
 }
@@ -553,6 +574,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
     cmd: &TestLikeSubcommand<'_>,
     target_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
+    overrides: Option<&TestPlanOverrides>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> Result<(rr_build::BuildMeta, rr_build::BuildInput, TestFilter), anyhow::Error> {
     // Keep the planning flow explicit:
@@ -585,6 +607,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
         name_filter: cmd.filter.clone(),
         ..Default::default()
     };
+    let overrides = overrides.cloned().unwrap_or_default();
     let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
         preconfig,
         &cli.unstable_feature,
@@ -597,6 +620,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
                 &mut filter,
                 target_backend,
                 UserDiagnostics::from_flags(cli),
+                &overrides,
             )
         }),
         resolve_output,
@@ -616,6 +640,7 @@ pub(crate) fn run_test_or_bench_internal(
     display_backend_hint: Option<()>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
+    let output = UserDiagnostics::from_flags(cli);
     debug!(
         run_mode = ?cmd.run_mode,
         update = cmd.update,
@@ -652,6 +677,57 @@ pub(crate) fn run_test_or_bench_internal(
     }
     if cmd.outline && cli.dry_run {
         anyhow::bail!("`--outline` cannot be used with `--dry-run`");
+    }
+
+    if selected_target_backend.is_none() {
+        let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
+            cmd.auto_sync_flags.frozen,
+            !cmd.build_flags.std(),
+            cmd.build_flags.enable_coverage,
+        )
+        .with_project_manifest_path(project_manifest_path);
+        let resolve_output =
+            moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir, mooncakes_dir)?;
+        let groups = resolve_test_target_groups(&resolve_output, &cmd, output)?;
+        if groups.is_empty() {
+            if cli.dry_run {
+                return Ok(0);
+            }
+            if cmd.outline {
+                print_test_outline(&[], output);
+            } else if cmd.build_only {
+                println!("[]");
+            } else {
+                print_test_summary(0, 0, cli.quiet, None, output);
+            }
+            return Ok(0);
+        }
+        if cmd.update && groups.len() > 1 {
+            anyhow::bail!("cannot update test on multiple targets");
+        }
+        let display_backend_hint = if groups.len() > 1 { Some(()) } else { None };
+        let mut ret = 0;
+        for group in groups {
+            let (build_meta, build_graph, filter) = plan_test_or_bench_rr_from_resolved(
+                cli,
+                &cmd,
+                target_dir,
+                Some(group.target_backend),
+                Some(&group.overrides),
+                resolve_output.clone(),
+            )?;
+            ret = ret.max(rr_test_from_plan(
+                cli,
+                &cmd,
+                source_dir,
+                target_dir,
+                display_backend_hint,
+                &build_meta,
+                build_graph,
+                filter,
+            )?);
+        }
+        return Ok(ret);
     }
 
     debug!("selecting test runner implementation");
@@ -735,7 +811,40 @@ fn apply_list_of_filters(
         affected_packages.iter().copied(),
         package_filter,
     );
-    let filtered_package_ids = package_matches.matched;
+    if package_matches.matched.is_empty() {
+        // No package matched
+        output.warn(format!(
+            "package `{}` not found, make sure you have spelled it correctly, e.g. `moonbitlang/core/hashmap`(exact match) or `hashmap`(fuzzy match)",
+            package_filter.join(", ")
+        ));
+        return Ok(InputDirective::default());
+    }
+
+    apply_selected_package_filters(
+        &package_matches.matched,
+        resolve_output,
+        file_filter,
+        index_filter,
+        doc_index_filter,
+        patch_file,
+        value_tracing,
+        target_backend,
+        out_filter,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_selected_package_filters(
+    filtered_package_ids: &[PackageId],
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    file_filter: Option<&str>,
+    index_filter: Option<TestIndexRange>,
+    doc_index_filter: Option<u32>,
+    patch_file: Option<&Path>,
+    value_tracing: bool,
+    target_backend: TargetBackend,
+    out_filter: &mut TestFilter,
+) -> Result<InputDirective, anyhow::Error> {
     ensure_packages_support_backend(
         resolve_output,
         filtered_package_ids.iter().copied(),
@@ -746,11 +855,9 @@ fn apply_list_of_filters(
         "package filters resolved"
     );
 
-    // Calculate resulting filter & target list
     let mut input_directive = InputDirective::default();
     #[allow(clippy::comparison_chain)]
     if filtered_package_ids.len() == 1 {
-        // Single filtered package, can apply file/index filtering
         let pkg_id = filtered_package_ids[0];
         if let Some(range) = index_filter {
             out_filter.add_autodetermine_target(
@@ -768,8 +875,6 @@ fn apply_list_of_filters(
         } else {
             out_filter.add_autodetermine_target(pkg_id, file_filter, None);
         }
-        // Currently, value tracing is only supported for single package testing
-        // It's not sure whether we should support it for multiple packages
         let trace_pkg = if value_tracing { Some(pkg_id) } else { None };
         input_directive =
             rr_build::build_patch_directive_for_package(pkg_id, false, trace_pkg, patch_file, true)
@@ -781,7 +886,6 @@ fn apply_list_of_filters(
                 .map(|id| resolve_output.pkg_dirs.get_package(*id).fqn.to_string())
                 .collect::<Vec<_>>()
         };
-        // Multiple filtered package, check if file/index filtering is applied
         if file_filter.is_some() || index_filter.is_some() || doc_index_filter.is_some() {
             bail!(
                 "Cannot filter by file or index when multiple packages are specified. Matched packages: {:?}",
@@ -794,18 +898,11 @@ fn apply_list_of_filters(
                 package_names()
             );
         }
-        for &pkg_id in &filtered_package_ids {
+        for &pkg_id in filtered_package_ids {
             out_filter.add_autodetermine_target(pkg_id, None, None);
         }
-    } else {
-        // No package matched
-        output.warn(format!(
-            "package `{}` not found, make sure you have spelled it correctly, e.g. `moonbitlang/core/hashmap`(exact match) or `hashmap`(fuzzy match)",
-            package_filter.join(", ")
-        ));
     }
     trace!("finished building package directive");
-
     Ok(input_directive)
 }
 
@@ -825,21 +922,17 @@ fn calc_user_intent(
     out_filter: &mut TestFilter,
     target_backend: moonutil::common::TargetBackend,
     output: UserDiagnostics,
+    overrides: &TestPlanOverrides,
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
-    let all_affected_packages: Vec<_> = resolve_output
-        .local_modules()
-        .iter()
-        .flat_map(|&module_id| {
-            resolve_output
-                .pkg_dirs
-                .packages_for_module(module_id)
-                .into_iter()
-                .flat_map(|packages| packages.values().copied())
-        })
-        .collect();
+    let module_scope = overrides
+        .module_scope
+        .as_deref()
+        .unwrap_or(resolve_output.local_modules());
+    let all_affected_packages: Vec<_> =
+        rr_build::local_packages_in_modules(resolve_output, module_scope).collect();
     debug!(
         package_count = all_affected_packages.len(),
-        module_count = resolve_output.local_modules().len(),
+        module_count = module_scope.len(),
         "calculating user intent for workspace"
     );
     let backend_affected_packages = all_affected_packages
@@ -848,7 +941,40 @@ fn calc_user_intent(
         .filter(|&pkg_id| package_supports_backend(resolve_output, pkg_id, target_backend))
         .collect::<Vec<_>>();
 
-    let directive = if !cmd.explicit_path_filters.is_empty() {
+    let directive = if let Some(resolved_paths) = overrides.resolved_paths.as_deref() {
+        let test_index = if let Some(index) = cmd.index {
+            Some(TestIndex::Regular(*index))
+        } else if let Some(id) = cmd.doc_index {
+            Some(TestIndex::DocTest(TestIndexRange::from_single(*id)?))
+        } else {
+            None
+        };
+
+        let mut unsupported_packages = Vec::new();
+        let mut supported_paths = 0;
+        for path in resolved_paths {
+            if !package_supports_backend(resolve_output, path.package, target_backend) {
+                if !unsupported_packages.contains(&path.package) {
+                    unsupported_packages.push(path.package);
+                }
+                output.info(format!(
+                    "skipping path `{}` because package `{}` does not support target backend `{}`. Supported backends: {}",
+                    path.path.display(),
+                    resolve_output.pkg_dirs.get_package(path.package).fqn,
+                    target_backend,
+                    format_supported_backends(resolve_output, path.package),
+                ));
+                continue;
+            }
+            supported_paths += 1;
+            out_filter.add_autodetermine_target(path.package, path.filename.as_deref(), test_index);
+        }
+
+        if supported_paths == 0 && !unsupported_packages.is_empty() {
+            ensure_packages_support_backend(resolve_output, unsupported_packages, target_backend)?;
+        }
+        Default::default()
+    } else if !cmd.explicit_path_filters.is_empty() {
         let test_index = if let Some(index) = cmd.index {
             Some(TestIndex::Regular(*index))
         } else if let Some(id) = cmd.doc_index {
@@ -920,6 +1046,18 @@ fn calc_user_intent(
             trace!("explicit path filters applied");
         }
         Default::default()
+    } else if let Some(selected_packages) = overrides.selected_packages.as_deref() {
+        apply_selected_package_filters(
+            selected_packages,
+            resolve_output,
+            cmd.file.as_deref(),
+            *cmd.index,
+            *cmd.doc_index,
+            cmd.patch_file.as_deref(),
+            cmd.build_flags.enable_value_tracing,
+            target_backend,
+            out_filter,
+        )?
     } else if let Some(package_filter) = cmd.package {
         let value_tracing = cmd.build_flags.enable_value_tracing;
         apply_list_of_filters(
@@ -963,6 +1101,107 @@ fn calc_user_intent(
     };
     debug!(intent_count = intents.len(), "calculated user intent");
     Ok((intents, directive).into())
+}
+
+fn resolve_test_target_groups(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    cmd: &TestLikeSubcommand<'_>,
+    output: UserDiagnostics,
+) -> anyhow::Result<Vec<TestTargetGroup>> {
+    if !cmd.explicit_path_filters.is_empty() {
+        let mut grouped =
+            std::collections::BTreeMap::<TargetBackend, Vec<ResolvedTestPathFilter>>::new();
+        for path in cmd.explicit_path_filters {
+            let (dir, filename) = canonicalize_with_filename(path)?;
+            let Ok(pkg) = filter_pkg_by_dir(resolve_output, &dir) else {
+                output.info(format!(
+                    "skipping path `{}` because it is not a package in the current work context.",
+                    path.display()
+                ));
+                continue;
+            };
+            let module_id = resolve_output.pkg_dirs.get_package(pkg).module;
+            grouped
+                .entry(rr_build::default_target_for_module(
+                    resolve_output,
+                    module_id,
+                ))
+                .or_default()
+                .push(ResolvedTestPathFilter {
+                    path: path.clone(),
+                    package: pkg,
+                    filename,
+                });
+        }
+        return Ok(grouped
+            .into_iter()
+            .map(|(target_backend, resolved_paths)| TestTargetGroup {
+                target_backend,
+                overrides: TestPlanOverrides {
+                    resolved_paths: Some(resolved_paths),
+                    ..Default::default()
+                },
+            })
+            .collect());
+    }
+
+    if let Some(package_filter) = cmd.package {
+        let all_affected_packages: Vec<_> =
+            rr_build::local_packages_in_modules(resolve_output, resolve_output.local_modules())
+                .collect();
+        let package_matches = match_packages_with_fuzzy(
+            resolve_output,
+            all_affected_packages.iter().copied(),
+            package_filter,
+        );
+        if !package_matches.missing.is_empty() {
+            for missing in package_matches.missing {
+                output.warn(format!("Input `{}` did not match any package", missing));
+            }
+        }
+        if package_matches.matched.is_empty() {
+            output.warn(format!(
+                "package `{}` not found, make sure you have spelled it correctly, e.g. `moonbitlang/core/hashmap`(exact match) or `hashmap`(fuzzy match)",
+                package_filter.join(", ")
+            ));
+            return Ok(Vec::new());
+        }
+
+        let mut grouped = std::collections::BTreeMap::<TargetBackend, Vec<PackageId>>::new();
+        for pkg_id in package_matches.matched {
+            let module_id = resolve_output.pkg_dirs.get_package(pkg_id).module;
+            grouped
+                .entry(rr_build::default_target_for_module(
+                    resolve_output,
+                    module_id,
+                ))
+                .or_default()
+                .push(pkg_id);
+        }
+        return Ok(grouped
+            .into_iter()
+            .map(|(target_backend, selected_packages)| TestTargetGroup {
+                target_backend,
+                overrides: TestPlanOverrides {
+                    selected_packages: Some(selected_packages),
+                    ..Default::default()
+                },
+            })
+            .collect());
+    }
+
+    Ok(
+        rr_build::group_modules_by_default_target(resolve_output, resolve_output.local_modules())
+            .into_iter()
+            .map(|(target_backend, modules)| TestTargetGroup {
+                target_backend,
+                overrides: TestPlanOverrides {
+                    module_scope: Some(modules),
+                    ..Default::default()
+                },
+            })
+            .collect(),
+    )
 }
 
 #[instrument(level = Level::DEBUG, skip_all)]

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -850,6 +850,14 @@ fn apply_selected_package_filters(
         filtered_package_ids.iter().copied(),
         target_backend,
     )?;
+    validate_multi_package_test_filters(
+        filtered_package_ids,
+        resolve_output,
+        file_filter,
+        index_filter,
+        doc_index_filter,
+        patch_file,
+    )?;
     trace!(
         filtered_packages = filtered_package_ids.len(),
         "package filters resolved"
@@ -880,30 +888,45 @@ fn apply_selected_package_filters(
             rr_build::build_patch_directive_for_package(pkg_id, false, trace_pkg, patch_file, true)
                 .context("failed to build input directive")?;
     } else if filtered_package_ids.len() > 1 {
-        let package_names = || {
-            filtered_package_ids
-                .iter()
-                .map(|id| resolve_output.pkg_dirs.get_package(*id).fqn.to_string())
-                .collect::<Vec<_>>()
-        };
-        if file_filter.is_some() || index_filter.is_some() || doc_index_filter.is_some() {
-            bail!(
-                "Cannot filter by file or index when multiple packages are specified. Matched packages: {:?}",
-                package_names()
-            );
-        }
-        if patch_file.is_some() {
-            bail!(
-                "Cannot apply patch file when multiple packages are specified. Matched packages: {:?}",
-                package_names()
-            );
-        }
         for &pkg_id in filtered_package_ids {
             out_filter.add_autodetermine_target(pkg_id, None, None);
         }
     }
     trace!("finished building package directive");
     Ok(input_directive)
+}
+
+fn validate_multi_package_test_filters(
+    filtered_package_ids: &[PackageId],
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    file_filter: Option<&str>,
+    index_filter: Option<TestIndexRange>,
+    doc_index_filter: Option<u32>,
+    patch_file: Option<&Path>,
+) -> anyhow::Result<()> {
+    if filtered_package_ids.len() <= 1 {
+        return Ok(());
+    }
+
+    let package_names = filtered_package_ids
+        .iter()
+        .map(|id| resolve_output.pkg_dirs.get_package(*id).fqn.to_string())
+        .collect::<Vec<_>>();
+
+    if file_filter.is_some() || index_filter.is_some() || doc_index_filter.is_some() {
+        bail!(
+            "Cannot filter by file or index when multiple packages are specified. Matched packages: {:?}",
+            package_names
+        );
+    }
+    if patch_file.is_some() {
+        bail!(
+            "Cannot apply patch file when multiple packages are specified. Matched packages: {:?}",
+            package_names
+        );
+    }
+
+    Ok(())
 }
 
 /// Calculate the user intent for the build system to construct.
@@ -1178,6 +1201,14 @@ fn resolve_test_target_groups(
             ));
             return Ok(Vec::new());
         }
+        validate_multi_package_test_filters(
+            &package_matches.matched,
+            resolve_output,
+            cmd.file.as_deref(),
+            *cmd.index,
+            *cmd.doc_index,
+            cmd.patch_file.as_deref(),
+        )?;
 
         let mut grouped = std::collections::BTreeMap::<TargetBackend, Vec<PackageId>>::new();
         for pkg_id in package_matches.matched {

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -37,7 +37,7 @@ use anyhow::Context;
 use indexmap::IndexMap;
 use moonbuild::entry::{N2RunStats, ResultCatcher, create_progress_console};
 use moonbuild_rupes_recta::{
-    CompileConfig, ResolveConfig, ResolveOutput,
+    CompileConfig, ResolveOutput,
     build_lower::{WarningCondition, artifact::n2_db_path},
     build_plan::InputDirective,
     fmt::{FmtConfig, FmtResolveOutput},
@@ -154,47 +154,58 @@ fn warn_local_legacy_supported_targets(resolve_output: &ResolveOutput, output: U
     }
 }
 
-pub(crate) fn local_packages(
-    resolve_output: &ResolveOutput,
-) -> impl Iterator<Item = PackageId> + '_ {
-    resolve_output
-        .local_modules()
-        .iter()
-        .flat_map(|&module_id| {
-            resolve_output
-                .pkg_dirs
-                .packages_for_module(module_id)
-                .into_iter()
-                .flat_map(|packages| packages.values().copied())
-        })
+pub(crate) fn local_packages_in_modules<'a>(
+    resolve_output: &'a ResolveOutput,
+    module_ids: &'a [moonutil::mooncakes::ModuleId],
+) -> impl Iterator<Item = PackageId> + 'a {
+    module_ids.iter().flat_map(|&module_id| {
+        resolve_output
+            .pkg_dirs
+            .packages_for_module(module_id)
+            .into_iter()
+            .flat_map(|packages| packages.values().copied())
+    })
 }
 
-fn workspace_preferred_target(
+pub(crate) fn default_target_for_module(
     resolve_output: &ResolveOutput,
-    output: UserDiagnostics,
-) -> Option<TargetBackend> {
-    if let Some(preferred_target) = resolve_output.workspace_preferred_target {
-        return Some(preferred_target);
-    }
+    module_id: moonutil::mooncakes::ModuleId,
+) -> TargetBackend {
+    resolve_output
+        .workspace_preferred_target
+        .or(resolve_output
+            .module_rel
+            .module_info(module_id)
+            .preferred_target)
+        .unwrap_or_default()
+}
 
+pub(crate) fn group_modules_by_default_target(
+    resolve_output: &ResolveOutput,
+    module_ids: &[moonutil::mooncakes::ModuleId],
+) -> Vec<(TargetBackend, Vec<moonutil::mooncakes::ModuleId>)> {
+    let mut grouped = BTreeMap::<TargetBackend, Vec<_>>::new();
+    for &module_id in module_ids {
+        grouped
+            .entry(default_target_for_module(resolve_output, module_id))
+            .or_default()
+            .push(module_id);
+    }
+    grouped.into_iter().collect()
+}
+
+fn uniform_default_target_for_local_modules(
+    resolve_output: &ResolveOutput,
+) -> Option<TargetBackend> {
     let preferred = resolve_output
         .local_modules()
         .iter()
-        .filter_map(|&module_id| {
-            resolve_output
-                .module_rel
-                .module_info(module_id)
-                .preferred_target
-        })
+        .map(|&module_id| default_target_for_module(resolve_output, module_id))
         .collect::<BTreeSet<_>>();
-
-    if preferred.len() > 1 {
-        output.warn(
-            "Multiple local modules specify different preferred targets; pass `--target` to choose one explicitly",
-        );
-        None
-    } else {
-        preferred.into_iter().next()
+    match preferred.len() {
+        0 => None,
+        1 => preferred.into_iter().next(),
+        _ => None,
     }
 }
 
@@ -288,7 +299,6 @@ impl BuildResult {
 /// This type might be subject to change.
 #[derive(Debug)]
 pub struct CompilePreConfig {
-    frozen: bool,
     target_backend: Option<TargetBackend>,
     opt_level: BuildProfile,
     action: RunMode,
@@ -395,7 +405,7 @@ impl CompilePreConfig {
 ///   debug; `moon bench`/`bundle` default to release).
 #[instrument(level = Level::DEBUG, skip_all)]
 pub fn preconfig_compile(
-    auto_sync_flags: &AutoSyncFlags,
+    _auto_sync_flags: &AutoSyncFlags,
     cli: &UniversalFlags,
     build_flags: &BuildFlags,
     selected_target_backend: Option<TargetBackend>,
@@ -405,7 +415,6 @@ pub fn preconfig_compile(
     let opt_level = build_flags.effective_profile(action);
 
     CompilePreConfig {
-        frozen: auto_sync_flags.frozen,
         target_dir: target_dir.to_owned(),
         target_backend: selected_target_backend,
         opt_level,
@@ -428,49 +437,6 @@ pub fn preconfig_compile(
         },
         warn_list: build_flags.warn_list.clone(),
     }
-}
-
-/// Plan the build process without executing it.
-///
-/// This function performs all the preparation steps: resolve dependencies,
-/// calculate user intent, and create the build graph, but does not execute
-/// the actual build tasks.
-///
-/// Returns the execution plan (metadata) and build graph separately, allowing
-/// execute_build to take ownership of just the graph while callers retain
-/// access to the metadata.
-#[instrument(skip_all)]
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn plan_build<'a>(
-    preconfig: CompilePreConfig,
-    unstable_features: &'a FeatureGate,
-    source_dir: &'a Path,
-    target_dir: &'a Path,
-    mooncakes_dir: &'a Path,
-    output: UserDiagnostics,
-    project_manifest_path: Option<&'a Path>,
-    calc_user_intent: Box<CalcUserIntentFn<'a>>,
-) -> anyhow::Result<(BuildMeta, BuildInput)> {
-    info!("Starting build planning");
-
-    let cfg = ResolveConfig::new_with_load_defaults(
-        preconfig.frozen,
-        !preconfig.use_std,
-        preconfig.enable_coverage,
-    )
-    .with_project_manifest_path(project_manifest_path);
-    let resolve_output = moonbuild_rupes_recta::resolve(&cfg, source_dir, mooncakes_dir)?;
-
-    info!("Resolve completed");
-
-    plan_build_from_resolved(
-        preconfig,
-        unstable_features,
-        target_dir,
-        output,
-        calc_user_intent,
-        resolve_output,
-    )
 }
 
 /// Plan the build process from an already resolved environment.
@@ -516,7 +482,7 @@ pub(crate) fn plan_build_from_resolved<'a>(
     let preferred_target = if preconfig.target_backend.is_some() {
         None
     } else {
-        workspace_preferred_target(&resolve_output, output)
+        uniform_default_target_for_local_modules(&resolve_output)
     };
     info!("Preferred backend: {:?}", preferred_target);
 

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -66,6 +66,7 @@ impl PlanningFixture {
             &borrowed,
             &self.target_dir,
             cmd.build_flags.resolve_single_target_backend()?,
+            None,
             self.resolve_output.clone(),
         )?;
         self.dump_plan(build_meta, build_graph)
@@ -82,6 +83,7 @@ impl PlanningFixture {
             &borrowed,
             &self.target_dir,
             cmd.build_flags.resolve_single_target_backend()?,
+            None,
             self.resolve_output.clone(),
         )?;
         self.dump_plan(build_meta, build_graph)
@@ -97,6 +99,8 @@ impl PlanningFixture {
             cmd,
             &self.target_dir,
             cmd.build_flags.resolve_single_target_backend()?,
+            None,
+            None,
             self.resolve_output.clone(),
         )?;
         self.dump_plan(build_meta, build_graph)
@@ -113,6 +117,8 @@ impl PlanningFixture {
             &self.source_dir,
             &self.target_dir,
             cmd.build_flags.resolve_single_target_backend()?,
+            None,
+            None,
             self.resolve_output.clone(),
         )?;
         self.dump_plan(build_meta, build_graph)

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-const PREFERRED_TARGET_CONFLICT_WARNING: &str = "Multiple local modules specify different preferred targets; pass `--target` to choose one explicitly";
-
 #[test]
 fn test_target_backend_cli_wiring_smoke() {
     let dir = TestDir::new("target_backend");
@@ -42,30 +40,30 @@ fn assert_contains_and_absent(output: &str, present: &[&str], absent: &[&str]) {
     }
 }
 
-fn assert_preferred_target_conflict_warning(stderr: &str) {
-    assert!(
-        stderr.contains(PREFERRED_TARGET_CONFLICT_WARNING),
-        "stderr: {stderr}"
-    );
-}
-
-fn assert_conflicting_workspace_preferred_targets_default_to_wasm_gc(
+fn assert_conflicting_workspace_preferred_targets_use_module_defaults(
     command: &str,
     stdout: &str,
     stderr: &str,
 ) {
-    assert_preferred_target_conflict_warning(stderr);
+    assert!(
+        !stderr.contains("Multiple local modules specify different preferred targets"),
+        "stderr: {stderr}"
+    );
     assert_contains_and_absent(
         stdout,
+        &[
+            "./_build/js/",
+            "./_build/native/",
+            "-target js",
+            "-target native",
+            "./js_preferred/src/lib/extra.js.mbt",
+            "./native_preferred/src/lib/extra.native.mbt",
+        ],
         &[
             "./_build/wasm-gc/",
             "-target wasm-gc",
             "./js_preferred/src/lib/extra.wasm-gc.mbt",
             "./native_preferred/src/lib/extra.wasm-gc.mbt",
-        ],
-        &[
-            "./js_preferred/src/lib/extra.js.mbt",
-            "./native_preferred/src/lib/extra.native.mbt",
         ],
     );
     assert!(
@@ -427,20 +425,23 @@ fn test_explicit_target_suppresses_conflicting_workspace_preferred_target_warnin
     let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
 
     let default_stderr = get_stderr(&dir, ["check", "--dry-run", "--sort-input"]);
-    assert_preferred_target_conflict_warning(&default_stderr);
+    assert!(
+        !default_stderr.contains("Multiple local modules specify different preferred targets"),
+        "stderr: {default_stderr}"
+    );
 
     let explicit_stderr = get_stderr(
         &dir,
         ["check", "--target", "js", "--dry-run", "--sort-input"],
     );
     assert!(
-        !explicit_stderr.contains(PREFERRED_TARGET_CONFLICT_WARNING),
+        !explicit_stderr.contains("Multiple local modules specify different preferred targets"),
         "stderr: {explicit_stderr}"
     );
 }
 
 #[test]
-fn test_conflicting_workspace_preferred_targets_default_to_wasm_gc_across_commands() {
+fn test_conflicting_workspace_preferred_targets_use_module_defaults_across_commands() {
     let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
     let commands = [
         ("build", &["build", "--dry-run", "--sort-input"][..]),
@@ -453,28 +454,28 @@ fn test_conflicting_workspace_preferred_targets_default_to_wasm_gc_across_comman
     for (command, args) in commands {
         let stdout = get_stdout(&dir, args.iter().copied());
         let stderr = get_stderr(&dir, args.iter().copied());
-        assert_conflicting_workspace_preferred_targets_default_to_wasm_gc(
+        assert_conflicting_workspace_preferred_targets_use_module_defaults(
             command, &stdout, &stderr,
         );
     }
 }
 
 #[test]
-fn test_conflicting_workspace_preferred_targets_info_defaults_to_wasm_gc() {
+fn test_conflicting_workspace_preferred_targets_info_uses_module_defaults() {
     let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
 
     let stderr = get_stderr(&dir, ["info"]);
-    assert_preferred_target_conflict_warning(&stderr);
+    assert!(
+        !stderr.contains("Multiple local modules specify different preferred targets"),
+        "stderr: {stderr}"
+    );
 
     let js_mbti =
         std::fs::read_to_string(dir.join("js_preferred/src/lib").join(MBTI_GENERATED)).unwrap();
     assert_contains_and_absent(
         &js_mbti,
-        &[
-            "pub fn js_value() -> Int",
-            "pub fn js_wasm_gc_extra() -> Int",
-        ],
-        &["js_extra", "native_extra", "native_wasm_gc_extra"],
+        &["pub fn js_value() -> Int", "pub fn js_extra() -> Int"],
+        &["js_wasm_gc_extra", "native_extra", "native_wasm_gc_extra"],
     );
 
     let native_mbti =
@@ -483,8 +484,27 @@ fn test_conflicting_workspace_preferred_targets_info_defaults_to_wasm_gc() {
         &native_mbti,
         &[
             "pub fn native_value() -> Int",
-            "pub fn native_wasm_gc_extra() -> Int",
+            "pub fn native_extra() -> Int",
         ],
-        &["native_extra", "js_extra", "js_wasm_gc_extra"],
+        &["native_wasm_gc_extra", "js_extra", "js_wasm_gc_extra"],
+    );
+}
+
+#[test]
+fn test_workspace_member_run_defaults_to_selected_module_preferred_target() {
+    let dir = TestDir::new("workspace_member_preferred_targets.in");
+
+    let js_out = get_stdout(&dir.join("js_app"), ["run", "main", "--dry-run"]);
+    assert_contains_and_absent(
+        &js_out,
+        &["./_build/js/", "-target js"],
+        &["./_build/native/", "-target native", "-target wasm-gc"],
+    );
+
+    let native_out = get_stdout(&dir.join("native_app"), ["run", "main", "--dry-run"]);
+    assert_contains_and_absent(
+        &native_out,
+        &["./_build/native/", "-target native"],
+        &["./_build/js/", "-target js", "-target wasm-gc"],
     );
 }

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -491,6 +491,74 @@ fn test_conflicting_workspace_preferred_targets_info_uses_module_defaults() {
 }
 
 #[test]
+fn test_conflicting_workspace_preferred_targets_check_validates_single_package_flags_before_grouping()
+ {
+    let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
+
+    let no_mi_err = get_err_stderr(
+        &dir,
+        [
+            "check",
+            "js_preferred/src/lib",
+            "native_preferred/src/lib",
+            "--no-mi",
+            "--dry-run",
+        ],
+    );
+    assert!(
+        no_mi_err.contains("`--no-mi` requires the selector to resolve to a single package"),
+        "stderr: {no_mi_err}"
+    );
+
+    let patch_err = get_err_stderr(
+        &dir,
+        [
+            "check",
+            "js_preferred/src/lib",
+            "native_preferred/src/lib",
+            "--patch-file",
+            "patch.json",
+            "--dry-run",
+        ],
+    );
+    assert!(
+        patch_err.contains("`--patch-file` requires the selector to resolve to a single package"),
+        "stderr: {patch_err}"
+    );
+}
+
+#[test]
+fn test_conflicting_workspace_preferred_targets_test_validates_package_filters_before_grouping() {
+    let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
+
+    let file_err = get_err_stderr(&dir, ["test", "-p", "lib", "-f", "asdf", "--dry-run"]);
+    assert!(
+        file_err.contains("Cannot filter by file or index when multiple packages are specified"),
+        "stderr: {file_err}"
+    );
+    assert!(file_err.contains("workspace/js_preferred/lib"));
+    assert!(file_err.contains("workspace/native_preferred/lib"));
+
+    let patch_err = get_err_stderr(
+        &dir,
+        [
+            "test",
+            "-p",
+            "lib",
+            "--patch-file",
+            "patch.json",
+            "--dry-run",
+        ],
+    );
+    assert!(
+        patch_err.contains("Cannot apply patch file when multiple packages are specified"),
+        "stderr: {patch_err}"
+    );
+    assert!(patch_err.contains("workspace/js_preferred/lib"));
+    assert!(patch_err.contains("workspace/native_preferred/lib"));
+}
+
+#[test]
 fn test_workspace_member_run_defaults_to_selected_module_preferred_target() {
     let dir = TestDir::new("workspace_member_preferred_targets.in");
 

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -559,6 +559,21 @@ fn test_conflicting_workspace_preferred_targets_test_validates_package_filters_b
 }
 
 #[test]
+fn test_conflicting_workspace_preferred_targets_build_only_emits_single_json_document() {
+    let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
+
+    let test_stdout = get_stdout(&dir, ["test", "--build-only"]);
+    let test_artifacts: serde_json::Value = serde_json::from_str(&test_stdout)
+        .unwrap_or_else(|err| panic!("invalid test --build-only JSON: {err}\n{test_stdout}"));
+    assert_eq!(test_artifacts, serde_json::json!({ "artifacts_path": [] }));
+
+    let bench_stdout = get_stdout(&dir, ["bench", "--build-only"]);
+    let bench_artifacts: serde_json::Value = serde_json::from_str(&bench_stdout)
+        .unwrap_or_else(|err| panic!("invalid bench --build-only JSON: {err}\n{bench_stdout}"));
+    assert_eq!(bench_artifacts, serde_json::json!({ "artifacts_path": [] }));
+}
+
+#[test]
 fn test_workspace_member_run_defaults_to_selected_module_preferred_target() {
     let dir = TestDir::new("workspace_member_preferred_targets.in");
 

--- a/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/js_app/main/main.mbt
+++ b/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/js_app/main/main.mbt
@@ -1,0 +1,3 @@
+fn main {
+  println("js")
+}

--- a/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/js_app/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/js_app/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/js_app/moon.mod.json
+++ b/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/js_app/moon.mod.json
@@ -1,0 +1,4 @@
+{
+  "name": "workspace/js_app",
+  "preferred-target": "js"
+}

--- a/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/moon.work
+++ b/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/moon.work
@@ -1,0 +1,4 @@
+members = [
+  "./js_app",
+  "./native_app",
+]

--- a/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/native_app/main/main.mbt
+++ b/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/native_app/main/main.mbt
@@ -1,0 +1,3 @@
+fn main {
+  println("native")
+}

--- a/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/native_app/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/native_app/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/native_app/moon.mod.json
+++ b/crates/moon/tests/test_cases/workspace_member_preferred_targets.in/native_app/moon.mod.json
@@ -1,0 +1,4 @@
+{
+  "name": "workspace/native_app",
+  "preferred-target": "native"
+}

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -140,7 +140,9 @@ explicit workspace root via `moon.work`, following the same discovery precedence
 The workspace manifest is intentionally small. `moon.work` currently supports:
 
 - `members = ["./app", "./lib"]` to list workspace roots.
-- `preferred_target = "wasm-gc"` to set the preferred default target for the workspace.
+- `preferred_target = "wasm-gc"` to set a workspace-wide default target. When it is omitted,
+  commands without `--target` fall back to each member module's `preferred-target`, then
+  to `wasm-gc`.
 
 When Moon writes `use` entries, relative paths are normalized with `/` separators. Absolute paths
 are kept as absolute OS-specific paths and are not made portable.

--- a/docs/dev/reference/supported-targets.md
+++ b/docs/dev/reference/supported-targets.md
@@ -62,6 +62,30 @@ Effective package support is:
 Note: file-level conditional compilation `targets` (map keyed by filename) is a
 separate feature and unchanged.
 
+## Default backend selection
+
+If the user passes `--target`, that explicit backend selection wins.
+
+Without `--target`, Moon resolves an effective default backend for each local
+module in this order:
+
+1. workspace `preferred_target` from `moon.work`, if present
+2. otherwise that module's `preferred-target`
+3. otherwise `wasm-gc`
+
+Member-scoped commands that act on one module, such as `moon run`,
+`moon doc`, and `moon prove`, use the selected module's effective default
+backend.
+
+Project-scoped commands that consume a backend, such as `moon build`,
+`moon check`, `moon test`, `moon bench`, `moon bundle`, and `moon info`,
+group local modules or explicitly selected packages/paths by effective default
+backend and run one backend-specific plan per group.
+
+`moon test --update` still requires one backend. If grouped defaults would span
+multiple backends, Moon errors until the user narrows the selection or passes
+`--target`.
+
 ## Command behavior matrix
 
 `B` means the backend selected for this invocation.
@@ -97,7 +121,7 @@ MVP does **not** include:
 
 * backend-scoped dependency declarations (`import` per backend), 
 * transitive constraint propagation or inference (deduce `supported_targets` based on dependencies), 
-* package-based backend guessing when `--target` is not provided.
+* one mixed-backend build graph across multiple backends in a single planner invocation.
 
 ## Mixed-backend usage pattern
 
@@ -116,3 +140,9 @@ my_app/
     web/      # is-main: true, supported-targets: ["js"]
     server/   # is-main: true, supported-targets: ["native"]
 ```
+
+In a multi-module workspace, if member modules choose different
+`preferred-target` values, project-scoped commands without `--target` run one
+plan per backend group instead of warning and falling back to `wasm-gc`.
+A workspace `preferred_target` overrides those member defaults and restores one
+uniform default backend.

--- a/docs/dev/reference/workspace.md
+++ b/docs/dev/reference/workspace.md
@@ -38,11 +38,23 @@ A workspace manifest defines:
 - `members`
   - the module directories contained by the workspace
 - `preferred_target`
-  - an optional default backend for the workspace
+  - an optional workspace-wide default backend
 
 Workspace members are canonicalized relative to the workspace root and deduped.
 
 The workspace root may or may not also contain a `moon.mod.json`.
+
+## Default Backend Resolution
+
+When a command needs a backend target, Moon resolves it in this order:
+
+1. explicit `--target`
+2. workspace `preferred_target`, if present
+3. the selected module's `preferred-target`
+4. `wasm-gc`
+
+If `moon.work` omits `preferred_target`, different workspace members may still
+resolve to different default backends.
 
 ## Selection Result
 
@@ -86,6 +98,8 @@ Representative examples:
 - `moon build`
 - `moon check`
 - `moon test`
+- `moon bench`
+- `moon bundle`
 - `moon fmt`
 - `moon info`
 
@@ -100,6 +114,20 @@ the whole workspace. They can be run from:
 
 They do not need an implicit default member.
 
+For project-scoped commands that consume a backend (`build`, `check`, `test`,
+`bench`, `bundle`, `info`):
+
+- with explicit `--target`, Moon keeps the existing single-backend behavior
+- without `--target`, Moon uses the workspace default rules above
+- if local modules resolve to different default backends, Moon runs one
+  backend-specific subplan per group instead of warning and falling back to
+  `wasm-gc`
+- explicit package/path filters are grouped by the owning module in the same
+  way
+
+`moon test --update` still requires one backend and errors if the default
+grouping would span multiple backends.
+
 ### Member-Scoped Commands
 
 These commands need one concrete module even when the selected project is a
@@ -107,6 +135,7 @@ workspace.
 
 Current examples:
 
+- `moon run`
 - `moon add`
 - `moon remove`
 - `moon tree`
@@ -123,16 +152,20 @@ These commands are still workspace-aware:
 
 But they are not workspace-wide commands.
 
-At a workspace root, they fail unless Moon can determine a member module from
-context. In practice, that means:
+When these commands omit `--target`, Moon uses the selected member module's
+effective default backend.
 
-- running them directly at the workspace root is not supported
+At a workspace root, they fail unless Moon can determine a member module from
+context or from the command input. In practice, that means:
+
+- `moon run` can infer the member from its required package/path selector
 - running them from a member directory is supported
 - passing `--manifest-path <member>/moon.mod.json` is supported
 
-This is why `publish`, `package`, `doc`, and `prove` only work for one selected
-module at a time today. There is no "publish the whole workspace" or "generate
-docs for the whole workspace" mode in the current design.
+This is why `run`, `publish`, `package`, `doc`, and `prove` only work for one
+selected module at a time today. There is no "publish the whole workspace",
+"generate docs for the whole workspace", or "run the whole workspace" mode in
+the current design.
 
 ### Workspace Maintenance Commands
 
@@ -164,7 +197,12 @@ The current design supports:
 - workspace roots that also contain `moon.mod.json`
 - selecting a member module from inside the member directory
 - selecting a member module with `--manifest-path <member>/moon.mod.json`
-- whole-workspace `build` / `check` / `test` / `fmt` / `info`
+- whole-workspace `build` / `check` / `test` / `bench` / `bundle` / `fmt` /
+  `info`
+- no-`--target` project-scoped execution in mixed-default workspaces by running
+  one backend-specific subplan per effective default backend
+- `run` selecting a workspace member from its package/path input while still
+  using workspace-local dependency resolution
 - member-scoped `package` / `publish` / `doc` / `prove` while still using
   workspace-local dependency resolution
 - nested discovery from non-module directories inside a workspace
@@ -324,7 +362,8 @@ selection.
 
 | Start point / flags | Result |
 | --- | --- |
-| workspace root + `build` / `check` / `test` / `fmt` / `info` | operate on the whole workspace |
+| workspace root + `build` / `check` / `test` / `bench` / `bundle` / `fmt` / `info` | operate on the whole workspace; without `--target`, backend-consuming commands may run one plan per effective default backend |
+| workspace root + `run <selector>` | select the member from the selector and use that member's effective default backend when `--target` is omitted |
 | workspace root + `add` / `remove` / `tree` / `package` / `publish` / `doc` / `prove` | error: no target member can be inferred |
 | member directory + member-scoped command | target that member and keep workspace context |
 | `--manifest-path app/moon.mod.json` | start from `app`, then allow workspace promotion |


### PR DESCRIPTION
## What changed
This changes the no-`--target` behavior for mixed workspaces so Moon no longer warns and falls back to `wasm-gc` when different member modules prefer different backends.

Instead, project-scoped backend-consuming commands now group workspace members by their effective default backend and run one backend-specific subplan per group. Explicit `--target` remains authoritative and keeps the existing single-backend path.

The implementation adds shared default-target grouping helpers in the RR build layer, wires grouped execution through `build`, `check`, `test`, `bench`, `bundle`, and `info`, and teaches member-scoped commands like `run`, `doc`, and `prove` to infer the selected module's preferred backend when `--target` is omitted.

This PR also updates the target-backend regression coverage, adds a dedicated workspace fixture for member-scoped default inference, preserves the legacy empty-workspace `no work to do` / `no test entry found` output, and refreshes the main-repo design docs to describe the new precedence and grouping rules.

## Why
Mixed workspaces should be easy to build and check without forcing users to pass `--target` every time.

The build graph and artifact model are still single-backend, though, so the low-risk transition is to keep that planner model intact and split mixed defaults at the CLI layer instead of attempting one large architectural rewrite.

## Impact
Users can now run project-scoped commands on mixed-preferred-target workspaces without hitting the old conflict warning and implicit `wasm-gc` fallback.

The effective default backend precedence is now:
1. explicit `--target`
2. workspace `preferred_target`
3. selected or owning module `preferred-target`
4. `wasm-gc`

`moon test --update` still requires one backend; if grouped defaults would span multiple backends, Moon errors until the user narrows the scope or passes `--target`.

## Validation
- `cargo test -p moon --test mod workspace_basic -- --nocapture`
- `cargo test -p moon --test mod target_backend -- --nocapture`
- `cargo fmt --check`