### PR TITLE
refactor(rr): use logical artifact needs

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -28,7 +28,7 @@ use tracing::{Level, instrument};
 use crate::{
     ResolveOutput,
     build_lower::artifact::LegacyLayout,
-    build_plan::{BuildPlan, FileDependencyKind},
+    build_plan::{BuildPlan, FileDependencyKind, PlanArtifactKind},
     discover::{DiscoverResult, DiscoveredPackage},
     model::{BuildPlanNode, BuildTarget},
     pkg_solve::DepRelationship,
@@ -358,8 +358,12 @@ impl<'a> BuildPlanLowerContext<'a> {
                     .get_build_target_info(&target)
                     .expect("Build target info should be present for BuildCore nodes");
                 let (mi, core) = match edge {
-                    FileDependencyKind::BuildCore { mi, core } => (mi, core),
-                    _ => (true, true),
+                    FileDependencyKind::AllFiles => (true, true),
+                    FileDependencyKind::Artifacts(need) => (
+                        need.contains(PlanArtifactKind::Interface),
+                        need.contains(PlanArtifactKind::CoreIr),
+                    ),
+                    _ => panic!("BuildCore only supports logical artifact or AllFiles edges"),
                 };
                 if mi && info.check_mi_against.is_none() && !info.no_mi() && !target.kind.is_test()
                 {

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -41,7 +41,7 @@ use regex::Regex;
 use tracing::{Level, debug, instrument, trace, warn};
 
 use crate::{
-    build_plan::{BuildBundleInfo, FileDependencyKind, PrebuildInfo},
+    build_plan::{BuildBundleInfo, FileDependencyKind, PlanArtifactNeed, PrebuildInfo},
     cond_comp::{self, CompileCondition},
     discover::DiscoveredPackage,
     model::{BuildPlanNode, BuildTarget, PackageId, TargetKind},
@@ -247,9 +247,6 @@ impl<'a> BuildPlanConstructor<'a> {
     /// dependency changes dirty downstream build-package actions. Check-only
     /// paths still require just `.mi`.
     ///
-    /// This dynamically maps into either `Build`, `Check` or `BuildVirtual`
-    /// nodes based on the property of the dependency package.
-    ///
     /// Backend compatibility is checked by `check_backend_compatibility_for_mi_dep`.
     /// Keep this function focused on graph wiring only.
     fn need_interface_of_dep(
@@ -274,15 +271,20 @@ impl<'a> BuildPlanConstructor<'a> {
             self.need_node(BuildPlanNode::BuildCore(dep))
         };
 
-        let edge_kind = if let BuildPlanNode::BuildCore(_) = dep_node {
-            FileDependencyKind::BuildCore {
-                mi: true,
-                core: mode.core_as_input(),
+        let edge = match dep_node {
+            BuildPlanNode::Check(_) => FileDependencyKind::Artifacts(PlanArtifactNeed::Interface),
+            BuildPlanNode::BuildCore(_) if !mode.core_as_input() => {
+                FileDependencyKind::Artifacts(PlanArtifactNeed::Interface)
             }
-        } else {
-            FileDependencyKind::AllFiles
+            BuildPlanNode::BuildCore(_) => {
+                FileDependencyKind::Artifacts(PlanArtifactNeed::InterfaceAndCoreIr)
+            }
+            BuildPlanNode::BuildVirtual(_) => FileDependencyKind::AllFiles,
+            _ => unreachable!(
+                "need_interface_of_dep only schedules Check, BuildCore or BuildVirtual"
+            ),
         };
-        self.add_edge_spec(node, dep_node, edge_kind);
+        self.add_edge_spec(node, dep_node, edge);
     }
 
     /// Specify a need on the proof artifacts of a dependency.
@@ -845,10 +847,7 @@ impl<'a> BuildPlanConstructor<'a> {
             self.add_edge_spec(
                 link_core_node,
                 dep_node,
-                FileDependencyKind::BuildCore {
-                    mi: false,
-                    core: true,
-                },
+                FileDependencyKind::Artifacts(PlanArtifactNeed::CoreIr),
             );
         }
 
@@ -1184,10 +1183,7 @@ impl<'a> BuildPlanConstructor<'a> {
             self.add_edge_spec(
                 _node,
                 build_node,
-                FileDependencyKind::BuildCore {
-                    mi: false,
-                    core: true,
-                },
+                FileDependencyKind::Artifacts(PlanArtifactNeed::CoreIr),
             );
 
             if pkg.is_virtual() {

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -24,7 +24,7 @@ use std::collections::HashSet;
 
 use crate::{
     ResolveOutput,
-    build_plan::{FileDependencyKind, InputDirective},
+    build_plan::{FileDependencyKind, InputDirective, PlanArtifactNeed},
     model::{BuildPlanNode, BuildTarget, PackageId},
     prebuild::PrebuildOutput,
     user_warning::UserWarning,
@@ -57,6 +57,64 @@ pub(super) struct BuildPlanConstructor<'a> {
     /// Only compiled in debug builds (cfg(debug_assertions)).
     #[cfg(debug_assertions)]
     pub(super) need_node_sources: HashMap<BuildPlanNode, Vec<(&'static str, u32, u32)>>,
+}
+
+fn merge_edge_kind(dst: &mut FileDependencyKind, src: FileDependencyKind) {
+    if matches!(src, FileDependencyKind::AllFiles) {
+        *dst = FileDependencyKind::AllFiles;
+        return;
+    }
+
+    match dst {
+        FileDependencyKind::AllFiles => {}
+        FileDependencyKind::Artifacts(dst_need) => {
+            let FileDependencyKind::Artifacts(need) = src else {
+                panic!(
+                    "Cannot merge incompatible edge kinds: {:?} and {:?}",
+                    dst, src
+                );
+            };
+            *dst_need = dst_need.union(need);
+        }
+        FileDependencyKind::ProofArtifacts {
+            mi: dst_mi,
+            mlw: dst_mlw,
+            report: dst_report,
+        } => {
+            let FileDependencyKind::ProofArtifacts { mi, mlw, report } = src else {
+                panic!(
+                    "Cannot merge incompatible edge kinds: {:?} and {:?}",
+                    dst, src
+                );
+            };
+            *dst_mi |= mi;
+            *dst_mlw |= mlw;
+            *dst_report |= report;
+        }
+        FileDependencyKind::GenerateTestInfo { meta: dst_meta } => {
+            let FileDependencyKind::GenerateTestInfo { meta } = src else {
+                panic!(
+                    "Cannot merge incompatible edge kinds: {:?} and {:?}",
+                    dst, src
+                );
+            };
+            *dst_meta |= meta;
+        }
+    }
+}
+
+fn edge_for_coalesced_check(edge: FileDependencyKind) -> FileDependencyKind {
+    match edge {
+        FileDependencyKind::AllFiles => FileDependencyKind::Artifacts(PlanArtifactNeed::Interface),
+        FileDependencyKind::Artifacts(need) => {
+            assert!(
+                need.is_subset_of(PlanArtifactNeed::Interface),
+                "Check only produces an interface artifact"
+            );
+            FileDependencyKind::Artifacts(need)
+        }
+        _ => panic!("Check edges can only request logical artifacts"),
+    }
 }
 
 impl<'a> BuildPlanConstructor<'a> {
@@ -137,56 +195,6 @@ impl<'a> BuildPlanConstructor<'a> {
     /// is also a fix for the virtual package semantics, because virtual
     /// packages don't know if they will be built or checked.
     fn postprocess_coalesce(&mut self) {
-        fn merge_edge_kind(dst: &mut FileDependencyKind, src: FileDependencyKind) {
-            if matches!(src, FileDependencyKind::AllFiles) {
-                *dst = FileDependencyKind::AllFiles;
-                return;
-            }
-
-            match dst {
-                FileDependencyKind::AllFiles => {
-                    *dst = FileDependencyKind::AllFiles;
-                }
-                FileDependencyKind::BuildCore {
-                    mi: dst_mi,
-                    core: dst_core,
-                } => {
-                    let FileDependencyKind::BuildCore { mi, core } = src else {
-                        panic!(
-                            "Cannot merge incompatible edge kinds: {:?} and {:?}",
-                            dst, src
-                        );
-                    };
-                    *dst_mi |= mi;
-                    *dst_core |= core;
-                }
-                FileDependencyKind::ProofArtifacts {
-                    mi: dst_mi,
-                    mlw: dst_mlw,
-                    report: dst_report,
-                } => {
-                    let FileDependencyKind::ProofArtifacts { mi, mlw, report } = src else {
-                        panic!(
-                            "Cannot merge incompatible edge kinds: {:?} and {:?}",
-                            dst, src
-                        );
-                    };
-                    *dst_mi |= mi;
-                    *dst_mlw |= mlw;
-                    *dst_report |= report;
-                }
-                FileDependencyKind::GenerateTestInfo { meta: dst_meta } => {
-                    let FileDependencyKind::GenerateTestInfo { meta } = src else {
-                        panic!(
-                            "Cannot merge incompatible edge kinds: {:?} and {:?}",
-                            dst, src
-                        );
-                    };
-                    *dst_meta |= meta;
-                }
-            }
-        }
-
         // list of nodes to coalesce and their input/output edges
         let mut plan = IndexMap::new();
         for node in self.res.all_nodes() {
@@ -225,6 +233,7 @@ impl<'a> BuildPlanConstructor<'a> {
             let to = *to;
             // Input edges
             for &(source, edge) in in_edges {
+                let edge = edge_for_coalesced_check(edge);
                 // Check if source is also coalesced
                 let source = if let Some((new_source, _, _)) = plan.get(&source) {
                     *new_source
@@ -404,9 +413,15 @@ impl<'a> BuildPlanConstructor<'a> {
     ) {
         // verify edge kind
         match (edge, end) {
-            (FileDependencyKind::BuildCore { .. }, BuildPlanNode::BuildCore(..)) => {}
-            (FileDependencyKind::BuildCore { .. }, _) => {
-                panic!("BuildCore edge can only point to BuildCore node")
+            (FileDependencyKind::Artifacts(need), BuildPlanNode::Check(..)) => {
+                assert!(
+                    need.is_subset_of(PlanArtifactNeed::Interface),
+                    "Check only produces an interface artifact"
+                );
+            }
+            (FileDependencyKind::Artifacts(_), BuildPlanNode::BuildCore(..)) => {}
+            (FileDependencyKind::Artifacts(_), _) => {
+                panic!("logical artifact edges can only point to Check or BuildCore nodes")
             }
             (
                 FileDependencyKind::ProofArtifacts { .. },
@@ -511,5 +526,40 @@ impl<'a> BuildPlanConstructor<'a> {
             self.warn_if_main_package_uses_blackbox_inputs(pkg, &regular_files);
         }
         self.res.build_target_infos.insert(target, info);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{edge_for_coalesced_check, merge_edge_kind};
+    use crate::build_plan::{FileDependencyKind, PlanArtifactNeed};
+
+    #[test]
+    fn coalesced_check_all_files_requests_build_core_interface() {
+        assert_eq!(
+            edge_for_coalesced_check(FileDependencyKind::AllFiles),
+            FileDependencyKind::Artifacts(PlanArtifactNeed::Interface)
+        );
+    }
+
+    #[test]
+    fn merging_logical_artifact_edges_unions_needs() {
+        let mut edge = FileDependencyKind::Artifacts(PlanArtifactNeed::Interface);
+
+        merge_edge_kind(
+            &mut edge,
+            FileDependencyKind::Artifacts(PlanArtifactNeed::CoreIr),
+        );
+
+        assert_eq!(
+            edge,
+            FileDependencyKind::Artifacts(PlanArtifactNeed::InterfaceAndCoreIr)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Check only produces an interface artifact")]
+    fn coalesced_check_rejects_core_ir_artifact_need() {
+        edge_for_coalesced_check(FileDependencyKind::Artifacts(PlanArtifactNeed::CoreIr));
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -115,23 +115,69 @@ pub struct BuildPlan {
     input_nodes: Vec<BuildPlanNode>,
 }
 
+/// Logical artifacts that can be requested from build-plan nodes.
+///
+/// These are planning-level package artifacts. Lowering remains responsible for
+/// mapping them to concrete paths.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PlanArtifactKind {
+    /// Package interface artifact, currently written as a `.mi` file.
+    Interface,
+    /// Compiler Core IR artifact, currently written as a `.core` file.
+    CoreIr,
+}
+
+/// The logical artifacts needed from a dependency node.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PlanArtifactNeed {
+    Interface,
+    CoreIr,
+    InterfaceAndCoreIr,
+}
+
+impl PlanArtifactNeed {
+    pub fn contains(self, kind: PlanArtifactKind) -> bool {
+        match self {
+            Self::Interface => matches!(kind, PlanArtifactKind::Interface),
+            Self::CoreIr => matches!(kind, PlanArtifactKind::CoreIr),
+            Self::InterfaceAndCoreIr => true,
+        }
+    }
+
+    pub fn is_subset_of(self, other: Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Interface, Self::Interface)
+                | (Self::CoreIr, Self::CoreIr)
+                | (_, Self::InterfaceAndCoreIr)
+        )
+    }
+
+    pub fn union(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Interface, Self::Interface) => Self::Interface,
+            (Self::CoreIr, Self::CoreIr) => Self::CoreIr,
+            _ => Self::InterfaceAndCoreIr,
+        }
+    }
+}
+
 /// Additional information about a build plan's edge
 ///
-/// # TODO
-///
-/// This is a temporary solution to determine which file is being depended on by
-/// the consumer node.
+/// `Artifacts` is the package-artifact selector shared by `Check` and
+/// `BuildCore`. Proof and test-info edges still keep node-specific selectors
+/// here.
 ///
 /// A more generic solution might be involving creating associated types for
 /// each node kind, specifying their output file list and order, and then
 /// use a bitmap or index list to specify which files are being depended on.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FileDependencyKind {
     /// Depending on all files available
     AllFiles,
 
-    /// Depending on specific files of a `BuildCore` node.
-    BuildCore { mi: bool, core: bool },
+    /// Depending on logical artifacts produced by a node.
+    Artifacts(PlanArtifactNeed),
 
     /// Depending on proof artifacts of an `EmitProof`/`Prove` node.
     ProofArtifacts { mi: bool, mlw: bool, report: bool },
@@ -288,6 +334,7 @@ pub struct LinkCoreInfo {
     // pub std: bool,
 }
 
+#[derive(Debug)]
 pub struct BuildCStubsInfo {
     /// The effective native toolchain for compiling the C stubs
     pub(crate) effective_native_toolchain: Toolchain,
@@ -298,6 +345,7 @@ pub struct BuildCStubsInfo {
     pub(crate) link_flags: Vec<String>,
 }
 
+#[derive(Debug)]
 pub struct MakeExecutableInfo {
     /// The effective native toolchain for this executable step
     pub(crate) effective_native_toolchain: Toolchain,
@@ -310,6 +358,7 @@ pub struct MakeExecutableInfo {
 }
 
 /// Resolved information about a prebuild command.
+#[derive(Debug)]
 pub struct PrebuildInfo {
     pub(crate) resolved_inputs: Vec<PathBuf>,
     pub(crate) resolved_outputs: Vec<PathBuf>,


### PR DESCRIPTION
## Why
PR #1754 fixed downstream rebuild behavior by tracking dependency `.core` inputs for build-package actions, but the build-plan edge selector still encoded that as a `BuildCore`-specific `mi/core` pair. That keeps planning terminology tied to one producer shape and makes the follow-up lowering boundary harder to review.

## What
- Introduce logical package artifact needs for interface and Core IR outputs.
- Replace `FileDependencyKind::BuildCore { mi, core }` with `FileDependencyKind::Artifacts(PlanArtifactNeed)`.
- Preserve the #1754 behavior: normal build dependencies request interface plus Core IR, while check-only paths request only the interface.
- Keep the existing lowerer path mapping in place for now.

## Why This Is Minimal
This PR only changes the build-plan edge vocabulary and the existing lowerer adapter needed to consume it. The `LoweringPlan` boundary and removal of planning internals from `build_lower` are intentionally left for a follow-up PR.