### PR TITLE
Resolve moon run projects from selector paths

### DIFF
--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -129,8 +129,32 @@ fn run_source_as_single_file(
     result
 }
 
+fn reject_manifest_path_for_run(cli: &UniversalFlags) -> anyhow::Result<()> {
+    if cli.source_tgt_dir.manifest_path.is_some() {
+        bail!(
+            "`--manifest-path` is no longer supported for `moon run`. Use `moon -C <project-dir> run ...` instead."
+        );
+    }
+    Ok(())
+}
+
+fn resolve_run_start_dir(input: &str) -> anyhow::Result<std::path::PathBuf> {
+    let input_path =
+        dunce::canonicalize(input).with_context(|| format!("failed to resolve path `{input}`"))?;
+    if input_path.is_dir() {
+        Ok(input_path)
+    } else {
+        input_path
+            .parent()
+            .context("run input path has no parent directory")
+            .map(Path::to_path_buf)
+    }
+}
+
 #[instrument(skip_all)]
 pub(crate) fn run_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
+    reject_manifest_path_for_run(cli)?;
+
     if cmd.command.is_some() {
         return run_inline_source_as_single_file(cli, cmd);
     }
@@ -144,17 +168,16 @@ pub(crate) fn run_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resul
     }
     let is_mbt = input.ends_with(".mbt");
     let is_mbtx = input.ends_with(".mbtx");
+    let run_start_dir = resolve_run_start_dir(input)?;
 
