### PR TITLE
[codex] Refine RR toolchain layout ownership

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -39,7 +39,10 @@ use indexmap::IndexMap;
 use moonbuild::entry::{N2RunStats, ResultCatcher, create_progress_console};
 use moonbuild_rupes_recta::{
     CompileConfig, ResolveConfig, ResolveOutput,
-    build_lower::{LoweringEnvironment, WarningCondition, artifact::n2_db_path},
+    build_lower::{
+        LoweringEnvironment, WarningCondition,
+        artifact::{LegacyLayout, LegacyLayoutBuilder, n2_db_path},
+    },
     build_plan::InputDirective,
     fmt::{FmtConfig, FmtResolveOutput},
     intent::UserIntent,
@@ -240,6 +243,9 @@ pub struct BuildMeta {
 
     /// The main optimization level used in this compile process
     pub opt_level: BuildProfile,
+
+    /// The standard library path selected for this build, if stdlib is imported.
+    pub stdlib_path: Option<PathBuf>,
 }
 
 /// Represents the result of the build process
@@ -367,6 +373,11 @@ impl CompilePreConfig {
             run_backend,
             tcc_run.is_some()
         );
+        let stdlib_path = if std {
+            Some(moonutil::toolchain::core())
+        } else {
+            None
+        };
 
         Ok(CompileConfig {
             target_dir: self.target_dir,
@@ -376,11 +387,7 @@ impl CompilePreConfig {
             opt_level: self.opt_level,
             action: self.action,
             debug_symbols: self.debug_symbols,
-            stdlib_path: if std {
-                Some(moonutil::moon_dir::core())
-            } else {
-                None
-            },
+            stdlib_path,
             lowering_environment: LoweringEnvironment::default(),
             enable_coverage: self.enable_coverage,
             output_wat: self.output_wat,
@@ -642,6 +649,7 @@ pub(crate) fn plan_resolved_build_from_intent(
         native_target: cx.native_target,
         tcc_run: cx.tcc_run.clone(),
         opt_level: cx.opt_level,
+        stdlib_path: cx.stdlib_path.clone(),
     };
 
     let db_path = n2_db_path(
@@ -770,13 +778,13 @@ pub fn generate_metadata(
     };
 
     let check_commands = collect_check_commands_by_output(build_input);
+    let layout = legacy_layout_for_build_meta(target_dir, build_meta, mode);
     let metadata = moonbuild_rupes_recta::metadata::gen_metadata_json(
         &build_meta.resolve_output,
         source_dir,
-        target_dir,
+        &layout,
         build_meta.opt_level,
         build_meta.target_backend.into(),
-        mode,
         &check_commands,
     );
     let orig_meta = std::fs::read_to_string(&metadata_file);
@@ -787,6 +795,27 @@ pub fn generate_metadata(
         std::fs::write(&metadata_file, meta).context("Failed to write build metadata")?;
     }
     Ok(())
+}
+
+fn legacy_layout_for_build_meta(
+    target_dir: &Path,
+    build_meta: &BuildMeta,
+    mode: RunMode,
+) -> LegacyLayout {
+    let resolve_output = &build_meta.resolve_output;
+    let main_module = match resolve_output.local_modules() {
+        &[module_id] => Some(resolve_output.module_rel.module_source(module_id).clone()),
+        _ => None,
+    };
+
+    LegacyLayoutBuilder::default()
+        .opt_level(build_meta.opt_level)
+        .run_mode(mode)
+        .stdlib_dir(build_meta.stdlib_path.clone())
+        .target_base_dir(target_dir.to_owned())
+        .main_module(main_module)
+        .build()
+        .expect("Failed to build legacy layout")
 }
 
 fn collect_check_commands_by_output(
@@ -815,27 +844,7 @@ pub fn generate_all_pkgs_json(
     build_meta: &BuildMeta,
     mode: RunMode,
 ) -> anyhow::Result<()> {
-    let resolve_output = &build_meta.resolve_output;
-    let main_module = match resolve_output.local_modules() {
-        &[module_id] => Some(resolve_output.module_rel.module_source(module_id).clone()),
-        _ => None,
-    };
-    let is_core = main_module.as_ref().is_some_and(|module| module.is_core());
-    // the necessary information to calculate the layout of the `target`
-    // directory
-    // When building stdlib itself, don't point to prebuilt stdlib artifacts.
-    let layout = moonbuild_rupes_recta::build_lower::artifact::LegacyLayoutBuilder::default()
-        .opt_level(build_meta.opt_level)
-        .run_mode(mode)
-        .stdlib_dir(if is_core {
-            None
-        } else {
-            Some(moonutil::moon_dir::core())
-        })
-        .target_base_dir(target_dir.to_owned())
-        .main_module(main_module)
-        .build()
-        .expect("Failed to build legacy layout");
+    let layout = legacy_layout_for_build_meta(target_dir, build_meta, mode);
 
     let all_pkgs_path = layout.all_pkgs_of_build_target(build_meta.target_backend.into());
     let all_pkgs_json = moonbuild_rupes_recta::all_pkgs::gen_all_pkgs_json(

--- a/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
@@ -137,7 +137,9 @@ pub struct LegacyLayout {
     /// the layout used for multi-root workspaces.
     main_module: Option<ModuleSource>,
 
-    /// The directory of the standard library
+    /// The directory of the standard library.
+    ///
+    /// Only `Some` when the build imports prebuilt stdlib artifacts.
     stdlib_dir: Option<PathBuf>,
 
     /// The optimization level, debug or release
@@ -145,8 +147,6 @@ pub struct LegacyLayout {
     /// The operation done
     run_mode: RunMode,
 }
-
-const LEGACY_NON_MAIN_MODULE_DIR: &str = ".mooncakes";
 
 /// A common structure for generating artifact basenames of packages.
 ///
@@ -235,7 +235,7 @@ impl LegacyLayout {
                 // no nested directory for the working module
             }
             Some(_) => {
-                dir.push(LEGACY_NON_MAIN_MODULE_DIR);
+                dir.push(moonutil::common::DEP_PATH);
                 dir.extend(pkg.module().name().segments());
             }
             None => {
@@ -713,25 +713,13 @@ fn object_file_ext(os: OperatingSystem) -> &'static str {
     }
 }
 
-/// Get the bundled core bundle path for the given backend.
-///
-/// This is a recreation of [`moonutil::moon_dir::core`], which we hope will be
-/// removed in the future.
 pub fn core_bundle_path(core_root: &Path, backend: TargetBackend) -> PathBuf {
-    let mut path = PathBuf::from(core_root);
-    path.push(moonutil::common::BUILD_DIR);
-    path.push(backend.to_dir_name());
-    path.push("release");
-    path.push("bundle");
-    path
+    moonutil::toolchain::core_bundle_in(core_root, backend)
 }
 
 /// Returns the path to abort.core for the given backend.
 pub fn abort_core_path(core_root: &Path, backend: TargetBackend) -> PathBuf {
-    let mut path = core_bundle_path(core_root, backend);
-    path.push("abort");
-    path.push("abort.core");
-    path
+    moonutil::toolchain::abort_core_in(core_root, backend)
 }
 
 pub fn abort_mi_path(
@@ -739,34 +727,22 @@ pub fn abort_mi_path(
     backend: TargetBackend,
     is_implementing_virtual: bool,
 ) -> PathBuf {
-    let mut path = core_bundle_path(core_root, backend);
-    path.push("abort");
-    if is_implementing_virtual {
-        path.push(format!("abort{}", IMPL_MI_EXTENSION));
-    } else {
-        path.push(format!("abort{}", MI_EXTENSION));
-    }
-    path
+    moonutil::toolchain::abort_mi_in(core_root, backend, is_implementing_virtual)
 }
 
 /// Returns the path to core.core for the given backend.
 pub fn core_core_path(core_root: &Path, backend: TargetBackend) -> PathBuf {
-    let mut path = core_bundle_path(core_root, backend);
-    path.push("core.core");
-    path
+    moonutil::toolchain::core_core_in(core_root, backend)
 }
 
 pub fn stdlib_mi_path(core_root: &Path, backend: TargetBackend, fqn: &PackageFQN) -> PathBuf {
-    let mut path = core_bundle_path(core_root, backend);
     let package_name = fqn.package().as_str();
     let package_last_segment = fqn
         .package()
         .segments()
         .next_back()
         .expect("Package must have at least one segment");
-    path.push(package_name);
-    path.push(format!("{}{}", package_last_segment, MI_EXTENSION));
-    path
+    moonutil::toolchain::core_package_mi_in(core_root, backend, package_name, package_last_segment)
 }
 
 #[cfg(test)]

--- a/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
@@ -270,7 +270,7 @@ impl LegacyLayout {
             && abort == target.package
         {
             if target.kind == TargetKind::Source {
-                return abort_core_path(
+                return moonutil::toolchain::abort_core_in(
                     self.stdlib_dir
                         .as_ref()
                         .expect("Standard library should be present"),
@@ -324,7 +324,7 @@ impl LegacyLayout {
             && abort == target.package
         {
             if target.kind == TargetKind::Source {
-                return MiPathResult::StdAbort(abort_mi_path(
+                return MiPathResult::StdAbort(moonutil::toolchain::abort_mi_in(
                     self.stdlib_dir
                         .as_ref()
                         .expect("Standard library should be present"),
@@ -711,28 +711,6 @@ fn object_file_ext(os: OperatingSystem) -> &'static str {
         OperatingSystem::Linux | OperatingSystem::MacOS => ".o",
         OperatingSystem::None => panic!("No object file extension for no-OS targets"),
     }
-}
-
-pub fn core_bundle_path(core_root: &Path, backend: TargetBackend) -> PathBuf {
-    moonutil::toolchain::core_bundle_in(core_root, backend)
-}
-
-/// Returns the path to abort.core for the given backend.
-pub fn abort_core_path(core_root: &Path, backend: TargetBackend) -> PathBuf {
-    moonutil::toolchain::abort_core_in(core_root, backend)
-}
-
-pub fn abort_mi_path(
-    core_root: &Path,
-    backend: TargetBackend,
-    is_implementing_virtual: bool,
-) -> PathBuf {
-    moonutil::toolchain::abort_mi_in(core_root, backend, is_implementing_virtual)
-}
-
-/// Returns the path to core.core for the given backend.
-pub fn core_core_path(core_root: &Path, backend: TargetBackend) -> PathBuf {
-    moonutil::toolchain::core_core_in(core_root, backend)
 }
 
 pub fn stdlib_mi_path(core_root: &Path, backend: TargetBackend, fqn: &PackageFQN) -> PathBuf {

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -33,7 +33,7 @@ use crate::{
     model::BuildTarget,
     pkg_solve::DepRelationship,
 };
-use moonutil::BINARIES;
+use moonutil::toolchain::BINARIES;
 
 use super::{
     BuildOptions, CommandArgMap, Commandline, LoweringError,

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -25,6 +25,7 @@ use moonutil::{
         make_cc_command_resolved,
     },
     mooncakes::{ModuleId, ModuleSourceKind},
+    toolchain::BINARIES,
 };
 use tracing::{Level, instrument};
 
@@ -90,7 +91,7 @@ impl<'a> super::LoweringContext<'a> {
             max_concurrent_tests: package.raw.max_concurrent_tests,
         };
 
-        let commandline = cmd.build_command(&*moonutil::BINARIES.moonbuild);
+        let commandline = cmd.build_command(&*BINARIES.moonbuild);
 
         // Track doctest files as extra inputs
         let mut extra_inputs = files_vec;
@@ -126,7 +127,7 @@ impl<'a> super::LoweringContext<'a> {
 
         BuildCommand {
             extra_inputs: vec![],
-            commandline: cmd.build_command(&*moonutil::BINARIES.moonc).into(),
+            commandline: cmd.build_command(&*BINARIES.moonc).into(),
         }
     }
 
@@ -209,7 +210,7 @@ impl<'a> super::LoweringContext<'a> {
 
         BuildCommand {
             extra_inputs: vec![],
-            commandline: cmd.build_command(&*moonutil::BINARIES.mooninfo).into(),
+            commandline: cmd.build_command(&*BINARIES.mooninfo).into(),
         }
     }
 
@@ -246,7 +247,7 @@ impl<'a> super::LoweringContext<'a> {
         );
 
         BuildCommand {
-            commandline: cmd.build_command(&*moonutil::BINARIES.moondoc).into(),
+            commandline: cmd.build_command(&*BINARIES.moondoc).into(),
             extra_inputs: vec![packages_json],
         }
     }
@@ -272,8 +273,8 @@ impl<'a> super::LoweringContext<'a> {
         let output = mbtlex_path.with_extension("mbt");
 
         let commandline = vec![
-            moonutil::BINARIES.moonrun.display().to_string(),
-            moonutil::BINARIES.moonlex.display().to_string(),
+            BINARIES.moonrun.display().to_string(),
+            BINARIES.moonlex.display().to_string(),
             "--".into(),
             mbtlex_path.display().to_string(),
             "-o".into(),
@@ -296,8 +297,8 @@ impl<'a> super::LoweringContext<'a> {
         let output = mby_path.with_extension("mbt");
 
         let commandline = vec![
-            moonutil::BINARIES.moonrun.display().to_string(),
-            moonutil::BINARIES.moonyacc.display().to_string(),
+            BINARIES.moonrun.display().to_string(),
+            BINARIES.moonyacc.display().to_string(),
             "--".into(),
             mby_path.display().to_string(),
             "-o".into(),

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -33,6 +33,7 @@ use moonutil::{
     cond_expr::OptLevel,
     mooncakes::{CORE_MODULE, ModuleId},
     package::JsFormat,
+    toolchain::BINARIES,
 };
 use petgraph::Direction;
 use tracing::{Level, instrument};
@@ -392,7 +393,7 @@ impl<'a> LoweringContext<'a> {
 
         BuildCommand {
             extra_inputs,
-            commandline: cmd.build_command(&*moonutil::BINARIES.moonc).into(),
+            commandline: cmd.build_command(&*BINARIES.moonc).into(),
         }
     }
 
@@ -442,7 +443,7 @@ impl<'a> LoweringContext<'a> {
 
         BuildCommand {
             extra_inputs,
-            commandline: cmd.build_command(&*moonutil::BINARIES.moonc).into(),
+            commandline: cmd.build_command(&*BINARIES.moonc).into(),
         }
     }
 
@@ -499,7 +500,7 @@ impl<'a> LoweringContext<'a> {
 
         BuildCommand {
             extra_inputs,
-            commandline: cmd.build_command(&*moonutil::BINARIES.moonc).into(),
+            commandline: cmd.build_command(&*BINARIES.moonc).into(),
         }
     }
 
@@ -578,7 +579,7 @@ impl<'a> LoweringContext<'a> {
         self.extend_extra_inputs(&cmd.defaults, &mut extra_inputs);
 
         BuildCommand {
-            commandline: cmd.build_command(&*moonutil::BINARIES.moonc).into(),
+            commandline: cmd.build_command(&*BINARIES.moonc).into(),
             extra_inputs,
         }
     }
@@ -687,7 +688,7 @@ impl<'a> LoweringContext<'a> {
 
         BuildCommand {
             extra_inputs,
-            commandline: cmd.build_command(&*moonutil::BINARIES.moonc).into(),
+            commandline: cmd.build_command(&*BINARIES.moonc).into(),
         }
     }
 
@@ -1270,7 +1271,7 @@ impl<'a> LoweringContext<'a> {
         // a response file so that `tcc` will run it later.
         //
         // We have a tool for this: `moon tool write-tcc-rsp-file <out> <args...>`
-        let moonbuild = moonutil::BINARIES
+        let moonbuild = BINARIES
             .moonbuild
             .to_str()
             .expect("moonbuild path is valid UTF-8");
@@ -1332,7 +1333,7 @@ impl<'a> LoweringContext<'a> {
         BuildCommand {
             // Track the user-written `.mbti` contract as an explicit input
             extra_inputs: vec![mbti_path.clone()],
-            commandline: cmd.build_command(&*moonutil::BINARIES.moonc).into(),
+            commandline: cmd.build_command(&*BINARIES.moonc).into(),
         }
     }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -127,11 +127,10 @@ impl<'a> LoweringContext<'a> {
         is_main: bool,
     ) -> BuildCommonConfig<'a> {
         // Standard library settings
-        let stdlib_core_file = self
-            .opt
-            .stdlib_path
-            .as_ref()
-            .map(|x| artifact::core_bundle_path(x, self.opt.target_backend.into()).into());
+        let stdlib_core_file =
+            self.opt.stdlib_path.as_ref().map(|x| {
+                moonutil::toolchain::core_bundle_in(x, self.opt.target_backend.into()).into()
+            });
 
         // Warning and error settings
         let error_format = if self.opt.moonc_output_json {
@@ -603,12 +602,12 @@ impl<'a> LoweringContext<'a> {
             // The two stdlib core files must be linked in the correct order,
             // in order to get the correct order of initialization.
             if !info.abort_overridden {
-                core_input_files.push(artifact::abort_core_path(
+                core_input_files.push(moonutil::toolchain::abort_core_in(
                     stdlib,
                     self.opt.target_backend.into(),
                 ));
             }
-            core_input_files.push(artifact::core_core_path(
+            core_input_files.push(moonutil::toolchain::core_core_in(
                 stdlib,
                 self.opt.target_backend.into(),
             ));
@@ -673,11 +672,11 @@ impl<'a> LoweringContext<'a> {
         // Ensure n2 sees stdlib core bundle changes as inputs
         let mut extra_inputs = Vec::new();
         if let Some(stdlib) = &self.opt.stdlib_path {
-            extra_inputs.push(artifact::abort_core_path(
+            extra_inputs.push(moonutil::toolchain::abort_core_in(
                 stdlib,
                 self.opt.target_backend.into(),
             ));
-            extra_inputs.push(artifact::core_core_path(
+            extra_inputs.push(moonutil::toolchain::core_core_in(
                 stdlib,
                 self.opt.target_backend.into(),
             ));
@@ -1326,7 +1325,8 @@ impl<'a> LoweringContext<'a> {
         // Provide std path when stdlib is enabled
         if let Some(stdlib_root) = &self.opt.stdlib_path {
             cmd.stdlib_core_file = Some(
-                artifact::core_bundle_path(stdlib_root, self.opt.target_backend.into()).into(),
+                moonutil::toolchain::core_bundle_in(stdlib_root, self.opt.target_backend.into())
+                    .into(),
             );
         }
 

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -36,6 +36,7 @@ use moonutil::{
     module::{MoonMod, MoonModRule},
     mooncakes::ModuleId,
     package::{MoonPkgGenerate, SupportedTargetsDeclKind},
+    toolchain::BINARIES,
 };
 use regex::Regex;
 use tracing::{Level, debug, instrument, trace, warn};
@@ -1579,7 +1580,7 @@ fn handle_build_command_new(
 
     let mut reconstructed = String::new();
 
-    let moon_bin_path = moonutil::BINARIES.moonbuild.to_string_lossy();
+    let moon_bin_path = BINARIES.moonbuild.to_string_lossy();
 
     let command = if let Some(command) = command.strip_prefix(":embed ") {
         reconstructed.push_str(&format!("{} tool embed ", moon_bin_path));

--- a/crates/moonbuild-rupes-recta/src/fmt.rs
+++ b/crates/moonbuild-rupes-recta/src/fmt.rs
@@ -38,6 +38,7 @@ use moonutil::common::{
     MOON_MOD, MOON_MOD_JSON, MOON_PKG, MOON_PKG_JSON, MOON_WORK, validate_module_dsl_deps,
 };
 use moonutil::mooncakes::{ModuleSourceKind, result::ResolvedModule};
+use moonutil::toolchain::BINARIES;
 use moonutil::workspace::workspace_manifest_path;
 use n2::graph::Build;
 
@@ -232,7 +233,7 @@ fn format_moon_mod_dsl(
 ) -> anyhow::Result<()> {
     if cfg.check_only || cfg.warn_only {
         let mut cmd = vec![
-            moonutil::BINARIES.moonbuild.to_string_lossy().into_owned(),
+            BINARIES.moonbuild.to_string_lossy().into_owned(),
             "tool".into(),
             "format-and-diff".into(),
             "--old".into(),
@@ -258,7 +259,7 @@ fn format_moon_mod_dsl(
         graph.add_build(build)?;
     } else {
         let fmt_cmd = [
-            moonutil::BINARIES.moonfmt.to_string_lossy().into_owned(),
+            BINARIES.moonfmt.to_string_lossy().into_owned(),
             moon_mod.to_string_lossy().into_owned(),
             "-w".into(),
             "-o".into(),
@@ -295,7 +296,7 @@ fn format_moon_mod_json_migrate(
 
     if cfg.check_only || cfg.warn_only {
         let mut cmd = vec![
-            moonutil::BINARIES.moonbuild.to_string_lossy().into_owned(),
+            BINARIES.moonbuild.to_string_lossy().into_owned(),
             "tool".into(),
             "format-and-diff".into(),
             "--old".into(),
@@ -324,7 +325,7 @@ fn format_moon_mod_json_migrate(
         graph.add_build(build)?;
     } else {
         let fmt_cmd = [
-            moonutil::BINARIES.moonfmt.to_string_lossy().into_owned(),
+            BINARIES.moonfmt.to_string_lossy().into_owned(),
             moon_mod_json.to_string_lossy().into_owned(),
             "-o".into(),
             target_moon_mod.to_string_lossy().into_owned(),
@@ -498,7 +499,7 @@ fn format_node(
         .into_owned();
     let cmd: Vec<String> = if cfg.check_only || cfg.warn_only {
         let mut cmd = vec![
-            moonutil::BINARIES.moonbuild.to_string_lossy().into_owned(),
+            BINARIES.moonbuild.to_string_lossy().into_owned(),
             "tool".into(),
             "format-and-diff".into(),
             "--old".into(),
@@ -516,7 +517,7 @@ fn format_node(
         cmd
     } else {
         let mut cmd = vec![
-            moonutil::BINARIES.moonfmt.to_string_lossy().into_owned(),
+            BINARIES.moonfmt.to_string_lossy().into_owned(),
             file.to_string_lossy().into_owned(),
             "-w".into(),
             "-o".into(),
@@ -555,7 +556,7 @@ fn format_moon_work_dsl(
 ) -> anyhow::Result<()> {
     if cfg.check_only || cfg.warn_only {
         let mut cmd = vec![
-            moonutil::BINARIES.moonbuild.to_string_lossy().into_owned(),
+            BINARIES.moonbuild.to_string_lossy().into_owned(),
             "tool".into(),
             "format-workspace".into(),
             "--old".into(),
@@ -579,7 +580,7 @@ fn format_moon_work_dsl(
         graph.add_build(build)?;
     } else {
         let fmt_cmd: Vec<String> = vec![
-            moonutil::BINARIES.moonbuild.to_string_lossy().into_owned(),
+            BINARIES.moonbuild.to_string_lossy().into_owned(),
             "tool".into(),
             "format-workspace".into(),
             "--old".into(),
@@ -670,7 +671,7 @@ fn format_moon_pkg_dsl(
     if cfg.check_only || cfg.warn_only {
         // In check/warn mode, use format-and-diff to compare
         let mut cmd = vec![
-            moonutil::BINARIES.moonbuild.to_string_lossy().into_owned(),
+            BINARIES.moonbuild.to_string_lossy().into_owned(),
             "tool".into(),
             "format-and-diff".into(),
             "--old".into(),
@@ -698,7 +699,7 @@ fn format_moon_pkg_dsl(
         // Format moon.pkg - use -w to write back to source and -o to target
         // This is consistent with how .mbt files are formatted
         let fmt_cmd: Vec<String> = vec![
-            moonutil::BINARIES.moonfmt.to_string_lossy().into_owned(),
+            BINARIES.moonfmt.to_string_lossy().into_owned(),
             moon_pkg.to_string_lossy().into_owned(),
             "-w".into(),
             "-o".into(),
@@ -747,7 +748,7 @@ fn format_moon_pkg_json_migrate(
     if cfg.check_only || cfg.warn_only {
         // In check/warn mode, use format-and-diff to compare
         let mut cmd = vec![
-            moonutil::BINARIES.moonbuild.to_string_lossy().into_owned(),
+            BINARIES.moonbuild.to_string_lossy().into_owned(),
             "tool".into(),
             "format-and-diff".into(),
             "--old".into(),
@@ -774,7 +775,7 @@ fn format_moon_pkg_json_migrate(
     } else {
         // Step 1: Format moon.pkg.json to target directory
         let fmt_cmd: Vec<String> = vec![
-            moonutil::BINARIES.moonfmt.to_string_lossy().into_owned(),
+            BINARIES.moonfmt.to_string_lossy().into_owned(),
             moon_pkg_json.to_string_lossy().into_owned(),
             "-o".into(),
             target_moon_pkg.to_string_lossy().into_owned(),

--- a/crates/moonbuild-rupes-recta/src/metadata.rs
+++ b/crates/moonbuild-rupes-recta/src/metadata.rs
@@ -23,16 +23,15 @@ use std::path::{Path, PathBuf};
 
 use indexmap::IndexMap;
 use moonutil::{
-    common::{RunMode, TargetBackend},
+    common::TargetBackend,
     cond_expr::{CompileCondition, OptLevel},
     module::ModuleDBJSON,
-    moon_dir::core,
     package::{AliasJSON, PackageJSON},
 };
 
 use crate::{
     ResolveOutput,
-    build_lower::artifact::{LegacyLayout, LegacyLayoutBuilder},
+    build_lower::artifact::LegacyLayout,
     cond_comp::file_metadatas,
     model::{BuildTarget, PackageId, TargetKind},
     pkg_solve::DepEdge,
@@ -49,18 +48,16 @@ pub type CheckCommandMap = BTreeMap<PathBuf, Vec<String>>;
 pub fn gen_metadata_json(
     ctx: &ResolveOutput,
     source_dir: &Path,
-    target_dir: &Path,
+    layout: &LegacyLayout,
     opt_level: OptLevel,
     backend: TargetBackend,
-    mode: RunMode,
     check_commands: &CheckCommandMap,
 ) -> ModuleDBJSON {
-    let (main_module, name, deps, source) = match ctx.local_modules() {
+    let (name, deps, source) = match ctx.local_modules() {
         &[main_module_id] => {
             let main_module = ctx.module_rel.module_source(main_module_id);
             let main_module_json = ctx.module_rel.module_info(main_module_id);
             (
-                Some(main_module.clone()),
                 main_module.name().to_string(),
                 main_module_json.deps.keys().cloned().collect(),
                 main_module_json.source.clone(),
@@ -77,23 +74,14 @@ pub fn gen_metadata_json(
                 .collect::<BTreeSet<_>>()
                 .into_iter()
                 .collect();
-            (None, "workspace".to_string(), deps, None)
+            ("workspace".to_string(), deps, None)
         }
     };
-
-    let layout = LegacyLayoutBuilder::default()
-        .main_module(main_module)
-        .opt_level(opt_level)
-        .stdlib_dir(Some(core()))
-        .run_mode(mode)
-        .target_base_dir(target_dir.to_owned())
-        .build()
-        .expect("Failed to build legacy layout");
 
     let mut packages: Vec<PackageJSON> = ctx
         .pkg_dirs
         .all_packages(true)
-        .map(|(id, _)| gen_package_json(ctx, &layout, id, backend, check_commands))
+        .map(|(id, _)| gen_package_json(ctx, layout, id, backend, check_commands))
         .collect();
     packages.sort_by(|x, y| (x.root.cmp(&y.root)).then_with(|| x.rel.cmp(&y.rel)));
 

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -1118,7 +1118,7 @@ impl MooncOpt {
     }
 }
 
-pub(crate) const DEP_PATH: &str = ".mooncakes";
+pub const DEP_PATH: &str = ".mooncakes";
 
 pub const BUILD_DIR: &str = "_build";
 

--- a/crates/moonutil/src/moon_dir.rs
+++ b/crates/moonutil/src/moon_dir.rs
@@ -129,23 +129,59 @@ pub fn core() -> PathBuf {
     lib().join("core")
 }
 
-pub fn core_bundle(backend: TargetBackend) -> PathBuf {
-    core()
+pub fn core_bundle_in(core_root: &Path, backend: TargetBackend) -> PathBuf {
+    core_root
         .join(BUILD_DIR)
         .join(backend.to_dir_name())
         .join("release")
         .join("bundle")
 }
 
+pub fn core_bundle(backend: TargetBackend) -> PathBuf {
+    core_bundle_in(&core(), backend)
+}
+
+pub fn abort_core_in(core_root: &Path, backend: TargetBackend) -> PathBuf {
+    core_bundle_in(core_root, backend)
+        .join("abort")
+        .join("abort.core")
+}
+
+pub fn core_core_in(core_root: &Path, backend: TargetBackend) -> PathBuf {
+    core_bundle_in(core_root, backend).join("core.core")
+}
+
+pub fn abort_mi_in(
+    core_root: &Path,
+    backend: TargetBackend,
+    is_implementing_virtual: bool,
+) -> PathBuf {
+    let mi_file = if is_implementing_virtual {
+        "abort.impl.mi"
+    } else {
+        "abort.mi"
+    };
+    core_bundle_in(core_root, backend)
+        .join("abort")
+        .join(mi_file)
+}
+
+pub fn core_package_mi_in(
+    core_root: &Path,
+    backend: TargetBackend,
+    package_path: &str,
+    package_last_segment: &str,
+) -> PathBuf {
+    core_bundle_in(core_root, backend)
+        .join(package_path)
+        .join(format!("{package_last_segment}.mi"))
+}
+
 // core.core & abort.core(virtual pkg default impl)
 pub fn core_core(backend: TargetBackend) -> Vec<String> {
     vec![
-        core_bundle(backend)
-            .join("abort")
-            .join("abort.core")
-            .display()
-            .to_string(),
-        core_bundle(backend).join("core.core").display().to_string(),
+        abort_core_in(&core(), backend).display().to_string(),
+        core_core_in(&core(), backend).display().to_string(),
     ]
 }
 

--- a/crates/moonutil/src/toolchain.rs
+++ b/crates/moonutil/src/toolchain.rs
@@ -16,36 +16,16 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-#![warn(clippy::clone_on_ref_ptr)]
+//! MoonBit toolchain layout and executable resolution.
+//!
+//! This module groups facts about the installed MoonBit toolchain: its root,
+//! shipped `bin`/`lib`/`include` directories, shipped standard-library
+//! artifacts, and resolved tool executable paths. Project-local build layout
+//! should live outside this module.
 
-mod binaries;
-pub mod build_script;
-pub mod cli;
-pub mod common;
-pub mod compiler_flags;
-pub mod cond_expr;
-pub mod demangle;
-pub mod dependency;
-pub mod dirs;
-pub mod error_code_docs;
-pub mod features;
-pub mod fuzzy_match;
-pub mod git;
-pub mod graph;
-pub mod module;
-pub mod moon_dir;
-pub mod moon_mod_patch;
-pub mod moon_pkg;
-pub mod mooncakes;
-pub mod package;
-pub mod path;
-pub mod platform;
-pub mod render;
-pub mod shlex;
-pub mod supported_targets;
-pub mod toolchain;
-pub mod user_warning;
-pub mod version;
-pub mod workspace;
-
-pub use binaries::BINARIES;
+pub use crate::BINARIES;
+pub use crate::binaries::CachedBinaries;
+pub use crate::moon_dir::{
+    MOON_DIRS, MoonDirs, abort_core_in, abort_mi_in, bin, core, core_bundle, core_bundle_in,
+    core_core, core_core_in, core_package_mi_in, include, is_toolchain_root, lib, toolchain_root,
+};

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -147,14 +147,15 @@ produced by dependency sync. `ResolveOutput` should contain resolved
 build-model data derived from those inputs, not repeat the captured discovery
 paths.
 
-Toolchain and host facts are not fully centralized today. `rr_build` and
-`compile` still make some host-dependent decisions while preparing planning and
-lowering. They should follow the same rule where practical: if a phase needs the
-host OS, compiler paths, standard-library path, or native toolchain choices,
-those should be owned by an explicit environment object and passed forward
-instead of being rediscovered at each use site. Such facts do not need to be
-eager: non-native builds should not resolve native-only OS/toolchain details
-unless a lowering path actually asks for them.
+Toolchain and host facts follow the same rule. `moonutil::toolchain` owns facts
+about the selected MoonBit toolchain tree, including known tool binaries and
+the shipped standard-library artifact layout. Command orchestration decides
+whether those facts apply to the current build, then passes the selected facts
+forward. In particular, `rr_build` chooses `stdlib_path` from `use_std &&
+!is_core`; RR lowering, metadata generation, and `all_pkgs.json` generation
+consume the resulting `LegacyLayout` instead of rediscovering the installed
+stdlib. Such facts do not need to be eager: non-native builds should not resolve
+native-only OS/toolchain details unless a lowering path actually asks for them.
 
 Prebuild configuration is another environment-sensitive input. When prebuild
 configuration scripts run, `rr_build` captures the process environment

--- a/docs/dev/reference/binaries.md
+++ b/docs/dev/reference/binaries.md
@@ -6,3 +6,8 @@
 2. Find the executable in the resolved toolchain root: `$MOON_TOOLCHAIN_ROOT/bin/{binary}`, the inferred current-executable toolchain root, or the legacy `$MOON_HOME/bin/{binary}` fallback
 3. Resolve the executable from `PATH` to an absolute path
 4. Fallback: just use the plain binary name, and rely on `PATH`
+
+The code entry point is `moonutil::toolchain::BINARIES`, which re-exports the
+cached binary resolver from `moonutil`. Build engines should use this entry
+point when they need MoonBit tool executables, rather than duplicating binary
+lookup rules locally.

--- a/docs/dev/reference/rr-special-cases.md
+++ b/docs/dev/reference/rr-special-cases.md
@@ -49,11 +49,11 @@ important ones and why they exist.
   (`build_lower::artifact`), calls that would normally resolve `.core`, `.mi`,
   or `.phony_mi` files check whether the target package is the recorded abort
   package. If so, and **only when stdlib is injected**, the code switches to
-  the stdlib’s prebuilt `abort` outputs (`abort_core_path` / `abort_mi_path`)
-  because those artifacts are shipped as part of the toolchain rather than
-  being rebuilt per project. When **building the stdlib itself**, the abort
-  package must resolve to local `_build/...` artifacts, so the prebuilt paths
-  are explicitly *not* used.
+  the stdlib’s prebuilt `abort` outputs via `moonutil::toolchain` because
+  those artifacts are shipped as part of the toolchain rather than being
+  rebuilt per project. When **building the stdlib itself**, the abort package
+  must resolve to local `_build/...` artifacts, so the prebuilt paths are
+  explicitly *not* used.
 - **Stdlib bundle paths are toolchain facts.** The bundled stdlib layout
   (`_build/<backend>/release/bundle`, `abort/abort.core`, package `.mi`
   files, and related paths) is owned by `moonutil::toolchain`, backed by the

--- a/docs/dev/reference/rr-special-cases.md
+++ b/docs/dev/reference/rr-special-cases.md
@@ -54,18 +54,36 @@ important ones and why they exist.
   being rebuilt per project. When **building the stdlib itself**, the abort
   package must resolve to local `_build/...` artifacts, so the prebuilt paths
   are explicitly *not* used.
+- **Stdlib bundle paths are toolchain facts.** The bundled stdlib layout
+  (`_build/<backend>/release/bundle`, `abort/abort.core`, package `.mi`
+  files, and related paths) is owned by `moonutil::toolchain`, backed by the
+  existing `moonutil::moon_dir` helpers. RR may translate an already selected
+  stdlib root into concrete artifact paths, but it should not rediscover the
+  installed stdlib root while lowering.
 
 ## Stdlib injection boundaries
 
+- **Stdlib injection is selected before RR lowering.** The `moon` command layer
+  computes `stdlib_path` from `use_std && !is_core` while building
+  `CompileConfig` / `BuildMeta`. For ordinary projects this is the installed
+  toolchain core directory. When building `moonbitlang/core` itself, it is
+  `None`, so stdlib packages resolve to local `_build/...` artifacts.
+- **RR consumes the selected layout.** `CompileConfig`, lowering options,
+  `LegacyLayout`, metadata generation, and `all_pkgs.json` generation all
+  consume the same selected `stdlib_path` / `LegacyLayout`. `metadata.rs` and
+  `all_pkgs.rs` should render paths from the supplied layout; they should not
+  call `moonutil::toolchain::core()` or otherwise decide whether prebuilt
+  stdlib artifacts are in use.
 - **`abort_pkg` is discovery-only, not build-mode.** We always record the abort
   package ID if it exists, even when building the stdlib. Build-mode decisions
   (use prebuilt paths vs local artifacts) are gated by whether stdlib is
   injected (`build_env.std` / `stdlib_dir.is_some()`), not by mutating
   `abort_pkg`.
-- **`all_pkgs.json` respects stdlib mode.** When building the stdlib (core
-  module), `all_pkgs.json` is generated without a stdlib directory so indirect
-  dependency resolution uses the locally built `.mi` files. For non-core
-  projects, the stdlib directory is set so prebuilt artifacts can be used.
+- **Metadata files respect stdlib mode.** When building the stdlib (core
+  module), `packages.json` and `all_pkgs.json` are generated without a stdlib
+  directory so package metadata and indirect dependency resolution use the
+  locally built `.mi` files. For non-core projects, the stdlib directory is set
+  so prebuilt artifacts can be used.
 
 ## Runtime + tooling side effects
 

--- a/docs/dev/reference/toolchain-layout.md
+++ b/docs/dev/reference/toolchain-layout.md
@@ -29,6 +29,21 @@ This means we do **not** need to redesign the internal tree into `lib/moonbit/..
 
 Mutable user state must stay outside the package-managed prefix.
 
+## Code ownership
+
+In code, facts about the selected MoonBit toolchain tree should be accessed via
+`moonutil::toolchain`. This includes known tool executables, the toolchain root,
+`bin`/`lib`/`include`, and shipped stdlib artifacts under `lib/core`.
+
+Project-local layout remains outside this module. For example, `.mooncakes`,
+`_build`, resolved package roots, and workspace discovery are project facts,
+not toolchain facts.
+
+RR should not decide whether a build uses the installed stdlib by calling
+`moonutil::toolchain::core()` in lowering or metadata code. The command
+orchestration layer selects `stdlib_path` first, then passes that value through
+`CompileConfig`, `BuildMeta`, and `LegacyLayout`.
+
 ## Packaging layouts by system
 
 ### Homebrew formula


### PR DESCRIPTION
## Summary

- Add `moonutil::toolchain` as the explicit entry point for MoonBit toolchain facts, including known binaries and shipped stdlib artifact paths.
- Move stdlib bundle path construction out of RR-local ad hoc logic and have RR consume the selected `stdlib_path` / `LegacyLayout` instead.
- Keep project-local layout knowledge, such as `.mooncakes`, outside the toolchain module.
- Update RR architecture docs to record where stdlib injection is selected and how metadata/all_pkgs should consume layout.

## Validation

- `cargo fmt`
- `cargo check -p moonbuild-rupes-recta -p moon -p moonutil`
- `cargo clippy -p moonbuild-rupes-recta -p moon -p moonutil --all-targets -- -D warnings`
- `cargo test -p moonbuild-rupes-recta build_lower::artifact --lib`
- `cargo test -p moon tests::planner`

## Notes

Rebased onto latest `origin/main` before pushing.