### PR TITLE
fix(mooncake): upsert moon.mod imports in moon add

### DIFF
--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -157,7 +157,7 @@ pub fn add(
         let patch = if bin {
             MoonModPatch::Rewrite(convert_module_to_mod_json(Arc::unwrap_or_clone(m)))
         } else {
-            MoonModPatch::InsertImportItem {
+            MoonModPatch::UpsertImportItem {
                 name: pkg_name_str,
                 version: version.clone(),
             }

--- a/crates/moonutil/src/moon_mod_patch.rs
+++ b/crates/moonutil/src/moon_mod_patch.rs
@@ -40,7 +40,7 @@ use crate::{
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum MoonModPatch {
-    InsertImportItem {
+    UpsertImportItem {
         name: String,
         version: semver::Version,
     },
@@ -202,9 +202,12 @@ fn locate_import_items(contents: &str, names: Vec<String>) -> IndexMap<String, I
 
 pub fn patch_module_dsl(mut patched: String, patch: MoonModPatch) -> String {
     match patch {
-        MoonModPatch::InsertImportItem { name, version } => {
+        MoonModPatch::UpsertImportItem { name, version } => {
             let quoted = format!("\"{name}@{version}\"");
-            if let Some(tail) = locate_import_rbrace(&patched) {
+            let mut items = locate_import_items(&patched, vec![name.clone()]);
+            if let Some(item) = items.shift_remove(&name) {
+                patched.replace_range(item.string, &quoted);
+            } else if let Some(tail) = locate_import_rbrace(&patched) {
                 patched.insert_str(tail.start, &format!("  {quoted},\n"));
             } else {
                 patched = format!("{patched}\nimport {{\n  {quoted},\n}}\n");
@@ -270,7 +273,7 @@ options(
 )
 "#
         .to_string();
-        let patch = MoonModPatch::InsertImportItem {
+        let patch = MoonModPatch::UpsertImportItem {
             name: "example/dep".to_string(),
             version: Version::new(1, 2, 3),
         };
@@ -303,7 +306,7 @@ import {
 }
 "#
         .to_string();
-        let patch = MoonModPatch::InsertImportItem {
+        let patch = MoonModPatch::UpsertImportItem {
             name: "example/dep".to_string(),
             version: Version::new(1, 2, 3),
         };
@@ -317,6 +320,33 @@ import {
               "example/other@0.1.0",
               // comment
               "example/dep@1.2.3",
+            }
+        "#]]
+        .assert_eq(&output);
+    }
+
+    #[test]
+    fn patch_module_dsl_upserts_existing_import() {
+        let input = r#"name = "example/mod"
+
+import {
+  "example/dep@1.0.0", // dep comment
+  "example/other@0.1.0",
+}
+"#
+        .to_string();
+        let patch = MoonModPatch::UpsertImportItem {
+            name: "example/dep".to_string(),
+            version: Version::new(1, 2, 3),
+        };
+        let output = patch_module_dsl(input, patch);
+
+        expect![[r#"
+            name = "example/mod"
+
+            import {
+              "example/dep@1.2.3", // dep comment
+              "example/other@0.1.0",
             }
         "#]]
         .assert_eq(&output);
@@ -494,7 +524,7 @@ import {
 import { "example/other@0.1.0", }
 "#
         .to_string();
-        let patch = MoonModPatch::InsertImportItem {
+        let patch = MoonModPatch::UpsertImportItem {
             name: "example/dep".to_string(),
             version: Version::new(1, 2, 3),
         };


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind:  Bugfix

## Summary

Fix `moon add` on `moon.mod` manifests to upsert existing import entries instead of appending duplicate dependencies.

## Metadata

- [X] Tests added/updated for bug fixes or new features
- [X] Compatible with Windows/Linux/macOS

@tonyfettes  @myfreess 
