### PR TITLE
fix: delay native C toolchain resolution

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -52,7 +52,7 @@ use moonutil::{
         BLACKBOX_TEST_PATCH, DiagnosticLevel, MOONBITLANG_CORE, RunMode, TargetBackend,
         WHITEBOX_TEST_PATCH,
     },
-    compiler_flags::CC,
+    compiler_flags::{CC, NativeToolchainSelection},
     cond_expr::OptLevel as BuildProfile,
     dirs::WorkspaceEnv,
     features::FeatureGate,
@@ -315,7 +315,7 @@ impl CompilePreConfig {
         resolve_output: &ResolveOutput,
         input_nodes: &[BuildPlanNode],
         output: UserDiagnostics,
-    ) -> CompileConfig {
+    ) -> anyhow::Result<CompileConfig> {
         info!("Determining compilation configuration");
 
         let std = self.use_std && !is_core;
@@ -356,7 +356,23 @@ impl CompilePreConfig {
         };
         info!("Final run backend: {:?}", target_backend);
 
-        CompileConfig {
+        let prefer_internal_tcc = target_backend == RunBackend::NativeTccRun
+            || (target_backend == RunBackend::Native && self.opt_level == BuildProfile::Debug);
+        let native_toolchain = if prefer_internal_tcc {
+            Some(NativeToolchainSelection::internal_tcc_first())
+        } else if target_backend.is_native() {
+            Some(NativeToolchainSelection::system_first())
+        } else {
+            None
+        };
+
+        let internal_tcc = (target_backend == RunBackend::NativeTccRun).then(|| {
+            internal_tcc
+                .clone()
+                .expect("NativeTccRun should only be selected when internal tcc is available")
+        });
+
+        Ok(CompileConfig {
             target_dir: self.target_dir,
             target_backend,
             opt_level: self.opt_level,
@@ -376,11 +392,9 @@ impl CompilePreConfig {
             warning_condition: self.warning_condition,
             warn_list: self.warn_list,
             info_no_alias: self.info_no_alias,
-            default_cc: CC::default(), // TODO: determine how CC will be set
-            internal_tcc: (target_backend == RunBackend::NativeTccRun)
-                .then_some(internal_tcc)
-                .flatten(),
-        }
+            internal_tcc,
+            native_toolchain,
+        })
     }
 }
 
