### PR TITLE
Bump n2 for simplified diagnostics output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "n2"
 version = "0.1.5"
-source = "git+https://github.com/moonbitlang/n2.git?rev=81b6be11b3b880b1e6acac063fb9e1a27aafe5bb#81b6be11b3b880b1e6acac063fb9e1a27aafe5bb"
+source = "git+https://github.com/moonbitlang/n2.git?rev=113d577c65f9ebf350f1f9f7359a242e64883b37#113d577c65f9ebf350f1f9f7359a242e64883b37"
 dependencies = [
  "anyhow",
  "argh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.90"
 edition = "2024"
 
 [workspace.dependencies]
-n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "81b6be11b3b880b1e6acac063fb9e1a27aafe5bb" }
+n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "113d577c65f9ebf350f1f9f7359a242e64883b37" }
 arcstr = { version = "1.2", features = ["serde"] }
 moonbuild = { path = "./crates/moonbuild", version = "*" }
 moonbuild-rupes-recta = { path = "./crates/moonbuild-rupes-recta", version = "*" }

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -892,15 +892,11 @@ fn test_moon_run_command_string_short_alias_c_reads_inline_script() {
 #[test]
 fn test_moon_run_command_string_invalid_source_keeps_diagnostics_on_stderr() {
     let dir = TestDir::new_empty();
-    let assert = snapbox::cmd::Command::new(moon_bin())
-        .current_dir(&dir)
-        .arg("run")
-        .arg("-e")
-        .arg(r#"println("hello")"#)
+    let assert = moon_cmd(&dir)
+        .args(["run", "-e", r#"println("hello")"#])
         .assert()
-        .failure();
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
-    assert!(stdout.contains("failed:"), "stdout: {stdout}");
+        .failure()
+        .stdout_eq("");
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
         stderr.contains("Missing main function in the main package"),

--- a/crates/moon/tests/test_cases/moon_prove/mod.rs
+++ b/crates/moon/tests/test_cases/moon_prove/mod.rs
@@ -300,7 +300,6 @@ fn test_moon_prove_mixed_workspace_failure() {
     snapbox::assert_data_eq!(
         replace_dir(&stdout, &dir).trim_end(),
         snapbox::str![[r#"
-failed: moonc prove -error-format json $ROOT/afail/afail.mbt $ROOT/afail/afail.mbtp -whyml-output-path $ROOT/_build/verif/afail/pkg_8_username_5_prove_5_afail.mlw -proof-report-output-path $ROOT/_build/verif/afail/afail.proof.json -why3-config $ROOT/_build/verif/why3.conf -why3-loadpath $MOON_HOME/lib/prelude_proof -pkg username/prove/afail -i $MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude -pkg-sources username/prove/afail:$ROOT/afail -workspace-path $ROOT -all-pkgs $ROOT/_build/wasm-gc/debug/prove/all_pkgs.json
 username/prove/afail
   Failed: [..]
   WhyML: _build/verif/afail/pkg_8_username_5_prove_5_afail.mlw

--- a/crates/moon/tests/test_cases/moon_prove/snapshots/afail.run.stdout
+++ b/crates/moon/tests/test_cases/moon_prove/snapshots/afail.run.stdout
@@ -1,4 +1,3 @@
-failed: moonc prove -error-format json $ROOT/afail/afail.mbt $ROOT/afail/afail.mbtp -whyml-output-path $ROOT/_build/verif/afail/pkg_8_username_5_prove_5_afail.mlw -proof-report-output-path $ROOT/_build/verif/afail/afail.proof.json -why3-config $ROOT/_build/verif/why3.conf -why3-loadpath $MOON_HOME/lib/prelude_proof -pkg username/prove/afail -i $MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude -pkg-sources username/prove/afail:$ROOT/afail -workspace-path $ROOT -all-pkgs $ROOT/_build/wasm-gc/debug/prove/all_pkgs.json
 username/prove/afail
   Failed: 12 goals proved, 1 timeout
   WhyML: _build/verif/afail/pkg_8_username_5_prove_5_afail.mlw

--- a/crates/moon/tests/test_cases/moon_prove/snapshots/cross_package.run.stdout
+++ b/crates/moon/tests/test_cases/moon_prove/snapshots/cross_package.run.stdout
@@ -1,4 +1,3 @@
-failed: moonc prove -error-format json $ROOT/dep/dep.mbt $ROOT/dep/dep.mbtp -whyml-output-path $ROOT/_build/verif/dep/pkg_8_username_12_prove_ucross_3_dep.mlw -proof-report-output-path $ROOT/_build/verif/dep/dep.proof.json -why3-config $ROOT/_build/verif/why3.conf -why3-loadpath $MOON_HOME/lib/prelude_proof -pkg username/prove_cross/dep -i $MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude -pkg-sources username/prove_cross/dep:$ROOT/dep -workspace-path $ROOT -all-pkgs $ROOT/_build/wasm-gc/debug/prove/all_pkgs.json
 username/prove_cross/dep
   Failed: 0 goals proved, 1 timeout
   WhyML: _build/verif/dep/pkg_8_username_12_prove_ucross_3_dep.mlw

--- a/crates/moon/tests/test_cases/warns/mod.rs
+++ b/crates/moon/tests/test_cases/warns/mod.rs
@@ -264,9 +264,7 @@ fn test_deny_warn() {
 
     check(
         get_err_stdout(&dir, ["check", "--deny-warn", "--sort-input"]),
-        expect![[r#"
-            failed: moonc check -error-format json -w @a $ROOT/lib/hello.mbt -o $ROOT/_build/wasm-gc/debug/check/lib/lib.mi -pkg username/hello/lib -std-path $MOON_HOME/lib/core/_build/wasm-gc/release/bundle -i $MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude -pkg-sources username/hello/lib:$ROOT/lib -target wasm-gc -workspace-path $ROOT -all-pkgs $ROOT/_build/wasm-gc/debug/check/all_pkgs.json
-        "#]],
+        expect![""],
     );
 
     check(
@@ -306,8 +304,6 @@ fn test_deny_warn() {
 
     check(
         get_err_stdout(&dir, ["build", "--deny-warn", "--sort-input"]),
-        expect![[r#"
-            failed: moonc build-package -error-format json -w @a $ROOT/lib/hello.mbt -o $ROOT/_build/wasm-gc/debug/build/lib/lib.core -pkg username/hello/lib -std-path $MOON_HOME/lib/core/_build/wasm-gc/release/bundle -i $MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude -pkg-sources username/hello/lib:$ROOT/lib -target wasm-gc -g -O0 -source-map -workspace-path $ROOT -all-pkgs $ROOT/_build/wasm-gc/debug/build/all_pkgs.json
-        "#]],
+        expect![""],
     );
 }


### PR DESCRIPTION
## Summary

- bump `n2` to the merged commit from moonbitlang/n2#15
- update existing output expectations for default diagnostic failures now that n2 no longer prints `failed: moonc ...` outside verbose mode

Fixes #1733.

## Tests

- `cargo test -p moon --test mod moon_commands`
- `cargo test -p moon --test mod warns`

Not run locally:

- `VERIFICATION_TESTS=1 cargo test -p moon --test mod moon_prove` because `why3` is not installed locally.