### PR TITLE
[codex] de-productionize moonbuild-debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,6 @@ dependencies = [
  "json-structural-diff",
  "line-index",
  "log",
- "moonbuild-debug",
  "mooncake",
  "moonutil",
  "n2",

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -31,7 +31,6 @@ moonbuild.workspace = true
 mooncake.workspace = true
 moonutil.workspace = true
 moonbuild-rupes-recta.workspace = true
-moonbuild-debug.workspace = true
 
 n2.workspace = true
 semver.workspace = true
@@ -94,6 +93,7 @@ clap-markdown = "0.1.4"
 similar.workspace = true
 colored.workspace = true
 libc.workspace = true
+moonbuild-debug.workspace = true
 moon-test-util = { path = "../moon-test-util" }
 
 

--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -343,7 +343,7 @@ fn print_dry_run_cram_command(
     executable_dirs: &[PathBuf],
     source_dir: &Path,
 ) {
-    let replacer = moonbuild_debug::graph::PathNormalizer::new(source_dir);
+    let replacer = moonbuild::dry_run::PathNormalizer::new(source_dir);
     let mut args = vec![
         format!(
             "PATH={}",
@@ -364,7 +364,7 @@ fn print_dry_run_cram_command(
 
 fn display_path_with_executable_dirs(
     executable_dirs: &[PathBuf],
-    replacer: &moonbuild_debug::graph::PathNormalizer,
+    replacer: &moonbuild::dry_run::PathNormalizer,
 ) -> String {
     let separator = if cfg!(windows) { ";" } else { ":" };
     executable_dirs

--- a/crates/moon/src/rr_build/dry_run.rs
+++ b/crates/moon/src/rr_build/dry_run.rs
@@ -60,7 +60,7 @@ pub fn print_dry_run_all(input: &BuildInput, source_dir: &Path, target_dir: &Pat
 ///
 /// If `stderr` is true, the command is assumed to write to stderr instead of stdout.
 pub fn dry_print_command(cmd: &Command, source_dir: &Path, stderr: bool) {
-    let replacer = moonbuild_debug::graph::PathNormalizer::new(source_dir);
+    let replacer = moonbuild::dry_run::PathNormalizer::new(source_dir);
 
     let args = std::iter::once(cmd.get_program())
         .chain(cmd.get_args())

--- a/crates/moonbuild/Cargo.toml
+++ b/crates/moonbuild/Cargo.toml
@@ -28,7 +28,6 @@ rust-version.workspace = true
 arcstr.workspace = true
 moonutil.workspace = true
 mooncake.workspace = true
-moonbuild-debug.workspace = true
 n2.workspace = true
 clap.workspace = true
 serde.workspace = true

--- a/crates/moonbuild/src/dry_run.rs
+++ b/crates/moonbuild/src/dry_run.rs
@@ -16,12 +16,20 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use moonbuild_debug::graph::try_debug_dump_build_graph_to_file;
 use n2::densemap::Index;
 use n2::graph::{BuildId, FileId, Graph};
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    io::Write,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
 
-use std::path::Path;
+use moonutil::moon_dir::{home, toolchain_root};
+
+const ENV_VAR: &str = "MOON_TEST_DUMP_BUILD_GRAPH";
+static DRY_RUN_TEST_OUTPUT: LazyLock<Option<String>> =
+    LazyLock::new(|| std::env::var(ENV_VAR).ok());
 
 /// Print build commands from a State
 pub fn print_build_commands(
@@ -31,7 +39,7 @@ pub fn print_build_commands(
     target_dir: &Path,
 ) {
     let _ = target_dir; // TODO
-    let replacer = moonbuild_debug::graph::PathNormalizer::new(source_dir);
+    let replacer = PathNormalizer::new(source_dir);
 
     if !default.is_empty() {
         let mut sorted_default = default.to_vec();
@@ -47,6 +55,253 @@ pub fn print_build_commands(
     }
 
     try_debug_dump_build_graph_to_file(graph, default, source_dir);
+}
+
+// FIXME: `PathNormalizer` is production-facing dry-run output formatting, not
+// moonbuild debug support. Move it to a non-debug utility module after
+// `moonbuild-debug` is no longer needed on production dependency paths.
+pub struct PathNormalizer {
+    canonical: Option<PathBuf>,
+    replace_table: Vec<(String, String)>,
+    binary_file_name_table: Vec<(String, String)>,
+    show_toolchain_root: bool,
+    toolchain_root: String,
+    moon_home: String,
+}
+
+impl PathNormalizer {
+    pub fn new(source_dir: &Path) -> Self {
+        let all_moon_bins = moonutil::BINARIES.all_moon_bins();
+        let replace_table = all_moon_bins
+            .iter()
+            .map(|(name, path)| (path.to_string_lossy().into_owned(), name.to_string()))
+            .collect();
+        let binary_file_name_table = all_moon_bins
+            .iter()
+            .filter_map(|(name, path)| {
+                let file_name = path.file_name()?.to_str()?;
+                (file_name != *name).then(|| (file_name.to_owned(), (*name).to_owned()))
+            })
+            .collect();
+        let toolchain_root = toolchain_root();
+        let moon_home = home();
+        let show_toolchain_root = match (
+            dunce::canonicalize(&toolchain_root),
+            dunce::canonicalize(&moon_home),
+        ) {
+            (Ok(toolchain_root), Ok(moon_home)) => toolchain_root != moon_home,
+            _ => toolchain_root != moon_home,
+        };
+
+        let canonical = dunce::canonicalize(source_dir).ok();
+        PathNormalizer {
+            canonical,
+            replace_table,
+            binary_file_name_table,
+            show_toolchain_root,
+            toolchain_root: toolchain_root.to_string_lossy().into_owned(),
+            moon_home: moon_home.to_string_lossy().into_owned(),
+        }
+    }
+
+    pub fn normalize_command(&self, command: &str) -> String {
+        let args = moonutil::shlex::split_native(command);
+        let normalized_args = args
+            .iter()
+            .map(|s| self.normalize_command_arg(s))
+            .collect::<Vec<_>>();
+        moonutil::shlex::join_unix(normalized_args.iter().map(|s| s.as_ref()))
+    }
+
+    pub fn normalize_command_arg(&self, s: &str) -> String {
+        let mut s = s.to_owned();
+        if let Some(canonical) = &self.canonical {
+            let prefix = canonical.to_string_lossy();
+            let prefix_str = prefix.as_ref();
+            let with_sep = format!("{prefix_str}{}", std::path::MAIN_SEPARATOR);
+            s = s.replace(&with_sep, "./");
+            s = s.replace(prefix_str, ".");
+        }
+
+        for (from, to) in &self.replace_table {
+            s = s.replace(from, to);
+        }
+        if self.show_toolchain_root {
+            s = s.replace(&self.toolchain_root, "$MOON_TOOLCHAIN_ROOT");
+        }
+        s = s.replace(&self.moon_home, "$MOON_HOME");
+        s = s.replace('\\', "/");
+        s = self.normalize_binary_file_name(s);
+
+        s
+    }
+
+    pub fn normalize_path(&self, path: &str) -> String {
+        let path_obj = Path::new(path);
+        if let Some(canonical) = &self.canonical
+            && let Ok(stripped) = path_obj.strip_prefix(canonical)
+        {
+            return Self::relative_from_path(stripped);
+        }
+        let mut path = path.to_owned();
+        if self.show_toolchain_root {
+            path = path.replace(&self.toolchain_root, "$MOON_TOOLCHAIN_ROOT");
+        }
+        path = path.replace(&self.moon_home, "$MOON_HOME");
+        path = path.replace('\\', "/");
+        path = self.normalize_binary_file_name(path);
+
+        path
+    }
+
+    fn normalize_binary_file_name(&self, s: String) -> String {
+        self.binary_file_name_table
+            .iter()
+            .find_map(|(from, to)| {
+                if s == *from {
+                    Some(to.clone())
+                } else {
+                    s.strip_suffix(from)
+                        .filter(|prefix| prefix.ends_with('/'))
+                        .map(|prefix| format!("{prefix}{to}"))
+                }
+            })
+            .unwrap_or(s)
+    }
+
+    fn relative_from_path(stripped: &Path) -> String {
+        if stripped.as_os_str().is_empty() {
+            ".".to_owned()
+        } else {
+            let normalized = stripped.to_string_lossy().replace('\\', "/");
+            format!("./{}", normalized)
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BuildGraphDump {
+    nodes: Vec<BuildNode>,
+}
+
+impl BuildGraphDump {
+    fn dump_to(&self, out: impl Write) -> anyhow::Result<()> {
+        let mut writer = std::io::BufWriter::new(out);
+        for node in &self.nodes {
+            serde_json::to_writer(&mut writer, node)?;
+            writeln!(&mut writer)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+struct BuildNode {
+    command: Option<String>,
+    inputs: Vec<String>,
+    outputs: Vec<String>,
+}
+
+fn debug_dump_build_graph(
+    graph: &n2::graph::Graph,
+    input_files: &[FileId],
+    source_dir: &Path,
+) -> BuildGraphDump {
+    let replacer = PathNormalizer::new(source_dir);
+
+    let accessible_nodes = dfs_for_accessible_nodes(graph, input_files);
+    generate_from_nodes(graph, accessible_nodes, &replacer)
+}
+
+// FIXME: `MOON_TEST_DUMP_BUILD_GRAPH` is integration-test infrastructure kept
+// in production-facing dry-run code only so existing snapshot tests can keep
+// invoking the compiled `moon` binary. Gate or relocate this once the test
+// harness no longer needs the runtime hook.
+fn try_debug_dump_build_graph_to_file(
+    build_graph: &n2::graph::Graph,
+    default_files: &[n2::graph::FileId],
+    source_dir: &Path,
+) {
+    let Some(out_file) = DRY_RUN_TEST_OUTPUT.as_deref() else {
+        return;
+    };
+
+    let file = std::fs::File::create(out_file).expect("Failed to create dry-run dump target");
+    let dump = debug_dump_build_graph(build_graph, default_files, source_dir);
+    dump.dump_to(file).expect("Failed to dump to target output");
+}
+
+fn dfs_for_accessible_nodes(graph: &n2::graph::Graph, start_files: &[FileId]) -> Vec<BuildId> {
+    let mut stack = Vec::<FileId>::new();
+    stack.extend_from_slice(start_files);
+    let mut visited_builds = HashSet::new();
+    let mut accessible_builds = vec![];
+
+    while let Some(fid) = stack.pop() {
+        let file = graph
+            .files
+            .by_id
+            .lookup(fid)
+            .expect("Unknown file in graph");
+        if let Some(bid) = file.input
+            && visited_builds.insert(bid)
+        {
+            let build = graph.builds.lookup(bid).expect("Unknown build in graph");
+            accessible_builds.push(bid);
+            // FIXME: This preserves the current graph dump behavior, but raw
+            // `ins.ids` collapses explicit, implicit, order-only, and
+            // validation/lazy inputs. Follow up by using the n2 accessor that
+            // matches the intended dry-run graph snapshot semantics.
+            for &in_fid in &build.ins.ids {
+                stack.push(in_fid);
+            }
+        }
+    }
+
+    accessible_builds
+}
+
+fn generate_from_nodes(
+    graph: &n2::graph::Graph,
+    accessible_nodes: impl IntoIterator<Item = BuildId>,
+    replacer: &PathNormalizer,
+) -> BuildGraphDump {
+    let mut nodes = vec![];
+    for node in accessible_nodes {
+        let node = graph.builds.lookup(node).expect("Unknown build in graph");
+        let command = node
+            .cmdline
+            .as_ref()
+            .map(|cmd| replacer.normalize_command(cmd));
+        let mut inputs = node
+            .ins
+            .ids
+            .iter()
+            .map(|&id| {
+                let file = graph.files.by_id.lookup(id).expect("Unknown node in graph");
+                replacer.normalize_path(&file.name)
+            })
+            .collect::<Vec<_>>();
+        inputs.sort();
+        let outputs = node
+            .outs
+            .ids
+            .iter()
+            .map(|&id| {
+                let file = graph.files.by_id.lookup(id).expect("Unknown node in graph");
+                replacer.normalize_path(&file.name)
+            })
+            .collect::<Vec<_>>();
+        nodes.push(BuildNode {
+            command,
+            inputs,
+            outputs,
+        });
+    }
+
+    nodes.sort_by(|a, b| a.outputs.cmp(&b.outputs));
+
+    BuildGraphDump { nodes }
 }
 
 /// Create a filename-based sorting key cache for stable graph traversal.
@@ -117,4 +372,73 @@ fn stable_toposort_graph(graph: &Graph, inputs: &[FileId]) -> Vec<BuildId> {
     }
 
     res
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PathNormalizer;
+
+    #[test]
+    fn normalizes_known_tool_exe_suffix_without_touching_native_outputs() {
+        let replacer = PathNormalizer {
+            canonical: None,
+            replace_table: vec![],
+            binary_file_name_table: vec![("moonc.exe".to_owned(), "moonc".to_owned())],
+            show_toolchain_root: true,
+            toolchain_root: "$MOON_TOOLCHAIN_ROOT".to_owned(),
+            moon_home: "$MOON_HOME".to_owned(),
+        };
+
+        assert_eq!(replacer.normalize_command_arg("moonc.exe"), "moonc");
+        assert_eq!(
+            replacer.normalize_command_arg("$MOON_HOME/bin/moonc.exe"),
+            "$MOON_HOME/bin/moonc"
+        );
+        assert_eq!(
+            replacer.normalize_path("./_build/native/debug/build/main/main.exe"),
+            "./_build/native/debug/build/main/main.exe"
+        );
+    }
+
+    #[test]
+    fn keeps_moon_home_when_roots_match() {
+        let replacer = PathNormalizer {
+            canonical: None,
+            replace_table: vec![],
+            binary_file_name_table: vec![],
+            show_toolchain_root: false,
+            toolchain_root: "/tmp/.moon".to_owned(),
+            moon_home: "/tmp/.moon".to_owned(),
+        };
+
+        assert_eq!(
+            replacer.normalize_command_arg("/tmp/.moon/lib/core/prelude"),
+            "$MOON_HOME/lib/core/prelude"
+        );
+        assert_eq!(
+            replacer.normalize_path("/tmp/.moon/bin/moonc"),
+            "$MOON_HOME/bin/moonc"
+        );
+    }
+
+    #[test]
+    fn keeps_toolchain_root_distinct_when_needed() {
+        let replacer = PathNormalizer {
+            canonical: None,
+            replace_table: vec![],
+            binary_file_name_table: vec![],
+            show_toolchain_root: true,
+            toolchain_root: "/tmp/toolchain".to_owned(),
+            moon_home: "/tmp/home".to_owned(),
+        };
+
+        assert_eq!(
+            replacer.normalize_command_arg("/tmp/toolchain/lib/core/prelude"),
+            "$MOON_TOOLCHAIN_ROOT/lib/core/prelude"
+        );
+        assert_eq!(
+            replacer.normalize_path("/tmp/toolchain/bin/moonc"),
+            "$MOON_TOOLCHAIN_ROOT/bin/moonc"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- move `moonbuild-debug` off the production dependency path for `moon` and `moonbuild`
- keep dry-run behavior unchanged by relocating the currently production-needed pieces into `moonbuild::dry_run`
- add FIXME notes for the temporary production-facing test/debug pieces that should be factored out later

## User-facing behavior

No intended behavior change. `moon ... --dry-run` should keep the same output, and `MOON_TEST_DUMP_BUILD_GRAPH` still works for existing integration snapshots.

## Size

Measured as unstripped `target/release/moon` on this machine, with the docs submodule initialized for both builds:

- before: `7,501,744` bytes
- after: `7,501,712` bytes
- delta: `-32` bytes (`-0.000427%`)

## Validation

- `cargo fmt`
- `cargo build -p moon --release`
- `cargo test -p moonbuild-debug`
- `cargo tree -p moon --edges normal -i moonbuild-debug` -> no normal dependency edge remains
- `cargo test -p moon --tests` was run with network access; all passed except `test_cases::native_backend::new_native_e2e::test_new_native_run_and_test_e2e`, which failed with a local `moonc` compiler ICE: `Machine_runtime_lower.lower_instr`: `mid-block high-level error call result lowering is unsupported` (`moonc v0.9.3+08f337e2c`).