### PR TITLE
Make build lowering environment capture explicit and lazy

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -30,6 +30,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
+    str::FromStr,
     sync::{Arc, Mutex},
 };
 
@@ -44,7 +45,8 @@ use moonbuild_rupes_recta::{
     fmt::{FmtConfig, FmtResolveOutput},
     intent::UserIntent,
     model::{
-        Artifacts, BuildPlanNode, NativeTarget, PackageId, RunBackend, TargetKind, TccRunConfig,
+        Artifacts, BuildPlanNode, NativeTarget, OperatingSystem, PackageId, RunBackend, TargetKind,
+        TccRunConfig,
     },
     prebuild::run_prebuild_config,
     user_warning::UserWarning,
@@ -55,7 +57,7 @@ use moonutil::{
         BLACKBOX_TEST_PATCH, DiagnosticLevel, MOONBITLANG_CORE, RunMode, TargetBackend,
         WHITEBOX_TEST_PATCH,
     },
-    compiler_flags::{self, CC},
+    compiler_flags::{self, CC, CompilerPaths},
     cond_expr::OptLevel as BuildProfile,
     dirs::WorkspaceEnv,
     features::FeatureGate,
@@ -381,6 +383,8 @@ impl CompilePreConfig {
             } else {
                 None
             },
+            os: OperatingSystem::from_str(std::env::consts::OS).expect("Unknown"),
+            compiler_paths: CompilerPaths::from_moon_dirs(),
             enable_coverage: self.enable_coverage,
             output_wat: self.output_wat,
             debug_export_build_plan: self.debug_export_build_plan,

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -30,7 +30,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
-    str::FromStr,
     sync::{Arc, Mutex},
 };
 
