### PR TITLE
[codex] Refine native backend pipeline lowering

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,26 @@
+# MoonBuild Context
+
+MoonBuild is the build system and package manager implementation for MoonBit.
+This context records project-specific terms that should stay stable across architecture discussions.
+
+## Language
+
+**Target backend**:
+The user-visible platform selected for a build invocation, such as `wasm`, `wasm-gc`, `js`, `native`, or `llvm`.
+_Avoid_: Backend when the distinction from execution strategy matters
+
+**Native C toolchain**:
+The resolved compiler driver, linker driver, archiver, command dialect, source of selection, and probed target facts used for native-oriented build steps.
+_Avoid_: C compiler when the archiver, linker driver, or target facts matter
+
+**Target platform**:
+The target operating system, architecture, ABI, object format, and runtime ecosystem that native-oriented artifacts are built for.
+_Avoid_: Host platform when cross-compilation is possible
+
+**Native pipeline model**:
+The internal model that decides how native-oriented artifacts move from link-core output to a runnable artifact: linked-core shape, runtime shape, C stub aggregation, final executable realization, and run invocation shape.
+_Avoid_: Native backend, native mode, native executable strategy
+
+**Backend lowering**:
+The phase that turns the action-level build plan into concrete artifact paths, command lines, and an n2 build graph.
+_Avoid_: Build execution, backend generation

--- a/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
@@ -47,22 +47,12 @@ const IMPL_MI_EXTENSION: &str = ".impl.mi";
 
 #[derive(Clone, Copy, Debug)]
 pub enum ExecutableArtifact {
-    Wasm {
-        use_wat: bool,
-    },
-    WasmGC {
-        use_wat: bool,
-    },
+    Wasm { use_wat: bool },
+    WasmGC { use_wat: bool },
     Js,
-    NativeExecutable {
-        os: OperatingSystem,
-        legacy_behavior: bool,
-    },
+    NativeExecutable,
     TccRunResponseFile,
-    LlvmExecutable {
-        os: OperatingSystem,
-        legacy_behavior: bool,
-    },
+    LlvmExecutable,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -103,8 +93,8 @@ impl ExecutableArtifact {
             Self::Wasm { .. } => TargetBackend::Wasm,
             Self::WasmGC { .. } => TargetBackend::WasmGC,
             Self::Js => TargetBackend::Js,
-            Self::NativeExecutable { .. } | Self::TccRunResponseFile => TargetBackend::Native,
-            Self::LlvmExecutable { .. } => TargetBackend::LLVM,
+            Self::NativeExecutable | Self::TccRunResponseFile => TargetBackend::Native,
+            Self::LlvmExecutable => TargetBackend::LLVM,
         }
     }
 
@@ -113,14 +103,7 @@ impl ExecutableArtifact {
             Self::Wasm { use_wat } | Self::WasmGC { use_wat } if use_wat => ".wat",
             Self::Wasm { .. } | Self::WasmGC { .. } => ".wasm",
             Self::Js => ".js",
-            Self::NativeExecutable {
-                os,
-                legacy_behavior,
-            }
-            | Self::LlvmExecutable {
-                os,
-                legacy_behavior,
-            } => executable_ext(os, legacy_behavior),
+            Self::NativeExecutable | Self::LlvmExecutable => ".exe",
             Self::TccRunResponseFile => ".rspfile",
         }
     }
@@ -668,19 +651,6 @@ fn build_kind_suffix_filename(kind: TargetKind) -> &'static str {
         TargetKind::BlackboxTest => "_blackbox_test",
         TargetKind::InlineTest => "_internal_test",
         TargetKind::SubPackage => "_sub",
