### PR TITLE
[codex] Cover Windows clang native toolchain behavior

### DIFF
--- a/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
@@ -60,6 +60,33 @@ fn test_prebuild_config_common(dir: TestDir) {
 }
 
 #[test]
+#[cfg(windows)]
+fn test_prebuild_config_js_with_clang() {
+    let dir = TestDir::new("prebuild_config_script/js");
+    let stdout = get_stdout_with_envs(
+        &dir,
+        ["build", "--target", "native", "--dry-run"],
+        [("MOON_CC", "clang")],
+    );
+    println!("{}", &stdout);
+
+    let found_final_link = OnceCell::<()>::new();
+    for line in stdout.lines() {
+        if line.starts_with("clang ")
+            && line.contains(" -o ./_build/native/debug/build/main/main.exe")
+        {
+            found_final_link.set(()).expect("final linking found twice");
+            assert!(line.contains("-l______this_is_added_by_config_script_______"));
+            assert!(line.contains("-lmylib"));
+            assert!(line.contains("-L/my-search-path"));
+            assert!(!line.contains("/LIBPATH:/my-search-path"));
+        }
+    }
+
+    found_final_link.get().expect("final linking not found");
+}
+
+#[test]
 #[cfg(unix)]
 fn test_prebuild_config_tcc_rspfile_snapshot() {
     let dir = TestDir::new("prebuild_config_script/tcc_rspfile");

--- a/crates/moon/tests/test_cases/prebuild_link_config_self/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_link_config_self/mod.rs
@@ -61,3 +61,30 @@ fn test_prebuild_link_config_self() {
         assert!(found_test_links >= 1, "test executable linking not found");
     }
 }
+
+#[test]
+#[cfg(windows)]
+fn test_prebuild_link_config_self_with_clang() {
+    let dir = TestDir::new("prebuild_link_config_self/prebuild_link_config_self.in");
+    let build_stdout = get_stdout_with_envs(
+        &dir,
+        ["build", "--target", "native", "--dry-run"],
+        [("MOON_CC", "clang")],
+    );
+    println!("{}", &build_stdout);
+
+    let found_final_link = OnceCell::<()>::new();
+    for line in build_stdout.lines() {
+        if line.starts_with("clang ")
+            && line.contains(" -o ./_build/native/debug/build/main/main.exe")
+        {
+            found_final_link.set(()).expect("final linking found twice");
+            assert!(line.contains("-l__prebuild_self_link_flag__"));
+            assert!(line.contains("-lprebuildselflib"));
+            assert!(line.contains("-L/prebuild-self-path"));
+            assert!(!line.contains("/LIBPATH:/prebuild-self-path"));
+        }
+    }
+
+    found_final_link.get().expect("final linking not found");
+}

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/link_core.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/link_core.rs
@@ -77,9 +77,9 @@ pub(crate) struct MooncLinkCore<'a> {
 
     /// Extra options passed from user configuration.
     pub extra_link_opts: &'a [String],
-    /// Whether the selected native toolchain targets MSVC.
+    /// LLVM target triple to pass to `moonc link-core`.
     #[cfg(target_os = "windows")]
-    pub native_toolchain_is_msvc: bool,
+    pub llvm_target: Option<&'a str>,
 }
 
 /// WebAssembly-specific linking configuration
@@ -263,12 +263,12 @@ impl CmdlineAbstraction for MooncLinkCore<'_> {
             args.push(opt.to_string());
         }
 
-        // Windows-specific LLVM target workaround
-        // FIXME: We should always provide target info for LLVM
         #[cfg(target_os = "windows")]
