### PR TITLE
[codex] Display moon run inline flag as -e

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ If you are working from mainland China, using the `.cn` domain may result in a s
 ## Other tools
 
 - The latest stable Rust toolchain is required.
+- Initialize and update Git submodules before developing or promoting snapshots:
+  `git submodule update --init --recursive`. Do not update snapshots while
+  submodules are missing or out of date, because generated test output may
+  differ from CI.
 - To insert license headers, you can run `cargo {install, binstall -y} hawkeye` and then `hawkeye format`.
 - Some maintainers use `jujutsu` to manage the repository. Check the local environment before choosing the tool to commit.
 

--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -153,6 +153,22 @@ pub(crate) enum MoonBuildSubcommands {
 }
 #[test]
 fn gen_docs_for_moon_help_page() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let error_codes_dir = std::path::PathBuf::from(&manifest_dir)
+        .join("../../crates/moonutil/resources/error_codes/language/error_codes");
+    let has_error_code_docs = error_codes_dir
+        .read_dir()
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .any(|entry| entry.path().extension().is_some_and(|ext| ext == "md"));
+    assert!(
+        has_error_code_docs,
+        "missing MoonBit docs submodule at {}. Run `git submodule update --init --recursive` before running tests or promoting snapshots.",
+        error_codes_dir.display()
+    );
+
     let markdown: String = clap_markdown::help_markdown::<MoonBuildSubcommands>();
     let markdown = markdown.replace("Default value: `zsh`", "Default value: `<your shell>`");
     let markdown = markdown.replace("Default value: `bash`", "Default value: `<your shell>`");
@@ -181,7 +197,6 @@ fn gen_docs_for_moon_help_page() {
         }
     }
     let markdown = lines.join("\n");
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let file_path =
         std::path::PathBuf::from(&manifest_dir).join("../../docs/manual-zh/src/commands.md");
     expect_test::expect_file!(file_path).assert_eq(&markdown);

--- a/crates/moon/src/cli/profile.rs
+++ b/crates/moon/src/cli/profile.rs
@@ -78,7 +78,7 @@ pub(crate) fn run_profiled_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyh
     ensure_xctrace_available()?;
 
     if cmd.command.is_some() {
-        bail!("`moon run --profile` does not support inline `-c` source");
+        bail!("`moon run --profile` does not support inline `-e` source");
     }
     if cmd.package_or_mbt_file.as_deref() == Some("-") {
         bail!("`moon run --profile` does not support stdin source");

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -45,8 +45,8 @@ pub(crate) struct RunSubcommand {
 
     /// Run `.mbtx` source passed in as a string
     #[clap(
-        short = 'c',
-        short_alias = 'e',
+        short = 'e',
+        short_alias = 'c',
         value_name = "SCRIPT",
         group = "run_source"
     )]
@@ -154,7 +154,7 @@ fn run_inline_source_as_single_file(
     let source = cmd
         .command
         .clone()
-        .expect("inline script should be present when `moon run -c` is selected");
+        .expect("inline script should be present when `moon run -e` is selected");
 
     run_source_as_single_file(cli, cmd, source, "command.mbtx", "command")
 }

--- a/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
@@ -2209,13 +2209,13 @@ _moon() {
             return 0
             ;;
         moon__run)
-            opts="-c -g -d -j -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --frozen --build-only --profile --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PACKAGE_OR_MBT_FILE] [ARGS]..."
+            opts="-e -g -d -j -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --frozen --build-only --profile --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PACKAGE_OR_MBT_FILE] [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                -c)
+                -e)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
@@ -224,7 +224,7 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;run'= {
-            cand -c 'Run `.mbtx` source passed in as a string'
+            cand -e 'Run `.mbtx` source passed in as a string'
             cand --target 'Select output target'
             cand --warn-list 'Warn list config'
             cand -j 'Set the max number of jobs to run in parallel'

--- a/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
@@ -185,7 +185,7 @@ complete -c moon -n "__fish_moon_using_subcommand prove" -l trace -d 'Trace the 
 complete -c moon -n "__fish_moon_using_subcommand prove" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand prove" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand prove" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand run" -s c -d 'Run `.mbtx` source passed in as a string' -r
