### PR TITLE
fix(fmt): reject moon.mod migration with local deps

### DIFF
--- a/crates/moon/tests/test_cases/fmt_moon_mod/mod.rs
+++ b/crates/moon/tests/test_cases/fmt_moon_mod/mod.rs
@@ -311,6 +311,41 @@ fn test_reading_module_warns_when_moon_mod_shadows_json() {
 }
 
 #[test]
+fn test_fmt_moon_mod_json_migration_local_deps_fail() {
+    let dir = TestDir::new_empty();
+    std::fs::create_dir_all(dir.join("main")).unwrap();
+    std::fs::write(
+        dir.join("moon.mod.json"),
+        r#"{
+  "name": "test/local_deps",
+  "deps": {
+    "example/local": { "path": "../local" }
+  }
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("main/moon.pkg"), r#"options("is-main": true)"#).unwrap();
+    std::fs::write(dir.join("main/main.mbt"), "fn main { println(1) }\n").unwrap();
+
+    let stderr = get_err_stderr(&dir, ["fmt", "--dry-run"]);
+    assert!(
+        stderr.contains("moon.mod does not support local dependency `example/local`"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("moon.work"), "{stderr}");
+
+    let stderr = get_err_stderr(&dir, ["fmt"]);
+    assert!(
+        stderr.contains("moon.mod does not support local dependency `example/local`"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("moon.work"), "{stderr}");
+    assert!(!dir.join("moon.mod").exists());
+    assert!(dir.join("moon.mod.json").exists());
+}
+
+#[test]
 fn test_fmt_moon_mod_local_deps_fail() {
     let dir = TestDir::new_empty();
     std::fs::create_dir_all(dir.join("main")).unwrap();

--- a/crates/moonbuild-rupes-recta/src/fmt.rs
+++ b/crates/moonbuild-rupes-recta/src/fmt.rs
@@ -34,8 +34,10 @@ use log::*;
 use std::{collections::HashSet, ffi::OsStr, path::Path};
 
 use anyhow::Context;
-use moonutil::common::{MOON_MOD, MOON_MOD_JSON, MOON_PKG, MOON_PKG_JSON, MOON_WORK};
-use moonutil::mooncakes::ModuleSourceKind;
+use moonutil::common::{
+    MOON_MOD, MOON_MOD_JSON, MOON_PKG, MOON_PKG_JSON, MOON_WORK, validate_module_dsl_deps,
+};
+use moonutil::mooncakes::{ModuleSourceKind, result::ResolvedModule};
 use moonutil::workspace::workspace_manifest_path;
 use n2::graph::Build;
 
@@ -131,13 +133,14 @@ pub fn build_graph_for_fmt(
     // If no path filter is provided, find and format `moon.mod`/`moon.mod.json`.
     if selected_packages.is_none() {
         for &module_id in &resolved.root_module_ids {
-            match resolved.root_modules[module_id].source().source() {
+            let module = &resolved.root_modules[module_id];
+            match module.source().source() {
                 ModuleSourceKind::Local(path) | ModuleSourceKind::Stdlib(path) => {
                     has_module_manifest |= format_moon_mod_node(
                         &mut graph,
                         cfg,
                         &layout,
-                        resolved.root_modules[module_id].source(),
+                        module,
                         path,
                         &mut user_warnings,
                     )?
@@ -179,7 +182,7 @@ fn format_moon_mod_node(
     graph: &mut n2::graph::Graph,
     cfg: &FmtConfig,
     layout: &LegacyLayout,
-    module_source: &moonutil::mooncakes::ModuleSource,
+    module: &ResolvedModule,
     module_dir: &Path,
     user_warnings: &mut Vec<UserWarning>,
 ) -> anyhow::Result<bool> {
@@ -193,7 +196,7 @@ fn format_moon_mod_node(
     }
 
     let target_moon_mod = layout.format_artifact_path(
-        &PackageFQN::new(module_source.clone(), PackagePath::empty()),
+        &PackageFQN::new(module.source().clone(), PackagePath::empty()),
         OsStr::new(MOON_MOD),
     );
 
@@ -212,6 +215,7 @@ fn format_moon_mod_node(
             &moon_mod_json,
             &target_moon_mod,
             &moon_mod,
+            module.module_info(),
             module_dir,
         )?;
     }
@@ -283,8 +287,12 @@ fn format_moon_mod_json_migrate(
     moon_mod_json: &Path,
     target_moon_mod: &Path,
     moon_mod: &Path,
+    module_info: &moonutil::module::MoonMod,
     module_dir: &Path,
 ) -> anyhow::Result<()> {
+    // moon.mod `import` cannot represent local dependencies; those must live in moon.work.
+    validate_module_dsl_deps(Some(&module_info.deps))?;
+
     if cfg.check_only || cfg.warn_only {
         let mut cmd = vec![
             moonutil::BINARIES.moonbuild.to_string_lossy().into_owned(),

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -304,7 +304,7 @@ pub fn validate_module_dsl_deps(
             }
             SourceDependencyInfo::Local(_) => {
                 bail!(
-                    "moon.mod does not support local dependency `{}` in `import`; use workspace configuration in `moon.work` instead",
+                    "moon.mod does not support local dependency `{}` in `import`; use workspace configuration in `moon.work` instead. See https://docs.moonbitlang.com/en/latest/toolchain/moon/module.html#dependency-management",
                     name
                 );
             }

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -287,7 +287,7 @@ pub enum MoonModJSONFormatErrorKind {
     SupportedTargets(anyhow::Error),
 }
 
-fn validate_module_dsl_deps(
+pub fn validate_module_dsl_deps(
     deps: Option<&IndexMap<String, crate::dependency::SourceDependencyInfo>>,
 ) -> anyhow::Result<()> {
     use crate::dependency::SourceDependencyInfo;


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

## Summary

Reject `moon.mod.json` to `moon.mod` migration when the module declares local dependencies, since `moon.mod` does not support them yet. The formatter now reports the existing `moon.work` guidance instead of generating an unsupported `moon.mod`.

Also adds regression coverage for both normal `fmt` and `fmt --dry-run`.

## Metadata

  - [x] Tests added/updated for bug fixes or new features
  - [x] Compatible with Windows/Linux/macOS

@myfreess 