### PR TITLE
docs: clarify workspace command planning

### DIFF
--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -283,7 +283,8 @@ that allows CLI subcommands to describe the action they want to perform on packa
 without committing to the details of which nodes to use.
 
 User intents are specified on individual packages.
-For project-wide subcommands like `moon check`, an intent is emitted for each individual package.
+For project-wide subcommands like `moon check` and `moon build`, an intent is
+emitted for each individual package.
 Filtering packages in subcommands operate by only emitting the intents of the target packages,
 instead of emitting for every (applicable) package in the project.
 
@@ -295,6 +296,11 @@ it will map into "check package source", "check package whitebox text" and "chec
 However, if the package does not contain whitebox test files,
 the "check whitebox" node will be omitted.
 If the package is virtual, then a list of virtual package checking nodes will be used instead.
+
+For `moon check` and `moon build` without an explicit `--target`, CLI planning
+may first split selected packages into multiple backend groups using
+`module preferred_target -> workspace preferred_target -> default backend`,
+then emit intents separately for each backend group.
 
 This mapping is also on a migration path for main packages: release N keeps the
 current nodes so warnings can be surfaced, while release N+1 will omit blackbox

--- a/docs/dev/reference/workspace.md
+++ b/docs/dev/reference/workspace.md
@@ -100,6 +100,25 @@ the whole workspace. They can be run from:
 
 They do not need an implicit default member.
 
+Within this category, it helps to distinguish two subgroups:
+
+- **Workspace-wide planning commands**:
+  `moon build`, `moon check`
+- **Workspace-wide inspection or transformation commands**:
+  `moon test`, `moon fmt`, `moon info`
+
+All of them operate on the selected project rather than a single member, but
+`build` and `check` now have a more explicit workspace-wide planning model:
+
+- they accept package/path selectors across the selected project,
+- they may split one invocation into multiple backend-specific runs when
+  `--target` is omitted,
+- and they use `module preferred_target -> workspace preferred_target ->
+  default backend` to decide those runs.
+
+That makes them more than just "project-scoped"; they are the current
+workspace-wide target-planning commands.
+
 ### Member-Scoped Commands
 
 These commands need one concrete module even when the selected project is a


### PR DESCRIPTION
## Summary
- clarify in the architecture docs that `moon build` and `moon check` may split one invocation into multiple backend groups when `--target` is omitted
- refine the workspace command model to distinguish workspace-wide target-planning commands from other project-scoped commands

## Testing
- not run (docs-only change)