### PR TITLE
refactor: share preferred backend grouping

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -29,8 +29,9 @@ use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
 
 use crate::filter::{
-    ensure_packages_support_backend, filter_pkg_by_dir, match_packages_by_name_rr,
-    package_supports_backend, select_packages, select_supported_packages,
+    TargetPackageGroup, ensure_packages_support_backend, filter_pkg_by_dir,
+    group_packages_by_preferred_backend, match_packages_by_name_rr, package_supports_backend,
+    select_packages, select_supported_packages,
 };
 use crate::rr_build;
 use crate::rr_build::BuildConfig;
@@ -42,12 +43,6 @@ use crate::watch::prebuild_output::{PrebuildWatchPaths, rr_get_prebuild_watch_pa
 use crate::watch::watching;
 
 use super::{BuildFlags, UniversalFlags};
-
-#[derive(Debug)]
-pub(crate) struct BuildTargetSelection {
-    pub target_backend: TargetBackend,
-    pub packages: Vec<PackageId>,
-}
 
 /// Build the current package
 #[derive(Debug, clap::Parser, Clone)]
@@ -365,7 +360,7 @@ fn has_explicit_build_selector(cmd: &BuildSubcommand) -> bool {
 fn narrow_build_request_to_selection(
     cmd: &BuildSubcommand,
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    selection: &BuildTargetSelection,
+    selection: &TargetPackageGroup,
 ) -> (BuildSubcommand, TargetBackend) {
     let mut scoped_cmd = cmd.clone();
     scoped_cmd.package = None;
@@ -382,44 +377,21 @@ fn resolve_build_target_selections(
     cmd: &BuildSubcommand,
     selected_target_backend: Option<TargetBackend>,
     output: UserDiagnostics,
-) -> anyhow::Result<Vec<BuildTargetSelection>> {
+) -> anyhow::Result<Vec<TargetPackageGroup>> {
     if let Some(target_backend) = selected_target_backend {
         let packages =
             resolve_selected_build_packages(resolve_output, cmd, Some(target_backend), output)?;
         if packages.is_empty() {
             return Ok(Vec::new());
         }
-        return Ok(vec![BuildTargetSelection {
+        return Ok(vec![TargetPackageGroup {
             target_backend,
             packages,
         }]);
     }
 
     let selected = resolve_selected_build_packages(resolve_output, cmd, None, output)?;
-    let mut selections = Vec::new();
-
-    for pkg in selected {
-        let module_id = resolve_output.pkg_dirs.get_package(pkg).module;
-        let target_backend = resolve_output
-            .module_rel
-            .module_info(module_id)
-            .preferred_target
-            .or(resolve_output.workspace_preferred_target)
-            .unwrap_or_default();
-        let Some(index) = selections
-            .iter()
-            .position(|selection: &BuildTargetSelection| {
-                selection.target_backend == target_backend
-            })
-        else {
-            selections.push(BuildTargetSelection {
-                target_backend,
-                packages: vec![pkg],
-            });
-            continue;
-        };
-        selections[index].packages.push(pkg);
-    }
+    let mut selections = group_packages_by_preferred_backend(resolve_output, selected);
 
     for selection in &mut selections {
         selection.packages = selection
@@ -430,7 +402,6 @@ fn resolve_build_target_selections(
             .collect();
     }
     selections.retain(|selection| !selection.packages.is_empty());
-    selections.sort_by_key(|selection| selection.target_backend);
 
     Ok(selections)
 }

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -43,8 +43,9 @@ use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
 
 use crate::filter::{
-    canonicalize_with_filename, ensure_package_supports_backend, ensure_packages_support_backend,
-    filter_pkg_by_dir, format_supported_backends, package_supports_backend, select_packages,
+    TargetPackageGroup, canonicalize_with_filename, ensure_package_supports_backend,
+    ensure_packages_support_backend, filter_pkg_by_dir, format_supported_backends,
+    group_packages_by_preferred_backend, package_supports_backend, select_packages,
     select_supported_packages,
 };
 use crate::rr_build::{self, BuildConfig, CalcUserIntentOutput, preconfig_compile};
@@ -53,12 +54,6 @@ use crate::watch::prebuild_output::{PrebuildWatchPaths, rr_get_prebuild_watch_pa
 use crate::watch::{WatchOutput, watching};
 
 use super::BuildFlags;
-
-#[derive(Debug)]
-pub(crate) struct CheckTargetSelection {
-    pub target_backend: TargetBackend,
-    pub packages: Vec<PackageId>,
-}
 
 /// Check the current package, but don't build object files
 #[derive(Debug, clap::Parser, Clone)]
@@ -625,7 +620,7 @@ pub(crate) fn plan_check_rr_from_resolved(
 fn narrow_check_request_to_selection(
     cmd: &CheckSubcommand,
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    selection: &CheckTargetSelection,
+    selection: &TargetPackageGroup,
 ) -> (CheckSubcommand, TargetBackend) {
     let mut scoped_cmd = cmd.clone();
     scoped_cmd.package_path = None;
@@ -639,7 +634,7 @@ pub(crate) fn resolve_check_target_selections(
     source_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     output: UserDiagnostics,
-) -> anyhow::Result<Vec<CheckTargetSelection>> {
+) -> anyhow::Result<Vec<TargetPackageGroup>> {
     if let Some(target_backend) = selected_target_backend {
         let packages = resolve_selected_packages(
             resolve_output,
@@ -648,31 +643,14 @@ pub(crate) fn resolve_check_target_selections(
             Some(target_backend),
             output,
         )?;
-        return Ok(vec![CheckTargetSelection {
+        return Ok(vec![TargetPackageGroup {
             target_backend,
             packages,
         }]);
     }
 
     let selected = resolve_selected_packages(resolve_output, cmd, source_dir, None, output)?;
-    let mut selections = Vec::new();
-
-    for pkg in selected {
-        let target_backend = module_preferred_target_backend(resolve_output, pkg);
-        let Some(index) = selections
-            .iter()
-            .position(|selection: &CheckTargetSelection| {
-                selection.target_backend == target_backend
-            })
-        else {
-            selections.push(CheckTargetSelection {
-                target_backend,
-                packages: vec![pkg],
-            });
-            continue;
-        };
-        selections[index].packages.push(pkg);
-    }
+    let selections = group_packages_by_preferred_backend(resolve_output, selected);
 
     let mut filtered = Vec::new();
     for selection in selections {
@@ -683,14 +661,12 @@ pub(crate) fn resolve_check_target_selections(
             output,
         )?;
         if !packages.is_empty() {
-            filtered.push(CheckTargetSelection {
+            filtered.push(TargetPackageGroup {
                 target_backend: selection.target_backend,
                 packages,
             });
         }
     }
-
-    filtered.sort_by_key(|selection| selection.target_backend);
 
     Ok(filtered)
 }
@@ -729,19 +705,6 @@ fn resolve_selected_packages(
                 .is_none_or(|backend| package_supports_backend(resolve_output, pkg, backend))
         })
         .collect())
-}
-
-fn module_preferred_target_backend(
-    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    pkg: PackageId,
-) -> TargetBackend {
-    let module_id = resolve_output.pkg_dirs.get_package(pkg).module;
-    resolve_output
-        .module_rel
-        .module_info(module_id)
-        .preferred_target
-        .or(resolve_output.workspace_preferred_target)
-        .unwrap_or_default()
 }
 
 fn filter_packages_for_backend(

--- a/crates/moon/src/cli/info/imp.rs
+++ b/crates/moon/src/cli/info/imp.rs
@@ -36,7 +36,7 @@ use moonutil::common::{MBTI_GENERATED, TargetBackend};
 use sha2::Digest;
 use tracing::error;
 
-use crate::rr_build::BuildMeta;
+use crate::{filter::preferred_target_backend_for_package, rr_build::BuildMeta};
 
 pub(super) struct InfoOutputPlan {
     packages: IndexMap<PackageId, PackageOutputPlan>,
@@ -104,11 +104,8 @@ pub(super) fn plan_info_outputs(
     for package_id in packages {
         planned.entry(package_id).or_insert_with(|| {
             let pkg = resolve_output.pkg_dirs.get_package(package_id);
-            let module = resolve_output.module_rel.module_info(pkg.module);
-            let canonical_backend = module
-                .preferred_target
-                .or(resolve_output.workspace_preferred_target)
-                .unwrap_or_default();
+            let canonical_backend =
+                preferred_target_backend_for_package(resolve_output, package_id);
 
             PackageOutputPlan::new_from_fqn(
                 &pkg.fqn,

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -16,10 +16,12 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use crate::filter::TargetPackageGroup;
 use crate::filter::canonicalize_with_filename;
 use crate::filter::ensure_packages_support_backend;
 use crate::filter::filter_pkg_by_dir;
 use crate::filter::format_supported_backends;
+use crate::filter::group_packages_by_preferred_backend;
 use crate::filter::match_packages_with_fuzzy;
 use crate::filter::package_supports_backend;
 use crate::filter::select_packages;
@@ -49,12 +51,6 @@ use tracing::{Level, debug, info, instrument, trace};
 
 use super::BenchSubcommand;
 use super::{BuildFlags, UniversalFlags};
-
-#[derive(Debug)]
-pub(crate) struct TestTargetSelection {
-    pub target_backend: TargetBackend,
-    pub packages: Vec<PackageId>,
-}
 
 struct TestSelectionOverride {
     explicit_path_filters: Option<Vec<PathBuf>>,
@@ -1131,7 +1127,7 @@ fn has_explicit_test_selector(cmd: &TestLikeSubcommand<'_>) -> bool {
 fn narrow_test_request_to_selection(
     cmd: &TestLikeSubcommand<'_>,
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    selection: &TestTargetSelection,
+    selection: &TargetPackageGroup,
 ) -> TestSelectionOverride {
     let explicit_path_filters = (!cmd.explicit_path_filters.is_empty()).then(|| {
         cmd.explicit_path_filters
@@ -1165,30 +1161,9 @@ fn resolve_test_target_selections(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     cmd: &TestLikeSubcommand<'_>,
     output: UserDiagnostics,
-) -> anyhow::Result<Vec<TestTargetSelection>> {
+) -> anyhow::Result<Vec<TargetPackageGroup>> {
     let selected = resolve_selected_test_packages(resolve_output, cmd, output)?;
-    let mut selections = Vec::new();
-
-    for pkg in selected {
-        let module_id = resolve_output.pkg_dirs.get_package(pkg).module;
-        let target_backend = resolve_output
-            .module_rel
-            .module_info(module_id)
-            .preferred_target
-            .or(resolve_output.workspace_preferred_target)
-            .unwrap_or_default();
-        let Some(index) = selections
-            .iter()
-            .position(|selection: &TestTargetSelection| selection.target_backend == target_backend)
-        else {
-            selections.push(TestTargetSelection {
-                target_backend,
-                packages: vec![pkg],
-            });
-            continue;
-        };
-        selections[index].packages.push(pkg);
-    }
+    let mut selections = group_packages_by_preferred_backend(resolve_output, selected);
 
     for selection in &mut selections {
         selection.packages = selection
@@ -1199,7 +1174,6 @@ fn resolve_test_target_selections(
             .collect();
     }
     selections.retain(|selection| !selection.packages.is_empty());
-    selections.sort_by_key(|selection| selection.target_backend);
 
     Ok(selections)
 }

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -314,6 +314,46 @@ pub(crate) fn package_supports_backend(
         .contains(&target_backend)
 }
 
+#[derive(Debug)]
+pub(crate) struct TargetPackageGroup {
+    pub target_backend: TargetBackend,
+    pub packages: Vec<PackageId>,
+}
+
+pub(crate) fn preferred_target_backend_for_package(
+    resolve_output: &ResolveOutput,
+    pkg_id: PackageId,
+) -> TargetBackend {
+    let module_id = resolve_output.pkg_dirs.get_package(pkg_id).module;
+    resolve_output
+        .module_rel
+        .module_info(module_id)
+        .preferred_target
+        .or(resolve_output.workspace_preferred_target)
+        .unwrap_or_default()
+}
+
+pub(crate) fn group_packages_by_preferred_backend(
+    resolve_output: &ResolveOutput,
+    packages: impl IntoIterator<Item = PackageId>,
+) -> Vec<TargetPackageGroup> {
+    let mut groups = BTreeMap::<TargetBackend, Vec<PackageId>>::new();
+    for pkg_id in packages {
+        groups
+            .entry(preferred_target_backend_for_package(resolve_output, pkg_id))
+            .or_default()
+            .push(pkg_id);
+    }
+
+    groups
+        .into_iter()
+        .map(|(target_backend, packages)| TargetPackageGroup {
+            target_backend,
+            packages,
+        })
+        .collect()
+}
+
 pub(crate) fn ensure_package_supports_backend(
     resolve_output: &ResolveOutput,
     pkg_id: PackageId,


### PR DESCRIPTION
## Summary
- Extract preferred-target backend grouping into `filter` as `TargetPackageGroup`
- Reuse the grouping stage in build, check, test, and bench planning
- Reuse the same preferred-backend calculation for `moon info` canonical output planning

## Verification
- `cargo fmt --check`
- `cargo check -p moon`
- `cargo test -p moon planner::target_backend_planning -- --nocapture`
- `cargo test -p moon planner::package_filter_planning -- --nocapture`
- `cargo test -p moon test_moon_info -- --nocapture`