### PR TITLE
[codex] Clarify dry-run and moonbuild history

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -78,22 +78,23 @@ cargo install --path ./crates/moon --debug --offline
   - `tests/test_cases/mod.rs`: all end-to-end tests are located in
     this file
 
-- `crates/moonbuild-rupes-recta`: the new build graph generation engine (now default)
+- `crates/moonbuild-rupes-recta`: the build graph generation engine
   - `src/build_lower`: lowers resolved modules to n2 build commands
   - `src/fmt.rs`: formatting support
   - `src/metadata.rs`: metadata generation for IDE/tooling
   - See `docs/dev/reference/compiler-cmd-ref.md` for compiler command reference
 
-- `crates/moonbuild`: the legacy build graph generation engine
-  - Being phased out in favor of `moonbuild-rupes-recta`
-  - `src/{check, gen, build, bundle, entry, runtest}`: generate
-    commands and n2 state according to `moon.mod.json` and `moon.pkg.json`
-  - `src/bundle.rs`: only for `moonbitlang/core`, not visible
-    to users
-  - `src/dry_run.rs`: prints commands without executing them,
-    mainly used by end-to-end tests.
-  - `src/expect.rs`: the implementation of expect tests in
-    `moon`
+- `crates/moonbuild`: shared support code that still has the historical crate
+  name. The old build graph generator was removed in
+  `cbb17459b refactor: remove legacy code`; current build graph generation is
+  in `moonbuild-rupes-recta`.
+  - `src/entry.rs`: n2 execution helpers, progress output, and result handling
+  - `src/dry_run.rs`: dry-run command rendering and the integration snapshot
+    graph-dump hook
+  - `src/build_script.rs`: prebuild/build-script support used by RR
+  - `src/expect.rs` and `src/runtest.rs`: expect/snapshot and test helpers
+  - `src/{new,upgrade,doc_http,bench,benchmark,section_capture,test_utils}.rs`:
+    command support utilities retained outside the RR graph generator
 
 - `crates/mooncake`: package manager
   - `src/pkg/add`: `moon add`
@@ -116,7 +117,8 @@ cargo install --path ./crates/moon --debug --offline
 
 - `crates/moonrun`: runtime for executing WASM MoonBit programs
 
-- `crates/moonbuild-debug`: debugging utilities for dry-run printing and snapshotting
+- `crates/moonbuild-debug`: test/debug utilities for dry-run graph
+  comparison. It is not intended to be on normal production dependency paths.
 
 ## Before PR
 

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -102,15 +102,22 @@ Implementation-wise:
 - Step 4 is handled separately in each individual subcommand.
 
 [^graph]:
-    Unless stated otherwise, "build graph generation" refers to the RR pipeline (`moonbuild-rupes-recta`).
-    The legacy pipeline (`moonbuild`) eagerly determines the packages to build,
-    generates a full Ninja-style command graph for the project
-    and relies on the executor to select the subset of commands to run for a given invocation.
+    Unless stated otherwise, "build graph generation" refers to the RR pipeline
+    (`moonbuild-rupes-recta`). The pre-RR generator used to live in the crate
+    named `moonbuild`, but that generator has been removed.
 
-    The legacy pipeline does not model logical build nodes or user intent:
-    it only materializes concrete commands and manually concatenates paths.
-    The "subset of command" is frequently just all commands within the build graph.
-    These limit the ability for it to precisely (or sometimes, correctly) determine the commands to run.
+    The `moonbuild` crate still exists as a shared support crate for execution,
+    dry-run rendering, build scripts, expect/snapshot support, and several CLI
+    utilities. Do not read the crate name as evidence that a selectable legacy
+    graph-generation backend still exists.
+
+    Historically, the legacy pipeline eagerly determined the packages to build,
+    generated a full Ninja-style command graph for the project, and relied on
+    the executor to select the subset of commands to run for a given invocation.
+    It did not model logical build nodes or user intent: it materialized
+    concrete commands and manually concatenated paths. The "subset of command"
+    was frequently just all commands within the build graph. These limitations
+    motivated the RR model described in this document.
 
 [moon_rr_build]: /crates/moon/src/rr_build/mod.rs
 [rr_home]: /crates/moonbuild-rupes-recta/src/lib.rs

--- a/docs/dev/reference/dry-run.md
+++ b/docs/dev/reference/dry-run.md
@@ -3,7 +3,7 @@
 > **This output is intentionally unstable and meant only for maintainers.**
 > Do not build tools or workflows that depend on the exact formatting or ordering.
 
