### PR TITLE
feat(moon.mod): allow metadata, supported_targets and preferred_target in top-level

### DIFF
--- a/crates/moon/tests/test_cases/fmt_moon_mod/mod.rs
+++ b/crates/moon/tests/test_cases/fmt_moon_mod/mod.rs
@@ -36,6 +36,32 @@ fn test_check_existing_moon_mod_dry_run() {
 }
 
 #[test]
+fn test_check_existing_moon_mod_supports_toplevel_config() {
+    let dir = TestDir::new("fmt_moon_mod_existing.in");
+    std::fs::write(
+        dir.join("moon.mod"),
+        r#"name = "test/check_moon_mod"
+
+version = "0.1.0"
+
+readme = "README.md"
+repository = "https://example.com/check_moon_mod"
+license = "Apache-2.0"
+keywords = ["moonbit", "dsl"]
+description = "Module metadata"
+preferred_target = "js"
+supported_targets = "js"
+"#,
+    )
+    .unwrap();
+
+    let output = get_stdout(&dir, ["check", "--dry-run", "--sort-input"]);
+
+    assert!(output.contains("moonc check ./main/main.mbt"), "{output}");
+    assert!(output.contains("./_build/js/debug/check/main"), "{output}");
+}
+
+#[test]
 fn test_fmt_existing_moon_mod_formats_in_place() {
     let dir = TestDir::new("fmt_moon_mod_existing.in");
 

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -336,7 +336,14 @@ pub fn read_module_from_dsl(path: &Path) -> anyhow::Result<MoonMod> {
         ("name", false),
         ("version", false),
         ("rule", true),
+        // metadata for mooncakes.io
+        ("readme", false),
+        ("repository", false),
+        ("license", false),
+        ("keywords", false),
+        ("description", false),
         ("supported_targets", false),
+        ("preferred_target", false),
     ]);
     let mut map = serde_json_lenient::Map::new();
     for (key, value) in dsl.iter() {
@@ -360,6 +367,9 @@ pub fn read_module_from_dsl(path: &Path) -> anyhow::Result<MoonMod> {
 
     if let serde_json_lenient::Value::Object(options) = map.remove("options").unwrap_or_default() {
         for (key, value) in options {
+            if map.contains_key(&key) {
+                bail!("Duplicate key '{}' found in moon.mod.", key);
+            }
             map.insert(key, value);
         }
     }
@@ -393,6 +403,11 @@ pub fn read_module_from_dsl(path: &Path) -> anyhow::Result<MoonMod> {
     } else {
         None
     };
+
+    if let Some(preferred_target) = map.remove("preferred_target") {
+        map.insert(String::from("preferred-target"), preferred_target);
+    }
+
     let supported_targets = map.remove("supported_targets");
     let legacy_supported_targets = map.remove("supported-targets");
     match (supported_targets, legacy_supported_targets) {

--- a/crates/moonutil/tests/expect_moon_mod.rs
+++ b/crates/moonutil/tests/expect_moon_mod.rs
@@ -19,7 +19,7 @@
 use std::path::PathBuf;
 
 use moonutil::common::{
-    read_module_desc_file_in_dir, read_module_from_dsl, write_module_dsl_to_file,
+    TargetBackend, read_module_desc_file_in_dir, read_module_from_dsl, write_module_dsl_to_file,
 };
 use moonutil::module::{MoonModJSON, convert_module_to_mod_json};
 use moonutil::package::SupportedTargetsConfig;
@@ -154,6 +154,52 @@ supported_targets = "js"
         Some(SupportedTargetsConfig::Expr(expr)) => assert_eq!(expr, "js"),
         other => panic!("unexpected supported_targets: {other:?}"),
     }
+}
+
+#[test]
+fn read_module_desc_supports_new_toplevel_fields_from_fixture() {
+    let module = read_module_desc_file_in_dir(&fixture_dir("module_dsl_toplevel")).unwrap();
+
+    assert_eq!(module.readme.as_deref(), Some("README.md"));
+    assert_eq!(
+        module.repository.as_deref(),
+        Some("https://example.com/toplevel")
+    );
+    assert_eq!(module.license.as_deref(), Some("Apache-2.0"));
+    assert_eq!(
+        module.keywords.as_deref(),
+        Some(["moonbit".to_string(), "dsl".to_string()].as_slice())
+    );
+    assert_eq!(module.description.as_deref(), Some("Module metadata"));
+    assert_eq!(module.preferred_target, Some(TargetBackend::Js));
+    match module.supported_targets {
+        Some(SupportedTargetsConfig::Expr(expr)) => assert_eq!(expr, "js"),
+        other => panic!("unexpected supported_targets: {other:?}"),
+    }
+}
+
+#[test]
+fn read_module_from_dsl_rejects_duplicate_toplevel_and_options_fields() {
+    let dir = temp_dir("duplicate-toplevel-options-module-read");
+    let path = dir.join("moon.mod");
+    std::fs::write(
+        &path,
+        r#"name = "example/mod"
+readme = "README.md"
+
+options(
+  readme: "README.old.md",
+)
+"#,
+    )
+    .unwrap();
+
+    let err = read_module_from_dsl(&path).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Duplicate key 'readme' found in moon.mod."),
+        "{err:?}"
+    );
 }
 
 #[test]

--- a/crates/moonutil/tests/fixtures/module_dsl_toplevel/moon.mod
+++ b/crates/moonutil/tests/fixtures/module_dsl_toplevel/moon.mod
@@ -1,0 +1,11 @@
+name = "example/toplevel"
+
+version = "0.1.0"
+
+readme = "README.md"
+repository = "https://example.com/toplevel"
+license = "Apache-2.0"
+keywords = ["moonbit", "dsl"]
+description = "Module metadata"
+preferred_target = "js"
+supported_targets = "js"


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind: feature

 ## Summary

  - Align `moon.mod` DSL parsing with the updated module config handling.
  - Support new top-level module metadata fields: `readme`, `repository`, `license`, `keywords`, and
  `description`.
  - Support `preferred_target = ...` at the top level by normalizing it to the existing internal
  `preferred-target` config.
  - Keep legacy `options(...)`-based configuration compatible.
  - Add fixture and command-level coverage for top-level `moon.mod` fields, including `preferred_target`
  affecting the build target.
  - **Requires a synchronized `moonc` change so `moon.mod` parsing, diagnostics, and normalization stay
  consistent between the compiler/toolchain side and `moon`.**

## Metadata

- [X] Tests added/updated for bug fixes or new features
- [X] Compatible with Windows/Linux/macOS
