### PR TITLE
fix: give an actionable error when moonbitlang/core is not bundled

### DIFF
--- a/crates/mooncake/src/resolver.rs
+++ b/crates/mooncake/src/resolver.rs
@@ -266,8 +266,24 @@ pub(crate) fn resolve_with_default_env(
 /// to the resolve graph, and mark it as the standard library.
 fn inject_std(res: &mut ResolvedEnv) -> anyhow::Result<()> {
     let core_dir = moon_dir::core();
-    let loaded_core =
-        read_module_desc_file_in_dir(&core_dir).context("Cannot load the core file")?;
+    let loaded_core = read_module_desc_file_in_dir(&core_dir).with_context(|| {
+        if core_dir.exists() {
+            format!(
+                "Cannot load the core file. The standard library at `{}` \
+                 does not appear to be bundled. Run `moon -C {} bundle --target all` \
+                 to bundle it",
+                core_dir.display(),
+                core_dir.display()
+            )
+        } else {
+            format!(
+                "Cannot load the core file. The standard library directory `{}` \
+                 does not exist. Reinstall the MoonBit toolchain, or set \
+                 $MOON_CORE_OVERRIDE to a checkout of moonbitlang/core",
+                core_dir.display()
+            )
+        }
+    })?;
     let source = ModuleSource::from_stdlib(&loaded_core, &core_dir);
     let id = res.add_module(source, Arc::new(loaded_core));
     res.register_stdlib(id);


### PR DESCRIPTION
- Related issues: Fixes #1718
- PR kind: Bugfix (diagnostics)

## Summary

`moon build` on a fresh install where `~/.moon/lib/core` exists but was never bundled now fails with an actionable message that names the core directory and the exact remediation (`moon -C <core_dir> bundle --target all`), instead of the generic `Cannot load the core file`. A missing core directory gets its own message pointing at reinstalling the toolchain or `$MOON_CORE_OVERRIDE`.

## Why this matters

#1718 hit this on Windows: the old error reads like a corruption/path bug and sends users down the wrong debugging path, while peter-jerry-ye's confirmed fix is just running the bundle command. The change is confined to the `.context(...)` on `read_module_desc_file_in_dir` in `inject_std` (`crates/mooncake/src/resolver.rs`); the underlying error stays in the source chain and the `CannotInjectCore` wrapper still prefixes the standard-library context.

Output after this change (exists-but-unbundled path):

```
Cannot inject the standard library `moonbitlang/core`: Cannot load the core file. The standard library at `/tmp/.../unbundled_core` does not appear to be bundled. Run `moon -C /tmp/.../unbundled_core bundle --target all` to bundle it
```

## Metadata

- [x] Tests added/updated for bug fixes or new features - N/A for this diagnostics-only change; both failure paths verified by running the built `moon` binary against a minimal project with `MOON_CORE_OVERRIDE` pointing at an empty dir and a nonexistent dir (outputs above)
- [x] Compatible with Windows/Linux/macOS - message formatting only, no platform-specific APIs; `cargo check -p mooncake` and `cargo fmt --check` pass