@@ -565,7 +579,7 @@ pub(crate) fn plan_resolved_build_from_intent(
         &resolve_output,
         &input_nodes,
         output,
-    );
+    )?;
     info!("Begin lowering to build graph");
     let compile_output = moonbuild_rupes_recta::compile(
         &cx,

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -356,11 +356,7 @@ impl CompilePreConfig {
         };
         info!("Final run backend: {:?}", target_backend);
 
-        let prefer_internal_tcc = target_backend == RunBackend::NativeTccRun
-            || (target_backend == RunBackend::Native && self.opt_level == BuildProfile::Debug);
-        let native_toolchain = if prefer_internal_tcc {
-            Some(NativeToolchainSelection::internal_tcc_first())
-        } else if target_backend.is_native() {
+        let native_toolchain = if target_backend.is_native() {
             Some(NativeToolchainSelection::system_first())
         } else {
             None

--- a/crates/moon/tests/support/util.rs
+++ b/crates/moon/tests/support/util.rs
@@ -19,7 +19,7 @@
 use std::path::{Path, PathBuf};
 
 use expect_test::Expect;
-use moonutil::{common::StringExt, compiler_flags::CC};
+use moonutil::{common::StringExt, compiler_flags};
 
 pub(crate) fn check<S: AsRef<str>>(actual: S, expect: Expect) {
     expect.assert_eq(actual.as_ref())
@@ -110,10 +110,12 @@ pub(crate) fn replace_dir(s: &str, dir: impl AsRef<std::path::Path>) -> String {
         dunce::canonicalize(moon_home).unwrap().to_str().unwrap(),
         "$MOON_HOME",
     );
-    let cc_path = CC::default().cc_path;
-    let ar_path = CC::default().ar_path;
-    let s = s.replace(&ar_path, CC::default().ar_name());
-    let s = s.replace(&cc_path, CC::default().cc_name());
+    let s = if let Ok(cc) = compiler_flags::try_default_cc(false) {
+        let s = s.replace(&cc.ar_path, cc.ar_name());
+        s.replace(&cc.cc_path, cc.cc_name())
+    } else {
+        s
+    };
     let s = s.replace(moon_bin().to_string_lossy().as_ref(), "moon");
     let s = s.replace("moon.exe", "moon");
     let s = moonutil::BINARIES

--- a/crates/moon/tests/support/util.rs
+++ b/crates/moon/tests/support/util.rs
@@ -110,7 +110,7 @@ pub(crate) fn replace_dir(s: &str, dir: impl AsRef<std::path::Path>) -> String {
         dunce::canonicalize(moon_home).unwrap().to_str().unwrap(),
         "$MOON_HOME",
     );
-    let s = if let Ok(cc) = compiler_flags::try_default_cc(false) {
+    let s = if let Ok(cc) = compiler_flags::try_default_cc() {
         let s = s.replace(&cc.ar_path, cc.ar_name());
         s.replace(&cc.cc_path, cc.cc_name())
     } else {

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/link_core.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/link_core.rs
@@ -77,6 +77,9 @@ pub(crate) struct MooncLinkCore<'a> {
 
     /// Extra options passed from user configuration.
     pub extra_link_opts: &'a [String],
+    /// Whether the selected native toolchain targets MSVC.
+    #[cfg(target_os = "windows")]
+    pub native_toolchain_is_msvc: bool,
 }
 
 /// WebAssembly-specific linking configuration
@@ -263,12 +266,9 @@ impl CmdlineAbstraction for MooncLinkCore<'_> {
         // Windows-specific LLVM target workaround
         // FIXME: We should always provide target info for LLVM
         #[cfg(target_os = "windows")]
-        if self.target_backend == TargetBackend::LLVM {
-            use moonutil::compiler_flags::CC;
-            if CC::default().is_msvc() {
-                args.push("-llvm-target".to_string());
-                args.push("x86_64-pc-windows-msvc".to_string());
-            }
+        if self.target_backend == TargetBackend::LLVM && self.native_toolchain_is_msvc {
+            args.push("-llvm-target".to_string());
+            args.push("x86_64-pc-windows-msvc".to_string());
         }
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -161,7 +161,9 @@ impl<'a> BuildPlanLowerContext<'a> {
                     .expect("Build target info should be present for GenerateTestInfo nodes");
                 self.lower_gen_test_driver(node, target, info)
             }
-            BuildPlanNode::BuildRuntimeLib => self.lower_compile_runtime(),
+            BuildPlanNode::BuildRuntimeLib => self
+                .lower_compile_runtime()
+                .map_err(LoweringError::RuntimeNativeToolchain)?,
             BuildPlanNode::BuildDocs(module_id) => self.lower_build_docs(module_id),
             BuildPlanNode::RunPrebuild(pkg, idx) => self.lower_run_prebuild(pkg, idx),
             BuildPlanNode::RunMoonLexPrebuild(pkg, idx) => self.lower_moon_lex_prebuild(pkg, idx),

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -21,8 +21,8 @@
 use moonutil::{
     common::DriverKind,
     compiler_flags::{
-        CC, CCConfigBuilder, OptLevel as CCOptLevel, OutputType as CCOutputType,
-        make_cc_command_resolved, resolve_cc,
+        CCConfigBuilder, OptLevel as CCOptLevel, OutputType as CCOutputType,
+        make_cc_command_resolved,
     },
     mooncakes::{ModuleId, ModuleSourceKind},
 };
@@ -136,7 +136,7 @@ impl<'a> super::BuildPlanLowerContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self))]
-    pub(super) fn lower_compile_runtime(&mut self) -> BuildCommand {
+    pub(super) fn lower_compile_runtime(&mut self) -> anyhow::Result<BuildCommand> {
         let artifact_path = self
             .layout
             .runtime_output_path(self.opt.target_backend, self.opt.os);
@@ -159,7 +159,13 @@ impl<'a> super::BuildPlanLowerContext<'a> {
             }
         };
 
-        let resolved_cc = resolve_cc(&CC::default(), None);
+        let resolved_cc = self
+            .opt
+            .native_toolchain
+            .ok_or_else(|| anyhow::anyhow!("native C toolchain is not selected for this build"))?
+            .resolve_default()?
+            .cc()
+            .clone();
         let use_tcc_run = matches!(self.opt.target_backend, RunBackend::NativeTccRun);
         let use_simdutf = !use_tcc_run
             && resolved_cc.can_use_simdutf()
@@ -188,10 +194,10 @@ impl<'a> super::BuildPlanLowerContext<'a> {
             &self.opt.compiler_paths,
         );
 
-        BuildCommand {
+        Ok(BuildCommand {
             extra_inputs: vec![runtime_c_path],
             commandline: cc_cmd.into(),
-        }
+        })
     }
 
     #[instrument(level = Level::DEBUG, skip(self))]

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -656,6 +656,12 @@ impl<'a> BuildPlanLowerContext<'a> {
             js_config: self.get_js_config(target, package),
             exports: package.exported_functions(self.opt.target_backend.into()),
             extra_link_opts: module.link_flags.as_deref().unwrap_or_default(),
+            #[cfg(target_os = "windows")]
+            native_toolchain_is_msvc: self
+                .opt
+                .native_toolchain
+                .and_then(|selection| selection.resolve_default().ok())
+                .is_some_and(|toolchain| toolchain.cc().is_msvc()),
         };
 
         // Ensure n2 sees stdlib core bundle changes as inputs

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -658,10 +658,9 @@ impl<'a> BuildPlanLowerContext<'a> {
             extra_link_opts: module.link_flags.as_deref().unwrap_or_default(),
             #[cfg(target_os = "windows")]
             native_toolchain_is_msvc: self
-                .opt
-                .native_toolchain
-                .and_then(|selection| selection.resolve_default().ok())
-                .is_some_and(|toolchain| toolchain.cc().is_msvc()),
+                .build_plan
+                .get_make_executable_info(&target)
+                .is_some_and(|info| info.effective_native_toolchain.cc().is_msvc()),
         };
 
         // Ensure n2 sees stdlib core bundle changes as inputs

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -24,7 +24,7 @@ use indexmap::IndexMap;
 use log::{debug, info};
 use moonutil::{
     common::RunMode,
-    compiler_flags::{CC, CompilerPaths, Toolchain},
+    compiler_flags::{CC, CompilerPaths, NativeToolchainSelection},
     cond_expr::OptLevel,
     mooncakes::ModuleSource,
 };
@@ -75,10 +75,10 @@ pub struct BuildOptions {
     pub stdlib_path: Option<PathBuf>,
     pub runtime_dot_c_path: PathBuf,
     pub compiler_paths: CompilerPaths,
-    /// Selected native toolchain for this invocation.
-    pub selected_native_toolchain: Toolchain,
     /// Resolved internal TCC toolchain when this invocation uses `tcc -run`.
     pub internal_tcc: Option<CC>,
+    /// Native toolchain selection policy, only when the backend needs one.
+    pub native_toolchain: Option<NativeToolchainSelection>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -103,6 +103,8 @@ pub enum LoweringError {
         node: BuildPlanNode,
         source: anyhow::Error,
     },
+    #[error("Failed to resolve native C toolchain for runtime")]
+    RuntimeNativeToolchain(#[source] anyhow::Error),
 }
 
 /// Structured command argv keyed by each generated output path.

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -59,6 +59,16 @@ static BUILD_VAR_REGEX: LazyLock<Regex> =
 const PROOF_ENABLED_WARN_SUPPRESSIONS: &str = "-1-2-3-29";
 
 impl<'a> BuildPlanConstructor<'a> {
+    fn effective_native_toolchain(&self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
+        if let Some(package_cc) = package_cc {
+            return Ok(Toolchain::from_package_override(package_cc.clone()));
+        }
+        self.build_env
+            .native_toolchain
+            .ok_or_else(|| anyhow::anyhow!("native C toolchain is not selected for this build"))?
+            .resolve_default()
+    }
+
     fn module_prebuild_vars(&self, module: ModuleId) -> Option<&HashMap<String, String>> {
         self.prebuild_config
             .and_then(|cfg| cfg.module_outputs.get(&module))
@@ -728,9 +738,8 @@ impl<'a> BuildPlanConstructor<'a> {
             .unwrap_or_default();
 
         let effective_native_toolchain = self
-            .build_env
-            .selected_native_toolchain
-            .with_package_override(stub_cc.as_ref());
+            .effective_native_toolchain(stub_cc.as_ref())
+            .map_err(|e| BuildPlanConstructError::FailedToSetStubCC(e, pkg.fqn.clone().into()))?;
 
         self.propagate_link_config(
             &effective_native_toolchain,
@@ -825,6 +834,11 @@ impl<'a> BuildPlanConstructor<'a> {
         }
         let c_stub_deps = c_stub_deps.into_iter().collect::<Vec<_>>();
 
+        if !self.build_env.target_backend.is_native() {
+            self.resolved_node(make_exec_node);
+            return Ok(());
+        }
+
         // Fill auxiliary flags for CC flags
         let pkg = self.input.pkg_dirs.get_package(target.package);
         let native_config = pkg.raw.link.as_ref().and_then(|x| x.native.as_ref());
@@ -864,9 +878,8 @@ impl<'a> BuildPlanConstructor<'a> {
         }
 
         let effective_native_toolchain = self
-            .build_env
-            .selected_native_toolchain
-            .with_package_override(cc.as_ref());
+            .effective_native_toolchain(cc.as_ref())
+            .map_err(|e| BuildPlanConstructError::FailedToSetCC(e, pkg.fqn.clone().into()))?;
 
         self.propagate_link_config(
             &effective_native_toolchain,
@@ -882,11 +895,8 @@ impl<'a> BuildPlanConstructor<'a> {
         };
         self.res.make_executable_info.insert(target, v);
 
-        // Native backends also needs a runtime library
-        if self.build_env.target_backend.is_native() {
-            let rt_node = self.need_node(BuildPlanNode::BuildRuntimeLib);
-            self.add_edge(make_exec_node, rt_node);
-        }
+        let rt_node = self.need_node(BuildPlanNode::BuildRuntimeLib);
+        self.add_edge(make_exec_node, rt_node);
 
         self.resolved_node(make_exec_node);
 

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -60,13 +60,10 @@ const PROOF_ENABLED_WARN_SUPPRESSIONS: &str = "-1-2-3-29";
 
 impl<'a> BuildPlanConstructor<'a> {
     fn effective_native_toolchain(&self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
-        if let Some(package_cc) = package_cc {
-            return Ok(Toolchain::from_package_override(package_cc.clone()));
-        }
         self.build_env
             .native_toolchain
             .ok_or_else(|| anyhow::anyhow!("native C toolchain is not selected for this build"))?
-            .resolve_default()
+            .resolve_with_package_override(package_cc)
     }
 
     fn module_prebuild_vars(&self, module: ModuleId) -> Option<&HashMap<String, String>> {

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -341,12 +341,14 @@ impl<'a> BuildPlanConstructor<'a> {
                 );
             }
             BuildPlanNode::MakeExecutable(build_target) => {
-                assert!(
-                    self.res.make_executable_info.contains_key(&build_target),
-                    "Make executable info for {:?} should be present when resolving node {:?}",
-                    build_target,
-                    node
-                );
+                if self.build_env.target_backend.is_native() {
+                    assert!(
+                        self.res.make_executable_info.contains_key(&build_target),
+                        "Make executable info for {:?} should be present when resolving node {:?}",
+                        build_target,
+                        node
+                    );
+                }
             }
             BuildPlanNode::GenerateMbti(_build_target) => (),
             BuildPlanNode::Bundle(module_id) => {

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -52,7 +52,7 @@ use std::{
 use log::{debug, info};
 use moonutil::{
     common::{RunMode, TargetBackend},
-    compiler_flags::Toolchain,
+    compiler_flags::{NativeToolchainSelection, Toolchain},
     cond_expr::OptLevel,
     mooncakes::ModuleId,
 };
@@ -334,8 +334,8 @@ pub struct BuildEnvironment {
     pub std: bool,
     /// Commandline_level warnings to enable/disable
     pub warn_list: Option<String>,
-    /// Selected native toolchain for this invocation.
-    pub selected_native_toolchain: Toolchain,
+    /// Native toolchain selection policy, only when the backend needs one.
+    pub native_toolchain: Option<NativeToolchainSelection>,
 }
 
 /// Directives provided along the input actions.

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -22,7 +22,7 @@ use indexmap::IndexMap;
 use log::{debug, info};
 use moonutil::{
     common::RunMode,
-    compiler_flags::{CC, CompilerPaths, Toolchain},
+    compiler_flags::{CC, CompilerPaths, NativeToolchainSelection},
     cond_expr::OptLevel,
 };
 use tracing::{Level, instrument};
@@ -74,10 +74,10 @@ pub struct CompileConfig {
     pub warn_list: Option<String>,
     /// Whether to not emit alias when running `mooninfo`
     pub info_no_alias: bool,
-    /// Preferred default C/C++ toolchain to use for native builds
-    pub default_cc: CC,
     /// Resolved internal TCC toolchain when this invocation uses `tcc -run`.
     pub internal_tcc: Option<CC>,
+    /// Native toolchain selection policy, only when the backend needs one.
+    pub native_toolchain: Option<NativeToolchainSelection>,
 }
 
 /// The output information of the compilation.
@@ -130,7 +130,7 @@ pub fn compile(
         action: cx.action,
         std: cx.stdlib_path.is_some(),
         warn_list: cx.warn_list.clone(),
-        selected_native_toolchain: Toolchain::from_cc(cx.default_cc.clone()),
+        native_toolchain: cx.native_toolchain,
     };
     let (plan, user_warnings) = build_plan::build_plan(
         resolve_output,
@@ -166,8 +166,8 @@ pub fn compile(
 
         stdlib_path: cx.stdlib_path.clone(),
         compiler_paths,
-        selected_native_toolchain: Toolchain::from_cc(cx.default_cc.clone()),
         internal_tcc: cx.internal_tcc.clone(),
+        native_toolchain: cx.native_toolchain,
         os: OperatingSystem::from_str(std::env::consts::OS).expect("Unknown"),
         runtime_dot_c_path,
     };

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -102,6 +102,21 @@ impl NativeToolchainSelection {
             DefaultNativeToolchain::SystemFirst => try_default_cc(false).map(Toolchain::from_cc),
         }
     }
+
+    pub fn resolve_with_package_override(
+        self,
+        package_cc: Option<&CC>,
+    ) -> anyhow::Result<Toolchain> {
+        if let Some(env_cc) = ENV_CC.as_ref() {
+            return Ok(
+                Toolchain::from_env_override(env_cc.clone()).with_package_override(package_cc)
+            );
+        }
+        if let Some(package_cc) = package_cc {
+            return Ok(Toolchain::from_package_override(package_cc.clone()));
+        }
+        self.resolve_default()
+    }
 }
 
 impl Toolchain {

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -57,12 +57,6 @@ pub struct CC {
     pub is_env_override: bool, // Whether the cc is set by env MOON_CC
 }
 
-impl Default for CC {
-    fn default() -> Self {
-        NATIVE_CC().clone()
-    }
-}
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ToolchainSource {
     EnvOverride,
@@ -74,6 +68,40 @@ pub enum ToolchainSource {
 pub struct Toolchain {
     cc: CC,
     source: ToolchainSource,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DefaultNativeToolchain {
+    InternalTccFirst,
+    SystemFirst,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NativeToolchainSelection {
+    default: DefaultNativeToolchain,
+}
+
+impl NativeToolchainSelection {
+    pub fn internal_tcc_first() -> Self {
+        Self {
+            default: DefaultNativeToolchain::InternalTccFirst,
+        }
+    }
+
+    pub fn system_first() -> Self {
+        Self {
+            default: DefaultNativeToolchain::SystemFirst,
+        }
+    }
+
+    pub fn resolve_default(self) -> anyhow::Result<Toolchain> {
+        match self.default {
+            DefaultNativeToolchain::InternalTccFirst => {
+                try_default_cc(true).map(Toolchain::from_cc)
+            }
+            DefaultNativeToolchain::SystemFirst => try_default_cc(false).map(Toolchain::from_cc),
+        }
+    }
 }
 
 impl Toolchain {
@@ -441,9 +469,7 @@ impl CC {
     /// Create a CC configured for the internal TCC shipped with Moon.
     /// Resolves MOON_DIRS.internal_tcc_path via which::which.
     pub fn internal_tcc() -> anyhow::Result<Self> {
-        let cc_path =
-            which::which(&MOON_DIRS.internal_tcc_path).context("internal tcc not found")?;
-        CC::try_from_cc_path_and_kind("", &cc_path, CCKind::Tcc)
+        try_internal_tcc()
     }
 }
 
@@ -474,36 +500,92 @@ pub static ENV_CC: std::sync::LazyLock<Option<CC>> = std::sync::LazyLock::new(||
     }
 });
 
-pub static DETECTED_CC: std::sync::LazyLock<CC> = std::sync::LazyLock::new(|| {
-    use CCKind::*;
+fn detect_path_candidate(cc_path: &Path, cc_kind: CCKind) -> anyhow::Result<CC> {
+    CC::try_from_detected_path(cc_path, cc_kind)
+        .with_context(|| format!("failed to use C compiler at {}", cc_path.display()))
+}
 
-    let (cc_kind, cc_path) = if let Ok(cc) = which::which("cl") {
-        (Msvc, cc)
-    } else if let Ok(cc) = which::which("cc") {
-        (SystemCC, cc)
-    } else if let Ok(cc) = which::which("gcc") {
-        (Gcc, cc)
-    } else if let Ok(cc) = which::which("clang") {
-        (Clang, cc)
-    } else {
-        let cc = which::which(&MOON_DIRS.internal_tcc_path)
-            .context("internal tcc not found")
-            .unwrap();
-        (Tcc, cc)
-    };
+fn detect_system_cc() -> anyhow::Result<CC> {
+    let mut errors = Vec::new();
+    for (name, kind) in [
+        ("cl", CCKind::Msvc),
+        ("cc", CCKind::SystemCC),
+        ("gcc", CCKind::Gcc),
+        ("clang", CCKind::Clang),
+    ] {
+        let Ok(cc_path) = which::which(name) else {
+            continue;
+        };
+        match detect_path_candidate(&cc_path, kind) {
+            Ok(cc) => return Ok(cc),
+            Err(e) => errors.push(format!("{e:#}")),
+        }
+    }
 
-    CC::try_from_detected_path(&cc_path, cc_kind)
-        .context("failed to detect native C toolchain")
-        .unwrap()
+    if errors.is_empty() {
+        anyhow::bail!("no system C compiler found; tried cl, cc, gcc, clang")
+    }
+    anyhow::bail!(
+        "failed to resolve system C compiler candidates: {}",
+        errors.join("; ")
+    )
+}
+
+fn detect_internal_tcc() -> anyhow::Result<CC> {
+    let cc_path = which::which(&MOON_DIRS.internal_tcc_path).with_context(|| {
+        format!(
+            "internal tcc not found at {}",
+            MOON_DIRS.internal_tcc_path.display()
+        )
+    })?;
+    detect_path_candidate(&cc_path, CCKind::Tcc)
+}
+
+static DETECTED_SYSTEM_CC: std::sync::LazyLock<anyhow::Result<CC>> =
+    std::sync::LazyLock::new(detect_system_cc);
+static DETECTED_INTERNAL_TCC: std::sync::LazyLock<anyhow::Result<CC>> =
+    std::sync::LazyLock::new(detect_internal_tcc);
+static DETECTED_CC: std::sync::LazyLock<anyhow::Result<CC>> = std::sync::LazyLock::new(|| {
+    match try_system_cc() {
+        Ok(cc) => Ok(cc),
+        Err(system_err) => try_internal_tcc().with_context(|| {
+            format!("failed to resolve fallback internal tcc after system C compiler detection failed: {system_err:#}")
+        }),
+    }
 });
 
-#[allow(non_snake_case)]
-pub fn NATIVE_CC() -> &'static CC {
+fn cached_cc(result: &std::sync::LazyLock<anyhow::Result<CC>>) -> anyhow::Result<CC> {
+    result
+        .as_ref()
+        .cloned()
+        .map_err(|e| anyhow::anyhow!("{e:#}"))
+}
+
+pub fn try_system_cc() -> anyhow::Result<CC> {
+    cached_cc(&DETECTED_SYSTEM_CC)
+}
+
+pub fn try_internal_tcc() -> anyhow::Result<CC> {
+    cached_cc(&DETECTED_INTERNAL_TCC)
+}
+
+pub fn try_detect_cc() -> anyhow::Result<CC> {
+    cached_cc(&DETECTED_CC)
+}
+
+pub fn try_default_cc(prefer_internal_tcc: bool) -> anyhow::Result<CC> {
     if let Some(env_cc) = ENV_CC.as_ref() {
-        env_cc
-    } else {
-        &DETECTED_CC
+        return Ok(env_cc.clone());
     }
+
+    if prefer_internal_tcc {
+        return match try_internal_tcc() {
+            Ok(tcc) => Ok(tcc),
+            Err(tcc_err) => try_system_cc()
+                .with_context(|| format!("failed to resolve preferred internal tcc: {tcc_err:#}")),
+        };
+    }
+    try_detect_cc()
 }
 
 #[derive(Clone, Copy, PartialEq)]

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -71,36 +71,15 @@ pub struct Toolchain {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DefaultNativeToolchain {
-    InternalTccFirst,
-    SystemFirst,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct NativeToolchainSelection {
-    default: DefaultNativeToolchain,
-}
+pub struct NativeToolchainSelection;
 
 impl NativeToolchainSelection {
-    pub fn internal_tcc_first() -> Self {
-        Self {
-            default: DefaultNativeToolchain::InternalTccFirst,
-        }
-    }
-
     pub fn system_first() -> Self {
-        Self {
-            default: DefaultNativeToolchain::SystemFirst,
-        }
+        Self
     }
 
     pub fn resolve_default(self) -> anyhow::Result<Toolchain> {
-        match self.default {
-            DefaultNativeToolchain::InternalTccFirst => {
-                try_default_cc(true).map(Toolchain::from_cc)
-            }
-            DefaultNativeToolchain::SystemFirst => try_default_cc(false).map(Toolchain::from_cc),
-        }
+        try_default_cc().map(Toolchain::from_cc)
     }
 
     pub fn resolve_with_package_override(
@@ -588,18 +567,11 @@ pub fn try_detect_cc() -> anyhow::Result<CC> {
     cached_cc(&DETECTED_CC)
 }
 
-pub fn try_default_cc(prefer_internal_tcc: bool) -> anyhow::Result<CC> {
+pub fn try_default_cc() -> anyhow::Result<CC> {
     if let Some(env_cc) = ENV_CC.as_ref() {
         return Ok(env_cc.clone());
     }
 
-    if prefer_internal_tcc {
-        return match try_internal_tcc() {
-            Ok(tcc) => Ok(tcc),
-            Err(tcc_err) => try_system_cc()
-                .with_context(|| format!("failed to resolve preferred internal tcc: {tcc_err:#}")),
-        };
-    }
     try_detect_cc()
 }
 


### PR DESCRIPTION
Stack split 1/3 from the original native toolchain PR.

This keeps the bug fix focused on avoiding eager native C toolchain resolution:

- remove infallible `CC::default()` usage from planning/lowering paths
- make system CC/internal tcc detection lazy and fallible
- avoid resolving native toolchains for non-native targets such as `moon check --target wasm-gc`
- keep non-native `MakeExecutable` as a no-op without requiring native make-executable info

Validation run locally:

- `cargo check -p moonutil -p moonbuild-rupes-recta -p moon`
- `cargo test -p moon --test mod test_cases::fmt_moon_mod::test_fmt_existing_moon_mod_formats_in_place`