### PR TITLE
[codex] Move registry path parsing helpers

### DIFF
--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -38,7 +38,7 @@ Warning name: `{mnemonic}`
     }
 }
 
-// Snapshot generated from `moonc check -warn-help` on 2026-06-01.
+// Snapshot generated from `moonc check -warn-help` on 2026-06-03.
 // Update this file manually when the compiler's warning table changes.
 const WARNING_ENTRIES: &[WarningEntry] = &[
     WarningEntry {
@@ -400,6 +400,11 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
         mnemonic: "lexmatch_longest_match",
         description: "Using `lexmatch` with longest-match semantics.",
         id: 77,
+    },
+    WarningEntry {
+        mnemonic: "result_error_return",
+        description: "Using `Result[T, E]` where `E` is an error type.",
+        id: 78,
     },
 ];
 

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -23,7 +23,7 @@ use moonbuild_rupes_recta::{
     intent::UserIntent,
     model::{BuildPlanNode, BuildTarget, PackageId, TargetKind},
 };
-use mooncake::registry::{OnlineRegistry, Registry};
+use mooncake::registry::{OnlineRegistry, Registry, path as registry_path};
 use moonutil::{
     cli::UniversalFlags,
     common::{FileLock, MOON_MOD, MOON_MOD_JSON, RunMode, TargetBackend},
@@ -182,14 +182,11 @@ pub(super) fn is_local_path(s: &str) -> bool {
         || s.chars().nth(1) == Some(':') // Windows drive letter
 }
 
-/// Yet another package path parser because we need to parse wildcard patterns.
 pub(super) fn parse_package_spec(input: &str) -> anyhow::Result<PackageSpec> {
     let (path_part, version) = if let Some(at_pos) = input.rfind('@') {
         let path = &input[..at_pos];
         let version_str = &input[at_pos + 1..];
-        let version = Version::parse(version_str)
-            .with_context(|| format!("Invalid version `{}`", version_str))?;
-        (path, Some(version))
+        (path, Some(version_str))
     } else {
         (input, None)
     };
@@ -200,30 +197,19 @@ pub(super) fn parse_package_spec(input: &str) -> anyhow::Result<PackageSpec> {
         (path_part, false)
     };
 
-    let components: Vec<&str> = path_part.split('/').collect();
-
-    if components.len() < 2 {
-        bail!(
-            "Invalid package path `{}`: must be in format `user/module/package`",
-            input
-        );
-    }
-
-    let module_name = ModuleName {
-        username: components[0].into(),
-        unqual: components[1].into(),
-    };
-
-    let package_path = if components.len() > 2 {
-        Some(components[2..].join("/"))
+    let version = if let Some(version) = version {
+        let version =
+            Version::parse(version).with_context(|| format!("Invalid version `{version}`"))?;
+        Some(version)
     } else {
-        // user/module or user/module/... -> package at root
-        Some(String::new())
+        None
     };
+    let parsed = registry_path::parse_install_style_path(path_part)
+        .with_context(|| format!("Invalid package path `{input}`"))?;
 
     Ok(PackageSpec {
-        module_name,
-        package_path,
+        module_name: parsed.module,
+        package_path: Some(parsed.package),
         version,
         is_wildcard,
     })

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -20,7 +20,7 @@ use std::{io::Write, path::PathBuf};
 
 use anyhow::{Context, bail};
 use moonbuild_rupes_recta::model::RunBackend;
-use mooncake::registry::{OnlineRegistry, Registry};
+use mooncake::registry::{OnlineRegistry, Registry, path as registry_path};
 use moonutil::{
     cli::UniversalFlags,
     common::FileLock,
@@ -321,22 +321,11 @@ fn parse_install_style_coordinate(
     version: Option<Version>,
 ) -> anyhow::Result<RunWasmCoordinate> {
     validate_components(input, path_part, "package")?;
-    let components = path_part.split('/').collect::<Vec<_>>();
-    if components.len() < 2 {
-        bail!("Invalid runwasm coordinate `{input}`: must be in format `user/module/package`");
-    }
-    let module_name = ModuleName {
-        username: components[0].into(),
-        unqual: components[1].into(),
-    };
-    let package_path = if components.len() > 2 {
-        components[2..].join("/")
-    } else {
-        String::new()
-    };
+    let parsed = registry_path::parse_install_style_path(path_part)
+        .with_context(|| format!("Invalid runwasm coordinate `{input}`"))?;
     Ok(RunWasmCoordinate {
-        module_name,
-        package_path,
+        module_name: parsed.module,
+        package_path: parsed.package,
         version,
     })
 }

--- a/crates/moon/src/cli/snapshots/explain_warning_index.txt
+++ b/crates/moon/src/cli/snapshots/explain_warning_index.txt
@@ -70,3 +70,4 @@
 0075	unnecessary_view_op	Unnecessary `[:]` view operator
 0076	lexmatch_first_match	Using `lexmatch` with first-match semantics.
 0077	lexmatch_longest_match	Using `lexmatch` with longest-match semantics.
+0078	result_error_return	Using `Result[T, E]` where `E` is an error type.

--- a/crates/moonbuild-rupes-recta/src/mbtx.rs
+++ b/crates/moonbuild-rupes-recta/src/mbtx.rs
@@ -180,8 +180,7 @@ fn split_mbtx_import_path(
 if version is omitted, the module path must be resolvable from local registry index (run `moon update` if needed)"
             )
         })?;
-    let module = module.to_string();
-    Ok((module, version, full_path_without_version))
+    Ok((module.to_string(), version, full_path_without_version))
 }
 
 /// Remove the leading `import {...}` declaration in `.mbtx`, then write the
@@ -274,6 +273,17 @@ mod tests {
         assert_eq!(module, "path/to/module");
         assert_eq!(version, "0.4.38");
         assert_eq!(package, "path/to/module");
+    }
+
+    #[test]
+    fn split_mbtx_import_path_preserves_three_segment_module_with_version() {
+        let registry = OnlineRegistry::mooncakes_io();
+        let (module, version, package) =
+            split_mbtx_import_path("moonbitlang/x/fs@0.4.39/path", &registry)
+                .expect("existing resolver accepts explicit multi-segment modules");
+        assert_eq!(module, "moonbitlang/x/fs");
+        assert_eq!(version, "0.4.39");
+        assert_eq!(package, "moonbitlang/x/fs/path");
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -31,7 +31,10 @@ use indexmap::IndexMap;
 use log::{debug, info};
 use std::str::FromStr;
 
-use mooncake::pkg::sync::{auto_sync, auto_sync_for_single_file_rr};
+use mooncake::{
+    pkg::sync::{auto_sync, auto_sync_for_single_file_rr},
+    registry::path as registry_path,
+};
 use moonutil::{
     common::{
         MBTI_USER_WRITTEN, MOONBITLANG_CORE, MbtMdHeader, TargetBackend, parse_front_matter_config,
@@ -219,37 +222,8 @@ fn parse_front_matter_imports(
 }
 
 fn split_import_path(path: &str) -> anyhow::Result<(String, Option<String>, Option<String>)> {
-    let parts: Vec<&str> = path.split('/').collect();
-    if parts.len() < 2 {
-        anyhow::bail!(
-            "import path '{path}' must be in the form 'username/module@version[/package]'"
-        );
-    }
-    let username = parts[0];
-    let module_and_version = parts[1];
-    let mut module_parts = module_and_version.splitn(2, '@');
-    let module = module_parts
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("import path '{path}' has an empty module name"))?;
-    let version = module_parts.next();
-    if module.is_empty() {
-        anyhow::bail!("import path '{path}' has an empty module name");
-    }
-    let version = match version {
-        Some("") => anyhow::bail!("import path '{path}' has an empty version"),
-        Some(v) => Some(v.to_string()),
-        None => None,
-    };
-    let package = if parts.len() > 2 {
-        let pkg = parts[2..].join("/");
-        if pkg.is_empty() {
-            anyhow::bail!("import path '{path}' has an empty package path");
-        }
-        Some(pkg)
-    } else {
-        None
-    };
-    Ok((format!("{username}/{module}"), version, package))
+    let parsed = registry_path::parse_front_matter_import_path(path)?;
+    Ok((parsed.module, parsed.version, parsed.package))
 }
 
 #[cfg(test)]

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -19,12 +19,12 @@
 #[cfg(test)]
 pub(crate) mod mock;
 pub(crate) mod online;
+pub mod path;
 
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 
-use moonutil::common::{MOD_NAME_STDLIB, MOONBITLANG_CORE};
 use moonutil::module::MoonMod;
-use moonutil::mooncakes::{DEFAULT_VERSION, ModuleName};
+use moonutil::mooncakes::ModuleName;
 pub use online::*;
 use semver::Version;
 
@@ -63,82 +63,13 @@ pub trait Registry {
         path: &str,
         allow_explicit_version: bool,
     ) -> Option<(ModuleName, String, String)> {
-        let contains_at = path.contains('@');
-
-        // reject paths like `moonbitlang/core@version` and `moonbitlang/core/path@version`
-        if path.starts_with(&format!("{MOONBITLANG_CORE}@"))
-            || contains_at && path.starts_with(&format!("{MOONBITLANG_CORE}/"))
-        {
-            return None;
-        }
-
-        // handle `moonbitlang/core` and `moonbitlang/core/path` (no @ in path) special case
-        if path == MOONBITLANG_CORE
-            || !contains_at && path.starts_with(&format!("{MOONBITLANG_CORE}/"))
-        {
-            return Some((
-                MOD_NAME_STDLIB.clone(),
-                DEFAULT_VERSION.to_string(),
-                path.to_string(),
-            ));
-        }
-
-        match (allow_explicit_version, contains_at) {
-            // handle explicit version case
-            // "path/to/module@version/package/path"
-            // "path/to/module@version"
-            (true, true) => {
-                if let Some((module_name, tail)) = path.rsplit_once('@') {
-                    let module_name = module_name.parse::<ModuleName>().ok()?;
-                    if module_name.username.is_empty() {
-                        return None;
-                    }
-                    let (version, package) = match tail.split_once('/') {
-                        Some((version, package)) => (version, package),
-                        None => (tail, ""),
-                    };
-                    if version.is_empty() {
-                        return None;
-                    }
-                    let module_name_str = module_name.to_string();
-                    let full_path_without_version = match package {
-                        "" => module_name_str,
-                        pkg => format!("{module_name_str}/{pkg}"),
-                    };
-                    Some((module_name, version.to_string(), full_path_without_version))
-                } else {
-                    panic!("unreachable: contains_at is true but no '@' found");
-                }
-            }
-            // reject explicit version case when disallowed
-            (false, true) => None,
-            // handle unversioned path case, try longest-prefix match to find the module and its latest version
-            // "a/b/c/d" -> prefer "a/b/c" over "a/b"
-            (_, false) => {
-                let segments: Vec<&str> = path.split('/').collect();
-                if segments.len() < 2 || segments.iter().any(|s| s.is_empty()) {
-                    return None;
-                }
-
-                for segment_count in (2..=segments.len()).rev() {
-                    let candidate_str = segments[..segment_count].join("/");
-                    let candidate = candidate_str.parse::<ModuleName>().ok()?;
-                    if candidate.username.is_empty() {
-                        return None;
-                    }
-                    let latest_version =
-                        self.all_versions_of(&candidate).ok().and_then(|versions| {
-                            versions
-                                .last_key_value()
-                                .map(|(latest_version, _)| latest_version.to_string())
-                        });
-                    if let Some(latest_version) = latest_version {
-                        return Some((candidate, latest_version, path.to_string()));
-                    }
-                }
-                None
-            }
-        }
+        path::resolve_registry_path(path, allow_explicit_version, |module| {
+            self.all_versions_of(module).ok().and_then(|versions| {
+                versions
+                    .last_key_value()
+                    .map(|(latest_version, _)| latest_version.to_string())
+            })
+        })
     }
 
     fn get_latest_version(&self, name: &ModuleName) -> Option<Arc<MoonMod>> {
@@ -341,10 +272,20 @@ mod tests {
 
         let (name, version, full_path) = registry
             .resolve_path("moonbitlang/x/fs@0.4.39/path", true)
-            .expect("explicit version path should resolve");
+            .expect("module root explicit version should resolve");
         assert_eq!(name.to_string(), "moonbitlang/x/fs");
         assert_eq!(version, "0.4.39");
         assert_eq!(full_path, "moonbitlang/x/fs/path");
+    }
+
+    #[test]
+    fn resolve_path_rejects_versioned_core_package_suffix() {
+        let registry = MockRegistry::new();
+        assert!(
+            registry
+                .resolve_path("moonbitlang/core/list@0.4.38", true)
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/mooncake/src/registry/path.rs
+++ b/crates/mooncake/src/registry/path.rs
@@ -1,0 +1,171 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use moonutil::{
+    common::{MOD_NAME_STDLIB, MOONBITLANG_CORE},
+    mooncakes::{DEFAULT_VERSION, ModuleName},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstallStylePath {
+    pub module: ModuleName,
+    pub package: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrontMatterImportPath {
+    pub module: String,
+    pub version: Option<String>,
+    pub package: Option<String>,
+}
+
+/// Parse `user/module[/package]` using the install/runwasm interpretation.
+///
+/// This intentionally preserves the current command behavior: the first two
+/// segments are always the module, and later segments are the package path.
+/// Callers remain responsible for extra validation such as rejecting empty,
+/// `.`/`..`, or drive-letter-like path components.
+pub fn parse_install_style_path(input: &str) -> anyhow::Result<InstallStylePath> {
+    let components = input.split('/').collect::<Vec<_>>();
+    if components.len() < 2 {
+        anyhow::bail!("must be in format `user/module/package`");
+    }
+
+    let module = ModuleName {
+        username: components[0].into(),
+        unqual: components[1].into(),
+    };
+    let package = if components.len() > 2 {
+        components[2..].join("/")
+    } else {
+        String::new()
+    };
+
+    Ok(InstallStylePath { module, package })
+}
+
+/// Parse `username/module[@version][/package]` using the moonbit.import grammar.
+pub fn parse_front_matter_import_path(path: &str) -> anyhow::Result<FrontMatterImportPath> {
+    let parts = path.split('/').collect::<Vec<_>>();
+    if parts.len() < 2 {
+        anyhow::bail!(
+            "import path '{path}' must be in the form 'username/module@version[/package]'"
+        );
+    }
+
+    let username = parts[0];
+    let module_and_version = parts[1];
+    let mut module_parts = module_and_version.splitn(2, '@');
+    let module = module_parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("import path '{path}' has an empty module name"))?;
+    let version = module_parts.next();
+    if module.is_empty() {
+        anyhow::bail!("import path '{path}' has an empty module name");
+    }
+    let version = match version {
+        Some("") => anyhow::bail!("import path '{path}' has an empty version"),
+        Some(v) => Some(v.to_string()),
+        None => None,
+    };
+    let package = if parts.len() > 2 {
+        let package = parts[2..].join("/");
+        if package.is_empty() {
+            anyhow::bail!("import path '{path}' has an empty package path");
+        }
+        Some(package)
+    } else {
+        None
+    };
+
+    Ok(FrontMatterImportPath {
+        module: format!("{username}/{module}"),
+        version,
+        package,
+    })
+}
+
+/// Resolve import-style registry paths using the current registry resolver
+/// behavior.
+///
+/// This preserves the existing permissive module-name behavior for explicit
+/// version paths and the existing longest-prefix lookup for unversioned paths.
+pub fn resolve_registry_path(
+    path: &str,
+    allow_explicit_version: bool,
+    mut latest_version_of: impl FnMut(&ModuleName) -> Option<String>,
+) -> Option<(ModuleName, String, String)> {
+    let contains_at = path.contains('@');
+
+    if path.starts_with(&format!("{MOONBITLANG_CORE}@"))
+        || contains_at && path.starts_with(&format!("{MOONBITLANG_CORE}/"))
+    {
+        return None;
+    }
+
+    if path == MOONBITLANG_CORE || !contains_at && path.starts_with(&format!("{MOONBITLANG_CORE}/"))
+    {
+        return Some((
+            MOD_NAME_STDLIB.clone(),
+            DEFAULT_VERSION.to_string(),
+            path.to_string(),
+        ));
+    }
+
+    match (allow_explicit_version, contains_at) {
+        (true, true) => {
+            let (module_name, tail) = path.rsplit_once('@')?;
+            let module_name = module_name.parse::<ModuleName>().ok()?;
+            if module_name.username.is_empty() {
+                return None;
+            }
+            let (version, package) = match tail.split_once('/') {
+                Some((version, package)) => (version, package),
+                None => (tail, ""),
+            };
+            if version.is_empty() {
+                return None;
+            }
+            let module_name_str = module_name.to_string();
+            let full_path_without_version = match package {
+                "" => module_name_str,
+                package => format!("{module_name_str}/{package}"),
+            };
+            Some((module_name, version.to_string(), full_path_without_version))
+        }
+        (false, true) => None,
+        (_, false) => {
+            let segments = path.split('/').collect::<Vec<_>>();
+            if segments.len() < 2 || segments.iter().any(|segment| segment.is_empty()) {
+                return None;
+            }
+
+            for segment_count in (2..=segments.len()).rev() {
+                let candidate_str = segments[..segment_count].join("/");
+                let candidate = candidate_str.parse::<ModuleName>().ok()?;
+                if candidate.username.is_empty() {
+                    return None;
+                }
+                if let Some(latest_version) = latest_version_of(&candidate) {
+                    return Some((candidate, latest_version, path.to_string()));
+                }
+            }
+            None
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Move the existing registry path parsing logic into `mooncake::registry::path` and wire the current callers through those helpers.

This is intentionally behavior-preserving for the first PR split:
- `moon install` and `moon runwasm` share the install-style parser for `user/module[/package]` after caller-specific version and wildcard handling.
- single-file front matter uses a dedicated `moonbit.import` parser.
- `.mbtx` continues to use `Registry::resolve_path`, with its resolver implementation moved into the shared path module.
- existing permissive handling for explicit multi-segment modules such as `moonbitlang/x/fs@0.4.39/path` is documented by test rather than changed here.

## Validation

- `cargo fmt`
- `cargo test -p mooncake registry::tests`
- `cargo test -p moon test_parse_package_spec`
- `cargo test -p moon parse_`
- `cargo test -p moon reject_invalid_coordinates`
- `cargo test -p moonbuild-rupes-recta split_import_path`
- `cargo test -p moonbuild-rupes-recta mbtx::tests`
- `git diff --check`