### PR TITLE
Warn when legacy manifests shadow JSON manifests

### DIFF
--- a/crates/moon/tests/test_cases/fmt_moon_mod/mod.rs
+++ b/crates/moon/tests/test_cases/fmt_moon_mod/mod.rs
@@ -300,6 +300,17 @@ readme = "README.md""#
 }
 
 #[test]
+fn test_reading_module_warns_when_moon_mod_shadows_json() {
+    let dir = TestDir::new("fmt_moon_mod_both.in");
+    let stderr = get_stderr(&dir, ["check", "--dry-run"]);
+
+    assert!(
+        stderr.contains("Both moon.mod.json and moon.mod exist at module root"),
+        "{stderr}"
+    );
+}
+
+#[test]
 fn test_fmt_moon_mod_local_deps_fail() {
     let dir = TestDir::new_empty();
     std::fs::create_dir_all(dir.join("main")).unwrap();

--- a/crates/moon/tests/test_cases/fmt_moon_pkg/mod.rs
+++ b/crates/moon/tests/test_cases/fmt_moon_pkg/mod.rs
@@ -75,6 +75,17 @@ fn test_fmt_moon_pkg_json_migration_dry_run() {
     }
 }
 
+#[test]
+fn test_reading_package_warns_when_moon_pkg_shadows_json() {
+    let dir = TestDir::new("fmt_moon_pkg_both.in");
+    let stderr = get_stderr(&dir, ["check", "--dry-run"]);
+
+    assert!(
+        stderr.contains("Both moon.pkg.json and moon.pkg exist at package root"),
+        "{stderr}"
+    );
+}
+
 /// Test that with rr_moon_pkg and rr_moon_mod disabled, legacy manifests are not migrated,
 /// but existing new-format manifests are still formatted.
 #[test]
