### PR TITLE
test: ignore prebuild cwd generated output

### DIFF
--- a/crates/moon/tests/test_cases/pre_build_cwd.in/.gitignore
+++ b/crates/moon/tests/test_cases/pre_build_cwd.in/.gitignore
@@ -1,0 +1,1 @@
+src/lib/generated.mbt


### PR DESCRIPTION
## Why

Running the `pre_build_cwd` fixture can leave its generated pre-build output in the fixture tree, which makes local working trees noisy even though the file is derived output rather than test input.

## What changed

Added a fixture-local `.gitignore` entry for the generated `src/lib/generated.mbt` file.

## Why this is correct

The test already generates and asserts the file contents during execution. The committed fixture only needs the inputs that drive that generation, so ignoring the derived output preserves the intended test behavior while keeping local status clean.

## Scope

The ignore rule is local to the `pre_build_cwd` fixture, so it does not hide generated MoonBit files elsewhere in the repository.