### PR TITLE
refactor: make project selection into staged queries

### DIFF
--- a/crates/moon/src/cli/bench.rs
+++ b/crates/moon/src/cli/bench.rs
@@ -65,7 +65,7 @@ pub(crate) fn run_bench(cli: UniversalFlags, cmd: BenchSubcommand) -> anyhow::Re
         target_dir,
         mooncakes_dir,
         project_manifest_path,
-    } = cli.source_tgt_dir.try_into_package_dirs()?;
+    } = cli.source_tgt_dir.query()?.package_dirs()?;
 
     if cmd.build_flags.target.is_empty() {
         return run_bench_internal(

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -78,7 +78,7 @@ pub(crate) fn run_build(cli: &UniversalFlags, cmd: BuildSubcommand) -> anyhow::R
         target_dir,
         mooncakes_dir,
         project_manifest_path,
-    } = cli.source_tgt_dir.try_into_package_dirs()?;
+    } = cli.source_tgt_dir.query()?.package_dirs()?;
 
     if cmd.build_flags.target.is_empty() {
         return run_build_internal(

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -54,7 +54,7 @@ pub(crate) fn run_bundle(cli: UniversalFlags, cmd: BundleSubcommand) -> anyhow::
         target_dir,
         mooncakes_dir,
         project_manifest_path,
-    } = cli.source_tgt_dir.try_into_package_dirs()?;
+    } = cli.source_tgt_dir.query()?.package_dirs()?;
 
     let mut surface_targets = cmd.build_flags.target.clone();
     if cmd.all {

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -37,6 +37,7 @@ use moonutil::common::RunMode;
 use moonutil::common::WATCH_MODE_DIR;
 use moonutil::common::lower_surface_targets;
 use moonutil::common::{FileLock, TargetBackend};
+use moonutil::dirs::ProjectProbe;
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
@@ -134,49 +135,40 @@ pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::
     }
 
     // Check if we're running within a project
-    let (source_dir, target_dir, mooncakes_dir, single_file, project_manifest_path) = match cli
-        .source_tgt_dir
-        .try_into_package_dirs()
+    let mut query = cli.source_tgt_dir.query()?;
+    let (source_dir, target_dir, mooncakes_dir, single_file, project_manifest_path) = match query
+        .probe_project()?
     {
-        Ok(dirs) => (
-            dirs.source_dir,
-            dirs.target_dir,
-            dirs.mooncakes_dir,
-            false,
-            dirs.project_manifest_path,
-        ),
-        Err(e) if e.allows_single_file_fallback() => {
+        ProjectProbe::Found(_) => {
+            let dirs = query.package_dirs()?;
+            (
+                dirs.source_dir,
+                dirs.target_dir,
+                dirs.mooncakes_dir,
+                false,
+                dirs.project_manifest_path,
+            )
+        }
+        ProjectProbe::NotFound(not_found) => {
             // Now we're talking about real single-file scenario.
             match cmd.path.as_slice() {
                 [path] => {
-                    let single_file_path = dunce::canonicalize(path).with_context(|| {
-                        format!("failed to resolve file path `{}`", path.display())
-                    })?;
-                    let source_dir = single_file_path
-                        .parent()
-                        .context("file path must have a parent directory")?
-                        .to_path_buf();
-                    let single_file_dirs = cli
-                        .source_tgt_dir
-                        .package_dirs_from_source_root(&source_dir)?;
-                    let target_dir = single_file_dirs.target_dir;
-                    let mooncakes_dir = single_file_dirs.mooncakes_dir;
+                    let single_file = cli.source_tgt_dir.single_file_package_dirs(path)?;
+                    let target_dir = single_file.package_dirs.target_dir;
+                    let mooncakes_dir = single_file.package_dirs.mooncakes_dir;
                     (
-                        single_file_dirs.source_dir,
+                        single_file.package_dirs.source_dir,
                         target_dir,
                         mooncakes_dir,
                         true,
                         None,
                     )
                 }
-                [] => return Err(e.into()),
+                [] => return Err(not_found.into_error().into()),
                 _ => {
                     anyhow::bail!("standalone single-file `moon check` expects exactly one `PATH`");
                 }
             }
-        }
-        Err(e) => {
-            return Err(e.into());
         }
     };
 

--- a/crates/moon/src/cli/clean.rs
+++ b/crates/moon/src/cli/clean.rs
@@ -28,7 +28,7 @@ pub(crate) fn run_clean(cli: &UniversalFlags) -> anyhow::Result<i32> {
         bail!("dry-run is not supported for clean");
     }
 
-    let src_tgt = cli.source_tgt_dir.try_into_package_dirs()?;
+    let src_tgt = cli.source_tgt_dir.query()?.package_dirs()?;
 
     let _lock = FileLock::lock(&src_tgt.target_dir)?;
 

--- a/crates/moon/src/cli/coverage.rs
+++ b/crates/moon/src/cli/coverage.rs
@@ -116,7 +116,7 @@ fn run_coverage_clean(cli: UniversalFlags) -> Result<i32, anyhow::Error> {
         source_dir: src,
         target_dir: tgt,
         ..
-    } = cli.source_tgt_dir.try_into_package_dirs()?;
+    } = cli.source_tgt_dir.query()?.package_dirs()?;
     clean_coverage_artifacts(&src, &tgt)?;
     Ok(0)
 }
@@ -138,7 +138,7 @@ fn run_coverage_report(cli: UniversalFlags, args: CoverageReportSubcommand) -> a
         source_dir: src,
         target_dir: _tgt,
         ..
-    } = cli.source_tgt_dir.try_into_package_dirs()?;
+    } = cli.source_tgt_dir.query()?.package_dirs()?;
 
     let res = run_coverage_report_command(args.args, &src, cli.dry_run);
     res.context("Unable to run coverage report")?

--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -21,13 +21,25 @@ use mooncake::pkg::{
     add::AddSubcommand, install::InstallSubcommand, remove::RemoveSubcommand, tree::TreeSubcommand,
 };
 use moonutil::{
-    dirs::PackageDirs,
+    dirs::{PackageDirs, ProjectContext},
     moon_dir,
     mooncakes::{ModuleName, RegistryConfig},
 };
 use std::path::{Path, PathBuf};
 
 use super::UniversalFlags;
