### PR TITLE
refactor(rr): realize backend products before lowering commands

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_action_plan/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/artifact.rs
@@ -25,7 +25,7 @@ use crate::model::{BuildTarget, PackageId};
 use super::BuildActionId;
 
 /// A logical artifact produced by a build action.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum PlannedArtifact {
     PackageInterface {
         producer: BuildActionId,

--- a/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/artifact.rs
@@ -47,22 +47,12 @@ const IMPL_MI_EXTENSION: &str = ".impl.mi";
 
 #[derive(Clone, Copy, Debug)]
 pub enum ExecutableArtifact {
-    Wasm {
-        use_wat: bool,
-    },
-    WasmGC {
-        use_wat: bool,
-    },
+    Wasm { use_wat: bool },
+    WasmGC { use_wat: bool },
     Js,
-    NativeExecutable {
-        os: OperatingSystem,
-        legacy_behavior: bool,
-    },
+    NativeExecutable,
     TccRunResponseFile,
-    LlvmExecutable {
-        os: OperatingSystem,
-        legacy_behavior: bool,
-    },
+    LlvmExecutable,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -103,8 +93,8 @@ impl ExecutableArtifact {
             Self::Wasm { .. } => TargetBackend::Wasm,
             Self::WasmGC { .. } => TargetBackend::WasmGC,
             Self::Js => TargetBackend::Js,
-            Self::NativeExecutable { .. } | Self::TccRunResponseFile => TargetBackend::Native,
-            Self::LlvmExecutable { .. } => TargetBackend::LLVM,
+            Self::NativeExecutable | Self::TccRunResponseFile => TargetBackend::Native,
+            Self::LlvmExecutable => TargetBackend::LLVM,
         }
     }
 
@@ -113,14 +103,7 @@ impl ExecutableArtifact {
             Self::Wasm { use_wat } | Self::WasmGC { use_wat } if use_wat => ".wat",
             Self::Wasm { .. } | Self::WasmGC { .. } => ".wasm",
             Self::Js => ".js",
-            Self::NativeExecutable {
-                os,
-                legacy_behavior,
-            }
-            | Self::LlvmExecutable {
-                os,
-                legacy_behavior,
-            } => executable_ext(os, legacy_behavior),
+            Self::NativeExecutable | Self::LlvmExecutable => ".exe",
             Self::TccRunResponseFile => ".rspfile",
         }
     }
@@ -668,19 +651,6 @@ fn build_kind_suffix_filename(kind: TargetKind) -> &'static str {
         TargetKind::BlackboxTest => "_blackbox_test",
         TargetKind::InlineTest => "_internal_test",
         TargetKind::SubPackage => "_sub",
-    }
-}
-
-/// The extension for executables. The legacy behavior forces everything into an `.exe`.
-fn executable_ext(os: OperatingSystem, legacy_behavior: bool) -> &'static str {
-    if legacy_behavior {
-        ".exe"
-    } else {
-        match os {
-            OperatingSystem::Windows => ".exe",
-            OperatingSystem::Linux | OperatingSystem::MacOS => "",
-            OperatingSystem::None => panic!("No executable extension for no-OS targets"),
-        }
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
@@ -1,0 +1,505 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Backend-specific product realization.
+//!
+//! Build planning deals in logical actions and artifacts. Lowering selects one
+//! backend branch, lets that branch decide concrete product paths, then hands
+//! those paths to command lowering and n2 graph construction.
+
+use std::path::PathBuf;
+
+use moonutil::common::TargetBackend;
+
+use crate::{
+    build_lower::artifact::{ExecutableArtifact, LegacyLayout, LinkedCoreArtifact},
+    discover::DiscoverResult,
+    model::{BuildTarget, NativeTarget, OperatingSystem, PackageId, RunBackend},
+};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum SelectedBackend {
+    Wasm(WasmBackend),
+    WasmGc(WasmGcBackend),
+    Js(JsBackend),
+    C(CBackend),
+    Llvm(LlvmBackend),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct WasmBackend {
+    use_wat: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct WasmGcBackend {
+    use_wat: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct JsBackend;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct CBackend {
+    os: OperatingSystem,
+    linked_core: CLinkedCoreRealization,
+    executable: CExecutableRealization,
+    runtime: CRuntimeRealization,
+    c_stubs: CStubLibraryRealization,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct LlvmBackend {
+    os: OperatingSystem,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum CLinkedCoreRealization {
+    GeneratedC,
+    DirectObject,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum CExecutableRealization {
+    CompileAndLinkGeneratedC,
+    LinkDirectObject,
+    WriteTccRunResponseFile,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum CRuntimeRealization {
+    StaticObject,
+    SharedLibraryForTccRun,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum CStubLibraryRealization {
+    StaticArchive,
+    SharedLibraryForTccRun,
+}
+
+impl SelectedBackend {
+    pub(crate) fn new(
+        target_backend: RunBackend,
+        native_target: Option<NativeTarget>,
+        use_tcc_run: bool,
+        output_wat: bool,
+        os: impl FnOnce() -> OperatingSystem,
+    ) -> Self {
+        debug_assert!(
+            !use_tcc_run || target_backend == RunBackend::Native,
+            "tcc-run is only valid for the C backend"
+        );
+        debug_assert!(
+            native_target.is_none() || target_backend == RunBackend::Native,
+            "direct native object lowering is only valid for the C backend"
+        );
+
+        match target_backend {
+            RunBackend::Wasm => Self::Wasm(WasmBackend {
+                use_wat: output_wat,
+            }),
+            RunBackend::WasmGC => Self::WasmGc(WasmGcBackend {
+                use_wat: output_wat,
+            }),
+            RunBackend::Js => Self::Js(JsBackend),
+            RunBackend::Native => Self::C(CBackend::new(os(), native_target, use_tcc_run)),
+            RunBackend::Llvm => Self::Llvm(LlvmBackend { os: os() }),
+        }
+    }
+
+    pub(crate) fn linked_core_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        match self {
+            Self::Wasm(backend) => backend.linked_core_path(layout, packages, target),
+            Self::WasmGc(backend) => backend.linked_core_path(layout, packages, target),
+            Self::Js(backend) => backend.linked_core_path(layout, packages, target),
+            Self::C(backend) => backend.linked_core_path(layout, packages, target),
+            Self::Llvm(backend) => backend.linked_core_path(layout, packages, target),
+        }
+    }
+
+    pub(crate) fn executable_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        match self {
+            Self::Wasm(backend) => backend.executable_path(layout, packages, target),
+            Self::WasmGc(backend) => backend.executable_path(layout, packages, target),
+            Self::Js(backend) => backend.executable_path(layout, packages, target),
+            Self::C(backend) => backend.executable_path(layout, packages, target),
+            Self::Llvm(backend) => backend.executable_path(layout, packages, target),
+        }
+    }
+
+    pub(crate) fn runtime_path(self, layout: &LegacyLayout) -> PathBuf {
+        match self {
+            Self::C(backend) => backend.runtime_path(layout),
+            Self::Llvm(backend) => backend.runtime_path(layout),
+            Self::Wasm(_) | Self::WasmGc(_) | Self::Js(_) => {
+                unreachable!("runtime products are only realized for C or LLVM backends")
+            }
+        }
+    }
+
+    pub(crate) fn c_stub_library_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        package: PackageId,
+        target_backend: TargetBackend,
+    ) -> PathBuf {
+        match self {
+            Self::C(backend) => {
+                backend.c_stub_library_path(layout, packages, package, target_backend)
+            }
+            Self::Llvm(backend) => {
+                backend.c_stub_library_path(layout, packages, package, target_backend)
+            }
+            Self::Wasm(_) | Self::WasmGc(_) | Self::Js(_) => {
+                unreachable!("C stubs are only realized for C or LLVM backends")
+            }
+        }
+    }
+
+    pub(crate) fn c_stub_library_realization(self) -> CStubLibraryRealization {
+        match self {
+            Self::C(backend) => backend.c_stub_library_realization(),
+            Self::Llvm(_) => CStubLibraryRealization::StaticArchive,
+            Self::Wasm(_) | Self::WasmGc(_) | Self::Js(_) => {
+                unreachable!("C stubs are only realized for C or LLVM backends")
+            }
+        }
+    }
+
+    pub(crate) fn uses_shared_runtime(self) -> bool {
+        match self {
+            Self::C(backend) => backend.uses_shared_runtime(),
+            Self::Llvm(_) => false,
+            Self::Wasm(_) | Self::WasmGc(_) | Self::Js(_) => {
+                unreachable!("runtime products are only realized for C or LLVM backends")
+            }
+        }
+    }
+}
+
+impl WasmBackend {
+    fn linked_core_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        layout.linked_core_of_build_target(
+            packages,
+            target,
+            LinkedCoreArtifact::Wasm {
+                use_wat: self.use_wat,
+            },
+        )
+    }
+
+    fn executable_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        layout.executable_of_build_target(
+            packages,
+            target,
+            ExecutableArtifact::Wasm {
+                use_wat: self.use_wat,
+            },
+        )
+    }
+}
+
+impl WasmGcBackend {
+    fn linked_core_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        layout.linked_core_of_build_target(
+            packages,
+            target,
+            LinkedCoreArtifact::WasmGC {
+                use_wat: self.use_wat,
+            },
+        )
+    }
+
+    fn executable_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        layout.executable_of_build_target(
+            packages,
+            target,
+            ExecutableArtifact::WasmGC {
+                use_wat: self.use_wat,
+            },
+        )
+    }
+}
+
+impl JsBackend {
+    fn linked_core_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        layout.linked_core_of_build_target(packages, target, LinkedCoreArtifact::Js)
+    }
+
+    fn executable_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        layout.executable_of_build_target(packages, target, ExecutableArtifact::Js)
+    }
+}
+
+impl CBackend {
+    fn new(os: OperatingSystem, native_target: Option<NativeTarget>, use_tcc_run: bool) -> Self {
+        if native_target.is_some() && use_tcc_run {
+            unreachable!("direct native object lowering and tcc-run are mutually exclusive")
+        }
+
+        let direct_object = native_target.is_some();
+        Self {
+            os,
+            linked_core: if direct_object {
+                CLinkedCoreRealization::DirectObject
+            } else {
+                CLinkedCoreRealization::GeneratedC
+            },
+            executable: if use_tcc_run {
+                CExecutableRealization::WriteTccRunResponseFile
+            } else if direct_object {
+                CExecutableRealization::LinkDirectObject
+            } else {
+                CExecutableRealization::CompileAndLinkGeneratedC
+            },
+            runtime: if use_tcc_run {
+                CRuntimeRealization::SharedLibraryForTccRun
+            } else {
+                CRuntimeRealization::StaticObject
+            },
+            c_stubs: if use_tcc_run {
+                CStubLibraryRealization::SharedLibraryForTccRun
+            } else {
+                CStubLibraryRealization::StaticArchive
+            },
+        }
+    }
+
+    fn linked_core_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        let linked_core = match self.linked_core {
+            CLinkedCoreRealization::GeneratedC => LinkedCoreArtifact::NativeC,
+            CLinkedCoreRealization::DirectObject => {
+                LinkedCoreArtifact::NativeObject { os: self.os }
+            }
+        };
+        layout.linked_core_of_build_target(packages, target, linked_core)
+    }
+
+    fn executable_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        let executable = match self.executable {
+            CExecutableRealization::CompileAndLinkGeneratedC
+            | CExecutableRealization::LinkDirectObject => ExecutableArtifact::NativeExecutable,
+            CExecutableRealization::WriteTccRunResponseFile => {
+                ExecutableArtifact::TccRunResponseFile
+            }
+        };
+        layout.executable_of_build_target(packages, target, executable)
+    }
+
+    pub(crate) fn executable_realization(self) -> CExecutableRealization {
+        self.executable
+    }
+
+    fn runtime_path(self, layout: &LegacyLayout) -> PathBuf {
+        layout.runtime_output_path(
+            RunBackend::Native,
+            self.runtime == CRuntimeRealization::SharedLibraryForTccRun,
+            self.os,
+        )
+    }
+
+    fn c_stub_library_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        package: PackageId,
+        target_backend: TargetBackend,
+    ) -> PathBuf {
+        match self.c_stubs {
+            CStubLibraryRealization::StaticArchive => {
+                layout.c_stub_archive_path(packages, package, target_backend, self.os)
+            }
+            CStubLibraryRealization::SharedLibraryForTccRun => {
+                layout.c_stub_link_dylib_path(packages, package, target_backend, self.os)
+            }
+        }
+    }
+
+    fn c_stub_library_realization(self) -> CStubLibraryRealization {
+        self.c_stubs
+    }
+
+    pub(crate) fn uses_shared_runtime(self) -> bool {
+        self.runtime == CRuntimeRealization::SharedLibraryForTccRun
+    }
+}
+
+impl LlvmBackend {
+    fn linked_core_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        layout.linked_core_of_build_target(
+            packages,
+            target,
+            LinkedCoreArtifact::LlvmObject { os: self.os },
+        )
+    }
+
+    fn executable_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        target: &BuildTarget,
+    ) -> PathBuf {
+        layout.executable_of_build_target(packages, target, ExecutableArtifact::LlvmExecutable)
+    }
+
+    fn runtime_path(self, layout: &LegacyLayout) -> PathBuf {
+        layout.runtime_output_path(RunBackend::Llvm, false, self.os)
+    }
+
+    fn c_stub_library_path(
+        self,
+        layout: &LegacyLayout,
+        packages: &DiscoverResult,
+        package: PackageId,
+        target_backend: TargetBackend,
+    ) -> PathBuf {
+        layout.c_stub_archive_path(packages, package, target_backend, self.os)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_native_backends_do_not_resolve_operating_system() {
+        let backend = SelectedBackend::new(RunBackend::Wasm, None, false, true, || {
+            panic!("non-native backend should not resolve the host OS")
+        });
+
+        assert!(matches!(
+            backend,
+            SelectedBackend::Wasm(WasmBackend { use_wat: true })
+        ));
+    }
+
+    #[test]
+    fn c_tcc_run_realizes_shared_runtime_and_response_file() {
+        let backend = SelectedBackend::new(RunBackend::Native, None, true, false, || {
+            OperatingSystem::Linux
+        });
+
+        let SelectedBackend::C(c_backend) = backend else {
+            panic!("native backend should select C lowering")
+        };
+        assert_eq!(
+            c_backend.executable_realization(),
+            CExecutableRealization::WriteTccRunResponseFile
+        );
+        assert_eq!(
+            c_backend.c_stub_library_realization(),
+            CStubLibraryRealization::SharedLibraryForTccRun
+        );
+        assert!(c_backend.uses_shared_runtime());
+    }
+
+    #[test]
+    fn c_direct_object_realizes_linker_executable() {
+        let backend = SelectedBackend::new(
+            RunBackend::Native,
+            Some(NativeTarget::Aarch64AppleDarwin),
+            false,
+            false,
+            || OperatingSystem::MacOS,
+        );
+
+        let SelectedBackend::C(c_backend) = backend else {
+            panic!("native backend should select C lowering")
+        };
+        assert_eq!(
+            c_backend.executable_realization(),
+            CExecutableRealization::LinkDirectObject
+        );
+        assert_eq!(
+            c_backend.c_stub_library_realization(),
+            CStubLibraryRealization::StaticArchive
+        );
+        assert!(!c_backend.uses_shared_runtime());
+    }
+
+    #[test]
+    fn llvm_backend_is_not_c_realization() {
+        let backend = SelectedBackend::new(RunBackend::Llvm, None, false, false, || {
+            OperatingSystem::Windows
+        });
+
+        assert!(matches!(backend, SelectedBackend::Llvm(_)));
+        assert_eq!(
+            backend.c_stub_library_realization(),
+            CStubLibraryRealization::StaticArchive
+        );
+        assert!(!backend.uses_shared_runtime());
+    }
+}

