### PR TITLE
refactor: remove RR intent callback

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -245,20 +245,27 @@ pub(crate) fn plan_build_rr_from_resolved(
     );
 
     let output = UserDiagnostics::from_flags(cli);
-    rr_build::plan_build_from_resolved(
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        &resolve_output,
+    )?;
+    let intent = calc_user_intent(
+        &cmd.path,
+        cmd.package.as_deref(),
+        &resolve_output,
+        planning_context.target_backend(),
+        output,
+    )?;
+    rr_build::plan_prepared_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
         output,
-        Box::new(|resolved, target_backend| {
-            calc_user_intent(
-                &cmd.path,
-                cmd.package.as_deref(),
-                resolved,
-                target_backend,
-                output,
-            )
-        }),
+        planning_context,
+        intent,
         resolve_output,
     )
 }
@@ -281,14 +288,26 @@ fn plan_build_rr_from_resolved_with_scope(
     );
 
     let output = UserDiagnostics::from_flags(cli);
-    rr_build::plan_build_from_resolved(
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        &resolve_output,
+    )?;
+    debug_assert_eq!(planning_context.target_backend(), target_backend);
+    let intent = calc_user_intent_from_scoped_packages(
+        &resolve_output,
+        &scoped_packages,
+        planning_context.target_backend(),
+    )?;
+    rr_build::plan_prepared_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
         output,
-        Box::new(move |resolved, target_backend| {
-            calc_user_intent_from_scoped_packages(resolved, &scoped_packages, target_backend)
-        }),
+        planning_context,
+        intent,
         resolve_output,
     )
 }

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -27,7 +27,7 @@ use moonutil::{
 use std::path::Path;
 use tracing::instrument;
 
-use crate::rr_build::{self, BuildConfig};
+use crate::rr_build::{self, BuildConfig, CalcUserIntentOutput};
 use crate::user_diagnostics::UserDiagnostics;
 
 use super::BuildFlags;
@@ -207,12 +207,22 @@ pub(crate) fn plan_bundle_rr_from_resolved(
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
     let preconfig = bundle_preconfig(cli, cmd, target_dir, selected_target_backend);
-    rr_build::plan_build_from_resolved(
+    let output = UserDiagnostics::from_flags(cli);
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        &resolve_output,
+    )?;
+    let intent = bundle_user_intent(&resolve_output);
+    rr_build::plan_prepared_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
-        UserDiagnostics::from_flags(cli),
-        bundle_user_intent(),
+        output,
+        planning_context,
+        intent,
         resolve_output,
     )
 }
@@ -239,13 +249,13 @@ fn bundle_preconfig(
     preconfig
 }
 
-fn bundle_user_intent<'a>() -> Box<rr_build::CalcUserIntentFn<'a>> {
-    Box::new(|resolved, _target_backend| {
-        Ok(resolved
-            .local_modules()
-            .iter()
-            .map(|&module| UserIntent::Bundle(module))
-            .collect::<Vec<_>>()
-            .into())
-    })
+fn bundle_user_intent(
+    resolve_output: &moonbuild_rupes_recta::ResolveOutput,
+) -> CalcUserIntentOutput {
+    resolve_output
+        .local_modules()
+        .iter()
+        .map(|&module| UserIntent::Bundle(module))
+        .collect::<Vec<_>>()
+        .into()
 }

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -332,13 +332,22 @@ fn run_check_for_single_file_rr(
         RunMode::Check,
     );
 
-    // The rest is similar to normal check flow
-    let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
+    let output = UserDiagnostics::from_flags(cli);
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        &resolved,
+    )?;
+    let intent = get_user_intents_single_file(&resolved, planning_context.target_backend())?;
+    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
-        UserDiagnostics::from_flags(cli),
-        Box::new(get_user_intents_single_file),
+        output,
+        planning_context,
+        intent,
         resolved,
     )
     .context("Failed to calculate build plan")?;
@@ -626,32 +635,39 @@ pub(crate) fn plan_check_rr_from_resolved(
     );
 
     let output = UserDiagnostics::from_flags(cli);
-    rr_build::plan_build_from_resolved(
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        &resolve_output,
+    )?;
+    let intent = if let Some(filter_path) = cmd.package_path.as_deref() {
+        calc_user_intent_from_package_path(
+            &resolve_output,
+            source_dir,
+            filter_path,
+            planning_context.target_backend(),
+            cmd.no_mi,
+            cmd.patch_file.as_deref(),
+        )?
+    } else {
+        calc_user_intent(
+            &resolve_output,
+            &cmd.path,
+            planning_context.target_backend(),
+            cmd.no_mi,
+            cmd.patch_file.as_deref(),
+            output,
+        )?
+    };
+    rr_build::plan_prepared_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
         output,
