### PR TITLE
test: strengthen shared moon test helpers

### DIFF
--- a/crates/moon/tests/mod.rs
+++ b/crates/moon/tests/mod.rs
@@ -146,6 +146,17 @@ pub fn snap_dry_run_graph(
 }
 
 #[track_caller]
+pub(crate) fn assert_dry_run_graph(
+    dir: &impl AsRef<std::path::Path>,
+    args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
+    expected: impl build_graph::IExpect,
+) {
+    let graph = tempfile::NamedTempFile::new().expect("dry-run graph temp file should create");
+    snap_dry_run_graph(dir, args, &graph.path());
+    build_graph::compare_graphs(graph.path(), expected);
+}
+
+#[track_caller]
 pub fn get_stderr(
     dir: &impl AsRef<std::path::Path>,
     args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,

--- a/crates/moon/tests/mod.rs
+++ b/crates/moon/tests/mod.rs
@@ -65,76 +65,36 @@ pub fn moon_process_cmd(dir: &impl AsRef<Path>) -> std::process::Command {
     cmd
 }
 
-#[track_caller]
-fn get_stdout_without_replace(
-    dir: &impl AsRef<std::path::Path>,
-    args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
-    envs: impl IntoIterator<Item = (impl AsRef<std::ffi::OsStr>, impl AsRef<std::ffi::OsStr>)>,
-) -> String {
-    let out = moon_cmd(dir)
-        .envs(envs)
-        .args(args)
-        .assert()
-        .success()
-        .get_output()
-        .stdout
-        .to_owned();
+enum ExpectedStatus {
+    Success,
+    Failure,
+}
 
-    std::str::from_utf8(&out).unwrap().to_string()
+enum OutputStream {
+    Stdout,
+    Stderr,
 }
 
 #[track_caller]
-fn get_stderr_without_replace(
+fn get_output_without_replace(
     dir: &impl AsRef<std::path::Path>,
     args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
     envs: impl IntoIterator<Item = (impl AsRef<std::ffi::OsStr>, impl AsRef<std::ffi::OsStr>)>,
+    status: ExpectedStatus,
+    stream: OutputStream,
 ) -> String {
-    let out = moon_cmd(dir)
-        .envs(envs)
-        .args(args)
-        .assert()
-        .success()
-        .get_output()
-        .stderr
-        .to_owned();
+    let assert = moon_cmd(dir).envs(envs).args(args).assert();
+    let assert = match status {
+        ExpectedStatus::Success => assert.success(),
+        ExpectedStatus::Failure => assert.failure(),
+    };
+    let output = assert.get_output();
+    let out = match stream {
+        OutputStream::Stdout => &output.stdout,
+        OutputStream::Stderr => &output.stderr,
+    };
 
-    std::str::from_utf8(&out).unwrap().to_string()
-}
-
-#[track_caller]
-fn get_err_stdout_without_replace(
-    dir: &impl AsRef<std::path::Path>,
-    args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
-    envs: impl IntoIterator<Item = (impl AsRef<std::ffi::OsStr>, impl AsRef<std::ffi::OsStr>)>,
-) -> String {
-    let out = moon_cmd(dir)
-        .envs(envs)
-        .args(args)
-        .assert()
-        .failure()
-        .get_output()
-        .stdout
-        .to_owned();
-
-    std::str::from_utf8(&out).unwrap().to_string()
-}
-
-#[track_caller]
-fn get_err_stderr_without_replace(
-    dir: &impl AsRef<std::path::Path>,
-    args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
-    envs: impl IntoIterator<Item = (impl AsRef<std::ffi::OsStr>, impl AsRef<std::ffi::OsStr>)>,
-) -> String {
-    let out = moon_cmd(dir)
-        .envs(envs)
-        .args(args)
-        .assert()
-        .failure()
-        .get_output()
-        .stderr
-        .to_owned();
-
-    std::str::from_utf8(&out).unwrap().to_string()
+    std::str::from_utf8(out).unwrap().to_string()
 }
 
 #[track_caller]
@@ -142,7 +102,13 @@ pub fn get_stdout(
     dir: &impl AsRef<std::path::Path>,
     args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
 ) -> String {
-    let s = get_stdout_without_replace(dir, args, [] as [(&str, &str); 0]);
+    let s = get_output_without_replace(
+        dir,
+        args,
+        [] as [(&str, &str); 0],
+        ExpectedStatus::Success,
+        OutputStream::Stdout,
+    );
     replace_dir(&s, dir)
 }
 
@@ -152,7 +118,13 @@ pub fn get_stdout_with_envs(
     args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
     envs: impl IntoIterator<Item = (impl AsRef<std::ffi::OsStr>, impl AsRef<std::ffi::OsStr>)>,
 ) -> String {
-    let s = get_stdout_without_replace(dir, args, envs);
+    let s = get_output_without_replace(
+        dir,
+        args,
+        envs,
+        ExpectedStatus::Success,
+        OutputStream::Stdout,
+    );
     replace_dir(&s, dir)
 }
 
@@ -178,7 +150,29 @@ pub fn get_stderr(
     dir: &impl AsRef<std::path::Path>,
     args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
 ) -> String {
-    let s = get_stderr_without_replace(dir, args, [] as [(&str, &str); 0]);
+    let s = get_output_without_replace(
+        dir,
+        args,
+        [] as [(&str, &str); 0],
+        ExpectedStatus::Success,
+        OutputStream::Stderr,
+    );
+    replace_dir(&s, dir)
+}
+
+#[track_caller]
+pub fn get_stderr_with_envs(
+    dir: &impl AsRef<std::path::Path>,
+    args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
+    envs: impl IntoIterator<Item = (impl AsRef<std::ffi::OsStr>, impl AsRef<std::ffi::OsStr>)>,
+) -> String {
+    let s = get_output_without_replace(
+        dir,
+        args,
+        envs,
+        ExpectedStatus::Success,
+        OutputStream::Stderr,
+    );
     replace_dir(&s, dir)
 }
 
@@ -195,7 +189,13 @@ pub fn get_err_stdout(
     dir: &impl AsRef<std::path::Path>,
     args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
 ) -> String {
-    let s = get_err_stdout_without_replace(dir, args, [] as [(&str, &str); 0]);
+    let s = get_output_without_replace(
+        dir,
+        args,
+        [] as [(&str, &str); 0],
+        ExpectedStatus::Failure,
+        OutputStream::Stdout,
+    );
     replace_dir(&s, dir)
 }
 
@@ -204,7 +204,13 @@ pub fn get_err_stderr(
     dir: &impl AsRef<std::path::Path>,
     args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
 ) -> String {
-    let s = get_err_stderr_without_replace(dir, args, [] as [(&str, &str); 0]);
+    let s = get_output_without_replace(
+        dir,
+        args,
+        [] as [(&str, &str); 0],
+        ExpectedStatus::Failure,
+        OutputStream::Stderr,
+    );
     replace_dir(&s, dir)
 }
 
@@ -214,6 +220,12 @@ pub fn get_err_stderr_with_envs(
     args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
     envs: impl IntoIterator<Item = (impl AsRef<std::ffi::OsStr>, impl AsRef<std::ffi::OsStr>)>,
 ) -> String {
-    let s = get_err_stderr_without_replace(dir, args, envs);
+    let s = get_output_without_replace(
+        dir,
+        args,
+        envs,
+        ExpectedStatus::Failure,
+        OutputStream::Stderr,
+    );
     replace_dir(&s, dir)
 }

--- a/crates/moon/tests/support/util.rs
+++ b/crates/moon/tests/support/util.rs
@@ -137,27 +137,55 @@ pub(crate) fn read<P: AsRef<Path>>(p: P) -> String {
 /// string. However, still updates if `UPDATE_EXPECT` is set, just like the
 /// original [`Expect`] functionality.
 pub(crate) fn assert_command_matches(s: impl AsRef<str>, expect: Expect) {
-    let actual_lines = s.as_ref().trim().lines().collect::<Vec<_>>();
-    let expected_lines = expect.data().trim().lines().collect::<Vec<_>>();
-
-    let mut diff_found = false;
-    for (l, r) in actual_lines.iter().zip(expected_lines.iter()) {
-        let actual_parts = shlex::split(l).unwrap_or_default();
-        let expected_parts = shlex::split(r).unwrap_or_default();
-
-        if actual_parts != expected_parts {
-            println!(
-                "Diff found:\nActual:   {:?}\nExpected: {:?}",
-                actual_parts, expected_parts
-            );
-            diff_found = true;
-            break;
-        }
-    }
+    let diff_found = command_lines_differ(s.as_ref(), expect.data()).unwrap_or_else(|err| {
+        panic!("{err}");
+    });
 
     if diff_found {
         expect.assert_eq(s.as_ref());
     }
+}
+
+fn command_lines_differ(actual: &str, expected: &str) -> Result<bool, String> {
+    let actual_lines = actual.trim().lines().collect::<Vec<_>>();
+    let expected_lines = expected.trim().lines().collect::<Vec<_>>();
+
+    if actual_lines.len() != expected_lines.len() {
+        println!(
+            "Line count differs:\nActual:   {}\nExpected: {}",
+            actual_lines.len(),
+            expected_lines.len()
+        );
+        return Ok(true);
+    }
+
+    for (idx, (actual_line, expected_line)) in
+        actual_lines.iter().zip(expected_lines.iter()).enumerate()
+    {
+        let actual_parts = split_command_line("actual", idx, actual_line)?;
+        let expected_parts = split_command_line("expected", idx, expected_line)?;
+
+        if actual_parts != expected_parts {
+            println!(
+                "Diff found on line {}:\nActual:   {:?}\nExpected: {:?}",
+                idx + 1,
+                actual_parts,
+                expected_parts
+            );
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn split_command_line(kind: &str, idx: usize, line: &str) -> Result<Vec<String>, String> {
+    shlex::split(line).ok_or_else(|| {
+        format!(
+            "failed to parse {kind} command line {} with shlex: {line:?}",
+            idx + 1
+        )
+    })
 }
 
 #[track_caller]

--- a/crates/moon/tests/support/util.rs
+++ b/crates/moon/tests/support/util.rs
@@ -177,7 +177,8 @@ pub(crate) fn run_moon_cmdtest(case_dir: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::replace_dir;
+    use super::{assert_command_matches, replace_dir};
+    use expect_test::expect;
 
     #[test]
     fn replace_dir_replaces_forward_slash_root_paths() {
@@ -191,6 +192,28 @@ mod tests {
         assert_eq!(
             replace_dir(&output, dir.path()),
             "moonc check $ROOT/b/hello.mbt -pkg-sources username/b:$ROOT/b -workspace-path $ROOT/b"
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn assert_command_matches_rejects_added_lines() {
+        assert_command_matches(
+            "moonc check\nmoonc build",
+            expect![[r#"
+                moonc check
+            "#]],
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "failed to parse actual command line 1")]
+    fn assert_command_matches_rejects_invalid_shell_syntax() {
+        assert_command_matches(
+            "moonc \"unterminated",
+            expect![[r#"
+                moonc
+            "#]],
         );
     }
 }

--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -4,7 +4,7 @@ mod with_cfg;
 
 use expect_test::expect_file;
 
-use crate::{build_graph::compare_graphs, dry_run_utils::assert_lines_in_order};
+use crate::dry_run_utils::assert_lines_in_order;
 
 use super::*;
 
@@ -44,14 +44,9 @@ fn test_moon_test_hello_exec() {
             Total tests: 1, passed: 1, failed: 0.
         "#]],
     );
-    let graph = dir.join("test_debug_graph.jsonl");
-    snap_dry_run_graph(
+    assert_dry_run_graph(
         &dir,
         ["test", "--dry-run", "--debug", "--sort-input"],
-        &graph,
-    );
-    compare_graphs(
-        &graph,
         expect_file!["moon_test_hello_exec_graph.jsonl.snap"],
     );
 }
@@ -66,10 +61,9 @@ fn test_moon_test_hello_exec_fntest() {
         "#]],
     );
 
-    let graph = dir.join("test_graph.jsonl");
-    snap_dry_run_graph(&dir, ["test", "-v", "--dry-run", "--sort-input"], &graph);
-    compare_graphs(
-        &graph,
+    assert_dry_run_graph(
+        &dir,
+        ["test", "-v", "--dry-run", "--sort-input"],
         expect_file!["moon_test_hello_exec_fntest_graph.jsonl.snap"],
     );
 

--- a/crates/moon/tests/test_cases/test_moonbitlang_x/mod.rs
+++ b/crates/moon/tests/test_cases/test_moonbitlang_x/mod.rs
@@ -1,4 +1,4 @@
-use crate::{TestDir, build_graph::compare_graphs, get_stdout, snap_dry_run_graph, util::check};
+use crate::{TestDir, assert_dry_run_graph, get_stdout, util::check};
 use expect_test::{expect, expect_file};
 
 #[test]
@@ -7,21 +7,15 @@ fn test_moonbitlang_x() {
     get_stdout(&dir, ["update"]);
     get_stdout(&dir, ["install"]);
 
-    let build_snap_file = dir.join("build_dry_run.jsonl");
-    snap_dry_run_graph(
+    assert_dry_run_graph(
         &dir,
         ["build", "--dry-run", "--sort-input"],
-        &build_snap_file,
-    );
-    compare_graphs(
-        &build_snap_file,
         expect_file!["moonbitlang_x_build_dry_run.jsonl.snap"],
     );
 
-    let test_snap_file = dir.join("test_dry_run.jsonl");
-    snap_dry_run_graph(&dir, ["test", "--dry-run", "--sort-input"], &test_snap_file);
-    compare_graphs(
-        &test_snap_file,
+    assert_dry_run_graph(
+        &dir,
+        ["test", "--dry-run", "--sort-input"],
         expect_file!["moonbitlang_x_test_dry_run.jsonl.snap"],
     );
 

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -1289,12 +1289,11 @@ fn test_moon_work_wins_over_legacy_workspace_disable_env() {
         "expected MOON_WORK to override deprecated env, got:\n{stdout}"
     );
 
-    let stderr = get_stderr_without_replace(
+    let stderr = get_stderr_with_envs(
         &dir,
         ["build", "--dry-run", "--sort-input"],
         [(MOON_WORK_ENV, "auto"), (MOON_NO_WORKSPACE, "1")],
     );
-    let stderr = replace_dir(&stderr, &dir);
     assert!(
         stderr
             .contains("`MOON_NO_WORKSPACE` is deprecated and ignored because `MOON_WORK` is set."),


### PR DESCRIPTION
## Summary

- Centralize moon command output capture behind shared stdout/stderr helpers.
- Fix `assert_command_matches` false negatives by comparing tokenized command lines instead of raw shell quoting.
- Add `assert_dry_run_graph` so dry-run graph tests can use the shared graph comparison path directly.

## Validation

- `cargo test -p moon --test mod support::util::tests::command_lines`
- `cargo test -p moon --test mod test_moon_test_hello_exec`
- `cargo test -p moon --test mod test_workspace_commands`
- `cargo test -p moon --test mod test_moonbitlang_x` (rerun with network access after the sandboxed run failed while cloning the registry index)