### PR TITLE
Test verbose diagnostic failure output

### DIFF
--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -910,6 +910,16 @@ fn test_moon_run_command_string_invalid_source_keeps_diagnostics_on_stderr() {
 }
 
 #[test]
+fn test_moon_run_command_string_invalid_source_shows_failed_command_in_verbose_mode() {
+    let dir = TestDir::new_empty();
+    moon_cmd(&dir)
+        .args(["run", "--verbose", "-e", r#"println("hello")"#])
+        .assert()
+        .failure()
+        .stdout_eq("failed: [..]moonc[..] build-package [..]\n");
+}
+
+#[test]
 fn test_moon_run_command_string_defaults_to_native() {
     let dir = TestDir::new_empty();
     let stdout = get_stdout(


### PR DESCRIPTION
## Summary

- add regression coverage that `moon run --verbose -e ...` still prints the failed compiler command
- use a cross-platform stdout pattern that allows Windows' normalized `moonc[EXE]` path form

Follows #1746.

## Tests

- `cargo test -p moon --test mod test_moon_run_command_string_invalid_source_shows_failed_command_in_verbose_mode`