### PR TITLE
fix(install): atomically replace installed binaries

### DIFF
--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -32,7 +32,6 @@ use moonutil::{
 };
 use semver::Version;
 use std::path::{Path, PathBuf};
-#[cfg(target_os = "macos")]
 use tracing::debug;
 
 use crate::{
@@ -672,19 +671,7 @@ fn build_and_install_packages(
         } else {
             pkg.binary_name.clone()
         };
-        let binary_dst = install_dir.join(dst_name);
-
-        #[cfg(target_os = "macos")]
-        macos_install_file(&binary_src, &binary_dst)?;
-
-        #[cfg(not(target_os = "macos"))]
-        std::fs::copy(&binary_src, &binary_dst).with_context(|| {
-            format!(
-                "Failed to copy binary from `{}` to `{}`",
-                binary_src.display(),
-                binary_dst.display()
-            )
-        })?;
+        let binary_dst = install_file_atomically(&binary_src, install_dir, &dst_name)?;
 
         #[cfg(unix)]
         {
@@ -713,30 +700,25 @@ fn build_and_install_packages(
     Ok(0)
 }
 
-/// macOS-only: copy `src` onto `dst` by writing to a sibling tempfile
-/// and atomically renaming it into place.
+/// Copy `src` into `install_dir/dst_name` by writing to a sibling tempfile
+/// and atomically replacing the destination command entry.
 ///
-/// Overwriting the destination with `fs::copy` would truncate it via
-/// `O_TRUNC`; on macOS the kernel SIGKILLs any process that re-execs the
-/// modified inode because the code-signature cache no longer matches the
-/// on-disk bytes. Renaming a fresh file into place avoids this — the
-/// old inode is unlinked but remains alive for the running process, and
-/// new executions resolve to the new inode.
+/// `moon install --bin <dir>` manages `<dir>/<binary>`, so an existing
+/// destination path is replaced rather than opened and overwritten in place.
+/// This avoids exposing a partially written executable and avoids platform
+/// traps such as macOS code-signature cache kills after truncating a Mach-O
+/// binary that has already been executed.
 ///
-/// The tempfile is created *inside* `install_dir` (a sibling of `dst`)
-/// so the final rename is same-filesystem and therefore atomic. `src`
-/// is copied rather than moved because it is the build graph's declared
-/// artifact and must remain in `_build` for subsequent no-op commands.
-///
-/// Linux has a related issue (`ETXTBSY` on truncate of a running text
-/// segment) and Windows has a sharing-violation failure mode, but
-/// those surface as loud errors the user can diagnose. Only the macOS
-/// SIGKILL is silent enough to justify the extra complexity here.
-#[cfg(target_os = "macos")]
-fn macos_install_file(src: &Path, dst: &Path) -> anyhow::Result<()> {
-    let install_dir = dst.parent().ok_or_else(|| {
-        anyhow::anyhow!("Install path `{}` has no parent directory", dst.display())
-    })?;
+/// The tempfile is created inside `install_dir` so the final persist is a
+/// same-filesystem replacement. `src` is copied rather than moved because it
+/// is the build graph's declared artifact and must remain in `_build` for
+/// subsequent no-op commands.
+fn install_file_atomically(
+    src: &Path,
+    install_dir: &Path,
+    dst_name: &str,
+) -> anyhow::Result<PathBuf> {
+    let dst = install_dir.join(dst_name);
 
     let tmp_path = tempfile::NamedTempFile::new_in(install_dir)
         .with_context(|| {
@@ -757,11 +739,11 @@ fn macos_install_file(src: &Path, dst: &Path) -> anyhow::Result<()> {
     debug!(src = %src.display(), "staged via copy");
 
     tmp_path
-        .persist(dst)
+        .persist(&dst)
         .map_err(|err| err.error)
         .with_context(|| format!("Failed to install binary to `{}`", dst.display()))?;
     debug!(dst = %dst.display(), "installed via rename");
-    Ok(())
+    Ok(dst)
 }
 
 #[cfg(test)]
@@ -922,31 +904,29 @@ mod tests {
         assert!(!filter.matches(&test_path(&["repo", "examples", "web", "demo"]), "web/demo",));
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
-    fn macos_install_file_fresh_destination() {
+    fn install_file_atomically_fresh_destination() {
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("src");
-        let dst = dir.path().join("dst");
         std::fs::write(&src, b"hello world").unwrap();
 
-        macos_install_file(&src, &dst).unwrap();
+        let dst = install_file_atomically(&src, dir.path(), "dst").unwrap();
 
         assert_eq!(std::fs::read(&dst).unwrap(), b"hello world");
         assert_eq!(std::fs::read(&src).unwrap(), b"hello world");
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
-    fn macos_install_file_overwrites_existing_destination() {
+    fn install_file_atomically_overwrites_existing_destination() {
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("src");
         let dst = dir.path().join("dst");
         std::fs::write(&src, b"new contents").unwrap();
         std::fs::write(&dst, b"old contents").unwrap();
 
-        macos_install_file(&src, &dst).unwrap();
+        let installed = install_file_atomically(&src, dir.path(), "dst").unwrap();
 
+        assert_eq!(installed, dst);
         assert_eq!(std::fs::read(&dst).unwrap(), b"new contents");
         assert_eq!(std::fs::read(&src).unwrap(), b"new contents");
 
@@ -964,6 +944,51 @@ mod tests {
                 std::ffi::OsString::from("dst"),
                 std::ffi::OsString::from("src")
             ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_file_atomically_replaces_existing_inode() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        std::fs::write(&src, b"new contents").unwrap();
+        std::fs::write(&dst, b"old contents").unwrap();
+        let old_ino = std::fs::metadata(&dst).unwrap().ino();
+
+        let installed = install_file_atomically(&src, dir.path(), "dst").unwrap();
+
+        let new_ino = std::fs::metadata(&dst).unwrap().ino();
+        assert_eq!(installed, dst);
+        assert_ne!(old_ino, new_ino);
+        assert_eq!(std::fs::read(&dst).unwrap(), b"new contents");
+        assert_eq!(std::fs::read(&src).unwrap(), b"new contents");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_file_atomically_replaces_destination_symlink_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let target = dir.path().join("target");
+        let dst = dir.path().join("dst");
+        std::fs::write(&src, b"new contents").unwrap();
+        std::fs::write(&target, b"old contents").unwrap();
+        std::os::unix::fs::symlink(&target, &dst).unwrap();
+
+        let installed = install_file_atomically(&src, dir.path(), "dst").unwrap();
+
+        assert_eq!(installed, dst);
+        assert_eq!(std::fs::read(&dst).unwrap(), b"new contents");
+        assert_eq!(std::fs::read(&target).unwrap(), b"old contents");
+        assert!(
+            !std::fs::symlink_metadata(&dst)
+                .unwrap()
+                .file_type()
+                .is_symlink()
         );
     }
 }

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -32,6 +32,8 @@ use moonutil::{
 };
 use semver::Version;
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use tracing::debug;
 
 use crate::{
     cli::BuildFlags,
@@ -672,6 +674,10 @@ fn build_and_install_packages(
         };
         let binary_dst = install_dir.join(dst_name);
 
+        #[cfg(target_os = "macos")]
+        macos_install_file(&binary_src, &binary_dst)?;
+
+        #[cfg(not(target_os = "macos"))]
         std::fs::copy(&binary_src, &binary_dst).with_context(|| {
             format!(
                 "Failed to copy binary from `{}` to `{}`",
@@ -705,6 +711,57 @@ fn build_and_install_packages(
     }
 
     Ok(0)
+}
+
+/// macOS-only: copy `src` onto `dst` by writing to a sibling tempfile
+/// and atomically renaming it into place.
+///
+/// Overwriting the destination with `fs::copy` would truncate it via
+/// `O_TRUNC`; on macOS the kernel SIGKILLs any process that re-execs the
+/// modified inode because the code-signature cache no longer matches the
+/// on-disk bytes. Renaming a fresh file into place avoids this — the
+/// old inode is unlinked but remains alive for the running process, and
+/// new executions resolve to the new inode.
+///
+/// The tempfile is created *inside* `install_dir` (a sibling of `dst`)
+/// so the final rename is same-filesystem and therefore atomic. `src`
+/// is copied rather than moved because it is the build graph's declared
+/// artifact and must remain in `_build` for subsequent no-op commands.
+///
+/// Linux has a related issue (`ETXTBSY` on truncate of a running text
+/// segment) and Windows has a sharing-violation failure mode, but
+/// those surface as loud errors the user can diagnose. Only the macOS
+/// SIGKILL is silent enough to justify the extra complexity here.
+#[cfg(target_os = "macos")]
+fn macos_install_file(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    let install_dir = dst.parent().ok_or_else(|| {
+        anyhow::anyhow!("Install path `{}` has no parent directory", dst.display())
+    })?;
+
+    let tmp_path = tempfile::NamedTempFile::new_in(install_dir)
+        .with_context(|| {
+            format!(
+                "Failed to create temporary file in `{}`",
+                install_dir.display()
+            )
+        })?
+        .into_temp_path();
+
+    std::fs::copy(src, &tmp_path).with_context(|| {
+        format!(
+            "Failed to copy binary from `{}` to `{}`",
+            src.display(),
+            tmp_path.display()
+        )
+    })?;
+    debug!(src = %src.display(), "staged via copy");
+
+    tmp_path
+        .persist(dst)
+        .map_err(|err| err.error)
+        .with_context(|| format!("Failed to install binary to `{}`", dst.display()))?;
+    debug!(dst = %dst.display(), "installed via rename");
+    Ok(())
 }
 
 #[cfg(test)]
@@ -863,5 +920,50 @@ mod tests {
             "native/pixeladventure",
         ));
         assert!(!filter.matches(&test_path(&["repo", "examples", "web", "demo"]), "web/demo",));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_install_file_fresh_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        std::fs::write(&src, b"hello world").unwrap();
+
+        macos_install_file(&src, &dst).unwrap();
+
+        assert_eq!(std::fs::read(&dst).unwrap(), b"hello world");
+        assert_eq!(std::fs::read(&src).unwrap(), b"hello world");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_install_file_overwrites_existing_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        std::fs::write(&src, b"new contents").unwrap();
+        std::fs::write(&dst, b"old contents").unwrap();
+
+        macos_install_file(&src, &dst).unwrap();
+
+        assert_eq!(std::fs::read(&dst).unwrap(), b"new contents");
+        assert_eq!(std::fs::read(&src).unwrap(), b"new contents");
+
+        // The build artifact must remain in place and no staging tempfile
+        // should remain behind.
+        let siblings: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        let mut siblings = siblings;
+        siblings.sort();
+        assert_eq!(
+            siblings,
+            vec![
+                std::ffi::OsString::from("dst"),
+                std::ffi::OsString::from("src")
+            ]
+        );
     }
 }

--- a/crates/moon/tests/test_cases/install_atomic_rename.in/.gitignore
+++ b/crates/moon/tests/test_cases/install_atomic_rename.in/.gitignore
@@ -1,0 +1,3 @@
+/.mooncakes/
+/_build/
+/target/

--- a/crates/moon/tests/test_cases/install_atomic_rename.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/install_atomic_rename.in/moon.mod.json
@@ -1,0 +1,8 @@
+{
+  "name": "install_atomic_rename",
+  "version": "0.1.0",
+  "source": "src",
+  "deps": {
+    "moonbitlang/async": "0.18.0"
+  }
+}

--- a/crates/moon/tests/test_cases/install_atomic_rename.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/install_atomic_rename.in/moon.mod.json
@@ -1,8 +1,5 @@
 {
   "name": "install_atomic_rename",
   "version": "0.1.0",
-  "source": "src",
-  "deps": {
-    "moonbitlang/async": "0.18.0"
-  }
+  "source": "src"
 }

--- a/crates/moon/tests/test_cases/install_atomic_rename.in/src/victim/main.mbt
+++ b/crates/moon/tests/test_cases/install_atomic_rename.in/src/victim/main.mbt
@@ -1,0 +1,11 @@
+///|
+async fn main {
+  println("baseline")
+  if @env.args().length() > 1 {
+    let self_path = @env.args()[0]
+    for {
+      @async.sleep(100)
+      let _ = (@process.run(self_path, []) : Int)
+    }
+  }
+}

--- a/crates/moon/tests/test_cases/install_atomic_rename.in/src/victim/main.mbt
+++ b/crates/moon/tests/test_cases/install_atomic_rename.in/src/victim/main.mbt
@@ -1,11 +1,8 @@
 ///|
-async fn main {
+fn main {
   println("baseline")
   if @env.args().length() > 1 {
-    let self_path = @env.args()[0]
-    for {
-      @async.sleep(100)
-      let _ = (@process.run(self_path, []) : Int)
+    for ;; {
     }
   }
 }

--- a/crates/moon/tests/test_cases/install_atomic_rename.in/src/victim/moon.pkg.json
+++ b/crates/moon/tests/test_cases/install_atomic_rename.in/src/victim/moon.pkg.json
@@ -1,0 +1,7 @@
+{
+  "is-main": true,
+  "import": [
+    "moonbitlang/async",
+    "moonbitlang/async/process"
+  ]
+}

--- a/crates/moon/tests/test_cases/install_atomic_rename.in/src/victim/moon.pkg.json
+++ b/crates/moon/tests/test_cases/install_atomic_rename.in/src/victim/moon.pkg.json
@@ -1,7 +1,6 @@
 {
   "is-main": true,
   "import": [
-    "moonbitlang/async",
-    "moonbitlang/async/process"
+    "moonbitlang/core/env"
   ]
 }

--- a/crates/moon/tests/test_cases/install_atomic_rename.rs
+++ b/crates/moon/tests/test_cases/install_atomic_rename.rs
@@ -1,0 +1,183 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::util::toolchain_root_for_tests;
+
+use super::TestDir;
+
+const CHILD_OUTPUT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Exercise the fix: install v1, keep a v1 child *running*, then
+/// install v2 on top of it. `macos_install_file`'s atomic rename
+/// must leave the running v1 alone while the destination path becomes
+/// a launchable v2. A pre-fix `fs::copy` reinstall poisons macOS's
+/// code-signing cache, so the fresh v2 launch below is killed.
+#[test]
+fn test_install_replaces_while_running() {
+    let moon_exe = PathBuf::from(env!("CARGO_BIN_EXE_moon"));
+    let fixture = TestDir::new("install_atomic_rename.in");
+    let pkg_path = fixture.join("src/victim");
+    let main_mbt = pkg_path.join("main.mbt");
+    let install_dir = tempfile::tempdir().expect("install tempdir");
+    let victim_path = install_dir.path().join("victim");
+
+    rewrite_version(&main_mbt, "version 1");
+    moon_install(&moon_exe, fixture.as_ref(), &pkg_path, install_dir.path());
+
+    let mut v1_child = Command::new(&victim_path)
+        .arg("hold")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn v1");
+    let v1_stdout = v1_child.stdout.take().expect("capture v1 stdout");
+    let v1_lines = child_stdout_lines(v1_stdout);
+    wait_for_line(&v1_lines, "version 1", CHILD_OUTPUT_TIMEOUT);
+
+    rewrite_version(&main_mbt, "version 2");
+    moon_install(&moon_exe, fixture.as_ref(), &pkg_path, install_dir.path());
+
+    let v2_out = Command::new(&victim_path).output().expect("run v2");
+    assert!(v2_out.status.success(), "v2 exit: {:?}", v2_out.status);
+    assert_eq!(
+        String::from_utf8_lossy(&v2_out.stdout).trim(),
+        "version 2",
+        "v2 stdout mismatch: reinstall did not leave v2 bytes on disk"
+    );
+
+    // The held v1 process should still be able to self-spawn through
+    // the destination path after reinstall. A pre-fix in-place copy
+    // kills that post-reinstall launch on macOS.
+    wait_for_line(&v1_lines, "version 2", CHILD_OUTPUT_TIMEOUT);
+    assert!(
+        matches!(v1_child.try_wait(), Ok(None)),
+        "running v1 died during reinstall: the atomic-rename path did \
+         not leave the running process usable"
+    );
+    let _ = v1_child.kill();
+    let _ = v1_child.wait();
+}
+
+fn child_stdout_lines(stdout: std::process::ChildStdout) -> std::sync::mpsc::Receiver<String> {
+    use std::io::BufRead;
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let reader = std::io::BufReader::new(stdout);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    rx
+}
+
+fn wait_for_line(
+    lines: &std::sync::mpsc::Receiver<String>,
+    expected: &str,
+    timeout: std::time::Duration,
+) {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut seen = Vec::new();
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            panic!("timed out waiting for `{expected}`; seen output: {seen:?}");
+        }
+        match lines.recv_timeout(remaining) {
+            Ok(line) if line.trim() == expected => return,
+            Ok(line) => seen.push(line),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                panic!("timed out waiting for `{expected}`; seen output: {seen:?}");
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("stdout closed while waiting for `{expected}`; seen output: {seen:?}");
+            }
+        }
+    }
+}
+
+fn moon_install(moon_exe: &Path, cwd: &Path, pkg_path: &Path, install_dir: &Path) {
+    let mut command = Command::new(moon_exe);
+    command
+        .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
+        .current_dir(cwd)
+        .args(["install", "--path"])
+        .arg(pkg_path)
+        .arg("--bin")
+        .arg(install_dir);
+
+    let output = command.output().expect("run moon install");
+    if !output.status.success() {
+        panic!(
+            "moon install failed: status={}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+}
+
+/// Write a `main.mbt` whose rodata diverges per `version`: a
+/// toplevel `Array[Int]` of sequential values offset by a
+/// version-derived constant, so every slot differs between v1 and
+/// v2. Summed at startup with the total folded into a branch the
+/// compiler cannot prove is dead, which keeps the array from being
+/// DCE'd. This gives v1 and v2 substantially different on-disk bytes
+/// across many code-signing pages, so an in-place `fs::copy` tamper
+/// during reinstall reliably invalidates the running binary's CS
+/// cache.
+fn rewrite_version(main_mbt: &Path, version: &str) {
+    const N: u32 = 50_000;
+    let offset: u32 = version
+        .as_bytes()
+        .iter()
+        .fold(0u32, |acc, &b| acc.wrapping_mul(131).wrapping_add(b as u32));
+    let mut body = String::with_capacity(N as usize * 8);
+    body.push_str("///|\nlet payload : ReadOnlyArray[Int] = [\n");
+    for i in 0..N {
+        let v = i.wrapping_add(offset) as i32;
+        body.push_str(&format!("{v},"));
+        if i % 32 == 31 {
+            body.push('\n');
+        }
+    }
+    body.push_str("\n]\n\n");
+    let main_fn = format!(
+        "///|\nasync fn main {{\n  \
+           let mut sum : Int64 = 0L\n  \
+           for v in payload {{ sum = sum + v.to_int64() }}\n  \
+           if sum == 0x7fffffffffffffffL {{ println(\"unreachable\") }}\n  \
+           println(\"{version}\")\n  \
+           if @env.args().length() > 1 {{\n    \
+             let self_path = @env.args()[0]\n    \
+             for ;; {{\n      \
+               @async.sleep(100)\n      \
+               let _ = (@process.run(self_path, []) : Int)\n    \
+             }}\n  \
+           }}\n\
+         }}\n"
+    );
+    std::fs::write(main_mbt, format!("{body}{main_fn}")).expect("rewrite main.mbt");
+}

--- a/crates/moon/tests/test_cases/install_atomic_rename.rs
+++ b/crates/moon/tests/test_cases/install_atomic_rename.rs
@@ -23,13 +23,20 @@ use crate::util::toolchain_root_for_tests;
 
 use super::TestDir;
 
-const CHILD_OUTPUT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+struct KillOnDrop(std::process::Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
 
 /// Exercise the fix: install v1, keep a v1 child *running*, then
-/// install v2 on top of it. `macos_install_file`'s atomic rename
-/// must leave the running v1 alone while the destination path becomes
-/// a launchable v2. A pre-fix `fs::copy` reinstall poisons macOS's
-/// code-signing cache, so the fresh v2 launch below is killed.
+/// install v2 on top of it. Atomic replacement must leave the running
+/// v1 alone while the destination path becomes a launchable v2. A
+/// pre-fix `fs::copy` reinstall poisons macOS's code-signing cache,
+/// so the fresh v2 launch below is killed.
 #[test]
 fn test_install_replaces_while_running() {
     let moon_exe = PathBuf::from(env!("CARGO_BIN_EXE_moon"));
@@ -42,16 +49,28 @@ fn test_install_replaces_while_running() {
     rewrite_version(&main_mbt, "version 1");
     moon_install(&moon_exe, fixture.as_ref(), &pkg_path, install_dir.path());
 
-    let mut v1_child = Command::new(&victim_path)
-        .arg("hold")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn v1");
-    let v1_stdout = v1_child.stdout.take().expect("capture v1 stdout");
-    let v1_lines = child_stdout_lines(v1_stdout);
-    wait_for_line(&v1_lines, "version 1", CHILD_OUTPUT_TIMEOUT);
+    let v1_out = Command::new(&victim_path).output().expect("run v1");
+    assert!(v1_out.status.success(), "v1 exit: {:?}", v1_out.status);
+    assert_eq!(
+        String::from_utf8_lossy(&v1_out.stdout).trim(),
+        "version 1",
+        "v1 stdout mismatch: initial install did not leave v1 bytes on disk"
+    );
+
+    let mut v1_child = KillOnDrop(
+        Command::new(&victim_path)
+            .arg("hold")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn v1"),
+    );
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    assert!(
+        matches!(v1_child.0.try_wait(), Ok(None)),
+        "held v1 exited before reinstall"
+    );
 
     rewrite_version(&main_mbt, "version 2");
     moon_install(&moon_exe, fixture.as_ref(), &pkg_path, install_dir.path());
@@ -64,58 +83,11 @@ fn test_install_replaces_while_running() {
         "v2 stdout mismatch: reinstall did not leave v2 bytes on disk"
     );
 
-    // The held v1 process should still be able to self-spawn through
-    // the destination path after reinstall. A pre-fix in-place copy
-    // kills that post-reinstall launch on macOS.
-    wait_for_line(&v1_lines, "version 2", CHILD_OUTPUT_TIMEOUT);
     assert!(
-        matches!(v1_child.try_wait(), Ok(None)),
+        matches!(v1_child.0.try_wait(), Ok(None)),
         "running v1 died during reinstall: the atomic-rename path did \
          not leave the running process usable"
     );
-    let _ = v1_child.kill();
-    let _ = v1_child.wait();
-}
-
-fn child_stdout_lines(stdout: std::process::ChildStdout) -> std::sync::mpsc::Receiver<String> {
-    use std::io::BufRead;
-
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let reader = std::io::BufReader::new(stdout);
-        for line in reader.lines() {
-            let Ok(line) = line else { break };
-            if tx.send(line).is_err() {
-                break;
-            }
-        }
-    });
-    rx
-}
-
-fn wait_for_line(
-    lines: &std::sync::mpsc::Receiver<String>,
-    expected: &str,
-    timeout: std::time::Duration,
-) {
-    let deadline = std::time::Instant::now() + timeout;
-    let mut seen = Vec::new();
-    loop {
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        if remaining.is_zero() {
-            panic!("timed out waiting for `{expected}`; seen output: {seen:?}");
-        }
-        match lines.recv_timeout(remaining) {
-            Ok(line) if line.trim() == expected => return,
-            Ok(line) => seen.push(line),
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                panic!("timed out waiting for `{expected}`; seen output: {seen:?}");
-            }
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                panic!("stdout closed while waiting for `{expected}`; seen output: {seen:?}");
-            }
-        }
-    }
 }
 
 fn moon_install(moon_exe: &Path, cwd: &Path, pkg_path: &Path, install_dir: &Path) {
@@ -165,16 +137,13 @@ fn rewrite_version(main_mbt: &Path, version: &str) {
     }
     body.push_str("\n]\n\n");
     let main_fn = format!(
-        "///|\nasync fn main {{\n  \
+        "///|\nfn main {{\n  \
            let mut sum : Int64 = 0L\n  \
            for v in payload {{ sum = sum + v.to_int64() }}\n  \
            if sum == 0x7fffffffffffffffL {{ println(\"unreachable\") }}\n  \
            println(\"{version}\")\n  \
            if @env.args().length() > 1 {{\n    \
-             let self_path = @env.args()[0]\n    \
              for ;; {{\n      \
-               @async.sleep(100)\n      \
-               let _ = (@process.run(self_path, []) : Int)\n    \
              }}\n  \
            }}\n\
          }}\n"

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -62,6 +62,8 @@ mod fuzzy_matching;
 mod hello;
 mod indirect_dep;
 mod inline_test;
+#[cfg(target_os = "macos")]
+mod install_atomic_rename;
 mod js_test_build_only;
 mod main_package;
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

This PR makes `moon install --bin <dir>` replace installed binaries atomically instead of overwriting the destination file in place.

The install command now treats `<dir>/<binary>` as the managed command entry:

- build output under `_build` is preserved
- the executable is copied into a temporary file inside the install directory
- the temporary file is persisted over `<dir>/<binary>` with an atomic same-directory replacement
- an existing destination symlink is replaced as the command entry instead of being followed

## Why

The previous `std::fs::copy(src, dst)` path opens an existing destination and truncates it before copying the new bytes. On macOS, reinstalling a native executable this way can poison the code-signing cache for the existing inode. The install succeeds, but later execution can be killed by the kernel before `main` runs.

Atomic replacement avoids mutating the old executable inode. Existing running processes keep the old file, and new launches resolve the installed path to the replacement file.

## Why this shape

The helper takes the install directory directly, stages the temporary file there, and returns the final installed path. That keeps the same-filesystem replacement invariant explicit without recomputing the parent from the destination path.

The change is intentionally scoped to binary installation: it defines the install operation as replacing the managed command entry while preserving the build artifact that the build graph owns.
