### PR TITLE
[codex] Trace native run startup

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -489,6 +489,7 @@ impl ResolvedBuildPlanningContext {
 /// backend. Commands that already resolved raw CLI selectors can use the
 /// returned backend to compute `CalcUserIntentOutput` outside the shared RR
 /// planning pipeline.
+#[instrument(level = Level::DEBUG, skip_all)]
 pub(crate) fn prepare_resolved_build(
     preconfig: &CompilePreConfig,
     unstable_features: &FeatureGate,
@@ -559,6 +560,7 @@ pub(crate) fn prepare_resolved_build(
 /// At this boundary, command adapters have already resolved user selectors and
 /// command-specific directives into `CalcUserIntentOutput`. RR consumes those
 /// identities plus the build-model paths stored in `ResolveOutput`.
+#[instrument(level = Level::DEBUG, skip_all)]
 pub(crate) fn plan_resolved_build_from_intent(
     preconfig: CompilePreConfig,
     unstable_features: &FeatureGate,

--- a/crates/moon/src/run/child.rs
+++ b/crates/moon/src/run/child.rs
@@ -19,11 +19,13 @@
 //! Handles spawning of a child process under the govern of `moon run`
 
 use std::process::{ExitStatus, Stdio};
+use std::time::Instant;
 
 use anyhow::Context;
 use moonbuild::section_capture::{SectionCapture, handle_stdout_async};
 use moonutil::platform::macos_with_sigchild_blocked;
 use tokio::process::Command;
+use tracing::debug;
 #[cfg(windows)]
 use tracing::warn;
 
@@ -66,10 +68,18 @@ pub(crate) async fn run<'a>(
     cmd.kill_on_drop(true); // to prevent zombie processes;
 
     // Preventing race conditions with SIGCHLD handlers, see definition for info
+    let spawn_start = Instant::now();
     let mut child = macos_with_sigchild_blocked(|| {
         cmd.spawn()
             .with_context(|| format!("Failed to spawn command {:?}", cmd))
     })?;
+    let child_pid = child.id();
+    let child_start = Instant::now();
+    debug!(
+        child_pid = ?child_pid,
+        duration_ms = spawn_start.elapsed().as_secs_f64() * 1000.0,
+        "spawn_child_process_finished"
+    );
     #[cfg(windows)]
     if let Err(err) = assign_child_to_job(&child) {
         warn!(?err, "Failed to assign child process to job object");
@@ -110,14 +120,24 @@ pub(crate) async fn run<'a>(
     }
 
     // Wait for the child process to finish
+    let post_stdout_wait_start = Instant::now();
+    let mut killed = false;
     let status = tokio::select! {
         res = child.wait() => res,
         _ = shutdown.cancelled() => {
+            killed = true;
             let _ = child.start_kill();
             child.wait().await
         }
-    }
-    .context("Failed to wait for child process")?;
+    };
+    debug!(
+        child_pid = ?child_pid,
+        killed = killed,
+        duration_ms = child_start.elapsed().as_secs_f64() * 1000.0,
+        post_stdout_wait_duration_ms = post_stdout_wait_start.elapsed().as_secs_f64() * 1000.0,
+        "child_process_finished"
+    );
+    let status = status.context("Failed to wait for child process")?;
 
     if let Some(task) = stderr_pipe_task {
         task.await

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -406,6 +406,7 @@ pub fn resolve(
 
 /// Performs the resolving process for a single file project. Will try to
 /// synthesize a minimal MoonBit project around the given file.
+#[instrument(skip_all, fields(run_mode = run_mode))]
 pub fn resolve_single_file_project(
     cfg: &ResolveConfig,
     target_dir: &Path,


### PR DESCRIPTION
## Summary

Adds focused tracing for native `moon run` startup diagnostics:

- record single-file resolution as a trace span
- record resolved build preparation and planning spans
- emit child process spawn and lifetime timing events with elapsed milliseconds

The child lifetime timing starts immediately after a successful spawn, so captured stdout draining does not hide the opaque child execution interval. The event also records the final post-stdout-drain wait duration separately.

This keeps tracing coarse enough to preserve readability while making the opaque child execution portion visible in `--trace` output.

## Validation

- `cargo fmt`
- `cargo check -p moon -p moonbuild-rupes-recta`
- `git diff --check`