### PR TITLE
[codex] Introduce build plan request

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -47,23 +47,39 @@ use super::{BuildFlags, UniversalFlags};
 /// Build the current package
 #[derive(Debug, clap::Parser, Clone)]
 pub(crate) struct BuildSubcommand {
-    /// Paths to the packages that should be built.
-    #[clap(name = "PATH", conflicts_with("package"))]
-    pub path: Vec<PathBuf>,
-
     #[clap(flatten)]
-    pub build_flags: BuildFlags,
-
-    #[clap(flatten)]
-    pub auto_sync_flags: AutoSyncFlags,
+    pub request: BuildPlanRequest,
 
     /// Monitor the file system and automatically build artifacts
     #[clap(long, short)]
     pub watch: bool,
+}
+
+#[derive(Debug, clap::Parser, Clone)]
+pub(crate) struct BuildPlanRequest {
+    /// Paths to the packages that should be built.
+    #[clap(name = "PATH", conflicts_with("package_filter"))]
+    path_filters: Vec<PathBuf>,
+
+    #[clap(flatten)]
+    build_flags: BuildFlags,
+
+    #[clap(flatten)]
+    auto_sync_flags: AutoSyncFlags,
 
     // package name (username/hello/lib)
-    #[clap(long, hide = true)]
-    pub package: Option<String>,
+    #[clap(long = "package", hide = true)]
+    package_filter: Option<String>,
+}
+
+impl BuildPlanRequest {
+    pub(crate) fn resolve_single_target_backend(&self) -> anyhow::Result<Option<TargetBackend>> {
+        self.build_flags.resolve_single_target_backend()
+    }
+
+    pub(crate) fn surface_targets(&self) -> &[moonutil::common::SurfaceTarget] {
+        &self.build_flags.target
+    }
 }
 
 #[instrument(skip_all)]
@@ -78,29 +94,30 @@ pub(crate) fn run_build(cli: &UniversalFlags, cmd: BuildSubcommand) -> anyhow::R
         .query(cli.workspace_env.clone())?
         .package_dirs()?;
 
