### PR TITLE
[codex] Add MOON_WORK workspace selection

### DIFF
--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -155,6 +155,9 @@ pub fn main() {
             "`--manifest-path` is deprecated. Prefer `-C <project-dir>` to select a different project.",
         );
     }
+    if let Some(warning) = moonutil::dirs::workspace_env_deprecation_warning() {
+        output.warn(warning);
+    }
 
     use MoonBuildSubcommands::*;
     let res = match cli.subcommand {

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -28,7 +28,7 @@ use moonutil::{
         BUILD_DIR, CargoPathExt, MBTI_GENERATED, MOON_BIN_DIR, MOON_MOD_JSON, StringExt,
         TargetBackend, get_cargo_pkg_version,
     },
-    dirs::{MOON_NO_WORKSPACE, PackageDirs},
+    dirs::{MOON_NO_WORKSPACE, MOON_WORK_ENV, PackageDirs},
     module::MoonModJSON,
 };
 use walkdir::WalkDir;
@@ -2882,6 +2882,7 @@ fn test_single_file_commands_work_with_workspace_disabled() {
     check(
         String::from_utf8(check_result).unwrap(),
         expect![[r#"
+            Warning: `MOON_NO_WORKSPACE` is deprecated. Use `MOON_WORK=off` to disable workspace mode.
             Finished. moon: ran 2 tasks, now up to date
         "#]],
     );
@@ -2895,6 +2896,13 @@ fn test_single_file_commands_work_with_workspace_disabled() {
 
     check(
         get_stdout_with_envs(&dir, ["run", "hello.mbt"], [(MOON_NO_WORKSPACE, "1")]),
+        expect![[r#"
+            hello
+        "#]],
+    );
+
+    check(
+        get_stdout_with_envs(&dir, ["run", "hello.mbt"], [(MOON_WORK_ENV, "off")]),
         expect![[r#"
             hello
         "#]],

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -1063,10 +1063,10 @@ fn test_pinned_workspace_path_builds_from_outside_workspace() {
 }
 
 #[test]
-fn test_pinned_workspace_path_ignores_unlisted_outer_module() {
+fn test_pinned_workspace_path_rejects_unlisted_outer_module() {
     let dir = nested_workspace_under_unrelated_module_dir();
 
-    let stdout = get_stdout_with_envs(
+    let stderr = get_err_stderr_with_envs(
         &dir,
         ["-C", "outer", "build", "--dry-run"],
         [(
@@ -1078,12 +1078,10 @@ fn test_pinned_workspace_path_ignores_unlisted_outer_module() {
     );
 
     assert!(
-        stdout.contains("alice/app/main"),
-        "expected pinned workspace to build the listed workspace member, got:\n{stdout}"
-    );
-    assert!(
-        !stdout.contains("alice/outer/outer"),
-        "expected pinned workspace to ignore the unlisted outer module, got:\n{stdout}"
+        stderr.contains(
+            "pinned workspace `$ROOT/outer/ws/moon.work` from MOON_WORK does not apply to module `$ROOT/outer`"
+        ),
+        "expected pinned workspace membership error, got:\n{stderr}"
     );
 }
 
@@ -1117,6 +1115,50 @@ fn test_pinned_workspace_path_accepts_nested_workspace_root() {
 }
 
 #[test]
+fn test_pinned_workspace_path_reuses_nested_workspace_root_for_work_use() {
+    let dir = nested_workspace_under_unrelated_module_dir();
+
+    check(
+        get_stdout_with_envs(
+            &dir,
+            ["-C", "outer/ws", "work", "use", "./app"],
+            [(
+                MOON_WORK_ENV,
+                dir.join("outer/ws/moon.work")
+                    .to_string_lossy()
+                    .into_owned(),
+            )],
+        ),
+        expect![[r#"
+            moon.work is already up to date
+        "#]],
+    );
+}
+
+#[test]
+fn test_pinned_workspace_path_rejects_work_use_from_unlisted_outer_module() {
+    let dir = nested_workspace_under_unrelated_module_dir();
+
+    let stderr = get_err_stderr_with_envs(
+        &dir,
+        ["-C", "outer", "work", "use", "ws/app"],
+        [(
+            MOON_WORK_ENV,
+            dir.join("outer/ws/moon.work")
+                .to_string_lossy()
+                .into_owned(),
+        )],
+    );
+
+    assert!(
+        stderr.contains(
+            "pinned workspace `$ROOT/outer/ws/moon.work` from MOON_WORK does not apply to module `$ROOT/outer`"
+        ),
+        "expected pinned workspace membership error, got:\n{stderr}"
+    );
+}
+
+#[test]
 fn test_pinned_workspace_path_selects_outer_module_when_listed() {
     let dir = nested_workspace_under_unrelated_module_dir();
     write_file(
@@ -1146,6 +1188,29 @@ preferred_target = "wasm-gc"
     assert!(
         !stdout.contains("alice/app/main"),
         "expected pinned workspace root to avoid unlisted app module, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_pinned_workspace_path_rejects_unlisted_manifest_path_module() {
+    let dir = nested_workspace_under_unrelated_module_dir();
+
+    let stderr = get_err_stderr_with_envs(
+        &dir,
+        ["--manifest-path", "outer/moon.mod.json", "tree"],
+        [(
+            MOON_WORK_ENV,
+            dir.join("outer/ws/moon.work")
+                .to_string_lossy()
+                .into_owned(),
+        )],
+    );
+
+    assert!(
+        stderr.contains(
+            "pinned workspace `$ROOT/outer/ws/moon.work` from MOON_WORK does not apply to module `$ROOT/outer`"
+        ),
+        "expected pinned workspace membership error, got:\n{stderr}"
     );
 }
 

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -1,5 +1,8 @@
 use super::*;
-use moonutil::{common::MBTI_GENERATED, dirs::MOON_NO_WORKSPACE};
+use moonutil::{
+    common::MBTI_GENERATED,
+    dirs::{MOON_NO_WORKSPACE, MOON_WORK_ENV},
+};
 use std::path::Path;
 
 fn assert_requires_target_module(stderr: &str, command: &str) {
@@ -25,7 +28,7 @@ fn assert_registry_resolution_failure(stderr: &str) {
 
 fn assert_workspace_disabled_without_module(stderr: &str) {
     assert!(
-        stderr.contains("workspace mode is disabled by MOON_NO_WORKSPACE"),
+        stderr.contains("workspace mode is disabled by MOON_WORK=off"),
         "expected workspace-disabled error, got:\n{stderr}"
     );
 }
@@ -795,7 +798,7 @@ fn test_member_dir_can_disable_implicit_workspace_mode() {
     let stderr = get_err_stderr_with_envs(
         &dir,
         ["-C", "app", "build", "--dry-run"],
-        [(MOON_NO_WORKSPACE, "1")],
+        [(MOON_WORK_ENV, "off")],
     );
     assert_registry_resolution_failure(&stderr);
 }
@@ -963,7 +966,7 @@ fn test_manifest_path_can_disable_implicit_workspace_mode() {
     let stderr = get_err_stderr_with_envs(
         &dir,
         ["--manifest-path", "app/moon.mod.json", "build", "--dry-run"],
-        [(MOON_NO_WORKSPACE, "1")],
+        [(MOON_WORK_ENV, "off")],
     );
     assert_registry_resolution_failure(&stderr);
 }
@@ -975,7 +978,7 @@ fn test_workspace_root_cannot_use_workspace_with_env_override() {
     let stderr = get_err_stderr_with_envs(
         &dir,
         ["build", "--dry-run", "--sort-input"],
-        [(MOON_NO_WORKSPACE, "1")],
+        [(MOON_WORK_ENV, "off")],
     );
     assert_workspace_disabled_without_module(&stderr);
 }
@@ -984,7 +987,7 @@ fn test_workspace_root_cannot_use_workspace_with_env_override() {
 fn test_same_root_module_can_disable_implicit_workspace_mode() {
     let dir = same_root_workspace_dir();
 
-    let stderr = get_err_stderr_with_envs(&dir, ["build", "--dry-run"], [(MOON_NO_WORKSPACE, "1")]);
+    let stderr = get_err_stderr_with_envs(&dir, ["build", "--dry-run"], [(MOON_WORK_ENV, "off")]);
     assert_registry_resolution_failure(&stderr);
 }
 
@@ -995,7 +998,7 @@ fn test_same_root_manifest_path_can_disable_implicit_workspace_mode() {
     let stderr = get_err_stderr_with_envs(
         &dir,
         ["--manifest-path", "moon.mod.json", "build", "--dry-run"],
-        [(MOON_NO_WORKSPACE, "1")],
+        [(MOON_WORK_ENV, "off")],
     );
     assert_registry_resolution_failure(&stderr);
 }
@@ -1013,7 +1016,7 @@ fn test_same_root_workspace_manifest_can_disable_workspace_mode_with_env_overrid
             "--dry-run",
             "--sort-input",
         ],
-        [(MOON_NO_WORKSPACE, "1")],
+        [(MOON_WORK_ENV, "off")],
     );
     assert_registry_resolution_failure(&stderr);
 }
@@ -1031,9 +1034,166 @@ fn test_workspace_manifest_path_cannot_use_workspace_with_env_override() {
             "--dry-run",
             "--sort-input",
         ],
-        [(MOON_NO_WORKSPACE, "1")],
+        [(MOON_WORK_ENV, "off")],
     );
     assert_workspace_disabled_without_module(&stderr);
+}
+
+#[test]
+fn test_pinned_workspace_path_builds_from_outside_workspace() {
+    let dir = TestDir::new("workspace_basic.in");
+
+    let stdout = get_stdout_with_envs(
+        &dir.join(".."),
+        ["build", "--dry-run", "--sort-input"],
+        [(
+            MOON_WORK_ENV,
+            dir.join("moon.work").to_string_lossy().into_owned(),
+        )],
+    );
+
+    assert!(
+        stdout.contains("alice/app/main"),
+        "expected pinned workspace build to select workspace members, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("-workspace-path ./app"),
+        "expected pinned workspace build to keep workspace layout, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_pinned_workspace_path_ignores_unlisted_outer_module() {
+    let dir = nested_workspace_under_unrelated_module_dir();
+
+    let stdout = get_stdout_with_envs(
+        &dir,
+        ["-C", "outer", "build", "--dry-run"],
+        [(
+            MOON_WORK_ENV,
+            dir.join("outer/ws/moon.work")
+                .to_string_lossy()
+                .into_owned(),
+        )],
+    );
+
+    assert!(
+        stdout.contains("alice/app/main"),
+        "expected pinned workspace to build the listed workspace member, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("alice/outer/outer"),
+        "expected pinned workspace to ignore the unlisted outer module, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_pinned_workspace_path_accepts_nested_workspace_root() {
+    let dir = nested_workspace_under_unrelated_module_dir();
+
+    let stdout = get_stdout_with_envs(
+        &dir,
+        ["-C", "outer/ws", "build", "--dry-run", "--sort-input"],
+        [(
+            MOON_WORK_ENV,
+            dir.join("outer/ws/moon.work")
+                .to_string_lossy()
+                .into_owned(),
+        )],
+    );
+
+    assert!(
+        stdout.contains("alice/app/main"),
+        "expected pinned workspace root to build the pinned workspace, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("-workspace-path ./app"),
+        "expected pinned workspace root to keep workspace-aware package layout, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("alice/outer/outer"),
+        "expected pinned workspace root to ignore the unrelated outer module, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_pinned_workspace_path_selects_outer_module_when_listed() {
+    let dir = nested_workspace_under_unrelated_module_dir();
+    write_file(
+        &dir.join("outer/ws/moon.work"),
+        r#"members = [
+  "../",
+]
+preferred_target = "wasm-gc"
+"#,
+    );
+
+    let stdout = get_stdout_with_envs(
+        &dir,
+        ["-C", "outer/ws", "build", "--dry-run", "--sort-input"],
+        [(
+            MOON_WORK_ENV,
+            dir.join("outer/ws/moon.work")
+                .to_string_lossy()
+                .into_owned(),
+        )],
+    );
+
+    assert!(
+        stdout.contains("alice/outer/outer"),
+        "expected pinned workspace root to select the listed outer module, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("alice/app/main"),
+        "expected pinned workspace root to avoid unlisted app module, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_legacy_workspace_disable_env_warns_and_still_works() {
+    let dir = TestDir::new("workspace_basic.in");
+
+    let stderr = get_err_stderr_with_envs(
+        &dir,
+        ["build", "--dry-run", "--sort-input"],
+        [(MOON_NO_WORKSPACE, "1")],
+    );
+
+    assert!(
+        stderr.contains(
+            "`MOON_NO_WORKSPACE` is deprecated. Use `MOON_WORK=off` to disable workspace mode."
+        ),
+        "expected deprecation warning, got:\n{stderr}"
+    );
+    assert_workspace_disabled_without_module(&stderr);
+}
+
+#[test]
+fn test_moon_work_wins_over_legacy_workspace_disable_env() {
+    let dir = TestDir::new("workspace_basic.in");
+
+    let stdout = get_stdout_with_envs(
+        &dir,
+        ["build", "--dry-run", "--sort-input"],
+        [(MOON_WORK_ENV, "auto"), (MOON_NO_WORKSPACE, "1")],
+    );
+
+    assert!(
+        stdout.contains("alice/app/main"),
+        "expected MOON_WORK to override deprecated env, got:\n{stdout}"
+    );
+
+    let stderr = get_stderr_without_replace(
+        &dir,
+        ["build", "--dry-run", "--sort-input"],
+        [(MOON_WORK_ENV, "auto"), (MOON_NO_WORKSPACE, "1")],
+    );
+    let stderr = replace_dir(&stderr, &dir);
+    assert!(
+        stderr
+            .contains("`MOON_NO_WORKSPACE` is deprecated and ignored because `MOON_WORK` is set."),
+        "expected precedence warning, got:\n{stderr}"
+    );
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -158,6 +158,26 @@ preferred_target = "wasm-gc"
     dir
 }
 
+fn add_unlisted_nested_workspace_module(dir: &TestDir) {
+    write_file(
+        &dir.join("outer/ws/tools/moon.mod.json"),
+        r#"{
+  "name": "alice/tools",
+  "version": "0.1.0",
+  "source": "src"
+}
+"#,
+    );
+    write_file(&dir.join("outer/ws/tools/src/tool/moon.pkg.json"), "{}\n");
+    write_file(
+        &dir.join("outer/ws/tools/src/tool/tool.mbt"),
+        r#"pub fn tool() -> Int {
+  0
+}
+"#,
+    );
+}
+
 fn empty_workspace_dir() -> TestDir {
     let dir = TestDir::new_empty();
     write_file(&dir.join("moon.work"), "members = []\n");
@@ -1132,6 +1152,30 @@ fn test_pinned_workspace_path_reuses_nested_workspace_root_for_work_use() {
         expect![[r#"
             moon.work is already up to date
         "#]],
+    );
+}
+
+#[test]
+fn test_pinned_workspace_path_rejects_unlisted_module_under_workspace_root() {
+    let dir = nested_workspace_under_unrelated_module_dir();
+    add_unlisted_nested_workspace_module(&dir);
+
+    let stderr = get_err_stderr_with_envs(
+        &dir,
+        ["-C", "outer/ws/tools", "build", "--dry-run"],
+        [(
+            MOON_WORK_ENV,
+            dir.join("outer/ws/moon.work")
+                .to_string_lossy()
+                .into_owned(),
+        )],
+    );
+
+    assert!(
+        stderr.contains(
+            "pinned workspace `$ROOT/outer/ws/moon.work` from MOON_WORK does not apply to module `$ROOT/outer/ws/tools`"
+        ),
+        "expected pinned workspace membership error, got:\n{stderr}"
     );
 }
 

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -24,7 +24,7 @@ use anyhow::Context;
 use indexmap::IndexMap;
 use moonutil::{
     common::{MOON_WORK, MbtMdHeader, MoonbuildOpt, MooncOpt, read_module_desc_file_in_dir},
-    dirs::{MOON_NO_WORKSPACE, find_ancestor_with_work},
+    dirs::{WorkspaceEnv, current_workspace_env, find_ancestor_with_work},
     module::MoonMod,
     mooncakes::{
         DirSyncResult, ModuleSource,
@@ -47,7 +47,7 @@ pub fn auto_sync(
     no_std: bool,
     project_manifest_path: Option<&Path>,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult, Option<MoonWork>)> {
-    let disable_workspace = disable_workspace_from_env();
+    let workspace_env = current_workspace_env()?;
     if let Some(project_manifest_path) = project_manifest_path {
         let manifest_dir = project_manifest_path
             .parent()
@@ -67,70 +67,36 @@ pub fn auto_sync(
             .file_name()
             .and_then(|name| name.to_str())
             == Some(MOON_WORK)
-            && !disable_workspace
+            && !matches!(workspace_env, WorkspaceEnv::Off)
         {
-            let workspace_root = manifest_dir.as_path();
-            let workspace = read_workspace_file(project_manifest_path)?;
-            let mut roots = ResolvedRootModules::with_key();
-            for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {
-                let module = Arc::new(read_module_desc_file_in_dir(&member_dir)?);
-                let source = ModuleSource::from_local_module(&module, &member_dir);
-                roots.insert(ResolvedModule::new(source, module));
-            }
-
-            let (resolved_env, sync_result) = super::install::install_impl(
+            return resolve_workspace_sync(
                 mooncakes_dir,
-                roots,
+                cli,
                 quiet,
-                false,
-                cli.dont_sync(),
                 no_std,
-            )?;
-            log::debug!("Dir sync result: {:?}", sync_result);
-            return Ok((resolved_env, sync_result, Some(workspace)));
-        } else if !disable_workspace
+                manifest_dir.as_path(),
+                read_workspace_file(project_manifest_path)?,
+            );
+        } else if !matches!(workspace_env, WorkspaceEnv::Off)
             && let Some(workspace_root) = find_ancestor_with_work(&manifest_dir)?
         {
             let workspace = read_workspace(&workspace_root)?.context(format!(
                 "failed to parse workspace file under `{}`",
                 workspace_root.display()
             ))?;
-            let mut roots = ResolvedRootModules::with_key();
-            for member_dir in canonical_workspace_module_dirs(&workspace_root, &workspace)? {
-                let module = Arc::new(read_module_desc_file_in_dir(&member_dir)?);
-                let source = ModuleSource::from_local_module(&module, &member_dir);
-                roots.insert(ResolvedModule::new(source, module));
-            }
-
-            let (resolved_env, sync_result) = super::install::install_impl(
+            return resolve_workspace_sync(
                 mooncakes_dir,
-                roots,
+                cli,
                 quiet,
-                false,
-                cli.dont_sync(),
                 no_std,
-            )?;
-            log::debug!("Dir sync result: {:?}", sync_result);
-            return Ok((resolved_env, sync_result, Some(workspace)));
+                &workspace_root,
+                workspace,
+            );
         }
-    } else if !disable_workspace && let Some(workspace) = read_workspace(source_dir)? {
-        let mut roots = ResolvedRootModules::with_key();
-        for member_dir in canonical_workspace_module_dirs(source_dir, &workspace)? {
-            let module = Arc::new(read_module_desc_file_in_dir(&member_dir)?);
-            let source = ModuleSource::from_local_module(&module, &member_dir);
-            roots.insert(ResolvedModule::new(source, module));
-        }
-
-        let (resolved_env, sync_result) = super::install::install_impl(
-            mooncakes_dir,
-            roots,
-            quiet,
-            false,
-            cli.dont_sync(),
-            no_std,
-        )?;
-        log::debug!("Dir sync result: {:?}", sync_result);
-        return Ok((resolved_env, sync_result, Some(workspace)));
+    } else if !matches!(workspace_env, WorkspaceEnv::Off)
+        && let Some(workspace) = read_workspace(source_dir)?
+    {
+        return resolve_workspace_sync(mooncakes_dir, cli, quiet, no_std, source_dir, workspace);
     }
 
     let module = Arc::new(read_module_desc_file_in_dir(source_dir)?);
@@ -143,12 +109,25 @@ pub fn auto_sync(
     Ok((resolved_env, sync_result, None))
 }
 
-fn disable_workspace_from_env() -> bool {
-    match std::env::var(MOON_NO_WORKSPACE) {
-        Ok(value) => value != "0",
-        Err(std::env::VarError::NotPresent) => false,
-        Err(std::env::VarError::NotUnicode(_)) => true,
+fn resolve_workspace_sync(
+    mooncakes_dir: &Path,
+    cli: &AutoSyncFlags,
+    quiet: bool,
+    no_std: bool,
+    workspace_root: &Path,
+    workspace: MoonWork,
+) -> anyhow::Result<(ResolvedEnv, DirSyncResult, Option<MoonWork>)> {
+    let mut roots = ResolvedRootModules::with_key();
+    for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {
+        let module = Arc::new(read_module_desc_file_in_dir(&member_dir)?);
+        let source = ModuleSource::from_local_module(&module, &member_dir);
+        roots.insert(ResolvedModule::new(source, module));
     }
+
+    let (resolved_env, sync_result) =
+        super::install::install_impl(mooncakes_dir, roots, quiet, false, cli.dont_sync(), no_std)?;
+    log::debug!("Dir sync result: {:?}", sync_result);
+    Ok((resolved_env, sync_result, Some(workspace)))
 }
 
 pub fn auto_sync_for_single_mbt_md(

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -344,20 +344,27 @@ pub fn find_ancestor_with_work(source_dir: &Path) -> anyhow::Result<Option<PathB
             .transpose(),
         WorkspaceEnv::Pinned(workspace_path) => {
             let workspace_root = manifest_root(&workspace_path)?;
+            if source_dir.starts_with(&workspace_root) {
+                return Ok(Some(workspace_root));
+            }
+
             let workspace = read_workspace_file(&workspace_path)?;
             let member_dirs = canonical_workspace_module_dirs(&workspace_root, &workspace)?;
-            if let Some(module_dir) = find_ancestor_with_mod(source_dir)
-                && !member_dirs
-                    .iter()
-                    .any(|member_dir| member_dir == &module_dir)
+            let Some(module_dir) = find_ancestor_with_mod(source_dir) else {
+                return Ok(Some(workspace_root));
+            };
+            if member_dirs
+                .iter()
+                .any(|member_dir| member_dir == &module_dir)
             {
-                return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
+                Ok(Some(workspace_root))
+            } else {
+                Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
                     workspace: workspace_path.to_path_buf(),
                     module: module_dir,
                 }
-                .into());
+                .into())
             }
-            Ok(Some(manifest_root(&workspace_path)?))
         }
     }
 }
@@ -402,12 +409,32 @@ fn resolve_project_selection_from_start_dir(
             let workspace = read_workspace_file(workspace_path).map_err(PackageDirsError::from)?;
             let member_dirs = canonical_workspace_module_dirs(&project_root, &workspace)
                 .map_err(PackageDirsError::from)?;
-            let module_dir = find_ancestor_with_mod(&start_dir).filter(|module_dir| {
-                member_dirs
+            let module_dir = if start_dir.starts_with(&project_root) {
+                find_ancestor_with_mod(&start_dir).filter(|module_dir| {
+                    member_dirs
+                        .iter()
+                        .any(|member_dir| member_dir == module_dir)
+                })
+            } else if let Some(module_dir) = find_ancestor_with_mod(&start_dir) {
+                if member_dirs
                     .iter()
-                    .any(|member_dir| member_dir == module_dir)
-            });
-            project_selection_from_pinned_workspace(workspace_path, module_dir)
+                    .any(|member_dir| member_dir == &module_dir)
+                {
+                    Some(module_dir)
+                } else {
+                    return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
+                        workspace: workspace_path.to_path_buf(),
+                        module: module_dir,
+                    });
+                }
+            } else {
+                None
+            };
+            Ok(ProjectSelection {
+                project_root,
+                module_dir,
+                project_manifest_path: workspace_path.to_path_buf(),
+            })
         }
         WorkspaceEnv::Auto => {
             let module_dir = find_ancestor_with_mod(&start_dir);
@@ -443,6 +470,20 @@ fn project_selection_from_pinned_workspace(
     module_dir: Option<PathBuf>,
 ) -> Result<ProjectSelection, PackageDirsError> {
     let project_root = manifest_root(workspace_path).map_err(PackageDirsError::from)?;
+    let workspace = read_workspace_file(workspace_path).map_err(PackageDirsError::from)?;
+    let member_dirs = canonical_workspace_module_dirs(&project_root, &workspace)
+        .map_err(PackageDirsError::from)?;
+    if let Some(module_dir) = &module_dir
+        && !member_dirs
+            .iter()
+            .any(|member_dir| member_dir == module_dir)
+    {
+        return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
+            workspace: workspace_path.to_path_buf(),
+            module: module_dir.to_path_buf(),
+        });
+    }
+
     Ok(ProjectSelection {
         project_root,
         module_dir,

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -469,7 +469,7 @@ fn resolve_project_selection_from_start_dir(
             }
 
             if let Some(module_dir) = module_dir {
-                let project_manifest_path = module_dir.join(MOON_MOD_JSON);
+                let project_manifest_path = module_manifest_path(&module_dir);
                 return Ok(ProjectSelection {
                     project_root: module_dir.clone(),
                     module_dir: Some(module_dir),
@@ -651,9 +651,15 @@ pub fn resolve_manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{PackageDirs, WorkspaceEnv, parse_workspace_env};
-    use crate::common::DEP_PATH;
-    use std::{ffi::OsString, path::PathBuf};
+    use super::{
+        PackageDirs, WorkspaceEnv, parse_workspace_env, resolve_project_selection_from_start_dir,
+    };
+    use crate::common::{DEP_PATH, MOON_MOD};
+    use std::{
+        ffi::OsString,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     #[test]
     fn mooncakes_dir_tracks_project_root() {
@@ -670,6 +676,33 @@ mod tests {
         let target = PathBuf::from("tmp-target");
         let dirs = PackageDirs::from_source_and_target(project.clone(), target);
         assert_eq!(dirs.mooncakes_dir, project.join(DEP_PATH));
+    }
+
+    #[test]
+    fn auto_selection_preserves_dsl_module_manifest_path() {
+        let test_root = std::env::temp_dir().join(format!(
+            "moonutil-dirs-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&test_root).unwrap();
+        std::fs::write(
+            test_root.join(MOON_MOD),
+            r#"name = "alice/app"
+
+version = "0.1.0"
+"#,
+        )
+        .unwrap();
+
+        let project =
+            resolve_project_selection_from_start_dir(test_root.clone(), &WorkspaceEnv::Auto)
+                .unwrap();
+        assert_eq!(project.project_manifest_path, test_root.join(MOON_MOD));
+
+        std::fs::remove_dir_all(test_root).unwrap();
     }
 
     #[test]

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -16,7 +16,10 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
@@ -29,6 +32,14 @@ use crate::workspace::{
 
 /// Set to a non-`0` value to disable workspace mode entirely.
 pub const MOON_NO_WORKSPACE: &str = "MOON_NO_WORKSPACE";
+pub const MOON_WORK_ENV: &str = "MOON_WORK";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceEnv {
+    Auto,
+    Off,
+    Pinned(PathBuf),
+}
 
 #[derive(Debug, Error)]
 pub enum PackageDirsError {
@@ -37,9 +48,11 @@ pub enum PackageDirsError {
     )]
     NotInProject(PathBuf),
     #[error(
-        "not in a Moon module (workspace mode is disabled by MOON_NO_WORKSPACE and no moon.mod or moon.mod.json was found starting from {0} or its ancestors)"
+        "not in a Moon module (workspace mode is disabled by MOON_WORK=off and no moon.mod or moon.mod.json was found starting from {0} or its ancestors)"
     )]
     WorkspaceDisabledNotInModule(PathBuf),
+    #[error("pinned workspace `{workspace}` from MOON_WORK does not apply to module `{module}`")]
+    PinnedWorkspaceDoesNotApply { workspace: PathBuf, module: PathBuf },
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -90,10 +103,11 @@ impl SourceTargetDirs {
         let start_dir = dunce::canonicalize(start_dir.as_ref())
             .context("failed to resolve source directory")
             .map_err(PackageDirsError::from)?;
+        let workspace_env = current_workspace_env().map_err(PackageDirsError::from)?;
         let project = if let Some(manifest_path) = &self.manifest_path {
-            Self::resolve_project_selection_from_manifest_path(manifest_path)?
+            Self::resolve_project_selection_from_manifest_path(manifest_path, &workspace_env)?
         } else {
-            self.resolve_project_selection_from(start_dir)?
+            resolve_project_selection_from_start_dir(start_dir, &workspace_env)?
         };
         let target_dir = self.resolve_target_dir(&project.project_root)?;
 
@@ -129,49 +143,21 @@ impl SourceTargetDirs {
     }
 
     fn resolve_project_selection(&self) -> Result<ProjectSelection, PackageDirsError> {
+        let workspace_env = current_workspace_env().map_err(PackageDirsError::from)?;
         if let Some(manifest_path) = &self.manifest_path {
-            return Self::resolve_project_selection_from_manifest_path(manifest_path);
+            return Self::resolve_project_selection_from_manifest_path(
+                manifest_path,
+                &workspace_env,
+            );
         }
 
-        self.resolve_project_selection_from(Self::current_dir()?)
-    }
-
-    fn resolve_project_selection_from(
-        &self,
-        start_dir: PathBuf,
-    ) -> Result<ProjectSelection, PackageDirsError> {
-        if disable_workspace_from_env() {
-            return project_selection_with_workspace_disabled(start_dir);
-        }
-
-        let module_dir = find_ancestor_with_mod(&start_dir);
-
-        if let Some(project_manifest_path) =
-            find_applicable_workspace_manifest_path(&start_dir).map_err(PackageDirsError::from)?
-        {
-            let project_root =
-                manifest_root(&project_manifest_path).map_err(PackageDirsError::from)?;
-            return Ok(ProjectSelection {
-                project_root,
-                module_dir,
-                project_manifest_path,
-            });
-        }
-
-        if let Some(module_dir) = module_dir {
-            let project_manifest_path = module_manifest_path(&module_dir);
-            return Ok(ProjectSelection {
-                project_root: module_dir.clone(),
-                module_dir: Some(module_dir),
-                project_manifest_path,
-            });
-        }
-
-        Err(PackageDirsError::NotInProject(start_dir))
+        let start_dir = Self::current_dir()?;
+        resolve_project_selection_from_start_dir(start_dir, &workspace_env)
     }
 
     fn resolve_project_selection_from_manifest_path(
         manifest_path: &Path,
+        workspace_env: &WorkspaceEnv,
     ) -> Result<ProjectSelection, PackageDirsError> {
         let manifest_path = dunce::canonicalize(manifest_path)
             .with_context(|| {
@@ -199,7 +185,7 @@ impl SourceTargetDirs {
             .map(Path::to_path_buf)
             .map_err(PackageDirsError::from)?;
 
-        if disable_workspace_from_env() {
+        if matches!(workspace_env, WorkspaceEnv::Off) {
             return match file_name {
                 Some(MOON_MOD | MOON_MOD_JSON) => Ok(ProjectSelection {
                     project_root: manifest_dir.clone(),
@@ -218,26 +204,32 @@ impl SourceTargetDirs {
         }
 
         match file_name {
-            Some(MOON_MOD | MOON_MOD_JSON) => {
-                if let Some(project_manifest_path) =
-                    find_applicable_workspace_manifest_path(&manifest_dir)
-                        .map_err(PackageDirsError::from)?
-                {
-                    let project_root =
-                        manifest_root(&project_manifest_path).map_err(PackageDirsError::from)?;
-                    Ok(ProjectSelection {
-                        project_root,
-                        module_dir: Some(manifest_dir),
-                        project_manifest_path,
-                    })
-                } else {
-                    Ok(ProjectSelection {
-                        project_root: manifest_dir.clone(),
-                        module_dir: Some(manifest_dir),
-                        project_manifest_path: manifest_path,
-                    })
+            Some(MOON_MOD | MOON_MOD_JSON) => match workspace_env {
+                WorkspaceEnv::Pinned(workspace_path) => {
+                    project_selection_from_pinned_workspace(workspace_path, Some(manifest_dir))
                 }
-            }
+                WorkspaceEnv::Auto => {
+                    if let Some(project_manifest_path) =
+                        find_applicable_workspace_manifest_path(&manifest_dir)
+                            .map_err(PackageDirsError::from)?
+                    {
+                        let project_root = manifest_root(&project_manifest_path)
+                            .map_err(PackageDirsError::from)?;
+                        Ok(ProjectSelection {
+                            project_root,
+                            module_dir: Some(manifest_dir),
+                            project_manifest_path,
+                        })
+                    } else {
+                        Ok(ProjectSelection {
+                            project_root: manifest_dir.clone(),
+                            module_dir: Some(manifest_dir),
+                            project_manifest_path: manifest_path,
+                        })
+                    }
+                }
+                WorkspaceEnv::Off => unreachable!("handled above"),
+            },
             Some(MOON_WORK) => Ok(ProjectSelection {
                 project_root: manifest_dir,
                 module_dir: None,
@@ -345,20 +337,28 @@ pub fn find_ancestor_with_mod(source_dir: &Path) -> Option<PathBuf> {
 }
 
 pub fn find_ancestor_with_work(source_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
-    if disable_workspace_from_env() {
-        return Ok(None);
-    }
-
-    find_applicable_workspace_manifest_path(source_dir)?
-        .map(|path| manifest_root(&path))
-        .transpose()
-}
-
-fn disable_workspace_from_env() -> bool {
-    match std::env::var(MOON_NO_WORKSPACE) {
-        Ok(value) => value != "0",
-        Err(std::env::VarError::NotPresent) => false,
-        Err(std::env::VarError::NotUnicode(_)) => true,
+    match current_workspace_env()? {
+        WorkspaceEnv::Off => Ok(None),
+        WorkspaceEnv::Auto => find_applicable_workspace_manifest_path(source_dir)?
+            .map(|path| manifest_root(&path))
+            .transpose(),
+        WorkspaceEnv::Pinned(workspace_path) => {
+            let workspace_root = manifest_root(&workspace_path)?;
+            let workspace = read_workspace_file(&workspace_path)?;
+            let member_dirs = canonical_workspace_module_dirs(&workspace_root, &workspace)?;
+            if let Some(module_dir) = find_ancestor_with_mod(source_dir)
+                && !member_dirs
+                    .iter()
+                    .any(|member_dir| member_dir == &module_dir)
+            {
+                return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
+                    workspace: workspace_path.to_path_buf(),
+                    module: module_dir,
+                }
+                .into());
+            }
+            Ok(Some(manifest_root(&workspace_path)?))
+        }
     }
 }
 
@@ -391,6 +391,135 @@ fn module_manifest_path(module_dir: &Path) -> PathBuf {
     }
 }
 
+fn resolve_project_selection_from_start_dir(
+    start_dir: PathBuf,
+    workspace_env: &WorkspaceEnv,
+) -> Result<ProjectSelection, PackageDirsError> {
+    match workspace_env {
+        WorkspaceEnv::Off => project_selection_with_workspace_disabled(start_dir),
+        WorkspaceEnv::Pinned(workspace_path) => {
+            let project_root = manifest_root(workspace_path).map_err(PackageDirsError::from)?;
+            let workspace = read_workspace_file(workspace_path).map_err(PackageDirsError::from)?;
+            let member_dirs = canonical_workspace_module_dirs(&project_root, &workspace)
+                .map_err(PackageDirsError::from)?;
+            let module_dir = find_ancestor_with_mod(&start_dir).filter(|module_dir| {
+                member_dirs
+                    .iter()
+                    .any(|member_dir| member_dir == module_dir)
+            });
+            project_selection_from_pinned_workspace(workspace_path, module_dir)
+        }
+        WorkspaceEnv::Auto => {
+            let module_dir = find_ancestor_with_mod(&start_dir);
+
+            if let Some(project_manifest_path) = find_applicable_workspace_manifest_path(&start_dir)
+                .map_err(PackageDirsError::from)?
+            {
+                let project_root =
+                    manifest_root(&project_manifest_path).map_err(PackageDirsError::from)?;
+                return Ok(ProjectSelection {
+                    project_root,
+                    module_dir,
+                    project_manifest_path,
+                });
+            }
+
+            if let Some(module_dir) = module_dir {
+                let project_manifest_path = module_dir.join(MOON_MOD_JSON);
+                return Ok(ProjectSelection {
+                    project_root: module_dir.clone(),
+                    module_dir: Some(module_dir),
+                    project_manifest_path,
+                });
+            }
+
+            Err(PackageDirsError::NotInProject(start_dir))
+        }
+    }
+}
+
+fn project_selection_from_pinned_workspace(
+    workspace_path: &Path,
+    module_dir: Option<PathBuf>,
+) -> Result<ProjectSelection, PackageDirsError> {
+    let project_root = manifest_root(workspace_path).map_err(PackageDirsError::from)?;
+    Ok(ProjectSelection {
+        project_root,
+        module_dir,
+        project_manifest_path: workspace_path.to_path_buf(),
+    })
+}
+
+pub fn current_workspace_env() -> anyhow::Result<WorkspaceEnv> {
+    parse_workspace_env(
+        std::env::var_os(MOON_WORK_ENV),
+        std::env::var_os(MOON_NO_WORKSPACE),
+    )
+}
+
+pub fn workspace_env_deprecation_warning() -> Option<&'static str> {
+    let moon_work = std::env::var_os(MOON_WORK_ENV);
+    let moon_no_workspace = std::env::var_os(MOON_NO_WORKSPACE);
+
+    match (moon_work, moon_no_workspace) {
+        (_, None) => None,
+        (Some(_), Some(_)) => Some(
+            "`MOON_NO_WORKSPACE` is deprecated and ignored because `MOON_WORK` is set. Use `MOON_WORK=off` to disable workspace mode.",
+        ),
+        (None, Some(_)) => Some(
+            "`MOON_NO_WORKSPACE` is deprecated. Use `MOON_WORK=off` to disable workspace mode.",
+        ),
+    }
+}
+
+fn parse_workspace_env(
+    moon_work: Option<OsString>,
+    moon_no_workspace: Option<OsString>,
+) -> anyhow::Result<WorkspaceEnv> {
+    if let Some(value) = moon_work {
+        if value.is_empty() {
+            return Ok(WorkspaceEnv::Auto);
+        }
+
+        let value_str = value.to_string_lossy();
+        if value_str == "auto" {
+            return Ok(WorkspaceEnv::Auto);
+        }
+        if value_str == "off" {
+            return Ok(WorkspaceEnv::Off);
+        }
+
+        return canonicalize_workspace_env_path(PathBuf::from(value)).map(WorkspaceEnv::Pinned);
+    }
+
+    match moon_no_workspace {
+        Some(value) if value.to_string_lossy() != "0" => Ok(WorkspaceEnv::Off),
+        _ => Ok(WorkspaceEnv::Auto),
+    }
+}
+
+fn canonicalize_workspace_env_path(path: PathBuf) -> anyhow::Result<PathBuf> {
+    let path = dunce::canonicalize(&path)
+        .with_context(|| format!("failed to resolve MOON_WORK path `{}`", path.display()))?;
+
+    if path.is_dir() {
+        anyhow::bail!(
+            "MOON_WORK must point to `{}` (got directory `{}`)",
+            MOON_WORK,
+            path.display()
+        );
+    }
+
+    if path.file_name().and_then(|name| name.to_str()) != Some(MOON_WORK) {
+        anyhow::bail!(
+            "MOON_WORK must point to `{}` (got `{}`)",
+            MOON_WORK,
+            path.display()
+        );
+    }
+
+    Ok(path)
+}
 fn find_applicable_workspace_manifest_path(source_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
     let mut module_root = None;
 
@@ -464,9 +593,9 @@ pub fn resolve_manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::PackageDirs;
+    use super::{PackageDirs, WorkspaceEnv, parse_workspace_env};
     use crate::common::DEP_PATH;
-    use std::path::PathBuf;
+    use std::{ffi::OsString, path::PathBuf};
 
     #[test]
     fn mooncakes_dir_tracks_project_root() {
@@ -483,5 +612,50 @@ mod tests {
         let target = PathBuf::from("tmp-target");
         let dirs = PackageDirs::from_source_and_target(project.clone(), target);
         assert_eq!(dirs.mooncakes_dir, project.join(DEP_PATH));
+    }
+
+    #[test]
+    fn parse_workspace_env_defaults_to_auto() {
+        assert_eq!(parse_workspace_env(None, None).unwrap(), WorkspaceEnv::Auto);
+    }
+
+    #[test]
+    fn parse_workspace_env_accepts_auto_and_empty() {
+        assert_eq!(
+            parse_workspace_env(Some(OsString::from("auto")), None).unwrap(),
+            WorkspaceEnv::Auto
+        );
+        assert_eq!(
+            parse_workspace_env(Some(OsString::from("")), None).unwrap(),
+            WorkspaceEnv::Auto
+        );
+    }
+
+    #[test]
+    fn parse_workspace_env_accepts_off() {
+        assert_eq!(
+            parse_workspace_env(Some(OsString::from("off")), None).unwrap(),
+            WorkspaceEnv::Off
+        );
+    }
+
+    #[test]
+    fn parse_workspace_env_falls_back_to_legacy_disable_switch() {
+        assert_eq!(
+            parse_workspace_env(None, Some(OsString::from("1"))).unwrap(),
+            WorkspaceEnv::Off
+        );
+        assert_eq!(
+            parse_workspace_env(None, Some(OsString::from("0"))).unwrap(),
+            WorkspaceEnv::Auto
+        );
+    }
+
+    #[test]
+    fn parse_workspace_env_prefers_moon_work_over_legacy_switch() {
+        assert_eq!(
+            parse_workspace_env(Some(OsString::from("auto")), Some(OsString::from("1"))).unwrap(),
+            WorkspaceEnv::Auto
+        );
     }
 }

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -345,6 +345,22 @@ pub fn find_ancestor_with_work(source_dir: &Path) -> anyhow::Result<Option<PathB
         WorkspaceEnv::Pinned(workspace_path) => {
             let workspace_root = manifest_root(&workspace_path)?;
             if source_dir.starts_with(&workspace_root) {
+                if let Some(module_dir) = find_ancestor_with_mod(source_dir)
+                    && module_dir.starts_with(&workspace_root)
+                {
+                    let workspace = read_workspace_file(&workspace_path)?;
+                    let member_dirs = canonical_workspace_module_dirs(&workspace_root, &workspace)?;
+                    if !member_dirs
+                        .iter()
+                        .any(|member_dir| member_dir == &module_dir)
+                    {
+                        return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
+                            workspace: workspace_path.to_path_buf(),
+                            module: module_dir,
+                        }
+                        .into());
+                    }
+                }
                 return Ok(Some(workspace_root));
             }
 
@@ -409,26 +425,27 @@ fn resolve_project_selection_from_start_dir(
             let workspace = read_workspace_file(workspace_path).map_err(PackageDirsError::from)?;
             let member_dirs = canonical_workspace_module_dirs(&project_root, &workspace)
                 .map_err(PackageDirsError::from)?;
-            let module_dir = if start_dir.starts_with(&project_root) {
-                find_ancestor_with_mod(&start_dir).filter(|module_dir| {
-                    member_dirs
-                        .iter()
-                        .any(|member_dir| member_dir == module_dir)
-                })
-            } else if let Some(module_dir) = find_ancestor_with_mod(&start_dir) {
-                if member_dirs
-                    .iter()
-                    .any(|member_dir| member_dir == &module_dir)
+            let module_dir = match find_ancestor_with_mod(&start_dir) {
+                Some(module_dir)
+                    if start_dir.starts_with(&project_root)
+                        && !module_dir.starts_with(&project_root) =>
                 {
-                    Some(module_dir)
-                } else {
-                    return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
-                        workspace: workspace_path.to_path_buf(),
-                        module: module_dir,
-                    });
+                    None
                 }
-            } else {
-                None
+                Some(module_dir) => {
+                    if member_dirs
+                        .iter()
+                        .any(|member_dir| member_dir == &module_dir)
+                    {
+                        Some(module_dir)
+                    } else {
+                        return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
+                            workspace: workspace_path.to_path_buf(),
+                            module: module_dir,
+                        });
+                    }
+                }
+                None => None,
             };
             Ok(ProjectSelection {
                 project_root,

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -137,6 +137,14 @@ explicit workspace root via `moon.work`, following the same discovery precedence
 - An ancestor workspace manifest found after that only applies if it explicitly lists that module.
 - Otherwise, fall back to that `moon.mod.json`.
 
+`MOON_WORK` can override this selection:
+
+- unset, empty, or `auto`: use the discovery rules above
+- `off`: disable workspace mode and stay in single-module mode
+- a path to `moon.work`: pin selection to that workspace
+
+`MOON_NO_WORKSPACE` remains as a deprecated alias for `MOON_WORK=off`.
+
 The workspace manifest is intentionally small. `moon.work` currently supports:
 
 - `members = ["./app", "./lib"]` to list workspace roots.

--- a/docs/dev/reference/workspace.md
+++ b/docs/dev/reference/workspace.md
@@ -204,31 +204,45 @@ Those commands need a selected member and will fail at workspace root with the
 Project selection depends on:
 
 - the working directory after `-C`
-- `MOON_NO_WORKSPACE`
+- `--manifest-path`
+- `MOON_WORK`
+- `MOON_NO_WORKSPACE` (deprecated fallback)
 
-## `MOON_NO_WORKSPACE`
+`--manifest-path` pins manifest resolution, but does not change the process
+working directory.
 
-`MOON_NO_WORKSPACE` is Moon's "workspace off" switch.
+## `MOON_WORK`
 
-If it is set to a non-`0` value:
+`MOON_WORK` is Moon's workspace-selection switch, intentionally close to
+`GOWORK` in Go.
+
+Accepted values:
+
+- unset, empty, or `auto`
+  - use normal ancestor-based workspace discovery
+- `off`
+  - disable workspace mode entirely
+- a path to `moon.work`
+  - pin selection to that workspace manifest
+
+With `MOON_WORK=off`:
 
 - implicit workspace discovery is disabled
 - commands behave as if workspace mode does not exist
 
-This is intentionally close to `GO_WORK=off` in Go.
+With `MOON_WORK=<path-to-moon.work>`:
 
-The resulting behavior is:
+- project-scoped commands use that workspace even outside the workspace tree
+- if the current or explicitly selected `moon.mod.json` is not a workspace
+  member, Moon fails instead of silently falling back
 
-- if a `moon.mod.json` can be found from the selected start directory upward,
-  Moon uses that module
-- otherwise the command behaves as "not in a Moon module"
+## `MOON_NO_WORKSPACE`
 
-This applies even when:
+`MOON_NO_WORKSPACE` is deprecated.
 
-- `moon.work` and `moon.mod.json` are colocated at the same root
-
-So `MOON_NO_WORKSPACE` does not mean "disable only implicit promotion into a
-workspace". It disables workspace behavior completely.
+- when `MOON_WORK` is unset, it is treated as a legacy alias for
+  `MOON_WORK=off`
+- when both are set, `MOON_WORK` wins
 
 ## Selection
 
@@ -242,20 +256,64 @@ outside the target project.
 The algorithm is:
 
 1. Canonicalize the current directory.
-2. If `MOON_NO_WORKSPACE` is enabled:
+2. If `MOON_WORK=off` is enabled:
    - find the nearest ancestor containing `moon.mod.json`
    - if found, select that module manifest
    - otherwise, fail because workspace mode is disabled and no module exists
-3. Otherwise, walk ancestors from nearest to farthest and look for applicable
+3. If `MOON_WORK` points to a `moon.work` file:
+   - select that workspace manifest
+   - if the nearest ancestor `moon.mod.json` exists and is not a workspace
+     member, fail
+4. Otherwise, walk ancestors from nearest to farthest and look for applicable
    workspace manifests.
-4. If an applicable workspace manifest is found, select that workspace
+5. If an applicable workspace manifest is found, select that workspace
    manifest.
-5. If no applicable workspace is found, fall back to the nearest ancestor
+6. If no applicable workspace is found, fall back to the nearest ancestor
    `moon.mod.json`.
-6. If neither exists, fail with "not in a Moon project".
+7. If neither exists, fail with "not in a Moon project".
 
 `--manifest-path` still exists as a deprecated compatibility flag for
 non-`run` commands, but the public recommendation is to use `-C` instead.
+
+## Selection With `--manifest-path`
+
+`--manifest-path` accepts exactly:
+
+- `moon.mod.json`
+- `moon.work`
+
+The selected manifest path is canonicalized first.
+
+### `--manifest-path <...>/moon.mod.json`
+
+This means "start from this module".
+
+- if `MOON_WORK=off` is enabled, the command stays in single-module mode
+- otherwise, Moon may still promote to an enclosing applicable workspace
+
+This is important: `--manifest-path moon.mod.json` does not mean "force
+single-module mode". It means "select this module as the starting point".
+
+If an enclosing workspace applies, the command keeps:
+
+- `project_manifest_path = workspace manifest`
+- `project_root = workspace root`
+- `module_dir = selected module`
+
+That is how member-scoped commands can act on one member while still using the
+workspace's local dependency graph.
+
+### `--manifest-path <...>/moon.work`
+
+This means "start from this workspace root", but only when workspace mode is
+enabled.
+
+If `MOON_WORK=off` is enabled:
+
+- Moon ignores the workspace manifest
+- Moon falls back to the nearest ancestor `moon.mod.json`, if any
+- otherwise the command fails because workspace mode is disabled and no module
+  is available
 
 ## How Moon Decides Whether A Workspace Applies
 
@@ -287,7 +345,7 @@ outer/
 From `outer/ws`, the nearer workspace should win while workspace mode is
 enabled.
 
-With `MOON_NO_WORKSPACE=1`, the workspace is ignored and selection falls back to
+With `MOON_WORK=off`, the workspace is ignored and selection falls back to
 the nearest ancestor module, which is `outer/moon.mod.json`.
 
 ## Colocated `moon.work` And `moon.mod.json`
@@ -295,7 +353,7 @@ the nearest ancestor module, which is `outer/moon.mod.json`.
 If a directory contains both:
 
 - with workspace mode enabled, Moon may select the workspace manifest
-- with `MOON_NO_WORKSPACE=1`, Moon must select `moon.mod.json` instead
+- with `MOON_WORK=off`, Moon must select `moon.mod.json` instead
 
 This was the bug shape that motivated the recent cleanup of workspace
 selection.
@@ -310,6 +368,10 @@ selection.
 | `-C app` | start from `app`, then allow workspace promotion |
 | `-C app` + member-scoped command | act on `app`, but keep workspace-local deps/layout if a workspace applies |
 | `moon run path/to/app` from outside the project | discover the project from `path/to/app` |
-| inside workspace member + `MOON_NO_WORKSPACE=1` | ignore the workspace and use the nearest ancestor `moon.mod.json` |
-| workspace root with no module + `MOON_NO_WORKSPACE=1` | error: workspace mode is disabled and no module is available |
+| `--manifest-path app/moon.mod.json` | start from `app`, then allow workspace promotion |
+| `--manifest-path app/moon.mod.json` + member-scoped command | act on `app`, but keep workspace-local deps/layout if a workspace applies |
+| `--manifest-path moon.work` | select the workspace manifest |
+| inside workspace member + `MOON_WORK=off` | ignore the workspace and use the nearest ancestor `moon.mod.json` |
+| workspace root with no module + `MOON_WORK=off` | error: workspace mode is disabled and no module is available |
+| anywhere + `MOON_WORK=/abs/path/to/moon.work` | pin selection to that workspace |
 | `moon work sync` outside a workspace | error: requires `moon.work` |


### PR DESCRIPTION
## Summary
- add `MOON_WORK` with Go-style workspace selection semantics
- keep `MOON_NO_WORKSPACE` as a deprecated fallback alias for `MOON_WORK=off`
- update workspace selection, auto-sync, tests, and docs to use the new behavior

## Why
Workspace selection had a single legacy off-switch, `MOON_NO_WORKSPACE`, but no `GOWORK`-style environment variable for explicitly disabling workspace mode or pinning a workspace file. That made workspace behavior harder to control consistently across command selection and sync paths.

## Root cause
Workspace env handling was split across multiple call sites and only modeled as a boolean disable flag. That left no shared typed representation for `auto`, `off`, or pinned workspace-path behavior.

## What changed
- centralize workspace env parsing in `moonutil::dirs` with `WorkspaceEnv::{Auto, Off, Pinned}`
- make project selection honor `MOON_WORK=auto|off|<path-to-moon.work>`
- reject pinned workspaces that do not apply to the selected module
- reuse the same workspace env behavior in `mooncake::pkg::sync`
- emit a deprecation warning when `MOON_NO_WORKSPACE` is used
- expand workspace tests for `MOON_WORK=off`, pinned workspaces, and precedence with the deprecated env
- document the new environment-variable behavior in the workspace references

## Validation
- `cargo fmt`
- `cargo test -p moonutil dirs::tests -- --nocapture`
- `cargo test -p moon workspace_basic -- --nocapture`