### PR TITLE
fix: delegate external commands directly

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -34,6 +34,7 @@ pub(crate) mod info;
 pub(crate) mod install_binary;
 pub(crate) mod mooncake_adapter;
 pub(crate) mod new;
+pub(crate) mod process;
 pub(crate) mod prove;
 pub(crate) mod run;
 pub(crate) mod shell_completion;

--- a/crates/moon/src/cli/external.rs
+++ b/crates/moon/src/cli/external.rs
@@ -25,13 +25,17 @@ use std::{
 };
 use which::which_global;
 
+use super::process;
+
 pub(crate) fn run_external(mut args: Vec<String>) -> anyhow::Result<i32> {
     if args.is_empty() {
         bail!("no external subcommand provided");
     };
     let subcmd = args.remove(0);
     let resolved = resolve_external_subcommand(&subcmd)?;
-    Ok(exec(Command::new(resolved).args(args))?.code().unwrap_or(0))
+    Ok(process::delegate(Command::new(resolved).args(args))?
+        .code()
+        .unwrap_or(0))
 }
 
 pub(crate) fn run_external_help(
@@ -65,8 +69,8 @@ fn resolve_external_subcommand(subcmd: &str) -> anyhow::Result<PathBuf> {
 fn run_external_command(
     cmd: &mut Command,
     args: impl IntoIterator<Item = OsString>,
-) -> std::io::Result<ExitStatus> {
-    cmd.args(args).status()
+) -> anyhow::Result<ExitStatus> {
+    process::delegate(cmd.args(args))
 }
 
 pub(crate) fn exit_if_ide_help_request(err: &clap::Error, raw_args: &[OsString]) {
@@ -104,32 +108,6 @@ fn ide_help_args(raw_args: &[OsString]) -> Option<(Option<PathBuf>, Vec<OsString
         }
         _ => None,
     }
-}
-
-#[cfg(unix)]
-fn exec(cmd: &mut Command) -> anyhow::Result<ExitStatus> {
-    use std::os::unix::prelude::*;
-
-    Err(cmd.exec().into())
-}
-
-#[cfg(windows)]
-fn exec(cmd: &mut Command) -> anyhow::Result<ExitStatus> {
-    use windows_sys::Win32::Foundation::{BOOL, FALSE, TRUE};
-    use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
-
-    unsafe extern "system" fn ctrlc_handler(_: u32) -> BOOL {
-        // Do nothing. Let the child process handle it.
-        TRUE
-    }
-
-    unsafe {
-        if SetConsoleCtrlHandler(Some(ctrlc_handler), TRUE) == FALSE {
-            bail!("could not set Ctrl-C handler")
-        }
-    }
-
-    Ok(cmd.status()?)
 }
 
 #[cfg(test)]

--- a/crates/moon/src/cli/mooncake_adapter.rs
+++ b/crates/moon/src/cli/mooncake_adapter.rs
@@ -29,6 +29,8 @@ use moonutil::{
 };
 use serde::Serialize;
 
+use super::process;
+
 pub(crate) fn execute_cli<T: Serialize>(
     cli: UniversalFlags,
     cmd: T,
@@ -69,16 +71,16 @@ pub(crate) fn execute_cli_with_inherit_stdin<T: Serialize>(
     display_name: &str,
 ) -> anyhow::Result<i32> {
     let current_moon = std::env::current_exe()?;
-    let mut child = Command::new(&*moonutil::BINARIES.mooncake)
+    let mut command = Command::new(&*moonutil::BINARIES.mooncake);
+    command
         .args(args)
         .env("MOONCAKE_ALLOW_DIRECT", "1")
         .env("MOON_OVERRIDE", current_moon)
         .stdout(Stdio::inherit())
         .stdin(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .spawn()?;
+        .stderr(Stdio::inherit());
 
-    let status = child.wait()?;
+    let status = process::delegate(&mut command)?;
     if status.success() {
         Ok(0)
     } else {

--- a/crates/moon/src/cli/process.rs
+++ b/crates/moon/src/cli/process.rs
@@ -1,0 +1,56 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::process::{Command, ExitStatus};
+
+/// Delegate to a command as directly as the platform allows.
+///
+/// On Unix this replaces the current process. On Windows there is no direct
+/// equivalent, so we run the child and wait while letting it handle Ctrl-C.
+/// Use this only for command paths that return directly to process exit.
+#[cfg(unix)]
+pub(crate) fn delegate(cmd: &mut Command) -> anyhow::Result<ExitStatus> {
+    use std::os::unix::prelude::*;
+
+    Err(cmd.exec().into())
+}
+
+/// Delegate to a command as directly as the platform allows.
+///
+/// On Unix this replaces the current process. On Windows there is no direct
+/// equivalent, so we run the child and wait while letting it handle Ctrl-C.
+/// Use this only for command paths that return directly to process exit.
+#[cfg(windows)]
+pub(crate) fn delegate(cmd: &mut Command) -> anyhow::Result<ExitStatus> {
+    use anyhow::bail;
+    use windows_sys::Win32::Foundation::{BOOL, FALSE, TRUE};
+    use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
+
+    unsafe extern "system" fn ctrlc_handler(_: u32) -> BOOL {
+        // Do nothing. Let the child process handle it.
+        TRUE
+    }
+
+    unsafe {
+        if SetConsoleCtrlHandler(Some(ctrlc_handler), TRUE) == FALSE {
+            bail!("could not set Ctrl-C handler")
+        }
+    }
+
+    Ok(cmd.status()?)
+}

--- a/crates/moon/tests/fixtures/external_signal_handler.rs
+++ b/crates/moon/tests/fixtures/external_signal_handler.rs
@@ -1,0 +1,88 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::{fs, thread, time::Duration};
+
+#[cfg(unix)]
+const SIGNAL_NAME: &str = "SIGINT";
+#[cfg(windows)]
+const SIGNAL_NAME: &str = "CTRL_BREAK_EVENT";
+
+#[cfg(unix)]
+mod signal {
+    const SIGINT: i32 = 2;
+
+    unsafe extern "C" {
+        fn signal(signum: i32, handler: usize) -> usize;
+        fn _exit(status: i32) -> !;
+    }
+
+    unsafe extern "C" fn handler(_: i32) {
+        unsafe {
+            _exit(42);
+        }
+    }
+
+    pub fn install() {
+        unsafe {
+            signal(SIGINT, handler as usize);
+        }
+    }
+}
+
+#[cfg(windows)]
+mod signal {
+    const CTRL_C_EVENT: u32 = 0;
+    const CTRL_BREAK_EVENT: u32 = 1;
+
+    unsafe extern "system" {
+        fn SetConsoleCtrlHandler(
+            handler: Option<unsafe extern "system" fn(u32) -> i32>,
+            add: i32,
+        ) -> i32;
+        fn ExitProcess(exit_code: u32) -> !;
+    }
+
+    unsafe extern "system" fn handler(ctrl: u32) -> i32 {
+        if ctrl == CTRL_C_EVENT || ctrl == CTRL_BREAK_EVENT {
+            unsafe {
+                ExitProcess(42);
+            }
+        }
+        0
+    }
+
+    pub fn install() {
+        unsafe {
+            if SetConsoleCtrlHandler(Some(handler), 1) == 0 {
+                std::process::exit(70);
+            }
+        }
+    }
+}
+
+fn main() {
+    signal::install();
+    let ready = std::env::args_os()
+        .nth(1)
+        .expect("expected ready-file path argument");
+    fs::write(ready, SIGNAL_NAME).unwrap();
+    loop {
+        thread::sleep(Duration::from_secs(1));
+    }
+}

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -81,6 +81,139 @@ fn test_moon_help() {
     );
 }
 
+#[cfg(any(unix, windows))]
+#[test]
+fn test_external_subcommand_delegation_handles_interrupt() {
+    let dir = TestDir::new_empty();
+    let fake_bin_dir = tempfile::TempDir::new().expect("failed to create fake bin dir");
+    let ready_file = fake_bin_dir.path().join("moon-test-behavior-ready");
+    compile_signal_fixture(fake_bin_dir.path());
+
+    let path = path_with_fake_bin(fake_bin_dir.path());
+    let mut command = interruptible_moon_command(&dir);
+    let mut child = command
+        .arg("test-behavior")
+        .arg(&ready_file)
+        .env("PATH", path)
+        .spawn()
+        .expect("failed to spawn moon test-behavior");
+
+    wait_for_ready_file(&mut child, &ready_file);
+    send_interrupt(child.id());
+    let status = wait_for_child_status(&mut child);
+    assert_eq!(
+        status.code(),
+        Some(42),
+        "fake moon-test-behavior did not handle interrupt itself; status was {status}"
+    );
+}
+
+#[cfg(unix)]
+fn interruptible_moon_command(dir: &impl AsRef<std::path::Path>) -> std::process::Command {
+    moon_process_cmd(dir)
+}
+
+#[cfg(windows)]
+fn interruptible_moon_command(dir: &impl AsRef<std::path::Path>) -> std::process::Command {
+    use std::os::windows::process::CommandExt;
+    use windows_sys::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP;
+
+    let mut command = moon_process_cmd(dir);
+    command.creation_flags(CREATE_NEW_PROCESS_GROUP);
+    command
+}
+
+#[cfg(unix)]
+fn send_interrupt(pid: u32) {
+    let rc = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
+    assert_eq!(
+        rc,
+        0,
+        "failed to send SIGINT to delegated process: {}",
+        std::io::Error::last_os_error()
+    );
+}
+
+#[cfg(windows)]
+fn send_interrupt(pid: u32) {
+    use windows_sys::Win32::System::Console::{CTRL_BREAK_EVENT, GenerateConsoleCtrlEvent};
+
+    let ok = unsafe { GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid) };
+    assert_ne!(
+        ok,
+        0,
+        "failed to send CTRL_BREAK_EVENT to delegated process group: {}",
+        std::io::Error::last_os_error()
+    );
+}
+
+#[cfg(any(unix, windows))]
+fn compile_signal_fixture(fake_bin_dir: &std::path::Path) {
+    let source =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/external_signal_handler.rs");
+    let executable = fake_bin_dir.join(format!(
+        "moon-test-behavior{}",
+        std::env::consts::EXE_SUFFIX
+    ));
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let status = std::process::Command::new(rustc)
+        .arg("--edition=2021")
+        .arg(&source)
+        .arg("-o")
+        .arg(&executable)
+        .status()
+        .expect("failed to compile fake moon-test-behavior");
+    assert!(
+        status.success(),
+        "failed to compile fake moon-test-behavior"
+    );
+}
+
+#[cfg(any(unix, windows))]
+fn path_with_fake_bin(fake_bin_dir: &std::path::Path) -> std::ffi::OsString {
+    std::env::join_paths(
+        std::iter::once(fake_bin_dir.to_path_buf()).chain(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        )),
+    )
+    .expect("failed to build PATH")
+}
+
+#[cfg(any(unix, windows))]
+fn wait_for_ready_file(child: &mut std::process::Child, ready_file: &std::path::Path) {
+    let start = std::time::Instant::now();
+    loop {
+        if ready_file.exists() {
+            break;
+        }
+        if let Some(status) = child.try_wait().expect("failed to poll moon subprocess") {
+            panic!("moon exited before fake moon-test-behavior was ready: {status}");
+        }
+        if start.elapsed() > std::time::Duration::from_secs(10) {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("timed out waiting for fake moon-test-behavior to be ready");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+#[cfg(any(unix, windows))]
+fn wait_for_child_status(child: &mut std::process::Child) -> std::process::ExitStatus {
+    let start = std::time::Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().expect("failed to poll moon subprocess") {
+            return status;
+        }
+        if start.elapsed() > std::time::Duration::from_secs(10) {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("timed out waiting for fake moon-test-behavior to exit");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 #[test]
 fn test_moon_info_help_explains_target_and_default_behavior() {
     let dir = TestDir::new_empty();


### PR DESCRIPTION
## Summary

- Factor external command delegation into a shared helper that uses Unix `exec` and the existing Windows spawn/wait fallback with Ctrl-C handling.
- Route external subcommands, `moon help ide ...`, and direct-stdio `mooncake` delegation through that helper.
- Add a cross-platform external-subcommand interrupt regression test using a shared `moon-test-behavior` fixture.

## Why

Some delegation paths still spawned a child and waited even though the child should behave as the foreground command. On Unix that means signals sent to the `moon` PID would not be handled by the delegated command. Windows has no direct `exec` equivalent, so the helper documents and preserves the platform fallback behavior.

## Validation

- `cargo fmt --check`
- `cargo test -p moon test_external_subcommand_delegation_handles_interrupt`
- `cargo clippy -p moon --all-targets -- -D warnings`
- `cargo check -p moon --tests --target x86_64-pc-windows-gnu`