### PR TITLE
test: centralize planner package summaries

### DIFF
--- a/crates/moon/src/tests/planner/cli_to_planner.rs
+++ b/crates/moon/src/tests/planner/cli_to_planner.rs
@@ -18,7 +18,9 @@
 
 use expect_test::expect;
 
-use super::fixture::{PlanningFixture, parse_run_command, parse_test_command};
+use super::fixture::{
+    PlanningFixture, parse_run_command, parse_test_command, planned_graph_inputs,
+};
 
 #[test]
 fn command_string_run_parses_as_expected() {
@@ -181,9 +183,10 @@ fn parsed_native_target_dry_run_test_command_plans_native_graph() {
     let graph = fixture
         .plan_test_with_cli(&cli, &cmd)
         .expect("native target test graph should plan");
+    let inputs = planned_graph_inputs(&graph);
 
-    assert!(graph.contains("./server/server_wbtest.mbt"));
-    assert!(graph.contains("./deps/nativedep/lib/lib.mbt"));
-    assert!(!graph.contains("./web/web_wbtest.mbt"));
-    assert!(!graph.contains("./deps/jsdep/lib/lib.mbt"));
+    assert!(inputs.contains("./server/server_wbtest.mbt"));
+    assert!(inputs.contains("./deps/nativedep/lib/lib.mbt"));
+    assert!(!inputs.contains("./web/web_wbtest.mbt"));
+    assert!(!inputs.contains("./deps/jsdep/lib/lib.mbt"));
 }

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -354,6 +354,27 @@ pub(super) fn planned_root_package_intent(
     }
 }
 
