### PR TITLE
refactor: clarify project selection pipeline

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -163,8 +163,8 @@ fn run_build_rr(
         cmd.auto_sync_flags.clone(),
         !cmd.build_flags.std(),
         cmd.build_flags.enable_coverage,
+        cli.workspace_env.clone(),
     )
-    .with_workspace_env(cli.workspace_env.clone())
     .with_project_manifest_path(project_manifest_path);
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir, mooncakes_dir)?;
     let prebuild_list = if watch {

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -285,8 +285,8 @@ fn run_check_for_single_file_rr(
         cmd.auto_sync_flags.clone(),
         false,
         cmd.build_flags.enable_coverage,
-    )
-    .with_workspace_env(cli.workspace_env.clone());
+        cli.workspace_env.clone(),
+    );
     let (resolved, backend) = moonbuild_rupes_recta::resolve::resolve_single_file_project(
         &resolve_cfg,
         target_dir,
@@ -434,8 +434,8 @@ fn run_check_normal_internal_rr(
         cmd.auto_sync_flags.clone(),
         !cmd.build_flags.std(),
         cmd.build_flags.enable_coverage,
+        cli.workspace_env.clone(),
     )
-    .with_workspace_env(cli.workspace_env.clone())
     .with_project_manifest_path(project_manifest_path);
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir, mooncakes_dir)
         .context("Failed to calculate build plan")?;

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -289,8 +289,8 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
         cmd.auto_sync_flags.frozen,
         !build_flags.std(),
         build_flags.enable_coverage,
+        cli.workspace_env.clone(),
     )
-    .with_workspace_env(cli.workspace_env.clone())
     .with_project_manifest_path(project_manifest_path.as_deref());
     let resolve_output = resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
     let output = UserDiagnostics::from_flags(&cli);

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -27,6 +27,7 @@ use mooncake::registry::{OnlineRegistry, Registry};
 use moonutil::{
     cli::UniversalFlags,
     common::{FileLock, MOON_MOD, MOON_MOD_JSON, RunMode, TargetBackend},
+    dirs::PackageDirs,
     mooncakes::{ModuleName, RegistryConfig},
 };
 use semver::Version;
@@ -282,7 +283,15 @@ pub(super) fn install_binary(
     let filter =
         PackageFilter::package_path(spec.package_path.clone().unwrap_or_default(), install_all);
 
-    build_and_install_packages(cli, &spec.module_name, module_dir, install_dir, filter)
+    let package_dirs = cli.source_tgt_dir.source_root_package_dirs(module_dir)?;
+    build_and_install_packages(
+        cli,
+        &spec.module_name,
+        module_dir,
+        package_dirs,
+        install_dir,
+        filter,
+    )
 }
 
 /// Install from a local path.
@@ -299,20 +308,30 @@ pub(super) fn install_from_local(
         )
     })?;
 
-    let module_root = moonutil::dirs::find_ancestor_with_mod(&input_path).ok_or_else(|| {
-        anyhow::anyhow!(
-            "Path `{}` is not in a MoonBit module (no {} or {} found in ancestors)",
-            input_path.display(),
-            MOON_MOD,
-            MOON_MOD_JSON
-        )
-    })?;
+    let module_dirs = cli
+        .source_tgt_dir
+        .source_module_package_dirs(&input_path)?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Path `{}` is not in a MoonBit module (no {} or {} found in ancestors)",
+                input_path.display(),
+                MOON_MOD,
+                MOON_MOD_JSON
+            )
+        })?;
 
-    let module = moonutil::common::read_module_desc_file_in_dir(&module_root)?;
+    let module = moonutil::common::read_module_desc_file_in_dir(&module_dirs.module_root)?;
     let module_name: ModuleName = module.name.parse().map_err(|e| anyhow::anyhow!("{}", e))?;
     let filter = PackageFilter::filesystem(input_path, install_all);
 
-    build_and_install_packages(cli, &module_name, &module_root, install_dir, filter)
+    build_and_install_packages(
+        cli,
+        &module_name,
+        &module_dirs.module_root,
+        module_dirs.package_dirs,
+        install_dir,
+        filter,
+    )
 }
 
 /// Git reference type for checkout.
@@ -419,16 +438,25 @@ pub(super) fn install_from_git(
         );
     }
 