-        Box::new(|resolved, target_backend| {
-            if let Some(filter_path) = cmd.package_path.as_deref() {
-                return calc_user_intent_from_package_path(
-                    resolved,
-                    source_dir,
-                    filter_path,
-                    target_backend,
-                    cmd.no_mi,
-                    cmd.patch_file.as_deref(),
-                );
-            }
-
-            calc_user_intent(
-                resolved,
-                &cmd.path,
-                target_backend,
-                cmd.no_mi,
-                cmd.patch_file.as_deref(),
-                output,
-            )
-        }),
+        planning_context,
+        intent,
         resolve_output,
     )
 }

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -118,19 +118,29 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
     );
     preconfig.docs_serve = cmd.serve;
 
-    let doc_source_dir_for_intent = doc_source_dir.clone();
-    let (build_meta, build_graph) = rr_build::plan_build(
+    let resolve_cfg = preconfig
+        .resolve_config()
+        .with_project_manifest_path(project_manifest_path.as_deref());
+    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+
+    let output = UserDiagnostics::from_flags(&cli);
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        &target_dir,
+        output,
+        &resolve_output,
+    )?;
+    let module_id = selected_doc_module_id(&resolve_output, &doc_source_dir)?;
+    let intent = vec![UserIntent::Doc(module_id)].into();
+    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        &source_dir,
         &target_dir,
-        &mooncakes_dir,
-        UserDiagnostics::from_flags(&cli),
-        project_manifest_path.as_deref(),
-        Box::new(move |resolve_output, _| {
-            let module_id = selected_doc_module_id(resolve_output, &doc_source_dir_for_intent)?;
-            Ok(vec![UserIntent::Doc(module_id)].into())
-        }),
+        output,
+        planning_context,
+        intent,
+        resolve_output,
     )?;
 
     // Early exit for dry-run

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -364,12 +364,22 @@ fn run_info_rr_internal(
         target_kind,
         output,
     };
-    let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        &resolve_output,
+    )?;
+    let intent =
+        calc_user_intent_for_info(&ctx, &resolve_output, planning_context.target_backend())?;
+    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
         output,
-        Box::new(move |resolve_output, tb| calc_user_intent_for_info(&ctx, resolve_output, tb)),
+        planning_context,
+        intent,
         resolve_output,
     )?;
     // Generate the all_pkgs.json for indirect dependency resolution

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -35,7 +35,7 @@ use std::path::{Path, PathBuf};
 
 use crate::{
     cli::BuildFlags,
-    rr_build::{self, BuildConfig, plan_build_from_resolved, preconfig_compile},
+    rr_build::{self, BuildConfig, preconfig_compile},
     user_diagnostics::UserDiagnostics,
 };
 
@@ -595,12 +595,22 @@ fn build_and_install_packages(
             RunMode::Build,
         );
 
-        let (build_meta, build_graph) = plan_build_from_resolved(
+        let output = UserDiagnostics::from_flags(cli);
+        let planning_context = rr_build::prepare_resolved_build(
+            &preconfig,
+            &cli.unstable_feature,
+            &target_dir,
+            output,
+            &resolve_output,
+        )?;
+        let intent = vec![UserIntent::Build(pkg.pkg_id)].into();
+        let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
             preconfig,
             &cli.unstable_feature,
             &target_dir,
-            UserDiagnostics::from_flags(cli),
-            Box::new(move |_, _| Ok(vec![UserIntent::Build(pkg.pkg_id)].into())),
+            output,
+            planning_context,
+            intent,
             resolve_output.clone(),
         )?;
 

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -147,23 +147,35 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
     let path_filter = cmd.path.as_deref();
     let prove_why3_config = why3_config_path.clone();
 
-    let (build_meta, build_graph) = rr_build::plan_build(
+    let resolve_cfg = preconfig
+        .resolve_config()
+        .with_project_manifest_path(project_manifest_path.as_deref());
+    let resolve_output =
+        moonbuild_rupes_recta::resolve(&resolve_cfg, &project_root, &mooncakes_dir)?;
+
+    let output = UserDiagnostics::from_flags(cli);
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        &target_dir,
+        output,
+        &resolve_output,
+    )?;
+    let intent = calc_user_intent(
+        path_filter,
+        module_dir.as_deref(),
+        &resolve_output,
+        planning_context.target_backend(),
+        prove_why3_config.as_deref(),
+    )?;
+    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        &project_root,
         &target_dir,
