### PR TITLE
feat: plan mixed-backend moon check runs

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -111,6 +111,9 @@ pub(crate) struct CheckSubcommand {
 #[instrument(skip_all)]
 pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::Result<i32> {
     let output = UserDiagnostics::from_flags(cli);
+    if cmd.no_mi {
+        output.warn("`moon check --no-mi` is deprecated");
+    }
     if cmd.fmt {
         let mut cli_for_fmt = cli.clone();
         cli_for_fmt.quiet = true;
@@ -509,6 +512,14 @@ pub(crate) fn plan_check_rr_from_resolved_all(
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<Vec<(rr_build::BuildMeta, rr_build::BuildInput)>> {
+    validate_selector_flags_before_split(
+        &resolve_output,
+        cmd,
+        source_dir,
+        selected_target_backend,
+        UserDiagnostics::from_flags(cli),
+    )?;
+
     let selections = resolve_check_target_selections(
         &resolve_output,
         cmd,
@@ -544,6 +555,28 @@ pub(crate) fn plan_check_rr_from_resolved_all(
             )
         })
         .collect()
+}
+
+fn validate_selector_flags_before_split(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    cmd: &CheckSubcommand,
+    source_dir: &Path,
+    target_backend: Option<TargetBackend>,
+    output: UserDiagnostics,
+) -> anyhow::Result<()> {
+    if !cmd.no_mi && cmd.patch_file.is_none() {
+        return Ok(());
+    }
+
+    let selected =
+        resolve_selected_packages(resolve_output, cmd, source_dir, target_backend, output)?;
+    if cmd.no_mi && selected.len() != 1 {
+        anyhow::bail!("`--no-mi` requires the selector to resolve to a single package");
+    }
+    if cmd.patch_file.is_some() && selected.len() != 1 {
+        anyhow::bail!("`--patch-file` requires the selector to resolve to a single package");
+    }
+    Ok(())
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -662,6 +695,8 @@ pub(crate) fn resolve_check_target_selections(
             });
         }
     }
+
+    filtered.sort_by_key(|selection| selection.target_backend);
 
     Ok(filtered)
 }

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -16,8 +16,22 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+//! Workflow overview for `moon check`:
+//!
+//! 1. Parse the CLI selector (`PATH`, `-p`, or whole workspace).
+//! 2. Resolve packages and decide which backend(s) to check:
+//!    - explicit `--target` keeps one backend;
+//!    - otherwise local packages are grouped by
+//!      `module preferred -> workspace preferred -> default backend`.
+//! 3. `plan_check_rr_from_resolved_all` turns those backend groups into an
+//!    ordered list of single-backend RR plans.
+//! 4. `plan_check_rr_from_resolved` still plans exactly one backend group.
+//! 5. The runtime executes planned runs in order; the last run updates
+//!    `packages.json`.
+//!
 use anyhow::Context;
 use moonbuild_rupes_recta::intent::UserIntent;
+use moonbuild_rupes_recta::model::PackageId;
 use moonutil::cli::UniversalFlags;
 use moonutil::common::RunMode;
 use moonutil::common::WATCH_MODE_DIR;
@@ -28,8 +42,9 @@ use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
 
 use crate::filter::{
-    canonicalize_with_filename, ensure_package_supports_backend, filter_pkg_by_dir,
-    package_supports_backend, select_supported_packages,
+    canonicalize_with_filename, ensure_package_supports_backend, ensure_packages_support_backend,
+    filter_pkg_by_dir, format_supported_backends, package_supports_backend, select_packages,
+    select_supported_packages,
 };
 use crate::rr_build::{self, BuildConfig, CalcUserIntentOutput, preconfig_compile};
 use crate::user_diagnostics::UserDiagnostics;
@@ -38,8 +53,14 @@ use crate::watch::{WatchOutput, watching};
 
 use super::BuildFlags;
 
