### PR TITLE
[codex] Print runwasm fixture args without escaping

### DIFF
--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -538,7 +538,8 @@ fn test_moon_run_with_cli_args() {
             "run", "main", "--", "中文", "😄👍", "hello", "1242", "--flag",
         ],
     );
-    assert!(s.contains("  \"中文\",\n  \"😄👍\",\n  \"hello\",\n  \"1242\",\n  \"--flag\","));
+    let expected_args = "中文\n😄👍\nhello\n1242\n--flag\n";
+    assert!(s.contains(expected_args));
 
     moon_cmd(&dir).args(["build"]).assert().success();
     let wasm_file = dir.join("_build/wasm-gc/debug/build/main/main.wasm");
@@ -552,7 +553,7 @@ fn test_moon_run_with_cli_args() {
         .stdout
         .clone();
     let s = replace_dir(std::str::from_utf8(&stdout).unwrap(), &dir);
-    assert!(s.contains("  \"中文\",\n  \"😄👍\",\n  \"hello\",\n  \"1242\",\n  \"--flag\","));
+    assert!(s.contains(expected_args));
 
     let stdout = moon_cmd(&dir)
         .arg("run")
@@ -601,7 +602,7 @@ fn test_moon_run_with_cli_args() {
             "run", "main", "--target", "js", "--", "中文", "😄👍", "hello", "1242", "--flag",
         ],
     );
-    assert!(s.contains("  \"中文\",\n  \"😄👍\",\n  \"hello\",\n  \"1242\",\n  \"--flag\","));
+    assert!(s.contains(expected_args));
 }
 
 #[cfg(unix)]

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -112,11 +112,9 @@ fn test_runwasm_uses_cached_asset_and_forwards_args() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-[
-  "[..]registry[..]cache[..]assets[..]moonbitlang[..]parser[..]0.3.3[..]cmd[..]moonfmt[..]moonfmt.wasm",
-  "--arg1",
-  "arg2",
-]
+[..]/registry/cache/assets/moonbitlang/parser/0.3.3/cmd/moonfmt/moonfmt.wasm
+--arg1
+arg2
 
 "#]])
         .stderr_eq("");

--- a/crates/moon/tests/test_cases/moon_run_with_cli_args.in/main/main_js.mbt
+++ b/crates/moon/tests/test_cases/moon_run_with_cli_args.in/main/main_js.mbt
@@ -8,5 +8,8 @@ extern "js" fn get_cli_args_internal() -> Array[String] =
   #| }
 
 fn main {
-  @debug.to_string(get_args()) |> println
+  let args = get_args()
+  for i = 0; i < args.length(); i = i + 1 {
+    println(args[i])
+  }
 }

--- a/crates/moon/tests/test_cases/moon_run_with_cli_args.in/main/main_wasm.mbt
+++ b/crates/moon/tests/test_cases/moon_run_with_cli_args.in/main/main_wasm.mbt
@@ -1,5 +1,8 @@
 fn main {
-  @debug.to_string(get_args()) |> println
+  let args = get_args()
+  for i = 0; i < args.length(); i = i + 1 {
+    println(args[i])
+  }
 }
 
 fn env_get_var(s : ExternString) -> ExternString = "__moonbit_fs_unstable" "env_get_var"


### PR DESCRIPTION
## What changed

- Changed the `moon_run_with_cli_args` wasm/js fixture to print each argv entry as a raw output line instead of rendering the whole array through `@debug.to_string`.
- Tightened the `moon runwasm` cache-hit snapshot back to a normal path suffix plus forwarded args.
- Updated the existing CLI argument assertions to match the raw-line fixture output.

## Why

The previous snapshot used broad `[..]` path redaction because the fixture printed escaped MoonBit string literals. On Windows, a path like `C:\...` was normalized by snapbox character-by-character, producing doubled slashes such as `C://...`. Printing raw argv lines lets snapbox normalize real path separators normally.

## Validation

- `cargo fmt`
- `cargo test -p moon test_runwasm_uses_cached_asset_and_forwards_args`
- `cargo test -p moon test_moon_run_with_cli_args`
- `cargo test -p moon runwasm`
- `cargo clippy -p moon --all-targets -- -D warnings`