### PR TITLE
Use workspace source_dir for moon doc metadata

### DIFF
--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -92,7 +92,7 @@ fn run_doc_query(symbol: &str, output: UserDiagnostics) -> anyhow::Result<i32> {
 pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Result<i32> {
     let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
     let project = query.project()?;
-    let doc_source_dir = project
+    let selected_module_dir = project
         .selected_module()
         .map(|module| module.root.clone())
         .ok_or_else(|| {
@@ -137,7 +137,7 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
         output,
         &resolve_output,
     )?;
-    let module_id = selected_doc_module_id(&resolve_output, &doc_source_dir)?;
+    let module_id = selected_doc_module_id(&resolve_output, &selected_module_dir)?;
     let intent = vec![UserIntent::Doc(module_id)].into();
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
@@ -166,7 +166,7 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
     rr_build::generate_all_pkgs_json(&build_meta)?;
     // Generate metadata for `moondoc`
     rr_build::generate_metadata(
-        &doc_source_dir,
+        &source_dir,
         &target_dir,
         &build_meta,
         &build_graph,
@@ -198,7 +198,6 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
                 static_dir.display()
             );
         }
-        let module_id = selected_doc_module_id(&build_meta.resolve_output, &doc_source_dir)?;
         let full_name = build_meta
             .resolve_output
             .module_rel

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -165,13 +165,7 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
     // before executing the build
     rr_build::generate_all_pkgs_json(&build_meta)?;
     // Generate metadata for `moondoc`
-    rr_build::generate_metadata(
-        &source_dir,
-        &target_dir,
-        &build_meta,
-        &build_graph,
-        None,
-    )?;
+    rr_build::generate_metadata(&source_dir, &target_dir, &build_meta, &build_graph, None)?;
 
     // Execute the build
     let cfg = BuildConfig::from_flags(

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -1368,7 +1368,7 @@ fn test_doc_targets_member_module_with_workspace_resolution() {
     let metadata = replace_dir(&metadata, &dir);
     let metadata: serde_json::Value = serde_json::from_str(&metadata).unwrap();
 
-    assert_eq!(metadata["source_dir"], "$ROOT/app");
+    assert_eq!(metadata["source_dir"], "$ROOT");
     assert_eq!(metadata["name"], "workspace");
     assert_eq!(metadata["deps"], serde_json::json!(["alice/liba"]));
 


### PR DESCRIPTION
moon currently generates differnt packages.json for `moon check` and `moon doc`, this is a hack because moondoc does not know workspace natively.

This PR removes the hack, since now moondoc uses the same logic as moon_lsp, making it support workspace natively.