### PR TITLE
refactor(rr): add lowering plan boundary

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_action_plan/action.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/action.rs
@@ -1,0 +1,100 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use moonutil::mooncakes::ModuleId;
+
+use crate::{
+    build_plan::{
+        BuildCStubsInfo, BuildTargetInfo, LinkCoreInfo, MakeExecutableInfo, PrebuildInfo,
+    },
+    model::{BuildTarget, PackageId},
+};
+
+/// Opaque identifier for an action in a [`BuildActionPlan`](super::BuildActionPlan).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct BuildActionId(pub(crate) usize);
+
+/// A build action with all planning metadata needed by backend lowering.
+#[derive(Clone, Copy, Debug)]
+pub enum BuildAction<'a> {
+    Check {
+        target: BuildTarget,
+        info: &'a BuildTargetInfo,
+    },
+    EmitProof {
+        target: BuildTarget,
+        info: &'a BuildTargetInfo,
+    },
+    Prove {
+        target: BuildTarget,
+        info: &'a BuildTargetInfo,
+    },
+    BuildCore {
+        target: BuildTarget,
+        info: &'a BuildTargetInfo,
+    },
+    BuildCStub {
+        package: PackageId,
+        index: u32,
+        info: &'a BuildCStubsInfo,
+    },
+    ArchiveOrLinkCStubs {
+        package: PackageId,
+        info: &'a BuildCStubsInfo,
+    },
+    LinkCore {
+        target: BuildTarget,
+        info: &'a LinkCoreInfo,
+        make_executable_info: Option<&'a MakeExecutableInfo>,
+    },
+    MakeExecutable {
+        target: BuildTarget,
+        info: Option<&'a MakeExecutableInfo>,
+    },
+    GenerateTestInfo {
+        target: BuildTarget,
+        info: &'a BuildTargetInfo,
+    },
+    GenerateMbti {
+        target: BuildTarget,
+    },
+    BuildVirtual {
+        package: PackageId,
+    },
+    Bundle {
+        module: ModuleId,
+        targets: &'a [BuildTarget],
+    },
+    BuildRuntimeLib,
+    BuildDocs {
+        module: ModuleId,
+    },
+    RunPrebuild {
+        package: PackageId,
+        index: u32,
+        info: &'a PrebuildInfo,
+    },
+    RunMoonLexPrebuild {
+        package: PackageId,
+        index: u32,
+    },
+    RunMoonYaccPrebuild {
+        package: PackageId,
+        index: u32,
+    },
+}

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/artifact.rs
@@ -1,0 +1,133 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::path::PathBuf;
+
+use moonutil::mooncakes::ModuleId;
+
+use crate::model::{BuildTarget, PackageId};
+
+use super::BuildActionId;
+
+/// A logical artifact produced by a build action.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PlannedArtifact {
+    PackageInterface {
+        producer: BuildActionId,
+        target: BuildTarget,
+    },
+    PackageCoreIr {
+        producer: BuildActionId,
+        target: BuildTarget,
+    },
+    ProofInterface {
+        producer: BuildActionId,
+        target: BuildTarget,
+    },
+    ProofWhyml {
+        producer: BuildActionId,
+        target: BuildTarget,
+    },
+    ProofReport {
+        producer: BuildActionId,
+        target: BuildTarget,
+    },
+    CStubObject {
+        producer: BuildActionId,
+        package: PackageId,
+        index: u32,
+    },
+    CStubLibrary {
+        producer: BuildActionId,
+        package: PackageId,
+    },
+    LinkedCore {
+        producer: BuildActionId,
+        target: BuildTarget,
+    },
+    Executable {
+        producer: BuildActionId,
+        target: BuildTarget,
+    },
+    GeneratedTestDriver {
+        producer: BuildActionId,
+        target: BuildTarget,
+    },
+    GeneratedTestMetadata {
+        producer: BuildActionId,
+        target: BuildTarget,
+    },
+    BundleResult {
+        producer: BuildActionId,
+        module: ModuleId,
+    },
+    RuntimeLib {
+        producer: BuildActionId,
+    },
+    GeneratedMbti {
+        producer: BuildActionId,
+        target: BuildTarget,
+    },
+    DocsDir {
+        producer: BuildActionId,
+    },
+    VirtualPackageInterface {
+        producer: BuildActionId,
+        package: PackageId,
+    },
+    MoonLexGeneratedSource {
+        producer: BuildActionId,
+        package: PackageId,
+        index: u32,
+    },
+    MoonYaccGeneratedSource {
+        producer: BuildActionId,
+        package: PackageId,
+        index: u32,
+    },
+    KnownPath {
+        producer: BuildActionId,
+        path: PathBuf,
+    },
+}
+
+impl PlannedArtifact {
+    pub fn producer(&self) -> BuildActionId {
+        match self {
+            PlannedArtifact::PackageInterface { producer, .. }
+            | PlannedArtifact::PackageCoreIr { producer, .. }
+            | PlannedArtifact::ProofInterface { producer, .. }
+            | PlannedArtifact::ProofWhyml { producer, .. }
+            | PlannedArtifact::ProofReport { producer, .. }
+            | PlannedArtifact::CStubObject { producer, .. }
+            | PlannedArtifact::CStubLibrary { producer, .. }
+            | PlannedArtifact::LinkedCore { producer, .. }
+            | PlannedArtifact::Executable { producer, .. }
+            | PlannedArtifact::GeneratedTestDriver { producer, .. }
+            | PlannedArtifact::GeneratedTestMetadata { producer, .. }
+            | PlannedArtifact::BundleResult { producer, .. }
+            | PlannedArtifact::RuntimeLib { producer }
+            | PlannedArtifact::GeneratedMbti { producer, .. }
+            | PlannedArtifact::DocsDir { producer }
+            | PlannedArtifact::VirtualPackageInterface { producer, .. }
+            | PlannedArtifact::MoonLexGeneratedSource { producer, .. }
+            | PlannedArtifact::MoonYaccGeneratedSource { producer, .. }
+            | PlannedArtifact::KnownPath { producer, .. } => *producer,
+        }
+    }
+}

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/mod.rs
@@ -1,0 +1,30 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Action-level build plan consumed by backend lowering.
+
+mod action;
+mod artifact;
+mod view;
+
+#[cfg(test)]
+mod tests;
+
+pub use action::{BuildAction, BuildActionId};
+pub use artifact::PlannedArtifact;
+pub use view::BuildActionPlan;

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/tests.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/tests.rs
@@ -1,0 +1,293 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::path::PathBuf;
+
+use slotmap::KeyData;
+
+use crate::{
+    build_plan::{BuildPlan, BuildTargetInfo, FileDependencyKind, PlanArtifactNeed, PrebuildInfo},
+    model::{BuildPlanNode, PackageId, TargetKind},
+};
+
+use super::{BuildAction, PlannedArtifact};
+
+fn package_id(raw: u64) -> PackageId {
+    PackageId::from(KeyData::from_ffi(raw))
+}
+
+fn target_info() -> BuildTargetInfo {
+    BuildTargetInfo {
+        regular_files: Vec::new(),
+        mbtp_files: Vec::new(),
+        whitebox_files: Vec::new(),
+        doctest_files: Vec::new(),
+        warn_list: None,
+        specified_no_mi: false,
+        patch_file: None,
+        why3_config: None,
+        check_mi_against: None,
+        value_tracing: false,
+    }
+}
+
+#[test]
+fn check_exposes_package_interface() {
+    let package = package_id(1);
+    let target = package.build_target(TargetKind::Source);
+    let node = BuildPlanNode::Check(target);
+    let mut plan = BuildPlan::default();
+    plan.test_add_node(node);
+    plan.test_insert_build_target_info(target, target_info());
+
+    let action_plan = plan.build_action_plan();
+    let producer = action_plan.id_for_node(node);
+
+    assert_eq!(
+        action_plan.output_artifacts(producer),
+        vec![PlannedArtifact::PackageInterface { producer, target }]
+    );
+}
+
+#[test]
+fn build_core_exposes_core_and_interface_when_it_emits_mi() {
+    let package = package_id(1);
+    let target = package.build_target(TargetKind::Source);
+    let node = BuildPlanNode::BuildCore(target);
+    let mut plan = BuildPlan::default();
+    plan.test_add_node(node);
+    plan.test_insert_build_target_info(target, target_info());
+
+    let action_plan = plan.build_action_plan();
+    let producer = action_plan.id_for_node(node);
+
+    assert_eq!(
+        action_plan.output_artifacts(producer),
+        vec![
+            PlannedArtifact::PackageInterface { producer, target },
+            PlannedArtifact::PackageCoreIr { producer, target },
+        ]
+    );
+}
+
+#[test]
+fn build_core_omits_interface_when_mi_is_disabled() {
+    let package = package_id(1);
+    let target = package.build_target(TargetKind::Source);
+    let node = BuildPlanNode::BuildCore(target);
+    let mut plan = BuildPlan::default();
+    plan.test_add_node(node);
+    let mut info = target_info();
+    info.specified_no_mi = true;
+    plan.test_insert_build_target_info(target, info);
+
+    let action_plan = plan.build_action_plan();
+    let producer = action_plan.id_for_node(node);
+
+    assert_eq!(
+        action_plan.output_artifacts(producer),
+        vec![PlannedArtifact::PackageCoreIr { producer, target }]
+    );
+}
+
+#[test]
+fn make_executable_action_allows_non_native_alias_without_info() {
+    let target = package_id(1).build_target(TargetKind::Source);
+    let node = BuildPlanNode::MakeExecutable(target);
+    let mut plan = BuildPlan::default();
+    plan.test_add_node(node);
+
+    let action_plan = plan.build_action_plan();
+    let producer = action_plan.id_for_node(node);
+
+    assert!(matches!(
+        action_plan.action(producer),
+        BuildAction::MakeExecutable { target: actual, info: None } if actual == target
+    ));
+    assert_eq!(
+        action_plan.output_artifacts(producer),
+        vec![PlannedArtifact::Executable { producer, target }]
+    );
+}
+
+#[test]
+fn check_interface_dependency_uses_selected_check_producer() {
+    let dependency = package_id(1).build_target(TargetKind::Source);
+    let consumer = package_id(2).build_target(TargetKind::Source);
+    let dependency_node = BuildPlanNode::Check(dependency);
+    let consumer_node = BuildPlanNode::BuildCore(consumer);
+    let mut plan = BuildPlan::default();
+    plan.test_add_edge(
+        consumer_node,
+        dependency_node,
+        FileDependencyKind::Artifacts(PlanArtifactNeed::Interface),
+    );
+
+    let action_plan = plan.build_action_plan();
+    let consumer_id = action_plan.id_for_node(consumer_node);
+    let dependency_id = action_plan.id_for_node(dependency_node);
+
+    assert_eq!(
+        action_plan.dependency_artifacts(consumer_id),
+        vec![PlannedArtifact::PackageInterface {
+            producer: dependency_id,
+            target: dependency,
+        }]
+    );
+}
+
+#[test]
+fn build_core_dependency_can_track_interface_and_core_ir() {
+    let dependency = package_id(1).build_target(TargetKind::Source);
+    let consumer = package_id(2).build_target(TargetKind::Source);
+    let dependency_node = BuildPlanNode::BuildCore(dependency);
+    let consumer_node = BuildPlanNode::BuildCore(consumer);
+    let mut plan = BuildPlan::default();
+    plan.test_add_edge(
+        consumer_node,
+        dependency_node,
+        FileDependencyKind::Artifacts(PlanArtifactNeed::InterfaceAndCoreIr),
+    );
+    plan.test_insert_build_target_info(dependency, target_info());
+
+    let action_plan = plan.build_action_plan();
+    let consumer_id = action_plan.id_for_node(consumer_node);
+    let dependency_id = action_plan.id_for_node(dependency_node);
+
+    assert_eq!(
+        action_plan.dependency_artifacts(consumer_id),
+        vec![
+            PlannedArtifact::PackageInterface {
+                producer: dependency_id,
+                target: dependency,
+            },
+            PlannedArtifact::PackageCoreIr {
+                producer: dependency_id,
+                target: dependency,
+            },
+        ]
+    );
+}
+
+#[test]
+fn generate_test_info_dependency_can_select_driver_only() {
+    let test_target = package_id(1).build_target(TargetKind::WhiteboxTest);
+    let consumer = package_id(2).build_target(TargetKind::Source);
+    let test_info_node = BuildPlanNode::GenerateTestInfo(test_target);
+    let consumer_node = BuildPlanNode::BuildCore(consumer);
+    let mut plan = BuildPlan::default();
+    plan.test_add_edge(
+        consumer_node,
+        test_info_node,
+        FileDependencyKind::GenerateTestInfo { meta: false },
+    );
+
+    let action_plan = plan.build_action_plan();
+    let consumer_id = action_plan.id_for_node(consumer_node);
+    let producer = action_plan.id_for_node(test_info_node);
+
+    assert_eq!(
+        action_plan.dependency_artifacts(consumer_id),
+        vec![PlannedArtifact::GeneratedTestDriver {
+            producer,
+            target: test_target,
+        }]
+    );
+}
+
+#[test]
+fn generate_test_info_dependency_can_select_driver_and_metadata() {
+    let test_target = package_id(1).build_target(TargetKind::WhiteboxTest);
+    let consumer = package_id(2).build_target(TargetKind::Source);
+    let test_info_node = BuildPlanNode::GenerateTestInfo(test_target);
+    let consumer_node = BuildPlanNode::BuildCore(consumer);
+    let mut plan = BuildPlan::default();
+    plan.test_add_edge(
+        consumer_node,
+        test_info_node,
+        FileDependencyKind::GenerateTestInfo { meta: true },
+    );
+
+    let action_plan = plan.build_action_plan();
+    let consumer_id = action_plan.id_for_node(consumer_node);
+    let producer = action_plan.id_for_node(test_info_node);
+
+    assert_eq!(
+        action_plan.dependency_artifacts(consumer_id),
+        vec![
+            PlannedArtifact::GeneratedTestDriver {
+                producer,
+                target: test_target,
+            },
+            PlannedArtifact::GeneratedTestMetadata {
+                producer,
+                target: test_target,
+            },
+        ]
+    );
+}
+
+#[test]
+fn run_prebuild_exposes_resolved_outputs_as_known_paths() {
+    let package = package_id(1);
+    let node = BuildPlanNode::RunPrebuild(package, 0);
+    let output = PathBuf::from("generated/out.mbt");
+    let mut plan = BuildPlan::default();
+    plan.test_add_node(node);
+    plan.test_insert_prebuild_info(
+        package,
+        vec![Some(PrebuildInfo {
+            resolved_inputs: Vec::new(),
+            resolved_outputs: vec![output.clone()],
+            command: "generate".to_string(),
+        })],
+    );
+
+    let action_plan = plan.build_action_plan();
+    let producer = action_plan.id_for_node(node);
+
+    assert_eq!(
+        action_plan.output_artifacts(producer),
+        vec![PlannedArtifact::KnownPath {
+            producer,
+            path: output,
+        }]
+    );
+}
+
+#[test]
+fn c_stub_archive_dependency_exposes_object_inputs() {
+    let package = package_id(1);
+    let archive_node = BuildPlanNode::ArchiveOrLinkCStubs(package);
+    let object_node = BuildPlanNode::BuildCStub(package, 0);
+    let mut plan = BuildPlan::default();
+    plan.test_add_edge(archive_node, object_node, FileDependencyKind::AllFiles);
+
+    let action_plan = plan.build_action_plan();
+    let archive_id = action_plan.id_for_node(archive_node);
+    let object_id = action_plan.id_for_node(object_node);
+
+    assert_eq!(
+        action_plan.dependency_artifacts(archive_id),
+        vec![PlannedArtifact::CStubObject {
+            producer: object_id,
+            package,
+            index: 0,
+        }]
+    );
+}

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/view.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/view.rs
@@ -1,0 +1,452 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::collections::HashMap;
+
+use moonutil::mooncakes::result::ResolvedEnv;
+
+use crate::{
+    build_plan::{BuildPlan, FileDependencyKind, PlanArtifactKind},
+    discover::DiscoverResult,
+    model::{BuildPlanNode, BuildTarget},
+};
+
+use super::{BuildAction, BuildActionId, PlannedArtifact};
+
+/// Normalized action-level view consumed by backend lowering.
+pub struct BuildActionPlan<'a> {
+    plan: &'a BuildPlan,
+    action_nodes: Vec<BuildPlanNode>,
+    action_ids_by_node: HashMap<BuildPlanNode, BuildActionId>,
+    input_actions: Vec<BuildActionId>,
+}
+
+impl BuildPlan {
+    pub fn build_action_plan(&self) -> BuildActionPlan<'_> {
+        let action_nodes = self.all_nodes().collect::<Vec<_>>();
+        let action_ids_by_node = action_nodes
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(idx, node)| (node, BuildActionId(idx)))
+            .collect::<HashMap<_, _>>();
+        let input_actions = self
+            .input_nodes()
+            .iter()
+            .map(|node| {
+                *action_ids_by_node
+                    .get(node)
+                    .expect("input node should be present in build action plan")
+            })
+            .collect();
+        BuildActionPlan {
+            plan: self,
+            action_nodes,
+            action_ids_by_node,
+            input_actions,
+        }
+    }
+}
+
+impl<'a> BuildActionPlan<'a> {
+    pub fn action_ids(&self) -> impl Iterator<Item = BuildActionId> + '_ {
+        (0..self.action_nodes.len()).map(BuildActionId)
+    }
+
+    pub fn input_action_ids(&self) -> &[BuildActionId] {
+        &self.input_actions
+    }
+
+    pub fn action(&self, id: BuildActionId) -> BuildAction<'a> {
+        let node = self.node(id);
+        match node {
+            BuildPlanNode::Check(target) => BuildAction::Check {
+                target,
+                info: self
+                    .plan
+                    .get_build_target_info(&target)
+                    .expect("Build target info should be present for Check nodes"),
+            },
+            BuildPlanNode::EmitProof(target) => BuildAction::EmitProof {
+                target,
+                info: self
+                    .plan
+                    .get_build_target_info(&target)
+                    .expect("Build target info should be present for EmitProof nodes"),
+            },
+            BuildPlanNode::Prove(target) => BuildAction::Prove {
+                target,
+                info: self
+                    .plan
+                    .get_build_target_info(&target)
+                    .expect("Build target info should be present for Prove nodes"),
+            },
+            BuildPlanNode::BuildCore(target) => BuildAction::BuildCore {
+                target,
+                info: self
+                    .plan
+                    .get_build_target_info(&target)
+                    .expect("Build target info should be present for BuildCore nodes"),
+            },
+            BuildPlanNode::BuildCStub(package, index) => BuildAction::BuildCStub {
+                package,
+                index,
+                info: self
+                    .plan
+                    .get_c_stubs_info(package)
+                    .expect("C stub info should be present for BuildCStub nodes"),
+            },
+            BuildPlanNode::ArchiveOrLinkCStubs(package) => BuildAction::ArchiveOrLinkCStubs {
+                package,
+                info: self
+                    .plan
+                    .get_c_stubs_info(package)
+                    .expect("C stubs info should be present for BuildCStubs nodes"),
+            },
+            BuildPlanNode::LinkCore(target) => BuildAction::LinkCore {
+                target,
+                info: self
+                    .plan
+                    .get_link_core_info(&target)
+                    .expect("Link core info should be present for LinkCore nodes"),
+                make_executable_info: self.plan.get_make_executable_info(&target),
+            },
+            BuildPlanNode::MakeExecutable(target) => BuildAction::MakeExecutable {
+                target,
+                info: self.plan.get_make_executable_info(&target),
+            },
+            BuildPlanNode::GenerateTestInfo(target) => BuildAction::GenerateTestInfo {
+                target,
+                info: self
+                    .plan
+                    .get_build_target_info(&target)
+                    .expect("Build target info should be present for GenerateTestInfo nodes"),
+            },
+            BuildPlanNode::GenerateMbti(target) => BuildAction::GenerateMbti { target },
+            BuildPlanNode::BuildVirtual(package) => BuildAction::BuildVirtual { package },
+            BuildPlanNode::Bundle(module) => BuildAction::Bundle {
+                module,
+                targets: &self
+                    .plan
+                    .bundle_info(module)
+                    .expect("Bundle info should be present when lowering bundle node")
+                    .bundle_targets,
+            },
+            BuildPlanNode::BuildRuntimeLib => BuildAction::BuildRuntimeLib,
+            BuildPlanNode::BuildDocs(module) => BuildAction::BuildDocs { module },
+            BuildPlanNode::RunPrebuild(package, index) => BuildAction::RunPrebuild {
+                package,
+                index,
+                info: self
+                    .plan
+                    .get_prebuild_info(package, index)
+                    .expect("Prebuild info should be populated before lowering run prebuild"),
+            },
+            BuildPlanNode::RunMoonLexPrebuild(package, index) => {
+                BuildAction::RunMoonLexPrebuild { package, index }
+            }
+            BuildPlanNode::RunMoonYaccPrebuild(package, index) => {
+                BuildAction::RunMoonYaccPrebuild { package, index }
+            }
+        }
+    }
+
+    pub fn dependency_artifacts(&self, id: BuildActionId) -> Vec<PlannedArtifact> {
+        self.plan
+            .dependency_edges(self.node(id))
+            .flat_map(|(node, kind)| self.artifacts_for_edge(node, kind))
+            .collect()
+    }
+
+    pub fn output_artifacts(&self, id: BuildActionId) -> Vec<PlannedArtifact> {
+        self.output_artifacts_for_node(self.node(id))
+    }
+
+    pub fn fileloc(
+        &self,
+        id: BuildActionId,
+        modules: &ResolvedEnv,
+        packages: &DiscoverResult,
+    ) -> String {
+        self.node(id).string_id(modules, packages)
+    }
+
+    pub fn human_desc(
+        &self,
+        id: BuildActionId,
+        modules: &ResolvedEnv,
+        packages: &DiscoverResult,
+    ) -> String {
+        self.node(id).human_desc(modules, packages)
+    }
+
+    pub fn package_for_error(&self, id: BuildActionId) -> Option<BuildTarget> {
+        self.node(id).extract_target()
+    }
+
+    pub fn can_dirty_on_output(&self, id: BuildActionId) -> bool {
+        matches!(
+            self.node(id),
+            BuildPlanNode::Check(_) | BuildPlanNode::EmitProof(_) | BuildPlanNode::Prove(_)
+        )
+    }
+
+    pub fn needs_moonc_tool_dep(&self, id: BuildActionId) -> bool {
+        matches!(
+            self.node(id),
+            BuildPlanNode::Check(_)
+                | BuildPlanNode::EmitProof(_)
+                | BuildPlanNode::Prove(_)
+                | BuildPlanNode::BuildCore(_)
+                | BuildPlanNode::LinkCore(_)
+                | BuildPlanNode::BuildVirtual(_)
+                | BuildPlanNode::Bundle(_)
+        )
+    }
+
+    pub fn build_plan_node(&self, id: BuildActionId) -> BuildPlanNode {
+        self.node(id)
+    }
+
+    pub(super) fn id_for_node(&self, node: BuildPlanNode) -> BuildActionId {
+        *self
+            .action_ids_by_node
+            .get(&node)
+            .expect("node should be present in build action plan")
+    }
+
+    fn node(&self, id: BuildActionId) -> BuildPlanNode {
+        self.action_nodes[id.0]
+    }
+
+    fn artifacts_for_edge(
+        &self,
+        node: BuildPlanNode,
+        kind: FileDependencyKind,
+    ) -> Vec<PlannedArtifact> {
+        match kind {
+            FileDependencyKind::AllFiles => self.output_artifacts_for_node(node),
+            FileDependencyKind::Artifacts(need) => {
+                let mut artifacts = Vec::new();
+                if need.contains(PlanArtifactKind::Interface) {
+                    self.push_package_interface(node, &mut artifacts);
+                }
+                if need.contains(PlanArtifactKind::CoreIr) {
+                    self.push_package_core_ir(node, &mut artifacts);
+                }
+                artifacts
+            }
+            FileDependencyKind::ProofArtifacts { mi, mlw, report } => {
+                let mut artifacts = Vec::new();
+                if mi {
+                    self.push_proof_interface(node, &mut artifacts);
+                }
+                if mlw {
+                    self.push_proof_whyml(node, &mut artifacts);
+                }
+                if report {
+                    self.push_proof_report(node, &mut artifacts);
+                }
+                artifacts
+            }
+            FileDependencyKind::GenerateTestInfo { meta } => {
+                let mut artifacts = Vec::new();
+                self.push_generated_test_driver(node, &mut artifacts);
+                if meta {
+                    self.push_generated_test_metadata(node, &mut artifacts);
+                }
+                artifacts
+            }
+        }
+    }
+
+    fn output_artifacts_for_node(&self, node: BuildPlanNode) -> Vec<PlannedArtifact> {
+        let producer = self.id_for_node(node);
+        match node {
+            BuildPlanNode::Check(target) => {
+                vec![PlannedArtifact::PackageInterface { producer, target }]
+            }
+            BuildPlanNode::EmitProof(target) => vec![
+                PlannedArtifact::ProofInterface { producer, target },
+                PlannedArtifact::ProofWhyml { producer, target },
+            ],
+            BuildPlanNode::Prove(target) => vec![
+                PlannedArtifact::ProofInterface { producer, target },
+                PlannedArtifact::ProofWhyml { producer, target },
+                PlannedArtifact::ProofReport { producer, target },
+            ],
+            BuildPlanNode::BuildCore(target) => {
+                let mut artifacts = Vec::new();
+                self.push_build_core_interface_if_emitted(target, producer, &mut artifacts);
+                artifacts.push(PlannedArtifact::PackageCoreIr { producer, target });
+                artifacts
+            }
+            BuildPlanNode::BuildCStub(package, index) => {
+                vec![PlannedArtifact::CStubObject {
+                    producer,
+                    package,
+                    index,
+                }]
+            }
+            BuildPlanNode::ArchiveOrLinkCStubs(package) => {
+                vec![PlannedArtifact::CStubLibrary { producer, package }]
+            }
+            BuildPlanNode::LinkCore(target) => {
+                vec![PlannedArtifact::LinkedCore { producer, target }]
+            }
+            BuildPlanNode::MakeExecutable(target) => {
+                vec![PlannedArtifact::Executable { producer, target }]
+            }
+            BuildPlanNode::GenerateTestInfo(target) => vec![
+                PlannedArtifact::GeneratedTestDriver { producer, target },
+                PlannedArtifact::GeneratedTestMetadata { producer, target },
+            ],
+            BuildPlanNode::Bundle(module) => {
+                vec![PlannedArtifact::BundleResult { producer, module }]
+            }
+            BuildPlanNode::BuildRuntimeLib => vec![PlannedArtifact::RuntimeLib { producer }],
+            BuildPlanNode::GenerateMbti(target) => {
+                vec![PlannedArtifact::GeneratedMbti { producer, target }]
+            }
+            BuildPlanNode::BuildDocs(_) => vec![PlannedArtifact::DocsDir { producer }],
+            BuildPlanNode::RunPrebuild(package, index) => self
+                .plan
+                .get_prebuild_info(package, index)
+                .expect("Prebuild info should be populated before lowering run prebuild")
+                .resolved_outputs
+                .iter()
+                .cloned()
+                .map(|path| PlannedArtifact::KnownPath { producer, path })
+                .collect(),
+            BuildPlanNode::BuildVirtual(package) => {
+                vec![PlannedArtifact::VirtualPackageInterface { producer, package }]
+            }
+            BuildPlanNode::RunMoonLexPrebuild(package, index) => {
+                vec![PlannedArtifact::MoonLexGeneratedSource {
+                    producer,
+                    package,
+                    index,
+                }]
+            }
+            BuildPlanNode::RunMoonYaccPrebuild(package, index) => {
+                vec![PlannedArtifact::MoonYaccGeneratedSource {
+                    producer,
+                    package,
+                    index,
+                }]
+            }
+        }
+    }
+
+    fn push_package_interface(&self, node: BuildPlanNode, artifacts: &mut Vec<PlannedArtifact>) {
+        let producer = self.id_for_node(node);
+        match node {
+            BuildPlanNode::Check(target) => {
+                artifacts.push(PlannedArtifact::PackageInterface { producer, target });
+            }
+            BuildPlanNode::BuildCore(target) => {
+                self.push_build_core_interface_if_emitted(target, producer, artifacts);
+            }
+            _ => panic!("Package interface artifact requested from non-package producer"),
+        }
+    }
+
+    fn push_package_core_ir(&self, node: BuildPlanNode, artifacts: &mut Vec<PlannedArtifact>) {
+        let producer = self.id_for_node(node);
+        match node {
+            BuildPlanNode::BuildCore(target) => {
+                artifacts.push(PlannedArtifact::PackageCoreIr { producer, target });
+            }
+            _ => panic!("Core IR artifact requested from non-BuildCore producer"),
+        }
+    }
+
+    fn push_build_core_interface_if_emitted(
+        &self,
+        target: BuildTarget,
+        producer: BuildActionId,
+        artifacts: &mut Vec<PlannedArtifact>,
+    ) {
+        let info = self
+            .plan
+            .get_build_target_info(&target)
+            .expect("Build target info should be present for BuildCore nodes");
+        if info.check_mi_against.is_none() && !info.no_mi() && !target.kind.is_test() {
+            artifacts.push(PlannedArtifact::PackageInterface { producer, target });
+        }
+    }
+
+    fn push_proof_interface(&self, node: BuildPlanNode, artifacts: &mut Vec<PlannedArtifact>) {
+        let producer = self.id_for_node(node);
+        match node {
+            BuildPlanNode::EmitProof(target) | BuildPlanNode::Prove(target) => {
+                artifacts.push(PlannedArtifact::ProofInterface { producer, target });
+            }
+            _ => panic!("Proof interface artifact requested from non-proof producer"),
+        }
+    }
+
+    fn push_proof_whyml(&self, node: BuildPlanNode, artifacts: &mut Vec<PlannedArtifact>) {
+        let producer = self.id_for_node(node);
+        match node {
+            BuildPlanNode::EmitProof(target) | BuildPlanNode::Prove(target) => {
+                artifacts.push(PlannedArtifact::ProofWhyml { producer, target });
+            }
+            _ => panic!("Proof WhyML artifact requested from non-proof producer"),
+        }
+    }
+
+    fn push_proof_report(&self, node: BuildPlanNode, artifacts: &mut Vec<PlannedArtifact>) {
+        let producer = self.id_for_node(node);
+        match node {
+            BuildPlanNode::Prove(target) => {
+                artifacts.push(PlannedArtifact::ProofReport { producer, target });
+            }
+            BuildPlanNode::EmitProof(_) => {}
+            _ => panic!("Proof report artifact requested from non-proof producer"),
+        }
+    }
+
+    fn push_generated_test_driver(
+        &self,
+        node: BuildPlanNode,
+        artifacts: &mut Vec<PlannedArtifact>,
+    ) {
+        let producer = self.id_for_node(node);
+        match node {
+            BuildPlanNode::GenerateTestInfo(target) => {
+                artifacts.push(PlannedArtifact::GeneratedTestDriver { producer, target });
+            }
+            _ => panic!("Test driver artifact requested from non-test-info producer"),
+        }
+    }
+
+    fn push_generated_test_metadata(
+        &self,
+        node: BuildPlanNode,
+        artifacts: &mut Vec<PlannedArtifact>,
+    ) {
+        let producer = self.id_for_node(node);
+        match node {
+            BuildPlanNode::GenerateTestInfo(target) => {
+                artifacts.push(PlannedArtifact::GeneratedTestMetadata { producer, target });
+            }
+            _ => panic!("Test metadata artifact requested from non-test-info producer"),
+        }
+    }
+}

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Build plan lowering context and core implementation.
+//! Lowering context and core implementation.
 
 use std::path::PathBuf;
 
