### PR TITLE
refactor: adjust moon info behavior for canonical backend

### DIFF
--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -21,8 +21,9 @@ mod imp;
 use std::path::PathBuf;
 
 use anyhow::bail;
-use moonbuild_rupes_recta::intent::UserIntent;
-use moonbuild_rupes_recta::model::PackageId;
+use moonbuild_rupes_recta::{
+    ResolveConfig, ResolveOutput, intent::UserIntent, model::PackageId, resolve,
+};
 use moonutil::{
     common::{RunMode, SurfaceTarget, TargetBackend, lower_surface_targets},
     dirs::PackageDirs,
@@ -41,14 +42,15 @@ use crate::{
 
 use super::UniversalFlags;
 
-#[derive(Debug)]
-pub(crate) struct InfoTargetSelection {
-    pub target_backend: TargetBackend,
-    pub packages: Vec<PackageId>,
-}
-
 /// Generate public interface (`.mbti`) files for all packages in the module or workspace
-#[derive(Debug, Clone, clap::Parser)]
+///
+/// By default, `moon info` writes `pkg.generated.mbti` from each selected package's
+/// canonical backend: module `preferred-backend`, then workspace
+/// `preferred-backend`, then `wasm-gc`.
+///
+/// `--target` inspects backend-specific interfaces and reports differences, but
+/// does not change which backend is written to `pkg.generated.mbti`.
+#[derive(Debug, clap::Parser)]
 pub(crate) struct InfoSubcommand {
     #[clap(flatten)]
     pub auto_sync_flags: AutoSyncFlags,
@@ -60,7 +62,8 @@ pub(crate) struct InfoSubcommand {
     #[clap(long, hide = true)]
     pub no_alias: bool,
 
-    /// Select output target
+    /// Inspect one or more target backends without changing the canonical
+    /// `pkg.generated.mbti` output
     #[clap(long, value_delimiter = ',')]
     pub target: Option<Vec<SurfaceTarget>>,
 
@@ -73,6 +76,189 @@ pub(crate) struct InfoSubcommand {
     /// Conflicts with `--package`.
     #[clap(name = "PATH", conflicts_with("package"))]
     pub path: Vec<PathBuf>,
+}
+
+struct PackageSelection {
+    mode: SelectionMode,
+    package_ids: Vec<PackageId>,
+    path_packages: Vec<(PathBuf, PackageId)>,
+}
+
+enum SelectionMode {
+    SinglePath,
+    Paths,
+    Packages,
+    All,
+}
+
+impl PackageSelection {
+    fn new(
+        cmd: &InfoSubcommand,
+        resolve_output: &ResolveOutput,
+        output: UserDiagnostics,
+    ) -> anyhow::Result<Self> {
+        let package_ids: Vec<_> = resolve_output
+            .local_modules()
+            .iter()
+            .flat_map(|&module_id| {
+                resolve_output
+                    .pkg_dirs
+                    .packages_for_module(module_id)
+                    .into_iter()
+                    .flat_map(|packages| packages.values().copied())
+            })
+            .collect();
+
+        if let [path] = cmd.path.as_slice() {
+            let (dir, _) = canonicalize_with_filename(path)?;
+            let pkg = filter_pkg_by_dir(resolve_output, &dir)?;
+            return Ok(Self {
+                mode: SelectionMode::SinglePath,
+                package_ids: vec![pkg],
+                path_packages: vec![],
+            });
+        }
+
+        if !cmd.path.is_empty() {
+            let path_packages = select_packages(&cmd.path, output, |dir| {
+                filter_pkg_by_dir(resolve_output, dir)
+            })?;
+            let package_ids = path_packages.iter().map(|(_, pkg_id)| *pkg_id).collect();
+            return Ok(Self {
+                mode: SelectionMode::Paths,
+                package_ids,
+                path_packages,
+            });
+        }
+
+        if let Some(filter) = cmd.package.as_deref() {
+            let matches = match_packages_with_fuzzy(
+                resolve_output,
+                package_ids.iter().copied(),
+                std::iter::once(filter),
+            );
+
+            if matches.matched.is_empty() {
+                bail!(
+                    "package `{}` not found, make sure you have spelled it correctly, e.g. `moonbitlang/core/hashmap`(exact match) or `hashmap`(fuzzy match)",
+                    filter
+                );
+            }
+
+            for missing in matches.missing {
+                output.warn(format!("Input `{}` did not match any package", missing));
+            }
+
+            return Ok(Self {
+                mode: SelectionMode::Packages,
+                package_ids: matches.matched,
+                path_packages: vec![],
+            });
+        }
+
+        Ok(Self {
+            mode: SelectionMode::All,
+            package_ids,
+            path_packages: vec![],
+        })
+    }
+}
+
+struct InfoIntentContext<'a> {
+    selection: &'a PackageSelection,
+    output_plan: &'a imp::InfoOutputPlan,
+    target_kind: imp::TargetKind,
+    output: UserDiagnostics,
+}
+
+fn calc_user_intent_for_info(
+    ctx: &InfoIntentContext,
+    resolve_output: &ResolveOutput,
+    target_backend: TargetBackend,
+) -> Result<CalcUserIntentOutput, anyhow::Error> {
+    let is_canonical_run = matches!(ctx.target_kind, imp::TargetKind::Canonical);
+
+    let intents = match &ctx.selection.mode {
+        SelectionMode::SinglePath => {
+            let package = ctx.selection.package_ids[0];
+            let canonical = ctx.output_plan.canonical_backend_for(&package) == Some(target_backend);
+            let supported = package_supports_backend(resolve_output, package, target_backend);
+
+            if (canonical || !is_canonical_run) && supported {
+                vec![UserIntent::Info(package)]
+            } else {
+                ctx.output.warn(format!(
+                    "Skipping package `{}` for `moon info`: it does not support target backend `{}`",
+                    resolve_output.pkg_dirs.get_package(package).fqn,
+                    target_backend
+                ));
+                Vec::new()
+            }
+        }
+        SelectionMode::Paths => {
+            let mut filtered = Vec::new();
+            let mut unsupported = Vec::new();
+
+            for (path, pkg_id) in &ctx.selection.path_packages {
+                let canonical =
+                    ctx.output_plan.canonical_backend_for(pkg_id) == Some(target_backend);
+                let supported = package_supports_backend(resolve_output, *pkg_id, target_backend);
+                let should_include = (canonical || !is_canonical_run) && supported;
+
+                if should_include {
+                    filtered.push(UserIntent::Info(*pkg_id));
+                } else {
+                    unsupported.push((path.clone(), *pkg_id));
+                }
+            }
+
+            for (path, pkg_id) in &unsupported {
+                let pkg = resolve_output.pkg_dirs.get_package(*pkg_id);
+                ctx.output.info(format!(
+                    "skipping path `{}` because package `{}` does not support target backend `{}`. Supported backends: {}",
+                    path.display(),
+                    pkg.fqn,
+                    target_backend,
+                    format_supported_backends(resolve_output, *pkg_id),
+                ));
+            }
+
+            if filtered.is_empty() && !unsupported.is_empty() {
+                ctx.output.warn(format!(
+                    "No selected package supports target backend `{}` for `moon info`",
+                    target_backend
+                ));
+            }
+
+            filtered
+        }
+        SelectionMode::Packages | SelectionMode::All => {
+            let filtered: Vec<_> = ctx
+                .selection
+                .package_ids
+                .iter()
+                .copied()
+                .filter(|&pkg_id| {
+                    let canonical =
+                        ctx.output_plan.canonical_backend_for(&pkg_id) == Some(target_backend);
+                    let supported =
+                        package_supports_backend(resolve_output, pkg_id, target_backend);
+                    (canonical || !is_canonical_run) && supported
+                })
+                .collect();
+
+            if filtered.is_empty() {
+                ctx.output.warn(format!(
+                    "No selected package supports target backend `{}` for `moon info`",
+                    target_backend
+                ));
+            }
+
+            filtered.into_iter().map(UserIntent::Info).collect()
+        }
+    };
+
+    Ok(intents.into())
 }
 
 pub(crate) fn run_info(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32> {
@@ -88,132 +274,98 @@ pub(crate) fn run_info(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Resu
 }
 
 pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32> {
-    // Determine which target to use
-    let target = &cmd.target;
-    let mut lowered_targets = vec![];
-    if let Some(tgts) = target {
-        lowered_targets.extend(lower_surface_targets(tgts));
-    }
-
-    // If there's zero or one target, just run normally and promote the results
-    if lowered_targets.len() <= 1 {
-        let build_flags = BuildFlags::default();
-        let PackageDirs {
-            source_dir,
-            target_dir,
-            mooncakes_dir,
-            project_manifest_path,
-        } = cli.source_tgt_dir.try_into_package_dirs()?;
-        let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
-            cmd.auto_sync_flags.frozen,
-            !build_flags.std(),
-            build_flags.enable_coverage,
-        )
-        .with_project_manifest_path(project_manifest_path.as_deref());
-        let resolve_output =
-            moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
-        let planned_runs = plan_info_rr_from_resolved_all(
-            &cli,
-            &cmd,
-            &target_dir,
-            lowered_targets.first().copied(),
-            resolve_output,
-        )?;
-
-        let mut ok = true;
-        let mut successful_meta = Vec::new();
-        for (build_meta, build_graph) in planned_runs {
-            let (success, meta) = execute_info_rr_plan(&cli, &target_dir, build_meta, build_graph)?;
-            ok &= success;
-            if success {
-                successful_meta.push(meta);
-            }
-        }
-        if ok {
-            for meta in &successful_meta {
-                imp::promote_info_results(meta);
-            }
-        }
-        return Ok(if ok { 0 } else { 1 });
-    }
-
-    // For multiple targets, we would like to run them one by one, and then
-    // check the consistency of generated mbti files.
-    lowered_targets.sort();
-    // Prefer WasmGC if present; otherwise use the first one after sorting
-    let canonical_target = lowered_targets
-        .iter()
-        .copied()
-        .find(|t| *t == TargetBackend::WasmGC)
-        .unwrap_or(lowered_targets[0]);
-
-    let mut all_meta = vec![];
-    for &tgt in &lowered_targets {
-        let (success, meta) = run_info_rr_internal(&cli, &cmd, Some(tgt))?;
-        if !success {
-            bail!("moon info failed for target {:?}", tgt);
-        }
-
-        all_meta.push((tgt, meta));
-    }
-
-    let identical = imp::compare_info_outputs(all_meta.iter(), canonical_target)?;
-    if identical {
-        imp::promote_info_results_multi_target(all_meta.iter(), canonical_target);
-    }
-
-    if identical { Ok(0) } else { Ok(1) }
-}
-
-/// Run `moon info` for the given target (`None` for default target)
-///
-/// Returns `(success, build metadata if not dry-run)`.
-pub(crate) fn run_info_rr_internal(
-    cli: &UniversalFlags,
-    cmd: &InfoSubcommand,
-    target: Option<TargetBackend>,
-) -> anyhow::Result<(bool, BuildMeta)> {
-    let build_flags = BuildFlags::default();
     let PackageDirs {
         source_dir,
         target_dir,
         mooncakes_dir,
         project_manifest_path,
     } = cli.source_tgt_dir.try_into_package_dirs()?;
-    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
+
+    let build_flags = BuildFlags::default();
+    let resolve_cfg = ResolveConfig::new_with_load_defaults(
         cmd.auto_sync_flags.frozen,
         !build_flags.std(),
         build_flags.enable_coverage,
     )
     .with_project_manifest_path(project_manifest_path.as_deref());
-    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+    let resolve_output = resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+    let output = UserDiagnostics::from_flags(&cli);
+    let selection = PackageSelection::new(&cmd, &resolve_output, output)?;
 
-    run_info_rr_from_resolved(cli, cmd, &target_dir, target, resolve_output)
+    let requested_targets = cmd
+        .target
+        .as_deref()
+        .map(lower_surface_targets)
+        .unwrap_or_default();
+    let output_plan =
+        imp::plan_info_outputs(&resolve_output, selection.package_ids.iter().copied());
+    let execution_targets = output_plan.execution_targets(&requested_targets);
+
+    let mut all_meta = vec![];
+    for (tgt, target_kind) in execution_targets {
+        let (success, meta) = run_info_rr_internal(
+            &cli,
+            &cmd,
+            tgt,
+            target_kind,
+            &target_dir,
+            resolve_output.clone(),
+            &selection,
+            &output_plan,
+        )?;
+        if !success {
+            bail!("moon info failed for target {:?}", tgt);
+        }
+        all_meta.push((tgt, meta));
+    }
+
+    imp::promote_info_results(&output_plan, all_meta.iter());
+    imp::report_info_outputs(&output_plan, all_meta.iter(), &requested_targets)?;
+    Ok(0)
 }
 
-pub(crate) fn run_info_rr_from_resolved(
+/// Run `moon info` for the given target.
+///
+/// Returns `(success, build metadata if not dry-run)`.
+#[allow(clippy::too_many_arguments)]
+fn run_info_rr_internal(
     cli: &UniversalFlags,
     cmd: &InfoSubcommand,
+    target: TargetBackend,
+    target_kind: imp::TargetKind,
     target_dir: &std::path::Path,
-    target: Option<TargetBackend>,
-    resolve_output: moonbuild_rupes_recta::ResolveOutput,
+    resolve_output: ResolveOutput,
+    selection: &PackageSelection,
+    output_plan: &imp::InfoOutputPlan,
 ) -> anyhow::Result<(bool, BuildMeta)> {
-    let (build_meta, build_graph) =
-        plan_info_rr_from_resolved(cli, cmd, target_dir, target, resolve_output)?;
-    execute_info_rr_plan(cli, target_dir, build_meta, build_graph)
-}
-
-fn execute_info_rr_plan(
-    cli: &UniversalFlags,
-    target_dir: &std::path::Path,
-    build_meta: BuildMeta,
-    build_graph: rr_build::BuildInput,
-) -> anyhow::Result<(bool, BuildMeta)> {
+    let mut preconfig = rr_build::preconfig_compile(
+        &cmd.auto_sync_flags,
+        cli,
+        &BuildFlags::default(),
+        Some(target),
+        target_dir,
+        RunMode::Check,
+    );
+    preconfig.info_no_alias = cmd.no_alias;
+    let output = UserDiagnostics::from_flags(cli);
+    let ctx = InfoIntentContext {
+        selection,
+        output_plan,
+        target_kind,
+        output,
+    };
+    let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
+        preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        Box::new(move |resolve_output, tb| calc_user_intent_for_info(&ctx, resolve_output, tb)),
+        resolve_output,
+    )?;
     // Generate the all_pkgs.json for indirect dependency resolution
     // before executing the build
     rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Check)?;
 
-    let output = UserDiagnostics::from_flags(cli);
     // TODO: UX: Consider mirroring flags from `moon check`?
     let cfg = BuildConfig::from_flags(
         &BuildFlags::default(),
@@ -225,288 +377,4 @@ fn execute_info_rr_plan(
     result.print_info(cli.quiet, "generating mbti files")?;
 
     Ok((result.successful(), build_meta))
-}
-
-pub(crate) fn plan_info_rr_from_resolved(
-    cli: &UniversalFlags,
-    cmd: &InfoSubcommand,
-    target_dir: &std::path::Path,
-    target: Option<TargetBackend>,
-    resolve_output: moonbuild_rupes_recta::ResolveOutput,
-) -> anyhow::Result<(BuildMeta, rr_build::BuildInput)> {
-    let mut preconfig = rr_build::preconfig_compile(
-        &cmd.auto_sync_flags,
-        cli,
-        &BuildFlags::default(),
-        target,
-        target_dir,
-        RunMode::Check,
-    );
-    preconfig.info_no_alias = cmd.no_alias;
-    let package_filter = cmd.package.clone();
-    let path_filter = cmd.path.clone();
-    let output = UserDiagnostics::from_flags(cli);
-    rr_build::plan_build_from_resolved(
-        preconfig,
-        &cli.unstable_feature,
-        target_dir,
-        output,
-        Box::new(move |resolve_output, tb| {
-            calc_user_intent(
-                package_filter.as_deref(),
-                &path_filter,
-                resolve_output,
-                tb,
-                output,
-            )
-        }),
-        resolve_output,
-    )
-}
-
-fn calc_user_intent(
-    package_filter: Option<&str>,
-    path_filter: &[PathBuf],
-    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    target_backend: TargetBackend,
-    output: UserDiagnostics,
-) -> Result<CalcUserIntentOutput, anyhow::Error> {
-    let package_ids: Vec<_> = resolve_output
-        .local_modules()
-        .iter()
-        .flat_map(|&module_id| {
-            resolve_output
-                .pkg_dirs
-                .packages_for_module(module_id)
-                .into_iter()
-                .flat_map(|packages| packages.values().copied())
-        })
-        .collect();
-
-    let intents = if let [path] = path_filter {
-        // Preserve the old single-path behavior exactly.
-        let (dir, _) = canonicalize_with_filename(path)?;
-        let pkg = filter_pkg_by_dir(resolve_output, &dir)?;
-        if package_supports_backend(resolve_output, pkg, target_backend) {
-            vec![UserIntent::Info(pkg)]
-        } else {
-            output.warn(format!(
-                "Skipping package `{}` for `moon info`: it does not support target backend `{}`",
-                resolve_output.pkg_dirs.get_package(pkg).fqn,
-                target_backend
-            ));
-            Vec::new()
-        }
-    } else if !path_filter.is_empty() {
-        let mut filtered = Vec::new();
-        let mut unsupported = Vec::new();
-
-        for (path, pkg_id) in select_packages(path_filter, output, |dir| {
-            filter_pkg_by_dir(resolve_output, dir)
-        })? {
-            if package_supports_backend(resolve_output, pkg_id, target_backend) {
-                filtered.push(UserIntent::Info(pkg_id));
-            } else {
-                unsupported.push((path, pkg_id));
-            }
-        }
-
-        for (path, pkg_id) in &unsupported {
-            let pkg = resolve_output.pkg_dirs.get_package(*pkg_id);
-            output.info(format!(
-                "skipping path `{}` because package `{}` does not support target backend `{}`. Supported backends: {}",
-                path.display(),
-                pkg.fqn,
-                target_backend,
-                format_supported_backends(resolve_output, *pkg_id),
-            ));
-        }
-
-        if filtered.is_empty() && !unsupported.is_empty() {
-            output.warn(format!(
-                "No selected package supports target backend `{}` for `moon info`",
-                target_backend
-            ));
-        }
-
-        filtered
-    } else if let Some(filter) = package_filter {
-        let matches = match_packages_with_fuzzy(
-            resolve_output,
-            package_ids.iter().copied(),
-            std::iter::once(filter),
-        );
-
-        if matches.matched.is_empty() {
-            bail!(
-                "package `{}` not found, make sure you have spelled it correctly, e.g. `moonbitlang/core/hashmap`(exact match) or `hashmap`(fuzzy match)",
-                filter
-            );
-        }
-        if !matches.missing.is_empty() {
-            for missing in matches.missing {
-                output.warn(format!("Input `{}` did not match any package", missing));
-            }
-        }
-
-        let filtered = matches
-            .matched
-            .into_iter()
-            .filter(|&pkg_id| package_supports_backend(resolve_output, pkg_id, target_backend))
-            .collect::<Vec<_>>();
-        if filtered.is_empty() {
-            output.warn(format!(
-                "No selected package supports target backend `{}` for `moon info`",
-                target_backend
-            ));
-        }
-
-        filtered
-            .into_iter()
-            .map(UserIntent::Info)
-            .collect::<Vec<_>>()
-    } else {
-        package_ids
-            .into_iter()
-            .filter(|&pkg_id| package_supports_backend(resolve_output, pkg_id, target_backend))
-            .map(UserIntent::Info)
-            .collect()
-    };
-
-    Ok(intents.into())
-}
-
-pub(crate) fn plan_info_rr_from_resolved_all(
-    cli: &UniversalFlags,
-    cmd: &InfoSubcommand,
-    target_dir: &std::path::Path,
-    selected_target_backend: Option<TargetBackend>,
-    resolve_output: moonbuild_rupes_recta::ResolveOutput,
-) -> anyhow::Result<Vec<(BuildMeta, rr_build::BuildInput)>> {
-    if let Some(target_backend) = selected_target_backend {
-        return plan_info_rr_from_resolved(
-            cli,
-            cmd,
-            target_dir,
-            Some(target_backend),
-            resolve_output,
-        )
-        .map(|plan| vec![plan]);
-    }
-
-    let selections =
-        resolve_info_target_selections(&resolve_output, cmd, UserDiagnostics::from_flags(cli))?;
-
-    if selections.is_empty() {
-        return plan_info_rr_from_resolved(cli, cmd, target_dir, None, resolve_output)
-            .map(|plan| vec![plan]);
-    }
-
-    selections
-        .into_iter()
-        .map(|selection| {
-            let scoped_cmd = narrow_info_request_to_selection(cmd, &resolve_output, &selection);
-            plan_info_rr_from_resolved(
-                cli,
-                &scoped_cmd,
-                target_dir,
-                Some(selection.target_backend),
-                resolve_output.clone(),
-            )
-        })
-        .collect()
-}
-
-fn resolve_info_target_selections(
-    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    cmd: &InfoSubcommand,
-    output: UserDiagnostics,
-) -> anyhow::Result<Vec<InfoTargetSelection>> {
-    let selected = resolve_selected_info_packages(resolve_output, cmd, output)?;
-    let mut selections = Vec::new();
-
-    for pkg in selected {
-        let module_id = resolve_output.pkg_dirs.get_package(pkg).module;
-        let target_backend = resolve_output
-            .module_rel
-            .module_info(module_id)
-            .preferred_target
-            .or(resolve_output.workspace_preferred_target)
-            .unwrap_or_default();
-        let Some(index) = selections
-            .iter()
-            .position(|selection: &InfoTargetSelection| selection.target_backend == target_backend)
-        else {
-            selections.push(InfoTargetSelection {
-                target_backend,
-                packages: vec![pkg],
-            });
-            continue;
-        };
-        selections[index].packages.push(pkg);
-    }
-
-    selections.sort_by_key(|selection| selection.target_backend);
-
-    Ok(selections)
-}
-
-fn resolve_selected_info_packages(
-    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    cmd: &InfoSubcommand,
-    output: UserDiagnostics,
-) -> anyhow::Result<Vec<PackageId>> {
-    if !cmd.path.is_empty() {
-        return Ok(select_packages(&cmd.path, output, |dir| {
-            filter_pkg_by_dir(resolve_output, dir)
-        })?
-        .into_iter()
-        .map(|(_, pkg_id)| pkg_id)
-        .collect());
-    }
-
-    if let Some(filter) = cmd.package.as_deref() {
-        let matches = match_packages_with_fuzzy(
-            resolve_output,
-            rr_build::local_packages(resolve_output),
-            std::iter::once(filter),
-        );
-
-        if matches.matched.is_empty() {
-            bail!(
-                "package `{}` not found, make sure you have spelled it correctly, e.g. `moonbitlang/core/hashmap`(exact match) or `hashmap`(fuzzy match)",
-                filter
-            );
-        }
-        if !matches.missing.is_empty() {
-            for missing in matches.missing {
-                output.warn(format!("Input `{}` did not match any package", missing));
-            }
-        }
-
-        return Ok(matches.matched);
-    }
-
-    Ok(rr_build::local_packages(resolve_output).collect())
-}
-
-fn narrow_info_request_to_selection(
-    cmd: &InfoSubcommand,
-    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    selection: &InfoTargetSelection,
-) -> InfoSubcommand {
-    let mut scoped_cmd = cmd.clone();
-    scoped_cmd.package = None;
-    scoped_cmd.path = selection
-        .packages
-        .iter()
-        .map(|pkg_id| {
-            resolve_output
-                .pkg_dirs
-                .get_package(*pkg_id)
-                .root_path
-                .to_path_buf()
-        })
-        .collect();
-    scoped_cmd
 }

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -302,6 +302,7 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
     let execution_targets = output_plan.execution_targets(&requested_targets);
 
     let mut all_meta = vec![];
+    let mut ok = true;
     for (tgt, target_kind) in execution_targets {
         let (success, meta) = run_info_rr_internal(
             &cli,
@@ -314,9 +315,14 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
             &output_plan,
         )?;
         if !success {
-            bail!("moon info failed for target {:?}", tgt);
+            ok = false;
+            continue;
         }
         all_meta.push((tgt, meta));
+    }
+
+    if !ok {
+        return Ok(1);
     }
 
     imp::promote_info_results(&output_plan, all_meta.iter());
@@ -374,7 +380,11 @@ fn run_info_rr_internal(
         output,
     );
     let result = rr_build::execute_build(&cfg, build_graph, target_dir)?;
-    result.print_info(cli.quiet, "generating mbti files")?;
+    let success = result.successful();
+    let print_result = result.print_info(cli.quiet, "generating mbti files");
+    if success {
+        print_result?;
+    }
 
-    Ok((result.successful(), build_meta))
+    Ok((success, build_meta))
 }

--- a/crates/moon/src/cli/info/imp.rs
+++ b/crates/moon/src/cli/info/imp.rs
@@ -18,64 +18,74 @@
 
 //! Actual implementation of `moon info` command.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Context;
 use colored::Colorize;
 use indexmap::IndexMap;
 use moonbuild::expect::write_diff;
-use moonbuild_rupes_recta::{model::BuildPlanNode, pkg_name::PackageFQN};
+use moonbuild_rupes_recta::{
+    ResolveOutput,
+    model::{BuildPlanNode, PackageId},
+    pkg_name::PackageFQN,
+};
 use moonutil::common::{MBTI_GENERATED, TargetBackend};
 use sha2::Digest;
 use tracing::error;
 
 use crate::rr_build::BuildMeta;
 
-/// Promote the given build run's info results to their respective package directories.
-pub(super) fn promote_info_results(meta: &BuildMeta) {
-    for (&node, artifact) in &meta.artifacts {
-        let BuildPlanNode::GenerateMbti(target) = node else {
-            continue;
-        };
-        assert!(
-            artifact.artifacts.len() == 1,
-            "mbti generation should only produce one artifact"
-        );
-        let mbti_path = artifact.artifacts.first().unwrap();
+pub(super) struct InfoOutputPlan {
+    packages: IndexMap<PackageId, PackageOutputPlan>,
+}
 
-        let package_path = &meta
-            .resolve_output
-            .pkg_dirs
-            .get_package(target.package)
-            .root_path;
-        let dest_path = package_path.join(MBTI_GENERATED);
+struct PackageOutputPlan {
+    pkg_name: String,
+    dest_path: PathBuf,
+    canonical_backend: TargetBackend,
+}
 
-        match std::fs::copy(mbti_path, &dest_path) {
-            Ok(_) => {}
-            Err(e) => {
-                error!(
-                    "Failed to copy generated mbti file from {} to {}: {}",
-                    mbti_path.display(),
-                    dest_path.display(),
-                    e
-                );
-            }
+impl PackageOutputPlan {
+    fn new_from_fqn(
+        pkg_name: &PackageFQN,
+        dest_path: PathBuf,
+        canonical_backend: TargetBackend,
+    ) -> Self {
+        Self {
+            pkg_name: pkg_name.to_string(),
+            dest_path,
+            canonical_backend,
         }
+    }
+
+    pub(super) fn canonical_backend(&self) -> TargetBackend {
+        self.canonical_backend
     }
 }
 
+impl InfoOutputPlan {
+    pub(super) fn canonical_backend_for(&self, package_id: &PackageId) -> Option<TargetBackend> {
+        self.packages.get(package_id).map(|p| p.canonical_backend())
+    }
+}
+
+pub(super) enum TargetKind {
+    Canonical,
+    Requested,
+}
+
 struct PackageOutputGroup<'a> {
-    pkg_name: String,
-    dest_path: PathBuf,
+    plan: &'a PackageOutputPlan,
     backend_files: IndexMap<TargetBackend, &'a Path>,
 }
 
 impl<'a> PackageOutputGroup<'a> {
-    fn new_from_fqn(pkg_name: &'a PackageFQN, dest_path: PathBuf) -> Self {
-        let pkg_name = pkg_name.to_string();
+    fn new(plan: &'a PackageOutputPlan) -> Self {
         Self {
-            pkg_name,
-            dest_path,
+            plan,
             backend_files: IndexMap::new(),
         }
     }
@@ -85,104 +95,146 @@ impl<'a> PackageOutputGroup<'a> {
     }
 }
 
-/// Compare the outputs of different targets for consistency. `canonical` is the
-/// target backend to use as the reference.
-///
-/// Prints any differences found, and returns `true` if all outputs are identical.
-pub(super) fn compare_info_outputs<'a>(
-    it: impl Iterator<Item = &'a (TargetBackend, BuildMeta)>,
-    canonical: TargetBackend,
-) -> anyhow::Result<bool> {
-    // First, transpose the data structure to group by package
-    let mut transposed = IndexMap::<_, PackageOutputGroup>::new();
-    for (backend, meta) in it {
-        for (&node, artifact) in &meta.artifacts {
-            let BuildPlanNode::GenerateMbti(target) = node else {
-                continue;
-            };
-            assert!(
-                artifact.artifacts.len() == 1,
-                "mbti generation should only produce one artifact"
-            );
-            let mbti_path = artifact.artifacts.first().unwrap();
-            transposed
-                .entry(target.package)
-                .or_insert_with(|| {
-                    let pkg = meta.resolve_output.pkg_dirs.get_package(target.package);
-                    PackageOutputGroup::new_from_fqn(&pkg.fqn, pkg.root_path.join(MBTI_GENERATED))
-                })
-                .insert(*backend, mbti_path);
-        }
+pub(super) fn plan_info_outputs(
+    resolve_output: &ResolveOutput,
+    packages: impl IntoIterator<Item = PackageId>,
+) -> InfoOutputPlan {
+    let mut planned = IndexMap::new();
+
+    for package_id in packages {
+        planned.entry(package_id).or_insert_with(|| {
+            let pkg = resolve_output.pkg_dirs.get_package(package_id);
+            let module = resolve_output.module_rel.module_info(pkg.module);
+            let canonical_backend = module
+                .preferred_target
+                .or(resolve_output.workspace_preferred_target)
+                .unwrap_or_default();
+
+            PackageOutputPlan::new_from_fqn(
+                &pkg.fqn,
+                pkg.root_path.join(MBTI_GENERATED),
+                canonical_backend,
+            )
+        });
     }
 
-    // For each package, compare the outputs across different backends
-    let mut identical = true;
-    for (_package, group) in transposed {
-        // Prefer the canonical backend as the reference. If not present, pick the first one.
-        // If a package has 0 files, it should not reach here, so unwrap is safe.
-        let reference_backend = if group.backend_files.contains_key(&canonical) {
-            canonical
-        } else {
-            *group
-                .backend_files
-                .keys()
-                .next()
-                .expect("No backend files found")
-        };
-        identical &= compare_info_output_for_package(reference_backend, &group)?;
-    }
-
-    Ok(identical)
+    InfoOutputPlan { packages: planned }
 }
 
-/// Promote multi-target `moon info` outputs.
+/// Determine the canonical backend for writing `.mbti` files:
 ///
-/// For each package, prefer canonical backend output if available, otherwise
-/// promote the first available backend output.
-pub(super) fn promote_info_results_multi_target<'a>(
-    it: impl Iterator<Item = &'a (TargetBackend, BuildMeta)>,
-    canonical: TargetBackend,
-) {
-    let mut transposed = IndexMap::<_, PackageOutputGroup>::new();
-    for (backend, meta) in it {
-        for (&node, artifact) in &meta.artifacts {
-            let BuildPlanNode::GenerateMbti(target) = node else {
-                continue;
-            };
-            assert!(
-                artifact.artifacts.len() == 1,
-                "mbti generation should only produce one artifact"
-            );
-            let mbti_path = artifact.artifacts.first().unwrap();
-            transposed
-                .entry(target.package)
-                .or_insert_with(|| {
-                    let pkg = meta.resolve_output.pkg_dirs.get_package(target.package);
-                    PackageOutputGroup::new_from_fqn(&pkg.fqn, pkg.root_path.join(MBTI_GENERATED))
-                })
-                .insert(*backend, mbti_path);
+/// 1. Module's `preferred-backend` (if set in `moon.mod.json`)
+/// 2. Workspace's `preferred-backend` (if set in `moon.work`)
+/// 3. `wasm-gc` (default fallback)
+///
+/// Note: If a package's `supported-targets` does NOT include the canonical backend,
+/// no `.mbti` file will be written. Users should set `preferred-backend` on the
+/// module or workspace to match their supported targets.
+impl InfoOutputPlan {
+    pub(super) fn execution_targets(
+        &self,
+        requested_backends: &[TargetBackend],
+    ) -> Vec<(TargetBackend, TargetKind)> {
+        if self.packages.is_empty() {
+            return Vec::new();
         }
-    }
 
-    for (_package, group) in transposed {
-        let source_path = group
+        let canonical_backends: BTreeSet<_> = self
+            .packages
+            .values()
+            .map(|plan| plan.canonical_backend)
+            .collect();
+
+        let mut targets: Vec<(TargetBackend, TargetKind)> = Vec::new();
+
+        for &backend in requested_backends {
+            targets.push((backend, TargetKind::Requested));
+        }
+
+        for backend in canonical_backends {
+            if !requested_backends.contains(&backend) {
+                targets.push((backend, TargetKind::Canonical));
+            }
+        }
+
+        targets
+    }
+}
+
+pub(super) fn promote_info_results<'a>(
+    plan: &'a InfoOutputPlan,
+    it: impl Iterator<Item = &'a (TargetBackend, BuildMeta)>,
+) {
+    for (_package, group) in collect_package_output_groups(plan, it) {
+        let Some(source_path) = group
             .backend_files
-            .get(&canonical)
+            .get(&group.plan.canonical_backend)
             .copied()
-            .or_else(|| group.backend_files.values().next().copied())
-            .expect("No backend files found");
-        match std::fs::copy(source_path, &group.dest_path) {
+        else {
+            continue;
+        };
+
+        match std::fs::copy(source_path, &group.plan.dest_path) {
             Ok(_) => {}
             Err(e) => {
                 error!(
                     "Failed to copy generated mbti file from {} to {}: {}",
                     source_path.display(),
-                    group.dest_path.display(),
+                    group.plan.dest_path.display(),
                     e
                 );
             }
         }
     }
+}
+
+pub(super) fn report_info_outputs<'a>(
+    plan: &'a InfoOutputPlan,
+    it: impl Iterator<Item = &'a (TargetBackend, BuildMeta)>,
+    requested_backends: &[TargetBackend],
+) -> anyhow::Result<()> {
+    if requested_backends.is_empty() {
+        return Ok(());
+    }
+
+    let requested_backends = requested_backends.iter().copied().collect::<BTreeSet<_>>();
+
+    for (_package, group) in collect_package_output_groups(plan, it) {
+        report_info_output_for_package(&requested_backends, &group)?;
+    }
+
+    Ok(())
+}
+
+fn collect_package_output_groups<'a>(
+    plan: &'a InfoOutputPlan,
+    it: impl Iterator<Item = &'a (TargetBackend, BuildMeta)>,
+) -> IndexMap<PackageId, PackageOutputGroup<'a>> {
+    let mut transposed = plan
+        .packages
+        .iter()
+        .map(|(&package, output_plan)| (package, PackageOutputGroup::new(output_plan)))
+        .collect::<IndexMap<_, _>>();
+
+    for (backend, meta) in it {
+        for (&node, artifact) in &meta.artifacts {
+            let BuildPlanNode::GenerateMbti(target) = node else {
+                continue;
+            };
+            let Some(group) = transposed.get_mut(&target.package) else {
+                continue;
+            };
+
+            assert!(
+                artifact.artifacts.len() == 1,
+                "mbti generation should only produce one artifact"
+            );
+            let mbti_path = artifact.artifacts.first().unwrap();
+            group.insert(*backend, mbti_path);
+        }
+    }
+
+    transposed
 }
 
 struct MbtiOutput<'a> {
@@ -191,27 +243,20 @@ struct MbtiOutput<'a> {
     hash: [u8; 32],
 }
 
-/// Compare the outputs of different targets for a single package.
-///
-/// Return `true` if all outputs are identical, `false` otherwise.
-fn compare_info_output_for_package(
-    canonical: TargetBackend,
-    group: &PackageOutputGroup,
-) -> anyhow::Result<bool> {
-    // Read the inputs for each backend
+fn read_backend_contents<'a>(
+    group: &'a PackageOutputGroup<'a>,
+) -> anyhow::Result<IndexMap<TargetBackend, MbtiOutput<'a>>> {
     let mut backend_contents = IndexMap::new();
+
     for (backend, path) in &group.backend_files {
         let content = std::fs::read_to_string(path).with_context(|| {
             format!(
                 "Failed to read mbti file for package {} at {}",
-                group.pkg_name,
+                group.plan.pkg_name,
                 path.display()
             )
         })?;
 
-        // MAINTAINERS: This hash is purely used for convenience, since sha2
-        // is used elsewhere in the codebase. You can replace it with any hash
-        // function. This is for easy grouping of identical contents.
         let hash0 = sha2::Sha256::digest(&content);
         let mut hash = [0u8; 32];
         hash.copy_from_slice(&hash0);
@@ -226,38 +271,68 @@ fn compare_info_output_for_package(
         );
     }
 
-    // Group by hashes
+    Ok(backend_contents)
+}
+
+fn report_info_output_for_package(
+    requested_backends: &BTreeSet<TargetBackend>,
+    group: &PackageOutputGroup,
+) -> anyhow::Result<()> {
+    let backend_contents = read_backend_contents(group)?;
+    let requested_outputs = requested_backends
+        .iter()
+        .copied()
+        .filter(|backend| backend_contents.contains_key(backend))
+        .collect::<Vec<_>>();
+
+    if requested_outputs.is_empty() {
+        return Ok(());
+    }
+
+    let canonical_backend = group.plan.canonical_backend;
+    let Some(canonical) = backend_contents.get(&canonical_backend) else {
+        return report_requested_outputs_without_canonical(
+            backend_contents,
+            requested_outputs,
+            group,
+        );
+    };
+
     let mut hash_groups: IndexMap<[u8; 32], Vec<TargetBackend>> = IndexMap::new();
-    for (backend, mbti_output) in &backend_contents {
-        hash_groups
-            .entry(mbti_output.hash)
-            .or_default()
-            .push(*backend);
-    }
-    let canonical_hash = &backend_contents
-        .get(&canonical)
-        .context("Canonical backend output not found")?
-        .hash;
-
-    if hash_groups.len() == 1 {
-        // All outputs are identical
-        return Ok(true);
-    }
-
-    // Now we can compare the groups
-    println!(
-        "#\n# Package {} has diverging interfaces across backends:",
-        group.pkg_name
-    );
-    for (hash, backends) in &hash_groups {
-        if hash == canonical_hash {
+    for backend in requested_outputs {
+        if backend == canonical_backend {
             continue;
         }
 
-        let expected = &backend_contents
-            .get(&canonical)
-            .context("Canonical backend output not found")?;
-        let actual = &backend_contents
+        let actual = backend_contents
+            .get(&backend)
+            .context("Requested backend output not found")?;
+        hash_groups.entry(actual.hash).or_default().push(backend);
+    }
+
+    let mut has_difference = false;
+    for hash in hash_groups.keys() {
+        if hash != &canonical.hash {
+            has_difference = true;
+            break;
+        }
+    }
+
+    if !has_difference {
+        return Ok(());
+    }
+
+    println!(
+        "#\n# Package {} has diverging interfaces across backends:",
+        group.plan.pkg_name
+    );
+
+    for (hash, backends) in hash_groups {
+        if hash == canonical.hash {
+            continue;
+        }
+
+        let actual = backend_contents
             .get(&backends[0])
             .context("Backend output not found")?;
 
@@ -265,26 +340,69 @@ fn compare_info_output_for_package(
         println!(
             "{} {} {:?} {}",
             "---".bright_red(),
-            group.pkg_name,
-            canonical,
-            format!("({})", expected.filename.display()).bright_black(),
+            group.plan.pkg_name,
+            canonical_backend,
+            format!("({})", canonical.filename.display()).bright_black(),
         );
-        for backend in backends {
+        for backend in &backends {
             let actual = backend_contents
                 .get(backend)
                 .context("Backend output not found")?;
             println!(
                 "{} {} {:?} {}",
                 "+++".bright_green(),
-                group.pkg_name,
+                group.plan.pkg_name,
                 backend,
                 format!("({})", actual.filename.display()).bright_black(),
             );
         }
 
-        write_diff(&expected.content, &actual.content, 1, 2, std::io::stdout())?;
+        write_diff(&canonical.content, &actual.content, 1, 2, std::io::stdout())?;
     }
-    println!("# ------");
 
-    Ok(false)
+    println!("# ------");
+    Ok(())
+}
+
+fn report_requested_outputs_without_canonical(
+    backend_contents: IndexMap<TargetBackend, MbtiOutput<'_>>,
+    requested_outputs: Vec<TargetBackend>,
+    group: &PackageOutputGroup,
+) -> anyhow::Result<()> {
+    let mut hash_groups: IndexMap<[u8; 32], Vec<TargetBackend>> = IndexMap::new();
+    for backend in requested_outputs {
+        let actual = backend_contents
+            .get(&backend)
+            .context("Requested backend output not found")?;
+        hash_groups.entry(actual.hash).or_default().push(backend);
+    }
+
+    println!(
+        "#\n# Package {} has no canonical interface for backend {:?}; showing requested outputs:",
+        group.plan.pkg_name, group.plan.canonical_backend
+    );
+
+    for backends in hash_groups.values() {
+        let actual = backend_contents
+            .get(&backends[0])
+            .context("Backend output not found")?;
+
+        println!("#\n# ---");
+        for backend in backends {
+            println!(
+                "{} {} {:?} {}",
+                "---".bright_green(),
+                group.plan.pkg_name,
+                backend,
+                format!("({})", actual.filename.display()).bright_black(),
+            );
+        }
+        print!("{}", actual.content);
+        if !actual.content.ends_with('\n') {
+            println!();
+        }
+    }
+
+    println!("# ------");
+    Ok(())
 }

--- a/crates/moon/src/cli/info/imp.rs
+++ b/crates/moon/src/cli/info/imp.rs
@@ -237,10 +237,12 @@ fn collect_package_output_groups<'a>(
     transposed
 }
 
+type ContentHash = [u8; 32];
+
 struct MbtiOutput<'a> {
     filename: &'a Path,
     content: String,
-    hash: [u8; 32],
+    hash: ContentHash,
 }
 
 fn read_backend_contents<'a>(
@@ -257,9 +259,7 @@ fn read_backend_contents<'a>(
             )
         })?;
 
-        let hash0 = sha2::Sha256::digest(&content);
-        let mut hash = [0u8; 32];
-        hash.copy_from_slice(&hash0);
+        let hash = content_hash(&content);
 
         backend_contents.insert(
             *backend,
@@ -290,45 +290,37 @@ fn report_info_output_for_package(
     }
 
     let canonical_backend = group.plan.canonical_backend;
-    let Some(canonical) = backend_contents.get(&canonical_backend) else {
-        return report_requested_outputs_without_canonical(
-            backend_contents,
-            requested_outputs,
-            group,
-        );
-    };
+    let canonical = backend_contents.get(&canonical_backend);
+    let baseline_content = canonical
+        .map(|output| output.content.as_str())
+        .unwrap_or("");
+    let baseline_hash = canonical
+        .map(|output| output.hash)
+        .unwrap_or_else(|| content_hash(""));
+    let baseline_file_label = canonical
+        .map(|output| format!("({})", output.filename.display()))
+        .unwrap_or_else(|| "(no generated interface)".to_string());
+    let hash_groups =
+        group_requested_outputs_by_hash(&backend_contents, requested_outputs, canonical_backend)?;
 
-    let mut hash_groups: IndexMap<[u8; 32], Vec<TargetBackend>> = IndexMap::new();
-    for backend in requested_outputs {
-        if backend == canonical_backend {
-            continue;
-        }
-
-        let actual = backend_contents
-            .get(&backend)
-            .context("Requested backend output not found")?;
-        hash_groups.entry(actual.hash).or_default().push(backend);
-    }
-
-    let mut has_difference = false;
-    for hash in hash_groups.keys() {
-        if hash != &canonical.hash {
-            has_difference = true;
-            break;
-        }
-    }
-
-    if !has_difference {
+    if hash_groups.keys().all(|hash| hash == &baseline_hash) {
         return Ok(());
     }
 
-    println!(
-        "#\n# Package {} has diverging interfaces across backends:",
-        group.plan.pkg_name
-    );
+    if canonical.is_some() {
+        println!(
+            "#\n# Package {} has diverging interfaces across backends:",
+            group.plan.pkg_name
+        );
+    } else {
+        println!(
+            "#\n# Package {} has requested interfaces different from canonical backend {:?}:",
+            group.plan.pkg_name, canonical_backend
+        );
+    }
 
     for (hash, backends) in hash_groups {
-        if hash == canonical.hash {
+        if hash == baseline_hash {
             continue;
         }
 
@@ -342,7 +334,7 @@ fn report_info_output_for_package(
             "---".bright_red(),
             group.plan.pkg_name,
             canonical_backend,
-            format!("({})", canonical.filename.display()).bright_black(),
+            baseline_file_label.bright_black(),
         );
         for backend in &backends {
             let actual = backend_contents
@@ -357,52 +349,39 @@ fn report_info_output_for_package(
             );
         }
 
-        write_diff(&canonical.content, &actual.content, 1, 2, std::io::stdout())?;
+        write_diff(baseline_content, &actual.content, 1, 2, std::io::stdout())?;
     }
 
     println!("# ------");
     Ok(())
 }
 
-fn report_requested_outputs_without_canonical(
-    backend_contents: IndexMap<TargetBackend, MbtiOutput<'_>>,
+fn content_hash(content: &str) -> ContentHash {
+    let hash0 = sha2::Sha256::digest(content);
+    let mut hash = [0u8; 32];
+    hash.copy_from_slice(&hash0);
+    hash
+}
+
+fn group_requested_outputs_by_hash(
+    backend_contents: &IndexMap<TargetBackend, MbtiOutput<'_>>,
     requested_outputs: Vec<TargetBackend>,
-    group: &PackageOutputGroup,
-) -> anyhow::Result<()> {
-    let mut hash_groups: IndexMap<[u8; 32], Vec<TargetBackend>> = IndexMap::new();
+    canonical_backend: TargetBackend,
+) -> anyhow::Result<IndexMap<ContentHash, Vec<TargetBackend>>> {
+    // Use a compact content hash as the grouping key so identical backend
+    // interfaces share one diff in the report.
+    let mut hash_groups: IndexMap<ContentHash, Vec<TargetBackend>> = IndexMap::new();
+
     for backend in requested_outputs {
+        if backend == canonical_backend {
+            continue;
+        }
+
         let actual = backend_contents
             .get(&backend)
             .context("Requested backend output not found")?;
         hash_groups.entry(actual.hash).or_default().push(backend);
     }
 
-    println!(
-        "#\n# Package {} has no canonical interface for backend {:?}; showing requested outputs:",
-        group.plan.pkg_name, group.plan.canonical_backend
-    );
-
-    for backends in hash_groups.values() {
-        let actual = backend_contents
-            .get(&backends[0])
-            .context("Backend output not found")?;
-
-        println!("#\n# ---");
-        for backend in backends {
-            println!(
-                "{} {} {:?} {}",
-                "---".bright_green(),
-                group.plan.pkg_name,
-                backend,
-                format!("({})", actual.filename.display()).bright_black(),
-            );
-        }
-        print!("{}", actual.content);
-        if !actual.content.ends_with('\n') {
-            println!();
-        }
-    }
-
-    println!("# ------");
-    Ok(())
+    Ok(hash_groups)
 }

--- a/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
@@ -401,7 +401,7 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;info'= {
-            cand --target 'Select output target'
+            cand --target 'Inspect one or more target backends without changing the canonical `pkg.generated.mbti` output'
             cand -p 'The full or subset of name of the package to emit `mbti` files for'
             cand --package 'The full or subset of name of the package to emit `mbti` files for'
             cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'

--- a/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
@@ -314,7 +314,7 @@ complete -c moon -n "__fish_moon_using_subcommand explain" -l trace -d 'Trace th
 complete -c moon -n "__fish_moon_using_subcommand explain" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand explain" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand explain" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand info" -l target -d 'Select output target' -r -f -a "{wasm\t'',wasm-gc\t'',js\t'',native\t'',llvm\t'',all\t''}"
+complete -c moon -n "__fish_moon_using_subcommand info" -l target -d 'Inspect one or more target backends without changing the canonical `pkg.generated.mbti` output' -r -f -a "{wasm\t'',wasm-gc\t'',js\t'',native\t'',llvm\t'',all\t''}"
 complete -c moon -n "__fish_moon_using_subcommand info" -s p -l package -d 'The full or subset of name of the package to emit `mbti` files for' -r
 complete -c moon -n "__fish_moon_using_subcommand info" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand info" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F

--- a/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
@@ -417,7 +417,7 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;info' {
-            [CompletionResult]::new('--target', 'target', [CompletionResultType]::ParameterName, 'Select output target')
+            [CompletionResult]::new('--target', 'target', [CompletionResultType]::ParameterName, 'Inspect one or more target backends without changing the canonical `pkg.generated.mbti` output')
             [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'The full or subset of name of the package to emit `mbti` files for')
             [CompletionResult]::new('--package', 'package', [CompletionResultType]::ParameterName, 'The full or subset of name of the package to emit `mbti` files for')
             [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -407,7 +407,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (info)
 _arguments "${_arguments_options[@]}" : \
-'*--target=[Select output target]:TARGET:(wasm wasm-gc js native llvm all)' \
+'*--target=[Inspect one or more target backends without changing the canonical \`pkg.generated.mbti\` output]:TARGET:(wasm wasm-gc js native llvm all)' \
 '-p+[The full or subset of name of the package to emit \`mbti\` files for]:PACKAGE: ' \
 '--package=[The full or subset of name of the package to emit \`mbti\` files for]:PACKAGE: ' \
 '--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \

--- a/crates/moon/tests/test_cases/filter_by_path/mod.rs
+++ b/crates/moon/tests/test_cases/filter_by_path/mod.rs
@@ -123,6 +123,34 @@ fn test_moon_info_filter_by_path_failure() {
 }
 
 #[test]
+fn test_moon_info_compile_failure_exits_with_status_1() {
+    let dir = TestDir::new_empty();
+    let lib = dir.join("lib");
+    std::fs::create_dir_all(&lib).unwrap();
+    std::fs::write(dir.join("moon.mod.json"), r#"{"name":"username/hello"}"#).unwrap();
+    std::fs::write(lib.join("moon.pkg.json"), "{}").unwrap();
+    std::fs::write(lib.join("bad.mbt"), "pub fn bad() -> Int { true }\n").unwrap();
+
+    let assert = snapbox::cmd::Command::new(moon_bin())
+        .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
+        .current_dir(&dir)
+        .args(["info"])
+        .assert()
+        .failure();
+
+    assert_eq!(assert.get_output().status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        !stderr.contains("moon info failed for target"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Error: failed when generating mbti files project"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn test_moon_info_filter_by_multiple_paths_success() {
     let dir = TestDir::new("test_filter/test_filter");
 

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -2215,11 +2215,12 @@ fn test_strip_debug() {
 #[test]
 fn test_diff_mbti() {
     let dir = TestDir::new("diff_mbti.in");
-    let content = get_err_stdout(&dir, ["info", "--target", "all"]);
+    let content = get_stdout(&dir, ["info", "--target", "all"]);
     assert!(content.contains("$ROOT/_build/wasm-gc/debug/check/lib/lib.mbti"));
     assert!(content.contains("$ROOT/_build/js/debug/check/lib/lib.mbti"));
     assert!(content.contains("-pub fn aaa() -> String"));
     assert!(content.contains("+pub fn a() -> String"));
+    assert!(dir.join("src/lib").join(MBTI_GENERATED).exists());
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -86,7 +86,9 @@ fn test_moon_info_help_explains_target_and_default_behavior() {
     let output = get_stdout(&dir, ["help", "info"]);
     assert!(output.contains("By default, `moon info` writes `pkg.generated.mbti`"));
     assert!(output.contains("canonical backend: module `preferred-backend`, then workspace"));
-    assert!(output.contains("`--target` inspects backend-specific interfaces and reports differences"));
+    assert!(
+        output.contains("`--target` inspects backend-specific interfaces and reports differences")
+    );
     assert!(output.contains("Inspect one or more target backends without changing the canonical"));
 }
 

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -81,6 +81,16 @@ fn test_moon_help() {
 }
 
 #[test]
+fn test_moon_info_help_explains_target_and_default_behavior() {
+    let dir = TestDir::new_empty();
+    let output = get_stdout(&dir, ["help", "info"]);
+    assert!(output.contains("By default, `moon info` writes `pkg.generated.mbti`"));
+    assert!(output.contains("canonical backend: module `preferred-backend`, then workspace"));
+    assert!(output.contains("`--target` inspects backend-specific interfaces and reports differences"));
+    assert!(output.contains("Inspect one or more target backends without changing the canonical"));
+}
+
+#[test]
 fn test_moon_explain_diagnostics_lists_warnings() {
     let dir = TestDir::new_empty();
     let output = get_stdout(&dir, ["explain", "--diagnostics"]);

--- a/crates/moon/tests/test_cases/moon_info_compare_backends/mod.rs
+++ b/crates/moon/tests/test_cases/moon_info_compare_backends/mod.rs
@@ -6,13 +6,15 @@ use moonutil::common::MBTI_GENERATED;
 fn test_moon_info_compare_backends() {
     // Run moon info against all backends; the fixture differs across backends
     let dir = TestDir::new("moon_info_compare_backends");
-    let out = get_err_stdout(&dir, ["info", "--target", "all"]);
+    let out = get_stdout(&dir, ["info", "--target", "all"]);
 
-    // Divergent outputs should not be promoted to package dir
+    // Divergent outputs should still promote the canonical interface to package dir
     assert!(
-        !dir.join("lib").join(MBTI_GENERATED).exists(),
-        "Diverging backends should not promote mbti outputs"
+        dir.join("lib").join(MBTI_GENERATED).exists(),
+        "Diverging backends should still promote the canonical mbti output"
     );
+    let mbti = std::fs::read_to_string(dir.join("lib").join(MBTI_GENERATED)).unwrap();
+    assert!(mbti.contains("pub fn hello_wasm_gc() -> String"));
 
     expect_file!["moon_info_compare_backends.out"].assert_eq(&out);
 }

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -217,34 +217,30 @@ fn test_mixed_backend_split_check_keeps_single_package_patch_file_rule() {
 fn test_mixed_backend_run_info_bundle_are_target_aware() {
     let dir = TestDir::new("mixed_backend_local_dep.in");
 
-    get_stdout(&dir, ["info", "--target", "js"]);
-    assert!(dir.join("shared").join(MBTI_GENERATED).exists());
-    assert!(dir.join("web").join(MBTI_GENERATED).exists());
-    assert!(!dir.join("server").join(MBTI_GENERATED).exists());
-
-    for pkg in ["shared", "web", "server"] {
-        let path = dir.join(pkg).join(MBTI_GENERATED);
-        if path.exists() {
-            std::fs::remove_file(path).unwrap();
-        }
-    }
-
-    get_stdout(&dir, ["info", "--target", "native"]);
-    assert!(dir.join("shared").join(MBTI_GENERATED).exists());
-    assert!(dir.join("server").join(MBTI_GENERATED).exists());
+    let info_js = get_stdout(&dir, ["info", "--target", "js"]);
+    assert!(!dir.join("shared").join(MBTI_GENERATED).exists());
     assert!(!dir.join("web").join(MBTI_GENERATED).exists());
+    assert!(!dir.join("server").join(MBTI_GENERATED).exists());
+    assert!(info_js.contains("Package mixed/localdep/shared has no canonical interface"));
+    assert!(info_js.contains("pub fn shared_banner() -> String"));
+    assert!(info_js.contains("pub fn web_banner() -> String"));
 
-    for pkg in ["shared", "web", "server"] {
-        let path = dir.join(pkg).join(MBTI_GENERATED);
-        if path.exists() {
-            std::fs::remove_file(path).unwrap();
-        }
-    }
+    let info_native = get_stdout(&dir, ["info", "--target", "native"]);
+    assert!(!dir.join("shared").join(MBTI_GENERATED).exists());
+    assert!(!dir.join("web").join(MBTI_GENERATED).exists());
+    assert!(!dir.join("server").join(MBTI_GENERATED).exists());
+    assert!(info_native.contains("Package mixed/localdep/shared has no canonical interface"));
+    assert!(info_native.contains("pub fn shared_banner() -> String"));
+    assert!(info_native.contains("pub fn server_banner() -> String"));
 
-    get_stdout(&dir, ["info", "--target", "js,native"]);
-    assert!(dir.join("shared").join(MBTI_GENERATED).exists());
-    assert!(dir.join("web").join(MBTI_GENERATED).exists());
-    assert!(dir.join("server").join(MBTI_GENERATED).exists());
+    let info_both = get_stdout(&dir, ["info", "--target", "js,native"]);
+    assert!(!dir.join("shared").join(MBTI_GENERATED).exists());
+    assert!(!dir.join("web").join(MBTI_GENERATED).exists());
+    assert!(!dir.join("server").join(MBTI_GENERATED).exists());
+    assert!(info_both.contains("Package mixed/localdep/shared has no canonical interface"));
+    assert!(info_both.contains("pub fn shared_banner() -> String"));
+    assert!(info_both.contains("pub fn web_banner() -> String"));
+    assert!(info_both.contains("pub fn server_banner() -> String"));
 
     let bundle_js = get_stdout(
         &dir,

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -221,7 +221,9 @@ fn test_mixed_backend_run_info_bundle_are_target_aware() {
     assert!(!dir.join("shared").join(MBTI_GENERATED).exists());
     assert!(!dir.join("web").join(MBTI_GENERATED).exists());
     assert!(!dir.join("server").join(MBTI_GENERATED).exists());
-    assert!(info_js.contains("Package mixed/localdep/shared has no canonical interface"));
+    assert!(info_js.contains(
+        "Package mixed/localdep/shared has requested interfaces different from canonical backend"
+    ));
     assert!(info_js.contains("pub fn shared_banner() -> String"));
     assert!(info_js.contains("pub fn web_banner() -> String"));
 
@@ -229,7 +231,9 @@ fn test_mixed_backend_run_info_bundle_are_target_aware() {
     assert!(!dir.join("shared").join(MBTI_GENERATED).exists());
     assert!(!dir.join("web").join(MBTI_GENERATED).exists());
     assert!(!dir.join("server").join(MBTI_GENERATED).exists());
-    assert!(info_native.contains("Package mixed/localdep/shared has no canonical interface"));
+    assert!(info_native.contains(
+        "Package mixed/localdep/shared has requested interfaces different from canonical backend"
+    ));
     assert!(info_native.contains("pub fn shared_banner() -> String"));
     assert!(info_native.contains("pub fn server_banner() -> String"));
 
@@ -237,7 +241,9 @@ fn test_mixed_backend_run_info_bundle_are_target_aware() {
     assert!(!dir.join("shared").join(MBTI_GENERATED).exists());
     assert!(!dir.join("web").join(MBTI_GENERATED).exists());
     assert!(!dir.join("server").join(MBTI_GENERATED).exists());
-    assert!(info_both.contains("Package mixed/localdep/shared has no canonical interface"));
+    assert!(info_both.contains(
+        "Package mixed/localdep/shared has requested interfaces different from canonical backend"
+    ));
     assert!(info_both.contains("pub fn shared_banner() -> String"));
     assert!(info_both.contains("pub fn web_banner() -> String"));
     assert!(info_both.contains("pub fn server_banner() -> String"));

--- a/docs/dev/reference/supported-targets.md
+++ b/docs/dev/reference/supported-targets.md
@@ -71,13 +71,14 @@ separate feature and unchanged.
 | `moon check` , `moon build` | keep packages that support `B` before root selection | selected package must support `B` |
 | `moon test` , `moon bench` | keep packages that support `B` | selected package(s) must support `B` |
 | `moon run` | N/A (explicit selector required) | selected package must support `B` |
-| `moon info` | keep packages that support `B` | unsupported selected package(s) are skipped with warning |
+| `moon info` | write canonical `preferred-backend` output; inspect requested backend `B` | unsupported selected package(s) are skipped with warning |
 | `moon bundle` | planner skips package targets that do not support `B` | no package-level explicit filter |
 
 Notes:
 
 * `--target all` expands to `wasm`,  `wasm-gc`,  `js`,  `native` (not `llvm`).
 * `llvm` is still a valid value in `supported_targets`.
+* `moon info` writes `pkg.generated.mbti` only from the canonical backend of each selected package: module `preferred-backend`, then workspace preferred backend, then `wasm-gc`.
 
 ## Dependency compatibility (fail-fast)
 

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -378,6 +378,11 @@ Generate public interface (`.mbti`) files for all packages in the module or work
 
 **Usage:** `moon info [OPTIONS] [PATH]...`
 
+`moon info` 只会把每个包的规范后端结果写入 `pkg.generated.mbti`：
+优先使用模块的 `preferred-backend`，否则使用工作区的首选后端，
+再否则回退到 `wasm-gc`。`--target` 请求的其他后端仍会参与生成用于检查，
+若与规范后端不同，会在标准输出中显示 diff 或完整接口内容。
+
 ###### **Arguments:**
 
 * `<PATH>` — The file-system path to the package or file in package to emit `mbti` files for

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -376,6 +376,10 @@ Resources:
 
 Generate public interface (`.mbti`) files for all packages in the module or workspace
 
+By default, `moon info` writes `pkg.generated.mbti` from each selected package's canonical backend: module `preferred-backend`, then workspace `preferred-backend`, then `wasm-gc`.
+
+`--target` inspects backend-specific interfaces and reports differences, but does not change which backend is written to `pkg.generated.mbti`.
+
 **Usage:** `moon info [OPTIONS] [PATH]...`
 
 ###### **Arguments:**
@@ -387,7 +391,7 @@ Generate public interface (`.mbti`) files for all packages in the module or work
 ###### **Options:**
 
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
-* `--target <TARGET>` — Select output target
+* `--target <TARGET>` — Inspect one or more target backends without changing the canonical `pkg.generated.mbti` output
 
   Possible values: `wasm`, `wasm-gc`, `js`, `native`, `llvm`, `all`
 

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -378,11 +378,6 @@ Generate public interface (`.mbti`) files for all packages in the module or work
 
 **Usage:** `moon info [OPTIONS] [PATH]...`
 
-`moon info` 只会把每个包的规范后端结果写入 `pkg.generated.mbti`：
-优先使用模块的 `preferred-backend`，否则使用工作区的首选后端，
-再否则回退到 `wasm-gc`。`--target` 请求的其他后端仍会参与生成用于检查，
-若与规范后端不同，会在标准输出中显示 diff 或完整接口内容。
-
 ###### **Arguments:**
 
 * `<PATH>` — The file-system path to the package or file in package to emit `mbti` files for

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -378,6 +378,12 @@ Generate public interface (`.mbti`) files for all packages in the module or work
 
 **Usage:** `moon info [OPTIONS] [PATH]...`
 
+`moon info` writes `pkg.generated.mbti` only from each package's canonical backend:
+the module `preferred-backend`, otherwise the workspace preferred backend,
+otherwise `wasm-gc`. Requested `--target` backends are still built for
+inspection, and differing non-canonical interfaces are printed to stdout as
+diffs or full interface dumps.
+
 ###### **Arguments:**
 
 * `<PATH>` — The file-system path to the package or file in package to emit `mbti` files for

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -378,12 +378,6 @@ Generate public interface (`.mbti`) files for all packages in the module or work
 
 **Usage:** `moon info [OPTIONS] [PATH]...`
 
-`moon info` writes `pkg.generated.mbti` only from each package's canonical backend:
-the module `preferred-backend`, otherwise the workspace preferred backend,
-otherwise `wasm-gc`. Requested `--target` backends are still built for
-inspection, and differing non-canonical interfaces are printed to stdout as
-diffs or full interface dumps.
-
 ###### **Arguments:**
 
 * `<PATH>` — The file-system path to the package or file in package to emit `mbti` files for

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -376,6 +376,10 @@ Resources:
 
 Generate public interface (`.mbti`) files for all packages in the module or workspace
 
+By default, `moon info` writes `pkg.generated.mbti` from each selected package's canonical backend: module `preferred-backend`, then workspace `preferred-backend`, then `wasm-gc`.
+
+`--target` inspects backend-specific interfaces and reports differences, but does not change which backend is written to `pkg.generated.mbti`.
+
 **Usage:** `moon info [OPTIONS] [PATH]...`
 
 ###### **Arguments:**
@@ -387,7 +391,7 @@ Generate public interface (`.mbti`) files for all packages in the module or work
 ###### **Options:**
 
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
-* `--target <TARGET>` — Select output target
+* `--target <TARGET>` — Inspect one or more target backends without changing the canonical `pkg.generated.mbti` output
 
   Possible values: `wasm`, `wasm-gc`, `js`, `native`, `llvm`, `all`
 


### PR DESCRIPTION
## Summary

Adjust `moon info` behavior to use canonical backend (module preferred-backend → workspace preferred-backend → wasm-gc) for writing `.mbti` files, while still building requested `--target` backends for inspection (diff reporting).

### Changes

1. **Refactored `InfoSelection` to free functions** - Now follows the same pattern as other commands (`check`, `build`, `test`, `run`, `prove`)

2. **Clarified canonical backend behavior** - Added documentation explaining:
   - Canonical backend is determined by: module's `preferred-backend` → workspace's `preferred-backend` → `wasm-gc`
   - If a package's `supported-targets` does NOT include the canonical backend, no `.mbti` file will be written

### Design Rationale

Per `supported-targets.md`:
- `moon info` writes `pkg.generated.mbti` from each package's canonical backend
- Requested `--target` backends are still built for inspection (differences printed to stdout)

This makes `moon info` a no-op for mixed-backend projects **unless** they set `preferred-backend` on their module or workspace to match their supported targets.

### Test Coverage

- All 14 info-related tests pass
- `test_mixed_backend_run_info_bundle_are_target_aware` - verifies js/native-only modules get no `.mbti` files without preferred-backend set