-    }
-}
-
-/// The extension for executables. The legacy behavior forces everything into an `.exe`.
-fn executable_ext(os: OperatingSystem, legacy_behavior: bool) -> &'static str {
-    if legacy_behavior {
-        ".exe"
-    } else {
-        match os {
-            OperatingSystem::Windows => ".exe",
-            OperatingSystem::Linux | OperatingSystem::MacOS => "",
-            OperatingSystem::None => panic!("No executable extension for no-OS targets"),
-        }
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/backend_pipeline.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/backend_pipeline.rs
@@ -1,0 +1,289 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Target backend pipeline decisions used by backend lowering.
+//!
+//! This module keeps the user-visible target backend separate from native
+//! pipeline details. In particular, `tcc -run` still consumes generated C from
+//! link-core; it only changes how the final runnable artifact is realized.
+
+use crate::model::{NativeTarget, OperatingSystem, RunBackend};
+
+use super::artifact::{ExecutableArtifact, LinkedCoreArtifact};
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum BackendPipeline {
+    Wasm { use_wat: bool },
+    WasmGC { use_wat: bool },
+    Js,
+    Native(NativePipeline),
+}
+
+impl BackendPipeline {
+    pub(crate) fn from_config(
+        target_backend: RunBackend,
+        native_target: Option<NativeTarget>,
+        use_tcc_run: bool,
+        output_wat: bool,
+        os: impl FnOnce() -> OperatingSystem,
+    ) -> Self {
+        debug_assert!(!use_tcc_run || target_backend == RunBackend::Native);
+        debug_assert!(!use_tcc_run || native_target.is_none());
+        debug_assert!(target_backend == RunBackend::Native || native_target.is_none());
+
+        match target_backend {
+            RunBackend::Wasm => Self::Wasm {
+                use_wat: output_wat,
+            },
+            RunBackend::WasmGC => Self::WasmGC {
+                use_wat: output_wat,
+            },
+            RunBackend::Js => Self::Js,
+            RunBackend::Native if use_tcc_run => Self::Native(NativePipeline::tcc_run(os())),
+            RunBackend::Native if native_target.is_some() => {
+                Self::Native(NativePipeline::direct_object(os()))
+            }
+            RunBackend::Native => Self::Native(NativePipeline::generated_c_executable(os())),
+            RunBackend::Llvm => Self::Native(NativePipeline::llvm_object(os())),
+        }
+    }
+
+    pub(crate) fn uses_tcc_run(self) -> bool {
+        matches!(self, Self::Native(native) if native.uses_tcc_run())
+    }
+
+    pub(crate) fn native_executable_realization(self) -> NativeExecutableRealization {
+        match self {
+            Self::Native(native) => native.executable,
+            Self::Wasm { .. } | Self::WasmGC { .. } | Self::Js => {
+                unreachable!(
+                    "native executable realization is not defined for non-native pipelines"
+                )
+            }
+        }
+    }
+
+    pub(crate) fn executable_artifact(self) -> ExecutableArtifact {
+        match self {
+            Self::Wasm { use_wat } => ExecutableArtifact::Wasm { use_wat },
+            Self::WasmGC { use_wat } => ExecutableArtifact::WasmGC { use_wat },
+            Self::Js => ExecutableArtifact::Js,
+            Self::Native(native) => native.executable_artifact(),
+        }
+    }
+
+    pub(crate) fn linked_core_artifact(self) -> LinkedCoreArtifact {
+        match self {
+            Self::Wasm { use_wat } => LinkedCoreArtifact::Wasm { use_wat },
+            Self::WasmGC { use_wat } => LinkedCoreArtifact::WasmGC { use_wat },
+            Self::Js => LinkedCoreArtifact::Js,
+            Self::Native(native) => native.linked_core_artifact(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct NativePipeline {
+    os: OperatingSystem,
+    linked_core: NativeLinkedCore,
+    executable: NativeExecutableRealization,
+}
+
+impl NativePipeline {
+    fn generated_c_executable(os: OperatingSystem) -> Self {
+        Self {
+            os,
+            linked_core: NativeLinkedCore::GeneratedC,
+            executable: NativeExecutableRealization::CompileAndLinkGeneratedC,
+        }
+    }
+
+    fn tcc_run(os: OperatingSystem) -> Self {
+        Self {
+            os,
+            linked_core: NativeLinkedCore::GeneratedC,
+            executable: NativeExecutableRealization::WriteTccRunResponseFile,
+        }
+    }
+
+    fn direct_object(os: OperatingSystem) -> Self {
+        Self {
+            os,
+            linked_core: NativeLinkedCore::DirectObject,
+            executable: NativeExecutableRealization::LinkNativeObject,
+        }
+    }
+
+    fn llvm_object(os: OperatingSystem) -> Self {
+        Self {
+            os,
+            linked_core: NativeLinkedCore::LlvmObject,
+            executable: NativeExecutableRealization::LinkLlvmObject,
+        }
+    }
+
+    fn uses_tcc_run(self) -> bool {
+        matches!(
+            self.executable,
+            NativeExecutableRealization::WriteTccRunResponseFile
+        )
+    }
+
+    fn linked_core_artifact(self) -> LinkedCoreArtifact {
+        match self.linked_core {
+            NativeLinkedCore::GeneratedC => LinkedCoreArtifact::NativeC,
+            NativeLinkedCore::DirectObject => LinkedCoreArtifact::NativeObject { os: self.os },
+            NativeLinkedCore::LlvmObject => LinkedCoreArtifact::LlvmObject { os: self.os },
+        }
+    }
+
+    fn executable_artifact(self) -> ExecutableArtifact {
+        match self.executable {
+            NativeExecutableRealization::CompileAndLinkGeneratedC
+            | NativeExecutableRealization::LinkNativeObject => ExecutableArtifact::NativeExecutable,
+            NativeExecutableRealization::WriteTccRunResponseFile => {
+                ExecutableArtifact::TccRunResponseFile
+            }
+            NativeExecutableRealization::LinkLlvmObject => ExecutableArtifact::LlvmExecutable,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum NativeLinkedCore {
+    GeneratedC,
+    DirectObject,
+    LlvmObject,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum NativeExecutableRealization {
+    CompileAndLinkGeneratedC,
+    LinkNativeObject,
+    WriteTccRunResponseFile,
+    LinkLlvmObject,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::model::{NativeTarget, OperatingSystem, RunBackend};
+
+    use super::*;
+
+    #[test]
+    fn tcc_run_keeps_link_core_as_generated_c() {
+        let pipeline = BackendPipeline::from_config(RunBackend::Native, None, true, false, || {
+            OperatingSystem::Linux
+        });
+
+        assert!(pipeline.uses_tcc_run());
+        assert!(matches!(
+            pipeline.linked_core_artifact(),
+            LinkedCoreArtifact::NativeC
+        ));
+        assert!(matches!(
+            pipeline.executable_artifact(),
+            ExecutableArtifact::TccRunResponseFile
+        ));
+    }
+
+    #[test]
+    fn direct_native_uses_object_link_core_and_native_executable() {
+        let pipeline = BackendPipeline::from_config(
+            RunBackend::Native,
+            Some(NativeTarget::Aarch64AppleDarwin),
+            false,
+            false,
+            || OperatingSystem::MacOS,
+        );
+
+        assert!(!pipeline.uses_tcc_run());
+        assert!(matches!(
+            pipeline.linked_core_artifact(),
+            LinkedCoreArtifact::NativeObject {
+                os: OperatingSystem::MacOS
+            }
+        ));
+        assert!(matches!(
+            pipeline.executable_artifact(),
+            ExecutableArtifact::NativeExecutable
+        ));
+    }
+
+    #[test]
+    fn llvm_uses_llvm_object_and_llvm_executable() {
+        let pipeline = BackendPipeline::from_config(RunBackend::Llvm, None, false, false, || {
+            OperatingSystem::Windows
+        });
+
+        assert!(matches!(
+            pipeline.linked_core_artifact(),
+            LinkedCoreArtifact::LlvmObject {
+                os: OperatingSystem::Windows
+            }
+        ));
+        assert!(matches!(
+            pipeline.executable_artifact(),
+            ExecutableArtifact::LlvmExecutable
+        ));
+    }
+
+    #[test]
+    fn non_native_backends_preserve_linked_core_and_executable_shape() {
+        let wasm = BackendPipeline::from_config(RunBackend::Wasm, None, false, true, || {
+            OperatingSystem::None
+        });
+        let wasm_gc = BackendPipeline::from_config(RunBackend::WasmGC, None, false, false, || {
+            OperatingSystem::None
+        });
+        let js = BackendPipeline::from_config(RunBackend::Js, None, false, false, || {
+            OperatingSystem::None
+        });
+
+        assert!(matches!(
+            wasm.linked_core_artifact(),
+            LinkedCoreArtifact::Wasm { use_wat: true }
+        ));
+        assert!(matches!(
+            wasm.executable_artifact(),
+            ExecutableArtifact::Wasm { use_wat: true }
+        ));
+        assert!(matches!(
+            wasm_gc.linked_core_artifact(),
+            LinkedCoreArtifact::WasmGC { use_wat: false }
+        ));
+        assert!(matches!(
+            wasm_gc.executable_artifact(),
+            ExecutableArtifact::WasmGC { use_wat: false }
+        ));
+        assert!(matches!(js.linked_core_artifact(), LinkedCoreArtifact::Js));
+        assert!(matches!(js.executable_artifact(), ExecutableArtifact::Js));
+    }
+
+    #[test]
+    fn non_native_backends_do_not_need_operating_system() {
+        let pipeline = BackendPipeline::from_config(RunBackend::Js, None, false, false, || {
+            panic!("non-native pipeline should not resolve operating system")
+        });
+
+        assert!(matches!(
+            pipeline.linked_core_artifact(),
+            LinkedCoreArtifact::Js
+        ));
+    }
+}

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -256,7 +256,7 @@ impl<'a> LoweringContext<'a> {
                 );
             }
             PlannedArtifact::CStubLibrary { package, .. } => {
-                if self.opt.use_tcc_run() {
+                if self.opt.backend_pipeline.uses_tcc_run() {
                     out.push(self.layout.c_stub_link_dylib_path(
                         self.packages,
                         *package,
@@ -276,14 +276,14 @@ impl<'a> LoweringContext<'a> {
                 out.push(self.layout.linked_core_of_build_target(
                     self.packages,
                     target,
-                    self.opt.linked_core_artifact(),
+                    self.opt.backend_pipeline.linked_core_artifact(),
                 ));
             }
             PlannedArtifact::Executable { target, .. } => {
                 out.push(self.layout.executable_of_build_target(
                     self.packages,
                     target,
-                    self.opt.executable_artifact(true),
+                    self.opt.backend_pipeline.executable_artifact(),
                 ))
             }
             PlannedArtifact::GeneratedTestDriver { target, .. } => {
@@ -310,7 +310,7 @@ impl<'a> LoweringContext<'a> {
             PlannedArtifact::RuntimeLib { .. } => {
                 out.push(self.layout.runtime_output_path(
                     self.opt.target_backend,
-                    self.opt.use_tcc_run(),
+                    self.opt.backend_pipeline.uses_tcc_run(),
                     self.opt.os(),
                 ));
             }

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -135,13 +135,13 @@ impl<'a> super::LoweringContext<'a> {
     pub(super) fn lower_compile_runtime(&mut self) -> anyhow::Result<BuildCommand> {
         let artifact_path = self.layout.runtime_output_path(
             self.opt.target_backend,
-            self.opt.use_tcc_run(),
+            self.opt.backend_pipeline.uses_tcc_run(),
             self.opt.os(),
         );
 
         let runtime_c_path = self.opt.runtime_dot_c_path();
 
-        let use_tcc_run = self.opt.use_tcc_run();
+        let use_tcc_run = self.opt.backend_pipeline.uses_tcc_run();
         let (output_ty, link_moonbitrun) = match self.opt.target_backend {
             RunBackend::Wasm | RunBackend::WasmGC | RunBackend::Js => {
                 panic!("Runtime compilation is not applicable for non-native backends")

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -41,7 +41,7 @@ use tracing::{Level, instrument};
 use crate::{
     build_action_plan::{BuildActionId, PlannedArtifact},
     build_lower::{
-        WarningCondition, artifact,
+        NativeExecutableRealization, WarningCondition, artifact,
         compiler::{
             BuildCommonConfig, BuildCommonInput, CmdlineAbstraction, ErrorFormat, JsConfig,
             MiDependency, PackageSource, WasmConfig,
@@ -625,7 +625,7 @@ impl<'a> LoweringContext<'a> {
         let out_file = self.layout.linked_core_of_build_target(
             self.packages,
             &target,
-            self.opt.linked_core_artifact(),
+            self.opt.backend_pipeline.linked_core_artifact(),
         );
 
         let core_fqn = PackageFQN::new(CORE_MODULE.clone(), PackagePath::empty());
@@ -810,7 +810,7 @@ impl<'a> LoweringContext<'a> {
             (false, false) => CCOptLevel::None,
         };
         // `tcc run` uses shared runtime, others use static runtime
-        let use_shared_runtime = self.opt.use_tcc_run();
+        let use_shared_runtime = self.opt.backend_pipeline.uses_tcc_run();
 
         let config = CCConfigBuilder::default()
             .no_sys_header(true)
@@ -872,7 +872,7 @@ impl<'a> LoweringContext<'a> {
             RunBackend::WasmGC | RunBackend::Wasm | RunBackend::Js => {
                 panic!("C stubs are not supported for non-native backends")
             }
-            RunBackend::Native if self.opt.use_tcc_run() => {
+            RunBackend::Native if self.opt.backend_pipeline.uses_tcc_run() => {
                 self.lower_link_c_stubs(target, info, &object_files)
             }
             RunBackend::Native | RunBackend::Llvm => {
@@ -940,7 +940,7 @@ impl<'a> LoweringContext<'a> {
         // Legacy adds runtime into build inputs then links via -lruntime using link_shared_runtime.
         let runtime_dylib = self.layout.runtime_output_path(
             self.opt.target_backend,
-            self.opt.use_tcc_run(),
+            self.opt.backend_pipeline.uses_tcc_run(),
             self.opt.os(),
         );
         let runtime_parent = runtime_dylib
@@ -1006,23 +1006,24 @@ impl<'a> LoweringContext<'a> {
                     .all(|package| planned_c_stubs.contains(package))
         });
 
-        match self.opt.target_backend {
-            RunBackend::WasmGC | RunBackend::Wasm | RunBackend::Js => {
-                panic!(
-                    "Non-native make-executable should be already matched and should not be here"
-                )
+        match self.opt.backend_pipeline.native_executable_realization() {
+            NativeExecutableRealization::WriteTccRunResponseFile => {
+                let internal_tcc = self
+                    .opt
+                    .tcc_run
+                    .as_ref()
+                    .expect("tcc-run pipeline requires tcc-run config")
+                    .internal_tcc()
+                    .clone();
+                self.build_tcc_run_driver_command(action, target, info, internal_tcc)
             }
-            RunBackend::Native => {
-                if let Some(tcc_run) = &self.opt.tcc_run {
-                    let internal_tcc = tcc_run.internal_tcc().clone();
-                    self.build_tcc_run_driver_command(action, target, info, internal_tcc)
-                } else if self.opt.native_target.is_some() {
-                    self.lower_link_new_native_exe(action, target, info)
-                } else {
-                    self.lower_build_exe_regular(action, target, info)
-                }
+            NativeExecutableRealization::LinkNativeObject => {
+                self.lower_link_new_native_exe(action, target, info)
             }
-            RunBackend::Llvm => self.lower_build_exe_regular(action, target, info),
+            NativeExecutableRealization::CompileAndLinkGeneratedC
+            | NativeExecutableRealization::LinkLlvmObject => {
+                self.lower_build_exe_regular(action, target, info)
+            }
         }
     }
 
@@ -1106,7 +1107,11 @@ impl<'a> LoweringContext<'a> {
 
         let dest = self
             .layout
-            .executable_of_build_target(self.packages, &target, self.opt.executable_artifact(true))
+            .executable_of_build_target(
+                self.packages,
+                &target,
+                self.opt.backend_pipeline.executable_artifact(),
+            )
             .display()
             .to_string();
 
@@ -1171,7 +1176,11 @@ impl<'a> LoweringContext<'a> {
 
         let dest = self
             .layout
-            .executable_of_build_target(self.packages, &target, self.opt.executable_artifact(true))
+            .executable_of_build_target(
+                self.packages,
+                &target,
+                self.opt.backend_pipeline.executable_artifact(),
+            )
             .display()
             .to_string();
 
@@ -1260,7 +1269,7 @@ impl<'a> LoweringContext<'a> {
         let c_file = self.layout.linked_core_of_build_target(
             self.packages,
             &target,
-            self.opt.linked_core_artifact(),
+            self.opt.backend_pipeline.linked_core_artifact(),
         );
         cmdline.push(c_file.display().to_string());
 
@@ -1282,7 +1291,7 @@ impl<'a> LoweringContext<'a> {
         let rsp_path = self.layout.executable_of_build_target(
             self.packages,
             &target,
-            self.opt.executable_artifact(false),
+            self.opt.backend_pipeline.executable_artifact(),
         );
 
         rsp_cmdline.push(rsp_path.display().to_string());

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -36,6 +36,7 @@ use crate::{
 };
 
 pub mod artifact;
+mod backend_pipeline;
 mod compiler;
 mod context;
 mod lower_aux;
@@ -44,7 +45,9 @@ mod utils;
 
 pub use utils::{build_ins, build_n2_fileloc, build_outs};
 
-use crate::build_lower::artifact::{ExecutableArtifact, LegacyLayoutBuilder, LinkedCoreArtifact};
+pub(crate) use backend_pipeline::{BackendPipeline, NativeExecutableRealization};
+
+use crate::build_lower::artifact::LegacyLayoutBuilder;
 use context::LoweringContext;
 
 /// Lazily resolved host/toolchain facts used during lowering.
@@ -96,6 +99,11 @@ pub struct BuildOptions {
     pub target_backend: RunBackend,
     pub native_target: Option<NativeTarget>,
     pub tcc_run: Option<TccRunConfig>,
+    /// Resolved artifact and run shape derived from the backend knobs.
+    ///
+    /// Lowering code should use this for linked-core, executable, and
+    /// `tcc -run` shape decisions instead of rematching the raw fields above.
+    pub(crate) backend_pipeline: BackendPipeline,
     pub opt_level: OptLevel,
     pub action: RunMode,
 
@@ -126,51 +134,6 @@ impl BuildOptions {
 
     pub fn runtime_dot_c_path(&self) -> PathBuf {
         self.lowering_environment.runtime_dot_c_path()
-    }
-
-    pub fn use_tcc_run(&self) -> bool {
-        let use_tcc_run = self.tcc_run.is_some();
-        debug_assert!(!use_tcc_run || self.target_backend == RunBackend::Native);
-        debug_assert!(!use_tcc_run || self.native_target.is_none());
-        use_tcc_run
-    }
-
-    pub fn executable_artifact(&self, legacy_behavior: bool) -> ExecutableArtifact {
-        match self.target_backend {
-            RunBackend::Wasm => ExecutableArtifact::Wasm {
-                use_wat: self.output_wat,
-            },
-            RunBackend::WasmGC => ExecutableArtifact::WasmGC {
-                use_wat: self.output_wat,
-            },
-            RunBackend::Js => ExecutableArtifact::Js,
-            RunBackend::Native if self.use_tcc_run() => ExecutableArtifact::TccRunResponseFile,
-            RunBackend::Native => ExecutableArtifact::NativeExecutable {
-                os: self.os(),
-                legacy_behavior,
-            },
-            RunBackend::Llvm => ExecutableArtifact::LlvmExecutable {
-                os: self.os(),
-                legacy_behavior,
-            },
-        }
-    }
-
-    pub fn linked_core_artifact(&self) -> LinkedCoreArtifact {
-        match self.target_backend {
-            RunBackend::Wasm => LinkedCoreArtifact::Wasm {
-                use_wat: self.output_wat,
-            },
-            RunBackend::WasmGC => LinkedCoreArtifact::WasmGC {
-                use_wat: self.output_wat,
-            },
-            RunBackend::Js => LinkedCoreArtifact::Js,
-            RunBackend::Native if self.native_target.is_some() => {
-                LinkedCoreArtifact::NativeObject { os: self.os() }
-            }
-            RunBackend::Native => LinkedCoreArtifact::NativeC,
-            RunBackend::Llvm => LinkedCoreArtifact::LlvmObject { os: self.os() },
-        }
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -152,6 +152,13 @@ pub fn compile(
         target_backend: cx.target_backend,
         native_target: cx.native_target,
         tcc_run: cx.tcc_run.clone(),
+        backend_pipeline: build_lower::BackendPipeline::from_config(
+            cx.target_backend,
+            cx.native_target,
+            cx.tcc_run.is_some(),
+            cx.output_wat,
+            || cx.lowering_environment.os(),
+        ),
         opt_level: cx.opt_level,
         action: cx.action,
 


### PR DESCRIPTION
## Summary

- Add a lowering-local backend pipeline model that separates the user-visible target backend from native linked-core and executable realization decisions.
- Route linked-core artifacts, executable artifacts, tcc-run shared-runtime choices, and native executable branching through that pipeline instead of rematching `RunBackend + native_target + tcc_run` at each call site.
- Remove the unused platform-default executable suffix mode; native and LLVM executable artifacts keep the existing `.exe` naming.
- Add `CONTEXT.md` vocabulary for the backend lowering terms used by the refactor.

## Why

The previous `BuildOptions` helpers concentrated several different concepts in a shallow interface: target backend, linked-core artifact shape, final runnable artifact shape, and tcc-run behavior. That made `tcc-run` look like a distinct C artifact path even though it still consumes generated C from link-core and only changes final execution realization.

## Validation

- `cargo test -p moonbuild-rupes-recta backend_pipeline`
- `cargo fmt --check`
- `cargo check -p moonbuild-rupes-recta`
- `cargo clippy -p moonbuild-rupes-recta --all-targets -- -D warnings`
