### PR TITLE
Make runtime command construction fallible

### DIFF
--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -248,7 +248,7 @@ fn run_inline_source_as_single_file(
     let source = cmd
         .command
         .clone()
-        .expect("inline script should be present when `moon run -e` is selected");
+        .context("inline script should be present when `moon run -e` is selected")?;
 
     run_source_as_single_file(
         cli,
@@ -330,7 +330,7 @@ fn build_wasm_file_executable_from_arg(
     let input = cmd
         .package_or_mbt_file
         .as_deref()
-        .expect("wasm run from arg requires a positional input path");
+        .context("wasm run from arg requires a positional input path")?;
     let wasm_path =
         dunce::canonicalize(input).with_context(|| format!("failed to resolve path `{input}`"))?;
     if !wasm_path.is_file() {
@@ -344,7 +344,7 @@ fn build_wasm_file_executable_from_arg(
             None,
             &wasm_path,
             None,
-        );
+        )?;
         run_cmd.args(&cmd.args);
         rr_build::dry_print_command(run_cmd.as_std(), &print_dir, false);
     }
@@ -408,7 +408,7 @@ pub(crate) fn build_run_executable(
     let input = cmd
         .package_or_mbt_file
         .as_deref()
-        .expect("run executable source should be materialized before building");
+        .context("run executable source should be materialized before building")?;
     if Path::new(input)
         .extension()
         .is_some_and(|extension| extension == "wasm")
@@ -460,7 +460,7 @@ fn build_package_executable(
     let run_start_dir = resolve_run_start_dir(
         cmd.package_or_mbt_file
             .as_deref()
-            .expect("package run planning requires a positional input"),
+            .context("package run planning requires a positional input")?,
     )?;
     let PackageDirs {
         source_dir,
@@ -533,7 +533,7 @@ pub(crate) fn plan_run_rr_from_resolved(
     let input_path = cmd
         .package_or_mbt_file
         .clone()
-        .expect("package run planning requires a positional input");
+        .context("package run planning requires a positional input")?;
     let value_tracing = cmd.build_flags.enable_value_tracing;
 
     let selection = resolve_run_selection(&input_path, &resolve_output)?;
@@ -563,28 +563,32 @@ pub(crate) fn plan_run_rr_from_resolved(
 }
 
 #[instrument(level = Level::DEBUG, skip_all)]
-fn get_run_cmd(build_meta: &rr_build::BuildMeta, argv: &[String]) -> tokio::process::Command {
-    let executable = get_run_executable(build_meta);
+fn get_run_cmd(
+    build_meta: &rr_build::BuildMeta,
+    argv: &[String],
+) -> anyhow::Result<tokio::process::Command> {
+    let executable = get_run_executable(build_meta)?;
     let mut cmd = crate::run::command_for(
         build_meta.target_backend,
         build_meta.tcc_run.as_ref(),
         executable,
         None,
-    );
+    )?;
     cmd.args(argv);
-    cmd
+    Ok(cmd)
 }
 
 /// Extract the single executable artifact emitted for a `UserIntent::Run` plan.
-fn get_run_executable(build_meta: &rr_build::BuildMeta) -> &Path {
+fn get_run_executable(build_meta: &rr_build::BuildMeta) -> anyhow::Result<&Path> {
     let (_, artifact) = build_meta
         .artifacts
         .first()
-        .expect("Expected exactly one build node emitted by `calc_user_intent`");
+        .context("run plan must emit exactly one build node")?;
     artifact
         .artifacts
         .first()
-        .expect("Expected exactly one executable as the output of the build node")
+        .map(PathBuf::as_path)
+        .context("run plan must emit exactly one executable artifact")
 }
 
 #[instrument(level = Level::DEBUG, skip_all)]
@@ -617,7 +621,7 @@ fn build_single_file_executable_from_arg(
     let single_file_dirs = cli.source_tgt_dir.single_file_package_dirs(
         cmd.package_or_mbt_file
             .as_deref()
-            .expect("single-file run from arg requires a positional input path"),
+            .context("single-file run from arg requires a positional input path")?,
     )?;
     let target_dir = single_file_dirs.package_dirs.target_dir;
     let mooncakes_dir = single_file_dirs.package_dirs.mooncakes_dir;
@@ -690,7 +694,7 @@ fn build_single_file_executable(
     )?;
     let package = rr_build::local_packages(&resolved)
         .next()
-        .expect("Single-file project must synthesize exactly one package");
+        .context("single-file project must synthesize exactly one package")?;
     let directive = if value_tracing {
         rr_build::build_patch_directive_for_package(package, false, Some(package), None, false)?
     } else {
@@ -743,11 +747,11 @@ fn build_executable_from_plan(
         );
 
         if options.print_dry_run_run_command {
-            let run_cmd = get_run_cmd(build_meta, &cmd.args);
+            let run_cmd = get_run_cmd(build_meta, &cmd.args)?;
             rr_build::dry_print_command(run_cmd.as_std(), source_dir, false);
         }
         return Ok(RunExecutable {
-            executable: get_run_executable(build_meta).to_path_buf(),
+            executable: get_run_executable(build_meta)?.to_path_buf(),
             target_backend: build_meta.target_backend,
             tcc_run: build_meta.tcc_run.clone(),
             opt_level: build_meta.opt_level,
@@ -773,7 +777,7 @@ fn build_executable_from_plan(
     let build_result = rr_build::execute_build(&build_config, build_graph, target_dir)?;
 
     Ok(RunExecutable {
-        executable: get_run_executable(build_meta).to_path_buf(),
+        executable: get_run_executable(build_meta)?.to_path_buf(),
         target_backend: build_meta.target_backend,
         tcc_run: build_meta.tcc_run.clone(),
         opt_level: build_meta.opt_level,
@@ -801,7 +805,7 @@ fn run_executable(
 
     let build_exit_code = executable
         .build_exit_code
-        .expect("non-dry run build should produce a build exit code");
+        .context("non-dry run build should produce a build exit code")?;
     if build_exit_code != 0 {
         if executable.force_success_exit {
             return Ok(0);
@@ -814,7 +818,7 @@ fn run_executable(
         executable.tcc_run.as_ref(),
         executable.executable.as_path(),
         None,
-    );
+    )?;
     run_cmd.args(&cmd.args);
     if cli.verbose {
         rr_build::dry_print_command(run_cmd.as_std(), &executable.source_dir, true);

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -96,7 +96,7 @@ impl RunWasmCoordinate {
             self.package_path
                 .rsplit('/')
                 .next()
-                .expect("non-empty package path must have a last segment")
+                .unwrap_or(&self.package_path)
                 .to_string()
         }
     }
@@ -158,7 +158,7 @@ pub(crate) fn run_runwasm(cli: &UniversalFlags, cmd: RunWasmSubcommand) -> anyho
     let asset = coordinate.with_version(version, &registry_config.registry);
     let wasm_path = ensure_cached_wasm(&asset, output)?;
 
-    let mut run_cmd = crate::run::command_for(RunBackend::WasmGC, None, &wasm_path, None);
+    let mut run_cmd = crate::run::command_for(RunBackend::WasmGC, None, &wasm_path, None)?;
     run_cmd.args(&cmd.args);
 
     if cli.verbose {

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -251,20 +251,24 @@ fn install_build_rr(
     bin_name: Option<&str>,
 ) -> anyhow::Result<()> {
     // Assume one artifact node and one artifact file
-    let (_node, arts) = meta.artifacts.get_index(0).unwrap();
+    let (_node, arts) = meta
+        .artifacts
+        .get_index(0)
+        .context("RR build should yield exactly one artifact node")?;
     let artifact = arts
         .artifacts
         .first()
         .context("RR build should yield exactly one artifact file")?;
 
     // Build command using existing runtime mapping, then shlex-join
-    let guard = crate::run::command_for(meta.target_backend, meta.tcc_run.as_ref(), artifact, None);
+    let guard =
+        crate::run::command_for(meta.target_backend, meta.tcc_run.as_ref(), artifact, None)?;
     let parts = std::iter::once(guard.as_std().get_program())
         .chain(guard.as_std().get_args())
         .map(|x| x.to_string_lossy().to_string())
         .collect::<Vec<_>>();
     let line = shlex::try_join(parts.iter().map(|s| &**s))
-        .expect("unexpected null byte in args when forming exec command");
+        .context("failed to join executable command arguments")?;
 
     // Determine filename
     // Matching legacy, it uses the following fallbacks:

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -627,7 +627,7 @@ fn run_one_test_executable(
         ctx.build_meta.tcc_run.as_ref(),
         &test.executable,
         Some(&test.args),
-    );
+    )?;
     let mut cov_cap = mk_coverage_capture();
     let mut test_cap = make_test_capture();
     if ctx.verbose {

--- a/crates/moon/src/run/runtime.rs
+++ b/crates/moon/src/run/runtime.rs
@@ -20,6 +20,7 @@
 
 use std::path::Path;
 
+use anyhow::Context;
 use moonbuild::entry::TestArgs;
 use moonbuild_rupes_recta::model::{RunBackend, TccRunConfig};
 use tokio::process::Command;
@@ -43,15 +44,15 @@ pub(crate) fn command_for(
     tcc_run: Option<&TccRunConfig>,
     mbt_executable: &Path,
     test: Option<&TestArgs>,
-) -> Command {
+) -> anyhow::Result<Command> {
     debug_assert!(tcc_run.is_none() || backend == RunBackend::Native);
 
-    match (backend, tcc_run) {
+    let cmd = match (backend, tcc_run) {
         (RunBackend::Wasm | RunBackend::WasmGC, _) => {
             let mut cmd = Command::new(&*moonutil::BINARIES.moonrun);
             if let Some(t) = test {
                 cmd.arg("--test-args");
-                cmd.arg(serde_json::to_string(t).unwrap());
+                cmd.arg(serde_json::to_string(t).context("failed to serialize test args")?);
             }
             cmd.arg(mbt_executable);
             cmd.arg("--");
@@ -70,7 +71,7 @@ pub(crate) fn command_for(
             cmd.arg("--enable-source-maps");
             cmd.arg(mbt_executable);
             if let Some(t) = test {
-                cmd.arg(serde_json::to_string(t).expect("Failed to serialize test args"));
+                cmd.arg(serde_json::to_string(t).context("failed to serialize test args")?);
             }
             cmd
         }
@@ -90,5 +91,7 @@ pub(crate) fn command_for(
             }
             cmd
         }
-    }
+    };
+
+    Ok(cmd)
 }


### PR DESCRIPTION
## Why

Runtime command construction still had direct panic paths around serializing test arguments and assembling commands. These are a natural next slice after mechanical unwrap cleanup because the command builder is a shared boundary used by `run`, `runwasm`, tests, and binary dependency installation.

## What Changed

This PR changes `crate::run::command_for` to return `anyhow::Result<Command>` and propagates failures through its callers. It also replaces adjacent command assembly unwraps in the binary dependency installer with contextual errors.

## Why This Is Correct

Serializing test arguments is required for correct test execution. Returning an error is preferable to either panicking or silently constructing a command without the intended arguments.

The change is limited to the command-construction boundary and direct callers, keeping broader metadata and build-graph invariant changes out of this PR.