@@ -40,13 +39,12 @@ use indexmap::IndexMap;
 use moonbuild::entry::{N2RunStats, ResultCatcher, create_progress_console};
 use moonbuild_rupes_recta::{
     CompileConfig, ResolveConfig, ResolveOutput,
-    build_lower::{WarningCondition, artifact::n2_db_path},
+    build_lower::{LoweringEnvironment, WarningCondition, artifact::n2_db_path},
     build_plan::InputDirective,
     fmt::{FmtConfig, FmtResolveOutput},
     intent::UserIntent,
     model::{
-        Artifacts, BuildPlanNode, NativeTarget, OperatingSystem, PackageId, RunBackend, TargetKind,
-        TccRunConfig,
+        Artifacts, BuildPlanNode, NativeTarget, PackageId, RunBackend, TargetKind, TccRunConfig,
     },
     prebuild::run_prebuild_config,
     user_warning::UserWarning,
@@ -57,7 +55,7 @@ use moonutil::{
         BLACKBOX_TEST_PATCH, DiagnosticLevel, MOONBITLANG_CORE, RunMode, TargetBackend,
         WHITEBOX_TEST_PATCH,
     },
-    compiler_flags::{self, CC, CompilerPaths},
+    compiler_flags::{self, CC},
     cond_expr::OptLevel as BuildProfile,
     dirs::WorkspaceEnv,
     features::FeatureGate,
@@ -383,8 +381,7 @@ impl CompilePreConfig {
             } else {
                 None
             },
-            os: OperatingSystem::from_str(std::env::consts::OS).expect("Unknown"),
-            compiler_paths: CompilerPaths::from_moon_dirs(),
+            lowering_environment: LoweringEnvironment::default(),
             enable_coverage: self.enable_coverage,
             output_wat: self.output_wat,
             debug_export_build_plan: self.debug_export_build_plan,

--- a/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
@@ -33,7 +33,7 @@ use moonutil::{
 
 use crate::{
     discover::DiscoverResult,
-    model::{BuildTarget, NativeTarget, OperatingSystem, PackageId, RunBackend, TargetKind},
+    model::{BuildTarget, OperatingSystem, PackageId, RunBackend, TargetKind},
     pkg_name::PackageFQN,
 };
 
@@ -63,6 +63,38 @@ pub enum ExecutableArtifact {
         os: OperatingSystem,
         legacy_behavior: bool,
     },
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum LinkedCoreArtifact {
+    Wasm { use_wat: bool },
+    WasmGC { use_wat: bool },
+    Js,
+    NativeC,
+    NativeObject { os: OperatingSystem },
+    LlvmObject { os: OperatingSystem },
+}
+
+impl LinkedCoreArtifact {
+    fn target_backend(self) -> TargetBackend {
+        match self {
+            Self::Wasm { .. } => TargetBackend::Wasm,
+            Self::WasmGC { .. } => TargetBackend::WasmGC,
+            Self::Js => TargetBackend::Js,
+            Self::NativeC | Self::NativeObject { .. } => TargetBackend::Native,
+            Self::LlvmObject { .. } => TargetBackend::LLVM,
+        }
+    }
+
+    fn extension(self) -> &'static str {
+        match self {
+            Self::Wasm { use_wat } | Self::WasmGC { use_wat } if use_wat => ".wat",
+            Self::Wasm { .. } | Self::WasmGC { .. } => ".wasm",
+            Self::Js => ".js",
+            Self::NativeC => ".c",
+            Self::NativeObject { os } | Self::LlvmObject { os } => object_file_ext(os),
+        }
+    }
 }
 
 impl ExecutableArtifact {
@@ -347,20 +379,18 @@ impl LegacyLayout {
         &self,
         pkg_list: &DiscoverResult,
         target: &BuildTarget,
-        backend: TargetBackend,
-        native_target: Option<NativeTarget>,
-        os: OperatingSystem,
-        wasm_use_wat: bool,
+        linked_core: LinkedCoreArtifact,
     ) -> PathBuf {
         let pkg_fqn = &pkg_list.get_package(target.package).fqn;
+        let backend = linked_core.target_backend();
         let mut base_dir = self.package_dir(pkg_fqn, backend);
-        if backend == TargetBackend::Native && native_target.is_some() {
+        if matches!(linked_core, LinkedCoreArtifact::NativeObject { .. }) {
             base_dir.push("__moonbit_link_core__");
         }
         base_dir.push(format!(
             "{}{}",
             artifact(pkg_fqn, target.kind),
-            linked_core_artifact_ext(backend, native_target, os, wasm_use_wat)
+            linked_core.extension()
         ));
         base_dir
     }
@@ -638,22 +668,6 @@ fn build_kind_suffix_filename(kind: TargetKind) -> &'static str {
         TargetKind::BlackboxTest => "_blackbox_test",
         TargetKind::InlineTest => "_internal_test",
         TargetKind::SubPackage => "_sub",
-    }
-}
-
-fn linked_core_artifact_ext(
-    backend: TargetBackend,
-    native_target: Option<NativeTarget>,
-    os: OperatingSystem,
-    wasm_use_wat: bool, // TODO: centralize knobs
-) -> &'static str {
-    match backend {
-        TargetBackend::Wasm | TargetBackend::WasmGC if wasm_use_wat => ".wat",
-        TargetBackend::Wasm | TargetBackend::WasmGC => ".wasm",
-        TargetBackend::Js => ".js",
-        TargetBackend::Native if native_target.is_some() => object_file_ext(os),
-        TargetBackend::Native => ".c",
-        TargetBackend::LLVM => object_file_ext(os),
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -276,10 +276,7 @@ impl<'a> LoweringContext<'a> {
                 out.push(self.layout.linked_core_of_build_target(
                     self.packages,
                     target,
-                    self.opt.target_backend.into(),
-                    self.opt.native_target,
-                    self.opt.os(),
-                    self.opt.output_wat,
+                    self.opt.linked_core_artifact(),
                 ));
             }
             PlannedArtifact::Executable { target, .. } => {

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -251,7 +251,7 @@ impl<'a> LoweringContext<'a> {
                             .file_stem()
                             .expect("c stub file should have a file name"),
                         self.opt.target_backend.into(),
-                        self.opt.os,
+                        self.opt.os(),
                     ),
                 );
             }
@@ -261,14 +261,14 @@ impl<'a> LoweringContext<'a> {
                         self.packages,
                         *package,
                         self.opt.target_backend.into(),
-                        self.opt.os,
+                        self.opt.os(),
                     ));
                 } else {
                     out.push(self.layout.c_stub_archive_path(
                         self.packages,
                         *package,
                         self.opt.target_backend.into(),
-                        self.opt.os,
+                        self.opt.os(),
                     ));
                 }
             }
