### PR TITLE
fix: Reuse resolved internal TCC

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -340,16 +340,19 @@ impl CompilePreConfig {
             "The final selected target backend must either be default or match the explicit one"
         );
 
-        let tcc_available =
+        let internal_tcc =
             check_tcc_availability(target_backend, resolve_output, input_nodes, output);
-        info!("`tcc -run` availability: {}", tcc_available);
+        info!("`tcc -run` availability: {}", internal_tcc.is_some());
 
         let target_backend = match target_backend {
             TargetBackend::Wasm => RunBackend::Wasm,
             TargetBackend::WasmGC => RunBackend::WasmGC,
             TargetBackend::Js => RunBackend::Js,
             TargetBackend::Native => {
-                if self.try_tcc_run && tcc_available && self.opt_level == BuildProfile::Debug {
+                if self.try_tcc_run
+                    && internal_tcc.is_some()
+                    && self.opt_level == BuildProfile::Debug
+                {
                     RunBackend::NativeTccRun
                 } else {
                     RunBackend::Native
@@ -380,6 +383,9 @@ impl CompilePreConfig {
             warn_list: self.warn_list,
             info_no_alias: self.info_no_alias,
             default_cc: CC::default(), // TODO: determine how CC will be set
+            internal_tcc: (target_backend == RunBackend::NativeTccRun)
+                .then_some(internal_tcc)
+                .flatten(),
         }
     }
 }
@@ -663,25 +669,25 @@ fn check_tcc_availability(
     resolve_output: &ResolveOutput,
     input_nodes: &[BuildPlanNode],
     output: UserDiagnostics,
-) -> bool {
+) -> Option<CC> {
     // Only for native target. Yes, not even LLVM.
     if target_backend != TargetBackend::Native {
         info!("Disabling `tcc -run`: Only available for native target backend");
-        return false;
+        return None;
     }
 
     // Check platform availability
     if !(cfg!(target_os = "linux") || cfg!(target_os = "macos")) {
         info!("`tcc -run` is only supported on Linux and macOS");
-        return false;
+        return None;
     }
 
     // Check if TCC is available
-    let _tcc = match CC::internal_tcc() {
+    let tcc = match CC::internal_tcc() {
         Ok(t) => t,
         Err(_) => {
             output.warn("Cannot find TCC compiler in the system; disabling `tcc -run`");
-            return false;
+            return None;
         }
     };
 
@@ -698,26 +704,26 @@ fn check_tcc_availability(
                     "Package '{}' overrides C/C++ toolchain, `tcc -run` will be disabled",
                     package.fqn
                 ));
-                return false;
+                return None;
             }
             if native.cc_flags.is_some() {
                 output.warn(format!(
                     "Package '{}' overrides C/C++ compiler flags, `tcc -run` will be disabled",
                     package.fqn
                 ));
-                return false;
+                return None;
             }
             if native.cc_link_flags.is_some() {
                 output.warn(format!(
                     "Package '{}' overrides C/C++ linker flags, `tcc -run` will be disabled",
                     package.fqn
                 ));
-                return false;
+                return None;
             }
         }
     }
 
-    true
+    Some(tcc)
 }
 
 /// Generate metadata file `packages.json` in the target directory.

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -26,7 +26,7 @@ use std::{
 use moonutil::{
     common::RunMode,
     compiler_flags::{
-        ArchiverConfigBuilder, CC, CCConfigBuilder, LinkerConfigBuilder, OptLevel as CCOptLevel,
+        ArchiverConfigBuilder, CCConfigBuilder, LinkerConfigBuilder, OptLevel as CCOptLevel,
         OutputType as CCOutputType, make_archiver_command_resolved, make_cc_command_resolved,
         make_cc_command_resolved_with_link_flags, make_linker_command_resolved,
     },
@@ -1090,8 +1090,11 @@ impl<'a> BuildPlanLowerContext<'a> {
         target: BuildTarget,
         info: &MakeExecutableInfo,
     ) -> BuildCommand {
-        // TODO: Get the CC instance from outside
-        let cc = CC::internal_tcc().expect("Should not go to tcc run path without tcc available");
+        let cc = self
+            .opt
+            .internal_tcc
+            .clone()
+            .expect("Should not go to tcc run path without tcc available");
 
         let mut sources = vec![];
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -24,7 +24,7 @@ use indexmap::IndexMap;
 use log::{debug, info};
 use moonutil::{
     common::RunMode,
-    compiler_flags::{CompilerPaths, Toolchain},
+    compiler_flags::{CC, CompilerPaths, Toolchain},
     cond_expr::OptLevel,
     mooncakes::ModuleSource,
 };
@@ -77,6 +77,8 @@ pub struct BuildOptions {
     pub compiler_paths: CompilerPaths,
     /// Selected native toolchain for this invocation.
     pub selected_native_toolchain: Toolchain,
+    /// Resolved internal TCC toolchain when this invocation uses `tcc -run`.
+    pub internal_tcc: Option<CC>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -76,6 +76,8 @@ pub struct CompileConfig {
     pub info_no_alias: bool,
     /// Preferred default C/C++ toolchain to use for native builds
     pub default_cc: CC,
+    /// Resolved internal TCC toolchain when this invocation uses `tcc -run`.
+    pub internal_tcc: Option<CC>,
 }
 
 /// The output information of the compilation.
@@ -162,6 +164,7 @@ pub fn compile(
         stdlib_path: cx.stdlib_path.clone(),
         compiler_paths,
         selected_native_toolchain: Toolchain::from_cc(cx.default_cc.clone()),
+        internal_tcc: cx.internal_tcc.clone(),
         os: OperatingSystem::from_str(std::env::consts::OS).expect("Unknown"),
         runtime_dot_c_path,
     };


### PR DESCRIPTION
## Summary

- Preserve the `CC::internal_tcc()` result from tcc-run availability checking.
- Pass the resolved internal TCC through compile config into build lowering.
- Use that cached toolchain when emitting tcc-run response-file commands instead of probing once per executable.

## Why

`CC::internal_tcc()` resolves the internal TCC path and probes the compiler target with `-dumpmachine`. Large tcc-run test plans can lower many `MakeExecutable` nodes, so repeating that probe per executable adds avoidable subprocess work during planning.

## Validation

- `cargo fmt --check`
- `cargo test -p moonbuild-rupes-recta`
- `cargo test -p moon --test mod test_native_backend_tcc_run`