### PR TITLE
Add context to check watch filesystem errors

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -363,7 +363,12 @@ fn run_check_for_single_file_rr(
         return Ok(0);
     }
 
-    let _lock = FileLock::lock(target_dir)?;
+    let _lock = FileLock::lock(target_dir).with_context(|| {
+        format!(
+            "failed to acquire build lock in target directory `{}`",
+            target_dir.display()
+        )
+    })?;
 
     // Generate all_pkgs.json for indirect dependency resolution
     rr_build::generate_all_pkgs_json(target_dir, &build_meta, RunMode::Check)?;
@@ -512,7 +517,12 @@ fn run_check_normal_internal_rr(
         }
         true
     } else {
-        let _lock = FileLock::lock(target_dir)?;
+        let _lock = FileLock::lock(target_dir).with_context(|| {
+            format!(
+                "failed to acquire build lock in target directory `{}`",
+                target_dir.display()
+            )
+        })?;
         let mut cfg = BuildConfig::from_flags(
             &cmd.build_flags,
             &cli.unstable_feature,

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -792,7 +792,12 @@ pub fn generate_metadata(
 
     // Only overwrite if changed
     if !orig_meta.is_ok_and(|o| o == meta) {
-        std::fs::write(&metadata_file, meta).context("Failed to write build metadata")?;
+        std::fs::write(&metadata_file, meta).with_context(|| {
+            format!(
+                "Failed to write build metadata to {}",
+                metadata_file.display()
+            )
+        })?;
     }
     Ok(())
 }
@@ -1026,12 +1031,18 @@ pub fn execute_build_partial(
         .parent()
         .map(std::fs::create_dir_all)
         .transpose()
-        .context("Failed to create parent for build cache DB")?;
+        .with_context(|| {
+            format!(
+                "Failed to create parent for build cache DB at {}",
+                db_path.display()
+            )
+        })?;
 
     // Generate n2 state
 
     let mut hashes = n2::graph::Hashes::default();
-    let n2_db = n2::db::open(&db_path, &mut build_graph, &mut hashes)?;
+    let n2_db = n2::db::open(&db_path, &mut build_graph, &mut hashes)
+        .with_context(|| format!("Failed to open build cache DB at {}", db_path.display()))?;
 
     let parallelism = cfg
         .parallelism


### PR DESCRIPTION
## Why

The reported watch-mode issue only mentioned a missing file or directory, which is not enough to identify which filesystem operation failed. The `moon check --watch` path still had a few places where target-directory filesystem failures could bubble up without naming the relevant path.

## What Changed

This PR adds path-aware context around the check build lock, build metadata writes, and n2 build-cache DB setup.

## Why This Is Correct

The change does not attempt broad panic cleanup or recovery. It keeps the same fail-fast behavior for filesystem failures, but reports the target directory, metadata path, or build-cache DB path that failed so sparse watch-mode reports are actionable.