--- a/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
@@ -34,25 +34,12 @@ use crate::{
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum SelectedBackend {
-    Wasm(WasmBackend),
-    WasmGc(WasmGcBackend),
-    Js(JsBackend),
+    Wasm { use_wat: bool },
+    WasmGc { use_wat: bool },
+    Js,
     C(CBackend),
-    Llvm(LlvmBackend),
+    Llvm { os: OperatingSystem },
 }
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct WasmBackend {
-    use_wat: bool,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct WasmGcBackend {
-    use_wat: bool,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct JsBackend;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct CBackend {
@@ -61,11 +48,6 @@ pub(crate) struct CBackend {
     executable: CExecutableRealization,
     runtime: CRuntimeRealization,
     c_stubs: CStubLibraryRealization,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct LlvmBackend {
-    os: OperatingSystem,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -111,15 +93,15 @@ impl SelectedBackend {
         );
 
         match target_backend {
-            RunBackend::Wasm => Self::Wasm(WasmBackend {
+            RunBackend::Wasm => Self::Wasm {
                 use_wat: output_wat,
-            }),
-            RunBackend::WasmGC => Self::WasmGc(WasmGcBackend {
+            },
+            RunBackend::WasmGC => Self::WasmGc {
                 use_wat: output_wat,
-            }),
-            RunBackend::Js => Self::Js(JsBackend),
+            },
+            RunBackend::Js => Self::Js,
             RunBackend::Native => Self::C(CBackend::new(os(), native_target, use_tcc_run)),
-            RunBackend::Llvm => Self::Llvm(LlvmBackend { os: os() }),
+            RunBackend::Llvm => Self::Llvm { os: os() },
         }
     }
 
@@ -130,11 +112,25 @@ impl SelectedBackend {
         target: &BuildTarget,
     ) -> PathBuf {
         match self {
-            Self::Wasm(backend) => backend.linked_core_path(layout, packages, target),
-            Self::WasmGc(backend) => backend.linked_core_path(layout, packages, target),
-            Self::Js(backend) => backend.linked_core_path(layout, packages, target),
+            Self::Wasm { use_wat } => layout.linked_core_of_build_target(
+                packages,
+                target,
+                LinkedCoreArtifact::Wasm { use_wat },
+            ),
+            Self::WasmGc { use_wat } => layout.linked_core_of_build_target(
+                packages,
+                target,
+                LinkedCoreArtifact::WasmGC { use_wat },
+            ),
+            Self::Js => {
+                layout.linked_core_of_build_target(packages, target, LinkedCoreArtifact::Js)
+            }
             Self::C(backend) => backend.linked_core_path(layout, packages, target),
-            Self::Llvm(backend) => backend.linked_core_path(layout, packages, target),
+            Self::Llvm { os } => layout.linked_core_of_build_target(
+                packages,
+                target,
+                LinkedCoreArtifact::LlvmObject { os },
+            ),
         }
     }
 
@@ -145,19 +141,31 @@ impl SelectedBackend {
         target: &BuildTarget,
     ) -> PathBuf {
         match self {
-            Self::Wasm(backend) => backend.executable_path(layout, packages, target),
-            Self::WasmGc(backend) => backend.executable_path(layout, packages, target),
-            Self::Js(backend) => backend.executable_path(layout, packages, target),
+            Self::Wasm { use_wat } => layout.executable_of_build_target(
+                packages,
+                target,
+                ExecutableArtifact::Wasm { use_wat },
+            ),
+            Self::WasmGc { use_wat } => layout.executable_of_build_target(
+                packages,
+                target,
+                ExecutableArtifact::WasmGC { use_wat },
+            ),
+            Self::Js => layout.executable_of_build_target(packages, target, ExecutableArtifact::Js),
             Self::C(backend) => backend.executable_path(layout, packages, target),
-            Self::Llvm(backend) => backend.executable_path(layout, packages, target),
+            Self::Llvm { .. } => layout.executable_of_build_target(
+                packages,
+                target,
+                ExecutableArtifact::LlvmExecutable,
+            ),
         }
     }
 
     pub(crate) fn runtime_path(self, layout: &LegacyLayout) -> PathBuf {
         match self {
             Self::C(backend) => backend.runtime_path(layout),
-            Self::Llvm(backend) => backend.runtime_path(layout),
-            Self::Wasm(_) | Self::WasmGc(_) | Self::Js(_) => {
+            Self::Llvm { os } => layout.runtime_output_path(RunBackend::Llvm, false, os),
+            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => {
                 unreachable!("runtime products are only realized for C or LLVM backends")
             }
         }
@@ -174,10 +182,8 @@ impl SelectedBackend {
             Self::C(backend) => {
                 backend.c_stub_library_path(layout, packages, package, target_backend)
             }
-            Self::Llvm(backend) => {
-                backend.c_stub_library_path(layout, packages, package, target_backend)
-            }
-            Self::Wasm(_) | Self::WasmGc(_) | Self::Js(_) => {
+            Self::Llvm { os } => layout.c_stub_archive_path(packages, package, target_backend, os),
+            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => {
                 unreachable!("C stubs are only realized for C or LLVM backends")
             }
         }
@@ -186,8 +192,8 @@ impl SelectedBackend {
     pub(crate) fn c_stub_library_realization(self) -> CStubLibraryRealization {
         match self {
             Self::C(backend) => backend.c_stub_library_realization(),
-            Self::Llvm(_) => CStubLibraryRealization::StaticArchive,
-            Self::Wasm(_) | Self::WasmGc(_) | Self::Js(_) => {
+            Self::Llvm { .. } => CStubLibraryRealization::StaticArchive,
+            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => {
                 unreachable!("C stubs are only realized for C or LLVM backends")
             }
         }
@@ -196,95 +202,11 @@ impl SelectedBackend {
     pub(crate) fn uses_shared_runtime(self) -> bool {
         match self {
             Self::C(backend) => backend.uses_shared_runtime(),
-            Self::Llvm(_) => false,
-            Self::Wasm(_) | Self::WasmGc(_) | Self::Js(_) => {
+            Self::Llvm { .. } => false,
+            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => {
                 unreachable!("runtime products are only realized for C or LLVM backends")
             }
         }
-    }
-}
-
-impl WasmBackend {
-    fn linked_core_path(
-        self,
-        layout: &LegacyLayout,
-        packages: &DiscoverResult,
-        target: &BuildTarget,
-    ) -> PathBuf {
-        layout.linked_core_of_build_target(
-            packages,
-            target,
-            LinkedCoreArtifact::Wasm {
-                use_wat: self.use_wat,
-            },
-        )
-    }
-
-    fn executable_path(
-        self,
-        layout: &LegacyLayout,
-        packages: &DiscoverResult,
-        target: &BuildTarget,
-    ) -> PathBuf {
-        layout.executable_of_build_target(
-            packages,
-            target,
-            ExecutableArtifact::Wasm {
-                use_wat: self.use_wat,
-            },
-        )
-    }
-}
-
-impl WasmGcBackend {
-    fn linked_core_path(
-        self,
-        layout: &LegacyLayout,
-        packages: &DiscoverResult,
-        target: &BuildTarget,
-    ) -> PathBuf {
-        layout.linked_core_of_build_target(
-            packages,
-            target,
-            LinkedCoreArtifact::WasmGC {
-                use_wat: self.use_wat,
-            },
-        )
-    }
-
-    fn executable_path(
-        self,
-        layout: &LegacyLayout,
-        packages: &DiscoverResult,
-        target: &BuildTarget,
-    ) -> PathBuf {
-        layout.executable_of_build_target(
-            packages,
-            target,
-            ExecutableArtifact::WasmGC {
-                use_wat: self.use_wat,
-            },
-        )
-    }
-}
-
-impl JsBackend {
-    fn linked_core_path(
-        self,
-        layout: &LegacyLayout,
-        packages: &DiscoverResult,
-        target: &BuildTarget,
-    ) -> PathBuf {
-        layout.linked_core_of_build_target(packages, target, LinkedCoreArtifact::Js)
-    }
-
-    fn executable_path(
-        self,
-        layout: &LegacyLayout,
-        packages: &DiscoverResult,
-        target: &BuildTarget,
-    ) -> PathBuf {
-        layout.executable_of_build_target(packages, target, ExecutableArtifact::Js)
     }
 }
 
@@ -391,44 +313,6 @@ impl CBackend {
     }
 }
 
-impl LlvmBackend {
-    fn linked_core_path(
-        self,
-        layout: &LegacyLayout,
-        packages: &DiscoverResult,
-        target: &BuildTarget,
-    ) -> PathBuf {
-        layout.linked_core_of_build_target(
-            packages,
-            target,
-            LinkedCoreArtifact::LlvmObject { os: self.os },
-        )
-    }
-
-    fn executable_path(
-        self,
-        layout: &LegacyLayout,
-        packages: &DiscoverResult,
-        target: &BuildTarget,
-    ) -> PathBuf {
-        layout.executable_of_build_target(packages, target, ExecutableArtifact::LlvmExecutable)
-    }
-
-    fn runtime_path(self, layout: &LegacyLayout) -> PathBuf {
-        layout.runtime_output_path(RunBackend::Llvm, false, self.os)
-    }
-
-    fn c_stub_library_path(
-        self,
-        layout: &LegacyLayout,
-        packages: &DiscoverResult,
-        package: PackageId,
-        target_backend: TargetBackend,
-    ) -> PathBuf {
-        layout.c_stub_archive_path(packages, package, target_backend, self.os)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -439,10 +323,7 @@ mod tests {
             panic!("non-native backend should not resolve the host OS")
         });
 
-        assert!(matches!(
-            backend,
-            SelectedBackend::Wasm(WasmBackend { use_wat: true })
-        ));
+        assert!(matches!(backend, SelectedBackend::Wasm { use_wat: true }));
     }
 
     #[test]
@@ -495,7 +376,7 @@ mod tests {
             OperatingSystem::Windows
         });
 
-        assert!(matches!(backend, SelectedBackend::Llvm(_)));
+        assert!(matches!(backend, SelectedBackend::Llvm { .. }));
         assert_eq!(
             backend.c_stub_library_realization(),
             CStubLibraryRealization::StaticArchive

--- a/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
@@ -191,7 +191,7 @@ impl SelectedBackend {
 
     pub(crate) fn c_stub_library_realization(self) -> CStubLibraryRealization {
         match self {
-            Self::C(backend) => backend.c_stub_library_realization(),
+            Self::C(backend) => backend.c_stubs,
             Self::Llvm { .. } => CStubLibraryRealization::StaticArchive,
             Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => {
                 unreachable!("C stubs are only realized for C or LLVM backends")
@@ -201,7 +201,7 @@ impl SelectedBackend {
 
     pub(crate) fn uses_shared_runtime(self) -> bool {
         match self {
-            Self::C(backend) => backend.uses_shared_runtime(),
+            Self::C(backend) => backend.runtime == CRuntimeRealization::SharedLibraryForTccRun,
             Self::Llvm { .. } => false,
             Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => {
                 unreachable!("runtime products are only realized for C or LLVM backends")
@@ -303,14 +303,6 @@ impl CBackend {
             }
         }
     }
-
-    fn c_stub_library_realization(self) -> CStubLibraryRealization {
-        self.c_stubs
-    }
-
-    pub(crate) fn uses_shared_runtime(self) -> bool {
-        self.runtime == CRuntimeRealization::SharedLibraryForTccRun
-    }
 }
 
 #[cfg(test)]
@@ -340,10 +332,10 @@ mod tests {
             CExecutableRealization::WriteTccRunResponseFile
         );
         assert_eq!(
-            c_backend.c_stub_library_realization(),
+            backend.c_stub_library_realization(),
             CStubLibraryRealization::SharedLibraryForTccRun
         );
-        assert!(c_backend.uses_shared_runtime());
+        assert!(backend.uses_shared_runtime());
     }
 
     #[test]
@@ -364,10 +356,10 @@ mod tests {
             CExecutableRealization::LinkDirectObject
         );
         assert_eq!(
-            c_backend.c_stub_library_realization(),
+            backend.c_stub_library_realization(),
             CStubLibraryRealization::StaticArchive
         );
-        assert!(!c_backend.uses_shared_runtime());
+        assert!(!backend.uses_shared_runtime());
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -101,10 +101,10 @@ impl<'a> LoweringContext<'a> {
 
         // Lower the action to its commands. This step should be infallible.
         let cmd = match action {
-            BuildAction::Check { target, info } => self.lower_check(target, info),
-            BuildAction::EmitProof { target, info } => self.lower_emit_proof(target, info),
-            BuildAction::Prove { target, info } => self.lower_prove(target, info),
-            BuildAction::BuildCore { target, info } => self.lower_build_mbt(target, info),
+            BuildAction::Check { target, info } => self.lower_check(id, target, info),
+            BuildAction::EmitProof { target, info } => self.lower_emit_proof(id, target, info),
+            BuildAction::Prove { target, info } => self.lower_prove(id, target, info),
+            BuildAction::BuildCore { target, info } => self.lower_build_mbt(id, target, info),
             BuildAction::BuildCStub {
                 package,
                 index,
@@ -126,11 +126,11 @@ impl<'a> LoweringContext<'a> {
                 panic!("native MakeExecutable actions should have executable info")
             }
             BuildAction::GenerateTestInfo { target, info } => {
-                self.lower_gen_test_driver(target, info)
+                self.lower_gen_test_driver(id, target, info)
             }
-            BuildAction::GenerateMbti { target } => self.lower_generate_mbti(target),
+            BuildAction::GenerateMbti { target } => self.lower_generate_mbti(id, target),
             BuildAction::BuildVirtual { package } => self.lower_parse_mbti(package),
-            BuildAction::Bundle { module, targets } => self.lower_bundle(module, targets),
+            BuildAction::Bundle { module, targets } => self.lower_bundle(id, module, targets),
             BuildAction::BuildRuntimeLib => self
                 .lower_compile_runtime(id)
                 .map_err(LoweringError::RuntimeNativeToolchain)?,
@@ -225,10 +225,18 @@ impl<'a> LoweringContext<'a> {
     }
 
     pub(super) fn single_artifact_path(&self, artifact: &PlannedArtifact) -> PathBuf {
+        self.optional_single_artifact_path(artifact)
+            .unwrap_or_else(|| unreachable!("expected exactly one path for artifact: {artifact:?}"))
+    }
+
+    pub(super) fn optional_single_artifact_path(
+        &self,
+        artifact: &PlannedArtifact,
+    ) -> Option<PathBuf> {
         let paths = self.products.paths(artifact);
         match paths {
-            [path] => path.clone(),
-            [] => unreachable!("expected exactly one path for artifact: {artifact:?}"),
+            [path] => Some(path.clone()),
+            [] => None,
             _ => unreachable!("expected one path for artifact, got {paths:?}: {artifact:?}"),
         }
     }
@@ -241,6 +249,38 @@ impl<'a> LoweringContext<'a> {
             _ => unreachable!(
                 "expected one output artifact for action, got {output_artifacts:?}: {action:?}"
             ),
+        }
+    }
+
+    pub(super) fn single_matching_output_path(
+        &self,
+        action: BuildActionId,
+        matches: impl Fn(&PlannedArtifact) -> bool,
+    ) -> Option<PathBuf> {
+        self.single_matching_artifact_path(self.plan.output_artifacts(action), matches)
+    }
+
+    pub(super) fn single_matching_dependency_path(
+        &self,
+        action: BuildActionId,
+        matches: impl Fn(&PlannedArtifact) -> bool,
+    ) -> Option<PathBuf> {
+        self.single_matching_artifact_path(self.plan.dependency_artifacts(action), matches)
+    }
+
+    fn single_matching_artifact_path(
+        &self,
+        artifacts: Vec<PlannedArtifact>,
+        matches: impl Fn(&PlannedArtifact) -> bool,
+    ) -> Option<PathBuf> {
+        let matched = artifacts
+            .iter()
+            .filter(|artifact| matches(artifact))
+            .collect::<Vec<_>>();
+        match matched.as_slice() {
+            [artifact] => self.optional_single_artifact_path(artifact),
+            [] => None,
+            _ => unreachable!("expected at most one matching artifact, got {matched:?}"),
         }
     }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -37,6 +37,7 @@ use moonutil::toolchain::BINARIES;
 
 use super::{
     BuildOptions, CommandArgMap, Commandline, LoweringError,
+    products::ProductTable,
     utils::{build_ins, build_n2_fileloc, build_outs},
 };
 
@@ -56,6 +57,7 @@ pub(crate) struct LoweringContext<'a> {
     pub(crate) rel: &'a DepRelationship,
     pub(crate) plan: &'a BuildActionPlan<'a>,
     pub(crate) opt: &'a BuildOptions,
+    pub(crate) products: ProductTable,
 }
 
 impl<'a> LoweringContext<'a> {
@@ -65,6 +67,7 @@ impl<'a> LoweringContext<'a> {
         plan: &'a BuildActionPlan<'a>,
         opt: &'a BuildOptions,
     ) -> Self {
+        let products = ProductTable::new(&layout, resolve_output, plan, opt);
         Self {
             graph: N2Graph::default(),
             command_args_by_output: CommandArgMap::new(),
@@ -75,6 +78,7 @@ impl<'a> LoweringContext<'a> {
             module_dirs: &resolve_output.module_dirs,
             plan,
             opt,
+            products,
         }
     }
 
@@ -105,7 +109,7 @@ impl<'a> LoweringContext<'a> {
                 package,
                 index,
                 info,
-            } => self.lower_build_c_stub(package, index, info),
+            } => self.lower_build_c_stub(id, package, index, info),
             BuildAction::ArchiveOrLinkCStubs { package, info } => {
                 self.lower_archive_or_link_c_stubs(id, package, info)
             }
@@ -113,7 +117,7 @@ impl<'a> LoweringContext<'a> {
                 target,
                 info,
                 make_executable_info,
-            } => self.lower_link_core(target, info, make_executable_info),
+            } => self.lower_link_core(id, target, info, make_executable_info),
             BuildAction::MakeExecutable {
                 target,
                 info: Some(info),
@@ -128,7 +132,7 @@ impl<'a> LoweringContext<'a> {
             BuildAction::BuildVirtual { package } => self.lower_parse_mbti(package),
             BuildAction::Bundle { module, targets } => self.lower_bundle(module, targets),
             BuildAction::BuildRuntimeLib => self
-                .lower_compile_runtime()
+                .lower_compile_runtime(id)
                 .map_err(LoweringError::RuntimeNativeToolchain)?,
             BuildAction::BuildDocs { module } => self.lower_build_docs(module),
             BuildAction::RunPrebuild { info, .. } => self.lower_run_prebuild(info),
@@ -206,146 +210,7 @@ impl<'a> LoweringContext<'a> {
         artifact: &PlannedArtifact,
         out: &mut Vec<PathBuf>,
     ) {
-        match artifact {
-            PlannedArtifact::PackageInterface { producer, target } => {
-                self.append_package_interface(*producer, *target, out);
-            }
-            PlannedArtifact::PackageCoreIr { target, .. } => {
-                out.push(self.layout.core_of_build_target(
-                    self.packages,
-                    target,
-                    self.opt.target_backend.into(),
-                ));
-            }
-            PlannedArtifact::ProofInterface { producer, target } => {
-                match self.plan.action(*producer) {
-                    BuildAction::EmitProof { .. } => {
-                        out.push(self.layout.emit_proof_mi_path(self.packages, target));
-                    }
-                    BuildAction::Prove { .. } => {
-                        out.push(self.layout.prove_mi_path(self.packages, target));
-                    }
-                    _ => panic!("proof interface producer should be a proof action"),
-                }
-            }
-            PlannedArtifact::ProofWhyml { producer, target } => match self.plan.action(*producer) {
-                BuildAction::EmitProof { .. } => {
-                    out.push(self.layout.emit_proof_whyml_path(self.packages, target));
-                }
-                BuildAction::Prove { .. } => {
-                    out.push(self.layout.prove_whyml_path(self.packages, target));
-                }
-                _ => panic!("proof whyml producer should be a proof action"),
-            },
-            PlannedArtifact::ProofReport { target, .. } => {
-                out.push(self.layout.prove_report_path(self.packages, target));
-            }
-            PlannedArtifact::CStubObject { package, index, .. } => {
-                let pkg = self.packages.get_package(*package);
-                let file_name = &pkg.c_stub_files[*index as usize];
-                out.push(
-                    self.layout.c_stub_object_path(
-                        self.packages,
-                        *package,
-                        file_name
-                            .file_stem()
-                            .expect("c stub file should have a file name"),
-                        self.opt.target_backend.into(),
-                        self.opt.os(),
-                    ),
-                );
-            }
-            PlannedArtifact::CStubLibrary { package, .. } => {
-                if self.opt.use_tcc_run() {
-                    out.push(self.layout.c_stub_link_dylib_path(
-                        self.packages,
-                        *package,
-                        self.opt.target_backend.into(),
-                        self.opt.os(),
-                    ));
-                } else {
-                    out.push(self.layout.c_stub_archive_path(
-                        self.packages,
-                        *package,
-                        self.opt.target_backend.into(),
-                        self.opt.os(),
-                    ));
-                }
-            }
-            PlannedArtifact::LinkedCore { target, .. } => {
-                out.push(self.layout.linked_core_of_build_target(
-                    self.packages,
-                    target,
-                    self.opt.linked_core_artifact(),
-                ));
-            }
-            PlannedArtifact::Executable { target, .. } => {
-                out.push(self.layout.executable_of_build_target(
-                    self.packages,
-                    target,
-                    self.opt.executable_artifact(true),
-                ))
-            }
-            PlannedArtifact::GeneratedTestDriver { target, .. } => {
-                out.push(self.layout.generated_test_driver(
-                    self.packages,
-                    target,
-                    self.opt.target_backend.into(),
-                ));
-            }
-            PlannedArtifact::GeneratedTestMetadata { target, .. } => {
-                out.push(self.layout.generated_test_driver_metadata(
-                    self.packages,
-                    target,
-                    self.opt.target_backend.into(),
-                ));
-            }
-            PlannedArtifact::BundleResult { module, .. } => {
-                let module_name = self.modules.module_source(*module);
-                out.push(
-                    self.layout
-                        .bundle_result_path(self.opt.target_backend.into(), module_name.name()),
-                );
-            }
-            PlannedArtifact::RuntimeLib { .. } => {
-                out.push(self.layout.runtime_output_path(
-                    self.opt.target_backend,
-                    self.opt.use_tcc_run(),
-                    self.opt.os(),
-                ));
-            }
-            PlannedArtifact::GeneratedMbti { target, .. } => {
-                out.push(self.layout.generated_mbti_path(
-                    self.packages,
-                    target,
-                    self.opt.target_backend.into(),
-                ));
-            }
-            PlannedArtifact::DocsDir { .. } => {
-                // The output is a whole folder
-                out.push(self.layout.doc_dir())
-            }
-            PlannedArtifact::VirtualPackageInterface { package, .. } => {
-                // The interface generated from `.mbti` is the `.mi` of the source target
-                let t = package.build_target(crate::model::TargetKind::Source);
-                out.push(self.layout.mi_of_build_target(
-                    self.packages,
-                    &t,
-                    self.opt.target_backend.into(),
-                ));
-            }
-            PlannedArtifact::MoonLexGeneratedSource { package, index, .. } => {
-                let pkg_info = self.packages.get_package(*package);
-                let mbtlex_file = &pkg_info.mbt_lex_files[*index as usize];
-                out.push(mbtlex_file.with_extension("mbt"));
-            }
-            PlannedArtifact::MoonYaccGeneratedSource { package, index, .. } => {
-                let pkg_info = self.packages.get_package(*package);
-                let mbtyacc_file = &pkg_info.mbt_yacc_files[*index as usize];
-                out.push(mbtyacc_file.with_extension("mbt"));
-            }
-            PlannedArtifact::KnownPath { path, .. } => out.push(path.clone()),
-        }
+        out.extend(self.products.paths(artifact).iter().cloned());
     }
 
     pub(super) fn planned_artifact_paths(
@@ -359,62 +224,23 @@ impl<'a> LoweringContext<'a> {
         paths
     }
 
-    fn append_package_interface(
-        &self,
-        producer: BuildActionId,
-        target: BuildTarget,
-        out: &mut Vec<PathBuf>,
-    ) {
-        match self.plan.action(producer) {
-            BuildAction::Check { info, .. } if info.check_mi_against.is_some() => {
-                // Generate a `.mi` artifact including the case besides normal
-                // cases:
-                // * --no-mi is enabled: need add mi to the artifacts so that n2
-                // run the command for it and notice in this case, the command
-                // will always be executed because it doesn't produce any output
-                // so n2 will think it's always dirty.
-                // * implementing a virtual package: no need to generate mi
-                // though, but still need to declare a `.mi` artifact so that n2
-                // executes it. And it actually produces a useless `.mi` file.
-                // So that n2 can check its timestamp to decide whether it
-                // needs to be rebuilt.
-                //
-                // Not generating `.mi` for the special case:
-                // * moonbitlang/core/abort when working on non-core packages.
-                // First, abort is injected as a dependency for every package.
-                // When working on core/non-core, abort will have a different
-                // PackageId. When working on non-core packages, the mi artifact
-                // of abort is not needed, and it avoids checking
-                // moonbitlang/core/abort, which is unnecessary. When working on
-                // core, the abort mi is returned as `Regular` below. So it will
-                // be actually checked.
-                match self.layout.mi_of_build_target_impl_virtual(
-                    self.packages,
-                    &target,
-                    self.opt.target_backend.into(),
-                ) {
-                    crate::build_lower::artifact::MiPathResult::StdAbort(_) => {}
-                    crate::build_lower::artifact::MiPathResult::Std(p) => {
-                        // this should not happen because there is no
-                        // implementation package in stdlib other than abort
-                        tracing::warn!(
-                            "stdlib mi should not be needed for check as an implementation package: {:?}",
-                            p
-                        );
-                    }
-                    crate::build_lower::artifact::MiPathResult::Regular(p) => {
-                        out.push(p);
-                    }
-                }
-            }
-            BuildAction::Check { .. } | BuildAction::BuildCore { .. } => {
-                out.push(self.layout.mi_of_build_target(
-                    self.packages,
-                    &target,
-                    self.opt.target_backend.into(),
-                ));
-            }
-            _ => panic!("package interface producer should be Check or BuildCore"),
+    pub(super) fn single_artifact_path(&self, artifact: &PlannedArtifact) -> PathBuf {
+        let paths = self.products.paths(artifact);
+        match paths {
+            [path] => path.clone(),
+            [] => unreachable!("expected exactly one path for artifact: {artifact:?}"),
+            _ => unreachable!("expected one path for artifact, got {paths:?}: {artifact:?}"),
+        }
+    }
+
+    pub(super) fn single_output_path(&self, action: BuildActionId) -> PathBuf {
+        let output_artifacts = self.plan.output_artifacts(action);
+        match output_artifacts.as_slice() {
+            [artifact] => self.single_artifact_path(artifact),
+            [] => unreachable!("expected exactly one output artifact for action: {action:?}"),
+            _ => unreachable!(
+                "expected one output artifact for action, got {output_artifacts:?}: {action:?}"
+            ),
         }
     }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -103,11 +103,15 @@ impl ActionProducts {
 
     pub(super) fn single_output_path(&self) -> PathBuf {
         match self.outputs.as_slice() {
-            [artifact] => Self::single_realized_path(artifact),
+            [artifact] => Self::optional_single_realized_path(artifact)
+                .unwrap_or_else(|| unreachable!("expected exactly one path for artifact")),
             [] => unreachable!("expected exactly one output artifact"),
             _ => unreachable!(
                 "expected one output artifact, got {:?}",
-                self.output_artifacts()
+                self.outputs
+                    .iter()
+                    .map(|realized| &realized.artifact)
+                    .collect::<Vec<_>>()
             ),
         }
     }
@@ -146,21 +150,10 @@ impl ActionProducts {
             .collect()
     }
 
-    pub(super) fn dependency_artifacts(&self) -> impl Iterator<Item = &PlannedArtifact> {
-        self.dependencies.iter().map(|realized| &realized.artifact)
-    }
-
     fn paths(realized: &[RealizedArtifact]) -> Vec<PathBuf> {
         realized
             .iter()
             .flat_map(|artifact| artifact.paths.iter().cloned())
-            .collect()
-    }
-
-    fn output_artifacts(&self) -> Vec<&PlannedArtifact> {
-        self.outputs
-            .iter()
-            .map(|realized| &realized.artifact)
             .collect()
     }
 
@@ -177,11 +170,6 @@ impl ActionProducts {
             [] => None,
             _ => unreachable!("expected at most one matching artifact"),
         }
-    }
-
-    fn single_realized_path(artifact: &RealizedArtifact) -> PathBuf {
-        Self::optional_single_realized_path(artifact)
-            .unwrap_or_else(|| unreachable!("expected exactly one path for artifact"))
     }
 
     fn optional_single_realized_path(artifact: &RealizedArtifact) -> Option<PathBuf> {
@@ -335,21 +323,14 @@ impl<'a> LoweringContext<'a> {
         build.can_dirty_on_output = self.plan.can_dirty_on_output(id);
 
         self.debug_print_command_and_files(id, &build);
-        self.lowered(build).map_err(|e| LoweringError::N2 {
-            package: fqn.into(),
-            action: id,
-            source: e,
-        })
-    }
-
-    /// Append the concrete path(s) corresponding to a planned artifact.
-    #[instrument(level = Level::DEBUG, skip(self, out))]
-    pub(super) fn append_planned_artifact(
-        &self,
-        artifact: &PlannedArtifact,
-        out: &mut Vec<PathBuf>,
-    ) {
-        out.extend(self.products.paths(artifact).iter().cloned());
+        self.graph
+            .add_build(build)
+            .map(|_| ())
+            .map_err(|e| LoweringError::N2 {
+                package: fqn.into(),
+                action: id,
+                source: e,
+            })
     }
 
     pub(super) fn planned_artifact_paths(
@@ -358,14 +339,9 @@ impl<'a> LoweringContext<'a> {
     ) -> Vec<PathBuf> {
         let mut paths = Vec::new();
         for artifact in artifacts {
-            self.append_planned_artifact(&artifact, &mut paths);
+            paths.extend(self.products.paths(&artifact).iter().cloned());
         }
         paths
-    }
-
-    fn lowered(&mut self, build: Build) -> Result<(), anyhow::Error> {
-        self.graph.add_build(build)?;
-        Ok(())
     }
 
     /// **For debug use only.** Prints debug information about a lowered action,

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -60,6 +60,142 @@ pub(crate) struct LoweringContext<'a> {
     pub(crate) products: ProductTable,
 }
 
+pub(super) struct ActionProducts {
+    outputs: Vec<RealizedArtifact>,
+    dependencies: Vec<RealizedArtifact>,
+}
+
+struct RealizedArtifact {
+    artifact: PlannedArtifact,
+    paths: Vec<PathBuf>,
+}
+
+impl ActionProducts {
+    fn new(plan: &BuildActionPlan<'_>, products: &ProductTable, action: BuildActionId) -> Self {
+        let outputs = Self::realize(plan.output_artifacts(action), products);
+        let dependencies = Self::realize(plan.dependency_artifacts(action), products);
+        Self {
+            outputs,
+            dependencies,
+        }
+    }
+
+    fn realize(
+        artifacts: impl IntoIterator<Item = PlannedArtifact>,
+        products: &ProductTable,
+    ) -> Vec<RealizedArtifact> {
+        artifacts
+            .into_iter()
+            .map(|artifact| RealizedArtifact {
+                paths: products.paths(&artifact).to_vec(),
+                artifact,
+            })
+            .collect()
+    }
+
+    pub(super) fn dependency_paths(&self) -> Vec<PathBuf> {
+        Self::paths(&self.dependencies)
+    }
+
+    pub(super) fn output_paths(&self) -> Vec<PathBuf> {
+        Self::paths(&self.outputs)
+    }
+
+    pub(super) fn single_output_path(&self) -> PathBuf {
+        match self.outputs.as_slice() {
+            [artifact] => Self::single_realized_path(artifact),
+            [] => unreachable!("expected exactly one output artifact"),
+            _ => unreachable!(
+                "expected one output artifact, got {:?}",
+                self.output_artifacts()
+            ),
+        }
+    }
+
+    pub(super) fn single_output_path_matching(
+        &self,
+        matches: impl Fn(&PlannedArtifact) -> bool,
+    ) -> PathBuf {
+        self.optional_single_output_path_matching(matches)
+            .unwrap_or_else(|| unreachable!("expected one matching output artifact"))
+    }
+
+    pub(super) fn optional_single_output_path_matching(
+        &self,
+        matches: impl Fn(&PlannedArtifact) -> bool,
+    ) -> Option<PathBuf> {
+        Self::single_matching_path(&self.outputs, matches)
+    }
+
+    pub(super) fn single_dependency_path_matching(
+        &self,
+        matches: impl Fn(&PlannedArtifact) -> bool,
+    ) -> PathBuf {
+        Self::single_matching_path(&self.dependencies, matches)
+            .unwrap_or_else(|| unreachable!("expected one matching dependency artifact"))
+    }
+
+    pub(super) fn dependency_paths_matching(
+        &self,
+        matches: impl Fn(&PlannedArtifact) -> bool,
+    ) -> Vec<PathBuf> {
+        self.dependencies
+            .iter()
+            .filter(|realized| matches(&realized.artifact))
+            .flat_map(|realized| realized.paths.iter().cloned())
+            .collect()
+    }
+
+    pub(super) fn dependency_artifacts(&self) -> impl Iterator<Item = &PlannedArtifact> {
+        self.dependencies.iter().map(|realized| &realized.artifact)
+    }
+
+    fn paths(realized: &[RealizedArtifact]) -> Vec<PathBuf> {
+        realized
+            .iter()
+            .flat_map(|artifact| artifact.paths.iter().cloned())
+            .collect()
+    }
+
+    fn output_artifacts(&self) -> Vec<&PlannedArtifact> {
+        self.outputs
+            .iter()
+            .map(|realized| &realized.artifact)
+            .collect()
+    }
+
+    fn single_matching_path(
+        realized: &[RealizedArtifact],
+        matches: impl Fn(&PlannedArtifact) -> bool,
+    ) -> Option<PathBuf> {
+        let matched = realized
+            .iter()
+            .filter(|realized| matches(&realized.artifact))
+            .collect::<Vec<_>>();
+        match matched.as_slice() {
+            [artifact] => Self::optional_single_realized_path(artifact),
+            [] => None,
+            _ => unreachable!("expected at most one matching artifact"),
+        }
+    }
+
+    fn single_realized_path(artifact: &RealizedArtifact) -> PathBuf {
+        Self::optional_single_realized_path(artifact)
+            .unwrap_or_else(|| unreachable!("expected exactly one path for artifact"))
+    }
+
+    fn optional_single_realized_path(artifact: &RealizedArtifact) -> Option<PathBuf> {
+        match artifact.paths.as_slice() {
+            [path] => Some(path.clone()),
+            [] => None,
+            _ => unreachable!(
+                "expected one path for artifact, got {:?}: {:?}",
+                artifact.paths, artifact.artifact
+            ),
+        }
+    }
+}
+
 impl<'a> LoweringContext<'a> {
     pub(super) fn new(
         layout: LegacyLayout,
@@ -98,41 +234,50 @@ impl<'a> LoweringContext<'a> {
         if self.is_action_noop(action) {
             return Ok(());
         }
+        let action_products = ActionProducts::new(self.plan, &self.products, id);
 
         // Lower the action to its commands. This step should be infallible.
         let cmd = match action {
-            BuildAction::Check { target, info } => self.lower_check(id, target, info),
-            BuildAction::EmitProof { target, info } => self.lower_emit_proof(id, target, info),
-            BuildAction::Prove { target, info } => self.lower_prove(id, target, info),
-            BuildAction::BuildCore { target, info } => self.lower_build_mbt(id, target, info),
+            BuildAction::Check { target, info } => self.lower_check(&action_products, target, info),
+            BuildAction::EmitProof { target, info } => {
+                self.lower_emit_proof(&action_products, target, info)
+            }
+            BuildAction::Prove { target, info } => self.lower_prove(&action_products, target, info),
+            BuildAction::BuildCore { target, info } => {
+                self.lower_build_mbt(&action_products, target, info)
+            }
             BuildAction::BuildCStub {
                 package,
                 index,
                 info,
-            } => self.lower_build_c_stub(id, package, index, info),
+            } => self.lower_build_c_stub(&action_products, package, index, info),
             BuildAction::ArchiveOrLinkCStubs { package, info } => {
-                self.lower_archive_or_link_c_stubs(id, package, info)
+                self.lower_archive_or_link_c_stubs(&action_products, package, info)
             }
             BuildAction::LinkCore {
                 target,
                 info,
                 make_executable_info,
-            } => self.lower_link_core(id, target, info, make_executable_info),
+            } => self.lower_link_core(&action_products, target, info, make_executable_info),
             BuildAction::MakeExecutable {
                 target,
                 info: Some(info),
-            } => self.lower_make_exe(id, target, info),
+            } => self.lower_make_exe(&action_products, target, info),
             BuildAction::MakeExecutable { info: None, .. } => {
                 panic!("native MakeExecutable actions should have executable info")
             }
             BuildAction::GenerateTestInfo { target, info } => {
-                self.lower_gen_test_driver(id, target, info)
+                self.lower_gen_test_driver(&action_products, target, info)
             }
-            BuildAction::GenerateMbti { target } => self.lower_generate_mbti(id, target),
+            BuildAction::GenerateMbti { target } => {
+                self.lower_generate_mbti(&action_products, target)
+            }
             BuildAction::BuildVirtual { package } => self.lower_parse_mbti(package),
-            BuildAction::Bundle { module, targets } => self.lower_bundle(id, module, targets),
+            BuildAction::Bundle { module, targets } => {
+                self.lower_bundle(&action_products, module, targets)
+            }
             BuildAction::BuildRuntimeLib => self
-                .lower_compile_runtime(id)
+                .lower_compile_runtime(&action_products)
                 .map_err(LoweringError::RuntimeNativeToolchain)?,
             BuildAction::BuildDocs { module } => self.lower_build_docs(module),
             BuildAction::RunPrebuild { info, .. } => self.lower_run_prebuild(info),
@@ -150,10 +295,7 @@ impl<'a> LoweringContext<'a> {
         // twice, once for the commandline and another here. This is currently
         // not a performance concern, but if you have found a way to optimize
         // this, or if you are duplicating a lot of code for it, please refactor.
-        let mut ins = vec![];
-        for artifact in self.plan.dependency_artifacts(id) {
-            self.append_planned_artifact(&artifact, &mut ins);
-        }
+        let mut ins = action_products.dependency_paths();
         ins.extend(cmd.extra_inputs);
         // Track tool binary dependencies so that n2 detects when compilers
         // or other toolchain binaries change (e.g. after a toolchain update)
@@ -164,10 +306,7 @@ impl<'a> LoweringContext<'a> {
         ins.sort(); // make sure the order is deterministic
         let ins = build_ins(&mut self.graph, ins);
 
-        let mut output_paths = vec![];
-        for artifact in self.plan.output_artifacts(id) {
-            self.append_planned_artifact(&artifact, &mut output_paths);
-        }
+        let output_paths = action_products.output_paths();
         if let Commandline::Args(args) = &cmd.commandline {
             for output_path in &output_paths {
                 self.command_args_by_output
@@ -222,66 +361,6 @@ impl<'a> LoweringContext<'a> {
             self.append_planned_artifact(&artifact, &mut paths);
         }
         paths
-    }
-
-    pub(super) fn single_artifact_path(&self, artifact: &PlannedArtifact) -> PathBuf {
-        self.optional_single_artifact_path(artifact)
-            .unwrap_or_else(|| unreachable!("expected exactly one path for artifact: {artifact:?}"))
-    }
-
-    pub(super) fn optional_single_artifact_path(
-        &self,
-        artifact: &PlannedArtifact,
-    ) -> Option<PathBuf> {
-        let paths = self.products.paths(artifact);
-        match paths {
-            [path] => Some(path.clone()),
-            [] => None,
-            _ => unreachable!("expected one path for artifact, got {paths:?}: {artifact:?}"),
-        }
-    }
-
-    pub(super) fn single_output_path(&self, action: BuildActionId) -> PathBuf {
-        let output_artifacts = self.plan.output_artifacts(action);
-        match output_artifacts.as_slice() {
-            [artifact] => self.single_artifact_path(artifact),
-            [] => unreachable!("expected exactly one output artifact for action: {action:?}"),
-            _ => unreachable!(
-                "expected one output artifact for action, got {output_artifacts:?}: {action:?}"
-            ),
-        }
-    }
-
-    pub(super) fn single_matching_output_path(
-        &self,
-        action: BuildActionId,
-        matches: impl Fn(&PlannedArtifact) -> bool,
-    ) -> Option<PathBuf> {
-        self.single_matching_artifact_path(self.plan.output_artifacts(action), matches)
-    }
-
-    pub(super) fn single_matching_dependency_path(
-        &self,
-        action: BuildActionId,
-        matches: impl Fn(&PlannedArtifact) -> bool,
-    ) -> Option<PathBuf> {
-        self.single_matching_artifact_path(self.plan.dependency_artifacts(action), matches)
-    }
-
-    fn single_matching_artifact_path(
-        &self,
-        artifacts: Vec<PlannedArtifact>,
-        matches: impl Fn(&PlannedArtifact) -> bool,
-    ) -> Option<PathBuf> {
-        let matched = artifacts
-            .iter()
-            .filter(|artifact| matches(artifact))
-            .collect::<Vec<_>>();
-        match matched.as_slice() {
-            [artifact] => self.optional_single_artifact_path(artifact),
-            [] => None,
-            _ => unreachable!("expected at most one matching artifact, got {matched:?}"),
-        }
     }
 
     fn lowered(&mut self, build: Build) -> Result<(), anyhow::Error> {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -30,7 +30,7 @@ use moonutil::{
 use tracing::{Level, instrument};
 
 use crate::{
-    build_action_plan::{BuildActionId, PlannedArtifact},
+    build_action_plan::PlannedArtifact,
     build_lower::{
         Commandline,
         compiler::{CmdlineAbstraction, MoondocCommand, Mooninfo},
@@ -39,24 +39,34 @@ use crate::{
     model::{BuildTarget, OperatingSystem, PackageId, TargetKind},
 };
 
-use super::{BuildCommand, compiler};
+use super::{BuildCommand, compiler, context::ActionProducts};
 
 impl<'a> super::LoweringContext<'a> {
-    #[instrument(level = Level::DEBUG, skip(self, info))]
+    #[instrument(level = Level::DEBUG, skip(self, products, info))]
     pub(super) fn lower_gen_test_driver(
         &mut self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: BuildTarget,
         info: &BuildTargetInfo,
     ) -> BuildCommand {
         let package = self.get_package(target);
-        let output_driver = self.single_artifact_path(&PlannedArtifact::GeneratedTestDriver {
-            producer: action,
-            target,
+        let output_driver = products.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                PlannedArtifact::GeneratedTestDriver {
+                    target: artifact_target,
+                    ..
+                } if *artifact_target == target
+            )
         });
-        let output_metadata = self.single_artifact_path(&PlannedArtifact::GeneratedTestMetadata {
-            producer: action,
-            target,
+        let output_metadata = products.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                PlannedArtifact::GeneratedTestMetadata {
+                    target: artifact_target,
+                    ..
+                } if *artifact_target == target
+            )
         });
         let driver_kind = match target.kind {
             TargetKind::Source => panic!("Source package cannot be a test driver"),
@@ -103,32 +113,34 @@ impl<'a> super::LoweringContext<'a> {
         }
     }
 
-    #[instrument(level = Level::DEBUG, skip(self))]
+    #[instrument(level = Level::DEBUG, skip(self, products))]
     pub(super) fn lower_bundle(
         &mut self,
-        action: BuildActionId,
+        products: &ActionProducts,
         module_id: ModuleId,
         targets: &[BuildTarget],
     ) -> BuildCommand {
-        let output = self.single_artifact_path(&PlannedArtifact::BundleResult {
-            producer: action,
-            module: module_id,
+        let output = products.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                PlannedArtifact::BundleResult {
+                    module: artifact_module,
+                    ..
+                } if *artifact_module == module_id
+            )
         });
 
         let mut inputs = vec![];
         for dep in targets {
-            inputs.push(
-                self.single_matching_dependency_path(action, |artifact| {
-                    matches!(
-                        artifact,
-                        PlannedArtifact::PackageCoreIr {
-                            target: artifact_target,
-                            ..
-                        } if artifact_target == dep
-                    )
-                })
-                .unwrap_or_else(|| unreachable!("Bundle targets should depend on core IR")),
-            );
+            inputs.push(products.single_dependency_path_matching(|artifact| {
+                matches!(
+                    artifact,
+                    PlannedArtifact::PackageCoreIr {
+                        target: artifact_target,
+                        ..
+                    } if artifact_target == dep
+                )
+            }));
         }
 
         let cmd = compiler::MooncBundleCore::new(&inputs, output);
@@ -139,13 +151,14 @@ impl<'a> super::LoweringContext<'a> {
         }
     }
 
-    #[instrument(level = Level::DEBUG, skip(self))]
+    #[instrument(level = Level::DEBUG, skip(self, products))]
     pub(super) fn lower_compile_runtime(
         &mut self,
-        action: BuildActionId,
+        products: &ActionProducts,
     ) -> anyhow::Result<BuildCommand> {
-        let artifact_path =
-            self.single_artifact_path(&PlannedArtifact::RuntimeLib { producer: action });
+        let artifact_path = products.single_output_path_matching(|artifact| {
+            matches!(artifact, PlannedArtifact::RuntimeLib { .. })
+        });
 
         let runtime_c_path = self.opt.runtime_dot_c_path();
 
@@ -199,18 +212,23 @@ impl<'a> super::LoweringContext<'a> {
         })
     }
 
-    #[instrument(level = Level::DEBUG, skip(self))]
+    #[instrument(level = Level::DEBUG, skip(self, products))]
     pub(super) fn lower_generate_mbti(
         &mut self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: BuildTarget,
     ) -> BuildCommand {
         let input =
             self.layout
                 .mi_of_build_target(self.packages, &target, self.opt.target_backend.into());
-        let output = self.single_artifact_path(&PlannedArtifact::GeneratedMbti {
-            producer: action,
-            target,
+        let output = products.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                PlannedArtifact::GeneratedMbti {
+                    target: artifact_target,
+                    ..
+                } if *artifact_target == target
+            )
         });
 
         let cmd = Mooninfo {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -45,20 +45,19 @@ impl<'a> super::LoweringContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self, info))]
     pub(super) fn lower_gen_test_driver(
         &mut self,
+        action: BuildActionId,
         target: BuildTarget,
         info: &BuildTargetInfo,
     ) -> BuildCommand {
         let package = self.get_package(target);
-        let output_driver = self.layout.generated_test_driver(
-            self.packages,
-            &target,
-            self.opt.target_backend.into(),
-        );
-        let output_metadata = self.layout.generated_test_driver_metadata(
-            self.packages,
-            &target,
-            self.opt.target_backend.into(),
-        );
+        let output_driver = self.single_artifact_path(&PlannedArtifact::GeneratedTestDriver {
+            producer: action,
+            target,
+        });
+        let output_metadata = self.single_artifact_path(&PlannedArtifact::GeneratedTestMetadata {
+            producer: action,
+            target,
+        });
         let driver_kind = match target.kind {
             TargetKind::Source => panic!("Source package cannot be a test driver"),
             TargetKind::WhiteboxTest => DriverKind::Whitebox,
@@ -107,21 +106,29 @@ impl<'a> super::LoweringContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self))]
     pub(super) fn lower_bundle(
         &mut self,
+        action: BuildActionId,
         module_id: ModuleId,
         targets: &[BuildTarget],
     ) -> BuildCommand {
-        let module = self.modules.module_source(module_id);
-        let output = self
-            .layout
-            .bundle_result_path(self.opt.target_backend.into(), module.name());
+        let output = self.single_artifact_path(&PlannedArtifact::BundleResult {
+            producer: action,
+            module: module_id,
+        });
 
         let mut inputs = vec![];
         for dep in targets {
-            inputs.push(self.layout.core_of_build_target(
-                self.packages,
-                dep,
-                self.opt.target_backend.into(),
-            ));
+            inputs.push(
+                self.single_matching_dependency_path(action, |artifact| {
+                    matches!(
+                        artifact,
+                        PlannedArtifact::PackageCoreIr {
+                            target: artifact_target,
+                            ..
+                        } if artifact_target == dep
+                    )
+                })
+                .unwrap_or_else(|| unreachable!("Bundle targets should depend on core IR")),
+            );
         }
 
         let cmd = compiler::MooncBundleCore::new(&inputs, output);
@@ -193,13 +200,18 @@ impl<'a> super::LoweringContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self))]
-    pub(super) fn lower_generate_mbti(&mut self, target: BuildTarget) -> BuildCommand {
+    pub(super) fn lower_generate_mbti(
+        &mut self,
+        action: BuildActionId,
+        target: BuildTarget,
+    ) -> BuildCommand {
         let input =
             self.layout
                 .mi_of_build_target(self.packages, &target, self.opt.target_backend.into());
-        let output =
-            self.layout
-                .generated_mbti_path(self.packages, &target, self.opt.target_backend.into());
+        let output = self.single_artifact_path(&PlannedArtifact::GeneratedMbti {
+            producer: action,
+            target,
+        });
 
         let cmd = Mooninfo {
             mi_in: input.into(),

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -30,12 +30,13 @@ use moonutil::{
 use tracing::{Level, instrument};
 
 use crate::{
+    build_action_plan::{BuildActionId, PlannedArtifact},
     build_lower::{
         Commandline,
         compiler::{CmdlineAbstraction, MoondocCommand, Mooninfo},
     },
     build_plan::{BuildTargetInfo, PrebuildInfo},
-    model::{BuildTarget, OperatingSystem, PackageId, RunBackend, TargetKind},
+    model::{BuildTarget, OperatingSystem, PackageId, TargetKind},
 };
 
 use super::{BuildCommand, compiler};
@@ -132,22 +133,20 @@ impl<'a> super::LoweringContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self))]
-    pub(super) fn lower_compile_runtime(&mut self) -> anyhow::Result<BuildCommand> {
-        let artifact_path = self.layout.runtime_output_path(
-            self.opt.target_backend,
-            self.opt.use_tcc_run(),
-            self.opt.os(),
-        );
+    pub(super) fn lower_compile_runtime(
+        &mut self,
+        action: BuildActionId,
+    ) -> anyhow::Result<BuildCommand> {
+        let artifact_path =
+            self.single_artifact_path(&PlannedArtifact::RuntimeLib { producer: action });
 
         let runtime_c_path = self.opt.runtime_dot_c_path();
 
-        let use_tcc_run = self.opt.use_tcc_run();
-        let (output_ty, link_moonbitrun) = match self.opt.target_backend {
-            RunBackend::Wasm | RunBackend::WasmGC | RunBackend::Js => {
-                panic!("Runtime compilation is not applicable for non-native backends")
-            }
-            RunBackend::Native if use_tcc_run => (CCOutputType::SharedLib, false),
-            RunBackend::Native | RunBackend::Llvm => (CCOutputType::Object, true),
+        let use_shared_runtime = self.opt.selected_backend.uses_shared_runtime();
+        let (output_ty, link_moonbitrun) = if use_shared_runtime {
+            (CCOutputType::SharedLib, false)
+        } else {
+            (CCOutputType::Object, true)
         };
 
         let resolved_cc = moonutil::compiler_flags::default_native_toolchain(
@@ -158,7 +157,7 @@ impl<'a> super::LoweringContext<'a> {
         )?
         .cc()
         .clone();
-        let use_simdutf = !use_tcc_run
+        let use_simdutf = !use_shared_runtime
             && resolved_cc.can_use_simdutf()
             && self.opt.compiler_paths().simdutf_object_paths().is_some();
 
@@ -172,8 +171,8 @@ impl<'a> super::LoweringContext<'a> {
                 .allow_stacktrace(
                     self.opt.debug_symbols && self.opt.os() != OperatingSystem::Windows,
                 )
-                .define_tinyc_macro(use_tcc_run)
-                .preserve_frame_pointer(use_tcc_run)
+                .define_tinyc_macro(use_shared_runtime)
+                .preserve_frame_pointer(use_shared_runtime)
                 .link_moonbitrun(link_moonbitrun)
                 .link_libbacktrace(output_ty == CCOutputType::SharedLib)
                 .define_use_shared_runtime_macro(false)

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -41,7 +41,8 @@ use tracing::{Level, instrument};
 use crate::{
     build_action_plan::{BuildActionId, PlannedArtifact},
     build_lower::{
-        WarningCondition, artifact,
+        CExecutableRealization, CStubLibraryRealization, SelectedBackend, WarningCondition,
+        artifact,
         compiler::{
             BuildCommonConfig, BuildCommonInput, CmdlineAbstraction, ErrorFormat, JsConfig,
             MiDependency, PackageSource, WasmConfig,
@@ -586,6 +587,7 @@ impl<'a> LoweringContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self, info))]
     pub(super) fn lower_link_core(
         &mut self,
+        action: BuildActionId,
         target: BuildTarget,
         info: &LinkCoreInfo,
         make_executable_info: Option<&MakeExecutableInfo>,
@@ -622,11 +624,10 @@ impl<'a> LoweringContext<'a> {
             core_input_files.push(core_path);
         }
 
-        let out_file = self.layout.linked_core_of_build_target(
-            self.packages,
-            &target,
-            self.opt.linked_core_artifact(),
-        );
+        let out_file = self.single_artifact_path(&PlannedArtifact::LinkedCore {
+            producer: action,
+            target,
+        });
 
         let core_fqn = PackageFQN::new(CORE_MODULE.clone(), PackagePath::empty());
         let package_sources = info
@@ -777,27 +778,23 @@ impl<'a> LoweringContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self, info))]
     pub(super) fn lower_build_c_stub(
         &mut self,
+        action: BuildActionId,
         target: PackageId,
         index: u32,
         info: &BuildCStubsInfo,
     ) -> BuildCommand {
-        assert!(
-            self.opt.target_backend.is_native(),
-            "Non-native make-executable should be already matched and should not be here"
-        );
+        if !self.opt.target_backend.is_native() {
+            unreachable!("C stubs are only lowered for C or LLVM backends")
+        }
 
         let package = self.packages.get_package(target);
 
         let input_file = &package.c_stub_files[index as usize];
-        let output_file = self.layout.c_stub_object_path(
-            self.packages,
-            target,
-            input_file
-                .file_stem()
-                .expect("stub lib should have a file name"),
-            self.opt.target_backend.into(),
-            self.opt.os(),
-        );
+        let output_file = self.single_artifact_path(&PlannedArtifact::CStubObject {
+            producer: action,
+            package: target,
+            index,
+        });
 
         // Match legacy to_opt_level function exactly
         let opt_level = match (
@@ -810,7 +807,7 @@ impl<'a> LoweringContext<'a> {
             (false, false) => CCOptLevel::None,
         };
         // `tcc run` uses shared runtime, others use static runtime
-        let use_shared_runtime = self.opt.use_tcc_run();
+        let use_shared_runtime = self.opt.selected_backend.uses_shared_runtime();
 
         let config = CCConfigBuilder::default()
             .no_sys_header(true)
@@ -852,10 +849,9 @@ impl<'a> LoweringContext<'a> {
         target: PackageId,
         info: &BuildCStubsInfo,
     ) -> BuildCommand {
-        assert!(
-            self.opt.target_backend.is_native(),
-            "Non-native make-executable should be already matched and should not be here"
-        );
+        if !self.opt.target_backend.is_native() {
+            unreachable!("C stubs are only lowered for C or LLVM backends")
+        }
 
         let mut object_files = Vec::new();
         for artifact in self.plan.dependency_artifacts(action) {
@@ -868,32 +864,27 @@ impl<'a> LoweringContext<'a> {
         // - When not using `tcc -run`, this creates an archive of the C stubs.
         // - When using `tcc -run`, this links the C stubs to an ELF .so, so tcc
         //   can load it at runtime.
-        match self.opt.target_backend {
-            RunBackend::WasmGC | RunBackend::Wasm | RunBackend::Js => {
-                panic!("C stubs are not supported for non-native backends")
+        let output = self.single_artifact_path(&PlannedArtifact::CStubLibrary {
+            producer: action,
+            package: target,
+        });
+
+        match self.opt.selected_backend.c_stub_library_realization() {
+            CStubLibraryRealization::SharedLibraryForTccRun => {
+                self.lower_link_c_stubs(info, &object_files, output)
             }
-            RunBackend::Native if self.opt.use_tcc_run() => {
-                self.lower_link_c_stubs(target, info, &object_files)
-            }
-            RunBackend::Native | RunBackend::Llvm => {
-                self.lower_archive_c_stubs(target, info, &object_files)
+            CStubLibraryRealization::StaticArchive => {
+                self.lower_archive_c_stubs(info, &object_files, output)
             }
         }
     }
 
     fn lower_archive_c_stubs(
         &mut self,
-        target: PackageId,
         info: &BuildCStubsInfo,
         object_files: &[PathBuf],
+        archive: PathBuf,
     ) -> BuildCommand {
-        let archive = self.layout.c_stub_archive_path(
-            self.packages,
-            target,
-            self.opt.target_backend.into(),
-            self.opt.os(),
-        );
-
         let config = ArchiverConfigBuilder::default()
             .archive_moonbitrun(false)
             .build()
@@ -919,17 +910,10 @@ impl<'a> LoweringContext<'a> {
 
     fn lower_link_c_stubs(
         &mut self,
-        target: PackageId,
         info: &BuildCStubsInfo,
         object_files: &[PathBuf],
+        dylib_out: PathBuf,
     ) -> BuildCommand {
-        // Output: lib{pkg}.{DYN_EXT}, exactly like legacy gen_link_stub_to_dynamic_lib_command()
-        let dylib_out = self.layout.c_stub_link_dylib_path(
-            self.packages,
-            target,
-            self.opt.target_backend.into(),
-            self.opt.os(),
-        );
         let dest_dir = dylib_out
             .parent()
             .expect("c stub dylib should have a parent directory")
@@ -938,11 +922,7 @@ impl<'a> LoweringContext<'a> {
 
         // Track libruntime.{DYN_EXT} as a dependency but do not pass it as a direct linker src.
         // Legacy adds runtime into build inputs then links via -lruntime using link_shared_runtime.
-        let runtime_dylib = self.layout.runtime_output_path(
-            self.opt.target_backend,
-            self.opt.use_tcc_run(),
-            self.opt.os(),
-        );
+        let runtime_dylib = self.opt.selected_backend.runtime_path(&self.layout);
         let runtime_parent = runtime_dylib
             .parent()
             .expect("runtime dylib should have a parent directory");
@@ -1006,23 +986,28 @@ impl<'a> LoweringContext<'a> {
                     .all(|package| planned_c_stubs.contains(package))
         });
 
-        match self.opt.target_backend {
-            RunBackend::WasmGC | RunBackend::Wasm | RunBackend::Js => {
-                panic!(
-                    "Non-native make-executable should be already matched and should not be here"
-                )
+        match self.opt.selected_backend {
+            SelectedBackend::Wasm(_) | SelectedBackend::WasmGc(_) | SelectedBackend::Js(_) => {
+                unreachable!("non-native make-executable actions are no-ops during lowering")
             }
-            RunBackend::Native => {
-                if let Some(tcc_run) = &self.opt.tcc_run {
+            SelectedBackend::C(backend) => match backend.executable_realization() {
+                CExecutableRealization::WriteTccRunResponseFile => {
+                    let tcc_run = self
+                        .opt
+                        .tcc_run
+                        .as_ref()
+                        .expect("tcc-run realization should carry tcc-run config");
                     let internal_tcc = tcc_run.internal_tcc().clone();
                     self.build_tcc_run_driver_command(action, target, info, internal_tcc)
-                } else if self.opt.native_target.is_some() {
+                }
+                CExecutableRealization::LinkDirectObject => {
                     self.lower_link_new_native_exe(action, target, info)
-                } else {
+                }
+                CExecutableRealization::CompileAndLinkGeneratedC => {
                     self.lower_build_exe_regular(action, target, info)
                 }
-            }
-            RunBackend::Llvm => self.lower_build_exe_regular(action, target, info),
+            },
+            SelectedBackend::Llvm(_) => self.lower_build_exe_regular(action, target, info),
         }
     }
 
@@ -1104,11 +1089,7 @@ impl<'a> LoweringContext<'a> {
             .build()
             .expect("Failed to build CC configuration for executable");
 
-        let dest = self
-            .layout
-            .executable_of_build_target(self.packages, &target, self.opt.executable_artifact(true))
-            .display()
-            .to_string();
+        let dest = self.single_output_path(action).display().to_string();
 
         // This directory is used for MSVC to place intermediate files.
         // Each package should use their own to minimize conflicts.
@@ -1169,11 +1150,7 @@ impl<'a> LoweringContext<'a> {
         };
         sources.extend(simdutf_objects.iter().cloned());
 
-        let dest = self
-            .layout
-            .executable_of_build_target(self.packages, &target, self.opt.executable_artifact(true))
-            .display()
-            .to_string();
+        let dest = self.single_output_path(action).display().to_string();
 
         let pkg_dir = self
             .layout
@@ -1225,7 +1202,7 @@ impl<'a> LoweringContext<'a> {
     fn build_tcc_run_driver_command(
         &self,
         action: BuildActionId,
-        target: BuildTarget,
+        _target: BuildTarget,
         info: &MakeExecutableInfo,
         cc: CC,
     ) -> BuildCommand {
@@ -1257,11 +1234,15 @@ impl<'a> LoweringContext<'a> {
 
         // The C file from moonc link-core
         cmdline.push("-run".to_string());
-        let c_file = self.layout.linked_core_of_build_target(
-            self.packages,
-            &target,
-            self.opt.linked_core_artifact(),
-        );
+        let c_file = self
+            .plan
+            .dependency_artifacts(action)
+            .into_iter()
+            .find_map(|artifact| {
+                matches!(artifact, PlannedArtifact::LinkedCore { .. })
+                    .then(|| self.single_artifact_path(&artifact))
+            })
+            .expect("tcc-run executable should depend on linked core");
         cmdline.push(c_file.display().to_string());
 
         // Note: at this point, we have our TCC command.
@@ -1279,11 +1260,7 @@ impl<'a> LoweringContext<'a> {
             "tool".to_string(),
             "write-tcc-rsp-file".to_string(),
         ];
-        let rsp_path = self.layout.executable_of_build_target(
-            self.packages,
-            &target,
-            self.opt.executable_artifact(false),
-        );
+        let rsp_path = self.single_output_path(action);
 
         rsp_cmdline.push(rsp_path.display().to_string());
         rsp_cmdline.extend(cmdline.into_iter().skip(1)); // skip original `tcc` command

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -1059,18 +1059,25 @@ impl<'a> LoweringContext<'a> {
         info: &MakeExecutableInfo,
     ) -> BuildCommand {
         debug_assert!({
-            let planned_c_stubs = products
-                .dependency_artifacts()
-                .filter_map(|artifact| match artifact {
-                    PlannedArtifact::CStubLibrary { package, .. } => Some(*package),
-                    _ => None,
+            let planned_c_stub_count = products
+                .dependency_paths_matching(|artifact| {
+                    matches!(artifact, PlannedArtifact::CStubLibrary { .. })
                 })
-                .collect::<Vec<_>>();
-            planned_c_stubs.len() == info.link_c_stubs.len()
-                && info
-                    .link_c_stubs
-                    .iter()
-                    .all(|package| planned_c_stubs.contains(package))
+                .len();
+            planned_c_stub_count == info.link_c_stubs.len()
+                && info.link_c_stubs.iter().all(|package| {
+                    !products
+                        .dependency_paths_matching(|artifact| {
+                            matches!(
+                                artifact,
+                                PlannedArtifact::CStubLibrary {
+                                    package: actual,
+                                    ..
+                                } if actual == package
+                            )
+                        })
+                        .is_empty()
+                })
         });
 
         match self.opt.selected_backend {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -327,22 +327,34 @@ impl<'a> LoweringContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self, info))]
-    pub(super) fn lower_check(&self, target: BuildTarget, info: &BuildTargetInfo) -> BuildCommand {
+    pub(super) fn lower_check(
+        &self,
+        action: BuildActionId,
+        target: BuildTarget,
+        info: &BuildTargetInfo,
+    ) -> BuildCommand {
         let package = self.get_package(target);
         let module = self.modules.module_info(package.module);
 
-        let mi_output = if info.check_mi_against.is_some() {
-            self.layout
-                .mi_of_build_target_impl_virtual(
-                    self.packages,
-                    &target,
-                    self.opt.target_backend.into(),
-                )
-                .into_path()
-        } else {
-            self.layout
-                .mi_of_build_target(self.packages, &target, self.opt.target_backend.into())
+        let package_interface = PlannedArtifact::PackageInterface {
+            producer: action,
+            target,
         };
+        let mi_output = self
+            .optional_single_artifact_path(&package_interface)
+            .unwrap_or_else(|| {
+                if info.check_mi_against.is_some() {
+                    self.layout
+                        .mi_of_build_target_impl_virtual(
+                            self.packages,
+                            &target,
+                            self.opt.target_backend.into(),
+                        )
+                        .into_path()
+                } else {
+                    unreachable!("regular Check actions should have one package interface product")
+                }
+            });
         let mi_inputs = self.mi_inputs_of(target);
 
         // Collect files iterator once so we can pass slices and extra inputs
@@ -400,6 +412,7 @@ impl<'a> LoweringContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self, info))]
     pub(super) fn lower_emit_proof(
         &self,
+        action: BuildActionId,
         target: BuildTarget,
         info: &BuildTargetInfo,
     ) -> BuildCommand {
@@ -410,7 +423,10 @@ impl<'a> LoweringContext<'a> {
         let files_vec = self.compiler_source_files(info);
 
         let backend = self.opt.target_backend.into();
-        let whyml_output = self.layout.emit_proof_whyml_path(self.packages, &target);
+        let whyml_output = self.single_artifact_path(&PlannedArtifact::ProofWhyml {
+            producer: action,
+            target,
+        });
         let dep_proofs = self.dep_proofs_of(target);
         let cmd = compiler::MooncProve {
             required: BuildCommonInput::new(
@@ -448,7 +464,12 @@ impl<'a> LoweringContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self, info))]
-    pub(super) fn lower_prove(&self, target: BuildTarget, info: &BuildTargetInfo) -> BuildCommand {
+    pub(super) fn lower_prove(
+        &self,
+        action: BuildActionId,
+        target: BuildTarget,
+        info: &BuildTargetInfo,
+    ) -> BuildCommand {
         let package = self.get_package(target);
         let module = self.modules.module_info(package.module);
         let mi_inputs = self.prove_mi_inputs_of(target);
@@ -460,8 +481,14 @@ impl<'a> LoweringContext<'a> {
             .why3_config
             .clone()
             .unwrap_or_else(|| self.layout.why3_config_path());
-        let whyml_output = self.layout.prove_whyml_path(self.packages, &target);
-        let proof_report_output = self.layout.prove_report_path(self.packages, &target);
+        let whyml_output = self.single_artifact_path(&PlannedArtifact::ProofWhyml {
+            producer: action,
+            target,
+        });
+        let proof_report_output = self.single_artifact_path(&PlannedArtifact::ProofReport {
+            producer: action,
+            target,
+        });
         let dep_proofs = self.dep_proofs_of(target);
         // Why3 needs every reachable non-stdlib proof directory on its loadpath
         // once emitted proof artifacts live alongside package-local verification
@@ -507,20 +534,34 @@ impl<'a> LoweringContext<'a> {
     #[instrument(level = Level::DEBUG, skip(self, info))]
     pub(super) fn lower_build_mbt(
         &self,
+        action: BuildActionId,
         target: BuildTarget,
         info: &BuildTargetInfo,
     ) -> BuildCommand {
         let package = self.get_package(target);
         let module = self.modules.module_info(package.module);
 
-        let core_output = self.layout.core_of_build_target(
-            self.packages,
-            &target,
-            self.opt.target_backend.into(),
-        );
-        let mi_output =
-            self.layout
-                .mi_of_build_target(self.packages, &target, self.opt.target_backend.into());
+        let core_output = self.single_artifact_path(&PlannedArtifact::PackageCoreIr {
+            producer: action,
+            target,
+        });
+        let mi_output = self
+            .single_matching_output_path(action, |artifact| {
+                matches!(
+                    artifact,
+                    PlannedArtifact::PackageInterface {
+                        target: artifact_target,
+                        ..
+                    } if *artifact_target == target
+                )
+            })
+            .unwrap_or_else(|| {
+                self.layout.mi_of_build_target(
+                    self.packages,
+                    &target,
+                    self.opt.target_backend.into(),
+                )
+            });
 
         let mi_inputs = self.mi_inputs_of(target);
 
@@ -528,11 +569,20 @@ impl<'a> LoweringContext<'a> {
         match target.kind {
             TargetKind::Source | TargetKind::SubPackage => {}
             TargetKind::WhiteboxTest | TargetKind::BlackboxTest | TargetKind::InlineTest => {
-                files.push(self.layout.generated_test_driver(
-                    self.packages,
-                    &target,
-                    self.opt.target_backend.into(),
-                ));
+                let test_driver = self
+                    .single_matching_dependency_path(action, |artifact| {
+                        matches!(
+                            artifact,
+                            PlannedArtifact::GeneratedTestDriver {
+                                target: artifact_target,
+                                ..
+                            } if *artifact_target == target
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        unreachable!("test BuildCore actions should depend on a test driver")
+                    });
+                files.push(test_driver);
             }
         };
 
@@ -616,11 +666,17 @@ impl<'a> LoweringContext<'a> {
         }
         // Linked core targets
         for target in &info.linked_order {
-            let core_path = self.layout.core_of_build_target(
-                self.packages,
-                target,
-                self.opt.target_backend.into(),
-            );
+            let core_path = self
+                .single_matching_dependency_path(action, |artifact| {
+                    matches!(
+                        artifact,
+                        PlannedArtifact::PackageCoreIr {
+                            target: artifact_target,
+                            ..
+                        } if artifact_target == target
+                    )
+                })
+                .unwrap_or_else(|| unreachable!("LinkCore targets should depend on core IR"));
             core_input_files.push(core_path);
         }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -39,7 +39,7 @@ use petgraph::Direction;
 use tracing::{Level, instrument};
 
 use crate::{
-    build_action_plan::{BuildActionId, PlannedArtifact},
+    build_action_plan::PlannedArtifact,
     build_lower::{
         CExecutableRealization, CStubLibraryRealization, SelectedBackend, WarningCondition,
         artifact,
@@ -55,7 +55,10 @@ use crate::{
     special_cases::{is_self_coverage_lib, should_skip_coverage},
 };
 
-use super::{BuildCommand, Commandline, compiler, context::LoweringContext};
+use super::{
+    BuildCommand, Commandline, compiler,
+    context::{ActionProducts, LoweringContext},
+};
 
 fn commandline_with_dsymutil(cmd: &[String], dest: &str) -> Commandline {
     let cmd_str = moonutil::shlex::join_unix(cmd.iter().map(|x| x.as_str()));
@@ -326,22 +329,26 @@ impl<'a> LoweringContext<'a> {
         prelude_proof.is_dir().then_some(prelude_proof)
     }
 
-    #[instrument(level = Level::DEBUG, skip(self, info))]
+    #[instrument(level = Level::DEBUG, skip(self, products, info))]
     pub(super) fn lower_check(
         &self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: BuildTarget,
         info: &BuildTargetInfo,
     ) -> BuildCommand {
         let package = self.get_package(target);
         let module = self.modules.module_info(package.module);
 
-        let package_interface = PlannedArtifact::PackageInterface {
-            producer: action,
-            target,
-        };
-        let mi_output = self
-            .optional_single_artifact_path(&package_interface)
+        let mi_output = products
+            .optional_single_output_path_matching(|artifact| {
+                matches!(
+                    artifact,
+                    PlannedArtifact::PackageInterface {
+                        target: artifact_target,
+                        ..
+                    } if *artifact_target == target
+                )
+            })
             .unwrap_or_else(|| {
                 if info.check_mi_against.is_some() {
                     self.layout
@@ -409,10 +416,10 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    #[instrument(level = Level::DEBUG, skip(self, info))]
+    #[instrument(level = Level::DEBUG, skip(self, products, info))]
     pub(super) fn lower_emit_proof(
         &self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: BuildTarget,
         info: &BuildTargetInfo,
     ) -> BuildCommand {
@@ -423,9 +430,14 @@ impl<'a> LoweringContext<'a> {
         let files_vec = self.compiler_source_files(info);
 
         let backend = self.opt.target_backend.into();
-        let whyml_output = self.single_artifact_path(&PlannedArtifact::ProofWhyml {
-            producer: action,
-            target,
+        let whyml_output = products.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                PlannedArtifact::ProofWhyml {
+                    target: artifact_target,
+                    ..
+                } if *artifact_target == target
+            )
         });
         let dep_proofs = self.dep_proofs_of(target);
         let cmd = compiler::MooncProve {
@@ -463,10 +475,10 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    #[instrument(level = Level::DEBUG, skip(self, info))]
+    #[instrument(level = Level::DEBUG, skip(self, products, info))]
     pub(super) fn lower_prove(
         &self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: BuildTarget,
         info: &BuildTargetInfo,
     ) -> BuildCommand {
@@ -481,13 +493,23 @@ impl<'a> LoweringContext<'a> {
             .why3_config
             .clone()
             .unwrap_or_else(|| self.layout.why3_config_path());
-        let whyml_output = self.single_artifact_path(&PlannedArtifact::ProofWhyml {
-            producer: action,
-            target,
+        let whyml_output = products.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                PlannedArtifact::ProofWhyml {
+                    target: artifact_target,
+                    ..
+                } if *artifact_target == target
+            )
         });
-        let proof_report_output = self.single_artifact_path(&PlannedArtifact::ProofReport {
-            producer: action,
-            target,
+        let proof_report_output = products.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                PlannedArtifact::ProofReport {
+                    target: artifact_target,
+                    ..
+                } if *artifact_target == target
+            )
         });
         let dep_proofs = self.dep_proofs_of(target);
         // Why3 needs every reachable non-stdlib proof directory on its loadpath
@@ -531,22 +553,27 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    #[instrument(level = Level::DEBUG, skip(self, info))]
+    #[instrument(level = Level::DEBUG, skip(self, products, info))]
     pub(super) fn lower_build_mbt(
         &self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: BuildTarget,
         info: &BuildTargetInfo,
     ) -> BuildCommand {
         let package = self.get_package(target);
         let module = self.modules.module_info(package.module);
 
-        let core_output = self.single_artifact_path(&PlannedArtifact::PackageCoreIr {
-            producer: action,
-            target,
+        let core_output = products.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                PlannedArtifact::PackageCoreIr {
+                    target: artifact_target,
+                    ..
+                } if *artifact_target == target
+            )
         });
-        let mi_output = self
-            .single_matching_output_path(action, |artifact| {
+        let mi_output = products
+            .optional_single_output_path_matching(|artifact| {
                 matches!(
                     artifact,
                     PlannedArtifact::PackageInterface {
@@ -569,19 +596,15 @@ impl<'a> LoweringContext<'a> {
         match target.kind {
             TargetKind::Source | TargetKind::SubPackage => {}
             TargetKind::WhiteboxTest | TargetKind::BlackboxTest | TargetKind::InlineTest => {
-                let test_driver = self
-                    .single_matching_dependency_path(action, |artifact| {
-                        matches!(
-                            artifact,
-                            PlannedArtifact::GeneratedTestDriver {
-                                target: artifact_target,
-                                ..
-                            } if *artifact_target == target
-                        )
-                    })
-                    .unwrap_or_else(|| {
-                        unreachable!("test BuildCore actions should depend on a test driver")
-                    });
+                let test_driver = products.single_dependency_path_matching(|artifact| {
+                    matches!(
+                        artifact,
+                        PlannedArtifact::GeneratedTestDriver {
+                            target: artifact_target,
+                            ..
+                        } if *artifact_target == target
+                    )
+                });
                 files.push(test_driver);
             }
         };
@@ -634,10 +657,10 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    #[instrument(level = Level::DEBUG, skip(self, info))]
+    #[instrument(level = Level::DEBUG, skip(self, products, info))]
     pub(super) fn lower_link_core(
         &mut self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: BuildTarget,
         info: &LinkCoreInfo,
         make_executable_info: Option<&MakeExecutableInfo>,
@@ -666,23 +689,26 @@ impl<'a> LoweringContext<'a> {
         }
         // Linked core targets
         for target in &info.linked_order {
-            let core_path = self
-                .single_matching_dependency_path(action, |artifact| {
-                    matches!(
-                        artifact,
-                        PlannedArtifact::PackageCoreIr {
-                            target: artifact_target,
-                            ..
-                        } if artifact_target == target
-                    )
-                })
-                .unwrap_or_else(|| unreachable!("LinkCore targets should depend on core IR"));
+            let core_path = products.single_dependency_path_matching(|artifact| {
+                matches!(
+                    artifact,
+                    PlannedArtifact::PackageCoreIr {
+                        target: artifact_target,
+                        ..
+                    } if artifact_target == target
+                )
+            });
             core_input_files.push(core_path);
         }
 
-        let out_file = self.single_artifact_path(&PlannedArtifact::LinkedCore {
-            producer: action,
-            target,
+        let out_file = products.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                PlannedArtifact::LinkedCore {
+                    target: artifact_target,
+                    ..
+                } if *artifact_target == target
+            )
         });
 
         let core_fqn = PackageFQN::new(CORE_MODULE.clone(), PackagePath::empty());
@@ -831,10 +857,10 @@ impl<'a> LoweringContext<'a> {
         })
     }
 
-    #[instrument(level = Level::DEBUG, skip(self, info))]
+    #[instrument(level = Level::DEBUG, skip(self, products, info))]
     pub(super) fn lower_build_c_stub(
         &mut self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: PackageId,
         index: u32,
         info: &BuildCStubsInfo,
@@ -846,10 +872,15 @@ impl<'a> LoweringContext<'a> {
         let package = self.packages.get_package(target);
 
         let input_file = &package.c_stub_files[index as usize];
-        let output_file = self.single_artifact_path(&PlannedArtifact::CStubObject {
-            producer: action,
-            package: target,
-            index,
+        let output_file = products.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                PlannedArtifact::CStubObject {
+                    package: artifact_package,
+                    index: artifact_index,
+                    ..
+                } if *artifact_package == target && *artifact_index == index
+            )
         });
 
         // Match legacy to_opt_level function exactly
@@ -898,10 +929,10 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    #[instrument(level = Level::DEBUG, skip(self, info))]
+    #[instrument(level = Level::DEBUG, skip(self, products, info))]
     pub(super) fn lower_archive_or_link_c_stubs(
         &mut self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: PackageId,
         info: &BuildCStubsInfo,
     ) -> BuildCommand {
@@ -909,20 +940,22 @@ impl<'a> LoweringContext<'a> {
             unreachable!("C stubs are only lowered for C or LLVM backends")
         }
 
-        let mut object_files = Vec::new();
-        for artifact in self.plan.dependency_artifacts(action) {
-            if matches!(artifact, PlannedArtifact::CStubObject { .. }) {
-                self.append_planned_artifact(&artifact, &mut object_files);
-            }
-        }
+        let object_files = products.dependency_paths_matching(|artifact| {
+            matches!(artifact, PlannedArtifact::CStubObject { .. })
+        });
 
         // There's two ways to handle this:
         // - When not using `tcc -run`, this creates an archive of the C stubs.
         // - When using `tcc -run`, this links the C stubs to an ELF .so, so tcc
         //   can load it at runtime.
-        let output = self.single_artifact_path(&PlannedArtifact::CStubLibrary {
-            producer: action,
-            package: target,
+        let output = products.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                PlannedArtifact::CStubLibrary {
+                    package: artifact_package,
+                    ..
+                } if *artifact_package == target
+            )
         });
 
         match self.opt.selected_backend.c_stub_library_realization() {
@@ -1018,20 +1051,18 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    #[instrument(level = Level::DEBUG, skip(self, info))]
+    #[instrument(level = Level::DEBUG, skip(self, products, info))]
     pub(super) fn lower_make_exe(
         &mut self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: BuildTarget,
         info: &MakeExecutableInfo,
     ) -> BuildCommand {
         debug_assert!({
-            let planned_c_stubs = self
-                .plan
-                .dependency_artifacts(action)
-                .into_iter()
+            let planned_c_stubs = products
+                .dependency_artifacts()
                 .filter_map(|artifact| match artifact {
-                    PlannedArtifact::CStubLibrary { package, .. } => Some(package),
+                    PlannedArtifact::CStubLibrary { package, .. } => Some(*package),
                     _ => None,
                 })
                 .collect::<Vec<_>>();
@@ -1043,7 +1074,7 @@ impl<'a> LoweringContext<'a> {
         });
 
         match self.opt.selected_backend {
-            SelectedBackend::Wasm(_) | SelectedBackend::WasmGc(_) | SelectedBackend::Js(_) => {
+            SelectedBackend::Wasm { .. } | SelectedBackend::WasmGc { .. } | SelectedBackend::Js => {
                 unreachable!("non-native make-executable actions are no-ops during lowering")
             }
             SelectedBackend::C(backend) => match backend.executable_realization() {
@@ -1054,52 +1085,43 @@ impl<'a> LoweringContext<'a> {
                         .as_ref()
                         .expect("tcc-run realization should carry tcc-run config");
                     let internal_tcc = tcc_run.internal_tcc().clone();
-                    self.build_tcc_run_driver_command(action, target, info, internal_tcc)
+                    self.build_tcc_run_driver_command(products, info, internal_tcc)
                 }
                 CExecutableRealization::LinkDirectObject => {
-                    self.lower_link_new_native_exe(action, target, info)
+                    self.lower_link_new_native_exe(products, target, info)
                 }
                 CExecutableRealization::CompileAndLinkGeneratedC => {
-                    self.lower_build_exe_regular(action, target, info)
+                    self.lower_build_exe_regular(products, target, info)
                 }
             },
-            SelectedBackend::Llvm(_) => self.lower_build_exe_regular(action, target, info),
+            SelectedBackend::Llvm { .. } => self.lower_build_exe_regular(products, target, info),
         }
     }
 
     fn native_executable_dependency_paths(
         &self,
-        action: BuildActionId,
+        products: &ActionProducts,
         info: &MakeExecutableInfo,
         include_linked_core: bool,
     ) -> Vec<PathBuf> {
-        let artifacts = self.plan.dependency_artifacts(action);
         let mut sources = Vec::new();
 
         // Preserve the legacy linker order: linked core, runtime, then C stubs.
         // Static library order can affect symbol resolution on Unix linkers.
         if include_linked_core {
-            for artifact in artifacts
-                .iter()
-                .filter(|artifact| matches!(artifact, PlannedArtifact::LinkedCore { .. }))
-            {
-                self.append_planned_artifact(artifact, &mut sources);
-            }
+            sources.extend(products.dependency_paths_matching(|artifact| {
+                matches!(artifact, PlannedArtifact::LinkedCore { .. })
+            }));
         }
 
-        for artifact in artifacts
-            .iter()
-            .filter(|artifact| matches!(artifact, PlannedArtifact::RuntimeLib { .. }))
-        {
-            self.append_planned_artifact(artifact, &mut sources);
-        }
+        sources.extend(products.dependency_paths_matching(|artifact| {
+            matches!(artifact, PlannedArtifact::RuntimeLib { .. })
+        }));
 
         for package in &info.link_c_stubs {
-            for artifact in artifacts.iter().filter(|artifact| {
+            sources.extend(products.dependency_paths_matching(|artifact| {
                 matches!(artifact, PlannedArtifact::CStubLibrary { package: actual, .. } if actual == package)
-            }) {
-                self.append_planned_artifact(artifact, &mut sources);
-            }
+            }));
         }
 
         sources
@@ -1107,7 +1129,7 @@ impl<'a> LoweringContext<'a> {
 
     fn lower_build_exe_regular(
         &mut self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: BuildTarget,
         info: &MakeExecutableInfo,
     ) -> BuildCommand {
@@ -1117,7 +1139,7 @@ impl<'a> LoweringContext<'a> {
         // - compile the program (if needed)
         // - link with runtime library & artifacts of other C stubs
 
-        let mut sources = self.native_executable_dependency_paths(action, info, true);
+        let mut sources = self.native_executable_dependency_paths(products, info, true);
         let cc = info.effective_native_toolchain.cc().clone();
         let simdutf_objects = if cc.can_use_simdutf() {
             self.opt
@@ -1145,7 +1167,7 @@ impl<'a> LoweringContext<'a> {
             .build()
             .expect("Failed to build CC configuration for executable");
 
-        let dest = self.single_output_path(action).display().to_string();
+        let dest = products.single_output_path().display().to_string();
 
         // This directory is used for MSVC to place intermediate files.
         // Each package should use their own to minimize conflicts.
@@ -1188,11 +1210,11 @@ impl<'a> LoweringContext<'a> {
 
     fn lower_link_new_native_exe(
         &mut self,
-        action: BuildActionId,
+        products: &ActionProducts,
         target: BuildTarget,
         info: &MakeExecutableInfo,
     ) -> BuildCommand {
-        let mut sources = self.native_executable_dependency_paths(action, info, true);
+        let mut sources = self.native_executable_dependency_paths(products, info, true);
 
         let cc = info.effective_native_toolchain.cc().clone();
         let simdutf_objects = if cc.can_use_simdutf() {
@@ -1206,7 +1228,7 @@ impl<'a> LoweringContext<'a> {
         };
         sources.extend(simdutf_objects.iter().cloned());
 
-        let dest = self.single_output_path(action).display().to_string();
+        let dest = products.single_output_path().display().to_string();
 
         let pkg_dir = self
             .layout
@@ -1257,12 +1279,11 @@ impl<'a> LoweringContext<'a> {
     /// putting that into a response file.
     fn build_tcc_run_driver_command(
         &self,
-        action: BuildActionId,
-        _target: BuildTarget,
+        products: &ActionProducts,
         info: &MakeExecutableInfo,
         cc: CC,
     ) -> BuildCommand {
-        let sources = self.native_executable_dependency_paths(action, info, false);
+        let sources = self.native_executable_dependency_paths(products, info, false);
 
         let cfg = CCConfigBuilder::default()
             .no_sys_header(true) // -DMOONBIT_NATIVE_NO_SYS_HEADER for TCC
@@ -1290,15 +1311,9 @@ impl<'a> LoweringContext<'a> {
 
         // The C file from moonc link-core
         cmdline.push("-run".to_string());
-        let c_file = self
-            .plan
-            .dependency_artifacts(action)
-            .into_iter()
-            .find_map(|artifact| {
-                matches!(artifact, PlannedArtifact::LinkedCore { .. })
-                    .then(|| self.single_artifact_path(&artifact))
-            })
-            .expect("tcc-run executable should depend on linked core");
+        let c_file = products.single_dependency_path_matching(|artifact| {
+            matches!(artifact, PlannedArtifact::LinkedCore { .. })
+        });
         cmdline.push(c_file.display().to_string());
 
         // Note: at this point, we have our TCC command.
@@ -1316,7 +1331,7 @@ impl<'a> LoweringContext<'a> {
             "tool".to_string(),
             "write-tcc-rsp-file".to_string(),
         ];
-        let rsp_path = self.single_output_path(action);
+        let rsp_path = products.single_output_path();
 
         rsp_cmdline.push(rsp_path.display().to_string());
         rsp_cmdline.extend(cmdline.into_iter().skip(1)); // skip original `tcc` command

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -36,15 +36,19 @@ use crate::{
 };
 
 pub mod artifact;
+mod backend;
 mod compiler;
 mod context;
 mod lower_aux;
 mod lower_build;
+mod products;
 mod utils;
 
 pub use utils::{build_ins, build_n2_fileloc, build_outs};
 
-use crate::build_lower::artifact::{ExecutableArtifact, LegacyLayoutBuilder, LinkedCoreArtifact};
+pub(crate) use backend::{CExecutableRealization, CStubLibraryRealization, SelectedBackend};
+
+use crate::build_lower::artifact::LegacyLayoutBuilder;
 use context::LoweringContext;
 
 /// Lazily resolved host/toolchain facts used during lowering.
@@ -96,6 +100,7 @@ pub struct BuildOptions {
     pub target_backend: RunBackend,
     pub native_target: Option<NativeTarget>,
     pub tcc_run: Option<TccRunConfig>,
+    pub(crate) selected_backend: SelectedBackend,
     pub opt_level: OptLevel,
     pub action: RunMode,
 
@@ -126,51 +131,6 @@ impl BuildOptions {
 
     pub fn runtime_dot_c_path(&self) -> PathBuf {
         self.lowering_environment.runtime_dot_c_path()
-    }
-
-    pub fn use_tcc_run(&self) -> bool {
-        let use_tcc_run = self.tcc_run.is_some();
-        debug_assert!(!use_tcc_run || self.target_backend == RunBackend::Native);
-        debug_assert!(!use_tcc_run || self.native_target.is_none());
-        use_tcc_run
-    }
-
-    pub fn executable_artifact(&self, legacy_behavior: bool) -> ExecutableArtifact {
-        match self.target_backend {
-            RunBackend::Wasm => ExecutableArtifact::Wasm {
-                use_wat: self.output_wat,
-            },
-            RunBackend::WasmGC => ExecutableArtifact::WasmGC {
-                use_wat: self.output_wat,
-            },
-            RunBackend::Js => ExecutableArtifact::Js,
-            RunBackend::Native if self.use_tcc_run() => ExecutableArtifact::TccRunResponseFile,
-            RunBackend::Native => ExecutableArtifact::NativeExecutable {
-                os: self.os(),
-                legacy_behavior,
-            },
-            RunBackend::Llvm => ExecutableArtifact::LlvmExecutable {
-                os: self.os(),
-                legacy_behavior,
-            },
-        }
-    }
-
-    pub fn linked_core_artifact(&self) -> LinkedCoreArtifact {
-        match self.target_backend {
-            RunBackend::Wasm => LinkedCoreArtifact::Wasm {
-                use_wat: self.output_wat,
-            },
-            RunBackend::WasmGC => LinkedCoreArtifact::WasmGC {
-                use_wat: self.output_wat,
-            },
-            RunBackend::Js => LinkedCoreArtifact::Js,
-            RunBackend::Native if self.native_target.is_some() => {
-                LinkedCoreArtifact::NativeObject { os: self.os() }
-            }
-            RunBackend::Native => LinkedCoreArtifact::NativeC,
-            RunBackend::Llvm => LinkedCoreArtifact::LlvmObject { os: self.os() },
-        }
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/products.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/products.rs
@@ -1,0 +1,231 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Realized paths for logical build products.
+
+use std::{collections::HashMap, path::PathBuf};
+
+use crate::{
+    ResolveOutput,
+    build_action_plan::{BuildAction, BuildActionPlan, PlannedArtifact},
+    build_lower::{
+        BuildOptions,
+        artifact::{LegacyLayout, MiPathResult},
+    },
+    model::TargetKind,
+};
+
+pub(crate) struct ProductTable {
+    paths_by_artifact: HashMap<PlannedArtifact, Vec<PathBuf>>,
+}
+
+impl ProductTable {
+    pub(crate) fn new(
+        layout: &LegacyLayout,
+        resolve_output: &ResolveOutput,
+        plan: &BuildActionPlan<'_>,
+        opt: &BuildOptions,
+    ) -> Self {
+        let resolver = ProductResolver {
+            layout,
+            resolve_output,
+            plan,
+            opt,
+        };
+        let mut paths_by_artifact = HashMap::new();
+        for action in plan.action_ids() {
+            for artifact in plan.output_artifacts(action) {
+                let paths = resolver.resolve(&artifact);
+                paths_by_artifact.insert(artifact, paths);
+            }
+        }
+        Self { paths_by_artifact }
+    }
+
+    pub(crate) fn paths(&self, artifact: &PlannedArtifact) -> &[PathBuf] {
+        self.paths_by_artifact
+            .get(artifact)
+            .unwrap_or_else(|| panic!("planned artifact should be realized: {artifact:?}"))
+    }
+}
+
+struct ProductResolver<'a, 'b> {
+    layout: &'a LegacyLayout,
+    resolve_output: &'a ResolveOutput,
+    plan: &'a BuildActionPlan<'b>,
+    opt: &'a BuildOptions,
+}
+
+impl ProductResolver<'_, '_> {
+    fn resolve(&self, artifact: &PlannedArtifact) -> Vec<PathBuf> {
+        let packages = &self.resolve_output.pkg_dirs;
+        let modules = &self.resolve_output.module_rel;
+        match artifact {
+            PlannedArtifact::PackageInterface { producer, target } => {
+                self.package_interface(*producer, *target)
+            }
+            PlannedArtifact::PackageCoreIr { target, .. } => {
+                vec![self.layout.core_of_build_target(
+                    packages,
+                    target,
+                    self.opt.target_backend.into(),
+                )]
+            }
+            PlannedArtifact::ProofInterface { producer, target } => {
+                match self.plan.action(*producer) {
+                    BuildAction::EmitProof { .. } => {
+                        vec![self.layout.emit_proof_mi_path(packages, target)]
+                    }
+                    BuildAction::Prove { .. } => vec![self.layout.prove_mi_path(packages, target)],
+                    _ => unreachable!("proof interface producer should be a proof action"),
+                }
+            }
+            PlannedArtifact::ProofWhyml { producer, target } => match self.plan.action(*producer) {
+                BuildAction::EmitProof { .. } => {
+                    vec![self.layout.emit_proof_whyml_path(packages, target)]
+                }
+                BuildAction::Prove { .. } => vec![self.layout.prove_whyml_path(packages, target)],
+                _ => unreachable!("proof whyml producer should be a proof action"),
+            },
+            PlannedArtifact::ProofReport { target, .. } => {
+                vec![self.layout.prove_report_path(packages, target)]
+            }
+            PlannedArtifact::CStubObject { package, index, .. } => {
+                let pkg = packages.get_package(*package);
+                let file_name = &pkg.c_stub_files[*index as usize];
+                vec![
+                    self.layout.c_stub_object_path(
+                        packages,
+                        *package,
+                        file_name
+                            .file_stem()
+                            .expect("c stub file should have a file name"),
+                        self.opt.target_backend.into(),
+                        self.opt.os(),
+                    ),
+                ]
+            }
+            PlannedArtifact::CStubLibrary { package, .. } => {
+                vec![self.opt.selected_backend.c_stub_library_path(
+                    self.layout,
+                    packages,
+                    *package,
+                    self.opt.target_backend.into(),
+                )]
+            }
+            PlannedArtifact::LinkedCore { target, .. } => {
+                vec![
+                    self.opt
+                        .selected_backend
+                        .linked_core_path(self.layout, packages, target),
+                ]
+            }
+            PlannedArtifact::Executable { target, .. } => {
+                vec![
+                    self.opt
+                        .selected_backend
+                        .executable_path(self.layout, packages, target),
+                ]
+            }
+            PlannedArtifact::GeneratedTestDriver { target, .. } => {
+                vec![self.layout.generated_test_driver(
+                    packages,
+                    target,
+                    self.opt.target_backend.into(),
+                )]
+            }
+            PlannedArtifact::GeneratedTestMetadata { target, .. } => {
+                vec![self.layout.generated_test_driver_metadata(
+                    packages,
+                    target,
+                    self.opt.target_backend.into(),
+                )]
+            }
+            PlannedArtifact::BundleResult { module, .. } => {
+                let module_name = modules.module_source(*module);
+                vec![
+                    self.layout
+                        .bundle_result_path(self.opt.target_backend.into(), module_name.name()),
+                ]
+            }
+            PlannedArtifact::RuntimeLib { .. } => {
+                vec![self.opt.selected_backend.runtime_path(self.layout)]
+            }
+            PlannedArtifact::GeneratedMbti { target, .. } => vec![self.layout.generated_mbti_path(
+                packages,
+                target,
+                self.opt.target_backend.into(),
+            )],
+            PlannedArtifact::DocsDir { .. } => vec![self.layout.doc_dir()],
+            PlannedArtifact::VirtualPackageInterface { package, .. } => {
+                let target = package.build_target(TargetKind::Source);
+                vec![self.layout.mi_of_build_target(
+                    packages,
+                    &target,
+                    self.opt.target_backend.into(),
+                )]
+            }
+            PlannedArtifact::MoonLexGeneratedSource { package, index, .. } => {
+                let pkg_info = packages.get_package(*package);
+                let mbtlex_file = &pkg_info.mbt_lex_files[*index as usize];
+                vec![mbtlex_file.with_extension("mbt")]
+            }
+            PlannedArtifact::MoonYaccGeneratedSource { package, index, .. } => {
+                let pkg_info = packages.get_package(*package);
+                let mbtyacc_file = &pkg_info.mbt_yacc_files[*index as usize];
+                vec![mbtyacc_file.with_extension("mbt")]
+            }
+            PlannedArtifact::KnownPath { path, .. } => vec![path.clone()],
+        }
+    }
+
+    fn package_interface(
+        &self,
+        producer: crate::build_action_plan::BuildActionId,
+        target: crate::model::BuildTarget,
+    ) -> Vec<PathBuf> {
+        let packages = &self.resolve_output.pkg_dirs;
+        match self.plan.action(producer) {
+            BuildAction::Check { info, .. } if info.check_mi_against.is_some() => {
+                match self.layout.mi_of_build_target_impl_virtual(
+                    packages,
+                    &target,
+                    self.opt.target_backend.into(),
+                ) {
+                    MiPathResult::StdAbort(_) => Vec::new(),
+                    MiPathResult::Std(p) => {
+                        tracing::warn!(
+                            "stdlib mi should not be needed for check as an implementation package: {:?}",
+                            p
+                        );
+                        Vec::new()
+                    }
+                    MiPathResult::Regular(p) => vec![p],
+                }
+            }
+            BuildAction::Check { .. } | BuildAction::BuildCore { .. } => {
+                vec![self.layout.mi_of_build_target(
+                    packages,
+                    &target,
+                    self.opt.target_backend.into(),
+                )]
+            }
+            _ => unreachable!("package interface producer should be Check or BuildCore"),
+        }
+    }
+}

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -143,6 +143,13 @@ pub fn compile(
     info!("Build plan created successfully");
     debug!("Build plan contains {} nodes", plan.node_count());
 
+    let selected_backend = build_lower::SelectedBackend::new(
+        cx.target_backend,
+        cx.native_target,
+        cx.tcc_run.is_some(),
+        cx.output_wat,
+        || cx.lowering_environment.os(),
+    );
     let lower_env = build_lower::BuildOptions {
         main_module: match resolve_output.local_modules() {
             &[module] => Some(resolve_output.module_rel.module_source(module).clone()),
@@ -152,6 +159,7 @@ pub fn compile(
         target_backend: cx.target_backend,
         native_target: cx.native_target,
         tcc_run: cx.tcc_run.clone(),
+        selected_backend,
         opt_level: cx.opt_level,
         action: cx.action,
 


### PR DESCRIPTION
## Why

Rupes Recta lowering was still reconstructing selected-backend product paths inside individual command lowerers. That made concrete product policy leak across command lowering and n2 output declaration, with the highest drift risk around C/native/TCC paths where linked core, executable, runtime, and C stub realizations vary together.

## What

- Introduce selected-backend realization for declared planned artifacts.
- Add a product table that maps logical MoonBuild products to concrete paths before command lowering.
- Route check/build/proof/test-driver/bundle/mbti command outputs, plus generated core/test-driver inputs, through realized products.
- Keep command lowerers on an action-local product view instead of passing raw `BuildActionId` through each lowerer.
- Collapse shallow non-C backend wrappers while keeping C realization centralized, where the native/TCC policy actually lives.

## Why This Is Correct

The realized paths still come from the existing layout helpers and selected backend facts. The action-local product view preserves the planned output/dependency order while hiding producer-keyed artifact lookup from command lowering. C, TCC-run, direct native object, runtime, and C-stub realization choices stay centralized and covered by focused tests.

## Why This Is Minimal

The PR stays scoped to declared MoonBuild products consumed by Rupes Recta lowering. Existing side effects that are not declared products remain intentionally outside this model for now, including dSYM bundles, source-map sidecars, JS declaration sidecars, docs directory contents, and undeclared prebuild side effects. The cleanup removes shallow backend wrapper types rather than expanding the abstraction surface.