@@ -27,10 +27,10 @@ use tracing::{Level, instrument};
 
 use crate::{
     ResolveOutput,
+    build_action_plan::{BuildAction, BuildActionId, BuildActionPlan, PlannedArtifact},
     build_lower::artifact::LegacyLayout,
-    build_plan::{BuildPlan, FileDependencyKind, PlanArtifactKind},
     discover::{DiscoverResult, DiscoveredPackage},
-    model::{BuildPlanNode, BuildTarget},
+    model::BuildTarget,
     pkg_solve::DepRelationship,
 };
 use moonutil::BINARIES;
@@ -40,7 +40,7 @@ use super::{
     utils::{build_ins, build_n2_fileloc, build_outs},
 };
 
-pub(crate) struct BuildPlanLowerContext<'a> {
+pub(crate) struct LoweringContext<'a> {
     // What we're building
     pub(crate) graph: N2Graph,
 
@@ -54,15 +54,15 @@ pub(crate) struct BuildPlanLowerContext<'a> {
     pub(crate) modules: &'a ResolvedEnv,
     pub(crate) module_dirs: &'a DirSyncResult,
     pub(crate) rel: &'a DepRelationship,
-    pub(crate) build_plan: &'a BuildPlan,
+    pub(crate) plan: &'a BuildActionPlan<'a>,
     pub(crate) opt: &'a BuildOptions,
 }
 