+complete -c moon -n "__fish_moon_using_subcommand run" -s e -d 'Run `.mbtx` source passed in as a string' -r
 complete -c moon -n "__fish_moon_using_subcommand run" -l target -d 'Select output target' -r -f -a "{wasm\t'',wasm-gc\t'',js\t'',native\t'',llvm\t'',all\t''}"
 complete -c moon -n "__fish_moon_using_subcommand run" -l warn-list -d 'Warn list config' -r
 complete -c moon -n "__fish_moon_using_subcommand run" -s j -l jobs -d 'Set the max number of jobs to run in parallel' -r

--- a/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
@@ -233,7 +233,7 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;run' {
-            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Run `.mbtx` source passed in as a string')
+            [CompletionResult]::new('-e', 'e', [CompletionResultType]::ParameterName, 'Run `.mbtx` source passed in as a string')
             [CompletionResult]::new('--target', 'target', [CompletionResultType]::ParameterName, 'Select output target')
             [CompletionResult]::new('--warn-list', 'warn-list', [CompletionResultType]::ParameterName, 'Warn list config')
             [CompletionResult]::new('-j', 'j', [CompletionResultType]::ParameterName, 'Set the max number of jobs to run in parallel')

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -210,7 +210,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (run)
 _arguments "${_arguments_options[@]}" : \
-'-c+[Run \`.mbtx\` source passed in as a string]:SCRIPT: ' \
+'-e+[Run \`.mbtx\` source passed in as a string]:SCRIPT: ' \
 '*--target=[Select output target]:TARGET:(wasm wasm-gc js native llvm all)' \
 '--warn-list=[Warn list config]:WARN_LIST: ' \
 '-j+[Set the max number of jobs to run in parallel]:JOBS: ' \

