### PR TITLE
refactor: separate native execution model cleanup

### DIFF
--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -112,10 +112,10 @@ pub(crate) struct RunSubcommand {
 /// `tcc -run`. Consumers that need a standalone executable, such as profilers,
 /// should disable it.
 pub(crate) struct BuildRunExecutableOptions {
-    /// Whether native debug builds may use `RunBackend::NativeTccRun`.
+    /// Whether native debug builds may use `tcc -run`.
     ///
-    /// `NativeTccRun` executes through `tcc @rspfile` and does not provide the
-    /// same standalone executable shape as the regular native backend.
+    /// `tcc -run` executes through `tcc @rspfile` and does not provide the same
+    /// standalone executable shape as regular native execution.
     pub(crate) try_tcc_run: bool,
     /// Whether dry-run output should include the final executable invocation.
     pub(crate) print_dry_run_run_command: bool,
@@ -141,6 +141,8 @@ pub(crate) struct RunExecutable {
     pub(crate) executable: PathBuf,
     /// Backend-specific runner to use for this artifact.
     pub(crate) target_backend: moonbuild_rupes_recta::model::RunBackend,
+    /// Present only when native debug execution selected `tcc -run`.
+    pub(crate) tcc_run: Option<moonbuild_rupes_recta::model::TccRunConfig>,
     pub(crate) opt_level: moonutil::cond_expr::OptLevel,
     pub(crate) target_dir: PathBuf,
     source_dir: PathBuf,
@@ -274,6 +276,7 @@ fn build_wasm_file_executable_from_arg(
     if cli.dry_run {
         let mut run_cmd = crate::run::command_for(
             moonbuild_rupes_recta::model::RunBackend::WasmGC,
+            None,
             &wasm_path,
             None,
         );
@@ -284,6 +287,7 @@ fn build_wasm_file_executable_from_arg(
     Ok(RunExecutable {
         executable: wasm_path,
         target_backend: moonbuild_rupes_recta::model::RunBackend::WasmGC,
+        tcc_run: None,
         opt_level: moonutil::cond_expr::OptLevel::Debug,
         target_dir: print_dir.clone(),
         source_dir: print_dir,
@@ -486,7 +490,12 @@ pub(crate) fn plan_run_rr_from_resolved(
 #[instrument(level = Level::DEBUG, skip_all)]
 fn get_run_cmd(build_meta: &rr_build::BuildMeta, argv: &[String]) -> tokio::process::Command {
     let executable = get_run_executable(build_meta);
-    let mut cmd = crate::run::command_for(build_meta.target_backend, executable, None);
+    let mut cmd = crate::run::command_for(
+        build_meta.target_backend,
+        build_meta.tcc_run.as_ref(),
+        executable,
+        None,
+    );
     cmd.args(argv);
     cmd
 }
@@ -657,6 +666,7 @@ fn build_executable_from_plan(
         return Ok(RunExecutable {
             executable: get_run_executable(build_meta).to_path_buf(),
             target_backend: build_meta.target_backend,
+            tcc_run: build_meta.tcc_run.clone(),
             opt_level: build_meta.opt_level,
             target_dir: target_dir.to_path_buf(),
             source_dir: source_dir.to_path_buf(),
@@ -681,6 +691,7 @@ fn build_executable_from_plan(
     Ok(RunExecutable {
         executable: get_run_executable(build_meta).to_path_buf(),
         target_backend: build_meta.target_backend,
+        tcc_run: build_meta.tcc_run.clone(),
         opt_level: build_meta.opt_level,
         target_dir: target_dir.to_path_buf(),
         source_dir: source_dir.to_path_buf(),
@@ -716,6 +727,7 @@ fn run_executable(
 
     let mut run_cmd = crate::run::command_for(
         executable.target_backend,
+        executable.tcc_run.as_ref(),
         executable.executable.as_path(),
         None,
     );

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -252,7 +252,7 @@ fn install_build_rr(
         .context("RR build should yield exactly one artifact file")?;
 
     // Build command using existing runtime mapping, then shlex-join
-    let guard = crate::run::command_for(meta.target_backend, artifact, None);
+    let guard = crate::run::command_for(meta.target_backend, meta.tcc_run.as_ref(), artifact, None);
     let parts = std::iter::once(guard.as_std().get_program())
         .chain(guard.as_std().get_args())
         .map(|x| x.to_string_lossy().to_string())

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -42,7 +42,7 @@ use moonbuild_rupes_recta::{
     build_plan::InputDirective,
     fmt::{FmtConfig, FmtResolveOutput},
     intent::UserIntent,
-    model::{Artifacts, BuildPlanNode, PackageId, RunBackend, TargetKind},
+    model::{Artifacts, BuildPlanNode, PackageId, RunBackend, TargetKind, TccRunConfig},
     prebuild::run_prebuild_config,
     user_warning::UserWarning,
 };
@@ -52,7 +52,7 @@ use moonutil::{
         BLACKBOX_TEST_PATCH, DiagnosticLevel, MOONBITLANG_CORE, RunMode, TargetBackend,
         WHITEBOX_TEST_PATCH,
     },
-    compiler_flags::{self, CC, NativeToolchainSelection},
+    compiler_flags::{self, CC},
     cond_expr::OptLevel as BuildProfile,
     dirs::WorkspaceEnv,
     features::FeatureGate,
@@ -230,6 +230,8 @@ pub struct BuildMeta {
 
     /// The target backend used in this compile process
     pub target_backend: RunBackend,
+    /// Configuration for `tcc -run`, if this compile process selected it.
+    pub tcc_run: Option<TccRunConfig>,
 
     /// The main optimization level used in this compile process
     pub opt_level: BuildProfile,
@@ -334,53 +336,26 @@ impl CompilePreConfig {
             "The final selected target backend must either be default or match the explicit one"
         );
 
-        let mut internal_tcc = None;
-        let target_backend = match target_backend {
-            TargetBackend::Wasm => RunBackend::Wasm,
-            TargetBackend::WasmGC => RunBackend::WasmGC,
-            TargetBackend::Js => RunBackend::Js,
-            TargetBackend::Native => {
-                let can_try_tcc_run = if !self.try_tcc_run {
-                    info!("Disabling `tcc -run`: not requested");
-                    false
-                } else if self.opt_level != BuildProfile::Debug {
-                    info!("Disabling `tcc -run`: only available for debug builds");
-                    false
-                } else if !(cfg!(target_os = "linux") || cfg!(target_os = "macos")) {
-                    info!("Disabling `tcc -run`: only supported on Linux and macOS");
-                    false
-                } else {
-                    true
-                };
-
-                if can_try_tcc_run {
-                    internal_tcc = check_tcc_run_availability(resolve_output, input_nodes, output);
-                    info!("`tcc -run` availability: {}", internal_tcc.is_some());
-                }
-
-                if internal_tcc.is_some() {
-                    RunBackend::NativeTccRun
-                } else {
-                    RunBackend::Native
-                }
-            }
-            TargetBackend::LLVM => RunBackend::Llvm,
+        let (run_backend, tcc_run) = match target_backend {
+            TargetBackend::Wasm => (RunBackend::Wasm, None),
+            TargetBackend::WasmGC => (RunBackend::WasmGC, None),
+            TargetBackend::Js => (RunBackend::Js, None),
+            TargetBackend::Native => (
+                RunBackend::Native,
+                self.select_tcc_run_config(resolve_output, input_nodes, output),
+            ),
+            TargetBackend::LLVM => (RunBackend::Llvm, None),
         };
-        info!("Final run backend: {:?}", target_backend);
-
-        let native_toolchain = match target_backend {
-            RunBackend::Native | RunBackend::Llvm => Some(NativeToolchainSelection::system_first()),
-            RunBackend::NativeTccRun => Some(NativeToolchainSelection::system_then_internal_tcc()),
-            RunBackend::Wasm | RunBackend::WasmGC | RunBackend::Js => None,
-        };
-
-        if target_backend != RunBackend::NativeTccRun {
-            internal_tcc = None;
-        }
+        info!(
+            "Final run backend: {:?}, tcc-run enabled: {}",
+            run_backend,
+            tcc_run.is_some()
+        );
 
         Ok(CompileConfig {
             target_dir: self.target_dir,
-            target_backend,
+            target_backend: run_backend,
+            tcc_run,
             opt_level: self.opt_level,
             action: self.action,
             debug_symbols: self.debug_symbols,
@@ -398,9 +373,36 @@ impl CompilePreConfig {
             warning_condition: self.warning_condition,
             warn_list: self.warn_list,
             info_no_alias: self.info_no_alias,
-            internal_tcc,
-            native_toolchain,
         })
+    }
+
+    fn select_tcc_run_config(
+        &self,
+        resolve_output: &ResolveOutput,
+        input_nodes: &[BuildPlanNode],
+        output: UserDiagnostics,
+    ) -> Option<TccRunConfig> {
+        if !self.try_tcc_run {
+            info!("Disabling `tcc -run`: not requested");
+            return None;
+        }
+        if self.opt_level != BuildProfile::Debug {
+            info!("Disabling `tcc -run`: only available for debug builds");
+            return None;
+        }
+        if !(cfg!(target_os = "linux") || cfg!(target_os = "macos")) {
+            info!("Disabling `tcc -run`: only supported on Linux and macOS");
+            return None;
+        }
+
+        let Some(internal_tcc) = check_tcc_run_availability(resolve_output, input_nodes, output)
+        else {
+            info!("`tcc -run` availability: false");
+            return None;
+        };
+
+        info!("`tcc -run` availability: true");
+        Some(TccRunConfig::new(internal_tcc))
     }
 }
 
@@ -614,6 +616,7 @@ pub(crate) fn plan_resolved_build_from_intent(
         resolve_output,
         artifacts: compile_output.artifacts,
         target_backend: cx.target_backend,
+        tcc_run: cx.tcc_run.clone(),
         opt_level: cx.opt_level,
     };
 

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -624,6 +624,7 @@ fn run_one_test_executable(
 
     let cmd = crate::run::command_for(
         ctx.build_meta.target_backend,
+        ctx.build_meta.tcc_run.as_ref(),
         &test.executable,
         Some(&test.args),
     );

--- a/crates/moon/src/run/runtime.rs
+++ b/crates/moon/src/run/runtime.rs
@@ -21,8 +21,7 @@
 use std::path::Path;
 
 use moonbuild::entry::TestArgs;
-use moonbuild_rupes_recta::model::RunBackend;
-use moonutil::compiler_flags::CC;
+use moonbuild_rupes_recta::model::{RunBackend, TccRunConfig};
 use tokio::process::Command;
 
 /// Returns a command to run the given MoonBit executable of a specific
@@ -39,14 +38,16 @@ use tokio::process::Command;
 ///
 /// ### Note
 ///
-/// Currently there's no support for using `tcc` to execute the target program.
 pub(crate) fn command_for(
     backend: RunBackend,
+    tcc_run: Option<&TccRunConfig>,
     mbt_executable: &Path,
     test: Option<&TestArgs>,
 ) -> Command {
-    match backend {
-        RunBackend::Wasm | RunBackend::WasmGC => {
+    debug_assert!(tcc_run.is_none() || backend == RunBackend::Native);
+
+    match (backend, tcc_run) {
+        (RunBackend::Wasm | RunBackend::WasmGC, _) => {
             let mut cmd = Command::new(&*moonutil::BINARIES.moonrun);
             if let Some(t) = test {
                 cmd.arg("--test-args");
@@ -56,7 +57,7 @@ pub(crate) fn command_for(
             cmd.arg("--");
             cmd
         }
-        RunBackend::Js => {
+        (RunBackend::Js, _) => {
             if test.is_some() {
                 // Also write package.json to the directory of the .js file being required
                 // to prevent node from finding the user's package.json with "type": "module"
@@ -73,17 +74,17 @@ pub(crate) fn command_for(
             }
             cmd
         }
-        RunBackend::Native | RunBackend::Llvm => {
-            let mut cmd = Command::new(mbt_executable);
+        (RunBackend::Native, Some(tcc_run)) => {
+            let tcc = tcc_run.internal_tcc();
+            let mut cmd = Command::new(tcc.cc_path());
+            cmd.arg(format!("@{}", mbt_executable.display()));
             if let Some(t) = test {
                 cmd.arg(t.to_cli_args_for_native());
             }
             cmd
         }
-        RunBackend::NativeTccRun => {
-            let tcc = CC::internal_tcc().expect("TCC must be available for TCC run backend");
-            let mut cmd = Command::new(tcc.cc_path());
-            cmd.arg(format!("@{}", mbt_executable.display()));
+        (RunBackend::Native | RunBackend::Llvm, _) => {
+            let mut cmd = Command::new(mbt_executable);
             if let Some(t) = test {
                 cmd.arg(t.to_cli_args_for_native());
             }

--- a/crates/moon/tests/support/util.rs
+++ b/crates/moon/tests/support/util.rs
@@ -110,7 +110,8 @@ pub(crate) fn replace_dir(s: &str, dir: impl AsRef<std::path::Path>) -> String {
         dunce::canonicalize(moon_home).unwrap().to_str().unwrap(),
         "$MOON_HOME",
     );
-    let s = if let Ok(cc) = compiler_flags::try_default_cc() {
+    let s = if let Ok(toolchain) = compiler_flags::default_native_toolchain(None) {
+        let cc = toolchain.cc();
         let s = s.replace(&cc.ar_path, cc.ar_name());
         s.replace(&cc.cc_path, cc.cc_name())
     } else {

--- a/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
@@ -44,6 +44,56 @@ const MI_EXTENSION: &str = ".mi";
 /// Implementation package will generate a dummy mi file so that it
 /// won't be rebuilt every time
 const IMPL_MI_EXTENSION: &str = ".impl.mi";
+
+#[derive(Clone, Copy, Debug)]
+pub enum ExecutableArtifact {
+    Wasm {
+        use_wat: bool,
+    },
+    WasmGC {
+        use_wat: bool,
+    },
+    Js,
+    NativeExecutable {
+        os: OperatingSystem,
+        legacy_behavior: bool,
+    },
+    TccRunResponseFile,
+    LlvmExecutable {
+        os: OperatingSystem,
+        legacy_behavior: bool,
+    },
+}
+
+impl ExecutableArtifact {
+    fn target_backend(self) -> TargetBackend {
+        match self {
+            Self::Wasm { .. } => TargetBackend::Wasm,
+            Self::WasmGC { .. } => TargetBackend::WasmGC,
+            Self::Js => TargetBackend::Js,
+            Self::NativeExecutable { .. } | Self::TccRunResponseFile => TargetBackend::Native,
+            Self::LlvmExecutable { .. } => TargetBackend::LLVM,
+        }
+    }
+
+    fn extension(self) -> &'static str {
+        match self {
+            Self::Wasm { use_wat } | Self::WasmGC { use_wat } if use_wat => ".wat",
+            Self::Wasm { .. } | Self::WasmGC { .. } => ".wasm",
+            Self::Js => ".js",
+            Self::NativeExecutable {
+                os,
+                legacy_behavior,
+            }
+            | Self::LlvmExecutable {
+                os,
+                legacy_behavior,
+            } => executable_ext(os, legacy_behavior),
+            Self::TccRunResponseFile => ".rspfile",
+        }
+    }
+}
+
 /// Target folder layout that matches the legacy (pre-beta) behavior
 #[derive(Builder)]
 pub struct LegacyLayout {
@@ -316,17 +366,14 @@ impl LegacyLayout {
         &self,
         pkg_list: &DiscoverResult,
         target: &BuildTarget,
-        backend: RunBackend,
-        os: OperatingSystem,
-        legacy_behavior: bool,
-        wasm_use_wat: bool,
+        executable: ExecutableArtifact,
     ) -> PathBuf {
         let pkg_fqn = &pkg_list.get_package(target.package).fqn;
-        let mut base_dir = self.package_dir(pkg_fqn, backend.into());
+        let mut base_dir = self.package_dir(pkg_fqn, executable.target_backend());
         base_dir.push(format!(
             "{}{}",
             artifact(pkg_fqn, target.kind),
-            make_executable_artifact_ext(backend, os, legacy_behavior, wasm_use_wat),
+            executable.extension(),
         ));
         base_dir
     }
@@ -368,18 +415,23 @@ impl LegacyLayout {
         result
     }
 
-    pub fn runtime_output_path(&self, backend: RunBackend, os: OperatingSystem) -> PathBuf {
+    pub fn runtime_output_path(
+        &self,
+        backend: RunBackend,
+        use_tcc_run: bool,
+        os: OperatingSystem,
+    ) -> PathBuf {
         let mut result = self.target_base_dir.clone();
         self.push_opt_and_run_mode(backend.into(), &mut result);
         match backend {
             RunBackend::WasmGC | RunBackend::Wasm | RunBackend::Js => {
                 panic!("Runtime output path is not applicable for non-native backends")
             }
+            RunBackend::Native if use_tcc_run => {
+                result.push(format!("libruntime{}", dynamic_library_ext(os)))
+            }
             RunBackend::Native | RunBackend::Llvm => {
                 result.push(format!("runtime{}", object_file_ext(os)))
-            }
-            RunBackend::NativeTccRun => {
-                result.push(format!("libruntime{}", dynamic_library_ext(os)))
             }
         }
         result
@@ -596,22 +648,6 @@ fn linked_core_artifact_ext(
         TargetBackend::Js => ".js",
         TargetBackend::Native => ".c",
         TargetBackend::LLVM => object_file_ext(os),
-    }
-}
-
-fn make_executable_artifact_ext(
-    backend: RunBackend,
-    os: OperatingSystem,
-    legacy_behavior: bool,
-    wasm_use_wat: bool,
-) -> &'static str {
-    match backend {
-        RunBackend::Wasm | RunBackend::WasmGC if wasm_use_wat => ".wat",
-        RunBackend::Wasm | RunBackend::WasmGC => ".wasm",
-        RunBackend::Js => ".js",
-        RunBackend::Native | RunBackend::Llvm => executable_ext(os, legacy_behavior),
-        // NB: TCC run relies on C artifacts and a response file to run the program
-        RunBackend::NativeTccRun => ".rspfile",
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -30,7 +30,7 @@ use crate::{
     build_lower::artifact::LegacyLayout,
     build_plan::{BuildPlan, FileDependencyKind},
     discover::{DiscoverResult, DiscoveredPackage},
-    model::{BuildPlanNode, BuildTarget, RunBackend},
+    model::{BuildPlanNode, BuildTarget},
     pkg_solve::DepRelationship,
 };
 use moonutil::BINARIES;
@@ -393,7 +393,7 @@ impl<'a> BuildPlanLowerContext<'a> {
                 );
             }
             BuildPlanNode::ArchiveOrLinkCStubs(_target) => {
-                if self.opt.target_backend == RunBackend::NativeTccRun {
+                if self.opt.use_tcc_run() {
                     out.push(self.layout.c_stub_link_dylib_path(
                         self.packages,
                         _target,
@@ -422,10 +422,7 @@ impl<'a> BuildPlanLowerContext<'a> {
                 out.push(self.layout.executable_of_build_target(
                     self.packages,
                     &target,
-                    self.opt.target_backend,
-                    self.opt.os,
-                    true,
-                    self.opt.output_wat,
+                    self.opt.executable_artifact(true),
                 ))
             }
             BuildPlanNode::GenerateTestInfo(target) => {
@@ -455,10 +452,11 @@ impl<'a> BuildPlanLowerContext<'a> {
                 );
             }
             BuildPlanNode::BuildRuntimeLib => {
-                out.push(
-                    self.layout
-                        .runtime_output_path(self.opt.target_backend, self.opt.os),
-                );
+                out.push(self.layout.runtime_output_path(
+                    self.opt.target_backend,
+                    self.opt.use_tcc_run(),
+                    self.opt.os,
+                ));
             }
             BuildPlanNode::GenerateMbti(_target) => {
                 out.push(self.layout.generated_mbti_path(

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -137,36 +137,31 @@ impl<'a> super::BuildPlanLowerContext<'a> {
 
     #[instrument(level = Level::DEBUG, skip(self))]
     pub(super) fn lower_compile_runtime(&mut self) -> anyhow::Result<BuildCommand> {
-        let artifact_path = self
-            .layout
-            .runtime_output_path(self.opt.target_backend, self.opt.os);
+        let artifact_path = self.layout.runtime_output_path(
+            self.opt.target_backend,
+            self.opt.use_tcc_run(),
+            self.opt.os,
+        );
 
         let runtime_c_path = self.opt.runtime_dot_c_path.clone();
 
-        let output_ty;
-        let link_moonbitrun;
-        match self.opt.target_backend {
+        let use_tcc_run = self.opt.use_tcc_run();
+        let (output_ty, link_moonbitrun) = match self.opt.target_backend {
             RunBackend::Wasm | RunBackend::WasmGC | RunBackend::Js => {
                 panic!("Runtime compilation is not applicable for non-native backends")
             }
-            RunBackend::Native | RunBackend::Llvm => {
-                output_ty = CCOutputType::Object;
-                link_moonbitrun = true;
-            }
-            RunBackend::NativeTccRun => {
-                output_ty = CCOutputType::SharedLib;
-                link_moonbitrun = false;
-            }
+            RunBackend::Native if use_tcc_run => (CCOutputType::SharedLib, false),
+            RunBackend::Native | RunBackend::Llvm => (CCOutputType::Object, true),
         };
 
-        let resolved_cc = self
-            .opt
-            .native_toolchain
-            .ok_or_else(|| anyhow::anyhow!("native C toolchain is not selected for this build"))?
-            .resolve_default()?
-            .cc()
-            .clone();
-        let use_tcc_run = matches!(self.opt.target_backend, RunBackend::NativeTccRun);
+        let resolved_cc = moonutil::compiler_flags::default_native_toolchain(
+            self.opt
+                .tcc_run
+                .as_ref()
+                .map(|config| config.internal_tcc()),
+        )?
+        .cc()
+        .clone();
         let use_simdutf = !use_tcc_run
             && resolved_cc.can_use_simdutf()
             && self.opt.compiler_paths.simdutf_object_paths().is_some();

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -26,7 +26,7 @@ use std::{
 use moonutil::{
     common::RunMode,
     compiler_flags::{
-        ArchiverConfigBuilder, CCConfigBuilder, LinkerConfigBuilder, OptLevel as CCOptLevel,
+        ArchiverConfigBuilder, CC, CCConfigBuilder, LinkerConfigBuilder, OptLevel as CCOptLevel,
         OutputType as CCOutputType, make_archiver_command_resolved, make_cc_command_resolved,
         make_cc_command_resolved_with_link_flags, make_linker_command_resolved,
     },
@@ -804,7 +804,7 @@ impl<'a> BuildPlanLowerContext<'a> {
             (false, false) => CCOptLevel::None,
         };
         // `tcc run` uses shared runtime, others use static runtime
-        let use_shared_runtime = matches!(self.opt.target_backend, RunBackend::NativeTccRun);
+        let use_shared_runtime = self.opt.use_tcc_run();
 
         let config = CCConfigBuilder::default()
             .no_sys_header(true)
@@ -868,10 +868,12 @@ impl<'a> BuildPlanLowerContext<'a> {
             RunBackend::WasmGC | RunBackend::Wasm | RunBackend::Js => {
                 panic!("C stubs are not supported for non-native backends")
             }
+            RunBackend::Native if self.opt.use_tcc_run() => {
+                self.lower_link_c_stubs(target, info, &object_files)
+            }
             RunBackend::Native | RunBackend::Llvm => {
                 self.lower_archive_c_stubs(target, info, &object_files)
             }
-            RunBackend::NativeTccRun => self.lower_link_c_stubs(target, info, &object_files),
         }
     }
 
@@ -932,9 +934,11 @@ impl<'a> BuildPlanLowerContext<'a> {
 
         // Track libruntime.{DYN_EXT} as a dependency but do not pass it as a direct linker src.
         // Legacy adds runtime into build inputs then links via -lruntime using link_shared_runtime.
-        let runtime_dylib = self
-            .layout
-            .runtime_output_path(self.opt.target_backend, self.opt.os);
+        let runtime_dylib = self.layout.runtime_output_path(
+            self.opt.target_backend,
+            self.opt.use_tcc_run(),
+            self.opt.os,
+        );
         let runtime_parent = runtime_dylib
             .parent()
             .expect("runtime dylib should have a parent directory");
@@ -986,8 +990,15 @@ impl<'a> BuildPlanLowerContext<'a> {
                     "Non-native make-executable should be already matched and should not be here"
                 )
             }
-            RunBackend::Native | RunBackend::Llvm => self.lower_build_exe_regular(target, info),
-            RunBackend::NativeTccRun => self.build_tcc_run_driver_command(target, info),
+            RunBackend::Native => {
+                if let Some(tcc_run) = &self.opt.tcc_run {
+                    let internal_tcc = tcc_run.internal_tcc().clone();
+                    self.build_tcc_run_driver_command(target, info, internal_tcc)
+                } else {
+                    self.lower_build_exe_regular(target, info)
+                }
+            }
+            RunBackend::Llvm => self.lower_build_exe_regular(target, info),
         }
     }
 
@@ -1043,14 +1054,7 @@ impl<'a> BuildPlanLowerContext<'a> {
 
         let dest = self
             .layout
-            .executable_of_build_target(
-                self.packages,
-                &target,
-                self.opt.target_backend,
-                self.opt.os,
-                true,
-                self.opt.output_wat,
-            )
+            .executable_of_build_target(self.packages, &target, self.opt.executable_artifact(true))
             .display()
             .to_string();
 
@@ -1104,13 +1108,8 @@ impl<'a> BuildPlanLowerContext<'a> {
         &self,
         target: BuildTarget,
         info: &MakeExecutableInfo,
+        cc: CC,
     ) -> BuildCommand {
-        let cc = self
-            .opt
-            .internal_tcc
-            .clone()
-            .expect("Should not go to tcc run path without tcc available");
-
         let mut sources = vec![];
 
         // Runtime path
@@ -1176,10 +1175,7 @@ impl<'a> BuildPlanLowerContext<'a> {
         let rsp_path = self.layout.executable_of_build_target(
             self.packages,
             &target,
-            self.opt.target_backend,
-            self.opt.os,
-            false,
-            self.opt.output_wat,
+            self.opt.executable_artifact(false),
         );
 
         rsp_cmdline.push(rsp_path.display().to_string());

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -23,10 +23,7 @@ use std::{collections::BTreeMap, path::PathBuf};
 use indexmap::IndexMap;
 use log::{debug, info};
 use moonutil::{
-    common::RunMode,
-    compiler_flags::{CC, CompilerPaths, NativeToolchainSelection},
-    cond_expr::OptLevel,
-    mooncakes::ModuleSource,
+    common::RunMode, compiler_flags::CompilerPaths, cond_expr::OptLevel, mooncakes::ModuleSource,
 };
 use n2::graph::Graph as N2Graph;
 use tracing::instrument;
@@ -34,7 +31,7 @@ use tracing::instrument;
 use crate::{
     ResolveOutput,
     build_plan::BuildPlan,
-    model::{Artifacts, BuildPlanNode, OperatingSystem, RunBackend},
+    model::{Artifacts, BuildPlanNode, OperatingSystem, RunBackend, TccRunConfig},
     pkg_name::OptionalPackageFQNWithSource,
 };
 
@@ -47,7 +44,7 @@ mod utils;
 
 pub use utils::{build_ins, build_n2_fileloc, build_outs};
 
-use crate::build_lower::artifact::LegacyLayoutBuilder;
+use crate::build_lower::artifact::{ExecutableArtifact, LegacyLayoutBuilder};
 use context::BuildPlanLowerContext;
 
 /// Knobs to tweak during build. Affects behaviors during lowering.
@@ -56,6 +53,7 @@ pub struct BuildOptions {
     pub target_dir_root: PathBuf,
     // FIXME: This overlaps with `crate::build_plan::BuildEnvironment`
     pub target_backend: RunBackend,
+    pub tcc_run: Option<TccRunConfig>,
     pub os: OperatingSystem,
     pub opt_level: OptLevel,
     pub action: RunMode,
@@ -75,10 +73,35 @@ pub struct BuildOptions {
     pub stdlib_path: Option<PathBuf>,
     pub runtime_dot_c_path: PathBuf,
     pub compiler_paths: CompilerPaths,
-    /// Resolved internal TCC toolchain when this invocation uses `tcc -run`.
-    pub internal_tcc: Option<CC>,
-    /// Native toolchain selection policy, only when the backend needs one.
-    pub native_toolchain: Option<NativeToolchainSelection>,
+}
+
+impl BuildOptions {
+    pub fn use_tcc_run(&self) -> bool {
+        let use_tcc_run = self.tcc_run.is_some();
+        debug_assert!(!use_tcc_run || self.target_backend == RunBackend::Native);
+        use_tcc_run
+    }
+
+    pub fn executable_artifact(&self, legacy_behavior: bool) -> ExecutableArtifact {
+        match self.target_backend {
+            RunBackend::Wasm => ExecutableArtifact::Wasm {
+                use_wat: self.output_wat,
+            },
+            RunBackend::WasmGC => ExecutableArtifact::WasmGC {
+                use_wat: self.output_wat,
+            },
+            RunBackend::Js => ExecutableArtifact::Js,
+            RunBackend::Native if self.use_tcc_run() => ExecutableArtifact::TccRunResponseFile,
+            RunBackend::Native => ExecutableArtifact::NativeExecutable {
+                os: self.os,
+                legacy_behavior,
+            },
+            RunBackend::Llvm => ExecutableArtifact::LlvmExecutable {
+                os: self.os,
+                legacy_behavior,
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -44,7 +44,7 @@ use crate::{
     build_plan::{BuildBundleInfo, FileDependencyKind, PrebuildInfo},
     cond_comp::{self, CompileCondition},
     discover::DiscoveredPackage,
-    model::{BuildPlanNode, BuildTarget, PackageId, RunBackend, TargetKind},
+    model::{BuildPlanNode, BuildTarget, PackageId, TargetKind},
     pkg_name::PackageFQNWithSource,
     user_warning::UserWarning,
 };
@@ -60,10 +60,14 @@ const PROOF_ENABLED_WARN_SUPPRESSIONS: &str = "-1-2-3-29";
 
 impl<'a> BuildPlanConstructor<'a> {
     fn effective_native_toolchain(&self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
-        self.build_env
-            .native_toolchain
-            .ok_or_else(|| anyhow::anyhow!("native C toolchain is not selected for this build"))?
-            .resolve_with_package_override(package_cc)
+        debug_assert!(self.build_env.target_backend.is_native());
+        moonutil::compiler_flags::effective_native_toolchain(
+            package_cc,
+            self.build_env
+                .tcc_run
+                .as_ref()
+                .map(|config| config.internal_tcc()),
+        )
     }
 
     fn module_prebuild_vars(&self, module: ModuleId) -> Option<&HashMap<String, String>> {
@@ -694,7 +698,7 @@ impl<'a> BuildPlanConstructor<'a> {
         }
 
         // If we're tcc run, also depend on the runtime library
-        if self.build_env.target_backend == RunBackend::NativeTccRun {
+        if self.build_env.tcc_run.is_some() {
             let make_exec_node = self.need_node(BuildPlanNode::BuildRuntimeLib);
             self.add_edge(node, make_exec_node);
         }

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -341,6 +341,9 @@ impl<'a> BuildPlanConstructor<'a> {
                 );
             }
             BuildPlanNode::MakeExecutable(build_target) => {
+                // Non-native MakeExecutable nodes are final-artifact aliases over
+                // LinkCore output. Only native backends need extra lowering info
+                // for the C toolchain/runtime/stub linking step.
                 if self.build_env.target_backend.is_native() {
                     assert!(
                         self.res.make_executable_info.contains_key(&build_target),

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -52,7 +52,7 @@ use std::{
 use log::{debug, info};
 use moonutil::{
     common::{RunMode, TargetBackend},
-    compiler_flags::{NativeToolchainSelection, Toolchain},
+    compiler_flags::Toolchain,
     cond_expr::OptLevel,
     mooncakes::ModuleId,
 };
@@ -61,7 +61,7 @@ use tracing::instrument;
 
 use crate::{
     ResolveOutput,
-    model::{BuildPlanNode, BuildTarget, PackageId, RunBackend},
+    model::{BuildPlanNode, BuildTarget, PackageId, RunBackend, TccRunConfig},
     pkg_name::PackageFQNWithSource,
     prebuild::PrebuildOutput,
     user_warning::UserWarning,
@@ -326,6 +326,7 @@ pub struct BuildBundleInfo {
 pub struct BuildEnvironment {
     // FIXME: Target backend should go into the solver, not here
     pub target_backend: RunBackend,
+    pub tcc_run: Option<TccRunConfig>,
     pub opt_level: OptLevel,
     pub action: RunMode,
     /// Whether compiling requires the standard library.
@@ -334,8 +335,6 @@ pub struct BuildEnvironment {
     pub std: bool,
     /// Commandline_level warnings to enable/disable
     pub warn_list: Option<String>,
-    /// Native toolchain selection policy, only when the backend needs one.
-    pub native_toolchain: Option<NativeToolchainSelection>,
 }
 
 /// Directives provided along the input actions.

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -20,17 +20,13 @@ use std::{path::PathBuf, str::FromStr};
 
 use indexmap::IndexMap;
 use log::{debug, info};
-use moonutil::{
-    common::RunMode,
-    compiler_flags::{CC, CompilerPaths, NativeToolchainSelection},
-    cond_expr::OptLevel,
-};
+use moonutil::{common::RunMode, compiler_flags::CompilerPaths, cond_expr::OptLevel};
 use tracing::{Level, instrument};
 
 use crate::{
     build_lower::{self, WarningCondition},
     build_plan::{self, BuildEnvironment, InputDirective},
-    model::{Artifacts, BuildPlanNode, OperatingSystem, RunBackend},
+    model::{Artifacts, BuildPlanNode, OperatingSystem, RunBackend, TccRunConfig},
     prebuild::PrebuildOutput,
     resolve::ResolveOutput,
     special_cases::should_skip_tests,
@@ -41,8 +37,10 @@ use crate::{
 pub struct CompileConfig {
     /// Target directory, i.e. `_build/`
     pub target_dir: PathBuf,
-    /// The backend to use for the compilation.
+    /// The backend selected for this build.
     pub target_backend: RunBackend,
+    /// Configuration for `tcc -run`, if the native build selected it.
+    pub tcc_run: Option<TccRunConfig>,
     /// The optimization level to use for the compilation.
     pub opt_level: OptLevel,
     /// The action done in this operation, currently only used in legacy directory layout
@@ -74,10 +72,6 @@ pub struct CompileConfig {
     pub warn_list: Option<String>,
     /// Whether to not emit alias when running `mooninfo`
     pub info_no_alias: bool,
-    /// Resolved internal TCC toolchain when this invocation uses `tcc -run`.
-    pub internal_tcc: Option<CC>,
-    /// Native toolchain selection policy, only when the backend needs one.
-    pub native_toolchain: Option<NativeToolchainSelection>,
 }
 
 /// The output information of the compilation.
@@ -126,11 +120,11 @@ pub fn compile(
 
     let build_env = BuildEnvironment {
         target_backend: cx.target_backend,
+        tcc_run: cx.tcc_run.clone(),
         opt_level: cx.opt_level,
         action: cx.action,
         std: cx.stdlib_path.is_some(),
         warn_list: cx.warn_list.clone(),
-        native_toolchain: cx.native_toolchain,
     };
     let (plan, user_warnings) = build_plan::build_plan(
         resolve_output,
@@ -152,6 +146,7 @@ pub fn compile(
         },
         target_dir_root: cx.target_dir.clone(),
         target_backend: cx.target_backend,
+        tcc_run: cx.tcc_run.clone(),
         opt_level: cx.opt_level,
         action: cx.action,
 
@@ -166,8 +161,6 @@ pub fn compile(
 
         stdlib_path: cx.stdlib_path.clone(),
         compiler_paths,
-        internal_tcc: cx.internal_tcc.clone(),
-        native_toolchain: cx.native_toolchain,
         os: OperatingSystem::from_str(std::env::consts::OS).expect("Unknown"),
         runtime_dot_c_path,
     };

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -181,10 +181,14 @@ pub enum BuildPlanNode {
     /// Link the `.core` file into an executable or library for the given target.
     LinkCore(BuildTarget),
 
-    /// If the output from `LinkCore` is not yet executable, make it executable.
+    /// The final runnable artifact for a target.
     ///
-    /// This is mainly for native targets, where the build output is a C file
-    /// that needs further compilation and linking to become an executable.
+    /// For wasm and js, `LinkCore` already emits the final `.wasm`, `.wat`, or
+    /// `.js` artifact, so this node is retained as the final artifact node but
+    /// lowers to no command.
+    ///
+    /// For native targets, the output from `LinkCore` is a C file or object
+    /// file that needs further compilation and linking to become an executable.
     ///
     /// In TCC mode, since linking is done at the same time as running, this
     /// step writes a response file containing the linking flags for TCC to use.

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 
 use moonutil::{
     common::TargetBackend,
+    compiler_flags::CC,
     mooncakes::{ModuleId, result::ResolvedEnv},
 };
 
@@ -30,29 +31,41 @@ slotmap::new_key_type! {
     pub struct PackageId;
 }
 
-/// Backend that affect how the build and artifact generation is performed.
+/// User-visible backend selected for the build and run artifact shape.
 ///
-/// Note: This is different from [`TargetBackend`]. That enum is a high-level
-/// abstraction of the user's choice and what kind of output format `moonc`
-/// produces, but this also cares about what toolchains are used, etc.
+/// This mirrors [`TargetBackend`] and intentionally does not encode native C
+/// compiler or execution-tool choices.
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub enum RunBackend {
     WasmGC,
     Wasm,
     Js,
     Native,
-    /// Like `Native`, but uses `tcc -run` to execute the program directly. Does
-    /// not produce a standalone binary artifact.
-    NativeTccRun,
     Llvm,
+}
+
+/// Configuration for the optional native `tcc -run` path.
+///
+/// Normal native execution, LLVM execution, and all non-native backends do not
+/// carry this value.
+#[derive(Clone, Debug)]
+pub struct TccRunConfig {
+    internal_tcc: CC,
+}
+
+impl TccRunConfig {
+    pub fn new(internal_tcc: CC) -> Self {
+        Self { internal_tcc }
+    }
+
+    pub fn internal_tcc(&self) -> &CC {
+        &self.internal_tcc
+    }
 }
 
 impl RunBackend {
     pub fn is_native(self) -> bool {
-        matches!(
-            self,
-            RunBackend::Native | RunBackend::NativeTccRun | RunBackend::Llvm
-        )
+        matches!(self, RunBackend::Native | RunBackend::Llvm)
     }
 
     pub fn to_target(self) -> TargetBackend {
@@ -67,7 +80,6 @@ impl From<RunBackend> for TargetBackend {
             RunBackend::Wasm => TargetBackend::Wasm,
             RunBackend::Js => TargetBackend::Js,
             RunBackend::Native => TargetBackend::Native,
-            RunBackend::NativeTccRun => TargetBackend::Native,
             RunBackend::Llvm => TargetBackend::LLVM,
         }
     }

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -70,54 +70,6 @@ pub struct Toolchain {
     source: ToolchainSource,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct NativeToolchainSelection {
-    internal_tcc_fallback: bool,
-}
-
-impl NativeToolchainSelection {
-    pub fn system_first() -> Self {
-        Self {
-            internal_tcc_fallback: false,
-        }
-    }
-
-    pub fn system_then_internal_tcc() -> Self {
-        Self {
-            internal_tcc_fallback: true,
-        }
-    }
-
-    pub fn resolve_default(self) -> anyhow::Result<Toolchain> {
-        match try_default_cc() {
-            Ok(cc) => Ok(Toolchain::from_cc(cc)),
-            Err(system_err) if self.internal_tcc_fallback => try_internal_tcc()
-                .with_context(|| {
-                    format!(
-                        "failed to resolve fallback internal tcc after system C compiler detection failed: {system_err:#}"
-                    )
-                })
-                .map(Toolchain::from_cc),
-            Err(err) => Err(err),
-        }
-    }
-
-    pub fn resolve_with_package_override(
-        self,
-        package_cc: Option<&CC>,
-    ) -> anyhow::Result<Toolchain> {
-        if let Some(env_cc) = ENV_CC.as_ref() {
-            return Ok(
-                Toolchain::from_env_override(env_cc.clone()).with_package_override(package_cc)
-            );
-        }
-        if let Some(package_cc) = package_cc {
-            return Ok(Toolchain::from_package_override(package_cc.clone()));
-        }
-        self.resolve_default()
-    }
-}
-
 impl Toolchain {
     pub fn from_env_override(cc: CC) -> Self {
         Self {
@@ -579,11 +531,30 @@ pub fn has_cc_env_override() -> bool {
     env::var_os(ENV_MOON_CC).is_some()
 }
 
-pub fn try_default_cc() -> anyhow::Result<CC> {
+pub fn default_native_toolchain(internal_tcc_fallback: Option<&CC>) -> anyhow::Result<Toolchain> {
     if let Some(env_cc) = ENV_CC.as_ref() {
-        return Ok(env_cc.clone());
+        return Ok(Toolchain::from_env_override(env_cc.clone()));
     }
-    try_system_cc()
+    match try_system_cc() {
+        Ok(cc) => Ok(Toolchain::from_path_probe(cc)),
+        Err(err) => match internal_tcc_fallback {
+            Some(internal_tcc) => Ok(Toolchain::from_path_probe(internal_tcc.clone())),
+            None => Err(err),
+        },
+    }
+}
+
+pub fn effective_native_toolchain(
+    package_cc: Option<&CC>,
+    internal_tcc_fallback: Option<&CC>,
+) -> anyhow::Result<Toolchain> {
+    if let Some(env_cc) = ENV_CC.as_ref() {
+        return Ok(Toolchain::from_env_override(env_cc.clone()).with_package_override(package_cc));
+    }
+    if let Some(package_cc) = package_cc {
+        return Ok(Toolchain::from_package_override(package_cc.clone()));
+    }
+    default_native_toolchain(internal_tcc_fallback)
 }
 
 #[derive(Clone, Copy, PartialEq)]


### PR DESCRIPTION
Stack split 3/3. Base: #1710 (`codex/native-toolchain-selection`).

This PR keeps the model cleanup separate from the behavior fixes:

- clarify `MakeExecutable` planner node wording
- remove tcc-run as a `RunBackend` concept
- carry optional `TccRunConfig` separately from the selected backend
- model executable-like artifacts with explicit variants, including `TccRunResponseFile`, instead of a flat options bag

Validation run locally:

- `cargo check -p moonutil -p moonbuild-rupes-recta -p moon`
- `cargo clippy -p moonbuild-rupes-recta -p moon --all-targets -- -D warnings`
- `cargo test -p moon --test mod native_backend::tcc_run::test_native_backend_tcc_run`
- `cargo test -p moon --test mod prebuild_config_script::test_prebuild_config_tcc_rspfile_snapshot`