-    if cmd.build_flags.target.is_empty() {
+    if cmd.request.surface_targets().is_empty() {
         return run_build_internal(
             cli,
-            &cmd,
+            &cmd.request,
             &source_dir,
             &target_dir,
             &mooncakes_dir,
             project_manifest_path.as_deref(),
-            None,
+            cmd.watch,
+            cmd.request.resolve_single_target_backend()?,
         );
     }
-    let surface_targets = cmd.build_flags.target.clone();
-    let targets = lower_surface_targets(&surface_targets);
+    let targets = lower_surface_targets(cmd.request.surface_targets());
 
     let mut ret_value = 0;
     for t in targets {
         let x = run_build_internal(
             cli,
-            &cmd,
+            &cmd.request,
             &source_dir,
             &target_dir,
             &mooncakes_dir,
             project_manifest_path.as_deref(),
+            cmd.watch,
             Some(t),
         )
         .context(format!("failed to run build for target {t:?}"))?;
@@ -112,17 +129,18 @@ pub(crate) fn run_build(cli: &UniversalFlags, cmd: BuildSubcommand) -> anyhow::R
 #[instrument(skip_all)]
 fn run_build_internal(
     cli: &UniversalFlags,
-    cmd: &BuildSubcommand,
+    request: &BuildPlanRequest,
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
     project_manifest_path: Option<&Path>,
+    watch: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     let f = |watch: bool| {
         run_build_rr(
             cli,
-            cmd,
+            request,
             source_dir,
             target_dir,
             mooncakes_dir,
@@ -132,7 +150,7 @@ fn run_build_internal(
         )
     };
 
-    if cmd.watch {
+    if watch {
         watching(|| f(true), source_dir, source_dir, target_dir)
     } else {
         f(false).map(|output| if output.ok { 0 } else { 1 })
@@ -146,7 +164,7 @@ fn run_build_internal(
 #[allow(clippy::too_many_arguments)]
 fn run_build_rr(
     cli: &UniversalFlags,
-    cmd: &BuildSubcommand,
+    request: &BuildPlanRequest,
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
@@ -155,9 +173,9 @@ fn run_build_rr(
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<WatchOutput> {
     let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new(
-        cmd.auto_sync_flags.clone(),
-        !cmd.build_flags.std(),
-        cmd.build_flags.enable_coverage,
+        request.auto_sync_flags.clone(),
+        !request.build_flags.std(),
+        request.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     )
     .with_project_manifest_path(project_manifest_path);
@@ -172,7 +190,7 @@ fn run_build_rr(
     };
     let planned_runs = plan_build_rr_from_resolved_all(
         cli,
-        cmd,
+        request,
         source_dir,
         target_dir,
         selected_target_backend,
@@ -192,7 +210,7 @@ fn run_build_rr(
     } else {
         let _lock = FileLock::lock(target_dir)?;
         let cfg = BuildConfig::from_flags(
-            &cmd.build_flags,
+            &request.build_flags,
             &cli.unstable_feature,
             cli.verbose,
             UserDiagnostics::from_flags(cli),
@@ -215,15 +233,15 @@ fn run_build_rr(
 
 pub(crate) fn plan_build_rr_from_resolved(
     cli: &UniversalFlags,
-    cmd: &BuildSubcommand,
+    request: &BuildPlanRequest,
     target_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
     let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+        &request.auto_sync_flags,
         cli,
-        &cmd.build_flags,
+        &request.build_flags,
         selected_target_backend,
         target_dir,
         RunMode::Build,
@@ -237,8 +255,8 @@ pub(crate) fn plan_build_rr_from_resolved(
         output,
         Box::new(|resolved, target_backend| {
             calc_user_intent(
-                &cmd.path,
-                cmd.package.as_deref(),
+                &request.path_filters,
+                request.package_filter.as_deref(),
                 resolved,
                 target_backend,
                 output,
@@ -250,16 +268,16 @@ pub(crate) fn plan_build_rr_from_resolved(
 
 fn plan_build_rr_from_resolved_with_scope(
     cli: &UniversalFlags,
-    cmd: &BuildSubcommand,
+    request: &BuildPlanRequest,
     target_dir: &Path,
     target_backend: TargetBackend,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
     scoped_packages: Vec<PackageId>,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
     let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
+        &request.auto_sync_flags,
         cli,
-        &cmd.build_flags,
+        &request.build_flags,
         Some(target_backend),
         target_dir,
         RunMode::Build,
@@ -280,17 +298,17 @@ fn plan_build_rr_from_resolved_with_scope(
 
 pub(crate) fn plan_build_rr_from_resolved_all(
     cli: &UniversalFlags,
-    cmd: &BuildSubcommand,
+    request: &BuildPlanRequest,
     _source_dir: &Path,
     target_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<Vec<(rr_build::BuildMeta, rr_build::BuildInput)>> {
     if let Some(target_backend) = selected_target_backend {
-        if has_explicit_build_selector(cmd)
+        if has_explicit_build_selector(request)
             && resolve_selected_build_packages(
                 &resolve_output,
-                cmd,
+                request,
                 Some(target_backend),
                 UserDiagnostics::from_flags(cli),
             )?
@@ -301,7 +319,7 @@ pub(crate) fn plan_build_rr_from_resolved_all(
 
         return plan_build_rr_from_resolved(
             cli,
-            cmd,
+            request,
             target_dir,
             Some(target_backend),
             resolve_output,
@@ -311,20 +329,20 @@ pub(crate) fn plan_build_rr_from_resolved_all(
 
     let selections = resolve_build_target_selections(
         &resolve_output,
-        cmd,
+        request,
         None,
         UserDiagnostics::from_flags(cli),
     )?;
 
-    if has_explicit_build_selector(cmd) {
+    if has_explicit_build_selector(request) {
         return selections
             .into_iter()
             .map(|selection| {
-                let (scoped_cmd, target_backend) =
-                    narrow_build_request_to_selection(cmd, &resolve_output, &selection);
+                let (scoped_request, target_backend) =
+                    narrow_build_request_to_selection(request, &resolve_output, &selection);
                 plan_build_rr_from_resolved(
                     cli,
-                    &scoped_cmd,
+                    &scoped_request,
                     target_dir,
                     Some(target_backend),
                     resolve_output.clone(),
@@ -334,7 +352,7 @@ pub(crate) fn plan_build_rr_from_resolved_all(
     }
 
     if selections.is_empty() {
-        return plan_build_rr_from_resolved(cli, cmd, target_dir, None, resolve_output)
+        return plan_build_rr_from_resolved(cli, request, target_dir, None, resolve_output)
             .map(|plan| vec![plan]);
     }
 
@@ -343,7 +361,7 @@ pub(crate) fn plan_build_rr_from_resolved_all(
         .map(|selection| {
             plan_build_rr_from_resolved_with_scope(
                 cli,
-                cmd,
+                request,
                 target_dir,
                 selection.target_backend,
                 resolve_output.clone(),
@@ -353,34 +371,34 @@ pub(crate) fn plan_build_rr_from_resolved_all(
         .collect()
 }
 
-fn has_explicit_build_selector(cmd: &BuildSubcommand) -> bool {
-    !cmd.path.is_empty() || cmd.package.is_some()
+fn has_explicit_build_selector(request: &BuildPlanRequest) -> bool {
+    !request.path_filters.is_empty() || request.package_filter.is_some()
 }
 
 fn narrow_build_request_to_selection(
-    cmd: &BuildSubcommand,
+    request: &BuildPlanRequest,
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     selection: &TargetPackageGroup,
-) -> (BuildSubcommand, TargetBackend) {
-    let mut scoped_cmd = cmd.clone();
-    scoped_cmd.package = None;
-    scoped_cmd.path = selection
+) -> (BuildPlanRequest, TargetBackend) {
+    let mut scoped_request = request.clone();
+    scoped_request.package_filter = None;
+    scoped_request.path_filters = selection
         .packages
         .iter()
         .map(|pkg| resolve_output.pkg_dirs.get_package(*pkg).root_path.clone())
         .collect();
-    (scoped_cmd, selection.target_backend)
+    (scoped_request, selection.target_backend)
 }
 
 fn resolve_build_target_selections(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    cmd: &BuildSubcommand,
+    request: &BuildPlanRequest,
     selected_target_backend: Option<TargetBackend>,
     output: UserDiagnostics,
 ) -> anyhow::Result<Vec<TargetPackageGroup>> {
     if let Some(target_backend) = selected_target_backend {
         let packages =
-            resolve_selected_build_packages(resolve_output, cmd, Some(target_backend), output)?;
+            resolve_selected_build_packages(resolve_output, request, Some(target_backend), output)?;
         if packages.is_empty() {
             return Ok(Vec::new());
         }
@@ -390,7 +408,7 @@ fn resolve_build_target_selections(
         }]);
     }
 
-    let selected = resolve_selected_build_packages(resolve_output, cmd, None, output)?;
+    let selected = resolve_selected_build_packages(resolve_output, request, None, output)?;
     let mut selections = group_packages_by_preferred_backend(resolve_output, selected);
 
     for selection in &mut selections {
@@ -408,15 +426,20 @@ fn resolve_build_target_selections(
 
 fn resolve_selected_build_packages(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    cmd: &BuildSubcommand,
+    request: &BuildPlanRequest,
     target_backend: Option<TargetBackend>,
     output: UserDiagnostics,
 ) -> anyhow::Result<Vec<PackageId>> {
-    if !cmd.path.is_empty() {
+    if !request.path_filters.is_empty() {
         if let Some(target_backend) = target_backend {
-            return select_supported_packages(resolve_output, &cmd.path, target_backend, output);
+            return select_supported_packages(
+                resolve_output,
+                &request.path_filters,
+                target_backend,
+                output,
+            );
         }
-        return Ok(select_packages(&cmd.path, output, |dir| {
+        return Ok(select_packages(&request.path_filters, output, |dir| {
             filter_pkg_by_dir(resolve_output, dir)
         })?
         .into_iter()
@@ -424,7 +447,7 @@ fn resolve_selected_build_packages(
         .collect());
     }
 
-    if let Some(package_filter) = cmd.package.as_deref() {
+    if let Some(package_filter) = request.package_filter.as_deref() {
         let pkgs = match_packages_by_name_rr(
             resolve_output,
             resolve_output.local_modules(),

--- a/crates/moon/src/tests/planner/dummy_core_planning.rs
+++ b/crates/moon/src/tests/planner/dummy_core_planning.rs
@@ -67,7 +67,7 @@ fn dummy_core_build_graph_matches_snapshots() {
     let (cli, cmd) = parse_build_command(&["build", "--dry-run", "--sort-input"]);
     expect_file!["../../../tests/test_cases/dummy_core/build_default.jsonl.snap"].assert_eq(
         &fixture
-            .plan_build_with_cli(&cli, &cmd)
+            .plan_build_with_request(&cli, &cmd)
             .expect("default build graph should plan"),
     );
 
@@ -75,7 +75,7 @@ fn dummy_core_build_graph_matches_snapshots() {
         parse_build_command(&["build", "--dry-run", "--target", "wasm", "--sort-input"]);
     expect_file!["../../../tests/test_cases/dummy_core/build_wasm.jsonl.snap"].assert_eq(
         &fixture
-            .plan_build_with_cli(&cli, &cmd)
+            .plan_build_with_request(&cli, &cmd)
             .expect("wasm build graph should plan"),
     );
 
@@ -83,14 +83,14 @@ fn dummy_core_build_graph_matches_snapshots() {
         parse_build_command(&["build", "--dry-run", "--target", "wasm-gc", "--sort-input"]);
     expect_file!["../../../tests/test_cases/dummy_core/build_wasm_gc.jsonl.snap"].assert_eq(
         &fixture
-            .plan_build_with_cli(&cli, &cmd)
+            .plan_build_with_request(&cli, &cmd)
             .expect("wasm-gc build graph should plan"),
     );
 
     let (cli, cmd) = parse_build_command(&["build", "--dry-run", "--target", "js", "--sort-input"]);
     expect_file!["../../../tests/test_cases/dummy_core/build_js.jsonl.snap"].assert_eq(
         &fixture
-            .plan_build_with_cli(&cli, &cmd)
+            .plan_build_with_request(&cli, &cmd)
             .expect("js build graph should plan"),
     );
 }

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -29,7 +29,7 @@ use moonutil::{
 };
 
 use crate::cli::{
-    BenchSubcommand, BuildSubcommand, BundleSubcommand, CheckSubcommand, MoonBuildCli,
+    BenchSubcommand, BuildPlanRequest, BundleSubcommand, CheckSubcommand, MoonBuildCli,
     MoonBuildSubcommands, RunSubcommand, TestLikeSubcommand, TestSubcommand,
 };
 
@@ -175,46 +175,46 @@ impl PlanningFixture {
         })
     }
 
-    pub(super) fn plan_build_with_cli(
+    pub(super) fn plan_build_with_request(
         &self,
         cli: &UniversalFlags,
-        cmd: &BuildSubcommand,
+        request: &BuildPlanRequest,
     ) -> anyhow::Result<String> {
-        self.dump_plan(self.plan_build_graph_with_cli(cli, cmd)?)
+        self.dump_plan(self.plan_build_graph_with_request(cli, request)?)
     }
 
-    pub(super) fn plan_build_graph_with_cli(
+    pub(super) fn plan_build_graph_with_request(
         &self,
         cli: &UniversalFlags,
-        cmd: &BuildSubcommand,
+        request: &BuildPlanRequest,
     ) -> anyhow::Result<PlannedGraph> {
         let (build_meta, build_graph) = crate::cli::build::plan_build_rr_from_resolved(
             cli,
-            cmd,
+            request,
             &self.target_dir,
-            cmd.build_flags.resolve_single_target_backend()?,
+            request.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
         Ok(PlannedGraph::new(build_meta, build_graph))
     }
 
-    pub(super) fn plan_build_all_with_cli(
+    pub(super) fn plan_build_all_with_request(
         &self,
         cli: &UniversalFlags,
-        cmd: &BuildSubcommand,
+        request: &BuildPlanRequest,
     ) -> anyhow::Result<Vec<PlannedGraph>> {
-        self.plan_build_all_with_backend(cli, cmd, cmd.build_flags.resolve_single_target_backend()?)
+        self.plan_build_all_with_backend(cli, request, request.resolve_single_target_backend()?)
     }
 
     pub(super) fn plan_build_all_with_backend(
         &self,
         cli: &UniversalFlags,
-        cmd: &BuildSubcommand,
+        request: &BuildPlanRequest,
         selected_target_backend: Option<moonutil::common::TargetBackend>,
     ) -> anyhow::Result<Vec<PlannedGraph>> {
         crate::cli::build::plan_build_rr_from_resolved_all(
             cli,
-            cmd,
+            request,
             &self.source_dir,
             &self.target_dir,
             selected_target_backend,
@@ -431,13 +431,13 @@ fn package_names(
         .collect()
 }
 
-pub(super) fn parse_build_command(args: &[&str]) -> (UniversalFlags, BuildSubcommand) {
+pub(super) fn parse_build_command(args: &[&str]) -> (UniversalFlags, BuildPlanRequest) {
     let parsed = MoonBuildCli::try_parse_from(std::iter::once("moon").chain(args.iter().copied()))
         .expect("build command should parse");
     let Some(MoonBuildSubcommands::Build(cmd)) = parsed.subcommand else {
         panic!("expected `moon build` to parse as the build subcommand");
     };
-    (parsed.flags, cmd)
+    (parsed.flags, cmd.request)
 }
 
 pub(super) fn parse_check_command(args: &[&str]) -> (UniversalFlags, CheckSubcommand) {

--- a/crates/moon/src/tests/planner/path_filter_planning.rs
+++ b/crates/moon/src/tests/planner/path_filter_planning.rs
@@ -32,7 +32,7 @@ fn expected_wasm_gc_packages(packages: &[&str]) -> Vec<PlannedPackageRun> {
 fn expect_build_packages(fixture: &PlanningFixture, path: &str, expected: &[&str]) {
     let (cli, cmd) = parse_build_command(&["build", path, "--dry-run", "--sort-input"]);
     let runs = fixture
-        .plan_build_all_with_cli(&cli, &cmd)
+        .plan_build_all_with_request(&cli, &cmd)
         .expect("build path filter should plan");
     assert_eq!(
         planned_root_package_runs(runs),

--- a/crates/moon/src/tests/planner/profile_planning.rs
+++ b/crates/moon/src/tests/planner/profile_planning.rs
@@ -238,7 +238,7 @@ fn build_graph_uses_selected_profile() {
     ] {
         let (cli, cmd) = parse_build_command(args);
         let graph = fixture
-            .plan_build_with_cli(&cli, &cmd)
+            .plan_build_with_request(&cli, &cmd)
             .unwrap_or_else(|err| panic!("{label} should plan: {err:#}"));
 
         assert_command_uses_profile(

--- a/crates/moon/src/tests/planner/target_backend_planning.rs
+++ b/crates/moon/src/tests/planner/target_backend_planning.rs
@@ -92,7 +92,7 @@ fn target_backend_build_planning_respects_default_and_explicit_backend() {
 
     let (cli, cmd) = parse_build_command(&["build", "--dry-run", "--nostd", "--sort-input"]);
     let default_graph = fixture
-        .plan_build_with_cli(&cli, &cmd)
+        .plan_build_with_request(&cli, &cmd)
         .expect("default build graph should plan");
     assert_graph_text_contains_and_omits(
         &default_graph,
@@ -112,7 +112,7 @@ fn target_backend_build_planning_respects_default_and_explicit_backend() {
         "--sort-input",
     ]);
     let js_graph = fixture
-        .plan_build_with_cli(&cli, &cmd)
+        .plan_build_with_request(&cli, &cmd)
         .expect("js build graph should plan");
     assert_graph_text_contains_and_omits(
         &js_graph,
@@ -164,7 +164,7 @@ fn many_target_planning_selects_requested_backends() {
         "--nostd",
         "--sort-input",
     ]);
-    let runs = lower_surface_targets(&cmd.build_flags.target)
+    let runs = lower_surface_targets(cmd.surface_targets())
         .into_iter()
         .flat_map(|target| {
             fixture
@@ -265,7 +265,7 @@ fn conflicting_workspace_preferred_targets_build_selection_splits_by_module_back
 
     let (cli, cmd) = parse_build_command(&["build", "--dry-run", "--sort-input"]);
     let runs = fixture
-        .plan_build_all_with_cli(&cli, &cmd)
+        .plan_build_all_with_request(&cli, &cmd)
         .expect("default build plans should resolve");
 
     assert_root_package_runs(
@@ -290,7 +290,7 @@ fn conflicting_workspace_preferred_targets_build_path_selection_uses_module_back
     let (cli, cmd) =
         parse_build_command(&["build", js_path, native_path, "--dry-run", "--sort-input"]);
     let runs = fixture
-        .plan_build_all_with_cli(&cli, &cmd)
+        .plan_build_all_with_request(&cli, &cmd)
         .expect("path-selected build plans should resolve");
 
     assert_root_package_runs(
@@ -309,7 +309,7 @@ fn explicit_build_target_keeps_single_backend_selection() {
 
     let (cli, cmd) = parse_build_command(&["build", "--target", "js", "--dry-run", "--sort-input"]);
     let runs = fixture
-        .plan_build_all_with_cli(&cli, &cmd)
+        .plan_build_all_with_request(&cli, &cmd)
         .expect("explicit js build plans should resolve");
 
     assert_root_package_runs(
@@ -456,7 +456,7 @@ fn mixed_backend_build_and_check_planning_are_target_aware() {
 
     let (cli, cmd) = parse_build_command(&["build", "--target", "js", "--dry-run", "--sort-input"]);
     let build_js = fixture
-        .plan_build_with_cli(&cli, &cmd)
+        .plan_build_with_request(&cli, &cmd)
         .expect("js build graph should plan");
     assert_graph_inputs(
         &build_js,
@@ -490,7 +490,7 @@ fn mixed_backend_build_and_check_planning_are_target_aware() {
     let (cli, cmd) =
         parse_build_command(&["build", "--target", "native", "--dry-run", "--sort-input"]);
     let build_native = fixture
-        .plan_build_with_cli(&cli, &cmd)
+        .plan_build_with_request(&cli, &cmd)
         .expect("native build graph should plan");
     assert_graph_inputs(
         &build_native,

--- a/crates/moon/src/tests/planner/whitespace_planning.rs
+++ b/crates/moon/src/tests/planner/whitespace_planning.rs
@@ -46,7 +46,7 @@ fn whitespace_cli_variants_resolve_to_same_main_package_intention() {
     ] {
         let (cli, cmd) = parse_build_command(args);
         let actual = fixture
-            .plan_build_graph_with_cli(&cli, &cmd)
+            .plan_build_graph_with_request(&cli, &cmd)
             .map(planned_root_package_intent)
             .expect("build command should resolve");
         assert_eq!(actual, expected, "unexpected build intention for {args:?}");


### PR DESCRIPTION
## What changed

This PR splits `moon build` into two layers:

- `BuildSubcommand`: the command wrapper, currently `request + watch`
- `BuildPlanRequest`: the build-planning input, containing path/package selection, build flags, and auto-sync flags

`BuildPlanRequest` is flattened into the Clap command, so this keeps the CLI surface unchanged while making the internal boundary explicit. After dispatch, `run_build_internal`, `run_build_rr`, and the RR planning helpers receive `BuildPlanRequest` instead of the full `BuildSubcommand`.

The planner fixture now mirrors that boundary: `parse_build_command` returns a `BuildPlanRequest`, and build planner fixture methods are named `*_with_request` rather than `*_with_cli`.

## Why this is better

The previous API let planning code depend on the full build command even though part of that command is not planning input. The clearest example is `watch`: it affects execution mode and file watching, but it should not be visible to graph planning.

This PR makes that impossible at the type boundary. Once the top-level command has selected `cmd.request` and `cmd.watch`, planner-facing code cannot accidentally read command-wrapper fields because it no longer receives the wrapper.

This also gives the tests a cleaner abstraction. Build planner tests still parse real CLI arguments when they need wiring coverage, but the value they pass into planning is now the semantic request. That means tests are checking this chain explicitly:

`Clap build command -> BuildPlanRequest -> planner`

instead of passing the whole Clap command object through and trusting each planner helper to ignore unrelated fields.

## What this lets us test or prevent

This does not add a new user-visible behavior. The practical improvement is architectural testability and API pressure:

- planner fixtures can now exercise build planning with a `BuildPlanRequest`, not a watch-capable `BuildSubcommand`
- the test harness verifies that parsed build CLI arguments lower into the same request type that production planning consumes
- future build command fields such as execution/watch/output-mode concerns do not automatically become available to planner helpers
- request narrowing for multi-backend planning mutates a planning request, not a parsed CLI command

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p moon`
- `cargo test -p moon target_backend_planning -- --nocapture`
- `cargo test -p moon --test mod test_moon_build_filter_by_path_success -- --nocapture`