--- a/crates/moon/tests/test_cases/debug_flag_test/mod.rs
+++ b/crates/moon/tests/test_cases/debug_flag_test/mod.rs
@@ -59,7 +59,7 @@ fn profile_flags_conflict_in_cli() {
         expect![[r#"
             error: the argument '--debug' cannot be used with '--release'
 
-            Usage: moon run --debug <PACKAGE_OR_MBT_FILE|-c <SCRIPT>> [ARGS]...
+            Usage: moon run --debug <PACKAGE_OR_MBT_FILE|-e <SCRIPT>> [ARGS]...
 
             For more information, try '--help'.
         "#]],

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -488,25 +488,15 @@ fn test_moon_run_dash_reads_stdin() {
 }
 
 #[test]
-fn test_moon_run_command_string_reads_inline_script() {
+fn test_moon_run_help_displays_inline_script_as_e() {
     let dir = TestDir::new_empty();
-    snapbox::cmd::Command::new(moon_bin())
-        .current_dir(&dir)
-        .arg("run")
-        .arg("-c")
-        .arg(
-            r#"fn main {
-  println("hello from run -c")
-}
-"#,
-        )
-        .assert()
-        .success()
-        .stdout_eq("hello from run -c\n");
+    let stdout = get_stdout(&dir, ["help", "run"]).replace("moon.exe", "moon");
+    assert!(stdout.contains("-e <SCRIPT>"), "stdout: {stdout}");
+    assert!(!stdout.contains("-c <SCRIPT>"), "stdout: {stdout}");
 }
 
 #[test]
-fn test_moon_run_command_string_short_alias_e_reads_inline_script() {
+fn test_moon_run_command_string_reads_inline_script() {
     let dir = TestDir::new_empty();
     snapbox::cmd::Command::new(moon_bin())
         .current_dir(&dir)
@@ -524,13 +514,31 @@ fn test_moon_run_command_string_short_alias_e_reads_inline_script() {
 }
 
 #[test]
+fn test_moon_run_command_string_short_alias_c_reads_inline_script() {
+    let dir = TestDir::new_empty();
+    snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .arg("run")
+        .arg("-c")
+        .arg(
+            r#"fn main {
+  println("hello from run -c")
+}
+"#,
+        )
+        .assert()
+        .success()
+        .stdout_eq("hello from run -c\n");
+}
+
+#[test]
 fn test_moon_run_command_string_conflicts_with_other_inputs() {
     let dir = TestDir::new_empty();
 
     let dash_stderr = snapbox::cmd::Command::new(moon_bin())
         .current_dir(&dir)
         .arg("run")
-        .arg("-c")
+        .arg("-e")
         .arg(r#"fn main { println("hello") }"#)
         .arg("-")
         .assert()
@@ -540,12 +548,12 @@ fn test_moon_run_command_string_conflicts_with_other_inputs() {
         .to_owned();
     let dash_stderr = String::from_utf8_lossy(&dash_stderr);
     assert!(dash_stderr.contains("cannot be used with"));
-    assert!(dash_stderr.contains("-c"));
+    assert!(dash_stderr.contains("-e"));
 
     let path_stderr = snapbox::cmd::Command::new(moon_bin())
         .current_dir(&dir)
         .arg("run")
-        .arg("-c")
+        .arg("-e")
         .arg(r#"fn main { println("hello") }"#)
         .arg("main")
         .assert()
@@ -555,7 +563,7 @@ fn test_moon_run_command_string_conflicts_with_other_inputs() {
         .to_owned();
     let path_stderr = String::from_utf8_lossy(&path_stderr);
     assert!(path_stderr.contains("cannot be used with"));
-    assert!(path_stderr.contains("-c"));
+    assert!(path_stderr.contains("-e"));
 }
 
 #[test]

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -210,7 +210,7 @@ Prove the current package
 
 Run a main package
 
-**Usage:** `moon run [OPTIONS] <PACKAGE_OR_MBT_FILE|-c <SCRIPT>> [ARGS]...`
+**Usage:** `moon run [OPTIONS] <PACKAGE_OR_MBT_FILE|-e <SCRIPT>> [ARGS]...`
 
 ###### **Arguments:**
 
@@ -219,7 +219,7 @@ Run a main package
 
 ###### **Options:**
 
-* `-c <SCRIPT>` — Run `.mbtx` source passed in as a string
+* `-e <SCRIPT>` — Run `.mbtx` source passed in as a string
 * `-g`, `--debug` — Emit debug information
 * `--release` — Compile in release mode
 * `--strip` — Enable stripping debug information

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -210,7 +210,7 @@ Prove the current package
 
 Run a main package
 
-**Usage:** `moon run [OPTIONS] <PACKAGE_OR_MBT_FILE|-c <SCRIPT>> [ARGS]...`
+**Usage:** `moon run [OPTIONS] <PACKAGE_OR_MBT_FILE|-e <SCRIPT>> [ARGS]...`
 
 ###### **Arguments:**
 
@@ -219,7 +219,7 @@ Run a main package
 
 ###### **Options:**
 
-* `-c <SCRIPT>` — Run `.mbtx` source passed in as a string
+* `-e <SCRIPT>` — Run `.mbtx` source passed in as a string
 * `-g`, `--debug` — Emit debug information
 * `--release` — Compile in release mode
 * `--strip` — Enable stripping debug information


### PR DESCRIPTION
## Summary

- Make `moon run -e` the canonical displayed short flag for inline `.mbtx` source while keeping `-c` accepted as a compatibility alias.
- Update profile diagnostics, command docs, and shell completion snapshots to show `-e`.
- Add `AGENTS.md` guidance to initialize submodules before development/snapshot promotion, plus a docs-generation test assertion that fails early when the error-code docs submodule is missing.
- Add a focused help-output regression and keep coverage for the `-c` alias.

## Validation

- `git submodule update --init --recursive`
- `cargo fmt`
- `UPDATE_EXPECT=1 cargo test -p moon cli::gen_docs_for_moon_help_page`
- `cargo test -p moon cli::gen_docs_for_moon_help_page`
- `cargo test -p moon test_moon_run_`
- `cargo test -p moon profile_flags_conflict_in_cli`
- `cargo test -p moon cli::shell_completion::tests::test_shell_completion_`
- `git diff --check`