### PR TITLE
Report moon metadata failures as errors

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -523,7 +523,7 @@ fn resolve_selected_build_packages(
             resolve_output.local_modules(),
             package_filter,
             output,
-        );
+        )?;
         if let Some(target_backend) = target_backend {
             ensure_packages_support_backend(resolve_output, pkgs.iter().copied(), target_backend)?;
         }
@@ -563,7 +563,7 @@ fn calc_user_intent(
             resolve_output.local_modules(),
             package_filter,
             output,
-        );
+        )?;
         ensure_packages_support_backend(resolve_output, pkgs.iter().copied(), target_backend)?;
         Ok(pkgs
             .into_iter()

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -337,7 +337,7 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
         return Ok(1);
     }
 
-    imp::promote_info_results(&output_plan, all_meta.iter());
+    imp::promote_info_results(&output_plan, all_meta.iter())?;
     imp::report_info_outputs(&output_plan, all_meta.iter(), &requested_targets)?;
     Ok(0)
 }

--- a/crates/moon/src/cli/info/imp.rs
+++ b/crates/moon/src/cli/info/imp.rs
@@ -23,7 +23,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use colored::Colorize;
 use indexmap::IndexMap;
 use moonbuild::expect::write_diff;
@@ -161,8 +161,10 @@ impl InfoOutputPlan {
 pub(super) fn promote_info_results<'a>(
     plan: &'a InfoOutputPlan,
     it: impl Iterator<Item = &'a (TargetBackend, BuildMeta)>,
-) {
-    for (_package, group) in collect_package_output_groups(plan, it) {
+) -> anyhow::Result<()> {
+    let groups = collect_package_output_groups(plan, it)?;
+
+    for (_package, group) in groups {
         let Some(source_path) = group
             .backend_files
             .get(&group.plan.canonical_backend)
@@ -183,6 +185,8 @@ pub(super) fn promote_info_results<'a>(
             }
         }
     }
+
+    Ok(())
 }
 
 pub(super) fn report_info_outputs<'a>(
@@ -196,7 +200,7 @@ pub(super) fn report_info_outputs<'a>(
 
     let requested_backends = requested_backends.iter().copied().collect::<BTreeSet<_>>();
 
-    for (_package, group) in collect_package_output_groups(plan, it) {
+    for (_package, group) in collect_package_output_groups(plan, it)? {
         report_info_output_for_package(&requested_backends, &group)?;
     }
 
@@ -206,7 +210,7 @@ pub(super) fn report_info_outputs<'a>(
 fn collect_package_output_groups<'a>(
     plan: &'a InfoOutputPlan,
     it: impl Iterator<Item = &'a (TargetBackend, BuildMeta)>,
-) -> IndexMap<PackageId, PackageOutputGroup<'a>> {
+) -> anyhow::Result<IndexMap<PackageId, PackageOutputGroup<'a>>> {
     let mut transposed = plan
         .packages
         .iter()
@@ -222,16 +226,14 @@ fn collect_package_output_groups<'a>(
                 continue;
             };
 
-            assert!(
-                artifact.artifacts.len() == 1,
-                "mbti generation should only produce one artifact"
-            );
-            let mbti_path = artifact.artifacts.first().unwrap();
+            let [mbti_path] = artifact.artifacts.as_slice() else {
+                bail!("mbti generation should only produce one artifact");
+            };
             group.insert(*backend, mbti_path);
         }
     }
 
