### PR TITLE
Update warning index snapshots

### DIFF
--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -38,7 +38,7 @@ Warning name: `{mnemonic}`
     }
 }
 
-// Snapshot generated from `moonc check -warn-help` on 2026-04-15.
+// Snapshot generated from `moonc check -warn-help` on 2026-04-21.
 // Update this file manually when the compiler's warning table changes.
 const WARNING_ENTRIES: &[WarningEntry] = &[
     WarningEntry {
@@ -390,6 +390,11 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
         mnemonic: "missing_doc",
         description: "Missing documentation for public definition",
         id: 74,
+    },
+    WarningEntry {
+        mnemonic: "unnecessary_view_op",
+        description: "Unnecessary `[:]` view operator",
+        id: 75,
     },
 ];
 

--- a/crates/moon/src/cli/snapshots/explain_warning_index.txt
+++ b/crates/moon/src/cli/snapshots/explain_warning_index.txt
@@ -68,3 +68,4 @@
 0072	unqualified_local_using	unqualified local using
 0073	unnecessary_annotation	unnecessary type annotation
 0074	missing_doc	Missing documentation for public definition
+0075	unnecessary_view_op	Unnecessary `[:]` view operator


### PR DESCRIPTION
## Summary
- add warning `0075 unnecessary_view_op` to the checked-in warning index snapshot
- update the warning entry table to keep the source list in sync with the snapshot
- refresh the snapshot generation date comment

## Testing
- `cargo test -p moon cli::explain::warning_index::tests::warning_index_snapshot_matches_checked_in_entries`
- `cargo test -p moon cli::explain::warning_index::tests::warning_index_snapshot_matches_moonc_warn_help`