### PR TITLE
[codex] Simplify registry path resolution API

### DIFF
--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -275,60 +275,32 @@ fn parse_runwasm_coordinate(input: &str) -> anyhow::Result<RunWasmCoordinate> {
         bail!("Invalid runwasm coordinate `{input}`: wildcard package paths are not supported");
     }
 
-    if let Some((module_part, version_and_package)) = input.split_once('@')
-        && let Some((version, package_path)) = version_and_package.split_once('/')
-    {
-        return parse_module_version_coordinate(input, module_part, version, package_path);
+    if input.contains('@') {
+        let parsed = if let Ok(parsed) = registry_path::parse_module_at_version_path(input) {
+            parsed
+        } else if let Ok(parsed) = registry_path::parse_package_at_version_path(input) {
+            parsed
+        } else {
+            bail!("Invalid runwasm coordinate `{input}`");
+        };
+        validate_components(input, &parsed.full_path_without_version(), "package")?;
+        let version = Version::parse(&parsed.version).with_context(|| {
+            format!("Invalid version `{}` in runwasm coordinate", parsed.version)
+        })?;
+        return Ok(RunWasmCoordinate {
+            module_name: parsed.module,
+            package_path: parsed.package,
+            version: Some(version),
+        });
     }
 
-    let (path_part, version) = if let Some((path, version)) = input.rsplit_once('@') {
-        let version = Version::parse(version)
-            .with_context(|| format!("Invalid version `{version}` in runwasm coordinate"))?;
-        (path, Some(version))
-    } else {
-        (input, None)
-    };
-    parse_install_style_coordinate(input, path_part, version)
-}
-
-fn parse_module_version_coordinate(
-    input: &str,
-    module_part: &str,
-    version: &str,
-    package_path: &str,
-) -> anyhow::Result<RunWasmCoordinate> {
-    validate_components(input, module_part, "module")?;
-    validate_components(input, package_path, "package")?;
-    let parsed = registry_path::parse_module_at_version_path(input)
+    validate_components(input, input, "package")?;
+    let parsed = registry_path::parse_install_style_path(input)
         .with_context(|| format!("Invalid runwasm coordinate `{input}`"))?;
-    let version = Version::parse(version)
-        .with_context(|| format!("Invalid version `{version}` in runwasm coordinate"))?;
     Ok(RunWasmCoordinate {
         module_name: parsed.module,
         package_path: parsed.package,
-        version: Some(version),
-    })
-}
-
-fn parse_install_style_coordinate(
-    input: &str,
-    path_part: &str,
-    version: Option<Version>,
-) -> anyhow::Result<RunWasmCoordinate> {
-    validate_components(input, path_part, "package")?;
-    let (module_name, package_path) = if version.is_some() {
-        let parsed = registry_path::parse_package_at_version_path(input)
-            .with_context(|| format!("Invalid runwasm coordinate `{input}`"))?;
-        (parsed.module, parsed.package)
-    } else {
-        let parsed = registry_path::parse_install_style_path(path_part)
-            .with_context(|| format!("Invalid runwasm coordinate `{input}`"))?;
-        (parsed.module, parsed.package)
-    };
-    Ok(RunWasmCoordinate {
-        module_name,
-        package_path,
-        version,
+        version: None,
     })
 }
 

--- a/crates/moonbuild-rupes-recta/src/mbtx.rs
+++ b/crates/moonbuild-rupes-recta/src/mbtx.rs
@@ -188,7 +188,7 @@ fn split_mbtx_import_path(
     }
 
     let (module, version, full_path_without_version) = registry
