### PR TITLE
[codex] add JSONL output for moon bench

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -151,6 +151,47 @@ pub(crate) enum MoonBuildSubcommands {
     #[clap(external_subcommand)]
     External(Vec<String>),
 }
+
+#[test]
+fn bench_jsonl_flag_parses() {
+    let cli = <MoonBuildCli as clap::Parser>::try_parse_from([
+        "moon",
+        "bench",
+        "--jsonl",
+        "result.jsonl",
+    ])
+    .expect("bench --jsonl <file> should parse");
+    let Some(MoonBuildSubcommands::Bench(cmd)) = cli.subcommand else {
+        panic!("expected bench subcommand");
+    };
+    assert_eq!(
+        cmd.jsonl.as_deref(),
+        Some(std::path::Path::new("result.jsonl"))
+    );
+}
+
+#[test]
+fn bench_jsonl_requires_output_file() {
+    let err = <MoonBuildCli as clap::Parser>::try_parse_from(["moon", "bench", "--jsonl"])
+        .expect_err("bench --jsonl should require an output file");
+
+    assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
+}
+
+#[test]
+fn bench_jsonl_flag_conflicts_with_build_only() {
+    let err = <MoonBuildCli as clap::Parser>::try_parse_from([
+        "moon",
+        "bench",
+        "--jsonl",
+        "result.jsonl",
+        "--build-only",
+    ])
+    .expect_err("bench --jsonl and --build-only should conflict");
+
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
 #[test]
 fn gen_docs_for_moon_help_page() {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();

--- a/crates/moon/src/cli/bench.rs
+++ b/crates/moon/src/cli/bench.rs
@@ -22,7 +22,11 @@ use moonutil::{
     dirs::PackageDirs,
     mooncakes::sync::AutoSyncFlags,
 };
-use std::path::Path;
+use std::{
+    fs::File,
+    io::{BufWriter, Write},
+    path::{Path, PathBuf},
+};
 use tracing::{Level, instrument};
 
 use super::{BuildFlags, UniversalFlags};
@@ -53,6 +57,10 @@ pub(crate) struct BenchSubcommand {
     #[clap(long)]
     pub build_only: bool,
 
+    /// Output benchmark results in JSON Lines format to the specified file
+    #[clap(long, value_name = "JSONL", conflicts_with = "build_only")]
+    pub jsonl: Option<PathBuf>,
+
     /// Run the benchmarks in a target backend sequentially
     #[clap(long)]
     pub no_parallelize: bool,
@@ -60,6 +68,20 @@ pub(crate) struct BenchSubcommand {
 
 #[instrument(skip_all)]
 pub(crate) fn run_bench(cli: UniversalFlags, cmd: BenchSubcommand) -> anyhow::Result<i32> {
+    if cmd.jsonl.is_some() && cli.dry_run {
+        anyhow::bail!("`--jsonl` cannot be used with `--dry-run`");
+    }
+
+    let mut jsonl_writer = cmd
+        .jsonl
+        .as_ref()
+        .map(|path| {
+            File::create(path)
+                .map(BufWriter::new)
+                .with_context(|| format!("failed to create JSON Lines file `{}`", path.display()))
+        })
+        .transpose()?;
+
     let PackageDirs {
         source_dir,
         target_dir,
@@ -70,8 +92,9 @@ pub(crate) fn run_bench(cli: UniversalFlags, cmd: BenchSubcommand) -> anyhow::Re
         .query(cli.workspace_env.clone())?
         .package_dirs()?;
 
-    if cmd.build_flags.target.is_empty() {
-        return run_bench_internal(
+    let exit_code = if cmd.build_flags.target.is_empty() {
+        let writer = jsonl_writer.as_mut().map(|writer| writer as &mut dyn Write);
+        run_bench_internal(
             &cli,
             &cmd,
             &source_dir,
@@ -80,28 +103,39 @@ pub(crate) fn run_bench(cli: UniversalFlags, cmd: BenchSubcommand) -> anyhow::Re
             project_manifest_path.as_deref(),
             None,
             None,
-        );
-    }
-    let surface_targets = cmd.build_flags.target.clone();
-    let targets = lower_surface_targets(&surface_targets);
-    let display_backend_hint = if targets.len() > 1 { Some(()) } else { None };
+            writer,
+        )?
+    } else {
+        let surface_targets = cmd.build_flags.target.clone();
+        let targets = lower_surface_targets(&surface_targets);
+        let display_backend_hint = if targets.len() > 1 { Some(()) } else { None };
 
-    let mut ret_value = 0;
-    for t in targets {
-        let x = run_bench_internal(
-            &cli,
-            &cmd,
-            &source_dir,
-            &target_dir,
-            &mooncakes_dir,
-            project_manifest_path.as_deref(),
-            display_backend_hint,
-            Some(t),
-        )
-        .context(format!("failed to run bench for target {t:?}"))?;
-        ret_value = ret_value.max(x);
+        let mut ret_value = 0;
+        for t in targets {
+            let writer = jsonl_writer.as_mut().map(|writer| writer as &mut dyn Write);
+            let x = run_bench_internal(
+                &cli,
+                &cmd,
+                &source_dir,
+                &target_dir,
+                &mooncakes_dir,
+                project_manifest_path.as_deref(),
+                display_backend_hint,
+                Some(t),
+                writer,
+            )
+            .context(format!("failed to run bench for target {t:?}"))?;
+            ret_value = ret_value.max(x);
+        }
+        ret_value
+    };
+
+    if let (Some(path), Some(writer)) = (cmd.jsonl.as_ref(), jsonl_writer.as_mut()) {
+        writer
+            .flush()
+            .with_context(|| format!("failed to flush JSON Lines file `{}`", path.display()))?;
     }
-    Ok(ret_value)
+    Ok(exit_code)
 }
 
 #[instrument(level = Level::DEBUG, skip_all)]
@@ -115,6 +149,7 @@ fn run_bench_internal(
     project_manifest_path: Option<&Path>,
     display_backend_hint: Option<()>,
     selected_target_backend: Option<TargetBackend>,
+    bench_jsonl_writer: Option<&mut dyn Write>,
 ) -> anyhow::Result<i32> {
     super::run_test_or_bench_internal(
         cli,
@@ -125,5 +160,6 @@ fn run_bench_internal(
         project_manifest_path,
         display_backend_hint,
         selected_target_backend,
+        bench_jsonl_writer,
     )
 }

--- a/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
@@ -447,7 +447,7 @@ _moon() {
             return 0
             ;;
         moon__bench)
-            opts="-g -d -j -p -f -i -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --package --file --index --frozen --build-only --no-parallelize --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-g -d -j -p -f -i -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --package --file --index --frozen --build-only --jsonl --no-parallelize --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -494,6 +494,10 @@ _moon() {
                     return 0
                     ;;
                 -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --jsonl)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
@@ -433,6 +433,7 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --file 'Run test in the specified file. Only valid when `--package` is also specified'
             cand -i 'Run only the index-th test in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when `--file` is also specified'
             cand --index 'Run only the index-th test in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when `--file` is also specified'
+            cand --jsonl 'Output benchmark results in JSON Lines format to the specified file'
             cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --std 'Enable the standard library (default)'

--- a/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
@@ -336,6 +336,7 @@ complete -c moon -n "__fish_moon_using_subcommand bench" -l render-no-loc -d 'Re
 complete -c moon -n "__fish_moon_using_subcommand bench" -s p -l package -d 'Run test in the specified package' -r
 complete -c moon -n "__fish_moon_using_subcommand bench" -s f -l file -d 'Run test in the specified file. Only valid when `--package` is also specified' -r
 complete -c moon -n "__fish_moon_using_subcommand bench" -s i -l index -d 'Run only the index-th test in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when `--file` is also specified' -r
+complete -c moon -n "__fish_moon_using_subcommand bench" -l jsonl -d 'Output benchmark results in JSON Lines format to the specified file' -r -F
 complete -c moon -n "__fish_moon_using_subcommand bench" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand bench" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand bench" -l std -d 'Enable the standard library (default)'

--- a/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
@@ -450,6 +450,7 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--file', 'file', [CompletionResultType]::ParameterName, 'Run test in the specified file. Only valid when `--package` is also specified')
             [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'Run only the index-th test in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when `--file` is also specified')
             [CompletionResult]::new('--index', 'index', [CompletionResultType]::ParameterName, 'Run only the index-th test in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when `--file` is also specified')
+            [CompletionResult]::new('--jsonl', 'jsonl', [CompletionResultType]::ParameterName, 'Output benchmark results in JSON Lines format to the specified file')
             [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--std', 'std', [CompletionResultType]::ParameterName, 'Enable the standard library (default)')

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -442,6 +442,7 @@ _arguments "${_arguments_options[@]}" : \
 '--file=[Run test in the specified file. Only valid when \`--package\` is also specified]:FILE: ' \
 '-i+[Run only the index-th test in the file. Accepts a single index or a left-inclusive right-exclusive range like \`0-2\`. Only valid when \`--file\` is also specified]:INDEX: ' \
 '--index=[Run only the index-th test in the file. Accepts a single index or a left-inclusive right-exclusive range like \`0-2\`. Only valid when \`--file\` is also specified]:INDEX: ' \
+'(--build-only)--jsonl=[Output benchmark results in JSON Lines format to the specified file]:JSONL:_files' \
 '--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '(--nostd)--std[Enable the standard library (default)]' \

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -48,7 +48,10 @@ use moonutil::common::{
 };
 use moonutil::dirs::ProjectProbe;
 use moonutil::mooncakes::sync::AutoSyncFlags;
-use std::path::{Path, PathBuf};
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
 use tracing::{Level, debug, info, instrument, trace};
 
 use super::BenchSubcommand;
@@ -480,6 +483,7 @@ fn run_test_internal(
         project_manifest_path,
         display_backend_hint,
         selected_target_backend,
+        None,
     )?;
     trace!(exit_code, "run_test_internal finished");
     Ok(exit_code)
@@ -609,6 +613,7 @@ fn run_test_in_single_file_rr(
         build_graph,
         filter,
         None,
+        None,
     )
 }
 
@@ -629,6 +634,7 @@ pub(crate) struct TestLikeSubcommand<'a> {
     pub no_parallelize: bool,
     pub outline: bool,
     pub test_failure_json: bool,
+    pub bench_jsonl: bool,
     pub patch_file: &'a Option<PathBuf>,
     pub include_skipped: bool,
     /// Glob pattern to filter tests by name
@@ -653,6 +659,7 @@ impl<'a> From<&'a TestSubcommand> for TestLikeSubcommand<'a> {
             no_parallelize: cmd.no_parallelize,
             outline: cmd.outline,
             test_failure_json: cmd.test_failure_json,
+            bench_jsonl: false,
             patch_file: &cmd.patch_file,
             include_skipped: cmd.include_skipped,
             filter: &cmd.filter,
@@ -677,6 +684,7 @@ impl<'a> From<&'a BenchSubcommand> for TestLikeSubcommand<'a> {
             no_parallelize: cmd.no_parallelize,
             outline: false,
             test_failure_json: false,
+            bench_jsonl: cmd.jsonl.is_some(),
             patch_file: &None,
             include_skipped: false,
             filter: &None,
@@ -880,6 +888,7 @@ pub(crate) fn run_test_or_bench_internal(
     project_manifest_path: Option<&Path>,
     display_backend_hint: Option<()>,
     selected_target_backend: Option<TargetBackend>,
+    bench_jsonl_writer: Option<&mut dyn Write>,
 ) -> anyhow::Result<i32> {
     debug!(
         run_mode = ?cmd.run_mode,
@@ -923,6 +932,9 @@ pub(crate) fn run_test_or_bench_internal(
     if cmd.profile && cmd.run_mode != RunMode::Test {
         anyhow::bail!("`--profile` is only supported for `moon test`");
     }
+    if cmd.bench_jsonl && cli.dry_run {
+        anyhow::bail!("`--jsonl` cannot be used with `--dry-run`");
+    }
 
     debug!("selecting test runner implementation");
     run_test_rr(
@@ -934,6 +946,7 @@ pub(crate) fn run_test_or_bench_internal(
         project_manifest_path,
         display_backend_hint,
         selected_target_backend,
+        bench_jsonl_writer,
     )
 }
 
@@ -948,6 +961,7 @@ fn run_test_rr(
     project_manifest_path: Option<&Path>,
     display_backend_hint: Option<()>, // FIXME: unsure why it's option but as-is for now
     selected_target_backend: Option<TargetBackend>,
+    mut bench_jsonl_writer: Option<&mut dyn Write>,
 ) -> Result<i32, anyhow::Error> {
     info!(run_mode = ?cmd.run_mode, update = cmd.update, build_only = cmd.build_only, "starting rupes-recta test run");
     let planned_runs = plan_test_or_bench_rr_from_resolved_all(
@@ -985,6 +999,9 @@ fn run_test_rr(
             "planned rupes-recta build graph"
         );
 
+        let bench_jsonl_writer = bench_jsonl_writer
+            .as_mut()
+            .map(|writer| &mut **writer as &mut dyn Write);
         exit_code = exit_code.max(rr_test_from_plan(
             cli,
             cmd,
@@ -995,6 +1012,7 @@ fn run_test_rr(
             build_graph,
             filter,
             build_only_artifacts.as_mut(),
+            bench_jsonl_writer,
         )?);
     }
     if !cli.dry_run
@@ -1496,6 +1514,7 @@ fn rr_test_from_plan(
     build_graph: rr_build::BuildInput,
     filter: TestFilter,
     build_only_artifacts: Option<&mut TestArtifacts>,
+    bench_jsonl_writer: Option<&mut dyn Write>,
 ) -> Result<i32, anyhow::Error> {
     let user_diagnostics = UserDiagnostics::from_flags(cli);
     let built = match execute_test_build_from_plan(
@@ -1668,15 +1687,24 @@ fn rr_test_from_plan(
         }
     }
 
-    test_result.print_result(build_meta, cli.verbose, cmd.test_failure_json);
     let summary = test_result.summary();
-    print_test_summary(
-        summary.total,
-        summary.passed,
-        cli.quiet,
-        backend_hint,
-        user_diagnostics,
-    );
+    if cmd.bench_jsonl {
+        let Some(writer) = bench_jsonl_writer else {
+            bail!("internal error: missing JSON Lines writer for `moon bench --jsonl`");
+        };
+        let report = test_result.bench_json_report(build_meta)?;
+        serde_json_lenient::to_writer(&mut *writer, &report)?;
+        writeln!(writer)?;
+    } else {
+        test_result.print_result(build_meta, cli.verbose, cmd.test_failure_json);
+        print_test_summary(
+            summary.total,
+            summary.passed,
+            cli.quiet,
+            backend_hint,
+            user_diagnostics,
+        );
+    }
 
     if summary.total == summary.passed {
         Ok(0)

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -1009,3 +1009,109 @@ fn print_test_result_normal(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn test_case_result(kind: TestResultKind, message: String) -> TestCaseResult {
+        TestCaseResult {
+            kind,
+            raw: Arc::new(TestStatistics {
+                package: "username/bench".to_string(),
+                filename: "bench.mbt".to_string(),
+                index: "7".to_string(),
+                test_name: "generated_name".to_string(),
+                message,
+            }),
+            meta: MbtTestInfo {
+                index: 7,
+                func: "test_7".to_string(),
+                name: Some("source bench name".to_string()),
+                line_number: Some(23),
+                attrs: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn bench_json_result_parses_batch_summary() {
+        let message = format!(
+            "{}{}",
+            BATCHBENCH,
+            r#"{"summaries":[{"name":"fast","min":1.0,"max":2.0,"mean":1.5,"median":1.4,"variance":0.25,"std_dev":0.5,"std_dev_pct":33.3,"median_abs_dev":0.1,"median_abs_dev_pct":7.1,"quartiles":[1.1,1.4,1.8],"iqr":0.7,"batch_size":20,"runs":10}]}"#
+        );
+        let case = test_case_result(TestResultKind::Passed, message);
+
+        let result = bench_json_result(&case).expect("bench summary should parse");
+
+        assert_eq!(result.package, "username/bench");
+        assert_eq!(result.filename, "bench.mbt");
+        assert_eq!(result.index, 7);
+        assert_eq!(result.test_name, "source bench name");
+        assert_eq!(result.line_number, Some(23));
+        assert_eq!(result.status, "ok");
+        assert_eq!(result.message, None);
+        assert_eq!(result.summaries.len(), 1);
+        assert_eq!(result.summaries[0].name.as_deref(), Some("fast"));
+        assert_eq!(result.summaries[0].mean, 1.5);
+        assert_eq!(result.summaries[0].runs, 10);
+    }
+
+    #[test]
+    fn bench_json_result_preserves_failure_message() {
+        let case = test_case_result(TestResultKind::Failed, "bench failed".to_string());
+
+        let result = bench_json_result(&case).expect("failure result should serialize");
+
+        assert_eq!(result.status, "failed");
+        assert!(result.summaries.is_empty());
+        assert_eq!(result.message.as_deref(), Some("bench failed"));
+
+        let encoded = serde_json::to_value(&result).expect("bench failure should encode as JSON");
+        assert!(encoded.get("summaries").is_none());
+        assert_eq!(encoded["message"], "bench failed");
+    }
+
+    #[test]
+    fn bench_json_result_omits_empty_success_details() {
+        let case = test_case_result(TestResultKind::Passed, String::new());
+
+        let result = bench_json_result(&case).expect("empty success should serialize");
+
+        assert_eq!(result.status, "ok");
+        assert!(result.summaries.is_empty());
+        assert_eq!(result.message, None);
+
+        let encoded = serde_json::to_value(&result).expect("bench success should encode as JSON");
+        assert!(encoded.get("summaries").is_none());
+        assert!(encoded.get("message").is_none());
+    }
+
+    #[test]
+    fn bench_json_result_falls_back_to_driver_test_name() {
+        let mut case = test_case_result(TestResultKind::Passed, String::new());
+        case.meta.name = None;
+
+        let result = bench_json_result(&case).expect("result without source name should serialize");
+
+        assert_eq!(result.test_name, "generated_name");
+    }
+
+    #[test]
+    fn bench_json_result_rejects_malformed_batch_summary() {
+        let case = test_case_result(
+            TestResultKind::Passed,
+            format!("{BATCHBENCH}not valid json"),
+        );
+
+        let err = bench_json_result(&case).expect_err("malformed bench summary should fail");
+
+        assert!(
+            err.to_string()
+                .contains("failed to parse benchmark summary"),
+            "unexpected error: {err:#}"
+        );
+    }
+}

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -69,7 +69,7 @@ use std::{
 use anyhow::Context;
 use indexmap::IndexMap;
 use moonbuild::{
-    benchmark::{BATCHBENCH, render_batch_bench_summary},
+    benchmark::{BATCHBENCH, BatchBenchSummaries, render_batch_bench_summary},
     entry::{CompactTestFormatter, TestArgs},
     expect::{
         ERROR, EXPECT_FAILED, PackageSrcResolver, RUNTIME_ERROR, SNAPSHOT_TESTING,
@@ -81,7 +81,7 @@ use moonbuild::{
 use moonbuild_rupes_recta::model::{BuildPlanNode, BuildTarget};
 use moonutil::common::{
     MOON_COVERAGE_DELIMITER_BEGIN, MOON_COVERAGE_DELIMITER_END, MOON_TEST_DELIMITER_BEGIN,
-    MOON_TEST_DELIMITER_END, MbtTestInfo, MooncGenTestInfo,
+    MOON_TEST_DELIMITER_END, MbtTestInfo, MooncGenTestInfo, TargetBackend,
 };
 use tokio::runtime::Runtime;
 use tracing::{debug, info, instrument, trace, warn};
@@ -290,6 +290,30 @@ pub(crate) struct TestSummary {
     pub passed: usize,
 }
 
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct BenchJsonReport {
+    pub backend: String,
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub results: Vec<BenchJsonResult>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct BenchJsonResult {
+    pub package: String,
+    pub filename: String,
+    pub index: u32,
+    pub test_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_number: Option<usize>,
+    pub status: &'static str,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub summaries: Vec<moonbuild::benchmark::BenchSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
 impl ReplaceableTestResults {
     #[instrument(level = "trace", skip(self, result))]
     fn merge_with_target(&mut self, target: BuildTarget, result: TargetTestResult) {
@@ -338,6 +362,27 @@ impl ReplaceableTestResults {
                 }
             }
         }
+    }
+
+    pub(crate) fn bench_json_report(&self, meta: &BuildMeta) -> anyhow::Result<BenchJsonReport> {
+        let summary = self.summary();
+        let mut results = Vec::new();
+        for result in self.map.values() {
+            for file_map in result.map.values() {
+                for res in file_map.values() {
+                    results.push(bench_json_result(res)?);
+                }
+            }
+        }
+        Ok(BenchJsonReport {
+            backend: TargetBackend::from(meta.target_backend)
+                .to_backend_ext()
+                .to_string(),
+            total: summary.total,
+            passed: summary.passed,
+            failed: summary.total - summary.passed,
+            results,
+        })
     }
 
     #[instrument(level = "trace", skip(self))]
@@ -819,6 +864,51 @@ fn parse_one_test_result(
         Failed
     };
     Ok(res)
+}
+
+fn bench_json_result(res: &TestCaseResult) -> anyhow::Result<BenchJsonResult> {
+    let test_name = res
+        .meta
+        .name
+        .as_ref()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| res.raw.test_name.clone());
+    let summaries = if matches!(res.kind, TestResultKind::Passed) {
+        if let Some(msg) = res.raw.message.strip_prefix(BATCHBENCH) {
+            serde_json_lenient::from_str::<BatchBenchSummaries>(msg)
+                .with_context(|| {
+                    format!(
+                        "failed to parse benchmark summary for {}:{}",
+                        res.raw.filename, res.raw.index
+                    )
+                })?
+                .summaries
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    };
+    let message = match res.kind {
+        TestResultKind::Passed if res.raw.message.starts_with(BATCHBENCH) => None,
+        TestResultKind::Passed if res.raw.message.is_empty() => None,
+        TestResultKind::ExpectPanic if res.raw.message.is_empty() => {
+            Some("panic is expected".to_string())
+        }
+        _ if res.raw.message.is_empty() => None,
+        _ => Some(res.raw.message.clone()),
+    };
+
+    Ok(BenchJsonResult {
+        package: res.raw.package.clone(),
+        filename: res.raw.filename.clone(),
+        index: res.meta.index,
+        test_name,
+        line_number: res.meta.line_number,
+        status: if res.passed() { "ok" } else { "failed" },
+        summaries,
+        message,
+    })
 }
 
 fn print_test_result(

--- a/crates/moon/tests/test_cases/bench2/mod.rs
+++ b/crates/moon/tests/test_cases/bench2/mod.rs
@@ -14,3 +14,82 @@ fn test_bench() {
     assert!(!(out.contains("[username/bench2] bench bench2_test.mbt:23 (#2) ok")));
     assert!(out.contains("[username/bench2] bench bench2.mbt:23 (#0) ok"));
 }
+
+#[test]
+fn test_bench_jsonl() {
+    let dir = TestDir::new("bench2.in");
+    let out = get_stdout(
+        &dir,
+        ["bench", "--jsonl", "bench.jsonl", "--target", "wasm-gc"],
+    );
+
+    assert_eq!(out, "");
+    assert!(!out.contains("[username/bench2] bench"), "stdout: {out}");
+
+    let report_content =
+        std::fs::read_to_string(dir.join("bench.jsonl")).expect("bench JSONL file should exist");
+    let lines = report_content.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 1, "jsonl: {report_content}");
+    let report: serde_json::Value =
+        serde_json::from_str(lines[0]).expect("bench --jsonl should write JSON Lines");
+    assert_eq!(report["backend"], "wasm-gc");
+    assert_eq!(report["total"], 2);
+    assert_eq!(report["passed"], 2);
+    assert_eq!(report["failed"], 0);
+
+    let results = report["results"]
+        .as_array()
+        .expect("bench report should contain results");
+    assert_eq!(results.len(), 2);
+    assert_bench_json_result(results, "bench2.mbt", 0);
+    assert_bench_json_result(results, "bench2_test.mbt", 2);
+}
+
+#[test]
+fn test_bench_jsonl_multi_target() {
+    let dir = TestDir::new("bench2.in");
+    let out = get_stdout(
+        &dir,
+        [
+            "bench",
+            "--jsonl",
+            "bench-multi.jsonl",
+            "--target",
+            "wasm,wasm-gc",
+        ],
+    );
+
+    assert_eq!(out, "");
+
+    let report_content = std::fs::read_to_string(dir.join("bench-multi.jsonl"))
+        .expect("bench JSONL file should exist");
+    let reports = report_content
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("valid JSONL report"))
+        .collect::<Vec<_>>();
+    assert_eq!(reports.len(), 2, "jsonl: {report_content}");
+    assert_eq!(reports[0]["backend"], "wasm");
+    assert_eq!(reports[1]["backend"], "wasm-gc");
+}
+
+fn assert_bench_json_result(results: &[serde_json::Value], filename: &str, index: u64) {
+    let result = results
+        .iter()
+        .find(|result| result["filename"] == filename && result["index"] == index)
+        .unwrap_or_else(|| panic!("missing result for {filename} #{index}: {results:#?}"));
+
+    assert_eq!(result["package"], "username/bench2");
+    assert_eq!(result["line_number"], 23);
+    assert_eq!(result["status"], "ok");
+    assert!(result.get("message").is_none(), "result: {result:#?}");
+
+    let summaries = result["summaries"]
+        .as_array()
+        .expect("bench result should contain summaries");
+    assert_eq!(summaries.len(), 1);
+    assert!(
+        summaries[0]["mean"].as_f64().is_some(),
+        "summary: {:#?}",
+        summaries[0]
+    );
+}

--- a/crates/moonbuild/src/benchmark.rs
+++ b/crates/moonbuild/src/benchmark.rs
@@ -20,7 +20,7 @@ use colored::Colorize;
 
 pub const BATCHBENCH: &str = "@BATCH_BENCH ";
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct BenchSummary {
     pub name: Option<String>,
     pub min: f64,
@@ -38,7 +38,7 @@ pub struct BenchSummary {
     pub runs: usize,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct BatchBenchSummaries {
     pub summaries: Vec<BenchSummary>,
 }

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -435,6 +435,7 @@ Run benchmarks in the current package
 * `-i`, `--index <INDEX>` — Run only the index-th test in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when `--file` is also specified
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not bench
+* `--jsonl <JSONL>` — Output benchmark results in JSON Lines format to the specified file
 * `--no-parallelize` — Run the benchmarks in a target backend sequentially
 
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -435,6 +435,7 @@ Run benchmarks in the current package
 * `-i`, `--index <INDEX>` — Run only the index-th test in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when `--file` is also specified
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not bench
+* `--jsonl <JSONL>` — Output benchmark results in JSON Lines format to the specified file
 * `--no-parallelize` — Run the benchmarks in a target backend sequentially
 
 


### PR DESCRIPTION
- Related issues: None
- PR kind: feature

## Summary

Adds `moon bench --jsonl <JSONL>` to write machine-readable benchmark results to the specified JSON Lines file. The flag requires an output path, conflicts with `--build-only`, and is rejected with `--dry-run`.

When JSONL output is enabled, `moon bench` writes one compact JSON report per executed backend/target run instead of printing the normal benchmark result listing and summary. A single-target run writes one line; multi-target runs append one report line per backend, keeping the file valid JSON Lines.

Each report includes the backend name, total/passed/failed counts, and per-benchmark result entries. Result entries include `package`, `filename`, `index`, `test_name`, optional `line_number`, and `status`; successful batch benchmark output is parsed into `summaries`, while failure output is preserved as `message`. Empty success details are omitted from the JSON.

The PR also makes benchmark summary structs serializable, adds CLI parsing/report serialization/integration coverage, and updates generated command docs plus shell completion snapshots for the new file-valued flag.

Validation run:

- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p moon bench_jsonl`
- `cargo test -p moon bench_json_result`

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