-    match cli.source_tgt_dir.try_into_package_dirs() {
+    match cli.source_tgt_dir.package_dirs_from(&run_start_dir) {
         Ok(_) => {
             if is_mbtx {
                 return run_single_file_from_arg(cli, cmd);
             }
             if is_mbt {
-                let moon_pkg_json_exist = std::env::current_dir()?
-                    .join(input)
-                    .parent()
-                    .is_some_and(is_moon_pkg_exist);
+                let moon_pkg_json_exist =
+                    std::fs::metadata(input)?.is_file() && is_moon_pkg_exist(&run_start_dir);
                 if !moon_pkg_json_exist {
                     return run_single_file_from_arg(cli, cmd);
                 }
@@ -197,12 +220,17 @@ fn run_run_rr(
     cmd: RunSubcommand,
     selected_target_backend: Option<TargetBackend>,
 ) -> Result<i32, anyhow::Error> {
+    let run_start_dir = resolve_run_start_dir(
+        cmd.package_or_mbt_file
+            .as_deref()
+            .expect("package run planning requires a positional input"),
+    )?;
     let PackageDirs {
         source_dir,
         target_dir,
         mooncakes_dir,
         project_manifest_path,
-    } = cli.source_tgt_dir.try_into_package_dirs()?;
+    } = cli.source_tgt_dir.package_dirs_from(&run_start_dir)?;
 
     let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
         cmd.auto_sync_flags.clone(),
@@ -288,31 +316,12 @@ fn get_run_cmd(build_meta: &rr_build::BuildMeta, argv: &[String]) -> tokio::proc
 #[instrument(level = Level::DEBUG, skip_all)]
 fn calc_user_intent(
     input_path: &str,
-    source_dir: &Path,
+    _source_dir: &Path,
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     value_tracing: bool,
     target_backend: TargetBackend,
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
-    // The legacy impl says the input path is based on `source_dir`, while
-    // if we want to match the behavior of other commands we need it to be based
-    // on current dir. We temporarily accept both behaviors here.
-    // TODO: Decide on one behavior and remove the other.
-    let (dir, _filename) = match crate::filter::canonicalize_with_filename(Path::new(input_path)) {
-        Ok((dir, filename)) => (dir, filename),
-        Err(e) => {
-            let backup_path = source_dir.join(input_path);
-            crate::filter::canonicalize_with_filename(&backup_path).map_err(|e2| {
-                anyhow::anyhow!(
-                    "Failed to canonicalize input path based on current working directory: {}\n\
-                    Also failed to canonicalize based on source directory `{}`: {}\n\
-                    Please make sure the path exists.",
-                    e,
-                    source_dir.display(),
-                    e2
-                )
-            })?
-        }
-    };
+    let (dir, _filename) = crate::filter::canonicalize_with_filename(Path::new(input_path))?;
     let pkg = crate::filter::filter_pkg_by_dir(resolve_output, &dir)?;
 
     // check whether it's a main package

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -36,7 +36,7 @@ use crate::user_diagnostics::UserDiagnostics;
 use super::{BuildFlags, UniversalFlags};
 
 /// Run a main package
-#[derive(Debug, clap::Parser)]
+#[derive(Debug, clap::Parser, Clone)]
 #[clap(group = clap::ArgGroup::new("run_source").required(true).multiple(false))]
 pub(crate) struct RunSubcommand {
     /// The package, .mbt/.mbtx file, or `-` to read `.mbtx` source from stdin

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -150,6 +150,11 @@ pub fn main() {
     for warning in flags.deprecation_warnings() {
         output.warn(warning);
     }
+    if flags.source_tgt_dir.manifest_path.is_some() && !matches!(cli.subcommand, Run(_)) {
+        output.warn(
+            "`--manifest-path` is deprecated. Prefer `-C <project-dir>` to select a different project.",
+        );
+    }
 
     use MoonBuildSubcommands::*;
     let res = match cli.subcommand {

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -195,9 +195,18 @@ impl PlanningFixture {
         cli: &UniversalFlags,
         cmd: &RunSubcommand,
     ) -> anyhow::Result<String> {
+        let mut cmd = cmd.clone();
+        if cmd.command.is_none()
+            && let Some(input) = cmd.package_or_mbt_file.as_deref()
+        {
+            let input_path = PathBuf::from(input);
+            if input_path.is_relative() {
+                cmd.package_or_mbt_file = Some(self.source_dir.join(input).display().to_string());
+            }
+        }
         let (build_meta, build_graph) = crate::cli::run::plan_run_rr_from_resolved(
             cli,
-            cmd,
+            &cmd,
             &self.source_dir,
             &self.target_dir,
             cmd.build_flags.resolve_single_target_backend()?,

--- a/crates/moon/tests/test_cases/filter_by_path/mod.rs
+++ b/crates/moon/tests/test_cases/filter_by_path/mod.rs
@@ -288,16 +288,38 @@ fn test_moon_run_filter_by_path_success() {
     "#]],
     );
 
-    // FIXME: `moon run` paths are based on project root, thus cwd-based
-    // paths like below are not supported yet.
-    //
-    // // Test run from inside package directory
-    // check(
-    //     get_stdout(&dir.join("main"), ["run", "."]),
-    //     expect![[r#"
-    //     Hello, world!
-    // "#]],
-    // );
+    // Test run from inside package directory
+    check(
+        get_stdout(&dir.join("main"), ["run", "."]),
+        expect![[r#"
+        Hello, world!
+    "#]],
+    );
+}
+
+#[test]
+fn test_moon_run_filter_by_path_from_outside_project() {
+    let dir = TestDir::new("test_filter/test_filter");
+
+    check(
+        get_stdout(
+            &std::env::temp_dir(),
+            ["run", dir.join("main").to_str().unwrap()],
+        ),
+        expect![[r#"
+        Hello, world!
+    "#]],
+    );
+
+    check(
+        get_stdout(
+            &std::env::temp_dir(),
+            ["run", dir.join("main/main.mbt").to_str().unwrap()],
+        ),
+        expect![[r#"
+        Hello, world!
+    "#]],
+    );
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -64,8 +64,6 @@ fn test_moon_help() {
             Common Options:
               -C <DIR>
                       Change to DIR before doing anything else (must appear before the subcommand). Relative paths in other options and arguments are interpreted relative to DIR. Example: `moon -C a run .` runs the same as invoking `moon run .` from within `a`
-                  --manifest-path <PATH>
-                      Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)
                   --target-dir <TARGET_DIR>
                       The target directory. Defaults to `<project-root>/_build`
               -q, --quiet
@@ -123,7 +121,6 @@ fn test_moon_explain_without_flags_shows_guidance() {
               -h, --help                            Print help
 
             Common Options:
-                  --manifest-path <PATH>     Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)
                   --target-dir <TARGET_DIR>  The target directory. Defaults to `<project-root>/_build`
               -q, --quiet                    Suppress output
               -v, --verbose                  Increase verbosity
@@ -483,6 +480,33 @@ fn test_moon_add_help_includes_no_update() {
 }
 
 #[test]
+fn test_manifest_path_deprecation_warning_for_non_run_commands() {
+    let dir = TestDir::new("moon_commands");
+    let stderr = get_stderr(
+        &dir,
+        ["check", "--manifest-path", "moon.mod.json", "--dry-run"],
+    );
+    assert!(
+        stderr.contains("`--manifest-path` is deprecated"),
+        "expected deprecation warning, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn test_run_rejects_manifest_path() {
+    let dir = TestDir::new("moon_commands");
+    let stderr = get_err_stderr(&dir, ["run", "--manifest-path", "moon.mod.json", "main1"]);
+    assert!(
+        stderr.contains("`--manifest-path` is no longer supported for `moon run`"),
+        "expected moon run manifest-path rejection, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Use `moon -C <project-dir> run ...` instead"),
+        "expected moon run manifest-path guidance, got:\n{stderr}"
+    );
+}
+
+#[test]
 #[ignore]
 #[cfg(unix)]
 fn test_bench4() {
@@ -492,9 +516,9 @@ fn test_bench4() {
         get_stdout(
             &dir,
             [
+                "-C",
+                "./bench4",
                 "run",
-                "--manifest-path",
-                "./bench4/moon.mod.json",
                 "--target-dir",
                 "./bench4/target",
                 "main",
@@ -508,9 +532,9 @@ fn test_bench4() {
     get_stdout(
         &dir,
         [
+            "-C",
+            "./bench4",
             "run",
-            "--manifest-path",
-            "./bench4/moon.mod.json",
             "--target-dir",
             "./bench4/target",
             "--trace",

--- a/crates/moon/tests/test_cases/moon_new/mod.rs
+++ b/crates/moon/tests/test_cases/moon_new/mod.rs
@@ -106,9 +106,9 @@ fn test_moon_new() {
         get_stdout(
             &dir,
             [
+                "-C",
+                "./hello",
                 "run",
-                "--manifest-path",
-                "./hello/moon.mod.json",
                 "--target-dir",
                 "./hello/target",
                 "cmd/main",

--- a/crates/moon/tests/test_cases/warns/mod.rs
+++ b/crates/moon/tests/test_cases/warns/mod.rs
@@ -167,6 +167,7 @@ fn test_warn_list_alerts() {
             ],
         ),
         expect![[r#"
+            Warning: `--manifest-path` is deprecated. Prefer `-C <project-dir>` to select a different project.
             Warning: [0014]
                ╭─[ $ROOT/a/main.mbt:2:3 ]
                │

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -965,7 +965,7 @@ fn test_manifest_path_can_disable_implicit_workspace_mode() {
         ["--manifest-path", "app/moon.mod.json", "build", "--dry-run"],
         [(MOON_NO_WORKSPACE, "1")],
     );
-    assert_workspace_disabled_without_module(&stderr);
+    assert_registry_resolution_failure(&stderr);
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -9,6 +9,10 @@ fn assert_requires_target_module(stderr: &str, command: &str) {
         )),
         "expected missing target module error, got:\n{stderr}"
     );
+    assert!(
+        stderr.contains(&format!("use `moon -C <member> {command} ...`")),
+        "expected -C guidance, got:\n{stderr}"
+    );
 }
 
 fn assert_registry_resolution_failure(stderr: &str) {
@@ -961,7 +965,7 @@ fn test_manifest_path_can_disable_implicit_workspace_mode() {
         ["--manifest-path", "app/moon.mod.json", "build", "--dry-run"],
         [(MOON_NO_WORKSPACE, "1")],
     );
-    assert_registry_resolution_failure(&stderr);
+    assert_workspace_disabled_without_module(&stderr);
 }
 
 #[test]

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -65,7 +65,12 @@ pub struct SourceTargetDirs {
     pub cwd: Option<PathBuf>,
 
     /// Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory).
-    #[arg(long = "manifest-path", global = true, value_name = "PATH")]
+    #[arg(
+        long = "manifest-path",
+        global = true,
+        value_name = "PATH",
+        hide = true
+    )]
     pub manifest_path: Option<PathBuf>,
 
     /// The target directory. Defaults to `<project-root>/_build`.
@@ -75,7 +80,21 @@ pub struct SourceTargetDirs {
 
 impl SourceTargetDirs {
     pub fn try_into_package_dirs(&self) -> Result<PackageDirs, PackageDirsError> {
-        let project = self.resolve_project_selection()?;
+        self.package_dirs_from(Self::current_dir()?)
+    }
+
+    pub fn package_dirs_from(
+        &self,
+        start_dir: impl AsRef<Path>,
+    ) -> Result<PackageDirs, PackageDirsError> {
+        let start_dir = dunce::canonicalize(start_dir.as_ref())
+            .context("failed to resolve source directory")
+            .map_err(PackageDirsError::from)?;
+        let project = if let Some(manifest_path) = &self.manifest_path {
+            Self::resolve_project_selection_from_manifest_path(manifest_path)?
+        } else {
+            self.resolve_project_selection_from(start_dir)?
+        };
         let target_dir = self.resolve_target_dir(&project.project_root)?;
 
         Ok(PackageDirs::from_source_and_target_with_manifest(
@@ -114,7 +133,13 @@ impl SourceTargetDirs {
             return Self::resolve_project_selection_from_manifest_path(manifest_path);
         }
 
-        let start_dir = Self::current_dir()?;
+        self.resolve_project_selection_from(Self::current_dir()?)
+    }
+
+    fn resolve_project_selection_from(
+        &self,
+        start_dir: PathBuf,
+    ) -> Result<ProjectSelection, PackageDirsError> {
         if disable_workspace_from_env() {
             return project_selection_with_workspace_disabled(start_dir);
         }
@@ -297,9 +322,8 @@ impl WorkspaceModuleDirs {
     pub fn require_module_dir(&self, command: &str) -> anyhow::Result<&PathBuf> {
         self.module_dir.as_ref().ok_or_else(|| {
             anyhow::anyhow!(
-                "`moon {command}` cannot infer a target module in workspace `{}`. Run it from a workspace member or pass `--manifest-path <member>/{}`.",
+                "`moon {command}` cannot infer a target module in workspace `{}`. Run it from a workspace member or use `moon -C <member> {command} ...`.",
                 self.project_root.display(),
-                MOON_MOD
             )
         })
     }

--- a/docs/dev/reference/workspace.md
+++ b/docs/dev/reference/workspace.md
@@ -95,8 +95,7 @@ the whole workspace. They can be run from:
 - the workspace root
 - a workspace member directory
 - a nested non-module directory under the workspace
-- `--manifest-path <member>/moon.mod.json`
-- `--manifest-path moon.work`
+- `-C <member>`
 
 They do not need an implicit default member.
 
@@ -147,7 +146,7 @@ context. In practice, that means:
 
 - running them directly at the workspace root is not supported
 - running them from a member directory is supported
-- passing `--manifest-path <member>/moon.mod.json` is supported
+- passing `-C <member>` is supported
 
 This is why `publish`, `package`, `doc`, and `prove` only work for one selected
 module at a time today. There is no "publish the whole workspace" or "generate
@@ -182,7 +181,7 @@ The current design supports:
 - workspace roots that contain only `moon.work`
 - workspace roots that also contain `moon.mod.json`
 - selecting a member module from inside the member directory
-- selecting a member module with `--manifest-path <member>/moon.mod.json`
+- selecting a member module with `-C <member>`
 - whole-workspace `build` / `check` / `test` / `fmt` / `info`
 - member-scoped `package` / `publish` / `doc` / `prove` while still using
   workspace-local dependency resolution
@@ -205,11 +204,7 @@ Those commands need a selected member and will fail at workspace root with the
 Project selection depends on:
 
 - the working directory after `-C`
-- `--manifest-path`
 - `MOON_NO_WORKSPACE`
-
-`--manifest-path` pins manifest resolution, but does not change the process
-working directory.
 
 ## `MOON_NO_WORKSPACE`
 
@@ -218,7 +213,6 @@ working directory.
 If it is set to a non-`0` value:
 
 - implicit workspace discovery is disabled
-- explicit `--manifest-path moon.work` is also disabled
 - commands behave as if workspace mode does not exist
 
 This is intentionally close to `GO_WORK=off` in Go.
@@ -232,14 +226,18 @@ The resulting behavior is:
 This applies even when:
 
 - `moon.work` and `moon.mod.json` are colocated at the same root
-- `--manifest-path` explicitly points to a workspace manifest
 
 So `MOON_NO_WORKSPACE` does not mean "disable only implicit promotion into a
 workspace". It disables workspace behavior completely.
 
-## Selection Without `--manifest-path`
+## Selection
 
-Without `--manifest-path`, Moon starts from the current directory after `-C`.
+Most commands start from the current directory after `-C`.
+
+`moon run` is the exception: it resolves its positional selector path first,
+then discovers the project from that selector location. That lets
+`moon run path/to/pkg` and `moon run path/to/file.mbt` work even when invoked
+outside the target project.
 
 The algorithm is:
 
@@ -256,45 +254,8 @@ The algorithm is:
    `moon.mod.json`.
 6. If neither exists, fail with "not in a Moon project".
 
-## Selection With `--manifest-path`
-
-`--manifest-path` accepts exactly:
-
-- `moon.mod.json`
-- `moon.work`
-
-The selected manifest path is canonicalized first.
-
-### `--manifest-path <...>/moon.mod.json`
-
-This means "start from this module".
-
-- if `MOON_NO_WORKSPACE` is enabled, the command stays in single-module mode
-- otherwise, Moon may still promote to an enclosing applicable workspace
-
-This is important: `--manifest-path moon.mod.json` does not mean "force
-single-module mode". It means "select this module as the starting point".
-
-If an enclosing workspace applies, the command keeps:
-
-- `project_manifest_path = workspace manifest`
-- `project_root = workspace root`
-- `module_dir = selected module`
-
-That is how member-scoped commands can act on one member while still using the
-workspace's local dependency graph.
-
-### `--manifest-path <...>/moon.work`
-
-This means "start from this workspace root", but only when workspace mode is
-enabled.
-
-If `MOON_NO_WORKSPACE` is enabled:
-
-- Moon ignores the workspace manifest
-- Moon falls back to the nearest ancestor `moon.mod.json`, if any
-- otherwise the command fails because workspace mode is disabled and no module
-  is available
+`--manifest-path` still exists as a deprecated compatibility flag for
+non-`run` commands, but the public recommendation is to use `-C` instead.
 
 ## How Moon Decides Whether A Workspace Applies
 
@@ -346,9 +307,9 @@ selection.
 | workspace root + `build` / `check` / `test` / `fmt` / `info` | operate on the whole workspace |
 | workspace root + `add` / `remove` / `tree` / `package` / `publish` / `doc` / `prove` | error: no target member can be inferred |
 | member directory + member-scoped command | target that member and keep workspace context |
-| `--manifest-path app/moon.mod.json` | start from `app`, then allow workspace promotion |
-| `--manifest-path app/moon.mod.json` + member-scoped command | act on `app`, but keep workspace-local deps/layout if a workspace applies |
-| `--manifest-path moon.work` | select the workspace manifest |
+| `-C app` | start from `app`, then allow workspace promotion |
+| `-C app` + member-scoped command | act on `app`, but keep workspace-local deps/layout if a workspace applies |
+| `moon run path/to/app` from outside the project | discover the project from `path/to/app` |
 | inside workspace member + `MOON_NO_WORKSPACE=1` | ignore the workspace and use the nearest ancestor `moon.mod.json` |
 | workspace root with no module + `MOON_NO_WORKSPACE=1` | error: workspace mode is disabled and no module is available |
 | `moon work sync` outside a workspace | error: requires `moon.work` |


### PR DESCRIPTION
## Summary
- make `moon run` resolve project/workspace context from the selector path instead of the current directory
- reject `--manifest-path` for `moon run`, warn that it is deprecated for other commands, and steer users to `-C`
- update tests and workspace docs to reflect the new public model

## Testing
- cargo fmt --check
- cargo test -p moon filter_by_path
- cargo test -p moon moon_commands
- cargo test -p moon workspace_basic