-        .resolve_path(path, false)
+        .resolve_unversioned_path(path)
         .with_context(|| {
             format!(
                 "import path '{path}' must be in the form 'username/module[/package/path]'; \

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -40,28 +40,20 @@ pub trait Registry {
         all_versions.get(version).cloned()
     }
 
-    /// Resolve an import-style path into:
+    /// Resolve an unversioned import-style path into:
     /// - module path
-    /// - resolved version string, if the path contains an explicit version,
-    ///   or the latest version of the resolved module if the path is unversioned
-    /// - full package path with the version marker removed
+    /// - the latest version of the resolved module
+    /// - full package path
     ///
     /// Resolution rules:
-    /// - If `allow_explicit_version` is `true` and `path` contains `@`,
-    ///   resolve `username/module@version[/package]`.
     /// - `moonbitlang/core[/package]` is resolved directly and uses
     ///   [`DEFAULT_VERSION`] as its version.
-    /// - Otherwise, resolve the first two path segments as the module name and
-    ///   fill the module version with that module's latest version.
+    /// - Otherwise, resolve the first two path segments as the module name.
     ///
-    /// Returns an error if the path is malformed, explicit versions are disallowed,
+    /// Returns an error if the path is malformed, contains an explicit version,
     /// or no module can be resolved from registry metadata.
-    fn resolve_path(
-        &self,
-        path: &str,
-        allow_explicit_version: bool,
-    ) -> anyhow::Result<(ModuleName, String, String)> {
-        path::resolve_registry_path(path, allow_explicit_version, |module| {
+    fn resolve_unversioned_path(&self, path: &str) -> anyhow::Result<(ModuleName, String, String)> {
+        path::resolve_unversioned_registry_path(path, |module| {
             self.all_versions_of(module).ok().and_then(|versions| {
                 versions
                     .last_key_value()
@@ -113,12 +105,8 @@ where
         (**self).get_latest_version(name)
     }
 
-    fn resolve_path(
-        &self,
-        path: &str,
-        allow_explicit_version: bool,
-    ) -> anyhow::Result<(ModuleName, String, String)> {
-        (**self).resolve_path(path, allow_explicit_version)
+    fn resolve_unversioned_path(&self, path: &str) -> anyhow::Result<(ModuleName, String, String)> {
+        (**self).resolve_unversioned_path(path)
     }
 }
 
@@ -151,12 +139,8 @@ where
         (**self).get_latest_version(name)
     }
 
-    fn resolve_path(
-        &self,
-        path: &str,
-        allow_explicit_version: bool,
-    ) -> anyhow::Result<(ModuleName, String, String)> {
-        (**self).resolve_path(path, allow_explicit_version)
+    fn resolve_unversioned_path(&self, path: &str) -> anyhow::Result<(ModuleName, String, String)> {
+        (**self).resolve_unversioned_path(path)
     }
 }
 
@@ -172,14 +156,14 @@ mod tests {
     use moonutil::{common::MOONBITLANG_CORE, mooncakes::DEFAULT_VERSION};
 
     #[test]
-    fn resolve_path_uses_latest_version_for_unversioned_path() {
+    fn resolve_unversioned_path_uses_latest_version() {
         let mut registry = MockRegistry::new();
         registry
             .add_module_full("path/to", "0.2.0", [])
             .add_module_full("path/to", "0.1.0", []);
 
         let (name, version, full_path) = registry
-            .resolve_path("path/to/module/a/b", true)
+            .resolve_unversioned_path("path/to/module/a/b")
             .expect("module path should resolve");
         assert_eq!(name.to_string(), "path/to");
         assert_eq!(version, "0.2.0");
@@ -187,14 +171,14 @@ mod tests {
     }
 
     #[test]
-    fn resolve_path_latest_prefers_release_over_same_base_prerelease() {
+    fn resolve_unversioned_path_latest_prefers_release_over_same_base_prerelease() {
         let mut registry = MockRegistry::new();
         registry
             .add_module_full("path/to", "1.2.0-rc.1", [])
             .add_module_full("path/to", "1.2.0", []);
 
         let (name, version, full_path) = registry
-            .resolve_path("path/to/module/a/b", true)
+            .resolve_unversioned_path("path/to/module/a/b")
             .expect("module path should resolve");
         assert_eq!(name.to_string(), "path/to");
         assert_eq!(version, "1.2.0");
@@ -202,14 +186,14 @@ mod tests {
     }
 
     #[test]
-    fn resolve_path_latest_uses_prerelease_when_it_is_semver_max() {
+    fn resolve_unversioned_path_latest_uses_prerelease_when_it_is_semver_max() {
         let mut registry = MockRegistry::new();
         registry
             .add_module_full("path/to", "1.2.9", [])
             .add_module_full("path/to", "1.3.0-rc.1", []);
 
         let (name, version, full_path) = registry
-            .resolve_path("path/to/module/a/b", true)
+            .resolve_unversioned_path("path/to/module/a/b")
             .expect("module path should resolve");
         assert_eq!(name.to_string(), "path/to");
         assert_eq!(version, "1.3.0-rc.1");
@@ -217,14 +201,14 @@ mod tests {
     }
 
     #[test]
-    fn resolve_path_uses_first_two_segments_as_module() {
+    fn resolve_unversioned_path_uses_first_two_segments_as_module() {
         let mut registry = MockRegistry::new();
         registry
             .add_module_full("a/b", "0.2.0", [])
             .add_module_full("a/b", "0.1.0", []);
 
         let (name, version, full_path) = registry
-            .resolve_path("a/b/c/d/e/f/g", true)
+            .resolve_unversioned_path("a/b/c/d/e/f/g")
             .expect("module path should resolve");
         assert_eq!(name.to_string(), "a/b");
         assert_eq!(version, "0.2.0");
@@ -232,17 +216,17 @@ mod tests {
     }
 
     #[test]
-    fn resolve_path_returns_default_version_for_core() {
+    fn resolve_unversioned_path_returns_default_version_for_core() {
         let registry = MockRegistry::new();
         let (root_name, root_version, root_full_path) = registry
-            .resolve_path("moonbitlang/core", true)
+            .resolve_unversioned_path("moonbitlang/core")
             .expect("core root path should resolve");
         assert_eq!(root_name.to_string(), MOONBITLANG_CORE);
         assert_eq!(root_version, DEFAULT_VERSION.to_string());
         assert_eq!(root_full_path, "moonbitlang/core");
 
         let (name, version, full_path) = registry
-            .resolve_path("moonbitlang/core/list", true)
+            .resolve_unversioned_path("moonbitlang/core/list")
             .expect("core path should resolve");
         assert_eq!(name.to_string(), MOONBITLANG_CORE);
         assert_eq!(version, DEFAULT_VERSION.to_string());
@@ -250,11 +234,11 @@ mod tests {
     }
 
     #[test]
-    fn resolve_path_does_not_treat_corexx_as_core() {
+    fn resolve_unversioned_path_does_not_treat_corexx_as_core() {
         let mut registry = MockRegistry::new();
         registry.add_module_full("moonbitlang/corexx", "0.1.0", []);
         let (name, version, full_path) = registry
-            .resolve_path("moonbitlang/corexx/list", true)
+            .resolve_unversioned_path("moonbitlang/corexx/list")
             .expect("corexx path should resolve as a normal module");
         assert_eq!(name.to_string(), "moonbitlang/corexx");
         assert_eq!(version, "0.1.0");
@@ -262,56 +246,11 @@ mod tests {
     }
 
     #[test]
-    fn resolve_path_uses_explicit_version_package_suffix_after_two_segment_module() {
-        let mut registry = MockRegistry::new();
-        registry.add_module_full("moonbitlang/x", "0.4.39", []);
-
-        let (name, version, full_path) = registry
-            .resolve_path("moonbitlang/x@0.4.39/fs/path", true)
-            .expect("explicit version path should resolve");
-        assert_eq!(name.to_string(), "moonbitlang/x");
-        assert_eq!(version, "0.4.39");
-        assert_eq!(full_path, "moonbitlang/x/fs/path");
-    }
-
-    #[test]
-    fn resolve_path_rejects_three_segment_explicit_module_name() {
+    fn resolve_unversioned_path_rejects_explicit_version() {
         let registry = MockRegistry::new();
         assert!(
             registry
-                .resolve_path("moonbitlang/x/fs@0.4.39/path", true)
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn resolve_path_rejects_package_version_suffix() {
-        let mut registry = MockRegistry::new();
-        registry.add_module_full("moonbitlang/x", "0.4.39", []);
-        assert!(
-            registry
-                .resolve_path("moonbitlang/x/fs@0.4.39", true)
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn resolve_path_rejects_versioned_core_package_suffix() {
-        let registry = MockRegistry::new();
-        assert!(
-            registry
-                .resolve_path("moonbitlang/core/list@0.4.38", true)
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn resolve_path_rejects_explicit_version_when_disallowed() {
-        let mut registry = MockRegistry::new();
-        registry.add_module_full("moonbitlang/x/fs", "0.4.39", []);
-        assert!(
-            registry
-                .resolve_path("moonbitlang/x@0.4.39/fs", false)
+                .resolve_unversioned_path("moonbitlang/x@0.4.39/fs")
                 .is_err()
         );
     }

--- a/crates/mooncake/src/registry/path.rs
+++ b/crates/mooncake/src/registry/path.rs
@@ -182,22 +182,16 @@ pub fn parse_front_matter_import_path(path: &str) -> anyhow::Result<FrontMatterI
     })
 }
 
-/// Resolve import-style registry paths.
-pub fn resolve_registry_path(
+/// Resolve unversioned import-style registry paths.
+pub fn resolve_unversioned_registry_path(
     path: &str,
-    allow_explicit_version: bool,
     mut latest_version_of: impl FnMut(&ModuleName) -> Option<String>,
 ) -> anyhow::Result<(ModuleName, String, String)> {
-    let contains_at = path.contains('@');
-
-    if path.starts_with(&format!("{MOONBITLANG_CORE}@"))
-        || contains_at && path.starts_with(&format!("{MOONBITLANG_CORE}/"))
-    {
-        anyhow::bail!("moonbitlang/core imports must not specify a version");
+    if path.contains('@') {
+        anyhow::bail!("explicit versions are not allowed in this registry path");
     }
 
-    if path == MOONBITLANG_CORE || !contains_at && path.starts_with(&format!("{MOONBITLANG_CORE}/"))
-    {
+    if path == MOONBITLANG_CORE || path.starts_with(&format!("{MOONBITLANG_CORE}/")) {
         return Ok((
             MOD_NAME_STDLIB.clone(),
             DEFAULT_VERSION.to_string(),
@@ -205,28 +199,17 @@ pub fn resolve_registry_path(
         ));
     }
 
-    match (allow_explicit_version, contains_at) {
-        (true, true) => {
-            let parsed = parse_module_at_version_path(path)?;
-            let full_path_without_version = parsed.full_path_without_version();
-            Ok((parsed.module, parsed.version, full_path_without_version))
-        }
-        (false, true) => {
-            anyhow::bail!("explicit versions are not allowed in this registry path")
-        }
-        (_, false) => {
-            let parsed = parse_install_style_path(path)?;
-            let latest_version = latest_version_of(&parsed.module)
-                .ok_or_else(|| anyhow::anyhow!("module `{}` not found", parsed.module))?;
-            Ok((parsed.module, latest_version, path.to_string()))
-        }
-    }
+    let parsed = parse_install_style_path(path)?;
+    let latest_version = latest_version_of(&parsed.module)
+        .ok_or_else(|| anyhow::anyhow!("module `{}` not found", parsed.module))?;
+    Ok((parsed.module, latest_version, path.to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_module_at_version_path, parse_package_at_version_path, resolve_registry_path,
+        parse_module_at_version_path, parse_package_at_version_path,
+        resolve_unversioned_registry_path,
     };
 
     #[test]
@@ -257,8 +240,8 @@ mod tests {
     }
 
     #[test]
-    fn resolve_registry_path_uses_first_two_segments_for_unversioned_path() {
-        let resolved = resolve_registry_path("a/b/c/d", true, |module| {
+    fn resolve_unversioned_registry_path_uses_first_two_segments() {
+        let resolved = resolve_unversioned_registry_path("a/b/c/d", |module| {
             (module.to_string() == "a/b").then(|| "1.0.0".to_string())
         })
         .unwrap();


### PR DESCRIPTION
## Summary

Clean up the registry path parsing API after the strict parsing split.

- replace `Registry::resolve_path(path, allow_explicit_version)` with `resolve_unversioned_path(path)`
- rename the helper resolver to `resolve_unversioned_registry_path`
- keep explicit-version handling at call sites through the exact parser helpers
- simplify `moon runwasm` coordinate parsing to try `module@version/pkg`, then lazily try `module/pkg@version`, then parse unversioned coordinates

This removes the remaining boolean mode switch from registry path resolution.

## Validation

- `cargo fmt`
- `cargo test -p mooncake registry::`
- `cargo test -p moonbuild-rupes-recta mbtx::tests`
- `cargo test -p moon parse_`
- `cargo test -p moon reject_invalid_coordinates`
- `cargo test -p moonbuild-rupes-recta split_import_path`
- `git diff --check`