### PR TITLE
moon: add profile mode for run via xctrace

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -35,6 +35,7 @@ pub(crate) mod install_binary;
 pub(crate) mod mooncake_adapter;
 pub(crate) mod new;
 pub(crate) mod process;
+pub(crate) mod profile;
 pub(crate) mod prove;
 pub(crate) mod run;
 pub(crate) mod shell_completion;

--- a/crates/moon/src/cli/profile.rs
+++ b/crates/moon/src/cli/profile.rs
@@ -142,7 +142,11 @@ fn run_profile_materialized(
         cli,
         &run_cmd,
         BuildRunExecutableOptions {
+            // Profiling needs a stable executable path for xctrace to launch.
+            // The TCC fast path may run directly from generated C instead.
             try_tcc_run: false,
+            // The dry-run output should show the profiled invocation, not the
+            // plain executable command that `moon run` would normally print.
             print_dry_run_run_command: false,
         },
     )?;
@@ -223,6 +227,8 @@ fn profile_run_subcommand(cmd: RunSubcommand) -> anyhow::Result<RunSubcommand> {
     {
         bail!("`moon run --profile` currently supports only `--target native`");
     }
+    // Time Profiler records a native process. Build release-with-symbols by
+    // default so samples are useful without requiring extra flags from users.
     build_flags.target = vec![SurfaceTarget::Native];
     if !build_flags.debug && !build_flags.release {
         build_flags.release = true;
@@ -380,6 +386,8 @@ fn xctrace_export_command(trace_path: &Path, xml_path: &Path) -> Command {
     cmd.arg(trace_path);
     cmd.args([
         "--xpath",
+        // Export only Time Profiler samples; the full trace export is much
+        // larger and contains many unrelated tables.
         "/trace-toc/run[@number=\"1\"]/data/table[@schema=\"time-profile\"]",
         "--output",
     ]);
@@ -420,6 +428,9 @@ fn parse_xctrace_time_profile(path: &Path) -> anyhow::Result<ParsedProfile> {
 }
 
 fn parse_xctrace_time_profile_xml(xml: &str) -> ParsedProfile {
+    // xctrace repeats common values by reference, for example
+    // `<thread-state ref="..."/>` and `<stack ref="..."/>`. Keep a small
+    // cache of previously seen values while walking rows in export order.
     let mut states: HashMap<String, String> = HashMap::new();
     let mut weights: HashMap<String, f64> = HashMap::new();
     let mut frames: HashMap<String, String> = HashMap::new();
@@ -550,6 +561,8 @@ fn parse_or_resolve_stack(
     frames: &mut HashMap<String, String>,
     stacks: &mut HashMap<String, Vec<String>>,
 ) -> Option<Vec<String>> {
+    // Different Xcode versions/export shapes expose the backtrace column under
+    // different tags, even though the schema mnemonic is usually `stack`.
     let stack_tag = first_tag(row, "stack")
         .or_else(|| first_tag(row, "tagged-backtrace"))
         .or_else(|| first_tag(row, "backtrace"))?;

--- a/crates/moon/src/cli/profile.rs
+++ b/crates/moon/src/cli/profile.rs
@@ -1,0 +1,776 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::{
+    collections::HashMap,
+    ffi::OsStr,
+    io::Read,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{Context, bail};
+use chrono::Local;
+use moonbuild_rupes_recta::model::RunBackend;
+use moonutil::common::{SurfaceTarget, TargetBackend};
+use serde::Serialize;
+
+use super::{RunSubcommand, UniversalFlags};
+use crate::cli::run::{BuildRunExecutableOptions, build_run_executable};
+use moonutil::dirs::ProjectProbe;
+
+const DEFAULT_TOP: usize = 12;
+
+#[derive(Debug, Clone, Serialize)]
+struct ProfileReport {
+    schema: u32,
+    backend: String,
+    executable: PathBuf,
+    trace_path: PathBuf,
+    time_profile_xml: PathBuf,
+    target_stdout: PathBuf,
+    total_samples: usize,
+    sample_weight_ms: f64,
+    top_self: Vec<ProfileEntry>,
+    top_inclusive: Vec<ProfileEntry>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ProfileEntry {
+    symbol: String,
+    mangled_symbol: String,
+    samples: usize,
+    time_ms: f64,
+    percent: f64,
+}
+
+#[derive(Debug, Default)]
+struct ParsedProfile {
+    total_samples: usize,
+    sample_weight_ms: f64,
+    self_counts: HashMap<String, usize>,
+    self_ms: HashMap<String, f64>,
+    inclusive_counts: HashMap<String, usize>,
+    inclusive_ms: HashMap<String, f64>,
+}
+
+pub(crate) fn run_profiled_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
+    if !cfg!(target_os = "macos") {
+        bail!("`moon run --profile` currently supports macOS only");
+    }
+
+    ensure_xctrace_available()?;
+
+    if cmd.command.is_some() {
+        return profile_inline_source(cli, cmd);
+    }
+    if cmd.package_or_mbt_file.as_deref() == Some("-") {
+        return profile_stdin_source(cli, cmd);
+    }
+
+    run_profile_materialized(cli, cmd, None)
+}
+
+fn profile_stdin_source(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
+    let mut source = String::new();
+    std::io::stdin()
+        .read_to_string(&mut source)
+        .context("failed to read `.mbtx` source from stdin")?;
+    profile_source_as_single_file(cli, cmd, source, "stdin.mbtx", "stdin")
+}
+
+fn profile_inline_source(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
+    let source = cmd
+        .command
+        .clone()
+        .expect("inline script should be present when `moon run -c --profile` is selected");
+    profile_source_as_single_file(cli, cmd, source, "command.mbtx", "command")
+}
+
+fn profile_source_as_single_file(
+    cli: &UniversalFlags,
+    cmd: RunSubcommand,
+    source: String,
+    temp_name: &str,
+    source_name: &str,
+) -> anyhow::Result<i32> {
+    let temp_dir = tempfile::TempDir::new().with_context(|| {
+        format!("failed to create temporary directory for {source_name} profile")
+    })?;
+    let input_path = temp_dir.path().join(temp_name);
+    std::fs::write(&input_path, source).with_context(|| {
+        format!(
+            "failed to write temporary {source_name} source file: {}",
+            input_path.display()
+        )
+    })?;
+
+    let cmd = RunSubcommand {
+        package_or_mbt_file: Some(input_path.to_string_lossy().into_owned()),
+        command: None,
+        ..cmd
+    };
+    let output_target_dir = profile_target_dir_from_cwd(cli)?;
+    let result = run_profile_materialized(cli, cmd, Some(output_target_dir));
+    drop(temp_dir);
+    result
+}
+
+fn run_profile_materialized(
+    cli: &UniversalFlags,
+    cmd: RunSubcommand,
+    output_target_dir: Option<PathBuf>,
+) -> anyhow::Result<i32> {
+    let source_label = profile_label(&cmd);
+    let run_cmd = profile_run_subcommand(cmd.clone())?;
+    let mut built = build_run_executable(
+        cli,
+        &run_cmd,
+        BuildRunExecutableOptions {
+            try_tcc_run: false,
+            print_dry_run_run_command: false,
+        },
+    )?;
+    built.ensure_build_success()?;
+
+    if built.target_backend != RunBackend::Native {
+        bail!("`moon run --profile` currently supports only the native backend");
+    }
+
+    let output_target_dir = output_target_dir.unwrap_or_else(|| built.target_dir.clone());
+    let output_dir = default_output_dir(&output_target_dir, built.opt_level, &source_label);
+
+    let trace_path = output_dir.join("profile.trace");
+    let xml_path = output_dir.join("time-profile.xml");
+    let report_path = output_dir.join("report.txt");
+    let json_path = output_dir.join("profile.json");
+    let stdout_path = output_dir.join("stdout.txt");
+
+    if cli.dry_run {
+        print_xctrace_record_command(&trace_path, &stdout_path, &built.executable, &cmd.args);
+        print_xctrace_export_command(&trace_path, &xml_path);
+        return Ok(0);
+    }
+
+    built.release_lock();
+
+    std::fs::create_dir_all(&output_dir).with_context(|| {
+        format!(
+            "failed to create profile output directory `{}`",
+            output_dir.display()
+        )
+    })?;
+
+    if trace_path.exists() {
+        bail!(
+            "profile trace `{}` already exists; try again or remove the profile output directory",
+            trace_path.display()
+        );
+    }
+
+    run_xctrace_record(&trace_path, &stdout_path, &built.executable, &cmd.args)?;
+    run_xctrace_export(&trace_path, &xml_path)?;
+
+    let parsed = parse_xctrace_time_profile(&xml_path)?;
+    let report = build_report(
+        parsed,
+        built.executable,
+        trace_path,
+        xml_path,
+        stdout_path,
+        DEFAULT_TOP,
+    );
+    let terminal_report = render_terminal_report(&report, &report_path, &json_path);
+    print!("{terminal_report}");
+    std::fs::write(&report_path, &terminal_report)
+        .with_context(|| format!("failed to write profile report `{}`", report_path.display()))?;
+    std::fs::write(&json_path, serde_json::to_string_pretty(&report)?)
+        .with_context(|| format!("failed to write profile json `{}`", json_path.display()))?;
+
+    Ok(0)
+}
+
+fn profile_target_dir_from_cwd(cli: &UniversalFlags) -> anyhow::Result<PathBuf> {
+    let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
+    match query.probe_project()? {
+        ProjectProbe::Found(_) => Ok(query.package_dirs()?.target_dir),
+        ProjectProbe::NotFound(_) => {
+            let cwd = std::env::current_dir().context("failed to get current directory")?;
+            Ok(cli.source_tgt_dir.source_root_package_dirs(cwd)?.target_dir)
+        }
+    }
+}
+
+fn profile_run_subcommand(cmd: RunSubcommand) -> anyhow::Result<RunSubcommand> {
+    let mut build_flags = cmd.build_flags;
+    if !build_flags.target.is_empty()
+        && build_flags.resolve_single_target_backend()? != Some(TargetBackend::Native)
+    {
+        bail!("`moon run --profile` currently supports only `--target native`");
+    }
+    build_flags.target = vec![SurfaceTarget::Native];
+    if !build_flags.debug && !build_flags.release {
+        build_flags.release = true;
+    }
+    if !build_flags.strip && !build_flags.no_strip {
+        build_flags.no_strip = true;
+    }
+
+    Ok(RunSubcommand {
+        package_or_mbt_file: cmd.package_or_mbt_file,
+        command: cmd.command,
+        build_flags,
+        args: cmd.args,
+        auto_sync_flags: cmd.auto_sync_flags,
+        build_only: false,
+        profile: false,
+    })
+}
+
+fn profile_label(cmd: &RunSubcommand) -> String {
+    let raw = if cmd.command.is_some() {
+        "command".to_string()
+    } else {
+        cmd.package_or_mbt_file
+            .as_deref()
+            .map(|s| {
+                Path::new(s)
+                    .file_stem()
+                    .and_then(OsStr::to_str)
+                    .unwrap_or(s)
+                    .to_string()
+            })
+            .unwrap_or_else(|| "stdin".to_string())
+    };
+    sanitize_path_component(&raw)
+}
+
+fn sanitize_path_component(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+            out.push(c);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() || out.chars().all(|c| c == '.') {
+        "profile".to_string()
+    } else {
+        out
+    }
+}
+
+fn default_output_dir(
+    target_dir: &Path,
+    opt_level: moonutil::cond_expr::OptLevel,
+    label: &str,
+) -> PathBuf {
+    let timestamp = Local::now().format("%Y%m%d-%H%M%S").to_string();
+    let profile = match opt_level {
+        moonutil::cond_expr::OptLevel::Debug => "debug",
+        moonutil::cond_expr::OptLevel::Release => "release",
+    };
+    target_dir
+        .join("profile")
+        .join(label)
+        .join(format!("{profile}-{timestamp}"))
+}
+
+fn ensure_xctrace_available() -> anyhow::Result<()> {
+    let output = Command::new("xcrun")
+        .args(["xctrace", "version"])
+        .output()
+        .context("failed to execute `xcrun xctrace version`")?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    bail!(
+        "`moon run --profile` on macOS requires `xcrun xctrace`.\n\n\
+         xctrace failed with:\n{}\n\
+         Try:\n  xcode-select --install\n\n\
+         If xctrace reports an Xcode license error:\n  sudo xcodebuild -license accept",
+        stderr.trim()
+    )
+}
+
+fn run_xctrace_record(
+    trace_path: &Path,
+    stdout_path: &Path,
+    executable: &Path,
+    args: &[String],
+) -> anyhow::Result<()> {
+    let mut cmd = xctrace_record_command(trace_path, stdout_path, executable, args);
+    let output = cmd
+        .output()
+        .context("failed to execute `xcrun xctrace record`")?;
+    if !output.status.success() {
+        bail!(
+            "`xcrun xctrace record` failed with {}\n{}{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn run_xctrace_export(trace_path: &Path, xml_path: &Path) -> anyhow::Result<()> {
+    let mut cmd = xctrace_export_command(trace_path, xml_path);
+    let output = cmd
+        .output()
+        .context("failed to execute `xcrun xctrace export`")?;
+    if !output.status.success() {
+        bail!(
+            "`xcrun xctrace export` failed with {}\n{}{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn xctrace_record_command(
+    trace_path: &Path,
+    stdout_path: &Path,
+    executable: &Path,
+    args: &[String],
+) -> Command {
+    let mut cmd = Command::new("xcrun");
+    cmd.args([
+        "xctrace",
+        "record",
+        "--quiet",
+        "--template",
+        "Time Profiler",
+        "--no-prompt",
+        "--output",
+    ]);
+    cmd.arg(trace_path);
+    cmd.arg("--target-stdout");
+    cmd.arg(stdout_path);
+    cmd.arg("--launch");
+    cmd.arg("--");
+    cmd.arg(executable);
+    cmd.args(args);
+    cmd
+}
+
+fn xctrace_export_command(trace_path: &Path, xml_path: &Path) -> Command {
+    let mut cmd = Command::new("xcrun");
+    cmd.args(["xctrace", "export", "--quiet", "--input"]);
+    cmd.arg(trace_path);
+    cmd.args([
+        "--xpath",
+        "/trace-toc/run[@number=\"1\"]/data/table[@schema=\"time-profile\"]",
+        "--output",
+    ]);
+    cmd.arg(xml_path);
+    cmd
+}
+
+fn print_xctrace_record_command(
+    trace_path: &Path,
+    stdout_path: &Path,
+    executable: &Path,
+    args: &[String],
+) {
+    let cmd = xctrace_record_command(trace_path, stdout_path, executable, args);
+    print_command(cmd);
+}
+
+fn print_xctrace_export_command(trace_path: &Path, xml_path: &Path) {
+    let cmd = xctrace_export_command(trace_path, xml_path);
+    print_command(cmd);
+}
+
+fn print_command(cmd: Command) {
+    let parts = std::iter::once(cmd.get_program())
+        .chain(cmd.get_args())
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    println!(
+        "{}",
+        moonutil::shlex::join_unix(parts.iter().map(String::as_str))
+    );
+}
+
+fn parse_xctrace_time_profile(path: &Path) -> anyhow::Result<ParsedProfile> {
+    let xml = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read xctrace export `{}`", path.display()))?;
+    Ok(parse_xctrace_time_profile_xml(&xml))
+}
+
+fn parse_xctrace_time_profile_xml(xml: &str) -> ParsedProfile {
+    let mut states: HashMap<String, String> = HashMap::new();
+    let mut weights: HashMap<String, f64> = HashMap::new();
+    let mut frames: HashMap<String, String> = HashMap::new();
+    let mut stacks: HashMap<String, Vec<String>> = HashMap::new();
+    let mut parsed = ParsedProfile {
+        sample_weight_ms: 1.0,
+        ..Default::default()
+    };
+
+    for row in rows(xml) {
+        for tag in tags(row, "thread-state") {
+            if let (Some(id), Some(fmt)) = (attr(tag, "id"), attr(tag, "fmt")) {
+                states.insert(id, unescape_xml_attr(&fmt));
+            }
+        }
+        for tag in tags(row, "weight") {
+            if let Some(id) = attr(tag, "id") {
+                let value = tag_text_after(row, tag).unwrap_or_default();
+                if let Ok(ns) = value.trim().parse::<u64>() {
+                    let ms = ns as f64 / 1_000_000.0;
+                    weights.insert(id, ms);
+                    parsed.sample_weight_ms = ms;
+                }
+            }
+        }
+
+        let stack = parse_or_resolve_stack(row, &mut frames, &mut stacks);
+
+        let state = first_tag(row, "thread-state")
+            .and_then(|tag| resolve_value(tag, &states, "fmt"))
+            .unwrap_or_default();
+        if state != "Running" {
+            continue;
+        }
+
+        let weight = first_tag(row, "weight")
+            .and_then(|tag| resolve_value(tag, &weights, ""))
+            .unwrap_or(parsed.sample_weight_ms);
+
+        let Some(stack) = stack else { continue };
+        let stack = stack
+            .into_iter()
+            .filter(|name| is_profile_symbol(name))
+            .collect::<Vec<_>>();
+        if stack.is_empty() {
+            continue;
+        }
+
+        parsed.total_samples += 1;
+        let top = stack[0].clone();
+        *parsed.self_counts.entry(top.clone()).or_default() += 1;
+        *parsed.self_ms.entry(top).or_default() += weight;
+
+        let mut seen = std::collections::HashSet::new();
+        for symbol in stack {
+            if seen.insert(symbol.clone()) {
+                *parsed.inclusive_counts.entry(symbol.clone()).or_default() += 1;
+                *parsed.inclusive_ms.entry(symbol).or_default() += weight;
+            }
+        }
+    }
+
+    parsed
+}
+
+fn rows(xml: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut rest = xml;
+    while let Some(start) = rest.find("<row") {
+        rest = &rest[start..];
+        let Some(end) = rest.find("</row>") else {
+            break;
+        };
+        let row = &rest[..end + "</row>".len()];
+        out.push(row);
+        rest = &rest[end + "</row>".len()..];
+    }
+    out
+}
+
+fn tags<'a>(row: &'a str, tag: &str) -> Vec<&'a str> {
+    let mut out = Vec::new();
+    let needle = format!("<{tag}");
+    let mut rest = row;
+    while let Some(start) = rest.find(&needle) {
+        rest = &rest[start..];
+        let Some(end) = rest.find('>') else { break };
+        out.push(&rest[..=end]);
+        rest = &rest[end + 1..];
+    }
+    out
+}
+
+fn first_tag<'a>(row: &'a str, tag: &str) -> Option<&'a str> {
+    tags(row, tag).into_iter().next()
+}
+
+fn attr(tag: &str, name: &str) -> Option<String> {
+    let needle = format!("{name}=\"");
+    let start = tag.find(&needle)? + needle.len();
+    let rest = &tag[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+fn tag_text_after(row: &str, tag: &str) -> Option<String> {
+    let start = row.find(tag)? + tag.len();
+    let end = row[start..].find('<')?;
+    Some(row[start..start + end].to_string())
+}
+
+fn resolve_value<T: Clone + std::str::FromStr>(
+    tag: &str,
+    refs: &HashMap<String, T>,
+    attr_name: &str,
+) -> Option<T> {
+    if let Some(reference) = attr(tag, "ref") {
+        return refs.get(&reference).cloned();
+    }
+    if attr_name.is_empty() {
+        return None;
+    }
+    attr(tag, attr_name)?.parse().ok()
+}
+
+fn parse_or_resolve_stack(
+    row: &str,
+    frames: &mut HashMap<String, String>,
+    stacks: &mut HashMap<String, Vec<String>>,
+) -> Option<Vec<String>> {
+    let stack_tag = first_tag(row, "stack")
+        .or_else(|| first_tag(row, "tagged-backtrace"))
+        .or_else(|| first_tag(row, "backtrace"))?;
+    if let Some(reference) = attr(stack_tag, "ref") {
+        return stacks.get(&reference).cloned();
+    }
+
+    for frame_tag in tags(row, "frame") {
+        if let (Some(id), Some(name)) = (attr(frame_tag, "id"), attr(frame_tag, "name")) {
+            frames.insert(id, unescape_xml_attr(&name));
+        }
+    }
+
+    let mut stack = Vec::new();
+    for frame_tag in tags(row, "frame") {
+        if let Some(reference) = attr(frame_tag, "ref") {
+            if let Some(name) = frames.get(&reference) {
+                stack.push(name.clone());
+            }
+        } else if let Some(name) = attr(frame_tag, "name") {
+            stack.push(unescape_xml_attr(&name));
+        }
+    }
+
+    if let Some(id) = attr(stack_tag, "id") {
+        stacks.insert(id, stack.clone());
+    }
+    Some(stack)
+}
+
+fn unescape_xml_attr(input: &str) -> String {
+    input
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+}
+
+fn is_profile_symbol(name: &str) -> bool {
+    name.starts_with("_M0")
+        || name.starts_with("moonbit_")
+        || name.starts_with("_mi_")
+        || name.starts_with("mi_")
+        || name.starts_with("OUTLINED_FUNCTION_")
+        || name == "<deduplicated_symbol>"
+        || name == "main"
+}
+
+fn build_report(
+    parsed: ParsedProfile,
+    executable: PathBuf,
+    trace_path: PathBuf,
+    xml_path: PathBuf,
+    stdout_path: PathBuf,
+    limit: usize,
+) -> ProfileReport {
+    let total = parsed.total_samples.max(1) as f64;
+    let top_self = top_entries(parsed.self_counts, parsed.self_ms, total, limit, |_| true);
+    let top_inclusive = top_entries(
+        parsed.inclusive_counts,
+        parsed.inclusive_ms,
+        total,
+        limit,
+        |symbol| !skip_inclusive_symbol(symbol),
+    );
+    ProfileReport {
+        schema: 1,
+        backend: "xctrace".to_string(),
+        executable,
+        trace_path,
+        time_profile_xml: xml_path,
+        target_stdout: stdout_path,
+        total_samples: parsed.total_samples,
+        sample_weight_ms: parsed.sample_weight_ms,
+        top_self,
+        top_inclusive,
+    }
+}
+
+fn top_entries(
+    counts: HashMap<String, usize>,
+    times: HashMap<String, f64>,
+    total_samples: f64,
+    limit: usize,
+    keep: impl Fn(&str) -> bool,
+) -> Vec<ProfileEntry> {
+    let mut entries = counts
+        .into_iter()
+        .filter(|(symbol, _)| keep(symbol))
+        .map(|(mangled_symbol, samples)| {
+            let time_ms = times
+                .get(&mangled_symbol)
+                .copied()
+                .unwrap_or(samples as f64);
+            let symbol = demangle_symbol(&mangled_symbol);
+            ProfileEntry {
+                symbol,
+                mangled_symbol,
+                samples,
+                time_ms,
+                percent: samples as f64 * 100.0 / total_samples,
+            }
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|a, b| {
+        b.samples
+            .cmp(&a.samples)
+            .then_with(|| a.symbol.cmp(&b.symbol))
+    });
+    entries.truncate(limit);
+    entries
+}
+
+fn demangle_symbol(symbol: &str) -> String {
+    if symbol.starts_with("_M0") {
+        moonutil::demangle::demangle_mangled_function_name(symbol)
+    } else {
+        symbol.to_string()
+    }
+}
+
+fn skip_inclusive_symbol(symbol: &str) -> bool {
+    let demangled = demangle_symbol(symbol);
+    demangled == "main"
+        || demangled.contains("____moonbit__main")
+        || demangled.starts_with("@moonbitlang/async/")
+}
+
+fn render_terminal_report(report: &ProfileReport, report_path: &Path, json_path: &Path) -> String {
+    let mut out = String::new();
+    out.push_str("Profile: native macOS Time Profiler\n");
+    out.push_str(&format!(
+        "Samples: {}, sample weight: {:.2}ms\n",
+        report.total_samples, report.sample_weight_ms
+    ));
+    out.push_str(&format!("Trace: {}\n", report.trace_path.display()));
+    out.push_str(&format!(
+        "Program stdout: {}\n",
+        report.target_stdout.display()
+    ));
+    out.push('\n');
+    out.push_str("Top self time:\n");
+    render_entries(&mut out, &report.top_self);
+    out.push('\n');
+    out.push_str("Top inclusive time:\n");
+    render_entries(&mut out, &report.top_inclusive);
+    out.push('\n');
+    out.push_str(&format!("Full text report: {}\n", report_path.display()));
+    out.push_str(&format!(
+        "Machine-readable report: {}\n",
+        json_path.display()
+    ));
+    out.push_str("Open the full trace in Instruments:\n");
+    out.push_str(&format!("  open {}\n", report.trace_path.display()));
+    out
+}
+
+fn render_entries(out: &mut String, entries: &[ProfileEntry]) {
+    if entries.is_empty() {
+        out.push_str("  no samples\n");
+        return;
+    }
+    for entry in entries {
+        out.push_str(&format!(
+            "  {:>5.1}% {:>8.2}ms {:>6}  {}\n",
+            entry.percent, entry.time_ms, entry.samples, entry.symbol
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_xctrace_time_profile_xml, sanitize_path_component};
+
+    #[test]
+    fn parses_referenced_xctrace_stack_rows() {
+        let xml = r#"
+<trace-query-result><node>
+<row><thread-state id="1" fmt="Running">Running</thread-state><weight id="2" fmt="1.00 ms">1000000</weight><stack id="3" fmt="_M0foo"><frame id="5" name="_M0foo" addr="0x1"/><frame id="6" name="_M0bar" addr="0x2"/></stack></row>
+<row><thread-state ref="1"/><weight ref="2"/><stack ref="3"/></row>
+<row><thread-state id="7" fmt="Blocked">Blocked</thread-state><weight ref="2"/><stack ref="3"/></row>
+</node></trace-query-result>
+"#;
+        let parsed = parse_xctrace_time_profile_xml(xml);
+        assert_eq!(parsed.total_samples, 2);
+        assert_eq!(parsed.self_counts["_M0foo"], 2);
+        assert_eq!(parsed.inclusive_counts["_M0bar"], 2);
+    }
+
+    #[test]
+    fn still_accepts_tagged_backtrace_rows() {
+        let xml = r#"
+<trace-query-result><node>
+<row><thread-state id="1" fmt="Running">Running</thread-state><weight id="2" fmt="1.00 ms">1000000</weight><tagged-backtrace id="3" fmt="_M0foo"><backtrace id="4"><frame id="5" name="_M0foo" addr="0x1"/></backtrace></tagged-backtrace></row>
+</node></trace-query-result>
+"#;
+        let parsed = parse_xctrace_time_profile_xml(xml);
+        assert_eq!(parsed.total_samples, 1);
+        assert_eq!(parsed.self_counts["_M0foo"], 1);
+    }
+
+    #[test]
+    fn parses_bare_backtrace_rows() {
+        let xml = r#"
+<trace-query-result><node>
+<row><thread-state id="1" fmt="Running">Running</thread-state><weight id="2" fmt="1.00 ms">1000000</weight><backtrace id="3"><frame id="5" name="_M0foo" addr="0x1"/><frame id="6" name="_M0bar" addr="0x2"/></backtrace></row>
+<row><thread-state ref="1"/><weight ref="2"/><backtrace ref="3"/></row>
+</node></trace-query-result>
+"#;
+        let parsed = parse_xctrace_time_profile_xml(xml);
+        assert_eq!(parsed.total_samples, 2);
+        assert_eq!(parsed.self_counts["_M0foo"], 2);
+        assert_eq!(parsed.inclusive_counts["_M0bar"], 2);
+    }
+
+    #[test]
+    fn sanitizes_dot_only_labels() {
+        assert_eq!(sanitize_path_component("."), "profile");
+        assert_eq!(sanitize_path_component(".."), "profile");
+        assert_eq!(sanitize_path_component("..."), "profile");
+        assert_eq!(sanitize_path_component("foo.bar"), "foo.bar");
+    }
+}

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -63,8 +63,12 @@ pub(crate) struct RunSubcommand {
     pub auto_sync_flags: AutoSyncFlags,
 
     /// Only build, do not run the code
-    #[clap(long)]
+    #[clap(long, conflicts_with = "profile")]
     pub build_only: bool,
+
+    /// Profile the native executable using Time Profiler on macOS
+    #[clap(long)]
+    pub profile: bool,
 }
 
 /// Controls how `moon run` builds the executable before it is consumed.
@@ -78,12 +82,15 @@ pub(crate) struct BuildRunExecutableOptions {
     /// `NativeTccRun` executes through `tcc @rspfile` and does not provide the
     /// same standalone executable shape as the regular native backend.
     pub(crate) try_tcc_run: bool,
+    /// Whether dry-run output should include the final executable invocation.
+    pub(crate) print_dry_run_run_command: bool,
 }
 
 impl BuildRunExecutableOptions {
     fn for_run(cli: &UniversalFlags) -> Self {
         Self {
             try_tcc_run: !cli.dry_run,
+            print_dry_run_run_command: true,
         }
     }
 }
@@ -99,13 +106,29 @@ pub(crate) struct RunExecutable {
     pub(crate) executable: PathBuf,
     /// Backend-specific runner to use for this artifact.
     pub(crate) target_backend: moonbuild_rupes_recta::model::RunBackend,
+    pub(crate) opt_level: moonutil::cond_expr::OptLevel,
+    pub(crate) target_dir: PathBuf,
     source_dir: PathBuf,
     build_exit_code: Option<i32>,
     force_success_exit: bool,
     lock: Option<FileLock>,
 }
 
+struct BuildExecutableFromPlanOptions {
+    force_success_exit: bool,
+    print_dry_run_run_command: bool,
+}
+
 impl RunExecutable {
+    pub(crate) fn ensure_build_success(&self) -> anyhow::Result<()> {
+        if let Some(build_exit_code) = self.build_exit_code
+            && build_exit_code != 0
+        {
+            bail!("failed to build run target; build exited with code {build_exit_code}");
+        }
+        Ok(())
+    }
+
     /// Release the target-directory lock without running the executable.
     pub(crate) fn release_lock(&mut self) {
         drop(self.lock.take());
@@ -159,6 +182,7 @@ fn run_source_as_single_file(
         args,
         auto_sync_flags,
         build_only,
+        profile,
         ..
     } = cmd;
     let cmd = RunSubcommand {
@@ -168,6 +192,7 @@ fn run_source_as_single_file(
         args,
         auto_sync_flags,
         build_only,
+        profile,
     };
     let result = run_single_file_from_arg(cli, cmd);
     drop(temp_dir);
@@ -199,6 +224,10 @@ fn resolve_run_start_dir(input: &str) -> anyhow::Result<std::path::PathBuf> {
 #[instrument(skip_all)]
 pub(crate) fn run_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
     reject_manifest_path_for_run(cli)?;
+
+    if cmd.profile {
+        return super::profile::run_profiled_run(cli, cmd);
+    }
 
     if cmd.command.is_some() {
         return run_inline_source_as_single_file(cli, cmd);
@@ -310,7 +339,10 @@ fn build_package_executable(
         &target_dir,
         &build_meta,
         build_graph,
-        selected_target_backend.is_some(),
+        BuildExecutableFromPlanOptions {
+            force_success_exit: selected_target_backend.is_some(),
+            print_dry_run_run_command: options.print_dry_run_run_command,
+        },
     )
 }
 
@@ -519,7 +551,10 @@ fn build_single_file_executable(
         &target_dir,
         &build_meta,
         build_graph,
-        false,
+        BuildExecutableFromPlanOptions {
+            force_success_exit: false,
+            print_dry_run_run_command: options.print_dry_run_run_command,
+        },
     )
 }
 
@@ -533,7 +568,7 @@ fn build_executable_from_plan(
     target_dir: &Path,
     build_meta: &rr_build::BuildMeta,
     build_graph: rr_build::BuildInput,
-    force_success_exit: bool,
+    options: BuildExecutableFromPlanOptions,
 ) -> Result<RunExecutable, anyhow::Error> {
     if cli.dry_run {
         rr_build::print_dry_run(
@@ -543,14 +578,18 @@ fn build_executable_from_plan(
             target_dir,
         );
 
-        let run_cmd = get_run_cmd(build_meta, &cmd.args);
-        rr_build::dry_print_command(run_cmd.as_std(), source_dir, false);
+        if options.print_dry_run_run_command {
+            let run_cmd = get_run_cmd(build_meta, &cmd.args);
+            rr_build::dry_print_command(run_cmd.as_std(), source_dir, false);
+        }
         return Ok(RunExecutable {
             executable: get_run_executable(build_meta).to_path_buf(),
             target_backend: build_meta.target_backend,
+            opt_level: build_meta.opt_level,
+            target_dir: target_dir.to_path_buf(),
             source_dir: source_dir.to_path_buf(),
             build_exit_code: None,
-            force_success_exit,
+            force_success_exit: options.force_success_exit,
             lock: None,
         });
     }
@@ -570,9 +609,11 @@ fn build_executable_from_plan(
     Ok(RunExecutable {
         executable: get_run_executable(build_meta).to_path_buf(),
         target_backend: build_meta.target_backend,
+        opt_level: build_meta.opt_level,
+        target_dir: target_dir.to_path_buf(),
         source_dir: source_dir.to_path_buf(),
         build_exit_code: Some(build_result.return_code_for_success()),
-        force_success_exit,
+        force_success_exit: options.force_success_exit,
         lock: Some(lock),
     })
 }

--- a/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
@@ -2209,7 +2209,7 @@ _moon() {
             return 0
             ;;
         moon__run)
-            opts="-c -g -d -j -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --frozen --build-only --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PACKAGE_OR_MBT_FILE] [ARGS]..."
+            opts="-c -g -d -j -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --frozen --build-only --profile --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PACKAGE_OR_MBT_FILE] [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
@@ -250,6 +250,7 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --enable-value-tracing 'Enable value tracing'
             cand --frozen 'Do not sync dependencies, assuming local dependencies are up-to-date'
             cand --build-only 'Only build, do not run the code'
+            cand --profile 'Profile the native executable using Time Profiler on macOS'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
             cand -v 'Increase verbosity'

--- a/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
@@ -208,6 +208,7 @@ complete -c moon -n "__fish_moon_using_subcommand run" -l output-json -d 'Output
 complete -c moon -n "__fish_moon_using_subcommand run" -l enable-value-tracing -d 'Enable value tracing'
 complete -c moon -n "__fish_moon_using_subcommand run" -l frozen -d 'Do not sync dependencies, assuming local dependencies are up-to-date'
 complete -c moon -n "__fish_moon_using_subcommand run" -l build-only -d 'Only build, do not run the code'
+complete -c moon -n "__fish_moon_using_subcommand run" -l profile -d 'Profile the native executable using Time Profiler on macOS'
 complete -c moon -n "__fish_moon_using_subcommand run" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand run" -s v -l verbose -d 'Increase verbosity'
 complete -c moon -n "__fish_moon_using_subcommand run" -l trace -d 'Trace the execution of the program'

--- a/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
@@ -259,6 +259,7 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--enable-value-tracing', 'enable-value-tracing', [CompletionResultType]::ParameterName, 'Enable value tracing')
             [CompletionResult]::new('--frozen', 'frozen', [CompletionResultType]::ParameterName, 'Do not sync dependencies, assuming local dependencies are up-to-date')
             [CompletionResult]::new('--build-only', 'build-only', [CompletionResultType]::ParameterName, 'Only build, do not run the code')
+            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'Profile the native executable using Time Profiler on macOS')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Increase verbosity')

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -235,7 +235,8 @@ _arguments "${_arguments_options[@]}" : \
 '(--no-render)--output-json[Output diagnostics in JSON format]' \
 '--enable-value-tracing[Enable value tracing]' \
 '--frozen[Do not sync dependencies, assuming local dependencies are up-to-date]' \
-'--build-only[Only build, do not run the code]' \
+'(--profile)--build-only[Only build, do not run the code]' \
+'--profile[Profile the native executable using Time Profiler on macOS]' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
 '-v[Increase verbosity]' \

--- a/crates/moon/src/tests/planner/cli_to_planner.rs
+++ b/crates/moon/src/tests/planner/cli_to_planner.rs
@@ -80,6 +80,7 @@ fn command_string_run_parses_as_expected() {
                     frozen: false,
                 },
                 build_only: false,
+                profile: false,
             },
         )
     "#]]

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -88,6 +88,7 @@ mod prebuild_link_config_self;
 mod query_symbol;
 mod run_doc_test;
 mod run_md_test;
+mod run_profile;
 mod simple_pkg;
 mod single_file_front_matter;
 mod snapshot_testing;

--- a/crates/moon/tests/test_cases/run_profile/mod.rs
+++ b/crates/moon/tests/test_cases/run_profile/mod.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_moon_run_profile_dry_run_prints_xctrace_commands() {
+    use crate::dry_run_utils::line_with;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TestDir::new("hello");
+    let tmp = tempfile::tempdir().expect("failed to create temporary directory");
+    let shim_path = tmp.path().join("xcrun");
+    std::fs::write(
+        &shim_path,
+        "#!/usr/bin/env sh\nif [ \"$1\" = \"xctrace\" ] && [ \"$2\" = \"version\" ]; then\n  exit 0\nfi\nexit 0\n",
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&shim_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&shim_path, perms).unwrap();
+
+    let path = std::env::var("PATH")
+        .map(|value| format!("{}:{}", tmp.path().display(), value))
+        .unwrap_or_else(|_| tmp.path().display().to_string());
+
+    let output = get_stdout_with_envs(
+        &dir,
+        ["run", "main", "--profile", "--dry-run"],
+        [("PATH", path)],
+    );
+
+    let record_cmd = line_with(
+        &output,
+        "xcrun xctrace record",
+        &[
+            "--quiet",
+            "--template",
+            "Time",
+            "Profiler",
+            "--no-prompt",
+            "--output",
+        ],
+    );
+    let export_cmd = line_with(&output, "xcrun xctrace export", &["--quiet", "--input"]);
+
+    assert!(
+        record_cmd.contains("--target-stdout"),
+        "record command missing --target-stdout: {record_cmd}"
+    );
+    assert!(
+        record_cmd.contains("--launch"),
+        "record command missing --launch: {record_cmd}"
+    );
+    assert!(
+        record_cmd.contains("_build/profile/main"),
+        "record command missing profile output path: {record_cmd}"
+    );
+    assert!(
+        export_cmd.contains("time-profile.xml"),
+        "export command missing time-profile.xml output: {export_cmd}"
+    );
+    assert!(
+        !output.lines().any(|line| line
+            .trim_start()
+            .starts_with("./_build/native/release/build/main/main.exe")),
+        "profile dry-run should not print the standalone executable invocation:\n{output}"
+    );
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn test_moon_run_profile_on_non_macos_reports_error() {
+    use crate::get_err_stderr;
+    let dir = TestDir::new("hello");
+    let output = get_err_stderr(&dir, ["run", "main", "--profile"]);
+
+    assert!(
+        output.contains("`moon run --profile` currently supports macOS only"),
+        "unexpected non-macos error: {output}"
+    );
+}

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -244,6 +244,7 @@ Run a main package
 
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not run the code
+* `--profile` — Profile the native executable using Time Profiler on macOS
 
 
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -244,6 +244,7 @@ Run a main package
 
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not run the code
+* `--profile` — Profile the native executable using Time Profiler on macOS
 
 
 


### PR DESCRIPTION
## Summary
- add `moon run --profile` for macOS native profiling through `xcrun xctrace`
- force a standalone native executable for profiling and post-process xctrace time-profile exports with MoonBit demangling
- print a brief terminal report plus paths to the trace, text report, JSON report, and target stdout
- cover xctrace stack/backtrace export shapes and profile dry-run command output

## Tests
- `cargo clippy -p moon --all-targets -- -D warnings`
- `cargo test -p moon profile::tests --no-fail-fast`
- `cargo test -p moon test_moon_run_profile_dry_run_prints_xctrace_commands --no-fail-fast`
