### PR TITLE
Replace moon CLI unwraps with contextual errors

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -300,7 +300,7 @@ fn run_check_for_single_file_rr(
     let path = cmd
         .path
         .first()
-        .expect("path should be set in single-file mode");
+        .context("standalone single-file `moon check` expects exactly one `PATH`")?;
     let single_file_path = dunce::canonicalize(path)
         .with_context(|| format!("failed to resolve file path `{}`", path.display()))?;
     std::fs::create_dir_all(target_dir).context("failed to create target directory")?;
@@ -402,11 +402,11 @@ fn get_user_intents_single_file(
     let m_packages = resolve_output
         .pkg_dirs
         .packages_for_module(resolve_output.local_modules()[0])
-        .expect("Local module must exist");
+        .context("single-file project must resolve a local module")?;
     let pkg = *m_packages
         .iter()
         .next()
-        .expect("Only one package should be resolved for single file package")
+        .context("single-file project must resolve exactly one package")?
         .1;
 
     Ok(vec![UserIntent::Check(pkg)].into())

--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -107,7 +107,9 @@ pub(crate) fn install_cli(cli: UniversalFlags, cmd: InstallSubcommand) -> anyhow
         return install_from_local(&cli, &local_path, &install_dir, false);
     }
 
-    let source = cmd.source.unwrap();
+    let source = cmd.source.ok_or_else(|| {
+        anyhow::anyhow!("`moon install` expects a package, local path, or git URL")
+    })?;
 
     // Local path install
     // These checks can't be done in clap because we need to inspect the value of source

--- a/crates/moon/src/cli/fetch.rs
+++ b/crates/moon/src/cli/fetch.rs
@@ -99,7 +99,7 @@ pub(crate) fn fetch_cli(cli: UniversalFlags, cmd: FetchSubcommand) -> anyhow::Re
             })?
             .version
             .clone()
-            .unwrap();
+            .ok_or_else(|| anyhow::anyhow!("latest registry entry for `{pkg_name}` has no version"))?;
         if !cli.quiet {
             println!("Latest version of {pkg_name} is {latest_version}");
         }

