### PR TITLE
[codex] Disable stable toolchain CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,8 @@ jobs:
 
   stable-test:
     needs: [typo-check, license-header-check]
+    # New moon is only supported with the current/nightly MoonBit toolchain.
+    if: ${{ false }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Disable the `stable-test` CI job entirely.

## Motivation

New `moon` is only supported with the current/nightly MoonBit toolchain. The stable-toolchain matrix runs a large snapshot-heavy test suite against an unsupported pairing, so unrelated snapshot output differences can make CI fail without producing useful signal.

Also, it gives false signal to anyone contributing to this project, thinking that both stable and nightly ci should pass, resulting in wasted work trying to make things work on both stable / nightly toolchain.

## Validation

- `git diff --check HEAD~1..HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ok"'`