-        &mooncakes_dir,
-        UserDiagnostics::from_flags(cli),
-        project_manifest_path.as_deref(),
-        Box::new(move |resolve_output, target_backend| {
-            calc_user_intent(
-                path_filter,
-                module_dir.as_deref(),
-                resolve_output,
-                target_backend,
-                prove_why3_config.as_deref(),
-            )
-        }),
+        output,
+        planning_context,
+        intent,
+        resolve_output,
     )?;
     let proof_reports = planned_proof_reports(&build_meta);
 

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -409,46 +409,45 @@ fn run_test_in_single_file_rr(
     // Enable tcc-run to match legacy debug test graph shape
     preconfig.try_tcc_run = true;
 
-    // Plan build: single UserIntent::Test for synthesized package; apply file/index filters
-    let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
+    let output = UserDiagnostics::from_flags(cli);
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        &resolved,
+    )?;
+    let pkg = rr_build::local_packages(&resolved)
+        .next()
+        .expect("Single-file project must synthesize exactly one package");
+
+    let test_index = if let Some(index) = cmd.index {
+        Some(TestIndex::Regular(index))
+    } else if let Some(id) = cmd.doc_index {
+        Some(TestIndex::DocTest(TestIndexRange::from_single(id)?))
+    } else {
+        None
+    };
+    let filename = single_file_path
+        .file_name()
+        .expect("single file path should have a filename")
+        .to_string_lossy();
+    filter.add_autodetermine_target(pkg, Some(&filename), test_index);
+
+    let trace_pkg = if cmd.build_flags.enable_value_tracing {
+        Some(pkg)
+    } else {
+        None
+    };
+    let directive = rr_build::build_patch_directive_for_package(pkg, false, trace_pkg, None, true)?;
+    let intent = (vec![UserIntent::Test(pkg)], directive).into();
+    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
-        UserDiagnostics::from_flags(cli),
-        Box::new(|r, _tb| {
-            let m_packages = r
-                .pkg_dirs
-                .packages_for_module(r.local_modules()[0])
-                .expect("Local module must exist");
-            let pkg = *m_packages
-                .iter()
-                .next()
-                .expect("Single-file project must synthesize exactly one package")
-                .1;
-
-            let test_index = if let Some(index) = cmd.index {
-                Some(TestIndex::Regular(index))
-            } else if let Some(id) = cmd.doc_index {
-                Some(TestIndex::DocTest(TestIndexRange::from_single(id)?))
-            } else {
-                None
-            };
-            let filename = single_file_path
-                .file_name()
-                .expect("single file path should have a filename")
-                .to_string_lossy();
-            filter.add_autodetermine_target(pkg, Some(&filename), test_index);
-
-            let trace_pkg = if cmd.build_flags.enable_value_tracing {
-                Some(pkg)
-            } else {
-                None
-            };
-            let directive =
-                rr_build::build_patch_directive_for_package(pkg, false, trace_pkg, None, true)?;
-
-            Ok((vec![UserIntent::Test(pkg)], directive).into())
-        }),
+        output,
+        planning_context,
+        intent,
         resolved,
     )?;
 
@@ -572,20 +571,28 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
         name_filter: cmd.filter.clone(),
         ..Default::default()
     };
-    let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
+    let output = UserDiagnostics::from_flags(cli);
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        &resolve_output,
+    )?;
+    let intent = calc_user_intent(
+        &resolve_output,
+        cmd,
+        &mut filter,
+        planning_context.target_backend(),
+        output,
+    )?;
+    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
-        UserDiagnostics::from_flags(cli),
-        Box::new(|resolved, target_backend| {
-            calc_user_intent(
-                resolved,
-                cmd,
-                &mut filter,
-                target_backend,
-                UserDiagnostics::from_flags(cli),
-            )
-        }),
+        output,
+        planning_context,
+        intent,
         resolve_output,
     )?;
     Ok((build_meta, build_graph, filter))
@@ -687,25 +694,29 @@ fn plan_test_or_bench_rr_from_resolved_scoped(
         preconfig.try_tcc_run = true;
     }
 
