### PR TITLE
fix: correct strategy syntax

### DIFF
--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -503,6 +503,21 @@ fn generate_strategy(solvers: &[DetectedSolver]) -> String {
         .collect();
 
     let solver_ref = |s: &DetectedSolver| format!("{},{}", s.name, s.version);
+    let parallel_prover_line = |time_limit: &str, step_limit: u32| {
+        let mut calls = ordered
+            .iter()
+            .map(|s| format!("{} {time_limit} {step_limit}", solver_ref(s)));
+        let Some(first) = calls.next() else {
+            return String::new();
+        };
+
+        let mut line = format!("c {first}");
+        for call in calls {
+            line.push_str(" | ");
+            line.push_str(&call);
+        }
+        line
+    };
     let mut strategy = String::new();
 
     // Stage 1: Quick sequential attempts (0.2s, 1000 steps)
@@ -511,11 +526,7 @@ fn generate_strategy(solvers: &[DetectedSolver]) -> String {
     }
 
     // Stage 2: Parallel medium attempts (1s, 1000 steps)
-    let medium: Vec<String> = ordered
-        .iter()
-        .map(|s| format!("c {} 1 1000", solver_ref(s)))
-        .collect();
-    strategy.push_str(&medium.join(" | "));
+    strategy.push_str(&parallel_prover_line("1", 1000));
     strategy.push('\n');
 
     // Stage 3: Transformations
@@ -523,11 +534,7 @@ fn generate_strategy(solvers: &[DetectedSolver]) -> String {
     strategy.push_str("t split_vc start\n");
 
     // Stage 4: Parallel long attempts (2s, 4000 steps)
-    let long: Vec<String> = ordered
-        .iter()
-        .map(|s| format!("c {} 2 4000", solver_ref(s)))
-        .collect();
-    strategy.push_str(&long.join(" | "));
+    strategy.push_str(&parallel_prover_line("2", 4000));
     strategy.push('\n');
 
     strategy
@@ -844,10 +851,10 @@ mod tests {
             strategy,
             "c Z3,4.15.3 .2 1000\n\
              c CVC5,1.3.1 .2 1000\n\
-             c Z3,4.15.3 1 1000 | c CVC5,1.3.1 1 1000\n\
+             c Z3,4.15.3 1 1000 | CVC5,1.3.1 1 1000\n\
              t compute_specified start\n\
              t split_vc start\n\
-             c Z3,4.15.3 2 4000 | c CVC5,1.3.1 2 4000\n"
+             c Z3,4.15.3 2 4000 | CVC5,1.3.1 2 4000\n"
         );
     }
 
@@ -864,10 +871,10 @@ mod tests {
             "c Alt-Ergo,2.6.2 .2 1000\n\
              c Z3,4.15.3 .2 1000\n\
              c CVC5,1.3.1 .2 1000\n\
-             c Alt-Ergo,2.6.2 1 1000 | c Z3,4.15.3 1 1000 | c CVC5,1.3.1 1 1000\n\
+             c Alt-Ergo,2.6.2 1 1000 | Z3,4.15.3 1 1000 | CVC5,1.3.1 1 1000\n\
              t compute_specified start\n\
              t split_vc start\n\
-             c Alt-Ergo,2.6.2 2 4000 | c Z3,4.15.3 2 4000 | c CVC5,1.3.1 2 4000\n"
+             c Alt-Ergo,2.6.2 2 4000 | Z3,4.15.3 2 4000 | CVC5,1.3.1 2 4000\n"
         );
     }
 

--- a/crates/moon/tests/test_cases/moon_prove/snapshots/afail.run.stdout
+++ b/crates/moon/tests/test_cases/moon_prove/snapshots/afail.run.stdout
@@ -1,10 +1,10 @@
 failed: moonc prove -error-format json $ROOT/afail/afail.mbt $ROOT/afail/afail.mbtp -whyml-output-path $ROOT/_build/verif/afail/pkg_8_username_5_prove_5_afail.mlw -proof-report-output-path $ROOT/_build/verif/afail/afail.proof.json -why3-config $ROOT/_build/verif/why3.conf -why3-loadpath $MOON_HOME/lib/prelude_proof -pkg username/prove/afail -i $MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude -pkg-sources username/prove/afail:$ROOT/afail -workspace-path $ROOT -all-pkgs $ROOT/_build/wasm-gc/debug/prove/all_pkgs.json
 username/prove/afail
-  Failed: 11 goals proved, 1 timeout
+  Failed: 12 goals proved, 1 timeout
   WhyML: _build/verif/afail/pkg_8_username_5_prove_5_afail.mlw
   Report: _build/verif/afail/afail.proof.json
   Failed goals: 1
 
 Summary:
   0 of 1 packages proved
-  11 goals proved, 1 timeout
+  12 goals proved, 1 timeout

--- a/crates/moon/tests/test_cases/moon_prove/snapshots/cross_package.run.stdout
+++ b/crates/moon/tests/test_cases/moon_prove/snapshots/cross_package.run.stdout
@@ -1,10 +1,10 @@
 failed: moonc prove -error-format json $ROOT/dep/dep.mbt $ROOT/dep/dep.mbtp -whyml-output-path $ROOT/_build/verif/dep/pkg_8_username_12_prove_ucross_3_dep.mlw -proof-report-output-path $ROOT/_build/verif/dep/dep.proof.json -why3-config $ROOT/_build/verif/why3.conf -why3-loadpath $MOON_HOME/lib/prelude_proof -pkg username/prove_cross/dep -i $MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude -pkg-sources username/prove_cross/dep:$ROOT/dep -workspace-path $ROOT -all-pkgs $ROOT/_build/wasm-gc/debug/prove/all_pkgs.json
 username/prove_cross/dep
-  Failed: 0 goals proved, 1 unknown
+  Failed: 0 goals proved, 1 timeout
   WhyML: _build/verif/dep/pkg_8_username_12_prove_ucross_3_dep.mlw
   Report: _build/verif/dep/dep.proof.json
   Failed goals: 1
 
 Summary:
   0 of 1 packages proved
-  0 goals proved, 1 unknown
+  0 goals proved, 1 timeout


### PR DESCRIPTION
The issue was the parallel strategy formatter emitted `c A ... | c B ...`; Why3 expects the command marker only once: `c A ... | B ....` I confirmed this against the local Why3 strategy format and patched the generator/tests accordingly.