### PR TITLE
[codex] fix: default inline moon run to native

### DIFF
--- a/crates/moon/src/cli/profile.rs
+++ b/crates/moon/src/cli/profile.rs
@@ -285,6 +285,7 @@ fn run_profile_materialized(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow:
             print_dry_run_run_command: false,
             suppress_build_progress: false,
             quiet_sync: false,
+            default_target_backend: TargetBackend::default(),
         },
     )?;
     built.ensure_build_success()?;

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -123,6 +123,8 @@ pub(crate) struct BuildRunExecutableOptions {
     pub(crate) suppress_build_progress: bool,
     /// Whether dependency sync/install progress should stay quiet.
     pub(crate) quiet_sync: bool,
+    /// Backend to use when neither CLI flags nor single-file metadata selects one.
+    pub(crate) default_target_backend: TargetBackend,
 }
 
 impl BuildRunExecutableOptions {
@@ -132,6 +134,7 @@ impl BuildRunExecutableOptions {
             print_dry_run_run_command: true,
             suppress_build_progress: false,
             quiet_sync: false,
+            default_target_backend: TargetBackend::default(),
         }
     }
 
@@ -141,6 +144,7 @@ impl BuildRunExecutableOptions {
             print_dry_run_run_command: true,
             suppress_build_progress: !cli.verbose,
             quiet_sync: !cli.verbose,
+            default_target_backend: TargetBackend::Native,
         }
     }
 }
@@ -623,13 +627,15 @@ fn build_single_file_executable(
         &input_path,
         true,
     )?;
-    let selected_target_backend = selected_target_backend.or(backend);
+    let selected_target_backend = selected_target_backend
+        .or(backend)
+        .unwrap_or(options.default_target_backend);
 
     let mut preconfig = preconfig_compile(
         &cmd.auto_sync_flags,
         cli,
         &cmd.build_flags,
-        selected_target_backend,
+        Some(selected_target_backend),
         &target_dir,
         RunMode::Run,
     );

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -858,6 +858,80 @@ fn test_moon_run_command_string_invalid_source_keeps_diagnostics_on_stderr() {
 }
 
 #[test]
+fn test_moon_run_command_string_defaults_to_native() {
+    let dir = TestDir::new_empty();
+    let stdout = get_stdout(
+        &dir,
+        [
+            "run",
+            "-e",
+            r#"fn main {
+  println("hello from run -e")
+}
+"#,
+            "--dry-run",
+        ],
+    );
+
+    assert!(stdout.contains("-target native"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("./_build/native/debug/build/single/single.core"),
+        "stdout: {stdout}"
+    );
+    assert!(!stdout.contains("-target wasm-gc"), "stdout: {stdout}");
+}
+
+#[test]
+fn test_moon_run_command_string_explicit_target_overrides_native_default() {
+    let dir = TestDir::new_empty();
+    let stdout = get_stdout(
+        &dir,
+        [
+            "run",
+            "-e",
+            r#"fn main {
+  println("hello from run -e")
+}
+"#,
+            "--target",
+            "wasm-gc",
+            "--dry-run",
+        ],
+    );
+
+    assert!(stdout.contains("-target wasm-gc"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("moonrun ./_build/wasm-gc/debug/build/single/single.wasm --"),
+        "stdout: {stdout}"
+    );
+    assert!(!stdout.contains("-target native"), "stdout: {stdout}");
+}
+
+#[test]
+fn test_moon_run_command_string_short_alias_c_defaults_to_native() {
+    let dir = TestDir::new_empty();
+    let stdout = get_stdout(
+        &dir,
+        [
+            "run",
+            "-c",
+            r#"fn main {
+  println("hello from run -c")
+}
+"#,
+            "--dry-run",
+        ],
+    );
+
+    assert!(stdout.contains("-target native"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("./_build/native/debug/build/single/single.core"),
+        "stdout: {stdout}"
+    );
+    assert!(!stdout.contains("-target wasm-gc"), "stdout: {stdout}");
+}
+
+#[test]
 fn test_moon_run_command_string_conflicts_with_other_inputs() {
     let dir = TestDir::new_empty();
 


### PR DESCRIPTION
## Summary

- Default inline scripts from `moon run -e` and the `-c` alias to the native backend when no explicit target is supplied.
- Preserve explicit `--target` behavior, including `--target wasm-gc`.
- Leave stdin mode, ordinary single-file runs, package runs, and profiling defaults unchanged.

## Notes

This PR intentionally does not include the quiet-output changes from #1735. It only changes the backend selected for inline command strings.

## Validation

- `cargo fmt --all`
- `cargo test -p moon test_moon_run_command_string`