### PR TITLE
feat(moon): support root version flag

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -79,14 +79,20 @@ pub(crate) use upgrade::*;
 pub(crate) use version::*;
 pub(crate) use whoami::*;
 pub(crate) use work::{WorkSubcommand, work_cli};
+
 #[derive(Debug, clap::Parser)]
 #[clap(
     name = "moon",
-    about = "The build system and package manager for MoonBit."
+    about = "The build system and package manager for MoonBit.",
+    override_usage = "moon [OPTIONS] <COMMAND>"
 )]
 pub(crate) struct MoonBuildCli {
     #[clap(subcommand)]
-    pub subcommand: MoonBuildSubcommands,
+    pub subcommand: Option<MoonBuildSubcommands>,
+
+    /// Print all version information and exit
+    #[clap(short = 'V', long)]
+    pub version: bool,
 
     #[clap(flatten)]
     pub flags: UniversalFlags,

--- a/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
@@ -391,7 +391,7 @@ _moon() {
 
     case "${cmd}" in
         moon)
-            opts="-C -q -v -Z -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --unstable-feature --help new bundle build check prove run test generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help"
+            opts="-V -C -q -v -Z -h --version --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --unstable-feature --help new bundle build check prove run test generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
@@ -23,6 +23,8 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -Z 'Unstable flags to MoonBuild'
             cand --unstable-feature 'Unstable flags to MoonBuild'
+            cand -V 'Print all version information and exit'
+            cand --version 'Print all version information and exit'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
             cand -v 'Increase verbosity'

--- a/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
@@ -1,6 +1,6 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_moon_global_optspecs
-	string join \n C= manifest-path= target-dir= q/quiet v/verbose trace dry-run build-graph Z/unstable-feature= h/help
+	string join \n V/version C= manifest-path= target-dir= q/quiet v/verbose trace dry-run build-graph Z/unstable-feature= h/help
 end
 
 function __fish_moon_needs_command
@@ -28,6 +28,7 @@ complete -c moon -n "__fish_moon_needs_command" -s C -d 'Change to DIR before do
 complete -c moon -n "__fish_moon_needs_command" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_needs_command" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_needs_command" -s Z -l unstable-feature -d 'Unstable flags to MoonBuild' -r
+complete -c moon -n "__fish_moon_needs_command" -s V -l version -d 'Print all version information and exit'
 complete -c moon -n "__fish_moon_needs_command" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_needs_command" -s v -l verbose -d 'Increase verbosity'
 complete -c moon -n "__fish_moon_needs_command" -l trace -d 'Trace the execution of the program'

--- a/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
@@ -26,6 +26,8 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-Z', 'Z ', [CompletionResultType]::ParameterName, 'Unstable flags to MoonBuild')
             [CompletionResult]::new('--unstable-feature', 'unstable-feature', [CompletionResultType]::ParameterName, 'Unstable flags to MoonBuild')
+            [CompletionResult]::new('-V', 'V ', [CompletionResultType]::ParameterName, 'Print all version information and exit')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print all version information and exit')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Increase verbosity')

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -20,6 +20,8 @@ _moon() {
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-Z+[Unstable flags to MoonBuild]:UNSTABLE_FEATURE: ' \
 '--unstable-feature=[Unstable flags to MoonBuild]:UNSTABLE_FEATURE: ' \
+'-V[Print all version information and exit]' \
+'--version[Print all version information and exit]' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
 '-v[Increase verbosity]' \

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -18,9 +18,12 @@
 
 #![warn(clippy::clone_on_ref_ptr)]
 
-use std::{any::Any, io::IsTerminal};
+use std::{
+    any::Any,
+    io::{IsTerminal, Write},
+};
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use cli::MoonBuildSubcommands;
 
 mod build_flags;
@@ -130,6 +133,20 @@ pub fn main() {
         err.exit();
     });
     let mut flags = cli.flags;
