### PR TITLE
Fix check watch target recovery

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -447,7 +447,7 @@ fn run_check_normal_internal(
             || run_once(true, &watch_target),
             source_dir,
             source_dir,
-            target_dir,
+            &watch_target,
         )
     } else {
         run_once(false, target_dir).map(|output| if output.ok { 0 } else { 1 })

--- a/crates/moon/tests/test_cases/check_watch/mod.rs
+++ b/crates/moon/tests/test_cases/check_watch/mod.rs
@@ -1,0 +1,130 @@
+use std::{
+    io::{BufRead, BufReader},
+    process::{Child, Stdio},
+    sync::mpsc,
+    time::{Duration, Instant},
+};
+
+use moonutil::common::{BUILD_DIR, WATCH_MODE_DIR};
+
+use super::*;
+
+struct WatchProcess {
+    child: Child,
+}
+
+impl Drop for WatchProcess {
+    fn drop(&mut self) {
+        if self.child.try_wait().expect("poll watch process").is_some() {
+            return;
+        }
+
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn check_watch_recovers_when_nested_watch_target_is_deleted() {
+    let dir = TestDir::new("hello");
+    let watch_target = dir.as_ref().join(BUILD_DIR).join(WATCH_MODE_DIR);
+    let main_file = dir.as_ref().join("main/main.mbt");
+
+    let mut child = moon_process_cmd(&dir)
+        .args(["check", "--watch"])
+        .env("RUST_LOG", "moon::watch=debug")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn moon check --watch");
+
+    let stdout = child.stdout.take().expect("watch process stdout");
+    let stderr = child.stderr.take().expect("watch process stderr");
+    let (tx, rx) = mpsc::channel();
+    let stderr_tx = tx.clone();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            if stderr_tx.send(format!("stderr: {line}")).is_err() {
+                break;
+            }
+        }
+    });
+
+    let _watch_process = WatchProcess { child };
+
+    wait_for_watch_success(&rx, "initial check");
+    wait_for_watch_message(&rx, "watcher startup", |line| {
+        line.contains("Watcher loop started")
+    });
+    assert!(watch_target.exists());
+
+    std::fs::remove_dir_all(&watch_target).expect("delete nested watch target");
+    std::fs::write(
+        &main_file,
+        r#"fn main {
+  println("Hello, watch!")
+}
+
+test {
+
+}
+"#,
+    )
+    .expect("update source file");
+
+    wait_for_watch_success(&rx, "rerun after deleting nested watch target");
+    assert!(watch_target.exists());
+}
+
+fn wait_for_watch_success(rx: &mpsc::Receiver<String>, phase: &str) {
+    wait_for_watch_message(rx, phase, |line| {
+        line.contains("Success, waiting for filesystem changes...")
+    });
+}
+
+fn wait_for_watch_message(
+    rx: &mpsc::Receiver<String>,
+    phase: &str,
+    matches: impl Fn(&str) -> bool,
+) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut output = Vec::new();
+
+    loop {
+        let now = Instant::now();
+        assert!(
+            now < deadline,
+            "timed out waiting for {phase}; output:\n{}",
+            output.join("\n")
+        );
+
+        match rx.recv_timeout(deadline.saturating_duration_since(now)) {
+            Ok(line) => {
+                let matched = matches(&line);
+                output.push(line);
+                if matched {
+                    return;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                panic!(
+                    "timed out waiting for {phase}; output:\n{}",
+                    output.join("\n")
+                );
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!(
+                    "watch process exited before {phase}; output:\n{}",
+                    output.join("\n")
+                );
+            }
+        }
+    }
+}

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -38,6 +38,7 @@ mod bench2;
 mod blackbox;
 mod build_package_dep_core;
 mod check_fmt;
+mod check_watch;
 mod circle_pkg_ab_001_test;
 mod clean;
 mod cond_comp;


### PR DESCRIPTION
## Summary

`moon check --watch` now asks the watcher to recreate the same nested target directory that the check run actually locks and writes. This keeps reruns working if the `_build/watch` directory is deleted while watch mode is still active.

The change also adds an integration regression that starts `moon check --watch`, waits for the watcher loop to become active, deletes the nested watch target, edits a source file, and verifies the rerun succeeds.

## Rationale

The check watch path runs builds under `_build/watch`, but the watcher recovery path was previously wired to the parent `_build` directory. If `_build/watch` disappeared while `_build` still existed, the recovery check did nothing and the next rerun failed when it tried to create the lock file under the missing nested directory.

Passing `_build/watch` to the watcher preserves the invariant that the recovery target is the same directory used by the watched command.

## Minimality

The implementation change is a single call-site correction. The rest of the PR is focused regression coverage for that exact watch-mode recovery path.