### PR TITLE
[codex] fix: quiet inline moon run output

### DIFF
--- a/crates/moon/src/cli/profile.rs
+++ b/crates/moon/src/cli/profile.rs
@@ -283,6 +283,8 @@ fn run_profile_materialized(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow:
             // The dry-run output should show the profiled invocation, not the
             // plain executable command that `moon run` would normally print.
             print_dry_run_run_command: false,
+            suppress_build_progress: false,
+            quiet_sync: false,
         },
     )?;
     built.ensure_build_success()?;

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -119,6 +119,10 @@ pub(crate) struct BuildRunExecutableOptions {
     pub(crate) try_tcc_run: bool,
     /// Whether dry-run output should include the final executable invocation.
     pub(crate) print_dry_run_run_command: bool,
+    /// Whether to suppress build progress output from n2.
+    pub(crate) suppress_build_progress: bool,
+    /// Whether dependency sync/install progress should stay quiet.
+    pub(crate) quiet_sync: bool,
 }
 
 impl BuildRunExecutableOptions {
@@ -126,6 +130,17 @@ impl BuildRunExecutableOptions {
         Self {
             try_tcc_run: !cli.dry_run,
             print_dry_run_run_command: true,
+            suppress_build_progress: false,
+            quiet_sync: false,
+        }
+    }
+
+    fn for_inline_run(cli: &UniversalFlags) -> Self {
+        Self {
+            try_tcc_run: !cli.dry_run,
+            print_dry_run_run_command: true,
+            suppress_build_progress: !cli.verbose,
+            quiet_sync: !cli.verbose,
         }
     }
 }
