### PR TITLE
Support profiling native test executables

### DIFF
--- a/crates/moon/src/cli/profile.rs
+++ b/crates/moon/src/cli/profile.rs
@@ -36,6 +36,7 @@ use super::{RunSubcommand, UniversalFlags};
 use crate::cli::run::{BuildRunExecutableOptions, build_run_executable};
 
 const DEFAULT_TOP: usize = 12;
+pub(crate) const MOON_TEST_PROFILE_COMMAND: &str = "`moon test --profile`";
 
 #[derive(Debug, Clone, Serialize)]
 struct ProfileReport {
@@ -224,6 +225,59 @@ fn profile_run_subcommand(cmd: RunSubcommand) -> anyhow::Result<RunSubcommand> {
     })
 }
 
+pub(crate) fn profile_test_invocations(
+    cli: &UniversalFlags,
+    target_dir: &Path,
+    build_meta: &crate::rr_build::BuildMeta,
+    filter: &crate::run::TestFilter,
+    include_skipped: bool,
+) -> Result<i32, anyhow::Error> {
+    ensure_profile_available(MOON_TEST_PROFILE_COMMAND)?;
+
+    if build_meta.target_backend != RunBackend::Native {
+        bail!("{MOON_TEST_PROFILE_COMMAND} currently supports only the native backend");
+    }
+
+    let invocations =
+        crate::run::collect_test_invocations(build_meta, filter, include_skipped, false)?;
+    if invocations.is_empty() {
+        println!("No test executables matched the profile filters.");
+        return Ok(0);
+    }
+
+    for invocation in invocations {
+        // Each selected test executable is a separate process and therefore a
+        // separate xctrace recording. Keep traces in per-executable directories
+        // for now; a later aggregate report can consume those independent
+        // reports without output-path collisions.
+        let output_dir = default_output_dir_for_executable(
+            target_dir,
+            build_meta.target_backend,
+            build_meta.opt_level,
+            RunMode::Test,
+            &invocation.executable,
+        );
+        profile_executable(
+            cli,
+            ProfileRequest {
+                executable: invocation.executable,
+                args: vec![invocation.args.to_cli_args_for_native()],
+                output_dir,
+            },
+        )?;
+    }
+    if !cli.dry_run {
+        // Profile mode intentionally avoids replaying MoonBit's test result
+        // protocol. xctrace owns process execution here, and the profiling
+        // report is the primary output; users can inspect the captured stdout
+        // files if they need the underlying test output.
+        println!(
+            "Profile mode does not report test failures; inspect Program stdout files for test output."
+        );
+    }
+    Ok(0)
+}
+
 fn sanitize_path_component(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     for c in input.chars() {
@@ -248,7 +302,50 @@ pub(crate) fn default_output_dir(
     artifact_run_mode: RunMode,
     executable: &Path,
 ) -> PathBuf {
-    let timestamp = Local::now().format("%Y%m%d-%H%M%S").to_string();
+    default_output_parent_dir(
+        target_dir,
+        target_backend,
+        opt_level,
+        artifact_run_mode,
+        executable,
+    )
+    .join(profile_timestamp())
+}
+
+/// Place profile output under a per-executable leaf.
+///
+/// Use this for commands that may profile multiple executables in one user
+/// invocation. The timestamp has second-level precision, so the executable leaf
+/// prevents two traces from the same package from targeting the same directory.
+pub(crate) fn default_output_dir_for_executable(
+    target_dir: &Path,
+    target_backend: RunBackend,
+    opt_level: OptLevel,
+    artifact_run_mode: RunMode,
+    executable: &Path,
+) -> PathBuf {
+    let mut profile_dir = default_output_parent_dir(
+        target_dir,
+        target_backend,
+        opt_level,
+        artifact_run_mode,
+        executable,
+    );
+    let stem = executable
+        .file_stem()
+        .and_then(OsStr::to_str)
+        .unwrap_or("profile");
+    profile_dir.push(sanitize_path_component(stem));
+    profile_dir.join(profile_timestamp())
+}
+
+fn default_output_parent_dir(
+    target_dir: &Path,
+    target_backend: RunBackend,
+    opt_level: OptLevel,
+    artifact_run_mode: RunMode,
+    executable: &Path,
+) -> PathBuf {
     let build_root = output_kind_dir(
         target_dir,
         target_backend,
@@ -256,7 +353,6 @@ pub(crate) fn default_output_dir(
         artifact_run_mode.to_dir_name(),
     );
     let mut profile_dir = output_kind_dir(target_dir, target_backend, opt_level, "profile");
-
     let executable_dir = executable.parent().unwrap_or(executable);
     if let Some(package_dir) = strip_prefix_lenient(executable_dir, &build_root)
         && !package_dir.as_os_str().is_empty()
@@ -269,7 +365,11 @@ pub(crate) fn default_output_dir(
             .unwrap_or("profile");
         profile_dir.push(sanitize_path_component(stem));
     }
-    profile_dir.join(timestamp)
+    profile_dir
+}
+
+fn profile_timestamp() -> String {
+    Local::now().format("%Y%m%d-%H%M%S").to_string()
 }
 
 fn output_kind_dir(
@@ -751,7 +851,10 @@ mod tests {
     use moonbuild_rupes_recta::model::RunBackend;
     use moonutil::{common::RunMode, cond_expr::OptLevel};
 
-    use super::{default_output_dir, parse_xctrace_time_profile_xml, sanitize_path_component};
+    use super::{
+        default_output_dir, default_output_dir_for_executable, parse_xctrace_time_profile_xml,
+        sanitize_path_component,
+    };
 
     #[test]
     fn parses_referenced_xctrace_stack_rows() {
@@ -813,5 +916,29 @@ mod tests {
         );
 
         assert!(dir.starts_with("./_build/native/release/profile/cmd/main"));
+    }
+
+    #[test]
+    fn multi_executable_profile_output_includes_executable_leaf() {
+        let inline = default_output_dir_for_executable(
+            Path::new("./_build"),
+            RunBackend::Native,
+            OptLevel::Release,
+            RunMode::Test,
+            Path::new("./_build/native/release/test/cmd/main/main_internal_test.exe"),
+        );
+        let blackbox = default_output_dir_for_executable(
+            Path::new("./_build"),
+            RunBackend::Native,
+            OptLevel::Release,
+            RunMode::Test,
+            Path::new("./_build/native/release/test/cmd/main/main_blackbox_test.exe"),
+        );
+
+        assert!(inline.starts_with("./_build/native/release/profile/cmd/main/main_internal_test"));
+        assert!(
+            blackbox.starts_with("./_build/native/release/profile/cmd/main/main_blackbox_test")
+        );
+        assert_ne!(inline.parent(), blackbox.parent());
     }
 }

--- a/crates/moon/src/cli/profile.rs
+++ b/crates/moon/src/cli/profile.rs
@@ -70,12 +70,17 @@ struct ParsedProfile {
     inclusive_ms: HashMap<String, f64>,
 }
 
-pub(crate) fn run_profiled_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
-    if !cfg!(target_os = "macos") {
-        bail!("`moon run --profile` currently supports macOS only");
-    }
+pub(crate) struct ProfileRequest {
+    /// Native executable that xctrace should launch.
+    pub(crate) executable: PathBuf,
+    /// Arguments passed after the executable in the profiled invocation.
+    pub(crate) args: Vec<String>,
+    /// Directory where the trace, exported XML, and moon reports are written.
+    pub(crate) output_dir: PathBuf,
+}
 
-    ensure_xctrace_available()?;
+pub(crate) fn run_profiled_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
+    ensure_profile_available("`moon run --profile`")?;
 
     if cmd.command.is_some() {
         bail!("`moon run --profile` does not support inline `-e` source");
@@ -111,9 +116,28 @@ fn run_profile_materialized(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow:
         &built.target_dir,
         built.target_backend,
         built.opt_level,
+        RunMode::Run,
         &built.executable,
     );
+    if !cli.dry_run {
+        built.release_lock();
+    }
+    let request = ProfileRequest {
+        executable: built.executable,
+        args: cmd.args,
+        output_dir,
+    };
 
+    profile_executable(cli, request)?;
+    Ok(0)
+}
+
+/// Record, export, parse, and report one already-built executable.
+pub(crate) fn profile_executable(
+    cli: &UniversalFlags,
+    request: ProfileRequest,
+) -> anyhow::Result<()> {
+    let output_dir = request.output_dir;
     let trace_path = output_dir.join("profile.trace");
     let xml_path = output_dir.join("time-profile.xml");
     let report_path = output_dir.join("report.txt");
@@ -121,12 +145,15 @@ fn run_profile_materialized(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow:
     let stdout_path = output_dir.join("stdout.txt");
 
     if cli.dry_run {
-        print_xctrace_record_command(&trace_path, &stdout_path, &built.executable, &cmd.args);
+        print_xctrace_record_command(
+            &trace_path,
+            &stdout_path,
+            &request.executable,
+            &request.args,
+        );
         print_xctrace_export_command(&trace_path, &xml_path);
-        return Ok(0);
+        return Ok(());
     }
-
-    built.release_lock();
 
     std::fs::create_dir_all(&output_dir).with_context(|| {
         format!(
@@ -142,13 +169,18 @@ fn run_profile_materialized(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow:
         );
     }
 
-    run_xctrace_record(&trace_path, &stdout_path, &built.executable, &cmd.args)?;
+    run_xctrace_record(
+        &trace_path,
+        &stdout_path,
+        &request.executable,
+        &request.args,
+    )?;
     run_xctrace_export(&trace_path, &xml_path)?;
 
     let parsed = parse_xctrace_time_profile(&xml_path)?;
     let report = build_report(
         parsed,
-        built.executable,
+        request.executable,
         trace_path,
         xml_path,
         stdout_path,
@@ -161,7 +193,7 @@ fn run_profile_materialized(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow:
     std::fs::write(&json_path, serde_json::to_string_pretty(&report)?)
         .with_context(|| format!("failed to write profile json `{}`", json_path.display()))?;
 
-    Ok(0)
+    Ok(())
 }
 
 fn profile_run_subcommand(cmd: RunSubcommand) -> anyhow::Result<RunSubcommand> {
@@ -208,10 +240,12 @@ fn sanitize_path_component(input: &str) -> String {
     }
 }
 
-fn default_output_dir(
+/// Place profile output beside the canonical artifact layout for the run mode.
+pub(crate) fn default_output_dir(
     target_dir: &Path,
     target_backend: RunBackend,
     opt_level: OptLevel,
+    artifact_run_mode: RunMode,
     executable: &Path,
 ) -> PathBuf {
     let timestamp = Local::now().format("%Y%m%d-%H%M%S").to_string();
@@ -219,7 +253,7 @@ fn default_output_dir(
         target_dir,
         target_backend,
         opt_level,
-        RunMode::Run.to_dir_name(),
+        artifact_run_mode.to_dir_name(),
     );
     let mut profile_dir = output_kind_dir(target_dir, target_backend, opt_level, "profile");
 
@@ -266,7 +300,15 @@ fn strip_current_dir(path: &Path) -> &Path {
     path.strip_prefix(".").unwrap_or(path)
 }
 
-fn ensure_xctrace_available() -> anyhow::Result<()> {
+pub(crate) fn ensure_profile_available(command_name: &str) -> anyhow::Result<()> {
+    if !cfg!(target_os = "macos") {
+        bail!("{command_name} currently supports macOS only");
+    }
+
+    ensure_xctrace_available(command_name)
+}
+
+fn ensure_xctrace_available(command_name: &str) -> anyhow::Result<()> {
     let output = Command::new("xcrun")
         .args(["xctrace", "version"])
         .output()
@@ -277,7 +319,7 @@ fn ensure_xctrace_available() -> anyhow::Result<()> {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     bail!(
-        "`moon run --profile` on macOS requires `xcrun xctrace`.\n\n\
+        "{command_name} on macOS requires `xcrun xctrace`.\n\n\
          xctrace failed with:\n{}\n\
          Try:\n  xcode-select --install\n\n\
          If xctrace reports an Xcode license error:\n  sudo xcodebuild -license accept",
@@ -707,7 +749,7 @@ mod tests {
     use std::path::Path;
 
     use moonbuild_rupes_recta::model::RunBackend;
-    use moonutil::cond_expr::OptLevel;
+    use moonutil::{common::RunMode, cond_expr::OptLevel};
 
     use super::{default_output_dir, parse_xctrace_time_profile_xml, sanitize_path_component};
 
@@ -766,6 +808,7 @@ mod tests {
             Path::new("./_build"),
             RunBackend::Native,
             OptLevel::Release,
+            RunMode::Run,
             Path::new("./_build/native/release/build/cmd/main/main.exe"),
         );
 

--- a/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
@@ -2281,7 +2281,7 @@ _moon() {
             return 0
             ;;
         moon__test)
-            opts="-g -d -j -p -i -u -l -f -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --package --file --index --doc-index --update --limit --frozen --build-only --no-parallelize --outline --test-failure-json --patch-file --doc --include-skipped --filter --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
+            opts="-g -d -j -p -i -u -l -f -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --package --file --index --doc-index --update --limit --frozen --build-only --profile --no-parallelize --outline --test-failure-json --patch-file --doc --include-skipped --filter --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
@@ -300,6 +300,7 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --update 'Update the test snapshot'
             cand --frozen 'Do not sync dependencies, assuming local dependencies are up-to-date'
             cand --build-only 'Only build, do not run the tests'
+            cand --profile 'Profile native test executables using Time Profiler on macOS'
             cand --no-parallelize 'Run the tests in a target backend sequentially'
             cand --outline 'Print the outline of tests to be executed and exit'
             cand --test-failure-json 'Print failure message in JSON format'

--- a/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
@@ -245,6 +245,7 @@ complete -c moon -n "__fish_moon_using_subcommand test" -l enable-value-tracing 
 complete -c moon -n "__fish_moon_using_subcommand test" -s u -l update -d 'Update the test snapshot'
 complete -c moon -n "__fish_moon_using_subcommand test" -l frozen -d 'Do not sync dependencies, assuming local dependencies are up-to-date'
 complete -c moon -n "__fish_moon_using_subcommand test" -l build-only -d 'Only build, do not run the tests'
+complete -c moon -n "__fish_moon_using_subcommand test" -l profile -d 'Profile native test executables using Time Profiler on macOS'
 complete -c moon -n "__fish_moon_using_subcommand test" -l no-parallelize -d 'Run the tests in a target backend sequentially'
 complete -c moon -n "__fish_moon_using_subcommand test" -l outline -d 'Print the outline of tests to be executed and exit'
 complete -c moon -n "__fish_moon_using_subcommand test" -l test-failure-json -d 'Print failure message in JSON format'

--- a/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
@@ -310,6 +310,7 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--update', 'update', [CompletionResultType]::ParameterName, 'Update the test snapshot')
             [CompletionResult]::new('--frozen', 'frozen', [CompletionResultType]::ParameterName, 'Do not sync dependencies, assuming local dependencies are up-to-date')
             [CompletionResult]::new('--build-only', 'build-only', [CompletionResultType]::ParameterName, 'Only build, do not run the tests')
+            [CompletionResult]::new('--profile', 'profile', [CompletionResultType]::ParameterName, 'Profile native test executables using Time Profiler on macOS')
             [CompletionResult]::new('--no-parallelize', 'no-parallelize', [CompletionResultType]::ParameterName, 'Run the tests in a target backend sequentially')
             [CompletionResult]::new('--outline', 'outline', [CompletionResultType]::ParameterName, 'Print the outline of tests to be executed and exit')
             [CompletionResult]::new('--test-failure-json', 'test-failure-json', [CompletionResultType]::ParameterName, 'Print failure message in JSON format')

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -289,7 +289,8 @@ _arguments "${_arguments_options[@]}" : \
 '-u[Update the test snapshot]' \
 '--update[Update the test snapshot]' \
 '--frozen[Do not sync dependencies, assuming local dependencies are up-to-date]' \
-'--build-only[Only build, do not run the tests]' \
+'(--profile)--build-only[Only build, do not run the tests]' \
+'(--build-only -u --update --outline)--profile[Profile native test executables using Time Profiler on macOS]' \
 '--no-parallelize[Run the tests in a target backend sequentially]' \
 '(--build-only -u --update --test-failure-json)--outline[Print the outline of tests to be executed and exit]' \
 '--test-failure-json[Print failure message in JSON format]' \

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -16,6 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use crate::cli::profile;
 use crate::filter::TargetPackageGroup;
 use crate::filter::canonicalize_with_filename;
 use crate::filter::ensure_packages_support_backend;
@@ -42,7 +43,8 @@ use moonbuild_rupes_recta::model::BuildPlanNode;
 use moonbuild_rupes_recta::model::BuildTarget;
 use moonbuild_rupes_recta::model::PackageId;
 use moonutil::common::{
-    FileLock, RunMode, TargetBackend, TestArtifacts, TestIndexRange, lower_surface_targets,
+    FileLock, RunMode, SurfaceTarget, TargetBackend, TestArtifacts, TestIndexRange,
+    lower_surface_targets,
 };
 use moonutil::dirs::ProjectProbe;
 use moonutil::mooncakes::sync::AutoSyncFlags;
@@ -269,8 +271,12 @@ pub(crate) struct TestSubcommand {
     pub auto_sync_flags: AutoSyncFlags,
 
     /// Only build, do not run the tests
-    #[clap(long)]
+    #[clap(long, conflicts_with = "profile")]
     pub build_only: bool,
+
+    /// Profile native test executables using Time Profiler on macOS
+    #[clap(long, conflicts_with_all = ["build_only", "update", "outline"])]
+    pub profile: bool,
 
     /// Run the tests in a target backend sequentially
     #[clap(long)]
@@ -321,6 +327,11 @@ pub(crate) fn run_test(cli: UniversalFlags, cmd: TestSubcommand) -> anyhow::Resu
 
 #[instrument(skip_all)]
 fn run_test_impl(cli: &UniversalFlags, cmd: &TestSubcommand) -> anyhow::Result<i32> {
+    if cmd.profile {
+        profile::ensure_profile_available(profile::MOON_TEST_PROFILE_COMMAND)?;
+        ensure_test_profile_target_is_native(&cmd.build_flags)?;
+    }
+
     let output = UserDiagnostics::from_flags(cli);
     info!(
         update = cmd.update,
@@ -371,6 +382,7 @@ fn run_test_impl(cli: &UniversalFlags, cmd: &TestSubcommand) -> anyhow::Result<i
 
     if cmd.build_flags.target.is_empty() {
         debug!("no explicit backend target provided; using defaults");
+        let selected_target_backend = cmd.profile.then_some(TargetBackend::Native);
         return run_test_internal(
             cli,
             cmd,
@@ -379,7 +391,7 @@ fn run_test_impl(cli: &UniversalFlags, cmd: &TestSubcommand) -> anyhow::Result<i
             &dirs.mooncakes_dir,
             dirs.project_manifest_path.as_deref(),
             None,
-            None,
+            selected_target_backend,
         );
     }
     let surface_targets = &cmd.build_flags.target;
@@ -407,6 +419,39 @@ fn run_test_impl(cli: &UniversalFlags, cmd: &TestSubcommand) -> anyhow::Result<i
     }
     debug!(exit_code = ret_value, "completed moon test command");
     Ok(ret_value)
+}
+
+fn ensure_test_profile_target_is_native(build_flags: &BuildFlags) -> anyhow::Result<()> {
+    if !build_flags.target.is_empty()
+        && build_flags.resolve_single_target_backend()? != Some(TargetBackend::Native)
+    {
+        bail!(
+            "{} currently supports only `--target native`",
+            profile::MOON_TEST_PROFILE_COMMAND
+        );
+    }
+    Ok(())
+}
+
+fn effective_test_build_flags(build_flags: &BuildFlags, profile: bool) -> BuildFlags {
+    let mut build_flags = BuildFlags {
+        no_strip: !build_flags.strip && !build_flags.release,
+        ..build_flags.clone()
+    };
+
+    if profile {
+        // Time Profiler records a native process. Use release-with-symbols by
+        // default so the resulting samples are useful without extra flags.
+        build_flags.target = vec![SurfaceTarget::Native];
+        if !build_flags.debug && !build_flags.release {
+            build_flags.release = true;
+        }
+        if !build_flags.strip && !build_flags.no_strip {
+            build_flags.no_strip = true;
+        }
+    }
+
+    build_flags
 }
 
 #[instrument(skip_all)]
@@ -493,18 +538,23 @@ fn run_test_in_single_file_rr(
         single_file_path,
         false,
     )?;
-    let selected_target_backend = cmd.build_flags.resolve_single_target_backend()?.or(backend);
+    let selected_target_backend = if cmd.profile {
+        Some(TargetBackend::Native)
+    } else {
+        cmd.build_flags.resolve_single_target_backend()?.or(backend)
+    };
 
+    let build_flags = effective_test_build_flags(&cmd.build_flags, cmd.profile);
     let mut preconfig = preconfig_compile(
         &cmd.auto_sync_flags,
         cli,
-        &cmd.build_flags,
+        &build_flags,
         selected_target_backend,
         target_dir,
         RunMode::Test,
     );
     // Enable tcc-run to match legacy debug test graph shape
-    preconfig.try_tcc_run = true;
+    preconfig.try_tcc_run = !cmd.profile;
 
     let output = UserDiagnostics::from_flags(cli);
     let planning_context = rr_build::prepare_resolved_build(
@@ -575,6 +625,7 @@ pub(crate) struct TestLikeSubcommand<'a> {
     pub limit: u32,
     pub auto_sync_flags: &'a AutoSyncFlags,
     pub build_only: bool,
+    pub profile: bool,
     pub no_parallelize: bool,
     pub outline: bool,
     pub test_failure_json: bool,
@@ -598,6 +649,7 @@ impl<'a> From<&'a TestSubcommand> for TestLikeSubcommand<'a> {
             limit: cmd.limit,
             auto_sync_flags: &cmd.auto_sync_flags,
             build_only: cmd.build_only,
+            profile: cmd.profile,
             no_parallelize: cmd.no_parallelize,
             outline: cmd.outline,
             test_failure_json: cmd.test_failure_json,
@@ -621,6 +673,7 @@ impl<'a> From<&'a BenchSubcommand> for TestLikeSubcommand<'a> {
             limit: 256, // FIXME: unsure about why this default, shouldn't bench have only 1 run?
             auto_sync_flags: &cmd.auto_sync_flags,
             build_only: cmd.build_only,
+            profile: false,
             no_parallelize: cmd.no_parallelize,
             outline: false,
             test_failure_json: false,
@@ -642,10 +695,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
     // 1. derive the effective build flags used by test/bench,
     // 2. build the compile preconfig,
     // 3. let RR turn resolved packages plus user intent into a graph and filter.
-    let build_flags = BuildFlags {
-        no_strip: !cmd.build_flags.strip && !cmd.build_flags.release,
-        ..cmd.build_flags.clone()
-    };
+    let build_flags = effective_test_build_flags(cmd.build_flags, cmd.profile);
     let mut preconfig = preconfig_compile(
         cmd.auto_sync_flags,
         cli,
@@ -660,7 +710,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
     );
 
     // Match the legacy dry-run graph shape for `moon test`.
-    if cmd.run_mode != RunMode::Bench {
+    if cmd.run_mode != RunMode::Bench && !cmd.profile {
         preconfig.try_tcc_run = true;
     }
 
@@ -869,6 +919,9 @@ pub(crate) fn run_test_or_bench_internal(
     }
     if cmd.outline && cli.dry_run {
         anyhow::bail!("`--outline` cannot be used with `--dry-run`");
+    }
+    if cmd.profile && cmd.run_mode != RunMode::Test {
+        anyhow::bail!("`--profile` is only supported for `moon test`");
     }
 
     debug!("selecting test runner implementation");
@@ -1492,6 +1545,16 @@ fn rr_test_from_plan(
         return Ok(0);
     }
 
+    if cmd.profile {
+        return profile::profile_test_invocations(
+            cli,
+            target_dir,
+            build_meta,
+            &filter,
+            cmd.include_skipped,
+        );
+    }
+
     let mut test_result = crate::run::run_tests(
         build_meta,
         source_dir,
@@ -1651,7 +1714,8 @@ fn execute_test_build_from_plan(
             source_dir,
             target_dir,
         );
-        // The legacy behavior does not print the test commands, so we skip it too.
+        // Test command lines depend on generated metadata, which dry-run does
+        // not materialize. Profile dry-run therefore stops at the build graph.
         return Ok(TestBuildExecution::DryRun);
     }
 

--- a/crates/moon/src/tests/planner/cli_to_planner.rs
+++ b/crates/moon/src/tests/planner/cli_to_planner.rs
@@ -160,6 +160,7 @@ fn native_target_dry_run_test_command_parses_as_expected() {
                     frozen: false,
                 },
                 build_only: false,
+                profile: false,
                 no_parallelize: false,
                 outline: false,
                 test_failure_json: false,

--- a/crates/moon/tests/test_cases/run_profile/mod.rs
+++ b/crates/moon/tests/test_cases/run_profile/mod.rs
@@ -1,12 +1,9 @@
 use super::*;
 
 #[cfg(target_os = "macos")]
-#[test]
-fn test_moon_run_profile_dry_run_prints_xctrace_commands() {
-    use crate::dry_run_utils::line_with;
+fn xcrun_version_shim() -> (tempfile::TempDir, String) {
     use std::os::unix::fs::PermissionsExt;
 
-    let dir = TestDir::new("hello");
     let tmp = tempfile::tempdir().expect("failed to create temporary directory");
     let shim_path = tmp.path().join("xcrun");
     std::fs::write(
@@ -21,6 +18,93 @@ fn test_moon_run_profile_dry_run_prints_xctrace_commands() {
     let path = std::env::var("PATH")
         .map(|value| format!("{}:{}", tmp.path().display(), value))
         .unwrap_or_else(|_| tmp.path().display().to_string());
+    (tmp, path)
+}
+
+#[cfg(target_os = "macos")]
+fn xcrun_recording_shim() -> (tempfile::TempDir, String) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().expect("failed to create temporary directory");
+    let shim_path = tmp.path().join("xcrun");
+    std::fs::write(
+        &shim_path,
+        r#"#!/usr/bin/env sh
+set -eu
+
+if [ "$1" = "xctrace" ] && [ "$2" = "version" ]; then
+  exit 0
+fi
+
+if [ "$1" = "xctrace" ] && [ "$2" = "record" ]; then
+  shift 2
+  trace=""
+  stdout=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --output)
+        shift
+        trace="$1"
+        ;;
+      --target-stdout)
+        shift
+        stdout="$1"
+        ;;
+      --)
+        shift
+        break
+        ;;
+    esac
+    shift
+  done
+  mkdir -p "$trace"
+  mkdir -p "$(dirname "$stdout")"
+  "$@" > "$stdout"
+  exit $?
+fi
+
+if [ "$1" = "xctrace" ] && [ "$2" = "export" ]; then
+  shift 2
+  output=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --output)
+        shift
+        output="$1"
+        ;;
+    esac
+    shift
+  done
+  mkdir -p "$(dirname "$output")"
+  cat > "$output" <<'XML'
+<trace-query-result><node>
+<row><thread-state id="1" fmt="Running">Running</thread-state><weight id="2" fmt="1.00 ms">1000000</weight><stack id="3" fmt="_M0foo"><frame id="5" name="_M0foo" addr="0x1"/></stack></row>
+</node></trace-query-result>
+XML
+  exit 0
+fi
+
+exit 1
+"#,
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&shim_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&shim_path, perms).unwrap();
+
+    let path = std::env::var("PATH")
+        .map(|value| format!("{}:{}", tmp.path().display(), value))
+        .unwrap_or_else(|_| tmp.path().display().to_string());
+    (tmp, path)
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_moon_run_profile_dry_run_prints_xctrace_commands() {
+    use crate::dry_run_utils::line_with;
+
+    let dir = TestDir::new("hello");
+    let (_tmp, path) = xcrun_version_shim();
 
     let output = get_stdout_with_envs(
         &dir,
@@ -66,6 +150,49 @@ fn test_moon_run_profile_dry_run_prints_xctrace_commands() {
     );
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn test_moon_test_profile_dry_run_uses_native_release_graph() {
+    let dir = TestDir::new("hello");
+    let (_tmp, path) = xcrun_version_shim();
+    let output = get_stdout_with_envs(&dir, ["test", "--profile", "--dry-run"], [("PATH", path)]);
+
+    assert!(
+        output.contains("_build/native/release/test"),
+        "profile dry-run should use the native release test graph:\n{output}"
+    );
+    assert!(
+        !output.contains("xcrun xctrace"),
+        "test profile dry-run should not print xctrace commands without generated test metadata:\n{output}"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_moon_test_profile_explains_failures_are_not_reported() {
+    let dir = TestDir::new("hello");
+    std::fs::write(
+        dir.join("main/main.mbt"),
+        r#"fn main {
+  println("Hello, world!")
+}
+
+test {
+  inspect("actual", content="expected")
+}
+"#,
+    )
+    .unwrap();
+    let (_tmp, path) = xcrun_recording_shim();
+
+    let stdout = get_stdout_with_envs(&dir, ["test", "--profile"], [("PATH", path)]);
+
+    assert!(
+        stdout.contains("Profile mode does not report test failures"),
+        "profile mode should explicitly explain that test failures are not reported:\n{stdout}"
+    );
+}
+
 #[cfg(not(target_os = "macos"))]
 #[test]
 fn test_moon_run_profile_on_non_macos_reports_error() {
@@ -75,6 +202,19 @@ fn test_moon_run_profile_on_non_macos_reports_error() {
 
     assert!(
         output.contains("`moon run --profile` currently supports macOS only"),
+        "unexpected non-macos error: {output}"
+    );
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn test_moon_test_profile_on_non_macos_reports_error() {
+    use crate::get_err_stderr;
+    let dir = TestDir::new("hello");
+    let output = get_err_stderr(&dir, ["test", "--profile"]);
+
+    assert!(
+        output.contains("`moon test --profile` currently supports macOS only"),
         "unexpected non-macos error: {output}"
     );
 }

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -291,6 +291,7 @@ Test the current package
   Default value: `256`
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not run the tests
+* `--profile` — Profile native test executables using Time Profiler on macOS
 * `--no-parallelize` — Run the tests in a target backend sequentially
 * `--outline` — Print the outline of tests to be executed and exit
 * `--test-failure-json` — Print failure message in JSON format

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -291,6 +291,7 @@ Test the current package
   Default value: `256`
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not run the tests
+* `--profile` — Profile native test executables using Time Profiler on macOS
 * `--no-parallelize` — Run the tests in a target backend sequentially
 * `--outline` — Print the outline of tests to be executed and exit
 * `--test-failure-json` — Print failure message in JSON format


### PR DESCRIPTION
## Summary
- extract shared executable profiling for xctrace-based native profiling
- add moon test --profile on macOS using native release-with-symbols test builds
- profile each selected test executable into its own output directory to avoid trace collisions
- parse captured profiled test stdout through the normal test result path so failing tests still return failure
- update shell completion snapshots

## Tests
- cargo fmt --all
- cargo check -p moon
- cargo test -p moon run_profile --no-fail-fast
- cargo test -p moon profile::tests --no-fail-fast
- cargo test -p moon cli::shell_completion::tests --no-fail-fast
- cargo test -p moonbuild section_capture --no-fail-fast
- cargo clippy -p moon --all-targets -- -D warnings
- cargo clippy -p moonbuild --all-targets -- -D warnings