### PR TITLE
Add wasm async event loop and timer host support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = crates/moonutil/resources/error_codes
 	url = https://github.com/moonbitlang/moonbit-docs.git
 	branch = markdown-build
+[submodule "third_party/moonbitlang_async"]
+	path = third_party/moonbitlang_async
+	url = https://github.com/moonbitlang/async.git
+	branch = codex/wasm-event-loop-timer

--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -9,6 +9,49 @@ use crate::dry_run_utils::assert_lines_in_order;
 
 use super::*;
 
+fn repo_root() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .unwrap()
+        .to_path_buf()
+}
+
+fn moonrun_bin() -> std::path::PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_moonrun") {
+        return path.into();
+    }
+
+    let mut path = std::env::current_exe().unwrap();
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.join(format!("moonrun{}", std::env::consts::EXE_SUFFIX))
+}
+
+fn run_upstream_async_wasm_package(package: &str) -> String {
+    let async_dir = repo_root().join("third_party/moonbitlang_async");
+    let output = moon_cmd(&async_dir)
+        .env("MOON_OVERRIDE", moon_bin())
+        .env("MOONRUN_OVERRIDE", moonrun_bin())
+        .args([
+            "test",
+            "--target",
+            "wasm",
+            "--package",
+            package,
+            "--sort-input",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    std::str::from_utf8(&output).unwrap().to_owned()
+}
+
 #[test]
 fn test_moon_test_succ() {
     // TODO: Audit that the environment access only happens in single-threaded code.
@@ -530,6 +573,36 @@ fn test_async_test() {
     );
     let last_line = out2.lines().last().unwrap_or("");
     check(last_line, expect!["Total tests: 1, passed: 0, failed: 1."])
+}
+
+#[test]
+fn test_async_wasm_upstream_src_package() {
+    check(
+        run_upstream_async_wasm_package("moonbitlang/async"),
+        expect![[r#"
+            Total tests: 91, passed: 91, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
+fn test_async_wasm_upstream_aqueue_package() {
+    check(
+        run_upstream_async_wasm_package("moonbitlang/async/aqueue"),
+        expect![[r#"
+            Total tests: 52, passed: 52, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
+fn test_async_wasm_upstream_semaphore_package() {
+    check(
+        run_upstream_async_wasm_package("moonbitlang/async/semaphore"),
+        expect![[r#"
+            Total tests: 12, passed: 12, failed: 0.
+        "#]],
+    );
 }
 
 #[test]

--- a/crates/moonbuild/template/test_driver_project/template_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_async.mbt
@@ -25,7 +25,18 @@ impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with fn run_as
 }
 
 ///|
-#cfg(not(any(target="wasm", target="wasm-gc")))
+#cfg(target="wasm")
+impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with fn run_async_tests(
+  tests,
+) {
+  for f in tests {
+    @moonbitlang/async.run_async_main(f)
+  }
+  // {COVERAGE_END}
+}
+
+///|
+#cfg(not(target="wasm-gc"))
 impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with fn is_being_cancelled() {
   @moonbitlang/async.is_being_cancelled()
 }

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -1,0 +1,39 @@
+# Moonrun
+
+Moonrun executes MoonBit wasm programs and provides host services that wasm
+code cannot perform directly.
+
+## Language
+
+**Job**:
+A host operation requested by guest code whose result is observed later by the
+guest coroutine.
+_Avoid_: Task, request
+
+**Worker**:
+A host execution unit that runs a job outside the guest coroutine loop.
+_Avoid_: Executor thread, background task
+
+**Completion**:
+The host-owned result of a finished job that is ready to wake or resume guest
+code.
+_Avoid_: Callback, event
+
+**Completion Queue**:
+A host-owned queue of completed job identifiers that the guest event loop drains
+to resume waiting coroutines.
+_Avoid_: Notify pipe, callback queue
+
+**Guest Memory**:
+The wasm linear memory owned by the guest program.
+_Avoid_: Wasm buffer, V8 memory
+
+**Host Buffer**:
+Memory owned by moonrun while servicing guest jobs.
+_Avoid_: Native buffer, temporary buffer
+
+**Native-Shaped Async Boundary**:
+The wasm async host boundary that keeps MoonBit-facing concepts aligned with
+`moonbitlang/async` native concepts even when moonrun uses different host
+representations.
+_Avoid_: Wasm-specific async API, shortcut API

--- a/crates/moonrun/src/async_api/event_loop.rs
+++ b/crates/moonrun/src/async_api/event_loop.rs
@@ -1,0 +1,42 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+pub(super) fn get_platform(
+    _scope: &mut v8::HandleScope,
+    _args: v8::FunctionCallbackArguments,
+    mut ret: v8::ReturnValue,
+) {
+    #[cfg(target_os = "linux")]
+    let platform = 0;
+    #[cfg(target_os = "macos")]
+    let platform = 1;
+    #[cfg(target_os = "windows")]
+    let platform = 2;
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    let platform = 0;
+
+    ret.set_int32(platform);
+}
+
+pub(super) fn errno_is_cancelled(
+    _scope: &mut v8::HandleScope,
+    _args: v8::FunctionCallbackArguments,
+    mut ret: v8::ReturnValue,
+) {
+    ret.set_bool(false);
+}

--- a/crates/moonrun/src/async_api/mod.rs
+++ b/crates/moonrun/src/async_api/mod.rs
@@ -1,0 +1,45 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::cell::Cell;
+
+mod event_loop;
+mod os_error;
+mod registry;
+mod runtime;
+mod thread_pool;
+mod time;
+mod unsupported;
+
+pub(crate) use registry::MOONBIT_V0_MODULE;
+
+thread_local! {
+    static LAST_ERRNO: Cell<i32> = const { Cell::new(0) };
+}
+
+pub(crate) fn init_env<'s>(obj: v8::Local<'s, v8::Object>, scope: &mut v8::HandleScope<'s>) {
+    registry::register_imports(obj, scope);
+}
+
+fn set_last_errno(errno: i32) {
+    LAST_ERRNO.with(|last_errno| last_errno.set(errno));
+}
+
+fn last_errno() -> i32 {
+    LAST_ERRNO.with(Cell::get)
+}

--- a/crates/moonrun/src/async_api/os_error.rs
+++ b/crates/moonrun/src/async_api/os_error.rs
@@ -1,0 +1,25 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+pub(super) fn get_errno(
+    _scope: &mut v8::HandleScope,
+    _args: v8::FunctionCallbackArguments,
+    mut ret: v8::ReturnValue,
+) {
+    ret.set_int32(super::last_errno());
+}

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -1,0 +1,580 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::v8_builder::ObjectExt;
+
+use super::{event_loop, os_error, runtime, thread_pool, time, unsupported};
+
+pub(crate) const MOONBIT_V0_MODULE: &str = "moonbit_v0";
+#[cfg(test)]
+const NATIVE_ASYNC_PREFIX: &str = "moonbitlang_async_";
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AsyncImportKind {
+    NativeMapped,
+    UnsupportedMvp,
+    WasmSupport,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceRoot {
+    MoonbitAsync,
+    Moonrun,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SourceLocation {
+    root: SourceRoot,
+    path: &'static str,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AsyncImport {
+    kind: AsyncImportKind,
+    wasm_symbol: &'static str,
+    native_symbol: Option<&'static str>,
+    sources: &'static [SourceLocation],
+}
+
+#[cfg(test)]
+macro_rules! import_kind {
+    (native) => {
+        AsyncImportKind::NativeMapped
+    };
+    (unsupported) => {
+        AsyncImportKind::UnsupportedMvp
+    };
+    (support) => {
+        AsyncImportKind::WasmSupport
+    };
+}
+
+#[cfg(test)]
+macro_rules! source_root {
+    (moonbit_async) => {
+        SourceRoot::MoonbitAsync
+    };
+    (moonrun) => {
+        SourceRoot::Moonrun
+    };
+}
+
+macro_rules! declare_async_imports {
+    ($(
+        $kind:ident $callback:path => $wasm_symbol:literal,
+        native = $native_symbol:expr,
+        sources = [$($source_root:ident:$source_path:literal),+ $(,)?];
+    )*) => {
+        #[cfg(test)]
+        const ASYNC_IMPORTS: &[AsyncImport] = &[
+            $(
+                AsyncImport {
+                    kind: import_kind!($kind),
+                    wasm_symbol: $wasm_symbol,
+                    native_symbol: $native_symbol,
+                    sources: &[
+                        $(
+                            SourceLocation {
+                                root: source_root!($source_root),
+                                path: $source_path,
+                            },
+                        )+
+                    ],
+                },
+            )*
+        ];
+
+        pub(super) fn register_imports<'s>(
+            obj: v8::Local<'s, v8::Object>,
+            scope: &mut v8::HandleScope<'s>,
+        ) {
+            $(
+                register_func_impl(obj, scope, $wasm_symbol, $callback);
+            )*
+        }
+    };
+}
+
+fn register_func_impl<'s>(
+    obj: v8::Local<'s, v8::Object>,
+    scope: &mut v8::HandleScope<'s>,
+    name: &str,
+    callback: impl v8::MapFnTo<v8::FunctionCallback>,
+) {
+    obj.set_func(scope, name, callback);
+}
+
+// Complete `moonbit_v0` async ABI surface registered by this split PR.
+//
+// Entry shape:
+//   kind callback maps to "namespace/wasm_symbol",
+//   native = Some("moonbitlang_async_native_symbol") | None,
+//   sources = [moonbit_async:"path/in/async", moonrun:"path/in/moonrun"];
+//
+// Kind legend:
+// - native: a supported import whose semantics are expected to follow the
+//   corresponding native C stub.
+// - support: wasm-only host glue or a supported import with wasm-specific
+//   behavior. A native symbol may still be listed for provenance.
+// - unsupported: registered for link compatibility and one-to-one C-stub
+//   inventory only; it fails loudly if PR1 accidentally reaches that surface.
+declare_async_imports! {
+    support runtime::exit => "runtime/exit",
+    native = None,
+    sources = [
+        moonbit_async:"src/integration.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/runtime.rs",
+    ];
+
+    // Wasm-only timer wait glue. This is not a native C-stub mapping; native
+    // `moonbitlang_async_poll_wait` is listed below as unsupported `poll/poll_wait`.
+    support runtime::wait_for_event => "runtime/wait_for_event",
+    native = None,
+    sources = [
+        moonbit_async:"src/internal/event_loop/event_loop.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/runtime.rs",
+    ];
+
+    native event_loop::get_platform => "runtime/get_platform",
+    native = Some("moonbitlang_async_get_platform"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.c",
+        moonbit_async:"src/internal/event_loop/event_loop.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/event_loop.rs",
+    ];
+
+    support time::get_ms_since_epoch => "time/get_ms_since_epoch",
+    native = None,
+    sources = [
+        moonbit_async:"src/internal/event_loop/event_loop.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/time.rs",
+    ];
+
+    native os_error::get_errno => "os_error/get_errno",
+    native = Some("moonbitlang_async_get_errno"),
+    sources = [
+        moonbit_async:"src/os_error/stub.c",
+        moonbit_async:"src/os_error/error.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/os_error.rs",
+    ];
+
+    support event_loop::errno_is_cancelled => "thread_pool/errno_is_cancelled",
+    native = Some("moonbitlang_async_errno_is_cancelled"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.c",
+        moonbit_async:"src/internal/event_loop/event_loop.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/event_loop.rs",
+    ];
+
+    support thread_pool::fetch_completion => "thread_pool/fetch_completion",
+    native = Some("moonbitlang_async_fetch_completion"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.c",
+        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/thread_pool.rs",
+    ];
+
+    // Native poller C ABI. PR1 does not expose the native fd/event-list poller,
+    // but the exact C stubs are still registered as unsupported ABI inventory.
+    unsupported unsupported::fail => "poll/poll_create",
+    native = Some("moonbitlang_async_poll_create"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/epoll.c",
+        moonbit_async:"src/internal/event_loop/kqueue.c",
+        moonbit_async:"src/internal/event_loop/iocp.c",
+    ];
+
+    unsupported unsupported::fail => "poll/poll_destroy",
+    native = Some("moonbitlang_async_poll_destroy"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/epoll.c",
+        moonbit_async:"src/internal/event_loop/kqueue.c",
+        moonbit_async:"src/internal/event_loop/iocp.c",
+    ];
+
+    unsupported unsupported::fail => "poll/poll_register",
+    native = Some("moonbitlang_async_poll_register"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/epoll.c",
+        moonbit_async:"src/internal/event_loop/kqueue.c",
+        moonbit_async:"src/internal/event_loop/iocp.c",
+    ];
+
+    unsupported unsupported::fail => "poll/support_wait_pid_via_poll",
+    native = Some("moonbitlang_async_support_wait_pid_via_poll"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/epoll.c",
+        moonbit_async:"src/internal/event_loop/kqueue.c",
+    ];
+
+    unsupported unsupported::fail => "poll/poll_register_pid",
+    native = Some("moonbitlang_async_poll_register_pid"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/epoll.c",
+        moonbit_async:"src/internal/event_loop/kqueue.c",
+    ];
+
+    unsupported unsupported::fail => "poll/poll_remove",
+    native = Some("moonbitlang_async_poll_remove"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/epoll.c",
+        moonbit_async:"src/internal/event_loop/kqueue.c",
+    ];
+
+    unsupported unsupported::fail => "poll/poll_remove_pid",
+    native = Some("moonbitlang_async_poll_remove_pid"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/epoll.c",
+        moonbit_async:"src/internal/event_loop/kqueue.c",
+    ];
+
+    unsupported unsupported::fail => "poll/poll_wait",
+    native = Some("moonbitlang_async_poll_wait"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/epoll.c",
+        moonbit_async:"src/internal/event_loop/kqueue.c",
+        moonbit_async:"src/internal/event_loop/iocp.c",
+    ];
+
+    unsupported unsupported::fail => "poll/event_list_get",
+    native = Some("moonbitlang_async_event_list_get"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/epoll.c",
+        moonbit_async:"src/internal/event_loop/kqueue.c",
+        moonbit_async:"src/internal/event_loop/iocp.c",
+    ];
+
+    unsupported unsupported::fail => "poll/event_get_fd",
+    native = Some("moonbitlang_async_event_get_fd"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/epoll.c",
+        moonbit_async:"src/internal/event_loop/kqueue.c",
+        moonbit_async:"src/internal/event_loop/iocp.c",
+    ];
+
+    unsupported unsupported::fail => "poll/event_get_events",
+    native = Some("moonbitlang_async_event_get_events"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/epoll.c",
+        moonbit_async:"src/internal/event_loop/kqueue.c",
+    ];
+
+    unsupported unsupported::fail => "poll/event_get_io_result",
+    native = Some("moonbitlang_async_event_get_io_result"),
+    sources = [moonbit_async:"src/internal/event_loop/iocp.c"];
+
+    unsupported unsupported::fail => "poll/event_get_bytes_transferred",
+    native = Some("moonbitlang_async_event_get_bytes_transferred"),
+    sources = [moonbit_async:"src/internal/event_loop/iocp.c"];
+
+    unsupported unsupported::fail => "thread_pool/spawn_worker",
+    native = Some("moonbitlang_async_spawn_worker"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.c",
+        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
+    ];
+
+    unsupported unsupported::fail => "thread_pool/free_worker",
+    native = Some("moonbitlang_async_free_worker"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.c",
+        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
+    ];
+
+    unsupported unsupported::fail => "thread_pool/wake_worker",
+    native = Some("moonbitlang_async_wake_worker"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.c",
+        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
+    ];
+
+    unsupported unsupported::fail => "thread_pool/worker_enter_idle",
+    native = Some("moonbitlang_async_worker_enter_idle"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.c",
+        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
+    ];
+
+    unsupported unsupported::fail => "thread_pool/cancel_worker",
+    native = Some("moonbitlang_async_cancel_worker"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.c",
+        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
+    ];
+
+    unsupported unsupported::fail => "thread_pool/free_job",
+    native = Some("moonbitlang_async_free_job"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.c",
+        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
+    ];
+
+    unsupported unsupported::fail => "thread_pool/run_job",
+    native = None,
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
+    ];
+
+    unsupported unsupported::fail => "thread_pool/job_get_ret",
+    native = Some("moonbitlang_async_job_get_ret"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.c",
+        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
+    ];
+
+    unsupported unsupported::fail => "thread_pool/job_get_err",
+    native = Some("moonbitlang_async_job_get_err"),
+    sources = [
+        moonbit_async:"src/internal/event_loop/thread_pool.c",
+        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
+        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|path| path.parent())
+            .unwrap()
+            .to_path_buf()
+    }
+
+    fn source_path(source: SourceLocation) -> PathBuf {
+        match source.root {
+            SourceRoot::MoonbitAsync => repo_root()
+                .join("third_party/moonbitlang_async")
+                .join(source.path),
+            SourceRoot::Moonrun => repo_root().join(source.path),
+        }
+    }
+
+    fn collect_moonbit_files(dir: &Path, files: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                collect_moonbit_files(&path, files);
+            } else if path.extension().is_some_and(|extension| extension == "mbt") {
+                files.push(path);
+            }
+        }
+    }
+
+    fn moonbit_v0_imports() -> HashSet<String> {
+        let marker = "\"moonbit_v0\" \"";
+        let mut files = Vec::new();
+        collect_moonbit_files(
+            &repo_root().join("third_party/moonbitlang_async/src"),
+            &mut files,
+        );
+
+        let mut imports = HashSet::new();
+        for file in files {
+            let contents = std::fs::read_to_string(file).unwrap();
+            for line in contents.lines() {
+                let mut rest = line;
+                while let Some(start) = rest.find(marker) {
+                    let symbol_start = start + marker.len();
+                    rest = &rest[symbol_start..];
+                    if let Some(end) = rest.find('"') {
+                        imports.insert(rest[..end].to_owned());
+                        rest = &rest[end..];
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+        imports
+    }
+
+    #[test]
+    fn import_names_are_unique() {
+        let mut names = HashSet::new();
+        for import in ASYNC_IMPORTS {
+            assert!(
+                names.insert(import.wasm_symbol),
+                "duplicate async import {}",
+                import.wasm_symbol
+            );
+        }
+    }
+
+    #[test]
+    fn registry_covers_async_wasm_imports() {
+        let declared = ASYNC_IMPORTS
+            .iter()
+            .map(|import| import.wasm_symbol)
+            .collect::<HashSet<_>>();
+        let actual = moonbit_v0_imports();
+        for import in actual {
+            assert!(
+                declared.contains(import.as_str()),
+                "missing moonbit_v0 async import registration for {import}"
+            );
+        }
+    }
+
+    #[test]
+    fn source_locations_exist() {
+        for import in ASYNC_IMPORTS {
+            for source in import.sources {
+                let path = source_path(*source);
+                assert!(
+                    path.exists(),
+                    "source for {} does not exist: {}",
+                    import.wasm_symbol,
+                    path.display()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn native_symbols_are_traceable_to_async_sources() {
+        for import in ASYNC_IMPORTS {
+            let Some(native_symbol) = import.native_symbol else {
+                continue;
+            };
+            assert!(
+                native_symbol.starts_with(NATIVE_ASYNC_PREFIX),
+                "native symbol for {} should use {NATIVE_ASYNC_PREFIX}: {native_symbol}",
+                import.wasm_symbol
+            );
+
+            let found = import
+                .sources
+                .iter()
+                .filter(|source| source.root == SourceRoot::MoonbitAsync)
+                .map(|source| std::fs::read_to_string(source_path(*source)).unwrap())
+                .any(|contents| contents.contains(native_symbol));
+            assert!(
+                found,
+                "native symbol {native_symbol} for {} is not present in its async sources",
+                import.wasm_symbol
+            );
+        }
+    }
+
+    #[test]
+    fn pr1_surface_stays_event_loop_timer_only() {
+        for import in ASYNC_IMPORTS {
+            assert!(
+                !import.wasm_symbol.starts_with("fs/")
+                    && !import.wasm_symbol.starts_with("process/")
+                    && !import.wasm_symbol.starts_with("socket/")
+                    && !import.wasm_symbol.starts_with("tls/")
+                    && !import.wasm_symbol.starts_with("fd_util/")
+                    && !import.wasm_symbol.starts_with("c_buffer/"),
+                "PR1 should not register broader async host import {}",
+                import.wasm_symbol
+            );
+        }
+    }
+
+    #[test]
+    fn native_poll_imports_are_explicit_unsupported_entries() {
+        let wait_for_event = ASYNC_IMPORTS
+            .iter()
+            .find(|import| import.wasm_symbol == "runtime/wait_for_event")
+            .expect("runtime/wait_for_event should be registered");
+        assert_eq!(wait_for_event.kind, AsyncImportKind::WasmSupport);
+        assert_eq!(wait_for_event.native_symbol, None);
+
+        for (wasm_symbol, native_symbol) in [
+            ("poll/poll_create", "moonbitlang_async_poll_create"),
+            ("poll/poll_destroy", "moonbitlang_async_poll_destroy"),
+            ("poll/poll_register", "moonbitlang_async_poll_register"),
+            (
+                "poll/support_wait_pid_via_poll",
+                "moonbitlang_async_support_wait_pid_via_poll",
+            ),
+            (
+                "poll/poll_register_pid",
+                "moonbitlang_async_poll_register_pid",
+            ),
+            ("poll/poll_remove", "moonbitlang_async_poll_remove"),
+            ("poll/poll_remove_pid", "moonbitlang_async_poll_remove_pid"),
+            ("poll/poll_wait", "moonbitlang_async_poll_wait"),
+            ("poll/event_list_get", "moonbitlang_async_event_list_get"),
+            ("poll/event_get_fd", "moonbitlang_async_event_get_fd"),
+            (
+                "poll/event_get_events",
+                "moonbitlang_async_event_get_events",
+            ),
+            (
+                "poll/event_get_io_result",
+                "moonbitlang_async_event_get_io_result",
+            ),
+            (
+                "poll/event_get_bytes_transferred",
+                "moonbitlang_async_event_get_bytes_transferred",
+            ),
+        ] {
+            let import = ASYNC_IMPORTS
+                .iter()
+                .find(|import| import.wasm_symbol == wasm_symbol)
+                .unwrap_or_else(|| panic!("{wasm_symbol} should be registered"));
+            assert_eq!(import.kind, AsyncImportKind::UnsupportedMvp);
+            assert_eq!(import.native_symbol, Some(native_symbol));
+        }
+    }
+
+    #[test]
+    fn worker_job_imports_are_link_stubs() {
+        let unsupported = ASYNC_IMPORTS
+            .iter()
+            .filter(|import| import.kind == AsyncImportKind::UnsupportedMvp)
+            .map(|import| import.wasm_symbol)
+            .collect::<HashSet<_>>();
+        for symbol in [
+            "thread_pool/spawn_worker",
+            "thread_pool/free_worker",
+            "thread_pool/wake_worker",
+            "thread_pool/worker_enter_idle",
+            "thread_pool/cancel_worker",
+            "thread_pool/free_job",
+            "thread_pool/run_job",
+            "thread_pool/job_get_ret",
+            "thread_pool/job_get_err",
+        ] {
+            assert!(
+                unsupported.contains(symbol),
+                "{symbol} should be unsupported in PR1"
+            );
+        }
+    }
+}

--- a/crates/moonrun/src/async_api/runtime.rs
+++ b/crates/moonrun/src/async_api/runtime.rs
@@ -1,0 +1,82 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+pub(super) fn exit(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    _ret: v8::ReturnValue,
+) {
+    let code = args.get(0).int32_value(scope).unwrap_or(1);
+    std::process::exit(code);
+}
+
+pub(super) fn wait_for_event(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut ret: v8::ReturnValue,
+) {
+    let timeout_ms = args.get(0).int32_value(scope).unwrap_or(-1);
+    match wait_for_event_impl(timeout_ms) {
+        Ok(()) => {
+            super::set_last_errno(0);
+            ret.set_int32(0);
+        }
+        Err(errno) => {
+            super::set_last_errno(errno);
+            ret.set_int32(-1);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_event_impl(timeout_ms: i32) -> Result<(), i32> {
+    let timeout = if timeout_ms < 0 { -1 } else { timeout_ms };
+    if unsafe { libc::poll(std::ptr::null_mut(), 0, timeout) } < 0 {
+        return Err(last_errno());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn last_errno() -> i32 {
+    #[cfg(target_os = "linux")]
+    {
+        unsafe { *libc::__errno_location() }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        unsafe { *libc::__error() }
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        std::io::Error::last_os_error().raw_os_error().unwrap_or(1)
+    }
+}
+
+#[cfg(windows)]
+fn wait_for_event_impl(timeout_ms: i32) -> Result<(), i32> {
+    let timeout = if timeout_ms < 0 {
+        windows_sys::Win32::System::Threading::INFINITE
+    } else {
+        timeout_ms as u32
+    };
+    unsafe {
+        windows_sys::Win32::System::Threading::Sleep(timeout);
+    }
+    Ok(())
+}

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -1,0 +1,25 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+pub(super) fn fetch_completion(
+    _scope: &mut v8::HandleScope,
+    _args: v8::FunctionCallbackArguments,
+    mut ret: v8::ReturnValue,
+) {
+    ret.set_int32(0);
+}

--- a/crates/moonrun/src/async_api/time.rs
+++ b/crates/moonrun/src/async_api/time.rs
@@ -1,0 +1,32 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::sync::OnceLock;
+use std::time::Instant;
+
+static MONOTONIC_CLOCK_ORIGIN: OnceLock<Instant> = OnceLock::new();
+
+pub(super) fn get_ms_since_epoch(
+    scope: &mut v8::HandleScope,
+    _args: v8::FunctionCallbackArguments,
+    mut ret: v8::ReturnValue,
+) {
+    let origin = MONOTONIC_CLOCK_ORIGIN.get_or_init(Instant::now);
+    let millis = i64::try_from(origin.elapsed().as_millis()).unwrap_or(i64::MAX);
+    ret.set(v8::BigInt::new_from_i64(scope, millis).into());
+}

--- a/crates/moonrun/src/async_api/unsupported.rs
+++ b/crates/moonrun/src/async_api/unsupported.rs
@@ -1,0 +1,28 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::v8_builder::ScopeExt;
+
+pub(super) fn fail(
+    scope: &mut v8::HandleScope,
+    _args: v8::FunctionCallbackArguments,
+    _ret: v8::ReturnValue,
+) {
+    let message = scope.string("moonbit_v0 async worker jobs are not supported in this PR");
+    scope.throw_exception(message.into());
+}

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 use std::{cell::Cell, io::Read, path::PathBuf, time::Instant};
 use v8::V8::set_flags_from_string;
 
+mod async_api;
 mod backtrace_api;
 mod demangle_js_template;
 mod fs_api_temp;
@@ -381,6 +382,11 @@ fn init_env(
             instant_elapsed_as_secs_f64,
         );
         time.set_func(scope, "now", now);
+    }
+
+    {
+        let async_runtime = global_proxy.child(scope, async_api::MOONBIT_V0_MODULE);
+        async_api::init_env(async_runtime, scope);
     }
 
     {

--- a/crates/moonrun/src/template/js_glue.js
+++ b/crates/moonrun/src/template/js_glue.js
@@ -143,6 +143,7 @@ const __moonbit_backtrace_runtime = globalThis.__moonbit_backtrace_runtime || {
 })(__moonbit_fs_unstable, __moonbit_run_env);
 
 const __moonbit_wasi_unstable = globalThis.__moonbit_wasi_unstable || {};
+const moonbit_v0 = globalThis.moonbit_v0 || {};
 
 delete globalThis.__moonbit_run_env;
 delete globalThis.__moonbit_backtrace_runtime;
@@ -436,6 +437,7 @@ const spectest = {
     __moonbit_io_unstable: __moonbit_io_unstable,
     __moonbit_sys_unstable: __moonbit_sys_unstable,
     __moonbit_time_unstable: __moonbit_time_unstable,
+    moonbit_v0: moonbit_v0,
     wasi_snapshot_preview1: wasi_snapshot_preview1,
     moonbit: {
         string_to_js_string() {

--- a/docs/adr/0001-async-wasm-host-boundary.md
+++ b/docs/adr/0001-async-wasm-host-boundary.md
@@ -1,0 +1,53 @@
+# Async Wasm Host Boundary
+
+We will support `moonbitlang/async` on the wasm backend through
+`#cfg(target="wasm")` bindings to a `moonbit_v0` host module in `moonrun`,
+without compiler changes or JS backend changes. The host follows the semantic
+contract of async's native C stubs, while this first split only implements the
+event-loop and timer foundation needed by the root async, async queue, and
+semaphore tests.
+
+## Decisions
+
+- Use a semantic C-stub boundary: `moonbit_v0` symbols map from
+  `moonbitlang_async_*` symbols by stripping that prefix and placing the leaf
+  name under an async namespace.
+- Keep the first split limited to event-loop and timer support. Filesystem,
+  process, socket, TLS, raw-fd, c-buffer, and real worker-job behavior remain
+  follow-up work.
+- Use monotonic elapsed milliseconds with an unspecified process-local origin
+  for wasm async time. The async timer contract uses differences between
+  readings; the absolute epoch is not meaningful.
+- Support Unix-family and Windows hosts first. Other host families are
+  deliberately compile-time unsupported until the async C-stub parity target is
+  defined for them.
+- Keep link-required worker symbols registered when the wasm event-loop module
+  references them, but make real worker/job operations fail loudly in this
+  split instead of causing missing-import instantiation failures.
+
+## PR1 Correspondence
+
+| `moonbit_v0` import | Native async correspondence | PR1 status |
+| --- | --- | --- |
+| `runtime/exit` | wasm support glue | implemented |
+| `runtime/get_platform` | `moonbitlang_async_get_platform` | implemented |
+| `runtime/wait_for_event` | wasm support glue | implemented |
+| `time/get_ms_since_epoch` | `moonbitlang_async_get_ms_since_epoch` | implemented with monotonic local origin |
+| `os_error/get_errno` | `moonbitlang_async_get_errno` | implemented for host callback errno |
+| `thread_pool/errno_is_cancelled` | `moonbitlang_async_errno_is_cancelled` | deterministic no-worker stub |
+| `thread_pool/fetch_completion` | `moonbitlang_async_fetch_completion` | deterministic no-completion stub |
+| `thread_pool/spawn_worker` | `moonbitlang_async_spawn_worker` | link-only unsupported stub |
+| `thread_pool/free_worker` | `moonbitlang_async_free_worker` | link-only unsupported stub |
+| `thread_pool/wake_worker` | `moonbitlang_async_wake_worker` | link-only unsupported stub |
+| `thread_pool/worker_enter_idle` | `moonbitlang_async_worker_enter_idle` | link-only unsupported stub |
+| `thread_pool/cancel_worker` | `moonbitlang_async_cancel_worker` | link-only unsupported stub |
+| `thread_pool/free_job` | wasm support glue | link-only unsupported stub |
+| `thread_pool/run_job` | wasm support glue | link-only unsupported stub |
+| `thread_pool/job_get_ret` | `moonbitlang_async_job_get_ret` | link-only unsupported stub |
+| `thread_pool/job_get_err` | `moonbitlang_async_job_get_err` | link-only unsupported stub |
+
+## Deferred
+
+Executor design, cancellation semantics, broad core FS, sockets, process, TLS,
+file watching, arbitrary external fd/HANDLE adoption, Wasmtime/WasmEdge
+adapters, and wasm-gc support remain follow-up work.


### PR DESCRIPTION
## Why

This splits the wasm async work down to the event-loop and timer foundation needed to run the first upstream async packages without bringing in filesystem, process, socket, TLS, raw-fd, c-buffer, or real worker-job behavior.

## What

- Adds the async submodule at the wasm event-loop/timer branch from moonbitlang/async#432.
- Adds a minimal `moonbit_v0` host ABI in `moonrun` for platform, wait, exit, monotonic time, errno, and deterministic worker-completion stubs.
- Wires the wasm async test driver to run async tests through `run_async_main`.
- Adds scoped upstream wasm package tests for the async root package, aqueue, and semaphore only.

## Correctness And Scope

The host wait path uses OS blocking primitives with the MoonBit timeout, the time import is monotonic, and worker completion currently returns no completions. Unsupported worker/job operations throw if called, so this PR cannot silently pretend to support fs/process/thread-pool jobs that belong in later split PRs.