### PR TITLE
refactor: Check zombie child liveness by PID

### DIFF
--- a/crates/moon/tests/mod.rs
+++ b/crates/moon/tests/mod.rs
@@ -23,7 +23,7 @@ use moonbuild_debug::graph::ENV_VAR;
 use std::path::{Path, PathBuf};
 use util::*;
 
-pub(crate) use support::{build_graph, dry_run_utils, util};
+pub(crate) use support::{build_graph, dry_run_utils, process, util};
 
 pub(crate) struct TestDir(moon_test_util::test_dir::TestDir);
 

--- a/crates/moon/tests/support/mod.rs
+++ b/crates/moon/tests/support/mod.rs
@@ -18,4 +18,5 @@
 
 pub(crate) mod build_graph;
 pub(crate) mod dry_run_utils;
+pub(crate) mod process;
 pub(crate) mod util;

--- a/crates/moon/tests/support/process.rs
+++ b/crates/moon/tests/support/process.rs
@@ -1,0 +1,129 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::{path::Path, process::Child, time::Duration};
+
+pub(crate) fn read_pid_file(pid_file: &Path) -> std::io::Result<u32> {
+    let content = std::fs::read_to_string(pid_file)?;
+    content
+        .trim()
+        .parse::<u32>()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, format!("{e}")))
+}
+
+pub(crate) fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
+    let start = std::time::Instant::now();
+    loop {
+        if child
+            .try_wait()
+            .expect("Failed to poll child process")
+            .is_some()
+        {
+            return true;
+        }
+        if start.elapsed() > timeout {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+pub(crate) fn wait_for_pid_exit(pid: u32, timeout: Duration) -> bool {
+    let start = std::time::Instant::now();
+    loop {
+        if !pid_is_alive(pid) {
+            return true;
+        }
+        if start.elapsed() > timeout {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn terminate_child(child: &mut Child) {
+    let pid = child.id() as libc::pid_t;
+    let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
+    if rc != 0 {
+        panic!(
+            "Failed to send SIGTERM to child process: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn terminate_child(child: &mut Child) {
+    child.kill().expect("Failed to terminate child process");
+}
+
+#[cfg(unix)]
+pub(crate) fn terminate_pid(pid: u32) {
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn terminate_pid(pid: u32) {
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, FALSE},
+        System::Threading::{OpenProcess, PROCESS_TERMINATE, TerminateProcess},
+    };
+
+    let handle = unsafe { OpenProcess(PROCESS_TERMINATE, FALSE, pid) };
+    if !handle.is_null() {
+        unsafe {
+            TerminateProcess(handle, 1);
+            CloseHandle(handle);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn pid_is_alive(pid: u32) -> bool {
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if rc == 0 {
+        return true;
+    }
+    match std::io::Error::last_os_error().raw_os_error() {
+        Some(libc::ESRCH) => false,
+        Some(libc::EPERM) => true,
+        _ => true,
+    }
+}
+
+#[cfg(windows)]
+fn pid_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, ERROR_INVALID_PARAMETER, FALSE, WAIT_OBJECT_0},
+        System::Threading::{OpenProcess, PROCESS_SYNCHRONIZE, WaitForSingleObject},
+    };
+
+    let handle = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, FALSE, pid) };
+    if handle.is_null() {
+        return std::io::Error::last_os_error().raw_os_error()
+            != Some(ERROR_INVALID_PARAMETER as i32);
+    }
+    let wait = unsafe { WaitForSingleObject(handle, 0) };
+    unsafe {
+        CloseHandle(handle);
+    }
+    wait != WAIT_OBJECT_0
+}

--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -105,131 +105,91 @@ fn test_moon_test_hello_lib() {
 
 #[test]
 fn test_zombie_child_process() {
+    use super::process::{
+        read_pid_file, terminate_child, terminate_pid, wait_for_child_exit, wait_for_pid_exit,
+    };
     use super::util::moon_bin;
+    use std::process::Stdio;
     use std::thread;
     use std::time::{Duration, Instant};
 
     let dir = TestDir::new("moon_test/zombie_child");
-    let lock_file = dir.join("test_lock_file.txt");
+    let child_pid_file = dir.join("test_child_pid.txt");
+    let moon = moon_bin();
+
+    let build_output = std::process::Command::new(&moon)
+        .current_dir(&dir)
+        .args(["test", "--target", "js", "--no-parallelize", "--build-only"])
+        .output()
+        .expect("Failed to build zombie child test fixture");
+    assert!(
+        build_output.status.success(),
+        "failed to build zombie child test fixture\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build_output.stdout),
+        String::from_utf8_lossy(&build_output.stderr)
+    );
 
     // Spawn moon test in background
-    let mut moon_child = std::process::Command::new(moon_bin())
+    let mut moon_child = std::process::Command::new(&moon)
         .current_dir(&dir)
         .args(["test", "--target", "js", "--no-parallelize"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("Failed to spawn moon test");
 
-    // Wait for lock file to be created
+    // Wait for the test executable to publish its PID.
     let start = Instant::now();
-    while !lock_file.exists() {
-        thread::sleep(Duration::from_millis(100));
-        if start.elapsed() > Duration::from_secs(10) {
-            panic!("Timeout waiting for lock file to be created");
+    let child_pid = loop {
+        if let Ok(pid) = read_pid_file(&child_pid_file) {
+            break pid;
         }
-    }
-
-    // Record the initial value written into the lock file.
-    // The MoonBit test writes an incrementing counter into the
-    // file on each heartbeat, so we can use this value to detect
-    // whether the writer is still alive after we kill `moon`.
-    let initial_counter =
-        read_lock_counter(&lock_file).expect("Failed to read initial counter from lock file");
+        if let Some(status) = moon_child
+            .try_wait()
+            .expect("Failed to poll moon test process")
+        {
+            let output = moon_child
+                .wait_with_output()
+                .expect("Failed to collect moon test output");
+            panic!(
+                "moon test exited before writing child PID: {status}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        thread::sleep(Duration::from_millis(100));
+        if start.elapsed() > Duration::from_secs(60) {
+            let _ = moon_child.kill();
+            let output = moon_child
+                .wait_with_output()
+                .expect("Failed to collect moon test output");
+            panic!(
+                "Timeout waiting for child PID to be written\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    };
 
     // Terminate the moon process (simulating the scenario in example/script.js)
     terminate_child(&mut moon_child);
 
     // When moon is killed, all child processes (moonrun/node) should also be terminated.
-    // This is verified by checking that the lock file eventually stops
-    // being updated after moon is killed.
-    // If the file is still being updated until timeout, it means the
-    // child process continues running as a zombie.
-    // If this assertion fails, it indicates a regression where child
-    // processes survive after termination.
-    let quiescent = wait_for_lock_quiescent(&lock_file, initial_counter);
-    if !quiescent {
-        // Clean up moon child process (if still alive)
-        moon_child.kill().expect("Failed to terminate moon process");
-        moon_child.wait().expect("Failed to wait moon process");
+    // This is verified by checking that the test executable PID exits after
+    // the parent `moon` process has been terminated.
+    if !wait_for_child_exit(&mut moon_child, Duration::from_secs(5)) {
+        let _ = moon_child.kill();
+        let _ = moon_child.wait();
+        terminate_pid(child_pid);
+        panic!("moon process did not exit after termination request");
+    }
+    if !wait_for_pid_exit(child_pid, Duration::from_secs(5)) {
+        terminate_pid(child_pid);
         panic!(
             "Child processes (moonrun/node) are not terminated when moon is killed. \
-        The lock file continues to be updated until timeout, indicating that spawned test processes remain running as zombies. \
+        The test executable process with PID {child_pid} is still alive after timeout. \
         Moon should properly propagate termination signals to all child processes."
         );
-    }
-}
-
-#[cfg(unix)]
-fn terminate_child(child: &mut std::process::Child) {
-    let pid = child.id() as i32;
-    let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
-    if rc != 0 {
-        panic!(
-            "Failed to send SIGTERM to moon process: {}",
-            std::io::Error::last_os_error()
-        );
-    }
-}
-
-#[cfg(windows)]
-fn terminate_child(child: &mut std::process::Child) {
-    child.kill().expect("Failed to terminate moon process");
-}
-
-/// Read the current heartbeat counter from the lock file.
-///
-/// The MoonBit test writes an incrementing integer to the lock file
-/// on each heartbeat. This helper reads the file as UTF-8 text,
-/// trims it, and parses it as `u64`.
-fn read_lock_counter(lock_file: &std::path::Path) -> std::io::Result<u64> {
-    let content = std::fs::read_to_string(lock_file)?;
-    let trimmed = content.trim();
-    let counter = trimmed
-        .parse::<u64>()
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, format!("{e}")))?;
-    Ok(counter)
-}
-
-/// Wait until the lock file's heartbeat counter stops increasing after
-/// `last_counter`.
-///
-/// Returns `true` if, within a bounded time window, we observe the
-/// counter become *quiescent* (no longer strictly greater than
-/// `last_counter`). This includes the cases where the file disappears
-/// or its contents become unreadable, because those all indicate that
-/// no further heartbeats are happening from the test process tree.
-///
-/// Returns `false` only if, for the entire timeout window, every poll
-/// observes a strictly larger counter than before, meaning the file
-/// keeps getting updated and the child process is likely still running.
-fn wait_for_lock_quiescent(lock_file: &std::path::Path, mut last_counter: u64) -> bool {
-    use std::time::{Duration, Instant};
-
-    let start = Instant::now();
-    let timeout = Duration::from_secs(5);
-    loop {
-        std::thread::sleep(Duration::from_millis(200));
-        if start.elapsed() > timeout {
-            return false;
-        }
-
-        let counter = match read_lock_counter(lock_file) {
-            Ok(counter) => counter,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // File disappeared: treat as quiescent (writer gone).
-                return true;
-            }
-            Err(_) => {
-                // Transient or format error: ignore this sample and
-                // try again until we either observe quiescence or
-                // hit the overall timeout.
-                continue;
-            }
-        };
-
-        if counter <= last_counter {
-            return true;
-        }
-        last_counter = counter;
     }
 }
 

--- a/crates/moon/tests/test_cases/moon_test/zombie_child/lib/hello_wbtest.mbt
+++ b/crates/moon/tests/test_cases/moon_test/zombie_child/lib/hello_wbtest.mbt
@@ -1,4 +1,4 @@
-extern "js" fn fs_write_file_sync(path: String, content: String) -> Unit = #|(path, content) => require('fs').writeFileSync(path, content)
+extern "js" fn fs_write_process_pid_sync(path: String) -> Unit = #|(path) => require('fs').writeFileSync(path, String(process.pid))
 
 extern "js" fn timeout(cb: () -> Unit, delay: Int) -> Unit = #|(cb, delay) => setTimeout(cb, delay)
 
@@ -6,19 +6,14 @@ extern "js" fn set_interval(cb: () -> Unit, delay: Int) -> Int = #|(cb, delay) =
 
 extern "js" fn clear_interval(id : Int) = #|(intervalID) => clearInterval(intervalID)
 
-test "holds_file_lock" {
-  let mut i = 0
-  let lock_file_path = "test_lock_file.txt"
-  fs_write_file_sync(lock_file_path, "\{i}")
-  i += 1
-  // Keep renewing lock every 100ms
+test "keeps_process_alive" {
+  let pid_file_path = "test_child_pid.txt"
+  fs_write_process_pid_sync(pid_file_path)
   let id = set_interval(fn() {
-    fs_write_file_sync(lock_file_path, "\{i}")
-    i += 1
+    ()
   }, 100)
   // Sleep for a long time to allow parent to kill us
   timeout(fn() {
     clear_interval(id)
   }, 1000000)
 }
-


### PR DESCRIPTION
## Summary

This changes the zombie child regression test to assert process liveness directly instead of inferring child survival from repeated file writes.

The JS fixture now writes its own `process.pid` once and keeps the event loop alive. The Rust test waits for that PID as the startup latch, terminates the parent `moon` process, and then checks whether the recorded child process exits using platform-specific process liveness checks.

## Why

Recent Windows CI failures related to `test_zombie_child_process` timed out waiting for the heartbeat file before the actual zombie-child assertion ran. The previous heartbeat-counter approach made the test sensitive to fixture startup and file update timing, and the failure message did not distinguish setup failure from a surviving child process.

## Validation

- `cargo test -p moon test_cases::moon_test::test_zombie_child_process -- --nocapture`
- `cargo fmt`
- `git diff --check`

I also attempted `cargo check -p moon --tests --target x86_64-pc-windows-msvc` locally, but this macOS environment cannot complete that cross-check because `ring` fails to compile for the MSVC target due to missing Windows C headers.