+pub(super) fn planned_graph_inputs(graph: &str) -> std::collections::BTreeSet<String> {
+    graph
+        .lines()
+        .flat_map(|line| {
+            let line_json: serde_json::Value =
+                serde_json::from_str(line).expect("planner dump line should be valid JSON");
+            line_json["inputs"]
+                .as_array()
+                .expect("planner dump line should contain inputs")
+                .iter()
+                .map(|input| {
+                    input
+                        .as_str()
+                        .expect("planner input path should be a string")
+                        .to_string()
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
 fn root_package_names(meta: &crate::rr_build::BuildMeta) -> Vec<String> {
     package_names(meta, |node| {
         node.extract_target().map(|target| target.package)

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -39,6 +39,11 @@ pub(super) struct PlanningFixture {
     resolve_output: ResolveOutput,
 }
 
+pub(super) struct PlannedGraph {
+    build_meta: crate::rr_build::BuildMeta,
+    build_graph: crate::rr_build::BuildInput,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct PlannedPackageRun {
     pub(super) target_backend: TargetBackend,
@@ -50,6 +55,18 @@ pub(super) struct PlannedPackageIntent {
     pub(super) target_backend: TargetBackend,
     pub(super) profile: OptLevel,
     pub(super) packages: Vec<String>,
+}
+
+impl PlannedGraph {
+    fn new(
+        build_meta: crate::rr_build::BuildMeta,
+        build_graph: crate::rr_build::BuildInput,
+    ) -> Self {
+        Self {
+            build_meta,
+            build_graph,
+        }
+    }
 }
 
 impl PlanningFixture {
@@ -88,14 +105,14 @@ impl PlanningFixture {
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
-        self.dump_plan(build_meta, build_graph)
+        self.dump_plan(PlannedGraph::new(build_meta, build_graph))
     }
 
     pub(super) fn plan_test_all_with_cli(
         &self,
         cli: &UniversalFlags,
         cmd: &TestSubcommand,
-    ) -> anyhow::Result<Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>> {
+    ) -> anyhow::Result<Vec<PlannedGraph>> {
         self.plan_test_all_with_backend(cli, cmd, cmd.build_flags.resolve_single_target_backend()?)
     }
 
@@ -104,7 +121,7 @@ impl PlanningFixture {
         cli: &UniversalFlags,
         cmd: &TestSubcommand,
         selected_target_backend: Option<moonutil::common::TargetBackend>,
-    ) -> anyhow::Result<Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>> {
+    ) -> anyhow::Result<Vec<PlannedGraph>> {
         let borrowed: TestLikeSubcommand<'_> = cmd.into();
         crate::cli::test::plan_test_or_bench_rr_from_resolved_all(
             cli,
@@ -116,7 +133,7 @@ impl PlanningFixture {
         .map(|plans| {
             plans
                 .into_iter()
-                .map(|(meta, graph, _filter)| (meta, graph))
+                .map(|(meta, graph, _filter)| PlannedGraph::new(meta, graph))
                 .collect()
         })
     }
@@ -134,14 +151,14 @@ impl PlanningFixture {
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
-        self.dump_plan(build_meta, build_graph)
+        self.dump_plan(PlannedGraph::new(build_meta, build_graph))
     }
 
     pub(super) fn plan_bench_all_with_cli(
         &self,
         cli: &UniversalFlags,
         cmd: &BenchSubcommand,
-    ) -> anyhow::Result<Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>> {
+    ) -> anyhow::Result<Vec<PlannedGraph>> {
         let borrowed: TestLikeSubcommand<'_> = cmd.into();
         crate::cli::test::plan_test_or_bench_rr_from_resolved_all(
             cli,
@@ -153,7 +170,7 @@ impl PlanningFixture {
         .map(|plans| {
             plans
                 .into_iter()
-                .map(|(meta, graph, _filter)| (meta, graph))
+                .map(|(meta, graph, _filter)| PlannedGraph::new(meta, graph))
                 .collect()
         })
     }
@@ -163,15 +180,14 @@ impl PlanningFixture {
         cli: &UniversalFlags,
         cmd: &BuildSubcommand,
     ) -> anyhow::Result<String> {
-        let (build_meta, build_graph) = self.plan_build_meta_with_cli(cli, cmd)?;
-        self.dump_plan(build_meta, build_graph)
+        self.dump_plan(self.plan_build_graph_with_cli(cli, cmd)?)
     }
 
-    pub(super) fn plan_build_meta_with_cli(
+    pub(super) fn plan_build_graph_with_cli(
         &self,
         cli: &UniversalFlags,
         cmd: &BuildSubcommand,
-    ) -> anyhow::Result<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)> {
+    ) -> anyhow::Result<PlannedGraph> {
         let (build_meta, build_graph) = crate::cli::build::plan_build_rr_from_resolved(
             cli,
             cmd,
@@ -179,14 +195,14 @@ impl PlanningFixture {
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
-        Ok((build_meta, build_graph))
+        Ok(PlannedGraph::new(build_meta, build_graph))
     }
 
     pub(super) fn plan_build_all_with_cli(
         &self,
         cli: &UniversalFlags,
         cmd: &BuildSubcommand,
-    ) -> anyhow::Result<Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>> {
+    ) -> anyhow::Result<Vec<PlannedGraph>> {
         self.plan_build_all_with_backend(cli, cmd, cmd.build_flags.resolve_single_target_backend()?)
     }
 
@@ -195,7 +211,7 @@ impl PlanningFixture {
         cli: &UniversalFlags,
         cmd: &BuildSubcommand,
         selected_target_backend: Option<moonutil::common::TargetBackend>,
-    ) -> anyhow::Result<Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>> {
+    ) -> anyhow::Result<Vec<PlannedGraph>> {
         crate::cli::build::plan_build_rr_from_resolved_all(
             cli,
             cmd,
@@ -204,6 +220,12 @@ impl PlanningFixture {
             selected_target_backend,
             self.resolve_output.clone(),
         )
+        .map(|plans| {
+            plans
+                .into_iter()
+                .map(|(meta, graph)| PlannedGraph::new(meta, graph))
+                .collect()
+        })
     }
 
     pub(super) fn plan_bundle_all_with_backend(
@@ -211,7 +233,7 @@ impl PlanningFixture {
         cli: &UniversalFlags,
         cmd: &BundleSubcommand,
         selected_target_backend: Option<moonutil::common::TargetBackend>,
-    ) -> anyhow::Result<Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>> {
+    ) -> anyhow::Result<Vec<PlannedGraph>> {
         crate::cli::bundle::plan_bundle_rr_from_resolved(
             cli,
             cmd,
@@ -219,7 +241,7 @@ impl PlanningFixture {
             selected_target_backend,
             self.resolve_output.clone(),
         )
-        .map(|plan| vec![plan])
+        .map(|(meta, graph)| vec![PlannedGraph::new(meta, graph)])
     }
 
     pub(super) fn plan_check_with_cli(
@@ -235,14 +257,14 @@ impl PlanningFixture {
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
-        self.dump_plan(build_meta, build_graph)
+        self.dump_plan(PlannedGraph::new(build_meta, build_graph))
     }
 
     pub(super) fn plan_check_all_with_cli(
         &self,
         cli: &UniversalFlags,
         cmd: &CheckSubcommand,
-    ) -> anyhow::Result<Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>> {
+    ) -> anyhow::Result<Vec<PlannedGraph>> {
         self.plan_check_all_with_backend(cli, cmd, cmd.build_flags.resolve_single_target_backend()?)
     }
 
@@ -251,7 +273,7 @@ impl PlanningFixture {
         cli: &UniversalFlags,
         cmd: &CheckSubcommand,
         selected_target_backend: Option<moonutil::common::TargetBackend>,
-    ) -> anyhow::Result<Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>> {
+    ) -> anyhow::Result<Vec<PlannedGraph>> {
         crate::cli::check::plan_check_rr_from_resolved_all(
             cli,
             cmd,
@@ -260,6 +282,12 @@ impl PlanningFixture {
             selected_target_backend,
             self.resolve_output.clone(),
         )
+        .map(|plans| {
+            plans
+                .into_iter()
+                .map(|(meta, graph)| PlannedGraph::new(meta, graph))
+                .collect()
+        })
     }
 
     pub(super) fn plan_run_with_cli(
@@ -267,15 +295,14 @@ impl PlanningFixture {
         cli: &UniversalFlags,
         cmd: &RunSubcommand,
     ) -> anyhow::Result<String> {
-        let (build_meta, build_graph) = self.plan_run_meta_with_cli(cli, cmd)?;
-        self.dump_plan(build_meta, build_graph)
+        self.dump_plan(self.plan_run_graph_with_cli(cli, cmd)?)
     }
 
-    pub(super) fn plan_run_meta_with_cli(
+    pub(super) fn plan_run_graph_with_cli(
         &self,
         cli: &UniversalFlags,
         cmd: &RunSubcommand,
-    ) -> anyhow::Result<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)> {
+    ) -> anyhow::Result<PlannedGraph> {
         let mut cmd = cmd.clone();
         if cmd.command.is_none()
             && let Some(input) = cmd.package_or_mbt_file.as_deref()
@@ -293,20 +320,17 @@ impl PlanningFixture {
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
-        Ok((build_meta, build_graph))
+        Ok(PlannedGraph::new(build_meta, build_graph))
     }
 
     pub(super) fn case_dir(&self) -> &std::path::Path {
         &self.source_dir
     }
 
-    fn dump_plan(
-        &self,
-        build_meta: crate::rr_build::BuildMeta,
-        build_graph: crate::rr_build::BuildInput,
-    ) -> anyhow::Result<String> {
-        let graph = build_graph.graph_for_test();
-        let default_files = build_meta
+    fn dump_plan(&self, plan: PlannedGraph) -> anyhow::Result<String> {
+        let graph = plan.build_graph.graph_for_test();
+        let default_files = plan
+            .build_meta
             .artifacts
             .values()
             .flat_map(|art| {
@@ -322,35 +346,35 @@ impl PlanningFixture {
     }
 }
 
-pub(super) fn planned_root_package_runs(
-    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
-) -> Vec<PlannedPackageRun> {
+pub(super) fn planned_root_package_runs(runs: Vec<PlannedGraph>) -> Vec<PlannedPackageRun> {
     runs.into_iter()
-        .map(|(meta, _)| PlannedPackageRun {
-            target_backend: meta.target_backend.into(),
-            packages: root_package_names(&meta),
+        .map(|plan| PlannedPackageRun {
+            target_backend: plan.build_meta.target_backend.into(),
+            packages: root_package_names(&plan.build_meta),
         })
         .collect()
 }
 
-pub(super) fn planned_check_package_runs(
-    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
-) -> Vec<PlannedPackageRun> {
+pub(super) fn planned_check_package_runs(runs: Vec<PlannedGraph>) -> Vec<PlannedPackageRun> {
     runs.into_iter()
-        .map(|(meta, _)| PlannedPackageRun {
-            target_backend: meta.target_backend.into(),
-            packages: check_package_names(&meta),
+        .map(|plan| PlannedPackageRun {
+            target_backend: plan.build_meta.target_backend.into(),
+            packages: check_package_names(&plan.build_meta),
         })
         .collect()
 }
 
-pub(super) fn planned_root_package_intent(
-    (meta, _): (crate::rr_build::BuildMeta, crate::rr_build::BuildInput),
-) -> PlannedPackageIntent {
+pub(super) fn planned_target_backends(runs: Vec<PlannedGraph>) -> Vec<TargetBackend> {
+    runs.into_iter()
+        .map(|plan| plan.build_meta.target_backend.into())
+        .collect()
+}
+
+pub(super) fn planned_root_package_intent(plan: PlannedGraph) -> PlannedPackageIntent {
     PlannedPackageIntent {
-        target_backend: meta.target_backend.into(),
-        profile: meta.opt_level,
-        packages: root_package_names(&meta),
+        target_backend: plan.build_meta.target_backend.into(),
+        profile: plan.build_meta.opt_level,
+        packages: root_package_names(&plan.build_meta),
     }
 }
 

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -20,8 +20,13 @@ use clap::Parser;
 use moonbuild_debug::graph::debug_dump_build_graph;
 use std::path::PathBuf;
 
-use moonbuild_rupes_recta::ResolveOutput;
-use moonutil::{cli::UniversalFlags, common::BUILD_DIR, dirs::WorkspaceEnv};
+use moonbuild_rupes_recta::{ResolveOutput, model::BuildPlanNode};
+use moonutil::{
+    cli::UniversalFlags,
+    common::{BUILD_DIR, TargetBackend},
+    cond_expr::OptLevel,
+    dirs::WorkspaceEnv,
+};
 
 use crate::cli::{
     BenchSubcommand, BuildSubcommand, BundleSubcommand, CheckSubcommand, MoonBuildCli,
@@ -32,6 +37,19 @@ pub(super) struct PlanningFixture {
     source_dir: PathBuf,
     target_dir: PathBuf,
     resolve_output: ResolveOutput,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct PlannedPackageRun {
+    pub(super) target_backend: TargetBackend,
+    pub(super) packages: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct PlannedPackageIntent {
+    pub(super) target_backend: TargetBackend,
+    pub(super) profile: OptLevel,
+    pub(super) packages: Vec<String>,
 }
 
 impl PlanningFixture {
@@ -302,6 +320,70 @@ impl PlanningFixture {
         dump.dump_to(&mut out).expect("graph dump should serialize");
         Ok(String::from_utf8(out).expect("graph dump should be valid UTF-8"))
     }
+}
+
+pub(super) fn planned_root_package_runs(
+    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
+) -> Vec<PlannedPackageRun> {
+    runs.into_iter()
+        .map(|(meta, _)| PlannedPackageRun {
+            target_backend: meta.target_backend.into(),
+            packages: root_package_names(&meta),
+        })
+        .collect()
+}
+
+pub(super) fn planned_check_package_runs(
+    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
+) -> Vec<PlannedPackageRun> {
+    runs.into_iter()
+        .map(|(meta, _)| PlannedPackageRun {
+            target_backend: meta.target_backend.into(),
+            packages: check_package_names(&meta),
+        })
+        .collect()
+}
+
+pub(super) fn planned_root_package_intent(
+    (meta, _): (crate::rr_build::BuildMeta, crate::rr_build::BuildInput),
+) -> PlannedPackageIntent {
+    PlannedPackageIntent {
+        target_backend: meta.target_backend.into(),
+        profile: meta.opt_level,
+        packages: root_package_names(&meta),
+    }
+}
+
+fn root_package_names(meta: &crate::rr_build::BuildMeta) -> Vec<String> {
+    package_names(meta, |node| {
+        node.extract_target().map(|target| target.package)
+    })
+}
+
+fn check_package_names(meta: &crate::rr_build::BuildMeta) -> Vec<String> {
+    package_names(meta, |node| match node {
+        BuildPlanNode::Check(target) => Some(target.package),
+        _ => None,
+    })
+}
+
+fn package_names(
+    meta: &crate::rr_build::BuildMeta,
+    package_of: impl Fn(&BuildPlanNode) -> Option<moonbuild_rupes_recta::model::PackageId>,
+) -> Vec<String> {
+    meta.artifacts
+        .keys()
+        .filter_map(package_of)
+        .map(|pkg_id| {
+            meta.resolve_output
+                .pkg_dirs
+                .get_package(pkg_id)
+                .fqn
+                .to_string()
+        })
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect()
 }
 
 pub(super) fn parse_build_command(args: &[&str]) -> (UniversalFlags, BuildSubcommand) {

--- a/crates/moon/src/tests/planner/path_filter_planning.rs
+++ b/crates/moon/src/tests/planner/path_filter_planning.rs
@@ -16,59 +16,17 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use super::fixture::{PlanningFixture, parse_build_command, parse_check_command};
-use moonbuild_rupes_recta::model::BuildPlanNode;
+use super::fixture::{
+    PlannedPackageRun, PlanningFixture, parse_build_command, parse_check_command,
+    planned_check_package_runs, planned_root_package_runs,
+};
 use moonutil::common::TargetBackend;
 
-fn build_packages(
-    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
-) -> Vec<(TargetBackend, Vec<String>)> {
-    runs.into_iter()
-        .map(|(meta, _)| {
-            let packages = meta
-                .artifacts
-                .keys()
-                .filter_map(|node| node.extract_target().map(|target| target.package))
-                .map(|pkg_id| {
-                    meta.resolve_output
-                        .pkg_dirs
-                        .get_package(pkg_id)
-                        .fqn
-                        .to_string()
-                })
-                .collect::<std::collections::BTreeSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>();
-            (meta.target_backend.into(), packages)
-        })
-        .collect()
-}
-
-fn check_packages(
-    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
-) -> Vec<(TargetBackend, Vec<String>)> {
-    runs.into_iter()
-        .map(|(meta, _)| {
-            let packages = meta
-                .artifacts
-                .keys()
-                .filter_map(|node| match node {
-                    BuildPlanNode::Check(target) => Some(target.package),
-                    _ => None,
-                })
-                .map(|pkg_id| {
-                    meta.resolve_output
-                        .pkg_dirs
-                        .get_package(pkg_id)
-                        .fqn
-                        .to_string()
-                })
-                .collect::<std::collections::BTreeSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>();
-            (meta.target_backend.into(), packages)
-        })
-        .collect()
+fn expected_wasm_gc_packages(packages: &[&str]) -> Vec<PlannedPackageRun> {
+    vec![PlannedPackageRun {
+        target_backend: TargetBackend::WasmGC,
+        packages: packages.iter().map(|pkg| (*pkg).to_string()).collect(),
+    }]
 }
 
 fn expect_build_packages(fixture: &PlanningFixture, path: &str, expected: &[&str]) {
@@ -77,11 +35,8 @@ fn expect_build_packages(fixture: &PlanningFixture, path: &str, expected: &[&str
         .plan_build_all_with_cli(&cli, &cmd)
         .expect("build path filter should plan");
     assert_eq!(
-        build_packages(runs),
-        vec![(
-            TargetBackend::WasmGC,
-            expected.iter().map(|pkg| (*pkg).to_string()).collect()
-        )]
+        planned_root_package_runs(runs),
+        expected_wasm_gc_packages(expected)
     );
 }
 
@@ -91,11 +46,8 @@ fn expect_check_packages(fixture: &PlanningFixture, path: &str, expected: &[&str
         .plan_check_all_with_cli(&cli, &cmd)
         .expect("check path filter should plan");
     assert_eq!(
-        check_packages(runs),
-        vec![(
-            TargetBackend::WasmGC,
-            expected.iter().map(|pkg| (*pkg).to_string()).collect()
-        )]
+        planned_check_package_runs(runs),
+        expected_wasm_gc_packages(expected)
     );
 }
 

--- a/crates/moon/src/tests/planner/target_backend_planning.rs
+++ b/crates/moon/src/tests/planner/target_backend_planning.rs
@@ -17,9 +17,10 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use super::fixture::{
-    PlannedPackageRun, PlanningFixture, parse_bench_command, parse_build_command,
+    PlannedGraph, PlannedPackageRun, PlanningFixture, parse_bench_command, parse_build_command,
     parse_bundle_command, parse_check_command, parse_run_command, parse_test_command,
     planned_check_package_runs, planned_graph_inputs, planned_root_package_runs,
+    planned_target_backends,
 };
 use moonutil::common::{TargetBackend, lower_surface_targets};
 
@@ -57,31 +58,18 @@ fn assert_graph_inputs(graph: &str, present: &[&str], absent: &[&str]) {
     }
 }
 
-fn assert_root_package_runs(
-    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
-    expected: &[(TargetBackend, &[&str])],
-) {
+fn assert_root_package_runs(runs: Vec<PlannedGraph>, expected: &[(TargetBackend, &[&str])]) {
     assert_eq!(
         planned_root_package_runs(runs),
         expected_package_runs(expected)
     );
 }
 
-fn assert_target_backend_runs(
-    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
-    expected: &[TargetBackend],
-) {
-    let actual = runs
-        .into_iter()
-        .map(|(meta, _)| meta.target_backend.into())
-        .collect::<Vec<TargetBackend>>();
-    assert_eq!(actual, expected);
+fn assert_target_backend_runs(runs: Vec<PlannedGraph>, expected: &[TargetBackend]) {
+    assert_eq!(planned_target_backends(runs), expected);
 }
 
-fn assert_check_package_runs(
-    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
-    expected: &[(TargetBackend, &[&str])],
-) {
+fn assert_check_package_runs(runs: Vec<PlannedGraph>, expected: &[(TargetBackend, &[&str])]) {
     assert_eq!(
         planned_check_package_runs(runs),
         expected_package_runs(expected)

--- a/crates/moon/src/tests/planner/target_backend_planning.rs
+++ b/crates/moon/src/tests/planner/target_backend_planning.rs
@@ -19,14 +19,14 @@
 use super::fixture::{
     PlannedPackageRun, PlanningFixture, parse_bench_command, parse_build_command,
     parse_bundle_command, parse_check_command, parse_run_command, parse_test_command,
-    planned_check_package_runs, planned_root_package_runs,
+    planned_check_package_runs, planned_graph_inputs, planned_root_package_runs,
 };
 use moonutil::common::{TargetBackend, lower_surface_targets};
 
 // Phase 3: these tests already know the selected backend and only need to
 // verify that planning keeps the right packages and commands in the graph.
 
-fn assert_contains_and_absent(graph: &str, present: &[&str], absent: &[&str]) {
+fn assert_graph_text_contains_and_omits(graph: &str, present: &[&str], absent: &[&str]) {
     for needle in present {
         assert!(
             graph.contains(needle),
@@ -37,6 +37,22 @@ fn assert_contains_and_absent(graph: &str, present: &[&str], absent: &[&str]) {
         assert!(
             !graph.contains(needle),
             "expected graph to not contain `{needle}`, got:\n{graph}"
+        );
+    }
+}
+
+fn assert_graph_inputs(graph: &str, present: &[&str], absent: &[&str]) {
+    let inputs = planned_graph_inputs(graph);
+    for input in present {
+        assert!(
+            inputs.contains(*input),
+            "expected graph inputs to contain `{input}`, got:\n{inputs:#?}"
+        );
+    }
+    for input in absent {
+        assert!(
+            !inputs.contains(*input),
+            "expected graph inputs to omit `{input}`, got:\n{inputs:#?}"
         );
     }
 }
@@ -90,7 +106,7 @@ fn target_backend_build_planning_respects_default_and_explicit_backend() {
     let default_graph = fixture
         .plan_build_with_cli(&cli, &cmd)
         .expect("default build graph should plan");
-    assert_contains_and_absent(
+    assert_graph_text_contains_and_omits(
         &default_graph,
         &[
             "./_build/wasm-gc/debug/build/main/main.wasm",
@@ -110,7 +126,7 @@ fn target_backend_build_planning_respects_default_and_explicit_backend() {
     let js_graph = fixture
         .plan_build_with_cli(&cli, &cmd)
         .expect("js build graph should plan");
-    assert_contains_and_absent(
+    assert_graph_text_contains_and_omits(
         &js_graph,
         &["./_build/js/debug/build/main/main.js", "-target js"],
         &[
@@ -436,7 +452,7 @@ fn mixed_backend_build_and_check_planning_are_target_aware() {
     let check_js = fixture
         .plan_check_with_cli(&cli, &cmd)
         .expect("js check graph should plan");
-    assert_contains_and_absent(
+    assert_graph_inputs(
         &check_js,
         &[
             "./shared/shared.mbt",
@@ -454,7 +470,7 @@ fn mixed_backend_build_and_check_planning_are_target_aware() {
     let build_js = fixture
         .plan_build_with_cli(&cli, &cmd)
         .expect("js build graph should plan");
-    assert_contains_and_absent(
+    assert_graph_inputs(
         &build_js,
         &[
             "./shared/shared.mbt",
@@ -469,7 +485,7 @@ fn mixed_backend_build_and_check_planning_are_target_aware() {
     let check_native = fixture
         .plan_check_with_cli(&cli, &cmd)
         .expect("native check graph should plan");
-    assert_contains_and_absent(
+    assert_graph_inputs(
         &check_native,
         &[
             "./shared/shared.mbt",
@@ -488,7 +504,7 @@ fn mixed_backend_build_and_check_planning_are_target_aware() {
     let build_native = fixture
         .plan_build_with_cli(&cli, &cmd)
         .expect("native build graph should plan");
-    assert_contains_and_absent(
+    assert_graph_inputs(
         &build_native,
         &[
             "./shared/shared.mbt",
@@ -509,7 +525,7 @@ fn mixed_backend_run_planning_is_target_aware() {
     let run_js = fixture
         .plan_run_with_cli(&cli, &cmd)
         .expect("js run graph should plan");
-    assert_contains_and_absent(
+    assert_graph_inputs(
         &run_js,
         &[
             "./shared/shared.mbt",
@@ -530,7 +546,7 @@ fn mixed_backend_run_planning_is_target_aware() {
     let run_native = fixture
         .plan_run_with_cli(&cli, &cmd)
         .expect("native run graph should plan");
-    assert_contains_and_absent(
+    assert_graph_inputs(
         &run_native,
         &[
             "./shared/shared.mbt",
@@ -550,7 +566,7 @@ fn supported_targets_empty_packages_are_skipped_in_check_planning() {
     let check_js = fixture
         .plan_check_with_cli(&cli, &cmd)
         .expect("js check graph should plan");
-    assert_contains_and_absent(
+    assert_graph_inputs(
         &check_js,
         &["./main/main.mbt", "./lib/lib.mbt"],
         &["./never/never.mbt"],
@@ -561,7 +577,7 @@ fn supported_targets_empty_packages_are_skipped_in_check_planning() {
     let check_native = fixture
         .plan_check_with_cli(&cli, &cmd)
         .expect("native check graph should plan");
-    assert_contains_and_absent(
+    assert_graph_inputs(
         &check_native,
         &["./main/main.mbt", "./lib/lib.mbt"],
         &["./never/never.mbt"],
@@ -652,7 +668,7 @@ fn module_supported_targets_intersection_filters_check_planning() {
     let check_wasm_gc = fixture
         .plan_check_with_cli(&cli, &cmd)
         .expect("wasm-gc check graph should plan");
-    assert_contains_and_absent(&check_wasm_gc, &["./lib/lib.mbt"], &["./main/main.mbt"]);
+    assert_graph_inputs(&check_wasm_gc, &["./lib/lib.mbt"], &["./main/main.mbt"]);
 
     let (cli, cmd) = parse_check_command(&[
         "check",
@@ -665,7 +681,7 @@ fn module_supported_targets_intersection_filters_check_planning() {
     let check_native = fixture
         .plan_check_with_cli(&cli, &cmd)
         .expect("native check graph should plan");
-    assert_contains_and_absent(&check_native, &["./lib/lib.mbt"], &["./main/main.mbt"]);
+    assert_graph_inputs(&check_native, &["./lib/lib.mbt"], &["./main/main.mbt"]);
 
     let (cli, cmd) = parse_check_command(&[
         "check",
@@ -678,5 +694,5 @@ fn module_supported_targets_intersection_filters_check_planning() {
     let check_llvm = fixture
         .plan_check_with_cli(&cli, &cmd)
         .expect("llvm check graph should plan");
-    assert_contains_and_absent(&check_llvm, &["./lib/lib.mbt"], &["./main/main.mbt"]);
+    assert_graph_inputs(&check_llvm, &["./lib/lib.mbt"], &["./main/main.mbt"]);
 }

--- a/crates/moon/src/tests/planner/target_backend_planning.rs
+++ b/crates/moon/src/tests/planner/target_backend_planning.rs
@@ -17,8 +17,9 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use super::fixture::{
-    PlanningFixture, parse_bench_command, parse_build_command, parse_bundle_command,
-    parse_check_command, parse_run_command, parse_test_command,
+    PlannedPackageRun, PlanningFixture, parse_bench_command, parse_build_command,
+    parse_bundle_command, parse_check_command, parse_run_command, parse_test_command,
+    planned_check_package_runs, planned_root_package_runs,
 };
 use moonutil::common::{TargetBackend, lower_surface_targets};
 
@@ -40,43 +41,14 @@ fn assert_contains_and_absent(graph: &str, present: &[&str], absent: &[&str]) {
     }
 }
 
-fn assert_build_runs(
+fn assert_root_package_runs(
     runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
     expected: &[(TargetBackend, &[&str])],
 ) {
-    let actual = runs
-        .into_iter()
-        .map(|(meta, _)| {
-            let packages = meta
-                .artifacts
-                .keys()
-                .filter_map(|node| node.extract_target().map(|target| target.package))
-                .map(|pkg_id| {
-                    meta.resolve_output
-                        .pkg_dirs
-                        .get_package(pkg_id)
-                        .fqn
-                        .to_string()
-                })
-                .collect::<std::collections::BTreeSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>();
-            (meta.target_backend.into(), packages)
-        })
-        .collect::<Vec<_>>();
-    let expected = expected
-        .iter()
-        .map(|(backend, packages)| {
-            (
-                *backend,
-                packages
-                    .iter()
-                    .map(|pkg| pkg.to_string())
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(actual, expected);
+    assert_eq!(
+        planned_root_package_runs(runs),
+        expected_package_runs(expected)
+    );
 }
 
 fn assert_target_backend_runs(
@@ -90,84 +62,24 @@ fn assert_target_backend_runs(
     assert_eq!(actual, expected);
 }
 
-fn assert_check_runs(
+fn assert_check_package_runs(
     runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
     expected: &[(TargetBackend, &[&str])],
 ) {
-    let actual = runs
-        .into_iter()
-        .map(|(meta, _)| {
-            let packages = meta
-                .artifacts
-                .keys()
-                .filter_map(|node| match node {
-                    moonbuild_rupes_recta::model::BuildPlanNode::Check(target) => Some(
-                        meta.resolve_output
-                            .pkg_dirs
-                            .get_package(target.package)
-                            .fqn
-                            .to_string(),
-                    ),
-                    _ => None,
-                })
-                .collect::<std::collections::BTreeSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>();
-            (meta.target_backend.into(), packages)
-        })
-        .collect::<Vec<_>>();
-    let expected = expected
-        .iter()
-        .map(|(backend, packages)| {
-            (
-                *backend,
-                packages
-                    .iter()
-                    .map(|pkg| (*pkg).to_string())
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(actual, expected);
+    assert_eq!(
+        planned_check_package_runs(runs),
+        expected_package_runs(expected)
+    );
 }
 
-fn assert_test_runs(
-    runs: Vec<(crate::rr_build::BuildMeta, crate::rr_build::BuildInput)>,
-    expected: &[(TargetBackend, &[&str])],
-) {
-    let actual = runs
-        .into_iter()
-        .map(|(meta, _)| {
-            let packages = meta
-                .artifacts
-                .keys()
-                .filter_map(|node| node.extract_target().map(|target| target.package))
-                .map(|pkg_id| {
-                    meta.resolve_output
-                        .pkg_dirs
-                        .get_package(pkg_id)
-                        .fqn
-                        .to_string()
-                })
-                .collect::<std::collections::BTreeSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>();
-            (meta.target_backend.into(), packages)
-        })
-        .collect::<Vec<_>>();
-    let expected = expected
+fn expected_package_runs(expected: &[(TargetBackend, &[&str])]) -> Vec<PlannedPackageRun> {
+    expected
         .iter()
-        .map(|(backend, packages)| {
-            (
-                *backend,
-                packages
-                    .iter()
-                    .map(|pkg| (*pkg).to_string())
-                    .collect::<Vec<_>>(),
-            )
+        .map(|(backend, packages)| PlannedPackageRun {
+            target_backend: *backend,
+            packages: packages.iter().map(|pkg| (*pkg).to_string()).collect(),
         })
-        .collect::<Vec<_>>();
-    assert_eq!(actual, expected);
+        .collect()
 }
 
 #[test]
@@ -231,7 +143,7 @@ fn many_target_planning_selects_requested_backends() {
                 .expect("multi-target check plans should resolve")
         })
         .collect::<Vec<_>>();
-    assert_check_runs(
+    assert_check_package_runs(
         runs,
         &[
             (TargetBackend::Wasm, all_packages),
@@ -256,7 +168,7 @@ fn many_target_planning_selects_requested_backends() {
                 .expect("multi-target build plans should resolve")
         })
         .collect::<Vec<_>>();
-    assert_build_runs(
+    assert_root_package_runs(
         runs,
         &[
             (TargetBackend::Wasm, root_packages),
@@ -300,7 +212,7 @@ fn many_target_planning_selects_requested_backends() {
                 .expect("multi-target test plans should resolve")
         })
         .collect::<Vec<_>>();
-    assert_test_runs(
+    assert_root_package_runs(
         runs,
         &[
             (TargetBackend::Wasm, all_packages),
@@ -331,7 +243,7 @@ fn all_target_test_planning_selects_every_concrete_backend() {
                 .expect("all-target test plans should resolve")
         })
         .collect::<Vec<_>>();
-    assert_test_runs(
+    assert_root_package_runs(
         runs,
         &[
             (TargetBackend::Wasm, packages),
@@ -352,7 +264,7 @@ fn conflicting_workspace_preferred_targets_build_selection_splits_by_module_back
         .plan_build_all_with_cli(&cli, &cmd)
         .expect("default build plans should resolve");
 
-    assert_build_runs(
+    assert_root_package_runs(
         runs,
         &[
             (TargetBackend::Js, &["workspace/js_preferred/lib"]),
@@ -377,7 +289,7 @@ fn conflicting_workspace_preferred_targets_build_path_selection_uses_module_back
         .plan_build_all_with_cli(&cli, &cmd)
         .expect("path-selected build plans should resolve");
 
-    assert_build_runs(
+    assert_root_package_runs(
         runs,
         &[
             (TargetBackend::Js, &["workspace/js_preferred/lib"]),
@@ -396,7 +308,7 @@ fn explicit_build_target_keeps_single_backend_selection() {
         .plan_build_all_with_cli(&cli, &cmd)
         .expect("explicit js build plans should resolve");
 
-    assert_build_runs(
+    assert_root_package_runs(
         runs,
         &[(
             TargetBackend::Js,
@@ -418,7 +330,7 @@ fn conflicting_workspace_preferred_targets_test_selection_splits_by_module_backe
         .plan_test_all_with_cli(&cli, &cmd)
         .expect("default test plans should resolve");
 
-    assert_test_runs(
+    assert_root_package_runs(
         runs,
         &[
             (TargetBackend::Js, &["workspace/js_preferred/lib"]),
@@ -443,7 +355,7 @@ fn conflicting_workspace_preferred_targets_test_path_selection_uses_module_backe
         .plan_test_all_with_cli(&cli, &cmd)
         .expect("path-selected test plans should resolve");
 
-    assert_test_runs(
+    assert_root_package_runs(
         runs,
         &[
             (TargetBackend::Js, &["workspace/js_preferred/lib"]),
@@ -462,7 +374,7 @@ fn explicit_test_target_keeps_single_backend_selection() {
         .plan_test_all_with_cli(&cli, &cmd)
         .expect("explicit js test plans should resolve");
 
-    assert_test_runs(
+    assert_root_package_runs(
         runs,
         &[(
             TargetBackend::Js,
@@ -484,7 +396,7 @@ fn conflicting_workspace_preferred_targets_bench_selection_splits_by_module_back
         .plan_bench_all_with_cli(&cli, &cmd)
         .expect("default bench plans should resolve");
 
-    assert_test_runs(
+    assert_root_package_runs(
         runs,
         &[
             (TargetBackend::Js, &["workspace/js_preferred/lib"]),
@@ -503,7 +415,7 @@ fn explicit_bench_target_keeps_single_backend_selection() {
         .plan_bench_all_with_cli(&cli, &cmd)
         .expect("explicit js bench plans should resolve");
 
-    assert_test_runs(
+    assert_root_package_runs(
         runs,
         &[(
             TargetBackend::Js,
@@ -666,7 +578,7 @@ fn conflicting_workspace_preferred_targets_check_selection_splits_by_module_back
         .plan_check_all_with_cli(&cli, &cmd)
         .expect("default check plans should resolve");
 
-    assert_check_runs(
+    assert_check_package_runs(
         runs,
         &[
             (TargetBackend::Js, &["workspace/js_preferred/lib"]),
@@ -691,7 +603,7 @@ fn conflicting_workspace_preferred_targets_check_path_selection_uses_module_back
         .plan_check_all_with_cli(&cli, &cmd)
         .expect("path-selected check plans should resolve");
 
-    assert_check_runs(
+    assert_check_package_runs(
         runs,
         &[
             (TargetBackend::Js, &["workspace/js_preferred/lib"]),
@@ -710,7 +622,7 @@ fn explicit_check_target_keeps_single_backend_selection() {
         .plan_check_all_with_cli(&cli, &cmd)
         .expect("explicit js check plans should resolve");
 
-    assert_check_runs(
+    assert_check_package_runs(
         runs,
         &[(
             TargetBackend::Js,

--- a/crates/moon/src/tests/planner/whitespace_planning.rs
+++ b/crates/moon/src/tests/planner/whitespace_planning.rs
@@ -46,7 +46,7 @@ fn whitespace_cli_variants_resolve_to_same_main_package_intention() {
     ] {
         let (cli, cmd) = parse_build_command(args);
         let actual = fixture
-            .plan_build_meta_with_cli(&cli, &cmd)
+            .plan_build_graph_with_cli(&cli, &cmd)
             .map(planned_root_package_intent)
             .expect("build command should resolve");
         assert_eq!(actual, expected, "unexpected build intention for {args:?}");
@@ -75,7 +75,7 @@ fn whitespace_cli_variants_resolve_to_same_main_package_intention() {
     ] {
         let (cli, cmd) = parse_run_command(args);
         let actual = fixture
-            .plan_run_meta_with_cli(&cli, &cmd)
+            .plan_run_graph_with_cli(&cli, &cmd)
             .map(planned_root_package_intent)
             .expect("run command should resolve");
         assert_eq!(actual, expected, "unexpected run intention for {args:?}");

--- a/crates/moon/src/tests/planner/whitespace_planning.rs
+++ b/crates/moon/src/tests/planner/whitespace_planning.rs
@@ -16,45 +16,16 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use super::fixture::{PlanningFixture, parse_build_command, parse_run_command};
+use super::fixture::{
+    PlannedPackageIntent, PlanningFixture, parse_build_command, parse_run_command,
+    planned_root_package_intent,
+};
 use moonutil::{common::TargetBackend, cond_expr::OptLevel};
-
-#[derive(Debug, PartialEq, Eq)]
-struct PlannedCliIntent {
-    target_backend: TargetBackend,
-    profile: OptLevel,
-    packages: Vec<String>,
-}
-
-fn planned_cli_intent(
-    (meta, _): (crate::rr_build::BuildMeta, crate::rr_build::BuildInput),
-) -> PlannedCliIntent {
-    let packages = meta
-        .artifacts
-        .keys()
-        .filter_map(|node| node.extract_target().map(|target| target.package))
-        .map(|pkg_id| {
-            meta.resolve_output
-                .pkg_dirs
-                .get_package(pkg_id)
-                .fqn
-                .to_string()
-        })
-        .collect::<std::collections::BTreeSet<_>>()
-        .into_iter()
-        .collect::<Vec<_>>();
-
-    PlannedCliIntent {
-        target_backend: meta.target_backend.into(),
-        profile: meta.opt_level,
-        packages,
-    }
-}
 
 #[test]
 fn whitespace_cli_variants_resolve_to_same_main_package_intention() {
     let fixture = PlanningFixture::new("whitespace_test.in").expect("fixture should resolve");
-    let expected = PlannedCliIntent {
+    let expected = PlannedPackageIntent {
         target_backend: TargetBackend::WasmGC,
         profile: OptLevel::Debug,
         packages: vec!["username/hello/main exe".to_string()],
@@ -76,7 +47,7 @@ fn whitespace_cli_variants_resolve_to_same_main_package_intention() {
         let (cli, cmd) = parse_build_command(args);
         let actual = fixture
             .plan_build_meta_with_cli(&cli, &cmd)
-            .map(planned_cli_intent)
+            .map(planned_root_package_intent)
             .expect("build command should resolve");
         assert_eq!(actual, expected, "unexpected build intention for {args:?}");
     }
@@ -105,7 +76,7 @@ fn whitespace_cli_variants_resolve_to_same_main_package_intention() {
         let (cli, cmd) = parse_run_command(args);
         let actual = fixture
             .plan_run_meta_with_cli(&cli, &cmd)
-            .map(planned_cli_intent)
+            .map(planned_root_package_intent)
             .expect("run command should resolve");
         assert_eq!(actual, expected, "unexpected run intention for {args:?}");
     }


### PR DESCRIPTION
## Why

Planner tests were repeatedly unpacking `BuildMeta` internals to answer the same high-level question: which target backend, profile, and root packages did planning select? That couples individual tests to artifact-node details and duplicates the same package-name extraction logic across `target_backend_planning` and `whitespace_planning`.

## What changed

- Add small planner-fixture summary types for planned package runs and single planned package intent.
- Move root-package and check-package extraction from individual tests into the fixture module.
- Update target-backend and whitespace planner tests to compare those summaries instead of hand-walking `BuildMeta`.

## Why this is correct

The new helpers preserve the existing extraction semantics: build/test/bench-style assertions still use `BuildPlanNode::extract_target`, and check assertions still collect only `BuildPlanNode::Check` targets. The tests still call the same planner entry points; only the test-side representation of the result moved to the fixture boundary.

## Why this is minimal

No production code changed. The cleanup touches only planner test support plus the two test modules that already duplicated this logic. It does not introduce a new snapshot strategy or alter CLI/integration tests.

## Verification

- `cargo fmt --check`
- `cargo test -p moon target_backend_planning -- --nocapture`
- `cargo test -p moon whitespace_planning -- --nocapture`
- `git diff --check`

Note: `cargo test -p moon planner -- --nocapture` still hits unrelated pre-existing dummy/profile snapshot ordering failures in this checkout; the focused touched modules pass.