-- **Deterministic order**. Build commands are printed in a topologically sorted order; executing them sequentially produces the expected build artifacts.
+- **Deterministic order**. Build commands are printed in a topologically sorted order that corresponds to the build plan selected for the invocation.
 - **Unix-style command lines**. Every command line is rewritten using Unix shell quoting, even on Windows hosts.
 - **Backslash normalize**. Backslashes `\` in the commandline is normalized to forward slash `/`.
 - **Home directory masking**. Any occurrence of the Moon home directory (`~/.moon` or a custom `$MOON_HOME`) is rewritten to the literal `$MOON_HOME`.
@@ -11,3 +11,81 @@
 - **Toolchain binary aliases**. Known Moon toolchain executables (e.g. `~/.moon/bin/moonc`) are shortened to their bare names (`moonc`). Other executables keep their original paths.
 - **`moon run --dry-run` extras**. After the build commands, the dry-run output also prints the command that would execute the produced binary (typically `moonrun`, `node`, or the final executable).
 - **`moon test --verbose` extras**. With `--verbose` set, `moon test` print the command that is executed for each test case.
+
+## Pasteability and privacy
+
+A reasonable product expectation is that dry-run output should be possible to
+copy into the same shell and execute, unless a command explicitly documents a
+different preview-only mode. Current output does not fully satisfy that
+expectation.
+
+The rendered text is command-shaped, but the current renderer also rewrites
+machine-specific paths for stability, snapshot review, and privacy. For example,
+`$MOON_HOME` is emitted as a literal marker and known toolchain executables may
+be shortened to bare names such as `moonc`. Depending on quoting and the
+caller's environment, copying the output directly into a shell may not reproduce
+the command that `moon` would execute internally.
+
+Any redesign should keep both goals in view:
+
+- **Pasteability.** If dry-run emits `$MOON_HOME`, `$MOON_TOOLCHAIN_ROOT`, or a
+  shortened tool name, the output must either be valid in the user's current
+  shell environment or print enough prelude/setup for the following commands to
+  work.
+- **Privacy.** Dry-run output is commonly copied into issues, review comments,
+  and snapshots. It should avoid exposing user-specific absolute paths such as
+  home directories, workspace roots, custom toolchain paths, or local package
+  cache paths unless the user opts into raw paths.
+
+The likely direction is a privacy-preserving pasteable form: keep project paths
+relative where possible, use stable symbolic variables for home/toolchain paths,
+and ensure those variables are shell-expandable rather than inert snapshot
+markers. The current implementation predates that contract and should be treated
+as a compatibility baseline, not as the final design.
+
+## Where the command text comes from
+
+For RR builds, `moonbuild-rupes-recta` assembles most compiler/tool invocations
+as structured argument vectors during lowering, then flattens them into the n2
+graph command string. The dry-run printer reads the selected n2 build nodes and
+prints their stored command lines after applying the dry-run path normalizer.
+
+There are exceptions:
+
+- user/configured prebuild commands are verbatim shell command strings;
+- `moon run --dry-run` also prints the final run command assembled outside the
+  build graph;
+- `moon cram --dry-run` prints the cram delegation command assembled in the cram
+  CLI path.
+
+## Why the path normalizer exists
+
+The path normalizer came from test/debug output, not from a fully specified
+user-facing pasteable-script design.
+
+- `9911da66b feat(rr): Allow tests to dump build graph to file` added the
+  `MOON_TEST_DUMP_BUILD_GRAPH` hook so integration tests could snapshot the n2
+  graph selected by dry-run invocations.
+- `e2445e409 feat(debug): Normalize dumped build graph` introduced path
+  normalization for that dumped graph. The immediate goal was stable snapshots:
+  remove local project roots, hide machine-specific Moon home paths, and make
+  tool paths comparable across machines.
+- `8c0fc5a58 refactor: unify to unix quoting when printing dry-run and graph cmp`
+  aligned dry-run output and graph comparison around Unix-style quoting.
+- `8b3525c00 fix: normalizer semantics` refined the replacement order and
+  semantics, including project-relative paths, `$MOON_HOME`, and tool aliases.
+- `98d282bfa refactor: de-productionize moonbuild-debug` moved the remaining
+  runtime pieces into `moonbuild::dry_run` because the compiled `moon` binary
+  still needs the integration-test graph-dump hook. That move was not intended
+  to make graph dumping or broad tool alias resolution part of normal build
+  semantics.
+
+## Known debt
+
+- The normalizer currently builds its alias table from all known Moon tool
+  binaries. This can force unrelated lazy binary paths to resolve just because a
+  dry-run command is being printed.
+- The `MOON_TEST_DUMP_BUILD_GRAPH` traversal still walks raw n2 `ins.ids`, which
+  collapses explicit, implicit, order-only, and validation/lazy inputs. That is
+  graph-dump test infrastructure and should not define dry-run dependency
+  semantics.

--- a/docs/dev/reference/virtual-pkg.md
+++ b/docs/dev/reference/virtual-pkg.md
@@ -12,20 +12,22 @@ During the scan phase, Moon records virtual metadata alongside the rest of the p
 - Any package that lists `overrides` gets a consumer-local mapping `<virtual> → <implementation>`.
 
 Doing this during the scan phase ensures every build mode sees a consistent view of virtual contracts, their implementations, and any consumer-specific overrides.
-See [`scan::scan_one_package()`](crates/moonutil/src/scan.rs:311).
+The current RR pipeline records this in discovery and package solving; see
+[`discover::model::Package`](../../../crates/moonbuild-rupes-recta/src/discover/model.rs)
+and [`pkg_solve`](../../../crates/moonbuild-rupes-recta/src/pkg_solve/mod.rs).
 
 ## Build pipeline
 
 The build stage adds three behaviours on top of what regular packages already do:
 
 1. **Compile the interface first.** The scanner chooses the `.mbti` file referenced in `virtual_pkg.interface`. Build compiles that file and pulls in the `.mi` files of any imports, producing the contract other packages must satisfy.
-   See [`gen_build::gen_build_interface_item()`](crates/moonbuild/src/gen/gen_build.rs:98) and [`gen_build::gen_build_interface_command()`](crates/moonbuild/src/gen/gen_build.rs:369).
+   See [`BuildPlanNode::BuildVirtual`](../../../crates/moonbuild-rupes-recta/src/model.rs) and [`LoweringCtx::lower_parse_mbti()`](../../../crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs).
 
 2. **Validate the default body (if any).** When `virtual_pkg.has_default` is true, Moon compiles the bundled body right after the interface and checks that the resulting `.core` stays compatible with the interface before exposing it.
-   See [`gen_build::gen_build_command()`](crates/moonbuild/src/gen/gen_build.rs:440).
+   See [`BuildTargetInfo::check_mi_against`](../../../crates/moonbuild-rupes-recta/src/build_plan/mod.rs) and [`BuildLoweringCtx::lower_build_common_config()`](../../../crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs).
 
 3. **Validate concrete implementations.** Packages that implement the virtual are compiled with the same compatibility checks and they reuse the virtual package’s `.mi` instead of emitting another one.
-   See [`gen_build::gen_build_build_item()`](crates/moonbuild/src/gen/gen_build.rs:195).
+   See [`BuildCommonConfig::add_virtual_package_implementation_build()`](../../../crates/moonbuild-rupes-recta/src/build_lower/compiler/build_common.rs).
 
 As long as interface compilation happens first and every body passes those checks, the dependency graph can treat virtual packages like ordinary ones: their `.mi` products feed downstream builds, and consumers will never see an out-of-date interface.
 
@@ -37,17 +39,17 @@ During traversal this also redirects the walk: once a virtual node is matched wi
 
 If a virtual package ships no default body, the build simply errors: dependency traversal stops with “virtual package … has no implementation” if no override is provided, so the failure happens before any link step runs.
 
-See [`gen_build::replace_virtual_pkg_core_with_impl_pkg_core()`](crates/moonbuild/src/gen/gen_build.rs:270) and [`gen::util::topo_from_node()`](crates/moonbuild/src/gen/util.rs:50).
+See the virtual usage information in [`pkg_solve::model`](../../../crates/moonbuild-rupes-recta/src/pkg_solve/model.rs) and the artifact/dependency construction in [`build_plan`](../../../crates/moonbuild-rupes-recta/src/build_plan/mod.rs).
 
 ## Consistency across build, check, and test
 
 The same behaviour repeats in every build mode:
 
 - **Check** mode regenerates interfaces, reruns default validation with `-check-mi`, and enforces `-check-mi/-impl-virtual` for implementations so diagnostics match the normal build.
-  See [`gen_check::gen_check()`](crates/moonbuild/src/gen/gen_check.rs:452).
+  See [`build_lower::compiler::check`](../../../crates/moonbuild-rupes-recta/src/build_lower/compiler/check.rs) and [`BuildCommonConfig::add_virtual_package_implementation_check()`](../../../crates/moonbuild-rupes-recta/src/build_lower/compiler/build_common.rs).
 
 - **Test** mode builds test drivers on top of the same interface/implementation pipeline, then applies overrides before generating runnable artifacts.
-  See [`gen_runtest::gen_runtest()`](crates/moonbuild/src/gen/gen_runtest.rs:966).
+  See [`BuildPlanNode`](../../../crates/moonbuild-rupes-recta/src/model.rs), [`build_plan`](../../../crates/moonbuild-rupes-recta/src/build_plan/mod.rs), and [`build_lower`](../../../crates/moonbuild-rupes-recta/src/build_lower/mod.rs).
 
 Test-only packages that implement a virtual package go through the same validation: their compiled artifacts are checked against the virtual interface before any test harness links them in, so mismatched implementations fail during the test build stage rather than at runtime. Black-box tests do not re-run that check; they import the already-validated package core instead of recompiling it.
 


### PR DESCRIPTION
## Summary
- Update developer docs to describe `moonbuild-rupes-recta` as the current graph generator and `moonbuild` as a historical-name shared support crate.
- Clarify `--dry-run` output: paste-ready shell commands are the expected product direction, but current output does not fully satisfy that contract.
- Document privacy constraints for dry-run rendering: avoid leaking home directories, workspace roots, custom toolchain paths, and local caches unless users opt into raw paths.
- Document the git history behind dry-run path normalization and the graph-dump test hook.
- Replace stale virtual-package references to removed `crates/moonbuild/src/gen/...` files with current RR module references.

## User-facing behavior
- Documentation only; no runtime behavior change.

## Validation
- `git diff --check`
- stale-reference `rg` checks for removed legacy-generator paths
- checked new RR doc link targets exist