### PR TITLE
feat: split default build by preferred backend

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -29,8 +29,8 @@ use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
 
 use crate::filter::{
-    ensure_packages_support_backend, match_packages_by_name_rr, package_supports_backend,
-    select_supported_packages,
+    ensure_packages_support_backend, filter_pkg_by_dir, match_packages_by_name_rr,
+    package_supports_backend, select_packages, select_supported_packages,
 };
 use crate::rr_build;
 use crate::rr_build::BuildConfig;
@@ -43,8 +43,14 @@ use crate::watch::watching;
 
 use super::{BuildFlags, UniversalFlags};
 
+#[derive(Debug)]
+pub(crate) struct BuildTargetSelection {
+    pub target_backend: TargetBackend,
+    pub packages: Vec<PackageId>,
+}
+
 /// Build the current package
-#[derive(Debug, clap::Parser)]
+#[derive(Debug, clap::Parser, Clone)]
 pub(crate) struct BuildSubcommand {
     /// Paths to the packages that should be built.
     #[clap(name = "PATH", conflicts_with("package"))]
@@ -137,7 +143,7 @@ fn run_build_internal(
 
 /// Run the build routine in RR backend
 ///
-/// - `_watch`: True if in watch mode, will output ignore paths for prebuild outputs
+/// - `watch`: True if in watch mode, will output ignore paths for prebuild outputs
 #[instrument(skip_all)]
 #[allow(clippy::too_many_arguments)]
 fn run_build_rr(
@@ -147,7 +153,7 @@ fn run_build_rr(
     target_dir: &Path,
     mooncakes_dir: &Path,
     project_manifest_path: Option<&Path>,
-    _watch: bool,
+    watch: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<WatchOutput> {
     let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
@@ -157,50 +163,49 @@ fn run_build_rr(
     )
     .with_project_manifest_path(project_manifest_path);
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir, mooncakes_dir)?;
-    let (build_meta, build_graph) = plan_build_rr_from_resolved(
-        cli,
-        cmd,
-        target_dir,
-        selected_target_backend,
-        resolve_output,
-    )?;
-
-    // Prepare for `watch` mode
-    let prebuild_list = if _watch {
-        rr_get_prebuild_watch_paths(&build_meta.resolve_output)
+    let prebuild_list = if watch {
+        rr_get_prebuild_watch_paths(&resolve_output)
     } else {
         PrebuildWatchPaths {
             ignored_paths: Vec::new(),
             watched_paths: Vec::new(),
         }
     };
+    let planned_runs = plan_build_rr_from_resolved_all(
+        cli,
+        cmd,
+        source_dir,
+        target_dir,
+        selected_target_backend,
+        resolve_output,
+    )?;
 
     let ok = if cli.dry_run {
-        rr_build::print_dry_run(
-            &build_graph,
-            build_meta.artifacts.values(),
-            source_dir,
-            target_dir,
-        );
+        for (build_meta, build_graph) in planned_runs {
+            rr_build::print_dry_run(
+                &build_graph,
+                build_meta.artifacts.values(),
+                source_dir,
+                target_dir,
+            );
+        }
         true
     } else {
         let _lock = FileLock::lock(target_dir)?;
-        // Generate all_pkgs.json for indirect dependency resolution
-        rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Build)?;
-
-        let result = rr_build::execute_build(
-            &BuildConfig::from_flags(
-                &cmd.build_flags,
-                &cli.unstable_feature,
-                cli.verbose,
-                UserDiagnostics::from_flags(cli),
-            ),
-            build_graph,
-            target_dir,
-        )?;
-        result.print_info(cli.quiet, "building")?;
-
-        result.successful()
+        let cfg = BuildConfig::from_flags(
+            &cmd.build_flags,
+            &cli.unstable_feature,
+            cli.verbose,
+            UserDiagnostics::from_flags(cli),
+        );
+        let mut ok = true;
+        for (build_meta, build_graph) in planned_runs {
+            rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Build)?;
+            let result = rr_build::execute_build(&cfg, build_graph, target_dir)?;
+            result.print_info(cli.quiet, "building")?;
+            ok &= result.successful();
+        }
+        ok
     };
     Ok(WatchOutput {
         ok,
@@ -244,6 +249,227 @@ pub(crate) fn plan_build_rr_from_resolved(
     )
 }
 
+fn plan_build_rr_from_resolved_with_scope(
+    cli: &UniversalFlags,
+    cmd: &BuildSubcommand,
+    target_dir: &Path,
+    target_backend: TargetBackend,
+    resolve_output: moonbuild_rupes_recta::ResolveOutput,
+    scoped_packages: Vec<PackageId>,
+) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
+    let preconfig = preconfig_compile(
+        &cmd.auto_sync_flags,
+        cli,
+        &cmd.build_flags,
+        Some(target_backend),
+        target_dir,
+        RunMode::Build,
+    );
+
+    let output = UserDiagnostics::from_flags(cli);
+    rr_build::plan_build_from_resolved(
+        preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        Box::new(move |resolved, target_backend| {
+            calc_user_intent_from_scoped_packages(resolved, &scoped_packages, target_backend)
+        }),
+        resolve_output,
+    )
+}
+
+pub(crate) fn plan_build_rr_from_resolved_all(
+    cli: &UniversalFlags,
+    cmd: &BuildSubcommand,
+    _source_dir: &Path,
+    target_dir: &Path,
+    selected_target_backend: Option<TargetBackend>,
+    resolve_output: moonbuild_rupes_recta::ResolveOutput,
+) -> anyhow::Result<Vec<(rr_build::BuildMeta, rr_build::BuildInput)>> {
+    if let Some(target_backend) = selected_target_backend {
+        if has_explicit_build_selector(cmd)
+            && resolve_selected_build_packages(
+                &resolve_output,
+                cmd,
+                Some(target_backend),
+                UserDiagnostics::from_flags(cli),
+            )?
+            .is_empty()
+        {
+            return Ok(Vec::new());
+        }
+
+        return plan_build_rr_from_resolved(
+            cli,
+            cmd,
+            target_dir,
+            Some(target_backend),
+            resolve_output,
+        )
+        .map(|plan| vec![plan]);
+    }
+
+    let selections = resolve_build_target_selections(
+        &resolve_output,
+        cmd,
+        None,
+        UserDiagnostics::from_flags(cli),
+    )?;
+
+    if has_explicit_build_selector(cmd) {
+        return selections
+            .into_iter()
+            .map(|selection| {
+                let (scoped_cmd, target_backend) =
+                    narrow_build_request_to_selection(cmd, &resolve_output, &selection);
+                plan_build_rr_from_resolved(
+                    cli,
+                    &scoped_cmd,
+                    target_dir,
+                    Some(target_backend),
+                    resolve_output.clone(),
+                )
+            })
+            .collect();
+    }
+
+    if selections.is_empty() {
+        return plan_build_rr_from_resolved(cli, cmd, target_dir, None, resolve_output)
+            .map(|plan| vec![plan]);
+    }
+
+    selections
+        .into_iter()
+        .map(|selection| {
+            plan_build_rr_from_resolved_with_scope(
+                cli,
+                cmd,
+                target_dir,
+                selection.target_backend,
+                resolve_output.clone(),
+                selection.packages,
+            )
+        })
+        .collect()
+}
+
+fn has_explicit_build_selector(cmd: &BuildSubcommand) -> bool {
+    !cmd.path.is_empty() || cmd.package.is_some()
+}
+
+fn narrow_build_request_to_selection(
+    cmd: &BuildSubcommand,
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    selection: &BuildTargetSelection,
+) -> (BuildSubcommand, TargetBackend) {
+    let mut scoped_cmd = cmd.clone();
+    scoped_cmd.package = None;
+    scoped_cmd.path = selection
+        .packages
+        .iter()
+        .map(|pkg| resolve_output.pkg_dirs.get_package(*pkg).root_path.clone())
+        .collect();
+    (scoped_cmd, selection.target_backend)
+}
+
+fn resolve_build_target_selections(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    cmd: &BuildSubcommand,
+    selected_target_backend: Option<TargetBackend>,
+    output: UserDiagnostics,
+) -> anyhow::Result<Vec<BuildTargetSelection>> {
+    if let Some(target_backend) = selected_target_backend {
+        let packages =
+            resolve_selected_build_packages(resolve_output, cmd, Some(target_backend), output)?;
+        if packages.is_empty() {
+            return Ok(Vec::new());
+        }
+        return Ok(vec![BuildTargetSelection {
+            target_backend,
+            packages,
+        }]);
+    }
+
+    let selected = resolve_selected_build_packages(resolve_output, cmd, None, output)?;
+    let mut selections = Vec::new();
+
+    for pkg in selected {
+        let module_id = resolve_output.pkg_dirs.get_package(pkg).module;
+        let target_backend = resolve_output
+            .module_rel
+            .module_info(module_id)
+            .preferred_target
+            .or(resolve_output.workspace_preferred_target)
+            .unwrap_or_default();
+        let Some(index) = selections
+            .iter()
+            .position(|selection: &BuildTargetSelection| {
+                selection.target_backend == target_backend
+            })
+        else {
+            selections.push(BuildTargetSelection {
+                target_backend,
+                packages: vec![pkg],
+            });
+            continue;
+        };
+        selections[index].packages.push(pkg);
+    }
+
+    for selection in &mut selections {
+        selection.packages = selection
+            .packages
+            .iter()
+            .copied()
+            .filter(|&pkg| package_supports_backend(resolve_output, pkg, selection.target_backend))
+            .collect();
+    }
+    selections.retain(|selection| !selection.packages.is_empty());
+    selections.sort_by_key(|selection| selection.target_backend);
+
+    Ok(selections)
+}
+
+fn resolve_selected_build_packages(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    cmd: &BuildSubcommand,
+    target_backend: Option<TargetBackend>,
+    output: UserDiagnostics,
+) -> anyhow::Result<Vec<PackageId>> {
+    if !cmd.path.is_empty() {
+        if let Some(target_backend) = target_backend {
+            return select_supported_packages(resolve_output, &cmd.path, target_backend, output);
+        }
+        return Ok(select_packages(&cmd.path, output, |dir| {
+            filter_pkg_by_dir(resolve_output, dir)
+        })?
+        .into_iter()
+        .map(|(_, pkg_id)| pkg_id)
+        .collect());
+    }
+
+    if let Some(package_filter) = cmd.package.as_deref() {
+        let pkgs = match_packages_by_name_rr(
+            resolve_output,
+            resolve_output.local_modules(),
+            package_filter,
+            output,
+        );
+        if let Some(target_backend) = target_backend {
+            ensure_packages_support_backend(resolve_output, pkgs.iter().copied(), target_backend)?;
+        }
+        return Ok(pkgs);
+    }
+
+    Ok(rr_build::local_packages(resolve_output)
+        .filter(|&pkg_id| {
+            target_backend
+                .is_none_or(|backend| package_supports_backend(resolve_output, pkg_id, backend))
+        })
+        .collect())
+}
+
 /// Generate user intent
 /// If any packages are linkable, compile those; otherwise, compile everything
 /// to core.
@@ -277,30 +503,40 @@ fn calc_user_intent(
             .collect::<Vec<_>>()
             .into())
     } else {
-        let supported_packages = rr_build::local_packages(resolve_output)
-            .filter(|&pkg_id| package_supports_backend(resolve_output, pkg_id, target_backend))
-            .collect::<Vec<_>>();
-        let linkable_pkgs = get_linkable_pkgs(
+        calc_user_intent_from_scoped_packages(
             resolve_output,
+            &rr_build::local_packages(resolve_output)
+                .filter(|&pkg_id| package_supports_backend(resolve_output, pkg_id, target_backend))
+                .collect::<Vec<_>>(),
             target_backend,
-            supported_packages.iter().copied(),
-        );
-        let intents: Vec<_> = if linkable_pkgs.is_empty() {
-            supported_packages
-                .into_iter()
-                .filter(|&pkg_id| {
-                    // Skip building stdlib packages because we should use prebuilt
-                    // stdlib artifacts instead.
-                    let pkg = resolve_output.pkg_dirs.get_package(pkg_id);
-                    !pkg.is_stdlib
-                })
-                .map(UserIntent::Build)
-                .collect()
-        } else {
-            linkable_pkgs.into_iter().map(UserIntent::Build).collect()
-        };
-        Ok(intents.into())
+        )
     }
+}
+
+fn calc_user_intent_from_scoped_packages(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+    supported_packages: &[PackageId],
+    target_backend: TargetBackend,
+) -> Result<CalcUserIntentOutput, anyhow::Error> {
+    let linkable_pkgs = get_linkable_pkgs(
+        resolve_output,
+        target_backend,
+        supported_packages.iter().copied(),
+    );
+    let intents: Vec<_> = if linkable_pkgs.is_empty() {
+        supported_packages
+            .iter()
+            .copied()
+            .filter(|&pkg_id| {
+                let pkg = resolve_output.pkg_dirs.get_package(pkg_id);
+                !pkg.is_stdlib
+            })
+            .map(UserIntent::Build)
+            .collect()
+    } else {
+        linkable_pkgs.into_iter().map(UserIntent::Build).collect()
+    };
+    Ok(intents.into())
 }
 
 fn get_linkable_pkgs(

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -102,6 +102,21 @@ impl PlanningFixture {
         self.dump_plan(build_meta, build_graph)
     }
 
+    pub(super) fn plan_build_all_with_cli(
+        &self,
+        cli: &UniversalFlags,
+        cmd: &BuildSubcommand,
+    ) -> anyhow::Result<Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>> {
+        crate::cli::build::plan_build_rr_from_resolved_all(
+            cli,
+            cmd,
+            &self.source_dir,
+            &self.target_dir,
+            cmd.build_flags.resolve_single_target_backend()?,
+            self.resolve_output.clone(),
+        )
+    }
+
     pub(super) fn plan_check_with_cli(
         &self,
         cli: &UniversalFlags,

--- a/crates/moon/src/tests/planner/target_backend_planning.rs
+++ b/crates/moon/src/tests/planner/target_backend_planning.rs
@@ -39,6 +39,45 @@ fn assert_contains_and_absent(graph: &str, present: &[&str], absent: &[&str]) {
     }
 }
 
+fn assert_build_runs(
+    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
+    expected: &[(TargetBackend, &[&str])],
+) {
+    let actual = runs
+        .into_iter()
+        .map(|(meta, _)| {
+            let packages = meta
+                .artifacts
+                .keys()
+                .filter_map(|node| node.extract_target().map(|target| target.package))
+                .map(|pkg_id| {
+                    meta.resolve_output
+                        .pkg_dirs
+                        .get_package(pkg_id)
+                        .fqn
+                        .to_string()
+                })
+                .collect::<std::collections::BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            (meta.target_backend.into(), packages)
+        })
+        .collect::<Vec<_>>();
+    let expected = expected
+        .iter()
+        .map(|(backend, packages)| {
+            (
+                *backend,
+                packages
+                    .iter()
+                    .map(|pkg| pkg.to_string())
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+}
+
 fn assert_check_runs(
     runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
     expected: &[(TargetBackend, &[&str])],
@@ -115,6 +154,72 @@ fn target_backend_build_planning_respects_default_and_explicit_backend() {
             "./_build/wasm-gc/debug/build/main/main.wasm",
             "-target wasm-gc",
         ],
+    );
+}
+
+#[test]
+fn conflicting_workspace_preferred_targets_build_selection_splits_by_module_backend() {
+    let fixture = PlanningFixture::new("workspace_conflicting_preferred_targets.in")
+        .expect("fixture should resolve");
+
+    let (cli, cmd) = parse_build_command(&["build", "--dry-run", "--sort-input"]);
+    let runs = fixture
+        .plan_build_all_with_cli(&cli, &cmd)
+        .expect("default build plans should resolve");
+
+    assert_build_runs(
+        runs,
+        &[
+            (TargetBackend::Js, &["workspace/js_preferred/lib"]),
+            (TargetBackend::Native, &["workspace/native_preferred/lib"]),
+        ],
+    );
+}
+
+#[test]
+fn conflicting_workspace_preferred_targets_build_path_selection_uses_module_backend() {
+    let fixture = PlanningFixture::new("workspace_conflicting_preferred_targets.in")
+        .expect("fixture should resolve");
+
+    let js_path = fixture.case_dir().join("js_preferred/src/lib");
+    let native_path = fixture.case_dir().join("native_preferred/src/lib");
+    let js_path = js_path.to_str().expect("fixture path should be UTF-8");
+    let native_path = native_path.to_str().expect("fixture path should be UTF-8");
+
+    let (cli, cmd) =
+        parse_build_command(&["build", js_path, native_path, "--dry-run", "--sort-input"]);
+    let runs = fixture
+        .plan_build_all_with_cli(&cli, &cmd)
+        .expect("path-selected build plans should resolve");
+
+    assert_build_runs(
+        runs,
+        &[
+            (TargetBackend::Js, &["workspace/js_preferred/lib"]),
+            (TargetBackend::Native, &["workspace/native_preferred/lib"]),
+        ],
+    );
+}
+
+#[test]
+fn explicit_build_target_keeps_single_backend_selection() {
+    let fixture = PlanningFixture::new("workspace_conflicting_preferred_targets.in")
+        .expect("fixture should resolve");
+
+    let (cli, cmd) = parse_build_command(&["build", "--target", "js", "--dry-run", "--sort-input"]);
+    let runs = fixture
+        .plan_build_all_with_cli(&cli, &cmd)
+        .expect("explicit js build plans should resolve");
+
+    assert_build_runs(
+        runs,
+        &[(
+            TargetBackend::Js,
+            &[
+                "workspace/js_preferred/lib",
+                "workspace/native_preferred/lib",
+            ],
+        )],
     );
 }
 

--- a/crates/moon/tests/test_cases/debug_flag_test/mod.rs
+++ b/crates/moon/tests/test_cases/debug_flag_test/mod.rs
@@ -174,6 +174,13 @@ fn check_path_selector_smoke() {
     }
 }
 
+#[test]
+fn build_explicit_empty_selection_does_not_expand_to_workspace() {
+    let dir = TestDir::new("debug_flag_test");
+    let stdout = get_stdout(&dir, ["build", "notes", "--target", "js", "--dry-run"]);
+    assert!(!stdout.contains("moonc build-package"), "stdout: {stdout}");
+}
+
 fn assert_moonrun_line(output: &str, release: bool) {
     let empty: &[&str] = &[];
     let line = line_with(output, "moonrun", empty);

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -78,6 +78,28 @@ fn assert_conflicting_workspace_preferred_targets_default_to_wasm_gc(
     );
 }
 
+fn assert_conflicting_workspace_preferred_targets_build_uses_module_backends(
+    stdout: &str,
+    stderr: &str,
+) {
+    assert!(
+        !stderr.contains(PREFERRED_TARGET_CONFLICT_WARNING),
+        "stderr: {stderr}"
+    );
+    assert_contains_and_absent(
+        stdout,
+        &[
+            "./_build/js/",
+            "./_build/native/",
+            "-target js",
+            "-target native",
+            "./js_preferred/src/lib/extra.js.mbt",
+            "./native_preferred/src/lib/extra.native.mbt",
+        ],
+        &["./_build/wasm-gc/", "-target wasm-gc"],
+    );
+}
+
 #[test]
 fn test_mixed_backend_explicit_selection_rejects_unsupported_backend() {
     let dir = TestDir::new("mixed_backend_local_dep.in");
@@ -259,6 +281,62 @@ fn test_mixed_backend_run_info_bundle_are_target_aware() {
             "./deps/unuseddep/lib/lib.mbt",
         ],
     );
+}
+
+#[test]
+fn test_build_conflicting_workspace_preferred_targets_do_not_warn() {
+    let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
+
+    let default_stderr = get_stderr(&dir, ["build", "--dry-run", "--sort-input"]);
+    assert!(
+        !default_stderr.contains(PREFERRED_TARGET_CONFLICT_WARNING),
+        "stderr: {default_stderr}"
+    );
+
+    let explicit_stderr = get_stderr(
+        &dir,
+        ["build", "--target", "js", "--dry-run", "--sort-input"],
+    );
+    assert!(
+        !explicit_stderr.contains(PREFERRED_TARGET_CONFLICT_WARNING),
+        "stderr: {explicit_stderr}"
+    );
+}
+
+#[test]
+fn test_build_without_target_respects_module_preferred_targets() {
+    let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
+
+    let stdout = get_stdout(&dir, ["build", "--dry-run", "--sort-input"]);
+    let stderr = get_stderr(&dir, ["build", "--dry-run", "--sort-input"]);
+    assert_conflicting_workspace_preferred_targets_build_uses_module_backends(&stdout, &stderr);
+}
+
+#[test]
+fn test_build_paths_split_by_module_preferred_targets() {
+    let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
+
+    let stdout = get_stdout(
+        &dir,
+        [
+            "build",
+            "js_preferred/src/lib",
+            "native_preferred/src/lib",
+            "--dry-run",
+            "--sort-input",
+        ],
+    );
+    let stderr = get_stderr(
+        &dir,
+        [
+            "build",
+            "js_preferred/src/lib",
+            "native_preferred/src/lib",
+            "--dry-run",
+            "--sort-input",
+        ],
+    );
+    assert_conflicting_workspace_preferred_targets_build_uses_module_backends(&stdout, &stderr);
 }
 
 #[test]
@@ -536,7 +614,6 @@ fn test_check_last_executed_backend_wins_for_packages_json() {
 fn test_conflicting_workspace_preferred_targets_default_to_wasm_gc_across_other_commands() {
     let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
     let commands = [
-        ("build", &["build", "--dry-run", "--sort-input"][..]),
         ("test", &["test", "--dry-run", "--sort-input"][..]),
         ("bundle", &["bundle", "--dry-run", "--sort-input"][..]),
         ("bench", &["bench", "--dry-run", "--sort-input"][..]),


### PR DESCRIPTION
## Summary
- split `moon build` without `--target` by module preferred backend, falling back to workspace preferred backend and then the default backend
- keep the single-backend planner intact by adding a `plan_build_rr_from_resolved_all(...)` wrapper that narrows each backend selection and reuses the existing planner
- add planner and integration coverage for conflicting preferred targets, path-selected builds, and stable backend execution order

## Notes
- explicit `--target` still keeps a single backend plan
- empty selections still fall back to the original single-plan path
- build runs are executed in stable backend order

## Testing
- `cargo test -p moon planner::target_backend_planning -- --nocapture`
- `cargo test -p moon target_backend -- --nocapture`
- `cargo test -p moon test_cases::workspace_basic::test_empty_workspace_commands_do_not_panic -- --nocapture`