@@ -154,6 +169,7 @@ pub(crate) struct RunExecutable {
 struct BuildExecutableFromPlanOptions {
     force_success_exit: bool,
     print_dry_run_run_command: bool,
+    suppress_build_progress: bool,
 }
 
 impl RunExecutable {
@@ -181,7 +197,14 @@ fn run_stdin_source_as_single_file(
         .read_to_string(&mut source)
         .context("failed to read `.mbtx` source from stdin")?;
 
-    run_source_as_single_file(cli, cmd, source, "stdin.mbtx", "stdin")
+    run_source_as_single_file(
+        cli,
+        cmd,
+        source,
+        "stdin.mbtx",
+        "stdin",
+        BuildRunExecutableOptions::for_run(cli),
+    )
 }
 
 fn run_inline_source_as_single_file(
@@ -193,7 +216,14 @@ fn run_inline_source_as_single_file(
         .clone()
         .expect("inline script should be present when `moon run -e` is selected");
 
-    run_source_as_single_file(cli, cmd, source, "command.mbtx", "command")
+    run_source_as_single_file(
+        cli,
+        cmd,
+        source,
+        "command.mbtx",
+        "command",
+        BuildRunExecutableOptions::for_inline_run(cli),
+    )
 }
 
 fn run_source_as_single_file(
@@ -202,6 +232,7 @@ fn run_source_as_single_file(
     source: String,
     temp_name: &str,
     source_name: &str,
+    options: BuildRunExecutableOptions,
 ) -> anyhow::Result<i32> {
     let temp_dir = tempfile::TempDir::new()
         .with_context(|| format!("failed to create temporary directory for {source_name} run"))?;
@@ -231,7 +262,7 @@ fn run_source_as_single_file(
         build_only,
         profile,
     };
-    let result = run_single_file_from_arg(cli, cmd);
+    let result = run_single_file_from_arg_with_options(cli, cmd, options);
     drop(temp_dir);
     result
 }
@@ -413,7 +444,8 @@ fn build_package_executable(
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     )
-    .with_project_manifest_path(project_manifest_path.as_deref());
+    .with_project_manifest_path(project_manifest_path.as_deref())
+    .with_quiet_sync(options.quiet_sync);
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
     let (build_meta, build_graph) = plan_run_rr_from_resolved(
         cli,
@@ -433,6 +465,7 @@ fn build_package_executable(
         BuildExecutableFromPlanOptions {
             force_success_exit: selected_target_backend.is_some(),
             print_dry_run_run_command: options.print_dry_run_run_command,
+            suppress_build_progress: options.suppress_build_progress,
         },
     )
 }
@@ -523,9 +556,12 @@ fn resolve_run_selection(
 }
 
 #[instrument(level = Level::DEBUG, skip_all)]
-fn run_single_file_from_arg(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
-    let executable =
-        build_single_file_executable_from_arg(cli, &cmd, BuildRunExecutableOptions::for_run(cli))?;
+fn run_single_file_from_arg_with_options(
+    cli: &UniversalFlags,
+    cmd: RunSubcommand,
+    options: BuildRunExecutableOptions,
+) -> anyhow::Result<i32> {
+    let executable = build_single_file_executable_from_arg(cli, &cmd, options)?;
     run_executable(cli, &cmd, executable)
 }
 
@@ -578,7 +614,8 @@ fn build_single_file_executable(
         false,
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
-    );
+    )
+    .with_quiet_sync(options.quiet_sync);
     let (resolved, backend) = moonbuild_rupes_recta::resolve::resolve_single_file_project(
         &resolve_cfg,
         target_dir.as_path(),
@@ -635,6 +672,7 @@ fn build_single_file_executable(
         BuildExecutableFromPlanOptions {
             force_success_exit: false,
             print_dry_run_run_command: options.print_dry_run_run_command,
+            suppress_build_progress: options.suppress_build_progress,
         },
     )
 }
@@ -685,7 +723,8 @@ fn build_executable_from_plan(
         &cli.unstable_feature,
         cli.verbose,
         UserDiagnostics::from_flags(cli),
-    );
+    )
+    .with_suppressed_progress(options.suppress_build_progress);
     let build_result = rr_build::execute_build(&build_config, build_graph, target_dir)?;
 
     Ok(RunExecutable {

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -877,6 +877,7 @@ pub struct BuildConfig {
 
     /// Verbose output for build progress and command echo
     verbose: bool,
+    suppress_progress: bool,
     user_diagnostics: UserDiagnostics,
 
     /// The patch file to use
@@ -898,9 +899,15 @@ impl BuildConfig {
             explain_errors: false,
             n2_explain: unstable_features.rr_n2_explain,
             verbose,
+            suppress_progress: false,
             user_diagnostics,
             patch_file: None,
         }
+    }
+
+    pub(crate) fn with_suppressed_progress(mut self, suppress_progress: bool) -> Self {
+        self.suppress_progress = suppress_progress;
+        self
     }
 }
 
@@ -914,6 +921,7 @@ impl Default for BuildConfig {
             explain_errors: false,
             n2_explain: false,
             verbose: false,
+            suppress_progress: false,
             user_diagnostics: UserDiagnostics::default(),
             patch_file: None,
         }
@@ -1011,15 +1019,18 @@ pub fn execute_build_partial(
         .unwrap();
 
     let result_catcher = Arc::new(Mutex::new(ResultCatcher::default()));
-    let mut prog_console = match cfg.output_style {
-        OutputStyle::Raw => {
-            create_progress_console(Some(Box::new(no_render_callback())), cfg.verbose)
-        }
+    let mut prog_console: Box<dyn n2::progress::Progress> = match cfg.output_style {
+        OutputStyle::Raw => create_progress_console(
+            Some(Box::new(no_render_callback())),
+            cfg.verbose,
+            cfg.suppress_progress,
+        ),
         OutputStyle::Fancy | OutputStyle::Json => create_progress_console(
             Some(Box::new(capture_diagnostics_callback(Arc::clone(
                 &result_catcher,
             )))),
             cfg.verbose,
+            cfg.suppress_progress,
         ),
     };
     let mut work = n2::work::Work::new(
@@ -1039,11 +1050,14 @@ pub fn execute_build_partial(
     want_files(&mut work).context("Failed to determine the files to be built")?;
 
     // The actual execution done by the n2 executor
-    let res = work.run().context("Failed to run n2 graph")?;
+    let res = work.run().context("Failed to run n2 graph");
+    drop(work);
+    drop(prog_console); // Ensure the progress bar won't mess with diagnostic output
+    let res = res?;
+    let build_succeeded = res.is_some();
 
     let mut result_catcher = result_catcher.lock().unwrap();
-    drop(prog_console); // Ensure the progress bar won't mess with diagnostic output
-    process_captured_diagnostics(&mut result_catcher, cfg);
+    process_captured_diagnostics(&mut result_catcher, cfg, build_succeeded);
     let stats = N2RunStats {
         n_tasks_executed: res,
         n_errors: result_catcher.n_errors,
@@ -1079,7 +1093,15 @@ fn no_render_callback() -> impl Fn(&str) {
     }
 }
 
-fn process_captured_diagnostics(catcher: &mut ResultCatcher, cfg: &BuildConfig) {
+fn should_render_non_diagnostic_build_output(cfg: &BuildConfig, build_succeeded: bool) -> bool {
+    !(cfg.suppress_progress && build_succeeded)
+}
+
+fn process_captured_diagnostics(
+    catcher: &mut ResultCatcher,
+    cfg: &BuildConfig,
+    build_succeeded: bool,
+) {
     let mut has_unprocessed = false;
     match cfg.output_style {
         OutputStyle::Json => {
@@ -1102,7 +1124,9 @@ fn process_captured_diagnostics(catcher: &mut ResultCatcher, cfg: &BuildConfig) 
                     Err(_) => {
                         // Non-diagnostics output, just print as-is
                         // This could happen for installing binaries dependencies etc.
-                        eprintln!("{content}");
+                        if should_render_non_diagnostic_build_output(cfg, build_succeeded) {
+                            eprintln!("{content}");
+                        }
                     }
                 };
             }
@@ -1131,7 +1155,9 @@ fn process_captured_diagnostics(catcher: &mut ResultCatcher, cfg: &BuildConfig) 
                     Err(_) => {
                         // Non-diagnostics output, just print as-is
                         // This could happen for installing binaries dependencies etc.
-                        eprintln!("{content}");
+                        if should_render_non_diagnostic_build_output(cfg, build_succeeded) {
+                            eprintln!("{content}");
+                        }
                     }
                 };
             }

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -810,7 +810,8 @@ fn test_moon_run_command_string_reads_inline_script() {
         )
         .assert()
         .success()
-        .stdout_eq("hello from run -e\n");
+        .stdout_eq("hello from run -e\n")
+        .stderr_eq("");
 }
 
 #[test]
@@ -828,7 +829,32 @@ fn test_moon_run_command_string_short_alias_c_reads_inline_script() {
         )
         .assert()
         .success()
-        .stdout_eq("hello from run -c\n");
+        .stdout_eq("hello from run -c\n")
+        .stderr_eq("");
+}
+
+#[test]
+fn test_moon_run_command_string_invalid_source_keeps_diagnostics_on_stderr() {
+    let dir = TestDir::new_empty();
+    let assert = snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .arg("run")
+        .arg("-e")
+        .arg(r#"println("hello")"#)
+        .assert()
+        .failure();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(stdout.contains("failed:"), "stdout: {stdout}");
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("Missing main function in the main package"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Parse error, unexpected token"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("failed:"), "stderr: {stderr}");
 }
 
 #[test]

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -85,6 +85,7 @@ impl ResolveOutput {
 #[derive(Debug)]
 pub struct ResolveConfig {
     sync_flags: AutoSyncFlags,
+    quiet_sync: bool,
     no_std: bool,
     /// Gate coverage injection in pkg_solve
     pub enable_coverage: bool,
@@ -285,6 +286,7 @@ impl ResolveConfig {
     ) -> Self {
         Self {
             sync_flags: AutoSyncFlags { frozen },
+            quiet_sync: false,
             no_std,
             enable_coverage,
             workspace_env,
@@ -301,6 +303,7 @@ impl ResolveConfig {
     ) -> Self {
         Self {
             sync_flags,
+            quiet_sync: false,
             no_std,
             enable_coverage,
             workspace_env,
@@ -310,6 +313,11 @@ impl ResolveConfig {
 
     pub fn with_project_manifest_path(mut self, project_manifest_path: Option<&Path>) -> Self {
         self.project_manifest_path = project_manifest_path.map(Path::to_path_buf);
+        self
+    }
+
+    pub fn with_quiet_sync(mut self, quiet_sync: bool) -> Self {
+        self.quiet_sync = quiet_sync;
         self
     }
 }
@@ -360,7 +368,7 @@ pub fn resolve(
         source_dir,
         mooncakes_dir,
         &cfg.sync_flags,
-        false,
+        cfg.quiet_sync,
         cfg.no_std,
         cfg.workspace_env.clone(),
         cfg.project_manifest_path.as_deref(),
@@ -483,6 +491,7 @@ Use moonbit.import with 'username/module@version[/package]' entries to opt in to
         mooncakes_dir,
         &cfg.sync_flags,
         front_matter_config.deps_to_sync.as_ref(),
+        cfg.quiet_sync,
     )
     .map_err(ResolveError::SyncModulesError)?;
     // Discover all packages in resolved modules

--- a/crates/moonbuild/src/entry.rs
+++ b/crates/moonbuild/src/entry.rs
@@ -29,8 +29,9 @@ use moonutil::common::MbtTestInfo;
 pub fn create_progress_console(
     callback: Option<Box<dyn Fn(&str) + Send>>,
     verbose: bool,
+    suppress_progress: bool,
 ) -> Box<dyn Progress> {
-    if terminal::use_fancy() {
+    if !suppress_progress && terminal::use_fancy() {
         Box::new(FancyConsoleProgress::new(verbose, callback))
     } else {
         Box::new(DumbConsoleProgress::new(verbose, callback))

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -183,6 +183,7 @@ pub fn auto_sync_for_single_file_rr(
     mooncakes_dir: &Path,
     sync_flags: &AutoSyncFlags,
     front_matter_deps: Option<&IndexMap<String, moonutil::dependency::SourceDependencyInfo>>,
+    quiet: bool,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult)> {
     let mut synth_deps = IndexMap::new();
     if let Some(deps_map) = front_matter_deps {
@@ -203,7 +204,7 @@ pub fn auto_sync_for_single_file_rr(
     let (resolved_env, dir_sync_result) = super::install::install_impl(
         mooncakes_dir,
         roots,
-        false,
+        quiet,
         false,
         sync_flags.dont_sync(),
         false,


### PR DESCRIPTION
## Summary

- Keep normal successful `moon run -e` and `moon run -c` inline runs focused on the executed program output.
- Disable fancy n2 progress for inline non-verbose runs so build progress does not leak into stdout.
- Silence dependency sync/install progress for inline resolution through the existing quiet sync path.
- Drop successful non-diagnostic compiler/linker chatter captured during quiet inline builds while preserving failure output and diagnostics.

## Notes

This PR intentionally does not change the default inline target backend. Failure banners may still be emitted on build failure; compiler diagnostics remain on stderr. Stdin, ordinary single-file, package runs, profiling, dry-run, and verbose behavior keep their existing contracts.

## Validation

- `cargo fmt --all`
- `cargo test -p moon test_moon_run_command_string`
- `cargo test -p moon moon_commands` was attempted locally before the split; inline tests passed, but unrelated `moon explain` tests failed because `crates/moonutil/resources/error_codes` is not initialized in this checkout.