### PR TITLE
Gate moon run output on verbosity

### DIFF
--- a/crates/moon/src/cli/profile.rs
+++ b/crates/moon/src/cli/profile.rs
@@ -273,21 +273,8 @@ pub(crate) fn run_profiled_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyh
 
 fn run_profile_materialized(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
     let run_cmd = profile_run_subcommand(cmd.clone())?;
-    let mut built = build_run_executable(
-        cli,
-        &run_cmd,
-        BuildRunExecutableOptions {
-            // Profiling needs a stable executable path for xctrace to launch.
-            // The TCC fast path may run directly from generated C instead.
-            try_tcc_run: false,
-            // The dry-run output should show the profiled invocation, not the
-            // plain executable command that `moon run` would normally print.
-            print_dry_run_run_command: false,
-            suppress_build_progress: false,
-            quiet_sync: false,
-            default_target_backend: TargetBackend::default(),
-        },
-    )?;
+    let mut built =
+        build_run_executable(cli, &run_cmd, BuildRunExecutableOptions::for_profile(cli))?;
     built.ensure_build_success()?;
 
     if built.target_backend != RunBackend::Native {

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -22,6 +22,7 @@ use anyhow::{Context, bail};
 use moonbuild_rupes_recta::{
     ResolveOutput, build_plan::InputDirective, intent::UserIntent, model::PackageId,
 };
+use mooncake::pkg::sync::SyncOutputOptions;
 use moonutil::common::{FileLock, RunMode, TargetBackend, TestArtifacts, is_moon_pkg_exist};
 use moonutil::dirs::{PackageDirs, ProjectProbe};
 use moonutil::mooncakes::sync::AutoSyncFlags;
@@ -106,6 +107,27 @@ pub(crate) struct RunSubcommand {
     pub profile: bool,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct RunOutputVerbosity {
+    verbose: bool,
+}
+
+impl RunOutputVerbosity {
+    fn from_flags(cli: &UniversalFlags) -> Self {
+        Self {
+            verbose: cli.verbose,
+        }
+    }
+
+    fn sync_output(self) -> SyncOutputOptions {
+        SyncOutputOptions::new(!self.verbose, self.verbose)
+    }
+
+    fn suppress_build_progress(self) -> bool {
+        !self.verbose
+    }
+}
+
 /// Controls how `moon run` builds the executable before it is consumed.
 ///
 /// Normal execution preserves the existing debug-native fast path by allowing
@@ -116,15 +138,12 @@ pub(crate) struct BuildRunExecutableOptions {
     ///
     /// `tcc -run` executes through `tcc @rspfile` and does not provide the same
     /// standalone executable shape as regular native execution.
-    pub(crate) try_tcc_run: bool,
+    try_tcc_run: bool,
     /// Whether dry-run output should include the final executable invocation.
-    pub(crate) print_dry_run_run_command: bool,
-    /// Whether to suppress build progress output from n2.
-    pub(crate) suppress_build_progress: bool,
-    /// Whether dependency sync/install progress should stay quiet.
-    pub(crate) quiet_sync: bool,
+    print_dry_run_run_command: bool,
+    output: RunOutputVerbosity,
     /// Backend to use when neither CLI flags nor single-file metadata selects one.
-    pub(crate) default_target_backend: TargetBackend,
+    default_target_backend: TargetBackend,
 }
 
 impl BuildRunExecutableOptions {
@@ -132,8 +151,7 @@ impl BuildRunExecutableOptions {
         Self {
             try_tcc_run: !cli.dry_run,
             print_dry_run_run_command: true,
-            suppress_build_progress: false,
-            quiet_sync: false,
+            output: RunOutputVerbosity::from_flags(cli),
             default_target_backend: TargetBackend::default(),
         }
     }
@@ -142,9 +160,21 @@ impl BuildRunExecutableOptions {
         Self {
             try_tcc_run: !cli.dry_run,
             print_dry_run_run_command: true,
-            suppress_build_progress: !cli.verbose,
-            quiet_sync: !cli.verbose,
+            output: RunOutputVerbosity::from_flags(cli),
             default_target_backend: TargetBackend::Native,
+        }
+    }
+
+    pub(crate) fn for_profile(cli: &UniversalFlags) -> Self {
+        Self {
+            // Profiling needs a stable executable path for xctrace to launch.
+            // The TCC fast path may run directly from generated C instead.
+            try_tcc_run: false,
+            // The dry-run output should show the profiled invocation, not the
+            // plain executable command that `moon run` would normally print.
+            print_dry_run_run_command: false,
+            output: RunOutputVerbosity::from_flags(cli),
+            default_target_backend: TargetBackend::default(),
         }
     }
 }
@@ -173,7 +203,7 @@ pub(crate) struct RunExecutable {
 struct BuildExecutableFromPlanOptions {
     force_success_exit: bool,
     print_dry_run_run_command: bool,
-    suppress_build_progress: bool,
+    output: RunOutputVerbosity,
 }
 
 impl RunExecutable {
@@ -449,7 +479,7 @@ fn build_package_executable(
         cli.workspace_env.clone(),
     )
     .with_project_manifest_path(project_manifest_path.as_deref())
-    .with_quiet_sync(options.quiet_sync);
+    .with_sync_output(options.output.sync_output());
     let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
     let (build_meta, build_graph) = plan_run_rr_from_resolved(
         cli,
@@ -469,7 +499,7 @@ fn build_package_executable(
         BuildExecutableFromPlanOptions {
             force_success_exit: selected_target_backend.is_some(),
             print_dry_run_run_command: options.print_dry_run_run_command,
-            suppress_build_progress: options.suppress_build_progress,
+            output: options.output,
         },
     )
 }
@@ -619,7 +649,7 @@ fn build_single_file_executable(
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     )
-    .with_quiet_sync(options.quiet_sync);
+    .with_sync_output(options.output.sync_output());
     let (resolved, backend) = moonbuild_rupes_recta::resolve::resolve_single_file_project(
         &resolve_cfg,
         target_dir.as_path(),
@@ -678,7 +708,7 @@ fn build_single_file_executable(
         BuildExecutableFromPlanOptions {
             force_success_exit: false,
             print_dry_run_run_command: options.print_dry_run_run_command,
-            suppress_build_progress: options.suppress_build_progress,
+            output: options.output,
         },
     )
 }
@@ -720,7 +750,7 @@ fn build_executable_from_plan(
         });
     }
 
-    let lock = FileLock::lock(target_dir)?;
+    let lock = FileLock::lock_with_verbosity(target_dir, options.output.verbose)?;
     // Generate all_pkgs.json for indirect dependency resolution
     rr_build::generate_all_pkgs_json(target_dir, build_meta, RunMode::Run)?;
 
@@ -730,7 +760,7 @@ fn build_executable_from_plan(
         cli.verbose,
         UserDiagnostics::from_flags(cli),
     )
-    .with_suppressed_progress(options.suppress_build_progress);
+    .with_suppressed_progress(options.output.suppress_build_progress());
     let build_result = rr_build::execute_build(&build_config, build_graph, target_dir)?;
 
     Ok(RunExecutable {

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -32,7 +32,7 @@ use log::{debug, info};
 use std::str::FromStr;
 
 use mooncake::{
-    pkg::sync::{auto_sync, auto_sync_for_single_file_rr},
+    pkg::sync::{SyncOutputOptions, auto_sync, auto_sync_for_single_file_rr},
     registry::path as registry_path,
 };
 use moonutil::{
@@ -88,7 +88,7 @@ impl ResolveOutput {
 #[derive(Debug)]
 pub struct ResolveConfig {
     sync_flags: AutoSyncFlags,
-    quiet_sync: bool,
+    sync_output: SyncOutputOptions,
     no_std: bool,
     /// Gate coverage injection in pkg_solve
     pub enable_coverage: bool,
@@ -265,7 +265,7 @@ impl ResolveConfig {
     ) -> Self {
         Self {
             sync_flags: AutoSyncFlags { frozen },
-            quiet_sync: false,
+            sync_output: SyncOutputOptions::default(),
             no_std,
             enable_coverage,
             workspace_env,
@@ -282,7 +282,7 @@ impl ResolveConfig {
     ) -> Self {
         Self {
             sync_flags,
-            quiet_sync: false,
+            sync_output: SyncOutputOptions::default(),
             no_std,
             enable_coverage,
             workspace_env,
@@ -296,7 +296,12 @@ impl ResolveConfig {
     }
 
     pub fn with_quiet_sync(mut self, quiet_sync: bool) -> Self {
-        self.quiet_sync = quiet_sync;
+        self.sync_output = self.sync_output.with_quiet(quiet_sync);
+        self
+    }
+
+    pub fn with_sync_output(mut self, sync_output: SyncOutputOptions) -> Self {
+        self.sync_output = sync_output;
         self
     }
 }
@@ -347,7 +352,7 @@ pub fn resolve(
         source_dir,
         mooncakes_dir,
         &cfg.sync_flags,
-        cfg.quiet_sync,
+        cfg.sync_output,
         cfg.no_std,
         cfg.workspace_env.clone(),
         cfg.project_manifest_path.as_deref(),
@@ -471,7 +476,7 @@ Use moonbit.import with 'username/module@version[/package]' entries to opt in to
         mooncakes_dir,
         &cfg.sync_flags,
         front_matter_config.deps_to_sync.as_ref(),
-        cfg.quiet_sync,
+        cfg.sync_output,
     )
     .map_err(ResolveError::SyncModulesError)?;
     // Discover all packages in resolved modules

--- a/crates/mooncake/src/dep_dir.rs
+++ b/crates/mooncake/src/dep_dir.rs
@@ -201,6 +201,7 @@ pub(crate) fn sync_deps(
     pkg_list: &ResolvedEnv,
     quiet: bool,
     frozen: bool,
+    verbose: bool,
 ) -> anyhow::Result<()> {
     // If nothing needs to be installed, don't bother
     let target_dep_dir = pkg_list_to_dep_dir_state(pkg_list.all_modules());
@@ -212,7 +213,7 @@ pub(crate) fn sync_deps(
     // Ensure the directory exists.
     std::fs::create_dir_all(dep_dir.path())?;
     // Lock with a file within the directory
-    let _lock = FileLock::lock(dep_dir.path()).with_context(|| {
+    let _lock = FileLock::lock_with_verbosity(dep_dir.path(), verbose).with_context(|| {
         format!(
             "Unable to lock folder `{}` for downloading dependencies",
             dep_dir.path().display()

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -30,7 +30,7 @@ use semver::Version;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::pkg::{install::install_impl, roots_for_selected_module};
+use crate::pkg::{install::install_impl, roots_for_selected_module, sync::SyncOutputOptions};
 use crate::registry::{self, Registry};
 
 /// Add a dependency
@@ -202,7 +202,14 @@ pub fn add(
         Arc::clone(&m),
         project_manifest_path,
     )?;
-    install_impl(mooncakes_dir, roots, quiet, false, false, true)?;
+    install_impl(
+        mooncakes_dir,
+        roots,
+        SyncOutputOptions::new(quiet, true),
+        false,
+        false,
+        true,
+    )?;
 
     if module_dir.join(MOON_MOD).exists() {
         let patch = if bin {

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -22,6 +22,7 @@ use crate::{
     resolver::{ResolveConfig, resolve_with_default_env_and_resolver},
 };
 
+use super::sync::SyncOutputOptions;
 use anyhow::Context;
 use moonutil::{
     common::{MOONBITLANG_CORE, read_module_desc_file_in_dir},
@@ -93,13 +94,21 @@ pub fn install(
     let m = Arc::new(m);
     let ms = ModuleSource::from_local_module(&m, source_dir);
     let (roots, _) = ResolvedModule::only_one_module(ms, m);
-    install_impl(mooncakes_dir, roots, quiet, verbose, false, no_std).map(|_| 0)
+    install_impl(
+        mooncakes_dir,
+        roots,
+        SyncOutputOptions::new(quiet, true),
+        verbose,
+        false,
+        no_std,
+    )
+    .map(|_| 0)
 }
 
 pub(crate) fn install_impl(
     mooncakes_dir: &Path,
     roots: ResolvedRootModules,
-    quiet: bool,
+    output_options: SyncOutputOptions,
     verbose: bool,
     dont_sync: bool,
     no_std: bool,
@@ -123,8 +132,9 @@ pub(crate) fn install_impl(
         &dep_dir,
         resolve_config.registry.as_ref(),
         &res,
-        quiet,
+        output_options.quiet(),
         dont_sync,
+        output_options.verbose(),
     )
     .context("When installing packages")?;
 

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -35,6 +35,37 @@ use moonutil::{
 };
 use semver::Version;
 
+#[derive(Debug, Clone, Copy)]
+pub struct SyncOutputOptions {
+    quiet: bool,
+    verbose: bool,
+}
+
+impl SyncOutputOptions {
+    pub fn new(quiet: bool, verbose: bool) -> Self {
+        Self { quiet, verbose }
+    }
+
+    pub fn quiet(self) -> bool {
+        self.quiet
+    }
+
+    pub fn verbose(self) -> bool {
+        self.verbose
+    }
+
+    pub fn with_quiet(mut self, quiet: bool) -> Self {
+        self.quiet = quiet;
+        self
+    }
+}
+
+impl Default for SyncOutputOptions {
+    fn default() -> Self {
+        Self::new(false, true)
+    }
+}
+
 /// Given the specified source directory, resolve the module dependency relation
 /// and their directories
 ///
@@ -43,7 +74,7 @@ pub fn auto_sync(
     source_dir: &Path,
     mooncakes_dir: &Path,
     cli: &AutoSyncFlags,
-    quiet: bool,
+    output_options: SyncOutputOptions,
     no_std: bool,
     workspace_env: WorkspaceEnv,
     project_manifest_path: Option<&Path>,
@@ -72,7 +103,7 @@ pub fn auto_sync(
             return resolve_workspace_sync(
                 mooncakes_dir,
                 cli,
-                quiet,
+                output_options,
                 no_std,
                 manifest_dir.as_path(),
                 read_workspace_file(project_manifest_path)?,
@@ -94,7 +125,7 @@ pub fn auto_sync(
             return resolve_workspace_sync(
                 mooncakes_dir,
                 cli,
-                quiet,
+                output_options,
                 no_std,
                 &workspace_root,
                 workspace,
@@ -103,15 +134,28 @@ pub fn auto_sync(
     } else if !matches!(workspace_env, WorkspaceEnv::Off)
         && let Some(workspace) = read_workspace(source_dir)?
     {
-        return resolve_workspace_sync(mooncakes_dir, cli, quiet, no_std, source_dir, workspace);
+        return resolve_workspace_sync(
+            mooncakes_dir,
+            cli,
+            output_options,
+            no_std,
+            source_dir,
+            workspace,
+        );
     }
 
     let module = Arc::new(read_module_desc_file_in_dir(source_dir)?);
     let source = ModuleSource::from_local_module(&module, source_dir);
     let (roots, _) = ResolvedModule::only_one_module(source, module);
 
-    let (resolved_env, sync_result) =
-        super::install::install_impl(mooncakes_dir, roots, quiet, false, cli.dont_sync(), no_std)?;
+    let (resolved_env, sync_result) = super::install::install_impl(
+        mooncakes_dir,
+        roots,
+        output_options,
+        false,
+        cli.dont_sync(),
+        no_std,
+    )?;
     log::debug!("Dir sync result: {:?}", sync_result);
     Ok((resolved_env, sync_result, None))
 }
@@ -119,7 +163,7 @@ pub fn auto_sync(
 fn resolve_workspace_sync(
     mooncakes_dir: &Path,
     cli: &AutoSyncFlags,
-    quiet: bool,
+    output_options: SyncOutputOptions,
     no_std: bool,
     workspace_root: &Path,
     workspace: MoonWork,
@@ -131,8 +175,14 @@ fn resolve_workspace_sync(
         roots.insert(ResolvedModule::new(source, module));
     }
 
-    let (resolved_env, sync_result) =
-        super::install::install_impl(mooncakes_dir, roots, quiet, false, cli.dont_sync(), no_std)?;
+    let (resolved_env, sync_result) = super::install::install_impl(
+        mooncakes_dir,
+        roots,
+        output_options,
+        false,
+        cli.dont_sync(),
+        no_std,
+    )?;
     log::debug!("Dir sync result: {:?}", sync_result);
     Ok((resolved_env, sync_result, Some(workspace)))
 }
@@ -169,7 +219,7 @@ pub fn auto_sync_for_single_mbt_md(
     let (resolved_env, dir_sync_result) = super::install::install_impl(
         mooncakes_dir,
         roots,
-        moonbuild_opt.quiet,
+        SyncOutputOptions::new(moonbuild_opt.quiet, true),
         moonbuild_opt.verbose,
         dont_sync,
         false,
@@ -183,7 +233,7 @@ pub fn auto_sync_for_single_file_rr(
     mooncakes_dir: &Path,
     sync_flags: &AutoSyncFlags,
     front_matter_deps: Option<&IndexMap<String, moonutil::dependency::SourceDependencyInfo>>,
-    quiet: bool,
+    output_options: SyncOutputOptions,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult)> {
     let mut synth_deps = IndexMap::new();
     if let Some(deps_map) = front_matter_deps {
@@ -204,7 +254,7 @@ pub fn auto_sync_for_single_file_rr(
     let (resolved_env, dir_sync_result) = super::install::install_impl(
         mooncakes_dir,
         roots,
-        quiet,
+        output_options,
         false,
         sync_flags.dont_sync(),
         false,

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -1382,15 +1382,21 @@ impl Drop for FileLock {
 
 impl FileLock {
     pub fn lock(path: &std::path::Path) -> std::io::Result<Self> {
+        Self::lock_with_verbosity(path, true)
+    }
+
+    pub fn lock_with_verbosity(path: &std::path::Path, verbose: bool) -> std::io::Result<Self> {
         let file = std::fs::File::create(path.join(MOON_LOCK))?;
         match file.try_lock_exclusive() {
             Ok(_) => Ok(FileLock { _file: file }),
             Err(_) => {
-                #[cfg(not(test))]
-                eprintln!(
-                    "Blocking waiting for file lock {} ...",
-                    path.join(MOON_LOCK).display()
-                );
+                if verbose {
+                    #[cfg(not(test))]
+                    eprintln!(
+                        "Blocking waiting for file lock {} ...",
+                        path.join(MOON_LOCK).display()
+                    );
+                }
                 file.lock_exclusive()
                     .map_err(|e| std::io::Error::new(e.kind(), "failed to lock target dir"))?;
                 Ok(FileLock { _file: file })


### PR DESCRIPTION
## Why
`moon run` lock waits could surface as user-facing output even when the command otherwise treats progress and sync chatter as quiet output. The output policy should be driven by verbosity instead of a lock-specific toggle.

## What changed
- Thread sync output as quiet plus verbose state through resolve and mooncake sync.
- Derive `moon run` sync quietness, build progress suppression, and lock wait messages from one verbosity value.
- Keep non-run lock wait behavior unchanged by default.

## Correctness
The locking behavior still uses the same blocking exclusive locks. This only changes whether the wait message is emitted: plain `moon run` stays quiet, while `moon run -v` enables build progress, sync progress, and lock wait output together.

## Scope
The change is limited to output-option plumbing and lock wait message emission.