### PR TITLE
[codex] Restore preferred target in moon new template

### DIFF
--- a/crates/moon/tests/test_cases/moon_new/new_snapshot.expect
+++ b/crates/moon/tests/test_cases/moon_new/new_snapshot.expect
@@ -170,6 +170,8 @@ license = "Apache-2.0"
 
 keywords = []
 
+preferred_target = "wasm-gc"
+
 description = ""
 
 === ./moon.pkg ===

--- a/crates/moon/tests/test_cases/moon_new/new_snapshot_with_user_name.expect
+++ b/crates/moon/tests/test_cases/moon_new/new_snapshot_with_user_name.expect
@@ -170,6 +170,8 @@ license = "Apache-2.0"
 
 keywords = []
 
+preferred_target = "wasm-gc"
+
 description = ""
 
 === ./moon.pkg ===

--- a/crates/moon/tests/test_cases/moon_new/new_snapshot_with_user_name_different.expect
+++ b/crates/moon/tests/test_cases/moon_new/new_snapshot_with_user_name_different.expect
@@ -155,6 +155,8 @@ license = "Apache-2.0"
 
 keywords = []
 
+preferred_target = "wasm-gc"
+
 description = ""
 
 === ./moon.pkg ===

--- a/crates/moonbuild/template/moon_new_template.toml
+++ b/crates/moonbuild/template/moon_new_template.toml
@@ -60,6 +60,8 @@ license = "Apache-2.0"
 
 keywords = []
 
+preferred_target = "wasm-gc"
+
 description = ""
 """
 

--- a/crates/moonbuild/template/moon_new_template/moon.mod
+++ b/crates/moonbuild/template/moon_new_template/moon.mod
@@ -21,4 +21,6 @@ license = "Apache-2.0"
 
 keywords = []
 
+preferred_target = "wasm-gc"
+
 description = ""


### PR DESCRIPTION
## Summary

Restore `preferred_target = "wasm-gc"` to the `moon new` DSL template after the template was migrated from `moon.mod.json` to `moon.mod`.

This keeps newly generated projects aligned with the intended default target preference and updates the generated-template snapshots accordingly.

## Validation

- `cargo test -p moon --test mod moon_new::`