-    // Find module root
-    let module_root = moonutil::dirs::find_ancestor_with_mod(&target_path).ok_or_else(|| {
-        anyhow::anyhow!("No {} or {} found in repository", MOON_MOD, MOON_MOD_JSON)
-    })?;
+    let module_dirs = cli
+        .source_tgt_dir
+        .source_module_package_dirs(&target_path)?
+        .ok_or_else(|| {
+            anyhow::anyhow!("No {} or {} found in repository", MOON_MOD, MOON_MOD_JSON)
+        })?;
 
-    let module = moonutil::common::read_module_desc_file_in_dir(&module_root)?;
+    let module = moonutil::common::read_module_desc_file_in_dir(&module_dirs.module_root)?;
     let module_name: ModuleName = module.name.parse().map_err(|e| anyhow::anyhow!("{}", e))?;
     let filter = PackageFilter::filesystem(target_path, install_all);
 
-    build_and_install_packages(cli, &module_name, &module_root, install_dir, filter)
+    build_and_install_packages(
+        cli,
+        &module_name,
+        &module_dirs.module_root,
+        module_dirs.package_dirs,
+        install_dir,
+        filter,
+    )
 }
 
 /// Build matching packages and install binaries using RR build engine.
@@ -436,18 +464,18 @@ fn build_and_install_packages(
     cli: &UniversalFlags,
     module_name: &ModuleName,
     module_dir: &Path,
+    package_dirs: PackageDirs,
     install_dir: &Path,
     filter: PackageFilter,
 ) -> anyhow::Result<i32> {
     let quiet = cli.quiet;
     let output = UserDiagnostics::from_flags(cli);
-    let package_dirs = cli.source_tgt_dir.source_root_package_dirs(module_dir)?;
     let source_dir = package_dirs.source_dir;
     let target_dir = package_dirs.target_dir;
     let mooncakes_dir = package_dirs.mooncakes_dir;
 
-    let resolve_cfg = ResolveConfig::new_with_load_defaults(false, false, false)
-        .with_workspace_env(cli.workspace_env.clone());
+    let resolve_cfg =
+        ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone());
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
 
     let main_module_id = resolve_output.local_modules()[0];

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -241,8 +241,8 @@ fn run_run_rr(
         cmd.auto_sync_flags.clone(),
         !cmd.build_flags.std(),
         cmd.build_flags.enable_coverage,
+        cli.workspace_env.clone(),
     )
-    .with_workspace_env(cli.workspace_env.clone())
     .with_project_manifest_path(project_manifest_path.as_deref());
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
     let (build_meta, build_graph) = plan_run_rr_from_resolved(
@@ -391,8 +391,8 @@ fn run_single_file_rr(
         cmd.auto_sync_flags.clone(),
         false,
         cmd.build_flags.enable_coverage,
-    )
-    .with_workspace_env(cli.workspace_env.clone());
+        cli.workspace_env.clone(),
+    );
     let (resolved, backend) = moonbuild_rupes_recta::resolve::resolve_single_file_project(
         &resolve_cfg,
         target_dir.as_path(),

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -374,8 +374,8 @@ fn run_test_in_single_file_rr(
         cmd.auto_sync_flags.clone(),
         false,
         cmd.build_flags.enable_coverage,
-    )
-    .with_workspace_env(cli.workspace_env.clone());
+        cli.workspace_env.clone(),
+    );
     let (resolved, backend) = moonbuild_rupes_recta::resolve::resolve_single_file_project(
         &resolve_cfg,
         target_dir,
@@ -797,8 +797,8 @@ fn run_test_rr(
                 cmd.auto_sync_flags.frozen,
                 !cmd.build_flags.std(),
                 cmd.build_flags.enable_coverage,
+                cli.workspace_env.clone(),
             )
-            .with_workspace_env(cli.workspace_env.clone())
             .with_project_manifest_path(project_manifest_path),
             source_dir,
             mooncakes_dir,

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -87,9 +87,9 @@ pub(crate) fn run_build_binary_dep(
     // bin-deps have their build target determined in `moon.pkg.json`, so we
     // must resolve the packages before settling on the build config and then
     // running the build plan.
-    let resolve_cfg = ResolveConfig::new_with_load_defaults(false, false, false)
-        .with_workspace_env(cli.workspace_env.clone())
-        .with_project_manifest_path(project_manifest_path.as_deref());
+    let resolve_cfg =
+        ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone())
+            .with_project_manifest_path(project_manifest_path.as_deref());
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
 
     // Note: There's a cyclic dependency!

--- a/crates/moon/src/cli/work.rs
+++ b/crates/moon/src/cli/work.rs
@@ -19,7 +19,7 @@
 use std::path::PathBuf;
 
 use anyhow::bail;
-use moonutil::dirs::PackageDirs;
+use moonutil::dirs::{PackageDirs, WorkRootSelection};
 
 use super::UniversalFlags;
 
@@ -60,7 +60,7 @@ pub(crate) fn work_cli(cli: UniversalFlags, cmd: WorkSubcommand) -> anyhow::Resu
                 bail!("dry-run is not supported for work init")
             }
 