-    transposed
+    Ok(transposed)
 }
 
 type ContentHash = [u8; 32];

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -1604,8 +1604,7 @@ fn rr_test_from_plan(
             // Promote test results
             let promotion_source = last_test_result.as_ref().unwrap_or(&test_result);
             let (rerun_count, rerun_filter_raw) =
-                perform_promotion(&build_meta.resolve_output.pkg_dirs, promotion_source)
-                    .expect("Failed to promote tests");
+                perform_promotion(&build_meta.resolve_output.pkg_dirs, promotion_source)?;
             debug!(
                 rerun_count,
                 pending_targets = rerun_filter_raw.0.len(),
@@ -1633,20 +1632,19 @@ fn rr_test_from_plan(
                 .expect("build graph backup should be present when update is true");
 
             // Calculate which files to rebuild
-            let want_files = rerun_filter_raw
+            let mut want_files = Vec::new();
+            for node in rerun_filter_raw
                 .0
                 .keys()
-                .cloned() // All targets to rerun
-                .flat_map(node_from_target) // converted to nodes
-                .flat_map(|node| {
-                    // their artifacts
-                    build_meta
-                        .artifacts
-                        .get(&node)
-                        .expect("test node from the last test run should have artifact")
-                        .artifacts
-                        .as_slice()
-                });
+                .cloned()
+                .flat_map(node_from_target)
+            {
+                let artifacts = build_meta
+                    .artifacts
+                    .get(&node)
+                    .with_context(|| format!("test node `{node:?}` should have artifacts"))?;
+                want_files.extend(artifacts.artifacts.iter().cloned());
+            }
 
             // Run the build
             let result = rr_build::execute_build_partial(
@@ -1657,9 +1655,9 @@ fn rr_test_from_plan(
                     trace!("requesting rerun artifacts");
                     for file_path in want_files {
                         let file_path_str = file_path.to_string_lossy();
-                        let file = work
-                            .lookup(&file_path_str)
-                            .expect("File should exist in work");
+                        let file = work.lookup(&file_path_str).with_context(|| {
+                            format!("file `{file_path_str}` should exist in work")
+                        })?;
                         work.want_file(file).context("Failed to want file")?;
                     }
                     Ok(())

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -31,7 +31,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use moonbuild_rupes_recta::{
     ResolveConfig, discover::DiscoveredPackage, intent::UserIntent, model::PackageId,
 };
@@ -108,7 +108,7 @@ pub(crate) fn run_build_binary_dep(
     // in its own `bin_target`, and if not present, fall back to the main
     // module's preferred target backend (or default backend if not specified).
     let &[main_module_id] = resolve_output.local_modules() else {
-        panic!("Expected exactly one main module when building all packages");
+        bail!("building binary dependencies expects exactly one local module");
     };
     let main_module_ref = resolve_output.module_rel.module_info(main_module_id);
     let default_backend = main_module_ref.preferred_target.unwrap_or_default();
@@ -133,7 +133,7 @@ pub(crate) fn run_build_binary_dep(
                 resolve_output.local_modules(),
                 pkg_name,
                 output,
-            );
+            )?;
             for pkg in pkgs {
                 let pkg_ref = resolve_output.pkg_dirs.get_package(pkg);
                 let pkg_bin_target = pkg_ref.raw.bin_target.unwrap_or(default_backend);

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -138,9 +138,9 @@ pub(crate) fn match_packages_by_name_rr(
     main_modules: &[moonutil::mooncakes::ModuleId],
     needle: &str,
     output: UserDiagnostics,
-) -> Vec<PackageId> {
+) -> anyhow::Result<Vec<PackageId>> {
     let &[main_module_id] = main_modules else {
-        panic!("No multiple main modules are supported");
+        anyhow::bail!("package name matching expects exactly one local module");
     };
 
     let res = fuzzy_match_by_name(needle, &resolve_output.pkg_dirs);
@@ -156,7 +156,7 @@ pub(crate) fn match_packages_by_name_rr(
             ));
         }
     }
-    res
+    Ok(res)
 }
 
 impl AsNameMap<PackageId> for moonbuild_rupes_recta::discover::DiscoverResult {

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -186,7 +186,8 @@ pub(crate) fn run_tests(
 
         let work_queue: std::sync::Arc<std::sync::Mutex<std::slice::Iter<'_, _>>> =
             std::sync::Arc::new(std::sync::Mutex::new(invocations.iter()));
-        let (result_tx, result_rx) = std::sync::mpsc::channel();
+        let (result_tx, result_rx) =
+            std::sync::mpsc::channel::<anyhow::Result<(BuildTarget, TargetTestResult)>>();
 
         std::thread::scope(|s| {
             for _ in 0..parallelism {
@@ -195,7 +196,13 @@ pub(crate) fn run_tests(
 
                 s.spawn(move || {
                     // Each thread creates its own runtime
-                    let rt = default_rt().expect("Failed to create runtime");
+                    let rt = match default_rt().context("Failed to create runtime") {
+                        Ok(rt) => rt,
+                        Err(err) => {
+                            let _ = result_tx.send(Err(err));
+                            return;
+                        }
+                    };
                     let ctx = TestRunCtx {
                         build_meta,
                         rt: &rt,
@@ -205,23 +212,27 @@ pub(crate) fn run_tests(
                     };
 
                     loop {
-                        let r = {
-                            let mut queue = work_queue.lock().unwrap();
-                            queue.next()
+                        let r = match work_queue.lock() {
+                            Ok(mut queue) => queue.next().cloned(),
+                            Err(_) => {
+                                let _ = result_tx
+                                    .send(Err(anyhow::anyhow!("test work queue lock poisoned")));
+                                return;
+                            }
                         };
                         let Some(r) = r else { break };
 
                         debug!(target = ?r.target, executable = %r.executable.display(), "running test invocation");
-                        let res = run_one_test_executable(&ctx, r);
-                        let _ = result_tx.send((r.target, res));
+                        let res = run_one_test_executable(&ctx, &r).map(|res| (r.target, res));
+                        let _ = result_tx.send(res);
                     }
                 });
             }
         });
 
         drop(result_tx);
-        for (target, res) in result_rx {
-            let res = res?;
+        for res in result_rx {
+            let (target, res) = res?;
             let cases_for_target = res.map.values().map(IndexMap::len).sum::<usize>();
             trace!(?target, cases = cases_for_target, "merging test results");
             total_cases += cases_for_target;
@@ -239,7 +250,7 @@ pub(crate) fn run_tests(
     Ok(stats)
 }
 
-#[derive(derive_builder::Builder, Debug)]
+#[derive(Clone, Copy, derive_builder::Builder, Debug)]
 #[builder(derive(Debug))]
 struct TestExecutableToRun<'a> {
     target: BuildTarget,
@@ -445,7 +456,7 @@ pub(crate) fn collect_test_outline(
     include_skipped: bool,
     bench: bool,
 ) -> anyhow::Result<Vec<TestOutlineEntry>> {
-    let executables = gather_tests(build_meta);
+    let executables = gather_tests(build_meta)?;
     debug!(count = executables.len(), "collecting test outline entries");
     let mut entries = Vec::new();
 
@@ -516,14 +527,14 @@ pub(crate) fn collect_test_outline(
 
 /// Gather tests executables from the build metadata.
 #[instrument(level = "trace", skip(build_meta))]
-fn gather_tests(build_meta: &BuildMeta) -> Vec<TestExecutableToRun<'_>> {
+fn gather_tests(build_meta: &BuildMeta) -> anyhow::Result<Vec<TestExecutableToRun<'_>>> {
     let mut pending = HashMap::with_capacity(build_meta.artifacts.len());
     let mut results = vec![];
 
     for (node, artifacts) in &build_meta.artifacts {
-        let target = node
-            .extract_target()
-            .expect("All artifacts of tests should contain a build target");
+        let Some(target) = node.extract_target() else {
+            anyhow::bail!("All artifacts of tests should contain a build target");
+        };
         trace!(?target, node = ?node, "processing test artifact");
 
         let working = pending.entry(target).or_insert_with(|| {
@@ -534,9 +545,17 @@ fn gather_tests(build_meta: &BuildMeta) -> Vec<TestExecutableToRun<'_>> {
 
         // FIXME: artifact index relies on implementation of append_artifact_of
         match node {
-            BuildPlanNode::MakeExecutable(_) => working.executable(&artifacts.artifacts[0]),
-            BuildPlanNode::GenerateTestInfo(_) => working.meta(&artifacts.artifacts[1]),
-            _ => panic!("Unexpected artifact for test: {:?}", artifacts.node),
+            BuildPlanNode::MakeExecutable(_) => {
+                if let Some(executable) = artifacts.artifacts.first() {
+                    working.executable(executable);
+                }
+            }
+            BuildPlanNode::GenerateTestInfo(_) => {
+                if let Some(meta) = artifacts.artifacts.get(1) {
+                    working.meta(meta);
+                }
+            }
+            _ => anyhow::bail!("Unexpected artifact for test: {:?}", artifacts.node),
         };
 
         if let Ok(tgt) = working.build() {
@@ -553,14 +572,11 @@ fn gather_tests(build_meta: &BuildMeta) -> Vec<TestExecutableToRun<'_>> {
         "completed gathering test executables"
     );
 
-    assert_eq!(
-        pending.len(),
-        0,
-        "Some test targets are missing artifacts: {:?}",
-        &pending
-    );
+    if !pending.is_empty() {
+        anyhow::bail!("Some test targets are missing artifacts: {:?}", &pending);
+    }
 
-    results
+    Ok(results)
 }
 
 pub(crate) fn collect_test_invocations(
@@ -570,7 +586,7 @@ pub(crate) fn collect_test_invocations(
     bench: bool,
 ) -> anyhow::Result<Vec<TestInvocation>> {
     let mut invocations = Vec::new();
-    for test in gather_tests(build_meta) {
+    for test in gather_tests(build_meta)? {
         let meta_bytes = std::fs::read(test.meta)
             .with_context(|| format!("Failed to read test metadata at {}", test.meta.display()))?;
         let meta: MooncGenTestInfo = serde_json_lenient::from_slice(&meta_bytes)


### PR DESCRIPTION
## Why

Some remaining panic paths represent malformed or missing build metadata discovered while running user-facing commands. These are still command failures, but routing them through the normal error path gives a clearer diagnostic than an internal panic.

## What Changed

This PR keeps only fail-fast conversions where the command still stops:

- package name matching reports unsupported multi-module metadata as an error
- MBTI output grouping reports unexpected artifact shape as an error
- binary dependency package selection reports unsupported local-module shape as an error
- test update and test artifact collection report missing artifacts/work entries as errors
- parallel test worker setup reports runtime or queue-lock failures through the test command result

## Why This Is Correct

The exceptional paths still terminate the command; this PR does not add fallback behavior, cancellation behavior, or log-and-continue recovery. The previous invariants are preserved, but failure now goes through the command error path with context instead of panicking.

This is intentionally separate from the mechanical unwrap cleanup in #1771. The fallible runtime command-builder split was closed because that API change mostly handled internal invariants rather than user-facing errors.