### PR TITLE
[codex] expand moon explain docs

### DIFF
--- a/crates/moon/src/cli/explain.rs
+++ b/crates/moon/src/cli/explain.rs
@@ -22,32 +22,59 @@ mod warning_index;
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, bail};
-use moonutil::error_code_docs::get_error_code_doc;
+use moonutil::error_code_docs::{
+    get_all_attribute_docs, get_all_error_code_docs, get_error_code_doc,
+};
 use moonutil::{BINARIES, cli::UniversalFlags};
 
-/// Explain diagnostics from the compiler.
+/// Explain compiler diagnostics and language topics.
 #[derive(Debug, clap::Parser)]
 #[clap(
     arg_required_else_help = true,
-    after_help = "Resources:\n    Docs: https://docs.moonbitlang.com\n    Skills: https://github.com/moonbitlang/skills\n\n    Use `moon explain --diagnostics` to list warning mnemonics and IDs."
+    group(
+        clap::ArgGroup::new("explain_mode")
+            .required(true)
+            .args(["diagnostic", "attribute"])
+    ),
+    after_help = "Resources:\n    Docs: https://docs.moonbitlang.com\n    Skills: https://github.com/moonbitlang/skills\n\n    Use `moon explain --diagnostic` to list diagnostic codes and names.\n    Use `moon explain --attribute` to list attributes."
 )]
 pub(crate) struct ExplainSubcommand {
-    /// Explain diagnostics. Without a query, list warning mnemonics and IDs from `moonc`.
+    /// Explain diagnostics. Without a query, list diagnostic codes and names.
+    #[clap(
+        long,
+        alias = "diagnostics",
+        num_args = 0..=1,
+        default_missing_value = "",
+        value_name = "ID_OR_NAME"
+    )]
+    pub diagnostic: Option<String>,
+
+    /// Explain attributes. Without a query, list attribute names.
     #[clap(
         long,
         num_args = 0..=1,
         default_missing_value = "",
-        value_name = "ID_OR_MNEMONIC"
+        value_name = "NAME"
     )]
