### PR TITLE
[codex] Add structural planner graph assertions

### DIFF
--- a/crates/moon/src/tests/planner/cli_to_planner.rs
+++ b/crates/moon/src/tests/planner/cli_to_planner.rs
@@ -18,9 +18,7 @@
 
 use expect_test::expect;
 
-use super::fixture::{
-    PlanningFixture, parse_run_command, parse_test_command, planned_graph_inputs,
-};
+use super::fixture::{PlanningFixture, parse_run_command, parse_test_command};
 
 #[test]
 fn command_string_run_parses_as_expected() {
@@ -181,9 +179,9 @@ fn parsed_native_target_dry_run_test_command_plans_native_graph() {
         PlanningFixture::new("mixed_backend_local_dep.in").expect("fixture should resolve");
 
     let graph = fixture
-        .plan_test_with_cli(&cli, &cmd)
+        .plan_test_graph_with_cli(&cli, &cmd)
         .expect("native target test graph should plan");
-    let inputs = planned_graph_inputs(&graph);
+    let inputs = graph.inputs();
 
     assert!(inputs.contains("./server/server_wbtest.mbt"));
     assert!(inputs.contains("./deps/nativedep/lib/lib.mbt"));

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -17,8 +17,11 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use clap::Parser;
-use moonbuild_debug::graph::debug_dump_build_graph;
-use std::path::PathBuf;
+use moonbuild_debug::graph::{BuildGraphDump, debug_dump_build_graph};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 use moonbuild_rupes_recta::{ResolveOutput, model::BuildPlanNode};
 use moonutil::{
@@ -40,6 +43,7 @@ pub(super) struct PlanningFixture {
 }
 
 pub(super) struct PlannedGraph {
+    source_dir: PathBuf,
     build_meta: crate::rr_build::BuildMeta,
     build_graph: crate::rr_build::BuildInput,
 }
@@ -59,13 +63,81 @@ pub(super) struct PlannedPackageIntent {
 
 impl PlannedGraph {
     fn new(
+        source_dir: &Path,
         build_meta: crate::rr_build::BuildMeta,
         build_graph: crate::rr_build::BuildInput,
     ) -> Self {
         Self {
+            source_dir: source_dir.to_path_buf(),
             build_meta,
             build_graph,
         }
+    }
+
+    fn dump(&self) -> BuildGraphDump {
+        let graph = self.build_graph.graph_for_test();
+        let default_files = self
+            .build_meta
+            .artifacts
+            .values()
+            .flat_map(|art| {
+                art.artifacts
+                    .iter()
+                    .flat_map(|file| graph.files.lookup(&file.to_string_lossy()))
+            })
+            .collect::<Vec<_>>();
+        debug_dump_build_graph(graph, &default_files, &self.source_dir)
+    }
+
+    pub(super) fn inputs(&self) -> BTreeSet<String> {
+        self.dump()
+            .nodes
+            .into_iter()
+            .flat_map(|node| node.inputs)
+            .collect()
+    }
+
+    pub(super) fn outputs(&self) -> BTreeSet<String> {
+        self.dump()
+            .nodes
+            .into_iter()
+            .flat_map(|node| node.outputs)
+            .collect()
+    }
+
+    pub(super) fn command_tokens(&self) -> Vec<Vec<String>> {
+        self.dump()
+            .nodes
+            .into_iter()
+            .filter_map(|node| node.command)
+            .map(|command| shlex::split(&command).expect("planner command should tokenize"))
+            .collect()
+    }
+
+    pub(super) fn command_tokens_matching(
+        &self,
+        program: &str,
+        required_tokens: &[&str],
+    ) -> Vec<String> {
+        let commands = self.command_tokens();
+        commands
+            .iter()
+            .find(|tokens| {
+                let Some(command) = tokens.first() else {
+                    return false;
+                };
+                command == program
+                    && required_tokens
+                        .iter()
+                        .all(|required| tokens.iter().any(|token| token == required))
+            })
+            .cloned()
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected command `{program}` with {:?}, got:\n{commands:#?}",
+                    required_tokens
+                )
+            })
     }
 }
 
@@ -97,6 +169,14 @@ impl PlanningFixture {
         cli: &UniversalFlags,
         cmd: &TestSubcommand,
     ) -> anyhow::Result<String> {
+        self.dump_plan(self.plan_test_graph_with_cli(cli, cmd)?)
+    }
+
+    pub(super) fn plan_test_graph_with_cli(
+        &self,
+        cli: &UniversalFlags,
+        cmd: &TestSubcommand,
+    ) -> anyhow::Result<PlannedGraph> {
         let borrowed: TestLikeSubcommand<'_> = cmd.into();
         let (build_meta, build_graph, _) = crate::cli::test::plan_test_or_bench_rr_from_resolved(
             cli,
@@ -105,7 +185,7 @@ impl PlanningFixture {
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
-        self.dump_plan(PlannedGraph::new(build_meta, build_graph))
+        Ok(PlannedGraph::new(&self.source_dir, build_meta, build_graph))
     }
 
     pub(super) fn plan_test_all_with_cli(
@@ -133,7 +213,7 @@ impl PlanningFixture {
         .map(|plans| {
             plans
                 .into_iter()
-                .map(|(meta, graph, _filter)| PlannedGraph::new(meta, graph))
+                .map(|(meta, graph, _filter)| PlannedGraph::new(&self.source_dir, meta, graph))
                 .collect()
         })
     }
@@ -143,6 +223,14 @@ impl PlanningFixture {
         cli: &UniversalFlags,
         cmd: &BenchSubcommand,
     ) -> anyhow::Result<String> {
+        self.dump_plan(self.plan_bench_graph_with_cli(cli, cmd)?)
+    }
+
+    pub(super) fn plan_bench_graph_with_cli(
+        &self,
+        cli: &UniversalFlags,
+        cmd: &BenchSubcommand,
+    ) -> anyhow::Result<PlannedGraph> {
         let borrowed: TestLikeSubcommand<'_> = cmd.into();
         let (build_meta, build_graph, _) = crate::cli::test::plan_test_or_bench_rr_from_resolved(
             cli,
@@ -151,7 +239,7 @@ impl PlanningFixture {
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
-        self.dump_plan(PlannedGraph::new(build_meta, build_graph))
+        Ok(PlannedGraph::new(&self.source_dir, build_meta, build_graph))
     }
 
     pub(super) fn plan_bench_all_with_cli(
@@ -170,7 +258,7 @@ impl PlanningFixture {
         .map(|plans| {
             plans
                 .into_iter()
-                .map(|(meta, graph, _filter)| PlannedGraph::new(meta, graph))
+                .map(|(meta, graph, _filter)| PlannedGraph::new(&self.source_dir, meta, graph))
                 .collect()
         })
     }
@@ -195,7 +283,7 @@ impl PlanningFixture {
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
-        Ok(PlannedGraph::new(build_meta, build_graph))
+        Ok(PlannedGraph::new(&self.source_dir, build_meta, build_graph))
     }
 
     pub(super) fn plan_build_all_with_cli(
@@ -223,7 +311,7 @@ impl PlanningFixture {
         .map(|plans| {
             plans
                 .into_iter()
-                .map(|(meta, graph)| PlannedGraph::new(meta, graph))
+                .map(|(meta, graph)| PlannedGraph::new(&self.source_dir, meta, graph))
                 .collect()
         })
     }
@@ -241,7 +329,7 @@ impl PlanningFixture {
             selected_target_backend,
             self.resolve_output.clone(),
         )
-        .map(|(meta, graph)| vec![PlannedGraph::new(meta, graph)])
+        .map(|(meta, graph)| vec![PlannedGraph::new(&self.source_dir, meta, graph)])
     }
 
     pub(super) fn plan_check_with_cli(
@@ -257,7 +345,23 @@ impl PlanningFixture {
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
-        self.dump_plan(PlannedGraph::new(build_meta, build_graph))
+        self.dump_plan(PlannedGraph::new(&self.source_dir, build_meta, build_graph))
+    }
+
+    pub(super) fn plan_check_graph_with_cli(
+        &self,
+        cli: &UniversalFlags,
+        cmd: &CheckSubcommand,
+    ) -> anyhow::Result<PlannedGraph> {
+        let (build_meta, build_graph) = crate::cli::check::plan_check_rr_from_resolved(
+            cli,
+            cmd,
+            &self.source_dir,
+            &self.target_dir,
+            cmd.build_flags.resolve_single_target_backend()?,
+            self.resolve_output.clone(),
+        )?;
+        Ok(PlannedGraph::new(&self.source_dir, build_meta, build_graph))
     }
 
     pub(super) fn plan_check_all_with_cli(
@@ -285,17 +389,9 @@ impl PlanningFixture {
         .map(|plans| {
             plans
                 .into_iter()
-                .map(|(meta, graph)| PlannedGraph::new(meta, graph))
+                .map(|(meta, graph)| PlannedGraph::new(&self.source_dir, meta, graph))
                 .collect()
         })
-    }
-
-    pub(super) fn plan_run_with_cli(
-        &self,
-        cli: &UniversalFlags,
-        cmd: &RunSubcommand,
-    ) -> anyhow::Result<String> {
-        self.dump_plan(self.plan_run_graph_with_cli(cli, cmd)?)
     }
 
     pub(super) fn plan_run_graph_with_cli(
@@ -320,7 +416,7 @@ impl PlanningFixture {
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
-        Ok(PlannedGraph::new(build_meta, build_graph))
+        Ok(PlannedGraph::new(&self.source_dir, build_meta, build_graph))
     }
 
     pub(super) fn case_dir(&self) -> &std::path::Path {
@@ -328,18 +424,7 @@ impl PlanningFixture {
     }
 
     fn dump_plan(&self, plan: PlannedGraph) -> anyhow::Result<String> {
-        let graph = plan.build_graph.graph_for_test();
-        let default_files = plan
-            .build_meta
-            .artifacts
-            .values()
-            .flat_map(|art| {
-                art.artifacts
-                    .iter()
-                    .flat_map(|file| graph.files.lookup(&file.to_string_lossy()))
-            })
-            .collect::<Vec<_>>();
-        let dump = debug_dump_build_graph(graph, &default_files, &self.source_dir);
+        let dump = plan.dump();
         let mut out = Vec::new();
         dump.dump_to(&mut out).expect("graph dump should serialize");
         Ok(String::from_utf8(out).expect("graph dump should be valid UTF-8"))
@@ -376,27 +461,6 @@ pub(super) fn planned_root_package_intent(plan: PlannedGraph) -> PlannedPackageI
         profile: plan.build_meta.opt_level,
         packages: root_package_names(&plan.build_meta),
     }
-}
-
-pub(super) fn planned_graph_inputs(graph: &str) -> std::collections::BTreeSet<String> {
-    graph
-        .lines()
-        .flat_map(|line| {
-            let line_json: serde_json::Value =
-                serde_json::from_str(line).expect("planner dump line should be valid JSON");
-            line_json["inputs"]
-                .as_array()
-                .expect("planner dump line should contain inputs")
-                .iter()
-                .map(|input| {
-                    input
-                        .as_str()
-                        .expect("planner input path should be a string")
-                        .to_string()
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect()
 }
 
 fn root_package_names(meta: &crate::rr_build::BuildMeta) -> Vec<String> {

--- a/crates/moon/src/tests/planner/profile_planning.rs
+++ b/crates/moon/src/tests/planner/profile_planning.rs
@@ -19,43 +19,21 @@
 use expect_test::expect_file;
 
 use super::fixture::{
-    PlanningFixture, parse_bench_command, parse_build_command, parse_check_command,
+    PlannedGraph, PlanningFixture, parse_bench_command, parse_build_command, parse_check_command,
     parse_run_command, parse_test_command,
 };
 
 // Phase 3: these tests start from an already chosen command configuration and
 // assert how the planner lowers that intent into the dry-run graph.
 
-fn line_with<'a>(graph: &'a str, command: &str, filter: &[&str]) -> &'a str {
-    graph
-        .lines()
-        .find(|line| line.contains(command) && filter.iter().all(|needle| line.contains(needle)))
-        .unwrap_or_else(|| {
-            panic!(
-                "expected graph line containing `{command}` and {:?}\n{graph}",
-                filter
-            )
-        })
-}
-
-fn command_tokens(graph: &str, command: &str, filter: &[&str]) -> Vec<String> {
-    let line = line_with(graph, command, filter);
-    let line_json: serde_json::Value =
-        serde_json::from_str(line).expect("planner dump line should be valid JSON");
-    let command = line_json["command"]
-        .as_str()
-        .expect("planner dump line should contain a command");
-    shlex::split(command).expect("planner command should tokenize")
-}
-
 fn assert_command_uses_profile(
-    graph: &str,
-    command: &str,
+    graph: &PlannedGraph,
+    program: &str,
     filter: &[&str],
     profile: &str,
     expect_debug_flags: bool,
 ) {
-    let tokens = command_tokens(graph, command, filter);
+    let tokens = graph.command_tokens_matching(program, filter);
     let expected_prefix = format!("./_build/wasm-gc/{profile}/");
     let other_prefix = if profile == "debug" {
         "./_build/wasm-gc/release/"
@@ -68,7 +46,7 @@ fn assert_command_uses_profile(
             .iter()
             .filter(|token| token.contains("./_build/wasm-gc/"))
             .all(|token| token.contains(&expected_prefix)),
-        "expected `{command}` with {:?} to use `{expected_prefix}`, got:\n{:?}",
+        "expected `{program}` with {:?} to use `{expected_prefix}`, got:\n{:?}",
         filter,
         tokens,
     );
@@ -77,7 +55,7 @@ fn assert_command_uses_profile(
             .iter()
             .filter(|token| token.contains("./_build/wasm-gc/"))
             .all(|token| !token.contains(other_prefix)),
-        "expected `{command}` with {:?} to avoid `{other_prefix}`, got:\n{:?}",
+        "expected `{program}` with {:?} to avoid `{other_prefix}`, got:\n{:?}",
         filter,
         tokens,
     );
@@ -86,7 +64,7 @@ fn assert_command_uses_profile(
         assert_eq!(
             tokens.iter().any(|token| token == flag),
             expect_debug_flags,
-            "expected `{command}` with {:?} to {} `{flag}`, got:\n{:?}",
+            "expected `{program}` with {:?} to {} `{flag}`, got:\n{:?}",
             filter,
             if expect_debug_flags {
                 "include"
@@ -104,26 +82,41 @@ fn bench_graph_uses_selected_codegen_profile() {
     let (cli, cmd) = parse_bench_command(&["bench", "--sort-input", "--dry-run"]);
 
     let default_graph = fixture
-        .plan_bench_with_cli(&cli, &cmd)
+        .plan_bench_graph_with_cli(&cli, &cmd)
         .expect("default bench graph should plan");
-    assert!(default_graph.contains("moonc"));
-    assert!(!default_graph.contains("-O0"));
+    assert!(
+        !default_graph
+            .command_tokens()
+            .iter()
+            .flatten()
+            .any(|token| token == "-O0")
+    );
 
     let (release_cli, release_cmd) =
         parse_bench_command(&["bench", "--release", "--sort-input", "--dry-run"]);
     let release_graph = fixture
-        .plan_bench_with_cli(&release_cli, &release_cmd)
+        .plan_bench_graph_with_cli(&release_cli, &release_cmd)
         .expect("release bench graph should plan");
-    assert!(release_graph.contains("moonc"));
-    assert!(!release_graph.contains("-O0"));
+    assert!(
+        !release_graph
+            .command_tokens()
+            .iter()
+            .flatten()
+            .any(|token| token == "-O0")
+    );
 
     let (debug_cli, debug_cmd) =
         parse_bench_command(&["bench", "--debug", "--sort-input", "--dry-run"]);
     let debug_graph = fixture
-        .plan_bench_with_cli(&debug_cli, &debug_cmd)
+        .plan_bench_graph_with_cli(&debug_cli, &debug_cmd)
         .expect("debug bench graph should plan");
-    assert!(debug_graph.contains("moonc"));
-    assert!(debug_graph.contains("-O0"));
+    assert!(
+        debug_graph
+            .command_tokens()
+            .iter()
+            .flatten()
+            .any(|token| token == "-O0")
+    );
 }
 
 #[test]
@@ -166,11 +159,23 @@ fn check_graph_uses_debug_profile_without_codegen_flags() {
     ] {
         let (cli, cmd) = parse_check_command(args);
         let graph = fixture
-            .plan_check_with_cli(&cli, &cmd)
+            .plan_check_graph_with_cli(&cli, &cmd)
             .unwrap_or_else(|err| panic!("{label} should plan: {err:#}"));
 
-        assert_command_uses_profile(&graph, "moonc check", &["./lib/hello.mbt"], "debug", false);
-        assert_command_uses_profile(&graph, "moonc check", &["./main/main.mbt"], "debug", false);
+        assert_command_uses_profile(
+            &graph,
+            "moonc",
+            &["check", "./lib/hello.mbt"],
+            "debug",
+            false,
+        );
+        assert_command_uses_profile(
+            &graph,
+            "moonc",
+            &["check", "./main/main.mbt"],
+            "debug",
+            false,
+        );
     }
 }
 
@@ -238,20 +243,20 @@ fn build_graph_uses_selected_profile() {
     ] {
         let (cli, cmd) = parse_build_command(args);
         let graph = fixture
-            .plan_build_with_cli(&cli, &cmd)
+            .plan_build_graph_with_cli(&cli, &cmd)
             .unwrap_or_else(|err| panic!("{label} should plan: {err:#}"));
 
         assert_command_uses_profile(
             &graph,
-            "moonc build-package",
-            &["./lib/hello.mbt"],
+            "moonc",
+            &["build-package", "./lib/hello.mbt"],
             profile,
             profile == "debug",
         );
         assert_command_uses_profile(
             &graph,
-            "moonc link-core",
-            &["-main", "hello/main"],
+            "moonc",
+            &["link-core", "-main", "hello/main"],
             profile,
             profile == "debug",
         );
@@ -341,20 +346,20 @@ fn run_graph_uses_selected_profile() {
     ] {
         let (cli, cmd) = parse_run_command(args);
         let graph = fixture
-            .plan_run_with_cli(&cli, &cmd)
+            .plan_run_graph_with_cli(&cli, &cmd)
             .unwrap_or_else(|err| panic!("{label} should plan: {err:#}"));
 
         assert_command_uses_profile(
             &graph,
-            "moonc build-package",
-            &["./lib/hello.mbt"],
+            "moonc",
+            &["build-package", "./lib/hello.mbt"],
             profile,
             profile == "debug",
         );
         assert_command_uses_profile(
             &graph,
-            "moonc link-core",
-            &["-main", "hello/main"],
+            "moonc",
+            &["link-core", "-main", "hello/main"],
             profile,
             profile == "debug",
         );

--- a/crates/moon/src/tests/planner/target_backend_planning.rs
+++ b/crates/moon/src/tests/planner/target_backend_planning.rs
@@ -19,31 +19,43 @@
 use super::fixture::{
     PlannedGraph, PlannedPackageRun, PlanningFixture, parse_bench_command, parse_build_command,
     parse_bundle_command, parse_check_command, parse_run_command, parse_test_command,
-    planned_check_package_runs, planned_graph_inputs, planned_root_package_runs,
-    planned_target_backends,
+    planned_check_package_runs, planned_root_package_runs, planned_target_backends,
 };
 use moonutil::common::{TargetBackend, lower_surface_targets};
 
 // Phase 3: these tests already know the selected backend and only need to
 // verify that planning keeps the right packages and commands in the graph.
 
-fn assert_graph_text_contains_and_omits(graph: &str, present: &[&str], absent: &[&str]) {
-    for needle in present {
+fn assert_plan_outputs(plan: &PlannedGraph, present: &[&str], absent: &[&str]) {
+    let outputs = plan.outputs();
+    for output in present {
         assert!(
-            graph.contains(needle),
-            "expected graph to contain `{needle}`, got:\n{graph}"
+            outputs.contains(*output),
+            "expected graph outputs to contain `{output}`, got:\n{outputs:#?}"
         );
     }
-    for needle in absent {
+    for output in absent {
         assert!(
-            !graph.contains(needle),
-            "expected graph to not contain `{needle}`, got:\n{graph}"
+            !outputs.contains(*output),
+            "expected graph outputs to omit `{output}`, got:\n{outputs:#?}"
         );
     }
 }
 
-fn assert_graph_inputs(graph: &str, present: &[&str], absent: &[&str]) {
-    let inputs = planned_graph_inputs(graph);
+fn assert_plan_has_command_token(plan: &PlannedGraph, token: &str, expected: bool) {
+    let commands = plan.command_tokens();
+    assert_eq!(
+        commands
+            .iter()
+            .any(|command| command.iter().any(|candidate| candidate == token)),
+        expected,
+        "expected graph commands to {} `{token}`, got:\n{commands:#?}",
+        if expected { "contain" } else { "omit" },
+    );
+}
+
+fn assert_plan_inputs(plan: &PlannedGraph, present: &[&str], absent: &[&str]) {
+    let inputs = plan.inputs();
     for input in present {
         assert!(
             inputs.contains(*input),
@@ -92,16 +104,15 @@ fn target_backend_build_planning_respects_default_and_explicit_backend() {
 
     let (cli, cmd) = parse_build_command(&["build", "--dry-run", "--nostd", "--sort-input"]);
     let default_graph = fixture
-        .plan_build_with_cli(&cli, &cmd)
+        .plan_build_graph_with_cli(&cli, &cmd)
         .expect("default build graph should plan");
-    assert_graph_text_contains_and_omits(
+    assert_plan_outputs(
         &default_graph,
-        &[
-            "./_build/wasm-gc/debug/build/main/main.wasm",
-            "-target wasm-gc",
-        ],
-        &["./_build/js/debug/build/main/main.js", "-target js"],
+        &["./_build/wasm-gc/debug/build/main/main.wasm"],
+        &["./_build/js/debug/build/main/main.js"],
     );
+    assert_plan_has_command_token(&default_graph, "wasm-gc", true);
+    assert_plan_has_command_token(&default_graph, "js", false);
 
     let (cli, cmd) = parse_build_command(&[
         "build",
@@ -112,16 +123,15 @@ fn target_backend_build_planning_respects_default_and_explicit_backend() {
         "--sort-input",
     ]);
     let js_graph = fixture
-        .plan_build_with_cli(&cli, &cmd)
+        .plan_build_graph_with_cli(&cli, &cmd)
         .expect("js build graph should plan");
-    assert_graph_text_contains_and_omits(
+    assert_plan_outputs(
         &js_graph,
-        &["./_build/js/debug/build/main/main.js", "-target js"],
-        &[
-            "./_build/wasm-gc/debug/build/main/main.wasm",
-            "-target wasm-gc",
-        ],
+        &["./_build/js/debug/build/main/main.js"],
+        &["./_build/wasm-gc/debug/build/main/main.wasm"],
     );
+    assert_plan_has_command_token(&js_graph, "js", true);
+    assert_plan_has_command_token(&js_graph, "wasm-gc", false);
 }
 
 #[test]
@@ -438,9 +448,9 @@ fn mixed_backend_build_and_check_planning_are_target_aware() {
 
     let (cli, cmd) = parse_check_command(&["check", "--target", "js", "--dry-run", "--sort-input"]);
     let check_js = fixture
-        .plan_check_with_cli(&cli, &cmd)
+        .plan_check_graph_with_cli(&cli, &cmd)
         .expect("js check graph should plan");
-    assert_graph_inputs(
+    assert_plan_inputs(
         &check_js,
         &[
             "./shared/shared.mbt",
@@ -456,9 +466,9 @@ fn mixed_backend_build_and_check_planning_are_target_aware() {
 
     let (cli, cmd) = parse_build_command(&["build", "--target", "js", "--dry-run", "--sort-input"]);
     let build_js = fixture
-        .plan_build_with_cli(&cli, &cmd)
+        .plan_build_graph_with_cli(&cli, &cmd)
         .expect("js build graph should plan");
-    assert_graph_inputs(
+    assert_plan_inputs(
         &build_js,
         &[
             "./shared/shared.mbt",
@@ -471,9 +481,9 @@ fn mixed_backend_build_and_check_planning_are_target_aware() {
     let (cli, cmd) =
         parse_check_command(&["check", "--target", "native", "--dry-run", "--sort-input"]);
     let check_native = fixture
-        .plan_check_with_cli(&cli, &cmd)
+        .plan_check_graph_with_cli(&cli, &cmd)
         .expect("native check graph should plan");
-    assert_graph_inputs(
+    assert_plan_inputs(
         &check_native,
         &[
             "./shared/shared.mbt",
@@ -490,9 +500,9 @@ fn mixed_backend_build_and_check_planning_are_target_aware() {
     let (cli, cmd) =
         parse_build_command(&["build", "--target", "native", "--dry-run", "--sort-input"]);
     let build_native = fixture
-        .plan_build_with_cli(&cli, &cmd)
+        .plan_build_graph_with_cli(&cli, &cmd)
         .expect("native build graph should plan");
-    assert_graph_inputs(
+    assert_plan_inputs(
         &build_native,
         &[
             "./shared/shared.mbt",
@@ -511,9 +521,9 @@ fn mixed_backend_run_planning_is_target_aware() {
     let (cli, cmd) =
         parse_run_command(&["run", "web", "--target", "js", "--dry-run", "--sort-input"]);
     let run_js = fixture
-        .plan_run_with_cli(&cli, &cmd)
+        .plan_run_graph_with_cli(&cli, &cmd)
         .expect("js run graph should plan");
-    assert_graph_inputs(
+    assert_plan_inputs(
         &run_js,
         &[
             "./shared/shared.mbt",
@@ -532,9 +542,9 @@ fn mixed_backend_run_planning_is_target_aware() {
         "--sort-input",
     ]);
     let run_native = fixture
-        .plan_run_with_cli(&cli, &cmd)
+        .plan_run_graph_with_cli(&cli, &cmd)
         .expect("native run graph should plan");
-    assert_graph_inputs(
+    assert_plan_inputs(
         &run_native,
         &[
             "./shared/shared.mbt",
@@ -552,9 +562,9 @@ fn supported_targets_empty_packages_are_skipped_in_check_planning() {
 
     let (cli, cmd) = parse_check_command(&["check", "--target", "js", "--dry-run", "--sort-input"]);
     let check_js = fixture
-        .plan_check_with_cli(&cli, &cmd)
+        .plan_check_graph_with_cli(&cli, &cmd)
         .expect("js check graph should plan");
-    assert_graph_inputs(
+    assert_plan_inputs(
         &check_js,
         &["./main/main.mbt", "./lib/lib.mbt"],
         &["./never/never.mbt"],
@@ -563,9 +573,9 @@ fn supported_targets_empty_packages_are_skipped_in_check_planning() {
     let (cli, cmd) =
         parse_check_command(&["check", "--target", "native", "--dry-run", "--sort-input"]);
     let check_native = fixture
-        .plan_check_with_cli(&cli, &cmd)
+        .plan_check_graph_with_cli(&cli, &cmd)
         .expect("native check graph should plan");
-    assert_graph_inputs(
+    assert_plan_inputs(
         &check_native,
         &["./main/main.mbt", "./lib/lib.mbt"],
         &["./never/never.mbt"],
@@ -654,9 +664,9 @@ fn module_supported_targets_intersection_filters_check_planning() {
         "--sort-input",
     ]);
     let check_wasm_gc = fixture
-        .plan_check_with_cli(&cli, &cmd)
+        .plan_check_graph_with_cli(&cli, &cmd)
         .expect("wasm-gc check graph should plan");
-    assert_graph_inputs(&check_wasm_gc, &["./lib/lib.mbt"], &["./main/main.mbt"]);
+    assert_plan_inputs(&check_wasm_gc, &["./lib/lib.mbt"], &["./main/main.mbt"]);
 
     let (cli, cmd) = parse_check_command(&[
         "check",
@@ -667,9 +677,9 @@ fn module_supported_targets_intersection_filters_check_planning() {
         "--sort-input",
     ]);
     let check_native = fixture
-        .plan_check_with_cli(&cli, &cmd)
+        .plan_check_graph_with_cli(&cli, &cmd)
         .expect("native check graph should plan");
-    assert_graph_inputs(&check_native, &["./lib/lib.mbt"], &["./main/main.mbt"]);
+    assert_plan_inputs(&check_native, &["./lib/lib.mbt"], &["./main/main.mbt"]);
 
     let (cli, cmd) = parse_check_command(&[
         "check",
@@ -680,7 +690,7 @@ fn module_supported_targets_intersection_filters_check_planning() {
         "--sort-input",
     ]);
     let check_llvm = fixture
-        .plan_check_with_cli(&cli, &cmd)
+        .plan_check_graph_with_cli(&cli, &cmd)
         .expect("llvm check graph should plan");
-    assert_graph_inputs(&check_llvm, &["./lib/lib.mbt"], &["./main/main.mbt"]);
+    assert_plan_inputs(&check_llvm, &["./lib/lib.mbt"], &["./main/main.mbt"]);
 }


### PR DESCRIPTION
## What changed

This PR adds structural query APIs to the planner test `PlannedGraph` value:

- `inputs()`
- `outputs()`
- `command_tokens()`
- `command_tokens_matching(...)`

Planner tests can now assert over the planned graph value directly instead of dumping to JSONL, reparsing it, and searching strings.

The existing JSONL dump path is kept for snapshot tests, so formatting compatibility remains covered where exact dry-run graph output is the point of the test.

## Why

The direction here is to keep the core planning result closer to a pure value and move effects/serialization to the boundary. Tests that care about planner semantics should ask semantic questions of `PlannedGraph`: which inputs, outputs, backends, packages, and command tokens were planned.

This does not force command selection logic into a shared abstraction. It improves the harness first, so subtle per-command behavior can be tested more directly before production boundaries are refactored.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p moon`
- `cargo test -p moon target_backend_planning -- --nocapture`
- `cargo test -p moon cli_to_planner -- --nocapture`
- `cargo test -p moon bench_graph_uses_selected_codegen_profile -- --nocapture`
- `cargo test -p moon check_graph_uses_debug_profile_without_codegen_flags -- --nocapture`
- `cargo test -p moon build_graph_uses_selected_profile -- --nocapture`
- `cargo test -p moon run_graph_uses_selected_profile -- --nocapture`

Note: I did not update the existing profile JSONL snapshots. Running the whole `profile_planning` filter locally also executes those snapshot tests, which currently fail only on input ordering in JSONL snapshots; this PR leaves that formatting coverage unchanged.
