### PR TITLE
Refactor test invocation collection

### DIFF
--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -1444,43 +1444,20 @@ fn rr_test_from_plan(
     filter: TestFilter,
     build_only_artifacts: Option<&mut TestArtifacts>,
 ) -> Result<i32, anyhow::Error> {
-    // Dry-run: share the same routine
-    if cli.dry_run {
-        rr_build::print_dry_run(
-            &build_graph,
-            build_meta.artifacts.values(),
-            source_dir,
-            target_dir,
-        );
-        // The legacy behavior does not print the test commands, so we skip it too.
-        return Ok(0);
-    }
-
-    let _lock = FileLock::lock(target_dir)?;
-    // Generate the all_pkgs.json for indirect dependency resolution
-    // before executing the build
-    rr_build::generate_all_pkgs_json(target_dir, build_meta, cmd.run_mode)?;
-
     let user_diagnostics = UserDiagnostics::from_flags(cli);
-    let build_config = BuildConfig::from_flags(
-        cmd.build_flags,
-        &cli.unstable_feature,
-        cli.verbose,
+    let built = match execute_test_build_from_plan(
+        cli,
+        cmd,
+        source_dir,
+        target_dir,
+        build_meta,
+        build_graph,
         user_diagnostics,
-    );
-
-    // since n2 build consumes the graph, we back it up for reruns
-    let build_graph_backup = cmd.update.then(|| build_graph.clone());
-    let result = rr_build::execute_build(&build_config, build_graph, target_dir)?;
-    debug!(
-        success = result.successful(),
-        exit_code = result.return_code_for_success(),
-        "executed rupes-recta build"
-    );
-
-    if !result.successful() {
-        return Ok(result.return_code_for_success());
-    }
+    )? {
+        TestBuildExecution::DryRun => return Ok(0),
+        TestBuildExecution::BuildFailed(exit_code) => return Ok(exit_code),
+        TestBuildExecution::Built(built) => built,
+    };
 
     if cmd.outline {
         let entries = collect_test_outline(
@@ -1560,7 +1537,8 @@ fn rr_test_from_plan(
             loop_count += 1;
 
             // Get the graph from backup
-            let build_graph = build_graph_backup
+            let build_graph = built
+                .build_graph_backup
                 .as_ref()
                 .cloned()
                 .expect("build graph backup should be present when update is true");
@@ -1583,7 +1561,7 @@ fn rr_test_from_plan(
 
             // Run the build
             let result = rr_build::execute_build_partial(
-                &build_config,
+                &built.build_config,
                 build_graph,
                 target_dir,
                 Box::new(|work| {
@@ -1644,6 +1622,73 @@ fn rr_test_from_plan(
     }
 }
 
+struct BuiltTestExecution {
+    _lock: FileLock,
+    build_config: BuildConfig,
+    build_graph_backup: Option<rr_build::BuildInput>,
+}
+
+enum TestBuildExecution {
+    DryRun,
+    BuildFailed(i32),
+    Built(BuiltTestExecution),
+}
+
+#[allow(clippy::too_many_arguments)]
+fn execute_test_build_from_plan(
+    cli: &UniversalFlags,
+    cmd: &TestLikeSubcommand<'_>,
+    source_dir: &Path,
+    target_dir: &Path,
+    build_meta: &rr_build::BuildMeta,
+    build_graph: rr_build::BuildInput,
+    user_diagnostics: UserDiagnostics,
+) -> Result<TestBuildExecution, anyhow::Error> {
+    if cli.dry_run {
+        rr_build::print_dry_run(
+            &build_graph,
+            build_meta.artifacts.values(),
+            source_dir,
+            target_dir,
+        );
+        // The legacy behavior does not print the test commands, so we skip it too.
+        return Ok(TestBuildExecution::DryRun);
+    }
+
+    let lock = FileLock::lock(target_dir)?;
+    // Generate the all_pkgs.json for indirect dependency resolution
+    // before executing the build
+    rr_build::generate_all_pkgs_json(target_dir, build_meta, cmd.run_mode)?;
+
+    let build_config = BuildConfig::from_flags(
+        cmd.build_flags,
+        &cli.unstable_feature,
+        cli.verbose,
+        user_diagnostics,
+    );
+
+    // since n2 build consumes the graph, we back it up for reruns
+    let build_graph_backup = cmd.update.then(|| build_graph.clone());
+    let result = rr_build::execute_build(&build_config, build_graph, target_dir)?;
+    debug!(
+        success = result.successful(),
+        exit_code = result.return_code_for_success(),
+        "executed rupes-recta build"
+    );
+
+    if !result.successful() {
+        return Ok(TestBuildExecution::BuildFailed(
+            result.return_code_for_success(),
+        ));
+    }
+
+    Ok(TestBuildExecution::Built(BuiltTestExecution {
+        _lock: lock,
+        build_config,
+        build_graph_backup,
+    }))
+}
+
 /// Collect test artifacts for --build-only mode, matching legacy behavior.
 /// For JS backend, creates .cjs wrapper files and returns those paths.
 /// For other backends, returns the executable paths directly.
@@ -1656,71 +1701,28 @@ fn collect_test_artifacts_for_build_only(
     bench: bool,
 ) -> anyhow::Result<TestArtifacts> {
     use moonbuild_rupes_recta::model::RunBackend;
-    use moonutil::common::MooncGenTestInfo;
 
     let mut artifacts_path = vec![];
     let mut test_filter_args = vec![];
 
-    // Gather test executables (only MakeExecutable nodes)
-    for (node, node_artifacts) in &build_meta.artifacts {
-        if !matches!(node, BuildPlanNode::MakeExecutable(_)) {
-            continue;
-        }
-
-        let target = node
-            .extract_target()
-            .expect("MakeExecutable should have a build target");
-
-        // Find the corresponding GenerateTestInfo node to check if there are actual tests
-        let meta_node = BuildPlanNode::GenerateTestInfo(target);
-        let meta_artifacts = match build_meta.artifacts.get(&meta_node) {
-            Some(a) => a,
-            None => continue,
-        };
-
-        // Read test info to check if there are actual tests
-        let meta_path = &meta_artifacts.artifacts[1]; // Second artifact is the JSON
-        let meta_file = match std::fs::File::open(meta_path) {
-            Ok(f) => f,
-            Err(_) => continue,
-        };
-        let meta: MooncGenTestInfo = match serde_json_lenient::from_reader(meta_file) {
-            Ok(m) => m,
-            Err(_) => continue,
-        };
-
-        // Skip if no tests exist (legacy behavior)
-        if meta.no_args_tests.values().all(|v| v.is_empty()) {
-            continue;
-        }
-
-        let executable_path = &node_artifacts.artifacts[0];
-
+    for invocation in
+        crate::run::collect_test_invocations(build_meta, filter, include_skipped, bench)?
+    {
         // For JS backend, create .cjs wrapper file (matching legacy behavior)
         if matches!(build_meta.target_backend, RunBackend::Js) {
             // Write package.json to prevent node from using outer "type": "module"
             let _ = std::fs::write(target_dir.join("package.json"), "{}");
-            if let Some(parent) = executable_path.parent() {
+            if let Some(parent) = invocation.executable.parent() {
                 let _ = std::fs::write(parent.join("package.json"), "{}");
             }
 
-            let Some(test_args) = crate::run::build_test_args_for_target(
-                build_meta,
-                filter,
-                target,
-                &meta,
-                include_skipped,
-                bench,
-            ) else {
-                continue;
-            };
-            let filter_arg = serde_json::to_string(&test_args)
+            let filter_arg = serde_json::to_string(&invocation.args)
                 .context("failed to serialize JS test filter args")?;
 
-            artifacts_path.push(executable_path.clone());
+            artifacts_path.push(invocation.executable);
             test_filter_args.push(filter_arg);
         } else {
-            artifacts_path.push(executable_path.clone());
+            artifacts_path.push(invocation.executable);
         }
     }
 

--- a/crates/moon/src/run/mod.rs
+++ b/crates/moon/src/run/mod.rs
@@ -24,7 +24,7 @@ mod runtime;
 
 pub(crate) use child::run;
 pub(crate) use runtest::{
-    PackageFilter, TestFilter, TestIndex, TestOutlineEntry, build_test_args_for_target,
+    PackageFilter, TestFilter, TestIndex, TestOutlineEntry, collect_test_invocations,
     collect_test_outline, perform_promotion, run_tests,
 };
 pub(crate) use runtime::command_for;

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -60,7 +60,11 @@
 mod filter;
 mod promotion;
 
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use anyhow::Context;
 use indexmap::IndexMap;
@@ -140,9 +144,8 @@ pub(crate) fn run_tests(
     no_parallelize: bool,
     parallelism: Option<usize>,
 ) -> anyhow::Result<ReplaceableTestResults> {
-    // Gathering artifacts
-    let executables = gather_tests(build_meta);
-    debug!(count = executables.len(), "collected test executables");
+    let invocations = collect_test_invocations(build_meta, filter, include_skipped, bench)?;
+    debug!(count = invocations.len(), "collected test invocations");
 
     // Parallelism is opt-in: sequential by default, parallel only when -j is given
     let parallelism = if no_parallelize {
@@ -154,7 +157,7 @@ pub(crate) fn run_tests(
     let mut stats = ReplaceableTestResults::default();
     let mut total_cases = 0usize;
 
-    if parallelism <= 1 || executables.len() <= 1 {
+    if parallelism <= 1 || invocations.len() <= 1 {
         // Sequential execution
         let rt = default_rt().context("Failed to create runtime")?;
         let ctx = TestRunCtx {
@@ -162,13 +165,10 @@ pub(crate) fn run_tests(
             rt: &rt,
             source_dir,
             target_dir,
-            filter,
-            include_skipped,
-            bench,
             verbose,
         };
-        for r in executables {
-            debug!(target = ?r.target, executable = %r.executable.display(), "running test executable");
+        for r in invocations {
+            debug!(target = ?r.target, executable = %r.executable.display(), "running test invocation");
             let res = run_one_test_executable(&ctx, &r)?;
             let cases_for_target = res.map.values().map(IndexMap::len).sum::<usize>();
             trace!(target = ?r.target, cases = cases_for_target, "merging test results");
@@ -177,15 +177,15 @@ pub(crate) fn run_tests(
         }
     } else {
         // Parallel execution using OS threads (like n2)
-        let parallelism = parallelism.min(executables.len()).max(1);
+        let parallelism = parallelism.min(invocations.len()).max(1);
         debug!(
             parallelism,
-            executables = executables.len(),
-            "running test executables in parallel"
+            invocations = invocations.len(),
+            "running test invocations in parallel"
         );
 
         let work_queue: std::sync::Arc<std::sync::Mutex<std::slice::Iter<'_, _>>> =
-            std::sync::Arc::new(std::sync::Mutex::new(executables.iter()));
+            std::sync::Arc::new(std::sync::Mutex::new(invocations.iter()));
         let (result_tx, result_rx) = std::sync::mpsc::channel();
 
         std::thread::scope(|s| {
@@ -201,9 +201,6 @@ pub(crate) fn run_tests(
                         rt: &rt,
                         source_dir,
                         target_dir,
-                        filter,
-                        include_skipped,
-                        bench,
                         verbose,
                     };
 
@@ -214,7 +211,7 @@ pub(crate) fn run_tests(
                         };
                         let Some(r) = r else { break };
 
-                        debug!(target = ?r.target, executable = %r.executable.display(), "running test executable");
+                        debug!(target = ?r.target, executable = %r.executable.display(), "running test invocation");
                         let res = run_one_test_executable(&ctx, r);
                         let _ = result_tx.send((r.target, res));
                     }
@@ -250,6 +247,14 @@ struct TestExecutableToRun<'a> {
     meta: &'a Path,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct TestInvocation {
+    pub(crate) target: BuildTarget,
+    pub(crate) executable: PathBuf,
+    pub(crate) args: TestArgs,
+    meta: MooncGenTestInfo,
+}
+
 /// Context for running a single compiled test executable. This is for reducing
 /// the number of parameters shifted around.
 struct TestRunCtx<'a> {
@@ -261,12 +266,6 @@ struct TestRunCtx<'a> {
     source_dir: &'a Path,
     /// Target directory; coverage output destination
     target_dir: &'a Path,
-    /// Package/file/index selection
-    filter: &'a TestFilter,
-    /// Include tests marked as skipped
-    include_skipped: bool,
-    /// Include benchmark cases
-    bench: bool,
     /// Enable verbose printing
     verbose: bool,
 }
@@ -564,10 +563,58 @@ fn gather_tests(build_meta: &BuildMeta) -> Vec<TestExecutableToRun<'_>> {
     results
 }
 
+pub(crate) fn collect_test_invocations(
+    build_meta: &BuildMeta,
+    filter: &TestFilter,
+    include_skipped: bool,
+    bench: bool,
+) -> anyhow::Result<Vec<TestInvocation>> {
+    let mut invocations = Vec::new();
+    for test in gather_tests(build_meta) {
+        let meta_bytes = std::fs::read(test.meta)
+            .with_context(|| format!("Failed to read test metadata at {}", test.meta.display()))?;
+        let meta: MooncGenTestInfo = serde_json_lenient::from_slice(&meta_bytes)
+            .with_context(|| format!("Failed to parse test metadata at {}", test.meta.display()))?;
+        trace!(path = %test.meta.display(), "loaded test metadata");
+
+        let Some(args) = build_test_args_for_target(
+            build_meta,
+            filter,
+            test.target,
+            &meta,
+            include_skipped,
+            bench,
+        ) else {
+            debug!(target = ?test.target, "skipping test executable due to filter");
+            continue;
+        };
+        if args
+            .file_and_index
+            .iter()
+            .all(|(_, ranges)| ranges.is_empty())
+        {
+            debug!(target = ?test.target, "skipping test executable with no selected cases");
+            continue;
+        }
+        trace!(
+            filter_entries = args.file_and_index.len(),
+            "applied test filter"
+        );
+
+        invocations.push(TestInvocation {
+            target: test.target,
+            executable: test.executable.to_path_buf(),
+            args,
+            meta,
+        });
+    }
+    Ok(invocations)
+}
+
 #[instrument(level = "debug", skip(ctx, test))]
 fn run_one_test_executable(
     ctx: &TestRunCtx<'_>,
-    test: &TestExecutableToRun,
+    test: &TestInvocation,
 ) -> Result<TargetTestResult, anyhow::Error> {
     let fqn = ctx
         .build_meta
@@ -575,40 +622,17 @@ fn run_one_test_executable(
         .pkg_dirs
         .fqn(test.target.package);
 
-    // Parse test metadata
-    let meta_bytes = std::fs::read(test.meta)
-        .with_context(|| format!("Failed to read test metadata at {}", test.meta.display()))?;
-    let meta: MooncGenTestInfo = serde_json_lenient::from_slice(&meta_bytes)
-        .with_context(|| format!("Failed to parse test metadata at {}", test.meta.display()))?;
-    trace!(path = %test.meta.display(), "loaded test metadata");
-
-    let Some(test_args) = build_test_args_for_target(
-        ctx.build_meta,
-        ctx.filter,
-        test.target,
-        &meta,
-        ctx.include_skipped,
-        ctx.bench,
-    ) else {
-        debug!(target = ?test.target, "skipping test executable due to filter");
-        return Ok(TargetTestResult::default());
-    };
-    trace!(
-        filter_entries = test_args.file_and_index.len(),
-        "applied test filter"
-    );
-
     let cmd = crate::run::command_for(
         ctx.build_meta.target_backend,
-        test.executable,
-        Some(&test_args),
+        &test.executable,
+        Some(&test.args),
     );
     let mut cov_cap = mk_coverage_capture();
     let mut test_cap = make_test_capture();
     if ctx.verbose {
         crate::rr_build::dry_print_command(cmd.as_std(), ctx.source_dir, true);
     }
-    info!(package = %test_args.package, executable = %test.executable.display(), "launching test executable");
+    info!(package = %test.args.package, executable = %test.executable.display(), "launching test executable");
 
     let exit_status = ctx
         .rt
@@ -630,7 +654,12 @@ fn run_one_test_executable(
 
     handle_finished_coverage(ctx.target_dir, cov_cap)?;
 
-    parse_test_results(meta, test_cap, &ctx.build_meta.resolve_output.pkg_dirs).with_context(|| {
+    parse_test_results(
+        test.meta.clone(),
+        test_cap,
+        &ctx.build_meta.resolve_output.pkg_dirs,
+    )
+    .with_context(|| {
         format!(
             "Failed to parse test results for {fqn} {:?}",
             test.target.kind


### PR DESCRIPTION
## Summary
- extract collection of concrete test executable invocations from the test runner
- reuse the collected invocation list in normal sequential and parallel test execution
- keep build-only artifact collection on the same invocation path

## Tests
- cargo fmt --all
- cargo test -p moon js_test_build_only --no-fail-fast
- cargo test -p moon test_async_test_inline --no-fail-fast
- cargo clippy -p moon --all-targets -- -D warnings