+
+fn require_selected_module(project: &ProjectContext, command: &str) -> anyhow::Result<PathBuf> {
+    project
+        .selected_module()
+        .map(|module| module.root.clone())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "`moon {command}` cannot infer a target module in workspace `{}`. Run it from a workspace member or use `moon -C <member> {command} ...`.",
+                project.root().display(),
+            )
+        })
+}
 use super::install_binary::{
     GitRef, install_binary, install_from_git, install_from_local, is_git_url, is_local_path,
     parse_package_spec, strip_wildcard_suffix,
@@ -63,7 +75,7 @@ pub(crate) fn install_cli(cli: UniversalFlags, cmd: InstallSubcommand) -> anyhow
             source_dir,
             mooncakes_dir,
             ..
-        } = cli.source_tgt_dir.try_into_package_dirs()?;
+        } = cli.source_tgt_dir.query()?.package_dirs()?;
         return mooncake::pkg::install::install(
             &source_dir,
             &mooncakes_dir,
@@ -147,9 +159,14 @@ pub(crate) fn install_cli(cli: UniversalFlags, cmd: InstallSubcommand) -> anyhow
 }
 
 pub(crate) fn remove_cli(cli: UniversalFlags, cmd: RemoveSubcommand) -> anyhow::Result<i32> {
-    let dirs = cli.source_tgt_dir.try_into_workspace_module_dirs()?;
-    let project_root = &dirs.project_root;
-    let module_dir = dirs.require_module_dir("remove")?;
+    let mut query = cli.source_tgt_dir.query()?;
+    let project = query.project()?;
+    let module_dir = require_selected_module(&project, "remove")?;
+    let PackageDirs {
+        source_dir: project_root,
+        project_manifest_path,
+        ..
+    } = query.package_dirs()?;
     let package_path = cmd.package_path;
     let parts: Vec<&str> = package_path.splitn(2, '/').collect();
     if parts.len() != 2 {
@@ -158,9 +175,9 @@ pub(crate) fn remove_cli(cli: UniversalFlags, cmd: RemoveSubcommand) -> anyhow::
     let username = parts[0];
     let pkgname = parts[1];
     mooncake::pkg::remove::remove(
-        project_root,
-        module_dir,
-        dirs.project_manifest_path.as_deref(),
+        &project_root,
+        &module_dir,
+        project_manifest_path.as_deref(),
         username,
         pkgname,
     )
@@ -168,9 +185,15 @@ pub(crate) fn remove_cli(cli: UniversalFlags, cmd: RemoveSubcommand) -> anyhow::
 
 pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result<i32> {
     let output = UserDiagnostics::from_flags(&cli);
-    let dirs = cli.source_tgt_dir.try_into_workspace_module_dirs()?;
-    let project_root = &dirs.project_root;
-    let module_dir = dirs.require_module_dir("add")?;
+    let mut query = cli.source_tgt_dir.query()?;
+    let project = query.project()?;
+    let module_dir = require_selected_module(&project, "add")?;
+    let PackageDirs {
+        source_dir: project_root,
+        mooncakes_dir,
+        project_manifest_path,
+        ..
+    } = query.package_dirs()?;
 
     // Update registry index by default (issue #963).
     // - `--no-update` keeps the previous behavior.
@@ -214,10 +237,10 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
         let version: &str = parts[1];
         let version = version.parse()?;
         mooncake::pkg::add::add(
-            project_root,
-            module_dir,
-            dirs.project_manifest_path.as_deref(),
-            &dirs.mooncakes_dir,
+            &project_root,
+            &module_dir,
+            project_manifest_path.as_deref(),
+            &mooncakes_dir,
             &pkg_name,
             cmd.bin,
             &version,
@@ -225,10 +248,10 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
         )
     } else {
         mooncake::pkg::add::add_latest(
-            project_root,
-            module_dir,
-            dirs.project_manifest_path.as_deref(),
-            &dirs.mooncakes_dir,
+            &project_root,
+            &module_dir,
+            project_manifest_path.as_deref(),
+            &mooncakes_dir,
             &pkg_name,
             cmd.bin,
             cli.quiet,
@@ -238,13 +261,15 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
 }
 
 pub(crate) fn tree_cli(cli: UniversalFlags, _cmd: TreeSubcommand) -> anyhow::Result<i32> {
-    let dirs = cli.source_tgt_dir.try_into_workspace_module_dirs()?;
-    let module_dir = dirs.require_module_dir("tree")?;
-    mooncake::pkg::tree::tree(
-        &dirs.project_root,
-        module_dir,
-        dirs.project_manifest_path.as_deref(),
-    )
+    let mut query = cli.source_tgt_dir.query()?;
+    let project = query.project()?;
+    let module_dir = require_selected_module(&project, "tree")?;
+    let PackageDirs {
+        source_dir: project_root,
+        project_manifest_path,
+        ..
+    } = query.package_dirs()?;
+    mooncake::pkg::tree::tree(&project_root, &module_dir, project_manifest_path.as_deref())
 }
 
 #[cfg(test)]

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -21,6 +21,7 @@ use std::path::Path;
 use anyhow::{Context as _, bail};
 use moonbuild_rupes_recta::intent::UserIntent;
 use moonutil::common::{FileLock, RunMode};
+use moonutil::dirs::PackageDirs;
 use moonutil::mooncakes::{ModuleId, sync::AutoSyncFlags};
 use tracing::instrument;
 
@@ -88,12 +89,23 @@ fn run_doc_query(symbol: &str, output: UserDiagnostics) -> anyhow::Result<i32> {
 
 #[instrument(skip_all)]
 pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Result<i32> {
-    let dirs = cli.source_tgt_dir.try_into_workspace_module_dirs()?;
-    let doc_source_dir = dirs.require_module_dir("doc")?.clone();
-    let mooncakes_dir = dirs.mooncakes_dir;
-    let source_dir = dirs.project_root;
-    let target_dir = dirs.target_dir;
-    let project_manifest_path = dirs.project_manifest_path;
+    let mut query = cli.source_tgt_dir.query()?;
+    let project = query.project()?;
+    let doc_source_dir = project
+        .selected_module()
+        .map(|module| module.root.clone())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "`moon doc` cannot infer a target module in workspace `{}`. Run it from a workspace member or use `moon -C <member> doc ...`.",
+                project.root().display(),
+            )
+        })?;
+    let PackageDirs {
+        source_dir,
+        target_dir,
+        mooncakes_dir,
+        project_manifest_path,
+    } = query.package_dirs()?;
 
     // FIXME: This is copied from `moon check`'s code. Share code if possible.
     let mut preconfig = preconfig_compile(

--- a/crates/moon/src/cli/fetch.rs
+++ b/crates/moon/src/cli/fetch.rs
@@ -107,7 +107,11 @@ pub(crate) fn fetch_cli(cli: UniversalFlags, cmd: FetchSubcommand) -> anyhow::Re
     };
 
     // If we are under a project, put it into `.repos` next to `.mooncakes`
-    let source_dir = match cli.source_tgt_dir.try_into_package_dirs() {
+    let source_dir = match cli
+        .source_tgt_dir
+        .query()
+        .and_then(|mut query| query.package_dirs())
+    {
         Ok(PackageDirs { source_dir, .. }) => source_dir,
         Err(_) => std::env::current_dir()?,
     };

--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -66,7 +66,7 @@ fn run_fmt_rr(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> {
         target_dir,
         project_manifest_path,
         ..
-    } = cli.source_tgt_dir.try_into_package_dirs()?;
+    } = cli.source_tgt_dir.query()?.package_dirs()?;
 
     let output = UserDiagnostics::from_flags(cli);
     let resolved =

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -279,7 +279,7 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
         target_dir,
         mooncakes_dir,
         project_manifest_path,
-    } = cli.source_tgt_dir.try_into_package_dirs()?;
+    } = cli.source_tgt_dir.query()?.package_dirs()?;
 
     let build_flags = BuildFlags::default();
     let resolve_cfg = ResolveConfig::new_with_load_defaults(

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -441,9 +441,7 @@ fn build_and_install_packages(
 ) -> anyhow::Result<i32> {
     let quiet = cli.quiet;
     let output = UserDiagnostics::from_flags(cli);
-    let package_dirs = cli
-        .source_tgt_dir
-        .package_dirs_from_source_root(module_dir)?;
+    let package_dirs = cli.source_tgt_dir.source_root_package_dirs(module_dir)?;
     let source_dir = package_dirs.source_dir;
     let target_dir = package_dirs.target_dir;
     let mooncakes_dir = package_dirs.mooncakes_dir;

--- a/crates/moon/src/cli/mooncake_adapter.rs
+++ b/crates/moon/src/cli/mooncake_adapter.rs
@@ -123,8 +123,17 @@ fn single_module_mooncake_cli(
     mut cli: UniversalFlags,
     command: &str,
 ) -> anyhow::Result<UniversalFlags> {
-    let dirs = cli.source_tgt_dir.try_into_workspace_module_dirs()?;
-    let module_dir = dirs.require_module_dir(command)?;
+    let mut query = cli.source_tgt_dir.query()?;
+    let project = query.project()?;
+    let module_dir = project
+        .selected_module()
+        .map(|module| module.root.clone())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "`moon {command}` cannot infer a target module in workspace `{}`. Run it from a workspace member or use `moon -C <member> {command} ...`.",
+                project.root().display(),
+            )
+        })?;
     cli.source_tgt_dir.cwd = None;
     cli.source_tgt_dir.manifest_path = Some(if module_dir.join(MOON_MOD).exists() {
         module_dir.join(MOON_MOD)

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -26,6 +26,7 @@ use moonbuild_rupes_recta::{intent::UserIntent, model::BuildPlanNode, user_warni
 use moonutil::{
     cli::UniversalFlags,
     common::{DiagnosticLevel, FileLock, RunMode, TargetBackend},
+    dirs::PackageDirs,
     mooncakes::{ModuleId, sync::AutoSyncFlags},
 };
 use serde::Deserialize;
@@ -96,16 +97,29 @@ impl ProveSubcommand {
 
 #[instrument(skip_all)]
 pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::Result<i32> {
-    let dirs = cli.source_tgt_dir.try_into_workspace_module_dirs()?;
+    let mut query = cli.source_tgt_dir.query()?;
+    let project = query.project()?;
     let module_dir = if cmd.path.is_some() {
-        dirs.module_dir.clone()
+        project.selected_module().map(|module| module.root.clone())
     } else {
-        Some(dirs.require_module_dir("prove")?.clone())
+        Some(
+            project
+                .selected_module()
+                .map(|module| module.root.clone())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "`moon prove` cannot infer a target module in workspace `{}`. Run it from a workspace member or use `moon -C <member> prove ...`.",
+                        project.root().display(),
+                    )
+                })?,
+        )
     };
-    let mooncakes_dir = dirs.mooncakes_dir;
-    let project_root = dirs.project_root;
-    let target_dir = dirs.target_dir;
-    let project_manifest_path = dirs.project_manifest_path;
+    let PackageDirs {
+        source_dir: project_root,
+        target_dir,
+        mooncakes_dir,
+        project_manifest_path,
+    } = query.package_dirs()?;
     let build_flags = cmd.to_build_flags();
     let verif_dir = target_dir.join("verif");
     let why3_config_path = cmd

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -22,7 +22,7 @@ use anyhow::{Context, bail};
 use moonbuild_rupes_recta::build_plan::InputDirective;
 use moonbuild_rupes_recta::intent::UserIntent;
 use moonutil::common::{FileLock, RunMode, TargetBackend, TestArtifacts, is_moon_pkg_exist};
-use moonutil::dirs::PackageDirs;
+use moonutil::dirs::{PackageDirs, ProjectProbe};
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use tracing::{Level, instrument};
 
@@ -170,8 +170,9 @@ pub(crate) fn run_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resul
     let is_mbtx = input.ends_with(".mbtx");
     let run_start_dir = resolve_run_start_dir(input)?;
 
-    match cli.source_tgt_dir.package_dirs_from(&run_start_dir) {
-        Ok(_) => {
+    let mut query = cli.source_tgt_dir.query_from(&run_start_dir)?;
+    match query.probe_project()? {
+        ProjectProbe::Found(_) => {
             if is_mbtx {
                 return run_single_file_from_arg(cli, cmd);
             }
@@ -183,13 +184,12 @@ pub(crate) fn run_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resul
                 }
             }
         }
-        Err(e) if e.allows_single_file_fallback() => {
+        ProjectProbe::NotFound(not_found) => {
             if is_mbt || is_mbtx {
                 return run_single_file_from_arg(cli, cmd);
             }
-            return Err(e.into());
+            return Err(not_found.into_error().into());
         }
-        Err(e) => return Err(e.into()),
     }
 
     let selected_target_backend = cmd.build_flags.resolve_single_target_backend()?;
@@ -230,7 +230,10 @@ fn run_run_rr(
         target_dir,
         mooncakes_dir,
         project_manifest_path,
-    } = cli.source_tgt_dir.package_dirs_from(&run_start_dir)?;
+    } = cli
+        .source_tgt_dir
+        .query_from(&run_start_dir)?
+        .package_dirs()?;
 
     let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
         cmd.auto_sync_flags.clone(),
@@ -347,25 +350,21 @@ fn calc_user_intent(
 
 #[instrument(level = Level::DEBUG, skip_all)]
 fn run_single_file_from_arg(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
-    let input_path = dunce::canonicalize(
+    let single_file_dirs = cli.source_tgt_dir.single_file_package_dirs(
         cmd.package_or_mbt_file
             .as_deref()
             .expect("single-file run from arg requires a positional input path"),
     )?;
-    let source_dir = input_path.parent().unwrap().to_path_buf();
-    let single_file_dirs = cli
-        .source_tgt_dir
-        .package_dirs_from_source_root(&source_dir)?;
-    let target_dir = single_file_dirs.target_dir;
-    let mooncakes_dir = single_file_dirs.mooncakes_dir;
+    let target_dir = single_file_dirs.package_dirs.target_dir;
+    let mooncakes_dir = single_file_dirs.package_dirs.mooncakes_dir;
 
     run_single_file_rr(
         cli,
         cmd,
-        single_file_dirs.source_dir,
+        single_file_dirs.package_dirs.source_dir,
         target_dir,
         mooncakes_dir,
-        input_path,
+        single_file_dirs.file_path,
     )
 }
 

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -42,6 +42,7 @@ use moonbuild_rupes_recta::model::PackageId;
 use moonutil::common::{
     FileLock, RunMode, TargetBackend, TestArtifacts, TestIndexRange, lower_surface_targets,
 };
+use moonutil::dirs::ProjectProbe;
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use std::path::{Path, PathBuf};
 use tracing::{Level, debug, info, instrument, trace};
@@ -220,40 +221,29 @@ fn run_test_impl(cli: &UniversalFlags, cmd: &TestSubcommand) -> anyhow::Result<i
         "starting moon test command"
     );
     // Check if we're running within a project
-    let dirs = match cli.source_tgt_dir.try_into_package_dirs() {
-        Ok(dirs) => dirs,
-        Err(e) if e.allows_single_file_fallback() => {
+    let mut query = cli.source_tgt_dir.query()?;
+    let dirs = match query.probe_project()? {
+        ProjectProbe::Found(_) => query.package_dirs()?,
+        ProjectProbe::NotFound(not_found) => {
             // Now we're talking about real single-file scenario.
             match cmd.path.as_slice() {
                 [path] => {
-                    let single_file_path = dunce::canonicalize(path).with_context(|| {
-                        format!("failed to resolve file path `{}`", path.display())
-                    })?;
-                    let source_dir = single_file_path
-                        .parent()
-                        .context("file path must have a parent directory")?
-                        .to_path_buf();
-                    let single_file_dirs = cli
-                        .source_tgt_dir
-                        .package_dirs_from_source_root(&source_dir)?;
-                    let target_dir = single_file_dirs.target_dir;
-                    let mooncakes_dir = single_file_dirs.mooncakes_dir;
+                    let single_file = cli.source_tgt_dir.single_file_package_dirs(path)?;
+                    let target_dir = single_file.package_dirs.target_dir;
+                    let mooncakes_dir = single_file.package_dirs.mooncakes_dir;
                     info!("delegating to single-file test runner");
                     return run_test_in_single_file(
                         cli,
                         cmd,
-                        &single_file_path,
-                        &single_file_dirs.source_dir,
+                        &single_file.file_path,
+                        &single_file.package_dirs.source_dir,
                         &target_dir,
                         &mooncakes_dir,
                     );
                 }
-                [] => return Err(e.into()),
+                [] => return Err(not_found.into_error().into()),
                 _ => anyhow::bail!("standalone single-file `moon test` expects exactly one `PATH`"),
             }
-        }
-        Err(e) => {
-            return Err(e.into());
         }
     };
 

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -76,7 +76,7 @@ pub(crate) fn run_build_binary_dep(
         target_dir,
         mooncakes_dir,
         project_manifest_path,
-    } = cli.source_tgt_dir.try_into_package_dirs()?;
+    } = cli.source_tgt_dir.query()?.package_dirs()?;
     if cli.dry_run {
         anyhow::bail!("--dry-run is not supported for `moon tool build-binary-dep`");
     }

--- a/crates/moon/src/cli/work.rs
+++ b/crates/moon/src/cli/work.rs
@@ -19,9 +19,7 @@
 use std::path::PathBuf;
 
 use anyhow::bail;
-use moonutil::dirs::{
-    PackageDirs, find_ancestor_with_mod, find_ancestor_with_work, resolve_manifest_root,
-};
+use moonutil::dirs::PackageDirs;
 
 use super::UniversalFlags;
 
@@ -78,29 +76,12 @@ pub(crate) fn work_cli(cli: UniversalFlags, cmd: WorkSubcommand) -> anyhow::Resu
                 bail!("dry-run is not supported for work sync")
             }
 
-            let PackageDirs { source_dir, .. } = cli.source_tgt_dir.try_into_package_dirs()?;
+            let PackageDirs { source_dir, .. } = cli.source_tgt_dir.query()?.package_dirs()?;
             mooncake::pkg::sync_workspace(&source_dir, cli.quiet)
         }
     }
 }
 
 fn work_root(cli: &UniversalFlags, prefer_existing_workspace: bool) -> anyhow::Result<PathBuf> {
-    let root = if let Some(manifest_path) = &cli.source_tgt_dir.manifest_path {
-        resolve_manifest_root(manifest_path)?
-    } else {
-        std::env::current_dir()?
-    };
-    let root = dunce::canonicalize(root)?;
-
-    // `work use` should extend the current workspace when the current module is
-    // already a member, but should otherwise stay local to the current module.
-    if prefer_existing_workspace && let Some(work_root) = find_ancestor_with_work(&root)? {
-        return Ok(work_root);
-    }
-
-    if let Some(module_root) = find_ancestor_with_mod(&root) {
-        Ok(module_root)
-    } else {
-        Ok(root)
-    }
+    Ok(cli.source_tgt_dir.work_root(prefer_existing_workspace)?)
 }

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -549,7 +549,9 @@ mod tests {
             manifest_path: Some(manifest_path),
             target_dir: None,
         }
-        .try_into_package_dirs()
+        .query()
+        .unwrap()
+        .package_dirs()
         .unwrap();
         moonbuild_rupes_recta::resolve(&cfg, &dirs.source_dir, &dirs.mooncakes_dir).unwrap()
     }

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -92,33 +92,18 @@ pub struct SourceTargetDirs {
 }
 
 impl SourceTargetDirs {
-    pub fn try_into_package_dirs(&self) -> Result<PackageDirs, PackageDirsError> {
-        self.package_dirs_from(Self::current_dir()?)
+    pub fn query(&self) -> Result<ProjectQuery, PackageDirsError> {
+        self.query_from(Self::current_dir()?)
     }
 
-    pub fn package_dirs_from(
+    pub fn query_from(
         &self,
         start_dir: impl AsRef<Path>,
-    ) -> Result<PackageDirs, PackageDirsError> {
-        let start_dir = dunce::canonicalize(start_dir.as_ref())
-            .context("failed to resolve source directory")
-            .map_err(PackageDirsError::from)?;
-        let workspace_env = current_workspace_env().map_err(PackageDirsError::from)?;
-        let project = if let Some(manifest_path) = &self.manifest_path {
-            Self::resolve_project_selection_from_manifest_path(manifest_path, &workspace_env)?
-        } else {
-            resolve_project_selection_from_start_dir(start_dir, &workspace_env)?
-        };
-        let target_dir = self.resolve_target_dir(&project.project_root)?;
-
-        Ok(PackageDirs::from_source_and_target_with_manifest(
-            project.project_root,
-            target_dir,
-            Some(project.project_manifest_path),
-        ))
+    ) -> Result<ProjectQuery, PackageDirsError> {
+        ProjectQuery::new(self, start_dir.as_ref())
     }
 
-    pub fn package_dirs_from_source_root(
+    pub fn source_root_package_dirs(
         &self,
         source_root: impl AsRef<Path>,
     ) -> Result<PackageDirs, PackageDirsError> {
@@ -129,120 +114,40 @@ impl SourceTargetDirs {
         Ok(PackageDirs::from_source_and_target(source_dir, target_dir))
     }
 
-    pub fn try_into_workspace_module_dirs(&self) -> Result<WorkspaceModuleDirs, PackageDirsError> {
-        let project = self.resolve_project_selection()?;
-        let target_dir = self.resolve_target_dir(&project.project_root)?;
-
-        Ok(WorkspaceModuleDirs {
-            mooncakes_dir: PackageDirs::mooncakes_dir_for_source(&project.project_root),
-            project_root: project.project_root,
-            module_dir: project.module_dir,
-            target_dir,
-            project_manifest_path: Some(project.project_manifest_path),
-        })
-    }
-
-    fn resolve_project_selection(&self) -> Result<ProjectSelection, PackageDirsError> {
-        let workspace_env = current_workspace_env().map_err(PackageDirsError::from)?;
-        if let Some(manifest_path) = &self.manifest_path {
-            return Self::resolve_project_selection_from_manifest_path(
-                manifest_path,
-                &workspace_env,
-            );
-        }
-
-        let start_dir = Self::current_dir()?;
-        resolve_project_selection_from_start_dir(start_dir, &workspace_env)
-    }
-
-    fn resolve_project_selection_from_manifest_path(
-        manifest_path: &Path,
-        workspace_env: &WorkspaceEnv,
-    ) -> Result<ProjectSelection, PackageDirsError> {
-        let manifest_path = dunce::canonicalize(manifest_path)
+    pub fn single_file_package_dirs(
+        &self,
+        file_path: impl AsRef<Path>,
+    ) -> Result<SingleFilePackageDirs, PackageDirsError> {
+        // This only builds the synthetic package directories. Whether a command
+        // may fall back to single-file mode depends on that command's argv.
+        let file_path = dunce::canonicalize(file_path.as_ref())
             .with_context(|| {
                 format!(
-                    "failed to resolve manifest path `{}`",
-                    manifest_path.display()
+                    "failed to resolve file path `{}`",
+                    file_path.as_ref().display()
                 )
             })
             .map_err(PackageDirsError::from)?;
-
-        if manifest_path.is_dir() {
-            return Err(PackageDirsError::from(anyhow::anyhow!(
-                "`--manifest-path` must point to `{}`, `{}`, or `{}` (got directory `{}`)",
-                MOON_MOD,
-                MOON_MOD_JSON,
-                MOON_WORK,
-                manifest_path.display()
-            )));
-        }
-
-        let file_name = manifest_path.file_name().and_then(|s| s.to_str());
-        let manifest_dir = manifest_path
+        let source_dir = file_path
             .parent()
-            .context("manifest path has no parent directory")
+            .context("file path must have a parent directory")
             .map(Path::to_path_buf)
             .map_err(PackageDirsError::from)?;
+        let package_dirs = self.source_root_package_dirs(source_dir)?;
+        Ok(SingleFilePackageDirs {
+            file_path,
+            package_dirs,
+        })
+    }
 
-        if matches!(workspace_env, WorkspaceEnv::Off) {
-            return match file_name {
-                Some(MOON_MOD | MOON_MOD_JSON) => Ok(ProjectSelection {
-                    project_root: manifest_dir.clone(),
-                    module_dir: Some(manifest_dir),
-                    project_manifest_path: manifest_path,
-                }),
-                Some(MOON_WORK) => project_selection_with_workspace_disabled(manifest_dir),
-                _ => Err(PackageDirsError::from(anyhow::anyhow!(
-                    "`--manifest-path` must point to `{}`, `{}`, or `{}` (got `{}`)",
-                    MOON_MOD,
-                    MOON_MOD_JSON,
-                    MOON_WORK,
-                    manifest_path.display()
-                ))),
-            };
-        }
-
-        match file_name {
-            Some(MOON_MOD | MOON_MOD_JSON) => match workspace_env {
-                WorkspaceEnv::Pinned(workspace_path) => {
-                    project_selection_from_pinned_workspace(workspace_path, Some(manifest_dir))
-                }
-                WorkspaceEnv::Auto => {
-                    if let Some(project_manifest_path) =
-                        find_applicable_workspace_manifest_path(&manifest_dir)
-                            .map_err(PackageDirsError::from)?
-                    {
-                        let project_root = manifest_root(&project_manifest_path)
-                            .map_err(PackageDirsError::from)?;
-                        Ok(ProjectSelection {
-                            project_root,
-                            module_dir: Some(manifest_dir),
-                            project_manifest_path,
-                        })
-                    } else {
-                        Ok(ProjectSelection {
-                            project_root: manifest_dir.clone(),
-                            module_dir: Some(manifest_dir),
-                            project_manifest_path: manifest_path,
-                        })
-                    }
-                }
-                WorkspaceEnv::Off => unreachable!("handled above"),
-            },
-            Some(MOON_WORK) => Ok(ProjectSelection {
-                project_root: manifest_dir,
-                module_dir: None,
-                project_manifest_path: manifest_path,
-            }),
-            _ => Err(PackageDirsError::from(anyhow::anyhow!(
-                "`--manifest-path` must point to `{}`, `{}`, or `{}` (got `{}`)",
-                MOON_MOD,
-                MOON_MOD_JSON,
-                MOON_WORK,
-                manifest_path.display()
-            ))),
-        }
+    pub fn work_root(&self, prefer_existing_workspace: bool) -> Result<PathBuf, PackageDirsError> {
+        let start_dir = Self::current_dir()?;
+        let mut query = if prefer_existing_workspace {
+            self.query_from(start_dir)?
+        } else {
+            ProjectQuery::new_with_workspace_env(self, &start_dir, WorkspaceEnv::Off)?
+        };
+        query.work_root(prefer_existing_workspace)
     }
 
     fn current_dir() -> Result<PathBuf, PackageDirsError> {
@@ -300,24 +205,95 @@ impl PackageDirs {
     }
 }
 
-pub struct WorkspaceModuleDirs {
-    /// Root used for workspace/project-wide resolution and default `_build`.
-    pub project_root: PathBuf,
-    /// Selected module root, if the command was invoked from within a module.
-    pub module_dir: Option<PathBuf>,
-    pub target_dir: PathBuf,
-    pub mooncakes_dir: PathBuf,
-    pub project_manifest_path: Option<PathBuf>,
+pub struct SingleFilePackageDirs {
+    pub file_path: PathBuf,
+    pub package_dirs: PackageDirs,
 }
 
-impl WorkspaceModuleDirs {
-    pub fn require_module_dir(&self, command: &str) -> anyhow::Result<&PathBuf> {
-        self.module_dir.as_ref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "`moon {command}` cannot infer a target module in workspace `{}`. Run it from a workspace member or use `moon -C <member> {command} ...`.",
-                self.project_root.display(),
-            )
-        })
+#[derive(Debug)]
+pub enum ProjectProbe {
+    Found(ProjectContext),
+    NotFound(ProjectNotFound),
+}
+
+#[derive(Debug)]
+pub struct ProjectNotFound {
+    error: PackageDirsError,
+}
+
+impl ProjectNotFound {
+    pub fn into_error(self) -> PackageDirsError {
+        self.error
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleRef {
+    pub root: PathBuf,
+    pub manifest_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceRef {
+    pub root: PathBuf,
+    pub manifest_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectContext {
+    Workspace {
+        root: PathBuf,
+        manifest_path: PathBuf,
+        selected_module: Option<ModuleRef>,
+    },
+    Module {
+        root: PathBuf,
+        manifest_path: PathBuf,
+    },
+}
+
+impl ProjectContext {
+    pub fn root(&self) -> &Path {
+        match self {
+            Self::Workspace { root, .. } => root,
+            Self::Module { root, .. } => root,
+        }
+    }
+
+    pub fn manifest_path(&self) -> &Path {
+        match self {
+            Self::Workspace { manifest_path, .. } => manifest_path,
+            Self::Module { manifest_path, .. } => manifest_path,
+        }
+    }
+
+    pub fn selected_module(&self) -> Option<ModuleRef> {
+        match self {
+            Self::Workspace {
+                selected_module, ..
+            } => selected_module.clone(),
+            Self::Module {
+                root,
+                manifest_path,
+            } => Some(ModuleRef {
+                root: root.clone(),
+                manifest_path: manifest_path.clone(),
+            }),
+        }
+    }
+
+    pub fn workspace_ref(&self) -> Option<WorkspaceRef> {
+        match self {
+            Self::Workspace {
+                root,
+                manifest_path,
+                ..
+            } => Some(WorkspaceRef {
+                root: root.clone(),
+                manifest_path: manifest_path.clone(),
+            }),
+            Self::Module { .. } => None,
+        }
     }
 }
 
@@ -337,73 +313,61 @@ pub fn find_ancestor_with_mod(source_dir: &Path) -> Option<PathBuf> {
 }
 
 pub fn find_ancestor_with_work(source_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
-    match current_workspace_env()? {
-        WorkspaceEnv::Off => Ok(None),
-        WorkspaceEnv::Auto => find_applicable_workspace_manifest_path(source_dir)?
-            .map(|path| manifest_root(&path))
-            .transpose(),
-        WorkspaceEnv::Pinned(workspace_path) => {
-            let workspace_root = manifest_root(&workspace_path)?;
-            if source_dir.starts_with(&workspace_root) {
-                if let Some(module_dir) = find_ancestor_with_mod(source_dir)
-                    && module_dir.starts_with(&workspace_root)
-                {
-                    let workspace = read_workspace_file(&workspace_path)?;
-                    let member_dirs = canonical_workspace_module_dirs(&workspace_root, &workspace)?;
-                    if !member_dirs
-                        .iter()
-                        .any(|member_dir| member_dir == &module_dir)
-                    {
-                        return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
-                            workspace: workspace_path.to_path_buf(),
-                            module: module_dir,
-                        }
-                        .into());
-                    }
-                }
-                return Ok(Some(workspace_root));
-            }
-
-            let workspace = read_workspace_file(&workspace_path)?;
-            let member_dirs = canonical_workspace_module_dirs(&workspace_root, &workspace)?;
-            let Some(module_dir) = find_ancestor_with_mod(source_dir) else {
-                return Ok(Some(workspace_root));
-            };
-            if member_dirs
-                .iter()
-                .any(|member_dir| member_dir == &module_dir)
-            {
-                Ok(Some(workspace_root))
-            } else {
-                Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
-                    workspace: workspace_path.to_path_buf(),
-                    module: module_dir,
-                }
-                .into())
-            }
-        }
-    }
-}
-
-fn project_selection_with_workspace_disabled(
-    start_dir: PathBuf,
-) -> Result<ProjectSelection, PackageDirsError> {
-    let Some(module_dir) = find_ancestor_with_mod(&start_dir) else {
-        return Err(PackageDirsError::WorkspaceDisabledNotInModule(start_dir));
+    let source_target_dirs = SourceTargetDirs {
+        cwd: None,
+        manifest_path: None,
+        target_dir: None,
     };
-
-    let project_manifest_path = module_manifest_path(&module_dir);
-    Ok(ProjectSelection {
-        project_root: module_dir.clone(),
-        module_dir: Some(module_dir),
-        project_manifest_path,
-    })
+    let mut query = source_target_dirs.query_from(source_dir)?;
+    query.workspace_root_for_sync().map_err(Into::into)
 }
 
-struct ProjectSelection {
-    project_root: PathBuf,
+pub fn resolve_work_root(
+    manifest_path: Option<&Path>,
+    prefer_existing_workspace: bool,
+) -> anyhow::Result<PathBuf> {
+    let source_target_dirs = SourceTargetDirs {
+        cwd: None,
+        manifest_path: manifest_path.map(Path::to_path_buf),
+        target_dir: None,
+    };
+    source_target_dirs
+        .work_root(prefer_existing_workspace)
+        .map_err(Into::into)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ManifestKind {
+    Module,
+    Workspace,
+}
+
+#[derive(Clone)]
+struct ManifestInput {
+    path: PathBuf,
+    root: PathBuf,
+    kind: ManifestKind,
+}
+
+struct WorkspaceFacts {
+    // Keep this as cheap path-level discovery. Parsed `moon.work` content and
+    // member canonicalization are projections, because many commands only need
+    // the workspace root or manifest path.
+    manifest_path: PathBuf,
+    root: PathBuf,
+}
+
+pub struct ProjectQuery {
+    // Inputs and cheap markers are captured once, then higher-level methods
+    // project only the artifacts their callers ask for.
+    target_dir: Option<PathBuf>,
+    start_dir: PathBuf,
+    workspace_env: WorkspaceEnv,
+    explicit_manifest: Option<ManifestInput>,
     module_dir: Option<PathBuf>,
-    project_manifest_path: PathBuf,
+    module_manifest_path: Option<PathBuf>,
+    workspace: Option<WorkspaceFacts>,
+    workspace_members: Option<Vec<PathBuf>>,
 }
 
 fn module_manifest_path(module_dir: &Path) -> PathBuf {
@@ -414,98 +378,493 @@ fn module_manifest_path(module_dir: &Path) -> PathBuf {
     }
 }
 
-fn resolve_project_selection_from_start_dir(
-    start_dir: PathBuf,
-    workspace_env: &WorkspaceEnv,
-) -> Result<ProjectSelection, PackageDirsError> {
-    match workspace_env {
-        WorkspaceEnv::Off => project_selection_with_workspace_disabled(start_dir),
-        WorkspaceEnv::Pinned(workspace_path) => {
-            let project_root = manifest_root(workspace_path).map_err(PackageDirsError::from)?;
-            let workspace = read_workspace_file(workspace_path).map_err(PackageDirsError::from)?;
-            let member_dirs = canonical_workspace_module_dirs(&project_root, &workspace)
-                .map_err(PackageDirsError::from)?;
-            let module_dir = match find_ancestor_with_mod(&start_dir) {
-                Some(module_dir)
-                    if start_dir.starts_with(&project_root)
-                        && !module_dir.starts_with(&project_root) =>
-                {
-                    None
+impl WorkspaceFacts {
+    fn from_manifest_path(manifest_path: PathBuf) -> Result<Self, PackageDirsError> {
+        let root = manifest_root(&manifest_path).map_err(PackageDirsError::from)?;
+        Ok(Self {
+            manifest_path,
+            root,
+        })
+    }
+
+    fn from_pinned_manifest_path(manifest_path: &Path) -> Result<Self, PackageDirsError> {
+        let manifest_path = dunce::canonicalize(manifest_path)
+            .context("failed to resolve pinned workspace path")
+            .map_err(PackageDirsError::from)?;
+        let root = manifest_root(&manifest_path).map_err(PackageDirsError::from)?;
+        Ok(Self {
+            manifest_path,
+            root,
+        })
+    }
+}
+
+impl ProjectQuery {
+    fn new(
+        source_target_dirs: &SourceTargetDirs,
+        start_dir: &Path,
+    ) -> Result<Self, PackageDirsError> {
+        let workspace_env = current_workspace_env().map_err(PackageDirsError::from)?;
+        Self::new_with_workspace_env(source_target_dirs, start_dir, workspace_env)
+    }
+
+    fn new_with_workspace_env(
+        source_target_dirs: &SourceTargetDirs,
+        start_dir: &Path,
+        workspace_env: WorkspaceEnv,
+    ) -> Result<Self, PackageDirsError> {
+        let start_dir = dunce::canonicalize(start_dir)
+            .with_context(|| {
+                format!(
+                    "failed to resolve source directory `{}`",
+                    start_dir.display()
+                )
+            })
+            .map_err(PackageDirsError::from)?;
+        let explicit_manifest = source_target_dirs
+            .manifest_path
+            .as_deref()
+            .map(manifest_input_from_path)
+            .transpose()
+            .map_err(PackageDirsError::from)?;
+        let module_dir = match &explicit_manifest {
+            Some(manifest) if manifest.kind == ManifestKind::Module => Some(manifest.root.clone()),
+            Some(manifest) => find_ancestor_with_mod(&manifest.root),
+            None => find_ancestor_with_mod(&start_dir),
+        };
+        let module_manifest_path = match &explicit_manifest {
+            Some(manifest) if manifest.kind == ManifestKind::Module => Some(manifest.path.clone()),
+            _ => module_dir.as_deref().map(module_manifest_path),
+        };
+        let workspace = match &workspace_env {
+            WorkspaceEnv::Off => None,
+            WorkspaceEnv::Pinned(workspace_path) => {
+                Some(WorkspaceFacts::from_pinned_manifest_path(workspace_path)?)
+            }
+            WorkspaceEnv::Auto => None,
+        };
+
+        Ok(Self {
+            target_dir: source_target_dirs.target_dir.clone(),
+            start_dir,
+            workspace_env,
+            explicit_manifest,
+            module_dir,
+            module_manifest_path,
+            workspace,
+            workspace_members: None,
+        })
+    }
+
+    pub fn probe_project(&mut self) -> Result<ProjectProbe, PackageDirsError> {
+        match self.resolve_project_context() {
+            Ok(project) => Ok(ProjectProbe::Found(project)),
+            Err(error) if error.allows_single_file_fallback() => {
+                Ok(ProjectProbe::NotFound(ProjectNotFound { error }))
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn project(&mut self) -> Result<ProjectContext, PackageDirsError> {
+        match self.probe_project()? {
+            ProjectProbe::Found(project) => Ok(project),
+            ProjectProbe::NotFound(not_found) => Err(not_found.into_error()),
+        }
+    }
+
+    pub fn package_dirs(&mut self) -> Result<PackageDirs, PackageDirsError> {
+        let project = self.project()?;
+        let target_dir = self.resolve_target_dir(project.root())?;
+        Ok(PackageDirs::from_source_and_target_with_manifest(
+            project.root().to_path_buf(),
+            target_dir,
+            Some(project.manifest_path().to_path_buf()),
+        ))
+    }
+
+    pub fn selected_module(&mut self) -> Result<Option<ModuleRef>, PackageDirsError> {
+        Ok(self.project()?.selected_module())
+    }
+
+    pub fn workspace_ref(&mut self) -> Result<Option<WorkspaceRef>, PackageDirsError> {
+        Ok(self.project()?.workspace_ref())
+    }
+
+    pub fn workspace_members(&mut self) -> Result<Option<Vec<PathBuf>>, PackageDirsError> {
+        if self.workspace_ref()?.is_none() {
+            return Ok(None);
+        }
+        self.ensure_workspace_members()
+            .map(|member_dirs| member_dirs.map(<[PathBuf]>::to_vec))
+    }
+
+    pub fn work_root(
+        &mut self,
+        prefer_existing_workspace: bool,
+    ) -> Result<PathBuf, PackageDirsError> {
+        if prefer_existing_workspace && let Some(work_root) = self.workspace_root_for_sync()? {
+            return Ok(work_root);
+        }
+
+        let start_dir = self.work_start_dir();
+        if let Some(module_dir) = find_ancestor_with_mod(&start_dir) {
+            Ok(module_dir)
+        } else {
+            Ok(start_dir)
+        }
+    }
+
+    fn resolve_project_context(&mut self) -> Result<ProjectContext, PackageDirsError> {
+        if let Some(manifest) = self.explicit_manifest.clone() {
+            return self.project_context_from_manifest(&manifest);
+        }
+
+        self.project_context_from_start_dir()
+    }
+
+    fn project_context_from_manifest(
+        &mut self,
+        manifest: &ManifestInput,
+    ) -> Result<ProjectContext, PackageDirsError> {
+        match &self.workspace_env {
+            WorkspaceEnv::Off => match manifest.kind {
+                ManifestKind::Module => Ok(ProjectContext::Module {
+                    root: manifest.root.clone(),
+                    manifest_path: manifest.path.clone(),
+                }),
+                ManifestKind::Workspace => {
+                    self.module_context_with_workspace_disabled(manifest.root.clone())
                 }
-                Some(module_dir) => {
-                    if member_dirs
-                        .iter()
-                        .any(|member_dir| member_dir == &module_dir)
-                    {
-                        Some(module_dir)
+            },
+            WorkspaceEnv::Auto => match manifest.kind {
+                ManifestKind::Module => {
+                    if let Some(workspace) = self.find_applicable_workspace_from(&manifest.root)? {
+                        Ok(ProjectContext::Workspace {
+                            root: workspace.root.clone(),
+                            manifest_path: workspace.manifest_path.clone(),
+                            selected_module: Some(ModuleRef {
+                                root: manifest.root.clone(),
+                                manifest_path: manifest.path.clone(),
+                            }),
+                        })
                     } else {
+                        Ok(ProjectContext::Module {
+                            root: manifest.root.clone(),
+                            manifest_path: manifest.path.clone(),
+                        })
+                    }
+                }
+                ManifestKind::Workspace => Ok(ProjectContext::Workspace {
+                    root: manifest.root.clone(),
+                    manifest_path: manifest.path.clone(),
+                    selected_module: None,
+                }),
+            },
+            WorkspaceEnv::Pinned(_) => match manifest.kind {
+                ManifestKind::Module => {
+                    self.project_context_from_pinned_workspace(Some(ModuleRef {
+                        root: manifest.root.clone(),
+                        manifest_path: manifest.path.clone(),
+                    }))
+                }
+                ManifestKind::Workspace => Ok(ProjectContext::Workspace {
+                    root: manifest.root.clone(),
+                    manifest_path: manifest.path.clone(),
+                    selected_module: None,
+                }),
+            },
+        }
+    }
+
+    fn project_context_from_start_dir(&mut self) -> Result<ProjectContext, PackageDirsError> {
+        match &self.workspace_env {
+            WorkspaceEnv::Off => {
+                self.module_context_with_workspace_disabled(self.start_dir.clone())
+            }
+            WorkspaceEnv::Pinned(_) => {
+                let workspace = self.pinned_workspace_ref();
+                let module_dir = match self.module_dir.clone() {
+                    // When invoked at a pinned workspace root nested under an
+                    // unrelated module, the outer module is not the selection.
+                    Some(module_dir)
+                        if self.start_dir.starts_with(&workspace.root)
+                            && !module_dir.starts_with(&workspace.root) =>
+                    {
+                        None
+                    }
+                    Some(module_dir) => {
+                        if self.workspace_contains_member(&module_dir)? {
+                            Some(module_dir)
+                        } else {
+                            return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
+                                workspace: workspace.manifest_path.clone(),
+                                module: module_dir,
+                            });
+                        }
+                    }
+                    None => None,
+                };
+
+                Ok(ProjectContext::Workspace {
+                    root: workspace.root.clone(),
+                    manifest_path: workspace.manifest_path.clone(),
+                    selected_module: module_dir.map(|root| ModuleRef {
+                        manifest_path: module_manifest_path(&root),
+                        root,
+                    }),
+                })
+            }
+            WorkspaceEnv::Auto => {
+                let start_dir = self.start_dir.clone();
+                if let Some(workspace) = self.find_applicable_workspace_from(&start_dir)? {
+                    return Ok(ProjectContext::Workspace {
+                        root: workspace.root.clone(),
+                        manifest_path: workspace.manifest_path.clone(),
+                        selected_module: self.module_dir.as_ref().map(|root| ModuleRef {
+                            root: root.clone(),
+                            manifest_path: self
+                                .module_manifest_path
+                                .clone()
+                                .unwrap_or_else(|| module_manifest_path(root)),
+                        }),
+                    });
+                }
+
+                if let Some(module_dir) = &self.module_dir {
+                    return Ok(ProjectContext::Module {
+                        root: module_dir.clone(),
+                        manifest_path: self
+                            .module_manifest_path
+                            .clone()
+                            .unwrap_or_else(|| module_manifest_path(module_dir)),
+                    });
+                }
+
+                Err(PackageDirsError::NotInProject(self.start_dir.clone()))
+            }
+        }
+    }
+
+    fn module_context_with_workspace_disabled(
+        &self,
+        error_start_dir: PathBuf,
+    ) -> Result<ProjectContext, PackageDirsError> {
+        let Some(module_dir) = &self.module_dir else {
+            return Err(PackageDirsError::WorkspaceDisabledNotInModule(
+                error_start_dir,
+            ));
+        };
+
+        Ok(ProjectContext::Module {
+            root: module_dir.clone(),
+            manifest_path: self
+                .module_manifest_path
+                .clone()
+                .unwrap_or_else(|| module_manifest_path(module_dir)),
+        })
+    }
+
+    fn project_context_from_pinned_workspace(
+        &mut self,
+        selected_module: Option<ModuleRef>,
+    ) -> Result<ProjectContext, PackageDirsError> {
+        let workspace = self.pinned_workspace_ref();
+        if let Some(module) = &selected_module
+            && !self.workspace_contains_member(&module.root)?
+        {
+            return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
+                workspace: workspace.manifest_path.clone(),
+                module: module.root.clone(),
+            });
+        }
+
+        Ok(ProjectContext::Workspace {
+            root: workspace.root.clone(),
+            manifest_path: workspace.manifest_path.clone(),
+            selected_module,
+        })
+    }
+
+    fn workspace_root_for_sync(&mut self) -> Result<Option<PathBuf>, PackageDirsError> {
+        match &self.workspace_env {
+            WorkspaceEnv::Off => Ok(None),
+            WorkspaceEnv::Auto => {
+                let start_dir = self.work_start_dir();
+                Ok(self
+                    .find_applicable_workspace_from(&start_dir)?
+                    .map(|workspace| workspace.root))
+            }
+            WorkspaceEnv::Pinned(_) => {
+                let workspace = self.pinned_workspace_ref();
+                let start_dir = self.work_start_dir();
+                if start_dir.starts_with(&workspace.root) {
+                    if let Some(module_dir) = self.module_dir.clone()
+                        && module_dir.starts_with(&workspace.root)
+                        && !self.workspace_contains_member(&module_dir)?
+                    {
                         return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
-                            workspace: workspace_path.to_path_buf(),
+                            workspace: workspace.manifest_path.clone(),
                             module: module_dir,
                         });
                     }
+                    return Ok(Some(workspace.root.clone()));
                 }
-                None => None,
-            };
-            Ok(ProjectSelection {
-                project_root,
-                module_dir,
-                project_manifest_path: workspace_path.to_path_buf(),
-            })
+
+                let Some(module_dir) = self.module_dir.clone() else {
+                    return Ok(Some(workspace.root.clone()));
+                };
+                if self.workspace_contains_member(&module_dir)? {
+                    Ok(Some(workspace.root.clone()))
+                } else {
+                    Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
+                        workspace: workspace.manifest_path.clone(),
+                        module: module_dir,
+                    })
+                }
+            }
         }
-        WorkspaceEnv::Auto => {
-            let module_dir = find_ancestor_with_mod(&start_dir);
+    }
 
-            if let Some(project_manifest_path) = find_applicable_workspace_manifest_path(&start_dir)
+    fn resolve_target_dir(&self, project_root: &Path) -> Result<PathBuf, PackageDirsError> {
+        let target_dir = self
+            .target_dir
+            .clone()
+            .unwrap_or_else(|| project_root.join(BUILD_DIR));
+        if !target_dir.exists() {
+            std::fs::create_dir_all(&target_dir)
+                .context("failed to create target directory")
+                .map_err(PackageDirsError::from)?;
+        }
+        dunce::canonicalize(target_dir)
+            .context("failed to set target directory")
+            .map_err(PackageDirsError::from)
+    }
+
+    fn workspace_contains_member(&mut self, module_dir: &Path) -> Result<bool, PackageDirsError> {
+        Ok(self
+            .ensure_workspace_members()?
+            .is_some_and(|members| members.iter().any(|member_dir| member_dir == module_dir)))
+    }
+
+    fn find_applicable_workspace_from(
+        &mut self,
+        source_dir: &Path,
+    ) -> Result<Option<WorkspaceRef>, PackageDirsError> {
+        if self.workspace.is_none() {
+            self.workspace = find_applicable_workspace_manifest_path(source_dir)
                 .map_err(PackageDirsError::from)?
-            {
-                let project_root =
-                    manifest_root(&project_manifest_path).map_err(PackageDirsError::from)?;
-                return Ok(ProjectSelection {
-                    project_root,
-                    module_dir,
-                    project_manifest_path,
-                });
-            }
+                .map(WorkspaceFacts::from_manifest_path)
+                .transpose()?;
+        }
+        Ok(self.workspace.as_ref().map(|workspace| WorkspaceRef {
+            root: workspace.root.clone(),
+            manifest_path: workspace.manifest_path.clone(),
+        }))
+    }
 
-            if let Some(module_dir) = module_dir {
-                let project_manifest_path = module_manifest_path(&module_dir);
-                return Ok(ProjectSelection {
-                    project_root: module_dir.clone(),
-                    module_dir: Some(module_dir),
-                    project_manifest_path,
-                });
-            }
+    fn ensure_workspace_members(&mut self) -> Result<Option<&[PathBuf]>, PackageDirsError> {
+        let Some(workspace) = &self.workspace else {
+            return Ok(None);
+        };
+        if self.workspace_members.is_none() {
+            let moon_work =
+                read_workspace_file(&workspace.manifest_path).map_err(PackageDirsError::from)?;
+            let member_dirs = canonical_workspace_module_dirs(&workspace.root, &moon_work)
+                .map_err(PackageDirsError::from)?;
+            self.workspace_members = Some(member_dirs);
+        }
+        Ok(self.workspace_members.as_deref())
+    }
 
-            Err(PackageDirsError::NotInProject(start_dir))
+    fn work_start_dir(&self) -> PathBuf {
+        self.explicit_manifest
+            .as_ref()
+            .map(|manifest| manifest.root.clone())
+            .unwrap_or_else(|| self.start_dir.clone())
+    }
+
+    fn pinned_workspace_ref(&self) -> WorkspaceRef {
+        let workspace = self
+            .workspace
+            .as_ref()
+            .expect("pinned workspace discovery must include workspace facts");
+        WorkspaceRef {
+            root: workspace.root.clone(),
+            manifest_path: workspace.manifest_path.clone(),
         }
     }
 }
 
-fn project_selection_from_pinned_workspace(
-    workspace_path: &Path,
-    module_dir: Option<PathBuf>,
-) -> Result<ProjectSelection, PackageDirsError> {
-    let project_root = manifest_root(workspace_path).map_err(PackageDirsError::from)?;
-    let workspace = read_workspace_file(workspace_path).map_err(PackageDirsError::from)?;
-    let member_dirs = canonical_workspace_module_dirs(&project_root, &workspace)
-        .map_err(PackageDirsError::from)?;
-    if let Some(module_dir) = &module_dir
-        && !member_dirs
-            .iter()
-            .any(|member_dir| member_dir == module_dir)
-    {
-        return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
-            workspace: workspace_path.to_path_buf(),
-            module: module_dir.to_path_buf(),
-        });
-    }
+#[cfg(test)]
+fn project_query_from_start_dir(
+    start_dir: PathBuf,
+    workspace_env: &WorkspaceEnv,
+) -> Result<ProjectQuery, PackageDirsError> {
+    let mut query = ProjectQuery {
+        target_dir: None,
+        start_dir: dunce::canonicalize(start_dir)
+            .context("failed to resolve source directory")
+            .map_err(PackageDirsError::from)?,
+        workspace_env: workspace_env.clone(),
+        explicit_manifest: None,
+        module_dir: None,
+        module_manifest_path: None,
+        workspace: None,
+        workspace_members: None,
+    };
+    let start_dir = query.start_dir.clone();
+    query.module_dir = find_ancestor_with_mod(&start_dir);
+    query.module_manifest_path = query.module_dir.as_deref().map(module_manifest_path);
+    query.workspace = match workspace_env {
+        WorkspaceEnv::Off => None,
+        WorkspaceEnv::Pinned(workspace_path) => {
+            Some(WorkspaceFacts::from_pinned_manifest_path(workspace_path)?)
+        }
+        WorkspaceEnv::Auto => None,
+    };
+    Ok(query)
+}
 
-    Ok(ProjectSelection {
-        project_root,
-        module_dir,
-        project_manifest_path: workspace_path.to_path_buf(),
-    })
+#[cfg(test)]
+fn resolve_project_context_from_start_dir(
+    start_dir: PathBuf,
+    workspace_env: &WorkspaceEnv,
+) -> Result<ProjectContext, PackageDirsError> {
+    project_query_from_start_dir(start_dir, workspace_env)?.project()
+}
+
+#[cfg(test)]
+fn resolve_project_context_from_manifest_path(
+    manifest_path: &Path,
+    workspace_env: &WorkspaceEnv,
+) -> Result<ProjectContext, PackageDirsError> {
+    let manifest = manifest_input_from_path(manifest_path).map_err(PackageDirsError::from)?;
+    let mut query = ProjectQuery {
+        target_dir: None,
+        start_dir: manifest.root.clone(),
+        workspace_env: workspace_env.clone(),
+        module_dir: match manifest.kind {
+            ManifestKind::Module => Some(manifest.root.clone()),
+            ManifestKind::Workspace => find_ancestor_with_mod(&manifest.root),
+        },
+        module_manifest_path: match manifest.kind {
+            ManifestKind::Module => Some(manifest.path.clone()),
+            ManifestKind::Workspace => find_ancestor_with_mod(&manifest.root)
+                .as_deref()
+                .map(module_manifest_path),
+        },
+        workspace: match (workspace_env, manifest.kind) {
+            (WorkspaceEnv::Off, _) => None,
+            (WorkspaceEnv::Pinned(workspace_path), _) => {
+                Some(WorkspaceFacts::from_pinned_manifest_path(workspace_path)?)
+            }
+            (WorkspaceEnv::Auto, _) => None,
+        },
+        explicit_manifest: Some(manifest),
+        workspace_members: None,
+    };
+    query.project()
 }
 
 pub fn current_workspace_env() -> anyhow::Result<WorkspaceEnv> {
@@ -611,7 +970,7 @@ fn manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {
         .map(Path::to_path_buf)
 }
 
-pub fn resolve_manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {
+fn manifest_input_from_path(manifest_path: &Path) -> anyhow::Result<ManifestInput> {
     let manifest_path = dunce::canonicalize(manifest_path).with_context(|| {
         format!(
             "failed to resolve manifest path `{}`",
@@ -643,23 +1002,109 @@ pub fn resolve_manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {
         );
     }
 
-    manifest_path
+    let kind = match file_name {
+        Some(MOON_MOD | MOON_MOD_JSON) => ManifestKind::Module,
+        Some(MOON_WORK) => ManifestKind::Workspace,
+        _ => unreachable!("manifest file name was validated above"),
+    };
+
+    let root = manifest_path
         .parent()
         .context("manifest path has no parent directory")
-        .map(Path::to_path_buf)
+        .map(Path::to_path_buf)?;
+
+    Ok(ManifestInput {
+        path: manifest_path,
+        root,
+        kind,
+    })
+}
+
+pub fn resolve_manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {
+    manifest_input_from_path(manifest_path).map(|manifest| manifest.root)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        PackageDirs, WorkspaceEnv, parse_workspace_env, resolve_project_selection_from_start_dir,
+        PackageDirs, PackageDirsError, ProjectContext, ProjectProbe, WorkspaceEnv,
+        parse_workspace_env, project_query_from_start_dir,
+        resolve_project_context_from_manifest_path, resolve_project_context_from_start_dir,
     };
-    use crate::common::{DEP_PATH, MOON_MOD};
+    use crate::common::{DEP_PATH, MOON_MOD, MOON_MOD_JSON};
     use std::{
         ffi::OsString,
-        path::PathBuf,
+        path::{Path, PathBuf},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    struct TestProject {
+        root: PathBuf,
+    }
+
+    impl TestProject {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "moonutil-dirs-{}",
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&root).unwrap();
+            Self { root }
+        }
+
+        fn path(&self) -> &Path {
+            &self.root
+        }
+
+        fn join(&self, path: impl AsRef<Path>) -> PathBuf {
+            self.root.join(path)
+        }
+    }
+
+    impl Drop for TestProject {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn canonical(path: impl AsRef<Path>) -> PathBuf {
+        dunce::canonicalize(path).unwrap()
+    }
+
+    fn write_json_module(path: &Path, name: &str) {
+        write_file(
+            &path.join(MOON_MOD_JSON),
+            &format!(
+                r#"{{
+  "name": "{name}",
+  "version": "0.1.0"
+}}
+"#
+            ),
+        );
+    }
+
+    fn nested_workspace_under_unrelated_module() -> TestProject {
+        let project = TestProject::new();
+        write_json_module(&project.join("outer"), "alice/outer");
+        write_file(
+            &project.join("outer/ws/moon.work"),
+            r#"members = [
+  "./app",
+]
+"#,
+        );
+        write_json_module(&project.join("outer/ws/app"), "alice/app");
+        project
+    }
 
     #[test]
     fn mooncakes_dir_tracks_project_root() {
@@ -680,29 +1125,152 @@ mod tests {
 
     #[test]
     fn auto_selection_preserves_dsl_module_manifest_path() {
-        let test_root = std::env::temp_dir().join(format!(
-            "moonutil-dirs-{}",
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&test_root).unwrap();
-        std::fs::write(
-            test_root.join(MOON_MOD),
+        let project = TestProject::new();
+        write_file(
+            &project.join(MOON_MOD),
             r#"name = "alice/app"
 
 version = "0.1.0"
 "#,
+        );
+
+        let selection = resolve_project_context_from_start_dir(
+            project.path().to_path_buf(),
+            &WorkspaceEnv::Auto,
+        )
+        .unwrap();
+        let ProjectContext::Module { manifest_path, .. } = selection else {
+            panic!("expected module context");
+        };
+        assert_eq!(manifest_path, canonical(project.join(MOON_MOD)));
+    }
+
+    #[test]
+    fn project_probe_reports_not_found_without_project() {
+        let project = TestProject::new();
+        let mut query =
+            project_query_from_start_dir(project.path().to_path_buf(), &WorkspaceEnv::Auto)
+                .unwrap();
+
+        let ProjectProbe::NotFound(not_found) = query.probe_project().unwrap() else {
+            panic!("expected project probe to report not found");
+        };
+        assert!(matches!(
+            not_found.into_error(),
+            PackageDirsError::NotInProject(path) if path == canonical(project.path())
+        ));
+    }
+
+    #[test]
+    fn workspace_members_are_projected_on_demand() {
+        let project = TestProject::new();
+        write_file(
+            &project.join("moon.work"),
+            "members = [\n  \"./missing\",\n]\n",
+        );
+
+        let mut query =
+            project_query_from_start_dir(project.path().to_path_buf(), &WorkspaceEnv::Auto)
+                .unwrap();
+        assert!(
+            matches!(query.project().unwrap(), ProjectContext::Workspace { .. }),
+            "workspace root should resolve without canonicalizing members"
+        );
+        assert!(
+            query.workspace_members().is_err(),
+            "workspace members projection should canonicalize member paths on demand"
+        );
+    }
+
+    #[test]
+    fn pinned_workspace_root_under_unrelated_outer_module_succeeds() {
+        let project = nested_workspace_under_unrelated_module();
+        let workspace_path = canonical(project.join("outer/ws/moon.work"));
+
+        let selection = resolve_project_context_from_start_dir(
+            project.join("outer/ws"),
+            &WorkspaceEnv::Pinned(workspace_path.clone()),
         )
         .unwrap();
 
-        let project =
-            resolve_project_selection_from_start_dir(test_root.clone(), &WorkspaceEnv::Auto)
-                .unwrap();
-        assert_eq!(project.project_manifest_path, test_root.join(MOON_MOD));
+        let ProjectContext::Workspace {
+            root,
+            manifest_path,
+            selected_module,
+        } = selection
+        else {
+            panic!("expected workspace context");
+        };
+        assert_eq!(root, canonical(project.join("outer/ws")));
+        assert_eq!(selected_module, None);
+        assert_eq!(manifest_path, workspace_path);
+    }
 
-        std::fs::remove_dir_all(test_root).unwrap();
+    #[test]
+    fn pinned_workspace_rejects_unlisted_module_under_workspace_root() {
+        let project = nested_workspace_under_unrelated_module();
+        let workspace_path = canonical(project.join("outer/ws/moon.work"));
+        write_json_module(&project.join("outer/ws/tools"), "alice/tools");
+
+        let err = resolve_project_context_from_start_dir(
+            project.join("outer/ws/tools"),
+            &WorkspaceEnv::Pinned(workspace_path.clone()),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            PackageDirsError::PinnedWorkspaceDoesNotApply { workspace, module }
+                if workspace == workspace_path && module == canonical(project.join("outer/ws/tools"))
+        ));
+    }
+
+    #[test]
+    fn pinned_workspace_rejects_unlisted_module_outside_workspace_root() {
+        let project = nested_workspace_under_unrelated_module();
+        let workspace_path = canonical(project.join("outer/ws/moon.work"));
+
+        let err = resolve_project_context_from_start_dir(
+            project.join("outer"),
+            &WorkspaceEnv::Pinned(workspace_path.clone()),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            PackageDirsError::PinnedWorkspaceDoesNotApply { workspace, module }
+                if workspace == workspace_path && module == canonical(project.join("outer"))
+        ));
+    }
+
+    #[test]
+    fn pinned_workspace_rejects_unlisted_manifest_path_module() {
+        let project = nested_workspace_under_unrelated_module();
+        let workspace_path = canonical(project.join("outer/ws/moon.work"));
+        let json_module = project.join("outer/ws/json-tool");
+        let dsl_module = project.join("outer/ws/dsl-tool");
+        write_json_module(&json_module, "alice/json-tool");
+        write_file(
+            &dsl_module.join(MOON_MOD),
+            r#"name = "alice/dsl-tool"
+
+version = "0.1.0"
+"#,
+        );
+
+        for manifest_path in [json_module.join(MOON_MOD_JSON), dsl_module.join(MOON_MOD)] {
+            let err = resolve_project_context_from_manifest_path(
+                &manifest_path,
+                &WorkspaceEnv::Pinned(workspace_path.clone()),
+            )
+            .unwrap_err();
+
+            assert!(matches!(
+                err,
+                PackageDirsError::PinnedWorkspaceDoesNotApply { workspace, module }
+                    if workspace == workspace_path && module == canonical(manifest_path.parent().unwrap())
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Refactor project selection in `moonutil::dirs` around a staged `ProjectQuery` pipeline. Commands now ask for concrete artifacts such as package dirs, selected modules, workspace refs, workspace members, or work roots instead of using conversion-style APIs.

This keeps single-file mode in command code: `check`, `test`, and `run` probe for a project first, then decide from argv whether single-file fallback applies.

## Notes

- Preserves pinned workspace conservative semantics.
- Preserves `moon.mod` vs `moon.mod.json` manifest fidelity.
- Keeps deprecated `--manifest-path` routed through the same query model.
- Workspace member parsing remains projection-driven where possible.

## Validation

- `cargo fmt --check`
- `cargo check -p moonutil -p moon`
- `cargo test -p moonutil dirs::tests -- --nocapture`
- `cargo test -p moon workspace_basic -- --nocapture`
- `cargo test -p moon single_file_front_matter -- --nocapture`
- `cargo test -p moon test_moon_run_single -- --nocapture`
- `cargo test -p moon fmt_moon_mod -- --nocapture`
- `cargo test -p moon test_single_file_nonexistent_path_error -- --nocapture`
- `cargo clippy -p moonutil -p moon --tests -- -D warnings`