+    let subcommand = if cli.version {
+        MoonBuildSubcommands::Version(cli::VersionSubcommand {
+            all: true,
+            json: false,
+            no_path: false,
+        })
+    } else if let Some(subcommand) = cli.subcommand {
+        subcommand
+    } else {
+        let mut stderr = std::io::stderr().lock();
+        let _ = cli::MoonBuildCli::command().write_long_help(&mut stderr);
+        let _ = writeln!(stderr);
+        std::process::exit(2);
+    };
     let output = UserDiagnostics::from_flags(&flags);
 
     if let Some(dir) = &flags.source_tgt_dir.cwd {
@@ -160,7 +177,7 @@ pub fn main() {
     for warning in flags.deprecation_warnings() {
         output.warn(warning);
     }
-    if flags.source_tgt_dir.manifest_path.is_some() && !matches!(cli.subcommand, Run(_)) {
+    if flags.source_tgt_dir.manifest_path.is_some() && !matches!(subcommand, Run(_)) {
         output.warn(
             "`--manifest-path` is deprecated. Prefer `-C <project-dir>` to select a different project.",
         );
@@ -170,7 +187,7 @@ pub fn main() {
     }
 
     use MoonBuildSubcommands::*;
-    let res = match cli.subcommand {
+    let res = match subcommand {
         Add(a) => cli::add_cli(flags, a),
         Bench(b) => cli::run_bench(flags, b),
         Build(b) => cli::run_build(&flags, b),

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -246,7 +246,7 @@ impl PlanningFixture {
 pub(super) fn parse_build_command(args: &[&str]) -> (UniversalFlags, BuildSubcommand) {
     let parsed = MoonBuildCli::try_parse_from(std::iter::once("moon").chain(args.iter().copied()))
         .expect("build command should parse");
-    let MoonBuildSubcommands::Build(cmd) = parsed.subcommand else {
+    let Some(MoonBuildSubcommands::Build(cmd)) = parsed.subcommand else {
         panic!("expected `moon build` to parse as the build subcommand");
     };
     (parsed.flags, cmd)
@@ -255,7 +255,7 @@ pub(super) fn parse_build_command(args: &[&str]) -> (UniversalFlags, BuildSubcom
 pub(super) fn parse_check_command(args: &[&str]) -> (UniversalFlags, CheckSubcommand) {
     let parsed = MoonBuildCli::try_parse_from(std::iter::once("moon").chain(args.iter().copied()))
         .expect("check command should parse");
-    let MoonBuildSubcommands::Check(cmd) = parsed.subcommand else {
+    let Some(MoonBuildSubcommands::Check(cmd)) = parsed.subcommand else {
         panic!("expected `moon check` to parse as the check subcommand");
     };
     (parsed.flags, cmd)
@@ -264,7 +264,7 @@ pub(super) fn parse_check_command(args: &[&str]) -> (UniversalFlags, CheckSubcom
 pub(super) fn parse_run_command(args: &[&str]) -> (UniversalFlags, RunSubcommand) {
     let parsed = MoonBuildCli::try_parse_from(std::iter::once("moon").chain(args.iter().copied()))
         .expect("run command should parse");
-    let MoonBuildSubcommands::Run(cmd) = parsed.subcommand else {
+    let Some(MoonBuildSubcommands::Run(cmd)) = parsed.subcommand else {
         panic!("expected `moon run` to parse as the run subcommand");
     };
     (parsed.flags, cmd)
@@ -273,7 +273,7 @@ pub(super) fn parse_run_command(args: &[&str]) -> (UniversalFlags, RunSubcommand
 pub(super) fn parse_test_command(args: &[&str]) -> (UniversalFlags, TestSubcommand) {
     let parsed = MoonBuildCli::try_parse_from(std::iter::once("moon").chain(args.iter().copied()))
         .expect("test command should parse");
-    let MoonBuildSubcommands::Test(cmd) = parsed.subcommand else {
+    let Some(MoonBuildSubcommands::Test(cmd)) = parsed.subcommand else {
         panic!("expected `moon test` to parse as the test subcommand");
     };
     (parsed.flags, cmd)
@@ -282,7 +282,7 @@ pub(super) fn parse_test_command(args: &[&str]) -> (UniversalFlags, TestSubcomma
 pub(super) fn parse_bench_command(args: &[&str]) -> (UniversalFlags, BenchSubcommand) {
     let parsed = MoonBuildCli::try_parse_from(std::iter::once("moon").chain(args.iter().copied()))
         .expect("bench command should parse");
-    let MoonBuildSubcommands::Bench(cmd) = parsed.subcommand else {
+    let Some(MoonBuildSubcommands::Bench(cmd)) = parsed.subcommand else {
         panic!("expected `moon bench` to parse as the bench subcommand");
     };
     (parsed.flags, cmd)

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -59,7 +59,8 @@ fn test_moon_help() {
               help                   Print this message or the help of the given subcommand(s)
 
             Options:
-              -h, --help  Print help
+              -V, --version  Print all version information and exit
+              -h, --help     Print help
 
             Common Options:
               -C <DIR>
@@ -146,6 +147,71 @@ fn test_moon_explain_without_flags_shows_guidance() {
                 Use `moon explain --diagnostics` to list warning mnemonics and IDs.
         "#]],
     );
+}
+
+#[test]
+fn test_moon_version_flag() {
+    let dir = TestDir::new_empty();
+    snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+moon [..]
+moonc [..]
+moonrun [..]
+...
+"#]])
+        .stderr_eq("");
+}
+
+#[test]
+fn test_moon_version_flag_reports_unstable_features() {
+    let dir = TestDir::new_empty();
+    snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .args(["-Z", "rr_moon_pkg", "--version"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+moon [..]
+moonc [..]
+moonrun [..]
+
+Feature flags enabled: rr_moon_pkg
+
+"#]])
+        .stderr_eq("");
+}
+
+#[test]
+fn test_moon_flag_without_subcommand_shows_help() {
+    let dir = TestDir::new_empty();
+    snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .arg("-q")
+        .assert()
+        .code(2)
+        .stdout_eq("")
+        .stderr_eq(snapbox::str![[r#"
+The build system and package manager for MoonBit.
+
+Usage: moon [OPTIONS] <COMMAND>
+
+Commands:
+...
+  version                Print version information and exit
+  help                   Print this message or the help of the given subcommand(s)
+
+Options:
+  -V, --version
+          Print all version information and exit
+...
+Common Options:
+...
+
+"#]]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a root -V/--version flag for moon
- route the flag through the existing version command as --all so feature flags are reported
- update CLI tests and shell completion snapshots

## Tests
- cargo test -p moon test_moon_version_flag --test mod
- cargo test -p moon test_moon_version_flag_reports_unstable_features --test mod
- cargo test -p moon test_moon_help --test mod
- cargo test -p moon shell_completion
- cargo clippy -p moon --tests -- -D warnings