@@ -278,7 +278,7 @@ impl<'a> LoweringContext<'a> {
                     target,
                     self.opt.target_backend.into(),
                     self.opt.native_target,
-                    self.opt.os,
+                    self.opt.os(),
                     self.opt.output_wat,
                 ));
             }
@@ -314,7 +314,7 @@ impl<'a> LoweringContext<'a> {
                 out.push(self.layout.runtime_output_path(
                     self.opt.target_backend,
                     self.opt.use_tcc_run(),
-                    self.opt.os,
+                    self.opt.os(),
                 ));
             }
             PlannedArtifact::GeneratedMbti { target, .. } => {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -135,10 +135,10 @@ impl<'a> super::LoweringContext<'a> {
         let artifact_path = self.layout.runtime_output_path(
             self.opt.target_backend,
             self.opt.use_tcc_run(),
-            self.opt.os,
+            self.opt.os(),
         );
 
-        let runtime_c_path = self.opt.runtime_dot_c_path.clone();
+        let runtime_c_path = self.opt.runtime_dot_c_path();
 
         let use_tcc_run = self.opt.use_tcc_run();
         let (output_ty, link_moonbitrun) = match self.opt.target_backend {
@@ -159,7 +159,7 @@ impl<'a> super::LoweringContext<'a> {
         .clone();
         let use_simdutf = !use_tcc_run
             && resolved_cc.can_use_simdutf()
-            && self.opt.compiler_paths.simdutf_object_paths().is_some();
+            && self.opt.compiler_paths().simdutf_object_paths().is_some();
 
         let cc_cmd = make_cc_command_resolved(
             resolved_cc,
@@ -168,7 +168,9 @@ impl<'a> super::LoweringContext<'a> {
                 .output_ty(output_ty)
                 .opt_level(CCOptLevel::Speed)
                 .debug_info(true)
-                .allow_stacktrace(self.opt.debug_symbols && self.opt.os != OperatingSystem::Windows)
+                .allow_stacktrace(
+                    self.opt.debug_symbols && self.opt.os() != OperatingSystem::Windows,
+                )
                 .define_tinyc_macro(use_tcc_run)
                 .preserve_frame_pointer(use_tcc_run)
                 .link_moonbitrun(link_moonbitrun)
@@ -181,7 +183,7 @@ impl<'a> super::LoweringContext<'a> {
             [runtime_c_path.display().to_string()],
             &self.opt.target_dir_root.display().to_string(),
             Some(&artifact_path.display().to_string()),
-            &self.opt.compiler_paths,
+            self.opt.compiler_paths(),
         );
 
         Ok(BuildCommand {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -627,7 +627,7 @@ impl<'a> LoweringContext<'a> {
             &target,
             self.opt.target_backend.into(),
             self.opt.native_target,
-            self.opt.os,
+            self.opt.os(),
             self.opt.output_wat,
         );
 
@@ -799,7 +799,7 @@ impl<'a> LoweringContext<'a> {
                 .file_stem()
                 .expect("stub lib should have a file name"),
             self.opt.target_backend.into(),
-            self.opt.os,
+            self.opt.os(),
         );
 
         // Match legacy to_opt_level function exactly
@@ -839,7 +839,7 @@ impl<'a> LoweringContext<'a> {
             [input_file.display().to_string()],
             &intermediate_dir,
             Some(&output_file.display().to_string()),
-            &self.opt.compiler_paths,
+            self.opt.compiler_paths(),
         );
 
         BuildCommand {
@@ -894,7 +894,7 @@ impl<'a> LoweringContext<'a> {
             self.packages,
             target,
             self.opt.target_backend.into(),
-            self.opt.os,
+            self.opt.os(),
         );
 
         let config = ArchiverConfigBuilder::default()
@@ -911,7 +911,7 @@ impl<'a> LoweringContext<'a> {
                 .map(|s| s.to_string_lossy())
                 .collect::<Vec<_>>(),
             &archive.display().to_string(),
-            &self.opt.compiler_paths,
+            self.opt.compiler_paths(),
         );
 
         BuildCommand {
@@ -931,7 +931,7 @@ impl<'a> LoweringContext<'a> {
             self.packages,
             target,
             self.opt.target_backend.into(),
-            self.opt.os,
+            self.opt.os(),
         );
         let dest_dir = dylib_out
             .parent()
@@ -944,7 +944,7 @@ impl<'a> LoweringContext<'a> {
         let runtime_dylib = self.layout.runtime_output_path(
             self.opt.target_backend,
             self.opt.use_tcc_run(),
-            self.opt.os,
+            self.opt.os(),
         );
         let runtime_parent = runtime_dylib
             .parent()
@@ -975,7 +975,7 @@ impl<'a> LoweringContext<'a> {
             &sources,
             &dest_dir,
             &dylib_out.display().to_string(),
-            &self.opt.compiler_paths.lib_path,
+            &self.opt.compiler_paths().lib_path,
         );
 
         // Note: Runtime input is tracked in build plan, so no need to add here.
@@ -1083,7 +1083,7 @@ impl<'a> LoweringContext<'a> {
         let cc = info.effective_native_toolchain.cc().clone();
         let simdutf_objects = if cc.can_use_simdutf() {
             self.opt
-                .compiler_paths
+                .compiler_paths()
                 .simdutf_object_paths()
                 .map(|objects| objects.into_iter().collect::<Vec<_>>())
                 .unwrap_or_default()
@@ -1132,12 +1132,12 @@ impl<'a> LoweringContext<'a> {
             sources.iter().map(|x| x.display().to_string()),
             &pkg_dir,
             Some(&dest),
-            &self.opt.compiler_paths,
+            self.opt.compiler_paths(),
         );
 
         // On macOS with LLVM backend and debug symbols, run dsymutil after linking
         // to generate the dSYM bundle for better debugging experience
-        let commandline = if self.opt.os == OperatingSystem::MacOS
+        let commandline = if self.opt.os() == OperatingSystem::MacOS
             && self.opt.target_backend == RunBackend::Llvm
             && self.opt.debug_symbols
         {
@@ -1163,7 +1163,7 @@ impl<'a> LoweringContext<'a> {
         let cc = info.effective_native_toolchain.cc().clone();
         let simdutf_objects = if cc.can_use_simdutf() {
             self.opt
-                .compiler_paths
+                .compiler_paths()
                 .simdutf_object_paths()
                 .map(|objects| objects.into_iter().collect::<Vec<_>>())
                 .unwrap_or_default()
@@ -1208,7 +1208,7 @@ impl<'a> LoweringContext<'a> {
             &source_args,
             &pkg_dir,
             &dest,
-            &self.opt.compiler_paths.lib_path,
+            &self.opt.compiler_paths().lib_path,
         );
 
         let commandline = if run_dsymutil {
@@ -1255,7 +1255,7 @@ impl<'a> LoweringContext<'a> {
             sources.iter().map(|x| x.to_string_lossy().into_owned()),
             "", // TCC is not MSVC, no need to set special dest dir
             None,
-            &self.opt.compiler_paths,
+            self.opt.compiler_paths(),
         );
 
         // The C file from moonc link-core
@@ -1265,7 +1265,7 @@ impl<'a> LoweringContext<'a> {
             &target,
             self.opt.target_backend.into(),
             self.opt.native_target,
-            self.opt.os,
+            self.opt.os(),
             self.opt.output_wat,
         );
         cmdline.push(c_file.display().to_string());

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -625,10 +625,7 @@ impl<'a> LoweringContext<'a> {
         let out_file = self.layout.linked_core_of_build_target(
             self.packages,
             &target,
-            self.opt.target_backend.into(),
-            self.opt.native_target,
-            self.opt.os(),
-            self.opt.output_wat,
+            self.opt.linked_core_artifact(),
         );
 
         let core_fqn = PackageFQN::new(CORE_MODULE.clone(), PackagePath::empty());
@@ -1263,10 +1260,7 @@ impl<'a> LoweringContext<'a> {
         let c_file = self.layout.linked_core_of_build_target(
             self.packages,
             &target,
-            self.opt.target_backend.into(),
-            self.opt.native_target,
-            self.opt.os(),
-            self.opt.output_wat,
+            self.opt.linked_core_artifact(),
         );
         cmdline.push(c_file.display().to_string());
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -44,7 +44,7 @@ mod utils;
 
 pub use utils::{build_ins, build_n2_fileloc, build_outs};
 
-use crate::build_lower::artifact::{ExecutableArtifact, LegacyLayoutBuilder};
+use crate::build_lower::artifact::{ExecutableArtifact, LegacyLayoutBuilder, LinkedCoreArtifact};
 use context::LoweringContext;
 
 /// Lazily resolved host/toolchain facts used during lowering.
@@ -153,6 +153,23 @@ impl BuildOptions {
                 os: self.os(),
                 legacy_behavior,
             },
+        }
+    }
+
+    pub fn linked_core_artifact(&self) -> LinkedCoreArtifact {
+        match self.target_backend {
+            RunBackend::Wasm => LinkedCoreArtifact::Wasm {
+                use_wat: self.output_wat,
+            },
+            RunBackend::WasmGC => LinkedCoreArtifact::WasmGC {
+                use_wat: self.output_wat,
+            },
+            RunBackend::Js => LinkedCoreArtifact::Js,
+            RunBackend::Native if self.native_target.is_some() => {
+                LinkedCoreArtifact::NativeObject { os: self.os() }
+            }
+            RunBackend::Native => LinkedCoreArtifact::NativeC,
+            RunBackend::Llvm => LinkedCoreArtifact::LlvmObject { os: self.os() },
         }
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -18,7 +18,7 @@
 
 //! Lowers the normalized action plan into `n2`'s build graph.
 
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::BTreeMap, path::PathBuf, str::FromStr, sync::OnceLock};
 
 use indexmap::IndexMap;
 use log::{debug, info};
@@ -47,6 +47,47 @@ pub use utils::{build_ins, build_n2_fileloc, build_outs};
 use crate::build_lower::artifact::{ExecutableArtifact, LegacyLayoutBuilder};
 use context::LoweringContext;
 
+/// Lazily resolved host/toolchain facts used during lowering.
+///
+/// The build pipeline passes this object explicitly so lower phases do not
+/// rediscover environment facts in place. Individual facts remain lazy because
+/// non-native backends do not need native OS/toolchain details.
+#[derive(Default)]
+pub struct LoweringEnvironment {
+    os: OnceLock<OperatingSystem>,
+    compiler_paths: OnceLock<CompilerPaths>,
+}
+
+impl Clone for LoweringEnvironment {
+    fn clone(&self) -> Self {
+        let cloned = Self::default();
+        if let Some(os) = self.os.get() {
+            let _ = cloned.os.set(*os);
+        }
+        if let Some(compiler_paths) = self.compiler_paths.get() {
+            let _ = cloned.compiler_paths.set(compiler_paths.clone());
+        }
+        cloned
+    }
+}
+
+impl LoweringEnvironment {
+    pub fn os(&self) -> OperatingSystem {
+        *self
+            .os
+            .get_or_init(|| OperatingSystem::from_str(std::env::consts::OS).expect("Unknown"))
+    }
+
+    pub fn compiler_paths(&self) -> &CompilerPaths {
+        self.compiler_paths
+            .get_or_init(CompilerPaths::from_moon_dirs)
+    }
+
+    pub fn runtime_dot_c_path(&self) -> PathBuf {
+        PathBuf::from(&self.compiler_paths().lib_path).join("runtime.c")
+    }
+}
+
 /// Knobs to tweak during build. Affects behaviors during lowering.
 pub struct BuildOptions {
     pub main_module: Option<ModuleSource>,
@@ -55,7 +96,6 @@ pub struct BuildOptions {
     pub target_backend: RunBackend,
     pub native_target: Option<NativeTarget>,
     pub tcc_run: Option<TccRunConfig>,
-    pub os: OperatingSystem,
     pub opt_level: OptLevel,
     pub action: RunMode,
 
@@ -72,11 +112,22 @@ pub struct BuildOptions {
     // Environments
     /// Only `Some` if we import standard library.
     pub stdlib_path: Option<PathBuf>,
-    pub runtime_dot_c_path: PathBuf,
-    pub compiler_paths: CompilerPaths,
+    pub lowering_environment: LoweringEnvironment,
 }
 
 impl BuildOptions {
+    pub fn os(&self) -> OperatingSystem {
+        self.lowering_environment.os()
+    }
+
+    pub fn compiler_paths(&self) -> &CompilerPaths {
+        self.lowering_environment.compiler_paths()
+    }
+
+    pub fn runtime_dot_c_path(&self) -> PathBuf {
+        self.lowering_environment.runtime_dot_c_path()
+    }
+
     pub fn use_tcc_run(&self) -> bool {
         let use_tcc_run = self.tcc_run.is_some();
         debug_assert!(!use_tcc_run || self.target_backend == RunBackend::Native);
@@ -95,11 +146,11 @@ impl BuildOptions {
             RunBackend::Js => ExecutableArtifact::Js,
             RunBackend::Native if self.use_tcc_run() => ExecutableArtifact::TccRunResponseFile,
             RunBackend::Native => ExecutableArtifact::NativeExecutable {
-                os: self.os,
+                os: self.os(),
                 legacy_behavior,
             },
             RunBackend::Llvm => ExecutableArtifact::LlvmExecutable {
-                os: self.os,
+                os: self.os(),
                 legacy_behavior,
             },
         }

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -16,17 +16,16 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::path::PathBuf;
-
 use indexmap::IndexMap;
 use log::{debug, info};
-use moonutil::{common::RunMode, compiler_flags::CompilerPaths, cond_expr::OptLevel};
+use moonutil::{common::RunMode, cond_expr::OptLevel};
+use std::path::PathBuf;
 use tracing::{Level, instrument};
 
 use crate::{
-    build_lower::{self, WarningCondition},
+    build_lower::{self, LoweringEnvironment, WarningCondition},
     build_plan::{self, BuildEnvironment, InputDirective},
-    model::{Artifacts, BuildPlanNode, NativeTarget, OperatingSystem, RunBackend, TccRunConfig},
+    model::{Artifacts, BuildPlanNode, NativeTarget, RunBackend, TccRunConfig},
     prebuild::PrebuildOutput,
     resolve::ResolveOutput,
     special_cases::should_skip_tests,
@@ -53,10 +52,8 @@ pub struct CompileConfig {
     /// The path to the standard library's project root, or `None` if to not
     /// import the standard library during compilation.
     pub stdlib_path: Option<PathBuf>,
-    /// Host operating system captured before planning/lowering.
-    pub os: OperatingSystem,
-    /// Toolchain paths captured before planning/lowering.
-    pub compiler_paths: CompilerPaths,
+    /// Host/toolchain facts resolved lazily during lowering.
+    pub lowering_environment: LoweringEnvironment,
 
     // MAINTAINERS: consider moving some of these to per-package/module options.
     /// Whether to export the build plan graph in the compile output.
@@ -144,7 +141,6 @@ pub fn compile(
     info!("Build plan created successfully");
     debug!("Build plan contains {} nodes", plan.node_count());
 
-    let runtime_dot_c_path = PathBuf::from(&cx.compiler_paths.lib_path).join("runtime.c");
     let lower_env = build_lower::BuildOptions {
         main_module: match resolve_output.local_modules() {
             &[module] => Some(resolve_output.module_rel.module_source(module).clone()),
@@ -167,9 +163,7 @@ pub fn compile(
         wasi_link: cx.wasi_link,
 
         stdlib_path: cx.stdlib_path.clone(),
-        compiler_paths: cx.compiler_paths.clone(),
-        os: cx.os,
-        runtime_dot_c_path,
+        lowering_environment: cx.lowering_environment.clone(),
     };
     let (build_graph, command_args_by_output, artifacts) = {
         let action_plan = plan.build_action_plan();

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::{path::PathBuf, str::FromStr};
+use std::path::PathBuf;
 
 use indexmap::IndexMap;
 use log::{debug, info};
@@ -53,6 +53,10 @@ pub struct CompileConfig {
     /// The path to the standard library's project root, or `None` if to not
     /// import the standard library during compilation.
     pub stdlib_path: Option<PathBuf>,
+    /// Host operating system captured before planning/lowering.
+    pub os: OperatingSystem,
+    /// Toolchain paths captured before planning/lowering.
+    pub compiler_paths: CompilerPaths,
 
     // MAINTAINERS: consider moving some of these to per-package/module options.
     /// Whether to export the build plan graph in the compile output.
@@ -140,8 +144,7 @@ pub fn compile(
     info!("Build plan created successfully");
     debug!("Build plan contains {} nodes", plan.node_count());
 
-    let compiler_paths = CompilerPaths::from_moon_dirs();
-    let runtime_dot_c_path = PathBuf::from(&compiler_paths.lib_path).join("runtime.c");
+    let runtime_dot_c_path = PathBuf::from(&cx.compiler_paths.lib_path).join("runtime.c");
     let lower_env = build_lower::BuildOptions {
         main_module: match resolve_output.local_modules() {
             &[module] => Some(resolve_output.module_rel.module_source(module).clone()),
@@ -164,8 +167,8 @@ pub fn compile(
         wasi_link: cx.wasi_link,
 
         stdlib_path: cx.stdlib_path.clone(),
-        compiler_paths,
-        os: OperatingSystem::from_str(std::env::consts::OS).expect("Unknown"),
+        compiler_paths: cx.compiler_paths.clone(),
+        os: cx.os,
         runtime_dot_c_path,
     };
     let (build_graph, command_args_by_output, artifacts) = {

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -116,6 +116,32 @@ Implementation-wise:
 [rr_home]: /crates/moonbuild-rupes-recta/src/lib.rs
 [n2]: https://github.com/moonbitlang/n2
 
+### Directory and environment facts
+
+Directory discovery is intentionally front-loaded. Command entry points should
+calculate facts such as the selected project root, target directory, workspace
+selection, and `.mooncakes` directory once, then pass those facts into later
+phases. Later phases should not rediscover them from the working directory.
+
+This is part of the compiler-style shape of the RR pipeline: for directory and
+project facts, the command layer captures user input and passes the result
+forward instead of letting later phases infer it again. In particular:
+
+- project and workspace selection are captured before package discovery;
+- the `.mooncakes` directory is passed into resolve and then threaded through
+  `ResolveOutput`;
+- the target directory is passed into planning/lowering and used for generated
+  build files and n2 state; and
+- package and module directories come from discovery results, not from later
+  path guessing.
+
+Toolchain and host facts are not fully centralized today. `rr_build` and
+`compile` still make some host-dependent decisions while preparing planning and
+lowering. They should follow the same rule where practical: if a phase needs the
+host OS, compiler paths, standard-library path, or native toolchain choices,
+those should be captured by a dedicated environment step and passed forward as
+explicit input instead of being rediscovered at each use site.
+
 ## Project discovery and layout
 
 Currently, most subcommands in `moon` still work on a single input module [^input_module]

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -139,8 +139,10 @@ Toolchain and host facts are not fully centralized today. `rr_build` and
 `compile` still make some host-dependent decisions while preparing planning and
 lowering. They should follow the same rule where practical: if a phase needs the
 host OS, compiler paths, standard-library path, or native toolchain choices,
-those should be captured by a dedicated environment step and passed forward as
-explicit input instead of being rediscovered at each use site.
+those should be owned by an explicit environment object and passed forward
+instead of being rediscovered at each use site. Such facts do not need to be
+eager: non-native builds should not resolve native-only OS/toolchain details
+unless a lowering path actually asks for them.
 
 ## Project discovery and layout
 


### PR DESCRIPTION
## Why

Build graph generation already captures directory and project facts up front, but some host and toolchain facts were still discovered inside lower phases. That made the environment inputs to planning less explicit, and it also made non-native outputs appear to depend on native-only facts such as the host operating system.

## What changed

- Document the invariant that directory facts are established before planning and should not be rediscovered later.
- Pass captured compiler environment through compile configuration instead of resolving it inside compile.
- Add an explicit lowering environment object that resolves host and toolchain facts lazily.
- Model linked-core artifact selection explicitly so host OS is only needed for object-producing native and LLVM outputs.

## Why this is correct

The generated artifact naming rules stay the same. The change moves existing decisions into explicit configuration objects and narrows when native-only environment facts are requested. Non-native linked-core outputs still use fixed wasm/js/C extensions without consulting host OS.

## Scope

This is intentionally limited to environment capture, lowering configuration, linked-core artifact selection, and the related developer reference documentation.