### PR TITLE
refactor: settle resolved build planning API

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -259,7 +259,7 @@ pub(crate) fn plan_build_rr_from_resolved(
         planning_context.target_backend(),
         output,
     )?;
-    rr_build::plan_prepared_build_from_intent(
+    rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
@@ -301,7 +301,7 @@ fn plan_build_rr_from_resolved_with_scope(
         &scoped_packages,
         planning_context.target_backend(),
     )?;
-    rr_build::plan_prepared_build_from_intent(
+    rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
@@ -338,7 +338,7 @@ fn plan_build_rr_from_selection(
         &resolve_output,
     )?;
     debug_assert_eq!(planning_context.target_backend(), target_backend);
-    rr_build::plan_prepared_build_from_intent(
+    rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -216,7 +216,7 @@ pub(crate) fn plan_bundle_rr_from_resolved(
         &resolve_output,
     )?;
     let intent = bundle_user_intent(&resolve_output);
-    rr_build::plan_prepared_build_from_intent(
+    rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -341,7 +341,7 @@ fn run_check_for_single_file_rr(
         &resolved,
     )?;
     let intent = get_user_intents_single_file(&resolved, planning_context.target_backend())?;
-    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
+    let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
@@ -661,7 +661,7 @@ pub(crate) fn plan_check_rr_from_resolved(
             output,
         )?
     };
-    rr_build::plan_prepared_build_from_intent(
+    rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
@@ -698,7 +698,7 @@ fn plan_check_rr_from_selection(
         &resolve_output,
     )?;
     debug_assert_eq!(planning_context.target_backend(), target_backend);
-    rr_build::plan_prepared_build_from_intent(
+    rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -133,7 +133,7 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
     )?;
     let module_id = selected_doc_module_id(&resolve_output, &doc_source_dir)?;
     let intent = vec![UserIntent::Doc(module_id)].into();
-    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
+    let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         &target_dir,

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -373,7 +373,7 @@ fn run_info_rr_internal(
     )?;
     let intent =
         calc_user_intent_for_info(&ctx, &resolve_output, planning_context.target_backend())?;
-    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
+    let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -604,7 +604,7 @@ fn build_and_install_packages(
             &resolve_output,
         )?;
         let intent = vec![UserIntent::Build(pkg.pkg_id)].into();
-        let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
+        let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
             preconfig,
             &cli.unstable_feature,
             &target_dir,

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -168,7 +168,7 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
         planning_context.target_backend(),
         prove_why3_config.as_deref(),
     )?;
-    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
+    let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         &target_dir,

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -472,7 +472,7 @@ pub(crate) fn plan_run_rr_from_resolved(
         value_tracing,
         planning_context.target_backend(),
     )?;
-    rr_build::plan_prepared_build_from_intent(
+    rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
@@ -606,7 +606,7 @@ fn build_single_file_executable(
         Default::default()
     };
     let intent = (vec![UserIntent::Run(package)], directive).into();
-    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
+    let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         &target_dir,

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -441,7 +441,7 @@ fn run_test_in_single_file_rr(
     };
     let directive = rr_build::build_patch_directive_for_package(pkg, false, trace_pkg, None, true)?;
     let intent = (vec![UserIntent::Test(pkg)], directive).into();
-    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
+    let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
@@ -586,7 +586,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
         planning_context.target_backend(),
         output,
     )?;
-    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
+    let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,
@@ -710,7 +710,7 @@ fn plan_test_or_bench_rr_from_resolved_scoped(
         planning_context.target_backend(),
     )?;
     let filter = resolved_intent.filter;
-    let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
+    let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         target_dir,

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -164,7 +164,7 @@ pub(crate) fn run_build_binary_dep(
             &resolve_output,
         )?;
         let intent = vec![UserIntent::Build(pkg)].into();
-        let (build_meta, build_graph) = rr_build::plan_prepared_build_from_intent(
+        let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
             preconfig,
             &cli.unstable_feature,
             &target_dir,

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -516,13 +516,12 @@ pub(crate) fn prepare_resolved_build(
     })
 }
 
-/// Plan from an already prepared resolved context and already calculated
-/// command intent.
+/// Plan a build graph from an already resolved project and command intent.
 ///
-/// At this boundary RR consumes package identities/directives and the
-/// build-model paths stored in `ResolveOutput`; it does not reinterpret raw CLI
-/// selector paths through a callback.
-pub(crate) fn plan_prepared_build_from_intent(
+/// At this boundary, command adapters have already resolved user selectors and
+/// command-specific directives into `CalcUserIntentOutput`. RR consumes those
+/// identities plus the build-model paths stored in `ResolveOutput`.
+pub(crate) fn plan_resolved_build_from_intent(
     preconfig: CompilePreConfig,
     unstable_features: &FeatureGate,
     target_dir: &Path,


### PR DESCRIPTION
## Summary

Rename the final RR planning entrypoint after the callback removal.

`plan_prepared_build_from_intent` is now `plan_resolved_build_from_intent`, and the doc comment now describes the steady-state boundary instead of the migration-era wording.

## Why

After #1691 removed the callback API, this function is no longer a temporary prepared-context migration helper. It is the command-to-RR planning boundary: command adapters have resolved selectors and produced `CalcUserIntentOutput`, while RR consumes that intent with `ResolveOutput` to build the graph.

The new name makes that final shape explicit.

## Scope

Mechanical rename plus the RR API comment. No behavior changes, no snapshots.

## Validation

- `cargo check -p moon`
- `cargo xtask ci`