### PR TITLE
[codex] Adopt dry-run graph helper in tests

### DIFF
--- a/crates/moon/tests/test_cases/abort_override/mod.rs
+++ b/crates/moon/tests/test_cases/abort_override/mod.rs
@@ -3,13 +3,11 @@ use super::*;
 #[test]
 fn test_abort_override_links_impl() {
     let dir = TestDir::new("abort_override/abort_override.in");
-    let run_graph = dir.join("run_graph.json");
-    snap_dry_run_graph(
+    assert_dry_run_graph(
         &dir,
         ["run", "main", "--dry-run", "--sort-input"],
-        &run_graph,
+        expect_file!["./run_graph.jsonl.snap"],
     );
-    compare_graphs(&run_graph, expect_file!["./run_graph.jsonl.snap"]);
 
     let out = get_err_stdout(&dir, ["run", "main"]);
     assert!(out.contains("---myabort---"));

--- a/crates/moon/tests/test_cases/import_stdlib/mod.rs
+++ b/crates/moon/tests/test_cases/import_stdlib/mod.rs
@@ -30,20 +30,12 @@ fn test_import_stdlib() {
 fn test_import_stdlib_dry_run() {
     let dir = TestDir::new("import_stdlib/import_stdlib.in");
 
-    let check_graph = dir.join("check_graph.jsonl");
-    snap_dry_run_graph(&dir, ["check", "--dry-run"], &check_graph);
-
-    compare_graphs(&check_graph, expect_file!["./check_graph.jsonl.snap"]);
-
-    let build_graph = dir.join("build_graph.jsonl");
-    snap_dry_run_graph(&dir, ["build", "--dry-run"], &build_graph);
-    compare_graphs(&build_graph, expect_file!["./build_graph.jsonl.snap"]);
-
-    let test_graph = dir.join("test_graph.jsonl");
-    snap_dry_run_graph(&dir, ["test", "--dry-run"], &test_graph);
-    compare_graphs(&test_graph, expect_file!["./test_graph.jsonl.snap"]);
-
-    let run_graph = dir.join("run_graph.jsonl");
-    snap_dry_run_graph(&dir, ["run", "cmd/main", "--dry-run"], &run_graph);
-    compare_graphs(&run_graph, expect_file!["./run_graph.jsonl.snap"]);
+    assert_dry_run_graph(&dir, ["check", "--dry-run"], expect_file!["./check_graph.jsonl.snap"]);
+    assert_dry_run_graph(&dir, ["build", "--dry-run"], expect_file!["./build_graph.jsonl.snap"]);
+    assert_dry_run_graph(&dir, ["test", "--dry-run"], expect_file!["./test_graph.jsonl.snap"]);
+    assert_dry_run_graph(
+        &dir,
+        ["run", "cmd/main", "--dry-run"],
+        expect_file!["./run_graph.jsonl.snap"],
+    );
 }

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -18,7 +18,6 @@
 
 use std::io::Write;
 
-use crate::build_graph::compare_graphs;
 use expect_test::expect_file;
 
 use super::*;
@@ -517,8 +516,7 @@ fn test_moon_run_with_cli_args() {
         "#]],
     );
 
-    let run_graph = dir.join("run_graph.jsonl");
-    snap_dry_run_graph(
+    assert_dry_run_graph(
         &dir,
         [
             "run",
@@ -530,10 +528,6 @@ fn test_moon_run_with_cli_args() {
             "hello",
             "1242",
         ],
-        &run_graph,
-    );
-    compare_graphs(
-        &run_graph,
         expect_file!["./moon_run_with_cli_args_graph.jsonl"],
     );
 
@@ -831,16 +825,14 @@ fn test_specify_source_dir_005() {
 #[test]
 fn test_specify_source_dir_with_deps() {
     let dir = TestDir::new("specify_source_dir_with_deps_001.in");
-    let check_graph = dir.join("check_graph.jsonl");
-    snap_dry_run_graph(&dir, ["check", "--dry-run", "--sort-input"], &check_graph);
-    compare_graphs(
-        &check_graph,
+    assert_dry_run_graph(
+        &dir,
+        ["check", "--dry-run", "--sort-input"],
         expect_file!["./specify_source_dir_with_deps_001.in/check_graph.jsonl.snap"],
     );
-    let test_graph = dir.join("test_graph.jsonl");
-    snap_dry_run_graph(&dir, ["test", "--dry-run", "--sort-input"], &test_graph);
-    compare_graphs(
-        &test_graph,
+    assert_dry_run_graph(
+        &dir,
+        ["test", "--dry-run", "--sort-input"],
         expect_file!["./specify_source_dir_with_deps_001.in/test_graph.jsonl.snap"],
     );
 

--- a/crates/moon/tests/test_cases/moon_test/patch.rs
+++ b/crates/moon/tests/test_cases/moon_test/patch.rs
@@ -1,14 +1,13 @@
 use expect_test::{expect, expect_file};
 
-use crate::{TestDir, build_graph::compare_graphs, get_stdout, snap_dry_run_graph, util::check};
+use crate::{TestDir, assert_dry_run_graph, get_stdout, util::check};
 
 #[test]
 fn test_moon_test_patch() {
     let dir = TestDir::new("moon_test/patch");
 
     // Apply patch to normal build
-    let graph_file = dir.join("dry_run_graph.jsonl");
-    snap_dry_run_graph(
+    assert_dry_run_graph(
         &dir,
         [
             "test",
@@ -22,9 +21,8 @@ fn test_moon_test_patch() {
             "--sort-input",
             "--nostd",
         ],
-        &graph_file,
+        expect_file!["patch_dry_run_graph.jsonl.snap"],
     );
-    compare_graphs(&graph_file, expect_file!["patch_dry_run_graph.jsonl.snap"]);
     check(
         get_stdout(
             &dir,
@@ -46,8 +44,7 @@ fn test_moon_test_patch() {
     );
 
     // Apply patch to white box test
-    let graph_file = dir.join("dry_run_wbtest_graph.jsonl");
-    snap_dry_run_graph(
+    assert_dry_run_graph(
         &dir,
         [
             "test",
@@ -61,10 +58,6 @@ fn test_moon_test_patch() {
             "--sort-input",
             "--nostd",
         ],
-        &graph_file,
-    );
-    compare_graphs(
-        &graph_file,
         expect_file!["patch_wbtest_dry_run_graph.jsonl.snap"],
     );
 
@@ -89,8 +82,7 @@ fn test_moon_test_patch() {
     );
 
     // Apply patch to black box test
-    let graph_file = dir.join("dry_run_bbtest_graph.jsonl");
-    snap_dry_run_graph(
+    assert_dry_run_graph(
         &dir,
         [
             "test",
@@ -104,10 +96,6 @@ fn test_moon_test_patch() {
             "--sort-input",
             "--nostd",
         ],
-        &graph_file,
-    );
-    compare_graphs(
-        &graph_file,
         expect_file!["patch_bbtest_dry_run_graph.jsonl.snap"],
     );
 
@@ -132,8 +120,7 @@ fn test_moon_test_patch() {
     );
 
     // no _test.mbt and _wbtest.mbt in original package
-    let graph_file = dir.join("dry_run_2_patch_graph.jsonl");
-    snap_dry_run_graph(
+    assert_dry_run_graph(
         &dir,
         [
             "test",
@@ -147,10 +134,6 @@ fn test_moon_test_patch() {
             "--sort-input",
             "--nostd",
         ],
-        &graph_file,
-    );
-    compare_graphs(
-        &graph_file,
         expect_file!["patch_2_bbtest_dry_run_graph.jsonl.snap"],
     );
 
@@ -174,8 +157,7 @@ fn test_moon_test_patch() {
         "#]],
     );
 
-    let graph_file = dir.join("dry_run_2_wbpatch_graph.jsonl");
-    snap_dry_run_graph(
+    assert_dry_run_graph(
         &dir,
         [
             "test",
@@ -189,10 +171,6 @@ fn test_moon_test_patch() {
             "--sort-input",
             "--nostd",
         ],
-        &graph_file,
-    );
-    compare_graphs(
-        &graph_file,
         expect_file!["patch_2_wbtest_dry_run_graph.jsonl.snap"],
     );
 

--- a/crates/moon/tests/test_cases/no_export_when_test/mod.rs
+++ b/crates/moon/tests/test_cases/no_export_when_test/mod.rs
@@ -3,9 +3,11 @@ use super::*;
 #[test]
 fn no_export_when_test() {
     let dir = TestDir::new("no_export_when_test.in");
-    let build_graph = dir.join("build_graph.json");
-    snap_dry_run_graph(&dir, ["test", "--dry-run"], &build_graph);
-    compare_graphs(&build_graph, expect_file!["./build_graph.jsonl"]);
+    assert_dry_run_graph(
+        &dir,
+        ["test", "--dry-run"],
+        expect_file!["./build_graph.jsonl"],
+    );
 
     let s = get_stdout(&dir, ["test"]);
     check(

--- a/crates/moon/tests/test_cases/specify_source_dir_001/mod.rs
+++ b/crates/moon/tests/test_cases/specify_source_dir_001/mod.rs
@@ -1,19 +1,23 @@
-use crate::build_graph::compare_graphs;
-
 use super::*;
 
 #[test]
 fn test_specify_source_dir_001() {
     let dir = TestDir::new("specify_source_dir_001.in");
-    let check_graph = dir.join("check_graph.jsonl");
-    snap_dry_run_graph(&dir, ["check", "--dry-run", "--sort-input"], &check_graph);
-    compare_graphs(&check_graph, expect_file!["check_graph.jsonl.snap"]);
-    let build_graph = dir.join("build_graph.jsonl");
-    snap_dry_run_graph(&dir, ["build", "--dry-run", "--sort-input"], &build_graph);
-    compare_graphs(&build_graph, expect_file!["build_graph.jsonl.snap"]);
-    let test_graph = dir.join("test_graph.jsonl");
-    snap_dry_run_graph(&dir, ["test", "--dry-run", "--sort-input"], &test_graph);
-    compare_graphs(&test_graph, expect_file!["test_graph.jsonl.snap"]);
+    assert_dry_run_graph(
+        &dir,
+        ["check", "--dry-run", "--sort-input"],
+        expect_file!["check_graph.jsonl.snap"],
+    );
+    assert_dry_run_graph(
+        &dir,
+        ["build", "--dry-run", "--sort-input"],
+        expect_file!["build_graph.jsonl.snap"],
+    );
+    assert_dry_run_graph(
+        &dir,
+        ["test", "--dry-run", "--sort-input"],
+        expect_file!["test_graph.jsonl.snap"],
+    );
     check(
         get_stderr(&dir, ["check", "--sort-input"]),
         expect![[r#"

--- a/crates/moon/tests/test_cases/value_tracing/mod.rs
+++ b/crates/moon/tests/test_cases/value_tracing/mod.rs
@@ -1,12 +1,9 @@
 use super::*;
 
-use crate::build_graph::compare_graphs;
-
 #[test]
 fn test_tracing_value_for_test_block() {
     let dir = TestDir::new("tracing_value_for_test_block.in");
-    let test_graph = dir.join("test_graph.jsonl");
-    snap_dry_run_graph(
+    assert_dry_run_graph(
         &dir,
         [
             "test",
@@ -15,9 +12,8 @@ fn test_tracing_value_for_test_block() {
             "moon_new/lib1",
             "--dry-run",
         ],
-        &test_graph,
+        expect_file!["test_graph.jsonl.snap"],
     );
-    compare_graphs(&test_graph, expect_file!["test_graph.jsonl.snap"]);
 
     let content = get_stdout(
         &dir,
@@ -59,9 +55,8 @@ fn test_tracing_value_for_test_block() {
 #[test]
 fn test_tracing_value_for_main_func() {
     let dir = TestDir::new("tracing_value.in");
-    let run_graph = dir.join("run_graph.jsonl");
     // main.mbt in package
-    snap_dry_run_graph(
+    assert_dry_run_graph(
         &dir,
         [
             "run",
@@ -69,9 +64,8 @@ fn test_tracing_value_for_main_func() {
             "--enable-value-tracing",
             "--dry-run",
         ],
-        &run_graph,
+        expect_file!["run_graph.jsonl.snap"],
     );
-    compare_graphs(&run_graph, expect_file!["run_graph.jsonl.snap"]);
 
     let content = get_stdout(&dir, ["run", "./main/main.mbt", "--enable-value-tracing"])
         .split("######MOONBIT_VALUE_TRACING_START######")

--- a/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
@@ -7,9 +7,11 @@ fn normalized_path(value: &serde_json::Value) -> &str {
 #[test]
 fn implement_third_party1() {
     let dir = TestDir::new("virtual_pkg2.in/p");
-    let check_graph = dir.join("check_graph.json");
-    snap_dry_run_graph(&dir, ["check", ".", "--dry-run"], &check_graph);
-    compare_graphs(&check_graph, expect_file!["./check_graph.jsonl"]);
+    assert_dry_run_graph(
+        &dir,
+        ["check", ".", "--dry-run"],
+        expect_file!["./check_graph.jsonl"],
+    );
 
     let s = get_stderr(&dir, ["check", "."]);
     check(
@@ -74,9 +76,11 @@ fn implement_third_party1() {
 #[test]
 fn implement_third_party2() {
     let dir = TestDir::new("virtual_pkg2.in/p");
-    let build_graph = dir.join("build_graph.json");
-    snap_dry_run_graph(&dir, ["build", "--dry-run"], &build_graph);
-    compare_graphs(&build_graph, expect_file!["./build_graph.jsonl"]);
+    assert_dry_run_graph(
+        &dir,
+        ["build", "--dry-run"],
+        expect_file!["./build_graph.jsonl"],
+    );
 
     let s = get_stderr(&dir, ["build"]);
     check(


### PR DESCRIPTION
## Summary

- Replace repeated `snap_dry_run_graph` plus `compare_graphs` sequences with `assert_dry_run_graph` in compiled graph-oriented integration tests.
- Keep custom graph handling and native normalization helpers unchanged.

## Validation

- `cargo fmt`
- `git diff --check`
- `cargo test -p moon --test mod test_cases::abort_override::test_abort_override_links_impl -- --exact`
- `cargo test -p moon --test mod test_cases::specify_source_dir_001::test_specify_source_dir_001 -- --exact`
- `cargo test -p moon --test mod test_cases::virtual_pkg2`
- `cargo test -p moon --test mod test_cases::no_export_when_test::no_export_when_test -- --exact`
- `cargo test -p moon --test mod test_cases::value_tracing`
- `cargo test -p moon --test mod test_cases::moon_test::patch::test_moon_test_patch -- --exact`
- `cargo test -p moon --test mod test_cases::test_moon_run_with_cli_args -- --exact`
- `cargo test -p moon --test mod test_cases::test_specify_source_dir_with_deps -- --exact`