-        if self.target_backend == TargetBackend::LLVM && self.native_toolchain_is_msvc {
-            args.push("-llvm-target".to_string());
-            args.push("x86_64-pc-windows-msvc".to_string());
+        if self.target_backend == TargetBackend::LLVM {
+            if let Some(llvm_target) = self.llvm_target {
+                args.push("-llvm-target".to_string());
+                args.push(llvm_target.to_string());
+            }
         }
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -657,10 +657,18 @@ impl<'a> BuildPlanLowerContext<'a> {
             exports: package.exported_functions(self.opt.target_backend.into()),
             extra_link_opts: module.link_flags.as_deref().unwrap_or_default(),
             #[cfg(target_os = "windows")]
-            native_toolchain_is_msvc: self
-                .build_plan
-                .get_make_executable_info(&target)
-                .is_some_and(|info| info.effective_native_toolchain.cc().is_msvc()),
+            llvm_target: if self.opt.target_backend == RunBackend::Llvm
+                && self
+                    .build_plan
+                    .get_make_executable_info(&target)
+                    .is_some_and(|info| info.effective_native_toolchain.cc().is_msvc())
+            {
+                // Preserve the legacy `cl` workaround; broader MSVC ABI target
+                // selection needs a separate policy.
+                Some("x86_64-pc-windows-msvc")
+            } else {
+                None
+            },
         };
 
         // Ensure n2 sees stdlib core bundle changes as inputs

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -1405,6 +1405,70 @@ mod tests {
     }
 
     #[test]
+    fn clang_msvc_target_keeps_clang_driver_syntax() {
+        let paths = CompilerPaths {
+            include_path: "headers".to_string(),
+            lib_path: "lib".to_string(),
+        };
+
+        let command = make_cc_command_resolved_with_link_flags(
+            fake_cc(CCKind::Clang, Some("x86_64-pc-windows-msvc")),
+            executable_cc_config(),
+            &[] as &[&str],
+            &["-lprebuildselflib", "-L/prebuild-self-path"],
+            ["main.c"],
+            "build/main",
+            Some("build/main/main.exe"),
+            &paths,
+        );
+
+        assert!(command.iter().any(|flag| flag == "-o"));
+        assert!(command.iter().any(|flag| flag == "build/main/main.exe"));
+        assert!(command.iter().any(|flag| flag == "-Iheaders"));
+        assert!(command.iter().any(|flag| flag == "-lprebuildselflib"));
+        assert!(command.iter().any(|flag| flag == "-L/prebuild-self-path"));
+        assert!(!command.iter().any(|flag| flag == "-lm"));
+        assert!(!command.iter().any(|flag| flag.starts_with("/Fe")));
+        assert!(!command.iter().any(|flag| flag.starts_with("/Fo")));
+        assert!(!command.iter().any(|flag| flag == "/link"));
+        assert!(!command.iter().any(|flag| flag.starts_with("/LIBPATH:")));
+    }
+
+    #[test]
+    fn msvc_driver_keeps_msvc_driver_syntax() {
+        let paths = CompilerPaths {
+            include_path: "headers".to_string(),
+            lib_path: "lib".to_string(),
+        };
+
+        let command = make_cc_command_resolved_with_link_flags(
+            fake_cc(CCKind::Msvc, None),
+            executable_cc_config(),
+            &[] as &[&str],
+            &["prebuildselflib.lib", "/LIBPATH:/prebuild-self-path"],
+            ["main.c"],
+            "build/main",
+            Some("build/main/main.exe"),
+            &paths,
+        );
+
+        assert!(command.iter().any(|flag| flag == "/Febuild/main/main.exe"));
+        assert!(command.iter().any(|flag| flag == "/Iheaders"));
+        assert!(command.iter().any(|flag| flag == "/nologo"));
+        assert!(command.iter().any(|flag| flag == "/link"));
+        assert!(command.iter().any(|flag| flag == "/LIBPATH:lib"));
+        assert!(command.iter().any(|flag| flag == "prebuildselflib.lib"));
+        assert!(
+            command
+                .iter()
+                .any(|flag| flag == "/LIBPATH:/prebuild-self-path")
+        );
+        assert!(!command.iter().any(|flag| flag == "-o"));
+        assert!(!command.iter().any(|flag| flag == "-Iheaders"));
+        assert!(!command.iter().any(|flag| flag == "-lprebuildselflib"));
+    }
+
+    #[test]
     fn simdutf_requires_supported_host_and_non_tcc_compiler() {
         assert_eq!(
             fake_cc(CCKind::Gcc, Some("x86_64-unknown-linux-gnu")).can_use_simdutf(),
@@ -1634,6 +1698,13 @@ mod tests {
     fn try_from_path_recognizes_clang_exe() {
         let cc = CC::try_from_path("C:/llvm/bin/clang.exe").expect("parse clang.exe");
         assert!(matches!(cc.cc_kind, CCKind::Clang));
+    }
+
+    #[test]
+    fn try_from_path_recognizes_clang_cl_as_msvc_driver() {
+        let cc = CC::try_from_path("C:/llvm/bin/clang-cl.exe").expect("parse clang-cl.exe");
+        assert!(matches!(cc.cc_kind, CCKind::Msvc));
+        assert!(cc.target_triple.is_none());
     }
 
     fn normalize_path_separators(path: &str) -> String {


### PR DESCRIPTION
## Summary

- Replace the Windows LLVM LinkCore plumbing field with an explicit optional `llvm_target` while preserving the existing `cl` behavior and hardcoded `x86_64-pc-windows-msvc` workaround.
- Add portable command-builder tests that distinguish Clang driver syntax from MSVC driver syntax, including `clang` targeting MSVC and `clang-cl.exe` parsing.
- Add Windows-only dry-run coverage for `MOON_CC=clang` prebuild link config propagation.

## Motivation

Windows native toolchains have two separate concerns: driver syntax and target ABI. `clang` may target MSVC while still using Clang/GNU-style command syntax, while `cl`/`clang-cl` use MSVC-style flags. The new tests lock down that distinction without changing the current behavior.

## Validation

- `cargo test -p moonutil compiler_flags::tests`
- `cargo test -p moon prebuild`
- `cargo xtask ci`
- `git diff --check`

Note: the new Windows-only integration tests are compiled out locally on macOS and are intended to run in Windows CI.