+#[derive(Debug)]
+pub(crate) struct CheckTargetSelection {
+    pub target_backend: TargetBackend,
+    pub packages: Vec<PackageId>,
+}
+
 /// Check the current package, but don't build object files
-#[derive(Debug, clap::Parser)]
+#[derive(Debug, clap::Parser, Clone)]
 #[clap(group = clap::ArgGroup::new("package_selector").multiple(false))]
 pub(crate) struct CheckSubcommand {
     #[clap(flatten)]
@@ -410,7 +431,7 @@ fn run_check_normal_internal_rr(
     target_dir: &Path,
     mooncakes_dir: &Path,
     project_manifest_path: Option<&Path>,
-    _watch: bool,
+    watch: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<WatchOutput> {
     let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
@@ -421,7 +442,15 @@ fn run_check_normal_internal_rr(
     .with_project_manifest_path(project_manifest_path);
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir, mooncakes_dir)
         .context("Failed to calculate build plan")?;
-    let (build_meta, build_graph) = plan_check_rr_from_resolved(
+    let prebuild_list = if watch {
+        rr_get_prebuild_watch_paths(&resolve_output)
+    } else {
+        PrebuildWatchPaths {
+            ignored_paths: Vec::new(),
+            watched_paths: Vec::new(),
+        }
+    };
+    let planned_runs = plan_check_rr_from_resolved_all(
         cli,
         cmd,
         source_dir,
@@ -431,34 +460,18 @@ fn run_check_normal_internal_rr(
     )
     .context("Failed to calculate build plan")?;
 
-    let prebuild_list = if _watch {
-        rr_get_prebuild_watch_paths(&build_meta.resolve_output)
-    } else {
-        PrebuildWatchPaths {
-            ignored_paths: Vec::new(),
-            watched_paths: Vec::new(),
+    let ok = if cli.dry_run {
+        for (build_meta, build_graph) in planned_runs {
+            rr_build::print_dry_run(
+                &build_graph,
+                build_meta.artifacts.values(),
+                source_dir,
+                target_dir,
+            );
         }
-    };
-
-    if cli.dry_run {
-        rr_build::print_dry_run(
-            &build_graph,
-            build_meta.artifacts.values(),
-            source_dir,
-            target_dir,
-        );
-        Ok(WatchOutput {
-            ok: true,
-            additional_ignored_paths: prebuild_list.ignored_paths,
-            additional_watched_paths: prebuild_list.watched_paths,
-        })
+        true
     } else {
         let _lock = FileLock::lock(target_dir)?;
-        // Generate all_pkgs.json for indirect dependency resolution
-        rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Check)?;
-        // Generate metadata for IDE
-        rr_build::generate_metadata(source_dir, target_dir, &build_meta, RunMode::Check, None)?;
-
         let mut cfg = BuildConfig::from_flags(
             &cmd.build_flags,
             &cli.unstable_feature,
@@ -467,16 +480,73 @@ fn run_check_normal_internal_rr(
         );
         cfg.patch_file = cmd.patch_file.clone();
         cfg.explain_errors |= cmd.explain;
-        let result = rr_build::execute_build(&cfg, build_graph, target_dir)?;
-        result.print_info(cli.quiet, "checking")?;
-        Ok(WatchOutput {
-            ok: result.successful(),
-            additional_ignored_paths: prebuild_list.ignored_paths,
-            additional_watched_paths: prebuild_list.watched_paths,
-        })
-    }
+        let mut ok = true;
+        for (build_meta, build_graph) in planned_runs {
+            // Generate all_pkgs.json for indirect dependency resolution
+            rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Check)?;
+            // Generate metadata for IDE. The last executed backend wins.
+            rr_build::generate_metadata(source_dir, target_dir, &build_meta, RunMode::Check, None)?;
+
+            let result = rr_build::execute_build(&cfg, build_graph, target_dir)?;
+            result.print_info(cli.quiet, "checking")?;
+            ok &= result.successful();
+        }
+        ok
+    };
+
+    Ok(WatchOutput {
+        ok,
+        additional_ignored_paths: prebuild_list.ignored_paths,
+        additional_watched_paths: prebuild_list.watched_paths,
+    })
 }
 
+pub(crate) fn plan_check_rr_from_resolved_all(
+    cli: &UniversalFlags,
+    cmd: &CheckSubcommand,
+    source_dir: &Path,
+    target_dir: &Path,
+    selected_target_backend: Option<TargetBackend>,
+    resolve_output: moonbuild_rupes_recta::ResolveOutput,
+) -> anyhow::Result<Vec<(rr_build::BuildMeta, rr_build::BuildInput)>> {
+    let selections = resolve_check_target_selections(
+        &resolve_output,
+        cmd,
+        source_dir,
+        selected_target_backend,
+        UserDiagnostics::from_flags(cli),
+    )?;
+
+    if selections.is_empty() {
+        return plan_check_rr_from_resolved(
+            cli,
+            cmd,
+            source_dir,
+            target_dir,
+            selected_target_backend,
+            resolve_output,
+        )
+        .map(|plan| vec![plan]);
+    }
+
+    selections
+        .into_iter()
+        .map(|selection| {
+            let (scoped_cmd, target_backend) =
+                narrow_check_request_to_selection(cmd, &resolve_output, &selection);
+            plan_check_rr_from_resolved(
+                cli,
+                &scoped_cmd,
+                source_dir,
+                target_dir,
+                Some(target_backend),
+                resolve_output.clone(),
+            )
+        })
+        .collect()
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn plan_check_rr_from_resolved(
     cli: &UniversalFlags,
     cmd: &CheckSubcommand,
@@ -525,9 +595,179 @@ pub(crate) fn plan_check_rr_from_resolved(
     )
 }
 
-/// Generate user intent of checking all packages in the current workspace.
-///
-#[instrument(level = Level::DEBUG, skip_all)]
+fn narrow_check_request_to_selection(
+    cmd: &CheckSubcommand,
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    selection: &CheckTargetSelection,
+) -> (CheckSubcommand, TargetBackend) {
+    let mut scoped_cmd = cmd.clone();
+    scoped_cmd.package_path = None;
+    scoped_cmd.path = selection_package_roots(resolve_output, &selection.packages);
+    (scoped_cmd, selection.target_backend)
+}
+
+pub(crate) fn resolve_check_target_selections(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    cmd: &CheckSubcommand,
+    source_dir: &Path,
+    selected_target_backend: Option<TargetBackend>,
+    output: UserDiagnostics,
+) -> anyhow::Result<Vec<CheckTargetSelection>> {
+    if let Some(target_backend) = selected_target_backend {
+        let packages = resolve_selected_packages(
+            resolve_output,
+            cmd,
+            source_dir,
+            Some(target_backend),
+            output,
+        )?;
+        return Ok(vec![CheckTargetSelection {
+            target_backend,
+            packages,
+        }]);
+    }
+
+    let selected = resolve_selected_packages(resolve_output, cmd, source_dir, None, output)?;
+    let mut selections = Vec::new();
+
+    for pkg in selected {
+        let target_backend = module_preferred_target_backend(resolve_output, pkg);
+        let Some(index) = selections
+            .iter()
+            .position(|selection: &CheckTargetSelection| {
+                selection.target_backend == target_backend
+            })
+        else {
+            selections.push(CheckTargetSelection {
+                target_backend,
+                packages: vec![pkg],
+            });
+            continue;
+        };
+        selections[index].packages.push(pkg);
+    }
+
+    let mut filtered = Vec::new();
+    for selection in selections {
+        let packages = filter_packages_for_backend(
+            resolve_output,
+            selection.packages,
+            selection.target_backend,
+            output,
+        )?;
+        if !packages.is_empty() {
+            filtered.push(CheckTargetSelection {
+                target_backend: selection.target_backend,
+                packages,
+            });
+        }
+    }
+
+    Ok(filtered)
+}
+
+fn resolve_selected_packages(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    cmd: &CheckSubcommand,
+    source_dir: &Path,
+    target_backend: Option<TargetBackend>,
+    output: UserDiagnostics,
+) -> anyhow::Result<Vec<PackageId>> {
+    if let Some(filter_path) = cmd.package_path.as_deref() {
+        let (dir, _) = canonicalize_with_filename(&source_dir.join(filter_path))?;
+        let pkg = filter_pkg_by_dir(resolve_output, &dir)?;
+        if let Some(target_backend) = target_backend {
+            ensure_package_supports_backend(resolve_output, pkg, target_backend)?;
+        }
+        return Ok(vec![pkg]);
+    }
+
+    if !cmd.path.is_empty() {
+        if let Some(target_backend) = target_backend {
+            return select_supported_packages(resolve_output, &cmd.path, target_backend, output);
+        }
+        return Ok(select_packages(&cmd.path, output, |dir| {
+            filter_pkg_by_dir(resolve_output, dir)
+        })?
+        .into_iter()
+        .map(|(_, pkg_id)| pkg_id)
+        .collect());
+    }
+
+    Ok(rr_build::local_packages(resolve_output)
+        .filter(|&pkg| {
+            target_backend
+                .is_none_or(|backend| package_supports_backend(resolve_output, pkg, backend))
+        })
+        .collect())
+}
+
+fn module_preferred_target_backend(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    pkg: PackageId,
+) -> TargetBackend {
+    let module_id = resolve_output.pkg_dirs.get_package(pkg).module;
+    resolve_output
+        .module_rel
+        .module_info(module_id)
+        .preferred_target
+        .or(resolve_output.workspace_preferred_target)
+        .unwrap_or_default()
+}
+
+fn filter_packages_for_backend(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    packages: Vec<PackageId>,
+    target_backend: TargetBackend,
+    output: UserDiagnostics,
+) -> anyhow::Result<Vec<PackageId>> {
+    let mut supported = Vec::new();
+    let mut unsupported = Vec::new();
+
+    for pkg in packages {
+        if package_supports_backend(resolve_output, pkg, target_backend) {
+            supported.push(pkg);
+        } else {
+            unsupported.push(pkg);
+        }
+    }
+
+    if supported.is_empty() && !unsupported.is_empty() {
+        if let [pkg] = unsupported.as_slice() {
+            ensure_package_supports_backend(resolve_output, *pkg, target_backend)?;
+        } else {
+            ensure_packages_support_backend(
+                resolve_output,
+                unsupported.iter().copied(),
+                target_backend,
+            )?;
+        }
+    }
+
+    for pkg in unsupported {
+        let pkg_id = pkg;
+        let pkg = resolve_output.pkg_dirs.get_package(pkg_id);
+        output.info(format!(
+            "skipping package `{}` because it does not support the selected target backend `{}`. Supported backends: {}",
+            pkg.fqn,
+            target_backend,
+            format_supported_backends(resolve_output, pkg_id),
+        ));
+    }
+
+    Ok(supported)
+}
+
+fn selection_package_roots(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    packages: &[PackageId],
+) -> Vec<PathBuf> {
+    packages
+        .iter()
+        .map(|pkg| resolve_output.pkg_dirs.get_package(*pkg).root_path.clone())
+        .collect()
+}
+
 fn calc_user_intent_from_package_path(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     source_dir: &Path,
@@ -575,29 +815,15 @@ fn build_directive_for_selected_packages(
     no_mi: bool,
     patch_file: Option<&Path>,
 ) -> anyhow::Result<moonbuild_rupes_recta::build_plan::InputDirective> {
-    match selected {
-        [pkg] => rr_build::build_patch_directive_for_package(*pkg, no_mi, None, patch_file, false),
-        [] => {
-            if no_mi {
-                anyhow::bail!("`--no-mi` requires the selector to resolve to a single package");
-            }
-            if patch_file.is_some() {
-                anyhow::bail!(
-                    "`--patch-file` requires the selector to resolve to a single package"
-                );
-            }
-            Ok(Default::default())
-        }
-        _ => {
-            if no_mi {
-                anyhow::bail!("`--no-mi` requires the selector to resolve to a single package");
-            }
-            if patch_file.is_some() {
-                anyhow::bail!(
-                    "`--patch-file` requires the selector to resolve to a single package"
-                );
-            }
-            Ok(Default::default())
-        }
+    if let [pkg] = selected {
+        return rr_build::build_patch_directive_for_package(*pkg, no_mi, None, patch_file, false);
     }
+
+    if no_mi {
+        anyhow::bail!("`--no-mi` requires the selector to resolve to a single package");
+    }
+    if patch_file.is_some() {
+        anyhow::bail!("`--patch-file` requires the selector to resolve to a single package");
+    }
+    Ok(Default::default())
 }

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -118,6 +118,21 @@ impl PlanningFixture {
         self.dump_plan(build_meta, build_graph)
     }
 
+    pub(super) fn plan_check_all_with_cli(
+        &self,
+        cli: &UniversalFlags,
+        cmd: &CheckSubcommand,
+    ) -> anyhow::Result<Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>> {
+        crate::cli::check::plan_check_rr_from_resolved_all(
+            cli,
+            cmd,
+            &self.source_dir,
+            &self.target_dir,
+            cmd.build_flags.resolve_single_target_backend()?,
+            self.resolve_output.clone(),
+        )
+    }
+
     pub(super) fn plan_run_with_cli(
         &self,
         cli: &UniversalFlags,

--- a/crates/moon/src/tests/planner/target_backend_planning.rs
+++ b/crates/moon/src/tests/planner/target_backend_planning.rs
@@ -19,6 +19,7 @@
 use super::fixture::{
     PlanningFixture, parse_build_command, parse_check_command, parse_run_command,
 };
+use moonutil::common::TargetBackend;
 
 // Phase 3: these tests already know the selected backend and only need to
 // verify that planning keeps the right packages and commands in the graph.
@@ -36,6 +37,47 @@ fn assert_contains_and_absent(graph: &str, present: &[&str], absent: &[&str]) {
             "expected graph to not contain `{needle}`, got:\n{graph}"
         );
     }
+}
+
+fn assert_check_runs(
+    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
+    expected: &[(TargetBackend, &[&str])],
+) {
+    let actual = runs
+        .into_iter()
+        .map(|(meta, _)| {
+            let packages = meta
+                .artifacts
+                .keys()
+                .filter_map(|node| match node {
+                    moonbuild_rupes_recta::model::BuildPlanNode::Check(target) => Some(
+                        meta.resolve_output
+                            .pkg_dirs
+                            .get_package(target.package)
+                            .fqn
+                            .to_string(),
+                    ),
+                    _ => None,
+                })
+                .collect::<std::collections::BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            (meta.target_backend.into(), packages)
+        })
+        .collect::<Vec<_>>();
+    let expected = expected
+        .iter()
+        .map(|(backend, packages)| {
+            (
+                *backend,
+                packages
+                    .iter()
+                    .map(|pkg| (*pkg).to_string())
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
 }
 
 #[test]
@@ -214,6 +256,72 @@ fn supported_targets_empty_packages_are_skipped_in_check_planning() {
         &check_native,
         &["./main/main.mbt", "./lib/lib.mbt"],
         &["./never/never.mbt"],
+    );
+}
+
+#[test]
+fn conflicting_workspace_preferred_targets_check_selection_splits_by_module_backend() {
+    let fixture = PlanningFixture::new("workspace_conflicting_preferred_targets.in")
+        .expect("fixture should resolve");
+
+    let (cli, cmd) = parse_check_command(&["check", "--dry-run", "--sort-input"]);
+    let runs = fixture
+        .plan_check_all_with_cli(&cli, &cmd)
+        .expect("default check plans should resolve");
+
+    assert_check_runs(
+        runs,
+        &[
+            (TargetBackend::Js, &["workspace/js_preferred/lib"]),
+            (TargetBackend::Native, &["workspace/native_preferred/lib"]),
+        ],
+    );
+}
+
+#[test]
+fn conflicting_workspace_preferred_targets_check_path_selection_uses_module_backend() {
+    let fixture = PlanningFixture::new("workspace_conflicting_preferred_targets.in")
+        .expect("fixture should resolve");
+
+    let js_path = fixture.case_dir().join("js_preferred/src/lib");
+    let native_path = fixture.case_dir().join("native_preferred/src/lib");
+    let js_path = js_path.to_str().expect("fixture path should be UTF-8");
+    let native_path = native_path.to_str().expect("fixture path should be UTF-8");
+
+    let (cli, cmd) =
+        parse_check_command(&["check", js_path, native_path, "--dry-run", "--sort-input"]);
+    let runs = fixture
+        .plan_check_all_with_cli(&cli, &cmd)
+        .expect("path-selected check plans should resolve");
+
+    assert_check_runs(
+        runs,
+        &[
+            (TargetBackend::Js, &["workspace/js_preferred/lib"]),
+            (TargetBackend::Native, &["workspace/native_preferred/lib"]),
+        ],
+    );
+}
+
+#[test]
+fn explicit_check_target_keeps_single_backend_selection() {
+    let fixture = PlanningFixture::new("workspace_conflicting_preferred_targets.in")
+        .expect("fixture should resolve");
+
+    let (cli, cmd) = parse_check_command(&["check", "--target", "js", "--dry-run", "--sort-input"]);
+    let runs = fixture
+        .plan_check_all_with_cli(&cli, &cmd)
+        .expect("explicit js check plans should resolve");
+
+    assert_check_runs(
+        runs,
+        &[(
+            TargetBackend::Js,
+            &[
+                "workspace/js_preferred/lib",
+                "workspace/native_preferred/lib",
+            ],
+        )],
     );
 }
 

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -171,6 +171,27 @@ fn test_mixed_backend_explicit_multi_path_selection_warns_only_in_verbose_mode()
 }
 
 #[test]
+fn test_mixed_backend_split_check_keeps_single_package_patch_file_rule() {
+    let dir = TestDir::new("mixed_backend_local_dep.in");
+
+    let stderr = get_err_stderr(
+        &dir,
+        [
+            "check",
+            "web",
+            "server",
+            "--patch-file",
+            "patch.json",
+            "--dry-run",
+        ],
+    );
+    assert!(
+        stderr.contains("`--patch-file` requires the selector to resolve to a single package"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn test_mixed_backend_run_info_bundle_are_target_aware() {
     let dir = TestDir::new("mixed_backend_local_dep.in");
 
@@ -509,19 +530,6 @@ fn test_check_last_executed_backend_wins_for_packages_json() {
             .unwrap();
 
     assert_eq!(packages_json["backend"], serde_json::json!("native"));
-
-    let packages = packages_json["packages"].as_array().unwrap();
-    let js_pkg = packages
-        .iter()
-        .find(|pkg| pkg["root"] == "workspace/js_preferred")
-        .unwrap();
-    assert!(
-        js_pkg["artifact"]
-            .as_str()
-            .unwrap()
-            .contains("/_build/native/debug/check/workspace/js_preferred/lib/lib.mi"),
-        "packages.json: {packages_json}"
-    );
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -423,11 +423,14 @@ fn test_legacy_supported_targets_warning_is_local_only() {
 }
 
 #[test]
-fn test_explicit_target_suppresses_conflicting_workspace_preferred_target_warning() {
+fn test_check_conflicting_workspace_preferred_targets_do_not_warn() {
     let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
 
     let default_stderr = get_stderr(&dir, ["check", "--dry-run", "--sort-input"]);
-    assert_preferred_target_conflict_warning(&default_stderr);
+    assert!(
+        !default_stderr.contains(PREFERRED_TARGET_CONFLICT_WARNING),
+        "stderr: {default_stderr}"
+    );
 
     let explicit_stderr = get_stderr(
         &dir,
@@ -440,11 +443,92 @@ fn test_explicit_target_suppresses_conflicting_workspace_preferred_target_warnin
 }
 
 #[test]
-fn test_conflicting_workspace_preferred_targets_default_to_wasm_gc_across_commands() {
+fn test_check_without_target_respects_module_preferred_targets() {
+    let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
+
+    let stdout = get_stdout(&dir, ["check", "--dry-run", "--sort-input"]);
+    let stderr = get_stderr(&dir, ["check", "--dry-run", "--sort-input"]);
+    assert!(
+        !stderr.contains(PREFERRED_TARGET_CONFLICT_WARNING),
+        "stderr: {stderr}"
+    );
+    assert_contains_and_absent(
+        &stdout,
+        &[
+            "./_build/js/",
+            "./_build/native/",
+            "-target js",
+            "-target native",
+            "./js_preferred/src/lib/extra.js.mbt",
+            "./native_preferred/src/lib/extra.native.mbt",
+        ],
+        &[
+            "./_build/wasm-gc/",
+            "-target wasm-gc",
+            "./js_preferred/src/lib/extra.wasm-gc.mbt",
+            "./native_preferred/src/lib/extra.wasm-gc.mbt",
+        ],
+    );
+}
+
+#[test]
+fn test_check_paths_split_by_module_preferred_targets() {
+    let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
+
+    let stdout = get_stdout(
+        &dir,
+        [
+            "check",
+            "js_preferred/src/lib",
+            "native_preferred/src/lib",
+            "--dry-run",
+            "--sort-input",
+        ],
+    );
+    assert_contains_and_absent(
+        &stdout,
+        &[
+            "./_build/js/",
+            "./_build/native/",
+            "-target js",
+            "-target native",
+            "./js_preferred/src/lib/extra.js.mbt",
+            "./native_preferred/src/lib/extra.native.mbt",
+        ],
+        &["./_build/wasm-gc/", "-target wasm-gc"],
+    );
+}
+
+#[test]
+fn test_check_last_executed_backend_wins_for_packages_json() {
+    let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
+
+    get_stdout(&dir, ["check", "--sort-input"]);
+    let packages_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dir.join("_build/packages.json")).unwrap())
+            .unwrap();
+
+    assert_eq!(packages_json["backend"], serde_json::json!("native"));
+
+    let packages = packages_json["packages"].as_array().unwrap();
+    let js_pkg = packages
+        .iter()
+        .find(|pkg| pkg["root"] == "workspace/js_preferred")
+        .unwrap();
+    assert!(
+        js_pkg["artifact"]
+            .as_str()
+            .unwrap()
+            .contains("/_build/native/debug/check/workspace/js_preferred/lib/lib.mi"),
+        "packages.json: {packages_json}"
+    );
+}
+
+#[test]
+fn test_conflicting_workspace_preferred_targets_default_to_wasm_gc_across_other_commands() {
     let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
     let commands = [
         ("build", &["build", "--dry-run", "--sort-input"][..]),
-        ("check", &["check", "--dry-run", "--sort-input"][..]),
         ("test", &["test", "--dry-run", "--sort-input"][..]),
         ("bundle", &["bundle", "--dry-run", "--sort-input"][..]),
         ("bench", &["bench", "--dry-run", "--sort-input"][..]),


### PR DESCRIPTION
## Summary
- plan `moon check` without `--target` as an ordered list of per-backend runs using module preferred backend, then workspace preferred backend, then the default backend
- keep the single-plan `plan_check_rr_from_resolved` flow intact and add `plan_check_rr_from_resolved_all` for mixed-backend check planning
- add planner coverage for multi-run check planning and update target-backend tests for conflicting preferred targets

## Testing
- cargo fmt --all
- cargo test -p moon target_backend -- --nocapture