--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -117,14 +117,17 @@ fn moonc_gen_test_info(
     generated
         .stdout
         .take()
-        .unwrap()
+        .context("failed to capture `moonc gen-test-info` stdout")?
         .read_to_string(&mut out)
         .with_context(|| gen_error_message(files))?;
     generated.wait()?;
 
     // when mauanlly execute command to generate test driver, we need to create the parent directory
-    if !output_path.parent().unwrap().exists() {
-        std::fs::create_dir_all(output_path.parent().unwrap())?;
+    let output_parent = output_path
+        .parent()
+        .with_context(|| format!("output path `{}` has no parent", output_path.display()))?;
+    if !output_parent.exists() {
+        std::fs::create_dir_all(output_parent)?;
     }
 
     let test_info_json_path = output_path;

--- a/crates/moon/src/cli/tool/format_and_diff.rs
+++ b/crates/moon/src/cli/tool/format_and_diff.rs
@@ -18,6 +18,8 @@
 
 use std::{io::BufRead, path::PathBuf, process::Stdio};
 
+use anyhow::Context;
+
 /// Format the code and print the difference
 #[derive(Debug, clap::Parser)]
 pub(crate) struct FormatAndDiffSubcommand {
@@ -41,17 +43,16 @@ pub(crate) struct FormatAndDiffSubcommand {
 }
 
 pub(crate) fn run_format_and_diff(cmd: FormatAndDiffSubcommand) -> anyhow::Result<i32> {
-    let mut args = vec![
-        "-exit-code",
-        cmd.old.to_str().unwrap(),
-        "-o",
-        cmd.new.to_str().unwrap(),
-    ];
+    let mut moonfmt = std::process::Command::new(&*moonutil::BINARIES.moonfmt);
+    moonfmt
+        .arg("-exit-code")
+        .arg(&cmd.old)
+        .arg("-o")
+        .arg(&cmd.new);
     if cmd.block_style {
-        args.push("-block-style")
+        moonfmt.arg("-block-style");
     }
-    let mut execution = std::process::Command::new(&*moonutil::BINARIES.moonfmt)
-        .args(args)
+    let mut execution = moonfmt
         .args(&cmd.args)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
@@ -74,18 +75,16 @@ pub(crate) fn run_format_and_diff(cmd: FormatAndDiffSubcommand) -> anyhow::Resul
     }
 
     let mut execution = std::process::Command::new(moonutil::BINARIES.git_or_default())
-        .args([
-            "--no-pager",
-            "diff",
-            "--color=always",
-            "--no-index",
-            cmd.old.to_str().unwrap(),
-            cmd.new.to_str().unwrap(),
-        ])
+        .args(["--no-pager", "diff", "--color=always", "--no-index"])
+        .arg(&cmd.old)
+        .arg(&cmd.new)
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .spawn()?;
-    let child_stdout = execution.stdout.take().unwrap();
+    let child_stdout = execution
+        .stdout
+        .take()
+        .context("failed to capture `git diff` stdout")?;
     let mut buf = String::new();
     let mut bufread = std::io::BufReader::new(child_stdout);
     while let Ok(n) = bufread.read_line(&mut buf) {
@@ -102,8 +101,8 @@ pub(crate) fn run_format_and_diff(cmd: FormatAndDiffSubcommand) -> anyhow::Resul
         _ => {
             eprintln!(
                 "failed to execute `git --no-pager diff --color=always --no-index {} {}`",
-                &cmd.old.to_str().unwrap(),
-                &cmd.new.to_str().unwrap()
+                cmd.old.display(),
+                cmd.new.display()
             );
             Ok(1)
         }

--- a/crates/moon/src/cli/tool/format_workspace.rs
+++ b/crates/moon/src/cli/tool/format_workspace.rs
@@ -22,6 +22,8 @@ use std::{
     process::Stdio,
 };
 
+use anyhow::Context;
+
 #[derive(Debug, clap::Parser)]
 pub(crate) struct FormatWorkspaceSubcommand {
     /// The source path of the workspace file to format
@@ -76,18 +78,16 @@ pub(crate) fn run_format_workspace(cmd: FormatWorkspaceSubcommand) -> anyhow::Re
 
 fn print_diff(old: &Path, new: &Path) -> anyhow::Result<i32> {
     let mut execution = std::process::Command::new(moonutil::BINARIES.git_or_default())
-        .args([
-            "--no-pager",
-            "diff",
-            "--color=always",
-            "--no-index",
-            old.to_str().unwrap(),
-            new.to_str().unwrap(),
-        ])
+        .args(["--no-pager", "diff", "--color=always", "--no-index"])
+        .arg(old)
+        .arg(new)
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .spawn()?;
-    let child_stdout = execution.stdout.take().unwrap();
+    let child_stdout = execution
+        .stdout
+        .take()
+        .context("failed to capture `git diff` stdout")?;
     let mut buf = String::new();
     let mut bufread = std::io::BufReader::new(child_stdout);
     while let Ok(n) = bufread.read_line(&mut buf) {
@@ -104,8 +104,8 @@ fn print_diff(old: &Path, new: &Path) -> anyhow::Result<i32> {
         _ => {
             eprintln!(
                 "failed to execute `git --no-pager diff --color=always --no-index {} {}`",
-                old.to_str().unwrap(),
-                new.to_str().unwrap()
+                old.display(),
+                new.display()
             );
             Ok(1)
         }


### PR DESCRIPTION
## Why

Several direct moon CLI paths used unwrap or expect even though the surrounding functions already return recoverable errors. Those panics make sparse user reports harder to diagnose because they bypass the normal contextual error path.

## What Changed

This PR keeps only the lowest-risk local cleanup cases:

- missing positional or registry data becomes a contextual command error
- path arguments are passed to subprocesses as paths instead of forcing UTF-8 conversion
- explicitly piped command stdout is reported as a command error if unavailable

## Why This Is Correct

The branch no longer changes startup, signal-handler, tracing, watch-handler, child-process, or documentation-generation invariants. Those cases can be reviewed separately because continuing, canceling, or returning from those paths may not be equivalent to the previous fail-fast behavior.

This PR is intentionally limited to the mechanical first slice.