### PR TITLE
fix: clean up native toolchain selection

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -52,7 +52,7 @@ use moonutil::{
         BLACKBOX_TEST_PATCH, DiagnosticLevel, MOONBITLANG_CORE, RunMode, TargetBackend,
         WHITEBOX_TEST_PATCH,
     },
-    compiler_flags::{CC, NativeToolchainSelection},
+    compiler_flags::{self, CC, NativeToolchainSelection},
     cond_expr::OptLevel as BuildProfile,
     dirs::WorkspaceEnv,
     features::FeatureGate,
@@ -334,19 +334,31 @@ impl CompilePreConfig {
             "The final selected target backend must either be default or match the explicit one"
         );
 
-        let internal_tcc =
-            check_tcc_availability(target_backend, resolve_output, input_nodes, output);
-        info!("`tcc -run` availability: {}", internal_tcc.is_some());
-
+        let mut internal_tcc = None;
         let target_backend = match target_backend {
             TargetBackend::Wasm => RunBackend::Wasm,
             TargetBackend::WasmGC => RunBackend::WasmGC,
             TargetBackend::Js => RunBackend::Js,
             TargetBackend::Native => {
-                if self.try_tcc_run
-                    && internal_tcc.is_some()
-                    && self.opt_level == BuildProfile::Debug
-                {
+                let can_try_tcc_run = if !self.try_tcc_run {
+                    info!("Disabling `tcc -run`: not requested");
+                    false
+                } else if self.opt_level != BuildProfile::Debug {
+                    info!("Disabling `tcc -run`: only available for debug builds");
+                    false
+                } else if !(cfg!(target_os = "linux") || cfg!(target_os = "macos")) {
+                    info!("Disabling `tcc -run`: only supported on Linux and macOS");
+                    false
+                } else {
+                    true
+                };
+
+                if can_try_tcc_run {
+                    internal_tcc = check_tcc_run_availability(resolve_output, input_nodes, output);
+                    info!("`tcc -run` availability: {}", internal_tcc.is_some());
+                }
+
+                if internal_tcc.is_some() {
                     RunBackend::NativeTccRun
                 } else {
                     RunBackend::Native
@@ -356,17 +368,15 @@ impl CompilePreConfig {
         };
         info!("Final run backend: {:?}", target_backend);
 
-        let native_toolchain = if target_backend.is_native() {
-            Some(NativeToolchainSelection::system_first())
-        } else {
-            None
+        let native_toolchain = match target_backend {
+            RunBackend::Native | RunBackend::Llvm => Some(NativeToolchainSelection::system_first()),
+            RunBackend::NativeTccRun => Some(NativeToolchainSelection::system_then_internal_tcc()),
+            RunBackend::Wasm | RunBackend::WasmGC | RunBackend::Js => None,
         };
 
-        let internal_tcc = (target_backend == RunBackend::NativeTccRun).then(|| {
-            internal_tcc
-                .clone()
-                .expect("NativeTccRun should only be selected when internal tcc is available")
-        });
+        if target_backend != RunBackend::NativeTccRun {
+            internal_tcc = None;
+        }
 
         Ok(CompileConfig {
             target_dir: self.target_dir,
@@ -657,35 +667,19 @@ pub fn plan_fmt(
 /// Check if we can actually run `tcc -run`.
 ///
 /// This is for usage in `moon run` and `moon test`. Based on the legacy impl,
-/// only if no packages override their C/C++ toolchain, we can use `tcc -run`.
-fn check_tcc_availability(
-    target_backend: TargetBackend,
+/// only if neither the user nor any package overrides the C/C++ toolchain, we
+/// can use `tcc -run`.
+fn check_tcc_run_availability(
     resolve_output: &ResolveOutput,
     input_nodes: &[BuildPlanNode],
     output: UserDiagnostics,
 ) -> Option<CC> {
-    // Only for native target. Yes, not even LLVM.
-    if target_backend != TargetBackend::Native {
-        info!("Disabling `tcc -run`: Only available for native target backend");
+    if compiler_flags::has_cc_env_override() {
+        info!("Disabling `tcc -run`: MOON_CC is set");
         return None;
     }
 
-    // Check platform availability
-    if !(cfg!(target_os = "linux") || cfg!(target_os = "macos")) {
-        info!("`tcc -run` is only supported on Linux and macOS");
-        return None;
-    }
-
-    // Check if TCC is available
-    let tcc = match CC::internal_tcc() {
-        Ok(t) => t,
-        Err(_) => {
-            output.warn("Cannot find TCC compiler in the system; disabling `tcc -run`");
-            return None;
-        }
-    };
-
-    // Check if any package overrides the C/C++ toolchain
+    // Check if any package overrides the C/C++ toolchain before probing TCC.
     for node in input_nodes {
         if let BuildPlanNode::MakeExecutable(build_target) = node {
             let package = resolve_output.pkg_dirs.get_package(build_target.package);
@@ -717,7 +711,13 @@ fn check_tcc_availability(
         }
     }
 
-    Some(tcc)
+    match CC::internal_tcc() {
+        Ok(tcc) => Some(tcc),
+        Err(_) => {
+            output.warn("Cannot find TCC compiler in the system; disabling `tcc -run`");
+            None
+        }
+    }
 }
 
 /// Generate metadata file `packages.json` in the target directory.

--- a/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
@@ -42,7 +42,8 @@ fn test_prebuild_config_common(dir: TestDir) {
             assert!(line.contains("-l______this_is_added_by_config_script_______"));
             assert!(line.contains("-lmylib"));
             assert!(line.contains("-L/my-search-path"));
-        } else if line.contains("cl.exe") // cl.exe might be quoted
+        } else if (line.contains("cl.exe") // cl.exe might be quoted
+            || line.starts_with("cl "))
             && line.contains("/Fe./_build/native/debug/build/main/main.exe")
             && cfg!(windows)
         {

--- a/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
@@ -2,7 +2,7 @@ use std::cell::OnceCell;
 
 use expect_test::expect_file;
 
-use crate::{TestDir, assert_success, get_err_stderr, get_stdout, util};
+use crate::{TestDir, assert_success, get_err_stderr, get_stdout, get_stdout_with_envs, util};
 
 // Notice the two `this-is-added-by-config-script`
 #[test]
@@ -18,7 +18,12 @@ fn test_prebuild_config_py() {
 }
 
 fn test_prebuild_config_common(dir: TestDir) {
-    let stdout = get_stdout(&dir, ["build", "--target", "native", "--dry-run"]);
+    let cc = if cfg!(windows) { "cl" } else { "cc" };
+    let stdout = get_stdout_with_envs(
+        &dir,
+        ["build", "--target", "native", "--dry-run"],
+        [("MOON_CC", cc)],
+    );
     println!("{}", &stdout);
     let lines = stdout.lines().collect::<Vec<_>>();
 

--- a/crates/moon/tests/test_cases/prebuild_link_config_self/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_link_config_self/mod.rs
@@ -1,11 +1,16 @@
 use std::cell::OnceCell;
 
-use crate::{TestDir, get_stdout};
+use crate::{TestDir, get_stdout_with_envs};
 
 #[test]
 fn test_prebuild_link_config_self() {
     let dir = TestDir::new("prebuild_link_config_self/prebuild_link_config_self.in");
-    let build_stdout = get_stdout(&dir, ["build", "--target", "native", "--dry-run"]);
+    let cc = if cfg!(windows) { "cl" } else { "cc" };
+    let build_stdout = get_stdout_with_envs(
+        &dir,
+        ["build", "--target", "native", "--dry-run"],
+        [("MOON_CC", cc)],
+    );
     println!("{}", &build_stdout);
     let lines = build_stdout.lines().collect::<Vec<_>>();
 
@@ -31,7 +36,11 @@ fn test_prebuild_link_config_self() {
     found_final_link.get().expect("final linking not found");
 
     if cfg!(unix) {
-        let test_stdout = get_stdout(&dir, ["test", "--target", "native", "--dry-run"]);
+        let test_stdout = get_stdout_with_envs(
+            &dir,
+            ["test", "--target", "native", "--dry-run"],
+            [("MOON_CC", cc)],
+        );
         println!("{}", &test_stdout);
         let lines = test_stdout.lines().collect::<Vec<_>>();
 

--- a/crates/moon/tests/test_cases/prebuild_link_config_self/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_link_config_self/mod.rs
@@ -22,7 +22,7 @@ fn test_prebuild_link_config_self() {
             assert!(line.contains("-l__prebuild_self_link_flag__"));
             assert!(line.contains("-lprebuildselflib"));
             assert!(line.contains("-L/prebuild-self-path"));
-        } else if line.contains("cl.exe")
+        } else if (line.contains("cl.exe") || line.starts_with("cl "))
             && line.contains("/Fe./_build/native/debug/build/main/main.exe")
             && cfg!(windows)
         {

--- a/crates/moonbuild/template/test_driver_project/template_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_async.mbt
@@ -3,7 +3,7 @@
 
 ///|
 #cfg(not(any(target="wasm", target="wasm-gc")))
-impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with run_async_tests(
+impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with fn run_async_tests(
   tests,
 ) {
   let moonbit_test_driver_internal_max_concurrent_tests : Int = 0 // REPLACE ME: moonbit_test_driver_internal_max_concurrent_tests
@@ -26,6 +26,6 @@ impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with run_async
 
 ///|
 #cfg(not(any(target="wasm", target="wasm-gc")))
-impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with is_being_cancelled() {
+impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with fn is_being_cancelled() {
   @moonbitlang/async.is_being_cancelled()
 }

--- a/crates/moonbuild/template/test_driver_project/template_no_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_no_args.mbt
@@ -6,7 +6,7 @@ let moonbit_test_driver_internal_no_args_tests : MoonBitTestDriverInternalTestMa
 ] = {} // REPLACE ME: moonbit_test_driver_internal_no_args_tests
 
 ///|
-impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_No_Args with run_test(
+impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_No_Args with fn run_test(
   _,
   filename,
   index,

--- a/crates/moonbuild/template/test_driver_project/template_no_args_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_no_args_async.mbt
@@ -7,7 +7,7 @@ let moonbit_test_driver_internal_async_tests : MoonBitTestDriverInternalTestMap[
 ] = {} // REPLACE ME: moonbit_test_driver_internal_async_tests
 
 ///|
-impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_Async_No_Args with run_test(
+impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_Async_No_Args with fn run_test(
   async_tests,
   filename,
   index,

--- a/crates/moonbuild/template/test_driver_project/template_with_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_args.mbt
@@ -7,7 +7,7 @@ let moonbit_test_driver_internal_with_args_tests : MoonBitTestDriverInternalTest
 ] = {} // REPLACE ME: moonbit_test_driver_internal_with_args_tests
 
 ///|
-impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_With_Args with run_test(
+impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_With_Args with fn run_test(
   _,
   filename,
   index,

--- a/crates/moonbuild/template/test_driver_project/template_with_args_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_args_async.mbt
@@ -7,7 +7,7 @@ let moonbit_test_driver_internal_async_tests_with_args : MoonBitTestDriverIntern
 ] = {} // REPLACE ME: moonbit_test_driver_internal_async_tests_with_args
 
 ///|
-impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_Async_With_Args with run_test(
+impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_Async_With_Args with fn run_test(
   async_tests,
   filename,
   index,

--- a/crates/moonbuild/template/test_driver_project/template_with_bench_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_bench_args.mbt
@@ -7,7 +7,7 @@ let moonbit_test_driver_internal_with_bench_args_tests : MoonBitTestDriverIntern
 ] = {} // REPLACE ME: moonbit_test_driver_internal_with_bench_args_tests
 
 ///|
-impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_With_Bench_Args with run_test(
+impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_With_Bench_Args with fn run_test(
   _,
   filename,
   index,

--- a/crates/moonbuild/template/test_driver_project/types.mbt
+++ b/crates/moonbuild/template/test_driver_project/types.mbt
@@ -9,12 +9,12 @@ trait MoonBit_Async_Test_Driver {
 }
 
 ///|
-impl MoonBit_Async_Test_Driver with run_async_tests(_) {
+impl MoonBit_Async_Test_Driver with fn run_async_tests(_) {
   ()
 }
 
 ///|
-impl MoonBit_Async_Test_Driver with is_being_cancelled() {
+impl MoonBit_Async_Test_Driver with fn is_being_cancelled() {
   false
 }
 
@@ -31,7 +31,7 @@ trait MoonBit_Test_Driver {
 }
 
 ///|
-impl MoonBit_Test_Driver with run_test(_, _, _, _, _) {
+impl MoonBit_Test_Driver with fn run_test(_, _, _, _, _) {
   false
 }
 

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -71,15 +71,35 @@ pub struct Toolchain {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct NativeToolchainSelection;
+pub struct NativeToolchainSelection {
+    internal_tcc_fallback: bool,
+}
 
 impl NativeToolchainSelection {
     pub fn system_first() -> Self {
-        Self
+        Self {
+            internal_tcc_fallback: false,
+        }
+    }
+
+    pub fn system_then_internal_tcc() -> Self {
+        Self {
+            internal_tcc_fallback: true,
+        }
     }
 
     pub fn resolve_default(self) -> anyhow::Result<Toolchain> {
-        try_default_cc().map(Toolchain::from_cc)
+        match try_default_cc() {
+            Ok(cc) => Ok(Toolchain::from_cc(cc)),
+            Err(system_err) if self.internal_tcc_fallback => try_internal_tcc()
+                .with_context(|| {
+                    format!(
+                        "failed to resolve fallback internal tcc after system C compiler detection failed: {system_err:#}"
+                    )
+                })
+                .map(Toolchain::from_cc),
+            Err(err) => Err(err),
+        }
     }
 
     pub fn resolve_with_package_override(
@@ -539,14 +559,6 @@ static DETECTED_SYSTEM_CC: std::sync::LazyLock<anyhow::Result<CC>> =
     std::sync::LazyLock::new(detect_system_cc);
 static DETECTED_INTERNAL_TCC: std::sync::LazyLock<anyhow::Result<CC>> =
     std::sync::LazyLock::new(detect_internal_tcc);
-static DETECTED_CC: std::sync::LazyLock<anyhow::Result<CC>> = std::sync::LazyLock::new(|| {
-    match try_system_cc() {
-        Ok(cc) => Ok(cc),
-        Err(system_err) => try_internal_tcc().with_context(|| {
-            format!("failed to resolve fallback internal tcc after system C compiler detection failed: {system_err:#}")
-        }),
-    }
-});
 
 fn cached_cc(result: &std::sync::LazyLock<anyhow::Result<CC>>) -> anyhow::Result<CC> {
     result
@@ -563,16 +575,15 @@ pub fn try_internal_tcc() -> anyhow::Result<CC> {
     cached_cc(&DETECTED_INTERNAL_TCC)
 }
 
-pub fn try_detect_cc() -> anyhow::Result<CC> {
-    cached_cc(&DETECTED_CC)
+pub fn has_cc_env_override() -> bool {
+    env::var_os(ENV_MOON_CC).is_some()
 }
 
 pub fn try_default_cc() -> anyhow::Result<CC> {
     if let Some(env_cc) = ENV_CC.as_ref() {
         return Ok(env_cc.clone());
     }
-
-    try_detect_cc()
+    try_system_cc()
 }
 
 #[derive(Clone, Copy, PartialEq)]


### PR DESCRIPTION
Follow-up to merged #1709, now based directly on `main`.

This keeps native toolchain selection cleanup separate from the lazy-resolution bug fix:

- keep normal native build/link toolchain system/user selected instead of falling back to internal tcc
- preserve internal tcc only for tcc-run execution
- disable tcc-run when `MOON_CC` is explicitly set
- pass an explicit LLVM target triple to `moonc link-core` from the effective native toolchain when it reports an MSVC target
- update prebuild native dry-run tests to use explicit `MOON_CC` and accept the Windows `cl` command spelling

Validation run locally:

- `cargo fmt --check`
- `cargo check -p moonutil -p moonbuild-rupes-recta -p moon`
- `cargo test -p moonutil`
- `cargo test -p moon --test mod prebuild_config_script::test_prebuild_config_js`
- `cargo test -p moon --test mod prebuild_config_script::test_prebuild_config_py`
- `cargo test -p moon --test mod prebuild_link_config_self::test_prebuild_link_config_self`
- `cargo test -p moon --test mod native_backend::tcc_run::test_native_backend_tcc_run`