### PR TITLE
feat: Allow moon run to execute wasm files

### DIFF
--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -221,6 +221,43 @@ fn resolve_run_start_dir(input: &str) -> anyhow::Result<std::path::PathBuf> {
     }
 }
 
+fn build_wasm_file_executable_from_arg(
+    cli: &UniversalFlags,
+    cmd: &RunSubcommand,
+) -> anyhow::Result<RunExecutable> {
+    let input = cmd
+        .package_or_mbt_file
+        .as_deref()
+        .expect("wasm run from arg requires a positional input path");
+    let wasm_path =
+        dunce::canonicalize(input).with_context(|| format!("failed to resolve path `{input}`"))?;
+    if !wasm_path.is_file() {
+        bail!("`{}` is not a file", input);
+    }
+
+    let print_dir = std::env::current_dir().context("failed to get current directory")?;
+    if cli.dry_run {
+        let mut run_cmd = crate::run::command_for(
+            moonbuild_rupes_recta::model::RunBackend::WasmGC,
+            &wasm_path,
+            None,
+        );
+        run_cmd.args(&cmd.args);
+        rr_build::dry_print_command(run_cmd.as_std(), &print_dir, false);
+    }
+
+    Ok(RunExecutable {
+        executable: wasm_path,
+        target_backend: moonbuild_rupes_recta::model::RunBackend::WasmGC,
+        opt_level: moonutil::cond_expr::OptLevel::Debug,
+        target_dir: print_dir.clone(),
+        source_dir: print_dir,
+        build_exit_code: (!cli.dry_run).then_some(0),
+        force_success_exit: false,
+        lock: None,
+    })
+}
+
 #[instrument(skip_all)]
 pub(crate) fn run_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
     reject_manifest_path_for_run(cli)?;
@@ -237,7 +274,16 @@ pub(crate) fn run_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Resul
         return run_stdin_source_as_single_file(cli, cmd);
     }
 
-    let executable = build_run_executable(cli, &cmd, BuildRunExecutableOptions::for_run(cli))?;
+    let executable = if cmd.package_or_mbt_file.as_deref().is_some_and(|input| {
+        Path::new(input)
+            .extension()
+            .is_some_and(|ext| ext == "wasm")
+            && std::fs::metadata(input).is_ok_and(|metadata| metadata.is_file())
+    }) {
+        build_wasm_file_executable_from_arg(cli, &cmd)?
+    } else {
+        build_run_executable(cli, &cmd, BuildRunExecutableOptions::for_run(cli))?
+    };
     let result = run_executable(cli, &cmd, executable);
     if crate::run::shutdown_requested() {
         return Ok(130);
@@ -259,6 +305,13 @@ pub(crate) fn build_run_executable(
         .package_or_mbt_file
         .as_deref()
         .expect("run executable source should be materialized before building");
+    if Path::new(input)
+        .extension()
+        .is_some_and(|extension| extension == "wasm")
+        && std::fs::metadata(input).is_ok_and(|metadata| metadata.is_file())
+    {
+        return build_wasm_file_executable_from_arg(cli, cmd);
+    }
     let is_mbt = input.ends_with(".mbt");
     let is_mbtx = input.ends_with(".mbtx");
     let run_start_dir = resolve_run_start_dir(input)?;

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -540,6 +540,61 @@ fn test_moon_run_with_cli_args() {
     );
     assert!(s.contains("  \"中文\",\n  \"😄👍\",\n  \"hello\",\n  \"1242\",\n  \"--flag\","));
 
+    moon_cmd(&dir).args(["build"]).assert().success();
+    let wasm_file = dir.join("_build/wasm-gc/debug/build/main/main.wasm");
+    let stdout = moon_cmd(&dir)
+        .arg("run")
+        .arg(&wasm_file)
+        .args(["--", "中文", "😄👍", "hello", "1242", "--flag"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = replace_dir(std::str::from_utf8(&stdout).unwrap(), &dir);
+    assert!(s.contains("  \"中文\",\n  \"😄👍\",\n  \"hello\",\n  \"1242\",\n  \"--flag\","));
+
+    let stdout = moon_cmd(&dir)
+        .arg("run")
+        .arg(&wasm_file)
+        .args(["--dry-run", "--", "hello"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    check(
+        replace_dir(std::str::from_utf8(&stdout).unwrap(), &dir),
+        expect![[r#"
+            moonrun ./_build/wasm-gc/debug/build/main/main.wasm -- hello
+        "#]],
+    );
+
+    let wasm_named_package = dir.join("main.wasm");
+    std::fs::create_dir_all(&wasm_named_package).unwrap();
+    std::fs::write(
+        wasm_named_package.join("moon.pkg.json"),
+        r#"{
+  "is-main": true
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        wasm_named_package.join("main.mbt"),
+        r#"fn main {
+  println("package directory ending in wasm")
+}
+"#,
+    )
+    .unwrap();
+    check(
+        get_stdout(&dir, ["run", "main.wasm"]),
+        expect![[r#"
+            package directory ending in wasm
+        "#]],
+    );
+
     let s = get_stdout(
         &dir,
         [


### PR DESCRIPTION
## Summary

- Allow `moon run` to accept a direct `.wasm` file path and delegate execution to the existing `moonrun` runtime wrapper.
- Preserve `moon run` behavior for forwarded program args, `--dry-run`, `--verbose`, and `--build-only`.
- Add regression coverage for direct wasm execution and dry-run command output.

## Why

`moon run` previously treated non-MoonBit paths as package/project inputs, so a direct wasm artifact could not be run through the Moon CLI even though the runtime support already existed through `moonrun`.

## Validation

- `cargo fmt`
- `cargo test -p moon --test mod test_moon_run_with_cli_args -- --nocapture`
