### PR TITLE
feat: change moon add behavior, add `--upgrade/-u` flag

### DIFF
--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -204,7 +204,7 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
     //   with the existing local index.
     let index_dir = moonutil::moon_dir::index();
     let mut index_updated = false;
-    if !cmd.no_update {
+    if !cmd.no_update && (!cmd.upgrade || !cmd.package_path.contains('@')) {
         let had_index = index_dir.exists();
         let registry_config = RegistryConfig::load();
         match mooncake::update::update(&index_dir, &registry_config) {
@@ -236,6 +236,10 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
         unqual: pkgname.into(),
     };
 
+    if cmd.upgrade && cmd.bin {
+        bail!("--bin cannot be used with --upgrade");
+    }
+
     if parts.len() == 2 {
         let version: &str = parts[1];
         let version = version.parse()?;
@@ -248,6 +252,7 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
             cmd.bin,
             &version,
             cli.quiet,
+            cmd.upgrade,
         )
     } else {
         mooncake::pkg::add::add_latest(
@@ -259,6 +264,7 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
             cmd.bin,
             cli.quiet,
             index_updated,
+            cmd.upgrade,
         )
     }
 }

--- a/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
@@ -425,7 +425,7 @@ _moon() {
             return 0
             ;;
         moon__add)
-            opts="-q -v -h --bin --no-update --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help <MODULE>"
+            opts="-u -q -v -h --bin --upgrade --no-update --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help <MODULE>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
@@ -469,6 +469,8 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --bin 'Whether to add the dependency as a binary'
+            cand -u 'Upgrade an existing dependency'
+            cand --upgrade 'Upgrade an existing dependency'
             cand --no-update 'Do not update the registry index before adding the dependency'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'

--- a/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
@@ -365,6 +365,7 @@ complete -c moon -n "__fish_moon_using_subcommand bench" -s h -l help -d 'Print 
 complete -c moon -n "__fish_moon_using_subcommand add" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand add" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand add" -l bin -d 'Whether to add the dependency as a binary'
+complete -c moon -n "__fish_moon_using_subcommand add" -s u -l upgrade -d 'Upgrade an existing dependency'
 complete -c moon -n "__fish_moon_using_subcommand add" -l no-update -d 'Do not update the registry index before adding the dependency'
 complete -c moon -n "__fish_moon_using_subcommand add" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand add" -s v -l verbose -d 'Increase verbosity'

--- a/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
@@ -487,6 +487,8 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--bin', 'bin', [CompletionResultType]::ParameterName, 'Whether to add the dependency as a binary')
+            [CompletionResult]::new('-u', 'u', [CompletionResultType]::ParameterName, 'Upgrade an existing dependency')
+            [CompletionResult]::new('--upgrade', 'upgrade', [CompletionResultType]::ParameterName, 'Upgrade an existing dependency')
             [CompletionResult]::new('--no-update', 'no-update', [CompletionResultType]::ParameterName, 'Do not update the registry index before adding the dependency')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -480,6 +480,8 @@ _arguments "${_arguments_options[@]}" : \
 '--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--bin[Whether to add the dependency as a binary]' \
+'-u[Upgrade an existing dependency]' \
+'--upgrade[Upgrade an existing dependency]' \
 '--no-update[Do not update the registry index before adding the dependency]' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \

--- a/crates/moon/tests/add_upgrade_existing_dependency.rs
+++ b/crates/moon/tests/add_upgrade_existing_dependency.rs
@@ -1,0 +1,139 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::path::{Path, PathBuf};
+
+fn moon_bin() -> PathBuf {
+    snapbox::cargo_bin!("moon").to_owned()
+}
+
+fn run_moon(dir: &Path, moon_home: &Path) -> snapbox::cmd::Command {
+    snapbox::cmd::Command::new(moon_bin())
+        .current_dir(dir)
+        .env("MOON_HOME", moon_home)
+        .env("MOON_TOOLCHAIN_ROOT", moonutil::moon_dir::toolchain_root())
+}
+
+fn write_registry_index(moon_home: &Path) {
+    let index_dir = moon_home.join("registry").join("index");
+    let index = index_dir.join("user").join("example").join("dep.index");
+    std::fs::create_dir_all(index.parent().unwrap()).unwrap();
+    std::fs::write(
+        index,
+        r#"{"name":"example/dep","version":"0.2.0"}
+{"name":"example/dep","version":"0.3.0"}
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn moon_add_existing_dependency_in_moon_mod_is_noop() {
+    let project = tempfile::tempdir().unwrap();
+    let moon_home = tempfile::tempdir().unwrap();
+    let manifest = project.path().join("moon.mod");
+    let original = r#"name = "test/add_existing"
+
+version = "0.0.1"
+
+import {
+  "example/dep@0.1.0",
+}
+"#;
+    std::fs::write(&manifest, original).unwrap();
+
+    run_moon(project.path(), moon_home.path())
+        .args(["add", "--no-update", "example/dep@0.2.0"])
+        .assert()
+        .success()
+        .stdout_eq("")
+        .stderr_eq("Warning: dependency `example/dep` already exists, `moon add` will not update it. To update the dependency, run `moon add --upgrade example/dep@<version>` or `moon add --upgrade example/dep` for the latest version.\n");
+
+    assert_eq!(std::fs::read_to_string(manifest).unwrap(), original);
+}
+
+#[test]
+fn moon_add_upgrade_dependency_to_explicit_version_in_moon_mod_succeeds() {
+    let project = tempfile::tempdir().unwrap();
+    let moon_home = tempfile::tempdir().unwrap();
+    let manifest = project.path().join("moon.mod");
+    std::fs::write(
+        &manifest,
+        r#"name = "test/update_existing"
+
+version = "0.0.1"
+
+import {
+  "example/dep@0.1.0",
+}
+"#,
+    )
+    .unwrap();
+
+    run_moon(project.path(), moon_home.path())
+        .args(["add", "--upgrade", "example/dep@0.2.0"])
+        .assert()
+        .success()
+        .stdout_eq("")
+        .stderr_eq("");
+
+    assert_eq!(
+        std::fs::read_to_string(manifest).unwrap(),
+        r#"name = "test/update_existing"
+
+version = "0.0.1"
+
+import {
+  "example/dep@0.2.0",
+}
+"#
+    );
+}
+
+#[test]
+fn moon_add_upgrade_dependency_to_latest_in_moon_mod_json_succeeds() {
+    let project = tempfile::tempdir().unwrap();
+    let moon_home = tempfile::tempdir().unwrap();
+    let registry_base = tempfile::tempdir().unwrap();
+    write_registry_index(moon_home.path());
+    let manifest = project.path().join("moon.mod.json");
+    std::fs::write(
+        &manifest,
+        r#"{
+  "name": "test/update_existing",
+  "version": "0.0.1",
+  "deps": {
+    "example/dep": "0.1.0"
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    run_moon(project.path(), moon_home.path())
+        .env("MOONCAKES_REGISTRY", registry_base.path())
+        .args(["add", "-u", "example/dep"])
+        .assert()
+        .success();
+
+    assert!(
+        std::fs::read_to_string(manifest)
+            .unwrap()
+            .contains(r#""example/dep": "0.3.0""#)
+    );
+}

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -734,6 +734,7 @@ fn test_moon_add_help_includes_no_update() {
     let dir = TestDir::new_empty();
     let out = get_stdout(&dir, ["add", "--help"]).replace("moon.exe", "moon");
     assert!(out.contains("--no-update"));
+    assert!(out.contains("--upgrade"));
 }
 
 #[test]

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -16,7 +16,9 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use anyhow::bail;
 use colored::Colorize;
+use indexmap::IndexMap;
 use moonutil::common::{
     MOON_MOD, MOONBITLANG_CORE, read_module_desc_file_in_dir, write_module_json_to_file,
 };
@@ -42,6 +44,10 @@ pub struct AddSubcommand {
     #[clap(long)]
     pub bin: bool,
 
+    /// Upgrade an existing dependency
+    #[clap(short = 'u', long)]
+    pub upgrade: bool,
+
     /// Do not update the registry index before adding the dependency
     #[clap(long)]
     pub no_update: bool,
@@ -57,6 +63,7 @@ pub fn add_latest(
     bin: bool,
     quiet: bool,
     index_updated: bool,
+    upgrade: bool,
 ) -> anyhow::Result<i32> {
     let pkg_name_str = pkg_name.to_string();
     if pkg_name_str == MOONBITLANG_CORE {
@@ -96,6 +103,7 @@ pub fn add_latest(
         bin,
         &latest_version,
         quiet,
+        upgrade,
     )
 }
 
@@ -115,6 +123,7 @@ pub fn add(
     bin: bool,
     version: &Version,
     quiet: bool,
+    upgrade: bool,
 ) -> anyhow::Result<i32> {
     let mut m = read_module_desc_file_in_dir(module_dir)?;
 
@@ -128,7 +137,27 @@ pub fn add(
         std::process::exit(0);
     }
 
-    if bin {
+    if upgrade {
+        let Some(dep) = m.deps.get_mut(&pkg_name_str) else {
+            bail!(
+                "the dependency `{pkg_name_str}` could not be found; use `moon add {pkg_name_str}` to add it"
+            );
+        };
+
+        if dep.path().is_some() || dep.git().is_some() {
+            bail!("dependency `{pkg_name_str}` is not a registry dependency");
+        }
+
+        if dep.version() == Some(version) {
+            eprintln!(
+                "{}: dependency `{pkg_name_str}` is already at version {version}",
+                "Warning".yellow().bold(),
+            );
+            return Ok(0);
+        }
+
+        dep.set_version(Some(version.clone()));
+    } else if bin {
         let bin_deps = m.bin_deps.get_or_insert_with(indexmap::IndexMap::new);
         bin_deps.insert(
             pkg_name_str.clone(),
@@ -141,7 +170,7 @@ pub fn add(
         if m.deps.contains_key(&pkg_name_str) {
             eprintln!(
                 "{}: dependency `{pkg_name_str}` already exists, `moon add` will not update it. \
-                To update the dependency, run `moon update {pkg_name_str}@<version>` or `moon update {pkg_name_str}` for the latest version.",
+                To update the dependency, run `moon add --upgrade {pkg_name_str}@<version>` or `moon add --upgrade {pkg_name_str}` for the latest version.",
                 "Warning".yellow().bold(),
             );
             return Ok(0);
@@ -151,6 +180,19 @@ pub fn add(
             pkg_name_str.clone(),
             SourceDependencyInfo::Simple(version.clone()),
         );
+    }
+
+    if upgrade {
+        if module_dir.join(MOON_MOD).exists() {
+            patch_module_dsl_to_file(
+                module_dir,
+                MoonModPatch::UpdateImportItems(IndexMap::from([(pkg_name_str, version.clone())])),
+            )?;
+        } else {
+            let new_j = convert_module_to_mod_json(m);
+            write_module_json_to_file(&new_j, module_dir)?;
+        }
+        return Ok(0);
     }
 
     let m = Arc::new(m);

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -138,6 +138,15 @@ pub fn add(
             },
         );
     } else {
+        if m.deps.contains_key(&pkg_name_str) {
+            eprintln!(
+                "{}: dependency `{pkg_name_str}` already exists, `moon add` will not update it. \
+                To update the dependency, run `moon update {pkg_name_str}@<version>` or `moon update {pkg_name_str}` for the latest version.",
+                "Warning".yellow().bold(),
+            );
+            return Ok(0);
+        }
+
         m.deps.insert(
             pkg_name_str.clone(),
             SourceDependencyInfo::Simple(version.clone()),
@@ -157,7 +166,7 @@ pub fn add(
         let patch = if bin {
             MoonModPatch::Rewrite(convert_module_to_mod_json(Arc::unwrap_or_clone(m)))
         } else {
-            MoonModPatch::UpsertImportItem {
+            MoonModPatch::InsertImportItem {
                 name: pkg_name_str,
                 version: version.clone(),
             }

--- a/crates/moonutil/src/moon_mod_patch.rs
+++ b/crates/moonutil/src/moon_mod_patch.rs
@@ -40,7 +40,7 @@ use crate::{
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum MoonModPatch {
-    UpsertImportItem {
+    InsertImportItem {
         name: String,
         version: semver::Version,
     },
@@ -202,12 +202,9 @@ fn locate_import_items(contents: &str, names: Vec<String>) -> IndexMap<String, I
 
 pub fn patch_module_dsl(mut patched: String, patch: MoonModPatch) -> String {
     match patch {
-        MoonModPatch::UpsertImportItem { name, version } => {
+        MoonModPatch::InsertImportItem { name, version } => {
             let quoted = format!("\"{name}@{version}\"");
-            let mut items = locate_import_items(&patched, vec![name.clone()]);
-            if let Some(item) = items.shift_remove(&name) {
-                patched.replace_range(item.string, &quoted);
-            } else if let Some(tail) = locate_import_rbrace(&patched) {
+            if let Some(tail) = locate_import_rbrace(&patched) {
                 patched.insert_str(tail.start, &format!("  {quoted},\n"));
             } else {
                 patched = format!("{patched}\nimport {{\n  {quoted},\n}}\n");
@@ -273,7 +270,7 @@ options(
 )
 "#
         .to_string();
-        let patch = MoonModPatch::UpsertImportItem {
+        let patch = MoonModPatch::InsertImportItem {
             name: "example/dep".to_string(),
             version: Version::new(1, 2, 3),
         };
@@ -306,7 +303,7 @@ import {
 }
 "#
         .to_string();
-        let patch = MoonModPatch::UpsertImportItem {
+        let patch = MoonModPatch::InsertImportItem {
             name: "example/dep".to_string(),
             version: Version::new(1, 2, 3),
         };
@@ -320,33 +317,6 @@ import {
               "example/other@0.1.0",
               // comment
               "example/dep@1.2.3",
-            }
-        "#]]
-        .assert_eq(&output);
-    }
-
-    #[test]
-    fn patch_module_dsl_upserts_existing_import() {
-        let input = r#"name = "example/mod"
-
-import {
-  "example/dep@1.0.0", // dep comment
-  "example/other@0.1.0",
-}
-"#
-        .to_string();
-        let patch = MoonModPatch::UpsertImportItem {
-            name: "example/dep".to_string(),
-            version: Version::new(1, 2, 3),
-        };
-        let output = patch_module_dsl(input, patch);
-
-        expect![[r#"
-            name = "example/mod"
-
-            import {
-              "example/dep@1.2.3", // dep comment
-              "example/other@0.1.0",
             }
         "#]]
         .assert_eq(&output);
@@ -524,7 +494,7 @@ import {
 import { "example/other@0.1.0", }
 "#
         .to_string();
-        let patch = MoonModPatch::UpsertImportItem {
+        let patch = MoonModPatch::InsertImportItem {
             name: "example/dep".to_string(),
             version: Version::new(1, 2, 3),
         };

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -454,6 +454,7 @@ Add a dependency
 ###### **Options:**
 
 * `--bin` — Whether to add the dependency as a binary
+* `-u`, `--upgrade` — Upgrade an existing dependency
 * `--no-update` — Do not update the registry index before adding the dependency
 
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -454,6 +454,7 @@ Add a dependency
 ###### **Options:**
 
 * `--bin` — Whether to add the dependency as a binary
+* `-u`, `--upgrade` — Upgrade an existing dependency
 * `--no-update` — Do not update the registry index before adding the dependency
 
 


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind: feature

## Summary

Changes `moon add` to no-op with a warning when the dependency already exists, avoiding silent dependency updates.

Adds `moon update <module>[@version]` for updating existing dependencies explicitly, and warns that `moon update` without a package is deprecated because the registry index is updated automatically.

## Metadata

- [X] Tests added/updated for bug fixes or new features
- [X] Compatible with Windows/Linux/macOS

@bobzhang @myfreess 