### PR TITLE
refactor: reduce command callbacks in RR planning

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -44,6 +44,21 @@ use crate::watch::watching;
 
 use super::{BuildFlags, UniversalFlags};
 
+#[derive(Debug, Clone)]
+struct ResolvedBuildSelection {
+    packages: Vec<PackageId>,
+}
+
+impl ResolvedBuildSelection {
+    fn into_user_intent(self) -> CalcUserIntentOutput {
+        self.packages
+            .into_iter()
+            .map(UserIntent::Build)
+            .collect::<Vec<_>>()
+            .into()
+    }
+}
+
 /// Build the current package
 #[derive(Debug, clap::Parser, Clone)]
 pub(crate) struct BuildSubcommand {
@@ -278,6 +293,43 @@ fn plan_build_rr_from_resolved_with_scope(
     )
 }
 
+fn plan_build_rr_from_selection(
+    cli: &UniversalFlags,
+    cmd: &BuildSubcommand,
+    target_dir: &Path,
+    target_backend: TargetBackend,
+    resolve_output: moonbuild_rupes_recta::ResolveOutput,
+    selection: ResolvedBuildSelection,
+) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
+    let preconfig = preconfig_compile(
+        &cmd.auto_sync_flags,
+        cli,
+        &cmd.build_flags,
+        Some(target_backend),
+        target_dir,
+        RunMode::Build,
+    );
+
+    let output = UserDiagnostics::from_flags(cli);
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        &resolve_output,
+    )?;
+    debug_assert_eq!(planning_context.target_backend(), target_backend);
+    rr_build::plan_prepared_build_from_intent(
+        preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        planning_context,
+        selection.into_user_intent(),
+        resolve_output,
+    )
+}
+
 pub(crate) fn plan_build_rr_from_resolved_all(
     cli: &UniversalFlags,
     cmd: &BuildSubcommand,
@@ -287,16 +339,26 @@ pub(crate) fn plan_build_rr_from_resolved_all(
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<Vec<(rr_build::BuildMeta, rr_build::BuildInput)>> {
     if let Some(target_backend) = selected_target_backend {
-        if has_explicit_build_selector(cmd)
-            && resolve_selected_build_packages(
+        if has_explicit_build_selector(cmd) {
+            let packages = resolve_selected_build_packages(
                 &resolve_output,
                 cmd,
                 Some(target_backend),
                 UserDiagnostics::from_flags(cli),
-            )?
-            .is_empty()
-        {
-            return Ok(Vec::new());
+            )?;
+            if packages.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            return plan_build_rr_from_selection(
+                cli,
+                cmd,
+                target_dir,
+                target_backend,
+                resolve_output,
+                ResolvedBuildSelection { packages },
+            )
+            .map(|plan| vec![plan]);
         }
 
         return plan_build_rr_from_resolved(
@@ -320,14 +382,18 @@ pub(crate) fn plan_build_rr_from_resolved_all(
         return selections
             .into_iter()
             .map(|selection| {
-                let (scoped_cmd, target_backend) =
-                    narrow_build_request_to_selection(cmd, &resolve_output, &selection);
-                plan_build_rr_from_resolved(
+                // Raw user selector paths/package names have already been
+                // resolved into PackageIds. RR will read build-model paths
+                // from ResolveOutput instead of reinterpreting those selectors.
+                plan_build_rr_from_selection(
                     cli,
-                    &scoped_cmd,
+                    cmd,
                     target_dir,
-                    Some(target_backend),
+                    selection.target_backend,
                     resolve_output.clone(),
+                    ResolvedBuildSelection {
+                        packages: selection.packages,
+                    },
                 )
             })
             .collect();
@@ -355,21 +421,6 @@ pub(crate) fn plan_build_rr_from_resolved_all(
 
 fn has_explicit_build_selector(cmd: &BuildSubcommand) -> bool {
     !cmd.path.is_empty() || cmd.package.is_some()
-}
-
-fn narrow_build_request_to_selection(
-    cmd: &BuildSubcommand,
-    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    selection: &TargetPackageGroup,
-) -> (BuildSubcommand, TargetBackend) {
-    let mut scoped_cmd = cmd.clone();
-    scoped_cmd.package = None;
-    scoped_cmd.path = selection
-        .packages
-        .iter()
-        .map(|pkg| resolve_output.pkg_dirs.get_package(*pkg).root_path.clone())
-        .collect();
-    (scoped_cmd, selection.target_backend)
 }
 
 fn resolve_build_target_selections(

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -55,6 +55,36 @@ use crate::watch::{WatchOutput, watching};
 
 use super::BuildFlags;
 
+#[derive(Debug, Clone)]
+struct ResolvedCheckSelection {
+    packages: Vec<PackageId>,
+    no_mi: bool,
+    patch_file: Option<PathBuf>,
+}
+
+impl ResolvedCheckSelection {
+    fn from_command(packages: Vec<PackageId>, cmd: &CheckSubcommand) -> Self {
+        Self {
+            packages,
+            no_mi: cmd.no_mi,
+            patch_file: cmd.patch_file.clone(),
+        }
+    }
+
+    fn into_user_intent(self) -> anyhow::Result<CalcUserIntentOutput> {
+        let directive = build_directive_for_selected_packages(
+            &self.packages,
+            self.no_mi,
+            self.patch_file.as_deref(),
+        )?;
+        Ok((
+            self.packages.into_iter().map(UserIntent::Check).collect(),
+            directive,
+        )
+            .into())
+    }
+}
+
 /// Check the current package, but don't build object files
 #[derive(Debug, clap::Parser, Clone)]
 #[clap(group = clap::ArgGroup::new("package_selector").multiple(false))]
@@ -540,15 +570,16 @@ pub(crate) fn plan_check_rr_from_resolved_all(
     selections
         .into_iter()
         .map(|selection| {
-            let (scoped_cmd, target_backend) =
-                narrow_check_request_to_selection(cmd, &resolve_output, &selection);
-            plan_check_rr_from_resolved(
+            // The command adapter has resolved raw CLI selectors into
+            // PackageIds. RR planning should use those identities and the
+            // build-model paths already stored in ResolveOutput.
+            plan_check_rr_from_selection(
                 cli,
-                &scoped_cmd,
-                source_dir,
+                cmd,
                 target_dir,
-                Some(target_backend),
+                selection.target_backend,
                 resolve_output.clone(),
+                ResolvedCheckSelection::from_command(selection.packages, cmd),
             )
         })
         .collect()
@@ -625,15 +656,41 @@ pub(crate) fn plan_check_rr_from_resolved(
     )
 }
 
-fn narrow_check_request_to_selection(
+fn plan_check_rr_from_selection(
+    cli: &UniversalFlags,
     cmd: &CheckSubcommand,
-    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    selection: &TargetPackageGroup,
-) -> (CheckSubcommand, TargetBackend) {
-    let mut scoped_cmd = cmd.clone();
-    scoped_cmd.package_path = None;
-    scoped_cmd.path = selection_package_roots(resolve_output, &selection.packages);
-    (scoped_cmd, selection.target_backend)
+    target_dir: &Path,
+    target_backend: TargetBackend,
+    resolve_output: moonbuild_rupes_recta::ResolveOutput,
+    selection: ResolvedCheckSelection,
+) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
+    let preconfig = preconfig_compile(
+        &cmd.auto_sync_flags,
+        cli,
+        &cmd.build_flags,
+        Some(target_backend),
+        target_dir,
+        RunMode::Check,
+    );
+
+    let output = UserDiagnostics::from_flags(cli);
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        &resolve_output,
+    )?;
+    debug_assert_eq!(planning_context.target_backend(), target_backend);
+    rr_build::plan_prepared_build_from_intent(
+        preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        planning_context,
+        selection.into_user_intent()?,
+        resolve_output,
+    )
 }
 
 pub(crate) fn resolve_check_target_selections(
@@ -756,16 +813,6 @@ fn filter_packages_for_backend(
     }
 
     Ok(supported)
-}
-
-fn selection_package_roots(
-    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
-    packages: &[PackageId],
-) -> Vec<PathBuf> {
-    packages
-        .iter()
-        .map(|pkg| resolve_output.pkg_dirs.get_package(*pkg).root_path.clone())
-        .collect()
 }
 
 fn calc_user_intent_from_package_path(

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -497,6 +497,51 @@ pub(crate) fn plan_build_from_resolved<'a>(
     calc_user_intent: Box<CalcUserIntentFn<'a>>,
     resolve_output: ResolveOutput,
 ) -> anyhow::Result<(BuildMeta, BuildInput)> {
+    let planning_context = prepare_resolved_build(
+        &preconfig,
+        unstable_features,
+        target_dir,
+        output,
+        &resolve_output,
+    )?;
+
+    info!("Calculating user intent");
+    let intent = calc_user_intent(&resolve_output, planning_context.target_backend())?;
+    plan_prepared_build_from_intent(
+        preconfig,
+        unstable_features,
+        target_dir,
+        output,
+        planning_context,
+        intent,
+        resolve_output,
+    )
+}
+
+pub(crate) struct ResolvedBuildPlanningContext {
+    target_backend: TargetBackend,
+    is_core: bool,
+}
+
+impl ResolvedBuildPlanningContext {
+    pub(crate) fn target_backend(&self) -> TargetBackend {
+        self.target_backend
+    }
+}
+
+/// Prepare the resolved build context before command intent is calculated.
+///
+/// This step emits resolve-time diagnostics and determines the effective target
+/// backend. Commands that already resolved raw CLI selectors can use the
+/// returned backend to compute `CalcUserIntentOutput` outside the shared RR
+/// planning pipeline.
+pub(crate) fn prepare_resolved_build(
+    preconfig: &CompilePreConfig,
+    unstable_features: &FeatureGate,
+    target_dir: &Path,
+    output: UserDiagnostics,
+    resolve_output: &ResolveOutput,
+) -> anyhow::Result<ResolvedBuildPlanningContext> {
     for message in &resolve_output.user_warnings {
         output.user_message(message);
     }
@@ -527,7 +572,7 @@ pub(crate) fn plan_build_from_resolved<'a>(
     let preferred_target = if preconfig.target_backend.is_some() {
         None
     } else {
-        workspace_preferred_target(&resolve_output, output)
+        workspace_preferred_target(resolve_output, output)
     };
     info!("Preferred backend: {:?}", preferred_target);
 
@@ -542,19 +587,38 @@ pub(crate) fn plan_build_from_resolved<'a>(
             "LLVM backend is experimental and only supported on nightly moonbit toolchain for now",
         );
     }
-    warn_local_legacy_supported_targets(&resolve_output, output);
-
-    info!("Calculating user intent");
-    let intent = calc_user_intent(&resolve_output, target_backend)?;
-    info!("User intent calculated: {:?}", intent.intents);
-    for warning in &intent.warnings {
-        output.user_message(warning);
-    }
+    warn_local_legacy_supported_targets(resolve_output, output);
 
     // std or no-std?
     // Ultimately we want to determine this from config instead of special cases.
     let is_core = main_module.is_some_and(|module| module.name == MOONBITLANG_CORE);
     info!("is_core: {}", is_core);
+
+    Ok(ResolvedBuildPlanningContext {
+        target_backend,
+        is_core,
+    })
+}
+
+/// Plan from an already prepared resolved context and already calculated
+/// command intent.
+///
+/// At this boundary RR consumes package identities/directives and the
+/// build-model paths stored in `ResolveOutput`; it does not reinterpret raw CLI
+/// selector paths through a callback.
+pub(crate) fn plan_prepared_build_from_intent(
+    preconfig: CompilePreConfig,
+    unstable_features: &FeatureGate,
+    target_dir: &Path,
+    output: UserDiagnostics,
+    planning_context: ResolvedBuildPlanningContext,
+    intent: CalcUserIntentOutput,
+    resolve_output: ResolveOutput,
+) -> anyhow::Result<(BuildMeta, BuildInput)> {
+    info!("User intent calculated: {:?}", intent.intents);
+    for warning in &intent.warnings {
+        output.user_message(warning);
+    }
 
     let prebuild_config = if preconfig.action == RunMode::Check {
         info!("Skipping prebuild configuration for check run mode");
@@ -574,15 +638,15 @@ pub(crate) fn plan_build_from_resolved<'a>(
             &mut input_nodes,
             &mut intent_messages,
             &intent.directive,
-            target_backend,
+            planning_context.target_backend,
         );
     }
     for message in &intent_messages {
         output.user_message(message);
     }
     let cx = preconfig.into_compile_config(
-        target_backend,
-        is_core,
+        planning_context.target_backend,
+        planning_context.is_core,
         &resolve_output,
         &input_nodes,
         output,


### PR DESCRIPTION
## Summary

This PR starts reducing command callbacks inside RR build planning.

The distinction is intentional: RR still owns build-model paths from `ResolveOutput` / `DiscoveredPackage` (`root_path`, source files, prebuild outputs). What this removes is part of the path where command-selected `PackageId`s were converted back into package root paths so the planning callback could reinterpret them as raw CLI selectors.

## What changed

- Add `rr_build::prepare_resolved_build` and `rr_build::plan_prepared_build_from_intent` so commands can calculate `CalcUserIntentOutput` outside the shared RR planning pipeline after RR determines the effective backend.
- Keep the existing callback-based `plan_build_from_resolved` as a compatibility wrapper for commands not migrated yet.
- Add command-local resolved selection structs for `build` and `check`.
- Migrate explicit selected-package `build` / `check` flows to compute intent in the command adapter and call the prepared RR planning entrypoint.

## Why

The old callback shape lets command-specific selector interpretation run inside the shared RR planning pipeline. This PR demonstrates the target shape for selected-package flows: command adapters resolve user selectors into package identities and directives; RR planning consumes resolved intent plus `ResolveOutput`.

The split is also intentionally not a global abstraction yet. `build` and `check` have similar but not identical command state, while `test` carries more coupled package/file/index/filter state and should get its own design.

## Validation

- `cargo xtask ci`
- `cargo check -p moon`
- `cargo test -p moon --test mod -- test_cases::filter_by_path::`
- `cargo test -p moon --test mod -- test_cases::target_backend::test_build_paths_split_by_module_preferred_targets`
- `cargo test -p moon --test mod -- test_cases::target_backend::test_check_paths_split_by_module_preferred_targets`
- `cargo test -p moon --test mod -- test_cases::target_backend::test_mixed_backend_explicit_multi_path_selection_filters_unsupported_packages`
- `cargo test -p moon --test mod -- test_cases::target_backend::test_mixed_backend_explicit_selection_rejects_unsupported_backend`