@@ -121,9 +132,9 @@ fn test_fmt_moon_pkg_both_exist() {
             ],
         ),
         expect![[r#"
+            Warning: Both moon.pkg.json and moon.pkg exist at package root '$ROOT/both', using the new format moon.pkg. Please remove the deprecated moon.pkg.json.
             Warning: Migrating to moon.mod at module root '$ROOT', deprecated moon.mod.json is removed.
             Warning: Migrating to moon.pkg in package 'test/fmt_moon_pkg_both', deprecated moon.pkg.json is removed.
-            Warning: Both moon.pkg.json and moon.pkg exist in package 'test/fmt_moon_pkg_both/both', using the new format moon.pkg. Please remove the deprecated moon.pkg.json.
         "#]],
     );
 

--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -50,8 +50,9 @@ use moonutil::mooncakes::{
 use moonutil::package::MoonPkg;
 use moonutil::{
     common::{
-        IGNORE_DIRS, MBTI_USER_WRITTEN, MOON_MOD, MOON_MOD_JSON, MOONBITLANG_ABORT,
-        read_module_desc_file_in_dir, read_package_desc_file_in_dir_with_supported_targets_decl,
+        IGNORE_DIRS, MBTI_USER_WRITTEN, MOON_MOD, MOON_MOD_JSON, MOON_PKG, MOON_PKG_JSON,
+        MOONBITLANG_ABORT, read_module_desc_file_in_dir,
+        read_package_desc_file_in_dir_with_supported_targets_decl, warn_if_shadowed_manifest,
     },
     mooncakes::ModuleSourceKind,
     package::resolve_supported_targets,
@@ -87,6 +88,12 @@ pub fn discover_packages(
         };
 
         let dir = dirs.get(id).expect("Bad module ID to get directory");
+        warn_if_shadowed_manifest(
+            dir,
+            MOON_MOD_JSON,
+            MOON_MOD,
+            &format!("at module root '{}'", dir.display()),
+        );
         discover_packages_for_mod(&mut res, dir, id, env.resolved_module(id))?;
     }
 
@@ -155,6 +162,12 @@ pub fn discover_local_project(
     let mut pkg_dirs = DiscoverResult::default();
 
     for module_dir in module_dirs {
+        warn_if_shadowed_manifest(
+            &module_dir,
+            MOON_MOD_JSON,
+            MOON_MOD,
+            &format!("at module root '{}'", module_dir.display()),
+        );
         let module = read_module_desc_file_in_dir(&module_dir).map_err(|inner| {
             DiscoverError::CantReadLocalModuleFile {
                 path: module_dir.clone(),
@@ -325,6 +338,12 @@ fn discover_one_package(
     let fqn = PackageFQN::new(m.clone(), pkg_path);
 
     // Discover the package config
+    warn_if_shadowed_manifest(
+        abs,
+        MOON_PKG_JSON,
+        MOON_PKG,
+        &format!("at package root '{}'", abs.display()),
+    );
     let (pkg_json, supported_targets_decl) =
         read_package_desc_file_in_dir_with_supported_targets_decl(abs).map_err(|e| {
             DiscoverError::CantReadPackageFile {

--- a/crates/moonbuild-rupes-recta/src/fmt.rs
+++ b/crates/moonbuild-rupes-recta/src/fmt.rs
@@ -197,17 +197,7 @@ fn format_moon_mod_node(
         OsStr::new(MOON_MOD),
     );
 
-    if has_dsl && has_json {
-        user_warnings.push(UserWarning::new(format!(
-            "Both {} and {} exist at module root '{}', using the new format {}. Please remove the deprecated {}.",
-            MOON_MOD_JSON,
-            MOON_MOD,
-            module_dir.display(),
-            MOON_MOD,
-            MOON_MOD_JSON
-        )));
-        format_moon_mod_dsl(graph, cfg, &moon_mod, &target_moon_mod, module_dir)?;
-    } else if has_dsl {
+    if has_dsl {
         format_moon_mod_dsl(graph, cfg, &moon_mod, &target_moon_mod, module_dir)?;
     } else if cfg.migrate_moon_mod_json {
         user_warnings.push(UserWarning::new(format!(
@@ -635,16 +625,8 @@ fn format_moon_pkg_node(
     // Output to target directory
     let target_moon_pkg = layout.format_artifact_path(&pkg.fqn, std::ffi::OsStr::new("moon.pkg"));
 
-    if has_dsl && has_json {
-        // Both files exist: prefer moon.pkg (new format), warn about duplicate
-        user_warnings.push(UserWarning::new(format!(
-            "Both {} and {} exist in package '{}', using the new format {}. Please remove the deprecated {}.",
-            MOON_PKG_JSON, MOON_PKG, pkg.fqn, MOON_PKG, MOON_PKG_JSON
-        )));
+    if has_dsl {
         // Format moon.pkg (new format)
-        format_moon_pkg_dsl(graph, cfg, &moon_pkg_dsl, &target_moon_pkg, pkg)
-    } else if has_dsl {
-        // Only moon.pkg exists: format it
         format_moon_pkg_dsl(graph, cfg, &moon_pkg_dsl, &target_moon_pkg, pkg)
     } else if cfg.migrate_moon_pkg_json {
         // Only moon.pkg.json exists: migrate to moon.pkg

--- a/crates/mooncake/src/pkg/work.rs
+++ b/crates/mooncake/src/pkg/work.rs
@@ -26,7 +26,7 @@ use anyhow::{Context, bail};
 use moonutil::{
     common::{
         MOON_MOD, MOON_MOD_JSON, MOON_WORK, MOONBITLANG_CORE, read_module_desc_file_in_dir,
-        write_module_json_to_file,
+        warn_if_shadowed_manifest, write_module_json_to_file,
     },
     dependency::SourceDependencyInfo,
     module::{MoonMod, convert_module_to_mod_json},
@@ -182,6 +182,12 @@ fn resolve_workspace_member(path: &Path) -> anyhow::Result<PathBuf> {
     if !member_dir.is_dir() {
         bail!("workspace member `{}` is not a directory", path.display());
     }
+    warn_if_shadowed_manifest(
+        &member_dir,
+        MOON_MOD_JSON,
+        MOON_MOD,
+        &format!("at module root '{}'", member_dir.display()),
+    );
     read_module_desc_file_in_dir(&member_dir).with_context(|| {
         format!(
             "workspace member `{}` does not contain `{}` or `{}`",
@@ -229,6 +235,12 @@ fn workspace_roots(member_dirs: &[PathBuf]) -> anyhow::Result<ResolvedRootModule
     let mut roots = ResolvedRootModules::with_key();
 
     for member_dir in member_dirs {
+        warn_if_shadowed_manifest(
+            member_dir,
+            MOON_MOD_JSON,
+            MOON_MOD,
+            &format!("at module root '{}'", member_dir.display()),
+        );
         let module = Arc::new(read_module_desc_file_in_dir(member_dir)?);
         let source = moonutil::mooncakes::ModuleSource::from_local_module(&module, member_dir);
         roots.insert(ResolvedModule::new(source, module));

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -519,7 +519,7 @@ fn read_package_from_json_with_supported_targets_decl(
     let file = File::open(path)?;
     let reader = BufReader::new(file);
     let j = serde_json_lenient::from_reader(reader).context(format!("Failed to parse {path:?}"))?;
-    let emit_warnings = should_warn_pkg(path);
+    let emit_warnings = should_warn_manifest(path);
     convert_pkg_json_to_package_with_supported_targets_decl(j, emit_warnings)
 }
 
@@ -530,15 +530,54 @@ fn read_package_from_dsl_with_supported_targets_decl(
     let file = File::open(path)?;
     let str = std::io::read_to_string(file)?;
     let dsl = moon_pkg::parse(&str)?;
-    let emit_warnings = should_warn_pkg(path);
+    let emit_warnings = should_warn_manifest(path);
     convert_pkg_dsl_to_package_with_supported_targets_decl(dsl, emit_warnings)
 }
 
-/// avoid emit warnings for moon.pkg in .mooncakes
-fn should_warn_pkg(path: &Path) -> bool {
+/// Avoid emitting manifest warnings for dependency cache files in .mooncakes.
+fn should_warn_manifest(path: &Path) -> bool {
     !path
         .components()
         .any(|component| component.as_os_str() == DEP_PATH)
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ManifestFormat {
+    New,
+    Legacy,
+}
+
+pub fn preferred_manifest_in_dir(
+    dir: &Path,
+    new_manifest: &'static str,
+    legacy_manifest: &'static str,
+) -> Option<(PathBuf, ManifestFormat)> {
+    let new_path = dir.join(new_manifest);
+    let legacy_path = dir.join(legacy_manifest);
+    match (new_path.exists(), legacy_path.exists()) {
+        (true, true) => Some((new_path, ManifestFormat::New)),
+        (true, false) => Some((new_path, ManifestFormat::New)),
+        (false, true) => Some((legacy_path, ManifestFormat::Legacy)),
+        (false, false) => None,
+    }
+}
+
+pub fn warn_if_shadowed_manifest(
+    dir: &Path,
+    legacy_manifest: &'static str,
+    new_manifest: &'static str,
+    location: &str,
+) {
+    if !should_warn_manifest(dir)
+        || !dir.join(new_manifest).exists()
+        || !dir.join(legacy_manifest).exists()
+    {
+        return;
+    }
+
+    eprintln!(
+        "Warning: Both {legacy_manifest} and {new_manifest} exist {location}, using the new format {new_manifest}. Please remove the deprecated {legacy_manifest}."
+    );
 }
 
 pub fn write_module_json_to_file(m: &MoonModJSON, source_dir: &Path) -> anyhow::Result<()> {
@@ -603,21 +642,16 @@ pub fn write_package_json_to_file(pkg: &MoonPkgJSON, path: &Path) -> anyhow::Res
 }
 
 pub fn read_module_desc_file_in_dir(dir: &Path) -> anyhow::Result<MoonMod> {
-    let mod_path = dir.join(MOON_MOD);
-    if mod_path.exists() {
-        return read_module_from_dsl(&mod_path);
-    }
-
-    let mod_json_path = dir.join(MOON_MOD_JSON);
-    if !mod_json_path.exists() {
-        bail!(
+    match preferred_manifest_in_dir(dir, MOON_MOD, MOON_MOD_JSON) {
+        Some((path, ManifestFormat::New)) => read_module_from_dsl(&path),
+        Some((path, ManifestFormat::Legacy)) => Ok(read_module_from_json(&path)?),
+        None => bail!(
             "Failed to find `{}` or `{}` for module at path `{}`",
             MOON_MOD,
             MOON_MOD_JSON,
             dir.display()
-        );
+        ),
     }
-    Ok(read_module_from_json(&mod_json_path)?)
 }
 
 pub fn read_package_desc_file_in_dir(dir: &Path) -> anyhow::Result<MoonPkg> {
@@ -627,18 +661,20 @@ pub fn read_package_desc_file_in_dir(dir: &Path) -> anyhow::Result<MoonPkg> {
 pub fn read_package_desc_file_in_dir_with_supported_targets_decl(
     dir: &Path,
 ) -> anyhow::Result<(MoonPkg, SupportedTargetsDeclKind)> {
-    if dir.join(MOON_PKG).exists() {
-        read_package_from_dsl_with_supported_targets_decl(&dir.join(MOON_PKG))
-    } else if dir.join(MOON_PKG_JSON).exists() {
-        read_package_from_json_with_supported_targets_decl(&dir.join(MOON_PKG_JSON))
-            .context(format!("Failed to load {:?}", dir.join(MOON_PKG_JSON)))
-    } else {
-        bail!(
+    match preferred_manifest_in_dir(dir, MOON_PKG, MOON_PKG_JSON) {
+        Some((path, ManifestFormat::New)) => {
+            read_package_from_dsl_with_supported_targets_decl(&path)
+        }
+        Some((path, ManifestFormat::Legacy)) => {
+            read_package_from_json_with_supported_targets_decl(&path)
+                .context(format!("Failed to load {:?}", path))
+        }
+        None => bail!(
             "Failed to find `{}` or `{}` for package at path `{}`",
             MOON_PKG,
             MOON_PKG_JSON,
             dir.display()
-        );
+        ),
     }
 }
 


### PR DESCRIPTION
## Summary
- add shared manifest resolution helpers that prefer `moon.mod`/`moon.pkg` while exposing the selected format
- warn when both legacy and JSON manifests exist for module, package, and workspace sync discovery paths
- update fmt/check tests to cover shadowed `moon.mod.json` and `moon.pkg.json` cases

## Validation
- `cargo fmt`
- `cargo clippy -p moonutil -p moonbuild-rupes-recta -p moon --tests -- -D warnings`
- `cargo test -p moon test_reading_`
- `cargo test -p moon test_fmt_moon_mod_both_exist`
- `cargo test -p moon test_fmt_moon_pkg_both_exist`
- `cargo test -p moonutil read_module_desc_prefers_dsl`
- `git diff --check`