### PR TITLE
Avoid unnecessary runwasm registry updates

### DIFF
--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -53,7 +53,8 @@ Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt
 
 Pinned coordinates use the given version directly. Unpinned coordinates resolve
-the latest version from the registry index. Fetched wasm files are cached under
+the latest version from the registry index, updating it only when the module is
+absent from the local index. Fetched wasm files are cached under
 $MOON_HOME/registry/cache/assets and reused on later runs."#
 )]
 pub(crate) struct RunWasmSubcommand {
@@ -78,6 +79,13 @@ struct ResolvedRunWasmAsset {
     url: String,
     checksum_url: String,
     cache_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LatestVersionLookup {
+    Found(Version),
+    NoVersionInformation,
+    NotFound,
 }
 
 impl RunWasmCoordinate {
@@ -145,7 +153,7 @@ pub(crate) fn run_runwasm(cli: &UniversalFlags, cmd: RunWasmSubcommand) -> anyho
     let registry_config = RegistryConfig::load();
     let version = match coordinate.version.clone() {
         Some(version) => version,
-        None => resolve_latest_version(cli, &coordinate.module_name, output)?,
+        None => resolve_latest_version(&coordinate.module_name, output)?,
     };
     let asset = coordinate.with_version(version, &registry_config.registry);
     let wasm_path = ensure_cached_wasm(&asset, output)?;
@@ -204,7 +212,6 @@ fn runwasm_as_run_subcommand(cmd: RunWasmSubcommand) -> RunSubcommand {
 }
 
 fn resolve_latest_version(
-    cli: &UniversalFlags,
     module_name: &ModuleName,
     output: UserDiagnostics,
 ) -> anyhow::Result<Version> {
@@ -212,11 +219,49 @@ fn resolve_latest_version(
     let registry_config = RegistryConfig::load();
     let had_index = index_dir.exists();
 
-    match mooncake::update::update_with_output(
-        &index_dir,
-        &registry_config,
-        mooncake::update::UpdateOutput::Quiet,
-    ) {
+    resolve_latest_version_with(
+        module_name,
+        output,
+        had_index,
+        || latest_version_from_local_registry(module_name),
+        || {
+            mooncake::update::update_with_output(
+                &index_dir,
+                &registry_config,
+                mooncake::update::UpdateOutput::Quiet,
+            )
+            .map(|_| ())
+        },
+    )
+}
+
+fn latest_version_from_local_registry(module_name: &ModuleName) -> LatestVersionLookup {
+    let registry = OnlineRegistry::mooncakes_io();
+    let versions = match registry.all_versions_of(module_name) {
+        Ok(versions) => versions,
+        Err(_) => return LatestVersionLookup::NotFound,
+    };
+    versions
+        .last_key_value()
+        .map(|(version, _)| LatestVersionLookup::Found(version.clone()))
+        .unwrap_or(LatestVersionLookup::NoVersionInformation)
+}
+
+fn resolve_latest_version_with(
+    module_name: &ModuleName,
+    output: UserDiagnostics,
+    had_index: bool,
+    mut lookup_latest_version: impl FnMut() -> LatestVersionLookup,
+    mut update_registry: impl FnMut() -> anyhow::Result<()>,
+) -> anyhow::Result<Version> {
+    if let LatestVersionLookup::Found(version) = lookup_latest_version() {
+        output.info(format!(
+            "Resolved {module_name} latest version to {version}"
+        ));
+        return Ok(version);
+    }
+
+    match update_registry() {
         Ok(_) => output.info("Updated registry index"),
         Err(e) => {
             if had_index {
@@ -230,23 +275,21 @@ fn resolve_latest_version(
         }
     }
 
-    let registry = OnlineRegistry::mooncakes_io();
-    let module_info = registry.get_latest_version(module_name).ok_or_else(|| {
-        if had_index {
-            anyhow::anyhow!("Module `{module_name}` not found in registry")
-        } else {
-            anyhow::anyhow!("Module `{module_name}` not found in registry after updating the index")
+    let version = match lookup_latest_version() {
+        LatestVersionLookup::Found(version) => version,
+        LatestVersionLookup::NoVersionInformation => {
+            bail!("Module `{module_name}` has no version information")
         }
-    })?;
-    let version = module_info
-        .version
-        .clone()
-        .ok_or_else(|| anyhow::anyhow!("Module `{module_name}` has no version information"))?;
-    if !cli.quiet {
-        output.info(format!(
-            "Resolved {module_name} latest version to {version}"
-        ));
-    }
+        LatestVersionLookup::NotFound if had_index => {
+            bail!("Module `{module_name}` not found in registry")
+        }
+        LatestVersionLookup::NotFound => {
+            bail!("Module `{module_name}` not found in registry after updating the index")
+        }
+    };
+    output.info(format!(
+        "Resolved {module_name} latest version to {version}"
+    ));
     Ok(version)
 }
 
@@ -476,6 +519,81 @@ mod tests {
         assert_eq!(parsed.module_name.to_string(), "moonbitlang/parser");
         assert_eq!(parsed.package_path, "cmd/moonfmt");
         assert_eq!(parsed.version, None);
+    }
+
+    #[test]
+    fn latest_resolution_uses_local_registry_before_updating() {
+        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
+        let mut update_called = false;
+
+        let version = resolve_latest_version_with(
+            &module_name,
+            UserDiagnostics::default(),
+            true,
+            || LatestVersionLookup::Found("0.3.3".parse().unwrap()),
+            || {
+                update_called = true;
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(version.to_string(), "0.3.3");
+        assert!(!update_called);
+    }
+
+    #[test]
+    fn latest_resolution_updates_after_local_registry_miss() {
+        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
+        let mut lookup_count = 0;
+        let mut update_called = false;
+
+        let version = resolve_latest_version_with(
+            &module_name,
+            UserDiagnostics::default(),
+            true,
+            || {
+                lookup_count += 1;
+                if lookup_count > 1 {
+                    LatestVersionLookup::Found("0.3.3".parse().unwrap())
+                } else {
+                    LatestVersionLookup::NotFound
+                }
+            },
+            || {
+                update_called = true;
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(version.to_string(), "0.3.3");
+        assert_eq!(lookup_count, 2);
+        assert!(update_called);
+    }
+
+    #[test]
+    fn latest_resolution_preserves_no_version_information_after_update() {
+        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
+        let mut update_called = false;
+
+        let err = resolve_latest_version_with(
+            &module_name,
+            UserDiagnostics::default(),
+            true,
+            || LatestVersionLookup::NoVersionInformation,
+            || {
+                update_called = true;
+                Ok(())
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Module `moonbitlang/parser` has no version information"
+        );
+        assert!(update_called);
     }
 
     #[test]

--- a/docs/dev/reference/readme.md
+++ b/docs/dev/reference/readme.md
@@ -23,6 +23,7 @@ This is a reference documentation of the current MoonBuild behavior.
 * [`tcc -run` mode](./tcc-run.md)
 * [`moon bundle`](./bundle.md)
 * [`moon install` binary installer behavior](./moon-install-binary.md)
+* [`moon runwasm` behavior](./runwasm.md)
 * [Rupes Recta special cases](./rr-special-cases.md)
 * [`moon test` execution flow](./tests.md)
 * [`supported_targets` behavior](./supported-targets.md)

--- a/docs/dev/reference/runwasm.md
+++ b/docs/dev/reference/runwasm.md
@@ -1,0 +1,83 @@
+# Behavior of `moon runwasm`
+
+> This page documents registry-backed prebuilt wasm mode of `moon runwasm`.
+> Local package inputs are delegated to `moon run --target wasm`.
+>
+> Status: expected behavior in this branch as of June 10, 2026.
+
+## Scope
+
+`moon runwasm` has two modes:
+
+1. Local package mode:
+   `moon runwasm <local-package>` builds and runs the package as wasm.
+2. Mooncakes asset mode:
+   `moon runwasm <user/module[/package][@version]>` runs a prebuilt wasm asset
+   published for a registry module version.
+
+This document focuses on Mooncakes asset mode.
+
+## Coordinate model
+
+A **pinned coordinate** includes an explicit version:
+
+- `user/module/package@1.2.3`
+- `user/module@1.2.3/package`
+
+An **unpinned coordinate** omits the version:
+
+- `user/module/package`
+
+Pinned coordinates use the supplied version directly. They do not need the
+registry index for version resolution.
+
+Unpinned coordinates must resolve the latest module version from the local
+registry index before the asset URL and cache path can be computed.
+
+## Registry update policy
+
+The registry update policy optimizes the common rerun case:
+
+1. The user runs an unpinned coordinate once.
+2. The latest version has already been resolved into the local registry index.
+3. The wasm asset may also already be cached.
+4. Running the same command again should not spend time updating the registry
+   index before using the already-resolvable version.
+
+Rules:
+
+- For pinned coordinates, skip registry index update.
+- For unpinned coordinates, read the local registry index first.
+- If the local index contains usable version metadata for the module, use that
+  version and skip registry index update.
+- If the local index does not contain usable version metadata for the module,
+  run the registry update once, then retry local resolution.
+- This is a module-level check. It does not inspect whether the requested package
+  path exists in newer versions.
+
+## Version lookup outcomes
+
+After retrying any needed registry update, version lookup has three outcomes:
+
+- Version found: use it to form the prebuilt wasm asset URL.
+- Module found but no version metadata: fail with a no-version-information error.
+- Module not found: fail with a module-not-found error.
+
+If a registry update fails while a local index already exists, the command warns
+and continues with the existing local index. If no local index exists, registry
+update failure is fatal because there is no cached metadata to use.
+
+Unreadable or corrupt local index data follows the existing registry behavior:
+it is treated as not resolving a latest version, so `runwasm` attempts the
+update/retry path.
+
+## Asset cache policy
+
+Version resolution and wasm asset caching are separate.
+
+Once a version is resolved, `runwasm` computes the asset URL and cache path for
+that exact module version and package path. A cache hit runs the cached wasm.
+A cache miss downloads and verifies the wasm asset.
+
+An asset cache miss does not trigger registry update. At that point the version
+has already been resolved.

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -268,7 +268,8 @@ Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt
 
 Pinned coordinates use the given version directly. Unpinned coordinates resolve
-the latest version from the registry index. Fetched wasm files are cached under
+the latest version from the registry index, updating it only when the module is
+absent from the local index. Fetched wasm files are cached under
 $MOON_HOME/registry/cache/assets and reused on later runs.
 
 **Usage:** `moon runwasm <LOCAL_PACKAGE|PACKAGE[@VERSION]> [ARGS]...`

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -268,7 +268,8 @@ Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt
 
 Pinned coordinates use the given version directly. Unpinned coordinates resolve
-the latest version from the registry index. Fetched wasm files are cached under
+the latest version from the registry index, updating it only when the module is
+absent from the local index. Fetched wasm files are cached under
 $MOON_HOME/registry/cache/assets and reused on later runs.
 
 **Usage:** `moon runwasm <LOCAL_PACKAGE|PACKAGE[@VERSION]> [ARGS]...`


### PR DESCRIPTION
## Why

Repeated `moon runwasm` calls with an unpinned Mooncakes coordinate were slow because latest-version resolution always ran a registry update before using already-available local registry metadata.

## What changed

This changes unpinned `runwasm` resolution to read the local registry index first and only update the registry when usable module version metadata is missing. Pinned coordinates continue to use their explicit version directly, and wasm asset cache/download behavior remains separate from registry index updates.

## Why this is correct

An unpinned coordinate only needs the registry index to resolve a module version. Once a local latest version is available, updating the index is unnecessary for rerunning the same command. The implementation keeps the existing fallback behavior when the local index cannot resolve the module and preserves the distinction between missing modules and modules with no version metadata.

## Scope

The change is limited to `runwasm` latest-version resolution and its documentation. Other registry-update behavior, including `moon install`, is unchanged.