-    pub diagnostics: Option<String>,
+    pub attribute: Option<String>,
 }
 
 pub(crate) fn run_explain(_cli: &UniversalFlags, cmd: ExplainSubcommand) -> anyhow::Result<i32> {
-    match cmd.diagnostics.as_deref() {
-        Some("") => list_diagnostics(),
-        Some(query) => explain_diagnostic(query),
-        None => unreachable!("clap requires an argument for `moon explain`"),
+    if let Some(query) = cmd.diagnostic.as_deref() {
+        return match query {
+            "" => list_diagnostics(),
+            query => explain_diagnostic(query),
+        };
     }
+
+    if let Some(query) = cmd.attribute.as_deref() {
+        return match query {
+            "" => list_attributes(),
+            query => explain_attribute(query),
+        };
+    }
+
+    unreachable!("clap requires an argument for `moon explain`")
 }
 
 fn list_diagnostics() -> anyhow::Result<i32> {
@@ -58,19 +85,28 @@ fn list_diagnostics() -> anyhow::Result<i32> {
         .stderr(Stdio::inherit())
         .status()
         .with_context(|| format!("failed to run `{}`", BINARIES.moonc.display()))?;
-
-    if status.success() {
-        Ok(status.code().unwrap_or(0))
-    } else {
-        bail!("`moonc check -warn-help` failed")
+    if !status.success() {
+        bail!("`moonc check -warn-help` failed");
     }
+
+    let entries = non_warning_diagnostic_index_entries();
+    if !entries.is_empty() {
+        println!();
+        println!("Available non-warning diagnostics:");
+        for entry in entries {
+            println!("  E{}  diagnostic {}", entry.code, entry.names.join(", "));
+        }
+        println!();
+        println!("Use `moon explain --diagnostic <ID_OR_NAME>` to show details.");
+    }
+    Ok(0)
 }
 
 fn explain_diagnostic(query: &str) -> anyhow::Result<i32> {
     let docs = diagnostic_docs(query);
     if docs.is_empty() {
         bail!(
-            "no integrated diagnostic docs found for `{}`. Try `moon explain --diagnostics` to list available warnings.",
+            "no integrated diagnostic docs found for `{}`. Try `moon explain --diagnostic` to list available diagnostics.",
             query.trim()
         );
     }
@@ -105,6 +141,20 @@ fn diagnostic_docs(query: &str) -> Vec<String> {
         };
     }
 
+    let docs: Vec<_> = get_all_error_code_docs()
+        .into_iter()
+        .filter(|(_, doc)| {
+            diagnostic_names(doc)
+                .1
+                .iter()
+                .any(|name| diagnostic_name_matches(name, query))
+        })
+        .map(|(_, doc)| doc.trim_end().to_owned())
+        .collect();
+    if !docs.is_empty() {
+        return docs;
+    }
+
     warning_index::get_warning_entries_by_mnemonic(query)
         .into_iter()
         .map(|entry| {
@@ -117,9 +167,168 @@ fn diagnostic_docs(query: &str) -> Vec<String> {
         .collect()
 }
 
+fn list_attributes() -> anyhow::Result<i32> {
+    let entries = attribute_doc_entries();
+    if entries.is_empty() {
+        bail!("no integrated attribute docs found. Run `git submodule update --init --recursive`.");
+    }
+
+    println!("Available attributes:");
+    for entry in entries {
+        let names = entry
+            .names
+            .iter()
+            .map(|name| format!("#{name}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("  {names}");
+    }
+    println!();
+    println!("Use `moon explain --attribute <NAME>` to show details.");
+    Ok(0)
+}
+
+fn explain_attribute(query: &str) -> anyhow::Result<i32> {
+    let docs = attribute_docs(query);
+    if docs.is_empty() {
+        bail!(
+            "no integrated attribute docs found for `{}`. Try `moon explain --attribute` to list available attributes.",
+            query.trim()
+        );
+    }
+
+    for (index, doc) in docs.into_iter().enumerate() {
+        if index > 0 {
+            println!();
+        }
+        println!("{doc}");
+    }
+    Ok(0)
+}
+
+fn attribute_docs(query: &str) -> Vec<String> {
+    let query = normalize_attribute_name(query);
+    attribute_doc_entries()
+        .into_iter()
+        .filter(|entry| {
+            normalize_attribute_name(entry.key) == query
+                || entry
+                    .names
+                    .iter()
+                    .any(|name| normalize_attribute_name(name) == query)
+        })
+        .map(|entry| entry.doc.trim_end().to_owned())
+        .collect()
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct DiagnosticIndexEntry<'a> {
+    code: &'a str,
+    kind: Option<&'static str>,
+    names: Vec<&'a str>,
+}
+
+fn diagnostic_index_entries() -> Vec<DiagnosticIndexEntry<'static>> {
+    get_all_error_code_docs()
+        .into_iter()
+        .map(|(code, doc)| {
+            let (kind, names) = diagnostic_names(doc);
+            DiagnosticIndexEntry { code, kind, names }
+        })
+        .collect()
+}
+
+fn non_warning_diagnostic_index_entries() -> Vec<DiagnosticIndexEntry<'static>> {
+    diagnostic_index_entries()
+        .into_iter()
+        .filter(|entry| entry.kind == Some("diagnostic") && !entry.names.is_empty())
+        .collect()
+}
+
+fn diagnostic_names(doc: &'static str) -> (Option<&'static str>, Vec<&'static str>) {
+    for line in doc.lines().map(str::trim) {
+        if let Some(names) = line.strip_prefix("Warning name:") {
+            return (Some("warning"), backtick_items(names));
+        }
+        if let Some(names) = line.strip_prefix("Compiler diagnostic name:") {
+            return (Some("diagnostic"), backtick_items(names));
+        }
+    }
+    (None, Vec::new())
+}
+
+fn diagnostic_name_matches(name: &str, query: &str) -> bool {
+    if name.eq_ignore_ascii_case(query) {
+        return true;
+    }
+
+    let name = name.to_ascii_lowercase();
+    let query = query.to_ascii_lowercase();
+    name.strip_suffix("<category>")
+        .is_some_and(|prefix| query.starts_with(prefix) && query.len() > prefix.len())
+}
+
+fn backtick_items(input: &str) -> Vec<&str> {
+    input
+        .split('`')
+        .skip(1)
+        .step_by(2)
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .collect()
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AttributeDocEntry {
+    key: &'static str,
+    doc: &'static str,
+    names: Vec<String>,
+}
+
+fn attribute_doc_entries() -> Vec<AttributeDocEntry> {
+    let mut entries: Vec<_> = get_all_attribute_docs()
+        .into_iter()
+        .map(|(key, doc)| {
+            let mut names = attribute_names(key);
+            if names.is_empty() {
+                names.push(key.to_owned());
+            }
+            AttributeDocEntry { key, doc, names }
+        })
+        .collect();
+    entries.sort_by(|left, right| left.names[0].cmp(&right.names[0]));
+    entries
+}
+
+fn attribute_names(key: &str) -> Vec<String> {
+    match key {
+        "borrow_and_owned" => vec!["borrow".to_owned(), "owned".to_owned()],
+        "coverage_skip" => vec!["coverage.skip".to_owned()],
+        "doc_hidden" => vec!["doc".to_owned()],
+        key => vec![key.to_owned()],
+    }
+}
+
+fn normalize_attribute_name(name: &str) -> String {
+    name.trim()
+        .trim_start_matches('#')
+        .split('(')
+        .next()
+        .unwrap_or_default()
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::diagnostic_docs;
+    use std::collections::BTreeSet;
+
+    use super::{
+        attribute_docs, diagnostic_docs, diagnostic_index_entries,
+        non_warning_diagnostic_index_entries, warning_index,
+    };
 
     #[test]
     fn resolves_prefixed_and_unprefixed_diagnostic_codes() {
@@ -132,5 +341,56 @@ mod tests {
     fn resolves_warning_mnemonics_through_integrated_docs() {
         let docs = diagnostic_docs("unused_value");
         assert_eq!(docs.len(), 2);
+    }
+
+    #[test]
+    fn lists_non_warning_diagnostic_docs() {
+        let entries = non_warning_diagnostic_index_entries();
+        assert!(
+            entries
+                .iter()
+                .any(|entry| { entry.code == "4056" && entry.names.contains(&"method_duplicate") })
+        );
+    }
+
+    #[test]
+    fn integrated_diagnostic_docs_cover_compiler_warning_ids() {
+        let documented_ids: BTreeSet<_> = diagnostic_index_entries()
+            .into_iter()
+            .filter_map(|entry| entry.code.parse::<u16>().ok())
+            .collect();
+        let compiler_warning_ids: BTreeSet<_> = warning_index::warning_entries()
+            .iter()
+            .map(|entry| entry.id)
+            .collect();
+
+        assert!(
+            compiler_warning_ids.is_subset(&documented_ids),
+            "integrated diagnostic docs are missing compiler warning IDs: {:?}",
+            compiler_warning_ids
+                .difference(&documented_ids)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn resolves_compiler_diagnostic_names_through_integrated_docs() {
+        let docs = diagnostic_docs("method_duplicate");
+        assert_eq!(docs.len(), 1);
+        assert!(docs[0].starts_with("# E4056\n"));
+    }
+
+    #[test]
+    fn resolves_attribute_docs_by_attribute_name() {
+        let docs = attribute_docs("coverage.skip");
+        assert_eq!(docs.len(), 1);
+        assert!(docs[0].starts_with("# Coverage Skip Attribute\n"));
+    }
+
+    #[test]
+    fn resolves_attribute_docs_by_file_stem() {
+        let docs = attribute_docs("borrow_and_owned");
+        assert_eq!(docs.len(), 1);
+        assert!(docs[0].starts_with("# Borrow and Owned Attribute\n"));
     }
 }

--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -405,6 +405,11 @@ pub(crate) fn get_warning_entries_by_mnemonic(mnemonic: &str) -> Vec<&'static Wa
 }
 
 #[cfg(test)]
+pub(crate) fn warning_entries() -> &'static [WarningEntry] {
+    WARNING_ENTRIES
+}
+
+#[cfg(test)]
 mod tests {
     use std::process::Command;
 

--- a/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
@@ -885,13 +885,17 @@ _moon() {
             return 0
             ;;
         moon__explain)
-            opts="-q -v -h --diagnostics --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --diagnostic --attribute --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --diagnostics)
+                --diagnostic)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --attribute)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
@@ -45,7 +45,7 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand clean 'Remove the _build directory'
             cand fmt 'Format source code'
             cand doc 'Generate documentation or searching documentation for a symbol'
-            cand explain 'Explain diagnostics from the compiler'
+            cand explain 'Explain compiler diagnostics and language topics'
             cand info 'Generate public interface (`.mbti`) files for all packages in the module or workspace'
             cand bench 'Run benchmarks in the current package'
             cand add 'Add a dependency'
@@ -390,7 +390,8 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;explain'= {
-            cand --diagnostics 'Explain diagnostics. Without a query, list warning mnemonics and IDs from `moonc`'
+            cand --diagnostic 'Explain diagnostics. Without a query, list diagnostic codes and names'
+            cand --attribute 'Explain attributes. Without a query, list attribute names'
             cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
@@ -1026,7 +1027,7 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand clean 'Remove the _build directory'
             cand fmt 'Format source code'
             cand doc 'Generate documentation or searching documentation for a symbol'
-            cand explain 'Explain diagnostics from the compiler'
+            cand explain 'Explain compiler diagnostics and language topics'
             cand info 'Generate public interface (`.mbti`) files for all packages in the module or workspace'
             cand bench 'Run benchmarks in the current package'
             cand add 'Add a dependency'

--- a/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
@@ -46,7 +46,7 @@ complete -c moon -n "__fish_moon_needs_command" -f -a "generate-test-driver" -d 
 complete -c moon -n "__fish_moon_needs_command" -f -a "clean" -d 'Remove the _build directory'
 complete -c moon -n "__fish_moon_needs_command" -f -a "fmt" -d 'Format source code'
 complete -c moon -n "__fish_moon_needs_command" -f -a "doc" -d 'Generate documentation or searching documentation for a symbol'
-complete -c moon -n "__fish_moon_needs_command" -f -a "explain" -d 'Explain diagnostics from the compiler'
+complete -c moon -n "__fish_moon_needs_command" -f -a "explain" -d 'Explain compiler diagnostics and language topics'
 complete -c moon -n "__fish_moon_needs_command" -f -a "info" -d 'Generate public interface (`.mbti`) files for all packages in the module or workspace'
 complete -c moon -n "__fish_moon_needs_command" -f -a "bench" -d 'Run benchmarks in the current package'
 complete -c moon -n "__fish_moon_needs_command" -f -a "add" -d 'Add a dependency'
@@ -308,7 +308,8 @@ complete -c moon -n "__fish_moon_using_subcommand doc" -l trace -d 'Trace the ex
 complete -c moon -n "__fish_moon_using_subcommand doc" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand doc" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand doc" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand explain" -l diagnostics -d 'Explain diagnostics. Without a query, list warning mnemonics and IDs from `moonc`' -r
+complete -c moon -n "__fish_moon_using_subcommand explain" -l diagnostic -d 'Explain diagnostics. Without a query, list diagnostic codes and names' -r
+complete -c moon -n "__fish_moon_using_subcommand explain" -l attribute -d 'Explain attributes. Without a query, list attribute names' -r
 complete -c moon -n "__fish_moon_using_subcommand explain" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand explain" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand explain" -s q -l quiet -d 'Suppress output'
@@ -705,7 +706,7 @@ complete -c moon -n "__fish_moon_using_subcommand help; and not __fish_seen_subc
 complete -c moon -n "__fish_moon_using_subcommand help; and not __fish_seen_subcommand_from new bundle build check prove run test generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help" -f -a "clean" -d 'Remove the _build directory'
 complete -c moon -n "__fish_moon_using_subcommand help; and not __fish_seen_subcommand_from new bundle build check prove run test generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help" -f -a "fmt" -d 'Format source code'
 complete -c moon -n "__fish_moon_using_subcommand help; and not __fish_seen_subcommand_from new bundle build check prove run test generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help" -f -a "doc" -d 'Generate documentation or searching documentation for a symbol'
-complete -c moon -n "__fish_moon_using_subcommand help; and not __fish_seen_subcommand_from new bundle build check prove run test generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help" -f -a "explain" -d 'Explain diagnostics from the compiler'
+complete -c moon -n "__fish_moon_using_subcommand help; and not __fish_seen_subcommand_from new bundle build check prove run test generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help" -f -a "explain" -d 'Explain compiler diagnostics and language topics'
 complete -c moon -n "__fish_moon_using_subcommand help; and not __fish_seen_subcommand_from new bundle build check prove run test generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help" -f -a "info" -d 'Generate public interface (`.mbti`) files for all packages in the module or workspace'
 complete -c moon -n "__fish_moon_using_subcommand help; and not __fish_seen_subcommand_from new bundle build check prove run test generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help" -f -a "bench" -d 'Run benchmarks in the current package'
 complete -c moon -n "__fish_moon_using_subcommand help; and not __fish_seen_subcommand_from new bundle build check prove run test generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help" -f -a "add" -d 'Add a dependency'

--- a/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
@@ -48,7 +48,7 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('clean', 'clean', [CompletionResultType]::ParameterValue, 'Remove the _build directory')
             [CompletionResult]::new('fmt', 'fmt', [CompletionResultType]::ParameterValue, 'Format source code')
             [CompletionResult]::new('doc', 'doc', [CompletionResultType]::ParameterValue, 'Generate documentation or searching documentation for a symbol')
-            [CompletionResult]::new('explain', 'explain', [CompletionResultType]::ParameterValue, 'Explain diagnostics from the compiler')
+            [CompletionResult]::new('explain', 'explain', [CompletionResultType]::ParameterValue, 'Explain compiler diagnostics and language topics')
             [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'Generate public interface (`.mbti`) files for all packages in the module or workspace')
             [CompletionResult]::new('bench', 'bench', [CompletionResultType]::ParameterValue, 'Run benchmarks in the current package')
             [CompletionResult]::new('add', 'add', [CompletionResultType]::ParameterValue, 'Add a dependency')
@@ -405,7 +405,8 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;explain' {
-            [CompletionResult]::new('--diagnostics', 'diagnostics', [CompletionResultType]::ParameterName, 'Explain diagnostics. Without a query, list warning mnemonics and IDs from `moonc`')
+            [CompletionResult]::new('--diagnostic', 'diagnostic', [CompletionResultType]::ParameterName, 'Explain diagnostics. Without a query, list diagnostic codes and names')
+            [CompletionResult]::new('--attribute', 'attribute', [CompletionResultType]::ParameterName, 'Explain attributes. Without a query, list attribute names')
             [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -1100,7 +1101,7 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('clean', 'clean', [CompletionResultType]::ParameterValue, 'Remove the _build directory')
             [CompletionResult]::new('fmt', 'fmt', [CompletionResultType]::ParameterValue, 'Format source code')
             [CompletionResult]::new('doc', 'doc', [CompletionResultType]::ParameterValue, 'Generate documentation or searching documentation for a symbol')
-            [CompletionResult]::new('explain', 'explain', [CompletionResultType]::ParameterValue, 'Explain diagnostics from the compiler')
+            [CompletionResult]::new('explain', 'explain', [CompletionResultType]::ParameterValue, 'Explain compiler diagnostics and language topics')
             [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'Generate public interface (`.mbti`) files for all packages in the module or workspace')
             [CompletionResult]::new('bench', 'bench', [CompletionResultType]::ParameterValue, 'Run benchmarks in the current package')
             [CompletionResult]::new('add', 'add', [CompletionResultType]::ParameterValue, 'Add a dependency')

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -394,7 +394,8 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (explain)
 _arguments "${_arguments_options[@]}" : \
-'--diagnostics=[Explain diagnostics. Without a query, list warning mnemonics and IDs from \`moonc\`]' \
+'--diagnostic=[Explain diagnostics. Without a query, list diagnostic codes and names]' \
+'--attribute=[Explain attributes. Without a query, list attribute names]' \
 '--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
@@ -1492,7 +1493,7 @@ _moon_commands() {
 'clean:Remove the _build directory' \
 'fmt:Format source code' \
 'doc:Generate documentation or searching documentation for a symbol' \
-'explain:Explain diagnostics from the compiler' \
+'explain:Explain compiler diagnostics and language topics' \
 'info:Generate public interface (\`.mbti\`) files for all packages in the module or workspace' \
 'bench:Run benchmarks in the current package' \
 'add:Add a dependency' \
@@ -1647,7 +1648,7 @@ _moon__help_commands() {
 'clean:Remove the _build directory' \
 'fmt:Format source code' \
 'doc:Generate documentation or searching documentation for a symbol' \
-'explain:Explain diagnostics from the compiler' \
+'explain:Explain compiler diagnostics and language topics' \
 'info:Generate public interface (\`.mbti\`) files for all packages in the module or workspace' \
 'bench:Run benchmarks in the current package' \
 'add:Add a dependency' \

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -36,7 +36,7 @@ fn test_moon_help() {
               clean                  Remove the _build directory
               fmt                    Format source code
               doc                    Generate documentation or searching documentation for a symbol
-              explain                Explain diagnostics from the compiler
+              explain                Explain compiler diagnostics and language topics
               info                   Generate public interface (`.mbti`) files for all packages in the module or workspace
               bench                  Run benchmarks in the current package
               add                    Add a dependency
@@ -227,29 +227,65 @@ fn test_moon_info_help_explains_target_and_default_behavior() {
 }
 
 #[test]
-fn test_moon_explain_diagnostics_lists_warnings() {
+fn test_moon_explain_diagnostic_lists_compiler_warnings_and_integrated_docs() {
     let dir = TestDir::new_empty();
-    let output = get_stdout(&dir, ["explain", "--diagnostics"]);
+    let output = get_stdout(&dir, ["explain", "--diagnostic"]);
     assert!(output.starts_with("Available warnings: \n"));
-    assert!(output.contains("unused_value               Unused variable or function."));
-    assert!(output.contains("partial_match              Partial pattern matching."));
+    assert!(output.contains("partial_match              Partial pattern matching.                                       11 error"));
+    assert!(output.contains("note: default alert exceptions: alert_unsafe=off"));
+    assert!(output.contains("Available non-warning diagnostics:"));
+    assert!(output.contains("E4056  diagnostic method_duplicate"));
 }
 
 #[test]
 fn test_moon_explain_diagnostics_number_uses_integrated_docs() {
     let dir = TestDir::new_empty();
-    let output = get_stdout(&dir, ["explain", "--diagnostics", "2"]);
+    let output = get_stdout(&dir, ["explain", "--diagnostic", "2"]);
     assert!(output.starts_with("# E0002\n"));
     assert!(output.contains("Warning name: `unused_value`"));
     assert!(output.contains("Unused variable."));
 }
 
 #[test]
+fn test_moon_explain_diagnostics_alias_uses_integrated_docs() {
+    let dir = TestDir::new_empty();
+    let output = get_stdout(&dir, ["explain", "--diagnostics", "2"]);
+    assert!(output.starts_with("# E0002\n"));
+    assert!(output.contains("Warning name: `unused_value`"));
+}
+
+#[test]
 fn test_moon_explain_diagnostics_mnemonic_uses_integrated_docs() {
     let dir = TestDir::new_empty();
-    let output = get_stdout(&dir, ["explain", "--diagnostics", "unused_value"]);
+    let output = get_stdout(&dir, ["explain", "--diagnostic", "unused_value"]);
     assert!(output.contains("# E0001"));
     assert!(output.contains("# E0002"));
+}
+
+#[test]
+fn test_moon_explain_diagnostics_name_uses_integrated_docs() {
+    let dir = TestDir::new_empty();
+    let output = get_stdout(&dir, ["explain", "--diagnostic", "method_duplicate"]);
+    assert!(output.starts_with("# E4056\n"));
+    assert!(output.contains("Compiler diagnostic name: `method_duplicate`"));
+}
+
+#[test]
+fn test_moon_explain_attribute_lists_integrated_docs() {
+    let dir = TestDir::new_empty();
+    let output = get_stdout(&dir, ["explain", "--attribute"]);
+    assert!(output.starts_with("Available attributes:\n"));
+    assert!(output.contains("#alert"));
+    assert!(output.contains("#coverage.skip"));
+    assert!(output.contains("#visibility"));
+}
+
+#[test]
+fn test_moon_explain_attribute_name_uses_integrated_docs() {
+    let dir = TestDir::new_empty();
+    let output = get_stdout(&dir, ["explain", "--attribute", "alert"]);
+    assert!(output.starts_with("# Alert Attribute\n"));
+    assert!(output.contains("The `#alert` attribute attaches a category and message to an API."));
 }
 
 #[test]
@@ -258,13 +294,14 @@ fn test_moon_explain_without_flags_shows_guidance() {
     check(
         get_err_stderr(&dir, ["explain"]),
         expect![[r#"
-            Explain diagnostics from the compiler
+            Explain compiler diagnostics and language topics
 
-            Usage: moon explain [OPTIONS]
+            Usage: moon explain [OPTIONS] <--diagnostic [<ID_OR_NAME>]|--attribute [<NAME>]>
 
             Options:
-                  --diagnostics [<ID_OR_MNEMONIC>]  Explain diagnostics. Without a query, list warning mnemonics and IDs from `moonc`
-              -h, --help                            Print help
+                  --diagnostic [<ID_OR_NAME>]  Explain diagnostics. Without a query, list diagnostic codes and names
+                  --attribute [<NAME>]         Explain attributes. Without a query, list attribute names
+              -h, --help                       Print help
 
             Common Options:
                   --target-dir <TARGET_DIR>  The target directory. Defaults to `<project-root>/_build`
@@ -277,7 +314,8 @@ fn test_moon_explain_without_flags_shows_guidance() {
                 Docs: https://docs.moonbitlang.com
                 Skills: https://github.com/moonbitlang/skills
 
-                Use `moon explain --diagnostics` to list warning mnemonics and IDs.
+                Use `moon explain --diagnostic` to list diagnostic codes and names.
+                Use `moon explain --attribute` to list attributes.
         "#]],
     );
 }

--- a/crates/moonutil/build.rs
+++ b/crates/moonutil/build.rs
@@ -37,32 +37,50 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("error_code_docs.rs");
 
-    let mut docs_map = String::from("{\n    #[allow(unused_mut)] let mut m = HashMap::new();\n");
-
-    let docs_dir = Path::new("resources/error_codes/language/error_codes");
-    if let Ok(entries) = fs::read_dir(docs_dir) {
-        for entry in entries.flatten() {
-            if let Some(file_name) = entry.file_name().to_str()
-                && file_name.ends_with(".md")
-                && let Ok(content) = fs::read_to_string(entry.path())
-            {
-                let error_code = file_name.trim_end_matches(".md").replace("E", "");
-                docs_map.push_str(&format!(
-                    "    m.insert(\"{error_code}\", r#\"{content}\"#);\n"
-                ));
-            }
-        }
-    }
-
-    docs_map.push_str("    m\n}");
+    let error_docs_map = collect_docs_map(
+        Path::new("resources/error_codes/language/error_codes"),
+        |file_name| {
+            let code = file_name.strip_prefix('E')?.strip_suffix(".md")?;
+            code.chars()
+                .all(|ch| ch.is_ascii_digit())
+                .then(|| code.to_owned())
+        },
+    );
+    let attribute_docs_map = collect_docs_map(
+        Path::new("resources/error_codes/language/attributes"),
+        |file_name| file_name.strip_suffix(".md").map(ToOwned::to_owned),
+    );
 
     fs::write(
         dest_path,
         format!(
-            "pub static ERROR_DOCS: std::sync::LazyLock<HashMap<&'static str, &'static str>> = std::sync::LazyLock::new(|| {docs_map});"
+            "pub static ERROR_DOCS: std::sync::LazyLock<HashMap<&'static str, &'static str>> = std::sync::LazyLock::new(|| {error_docs_map});\n\
+             pub static ATTRIBUTE_DOCS: std::sync::LazyLock<HashMap<&'static str, &'static str>> = std::sync::LazyLock::new(|| {attribute_docs_map});"
         ),
     )
     .unwrap();
 
     Ok(())
+}
+
+fn collect_docs_map(docs_dir: &Path, key_for_file: impl Fn(&str) -> Option<String>) -> String {
+    let mut docs = Vec::new();
+    if let Ok(entries) = fs::read_dir(docs_dir) {
+        for entry in entries.flatten() {
+            if let Some(file_name) = entry.file_name().to_str()
+                && let Some(key) = key_for_file(file_name)
+                && let Ok(content) = fs::read_to_string(entry.path())
+            {
+                docs.push((key, content));
+            }
+        }
+    }
+    docs.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    let mut docs_map = String::from("{\n    #[allow(unused_mut)] let mut m = HashMap::new();\n");
+    for (key, content) in docs {
+        docs_map.push_str(&format!("    m.insert({key:?}, {content:?});\n"));
+    }
+    docs_map.push_str("    m\n}");
+    docs_map
 }

--- a/crates/moonutil/src/error_code_docs.rs
+++ b/crates/moonutil/src/error_code_docs.rs
@@ -24,3 +24,18 @@ include!(concat!(env!("OUT_DIR"), "/error_code_docs.rs"));
 pub fn get_error_code_doc(error_code: &str) -> Option<&'static str> {
     ERROR_DOCS.get(error_code).copied()
 }
+
+pub fn get_all_error_code_docs() -> Vec<(&'static str, &'static str)> {
+    let mut docs: Vec<_> = ERROR_DOCS.iter().map(|(code, doc)| (*code, *doc)).collect();
+    docs.sort_by(|(left, _), (right, _)| left.cmp(right));
+    docs
+}
+
+pub fn get_all_attribute_docs() -> Vec<(&'static str, &'static str)> {
+    let mut docs: Vec<_> = ATTRIBUTE_DOCS
+        .iter()
+        .map(|(attribute, doc)| (*attribute, *doc))
+        .collect();
+    docs.sort_by(|(left, _), (right, _)| left.cmp(right));
+    docs
+}

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -56,7 +56,7 @@ This document contains the help content for the `moon` command-line program.
 * `clean` — Remove the _build directory
 * `fmt` — Format source code
 * `doc` — Generate documentation or searching documentation for a symbol
-* `explain` — Explain diagnostics from the compiler
+* `explain` — Explain compiler diagnostics and language topics
 * `info` — Generate public interface (`.mbti`) files for all packages in the module or workspace
 * `bench` — Run benchmarks in the current package
 * `add` — Add a dependency
@@ -357,19 +357,21 @@ Generate documentation or searching documentation for a symbol
 
 ## `moon explain`
 
-Explain diagnostics from the compiler
+Explain compiler diagnostics and language topics
 
-**Usage:** `moon explain [OPTIONS]`
+**Usage:** `moon explain <--diagnostic [<ID_OR_NAME>]|--attribute [<NAME>]>`
 
 Resources:
     Docs: https://docs.moonbitlang.com
     Skills: https://github.com/moonbitlang/skills
 
-    Use `moon explain --diagnostics` to list warning mnemonics and IDs.
+    Use `moon explain --diagnostic` to list diagnostic codes and names.
+    Use `moon explain --attribute` to list attributes.
 
 ###### **Options:**
 
-* `--diagnostics <ID_OR_MNEMONIC>` — Explain diagnostics. Without a query, list warning mnemonics and IDs from `moonc`
+* `--diagnostic <ID_OR_NAME>` — Explain diagnostics. Without a query, list diagnostic codes and names
+* `--attribute <NAME>` — Explain attributes. Without a query, list attribute names
 
 
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -56,7 +56,7 @@ This document contains the help content for the `moon` command-line program.
 * `clean` — Remove the _build directory
 * `fmt` — Format source code
 * `doc` — Generate documentation or searching documentation for a symbol
-* `explain` — Explain diagnostics from the compiler
+* `explain` — Explain compiler diagnostics and language topics
 * `info` — Generate public interface (`.mbti`) files for all packages in the module or workspace
 * `bench` — Run benchmarks in the current package
 * `add` — Add a dependency
@@ -357,19 +357,21 @@ Generate documentation or searching documentation for a symbol
 
 ## `moon explain`
 
-Explain diagnostics from the compiler
+Explain compiler diagnostics and language topics
 
-**Usage:** `moon explain [OPTIONS]`
+**Usage:** `moon explain <--diagnostic [<ID_OR_NAME>]|--attribute [<NAME>]>`
 
 Resources:
     Docs: https://docs.moonbitlang.com
     Skills: https://github.com/moonbitlang/skills
 
-    Use `moon explain --diagnostics` to list warning mnemonics and IDs.
+    Use `moon explain --diagnostic` to list diagnostic codes and names.
+    Use `moon explain --attribute` to list attributes.
 
 ###### **Options:**
 
-* `--diagnostics <ID_OR_MNEMONIC>` — Explain diagnostics. Without a query, list warning mnemonics and IDs from `moonc`
+* `--diagnostic <ID_OR_NAME>` — Explain diagnostics. Without a query, list diagnostic codes and names
+* `--attribute <NAME>` — Explain attributes. Without a query, list attribute names
 
 
 


### PR DESCRIPTION
## Summary

- update `moon explain` to expose `--diagnostic` and `--attribute` as the documented flags
- keep `--diagnostics` as a compatibility alias for now
- use `moonc check -warn-help` for compiler-owned warning defaults, then append integrated non-warning diagnostic docs
- embed attribute docs from the error-code docs submodule and update the submodule to the latest `markdown-build`

## Validation

- `cargo fmt`
- `cargo test -p moon cli::explain`
- `cargo test -p moon test_moon_explain`
- `cargo test -p moon test_moon_help`
- `cargo clippy -p moon --all-targets`
- `git diff --check`