### PR TITLE
[codex] Tighten registry path parsing

### DIFF
--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -197,15 +197,24 @@ pub(super) fn parse_package_spec(input: &str) -> anyhow::Result<PackageSpec> {
         (path_part, false)
     };
 
-    let version = if let Some(version) = version {
-        let version =
-            Version::parse(version).with_context(|| format!("Invalid version `{version}`"))?;
-        Some(version)
+    let (parsed, version) = if let Some(version) = version {
+        let normalized = format!("{path_part}@{version}");
+        let parsed = registry_path::parse_package_at_version_path(&normalized)
+            .with_context(|| format!("Invalid package path `{input}`"))?;
+        let version = Version::parse(&parsed.version)
+            .with_context(|| format!("Invalid version `{}`", parsed.version))?;
+        (
+            registry_path::InstallStylePath {
+                module: parsed.module,
+                package: parsed.package,
+            },
+            Some(version),
+        )
     } else {
-        None
+        let parsed = registry_path::parse_install_style_path(path_part)
+            .with_context(|| format!("Invalid package path `{input}`"))?;
+        (parsed, None)
     };
-    let parsed = registry_path::parse_install_style_path(path_part)
-        .with_context(|| format!("Invalid package path `{input}`"))?;
 
     Ok(PackageSpec {
         module_name: parsed.module,

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -299,18 +299,13 @@ fn parse_module_version_coordinate(
 ) -> anyhow::Result<RunWasmCoordinate> {
     validate_components(input, module_part, "module")?;
     validate_components(input, package_path, "package")?;
-    if module_part.split('/').count() != 2 {
-        bail!("Invalid runwasm coordinate `{input}`: module name must be in format `user/module`");
-    }
+    let parsed = registry_path::parse_module_at_version_path(input)
+        .with_context(|| format!("Invalid runwasm coordinate `{input}`"))?;
     let version = Version::parse(version)
         .with_context(|| format!("Invalid version `{version}` in runwasm coordinate"))?;
-    let module_name = ModuleName::from(module_part);
-    if module_name.username.is_empty() {
-        bail!("Invalid runwasm coordinate `{input}`: module name must include a username");
-    }
     Ok(RunWasmCoordinate {
-        module_name,
-        package_path: package_path.to_string(),
+        module_name: parsed.module,
+        package_path: parsed.package,
         version: Some(version),
     })
 }
@@ -321,11 +316,18 @@ fn parse_install_style_coordinate(
     version: Option<Version>,
 ) -> anyhow::Result<RunWasmCoordinate> {
     validate_components(input, path_part, "package")?;
-    let parsed = registry_path::parse_install_style_path(path_part)
-        .with_context(|| format!("Invalid runwasm coordinate `{input}`"))?;
+    let (module_name, package_path) = if version.is_some() {
+        let parsed = registry_path::parse_package_at_version_path(input)
+            .with_context(|| format!("Invalid runwasm coordinate `{input}`"))?;
+        (parsed.module, parsed.package)
+    } else {
+        let parsed = registry_path::parse_install_style_path(path_part)
+            .with_context(|| format!("Invalid runwasm coordinate `{input}`"))?;
+        (parsed.module, parsed.package)
+    };
     Ok(RunWasmCoordinate {
-        module_name: parsed.module,
-        package_path: parsed.package,
+        module_name,
+        package_path,
         version,
     })
 }

--- a/crates/moonbuild-rupes-recta/src/mbtx.rs
+++ b/crates/moonbuild-rupes-recta/src/mbtx.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use anyhow::Context;
 use indexmap::IndexMap;
-use mooncake::registry::Registry;
+use mooncake::registry::{Registry, path as registry_path};
 use moonutil::{common::MOONBITLANG_CORE, dependency::SourceDependencyInfo, package::Import};
 
 #[derive(Default)]
@@ -171,12 +171,27 @@ fn split_mbtx_import_path(
     if path.starts_with(&format!("{MOONBITLANG_CORE}@")) {
         anyhow::bail!("moonbitlang/core imports must not specify a version");
     }
+
+    if path.contains('@') {
+        let parsed = registry_path::parse_module_at_version_path(path).with_context(|| {
+            format!(
+                "import path '{path}' must be in the form \
+'username/module@version[/package/path]'"
+            )
+        })?;
+        let full_path_without_version = parsed.full_path_without_version();
+        return Ok((
+            parsed.module.to_string(),
+            parsed.version,
+            full_path_without_version,
+        ));
+    }
+
     let (module, version, full_path_without_version) = registry
-        .resolve_path(path, true)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "import path '{path}' must be in the form 'username/module[/package/path]' or \
-'path/to/module@version[/package/path]'; \
+        .resolve_path(path, false)
+        .with_context(|| {
+            format!(
+                "import path '{path}' must be in the form 'username/module[/package/path]'; \
 if version is omitted, the module path must be resolvable from local registry index (run `moon update` if needed)"
             )
         })?;
@@ -248,19 +263,19 @@ mod tests {
     fn split_mbtx_import_path_supports_module_package() {
         let registry = OnlineRegistry::mooncakes_io();
         let (module, version, package) =
-            split_mbtx_import_path("path/to/module@0.4.38/package/path", &registry)
+            split_mbtx_import_path("path/module@0.4.38/package/path", &registry)
                 .expect("module package import should parse");
-        assert_eq!(module, "path/to/module");
+        assert_eq!(module, "path/module");
         assert_eq!(version, "0.4.38");
-        assert_eq!(package, "path/to/module/package/path");
+        assert_eq!(package, "path/module/package/path");
     }
 
     #[test]
     fn split_mbtx_import_path_normalizes_relative_package_with_module_prefix() {
         let registry = OnlineRegistry::mooncakes_io();
-        let (module, version, package) = split_mbtx_import_path("a/b/c@version/d/e", &registry)
+        let (module, version, package) = split_mbtx_import_path("a/b@version/c/d/e", &registry)
             .expect("module package import should parse");
-        assert_eq!(module, "a/b/c");
+        assert_eq!(module, "a/b");
         assert_eq!(version, "version");
         assert_eq!(package, "a/b/c/d/e");
     }
@@ -268,22 +283,17 @@ mod tests {
     #[test]
     fn split_mbtx_import_path_supports_module_root() {
         let registry = OnlineRegistry::mooncakes_io();
-        let (module, version, package) = split_mbtx_import_path("path/to/module@0.4.38", &registry)
+        let (module, version, package) = split_mbtx_import_path("path/module@0.4.38", &registry)
             .expect("module root import should parse");
-        assert_eq!(module, "path/to/module");
+        assert_eq!(module, "path/module");
         assert_eq!(version, "0.4.38");
-        assert_eq!(package, "path/to/module");
+        assert_eq!(package, "path/module");
     }
 
     #[test]
-    fn split_mbtx_import_path_preserves_three_segment_module_with_version() {
+    fn split_mbtx_import_path_rejects_three_segment_module_with_version() {
         let registry = OnlineRegistry::mooncakes_io();
-        let (module, version, package) =
-            split_mbtx_import_path("moonbitlang/x/fs@0.4.39/path", &registry)
-                .expect("existing resolver accepts explicit multi-segment modules");
-        assert_eq!(module, "moonbitlang/x/fs");
-        assert_eq!(version, "0.4.39");
-        assert_eq!(package, "moonbitlang/x/fs/path");
+        assert!(split_mbtx_import_path("moonbitlang/x/fs@0.4.39/path", &registry).is_err());
     }
 
     #[test]
@@ -395,12 +405,11 @@ import {
 
     #[test]
     fn parse_mbtx_imports_supports_top_level_package_path() {
-        let parsed =
-            parse_imports_from_source("import { \"path/to/module@0.4.38/path/to/pkg\" }\n")
-                .expect("value should parse");
+        let parsed = parse_imports_from_source("import { \"path/module@0.4.38/path/to/pkg\" }\n")
+            .expect("value should parse");
         assert_eq!(parsed.imports.len(), 1);
-        assert_eq!(parsed.imports[0].get_path(), "path/to/module/path/to/pkg");
-        assert!(parsed.deps.contains_key("path/to/module"));
+        assert_eq!(parsed.imports[0].get_path(), "path/module/path/to/pkg");
+        assert!(parsed.deps.contains_key("path/module"));
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -247,6 +247,11 @@ mod tests {
         assert_eq!(version.as_deref(), Some("0.4.38"));
         assert_eq!(package.as_deref(), Some("stack"));
     }
+
+    #[test]
+    fn split_import_path_rejects_package_version_suffix() {
+        assert!(split_import_path("moonbitlang/x/stack@0.4.38").is_err());
+    }
 }
 
 impl ResolveConfig {

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -48,21 +48,19 @@ pub trait Registry {
     ///
     /// Resolution rules:
     /// - If `allow_explicit_version` is `true` and `path` contains `@`,
-    ///   the part before the rightmost `@` is treated as the module name and
-    ///   the part right after `@` (up to next `/`) is treated as version.
+    ///   resolve `username/module@version[/package]`.
     /// - `moonbitlang/core[/package]` is resolved directly and uses
     ///   [`DEFAULT_VERSION`] as its version.
-    /// - Otherwise, resolve by longest-prefix match against existing modules in
-    ///   the registry (for example, `a/b/c/d` prefers module `a/b/c` over `a/b`)
-    ///   and fill the module version with that module's latest version.
+    /// - Otherwise, resolve the first two path segments as the module name and
+    ///   fill the module version with that module's latest version.
     ///
-    /// Returns `None` if the path is malformed, explicit versions are disallowed,
+    /// Returns an error if the path is malformed, explicit versions are disallowed,
     /// or no module can be resolved from registry metadata.
     fn resolve_path(
         &self,
         path: &str,
         allow_explicit_version: bool,
-    ) -> Option<(ModuleName, String, String)> {
+    ) -> anyhow::Result<(ModuleName, String, String)> {
         path::resolve_registry_path(path, allow_explicit_version, |module| {
             self.all_versions_of(module).ok().and_then(|versions| {
                 versions
@@ -119,7 +117,7 @@ where
         &self,
         path: &str,
         allow_explicit_version: bool,
-    ) -> Option<(ModuleName, String, String)> {
+    ) -> anyhow::Result<(ModuleName, String, String)> {
         (**self).resolve_path(path, allow_explicit_version)
     }
 }
@@ -157,7 +155,7 @@ where
         &self,
         path: &str,
         allow_explicit_version: bool,
-    ) -> Option<(ModuleName, String, String)> {
+    ) -> anyhow::Result<(ModuleName, String, String)> {
         (**self).resolve_path(path, allow_explicit_version)
     }
 }
@@ -177,13 +175,13 @@ mod tests {
     fn resolve_path_uses_latest_version_for_unversioned_path() {
         let mut registry = MockRegistry::new();
         registry
-            .add_module_full("path/to/module", "0.2.0", [])
-            .add_module_full("path/to/module", "0.1.0", []);
+            .add_module_full("path/to", "0.2.0", [])
+            .add_module_full("path/to", "0.1.0", []);
 
         let (name, version, full_path) = registry
             .resolve_path("path/to/module/a/b", true)
             .expect("module path should resolve");
-        assert_eq!(name.to_string(), "path/to/module");
+        assert_eq!(name.to_string(), "path/to");
         assert_eq!(version, "0.2.0");
         assert_eq!(full_path, "path/to/module/a/b");
     }
@@ -192,13 +190,13 @@ mod tests {
     fn resolve_path_latest_prefers_release_over_same_base_prerelease() {
         let mut registry = MockRegistry::new();
         registry
-            .add_module_full("path/to/module", "1.2.0-rc.1", [])
-            .add_module_full("path/to/module", "1.2.0", []);
+            .add_module_full("path/to", "1.2.0-rc.1", [])
+            .add_module_full("path/to", "1.2.0", []);
 
         let (name, version, full_path) = registry
             .resolve_path("path/to/module/a/b", true)
             .expect("module path should resolve");
-        assert_eq!(name.to_string(), "path/to/module");
+        assert_eq!(name.to_string(), "path/to");
         assert_eq!(version, "1.2.0");
         assert_eq!(full_path, "path/to/module/a/b");
     }
@@ -207,31 +205,29 @@ mod tests {
     fn resolve_path_latest_uses_prerelease_when_it_is_semver_max() {
         let mut registry = MockRegistry::new();
         registry
-            .add_module_full("path/to/module", "1.2.9", [])
-            .add_module_full("path/to/module", "1.3.0-rc.1", []);
+            .add_module_full("path/to", "1.2.9", [])
+            .add_module_full("path/to", "1.3.0-rc.1", []);
 
         let (name, version, full_path) = registry
             .resolve_path("path/to/module/a/b", true)
             .expect("module path should resolve");
-        assert_eq!(name.to_string(), "path/to/module");
+        assert_eq!(name.to_string(), "path/to");
         assert_eq!(version, "1.3.0-rc.1");
         assert_eq!(full_path, "path/to/module/a/b");
     }
 
     #[test]
-    fn resolve_path_longest_prefix() {
+    fn resolve_path_uses_first_two_segments_as_module() {
         let mut registry = MockRegistry::new();
         registry
-            .add_module_full("a/b/c", "0.2.0", [])
-            .add_module_full("a/b/c", "0.1.0", [])
-            .add_module_full("a/b/c/d/e", "0.3.0", [])
-            .add_module_full("a/b/c/d/e", "0.1.0", []);
+            .add_module_full("a/b", "0.2.0", [])
+            .add_module_full("a/b", "0.1.0", []);
 
         let (name, version, full_path) = registry
             .resolve_path("a/b/c/d/e/f/g", true)
             .expect("module path should resolve");
-        assert_eq!(name.to_string(), "a/b/c/d/e");
-        assert_eq!(version, "0.3.0");
+        assert_eq!(name.to_string(), "a/b");
+        assert_eq!(version, "0.2.0");
         assert_eq!(full_path, "a/b/c/d/e/f/g");
     }
 
@@ -266,16 +262,37 @@ mod tests {
     }
 
     #[test]
-    fn resolve_path_uses_explicit_version_boundary() {
+    fn resolve_path_uses_explicit_version_package_suffix_after_two_segment_module() {
         let mut registry = MockRegistry::new();
-        registry.add_module_full("moonbitlang/x/fs", "0.4.39", []);
+        registry.add_module_full("moonbitlang/x", "0.4.39", []);
 
         let (name, version, full_path) = registry
-            .resolve_path("moonbitlang/x/fs@0.4.39/path", true)
-            .expect("module root explicit version should resolve");
-        assert_eq!(name.to_string(), "moonbitlang/x/fs");
+            .resolve_path("moonbitlang/x@0.4.39/fs/path", true)
+            .expect("explicit version path should resolve");
+        assert_eq!(name.to_string(), "moonbitlang/x");
         assert_eq!(version, "0.4.39");
         assert_eq!(full_path, "moonbitlang/x/fs/path");
+    }
+
+    #[test]
+    fn resolve_path_rejects_three_segment_explicit_module_name() {
+        let registry = MockRegistry::new();
+        assert!(
+            registry
+                .resolve_path("moonbitlang/x/fs@0.4.39/path", true)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn resolve_path_rejects_package_version_suffix() {
+        let mut registry = MockRegistry::new();
+        registry.add_module_full("moonbitlang/x", "0.4.39", []);
+        assert!(
+            registry
+                .resolve_path("moonbitlang/x/fs@0.4.39", true)
+                .is_err()
+        );
     }
 
     #[test]
@@ -284,7 +301,7 @@ mod tests {
         assert!(
             registry
                 .resolve_path("moonbitlang/core/list@0.4.38", true)
-                .is_none()
+                .is_err()
         );
     }
 
@@ -294,8 +311,8 @@ mod tests {
         registry.add_module_full("moonbitlang/x/fs", "0.4.39", []);
         assert!(
             registry
-                .resolve_path("moonbitlang/x/fs@0.4.39/path", false)
-                .is_none()
+                .resolve_path("moonbitlang/x@0.4.39/fs", false)
+                .is_err()
         );
     }
 }

--- a/crates/mooncake/src/registry/path.rs
+++ b/crates/mooncake/src/registry/path.rs
@@ -28,6 +28,24 @@ pub struct InstallStylePath {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionedPackagePath {
+    pub module: ModuleName,
+    pub version: String,
+    pub package: String,
+}
+
+impl VersionedPackagePath {
+    pub fn full_path_without_version(&self) -> String {
+        let module = self.module.to_string();
+        if self.package.is_empty() {
+            module
+        } else {
+            format!("{module}/{}", self.package)
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FrontMatterImportPath {
     pub module: String,
     pub version: Option<String>,
@@ -42,7 +60,7 @@ pub struct FrontMatterImportPath {
 /// `.`/`..`, or drive-letter-like path components.
 pub fn parse_install_style_path(input: &str) -> anyhow::Result<InstallStylePath> {
     let components = input.split('/').collect::<Vec<_>>();
-    if components.len() < 2 {
+    if components.len() < 2 || components.iter().any(|component| component.is_empty()) {
         anyhow::bail!("must be in format `user/module/package`");
     }
 
@@ -59,8 +77,69 @@ pub fn parse_install_style_path(input: &str) -> anyhow::Result<InstallStylePath>
     Ok(InstallStylePath { module, package })
 }
 
+/// Parse `username/module@version[/package]`.
+pub fn parse_module_at_version_path(input: &str) -> anyhow::Result<VersionedPackagePath> {
+    if input.matches('@').count() > 1 {
+        anyhow::bail!("must contain a single version marker");
+    }
+    let (module_part, tail) = input
+        .split_once('@')
+        .ok_or_else(|| anyhow::anyhow!("must be in format `user/module@version/package`"))?;
+    let (version, package) = match tail.split_once('/') {
+        Some((version, package)) => (version, package),
+        None => (tail, ""),
+    };
+    if version.is_empty() || version.contains('/') {
+        anyhow::bail!("version must not be empty or contain path separators");
+    }
+
+    let module_components = module_part.split('/').collect::<Vec<_>>();
+    if module_components.len() != 2
+        || module_components
+            .iter()
+            .any(|component| component.is_empty())
+    {
+        anyhow::bail!("module name must be in format `user/module`");
+    }
+    if !package.is_empty() && package.split('/').any(|component| component.is_empty()) {
+        anyhow::bail!("package path must not contain empty components");
+    }
+
+    Ok(VersionedPackagePath {
+        module: ModuleName {
+            username: module_components[0].into(),
+            unqual: module_components[1].into(),
+        },
+        version: version.to_string(),
+        package: package.to_string(),
+    })
+}
+
+/// Parse `username/module[/package]@version`.
+pub fn parse_package_at_version_path(input: &str) -> anyhow::Result<VersionedPackagePath> {
+    if input.matches('@').count() > 1 {
+        anyhow::bail!("must contain a single version marker");
+    }
+    let (path, version) = input
+        .rsplit_once('@')
+        .ok_or_else(|| anyhow::anyhow!("must be in format `user/module/package@version`"))?;
+    if version.is_empty() || version.contains('/') {
+        anyhow::bail!("version must not be empty or contain path separators");
+    }
+
+    let parsed = parse_install_style_path(path)?;
+    Ok(VersionedPackagePath {
+        module: parsed.module,
+        version: version.to_string(),
+        package: parsed.package,
+    })
+}
+
 /// Parse `username/module[@version][/package]` using the moonbit.import grammar.
 pub fn parse_front_matter_import_path(path: &str) -> anyhow::Result<FrontMatterImportPath> {
+    if path.matches('@').count() > 1 {
+        anyhow::bail!("import path '{path}' must contain at most one version marker");
+    }
     let parts = path.split('/').collect::<Vec<_>>();
     if parts.len() < 2 {
         anyhow::bail!(
@@ -83,6 +162,9 @@ pub fn parse_front_matter_import_path(path: &str) -> anyhow::Result<FrontMatterI
         Some(v) => Some(v.to_string()),
         None => None,
     };
+    if version.is_none() && parts[2..].iter().any(|part| part.contains('@')) {
+        anyhow::bail!("import path '{path}' has a version marker outside the module segment");
+    }
     let package = if parts.len() > 2 {
         let package = parts[2..].join("/");
         if package.is_empty() {
@@ -100,27 +182,23 @@ pub fn parse_front_matter_import_path(path: &str) -> anyhow::Result<FrontMatterI
     })
 }
 
-/// Resolve import-style registry paths using the current registry resolver
-/// behavior.
-///
-/// This preserves the existing permissive module-name behavior for explicit
-/// version paths and the existing longest-prefix lookup for unversioned paths.
+/// Resolve import-style registry paths.
 pub fn resolve_registry_path(
     path: &str,
     allow_explicit_version: bool,
     mut latest_version_of: impl FnMut(&ModuleName) -> Option<String>,
-) -> Option<(ModuleName, String, String)> {
+) -> anyhow::Result<(ModuleName, String, String)> {
     let contains_at = path.contains('@');
 
     if path.starts_with(&format!("{MOONBITLANG_CORE}@"))
         || contains_at && path.starts_with(&format!("{MOONBITLANG_CORE}/"))
     {
-        return None;
+        anyhow::bail!("moonbitlang/core imports must not specify a version");
     }
 
     if path == MOONBITLANG_CORE || !contains_at && path.starts_with(&format!("{MOONBITLANG_CORE}/"))
     {
-        return Some((
+        return Ok((
             MOD_NAME_STDLIB.clone(),
             DEFAULT_VERSION.to_string(),
             path.to_string(),
@@ -129,43 +207,63 @@ pub fn resolve_registry_path(
 
     match (allow_explicit_version, contains_at) {
         (true, true) => {
-            let (module_name, tail) = path.rsplit_once('@')?;
-            let module_name = module_name.parse::<ModuleName>().ok()?;
-            if module_name.username.is_empty() {
-                return None;
-            }
-            let (version, package) = match tail.split_once('/') {
-                Some((version, package)) => (version, package),
-                None => (tail, ""),
-            };
-            if version.is_empty() {
-                return None;
-            }
-            let module_name_str = module_name.to_string();
-            let full_path_without_version = match package {
-                "" => module_name_str,
-                package => format!("{module_name_str}/{package}"),
-            };
-            Some((module_name, version.to_string(), full_path_without_version))
+            let parsed = parse_module_at_version_path(path)?;
+            let full_path_without_version = parsed.full_path_without_version();
+            Ok((parsed.module, parsed.version, full_path_without_version))
         }
-        (false, true) => None,
+        (false, true) => {
+            anyhow::bail!("explicit versions are not allowed in this registry path")
+        }
         (_, false) => {
-            let segments = path.split('/').collect::<Vec<_>>();
-            if segments.len() < 2 || segments.iter().any(|segment| segment.is_empty()) {
-                return None;
-            }
-
-            for segment_count in (2..=segments.len()).rev() {
-                let candidate_str = segments[..segment_count].join("/");
-                let candidate = candidate_str.parse::<ModuleName>().ok()?;
-                if candidate.username.is_empty() {
-                    return None;
-                }
-                if let Some(latest_version) = latest_version_of(&candidate) {
-                    return Some((candidate, latest_version, path.to_string()));
-                }
-            }
-            None
+            let parsed = parse_install_style_path(path)?;
+            let latest_version = latest_version_of(&parsed.module)
+                .ok_or_else(|| anyhow::anyhow!("module `{}` not found", parsed.module))?;
+            Ok((parsed.module, latest_version, path.to_string()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        parse_module_at_version_path, parse_package_at_version_path, resolve_registry_path,
+    };
+
+    #[test]
+    fn parse_module_at_version_path_supports_package_suffix() {
+        let parsed = parse_module_at_version_path("moonbitlang/x@0.4.39/fs/path").unwrap();
+        assert_eq!(parsed.module.to_string(), "moonbitlang/x");
+        assert_eq!(parsed.version, "0.4.39");
+        assert_eq!(parsed.package, "fs/path");
+        assert_eq!(parsed.full_path_without_version(), "moonbitlang/x/fs/path");
+    }
+
+    #[test]
+    fn parse_module_at_version_path_rejects_three_segment_module() {
+        assert!(parse_module_at_version_path("moonbitlang/x/fs@0.4.39/path").is_err());
+    }
+
+    #[test]
+    fn parse_package_at_version_path_supports_package_version_suffix() {
+        let parsed = parse_package_at_version_path("moonbitlang/x/fs/path@0.4.39").unwrap();
+        assert_eq!(parsed.module.to_string(), "moonbitlang/x");
+        assert_eq!(parsed.version, "0.4.39");
+        assert_eq!(parsed.package, "fs/path");
+    }
+
+    #[test]
+    fn parse_package_at_version_path_rejects_module_version_package_suffix() {
+        assert!(parse_package_at_version_path("moonbitlang/x@0.4.39/fs/path").is_err());
+    }
+
+    #[test]
+    fn resolve_registry_path_uses_first_two_segments_for_unversioned_path() {
+        let resolved = resolve_registry_path("a/b/c/d", true, |module| {
+            (module.to_string() == "a/b").then(|| "1.0.0".to_string())
+        })
+        .unwrap();
+        assert_eq!(resolved.0.to_string(), "a/b");
+        assert_eq!(resolved.1, "1.0.0");
+        assert_eq!(resolved.2, "a/b/c/d");
     }
 }


### PR DESCRIPTION
## Summary

Follow up the shared parser move by making the accepted registry path shapes explicit and strict.

- add separate helpers for `username/module@version[/package]` and `username/module[/package]@version`
- make `Registry::resolve_path` return `anyhow::Result` and resolve unversioned paths by the first two module segments
- reject ambiguous package-level version suffixes in `.mbtx` and `moonbit.import`
- keep caller-selected syntax: `moon install` accepts package-at-version, `.mbtx`/front matter accept module-at-version, and `moon runwasm` accepts both intentionally

This means paths like `moonbitlang/x/fs@0.4.39/path` are no longer accepted by `.mbtx` or the registry resolver as a three-segment explicit module.

## Validation

- `cargo fmt`
- `cargo test -p mooncake registry::`
- `cargo test -p moon test_parse_package_spec`
- `cargo test -p moon parse_`
- `cargo test -p moon reject_invalid_coordinates`
- `cargo test -p moonbuild-rupes-recta split_import_path`
- `cargo test -p moonbuild-rupes-recta mbtx::tests`
- `git diff --check`