-    let mut filter = TestFilter {
-        name_filter: cmd.filter.clone(),
-        ..Default::default()
-    };
-    let (build_meta, build_graph) = rr_build::plan_build_from_resolved(
+    let output = UserDiagnostics::from_flags(cli);
+    let planning_context = rr_build::prepare_resolved_build(
+        &preconfig,
+        &cli.unstable_feature,
+        target_dir,
+        output,
+        &resolve_output,
+    )?;
+    debug_assert_eq!(planning_context.target_backend(), target_backend);
+    let resolved_intent = lower_resolved_scoped_test_selection(
+        &resolve_output,
+        cmd,
+        resolved_selection,
+        planning_context.target_backend(),
+    )?;
+    let filter = resolved_intent.filter;
+    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
-        UserDiagnostics::from_flags(cli),
-        Box::new(|resolved, target_backend| {
-            let resolved_intent = lower_resolved_scoped_test_selection(
-                resolved,
-                cmd,
-                resolved_selection,
-                target_backend,
-            )?;
-            filter = resolved_intent.filter;
-            Ok(resolved_intent.intent)
-        }),
+        output,
+        planning_context,
+        resolved_intent.intent,
         resolve_output,
     )?;
     Ok((build_meta, build_graph, filter))

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -45,7 +45,7 @@ use moonutil::{
 use crate::{
     cli::BuildFlags,
     filter::match_packages_by_name_rr,
-    rr_build::{self, BuildConfig, BuildMeta, plan_build_from_resolved, preconfig_compile},
+    rr_build::{self, BuildConfig, BuildMeta, preconfig_compile},
     user_diagnostics::UserDiagnostics,
 };
 
@@ -155,12 +155,22 @@ pub(crate) fn run_build_binary_dep(
             &target_dir,
             RunMode::Build,
         );
-        let (build_meta, build_graph) = plan_build_from_resolved(
+        let output = UserDiagnostics::from_flags(cli);
+        let planning_context = rr_build::prepare_resolved_build(
+            &preconfig,
+            &cli.unstable_feature,
+            &target_dir,
+            output,
+            &resolve_output,
+        )?;
+        let intent = vec![UserIntent::Build(pkg)].into();
+        let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
             preconfig,
             &cli.unstable_feature,
             &target_dir,
-            UserDiagnostics::from_flags(cli),
-            Box::new(|_, _| Ok(vec![UserIntent::Build(pkg)].into())),
+            output,
+            planning_context,
+            intent,
             // FIXME: cloning is not the best way to do this, it takes in this
             // type only to be returned in build meta. We should refactor later.
             resolve_output.clone(),

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -68,21 +68,6 @@ use crate::user_diagnostics::UserDiagnostics;
 mod dry_run;
 pub use dry_run::{dry_print_command, print_dry_run, print_dry_run_all};
 
-/// The function that calculates the user intent for the build process.
-///
-/// Params:
-/// - The output of the resolve step. All modules and packages that this module
-///   are available in this value.
-/// - The target backend to build for.
-///
-/// Returns: A vector of [`UserIntent`]s, representing what the user would like
-/// to do
-pub type CalcUserIntentFn<'b> = dyn for<'a> FnOnce(
-        &'a ResolveOutput,
-        moonutil::common::TargetBackend,
-    ) -> anyhow::Result<CalcUserIntentOutput>
-    + 'b;
-
 /// The output of a calculate user intent operation.
 pub struct CalcUserIntentOutput {
     /// The list of user intents; will be expanded to concrete BuildPlanNode(s) later.
@@ -314,6 +299,15 @@ pub struct CompilePreConfig {
 }
 
 impl CompilePreConfig {
+    pub(crate) fn resolve_config(&self) -> ResolveConfig {
+        ResolveConfig::new_with_load_defaults(
+            self.frozen,
+            !self.use_std,
+            self.enable_coverage,
+            self.workspace_env.clone(),
+        )
+    }
+
     fn into_compile_config(
         self,
         final_target_backend: TargetBackend,
@@ -438,84 +432,6 @@ pub fn preconfig_compile(
         },
         warn_list: build_flags.warn_list.clone(),
     }
-}
-
-/// Plan the build process without executing it.
-///
-/// This function performs all the preparation steps: resolve dependencies,
-/// calculate user intent, and create the build graph, but does not execute
-/// the actual build tasks.
-///
-/// Returns the execution plan (metadata) and build graph separately, allowing
-/// execute_build to take ownership of just the graph while callers retain
-/// access to the metadata.
-#[instrument(skip_all)]
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn plan_build<'a>(
-    preconfig: CompilePreConfig,
-    unstable_features: &'a FeatureGate,
-    source_dir: &'a Path,
-    target_dir: &'a Path,
-    mooncakes_dir: &'a Path,
-    output: UserDiagnostics,
-    project_manifest_path: Option<&'a Path>,
-    calc_user_intent: Box<CalcUserIntentFn<'a>>,
-) -> anyhow::Result<(BuildMeta, BuildInput)> {
-    info!("Starting build planning");
-
-    let cfg = ResolveConfig::new_with_load_defaults(
-        preconfig.frozen,
-        !preconfig.use_std,
-        preconfig.enable_coverage,
-        preconfig.workspace_env.clone(),
-    )
-    .with_project_manifest_path(project_manifest_path);
-    let resolve_output = moonbuild_rupes_recta::resolve(&cfg, source_dir, mooncakes_dir)?;
-
-    info!("Resolve completed");
-
-    plan_build_from_resolved(
-        preconfig,
-        unstable_features,
-        target_dir,
-        output,
-        calc_user_intent,
-        resolve_output,
-    )
-}
-
-/// Plan the build process from an already resolved environment.
-///
-/// This function exists because [someone demands target determination **after**
-/// resolving completes](crate::cli::tool::build_binary_dep). For most cases,
-/// use [`plan_build`] instead.
-pub(crate) fn plan_build_from_resolved<'a>(
-    preconfig: CompilePreConfig,
-    unstable_features: &'a FeatureGate,
-    target_dir: &'a Path,
-    output: UserDiagnostics,
-    calc_user_intent: Box<CalcUserIntentFn<'a>>,
-    resolve_output: ResolveOutput,
-) -> anyhow::Result<(BuildMeta, BuildInput)> {
-    let planning_context = prepare_resolved_build(
-        &preconfig,
-        unstable_features,
-        target_dir,
-        output,
-        &resolve_output,
-    )?;
-
-    info!("Calculating user intent");
-    let intent = calc_user_intent(&resolve_output, planning_context.target_backend())?;
-    plan_prepared_build_from_intent(
-        preconfig,
-        unstable_features,
-        target_dir,
-        output,
-        planning_context,
-        intent,
-        resolve_output,
-    )
 }
 
 pub(crate) struct ResolvedBuildPlanningContext {


### PR DESCRIPTION
## Summary

Remove the callback-shaped RR planning boundary.

This deletes `CalcUserIntentFn`, `rr_build::plan_build`, and `rr_build::plan_build_from_resolved`. Command adapters now follow the explicit boundary used by the previous selection cleanup PRs:

1. resolve the project into `ResolveOutput`;
2. call `rr_build::prepare_resolved_build` to emit resolve diagnostics and determine the effective backend;
3. calculate command-local `CalcUserIntentOutput` in the command adapter;
4. call `rr_build::plan_prepared_build_from_intent`.

`CompilePreConfig::resolve_config` is added so commands that previously used `plan_build` for internal resolution (`doc` and `prove`) can still construct the same resolve config without reintroducing a callback.

## Why

The old callback let command-specific selector interpretation run from inside RR planning. That made the boundary ambiguous: RR both prepared build-model state and invoked CLI code to decide intent. After the previous `build`/`check`/`test`/`run` work, the remaining users could be migrated directly, so the compatibility layer is no longer needed.

Now RR consumes resolved intent and `ResolveOutput`; command adapters own selector resolution and command-specific directives.

## Scope

This is a boundary refactor. It does not change command behavior intentionally, and no snapshots changed.

Migrated remaining users in:

- `build`
- `check`
- `test` / `bench`
- `bundle`
- `info`
- `doc`
- `prove`
- binary install helpers

## Validation

- `cargo check -p moon`
- `cargo xtask ci`
- `cargo test -p moon tests::planner::target_backend_planning`
- `cargo test -p moon --test mod -- test_cases::filter_by_path::`
- `cargo test -p moon --test mod -- test_cases::target_backend::`
- `cargo test -p moon --test mod -- test_cases::moon_prove::`
- `cargo test -p moon --test mod -- test_moon_doc`
- `cargo test -p moon --test mod -- test_moon_install_bin`
- `cargo test -p moon --test mod -- test_moon_install_global_local_path`