### PR TITLE
[codex] Fix Windows clippy warning checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,10 @@ jobs:
       - name: Build
         run: cargo build
 
+      - name: Clippy (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
       - name: Set built binary to PATH (Unix)
         if: ${{ matrix.os != 'windows-latest' }}
         run: echo "$GITHUB_WORKSPACE/target/debug" >> $GITHUB_PATH

--- a/crates/moon/tests/test_cases/debug_flag_test/mod.rs
+++ b/crates/moon/tests/test_cases/debug_flag_test/mod.rs
@@ -1,9 +1,10 @@
+#[cfg(unix)]
 use expect_test::expect;
 
-use crate::{TestDir, dry_run_utils::line_with, get_stdout, util::check};
+use crate::{TestDir, dry_run_utils::line_with, get_stdout};
 
 #[cfg(unix)]
-use crate::get_err_stderr;
+use crate::{get_err_stderr, util::check};
 
 #[test]
 fn run_dry_run_uses_selected_profile_for_runtime_artifact() {

--- a/crates/moon/tests/test_cases/fmt/mod.rs
+++ b/crates/moon/tests/test_cases/fmt/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+#[cfg(unix)]
 use moonutil::common::BUILD_DIR;
 
 #[test]

--- a/crates/moon/tests/test_cases/mbti/mod.rs
+++ b/crates/moon/tests/test_cases/mbti/mod.rs
@@ -2,7 +2,6 @@ use super::*;
 use moonutil::common::MBTI_GENERATED;
 
 #[test]
-#[cfg(unix)]
 fn test_mbti() {
     let dir = TestDir::new("mbti");
     let _ = get_stdout(&dir, ["info"]);
@@ -51,7 +50,6 @@ fn test_mbti() {
 }
 
 #[test]
-#[cfg(unix)]
 fn test_mbti_no_alias() {
     let dir = TestDir::new("mbti");
     let _ = get_stdout(&dir, ["info", "--no-alias"]);

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -62,6 +62,7 @@ mod indirect_dep;
 mod inline_test;
 mod js_test_build_only;
 mod main_package;
+#[cfg(unix)]
 mod mbti;
 mod moon_bench;
 mod moon_build_package;
@@ -76,6 +77,7 @@ mod moon_new;
 mod moon_prove;
 mod moon_test;
 mod moon_version;
+#[cfg(unix)]
 mod native_abort_trace;
 mod native_backend;
 mod native_stub_stability;

--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -1,4 +1,5 @@
 mod patch;
+#[cfg(unix)]
 mod use_cc_for_native_release;
 mod with_cfg;
 

--- a/crates/moon/tests/test_cases/moon_test/use_cc_for_native_release.rs
+++ b/crates/moon/tests/test_cases/moon_test/use_cc_for_native_release.rs
@@ -17,7 +17,6 @@ fn assert_dry_run_graph(
     });
 }
 
-#[cfg(unix)]
 #[test]
 fn test_use_cc_for_native_release() {
     let dir = TestDir::new("moon_test/hello_exec_fntest");

--- a/crates/moon/tests/test_cases/native_abort_trace/mod.rs
+++ b/crates/moon/tests/test_cases/native_abort_trace/mod.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-#[cfg(unix)]
 #[test]
 fn test_native_abort_trace() {
     let dir = TestDir::new("native_abort_trace/native_abort_trace.in");

--- a/crates/moon/tests/test_cases/native_backend/cc_flags.rs
+++ b/crates/moon/tests/test_cases/native_backend/cc_flags.rs
@@ -5,9 +5,11 @@ use std::process::Command;
 use crate::TestDir;
 #[cfg(windows)]
 use crate::{TestDir, get_stdout_with_envs};
+#[cfg(unix)]
 use expect_test::expect_file;
 
-use super::{assert_native_backend_graph, assert_native_backend_graph_no_env};
+#[cfg(unix)]
+use super::unix_graph::{assert_native_backend_graph, assert_native_backend_graph_no_env};
 
 #[cfg(windows)]
 fn link_commands_with_compiler(output: &str, compiler_name: &str) -> Vec<String> {

--- a/crates/moon/tests/test_cases/native_backend/mod.rs
+++ b/crates/moon/tests/test_cases/native_backend/mod.rs
@@ -1,72 +1,77 @@
-use expect_test::ExpectFile;
-use moonbuild_debug::graph::ENV_VAR;
-
-use crate::{TestDir, build_graph::compare_graphs_with_replacements, get_stdout_with_envs};
-
 mod cc_flags;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 mod new_native_e2e;
+#[cfg(windows)]
 mod parallel_msvc;
 #[cfg(unix)]
 mod simdutf;
+#[cfg(unix)]
 mod tcc_run;
 mod test_filter;
 
-#[track_caller]
-pub(super) fn assert_native_backend_graph(
-    dir: &TestDir,
-    tmp_name: &str,
-    args: &[&str],
-    envs: &[(&str, &str)],
-    expected: ExpectFile,
-) {
-    let graph = dir.join(tmp_name);
-    let mut env_pairs: Vec<(String, String)> = envs
-        .iter()
-        .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
-        .collect();
-    env_pairs.push((ENV_VAR.to_string(), graph.to_string_lossy().into_owned()));
-    get_stdout_with_envs(dir, args.iter().copied(), env_pairs);
-    compare_graphs_with_replacements(&graph, expected, |s| {
-        // Normalize clang-only warnings to keep snapshots portable across macOS/Linux.
-        *s = s.replace(" -Wno-unused-value", "");
-        *s = s.replace(".dylib", ".so");
-        normalize_macos_sdk_path(s);
-    });
-}
+#[cfg(unix)]
+mod unix_graph {
+    use expect_test::ExpectFile;
+    use moonbuild_debug::graph::ENV_VAR;
 
-#[track_caller]
-pub(super) fn assert_native_backend_graph_no_env(
-    dir: &TestDir,
-    tmp_name: &str,
-    args: &[&str],
-    expected: ExpectFile,
-) {
-    assert_native_backend_graph(dir, tmp_name, args, &[], expected);
-}
+    use crate::{TestDir, build_graph::compare_graphs_with_replacements, get_stdout_with_envs};
 
-#[cfg(target_os = "macos")]
-fn normalize_macos_sdk_path(s: &mut String) {
-    let Ok(output) = std::process::Command::new("xcrun")
-        .args(["--sdk", "macosx", "--show-sdk-path"])
-        .output()
-    else {
-        return;
-    };
-    if !output.status.success() {
-        return;
+    #[track_caller]
+    pub(super) fn assert_native_backend_graph(
+        dir: &TestDir,
+        tmp_name: &str,
+        args: &[&str],
+        envs: &[(&str, &str)],
+        expected: ExpectFile,
+    ) {
+        let graph = dir.join(tmp_name);
+        let mut env_pairs: Vec<(String, String)> = envs
+            .iter()
+            .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+            .collect();
+        env_pairs.push((ENV_VAR.to_string(), graph.to_string_lossy().into_owned()));
+        get_stdout_with_envs(dir, args.iter().copied(), env_pairs);
+        compare_graphs_with_replacements(&graph, expected, |s| {
+            // Normalize clang-only warnings to keep snapshots portable across macOS/Linux.
+            *s = s.replace(" -Wno-unused-value", "");
+            *s = s.replace(".dylib", ".so");
+            normalize_macos_sdk_path(s);
+        });
     }
 
-    let sdk_root = String::from_utf8_lossy(&output.stdout);
-    let Some(sdk_root) = sdk_root.lines().next().map(str::trim) else {
-        return;
-    };
-    if sdk_root.is_empty() {
-        return;
+    #[track_caller]
+    pub(super) fn assert_native_backend_graph_no_env(
+        dir: &TestDir,
+        tmp_name: &str,
+        args: &[&str],
+        expected: ExpectFile,
+    ) {
+        assert_native_backend_graph(dir, tmp_name, args, &[], expected);
     }
 
-    *s = s.replace(&format!("-L{sdk_root}/usr/lib"), "-L$MACOSX_SDK/usr/lib");
-}
+    #[cfg(target_os = "macos")]
+    fn normalize_macos_sdk_path(s: &mut String) {
+        let Ok(output) = std::process::Command::new("xcrun")
+            .args(["--sdk", "macosx", "--show-sdk-path"])
+            .output()
+        else {
+            return;
+        };
+        if !output.status.success() {
+            return;
+        }
 
-#[cfg(not(target_os = "macos"))]
-fn normalize_macos_sdk_path(_s: &mut String) {}
+        let sdk_root = String::from_utf8_lossy(&output.stdout);
+        let Some(sdk_root) = sdk_root.lines().next().map(str::trim) else {
+            return;
+        };
+        if sdk_root.is_empty() {
+            return;
+        }
+
+        *s = s.replace(&format!("-L{sdk_root}/usr/lib"), "-L$MACOSX_SDK/usr/lib");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn normalize_macos_sdk_path(_s: &mut String) {}
+}

--- a/crates/moon/tests/test_cases/native_backend/parallel_msvc.rs
+++ b/crates/moon/tests/test_cases/native_backend/parallel_msvc.rs
@@ -1,10 +1,8 @@
-#[cfg(windows)]
 use crate::{TestDir, get_stdout, util::copy};
 
 /// This test is probabilistic. It ensures that MSVC builds don't share an
 /// intermediate directory when run in parallel, which can cause conflicts.
 #[test]
-#[cfg(windows)]
 fn test_parallel_msvc() {
     let dir = TestDir::new("native_backend/parallel_msvc");
     let template = dir.join("template");

--- a/crates/moon/tests/test_cases/native_backend/tcc_run.rs
+++ b/crates/moon/tests/test_cases/native_backend/tcc_run.rs
@@ -1,10 +1,9 @@
 use crate::TestDir;
 use expect_test::expect_file;
 
-use super::assert_native_backend_graph_no_env;
+use super::unix_graph::assert_native_backend_graph_no_env;
 
 #[test]
-#[cfg(unix)]
 fn test_native_backend_tcc_run() {
     let dir = TestDir::new("native_backend/tcc_run");
     assert_native_backend_graph_no_env(

--- a/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
@@ -1,6 +1,8 @@
 use std::cell::OnceCell;
 
-use crate::{TestDir, assert_success, get_err_stderr, get_stdout, get_stdout_with_envs, util};
+use crate::{TestDir, assert_success, get_err_stderr, get_stdout_with_envs};
+#[cfg(unix)]
+use crate::{get_stdout, util};
 
 // Notice the two `this-is-added-by-config-script`
 #[test]


### PR DESCRIPTION
## Summary

- Add a Windows CI clippy step that runs `cargo clippy --all-targets --all-features -- -D warnings`.
- Fix Windows-only clippy warnings in test builds by moving platform cfgs to module boundaries where possible.
- Box the large `TestBuildExecution::Built` variant to satisfy Windows clippy.

## Root Cause

The existing CI ran the full warning-deny clippy check through `xtask ci` only on Ubuntu. Windows test builds could therefore accumulate platform-specific unused imports, unused helpers, and enum-layout warnings without failing CI.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy -p moon --target x86_64-pc-windows-gnu --test mod -- -D warnings`
- `git diff --check`

Full local Windows workspace clippy is not possible on this macOS host: MSVC cross-checking stops in `ring` without Windows C headers, and the GNU full-workspace route stops because `rusty_v8` has no `x86_64-pc-windows-gnu` archive for this version. The new CI step runs the full command on `windows-latest` with MSVC.