### PR TITLE
Make RR project inputs explicit

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -270,7 +270,6 @@ pub(crate) fn plan_build_rr_from_resolved(
     rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         intent,
@@ -314,7 +313,6 @@ fn plan_build_rr_from_resolved_with_scope(
     rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         intent,
@@ -353,7 +351,6 @@ fn plan_build_rr_from_selection(
     rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         selection.into_user_intent(),

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -174,9 +174,15 @@ fn run_build_rr(
         !cmd.build_flags.std(),
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
-    )
-    .with_project_manifest_path(project_manifest_path);
-    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir, mooncakes_dir)?;
+    );
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(
+        &resolve_cfg,
+        source_dir,
+        mooncakes_dir,
+        project_manifest_path,
+    )?;
+    let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
     let prebuild_list = if watch {
         rr_get_prebuild_watch_paths(&resolve_output)
     } else {
@@ -190,6 +196,7 @@ fn run_build_rr(
         cmd,
         source_dir,
         target_dir,
+        &mooncake_bin_dir,
         selected_target_backend,
         resolve_output,
     )?;
@@ -232,6 +239,7 @@ pub(crate) fn plan_build_rr_from_resolved(
     cli: &UniversalFlags,
     cmd: &BuildSubcommand,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
@@ -266,6 +274,7 @@ pub(crate) fn plan_build_rr_from_resolved(
         output,
         planning_context,
         intent,
+        mooncake_bin_dir,
         resolve_output,
     )
 }
@@ -274,6 +283,7 @@ fn plan_build_rr_from_resolved_with_scope(
     cli: &UniversalFlags,
     cmd: &BuildSubcommand,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     target_backend: TargetBackend,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
     scoped_packages: Vec<PackageId>,
@@ -308,6 +318,7 @@ fn plan_build_rr_from_resolved_with_scope(
         output,
         planning_context,
         intent,
+        mooncake_bin_dir,
         resolve_output,
     )
 }
@@ -316,6 +327,7 @@ fn plan_build_rr_from_selection(
     cli: &UniversalFlags,
     cmd: &BuildSubcommand,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     target_backend: TargetBackend,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
     selection: ResolvedBuildSelection,
@@ -345,6 +357,7 @@ fn plan_build_rr_from_selection(
         output,
         planning_context,
         selection.into_user_intent(),
+        mooncake_bin_dir,
         resolve_output,
     )
 }
@@ -354,6 +367,7 @@ pub(crate) fn plan_build_rr_from_resolved_all(
     cmd: &BuildSubcommand,
     _source_dir: &Path,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<Vec<(rr_build::BuildMeta, rr_build::BuildInput)>> {
@@ -373,6 +387,7 @@ pub(crate) fn plan_build_rr_from_resolved_all(
                 cli,
                 cmd,
                 target_dir,
+                mooncake_bin_dir,
                 target_backend,
                 resolve_output,
                 ResolvedBuildSelection { packages },
@@ -384,6 +399,7 @@ pub(crate) fn plan_build_rr_from_resolved_all(
             cli,
             cmd,
             target_dir,
+            mooncake_bin_dir,
             Some(target_backend),
             resolve_output,
         )
@@ -402,12 +418,14 @@ pub(crate) fn plan_build_rr_from_resolved_all(
             .into_iter()
             .map(|selection| {
                 // Raw user selector paths/package names have already been
-                // resolved into PackageIds. RR will read build-model paths
-                // from ResolveOutput instead of reinterpreting those selectors.
+                // resolved into PackageIds. RR will use those identities plus
+                // the bin-dependency launcher directory captured by the
+                // command adapter.
                 plan_build_rr_from_selection(
                     cli,
                     cmd,
                     target_dir,
+                    mooncake_bin_dir,
                     selection.target_backend,
                     resolve_output.clone(),
                     ResolvedBuildSelection {
@@ -419,8 +437,15 @@ pub(crate) fn plan_build_rr_from_resolved_all(
     }
 
     if selections.is_empty() {
-        return plan_build_rr_from_resolved(cli, cmd, target_dir, None, resolve_output)
-            .map(|plan| vec![plan]);
+        return plan_build_rr_from_resolved(
+            cli,
+            cmd,
+            target_dir,
+            mooncake_bin_dir,
+            None,
+            resolve_output,
+        )
+        .map(|plan| vec![plan]);
     }
 
     selections
@@ -430,6 +455,7 @@ pub(crate) fn plan_build_rr_from_resolved_all(
                 cli,
                 cmd,
                 target_dir,
+                mooncake_bin_dir,
                 selection.target_backend,
                 resolve_output.clone(),
                 selection.packages,

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -187,13 +187,20 @@ pub(crate) fn plan_bundle_rr(
         !cmd.build_flags.std(),
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
-    )
-    .with_project_manifest_path(project_manifest_path);
-    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir, mooncakes_dir)?;
+    );
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(
+        &resolve_cfg,
+        source_dir,
+        mooncakes_dir,
+        project_manifest_path,
+    )?;
+    let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
     plan_bundle_rr_from_resolved(
         cli,
         cmd,
         target_dir,
+        &mooncake_bin_dir,
         selected_target_backend,
         resolve_output,
     )
@@ -203,6 +210,7 @@ pub(crate) fn plan_bundle_rr_from_resolved(
     cli: &UniversalFlags,
     cmd: &BundleSubcommand,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
@@ -223,6 +231,7 @@ pub(crate) fn plan_bundle_rr_from_resolved(
         output,
         planning_context,
         intent,
+        mooncake_bin_dir,
         resolve_output,
     )
 }

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -227,7 +227,6 @@ pub(crate) fn plan_bundle_rr_from_resolved(
     rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         intent,

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -345,7 +345,6 @@ fn run_check_for_single_file_rr(
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         intent,
@@ -679,7 +678,6 @@ pub(crate) fn plan_check_rr_from_resolved(
     rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         intent,
@@ -718,7 +716,6 @@ fn plan_check_rr_from_selection(
     rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         selection.into_user_intent()?,

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -319,6 +319,7 @@ fn run_check_for_single_file_rr(
         &single_file_path,
         false,
     )?;
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
     let selected_target_backend = selected_target_backend
         .or(cmd.build_flags.resolve_single_target_backend()?)
         .or(backend);
@@ -348,6 +349,7 @@ fn run_check_for_single_file_rr(
         output,
         planning_context,
         intent,
+        &mooncake_bin_dir,
         resolved,
     )
     .context("Failed to calculate build plan")?;
@@ -470,9 +472,16 @@ fn run_check_normal_internal_rr(
         !cmd.build_flags.std(),
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
+    );
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(
+        &resolve_cfg,
+        source_dir,
+        mooncakes_dir,
+        project_manifest_path,
     )
-    .with_project_manifest_path(project_manifest_path);
-    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, source_dir, mooncakes_dir)
+    .context("Failed to calculate build plan")?;
+    let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)
         .context("Failed to calculate build plan")?;
     let prebuild_list = if watch {
         rr_get_prebuild_watch_paths(&resolve_output)
@@ -487,6 +496,7 @@ fn run_check_normal_internal_rr(
         cmd,
         source_dir,
         target_dir,
+        &mooncake_bin_dir,
         selected_target_backend,
         resolve_output,
     )
@@ -545,6 +555,7 @@ pub(crate) fn plan_check_rr_from_resolved_all(
     cmd: &CheckSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<Vec<(rr_build::BuildMeta, rr_build::BuildInput)>> {
@@ -570,6 +581,7 @@ pub(crate) fn plan_check_rr_from_resolved_all(
             cmd,
             source_dir,
             target_dir,
+            mooncake_bin_dir,
             selected_target_backend,
             resolve_output,
         )
@@ -581,11 +593,13 @@ pub(crate) fn plan_check_rr_from_resolved_all(
         .map(|selection| {
             // The command adapter has resolved raw CLI selectors into
             // PackageIds. RR planning should use those identities and the
-            // build-model paths already stored in ResolveOutput.
+            // bin-dependency launcher directory captured by the command
+            // adapter.
             plan_check_rr_from_selection(
                 cli,
                 cmd,
                 target_dir,
+                mooncake_bin_dir,
                 selection.target_backend,
                 resolve_output.clone(),
                 ResolvedCheckSelection::from_command(selection.packages, cmd),
@@ -622,6 +636,7 @@ pub(crate) fn plan_check_rr_from_resolved(
     cmd: &CheckSubcommand,
     source_dir: &Path,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
@@ -668,6 +683,7 @@ pub(crate) fn plan_check_rr_from_resolved(
         output,
         planning_context,
         intent,
+        mooncake_bin_dir,
         resolve_output,
     )
 }
@@ -676,6 +692,7 @@ fn plan_check_rr_from_selection(
     cli: &UniversalFlags,
     cmd: &CheckSubcommand,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     target_backend: TargetBackend,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
     selection: ResolvedCheckSelection,
@@ -705,6 +722,7 @@ fn plan_check_rr_from_selection(
         output,
         planning_context,
         selection.into_user_intent()?,
+        mooncake_bin_dir,
         resolve_output,
     )
 }

--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -130,15 +130,22 @@ fn run_cram_test(cli: &UniversalFlags, cmd: CramTestSubcommand) -> anyhow::Resul
         !build_cmd.build_flags.std(),
         build_cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
-    )
-    .with_project_manifest_path(project_manifest_path.as_deref());
-    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+    );
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(
+        &resolve_cfg,
+        &source_dir,
+        &mooncakes_dir,
+        project_manifest_path.as_deref(),
+    )?;
+    let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
 
     let planned_runs = crate::cli::plan_build_rr_from_resolved_all(
         cli,
         &build_cmd,
         &source_dir,
         &target_dir,
+        &mooncake_bin_dir,
         Some(TargetBackend::Native),
         resolve_output,
     )?;

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -141,7 +141,6 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        &target_dir,
         output,
         planning_context,
         intent,

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -118,10 +118,15 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
     );
     preconfig.docs_serve = cmd.serve;
 
-    let resolve_cfg = preconfig
-        .resolve_config()
-        .with_project_manifest_path(project_manifest_path.as_deref());
-    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+    let resolve_cfg = preconfig.resolve_config();
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(
+        &resolve_cfg,
+        &source_dir,
+        &mooncakes_dir,
+        project_manifest_path.as_deref(),
+    )?;
+    let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
 
     let output = UserDiagnostics::from_flags(&cli);
     let planning_context = rr_build::prepare_resolved_build(
@@ -140,6 +145,7 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
         output,
         planning_context,
         intent,
+        &mooncake_bin_dir,
         resolve_output,
     )?;
 

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -385,7 +385,6 @@ fn run_info_rr_internal(
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         intent,

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -22,7 +22,8 @@ use std::path::PathBuf;
 
 use anyhow::bail;
 use moonbuild_rupes_recta::{
-    ResolveConfig, ResolveOutput, intent::UserIntent, model::PackageId, resolve,
+    ResolveConfig, ResolveOutput, intent::UserIntent, model::PackageId, resolve_synced_project,
+    sync_dependencies,
 };
 use moonutil::{
     common::{RunMode, SurfaceTarget, TargetBackend, lower_surface_targets},
@@ -290,9 +291,15 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
         !build_flags.std(),
         build_flags.enable_coverage,
         cli.workspace_env.clone(),
-    )
-    .with_project_manifest_path(project_manifest_path.as_deref());
-    let resolve_output = resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+    );
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+    let synced_env = sync_dependencies(
+        &resolve_cfg,
+        &source_dir,
+        &mooncakes_dir,
+        project_manifest_path.as_deref(),
+    )?;
+    let resolve_output = resolve_synced_project(&resolve_cfg, synced_env)?;
     let output = UserDiagnostics::from_flags(&cli);
     let selection = PackageSelection::new(&cmd, &resolve_output, output)?;
 
@@ -314,6 +321,7 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
             tgt,
             target_kind,
             &target_dir,
+            &mooncake_bin_dir,
             resolve_output.clone(),
             &selection,
             &output_plan,
@@ -344,6 +352,7 @@ fn run_info_rr_internal(
     target: TargetBackend,
     target_kind: imp::TargetKind,
     target_dir: &std::path::Path,
+    mooncake_bin_dir: &std::path::Path,
     resolve_output: ResolveOutput,
     selection: &PackageSelection,
     output_plan: &imp::InfoOutputPlan,
@@ -380,6 +389,7 @@ fn run_info_rr_internal(
         output,
         planning_context,
         intent,
+        mooncake_bin_dir,
         resolve_output,
     )?;
     // Generate the all_pkgs.json for indirect dependency resolution

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -610,7 +610,6 @@ fn build_and_install_packages(
         let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
             preconfig,
             &cli.unstable_feature,
-            &target_dir,
             output,
             planning_context,
             intent,

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -468,10 +468,18 @@ fn build_and_install_packages(
     let source_dir = package_dirs.source_dir;
     let target_dir = package_dirs.target_dir;
     let mooncakes_dir = package_dirs.mooncakes_dir;
+    let project_manifest_path = package_dirs.project_manifest_path;
 
     let resolve_cfg =
         ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone());
-    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(
+        &resolve_cfg,
+        &source_dir,
+        &mooncakes_dir,
+        project_manifest_path.as_deref(),
+    )?;
+    let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
 
     let main_module_id = resolve_output.local_modules()[0];
     let Some(all_pkgs) = resolve_output.pkg_dirs.packages_for_module(main_module_id) else {
@@ -606,6 +614,7 @@ fn build_and_install_packages(
             output,
             planning_context,
             intent,
+            &mooncake_bin_dir,
             resolve_output.clone(),
         )?;
 

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -152,11 +152,15 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
     let path_filter = cmd.path.as_deref();
     let prove_why3_config = why3_config_path.clone();
 
-    let resolve_cfg = preconfig
-        .resolve_config()
-        .with_project_manifest_path(project_manifest_path.as_deref());
-    let resolve_output =
-        moonbuild_rupes_recta::resolve(&resolve_cfg, &project_root, &mooncakes_dir)?;
+    let resolve_cfg = preconfig.resolve_config();
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(
+        &resolve_cfg,
+        &project_root,
+        &mooncakes_dir,
+        project_manifest_path.as_deref(),
+    )?;
+    let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
 
     let output = UserDiagnostics::from_flags(cli);
     let planning_context = rr_build::prepare_resolved_build(
@@ -180,6 +184,7 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
         output,
         planning_context,
         intent,
+        &mooncake_bin_dir,
         resolve_output,
     )?;
     let proof_reports = planned_proof_reports(&build_meta);

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -180,7 +180,6 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        &target_dir,
         output,
         planning_context,
         intent,

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -554,7 +554,6 @@ pub(crate) fn plan_run_rr_from_resolved(
     rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         intent,
@@ -701,7 +700,6 @@ fn build_single_file_executable(
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        &target_dir,
         output,
         planning_context,
         intent,

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -478,13 +478,20 @@ fn build_package_executable(
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     )
-    .with_project_manifest_path(project_manifest_path.as_deref())
     .with_sync_output(options.output.sync_output());
-    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(
+        &resolve_cfg,
+        &source_dir,
+        &mooncakes_dir,
+        project_manifest_path.as_deref(),
+    )?;
+    let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
     let (build_meta, build_graph) = plan_run_rr_from_resolved(
         cli,
         cmd,
         &target_dir,
+        &mooncake_bin_dir,
         selected_target_backend,
         resolve_output,
         options.try_tcc_run,
@@ -508,6 +515,7 @@ pub(crate) fn plan_run_rr_from_resolved(
     cli: &UniversalFlags,
     cmd: &RunSubcommand,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: ResolveOutput,
     try_tcc_run: bool,
@@ -550,6 +558,7 @@ pub(crate) fn plan_run_rr_from_resolved(
         output,
         planning_context,
         intent,
+        mooncake_bin_dir,
         resolve_output,
     )
 }
@@ -657,6 +666,7 @@ fn build_single_file_executable(
         &input_path,
         true,
     )?;
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
     let selected_target_backend = selected_target_backend
         .or(backend)
         .unwrap_or(options.default_target_backend);
@@ -695,6 +705,7 @@ fn build_single_file_executable(
         output,
         planning_context,
         intent,
+        &mooncake_bin_dir,
         resolved,
     )?;
 

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -592,7 +592,6 @@ fn run_test_in_single_file_rr(
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         intent,
@@ -739,7 +738,6 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         intent,
@@ -883,7 +881,6 @@ fn plan_test_or_bench_rr_from_resolved_scoped(
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        target_dir,
         output,
         planning_context,
         intent,

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -538,6 +538,7 @@ fn run_test_in_single_file_rr(
         single_file_path,
         false,
     )?;
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
     let selected_target_backend = if cmd.profile {
         Some(TargetBackend::Native)
     } else {
@@ -595,6 +596,7 @@ fn run_test_in_single_file_rr(
         output,
         planning_context,
         intent,
+        &mooncake_bin_dir,
         resolved,
     )?;
 
@@ -688,6 +690,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
     cli: &UniversalFlags,
     cmd: &TestLikeSubcommand<'_>,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> Result<(rr_build::BuildMeta, rr_build::BuildInput, TestFilter), anyhow::Error> {
@@ -740,6 +743,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved(
         output,
         planning_context,
         intent,
+        mooncake_bin_dir,
         resolve_output,
     )?;
     Ok((build_meta, build_graph, filter))
@@ -749,6 +753,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved_all(
     cli: &UniversalFlags,
     cmd: &TestLikeSubcommand<'_>,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
 ) -> Result<Vec<(rr_build::BuildMeta, rr_build::BuildInput, TestFilter)>, anyhow::Error> {
@@ -757,6 +762,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved_all(
             cli,
             cmd,
             target_dir,
+            mooncake_bin_dir,
             Some(target_backend),
             resolve_output,
         )
@@ -769,8 +775,15 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved_all(
 
     if has_explicit_test_selector(cmd) {
         if selections.is_empty() {
-            return plan_test_or_bench_rr_from_resolved(cli, cmd, target_dir, None, resolve_output)
-                .map(|plan| vec![plan]);
+            return plan_test_or_bench_rr_from_resolved(
+                cli,
+                cmd,
+                target_dir,
+                mooncake_bin_dir,
+                None,
+                resolve_output,
+            )
+            .map(|plan| vec![plan]);
         }
 
         return selections
@@ -782,6 +795,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved_all(
                     cli,
                     cmd,
                     target_dir,
+                    mooncake_bin_dir,
                     selection.target_backend,
                     resolve_output.clone(),
                     resolved_selection,
@@ -791,8 +805,15 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved_all(
     }
 
     if selections.is_empty() {
-        return plan_test_or_bench_rr_from_resolved(cli, cmd, target_dir, None, resolve_output)
-            .map(|plan| vec![plan]);
+        return plan_test_or_bench_rr_from_resolved(
+            cli,
+            cmd,
+            target_dir,
+            mooncake_bin_dir,
+            None,
+            resolve_output,
+        )
+        .map(|plan| vec![plan]);
     }
 
     selections
@@ -804,6 +825,7 @@ pub(crate) fn plan_test_or_bench_rr_from_resolved_all(
                 cli,
                 cmd,
                 target_dir,
+                mooncake_bin_dir,
                 selection.target_backend,
                 resolve_output.clone(),
                 resolved_selection,
@@ -816,6 +838,7 @@ fn plan_test_or_bench_rr_from_resolved_scoped(
     cli: &UniversalFlags,
     cmd: &TestLikeSubcommand<'_>,
     target_dir: &Path,
+    mooncake_bin_dir: &Path,
     target_backend: TargetBackend,
     resolve_output: moonbuild_rupes_recta::ResolveOutput,
     resolved_selection: ResolvedTestSelection,
@@ -864,6 +887,7 @@ fn plan_test_or_bench_rr_from_resolved_scoped(
         output,
         planning_context,
         intent,
+        mooncake_bin_dir,
         resolve_output,
     )?;
     Ok((build_meta, build_graph, filter))
@@ -950,22 +974,27 @@ fn run_test_rr(
     selected_target_backend: Option<TargetBackend>,
 ) -> Result<i32, anyhow::Error> {
     info!(run_mode = ?cmd.run_mode, update = cmd.update, build_only = cmd.build_only, "starting rupes-recta test run");
+    let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
+        cmd.auto_sync_flags.frozen,
+        !cmd.build_flags.std(),
+        cmd.build_flags.enable_coverage,
+        cli.workspace_env.clone(),
+    );
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(
+        &resolve_cfg,
+        source_dir,
+        mooncakes_dir,
+        project_manifest_path,
+    )?;
+    let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
     let planned_runs = plan_test_or_bench_rr_from_resolved_all(
         cli,
         cmd,
         target_dir,
+        &mooncake_bin_dir,
         selected_target_backend,
-        moonbuild_rupes_recta::resolve(
-            &moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
-                cmd.auto_sync_flags.frozen,
-                !cmd.build_flags.std(),
-                cmd.build_flags.enable_coverage,
-                cli.workspace_env.clone(),
-            )
-            .with_project_manifest_path(project_manifest_path),
-            source_dir,
-            mooncakes_dir,
-        )?,
+        resolve_output,
     )?;
     let effective_display_backend_hint = if planned_runs.len() > 1 {
         Some(())

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -173,7 +173,6 @@ pub(crate) fn run_build_binary_dep(
         let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
             preconfig,
             &cli.unstable_feature,
-            &target_dir,
             output,
             planning_context,
             intent,

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -88,9 +88,15 @@ pub(crate) fn run_build_binary_dep(
     // must resolve the packages before settling on the build config and then
     // running the build plan.
     let resolve_cfg =
-        ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone())
-            .with_project_manifest_path(project_manifest_path.as_deref());
-    let resolve_output = moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+        ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone());
+    let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(
+        &resolve_cfg,
+        &source_dir,
+        &mooncakes_dir,
+        project_manifest_path.as_deref(),
+    )?;
+    let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
 
     // Note: There's a cyclic dependency!
     //
@@ -171,6 +177,7 @@ pub(crate) fn run_build_binary_dep(
             output,
             planning_context,
             intent,
+            &mooncake_bin_dir,
             // FIXME: cloning is not the best way to do this, it takes in this
             // type only to be returned in build meta. We should refactor later.
             resolve_output.clone(),

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -593,7 +593,14 @@ mod tests {
         .unwrap()
         .package_dirs()
         .unwrap();
-        moonbuild_rupes_recta::resolve(&cfg, &dirs.source_dir, &dirs.mooncakes_dir).unwrap()
+        let synced_env = moonbuild_rupes_recta::sync_dependencies(
+            &cfg,
+            &dirs.source_dir,
+            &dirs.mooncakes_dir,
+            dirs.project_manifest_path.as_deref(),
+        )
+        .unwrap();
+        moonbuild_rupes_recta::resolve_synced_project(&cfg, synced_env).unwrap()
     }
 
     #[test]

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -46,7 +46,7 @@ use moonbuild_rupes_recta::{
     model::{
         Artifacts, BuildPlanNode, NativeTarget, PackageId, RunBackend, TargetKind, TccRunConfig,
     },
-    prebuild::run_prebuild_config,
+    prebuild::{PrebuildEnvironment, run_prebuild_config},
     user_warning::UserWarning,
 };
 use moonutil::{
@@ -582,7 +582,8 @@ pub(crate) fn plan_resolved_build_from_intent(
         None
     } else {
         info!("Running prebuild configuration");
-        Some(run_prebuild_config(&resolve_output)?)
+        let prebuild_environment = PrebuildEnvironment::new(std::env::vars().collect());
+        Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
     };
 
     // Expand user intents to concrete BuildPlanNode inputs

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -561,7 +561,7 @@ pub(crate) fn prepare_resolved_build(
 ///
 /// At this boundary, command adapters have already resolved user selectors and
 /// command-specific directives into `CalcUserIntentOutput`. RR consumes those
-/// identities plus the build-model paths stored in `ResolveOutput`.
+/// identities plus precomputed build-context paths from the command adapter.
 #[instrument(level = Level::DEBUG, skip_all)]
 pub(crate) fn plan_resolved_build_from_intent(
     preconfig: CompilePreConfig,
@@ -570,6 +570,7 @@ pub(crate) fn plan_resolved_build_from_intent(
     output: UserDiagnostics,
     planning_context: ResolvedBuildPlanningContext,
     intent: CalcUserIntentOutput,
+    mooncake_bin_dir: &Path,
     resolve_output: ResolveOutput,
 ) -> anyhow::Result<(BuildMeta, BuildInput)> {
     info!("User intent calculated: {:?}", intent.intents);
@@ -612,6 +613,7 @@ pub(crate) fn plan_resolved_build_from_intent(
     info!("Begin lowering to build graph");
     let compile_output = moonbuild_rupes_recta::compile(
         &cx,
+        mooncake_bin_dir,
         &resolve_output,
         &input_nodes,
         &intent.directive,

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -566,13 +566,13 @@ pub(crate) fn prepare_resolved_build(
 pub(crate) fn plan_resolved_build_from_intent(
     preconfig: CompilePreConfig,
     unstable_features: &FeatureGate,
-    target_dir: &Path,
     output: UserDiagnostics,
     planning_context: ResolvedBuildPlanningContext,
     intent: CalcUserIntentOutput,
     mooncake_bin_dir: &Path,
     resolve_output: ResolveOutput,
 ) -> anyhow::Result<(BuildMeta, BuildInput)> {
+    let target_dir = preconfig.target_dir.clone();
     info!("User intent calculated: {:?}", intent.intents);
     for warning in &intent.warnings {
         output.user_message(warning);
@@ -645,7 +645,7 @@ pub(crate) fn plan_resolved_build_from_intent(
     };
 
     let db_path = n2_db_path(
-        target_dir,
+        &target_dir,
         cx.target_backend.into(),
         cx.opt_level,
         cx.action,

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -36,6 +36,7 @@ use crate::cli::{
 pub(super) struct PlanningFixture {
     source_dir: PathBuf,
     target_dir: PathBuf,
+    mooncake_bin_dir: PathBuf,
     resolve_output: ResolveOutput,
 }
 
@@ -83,11 +84,19 @@ impl PlanningFixture {
             false,
             WorkspaceEnv::Auto,
         );
+        let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
+        let synced_env = moonbuild_rupes_recta::sync_dependencies(
+            &resolve_cfg,
+            &source_dir,
+            &mooncakes_dir,
+            None,
+        )?;
         let resolve_output =
-            moonbuild_rupes_recta::resolve(&resolve_cfg, &source_dir, &mooncakes_dir)?;
+            moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
         Ok(Self {
             source_dir,
             target_dir,
+            mooncake_bin_dir,
             resolve_output,
         })
     }
@@ -102,6 +111,7 @@ impl PlanningFixture {
             cli,
             &borrowed,
             &self.target_dir,
+            &self.mooncake_bin_dir,
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
@@ -127,6 +137,7 @@ impl PlanningFixture {
             cli,
             &borrowed,
             &self.target_dir,
+            &self.mooncake_bin_dir,
             selected_target_backend,
             self.resolve_output.clone(),
         )
@@ -148,6 +159,7 @@ impl PlanningFixture {
             cli,
             &borrowed,
             &self.target_dir,
+            &self.mooncake_bin_dir,
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
@@ -164,6 +176,7 @@ impl PlanningFixture {
             cli,
             &borrowed,
             &self.target_dir,
+            &self.mooncake_bin_dir,
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )
@@ -192,6 +205,7 @@ impl PlanningFixture {
             cli,
             cmd,
             &self.target_dir,
+            &self.mooncake_bin_dir,
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
@@ -217,6 +231,7 @@ impl PlanningFixture {
             cmd,
             &self.source_dir,
             &self.target_dir,
+            &self.mooncake_bin_dir,
             selected_target_backend,
             self.resolve_output.clone(),
         )
@@ -238,6 +253,7 @@ impl PlanningFixture {
             cli,
             cmd,
             &self.target_dir,
+            &self.mooncake_bin_dir,
             selected_target_backend,
             self.resolve_output.clone(),
         )
@@ -254,6 +270,7 @@ impl PlanningFixture {
             cmd,
             &self.source_dir,
             &self.target_dir,
+            &self.mooncake_bin_dir,
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
         )?;
@@ -279,6 +296,7 @@ impl PlanningFixture {
             cmd,
             &self.source_dir,
             &self.target_dir,
+            &self.mooncake_bin_dir,
             selected_target_backend,
             self.resolve_output.clone(),
         )
@@ -316,6 +334,7 @@ impl PlanningFixture {
             cli,
             &cmd,
             &self.target_dir,
+            &self.mooncake_bin_dir,
             cmd.build_flags.resolve_single_target_backend()?,
             self.resolve_output.clone(),
             !cli.dry_run,

--- a/crates/moon/src/watch/prebuild_output.rs
+++ b/crates/moon/src/watch/prebuild_output.rs
@@ -88,7 +88,9 @@ fn push_prebuild_paths(
 mod tests {
     use super::*;
 
-    use moonbuild_rupes_recta::resolve::{ResolveConfig, resolve};
+    use moonbuild_rupes_recta::resolve::{
+        ResolveConfig, resolve_synced_project, sync_dependencies,
+    };
     use moonutil::dirs::WorkspaceEnv;
 
     #[test]
@@ -102,12 +104,12 @@ mod tests {
         )
         .unwrap();
 
-        let resolved = resolve(
-            &ResolveConfig::new_with_load_defaults(false, false, false, WorkspaceEnv::Auto),
-            temp_dir.path(),
-            &temp_dir.path().join(".mooncakes"),
-        )
-        .unwrap();
+        let resolve_cfg =
+            ResolveConfig::new_with_load_defaults(false, false, false, WorkspaceEnv::Auto);
+        let mooncakes_dir = temp_dir.path().join(".mooncakes");
+        let synced_env =
+            sync_dependencies(&resolve_cfg, temp_dir.path(), &mooncakes_dir, None).unwrap();
+        let resolved = resolve_synced_project(&resolve_cfg, synced_env).unwrap();
 
         let watch_paths = rr_get_prebuild_watch_paths(&resolved);
         assert!(watch_paths.ignored_paths.is_empty());
@@ -138,12 +140,12 @@ mod tests {
         )
         .unwrap();
 
-        let resolved = resolve(
-            &ResolveConfig::new_with_load_defaults(false, false, false, WorkspaceEnv::Auto),
-            temp_dir.path(),
-            &temp_dir.path().join(".mooncakes"),
-        )
-        .unwrap();
+        let resolve_cfg =
+            ResolveConfig::new_with_load_defaults(false, false, false, WorkspaceEnv::Auto);
+        let mooncakes_dir = temp_dir.path().join(".mooncakes");
+        let synced_env =
+            sync_dependencies(&resolve_cfg, temp_dir.path(), &mooncakes_dir, None).unwrap();
+        let resolved = resolve_synced_project(&resolve_cfg, synced_env).unwrap();
 
         let watch_paths = rr_get_prebuild_watch_paths(&resolved);
         let root = dunce::canonicalize(temp_dir.path()).unwrap();

--- a/crates/moon/tests/test_cases/moon_bench/mod.rs
+++ b/crates/moon/tests/test_cases/moon_bench/mod.rs
@@ -1,9 +1,19 @@
 use super::*;
 
+const DIAGNOSTIC_RENDER_WARNING: &str = "Warning: Some diagnostics could not be rendered, please run with --no-render to see raw output.";
+
+fn check_build_only_stderr(stderr: String) {
+    let stderr = stderr.trim();
+    assert!(
+        stderr.is_empty() || stderr == DIAGNOSTIC_RENDER_WARNING,
+        "unexpected stderr:\n{stderr}"
+    );
+}
+
 #[test]
 fn test_bench_driver_build() {
     let dir = TestDir::new("moon_bench");
-    check(get_stderr(&dir, ["bench", "--build-only"]), expect![""]);
+    check_build_only_stderr(get_stderr(&dir, ["bench", "--build-only"]));
 }
 
 #[test]
@@ -19,20 +29,20 @@ fn test_bench_wasi_link() {
 #[test]
 fn test_bench_driver_build_js() {
     let dir = TestDir::new("moon_bench");
-    check(
-        get_stderr(&dir, ["bench", "--build-only", "--target", "js"]),
-        expect![""],
-    );
+    check_build_only_stderr(get_stderr(
+        &dir,
+        ["bench", "--build-only", "--target", "js"],
+    ));
 }
 
 #[test]
 #[cfg(not(windows))]
 fn test_bench_driver_build_native() {
     let dir = TestDir::new("moon_bench");
-    check(
-        get_stderr(&dir, ["bench", "--build-only", "--target", "native"]),
-        expect![""],
-    );
+    check_build_only_stderr(get_stderr(
+        &dir,
+        ["bench", "--build-only", "--target", "native"],
+    ));
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/query_symbol/mod.rs
+++ b/crates/moon/tests/test_cases/query_symbol/mod.rs
@@ -8,6 +8,7 @@ fn test_query_not_in_project() {
     let output = output
         .lines()
         .map(|line| line.trim_end())
+        .map(|line| line.replace("@test.assert_eq", "assert_eq"))
         .filter(|line| !line.is_empty())
         .collect::<Vec<_>>()
         .join("\n");

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -29,8 +29,8 @@ use std::{
 use indexmap::{IndexSet, set::MutableValues};
 use moonutil::{
     common::{
-        DOT_MBT_DOT_MD, IgnoredMoonScript, MOD_DIR, MOON_BIN_DIR, MOONCAKE_BIN, PKG_DIR,
-        TargetBackend, is_moon_mod, is_moon_pkg, is_moon_script_ignored,
+        DOT_MBT_DOT_MD, IgnoredMoonScript, MOD_DIR, MOONCAKE_BIN, PKG_DIR, TargetBackend,
+        is_moon_mod, is_moon_pkg, is_moon_script_ignored,
     },
     compiler_flags::{CC, Toolchain},
     module::{MoonMod, MoonModRule},
@@ -1390,7 +1390,6 @@ impl<'a> BuildPlanConstructor<'a> {
 
         let pkg = self.input.pkg_dirs.get_package(package);
         let module = &self.input.module_dirs[pkg.module];
-        let mooncakes_dir = &self.input.mooncakes_dir;
         let prebuild_cmd =
             &pkg.raw.pre_build.as_ref().expect("Prebuild must exist")[index as usize];
 
@@ -1457,7 +1456,7 @@ impl<'a> BuildPlanConstructor<'a> {
         let command = handle_build_command_new(
             &command,
             module,
-            mooncakes_dir,
+            self.mooncake_bin_dir,
             &pkg.root_path,
             &input_paths,
             &output_paths,
@@ -1554,7 +1553,7 @@ static PREBUILD_AUTOMATA: LazyLock<aho_corasick::AhoCorasick> = LazyLock::new(||
 /// dependency artifacts. Artifacts built by binary dependencies are placed in
 /// either of these two locations:
 ///
-/// - `<resolve-mooncakes-dir>/__moonbin__/[bin-target-name]`, if the artifact
+/// - `<project .mooncakes dir>/__moonbin__/[bin-target-name]`, if the artifact
 ///   comes from a regular dependency from the official registry.
 /// - At the root of the corresponding module's source directory, if the
 ///   artifact comes from a local dependency.
@@ -1571,7 +1570,7 @@ static PREBUILD_AUTOMATA: LazyLock<aho_corasick::AhoCorasick> = LazyLock::new(||
 fn handle_build_command_new(
     command: &str,
     mod_source: &Path,
-    mooncakes_dir: &Path,
+    mooncake_bin_dir: &Path,
     pkg_source: &Path,
     input_files: &[PathBuf],
     output_files: &[PathBuf],
@@ -1600,10 +1599,9 @@ fn handle_build_command_new(
         // Insert replacement
         // See the IDs in CHECK_AUTOMATA
         match magic.pattern().as_usize() {
-            // $mooncake_bin => <resolve-mooncakes-dir>/__moonbin__
+            // $mooncake_bin => <project .mooncakes dir>/__moonbin__
             0 => {
-                let replacement = mooncakes_dir.join(MOON_BIN_DIR);
-                write!(reconstructed, "{}", replacement.display()).expect("write can't fail");
+                write!(reconstructed, "{}", mooncake_bin_dir.display()).expect("write can't fail");
             }
             // $mod_dir => <mod_source>
             1 => {

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -20,7 +20,7 @@
 
 #[cfg(debug_assertions)]
 use std::collections::HashMap;
-use std::collections::HashSet;
+use std::{collections::HashSet, path::Path};
 
 use crate::{
     ResolveOutput,
@@ -39,6 +39,7 @@ use super::{BuildEnvironment, BuildPlan, BuildPlanConstructError};
 pub(super) struct BuildPlanConstructor<'a> {
     // Input environment
     pub(super) input: &'a ResolveOutput,
+    pub(super) mooncake_bin_dir: &'a Path,
     pub(super) build_env: &'a BuildEnvironment,
     pub(super) input_directive: &'a InputDirective,
     pub(super) prebuild_config: Option<&'a PrebuildOutput>,
@@ -120,12 +121,14 @@ fn edge_for_coalesced_check(edge: FileDependencyKind) -> FileDependencyKind {
 impl<'a> BuildPlanConstructor<'a> {
     pub(super) fn new(
         resolved: &'a ResolveOutput,
+        mooncake_bin_dir: &'a Path,
         build_env: &'a BuildEnvironment,
         input_directive: &'a InputDirective,
         prebuild_config: Option<&'a PrebuildOutput>,
     ) -> Self {
         Self {
             input: resolved,
+            mooncake_bin_dir,
             build_env,
             input_directive,
             prebuild_config,

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -491,6 +491,7 @@ pub enum BuildPlanConstructError {
 #[instrument(skip_all)]
 pub fn build_plan(
     resolved: &ResolveOutput,
+    mooncake_bin_dir: &Path,
     build_env: &BuildEnvironment,
     input: impl Iterator<Item = BuildPlanNode>,
     input_directive: &InputDirective,
@@ -502,8 +503,13 @@ pub fn build_plan(
         build_env.target_backend, build_env.opt_level
     );
 
-    let mut constructor =
-        BuildPlanConstructor::new(resolved, build_env, input_directive, prebuild_config);
+    let mut constructor = BuildPlanConstructor::new(
+        resolved,
+        mooncake_bin_dir,
+        build_env,
+        input_directive,
+        prebuild_config,
+    );
     constructor.build(input)?;
     let result = constructor.finish();
 

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -19,7 +19,7 @@
 use indexmap::IndexMap;
 use log::{debug, info};
 use moonutil::{common::RunMode, cond_expr::OptLevel};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
 
 use crate::{
@@ -106,6 +106,7 @@ pub enum CompileGraphError {
 #[instrument(skip_all)]
 pub fn compile(
     cx: &CompileConfig,
+    mooncake_bin_dir: &Path,
     resolve_output: &ResolveOutput,
     input_nodes: &[BuildPlanNode],
     input_directive: &InputDirective,
@@ -132,6 +133,7 @@ pub fn compile(
     };
     let (plan, user_warnings) = build_plan::build_plan(
         resolve_output,
+        mooncake_bin_dir,
         &build_env,
         input_nodes,
         input_directive,

--- a/crates/moonbuild-rupes-recta/src/lib.rs
+++ b/crates/moonbuild-rupes-recta/src/lib.rs
@@ -129,5 +129,5 @@ pub mod util;
 
 // Reexports
 pub use compile::{CompileConfig, CompileOutput, compile};
-pub use resolve::{ResolveConfig, ResolveOutput, resolve};
+pub use resolve::{ResolveConfig, ResolveOutput, resolve_synced_project, sync_dependencies};
 pub use user_warning::{UserMessageLevel, UserWarning};

--- a/crates/moonbuild-rupes-recta/src/prebuild.rs
+++ b/crates/moonbuild-rupes-recta/src/prebuild.rs
@@ -50,14 +50,28 @@ pub struct ModulePrebuildOutput {
     pub vars: HashMap<String, String>,
 }
 
+/// Process environment made available to prebuild configuration scripts.
+#[derive(Debug)]
+pub struct PrebuildEnvironment {
+    vars: HashMap<String, String>,
+}
+
+impl PrebuildEnvironment {
+    pub fn new(vars: HashMap<String, String>) -> Self {
+        Self { vars }
+    }
+}
+
 #[instrument(skip_all)]
-pub fn run_prebuild_config(resolve_output: &ResolveOutput) -> anyhow::Result<PrebuildOutput> {
-    let env_vars: HashMap<String, String> = std::env::vars().collect();
+pub fn run_prebuild_config(
+    resolve_output: &ResolveOutput,
+    environment: &PrebuildEnvironment,
+) -> anyhow::Result<PrebuildOutput> {
     let mut output = PrebuildOutput::default();
 
     // Run prebuild scripts
     for (m, ms) in resolve_output.module_rel.all_modules_and_id() {
-        run_prebuild_for_module(m, ms, resolve_output, &env_vars, &mut output)?;
+        run_prebuild_for_module(m, ms, resolve_output, environment, &mut output)?;
     }
 
     Ok(output)
@@ -67,7 +81,7 @@ fn run_prebuild_for_module(
     m: ModuleId,
     ms: &ModuleSource,
     resolve_output: &ResolveOutput,
-    env_vars: &HashMap<String, String>,
+    environment: &PrebuildEnvironment,
     ret: &mut PrebuildOutput,
 ) -> anyhow::Result<()> {
     let m_info = &**resolve_output.module_rel.module_info(m);
@@ -77,7 +91,7 @@ fn run_prebuild_for_module(
     };
 
     // Run the prebuild script
-    let input = make_prebuild_input_from_module(m_dir, env_vars);
+    let input = make_prebuild_input_from_module(m_dir, &environment.vars);
     let output = moonbuild::build_script::run_build_script_for_module(ms, m_dir, input, prebuild)
         .context(format!(
         "Failed to run prebuild script for module {}",

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -18,13 +18,12 @@
 
 //! High-level abstraction that handles module and package resolving.
 //!
-//! This module is a relatively straightforward wrapper of relevant functions
-//! that needs to be called in order to resolve the build environment.
-//! Nevertheless, it should remain pretty useful as it abstracts away
-//! intermediate steps and provides a single entry point for resolving the
-//! build environment.
+//! Normal project resolution is split into an explicit dependency sync step and
+//! a package discovery/solve step. This keeps dependency-directory mutation
+//! visible to command adapters before RR consumes the synced dependencies as
+//! input.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Context;
 use indexmap::IndexMap;
@@ -63,8 +62,6 @@ pub struct ResolveOutput {
     pub module_rel: ResolvedEnv,
     /// Module directories
     pub module_dirs: DirSyncResult,
-    /// Threaded `.mooncakes` directory for this resolve run.
-    pub mooncakes_dir: PathBuf,
     /// Package directories
     pub pkg_dirs: DiscoverResult,
     /// Package dependency relationship
@@ -93,7 +90,6 @@ pub struct ResolveConfig {
     /// Gate coverage injection in pkg_solve
     pub enable_coverage: bool,
     workspace_env: WorkspaceEnv,
-    project_manifest_path: Option<PathBuf>,
 }
 
 struct FrontMatterImports {
@@ -269,7 +265,6 @@ impl ResolveConfig {
             no_std,
             enable_coverage,
             workspace_env,
-            project_manifest_path: None,
         }
     }
 
@@ -286,13 +281,7 @@ impl ResolveConfig {
             no_std,
             enable_coverage,
             workspace_env,
-            project_manifest_path: None,
         }
-    }
-
-    pub fn with_project_manifest_path(mut self, project_manifest_path: Option<&Path>) -> Self {
-        self.project_manifest_path = project_manifest_path.map(Path::to_path_buf);
-        self
     }
 
     pub fn with_quiet_sync(mut self, quiet_sync: bool) -> Self {
@@ -335,15 +324,16 @@ impl ResolveError {
 }
 
 /// Performs the resolving process from a raw working directory, until all of
-/// the modules and packages affected are resolved.
+/// modules and package directories are ready for package discovery.
 #[instrument(skip_all)]
-pub fn resolve(
+pub fn sync_dependencies(
     cfg: &ResolveConfig,
     source_dir: &Path,
     mooncakes_dir: &Path,
-) -> Result<ResolveOutput, ResolveError> {
+    project_manifest_path: Option<&Path>,
+) -> Result<(ResolvedEnv, DirSyncResult, Option<TargetBackend>), ResolveError> {
     info!(
-        "Starting resolve process for source directory: {}",
+        "Starting dependency sync for source directory: {}",
         source_dir.display()
     );
     debug!("Resolve config: sync_flags={:?}", cfg.sync_flags);
@@ -355,11 +345,26 @@ pub fn resolve(
         cfg.sync_output,
         cfg.no_std,
         cfg.workspace_env.clone(),
-        cfg.project_manifest_path.as_deref(),
+        project_manifest_path,
     )
     .map_err(ResolveError::SyncModulesError)?;
     info!("Module dependency resolution completed successfully");
     debug!("Resolved {} modules", resolved_env.module_count());
+
+    Ok((
+        resolved_env,
+        dir_sync_result,
+        workspace.and_then(|workspace| workspace.preferred_target),
+    ))
+}
+
+/// Resolves packages and package relationships from already synced dependencies.
+#[instrument(skip_all)]
+pub fn resolve_synced_project(
+    cfg: &ResolveConfig,
+    synced_dependencies: (ResolvedEnv, DirSyncResult, Option<TargetBackend>),
+) -> Result<ResolveOutput, ResolveError> {
+    let (resolved_env, dir_sync_result, workspace_preferred_target) = synced_dependencies;
 
     let mut discover_result = discover_packages(&resolved_env, &dir_sync_result)?;
     let main_is_core = {
@@ -401,10 +406,9 @@ pub fn resolve(
     Ok(ResolveOutput {
         module_rel: resolved_env,
         module_dirs: dir_sync_result,
-        mooncakes_dir: mooncakes_dir.to_path_buf(),
         pkg_dirs: discover_result,
         pkg_rel: dep_relationship,
-        workspace_preferred_target: workspace.and_then(|workspace| workspace.preferred_target),
+        workspace_preferred_target,
         user_warnings,
     })
 }
@@ -511,7 +515,6 @@ Use moonbit.import with 'username/module@version[/package]' entries to opt in to
     let res = ResolveOutput {
         module_rel: resolved_env,
         module_dirs: dir_sync_result,
-        mooncakes_dir: mooncakes_dir.to_path_buf(),
         pkg_dirs: discover_result,
         pkg_rel: dep_relationship,
         workspace_preferred_target: None,

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -76,7 +76,8 @@ In a broad sense, `moon` subcommands follows this order when executing project-b
 
 1. Resolve project layout
    - Discover module root.
-   - Resolve module-level dependencies.
+   - Sync module-level dependencies into the `.mooncakes` directory when needed.
+   - Resolve module-level dependencies from the synced dependency result.
    - Discover packages within modules.
    - Resolve package-level dependencies.
 2. Generate build graph based on the intent of the user [^graph]
@@ -124,16 +125,27 @@ selection, and `.mooncakes` directory once, then pass those facts into later
 phases. Later phases should not rediscover them from the working directory.
 
 This is part of the compiler-style shape of the RR pipeline: for directory and
-project facts, the command layer captures user input and passes the result
+project paths, the command layer captures user input and passes the result
 forward instead of letting later phases infer it again. In particular:
 
 - project and workspace selection are captured before package discovery;
-- the `.mooncakes` directory is passed into resolve and then threaded through
-  `ResolveOutput`;
+- the `.mooncakes` directory is computed during project discovery and passed
+  into dependency sync;
+- `$mooncake_bin` is resolved by the command adapter to a `mooncake_bin_dir`
+  path before build planning, so RR planning substitutes an already-computed
+  launcher directory instead of deriving it from project layout;
 - the target directory is passed into planning/lowering and used for generated
   build files and n2 state; and
 - package and module directories come from discovery results, not from later
   path guessing.
+
+Source directory, `.mooncakes` directory, target directory, and optional project
+manifest path are user/config facts from project discovery. The synced
+dependency result is derived data: it contains the resolved module
+relationships, module source directories, and workspace preferred target
+produced by dependency sync. `ResolveOutput` should contain resolved
+build-model data derived from those inputs, not repeat the captured discovery
+paths.
 
 Toolchain and host facts are not fully centralized today. `rr_build` and
 `compile` still make some host-dependent decisions while preparing planning and
@@ -149,6 +161,12 @@ configuration scripts run, `rr_build` captures the process environment
 explicitly and passes it to prebuild execution. Commands that skip prebuild,
 such as `check`, should not capture that environment just to construct a build
 plan.
+
+Dependency synchronization is explicit in the normal project path. Command
+adapters first call dependency sync, then pass the synced dependency result to
+package discovery and package relationship resolution. RR should not hide
+dependency downloads or `.mooncakes` directory updates behind a plain
+project-resolve call.
 
 ## Project discovery and layout
 

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -144,6 +144,12 @@ instead of being rediscovered at each use site. Such facts do not need to be
 eager: non-native builds should not resolve native-only OS/toolchain details
 unless a lowering path actually asks for them.
 
+Prebuild configuration is another environment-sensitive input. When prebuild
+configuration scripts run, `rr_build` captures the process environment
+explicitly and passes it to prebuild execution. Commands that skip prebuild,
+such as `check`, should not capture that environment just to construct a build
+plan.
+
 ## Project discovery and layout
 
 Currently, most subcommands in `moon` still work on a single input module [^input_module]

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -99,6 +99,14 @@ Behavior:
 - Only declared outputs ending in `.mbt` or `.mbt.md` are included as MoonBit sources for
   compilation, and only when they live in the package directory itself.
 
+## Environment Capture
+
+- Module-level prebuild configuration scripts receive a snapshot of the process
+  environment captured by `rr_build` before prebuild execution.
+- Commands that skip prebuild configuration do not capture this environment.
+- The snapshot is passed to each module prebuild script as part of its prebuild
+  input; it is not rediscovered inside individual module execution.
+
 ## Failure Conditions
 
 A task is considered failed (for the build) if any of the following holds after substitution and tool semantics:

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -37,9 +37,10 @@ Notes:
 - `input`/`output` are resolved relative to the package directory before substitution.
 - `$input`/`$output` expand to absolute file paths.
 - `$pkg_dir`/`$mod_dir` expand to absolute directories.
-- `$mooncake_bin` expands to `<module-root>/.mooncakes/__moonbin__`.
-  This directory contains launchers installed for the current module's direct
-  `bin-deps`.
+- `$mooncake_bin` expands to `<project .mooncakes dir>/__moonbin__`.
+  The command adapter computes this `mooncake_bin_dir` from project discovery
+  before build planning; prebuild planning does not rediscover it from the
+  package or module directory.
 
 ## Placeholder Substitution
 
@@ -58,8 +59,8 @@ Only the `command` field is substituted. The following placeholders are recogniz
   Expands to the absolute path of the current package directory (the directory containing this `moon.pkg.json`).
 
 - `$mooncake_bin`  
-  Expands to the absolute path `<module-root>/.mooncakes/__moonbin__`.
-  This currently refers to launchers installed from the current module's direct
+  Expands to the absolute path `<project .mooncakes dir>/__moonbin__`.
+  This refers to launchers installed from the current project's direct
   `bin-deps`.
 
 Substitution semantics:


### PR DESCRIPTION
## Summary

This PR makes RR project-build inputs more explicit without adding a new project-discovery abstraction.

- Capture prebuild process environment explicitly and only when prebuild runs.
- Split normal project dependency sync from package discovery/relationship resolution.
- Remove `.mooncakes_dir` from `ResolveOutput`.
- Compute `mooncake_bin_dir` in command adapters and pass that exact path into RR planning for `$mooncake_bin` substitution.

## Why

RR is moving toward a compiler-style pipeline: command adapters capture user input, project discovery, config, and environment inputs once, then pass explicit values forward. That keeps dependency-directory mutation and environment capture visible instead of hiding them inside resolve or planning.

## Why This Is Correct

Dependency sync still receives the same source directory, `.mooncakes` directory, and optional project manifest path from existing project discovery. The synced dependency result remains the input to package discovery and package relationship solving. Build planning now receives only the precomputed `mooncake_bin_dir` it needs for `$mooncake_bin`, so `ResolveOutput` stays focused on resolved build-model data.

## Minimality

The change reuses the existing project discovery outputs instead of introducing a new `ProjectFacts` type. Single-file resolution remains specialized, and the normal project path keeps the same command-level control flow with the sync step made explicit.