### PR TITLE
fix(moonbuild): normalize prebuild placeholders relative to cwd

### DIFF
--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -1289,6 +1289,55 @@ fn test_pre_build_runs_from_module_root() {
 }
 
 #[test]
+fn test_pre_build_dry_run_uses_cwd_relative_placeholders() {
+    let dir = TestDir::new("pre_build.in");
+    let assert = moon_cmd(&dir)
+        .args(["check", "--dry-run", "--sort-input"])
+        .assert()
+        .success();
+    let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();
+    let prebuild_lines = stdout
+        .lines()
+        .filter(|line| line.contains(" tool embed "))
+        .collect::<Vec<_>>();
+
+    assert!(
+        prebuild_lines
+            .iter()
+            .any(|line| line.contains(" -i ./src/lib/a.txt -o ./src/lib/a.mbt")),
+        "dry-run should show cwd-relative placeholders, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_pre_build_dry_run_uses_prebuild_cwd_with_manifest_path() {
+    let dir = TestDir::new("pre_build.in");
+    let src_dir = dir.join("src");
+    let assert = moon_cmd(&src_dir)
+        .args([
+            "--manifest-path",
+            "../moon.mod.json",
+            "check",
+            "--dry-run",
+            "--sort-input",
+        ])
+        .assert()
+        .success();
+    let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();
+    let prebuild_lines = stdout
+        .lines()
+        .filter(|line| line.contains(" tool embed "))
+        .collect::<Vec<_>>();
+
+    assert!(
+        prebuild_lines
+            .iter()
+            .any(|line| line.contains(" -i ./src/lib/a.txt -o ./src/lib/a.mbt")),
+        "dry-run should show placeholders relative to prebuild cwd, got:\n{stdout}"
+    );
+}
+
+#[test]
 #[cfg(unix)]
 fn test_rule_dev_build() {
     let dir = TestDir::new("define_rule_dev_build.in");

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -39,6 +39,7 @@ use moonutil::{
     toolchain::BINARIES,
 };
 use regex::Regex;
+use relative_path::PathExt;
 use tracing::{Level, debug, instrument, trace, warn};
 
 use crate::{
@@ -1439,6 +1440,9 @@ impl<'a> BuildPlanConstructor<'a> {
             .iter()
             .map(|x| pkg.root_path.join(x))
             .collect::<Vec<_>>();
+        let command_cwd = module.as_path();
+        let command_input_paths = prebuild_command_paths(command_cwd, &input_paths);
+        let command_output_paths = prebuild_command_paths(command_cwd, &output_paths);
 
         let command = match prebuild_cmd {
             MoonPkgGenerate::Direct { command, .. } => Cow::Borrowed(command.as_str()),
@@ -1459,14 +1463,14 @@ impl<'a> BuildPlanConstructor<'a> {
             module,
             self.mooncake_bin_dir,
             &pkg.root_path,
-            &input_paths,
-            &output_paths,
+            &command_input_paths,
+            &command_output_paths,
         );
 
         let info = PrebuildInfo {
             resolved_inputs: input_paths,
             resolved_outputs: output_paths,
-            cwd: module.to_path_buf(),
+            cwd: command_cwd.to_path_buf(),
             command,
         };
 
@@ -1574,8 +1578,8 @@ fn handle_build_command_new(
     mod_source: &Path,
     mooncake_bin_dir: &Path,
     pkg_source: &Path,
-    input_files: &[PathBuf],
-    output_files: &[PathBuf],
+    input_files: &[String],
+    output_files: &[String],
 ) -> String {
     use std::fmt::Write;
 
@@ -1619,7 +1623,7 @@ fn handle_build_command_new(
                     if i != 0 {
                         write!(reconstructed, " ").expect("write can't fail");
                     }
-                    write!(reconstructed, "{}", f.display()).expect("write can't fail");
+                    write!(reconstructed, "{f}").expect("write can't fail");
                 }
             }
             4 => {
@@ -1627,7 +1631,7 @@ fn handle_build_command_new(
                     if i != 0 {
                         write!(reconstructed, " ").expect("write can't fail");
                     }
-                    write!(reconstructed, "{}", f.display()).expect("write can't fail");
+                    write!(reconstructed, "{f}").expect("write can't fail");
                 }
             }
             _ => unreachable!("Unexpected pattern id from CHECK_AUTOMATA"),
@@ -1676,6 +1680,27 @@ fn handle_build_command_new(
     reconstructed
 }
 
+fn prebuild_command_path(cwd: &Path, path: &Path) -> String {
+    match path.relative_to(cwd) {
+        Ok(relative_path) => {
+            let normalized = relative_path.normalize();
+            if normalized.as_str().is_empty() {
+                ".".to_string()
+            } else {
+                format!("./{normalized}")
+            }
+        }
+        Err(_) => path.display().to_string(),
+    }
+}
+
+fn prebuild_command_paths(cwd: &Path, paths: &[PathBuf]) -> Vec<String> {
+    paths
+        .iter()
+        .map(|path| prebuild_command_path(cwd, path))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1693,6 +1718,76 @@ mod tests {
             moonutil::mooncakes::ModuleSource::from_local_module(module, std::path::Path::new(".")),
             crate::pkg_name::PackagePath::new("").expect("empty package path should parse"),
         )
+    }
+
+    #[test]
+    fn prebuild_command_path_is_relative_to_command_cwd() {
+        assert_eq!(
+            prebuild_command_path(Path::new("module"), Path::new("module/src/lib/input.txt")),
+            "./src/lib/input.txt"
+        );
+    }
+
+    #[test]
+    fn prebuild_command_path_can_include_module_from_workspace_cwd() {
+        assert_eq!(
+            prebuild_command_path(
+                Path::new("workspace"),
+                Path::new("workspace/member/src/lib/input.txt")
+            ),
+            "./member/src/lib/input.txt"
+        );
+    }
+
+    #[test]
+    fn prebuild_command_path_normalizes_dot_segments() {
+        assert_eq!(
+            prebuild_command_path(
+                Path::new("module"),
+                Path::new("module/src/lib/../assets/./input.txt")
+            ),
+            "./src/assets/input.txt"
+        );
+    }
+
+    #[test]
+    fn prebuild_command_path_handles_absolute_paths() {
+        assert_eq!(
+            prebuild_command_path(
+                Path::new("/module"),
+                Path::new("/module/src/lib/../assets/input.txt")
+            ),
+            "./src/assets/input.txt"
+        );
+    }
+
+    #[test]
+    fn handle_build_command_uses_relative_input_and_output_placeholders() {
+        let command = handle_build_command_new(
+            "generate --inputs $input --outputs $output",
+            Path::new("module"),
+            Path::new("module/.mooncakes/__moonbin__"),
+            Path::new("module/src/lib"),
+            &prebuild_command_paths(
+                Path::new("module"),
+                &[
+                    PathBuf::from("module/src/lib/input.txt"),
+                    PathBuf::from("module/src/lib/../assets/second.txt"),
+                ],
+            ),
+            &prebuild_command_paths(
+                Path::new("module"),
+                &[
+                    PathBuf::from("module/src/lib/generated.mbt"),
+                    PathBuf::from("module/src/lib/./generated_2.mbt"),
+                ],
+            ),
+        );
+
+        assert_eq!(
+            command,
+            "generate --inputs ./src/lib/input.txt ./src/assets/second.txt --outputs ./src/lib/generated.mbt ./src/lib/generated_2.mbt"
+        );
     }
 
     #[test]

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -27,15 +27,15 @@ Define tasks in the `pre-build` array of `moon.pkg.json`:
 
 Notes:
 
-- `input`/`output` paths are package-relative in config and expand to absolute paths inside the command.
+- `input`/`output` paths are package-relative in config and expand to prebuild-cwd-relative paths inside the command.
 - When arrays are used, placeholders expand to space-separated lists in declaration order.
 - All declared outputs are tracked as build outputs.
 - Only `.mbt` and `.mbt.md` outputs are added back to the package's MoonBit source set.
 
 ## Path Resolution
 
-- `input`/`output` are resolved relative to the package directory before substitution.
-- `$input`/`$output` expand to absolute file paths.
+- `input`/`output` are resolved relative to the package directory for build dependency tracking.
+- `$input`/`$output` expand to paths relative to the prebuild command working directory. These substituted paths are lexically normalized and start with `./`, for example `./src/lib/input.txt`.
 - `$pkg_dir`/`$mod_dir` expand to absolute directories.
 - `$mooncake_bin` expands to `<project .mooncakes dir>/__moonbin__`.
   The command adapter computes this `mooncake_bin_dir` from project discovery
@@ -47,10 +47,10 @@ Notes:
 Only the `command` field is substituted. The following placeholders are recognized:
 
 - `$input`  
-  Expands to a space-separated list of absolute paths for all declared inputs (in order). If `input` is a single string, this is one absolute path.
+  Expands to a space-separated list of normalized prebuild-cwd-relative paths for all declared inputs (in order). If `input` is a single string, this is one path.
 
 - `$output`  
-  Expands to a space-separated list of absolute paths for all declared outputs (in order). If `output` is a single string, this is one absolute path.
+  Expands to a space-separated list of normalized prebuild-cwd-relative paths for all declared outputs (in order). If `output` is a single string, this is one path.
 
 - `$mod_dir`  
   Expands to the absolute path of the module root directory (the directory containing `moon.mod.json`).
@@ -66,7 +66,8 @@ Only the `command` field is substituted. The following placeholders are recogniz
 Substitution semantics:
 
 - Pure textual replacement over the `command` string; unknown tokens are left as-is.
-- Paths expand to absolute, platform-native strings; no quotes are added by substitution.
+- `$input` and `$output` expand to `./...` paths relative to the prebuild command working directory; no quotes are added by substitution.
+- Directory placeholders expand to absolute, platform-native strings.
   - If paths may contain spaces or shell-special characters, quote or escape them in the command template.
 - For array `input`/`output`, items are joined by a single space in insertion order.
 


### PR DESCRIPTION
## Why

`$input` and `$output` should match the prebuild command's working directory semantics. Expanding them as resolved filesystem paths leaks cwd-independent absolute paths into commands and dry-runs, while the intended command contract is relative to the cwd the command will execute in.

## What

- Keep resolved `input` and `output` paths for build dependency tracking.
- Format command-facing `$input` and `$output` paths relative to the prebuild command cwd.
- Expand `$input` and `$output` as space-separated `./...` paths in declaration order.
- Use `relative-path` for logical relative path computation and dot-segment normalization.
- Document the placeholder behavior in the prebuild reference.

## Correctness and Scope

Only command placeholder substitution changes. The n2 dependency paths, `$mod_dir`, `$pkg_dir`, `$mooncake_bin`, prebuild ordering, and command lowering stay unchanged. The path formatter is scoped to command substitution and is covered for subpackage paths, multiple entries, dot segments, dry-run output, and `--manifest-path` invocation from a non-module cwd.