-            let workspace_root = work_root(&cli, false)?;
+            let workspace_root = work_root(&cli, WorkRootSelection::CreateWorkspace)?;
             mooncake::pkg::init_workspace(&workspace_root, &cmd.paths, cli.quiet)
         }
         WorkSubcommands::Use(cmd) => {
@@ -68,7 +68,7 @@ pub(crate) fn work_cli(cli: UniversalFlags, cmd: WorkSubcommand) -> anyhow::Resu
                 bail!("dry-run is not supported for work use")
             }
 
-            let workspace_root = work_root(&cli, true)?;
+            let workspace_root = work_root(&cli, WorkRootSelection::ReuseExistingWorkspace)?;
             mooncake::pkg::use_workspace(&workspace_root, &cmd.paths, cli.quiet)
         }
         WorkSubcommands::Sync => {
@@ -85,8 +85,8 @@ pub(crate) fn work_cli(cli: UniversalFlags, cmd: WorkSubcommand) -> anyhow::Resu
     }
 }
 
-fn work_root(cli: &UniversalFlags, prefer_existing_workspace: bool) -> anyhow::Result<PathBuf> {
+fn work_root(cli: &UniversalFlags, selection: WorkRootSelection) -> anyhow::Result<PathBuf> {
     Ok(cli
         .source_tgt_dir
-        .work_root(prefer_existing_workspace, cli.workspace_env.clone())?)
+        .work_root(selection, cli.workspace_env.clone())?)
 }

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -538,7 +538,7 @@ mod tests {
     }
 
     fn resolve_output(source_dir: &Path) -> moonbuild_rupes_recta::ResolveOutput {
-        let cfg = ResolveConfig::new_with_load_defaults(false, false, false);
+        let cfg = ResolveConfig::new_with_load_defaults(false, false, false, WorkspaceEnv::Auto);
         let manifest_path = if source_dir.join(MOON_WORK).exists() {
             source_dir.join(MOON_WORK)
         } else {

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -460,8 +460,8 @@ pub(crate) fn plan_build<'a>(
         preconfig.frozen,
         !preconfig.use_std,
         preconfig.enable_coverage,
+        preconfig.workspace_env.clone(),
     )
-    .with_workspace_env(preconfig.workspace_env.clone())
     .with_project_manifest_path(project_manifest_path);
     let resolve_output = moonbuild_rupes_recta::resolve(&cfg, source_dir, mooncakes_dir)?;
 

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -21,7 +21,7 @@ use moonbuild_debug::graph::debug_dump_build_graph;
 use std::path::PathBuf;
 
 use moonbuild_rupes_recta::ResolveOutput;
-use moonutil::{cli::UniversalFlags, common::BUILD_DIR, dirs::PackageDirs};
+use moonutil::{cli::UniversalFlags, common::BUILD_DIR, dirs::WorkspaceEnv};
 
 use crate::cli::{
     BenchSubcommand, BuildSubcommand, CheckSubcommand, MoonBuildCli, MoonBuildSubcommands,
@@ -40,12 +40,14 @@ impl PlanningFixture {
         // These planner tests only inspect graph construction, so they can use
         // the checked-in fixture directly without copying it to a temp directory.
         let source_dir = dunce::canonicalize(case_root.join(case))?;
-        let package_dirs =
-            PackageDirs::from_source_and_target(source_dir.clone(), source_dir.join(BUILD_DIR));
-        let target_dir = package_dirs.target_dir;
-        let mooncakes_dir = package_dirs.mooncakes_dir;
-        let resolve_cfg =
-            moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(true, false, false);
+        let target_dir = source_dir.join(BUILD_DIR);
+        let mooncakes_dir = source_dir.join(".mooncakes");
+        let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
+            true,
+            false,
+            false,
+            WorkspaceEnv::Auto,
+        );
         let resolve_output =
             moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
         Ok(Self {

--- a/crates/moon/src/watch/prebuild_output.rs
+++ b/crates/moon/src/watch/prebuild_output.rs
@@ -89,7 +89,7 @@ mod tests {
     use super::*;
 
     use moonbuild_rupes_recta::resolve::{ResolveConfig, resolve};
-    use moonutil::dirs::PackageDirs;
+    use moonutil::dirs::WorkspaceEnv;
 
     #[test]
     fn rr_get_prebuild_watch_paths_skips_empty_modules() {
@@ -103,9 +103,9 @@ mod tests {
         .unwrap();
 
         let resolved = resolve(
-            &ResolveConfig::new_with_load_defaults(false, false, false),
+            &ResolveConfig::new_with_load_defaults(false, false, false, WorkspaceEnv::Auto),
             temp_dir.path(),
-            &PackageDirs::mooncakes_dir_for_source(temp_dir.path()),
+            &temp_dir.path().join(".mooncakes"),
         )
         .unwrap();
 
@@ -139,9 +139,9 @@ mod tests {
         .unwrap();
 
         let resolved = resolve(
-            &ResolveConfig::new_with_load_defaults(false, false, false),
+            &ResolveConfig::new_with_load_defaults(false, false, false, WorkspaceEnv::Auto),
             temp_dir.path(),
-            &PackageDirs::mooncakes_dir_for_source(temp_dir.path()),
+            &temp_dir.path().join(".mooncakes"),
         )
         .unwrap();
 

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -25,10 +25,9 @@ use super::*;
 use expect_test::expect;
 use moonutil::{
     common::{
-        BUILD_DIR, CargoPathExt, MBTI_GENERATED, MOON_BIN_DIR, MOON_MOD_JSON, StringExt,
-        TargetBackend, get_cargo_pkg_version,
+        BUILD_DIR, CargoPathExt, MBTI_GENERATED, MOON_BIN_DIR, MOON_MOD_JSON, MOON_NO_WORKSPACE,
+        MOON_WORK_ENV, StringExt, TargetBackend, get_cargo_pkg_version,
     },
-    dirs::{MOON_NO_WORKSPACE, MOON_WORK_ENV, PackageDirs},
     module::MoonModJSON,
 };
 use walkdir::WalkDir;
@@ -571,9 +570,7 @@ fn mooncakes_io_smoke_test() {
     )
     .unwrap();
 
-    let mooncakes_dir =
-        PackageDirs::from_source_and_target(dir.as_ref().to_path_buf(), dir.join(BUILD_DIR))
-            .mooncakes_dir;
+    let mooncakes_dir = dir.as_ref().join(".mooncakes");
 
     assert!(
         mooncakes_dir
@@ -1488,9 +1485,8 @@ fn test_pre_build_mooncake_bin_shape() {
         .replace('\\', "/");
 
     let source_dir = dunce::canonicalize(&dir).unwrap();
-    let dirs = PackageDirs::from_source_and_target(source_dir.clone(), source_dir.join(BUILD_DIR));
-    let expected_path = dirs
-        .mooncakes_dir
+    let expected_path = source_dir
+        .join(".mooncakes")
         .join(MOON_BIN_DIR)
         .to_string_lossy()
         .replace('\\', "/");

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -1,8 +1,5 @@
 use super::*;
-use moonutil::{
-    common::MBTI_GENERATED,
-    dirs::{MOON_NO_WORKSPACE, MOON_WORK_ENV},
-};
+use moonutil::common::{MBTI_GENERATED, MOON_NO_WORKSPACE, MOON_WORK_ENV};
 use std::path::Path;
 
 fn assert_requires_target_module(stderr: &str, command: &str) {

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -277,30 +277,35 @@ mod tests {
 impl ResolveConfig {
     /// Creates a new `ResolveConfig` with whether to freeze package resolving,
     /// and other flags populated with sensible defaults.
-    pub fn new_with_load_defaults(frozen: bool, no_std: bool, enable_coverage: bool) -> Self {
+    pub fn new_with_load_defaults(
+        frozen: bool,
+        no_std: bool,
+        enable_coverage: bool,
+        workspace_env: WorkspaceEnv,
+    ) -> Self {
         Self {
             sync_flags: AutoSyncFlags { frozen },
             no_std,
             enable_coverage,
-            workspace_env: WorkspaceEnv::Auto,
+            workspace_env,
             project_manifest_path: None,
         }
     }
 
     /// Creates a new `ResolveConfig` with the given sync and build flags.
-    pub fn new(sync_flags: AutoSyncFlags, no_std: bool, enable_coverage: bool) -> Self {
+    pub fn new(
+        sync_flags: AutoSyncFlags,
+        no_std: bool,
+        enable_coverage: bool,
+        workspace_env: WorkspaceEnv,
+    ) -> Self {
         Self {
             sync_flags,
             no_std,
             enable_coverage,
-            workspace_env: WorkspaceEnv::Auto,
+            workspace_env,
             project_manifest_path: None,
         }
-    }
-
-    pub fn with_workspace_env(mut self, workspace_env: WorkspaceEnv) -> Self {
-        self.workspace_env = workspace_env;
-        self
     }
 
     pub fn with_project_manifest_path(mut self, project_manifest_path: Option<&Path>) -> Self {

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -17,7 +17,6 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::cond_expr::{CompileCondition, OptLevel};
-pub use crate::dirs::check_moon_mod_exists;
 use crate::module::{MoonMod, MoonModJSON};
 use crate::moon_pkg;
 use crate::mooncakes::ModuleName;
@@ -45,6 +44,8 @@ pub const MOON_MOD: &str = "moon.mod";
 pub const MOON_MOD_JSON: &str = "moon.mod.json";
 pub const MOON_PKG_JSON: &str = "moon.pkg.json";
 pub const MOON_WORK: &str = "moon.work";
+pub const MOON_WORK_ENV: &str = "MOON_WORK";
+pub const MOON_NO_WORKSPACE: &str = "MOON_NO_WORKSPACE";
 pub const MOON_PKG: &str = "moon.pkg";
 pub const MBTI_GENERATED: &str = "pkg.generated.mbti";
 pub const MBTI_USER_WRITTEN: &str = "pkg.mbti";

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -120,7 +120,13 @@ impl SourceTargetDirs {
             .context("failed to resolve source directory")
             .map_err(PackageDirsError::from)?;
         let target_dir = self.resolve_target_dir(&source_dir)?;
-        Ok(PackageDirs::from_source_and_target(source_dir, target_dir))
+        let mooncakes_dir = source_dir.join(DEP_PATH);
+        Ok(PackageDirs {
+            source_dir,
+            target_dir,
+            mooncakes_dir,
+            project_manifest_path: None,
+        })
     }
 
     pub fn source_module_package_dirs(
@@ -180,8 +186,7 @@ impl SourceTargetDirs {
     fn deprecated_manifest_override(
         &self,
     ) -> Result<Option<ExplicitManifestOverride>, PackageDirsError> {
-        // Compatibility path for deprecated `--manifest-path`. Keep all parsing
-        // here so removing the flag later does not disturb normal discovery.
+        // TODO: Remove this compatibility path when deprecated `--manifest-path` is removed.
         self.manifest_path
             .as_deref()
             .map(deprecated_manifest_override_from_path)
@@ -219,29 +224,6 @@ pub struct PackageDirs {
     pub target_dir: PathBuf,
     pub mooncakes_dir: PathBuf,
     pub project_manifest_path: Option<PathBuf>,
-}
-
-impl PackageDirs {
-    fn mooncakes_dir_for_source(source_dir: &Path) -> PathBuf {
-        source_dir.join(DEP_PATH)
-    }
-
-    fn from_source_and_target(source_dir: PathBuf, target_dir: PathBuf) -> Self {
-        Self::from_source_and_target_with_manifest(source_dir, target_dir, None)
-    }
-
-    fn from_source_and_target_with_manifest(
-        source_dir: PathBuf,
-        target_dir: PathBuf,
-        project_manifest_path: Option<PathBuf>,
-    ) -> Self {
-        Self {
-            source_dir: source_dir.clone(),
-            target_dir,
-            mooncakes_dir: Self::mooncakes_dir_for_source(&source_dir),
-            project_manifest_path,
-        }
-    }
 }
 
 pub struct SingleFilePackageDirs {
@@ -414,17 +396,6 @@ impl WorkspaceFacts {
             root,
         })
     }
-
-    fn from_pinned_manifest_path(manifest_path: &Path) -> Result<Self, PackageDirsError> {
-        let manifest_path = dunce::canonicalize(manifest_path)
-            .context("failed to resolve pinned workspace path")
-            .map_err(PackageDirsError::from)?;
-        let root = manifest_root(&manifest_path).map_err(PackageDirsError::from)?;
-        Ok(Self {
-            manifest_path,
-            root,
-        })
-    }
 }
 
 impl ProjectQuery {
@@ -454,7 +425,14 @@ impl ProjectQuery {
         let workspace = match &workspace_env {
             WorkspaceEnv::Off => None,
             WorkspaceEnv::Pinned(workspace_path) => {
-                Some(WorkspaceFacts::from_pinned_manifest_path(workspace_path)?)
+                let manifest_path = dunce::canonicalize(workspace_path)
+                    .context("failed to resolve pinned workspace path")
+                    .map_err(PackageDirsError::from)?;
+                let root = manifest_root(&manifest_path).map_err(PackageDirsError::from)?;
+                Some(WorkspaceFacts {
+                    manifest_path,
+                    root,
+                })
             }
             WorkspaceEnv::Auto => None,
         };
@@ -472,7 +450,13 @@ impl ProjectQuery {
     }
 
     pub fn probe_project(&mut self) -> Result<ProjectProbe, PackageDirsError> {
-        match self.resolve_project_context() {
+        let project_context = if let Some(manifest) = self.deprecated_manifest_override.clone() {
+            self.project_context_from_deprecated_manifest_override(&manifest)
+        } else {
+            self.project_context_from_start_dir()
+        };
+
+        match project_context {
             Ok(project) => Ok(ProjectProbe::Found(project)),
             Err(error) if error.allows_single_file_fallback() => {
                 Ok(ProjectProbe::NotFound(ProjectNotFound { error }))
@@ -491,11 +475,14 @@ impl ProjectQuery {
     pub fn package_dirs(&mut self) -> Result<PackageDirs, PackageDirsError> {
         let project = self.project()?;
         let target_dir = self.resolve_target_dir(project.root())?;
-        Ok(PackageDirs::from_source_and_target_with_manifest(
-            project.root().to_path_buf(),
+        let source_dir = project.root().to_path_buf();
+        let mooncakes_dir = source_dir.join(DEP_PATH);
+        Ok(PackageDirs {
+            source_dir,
             target_dir,
-            Some(project.manifest_path().to_path_buf()),
-        ))
+            mooncakes_dir,
+            project_manifest_path: Some(project.manifest_path().to_path_buf()),
+        })
     }
 
     pub fn workspace_ref(&mut self) -> Result<Option<WorkspaceRef>, PackageDirsError> {
@@ -515,14 +502,6 @@ impl ProjectQuery {
         } else {
             Ok(start_dir)
         }
-    }
-
-    fn resolve_project_context(&mut self) -> Result<ProjectContext, PackageDirsError> {
-        if let Some(manifest) = self.deprecated_manifest_override.clone() {
-            return self.project_context_from_deprecated_manifest_override(&manifest);
-        }
-
-        self.project_context_from_start_dir()
     }
 
     fn project_context_from_deprecated_manifest_override(
@@ -997,7 +976,7 @@ fn deprecated_manifest_override_from_path(
 #[cfg(test)]
 mod tests {
     use super::{
-        PackageDirs, PackageDirsError, ProjectContext, ProjectProbe, WorkspaceEnv,
+        PackageDirsError, ProjectContext, ProjectProbe, SourceTargetDirs, WorkspaceEnv,
         parse_workspace_env, project_query_from_start_dir,
         resolve_project_context_from_manifest_path, resolve_project_context_from_start_dir,
     };
@@ -1077,20 +1056,17 @@ mod tests {
     }
 
     #[test]
-    fn mooncakes_dir_tracks_project_root() {
-        let project = PathBuf::from("project");
-        assert_eq!(
-            PackageDirs::mooncakes_dir_for_source(&project),
-            project.join(DEP_PATH)
-        );
-    }
-
-    #[test]
     fn mooncakes_dir_comes_from_source_even_with_custom_target() {
-        let project = PathBuf::from("project");
-        let target = PathBuf::from("tmp-target");
-        let dirs = PackageDirs::from_source_and_target(project.clone(), target);
-        assert_eq!(dirs.mooncakes_dir, project.join(DEP_PATH));
+        let project = TestProject::new();
+        let target = project.join("tmp-target");
+        let dirs = SourceTargetDirs {
+            cwd: None,
+            manifest_path: None,
+            target_dir: Some(target),
+        }
+        .source_root_package_dirs(project.path())
+        .unwrap();
+        assert_eq!(dirs.mooncakes_dir, canonical(project.path()).join(DEP_PATH));
     }
 
     #[test]

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -25,14 +25,12 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::common::{BUILD_DIR, DEP_PATH, MOON_MOD, MOON_MOD_JSON, MOON_WORK};
+use crate::common::{
+    BUILD_DIR, DEP_PATH, MOON_MOD, MOON_MOD_JSON, MOON_NO_WORKSPACE, MOON_WORK, MOON_WORK_ENV,
+};
 use crate::workspace::{
     canonical_workspace_module_dirs, read_workspace_file, workspace_manifest_path,
 };
-
-/// Set to a non-`0` value to disable workspace mode entirely.
-pub const MOON_NO_WORKSPACE: &str = "MOON_NO_WORKSPACE";
-pub const MOON_WORK_ENV: &str = "MOON_WORK";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WorkspaceEnv {
@@ -64,7 +62,7 @@ pub enum PackageDirsError {
 }
 
 impl PackageDirsError {
-    pub fn allows_single_file_fallback(&self) -> bool {
+    fn allows_single_file_fallback(&self) -> bool {
         matches!(
             self,
             Self::NotInProject(_) | Self::WorkspaceDisabledNotInModule(_)
@@ -125,6 +123,20 @@ impl SourceTargetDirs {
         Ok(PackageDirs::from_source_and_target(source_dir, target_dir))
     }
 
+    pub fn source_module_package_dirs(
+        &self,
+        source_path: impl AsRef<Path>,
+    ) -> Result<Option<SourceModulePackageDirs>, PackageDirsError> {
+        let Some(module_root) = find_enclosing_module_root(source_path.as_ref()) else {
+            return Ok(None);
+        };
+        let package_dirs = self.source_root_package_dirs(&module_root)?;
+        Ok(Some(SourceModulePackageDirs {
+            module_root,
+            package_dirs,
+        }))
+    }
+
     pub fn single_file_package_dirs(
         &self,
         file_path: impl AsRef<Path>,
@@ -153,16 +165,16 @@ impl SourceTargetDirs {
 
     pub fn work_root(
         &self,
-        prefer_existing_workspace: bool,
+        selection: WorkRootSelection,
         workspace_env: WorkspaceEnv,
     ) -> Result<PathBuf, PackageDirsError> {
         let start_dir = Self::current_dir()?;
-        let mut query = if prefer_existing_workspace {
+        let mut query = if selection.prefers_existing_workspace() {
             self.query_from(&start_dir, workspace_env)?
         } else {
             self.query_from(&start_dir, WorkspaceEnv::Off)?
         };
-        query.work_root(prefer_existing_workspace)
+        query.work_root(selection)
     }
 
     fn deprecated_manifest_override(
@@ -210,15 +222,15 @@ pub struct PackageDirs {
 }
 
 impl PackageDirs {
-    pub fn mooncakes_dir_for_source(source_dir: &Path) -> PathBuf {
+    fn mooncakes_dir_for_source(source_dir: &Path) -> PathBuf {
         source_dir.join(DEP_PATH)
     }
 
-    pub fn from_source_and_target(source_dir: PathBuf, target_dir: PathBuf) -> Self {
+    fn from_source_and_target(source_dir: PathBuf, target_dir: PathBuf) -> Self {
         Self::from_source_and_target_with_manifest(source_dir, target_dir, None)
     }
 
-    pub fn from_source_and_target_with_manifest(
+    fn from_source_and_target_with_manifest(
         source_dir: PathBuf,
         target_dir: PathBuf,
         project_manifest_path: Option<PathBuf>,
@@ -235,6 +247,23 @@ impl PackageDirs {
 pub struct SingleFilePackageDirs {
     pub file_path: PathBuf,
     pub package_dirs: PackageDirs,
+}
+
+pub struct SourceModulePackageDirs {
+    pub module_root: PathBuf,
+    pub package_dirs: PackageDirs,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkRootSelection {
+    CreateWorkspace,
+    ReuseExistingWorkspace,
+}
+
+impl WorkRootSelection {
+    fn prefers_existing_workspace(self) -> bool {
+        matches!(self, Self::ReuseExistingWorkspace)
+    }
 }
 
 #[derive(Debug)]
@@ -324,14 +353,14 @@ impl ProjectContext {
     }
 }
 
-pub fn check_moon_mod_exists(source_dir: &Path) -> bool {
+fn has_module_manifest(source_dir: &Path) -> bool {
     source_dir.join(MOON_MOD).exists() || source_dir.join(MOON_MOD_JSON).exists()
 }
 
-pub fn find_ancestor_with_mod(source_dir: &Path) -> Option<PathBuf> {
+fn find_enclosing_module_root(source_dir: &Path) -> Option<PathBuf> {
     source_dir
         .ancestors()
-        .find(|dir| check_moon_mod_exists(dir))
+        .find(|dir| has_module_manifest(dir))
         .map(|p| p.to_path_buf())
 }
 
@@ -415,8 +444,8 @@ impl ProjectQuery {
         let deprecated_manifest_override = source_target_dirs.deprecated_manifest_override()?;
         let module_dir = match &deprecated_manifest_override {
             Some(manifest) if manifest.kind == ManifestKind::Module => Some(manifest.root.clone()),
-            Some(manifest) => find_ancestor_with_mod(&manifest.root),
-            None => find_ancestor_with_mod(&start_dir),
+            Some(manifest) => find_enclosing_module_root(&manifest.root),
+            None => find_enclosing_module_root(&start_dir),
         };
         let module_manifest_path = match &deprecated_manifest_override {
             Some(manifest) if manifest.kind == ManifestKind::Module => Some(manifest.path.clone()),
@@ -469,32 +498,19 @@ impl ProjectQuery {
         ))
     }
 
-    pub fn selected_module(&mut self) -> Result<Option<ModuleRef>, PackageDirsError> {
-        Ok(self.project()?.selected_module())
-    }
-
     pub fn workspace_ref(&mut self) -> Result<Option<WorkspaceRef>, PackageDirsError> {
         Ok(self.project()?.workspace_ref())
     }
 
-    pub fn workspace_members(&mut self) -> Result<Option<Vec<PathBuf>>, PackageDirsError> {
-        if self.workspace_ref()?.is_none() {
-            return Ok(None);
-        }
-        self.ensure_workspace_members()
-            .map(|member_dirs| member_dirs.map(<[PathBuf]>::to_vec))
-    }
-
-    pub fn work_root(
-        &mut self,
-        prefer_existing_workspace: bool,
-    ) -> Result<PathBuf, PackageDirsError> {
-        if prefer_existing_workspace && let Some(work_root) = self.workspace_root_for_sync()? {
+    pub fn work_root(&mut self, selection: WorkRootSelection) -> Result<PathBuf, PackageDirsError> {
+        if selection.prefers_existing_workspace()
+            && let Some(work_root) = self.workspace_root_for_sync()?
+        {
             return Ok(work_root);
         }
 
         let start_dir = self.work_start_dir();
-        if let Some(module_dir) = find_ancestor_with_mod(&start_dir) {
+        if let Some(module_dir) = find_enclosing_module_root(&start_dir) {
             Ok(module_dir)
         } else {
             Ok(start_dir)
@@ -898,7 +914,7 @@ fn find_applicable_workspace_manifest_path(source_dir: &Path) -> anyhow::Result<
 
     for dir in source_dir.ancestors() {
         let Some(workspace_path) = workspace_manifest_path(dir) else {
-            if module_root.is_none() && check_moon_mod_exists(dir) {
+            if module_root.is_none() && has_module_manifest(dir) {
                 module_root = Some(dir);
             }
             continue;
@@ -1113,27 +1129,6 @@ version = "0.1.0"
             not_found.into_error(),
             PackageDirsError::NotInProject(path) if path == canonical(project.path())
         ));
-    }
-
-    #[test]
-    fn workspace_members_are_projected_on_demand() {
-        let project = TestProject::new();
-        write_file(
-            &project.join("moon.work"),
-            "members = [\n  \"./missing\",\n]\n",
-        );
-
-        let mut query =
-            project_query_from_start_dir(project.path().to_path_buf(), &WorkspaceEnv::Auto)
-                .unwrap();
-        assert!(
-            matches!(query.project().unwrap(), ProjectContext::Workspace { .. }),
-            "workspace root should resolve without canonicalizing members"
-        );
-        assert!(
-            query.workspace_members().is_err(),
-            "workspace members projection should canonicalize member paths on demand"
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make `ResolveConfig` require an explicit `WorkspaceEnv` at construction and remove `with_workspace_env`
- route command project selection through explicit pipeline projections for workspace-aware commands, local discovery, single-file fallback, and work roots
- remove low-level/test-only public APIs from `moonutil::dirs`, including direct ancestor module probing

## Verification
- `cargo fmt --check`
- `cargo check -p moonutil -p mooncake -p moonbuild-rupes-recta -p moon`
- `cargo clippy -p moonutil -p moon --tests -- -D warnings`
- `cargo test -p moonutil dirs::tests -- --nocapture`
- `cargo test -p moon cli_to_planner -- --nocapture`
- `cargo test -p moon rr_get_prebuild_watch_paths -- --nocapture`
- `cargo test -p moon workspace_basic -- --nocapture`
- `cargo test -p moon single_file_front_matter -- --nocapture`
- `cargo test -p moon test_moon_run_single -- --nocapture`
- `cargo test -p moon fmt_moon_mod -- --nocapture`
- `git diff --check`