### PR TITLE
feat: support moon run -c scripts

### DIFF
--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -37,14 +37,26 @@ use super::{BuildFlags, UniversalFlags};
 
 /// Run a main package
 #[derive(Debug, clap::Parser)]
+#[clap(group = clap::ArgGroup::new("run_source").required(true).multiple(false))]
 pub(crate) struct RunSubcommand {
     /// The package, .mbt/.mbtx file, or `-` to read `.mbtx` source from stdin
-    pub package_or_mbt_file: String,
+    #[clap(group = "run_source")]
+    pub package_or_mbt_file: Option<String>,
+
+    /// Run `.mbtx` source passed in as a string
+    #[clap(
+        short = 'c',
+        short_alias = 'e',
+        value_name = "SCRIPT",
+        group = "run_source"
+    )]
+    pub command: Option<String>,
 
     #[clap(flatten)]
     pub build_flags: BuildFlags,
 
     /// The arguments provided to the program to be run
+    #[clap(trailing_var_arg = true, num_args = 0.., allow_hyphen_values = true)]
     pub args: Vec<String>,
 
     #[clap(flatten)]
@@ -64,17 +76,40 @@ fn run_stdin_source_as_single_file(
         .read_to_string(&mut source)
         .context("failed to read `.mbtx` source from stdin")?;
 
-    let temp_dir =
-        tempfile::TempDir::new().context("failed to create temporary directory for stdin run")?;
-    let input_path = temp_dir.path().join("stdin.mbtx");
+    run_source_as_single_file(cli, cmd, source, "stdin.mbtx", "stdin")
+}
+
+fn run_inline_source_as_single_file(
+    cli: &UniversalFlags,
+    cmd: RunSubcommand,
+) -> anyhow::Result<i32> {
+    let source = cmd
+        .command
+        .clone()
+        .expect("inline script should be present when `moon run -c` is selected");
+
+    run_source_as_single_file(cli, cmd, source, "command.mbtx", "command")
+}
+
+fn run_source_as_single_file(
+    cli: &UniversalFlags,
+    cmd: RunSubcommand,
+    source: String,
+    temp_name: &str,
+    source_name: &str,
+) -> anyhow::Result<i32> {
+    let temp_dir = tempfile::TempDir::new()
+        .with_context(|| format!("failed to create temporary directory for {source_name} run"))?;
+    let input_path = temp_dir.path().join(temp_name);
     std::fs::write(&input_path, source).with_context(|| {
         format!(
-            "failed to write temporary stdin source file: {}",
+            "failed to write temporary {source_name} source file: {}",
             input_path.display()
         )
     })?;
 
     let RunSubcommand {
+        command: _,
         build_flags,
         args,
         auto_sync_flags,
@@ -82,7 +117,8 @@ fn run_stdin_source_as_single_file(
         ..
     } = cmd;
     let cmd = RunSubcommand {
-        package_or_mbt_file: input_path.to_string_lossy().into_owned(),
+        package_or_mbt_file: Some(input_path.to_string_lossy().into_owned()),
+        command: None,
         build_flags,
         args,
         auto_sync_flags,
@@ -95,7 +131,14 @@ fn run_stdin_source_as_single_file(
 
 #[instrument(skip_all)]
 pub(crate) fn run_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
-    let input = cmd.package_or_mbt_file.as_str();
+    if cmd.command.is_some() {
+        return run_inline_source_as_single_file(cli, cmd);
+    }
+
+    let input = cmd
+        .package_or_mbt_file
+        .as_deref()
+        .expect("run source is required by clap");
     if input == "-" {
         return run_stdin_source_as_single_file(cli, cmd);
     }
@@ -204,7 +247,10 @@ pub(crate) fn plan_run_rr_from_resolved(
     );
     preconfig.try_tcc_run = !cli.dry_run;
 
-    let input_path = cmd.package_or_mbt_file.clone();
+    let input_path = cmd
+        .package_or_mbt_file
+        .clone()
+        .expect("package run planning requires a positional input");
     let value_tracing = cmd.build_flags.enable_value_tracing;
     rr_build::plan_build_from_resolved(
         preconfig,
@@ -292,7 +338,11 @@ fn calc_user_intent(
 
 #[instrument(level = Level::DEBUG, skip_all)]
 fn run_single_file_from_arg(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
-    let input_path = dunce::canonicalize(&cmd.package_or_mbt_file)?;
+    let input_path = dunce::canonicalize(
+        cmd.package_or_mbt_file
+            .as_deref()
+            .expect("single-file run from arg requires a positional input path"),
+    )?;
     let source_dir = input_path.parent().unwrap().to_path_buf();
     let single_file_dirs = cli
         .source_tgt_dir

--- a/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
@@ -2209,12 +2209,16 @@ _moon() {
             return 0
             ;;
         moon__run)
-            opts="-g -d -j -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --frozen --build-only --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help <PACKAGE_OR_MBT_FILE> [ARGS]..."
+            opts="-c -g -d -j -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --frozen --build-only --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PACKAGE_OR_MBT_FILE] [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --target)
                     COMPREPLY=($(compgen -W "wasm wasm-gc js native llvm all" -- "${cur}"))
                     return 0

--- a/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
@@ -222,6 +222,7 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;run'= {
+            cand -c 'Run `.mbtx` source passed in as a string'
             cand --target 'Select output target'
             cand --warn-list 'Warn list config'
             cand -j 'Set the max number of jobs to run in parallel'

--- a/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
@@ -184,6 +184,7 @@ complete -c moon -n "__fish_moon_using_subcommand prove" -l trace -d 'Trace the 
 complete -c moon -n "__fish_moon_using_subcommand prove" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand prove" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand prove" -s h -l help -d 'Print help'
+complete -c moon -n "__fish_moon_using_subcommand run" -s c -d 'Run `.mbtx` source passed in as a string' -r
 complete -c moon -n "__fish_moon_using_subcommand run" -l target -d 'Select output target' -r -f -a "{wasm\t'',wasm-gc\t'',js\t'',native\t'',llvm\t'',all\t''}"
 complete -c moon -n "__fish_moon_using_subcommand run" -l warn-list -d 'Warn list config' -r
 complete -c moon -n "__fish_moon_using_subcommand run" -s j -l jobs -d 'Set the max number of jobs to run in parallel' -r

--- a/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
@@ -231,6 +231,7 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;run' {
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Run `.mbtx` source passed in as a string')
             [CompletionResult]::new('--target', 'target', [CompletionResultType]::ParameterName, 'Select output target')
             [CompletionResult]::new('--warn-list', 'warn-list', [CompletionResultType]::ParameterName, 'Warn list config')
             [CompletionResult]::new('-j', 'j', [CompletionResultType]::ParameterName, 'Set the max number of jobs to run in parallel')

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -208,6 +208,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (run)
 _arguments "${_arguments_options[@]}" : \
+'-c+[Run \`.mbtx\` source passed in as a string]:SCRIPT: ' \
 '*--target=[Select output target]:TARGET:(wasm wasm-gc js native llvm all)' \
 '--warn-list=[Warn list config]:WARN_LIST: ' \
 '-j+[Set the max number of jobs to run in parallel]:JOBS: ' \
@@ -242,7 +243,7 @@ _arguments "${_arguments_options[@]}" : \
 '(--dry-run)--build-graph[]' \
 '-h[Print help]' \
 '--help[Print help]' \
-':package_or_mbt_file -- The package, .mbt/.mbtx file, or `-` to read `.mbtx` source from stdin:' \
+'::package_or_mbt_file -- The package, .mbt/.mbtx file, or `-` to read `.mbtx` source from stdin:' \
 '*::args -- The arguments provided to the program to be run:' \
 && ret=0
 ;;

--- a/crates/moon/src/tests/planner/cli_to_planner.rs
+++ b/crates/moon/src/tests/planner/cli_to_planner.rs
@@ -18,7 +18,80 @@
 
 use expect_test::expect;
 
-use super::fixture::{PlanningFixture, parse_test_command};
+use super::fixture::{PlanningFixture, parse_run_command, parse_test_command};
+
+#[test]
+fn command_string_run_parses_as_expected() {
+    let (cli, cmd) = parse_run_command(&["run", "-c", r#"fn main { println("hello") }"#]);
+
+    expect![[r#"
+        (
+            UniversalFlags {
+                source_tgt_dir: SourceTargetDirs {
+                    cwd: None,
+                    manifest_path: None,
+                    target_dir: None,
+                },
+                quiet: false,
+                verbose: false,
+                trace: false,
+                dry_run: false,
+                build_graph: false,
+                unstable_feature: FeatureGate {
+                    rr_export_module_graph: false,
+                    rr_export_package_graph: false,
+                    rr_export_build_plan: false,
+                    rr_n2_explain: false,
+                    rr_moon_pkg: true,
+                    wasi_auto_export_memory: false,
+                },
+            },
+            RunSubcommand {
+                package_or_mbt_file: None,
+                command: Some(
+                    "fn main { println(\"hello\") }",
+                ),
+                build_flags: BuildFlags {
+                    std: false,
+                    no_std: false,
+                    debug: false,
+                    release: false,
+                    strip: false,
+                    no_strip: false,
+                    target: [],
+                    serial: false,
+                    enable_coverage: false,
+                    sort_input: false,
+                    output_wat: false,
+                    deny_warn: false,
+                    no_render: false,
+                    output_json: false,
+                    warn_list: None,
+                    enable_value_tracing: false,
+                    jobs: None,
+                    render_no_loc: Error,
+                },
+                args: [],
+                auto_sync_flags: AutoSyncFlags {
+                    frozen: false,
+                },
+                build_only: false,
+            },
+        )
+    "#]]
+    .assert_debug_eq(&(cli, cmd));
+}
+
+#[test]
+fn command_string_run_short_alias_e_still_parses() {
+    let (_, cmd) = parse_run_command(&["run", "-e", r#"fn main { println("hello") }"#]);
+
+    assert_eq!(
+        cmd.command.as_deref(),
+        Some(r#"fn main { println("hello") }"#)
+    );
+    assert_eq!(cmd.package_or_mbt_file, None);
+}
 
 #[test]
 fn native_target_dry_run_test_command_parses_as_expected() {

--- a/crates/moon/tests/test_cases/debug_flag_test/mod.rs
+++ b/crates/moon/tests/test_cases/debug_flag_test/mod.rs
@@ -59,7 +59,7 @@ fn profile_flags_conflict_in_cli() {
         expect![[r#"
             error: the argument '--debug' cannot be used with '--release'
 
-            Usage: moon run --debug <PACKAGE_OR_MBT_FILE> [ARGS]...
+            Usage: moon run --debug <PACKAGE_OR_MBT_FILE|-c <SCRIPT>> [ARGS]...
 
             For more information, try '--help'.
         "#]],

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -280,6 +280,77 @@ fn test_moon_run_dash_reads_stdin() {
 }
 
 #[test]
+fn test_moon_run_command_string_reads_inline_script() {
+    let dir = TestDir::new_empty();
+    snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .arg("run")
+        .arg("-c")
+        .arg(
+            r#"fn main {
+  println("hello from run -c")
+}
+"#,
+        )
+        .assert()
+        .success()
+        .stdout_eq("hello from run -c\n");
+}
+
+#[test]
+fn test_moon_run_command_string_short_alias_e_reads_inline_script() {
+    let dir = TestDir::new_empty();
+    snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .arg("run")
+        .arg("-e")
+        .arg(
+            r#"fn main {
+  println("hello from run -e")
+}
+"#,
+        )
+        .assert()
+        .success()
+        .stdout_eq("hello from run -e\n");
+}
+
+#[test]
+fn test_moon_run_command_string_conflicts_with_other_inputs() {
+    let dir = TestDir::new_empty();
+
+    let dash_stderr = snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .arg("run")
+        .arg("-c")
+        .arg(r#"fn main { println("hello") }"#)
+        .arg("-")
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .to_owned();
+    let dash_stderr = String::from_utf8_lossy(&dash_stderr);
+    assert!(dash_stderr.contains("cannot be used with"));
+    assert!(dash_stderr.contains("-c"));
+
+    let path_stderr = snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .arg("run")
+        .arg("-c")
+        .arg(r#"fn main { println("hello") }"#)
+        .arg("main")
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .to_owned();
+    let path_stderr = String::from_utf8_lossy(&path_stderr);
+    assert!(path_stderr.contains("cannot be used with"));
+    assert!(path_stderr.contains("-c"));
+}
+
+#[test]
 fn test_moon_run_dash_reads_stdin_with_common_flags() {
     let dir = TestDir::new_empty();
     let subdir = dir.join("subdir");

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -210,7 +210,7 @@ Prove the current package
 
 Run a main package
 
-**Usage:** `moon run [OPTIONS] <PACKAGE_OR_MBT_FILE> [ARGS]...`
+**Usage:** `moon run [OPTIONS] <PACKAGE_OR_MBT_FILE|-c <SCRIPT>> [ARGS]...`
 
 ###### **Arguments:**
 
@@ -219,6 +219,7 @@ Run a main package
 
 ###### **Options:**
 
+* `-c <SCRIPT>` — Run `.mbtx` source passed in as a string
 * `-g`, `--debug` — Emit debug information
 * `--release` — Compile in release mode
 * `--strip` — Enable stripping debug information

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -210,7 +210,7 @@ Prove the current package
 
 Run a main package
 
-**Usage:** `moon run [OPTIONS] <PACKAGE_OR_MBT_FILE> [ARGS]...`
+**Usage:** `moon run [OPTIONS] <PACKAGE_OR_MBT_FILE|-c <SCRIPT>> [ARGS]...`
 
 ###### **Arguments:**
 
@@ -219,6 +219,7 @@ Run a main package
 
 ###### **Options:**
 
+* `-c <SCRIPT>` — Run `.mbtx` source passed in as a string
 * `-g`, `--debug` — Emit debug information
 * `--release` — Compile in release mode
 * `--strip` — Enable stripping debug information


### PR DESCRIPTION
## Summary
- add `moon run -c SCRIPT` to run inline `.mbtx` source strings
- accept `-e` as a compatibility alias while keeping `-c` as the primary spelling
- route inline source through the existing single-file temp-file execution path
- add parser and command tests for inline execution and source-selector conflicts, and update generated help/completion docs

## Why
`moon run` could read `.mbtx` from stdin with `moon run -`, but it could not accept source directly from a string. This adds a Python-style `-c` entry point for shell pipelines and inline invocations while tolerating `-e` for users coming from Node-style CLIs.

## User impact
Users can now run inline MoonBit scripts with:

```sh
moon run -c 'fn main { println("hello") }'
```

`moon run -e '...'` is also accepted as an alias.

`-c`/`-e` conflict with `moon run -` and `moon run xxx`, so the run source remains unambiguous.

## Root cause
The CLI only accepted a positional source selector (`PACKAGE_OR_MBT_FILE`) and had bespoke handling for the special `-` stdin case.

## Validation
- `cargo fmt --check`
- `cargo test -p moon command_string_run_parses_as_expected -- --nocapture`
- `cargo test -p moon command_string_run_ -- --nocapture`
- `cargo test -p moon test_moon_run_command_string -- --nocapture`
- `cargo test -p moon debug_flag_test -- --nocapture`
- `cargo test -p moon test_moon_run_with_cli_args -- --nocapture`
- `cargo test -p moon test_moon_run_dash_reads_stdin -- --nocapture`
- `cargo test -p moon shell_completion -- --nocapture`
- `cargo test -p moon gen_docs_for_moon_help_page -- --nocapture`