-impl<'a> BuildPlanLowerContext<'a> {
+impl<'a> LoweringContext<'a> {
     pub(super) fn new(
         layout: LegacyLayout,
         resolve_output: &'a ResolveOutput,
-        build_plan: &'a BuildPlan,
+        plan: &'a BuildActionPlan<'a>,
         opt: &'a BuildOptions,
     ) -> Self {
         Self {
@@ -73,14 +73,15 @@ impl<'a> BuildPlanLowerContext<'a> {
             modules: &resolve_output.module_rel,
             packages: &resolve_output.pkg_dirs,
             module_dirs: &resolve_output.module_dirs,
-            build_plan,
+            plan,
             opt,
         }
     }
 
-    /// Some nodes are no-op in n2 build graph. Early bailing.
-    fn is_node_noop(&self, node: BuildPlanNode) -> bool {
-        (!self.opt.target_backend.is_native()) && matches!(node, BuildPlanNode::MakeExecutable(_))
+    /// Some actions are no-op in n2 build graph. Early bailing.
+    fn is_action_noop(&self, action: BuildAction<'_>) -> bool {
+        (!self.opt.target_backend.is_native())
+            && matches!(action, BuildAction::MakeExecutable { .. })
     }
 
     pub(super) fn get_package(&self, target: BuildTarget) -> &DiscoveredPackage {
@@ -88,86 +89,55 @@ impl<'a> BuildPlanLowerContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self))]
-    pub(super) fn lower_node(&mut self, node: BuildPlanNode) -> Result<(), LoweringError> {
-        if self.is_node_noop(node) {
+    pub(super) fn lower_action(&mut self, id: BuildActionId) -> Result<(), LoweringError> {
+        let action = self.plan.action(id);
+        if self.is_action_noop(action) {
             return Ok(());
         }
 
         // Lower the action to its commands. This step should be infallible.
-        let cmd = match node {
-            BuildPlanNode::Check(target) => {
-                let info = self
-                    .build_plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for Check nodes");
-                self.lower_check(node, target, info)
+        let cmd = match action {
+            BuildAction::Check { target, info } => self.lower_check(target, info),
+            BuildAction::EmitProof { target, info } => self.lower_emit_proof(target, info),
+            BuildAction::Prove { target, info } => self.lower_prove(target, info),
+            BuildAction::BuildCore { target, info } => self.lower_build_mbt(target, info),
+            BuildAction::BuildCStub {
+                package,
+                index,
+                info,
+            } => self.lower_build_c_stub(package, index, info),
+            BuildAction::ArchiveOrLinkCStubs { package, info } => {
+                self.lower_archive_or_link_c_stubs(id, package, info)
             }
-            BuildPlanNode::EmitProof(target) => {
-                let info = self
-                    .build_plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for EmitProof nodes");
-                self.lower_emit_proof(node, target, info)
+            BuildAction::LinkCore {
+                target,
+                info,
+                make_executable_info,
+            } => self.lower_link_core(target, info, make_executable_info),
+            BuildAction::MakeExecutable {
+                target,
+                info: Some(info),
+            } => self.lower_make_exe(id, target, info),
+            BuildAction::MakeExecutable { info: None, .. } => {
+                panic!("native MakeExecutable actions should have executable info")
             }
-            BuildPlanNode::Prove(target) => {
-                let info = self
-                    .build_plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for Prove nodes");
-                self.lower_prove(node, target, info)
+            BuildAction::GenerateTestInfo { target, info } => {
+                self.lower_gen_test_driver(target, info)
             }
-            BuildPlanNode::BuildCore(target) => {
-                let info = self
-                    .build_plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for BuildCore nodes");
-                self.lower_build_mbt(node, target, info)
-            }
-            BuildPlanNode::BuildCStub(target, index) => {
-                let info = self
-                    .build_plan
-                    .get_c_stubs_info(target)
-                    .expect("C stub info should be present for BuildCStub nodes");
-                self.lower_build_c_stub(target, index, info)
-            }
-            BuildPlanNode::ArchiveOrLinkCStubs(_target) => {
-                let info = self
-                    .build_plan
-                    .get_c_stubs_info(_target)
-                    .expect("C stubs info should be present for BuildCStubs nodes");
-                self.lower_archive_or_link_c_stubs(node, _target, info)
-            }
-            BuildPlanNode::LinkCore(target) => {
-                let info = self
-                    .build_plan
-                    .get_link_core_info(&target)
-                    .expect("Link core info should be present for LinkCore nodes");
-                self.lower_link_core(node, target, info)
-            }
-            BuildPlanNode::MakeExecutable(target) => {
-                let info = self
-                    .build_plan
-                    .get_make_executable_info(&target)
-                    .expect("Make executable info should be present for MakeExecutable nodes");
-                self.lower_make_exe(target, info)
-            }
-            BuildPlanNode::GenerateMbti(target) => self.lower_generate_mbti(target),
-            BuildPlanNode::BuildVirtual(target) => self.lower_parse_mbti(node, target),
-            BuildPlanNode::Bundle(module_id) => self.lower_bundle(node, module_id),
-            BuildPlanNode::GenerateTestInfo(target) => {
-                let info = self
-                    .build_plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for GenerateTestInfo nodes");
-                self.lower_gen_test_driver(node, target, info)
-            }
-            BuildPlanNode::BuildRuntimeLib => self
+            BuildAction::GenerateMbti { target } => self.lower_generate_mbti(target),
+            BuildAction::BuildVirtual { package } => self.lower_parse_mbti(package),
+            BuildAction::Bundle { module, targets } => self.lower_bundle(module, targets),
+            BuildAction::BuildRuntimeLib => self
                 .lower_compile_runtime()
                 .map_err(LoweringError::RuntimeNativeToolchain)?,
-            BuildPlanNode::BuildDocs(module_id) => self.lower_build_docs(module_id),
-            BuildPlanNode::RunPrebuild(pkg, idx) => self.lower_run_prebuild(pkg, idx),
-            BuildPlanNode::RunMoonLexPrebuild(pkg, idx) => self.lower_moon_lex_prebuild(pkg, idx),
-            BuildPlanNode::RunMoonYaccPrebuild(pkg, idx) => self.lower_moon_yacc_prebuild(pkg, idx),
+            BuildAction::BuildDocs { module } => self.lower_build_docs(module),
+            BuildAction::RunPrebuild { info, .. } => self.lower_run_prebuild(info),
+            BuildAction::RunMoonLexPrebuild { package, index } => {
+                self.lower_moon_lex_prebuild(package, index)
+            }
+            BuildAction::RunMoonYaccPrebuild { package, index } => {
+                self.lower_moon_yacc_prebuild(package, index)
+            }
         };
 
         // Collect n2 inputs and outputs.
@@ -177,19 +147,23 @@ impl<'a> BuildPlanLowerContext<'a> {
         // not a performance concern, but if you have found a way to optimize
         // this, or if you are duplicating a lot of code for it, please refactor.
         let mut ins = vec![];
-        for (n, edge) in self.build_plan.dependency_edges(node) {
-            self.append_artifact_of(n, edge, &mut ins);
+        for artifact in self.plan.dependency_artifacts(id) {
+            self.append_planned_artifact(&artifact, &mut ins);
         }
         ins.extend(cmd.extra_inputs);
         // Track tool binary dependencies so that n2 detects when compilers
         // or other toolchain binaries change (e.g. after a toolchain update)
         // and triggers a rebuild.
-        ins.extend(Self::tool_deps_of(node));
+        if self.plan.needs_moonc_tool_dep(id) {
+            ins.push(BINARIES.moonc.clone());
+        }
         ins.sort(); // make sure the order is deterministic
         let ins = build_ins(&mut self.graph, ins);
 
         let mut output_paths = vec![];
-        self.append_all_artifacts_of(node, &mut output_paths);
+        for artifact in self.plan.output_artifacts(id) {
+            self.append_planned_artifact(&artifact, &mut output_paths);
+        }
         if let Commandline::Args(args) = &cmd.commandline {
             for output_path in &output_paths {
                 self.command_args_by_output
@@ -199,75 +173,203 @@ impl<'a> BuildPlanLowerContext<'a> {
         let outs = build_outs(&mut self.graph, output_paths);
 
         // Construct n2 build node
-        let fqn = node
-            .extract_target()
+        let fqn = self
+            .plan
+            .package_for_error(id)
             .map(|x| self.get_package(x).fqn.clone());
         let mut build = Build::new(
-            build_n2_fileloc(node.string_id(self.modules, self.packages)),
+            build_n2_fileloc(self.plan.fileloc(id, self.modules, self.packages)),
             ins,
             outs,
         );
         build.cmdline = Some(cmd.commandline.to_n2_string());
-        build.desc = Some(node.human_desc(self.modules, self.packages));
+        build.desc = Some(self.plan.human_desc(id, self.modules, self.packages));
         // n2 can't capture and replay command outputs. this is a workaround to
         // avoid losing warnings from `moonc`. According to legacy code, this
         // only triggers for `Check` nodes.
         //
         // FIXME: Revisit for other `moonc` invocations, e.g. `BuildCore`.
-        build.can_dirty_on_output = matches!(
-            node,
-            BuildPlanNode::Check(_) | BuildPlanNode::EmitProof(_) | BuildPlanNode::Prove(_)
-        );
+        build.can_dirty_on_output = self.plan.can_dirty_on_output(id);
 
-        self.debug_print_command_and_files(node, &build);
+        self.debug_print_command_and_files(id, &build);
         self.lowered(build).map_err(|e| LoweringError::N2 {
             package: fqn.into(),
-            node,
+            action: id,
             source: e,
         })
     }
 
-    /// Returns the tool binary paths that should be tracked as input
-    /// dependencies for the given build node. When any of these binaries
-    /// change (e.g. after a toolchain update), n2 will re-execute the
-    /// corresponding build step.
-    ///
-    /// Only absolute paths are returned, since relative/bare names (from PATH
-    /// fallback) cannot be meaningfully tracked by n2's timestamp-based
-    /// invalidation.
-    fn tool_deps_of(node: BuildPlanNode) -> Vec<PathBuf> {
-        let dominated_by_moonc = matches!(
-            node,
-            BuildPlanNode::Check(_)
-                | BuildPlanNode::EmitProof(_)
-                | BuildPlanNode::Prove(_)
-                | BuildPlanNode::BuildCore(_)
-                | BuildPlanNode::LinkCore(_)
-                | BuildPlanNode::BuildVirtual(_)
-                | BuildPlanNode::Bundle(_)
-        );
-        if dominated_by_moonc {
-            vec![BINARIES.moonc.clone()]
-        } else {
-            vec![]
+    /// Append the concrete path(s) corresponding to a planned artifact.
+    #[instrument(level = Level::DEBUG, skip(self, out))]
+    pub(super) fn append_planned_artifact(
+        &self,
+        artifact: &PlannedArtifact,
+        out: &mut Vec<PathBuf>,
+    ) {
+        match artifact {
+            PlannedArtifact::PackageInterface { producer, target } => {
+                self.append_package_interface(*producer, *target, out);
+            }
+            PlannedArtifact::PackageCoreIr { target, .. } => {
+                out.push(self.layout.core_of_build_target(
+                    self.packages,
+                    target,
+                    self.opt.target_backend.into(),
+                ));
+            }
+            PlannedArtifact::ProofInterface { producer, target } => {
+                match self.plan.action(*producer) {
+                    BuildAction::EmitProof { .. } => {
+                        out.push(self.layout.emit_proof_mi_path(self.packages, target));
+                    }
+                    BuildAction::Prove { .. } => {
+                        out.push(self.layout.prove_mi_path(self.packages, target));
+                    }
+                    _ => panic!("proof interface producer should be a proof action"),
+                }
+            }
+            PlannedArtifact::ProofWhyml { producer, target } => match self.plan.action(*producer) {
+                BuildAction::EmitProof { .. } => {
+                    out.push(self.layout.emit_proof_whyml_path(self.packages, target));
+                }
+                BuildAction::Prove { .. } => {
+                    out.push(self.layout.prove_whyml_path(self.packages, target));
+                }
+                _ => panic!("proof whyml producer should be a proof action"),
+            },
+            PlannedArtifact::ProofReport { target, .. } => {
+                out.push(self.layout.prove_report_path(self.packages, target));
+            }
+            PlannedArtifact::CStubObject { package, index, .. } => {
+                let pkg = self.packages.get_package(*package);
+                let file_name = &pkg.c_stub_files[*index as usize];
+                out.push(
+                    self.layout.c_stub_object_path(
+                        self.packages,
+                        *package,
+                        file_name
+                            .file_stem()
+                            .expect("c stub file should have a file name"),
+                        self.opt.target_backend.into(),
+                        self.opt.os,
+                    ),
+                );
+            }
+            PlannedArtifact::CStubLibrary { package, .. } => {
+                if self.opt.use_tcc_run() {
+                    out.push(self.layout.c_stub_link_dylib_path(
+                        self.packages,
+                        *package,
+                        self.opt.target_backend.into(),
+                        self.opt.os,
+                    ));
+                } else {
+                    out.push(self.layout.c_stub_archive_path(
+                        self.packages,
+                        *package,
+                        self.opt.target_backend.into(),
+                        self.opt.os,
+                    ));
+                }
+            }
+            PlannedArtifact::LinkedCore { target, .. } => {
+                out.push(self.layout.linked_core_of_build_target(
+                    self.packages,
+                    target,
+                    self.opt.target_backend.into(),
+                    self.opt.native_target,
+                    self.opt.os,
+                    self.opt.output_wat,
+                ));
+            }
+            PlannedArtifact::Executable { target, .. } => {
+                out.push(self.layout.executable_of_build_target(
+                    self.packages,
+                    target,
+                    self.opt.executable_artifact(true),
+                ))
+            }
+            PlannedArtifact::GeneratedTestDriver { target, .. } => {
+                out.push(self.layout.generated_test_driver(
+                    self.packages,
+                    target,
+                    self.opt.target_backend.into(),
+                ));
+            }
+            PlannedArtifact::GeneratedTestMetadata { target, .. } => {
+                out.push(self.layout.generated_test_driver_metadata(
+                    self.packages,
+                    target,
+                    self.opt.target_backend.into(),
+                ));
+            }
+            PlannedArtifact::BundleResult { module, .. } => {
+                let module_name = self.modules.module_source(*module);
+                out.push(
+                    self.layout
+                        .bundle_result_path(self.opt.target_backend.into(), module_name.name()),
+                );
+            }
+            PlannedArtifact::RuntimeLib { .. } => {
+                out.push(self.layout.runtime_output_path(
+                    self.opt.target_backend,
+                    self.opt.use_tcc_run(),
+                    self.opt.os,
+                ));
+            }
+            PlannedArtifact::GeneratedMbti { target, .. } => {
+                out.push(self.layout.generated_mbti_path(
+                    self.packages,
+                    target,
+                    self.opt.target_backend.into(),
+                ));
+            }
+            PlannedArtifact::DocsDir { .. } => {
+                // The output is a whole folder
+                out.push(self.layout.doc_dir())
+            }
+            PlannedArtifact::VirtualPackageInterface { package, .. } => {
+                // The interface generated from `.mbti` is the `.mi` of the source target
+                let t = package.build_target(crate::model::TargetKind::Source);
+                out.push(self.layout.mi_of_build_target(
+                    self.packages,
+                    &t,
+                    self.opt.target_backend.into(),
+                ));
+            }
+            PlannedArtifact::MoonLexGeneratedSource { package, index, .. } => {
+                let pkg_info = self.packages.get_package(*package);
+                let mbtlex_file = &pkg_info.mbt_lex_files[*index as usize];
+                out.push(mbtlex_file.with_extension("mbt"));
+            }
+            PlannedArtifact::MoonYaccGeneratedSource { package, index, .. } => {
+                let pkg_info = self.packages.get_package(*package);
+                let mbtyacc_file = &pkg_info.mbt_yacc_files[*index as usize];
+                out.push(mbtyacc_file.with_extension("mbt"));
+            }
+            PlannedArtifact::KnownPath { path, .. } => out.push(path.clone()),
         }
     }
 
-    /// Append the output artifacts of the given node to the provided vector.
-    #[instrument(level = Level::DEBUG, skip(self, out))]
-    pub(super) fn append_artifact_of(
+    pub(super) fn planned_artifact_paths(
         &self,
-        node: BuildPlanNode,
-        edge: FileDependencyKind,
+        artifacts: impl IntoIterator<Item = PlannedArtifact>,
+    ) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        for artifact in artifacts {
+            self.append_planned_artifact(&artifact, &mut paths);
+        }
+        paths
+    }
+
+    fn append_package_interface(
+        &self,
+        producer: BuildActionId,
+        target: BuildTarget,
         out: &mut Vec<PathBuf>,
     ) {
-        match node {
-            BuildPlanNode::Check(target) => {
-                let info = self
-                    .build_plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for Check nodes");
-
+        match self.plan.action(producer) {
+            BuildAction::Check { info, .. } if info.check_mi_against.is_some() => {
                 // Generate a `.mi` artifact including the case besides normal
                 // cases:
                 // * --no-mi is enabled: need add mi to the artifacts so that n2
@@ -289,224 +391,34 @@ impl<'a> BuildPlanLowerContext<'a> {
                 // moonbitlang/core/abort, which is unnecessary. When working on
                 // core, the abort mi is returned as `Regular` below. So it will
                 // be actually checked.
-                if info.check_mi_against.is_some() {
-                    match self.layout.mi_of_build_target_impl_virtual(
-                        self.packages,
-                        &target,
-                        self.opt.target_backend.into(),
-                    ) {
-                        crate::build_lower::artifact::MiPathResult::StdAbort(_) => {}
-                        crate::build_lower::artifact::MiPathResult::Std(p) => {
-                            // this should not happen because there is no
-                            // implementation package in stdlib other than abort
-                            tracing::warn!(
-                                "stdlib mi should not be needed for check as an implementation package: {:?}",
-                                p
-                            );
-                        }
-                        crate::build_lower::artifact::MiPathResult::Regular(p) => {
-                            out.push(p);
-                        }
+                match self.layout.mi_of_build_target_impl_virtual(
+                    self.packages,
+                    &target,
+                    self.opt.target_backend.into(),
+                ) {
+                    crate::build_lower::artifact::MiPathResult::StdAbort(_) => {}
+                    crate::build_lower::artifact::MiPathResult::Std(p) => {
+                        // this should not happen because there is no
+                        // implementation package in stdlib other than abort
+                        tracing::warn!(
+                            "stdlib mi should not be needed for check as an implementation package: {:?}",
+                            p
+                        );
                     }
-                } else {
-                    let mi_artifact_path = self.layout.mi_of_build_target(
-                        self.packages,
-                        &target,
-                        self.opt.target_backend.into(),
-                    );
-                    out.push(mi_artifact_path);
-                };
-            }
-            BuildPlanNode::EmitProof(target) => {
-                // Proof nodes are queried in two situations:
-                // 1. `ProofArtifacts { .. }` edges from downstream proof consumers,
-                //    which request just the subset they need.
-                // 2. `AllFiles` when lowering the node itself or when collecting
-                //    top-level `BuildMeta.artifacts`, which should list the node's
-                //    full output set.
-                let (mi, mlw) = match edge {
-                    FileDependencyKind::ProofArtifacts { mi, mlw, .. } => (mi, mlw),
-                    FileDependencyKind::AllFiles => (true, true),
-                    _ => panic!("EmitProof only supports ProofArtifacts or AllFiles edges"),
-                };
-                if mi {
-                    out.push(self.layout.emit_proof_mi_path(self.packages, &target));
-                }
-                if mlw {
-                    out.push(self.layout.emit_proof_whyml_path(self.packages, &target));
+                    crate::build_lower::artifact::MiPathResult::Regular(p) => {
+                        out.push(p);
+                    }
                 }
             }
-            BuildPlanNode::Prove(target) => {
-                let (mi, mlw, report) = match edge {
-                    FileDependencyKind::ProofArtifacts { mi, mlw, report } => (mi, mlw, report),
-                    FileDependencyKind::AllFiles => (true, true, true),
-                    _ => panic!("Prove only supports ProofArtifacts or AllFiles edges"),
-                };
-                if mi {
-                    out.push(self.layout.prove_mi_path(self.packages, &target));
-                }
-                if mlw {
-                    out.push(self.layout.prove_whyml_path(self.packages, &target));
-                }
-                if report {
-                    out.push(self.layout.prove_report_path(self.packages, &target));
-                }
-            }
-            BuildPlanNode::BuildCore(target) => {
-                let info = self
-                    .build_plan
-                    .get_build_target_info(&target)
-                    .expect("Build target info should be present for BuildCore nodes");
-                let (mi, core) = match edge {
-                    FileDependencyKind::AllFiles => (true, true),
-                    FileDependencyKind::Artifacts(need) => (
-                        need.contains(PlanArtifactKind::Interface),
-                        need.contains(PlanArtifactKind::CoreIr),
-                    ),
-                    _ => panic!("BuildCore only supports logical artifact or AllFiles edges"),
-                };
-                if mi && info.check_mi_against.is_none() && !info.no_mi() && !target.kind.is_test()
-                {
-                    out.push(self.layout.mi_of_build_target(
-                        self.packages,
-                        &target,
-                        self.opt.target_backend.into(),
-                    ));
-                }
-                if core {
-                    out.push(self.layout.core_of_build_target(
-                        self.packages,
-                        &target,
-                        self.opt.target_backend.into(),
-                    ));
-                }
-            }
-            BuildPlanNode::BuildCStub(package, index) => {
-                let pkg = self.packages.get_package(package);
-                let file_name = &pkg.c_stub_files[index as usize];
-                out.push(
-                    self.layout.c_stub_object_path(
-                        self.packages,
-                        package,
-                        file_name
-                            .file_stem()
-                            .expect("c stub file should have a file name"),
-                        self.opt.target_backend.into(),
-                        self.opt.os,
-                    ),
-                );
-            }
-            BuildPlanNode::ArchiveOrLinkCStubs(_target) => {
-                if self.opt.use_tcc_run() {
-                    out.push(self.layout.c_stub_link_dylib_path(
-                        self.packages,
-                        _target,
-                        self.opt.target_backend.into(),
-                        self.opt.os,
-                    ));
-                } else {
-                    out.push(self.layout.c_stub_archive_path(
-                        self.packages,
-                        _target,
-                        self.opt.target_backend.into(),
-                        self.opt.os,
-                    ));
-                }
-            }
-            BuildPlanNode::LinkCore(target) => {
-                out.push(self.layout.linked_core_of_build_target(
-                    self.packages,
-                    &target,
-                    self.opt.target_backend.into(),
-                    self.opt.native_target,
-                    self.opt.os,
-                    self.opt.output_wat,
-                ));
-            }
-            BuildPlanNode::MakeExecutable(target) => {
-                out.push(self.layout.executable_of_build_target(
-                    self.packages,
-                    &target,
-                    self.opt.executable_artifact(true),
-                ))
-            }
-            BuildPlanNode::GenerateTestInfo(target) => {
-                let meta = if let FileDependencyKind::GenerateTestInfo { meta } = edge {
-                    meta
-                } else {
-                    true
-                };
-                out.push(self.layout.generated_test_driver(
-                    self.packages,
-                    &target,
-                    self.opt.target_backend.into(),
-                ));
-                if meta {
-                    out.push(self.layout.generated_test_driver_metadata(
-                        self.packages,
-                        &target,
-                        self.opt.target_backend.into(),
-                    ));
-                }
-            }
-            BuildPlanNode::Bundle(id) => {
-                let module_name = self.modules.module_source(id);
-                out.push(
-                    self.layout
-                        .bundle_result_path(self.opt.target_backend.into(), module_name.name()),
-                );
-            }
-            BuildPlanNode::BuildRuntimeLib => {
-                out.push(self.layout.runtime_output_path(
-                    self.opt.target_backend,
-                    self.opt.use_tcc_run(),
-                    self.opt.os,
-                ));
-            }
-            BuildPlanNode::GenerateMbti(_target) => {
-                out.push(self.layout.generated_mbti_path(
-                    self.packages,
-                    &_target,
-                    self.opt.target_backend.into(),
-                ));
-            }
-            BuildPlanNode::BuildDocs(_) => {
-                // The output is a whole folder
-                out.push(self.layout.doc_dir())
-            }
-            BuildPlanNode::RunPrebuild(pkg, idx) => {
-                let cfg = self
-                    .build_plan
-                    .get_prebuild_info(pkg, idx)
-                    .expect("Prebuild info should be populated before lowering run prebuild");
-                out.extend(cfg.resolved_outputs.iter().cloned());
-            }
-            BuildPlanNode::BuildVirtual(_target) => {
-                // The interface generated from `.mbti` is the `.mi` of the source target
-                let t = _target.build_target(crate::model::TargetKind::Source);
+            BuildAction::Check { .. } | BuildAction::BuildCore { .. } => {
                 out.push(self.layout.mi_of_build_target(
                     self.packages,
-                    &t,
+                    &target,
                     self.opt.target_backend.into(),
                 ));
             }
-            BuildPlanNode::RunMoonLexPrebuild(pkg, idx) => {
-                let pkg_info = self.packages.get_package(pkg);
-                let mbtlex_file = &pkg_info.mbt_lex_files[idx as usize];
-                out.push(mbtlex_file.with_extension("mbt"));
-            }
-            BuildPlanNode::RunMoonYaccPrebuild(pkg, idx) => {
-                let pkg_info = self.packages.get_package(pkg);
-                let mbtyacc_file = &pkg_info.mbt_yacc_files[idx as usize];
-                out.push(mbtyacc_file.with_extension("mbt"));
-            }
+            _ => panic!("package interface producer should be Check or BuildCore"),
         }
-    }
-
-    /// Convenience alias for depending on all artifacts from a node.
-    #[inline]
-    pub(super) fn append_all_artifacts_of(&self, node: BuildPlanNode, out: &mut Vec<PathBuf>) {
-        self.append_artifact_of(node, FileDependencyKind::AllFiles, out);
     }
 
     fn lowered(&mut self, build: Build) -> Result<(), anyhow::Error> {
@@ -514,11 +426,10 @@ impl<'a> BuildPlanLowerContext<'a> {
         Ok(())
     }
 
-    /// **For debug use only.** Prints debug information about a specific build
-    /// plan node, the n2 build it's mapped into, and the input and output files
-    /// of it.
+    /// **For debug use only.** Prints debug information about a lowered action,
+    /// the n2 build it's mapped into, and its input and output files.
     #[doc(hidden)]
-    fn debug_print_command_and_files(&mut self, node: BuildPlanNode, build: &Build) {
+    fn debug_print_command_and_files(&mut self, action: BuildActionId, build: &Build) {
         if log::log_enabled!(log::Level::Debug) {
             let in_files = build
                 .ins
@@ -551,7 +462,7 @@ impl<'a> BuildPlanLowerContext<'a> {
 
             debug!(
                 "lowered: {:?}\n into {:?};\n ins: {:?};\n outs: {:?}",
-                node, build.cmdline, in_files, out_files
+                action, build.cmdline, in_files, out_files
             );
         }
     }

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -33,17 +33,16 @@ use crate::{
         Commandline,
         compiler::{CmdlineAbstraction, MoondocCommand, Mooninfo},
     },
-    build_plan::BuildTargetInfo,
-    model::{BuildPlanNode, BuildTarget, OperatingSystem, PackageId, RunBackend, TargetKind},
+    build_plan::{BuildTargetInfo, PrebuildInfo},
+    model::{BuildTarget, OperatingSystem, PackageId, RunBackend, TargetKind},
 };
 
 use super::{BuildCommand, compiler};
 
-impl<'a> super::BuildPlanLowerContext<'a> {
+impl<'a> super::LoweringContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self, info))]
     pub(super) fn lower_gen_test_driver(
         &mut self,
-        _node: BuildPlanNode,
         target: BuildTarget,
         info: &BuildTargetInfo,
     ) -> BuildCommand {
@@ -106,20 +105,16 @@ impl<'a> super::BuildPlanLowerContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self))]
     pub(super) fn lower_bundle(
         &mut self,
-        node: BuildPlanNode,
         module_id: ModuleId,
+        targets: &[BuildTarget],
     ) -> BuildCommand {
         let module = self.modules.module_source(module_id);
         let output = self
             .layout
             .bundle_result_path(self.opt.target_backend.into(), module.name());
-        let info = self
-            .build_plan
-            .bundle_info(module_id)
-            .expect("Bundle info should be present when lowering bundle node");
 
         let mut inputs = vec![];
-        for dep in info.bundle_targets.iter() {
+        for dep in targets {
             inputs.push(self.layout.core_of_build_target(
                 self.packages,
                 dep,
@@ -255,12 +250,7 @@ impl<'a> super::BuildPlanLowerContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self))]
-    pub(super) fn lower_run_prebuild(&self, pkg: PackageId, idx: u32) -> BuildCommand {
-        let info = self
-            .build_plan
-            .get_prebuild_info(pkg, idx)
-            .expect("Prebuild info should be populated before lowering run prebuild");
-
+    pub(super) fn lower_run_prebuild(&self, info: &PrebuildInfo) -> BuildCommand {
         // Note: we are tracking dependencies between prebuild commands via n2.
         // Ideally we can do this ourselves, but n2 does it anyway so we don't bother.
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Loweing implementation for build nodes
+//! Lowering implementation for build actions.
 
 use std::{
     collections::{BTreeSet, HashSet},
@@ -38,6 +38,7 @@ use petgraph::Direction;
 use tracing::{Level, instrument};
 
 use crate::{
+    build_action_plan::{BuildActionId, PlannedArtifact},
     build_lower::{
         WarningCondition, artifact,
         compiler::{
@@ -47,15 +48,12 @@ use crate::{
     },
     build_plan::{BuildCStubsInfo, BuildTargetInfo, LinkCoreInfo, MakeExecutableInfo},
     discover::DiscoveredPackage,
-    model::{
-        BuildPlanNode, BuildTarget, NativeTarget, OperatingSystem, PackageId, RunBackend,
-        TargetKind,
-    },
+    model::{BuildTarget, NativeTarget, OperatingSystem, PackageId, RunBackend, TargetKind},
     pkg_name::{PackageFQN, PackagePath},
     special_cases::{is_self_coverage_lib, should_skip_coverage},
 };
 
-use super::{BuildCommand, Commandline, compiler, context::BuildPlanLowerContext};
+use super::{BuildCommand, Commandline, compiler, context::LoweringContext};
 
 fn commandline_with_dsymutil(cmd: &[String], dest: &str) -> Commandline {
     let cmd_str = moonutil::shlex::join_unix(cmd.iter().map(|x| x.as_str()));
@@ -74,7 +72,7 @@ fn should_run_new_native_dsymutil(
         && cc.targets_apple_darwin()
 }
 
-impl<'a> BuildPlanLowerContext<'a> {
+impl<'a> LoweringContext<'a> {
     fn compiler_source_files(&self, info: &BuildTargetInfo) -> Vec<PathBuf> {
         let mut files = info.files().map(|x| x.to_owned()).collect::<Vec<_>>();
         files.extend(info.mbtp_files().map(|x| x.to_owned()));
@@ -328,12 +326,7 @@ impl<'a> BuildPlanLowerContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self, info))]
-    pub(super) fn lower_check(
-        &self,
-        node: BuildPlanNode,
-        target: BuildTarget,
-        info: &BuildTargetInfo,
-    ) -> BuildCommand {
+    pub(super) fn lower_check(&self, target: BuildTarget, info: &BuildTargetInfo) -> BuildCommand {
         let package = self.get_package(target);
         let module = self.modules.module_info(package.module);
 
@@ -349,7 +342,7 @@ impl<'a> BuildPlanLowerContext<'a> {
             self.layout
                 .mi_of_build_target(self.packages, &target, self.opt.target_backend.into())
         };
-        let mi_inputs = self.mi_inputs_of(node, target);
+        let mi_inputs = self.mi_inputs_of(target);
 
         // Collect files iterator once so we can pass slices and extra inputs
         let files_vec = self.compiler_source_files(info);
@@ -406,7 +399,6 @@ impl<'a> BuildPlanLowerContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self, info))]
     pub(super) fn lower_emit_proof(
         &self,
-        _node: BuildPlanNode,
         target: BuildTarget,
         info: &BuildTargetInfo,
     ) -> BuildCommand {
@@ -455,12 +447,7 @@ impl<'a> BuildPlanLowerContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self, info))]
-    pub(super) fn lower_prove(
-        &self,
-        _node: BuildPlanNode,
-        target: BuildTarget,
-        info: &BuildTargetInfo,
-    ) -> BuildCommand {
+    pub(super) fn lower_prove(&self, target: BuildTarget, info: &BuildTargetInfo) -> BuildCommand {
         let package = self.get_package(target);
         let module = self.modules.module_info(package.module);
         let mi_inputs = self.prove_mi_inputs_of(target);
@@ -519,7 +506,6 @@ impl<'a> BuildPlanLowerContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self, info))]
     pub(super) fn lower_build_mbt(
         &self,
-        node: BuildPlanNode,
         target: BuildTarget,
         info: &BuildTargetInfo,
     ) -> BuildCommand {
@@ -535,7 +521,7 @@ impl<'a> BuildPlanLowerContext<'a> {
             self.layout
                 .mi_of_build_target(self.packages, &target, self.opt.target_backend.into());
 
-        let mi_inputs = self.mi_inputs_of(node, target);
+        let mi_inputs = self.mi_inputs_of(target);
 
         let mut files = self.compiler_source_files(info);
         match target.kind {
@@ -600,10 +586,13 @@ impl<'a> BuildPlanLowerContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self, info))]
     pub(super) fn lower_link_core(
         &mut self,
-        _node: BuildPlanNode,
         target: BuildTarget,
         info: &LinkCoreInfo,
+        make_executable_info: Option<&MakeExecutableInfo>,
     ) -> BuildCommand {
+        #[cfg(not(target_os = "windows"))]
+        let _ = make_executable_info;
+
         let package = self.get_package(target);
         let module = self.modules.module_info(package.module);
 
@@ -679,9 +668,7 @@ impl<'a> BuildPlanLowerContext<'a> {
             exports: package.exported_functions(self.opt.target_backend.into()),
             extra_link_opts: module.link_flags.as_deref().unwrap_or_default(),
             #[cfg(target_os = "windows")]
-            native_toolchain_is_msvc: self
-                .build_plan
-                .get_make_executable_info(&target)
+            native_toolchain_is_msvc: make_executable_info
                 .is_some_and(|info| info.effective_native_toolchain.cc().is_msvc()),
         };
 
@@ -864,7 +851,7 @@ impl<'a> BuildPlanLowerContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self, info))]
     pub(super) fn lower_archive_or_link_c_stubs(
         &mut self,
-        node: BuildPlanNode,
+        action: BuildActionId,
         target: PackageId,
         info: &BuildCStubsInfo,
     ) -> BuildCommand {
@@ -874,12 +861,10 @@ impl<'a> BuildPlanLowerContext<'a> {
         );
 
         let mut object_files = Vec::new();
-        for (input, edge) in self.build_plan.dependency_edges(node) {
-            // FIXME: we need a better way to separate the different kinds of input edges
-            if !matches!(input, BuildPlanNode::BuildCStub { .. }) {
-                continue;
+        for artifact in self.plan.dependency_artifacts(action) {
+            if matches!(artifact, PlannedArtifact::CStubObject { .. }) {
+                self.append_planned_artifact(&artifact, &mut object_files);
             }
-            self.append_artifact_of(input, edge, &mut object_files);
         }
 
         // There's two ways to handle this:
@@ -1003,9 +988,27 @@ impl<'a> BuildPlanLowerContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self, info))]
     pub(super) fn lower_make_exe(
         &mut self,
+        action: BuildActionId,
         target: BuildTarget,
         info: &MakeExecutableInfo,
     ) -> BuildCommand {
+        debug_assert!({
+            let planned_c_stubs = self
+                .plan
+                .dependency_artifacts(action)
+                .into_iter()
+                .filter_map(|artifact| match artifact {
+                    PlannedArtifact::CStubLibrary { package, .. } => Some(package),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            planned_c_stubs.len() == info.link_c_stubs.len()
+                && info
+                    .link_c_stubs
+                    .iter()
+                    .all(|package| planned_c_stubs.contains(package))
+        });
+
         match self.opt.target_backend {
             RunBackend::WasmGC | RunBackend::Wasm | RunBackend::Js => {
                 panic!(
@@ -1015,19 +1018,58 @@ impl<'a> BuildPlanLowerContext<'a> {
             RunBackend::Native => {
                 if let Some(tcc_run) = &self.opt.tcc_run {
                     let internal_tcc = tcc_run.internal_tcc().clone();
-                    self.build_tcc_run_driver_command(target, info, internal_tcc)
+                    self.build_tcc_run_driver_command(action, target, info, internal_tcc)
                 } else if self.opt.native_target.is_some() {
-                    self.lower_link_new_native_exe(target, info)
+                    self.lower_link_new_native_exe(action, target, info)
                 } else {
-                    self.lower_build_exe_regular(target, info)
+                    self.lower_build_exe_regular(action, target, info)
                 }
             }
-            RunBackend::Llvm => self.lower_build_exe_regular(target, info),
+            RunBackend::Llvm => self.lower_build_exe_regular(action, target, info),
         }
+    }
+
+    fn native_executable_dependency_paths(
+        &self,
+        action: BuildActionId,
+        info: &MakeExecutableInfo,
+        include_linked_core: bool,
+    ) -> Vec<PathBuf> {
+        let artifacts = self.plan.dependency_artifacts(action);
+        let mut sources = Vec::new();
+
+        // Preserve the legacy linker order: linked core, runtime, then C stubs.
+        // Static library order can affect symbol resolution on Unix linkers.
+        if include_linked_core {
+            for artifact in artifacts
+                .iter()
+                .filter(|artifact| matches!(artifact, PlannedArtifact::LinkedCore { .. }))
+            {
+                self.append_planned_artifact(artifact, &mut sources);
+            }
+        }
+
+        for artifact in artifacts
+            .iter()
+            .filter(|artifact| matches!(artifact, PlannedArtifact::RuntimeLib { .. }))
+        {
+            self.append_planned_artifact(artifact, &mut sources);
+        }
+
+        for package in &info.link_c_stubs {
+            for artifact in artifacts.iter().filter(|artifact| {
+                matches!(artifact, PlannedArtifact::CStubLibrary { package: actual, .. } if actual == package)
+            }) {
+                self.append_planned_artifact(artifact, &mut sources);
+            }
+        }
+
+        sources
     }
 
     fn lower_build_exe_regular(
         &mut self,
+        action: BuildActionId,
         target: BuildTarget,
         info: &MakeExecutableInfo,
     ) -> BuildCommand {
@@ -1037,18 +1079,7 @@ impl<'a> BuildPlanLowerContext<'a> {
         // - compile the program (if needed)
         // - link with runtime library & artifacts of other C stubs
 
-        let mut sources = vec![];
-        // C artifact path
-        self.append_all_artifacts_of(BuildPlanNode::LinkCore(target), &mut sources);
-        // Runtime path
-        self.append_all_artifacts_of(BuildPlanNode::BuildRuntimeLib, &mut sources);
-        // C stubs to link
-        for &stub_tgt in &info.link_c_stubs {
-            self.append_all_artifacts_of(
-                BuildPlanNode::ArchiveOrLinkCStubs(stub_tgt),
-                &mut sources,
-            );
-        }
+        let mut sources = self.native_executable_dependency_paths(action, info, true);
         let cc = info.effective_native_toolchain.cc().clone();
         let simdutf_objects = if cc.can_use_simdutf() {
             self.opt
@@ -1123,18 +1154,11 @@ impl<'a> BuildPlanLowerContext<'a> {
 
     fn lower_link_new_native_exe(
         &mut self,
+        action: BuildActionId,
         target: BuildTarget,
         info: &MakeExecutableInfo,
     ) -> BuildCommand {
-        let mut sources = vec![];
-        self.append_all_artifacts_of(BuildPlanNode::LinkCore(target), &mut sources);
-        self.append_all_artifacts_of(BuildPlanNode::BuildRuntimeLib, &mut sources);
-        for &stub_tgt in &info.link_c_stubs {
-            self.append_all_artifacts_of(
-                BuildPlanNode::ArchiveOrLinkCStubs(stub_tgt),
-                &mut sources,
-            );
-        }
+        let mut sources = self.native_executable_dependency_paths(action, info, true);
 
         let cc = info.effective_native_toolchain.cc().clone();
         let simdutf_objects = if cc.can_use_simdutf() {
@@ -1203,21 +1227,12 @@ impl<'a> BuildPlanLowerContext<'a> {
     /// putting that into a response file.
     fn build_tcc_run_driver_command(
         &self,
+        action: BuildActionId,
         target: BuildTarget,
         info: &MakeExecutableInfo,
         cc: CC,
     ) -> BuildCommand {
-        let mut sources = vec![];
-
-        // Runtime path
-        self.append_all_artifacts_of(BuildPlanNode::BuildRuntimeLib, &mut sources);
-        // C stubs to link
-        for &stub_tgt in &info.link_c_stubs {
-            self.append_all_artifacts_of(
-                BuildPlanNode::ArchiveOrLinkCStubs(stub_tgt),
-                &mut sources,
-            );
-        }
+        let sources = self.native_executable_dependency_paths(action, info, false);
 
         let cfg = CCConfigBuilder::default()
             .no_sys_header(true) // -DMOONBIT_NATIVE_NO_SYS_HEADER for TCC
@@ -1286,7 +1301,7 @@ impl<'a> BuildPlanLowerContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self))]
-    pub(super) fn lower_parse_mbti(&mut self, node: BuildPlanNode, pid: PackageId) -> BuildCommand {
+    pub(super) fn lower_parse_mbti(&mut self, pid: PackageId) -> BuildCommand {
         let pkg = self.packages.get_package(pid);
         let Some(mbti_path) = &pkg.virtual_mbti else {
             panic!(
@@ -1302,7 +1317,7 @@ impl<'a> BuildPlanLowerContext<'a> {
                 .mi_of_build_target(self.packages, &target, self.opt.target_backend.into());
 
         // Resolve interface dependencies from the dep graph (path:alias pairs)
-        let mi_inputs = self.mi_inputs_of(node, target);
+        let mi_inputs = self.mi_inputs_of(target);
 
         // Construct `moonc build-interface` command
         let mut cmd = compiler::MooncBuildInterface::new(
@@ -1328,11 +1343,7 @@ impl<'a> BuildPlanLowerContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self))]
-    pub(super) fn mi_inputs_of(
-        &self,
-        _node: BuildPlanNode,
-        target: BuildTarget,
-    ) -> Vec<MiDependency<'a>> {
+    pub(super) fn mi_inputs_of(&self, target: BuildTarget) -> Vec<MiDependency<'a>> {
         let mut deps: Vec<MiDependency<'a>> = self
             .rel
             .dep_graph

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Lowers a [Build plan](crate::build_plan) into `n2`'s Build graph
+//! Lowers the normalized action plan into `n2`'s build graph.
 
 use std::{collections::BTreeMap, path::PathBuf};
 
@@ -30,8 +30,8 @@ use tracing::instrument;
 
 use crate::{
     ResolveOutput,
-    build_plan::BuildPlan,
-    model::{Artifacts, BuildPlanNode, NativeTarget, OperatingSystem, RunBackend, TccRunConfig},
+    build_action_plan::{BuildActionId, BuildActionPlan},
+    model::{NativeTarget, OperatingSystem, RunBackend, TccRunConfig},
     pkg_name::OptionalPackageFQNWithSource,
 };
 
@@ -45,7 +45,7 @@ mod utils;
 pub use utils::{build_ins, build_n2_fileloc, build_outs};
 
 use crate::build_lower::artifact::{ExecutableArtifact, LegacyLayoutBuilder};
-use context::BuildPlanLowerContext;
+use context::LoweringContext;
 
 /// Knobs to tweak during build. Affects behaviors during lowering.
 pub struct BuildOptions {
@@ -116,16 +116,16 @@ pub enum WarningCondition {
     Allow,
 }
 
-/// An error that may be raised during build plan lowering
+/// An error that may be raised during action plan lowering.
 #[derive(thiserror::Error, Debug)]
 pub enum LoweringError {
     #[error(
         "An error was reported by n2 (the build graph executor), \
-        when lowering for package {package}, build node {node:?}"
+        when lowering for package {package}, action {action:?}"
     )]
     N2 {
         package: OptionalPackageFQNWithSource,
-        node: BuildPlanNode,
+        action: BuildActionId,
         source: anyhow::Error,
     },
     #[error("Failed to resolve native C toolchain for runtime")]
@@ -143,11 +143,16 @@ pub struct LoweringResult {
     /// vectors before they are rendered into n2 command strings.
     pub command_args_by_output: CommandArgMap,
 
-    /// The list of artifacts corresponding to the root input nodes.
+    /// The list of artifacts corresponding to the root input actions.
     ///
     /// Rationale for being a map: users (especially tests) need to look up
-    /// artifacts corresponding to specific nodes for rebuilding.
-    pub artifacts: IndexMap<BuildPlanNode, Artifacts>,
+    /// artifacts corresponding to specific actions for rebuilding.
+    pub artifacts: IndexMap<BuildActionId, LoweredArtifacts>,
+}
+
+pub struct LoweredArtifacts {
+    pub action: BuildActionId,
+    pub artifacts: Vec<PathBuf>,
 }
 
 /// The command to execute for n2.
@@ -223,14 +228,14 @@ struct BuildCommand {
     commandline: Commandline,
 }
 
-/// Lowers a [`BuildPlan`] into a n2 [Build Graph](n2::graph::Graph).
+/// Lowers a normalized action plan into an n2 [Build Graph](n2::graph::Graph).
 #[instrument(skip_all)]
 pub fn lower_build_plan(
     resolve_output: &ResolveOutput,
-    build_plan: &BuildPlan,
+    plan: &BuildActionPlan<'_>,
     opt: &BuildOptions,
 ) -> Result<LoweringResult, LoweringError> {
-    info!("Starting build plan lowering to n2 graph");
+    info!("Starting action plan lowering to n2 graph");
     debug!(
         "Build options: backend={:?}, opt_level={:?}, debug_symbols={}",
         opt.target_backend, opt.opt_level, opt.debug_symbols
@@ -245,30 +250,23 @@ pub fn lower_build_plan(
         .build()
         .expect("Failed to build legacy layout");
 
-    let mut ctx = BuildPlanLowerContext::new(layout, resolve_output, build_plan, opt);
+    let mut ctx = LoweringContext::new(layout, resolve_output, plan, opt);
 
-    for node in build_plan.all_nodes() {
-        debug!("Lowering build node: {:?}", node);
-        ctx.lower_node(node)?;
+    for id in plan.action_ids() {
+        debug!("Lowering action: {:?}", id);
+        ctx.lower_action(id)?;
     }
 
-    let mut out_artifcts = IndexMap::with_capacity(build_plan.input_nodes().len());
-    for n in build_plan.input_nodes() {
-        let mut a = vec![];
-        ctx.append_all_artifacts_of(*n, &mut a);
-        out_artifcts.insert(
-            *n,
-            Artifacts {
-                node: *n,
-                artifacts: a,
-            },
-        );
+    let mut out_artifacts = IndexMap::with_capacity(plan.input_action_ids().len());
+    for &action in plan.input_action_ids() {
+        let artifacts = ctx.planned_artifact_paths(plan.output_artifacts(action));
+        out_artifacts.insert(action, LoweredArtifacts { action, artifacts });
     }
 
-    info!("Build plan lowering completed successfully");
+    info!("Action plan lowering completed successfully");
     Ok(LoweringResult {
         build_graph: ctx.graph,
         command_args_by_output: ctx.command_args_by_output,
-        artifacts: out_artifcts,
+        artifacts: out_artifacts,
     })
 }

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -117,8 +117,9 @@ pub struct BuildPlan {
 
 /// Logical artifacts that can be requested from build-plan nodes.
 ///
-/// These are planning-level package artifacts. Lowering remains responsible for
-/// mapping them to concrete paths.
+/// These are planning-level package artifacts. `BuildActionPlan` expands them,
+/// together with node-specific edge selectors, into the logical artifact set
+/// consumed by backend lowering.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PlanArtifactKind {
     /// Package interface artifact, currently written as a `.mi` file.
@@ -166,7 +167,8 @@ impl PlanArtifactNeed {
 ///
 /// `Artifacts` is the package-artifact selector shared by `Check` and
 /// `BuildCore`. Proof and test-info edges still keep node-specific selectors
-/// here.
+/// here; `BuildActionPlan` is responsible for translating all edge selectors into
+/// `PlannedArtifact` values before backend lowering sees them.
 ///
 /// A more generic solution might be involving creating associated types for
 /// each node kind, specifying their output file list and order, and then
@@ -250,6 +252,38 @@ impl BuildPlan {
 
     pub fn input_nodes(&self) -> &[BuildPlanNode] {
         &self.input_nodes
+    }
+}
+
+#[cfg(test)]
+impl BuildPlan {
+    pub(crate) fn test_add_node(&mut self, node: BuildPlanNode) {
+        self.graph.add_node(node);
+    }
+
+    pub(crate) fn test_add_edge(
+        &mut self,
+        start: BuildPlanNode,
+        end: BuildPlanNode,
+        kind: FileDependencyKind,
+    ) {
+        self.graph.add_edge(start, end, kind);
+    }
+
+    pub(crate) fn test_insert_build_target_info(
+        &mut self,
+        target: BuildTarget,
+        info: BuildTargetInfo,
+    ) {
+        self.build_target_infos.insert(target, info);
+    }
+
+    pub(crate) fn test_insert_prebuild_info(
+        &mut self,
+        package: PackageId,
+        info: Vec<Option<PrebuildInfo>>,
+    ) {
+        self.prebuild_info.insert(package, info);
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -168,15 +168,34 @@ pub fn compile(
         os: OperatingSystem::from_str(std::env::consts::OS).expect("Unknown"),
         runtime_dot_c_path,
     };
-    let res = build_lower::lower_build_plan(resolve_output, &plan, &lower_env)?;
+    let (build_graph, command_args_by_output, artifacts) = {
+        let action_plan = plan.build_action_plan();
+        let res = build_lower::lower_build_plan(resolve_output, &action_plan, &lower_env)?;
+        let artifacts = res
+            .artifacts
+            .into_iter()
+            .map(|(action, lowered)| {
+                debug_assert_eq!(action, lowered.action);
+                let node = action_plan.build_plan_node(action);
+                (
+                    node,
+                    Artifacts {
+                        node,
+                        artifacts: lowered.artifacts,
+                    },
+                )
+            })
+            .collect();
+        (res.build_graph, res.command_args_by_output, artifacts)
+    };
 
     info!("Build graph lowering completed successfully");
     debug!("Final build graph created with n2");
 
     Ok(CompileOutput {
-        build_graph: res.build_graph,
-        command_args_by_output: res.command_args_by_output,
-        artifacts: res.artifacts,
+        build_graph,
+        command_args_by_output,
+        artifacts,
         user_warnings,
         build_plan: if cx.debug_export_build_plan {
             Some(Box::new(plan))

--- a/crates/moonbuild-rupes-recta/src/lib.rs
+++ b/crates/moonbuild-rupes-recta/src/lib.rs
@@ -66,9 +66,11 @@
     6. From this list of build actions, resolve the whole abstract build graph
        that represents the list of actions to be executed
        ([`crate::build_plan`]).
-    7. Lower the build graph to a concrete one acceptable by [`n2`] (which is an
-       in-process `ninja` equivalent) ([`crate::build_lower`]).
-    8. Execute the build graph using `n2`.
+    7. Convert the abstract build graph into the action-level build plan consumed
+       by backend lowering ([`crate::build_action_plan`]).
+    8. Lower the action-level build plan to a concrete graph acceptable by [`n2`]
+       (which is an in-process `ninja` equivalent) ([`crate::build_lower`]).
+    9. Execute the build graph using `n2`.
 
     Additional information about the build process, project layout, special
     cases, and random quirks of build systems can be found in the repository's
@@ -99,6 +101,7 @@
 
 #![warn(clippy::unwrap_used)] // We prefer clear panic messages
 
+pub mod build_action_plan;
 pub mod build_lower;
 pub mod build_plan;
 pub mod discover;

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -1,0 +1,169 @@
+# Build plan artifact dependencies
+
+Rupes Recta now uses a compiler-style split between planning, the action-level
+plan consumed by lowering, and backend graph construction:
+
+```text
+BuildPlan       = planning IR: graph nodes, edge semantics, coalescing
+BuildActionPlan = action-level build plan: action ids, hydrated action data, logical artifacts
+build_lower/n2  = backend IR: concrete paths, command lines, n2 graph
+```
+
+The important invariant is that `build_lower` consumes `BuildActionPlan` only. It
+does not import or match on planning internals such as `BuildPlanNode`,
+`FileDependencyKind`, or `PlanArtifactNeed`.
+
+## Planning IR
+
+`BuildPlan` still owns graph traversal, action coalescing, and edge semantics.
+Edges describe what logical output a consumer needs from a producer:
+
+```rust
+pub enum FileDependencyKind {
+    AllFiles,
+    Artifacts(PlanArtifactNeed),
+    ProofArtifacts { mi: bool, mlw: bool, report: bool },
+    GenerateTestInfo { meta: bool },
+}
+
+pub enum PlanArtifactNeed {
+    Interface,
+    CoreIr,
+    InterfaceAndCoreIr,
+}
+```
+
+`CoreIr` names the compiler IR artifact written with the `.core` extension. It
+is not related to the `moonbitlang/core` package.
+
+Builders request logical needs instead of path-shaped artifacts. `Check`
+dependencies need only the interface. Normal downstream `BuildCore`
+dependencies also track Core IR as an n2 input, so a dependency implementation
+change that leaves the interface stable still rebuilds the dependent package:
+
+```rust
+let edge = match dep_node {
+    BuildPlanNode::Check(_) => FileDependencyKind::Artifacts(PlanArtifactNeed::Interface),
+    BuildPlanNode::BuildCore(_) if check_only => {
+        FileDependencyKind::Artifacts(PlanArtifactNeed::Interface)
+    }
+    BuildPlanNode::BuildCore(_) => {
+        FileDependencyKind::Artifacts(PlanArtifactNeed::InterfaceAndCoreIr)
+    }
+    BuildPlanNode::BuildVirtual(_) => FileDependencyKind::AllFiles,
+    _ => unreachable!(
+        "need_interface_of_dep only schedules Check, BuildCore or BuildVirtual"
+    ),
+};
+self.add_edge_spec(node, dep_node, edge);
+```
+
+When `Check(target)` is coalesced into `BuildCore(target)`, `BuildPlan`
+converts broad `Check` edges to the logical interface need that `BuildCore` can
+satisfy:
+
+```rust
+fn edge_for_coalesced_check(edge: FileDependencyKind) -> FileDependencyKind {
+    match edge {
+        FileDependencyKind::AllFiles => FileDependencyKind::Artifacts(PlanArtifactNeed::Interface),
+        FileDependencyKind::Artifacts(need) => {
+            assert!(need.is_subset_of(PlanArtifactNeed::Interface));
+            FileDependencyKind::Artifacts(need)
+        }
+        _ => panic!("Check edges can only request logical artifacts"),
+    }
+}
+```
+
+## Build Action Plan
+
+`BuildPlan::build_action_plan()` creates the view consumed by backend lowering:
+
+```rust
+pub struct BuildActionId(usize);
+
+pub enum BuildAction<'a> {
+    Check { target: BuildTarget, info: &'a BuildTargetInfo },
+    BuildCore { target: BuildTarget, info: &'a BuildTargetInfo },
+    LinkCore { target: BuildTarget, info: &'a LinkCoreInfo, make_executable_info: Option<&'a MakeExecutableInfo> },
+    MakeExecutable { target: BuildTarget, info: Option<&'a MakeExecutableInfo> },
+    // other action variants carry the same hydrated planning metadata
+}
+```
+
+`MakeExecutableInfo` is present only for native executable work. For non-native
+backends, `MakeExecutable` remains a final-artifact alias over `LinkCore` and is
+a no-op in backend lowering.
+
+Logical outputs are exposed as `PlannedArtifact` values:
+
+```rust
+pub enum PlannedArtifact {
+    PackageInterface { producer: BuildActionId, target: BuildTarget },
+    PackageCoreIr { producer: BuildActionId, target: BuildTarget },
+    GeneratedTestDriver { producer: BuildActionId, target: BuildTarget },
+    CStubObject { producer: BuildActionId, package: PackageId, index: u32 },
+    KnownPath { producer: BuildActionId, path: PathBuf },
+    // other logical outputs
+}
+```
+
+This is where graph edge selectors become logical dependency artifacts:
+
+```rust
+pub fn dependency_artifacts(&self, id: BuildActionId) -> Vec<PlannedArtifact> {
+    self.plan
+        .dependency_edges(self.node(id))
+        .flat_map(|(node, kind)| self.artifacts_for_edge(node, kind))
+        .collect()
+}
+```
+
+For example, an archive/link C-stub action no longer scans raw build-plan
+edges in `build_lower`. Its object inputs are exposed by `BuildActionPlan` as
+`PlannedArtifact::CStubObject` dependencies.
+
+## Backend Lowering
+
+`build_lower` now matches on `BuildAction` and maps `PlannedArtifact` to
+legacy layout paths:
+
+```rust
+let cmd = match self.plan.action(id) {
+    BuildAction::Check { target, info } => self.lower_check(target, info),
+    BuildAction::BuildCore { target, info } => self.lower_build_mbt(target, info),
+    BuildAction::ArchiveOrLinkCStubs { package, info } => {
+        self.lower_archive_or_link_c_stubs(id, package, info)
+    }
+    // ...
+};
+
+let mut ins = Vec::new();
+for artifact in self.plan.dependency_artifacts(id) {
+    self.append_planned_artifact(&artifact, &mut ins);
+}
+```
+
+This keeps responsibilities separate:
+
+- `BuildPlan` owns graph edges, coalescing, and planning-only terminology.
+- `BuildActionPlan` owns the normalized action/artifact interface between phases.
+- `build_lower` owns path mapping, command construction, and n2 graph output.
+
+## Compatibility
+
+`LoweringResult` returns artifacts keyed by `BuildActionId`. The compile
+layer re-keys those artifacts back to `BuildPlanNode` for the existing public
+`CompileOutput` shape. That keeps compatibility above lowering while proving
+that backend lowering no longer sees planning internals.
+
+## Checks
+
+The boundary can be checked with:
+
+```sh
+rg -n '\bBuildPlan\b|BuildPlanNode|FileDependencyKind|PlanArtifact' \
+  crates/moonbuild-rupes-recta/src/build_lower
+```
+
+There should be no meaningful matches.

--- a/docs/dev/reference/readme.md
+++ b/docs/dev/reference/readme.md
@@ -8,6 +8,7 @@ This is a reference documentation of the current MoonBuild behavior.
 * [Modules and packages](./modules-packages.md)
 * [Workspace](./workspace.md)
 * [Package build process](./build.md)
+* [Build plan artifact dependencies](./build-plan-artifact-dependencies.md)
 * [How binaries are found](./binaries.md)
 * [Native C toolchain resolution](./native-c-toolchain-resolution.md)
 * [Toolchain packaging layouts and discovery](./toolchain-layout.md)


### PR DESCRIPTION
## Why
`build_lower` still consumed build-plan graph internals directly, which made the phase boundary blurry: planning owned graph edges and coalescing, while backend lowering also had to understand planning nodes and edge selectors. After the logical artifact cleanup, the next step is to make the compiler-style IR split explicit.

## What
- Add `build_plan::lowering` with opaque `LoweringActionId`, hydrated `LoweringAction`, and logical `PlannedArtifact` values.
- Move graph-edge and artifact-selection interpretation behind `LoweringPlan`.
- Change `build_lower` to consume `LoweringPlan` actions and planned artifacts rather than build-plan internals.
- Re-key lowered artifacts back to `BuildPlanNode` in the compile layer to preserve the existing public `CompileOutput` shape.
- Document the planning/lowering/backend split in the MoonBuild reference docs.

## Why This Is Minimal
This PR builds directly on the logical artifact needs already merged in PR #1757. It does not change command semantics or legacy layout path ownership; `build_lower` still owns concrete paths and command construction. The compatibility re-keying keeps callers unchanged while proving that backend lowering no longer imports planning internals.