### PR TITLE
[codex] Clarify debug snapshot guidance

### DIFF
--- a/crates/moonbuild/template/moon_new_template.toml
+++ b/crates/moonbuild/template/moon_new_template.toml
@@ -416,8 +416,10 @@ You can browse and install extra skills here:
   changes affect outputs, run `moon test --update` to refresh snapshots.
 
 - Prefer `assert_eq` or `assert_true(pattern is Pattern(...))` for results that
-  are stable or very unlikely to change. Use snapshot tests to record current
-  behavior. For solid, well-defined results (e.g. scientific computations),
-  prefer assertion tests. You can use `moon coverage analyze > uncovered.log` to
-  see which parts of your code are not covered by tests.
+  are stable or very unlikely to change. For snapshot tests that record
+  structured debugging output, derive `Debug` and use `debug_inspect`, rather
+  than deriving `Show` for debugging. For solid, well-defined results (e.g.
+  scientific computations), prefer assertion tests. You can use
+  `moon coverage analyze > uncovered.log` to see which parts of your code are
+  not covered by tests.
 """

--- a/crates/moonbuild/template/moon_new_template/Agents.md
+++ b/crates/moonbuild/template/moon_new_template/Agents.md
@@ -45,7 +45,9 @@ You can browse and install extra skills here:
   changes affect outputs, run `moon test --update` to refresh snapshots.
 
 - Prefer `assert_eq` or `assert_true(pattern is Pattern(...))` for results that
-  are stable or very unlikely to change. Use snapshot tests to record current
-  behavior. For solid, well-defined results (e.g. scientific computations),
-  prefer assertion tests. You can use `moon coverage analyze > uncovered.log` to
-  see which parts of your code are not covered by tests.
+  are stable or very unlikely to change. For snapshot tests that record
+  structured debugging output, derive `Debug` and use `debug_inspect`, rather
+  than deriving `Show` for debugging. For solid, well-defined results (e.g.
+  scientific computations), prefer assertion tests. You can use
+  `moon coverage analyze > uncovered.log` to see which parts of your code are
+  not covered by tests.


### PR DESCRIPTION
## Summary

- Clarify that snapshot tests recording structured debugging output should derive `Debug` and use `debug_inspect`.
- Keep the generated `Agents.md` template and embedded TOML copy synchronized.

## Validation

- `git diff --check`