### PR TITLE
Implement async wasm filesystem host runtime

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "third_party/moonbitlang_async"]
 	path = third_party/moonbitlang_async
 	url = https://github.com/moonbitlang/async.git
-	branch = codex/wasm-event-loop-timer
+	branch = codex/wasm-async-fs-host-upstream

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,6 +1730,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json_lenient",
+ "slotmap",
  "snapbox",
  "tempfile",
  "tracing",

--- a/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_fs/app/main/fs_smoke.mbt
+++ b/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_fs/app/main/fs_smoke.mbt
@@ -1,0 +1,36 @@
+///|
+async test "write and read file through async fs" {
+  let path = "async-fs-smoke.txt"
+  @fs.write_file(path, b"wasm async fs", create_mode=CreateOrTruncate)
+  let content = @fs.read_file(path).text()
+  inspect(content, content="wasm async fs")
+  {
+    let file = @fs.open(path, mode=ReadWrite)
+    defer file.close()
+    file.write_at(b"IO", position=5)
+    let buf = FixedArray::make(2, b'\x00')
+    let n = file.read_at(buf, position=5)
+    inspect(n, content="2")
+    json_inspect(buf.unsafe_reinterpret_as_bytes()[:n], content="IO")
+  }
+  let content = @fs.read_file(path).text()
+  inspect(content, content="wasm IOync fs")
+}
+
+///|
+async test "directory entries and timestamps through async fs" {
+  let dir = "async-fs-smoke-dir"
+  let path = "\{dir}/entry.txt"
+  @fs.mkdir(dir)
+  @fs.write_file(path, b"entry", create_mode=CreateOrTruncate)
+  let entries = @fs.readdir(dir, sort=true)
+  json_inspect(entries, content=["entry.txt"])
+  let (path_sec, path_nsec) = @fs.mtime(path)
+  assert_true(path_sec >= 0)
+  assert_true(path_nsec >= 0)
+  let file = @fs.open(path, mode=ReadOnly)
+  defer file.close()
+  let (file_sec, file_nsec) = file.mtime()
+  assert_true(file_sec >= 0)
+  assert_true(file_nsec >= 0)
+}

--- a/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_fs/app/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_fs/app/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "import": [ "moonbitlang/async", "moonbitlang/async/fs" ]
+}

--- a/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_fs/app/moon.mod.template
+++ b/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_fs/app/moon.mod.template
@@ -1,0 +1,11 @@
+name = "moon/async_fs_workspace"
+
+version = "0.1.0"
+
+import {
+  "moonbitlang/async@0.19.1",
+}
+
+options(
+  source: ".",
+)

--- a/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_fs/moon.work.template
+++ b/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_fs/moon.work.template
@@ -1,0 +1,5 @@
+members = [
+  "./app",
+  "@@ASYNC_MEMBER@@",
+]
+preferred_target = "wasm"

--- a/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_timer/app/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_timer/app/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "import": [ "moonbitlang/async" ]
+}

--- a/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_timer/app/main/timer.mbt
+++ b/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_timer/app/main/timer.mbt
@@ -1,0 +1,5 @@
+///|
+async test "timer sleep resumes" {
+  @async.sleep(1)
+  println("timer resumed")
+}

--- a/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_timer/app/moon.mod.template
+++ b/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_timer/app/moon.mod.template
@@ -1,0 +1,11 @@
+name = "moon/async_timer_workspace"
+
+version = "0.1.0"
+
+import {
+  "moonbitlang/async@0.19.1",
+}
+
+options(
+  source: ".",
+)

--- a/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_timer/moon.work.template
+++ b/crates/moon/tests/test_cases/moon_test/async_wasm_workspace_timer/moon.work.template
@@ -1,0 +1,5 @@
+members = [
+  "./app",
+  "@@ASYNC_MEMBER@@",
+]
+preferred_target = "wasm"

--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -1,3 +1,21 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
 mod patch;
 #[cfg(unix)]
 mod use_cc_for_native_release;
@@ -17,10 +35,43 @@ fn repo_root() -> std::path::PathBuf {
         .to_path_buf()
 }
 
-fn moonrun_bin() -> std::path::PathBuf {
-    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_moonrun") {
-        return path.into();
+// Upstream async has tick-sensitive tests; keep wasm package runs isolated
+// from the Rust test harness's package-level concurrency.
+static ASYNC_WASM_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn prepare_async_wasm_workspace(dir: &TestDir) -> std::path::PathBuf {
+    let repo_root = repo_root();
+    let async_dir = repo_root.join("third_party/moonbitlang_async");
+    let async_member = async_dir
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+
+    std::fs::write(
+        dir.join("moon.work"),
+        crate::util::read(dir.join("moon.work.template"))
+            .replace("@@ASYNC_MEMBER@@", &async_member),
+    )
+    .unwrap();
+    std::fs::copy(dir.join("app/moon.mod.template"), dir.join("app/moon.mod")).unwrap();
+
+    async_dir
+}
+
+fn build_moonrun() -> std::path::PathBuf {
+    let repo_root = repo_root();
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut build_moonrun = std::process::Command::new(cargo);
+    build_moonrun
+        .current_dir(&repo_root)
+        .args(["build", "--quiet", "-p", "moonrun"]);
+    if !cfg!(debug_assertions) {
+        build_moonrun.arg("--release");
     }
+    let status = build_moonrun
+        .status()
+        .expect("failed to spawn cargo build for moonrun");
+    assert!(status.success(), "failed to build moonrun");
 
     let mut path = std::env::current_exe().unwrap();
     path.pop();
@@ -30,11 +81,42 @@ fn moonrun_bin() -> std::path::PathBuf {
     path.join(format!("moonrun{}", std::env::consts::EXE_SUFFIX))
 }
 
+fn run_async_wasm_package(dir: &TestDir, package: &str) -> String {
+    let _guard = ASYNC_WASM_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let moonrun = build_moonrun();
+    let output = moon_cmd(dir)
+        .env("MOON_OVERRIDE", moon_bin())
+        .env("MOONRUN_OVERRIDE", &moonrun)
+        .args([
+            "-C",
+            "app/main",
+            "test",
+            "--target",
+            "wasm",
+            "--package",
+            package,
+            "--sort-input",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    std::str::from_utf8(&output).unwrap().to_owned()
+}
+
 fn run_upstream_async_wasm_package(package: &str) -> String {
+    let _guard = ASYNC_WASM_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let moonrun = build_moonrun();
     let async_dir = repo_root().join("third_party/moonbitlang_async");
     let output = moon_cmd(&async_dir)
         .env("MOON_OVERRIDE", moon_bin())
-        .env("MOONRUN_OVERRIDE", moonrun_bin())
+        .env("MOONRUN_OVERRIDE", &moonrun)
         .args([
             "test",
             "--target",
@@ -625,6 +707,33 @@ fn test_async_test() {
 }
 
 #[test]
+fn test_async_wasm_workspace_timer() {
+    let dir = TestDir::new("moon_test/async_wasm_workspace_timer");
+    prepare_async_wasm_workspace(&dir);
+
+    check(
+        run_async_wasm_package(&dir, "moon/async_timer_workspace/main"),
+        expect![[r#"
+            timer resumed
+            Total tests: 1, passed: 1, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
+fn test_async_wasm_workspace_fs_smoke() {
+    let dir = TestDir::new("moon_test/async_wasm_workspace_fs");
+    prepare_async_wasm_workspace(&dir);
+
+    check(
+        run_async_wasm_package(&dir, "moon/async_fs_workspace/main"),
+        expect![[r#"
+            Total tests: 2, passed: 2, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
 fn test_async_wasm_upstream_src_package() {
     check(
         run_upstream_async_wasm_package("moonbitlang/async"),
@@ -645,11 +754,41 @@ fn test_async_wasm_upstream_aqueue_package() {
 }
 
 #[test]
+fn test_async_wasm_upstream_cond_var_package() {
+    check(
+        run_upstream_async_wasm_package("moonbitlang/async/cond_var"),
+        expect![[r#"
+            Total tests: 8, passed: 8, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
 fn test_async_wasm_upstream_semaphore_package() {
     check(
         run_upstream_async_wasm_package("moonbitlang/async/semaphore"),
         expect![[r#"
             Total tests: 12, passed: 12, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
+fn test_async_wasm_upstream_fs_package() {
+    check(
+        run_upstream_async_wasm_package("moonbitlang/async/fs"),
+        expect![[r#"
+        Total tests: 31, passed: 31, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
+fn test_async_wasm_upstream_pipe_package() {
+    check(
+        run_upstream_async_wasm_package("moonbitlang/async/pipe"),
+        expect![[r#"
+            Total tests: 3, passed: 3, failed: 0.
         "#]],
     );
 }

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -1,13 +1,11 @@
 # Moonrun
 
-Moonrun executes MoonBit wasm programs and provides host services that wasm
-code cannot perform directly.
+Moonrun executes MoonBit wasm programs and provides host services that wasm code cannot perform directly.
 
 ## Language
 
 **Job**:
-A host operation requested by guest code whose result is observed later by the
-guest coroutine.
+A host operation requested by guest code whose result is observed later by the guest coroutine.
 _Avoid_: Task, request
 
 **Worker**:
@@ -15,25 +13,46 @@ A host execution unit that runs a job outside the guest coroutine loop.
 _Avoid_: Executor thread, background task
 
 **Completion**:
-The host-owned result of a finished job that is ready to wake or resume guest
-code.
+The host-owned result of a finished job that is ready to wake or resume guest code.
 _Avoid_: Callback, event
 
 **Completion Queue**:
-A host-owned queue of completed job identifiers that the guest event loop drains
-to resume waiting coroutines.
+A host-owned queue of completed job identifiers that the guest event loop drains to resume waiting coroutines.
 _Avoid_: Notify pipe, callback queue
 
 **Guest Memory**:
 The wasm linear memory owned by the guest program.
 _Avoid_: Wasm buffer, V8 memory
 
+**Guest String Path**:
+A MoonBit `String` pointer plus UTF-16 code-unit length used for async path arguments crossing `moonbitlang/async`.
+Moonrun converts this directly into `OsString`; guest code must not send UTF-8 `Bytes` for paths.
+_Avoid_: Guest UTF-8 path buffer
+
 **Host Buffer**:
 Memory owned by moonrun while servicing guest jobs.
 _Avoid_: Native buffer, temporary buffer
 
 **Native-Shaped Async Boundary**:
-The wasm async host boundary that keeps MoonBit-facing concepts aligned with
-`moonbitlang/async` native concepts even when moonrun uses different host
-representations.
+The wasm async host boundary that keeps MoonBit-facing concepts aligned with `moonbitlang/async` native concepts even when moonrun uses different host representations.
 _Avoid_: Wasm-specific async API, shortcut API
+
+**Async API**:
+The V8-facing `moonbitlang/async` adapter that registers imports, decodes wasm ABI values, reacquires guest memory, sets return values, and reports traps.
+_Avoid_: Runtime state, native-stub implementation
+
+**Async Host**:
+Moonrun-owned async runtime state for one V8 `moonbitlang/async` host instance: handle tables, host workers, completion queues, guest-memory helper types, and opaque host poll instances.
+_Avoid_: `moonbitlang/async` source mirror
+
+**Async Sys**:
+The V8-free native-stub port layer. Implemented files follow the `moonbitlang/async` source layout and carry provenance for the native source path and symbol they track. Poller files are direct ports behind the wasm `poll/*` imports.
+_Avoid_: V8 adapter, placeholder unsupported imports
+
+**Host Poller**:
+The `async_sys::internal::event_loop::poll` port of native epoll, kqueue, or IOCP. The wasm event loop owns opaque `Instance` handles and calls `poll/wait`, `poll/event_fd`, and `poll/event_events`; moonrun resolves registered host fd handles to platform fds or HANDLEs.
+_Avoid_: Completion queue, worker wakeup
+
+**Thread-Pool Completion Source**:
+The host-side notify handle corresponding to `thread_pool.c`'s `pool.notify_send`. Worker threads write or post completed job ids through it so `poll/wait` reports the completion source key, after which MoonBit drains `thread_pool/fetch_completion`.
+_Avoid_: Host Poller, Barrier, worker wakeup

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -28,6 +28,7 @@ anyhow.workspace = true
 clap.workspace = true
 serde.workspace = true
 serde_json_lenient.workspace = true
+slotmap.workspace = true
 rand = "0.8.5"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
@@ -40,8 +41,17 @@ libc.workspace = true
 version = "0.59.0"
 features = [
     "Win32_Foundation",
+    "Win32_Networking_WinSock",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
     "Win32_System_Console",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_IO",
+    "Win32_System_Ioctl",
+    "Win32_System_Pipes",
+    "Win32_System_SystemServices",
     "Win32_System_Threading",
+    "Win32_System_WindowsProgramming",
 ]
 
 [build-dependencies]

--- a/crates/moonrun/docs/adr/0001-copy-worker-results-through-host-completions.md
+++ b/crates/moonrun/docs/adr/0001-copy-worker-results-through-host-completions.md
@@ -1,0 +1,3 @@
+# Copy Worker Results Through Host Completions
+
+Moonrun will not let async workers retain guest-memory pointers or write directly into guest memory after an import returns. Worker jobs produce host-owned completions, and guest-visible result data is copied into current guest memory only when the guest resumes and calls back into moonrun. This adds a copy, but keeps wasm memory growth/replacement and worker-thread execution separated.

--- a/crates/moonrun/docs/adr/0002-preserve-native-shaped-worker-boundary.md
+++ b/crates/moonrun/docs/adr/0002-preserve-native-shaped-worker-boundary.md
@@ -1,0 +1,3 @@
+# Preserve Native-Shaped Worker Boundary
+
+Moonrun will preserve the `moonbitlang/async` native-shaped `Worker` and `Job` boundary for wasm instead of exposing a separate wasm-specific scheduler API to MoonBit. In wasm, worker handles may represent scheduler resources rather than raw OS threads, but the MoonBit-facing structure should stay close to the native async implementation to reduce maintenance drift.

--- a/crates/moonrun/docs/adr/0003-use-native-shaped-worker-threads-first.md
+++ b/crates/moonrun/docs/adr/0003-use-native-shaped-worker-threads-first.md
@@ -1,0 +1,3 @@
+# Use Native-Shaped Worker Threads First
+
+Moonrun will implement the first wasm async executor with one host thread per active native-shaped worker handle, subject to the same worker-count policy as `moonbitlang/async`. This favors behavioral parity and easier cancellation reasoning over starting with a more abstract shared Rust executor pool.

--- a/crates/moonrun/docs/adr/0004-use-host-completion-queue-for-wasm-workers.md
+++ b/crates/moonrun/docs/adr/0004-use-host-completion-queue-for-wasm-workers.md
@@ -1,0 +1,7 @@
+# Use Host Completion Queue For Wasm Workers
+
+Moonrun will expose a native-shaped completion-drain import for wasm async workers rather than forcing an OS notify fd into the V8 adapter. The MoonBit side keeps the `fetch_completion` shape, while moonrun can implement the queue with host synchronization primitives and fill guest buffers only during the drain call.
+
+Worker threads must not write directly into wasm guest memory. They do not run inside a V8 import callback, and the current memory view must be reacquired after potential memory growth. Worker jobs therefore copy borrowed inputs into host-owned values at job creation, compute host-owned result payloads, publish a completion record, and let the guest thread copy output bytes while draining completions.
+
+This delayed copy-out is part of the boundary design for output buffers such as read, readdir, and file-time results. The MoonBit wasm wrapper treats jobs as opaque handles as the native backend does; `fetch_completion` is the single readiness-and-copy-out boundary. Fixed-size portable records should still avoid unnecessary intermediate structure: wasm `FileTime` is a 48-byte little-endian record, so completion draining should encode that record directly into guest memory and the MoonBit wasm wrapper should read its fields directly instead of calling back into host accessors for each field.

--- a/crates/moonrun/docs/adr/0005-suspend-coroutines-for-wasm-worker-jobs.md
+++ b/crates/moonrun/docs/adr/0005-suspend-coroutines-for-wasm-worker-jobs.md
@@ -1,0 +1,3 @@
+# Suspend Coroutines For Wasm Worker Jobs
+
+Moonrun will make wasm worker jobs suspend the waiting coroutine once the real executor is implemented. The current synchronous `run_job` path is only a temporary runnable slice; leaving it as observable behavior would block the guest event loop and diverge from `moonbitlang/async` native semantics.

--- a/crates/moonrun/docs/adr/0006-let-workers-own-running-jobs.md
+++ b/crates/moonrun/docs/adr/0006-let-workers-own-running-jobs.md
@@ -1,0 +1,3 @@
+# Let Workers Own Running Jobs
+
+Moonrun will follow `moonbitlang/async` by treating a worker as owning its current running job while the blocking operation executes. The guest-visible job handle remains stable, but moonrun should not require central job-table locks around blocking syscalls; completion publishes the finished job state back for the guest event loop to observe.

--- a/crates/moonrun/docs/adr/0007-split-read-job-guest-destination-from-host-buffer.md
+++ b/crates/moonrun/docs/adr/0007-split-read-job-guest-destination-from-host-buffer.md
@@ -1,0 +1,3 @@
+# Split Read Job Guest Destination From Host Buffer
+
+Moonrun read jobs will keep guest destination metadata on the stable job state while workers read into host-owned buffers. Completion records the produced byte count, and moonrun copies the host buffer into current guest memory only when the guest resumes. This preserves the native read-job contract without retaining guest-memory pointers in worker threads.

--- a/crates/moonrun/src/async_api/c_buffer.rs
+++ b/crates/moonrun/src/async_api/c_buffer.rs
@@ -1,0 +1,87 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory};
+use crate::async_sys::internal::c_buffer::stub;
+
+use super::context::ImportContext;
+use super::provenance::ported_imports;
+
+ported_imports! {
+pub(super) fn is_null(_context: &mut ImportContext, ptr: u64) -> i32 {
+    i32::from(ptr == crate::async_host::INVALID_HOST_HANDLE)
+}
+
+#[ported(source = "src/internal/c_buffer/stub.c")]
+pub(super) fn blit_to_c(
+    context: &mut ImportContext,
+    dst: u64,
+    src: i32,
+    offset: i32,
+    len: i32,
+) -> AsyncHostResult<()> {
+    let src_len = checked_add_i32(offset, len)?;
+    let src = context.with_memory_mut(|memory| Ok(memory.read_exact(src, src_len)?.to_vec()))?;
+    context
+        .host
+        .with_c_buffer_mut(dst, |dst| stub::blit_to_c(dst, &src, offset, len))
+}
+
+#[ported(source = "src/internal/c_buffer/stub.c")]
+pub(super) fn blit_from_c(
+    context: &mut ImportContext,
+    src: u64,
+    dst: i32,
+    offset: i32,
+    len: i32,
+) -> AsyncHostResult<()> {
+    let dst_len = checked_add_i32(offset, len)?;
+    let src = context.host.with_c_buffer(src, |src| {
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        Ok(src.get(..len).ok_or(AsyncHostError::Fault)?.to_vec())
+    })?;
+    context.with_memory_mut(|memory| {
+        let dst = memory.read_exact_mut(dst, dst_len)?;
+        stub::blit_from_c(&src, dst, offset, len)
+    })
+}
+
+#[ported(source = "src/internal/c_buffer/stub.c")]
+pub(super) fn c_buffer_get(
+    context: &mut ImportContext,
+    buf: u64,
+    index: i32,
+) -> AsyncHostResult<i32> {
+    context
+        .host
+        .with_c_buffer(buf, |buf| stub::c_buffer_get(buf, index).map(i32::from))
+}
+
+#[ported(source = "src/internal/c_buffer/stub.c")]
+pub(super) fn strlen(context: &mut ImportContext, buf: u64) -> AsyncHostResult<i32> {
+    context.host.with_c_buffer(buf, stub::strlen)
+}
+
+pub(super) fn free(context: &mut ImportContext, ptr: u64) -> AsyncHostResult<()> {
+    context.host.free_c_buffer(ptr)
+}
+
+fn checked_add_i32(lhs: i32, rhs: i32) -> AsyncHostResult<i32> {
+    lhs.checked_add(rhs).ok_or(AsyncHostError::Fault)
+}
+}

--- a/crates/moonrun/src/async_api/context.rs
+++ b/crates/moonrun/src/async_api/context.rs
@@ -1,0 +1,260 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::ptr::NonNull;
+
+use crate::async_host::{AsyncHost, AsyncHostError, AsyncHostResult};
+
+pub(super) struct AsyncContext {
+    pub(super) host: AsyncHost,
+    imports: v8::Global<v8::Object>,
+}
+
+impl AsyncContext {
+    pub(super) fn new<'s>(
+        scope: &mut v8::HandleScope<'s>,
+        imports: v8::Local<'s, v8::Object>,
+        host: AsyncHost,
+    ) -> Self {
+        Self {
+            host,
+            imports: v8::Global::new(scope, imports),
+        }
+    }
+}
+
+pub(super) fn callback_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s AsyncContext {
+    let data = args.data();
+    assert!(data.is_external());
+    let data: v8::Local<v8::Data> = data.into();
+    let ptr = v8::Local::<v8::External>::try_from(data).unwrap().value();
+    unsafe { &*(ptr as *const AsyncContext) }
+}
+
+pub(super) struct ImportContext<'a, 'scope> {
+    pub(super) scope: &'a mut v8::HandleScope<'scope>,
+    pub(super) host: &'a AsyncHost,
+    imports: &'a v8::Global<v8::Object>,
+}
+
+impl<'a, 'scope> ImportContext<'a, 'scope> {
+    pub(super) fn new(scope: &'a mut v8::HandleScope<'scope>, context: &'a AsyncContext) -> Self {
+        Self {
+            scope,
+            host: &context.host,
+            imports: &context.imports,
+        }
+    }
+
+    pub(super) fn with_memory_mut<T>(
+        &mut self,
+        f: impl FnOnce(&mut [u8]) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
+        let memory_object = memory_object(self.scope, self.imports)?;
+        let buffer = memory_object.buffer();
+        let len = buffer.byte_length();
+
+        let ptr = match buffer.data() {
+            Some(ptr) => ptr.cast::<u8>(),
+            None if len == 0 => NonNull::dangling(),
+            None => return Err(AsyncHostError::Fault),
+        };
+
+        let memory = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), len) };
+        f(memory)
+    }
+}
+
+pub(super) struct ImportArgs<'a, 'scope, 'args> {
+    scope: &'a mut v8::HandleScope<'scope>,
+    args: &'a v8::FunctionCallbackArguments<'args>,
+    next_index: i32,
+}
+
+impl<'a, 'scope, 'args> ImportArgs<'a, 'scope, 'args> {
+    pub(super) fn new(
+        scope: &'a mut v8::HandleScope<'scope>,
+        args: &'a v8::FunctionCallbackArguments<'args>,
+    ) -> Self {
+        Self {
+            scope,
+            args,
+            next_index: 0,
+        }
+    }
+
+    pub(super) fn next_i32(&mut self) -> AsyncHostResult<i32> {
+        let index = self.next_index;
+        self.next_index += 1;
+        self.args
+            .get(index)
+            .int32_value(self.scope)
+            .ok_or(AsyncHostError::Inval)
+    }
+
+    pub(super) fn next_i64(&mut self) -> AsyncHostResult<i64> {
+        let index = self.next_index;
+        self.next_index += 1;
+        let value = self.args.get(index);
+        if value.is_big_int() {
+            let bigint =
+                v8::Local::<v8::BigInt>::try_from(value).map_err(|_| AsyncHostError::Inval)?;
+            let (result, lossless) = bigint.i64_value();
+            if lossless {
+                return Ok(result);
+            }
+        }
+        value.integer_value(self.scope).ok_or(AsyncHostError::Inval)
+    }
+
+    pub(super) fn next_u64(&mut self) -> AsyncHostResult<u64> {
+        let index = self.next_index;
+        self.next_index += 1;
+        let value = self.args.get(index);
+        if !value.is_big_int() {
+            return Err(AsyncHostError::Inval);
+        }
+        let bigint = v8::Local::<v8::BigInt>::try_from(value).map_err(|_| AsyncHostError::Inval)?;
+        let (result, lossless) = bigint.u64_value();
+        if lossless {
+            Ok(result)
+        } else {
+            Err(AsyncHostError::Inval)
+        }
+    }
+}
+
+fn memory_object<'s>(
+    scope: &mut v8::HandleScope<'s>,
+    imports: &v8::Global<v8::Object>,
+) -> AsyncHostResult<v8::Local<'s, v8::WasmMemoryObject>> {
+    let imports = v8::Local::new(scope, imports);
+    let key = v8::String::new(scope, "memory").ok_or(AsyncHostError::Fault)?;
+    let memory = imports
+        .get(scope, key.into())
+        .ok_or(AsyncHostError::Fault)?;
+    v8::Local::<v8::WasmMemoryObject>::try_from(memory).map_err(|_| AsyncHostError::Fault)
+}
+
+pub(super) fn throw_import_error(
+    scope: &mut v8::HandleScope,
+    import_name: &str,
+    error: AsyncHostError,
+) {
+    let message = format!("moonbitlang/async.{import_name} failed: {error:?}");
+    let message = v8::String::new(scope, &message).unwrap_or_else(|| v8::String::empty(scope));
+    let exception = v8::Exception::error(scope, message);
+    scope.throw_exception(exception);
+}
+
+pub(super) trait FinishVoid {
+    fn finish_void(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str);
+}
+
+impl FinishVoid for () {
+    fn finish_void(
+        self,
+        _scope: &mut v8::HandleScope,
+        ret: &mut v8::ReturnValue,
+        _import_name: &str,
+    ) {
+        ret.set_undefined();
+    }
+}
+
+impl FinishVoid for AsyncHostResult<()> {
+    fn finish_void(
+        self,
+        scope: &mut v8::HandleScope,
+        ret: &mut v8::ReturnValue,
+        import_name: &str,
+    ) {
+        match self {
+            Ok(()) => ret.set_undefined(),
+            Err(error) => throw_import_error(scope, import_name, error),
+        }
+    }
+}
+
+pub(super) trait FinishI32 {
+    fn finish_i32(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str);
+}
+
+impl FinishI32 for i32 {
+    fn finish_i32(
+        self,
+        _scope: &mut v8::HandleScope,
+        ret: &mut v8::ReturnValue,
+        _import_name: &str,
+    ) {
+        ret.set_int32(self);
+    }
+}
+
+impl FinishI32 for AsyncHostResult<i32> {
+    fn finish_i32(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str) {
+        match self {
+            Ok(value) => ret.set_int32(value),
+            Err(error) => throw_import_error(scope, import_name, error),
+        }
+    }
+}
+
+pub(super) trait FinishI64 {
+    fn finish_i64(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str);
+}
+
+impl FinishI64 for i64 {
+    fn finish_i64(
+        self,
+        scope: &mut v8::HandleScope,
+        ret: &mut v8::ReturnValue,
+        _import_name: &str,
+    ) {
+        ret.set(v8::BigInt::new_from_i64(scope, self).into());
+    }
+}
+
+impl FinishI64 for u64 {
+    fn finish_i64(
+        self,
+        scope: &mut v8::HandleScope,
+        ret: &mut v8::ReturnValue,
+        _import_name: &str,
+    ) {
+        ret.set(v8::BigInt::new_from_u64(scope, self).into());
+    }
+}
+
+impl FinishI64 for AsyncHostResult<i64> {
+    fn finish_i64(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str) {
+        match self {
+            Ok(value) => value.finish_i64(scope, ret, import_name),
+            Err(error) => throw_import_error(scope, import_name, error),
+        }
+    }
+}
+
+impl FinishI64 for AsyncHostResult<u64> {
+    fn finish_i64(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str) {
+        match self {
+            Ok(value) => value.finish_i64(scope, ret, import_name),
+            Err(error) => throw_import_error(scope, import_name, error),
+        }
+    }
+}

--- a/crates/moonrun/src/async_api/env_util.rs
+++ b/crates/moonrun/src/async_api/env_util.rs
@@ -1,0 +1,29 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_sys::internal::env_util::stub;
+
+use super::context::ImportContext;
+use super::provenance::ported_imports;
+
+ported_imports! {
+#[ported(source = "src/internal/env_util/stub.c")]
+pub(super) fn getpid(_context: &mut ImportContext) -> i32 {
+    stub::get_pid() as i32
+}
+}

--- a/crates/moonrun/src/async_api/event_bus.rs
+++ b/crates/moonrun/src/async_api/event_bus.rs
@@ -1,0 +1,166 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::AsyncHostResult;
+
+use super::context::ImportContext;
+#[cfg(test)]
+use super::provenance::{PortedImport, SourceLocation, SourceRoot};
+
+#[cfg(all(test, target_os = "linux"))]
+const EVENT_BUS_SOURCE: &str = "src/internal/event_loop/epoll.c";
+#[cfg(all(test, target_os = "macos"))]
+const EVENT_BUS_SOURCE: &str = "src/internal/event_loop/kqueue.c";
+#[cfg(all(test, windows))]
+const EVENT_BUS_SOURCE: &str = "src/internal/event_loop/iocp.c";
+#[cfg(all(test, windows))]
+const IOCP_SOURCE: &str = "src/internal/event_loop/iocp.c";
+#[cfg(test)]
+const EVENT_BUS_SOURCES: &[SourceLocation] = &[SourceLocation {
+    root: SourceRoot::MoonbitAsync,
+    path: EVENT_BUS_SOURCE,
+}];
+#[cfg(all(test, windows))]
+const IOCP_SOURCES: &[SourceLocation] = &[SourceLocation {
+    root: SourceRoot::MoonbitAsync,
+    path: IOCP_SOURCE,
+}];
+
+#[cfg(test)]
+pub(super) const PORTED_IMPORTS: &[PortedImport] = &[
+    ported_from(
+        EVENT_BUS_SOURCES,
+        "create",
+        "moonbitlang_async_event_bus_create",
+    ),
+    ported_from(
+        EVENT_BUS_SOURCES,
+        "destroy",
+        "moonbitlang_async_event_bus_destroy",
+    ),
+    ported_from(
+        EVENT_BUS_SOURCES,
+        "register",
+        "moonbitlang_async_event_bus_register",
+    ),
+    ported_from(
+        EVENT_BUS_SOURCES,
+        "wait",
+        "moonbitlang_async_event_bus_wait",
+    ),
+    ported_from(
+        EVENT_BUS_SOURCES,
+        "get_event",
+        "moonbitlang_async_event_list_get",
+    ),
+    ported_from(
+        EVENT_BUS_SOURCES,
+        "event_fd",
+        "moonbitlang_async_event_get_fd",
+    ),
+    #[cfg(unix)]
+    ported_from(
+        EVENT_BUS_SOURCES,
+        "event_events",
+        "moonbitlang_async_event_get_events",
+    ),
+    #[cfg(windows)]
+    ported_from(
+        IOCP_SOURCES,
+        "event_io_result",
+        "moonbitlang_async_event_get_io_result",
+    ),
+    #[cfg(windows)]
+    ported_from(
+        IOCP_SOURCES,
+        "event_bytes_transferred",
+        "moonbitlang_async_event_get_bytes_transferred",
+    ),
+];
+
+#[cfg(test)]
+const fn ported_from(
+    sources: &'static [SourceLocation],
+    rust_symbol: &'static str,
+    native_symbol: &'static str,
+) -> PortedImport {
+    PortedImport {
+        rust_module: module_path!(),
+        rust_symbol,
+        native_symbol: Some(native_symbol),
+        sources,
+    }
+}
+
+pub(super) fn create(context: &mut ImportContext) -> AsyncHostResult<u64> {
+    context.host.poll_create()
+}
+
+pub(super) fn destroy(context: &mut ImportContext, bus: u64) -> AsyncHostResult<()> {
+    context.host.poll_destroy(bus)
+}
+
+pub(super) fn register(context: &mut ImportContext, bus: u64, fd: u64, read_only: i32) -> i32 {
+    poll_errno_result(context, context.host.poll_register(bus, fd, read_only != 0))
+}
+
+pub(super) fn wait(context: &mut ImportContext, bus: u64, timeout_ms: i32) -> i32 {
+    match context.host.poll_wait(bus, timeout_ms) {
+        Ok(n) => n,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+pub(super) fn get_event(context: &mut ImportContext, bus: u64, index: i32) -> AsyncHostResult<u64> {
+    context.host.poll_get_event(bus, index)
+}
+
+pub(super) fn event_fd(context: &mut ImportContext, event: u64) -> AsyncHostResult<u64> {
+    context.host.poll_event_fd(event)
+}
+
+#[cfg(unix)]
+pub(super) fn event_events(context: &mut ImportContext, event: u64) -> AsyncHostResult<i32> {
+    context.host.poll_event_events(event)
+}
+
+#[cfg(windows)]
+pub(super) fn event_io_result(context: &mut ImportContext, event: u64) -> AsyncHostResult<u64> {
+    context.host.poll_event_io_result(event)
+}
+
+#[cfg(windows)]
+pub(super) fn event_bytes_transferred(
+    context: &mut ImportContext,
+    event: u64,
+) -> AsyncHostResult<i32> {
+    context.host.poll_event_bytes_transferred(event)
+}
+
+fn poll_errno_result(context: &ImportContext, result: AsyncHostResult<()>) -> i32 {
+    match result {
+        Ok(()) => 0,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}

--- a/crates/moonrun/src/async_api/event_loop.rs
+++ b/crates/moonrun/src/async_api/event_loop.rs
@@ -16,27 +16,23 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-pub(super) fn get_platform(
-    _scope: &mut v8::HandleScope,
-    _args: v8::FunctionCallbackArguments,
-    mut ret: v8::ReturnValue,
-) {
-    #[cfg(target_os = "linux")]
-    let platform = 0;
-    #[cfg(target_os = "macos")]
-    let platform = 1;
-    #[cfg(target_os = "windows")]
-    let platform = 2;
-    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-    let platform = 0;
+use crate::async_sys::internal::event_loop::thread_pool;
 
-    ret.set_int32(platform);
+use super::context::ImportContext;
+use super::provenance::ported_imports;
+
+ported_imports! {
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn get_platform(_context: &mut ImportContext) -> i32 {
+    thread_pool::get_platform()
 }
 
-pub(super) fn errno_is_cancelled(
-    _scope: &mut v8::HandleScope,
-    _args: v8::FunctionCallbackArguments,
-    mut ret: v8::ReturnValue,
-) {
-    ret.set_bool(false);
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn errno_is_cancelled(_context: &mut ImportContext, errno: i32) -> i32 {
+    if thread_pool::errno_is_cancelled(errno) {
+        1
+    } else {
+        0
+    }
+}
 }

--- a/crates/moonrun/src/async_api/fd_util.rs
+++ b/crates/moonrun/src/async_api/fd_util.rs
@@ -1,0 +1,132 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory};
+
+use super::context::ImportContext;
+use super::provenance::ported_imports;
+
+ported_imports! {
+const FILE_TIME_RECORD_LEN: i32 = 48;
+const ATIME_SEC_OFFSET: i32 = 0;
+const ATIME_NSEC_OFFSET: i32 = 8;
+const MTIME_SEC_OFFSET: i32 = 16;
+const MTIME_NSEC_OFFSET: i32 = 24;
+const CTIME_SEC_OFFSET: i32 = 32;
+const CTIME_NSEC_OFFSET: i32 = 40;
+
+pub(super) fn invalid_fd(context: &mut ImportContext) -> u64 {
+    context.host.invalid_fd()
+}
+
+pub(super) fn sizeof_file_time(_context: &mut ImportContext) -> i32 {
+    FILE_TIME_RECORD_LEN
+}
+
+#[ported(source = "src/internal/fd_util/stub.c")]
+pub(super) fn get_atime_sec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i64> {
+    file_time_i64(context, ptr, ATIME_SEC_OFFSET)
+}
+
+#[ported(source = "src/internal/fd_util/stub.c")]
+pub(super) fn get_atime_nsec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i32> {
+    file_time_i32(context, ptr, ATIME_NSEC_OFFSET)
+}
+
+#[ported(source = "src/internal/fd_util/stub.c")]
+pub(super) fn get_mtime_sec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i64> {
+    file_time_i64(context, ptr, MTIME_SEC_OFFSET)
+}
+
+#[ported(source = "src/internal/fd_util/stub.c")]
+pub(super) fn get_mtime_nsec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i32> {
+    file_time_i32(context, ptr, MTIME_NSEC_OFFSET)
+}
+
+#[ported(source = "src/internal/fd_util/stub.c")]
+pub(super) fn get_ctime_sec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i64> {
+    file_time_i64(context, ptr, CTIME_SEC_OFFSET)
+}
+
+#[ported(source = "src/internal/fd_util/stub.c")]
+pub(super) fn get_ctime_nsec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i32> {
+    file_time_i32(context, ptr, CTIME_NSEC_OFFSET)
+}
+
+#[ported(source = "src/internal/fd_util/stub.c")]
+pub(super) fn pipe(
+    context: &mut ImportContext,
+    dst: i32,
+    len: i32,
+    read_end_is_async: i32,
+    write_end_is_async: i32,
+) -> i32 {
+    let result = (|| {
+        if len < 2 {
+            return Err(AsyncHostError::Fault);
+        }
+        context.with_memory_mut(|memory| memory.read_exact_mut(dst, 16).map(|_| ()))?;
+        let fds = context
+            .host
+            .pipe(read_end_is_async != 0, write_end_is_async != 0)?;
+        context.with_memory_mut(|memory| {
+            memory.write_u64_le(dst, fds[0])?;
+            memory.write_u64_le(dst.checked_add(8).ok_or(AsyncHostError::Fault)?, fds[1])
+        })
+    })();
+    match result {
+        Ok(()) => 0,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(source = "src/internal/fd_util/stub.c")]
+#[cfg(unix)]
+pub(super) fn set_nonblocking(context: &mut ImportContext, fd: u64) -> i32 {
+    match context.host.set_nonblocking(fd) {
+        Ok(()) => 0,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+fn file_time_i64(context: &mut ImportContext, ptr: i32, field_offset: i32) -> AsyncHostResult<i64> {
+    read_field(context, ptr, field_offset, 8)
+        .map(|bytes| i64::from_le_bytes(bytes.as_slice().try_into().unwrap()))
+}
+
+fn file_time_i32(context: &mut ImportContext, ptr: i32, field_offset: i32) -> AsyncHostResult<i32> {
+    read_field(context, ptr, field_offset, 4)
+        .map(|bytes| i32::from_le_bytes(bytes.as_slice().try_into().unwrap()))
+}
+
+fn read_field(
+    context: &mut ImportContext,
+    ptr: i32,
+    field_offset: i32,
+    len: i32,
+) -> AsyncHostResult<Vec<u8>> {
+    let offset = ptr.checked_add(field_offset).ok_or(AsyncHostError::Fault)?;
+    context.with_memory_mut(|memory| Ok(memory.read_exact(offset, len)?.to_vec()))
+}
+}

--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -1,0 +1,204 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory, write_u16};
+use crate::async_sys::fs::dir;
+use crate::async_sys::fs::stub;
+
+use super::context::ImportContext;
+use super::provenance::ported_imports;
+
+ported_imports! {
+pub(super) fn get_tmp_path_len(context: &mut ImportContext) -> i32 {
+    match tmp_path_utf16_units()
+        .and_then(|units| i32::try_from(units.len()).map_err(|_| AsyncHostError::Fault))
+    {
+        Ok(len) => len,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(source = "src/fs/stub.c")]
+pub(super) fn get_tmp_path(context: &mut ImportContext, ptr: i32, len: i32) -> i32 {
+    let result = (|| {
+        let units = tmp_path_utf16_units()?;
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        if len != units.len() {
+            return Err(AsyncHostError::Inval);
+        }
+        context.with_memory_mut(|memory| write_u16(memory, ptr, &units))
+    })();
+    zero_or_minus_one(context, result)
+}
+
+#[ported(source = "src/internal/fd_util/stub.c")]
+pub(super) fn close_fd(context: &mut ImportContext, fd: u64) -> i32 {
+    zero_or_minus_one(context, context.host.close_fd(fd))
+}
+
+#[ported(source = "src/fs/dir.c")]
+pub(super) fn dir_buffer_min_size(_context: &mut ImportContext) -> i32 {
+    dir::buffer_min_size()
+}
+
+#[ported(source = "src/fs/dir.c")]
+pub(super) fn dir_entry_length(
+    context: &mut ImportContext,
+    buf: i32,
+    offset: i32,
+) -> AsyncHostResult<i32> {
+    context.with_memory_mut(|memory| dir::entry_length(memory.bytes(), buf, offset))
+}
+
+#[ported(source = "src/fs/dir.c")]
+pub(super) fn dir_entry_name_len(
+    context: &mut ImportContext,
+    buf: i32,
+    offset: i32,
+) -> AsyncHostResult<i32> {
+    context.with_memory_mut(|memory| dir::entry_name_len(memory.bytes(), buf, offset))
+}
+
+#[ported(source = "src/fs/dir.c")]
+pub(super) fn dir_entry_name(
+    context: &mut ImportContext,
+    buf: i32,
+    offset: i32,
+) -> AsyncHostResult<u64> {
+    let name = context.with_memory_mut(|memory| {
+        Ok(dir::entry_name(memory.bytes(), buf, offset)?.to_vec())
+    })?;
+    Ok(context.host.insert_c_buffer(name))
+}
+
+#[ported(source = "src/fs/dir.c")]
+pub(super) fn dir_entry_is_dir(
+    context: &mut ImportContext,
+    buf: i32,
+    offset: i32,
+) -> AsyncHostResult<i32> {
+    context.with_memory_mut(|memory| dir::entry_is_dir(memory.bytes(), buf, offset))
+}
+
+#[ported(source = "src/fs/dir.c")]
+pub(super) fn dir_entry_is_hidden(
+    context: &mut ImportContext,
+    buf: i32,
+    offset: i32,
+) -> AsyncHostResult<i32> {
+    context
+        .with_memory_mut(|memory| dir::entry_is_hidden(memory.bytes(), buf, offset))
+        .map(|value| if value { 1 } else { 0 })
+}
+
+#[ported(source = "src/fs/dir.c")]
+pub(super) fn dir_entry_file_id(
+    context: &mut ImportContext,
+    buf: i32,
+    offset: i32,
+) -> AsyncHostResult<u64> {
+    context.with_memory_mut(|memory| dir::entry_file_id(memory.bytes(), buf, offset))
+}
+
+fn tmp_path_utf16_units() -> AsyncHostResult<Vec<u16>> {
+    os_string_to_utf16_units(stub::get_tmp_path()?)
+}
+
+#[cfg(unix)]
+fn os_string_to_utf16_units(path: std::ffi::OsString) -> AsyncHostResult<Vec<u16>> {
+    use std::os::unix::ffi::OsStringExt;
+
+    let path = String::from_utf8(path.into_vec()).map_err(|_| AsyncHostError::Inval)?;
+    Ok(path.encode_utf16().collect())
+}
+
+#[cfg(windows)]
+fn os_string_to_utf16_units(path: std::ffi::OsString) -> AsyncHostResult<Vec<u16>> {
+    use std::os::windows::ffi::OsStrExt;
+
+    Ok(path.as_os_str().encode_wide().collect())
+}
+
+#[ported(source = "src/fs/stub.c")]
+pub(super) fn errno_is_lock_violation(_context: &mut ImportContext, errno: i32) -> i32 {
+    if stub::errno_is_lock_violation(errno) {
+        1
+    } else {
+        0
+    }
+}
+
+#[ported(source = "src/fs/stub.c")]
+pub(super) fn try_lock_file(context: &mut ImportContext, fd: u64, exclusive: i32) -> i32 {
+    zero_or_minus_one(context, context.host.try_lock_file(fd, exclusive != 0))
+}
+
+#[ported(source = "src/fs/stub.c")]
+pub(super) fn unlock_file(context: &mut ImportContext, fd: u64) -> i32 {
+    zero_or_minus_one(context, context.host.unlock_file(fd))
+}
+
+fn zero_or_minus_one(context: &ImportContext, result: AsyncHostResult<()>) -> i32 {
+    match result {
+        Ok(()) => 0,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn tmp_path_encodes_unix_path_as_utf16_units() {
+        let path = std::ffi::OsString::from("/tmp/\u{6587}");
+
+        let units = os_string_to_utf16_units(path).unwrap();
+
+        assert_eq!(units, "/tmp/\u{6587}".encode_utf16().collect::<Vec<_>>());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tmp_path_rejects_non_utf8_unix_os_string() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = std::ffi::OsString::from_vec(b"/tmp/\xff".to_vec());
+
+        assert_eq!(os_string_to_utf16_units(path), Err(AsyncHostError::Inval));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn tmp_path_preserves_windows_wide_units() {
+        let path = std::ffi::OsString::from("A\u{10000}");
+
+        let units = os_string_to_utf16_units(path).unwrap();
+
+        assert_eq!(units, vec![0x0041, 0xd800, 0xdc00]);
+    }
+}

--- a/crates/moonrun/src/async_api/io.rs
+++ b/crates/moonrun/src/async_api/io.rs
@@ -1,0 +1,183 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use super::context::ImportContext;
+use super::provenance::ported_imports;
+
+ported_imports! {
+#[ported(source = "src/internal/event_loop/io_unix.c")]
+#[cfg(unix)]
+pub(super) fn read(
+    context: &mut ImportContext,
+    fd: u64,
+    dst: i32,
+    offset: i32,
+    len: i32,
+) -> i32 {
+    let host = context.host;
+    // Unix io/read is the pollable nonblocking path. Regular files are routed
+    // through worker jobs, so this borrowed guest slice must not outlive the syscall.
+    match context.with_memory_mut(|memory| host.read_fd(memory, fd, dst, offset, len)) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(source = "src/internal/event_loop/io_unix.c")]
+#[cfg(unix)]
+pub(super) fn write(
+    context: &mut ImportContext,
+    fd: u64,
+    src: i32,
+    offset: i32,
+    len: i32,
+) -> i32 {
+    let host = context.host;
+    // See io/read: this import is for pollable nonblocking handles, not
+    // regular files, and the borrowed guest slice is used only for the syscall.
+    match context.with_memory_mut(|memory| host.write_fd(memory, fd, src, offset, len)) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_make_file_io_result"
+)]
+#[cfg(windows)]
+pub(super) fn make_file_io_result(
+    context: &mut ImportContext,
+    events: i32,
+    buf: i32,
+    offset: i32,
+    len: i32,
+    position: i64,
+) -> crate::async_host::AsyncHostResult<u64> {
+    let host = context.host;
+    context.with_memory_mut(|memory| {
+        host.make_file_io_result(memory, events, buf, offset, len, position)
+    })
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_free_io_result"
+)]
+#[cfg(windows)]
+pub(super) fn free_io_result(
+    context: &mut ImportContext,
+    result: u64,
+) -> crate::async_host::AsyncHostResult<()> {
+    context.host.free_io_result(result)
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_io_result_get_event"
+)]
+#[cfg(windows)]
+pub(super) fn io_result_get_event(
+    context: &mut ImportContext,
+    result: u64,
+) -> crate::async_host::AsyncHostResult<i32> {
+    context.host.io_result_get_event(result)
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_cancel_io_result"
+)]
+#[cfg(windows)]
+pub(super) fn cancel_io_result(context: &mut ImportContext, result: u64, fd: u64) -> i32 {
+    match context.host.cancel_io_result(result, fd) {
+        Ok(status) => status,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_io_result_get_status"
+)]
+#[cfg(windows)]
+pub(super) fn io_result_get_status(context: &mut ImportContext, result: u64, fd: u64) -> i32 {
+    let host = context.host;
+    match context.with_memory_mut(|memory| host.io_result_get_status(memory, result, fd)) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_read"
+)]
+#[cfg(windows)]
+pub(super) fn read_io_result(context: &mut ImportContext, fd: u64, result: u64) -> i32 {
+    let host = context.host;
+    match context.with_memory_mut(|memory| host.read_io_result(memory, fd, result)) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_write"
+)]
+#[cfg(windows)]
+pub(super) fn write_io_result(context: &mut ImportContext, fd: u64, result: u64) -> i32 {
+    let host = context.host;
+    match context.with_memory_mut(|memory| host.write_io_result(memory, fd, result)) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_errno_is_read_EOF"
+)]
+#[cfg(windows)]
+pub(super) fn errno_is_read_eof(_context: &mut ImportContext, errno: i32) -> i32 {
+    if crate::async_sys::internal::event_loop::io::errno_is_read_eof(errno) {
+        1
+    } else {
+        0
+    }
+}
+}

--- a/crates/moonrun/src/async_api/mod.rs
+++ b/crates/moonrun/src/async_api/mod.rs
@@ -16,30 +16,43 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::cell::Cell;
+//! V8-facing `moonbitlang/async` import adapter.
+//!
+//! This layer registers wasm imports, decodes wasm ABI values from V8 callback
+//! arguments, acquires guest memory, sets return values, and reports traps.
+//! Ported native-stub behavior belongs in `async_sys`; shared runtime state
+//! belongs in `async_host`.
 
+mod c_buffer;
+mod context;
+mod env_util;
+mod event_bus;
 mod event_loop;
+mod fd_util;
+mod fs;
+mod io;
 mod os_error;
+mod os_string;
+mod provenance;
 mod registry;
 mod runtime;
 mod thread_pool;
 mod time;
-mod unsupported;
 
-pub(crate) use registry::MOONBIT_V0_MODULE;
+use std::any::Any;
 
-thread_local! {
-    static LAST_ERRNO: Cell<i32> = const { Cell::new(0) };
-}
+use crate::async_host::AsyncHost;
 
-pub(crate) fn init_env<'s>(obj: v8::Local<'s, v8::Object>, scope: &mut v8::HandleScope<'s>) {
-    registry::register_imports(obj, scope);
-}
+pub(crate) use registry::MOONBIT_ASYNC_MODULE;
 
-fn set_last_errno(errno: i32) {
-    LAST_ERRNO.with(|last_errno| last_errno.set(errno));
-}
+pub(crate) fn init_env<'s>(
+    obj: v8::Local<'s, v8::Object>,
+    scope: &mut v8::HandleScope<'s>,
+    dtors: &mut Vec<Box<dyn Any>>,
+) {
+    let context = Box::new(context::AsyncContext::new(scope, obj, AsyncHost::default()));
+    let context_ptr = &*context as *const context::AsyncContext;
+    dtors.push(context);
 
-fn last_errno() -> i32 {
-    LAST_ERRNO.with(Cell::get)
+    registry::register_imports(obj, scope, context_ptr);
 }

--- a/crates/moonrun/src/async_api/os_error.rs
+++ b/crates/moonrun/src/async_api/os_error.rs
@@ -16,10 +16,108 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-pub(super) fn get_errno(
-    _scope: &mut v8::HandleScope,
-    _args: v8::FunctionCallbackArguments,
-    mut ret: v8::ReturnValue,
-) {
-    ret.set_int32(super::last_errno());
+use crate::async_host::{AsyncHostError, write_u16};
+use crate::async_sys::os_error::stub;
+
+use super::context::ImportContext;
+use super::provenance::ported_imports;
+
+ported_imports! {
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn get_errno(context: &mut ImportContext) -> i32 {
+    stub::get_errno(context.host)
+}
+
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn is_nonblocking_io_error(_context: &mut ImportContext, errno: i32) -> i32 {
+    if stub::is_nonblocking_io_error(errno) {
+        1
+    } else {
+        0
+    }
+}
+
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn is_eintr(_context: &mut ImportContext, errno: i32) -> i32 {
+    if stub::is_eintr(errno) { 1 } else { 0 }
+}
+
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn is_enoent(_context: &mut ImportContext, errno: i32) -> i32 {
+    if stub::is_enoent(errno) { 1 } else { 0 }
+}
+
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn is_eexist(_context: &mut ImportContext, errno: i32) -> i32 {
+    if stub::is_eexist(errno) { 1 } else { 0 }
+}
+
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn is_eacces(_context: &mut ImportContext, errno: i32) -> i32 {
+    if stub::is_eacces(errno) { 1 } else { 0 }
+}
+
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn is_econnrefused(_context: &mut ImportContext, errno: i32) -> i32 {
+    if stub::is_econnrefused(errno) { 1 } else { 0 }
+}
+
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn is_error_notify_enum_dir(_context: &mut ImportContext, errno: i32) -> i32 {
+    if stub::is_error_notify_enum_dir(errno) {
+        1
+    } else {
+        0
+    }
+}
+
+pub(super) fn errno_to_string_len(context: &mut ImportContext, errno: i32) -> i32 {
+    match i32::try_from(errno_to_string_utf16(errno).len()).map_err(|_| AsyncHostError::Fault) {
+        Ok(len) => len,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn errno_to_string(context: &mut ImportContext, errno: i32, ptr: i32, len: i32) -> i32 {
+    let result = (|| {
+        let units = errno_to_string_utf16(errno);
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        if len != units.len() {
+            return Err(AsyncHostError::Inval);
+        }
+
+        context.with_memory_mut(|memory| write_u16(memory, ptr, &units))
+    })();
+
+    match result {
+        Ok(()) => 0,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn get_enotdir(_context: &mut ImportContext) -> i32 {
+    stub::get_enotdir()
+}
+
+fn errno_to_string_utf16(errno: i32) -> Vec<u16> {
+    stub::errno_to_string(errno).encode_utf16().collect()
+}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn errno_to_string_utf16_returns_message_units() {
+        assert!(!errno_to_string_utf16(stub::get_enotdir()).is_empty());
+    }
 }

--- a/crates/moonrun/src/async_api/os_string.rs
+++ b/crates/moonrun/src/async_api/os_string.rs
@@ -1,0 +1,123 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult, write_u16};
+
+use super::context::ImportContext;
+
+pub(super) fn decode_len(context: &mut ImportContext, ptr: u64, len: i32) -> AsyncHostResult<i32> {
+    let string = context
+        .host
+        .with_c_buffer(ptr, |buffer| decode_native_string(buffer, len))?;
+    utf16_len(&string)
+}
+
+pub(super) fn decode(
+    context: &mut ImportContext,
+    ptr: u64,
+    len: i32,
+    out: i32,
+    out_len: i32,
+) -> AsyncHostResult<()> {
+    let string = context
+        .host
+        .with_c_buffer(ptr, |buffer| decode_native_string(buffer, len))?;
+    let units = string.encode_utf16().collect::<Vec<_>>();
+    let actual_len = i32::try_from(units.len()).map_err(|_| AsyncHostError::Fault)?;
+    if actual_len != out_len {
+        return Err(AsyncHostError::Inval);
+    }
+    context.with_memory_mut(|memory| write_u16(memory, out, &units))
+}
+
+fn utf16_len(string: &str) -> AsyncHostResult<i32> {
+    i32::try_from(string.encode_utf16().count()).map_err(|_| AsyncHostError::Fault)
+}
+
+fn decode_native_string(bytes: &[u8], len: i32) -> AsyncHostResult<String> {
+    let bytes = if len == -1 {
+        native_string_bytes(bytes)?
+    } else {
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        bytes.get(..len).ok_or(AsyncHostError::Fault)?
+    };
+    decode_native_string_bytes(bytes)
+}
+
+#[cfg(unix)]
+fn native_string_bytes(bytes: &[u8]) -> AsyncHostResult<&[u8]> {
+    let len = crate::async_sys::internal::c_buffer::stub::strlen(bytes)?;
+    let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+    Ok(&bytes[..len])
+}
+
+#[cfg(windows)]
+fn native_string_bytes(bytes: &[u8]) -> AsyncHostResult<&[u8]> {
+    for (index, chunk) in bytes.chunks_exact(2).enumerate() {
+        if chunk == [0, 0] {
+            let len = index
+                .checked_mul(std::mem::size_of::<u16>())
+                .ok_or(AsyncHostError::Fault)?;
+            return Ok(&bytes[..len]);
+        }
+    }
+    Err(AsyncHostError::Fault)
+}
+
+#[cfg(unix)]
+fn decode_native_string_bytes(bytes: &[u8]) -> AsyncHostResult<String> {
+    Ok(String::from_utf8_lossy(bytes).into_owned())
+}
+
+#[cfg(windows)]
+fn decode_native_string_bytes(bytes: &[u8]) -> AsyncHostResult<String> {
+    if !bytes.len().is_multiple_of(std::mem::size_of::<u16>()) {
+        return Err(AsyncHostError::Inval);
+    }
+    let units = bytes
+        .chunks_exact(2)
+        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]));
+    Ok(std::char::decode_utf16(units)
+        .map(|result| result.unwrap_or(std::char::REPLACEMENT_CHARACTER))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_decode_native_string_stops_at_nul_byte() {
+        assert_eq!(decode_native_string(b"abc\0def", -1), Ok("abc".to_string()));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_decode_native_string_stops_at_nul_wchar() {
+        assert_eq!(
+            decode_native_string(&[b'a', 0, b'b', 0, 0, 0], -1),
+            Ok("ab".to_string())
+        );
+    }
+
+    #[test]
+    fn decoded_len_is_utf16_code_units() {
+        assert_eq!(utf16_len("a\u{10000}"), Ok(3));
+    }
+}

--- a/crates/moonrun/src/async_api/provenance.rs
+++ b/crates/moonrun/src/async_api/provenance.rs
@@ -1,0 +1,180 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceRoot {
+    MoonbitAsync,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SourceLocation {
+    pub(crate) root: SourceRoot,
+    pub(crate) path: &'static str,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PortedImport {
+    pub(crate) rust_module: &'static str,
+    pub(crate) rust_symbol: &'static str,
+    pub(crate) native_symbol: Option<&'static str>,
+    pub(crate) sources: &'static [SourceLocation],
+}
+
+macro_rules! ported_imports {
+    (@collect [$($entries:tt)*] [$($out:tt)*]) => {
+        #[cfg(test)]
+        pub(super) const PORTED_IMPORTS: &[$crate::async_api::provenance::PortedImport] = &[
+            $($entries)*
+        ];
+
+        $($out)*
+    };
+    (
+        @collect [$($entries:tt)*] [$($out:tt)*]
+        #[ported(source = $source_path:literal, original = $original:literal)]
+        #[cfg($($cfg:tt)*)]
+        $(#[$meta:meta])*
+        $vis:vis fn $function:ident($($params:tt)*) $(-> $ret:ty)? $body:block
+        $($rest:tt)*
+    ) => {
+        ported_imports!(
+            @collect [
+                $($entries)*
+                #[cfg($($cfg)*)]
+                $crate::async_api::provenance::PortedImport {
+                    rust_module: module_path!(),
+                    rust_symbol: stringify!($function),
+                    native_symbol: Some($original),
+                    sources: &[
+                        $crate::async_api::provenance::SourceLocation {
+                            root: $crate::async_api::provenance::SourceRoot::MoonbitAsync,
+                            path: $source_path,
+                        },
+                    ],
+                },
+            ] [
+                $($out)*
+                #[cfg($($cfg)*)]
+                $(#[$meta])*
+                $vis fn $function($($params)*) $(-> $ret)? $body
+            ]
+            $($rest)*
+        );
+    };
+    (
+        @collect [$($entries:tt)*] [$($out:tt)*]
+        #[ported(source = $source_path:literal, original = $original:literal)]
+        $(#[$meta:meta])*
+        $vis:vis fn $function:ident($($params:tt)*) $(-> $ret:ty)? $body:block
+        $($rest:tt)*
+    ) => {
+        ported_imports!(
+            @collect [
+                $($entries)*
+                $crate::async_api::provenance::PortedImport {
+                    rust_module: module_path!(),
+                    rust_symbol: stringify!($function),
+                    native_symbol: Some($original),
+                    sources: &[
+                        $crate::async_api::provenance::SourceLocation {
+                            root: $crate::async_api::provenance::SourceRoot::MoonbitAsync,
+                            path: $source_path,
+                        },
+                    ],
+                },
+            ] [
+                $($out)*
+                $(#[$meta])*
+                $vis fn $function($($params)*) $(-> $ret)? $body
+            ]
+            $($rest)*
+        );
+    };
+    (
+        @collect [$($entries:tt)*] [$($out:tt)*]
+        #[ported(source = $source_path:literal)]
+        #[cfg($($cfg:tt)*)]
+        $(#[$meta:meta])*
+        $vis:vis fn $function:ident($($params:tt)*) $(-> $ret:ty)? $body:block
+        $($rest:tt)*
+    ) => {
+        ported_imports!(
+            @collect [
+                $($entries)*
+                #[cfg($($cfg)*)]
+                $crate::async_api::provenance::PortedImport {
+                    rust_module: module_path!(),
+                    rust_symbol: stringify!($function),
+                    native_symbol: None,
+                    sources: &[
+                        $crate::async_api::provenance::SourceLocation {
+                            root: $crate::async_api::provenance::SourceRoot::MoonbitAsync,
+                            path: $source_path,
+                        },
+                    ],
+                },
+            ] [
+                $($out)*
+                #[cfg($($cfg)*)]
+                $(#[$meta])*
+                $vis fn $function($($params)*) $(-> $ret)? $body
+            ]
+            $($rest)*
+        );
+    };
+    (
+        @collect [$($entries:tt)*] [$($out:tt)*]
+        #[ported(source = $source_path:literal)]
+        $(#[$meta:meta])*
+        $vis:vis fn $function:ident($($params:tt)*) $(-> $ret:ty)? $body:block
+        $($rest:tt)*
+    ) => {
+        ported_imports!(
+            @collect [
+                $($entries)*
+                $crate::async_api::provenance::PortedImport {
+                    rust_module: module_path!(),
+                    rust_symbol: stringify!($function),
+                    native_symbol: None,
+                    sources: &[
+                        $crate::async_api::provenance::SourceLocation {
+                            root: $crate::async_api::provenance::SourceRoot::MoonbitAsync,
+                            path: $source_path,
+                        },
+                    ],
+                },
+            ] [
+                $($out)*
+                $(#[$meta])*
+                $vis fn $function($($params)*) $(-> $ret)? $body
+            ]
+            $($rest)*
+        );
+    };
+    (@collect [$($entries:tt)*] [$($out:tt)*] $item:item $($rest:tt)*) => {
+        ported_imports!(@collect [$($entries)*] [$($out)* $item] $($rest)*);
+    };
+    ($($items:tt)*) => {
+        ported_imports!(@collect [] [] $($items)*);
+    };
+}
+
+pub(super) use ported_imports;

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -18,87 +18,145 @@
 
 use crate::v8_builder::ObjectExt;
 
-use super::{event_loop, os_error, runtime, thread_pool, time, unsupported};
+#[cfg(test)]
+use super::provenance::{PortedImport, SourceLocation, SourceRoot};
+use super::{
+    c_buffer,
+    context::{
+        AsyncContext, FinishI32, FinishI64, FinishVoid, ImportArgs, ImportContext,
+        callback_context, throw_import_error,
+    },
+    env_util, event_bus, event_loop, fd_util, fs, io, os_error, os_string, runtime, thread_pool,
+    time,
+};
 
-pub(crate) const MOONBIT_V0_MODULE: &str = "moonbit_v0";
+pub(crate) const MOONBIT_ASYNC_MODULE: &str = "moonbitlang/async";
 #[cfg(test)]
 const NATIVE_ASYNC_PREFIX: &str = "moonbitlang_async_";
 
 #[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AsyncImportKind {
-    NativeMapped,
-    UnsupportedMvp,
-    WasmSupport,
+    Ported,
+    Helper,
+    Fake,
 }
 
 #[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SourceRoot {
-    MoonbitAsync,
-    Moonrun,
-}
-
-#[cfg(test)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct SourceLocation {
-    root: SourceRoot,
-    path: &'static str,
+enum WasmType {
+    I32,
+    I64,
 }
 
 #[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct AsyncImport {
     kind: AsyncImportKind,
+    callback_module: &'static str,
+    callback_symbol: &'static str,
     wasm_symbol: &'static str,
-    native_symbol: Option<&'static str>,
-    sources: &'static [SourceLocation],
+    params: &'static [WasmType],
+    result: Option<WasmType>,
 }
 
 #[cfg(test)]
 macro_rules! import_kind {
-    (native) => {
-        AsyncImportKind::NativeMapped
+    (ported) => {
+        AsyncImportKind::Ported
     };
-    (unsupported) => {
-        AsyncImportKind::UnsupportedMvp
+    (helper) => {
+        AsyncImportKind::Helper
     };
-    (support) => {
-        AsyncImportKind::WasmSupport
+    (fake) => {
+        AsyncImportKind::Fake
     };
 }
 
 #[cfg(test)]
-macro_rules! source_root {
-    (moonbit_async) => {
-        SourceRoot::MoonbitAsync
+macro_rules! wasm_type {
+    (i32) => {
+        WasmType::I32
     };
-    (moonrun) => {
-        SourceRoot::Moonrun
+    (i64) => {
+        WasmType::I64
+    };
+    (u64) => {
+        WasmType::I64
+    };
+}
+
+#[cfg(test)]
+macro_rules! wasm_result {
+    (void) => {
+        None
+    };
+    ($ty:ident) => {
+        Some(wasm_type!($ty))
+    };
+}
+
+macro_rules! decode_wasm_arg {
+    ($args:ident, i32) => {
+        $args.next_i32()
+    };
+    ($args:ident, i64) => {
+        $args.next_i64()
+    };
+    ($args:ident, u64) => {
+        $args.next_u64()
+    };
+}
+
+macro_rules! decode_wasm_args {
+    ($scope:ident, $args:ident,) => {
+        Ok(())
+    };
+    ($scope:ident, $args:ident, $($arg:ident : $arg_ty:ident),+ $(,)?) => {{
+        let mut import_args = ImportArgs::new($scope, &$args);
+        let decoded_args: crate::async_host::AsyncHostResult<_> = (|| {
+            $(
+                let $arg = decode_wasm_arg!(import_args, $arg_ty)?;
+            )*
+            Ok(($($arg,)*))
+        })();
+        decoded_args
+    }};
+}
+
+macro_rules! finish_wasm_import {
+    ($scope:ident, $ret:ident, $name:expr, void, $result:expr) => {
+        $result.finish_void($scope, &mut $ret, $name)
+    };
+    ($scope:ident, $ret:ident, $name:expr, i32, $result:expr) => {
+        $result.finish_i32($scope, &mut $ret, $name)
+    };
+    ($scope:ident, $ret:ident, $name:expr, i64, $result:expr) => {
+        $result.finish_i64($scope, &mut $ret, $name)
+    };
+    ($scope:ident, $ret:ident, $name:expr, u64, $result:expr) => {
+        $result.finish_i64($scope, &mut $ret, $name)
     };
 }
 
 macro_rules! declare_async_imports {
     ($(
-        $kind:ident $callback:path => $wasm_symbol:literal,
-        native = $native_symbol:expr,
-        sources = [$($source_root:ident:$source_path:literal),+ $(,)?];
+        $(#[$meta:meta])*
+        $kind:ident $module:ident::$callback:ident (
+            $($arg:ident : $arg_ty:ident),* $(,)?
+        ) -> $ret_ty:ident => $wasm_symbol:literal;
     )*) => {
         #[cfg(test)]
         const ASYNC_IMPORTS: &[AsyncImport] = &[
             $(
+                $(#[$meta])*
                 AsyncImport {
                     kind: import_kind!($kind),
+                    callback_module: stringify!($module),
+                    callback_symbol: stringify!($callback),
                     wasm_symbol: $wasm_symbol,
-                    native_symbol: $native_symbol,
-                    sources: &[
-                        $(
-                            SourceLocation {
-                                root: source_root!($source_root),
-                                path: $source_path,
-                            },
-                        )+
-                    ],
+                    params: &[$(wasm_type!($arg_ty)),*],
+                    result: wasm_result!($ret_ty),
                 },
             )*
         ];
@@ -106,12 +164,83 @@ macro_rules! declare_async_imports {
         pub(super) fn register_imports<'s>(
             obj: v8::Local<'s, v8::Object>,
             scope: &mut v8::HandleScope<'s>,
+            context_ptr: *const AsyncContext,
         ) {
             $(
-                register_func_impl(obj, scope, $wasm_symbol, $callback);
+                $(#[$meta])*
+                register_async_import!(
+                    $kind,
+                    obj,
+                    scope,
+                    context_ptr,
+                    $wasm_symbol,
+                    $ret_ty,
+                    $module::$callback,
+                    ($($arg : $arg_ty),*)
+                );
             )*
         }
     };
+}
+
+macro_rules! register_async_import {
+    (
+        fake,
+        $obj:ident,
+        $scope:ident,
+        $context_ptr:ident,
+        $wasm_symbol:literal,
+        $ret_ty:ident,
+        $module:ident::$callback:ident,
+        ($($arg:ident : $arg_ty:ident),* $(,)?)
+    ) => {{
+        fn callback(
+            _scope: &mut v8::HandleScope,
+            _args: v8::FunctionCallbackArguments,
+            _ret: v8::ReturnValue,
+        ) {
+            unreachable!("fake async import should not be called")
+        }
+        register_func_impl($obj, $scope, $wasm_symbol, callback, $context_ptr);
+    }};
+    (
+        $kind:ident,
+        $obj:ident,
+        $scope:ident,
+        $context_ptr:ident,
+        $wasm_symbol:literal,
+        $ret_ty:ident,
+        $module:ident::$callback:ident,
+        ($($arg:ident : $arg_ty:ident),* $(,)?)
+    ) => {{
+        fn callback(
+            scope: &mut v8::HandleScope,
+            args: v8::FunctionCallbackArguments,
+            mut ret: v8::ReturnValue,
+        ) {
+            let _ = &args;
+            let host_context = callback_context(&args);
+            let decoded_args: crate::async_host::AsyncHostResult<_> =
+                decode_wasm_args!(scope, args, $($arg : $arg_ty),*);
+            match decoded_args {
+                Ok(($($arg,)*)) => {
+                    let result = {
+                        let mut context = ImportContext::new(scope, host_context);
+                        $module::$callback(&mut context, $($arg),*)
+                    };
+                    finish_wasm_import!(
+                        scope,
+                        ret,
+                        $wasm_symbol,
+                        $ret_ty,
+                        result
+                    );
+                }
+                Err(error) => throw_import_error(scope, $wasm_symbol, error),
+            }
+        }
+        register_func_impl($obj, $scope, $wasm_symbol, callback, $context_ptr);
+    }};
 }
 
 fn register_func_impl<'s>(
@@ -119,314 +248,438 @@ fn register_func_impl<'s>(
     scope: &mut v8::HandleScope<'s>,
     name: &str,
     callback: impl v8::MapFnTo<v8::FunctionCallback>,
+    context_ptr: *const AsyncContext,
 ) {
-    obj.set_func(scope, name, callback);
+    let data = v8::External::new(scope, context_ptr as *mut std::ffi::c_void);
+    let function = v8::Function::builder(callback)
+        .data(data.into())
+        .build(scope)
+        .unwrap();
+    obj.set_value(scope, name, function.into());
 }
 
-// Complete `moonbit_v0` async ABI surface registered by this split PR.
+// This block is the complete `moonbitlang/async` ABI surface registered by moonrun.
 //
 // Entry shape:
-//   kind callback maps to "namespace/wasm_symbol",
-//   native = Some("moonbitlang_async_native_symbol") | None,
-//   sources = [moonbit_async:"path/in/async", moonrun:"path/in/moonrun"];
+//   kind callback maps to "namespace/wasm_symbol".
 //
 // Kind legend:
-// - native: a supported import whose semantics are expected to follow the
-//   corresponding native C stub.
-// - support: wasm-only host glue or a supported import with wasm-specific
-//   behavior. A native symbol may still be listed for provenance.
-// - unsupported: registered for link compatibility and one-to-one C-stub
-//   inventory only; it fails loudly if PR1 accidentally reaches that surface.
+// - ported: imports that have Rust ports corresponding to native async C stubs.
+//   Tests require separate native provenance entries for these imports.
+// - helper: wasm-only support import or host-control glue.
+// - fake: link-only import for runtime-dispatched wasm; the generated callback is unreachable.
 declare_async_imports! {
-    support runtime::exit => "runtime/exit",
-    native = None,
-    sources = [
-        moonbit_async:"src/integration.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/runtime.rs",
-    ];
 
-    // Wasm-only timer wait glue. This is not a native C-stub mapping; native
-    // `moonbitlang_async_poll_wait` is listed below as unsupported `poll/poll_wait`.
-    support runtime::wait_for_event => "runtime/wait_for_event",
-    native = None,
-    sources = [
-        moonbit_async:"src/internal/event_loop/event_loop.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/runtime.rs",
-    ];
+    // Runtime platform and worker control.
+    helper runtime::exit(code: i32) -> void => "runtime/exit";
 
-    native event_loop::get_platform => "runtime/get_platform",
-    native = Some("moonbitlang_async_get_platform"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.c",
-        moonbit_async:"src/internal/event_loop/event_loop.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/event_loop.rs",
-    ];
+    ported event_loop::get_platform() -> i32 => "runtime/get_platform";
 
-    support time::get_ms_since_epoch => "time/get_ms_since_epoch",
-    native = None,
-    sources = [
-        moonbit_async:"src/internal/event_loop/event_loop.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/time.rs",
-    ];
+    ported event_bus::create() -> u64 => "event_bus/create";
 
-    native os_error::get_errno => "os_error/get_errno",
-    native = Some("moonbitlang_async_get_errno"),
-    sources = [
-        moonbit_async:"src/os_error/stub.c",
-        moonbit_async:"src/os_error/error.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/os_error.rs",
-    ];
+    ported event_bus::destroy(bus: u64) -> void => "event_bus/destroy";
 
-    support event_loop::errno_is_cancelled => "thread_pool/errno_is_cancelled",
-    native = Some("moonbitlang_async_errno_is_cancelled"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.c",
-        moonbit_async:"src/internal/event_loop/event_loop.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/event_loop.rs",
-    ];
+    ported event_bus::register(
+        bus: u64,
+        fd: u64,
+        read_only: i32,
+    ) -> i32 => "event_bus/register";
 
-    support thread_pool::fetch_completion => "thread_pool/fetch_completion",
-    native = Some("moonbitlang_async_fetch_completion"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.c",
-        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/thread_pool.rs",
-    ];
+    ported event_bus::wait(bus: u64, timeout_ms: i32) -> i32 => "event_bus/wait";
 
-    // Native poller C ABI. PR1 does not expose the native fd/event-list poller,
-    // but the exact C stubs are still registered as unsupported ABI inventory.
-    unsupported unsupported::fail => "poll/poll_create",
-    native = Some("moonbitlang_async_poll_create"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/epoll.c",
-        moonbit_async:"src/internal/event_loop/kqueue.c",
-        moonbit_async:"src/internal/event_loop/iocp.c",
-    ];
+    ported event_bus::get_event(bus: u64, index: i32) -> u64 => "event_bus/get_event";
 
-    unsupported unsupported::fail => "poll/poll_destroy",
-    native = Some("moonbitlang_async_poll_destroy"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/epoll.c",
-        moonbit_async:"src/internal/event_loop/kqueue.c",
-        moonbit_async:"src/internal/event_loop/iocp.c",
-    ];
+    ported event_bus::event_fd(event: u64) -> u64 => "event_bus/event_fd";
 
-    unsupported unsupported::fail => "poll/poll_register",
-    native = Some("moonbitlang_async_poll_register"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/epoll.c",
-        moonbit_async:"src/internal/event_loop/kqueue.c",
-        moonbit_async:"src/internal/event_loop/iocp.c",
-    ];
+    #[cfg(unix)]
+    ported event_bus::event_events(event: u64) -> i32 => "event_bus/event_events/unix";
 
-    unsupported unsupported::fail => "poll/support_wait_pid_via_poll",
-    native = Some("moonbitlang_async_support_wait_pid_via_poll"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/epoll.c",
-        moonbit_async:"src/internal/event_loop/kqueue.c",
-    ];
+    #[cfg(windows)]
+    fake event_bus::event_events(event: u64) -> i32 => "event_bus/event_events/unix";
 
-    unsupported unsupported::fail => "poll/poll_register_pid",
-    native = Some("moonbitlang_async_poll_register_pid"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/epoll.c",
-        moonbit_async:"src/internal/event_loop/kqueue.c",
-    ];
+    #[cfg(windows)]
+    ported event_bus::event_io_result(event: u64) -> u64 => "event_bus/event_io_result/windows";
 
-    unsupported unsupported::fail => "poll/poll_remove",
-    native = Some("moonbitlang_async_poll_remove"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/epoll.c",
-        moonbit_async:"src/internal/event_loop/kqueue.c",
-    ];
+    #[cfg(not(windows))]
+    fake event_bus::event_io_result(event: u64) -> u64 => "event_bus/event_io_result/windows";
 
-    unsupported unsupported::fail => "poll/poll_remove_pid",
-    native = Some("moonbitlang_async_poll_remove_pid"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/epoll.c",
-        moonbit_async:"src/internal/event_loop/kqueue.c",
-    ];
+    #[cfg(windows)]
+    ported event_bus::event_bytes_transferred(event: u64) -> i32 => "event_bus/event_bytes_transferred/windows";
 
-    unsupported unsupported::fail => "poll/poll_wait",
-    native = Some("moonbitlang_async_poll_wait"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/epoll.c",
-        moonbit_async:"src/internal/event_loop/kqueue.c",
-        moonbit_async:"src/internal/event_loop/iocp.c",
-    ];
+    #[cfg(not(windows))]
+    fake event_bus::event_bytes_transferred(event: u64) -> i32 => "event_bus/event_bytes_transferred/windows";
 
-    unsupported unsupported::fail => "poll/event_list_get",
-    native = Some("moonbitlang_async_event_list_get"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/epoll.c",
-        moonbit_async:"src/internal/event_loop/kqueue.c",
-        moonbit_async:"src/internal/event_loop/iocp.c",
-    ];
+    ported event_loop::errno_is_cancelled(errno: i32) -> i32 => "thread_pool/errno_is_cancelled";
 
-    unsupported unsupported::fail => "poll/event_get_fd",
-    native = Some("moonbitlang_async_event_get_fd"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/epoll.c",
-        moonbit_async:"src/internal/event_loop/kqueue.c",
-        moonbit_async:"src/internal/event_loop/iocp.c",
-    ];
+    ported thread_pool::job_get_ret(job: u64) -> i32 => "thread_pool/job_get_ret";
 
-    unsupported unsupported::fail => "poll/event_get_events",
-    native = Some("moonbitlang_async_event_get_events"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/epoll.c",
-        moonbit_async:"src/internal/event_loop/kqueue.c",
-    ];
+    ported thread_pool::job_get_err(job: u64) -> i32 => "thread_pool/job_get_err";
 
-    unsupported unsupported::fail => "poll/event_get_io_result",
-    native = Some("moonbitlang_async_event_get_io_result"),
-    sources = [moonbit_async:"src/internal/event_loop/iocp.c"];
+    helper thread_pool::free_job(job: u64) -> void => "thread_pool/free_job";
 
-    unsupported unsupported::fail => "poll/event_get_bytes_transferred",
-    native = Some("moonbitlang_async_event_get_bytes_transferred"),
-    sources = [moonbit_async:"src/internal/event_loop/iocp.c"];
+    helper thread_pool::run_job(job: u64) -> void => "thread_pool/run_job";
 
-    unsupported unsupported::fail => "thread_pool/spawn_worker",
-    native = Some("moonbitlang_async_spawn_worker"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.c",
-        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
-    ];
+    ported thread_pool::spawn_worker(worker_id: i32, waiting_worker_id: u64) -> u64 => "thread_pool/spawn_worker";
 
-    unsupported unsupported::fail => "thread_pool/free_worker",
-    native = Some("moonbitlang_async_free_worker"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.c",
-        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
-    ];
+    ported thread_pool::free_worker(worker: u64) -> void => "thread_pool/free_worker";
 
-    unsupported unsupported::fail => "thread_pool/wake_worker",
-    native = Some("moonbitlang_async_wake_worker"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.c",
-        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
-    ];
+    ported thread_pool::wake_worker(worker: u64, job_id: i32, job: u64) -> void => "thread_pool/wake_worker";
 
-    unsupported unsupported::fail => "thread_pool/worker_enter_idle",
-    native = Some("moonbitlang_async_worker_enter_idle"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.c",
-        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
-    ];
+    ported thread_pool::worker_enter_idle(worker: u64) -> void => "thread_pool/worker_enter_idle";
 
-    unsupported unsupported::fail => "thread_pool/cancel_worker",
-    native = Some("moonbitlang_async_cancel_worker"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.c",
-        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
-    ];
+    ported thread_pool::cancel_worker(worker: u64) -> i32 => "thread_pool/cancel_worker";
 
-    unsupported unsupported::fail => "thread_pool/free_job",
-    native = Some("moonbitlang_async_free_job"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.c",
-        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
-    ];
+    helper thread_pool::init_thread_pool(poll: u64) -> u64 => "thread_pool/init_thread_pool";
 
-    unsupported unsupported::fail => "thread_pool/run_job",
-    native = None,
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
-    ];
+    helper thread_pool::destroy_thread_pool() -> void => "thread_pool/destroy_thread_pool";
 
-    unsupported unsupported::fail => "thread_pool/job_get_ret",
-    native = Some("moonbitlang_async_job_get_ret"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.c",
-        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
-    ];
+    #[cfg(unix)]
+    helper thread_pool::fetch_completion(source_fd: u64, dst: i32, max_jobs: i32) -> i32 => "thread_pool/fetch_completion/unix";
 
-    unsupported unsupported::fail => "thread_pool/job_get_err",
-    native = Some("moonbitlang_async_job_get_err"),
-    sources = [
-        moonbit_async:"src/internal/event_loop/thread_pool.c",
-        moonbit_async:"src/internal/event_loop/thread_pool.wasm.mbt",
-        moonrun:"crates/moonrun/src/async_api/unsupported.rs",
-    ];
+    #[cfg(windows)]
+    fake thread_pool::fetch_completion(source_fd: u64, dst: i32, max_jobs: i32) -> i32 => "thread_pool/fetch_completion/unix";
+
+    ported thread_pool::make_sleep_job(duration_ms: i32) -> u64 => "thread_pool/make_sleep_job";
+
+    // Time helpers.
+    helper time::get_ms_since_epoch() -> i64 => "time/get_ms_since_epoch";
+
+    // os_error/stub.c predicates, errno accessors, and string formatting.
+    ported os_error::get_errno() -> i32 => "os_error/get_errno";
+
+    ported os_error::is_nonblocking_io_error(errno: i32) -> i32 => "os_error/is_nonblocking_io_error";
+
+    ported os_error::is_eintr(errno: i32) -> i32 => "os_error/is_EINTR";
+
+    ported os_error::is_enoent(errno: i32) -> i32 => "os_error/is_ENOENT";
+
+    ported os_error::is_eexist(errno: i32) -> i32 => "os_error/is_EEXIST";
+
+    ported os_error::is_eacces(errno: i32) -> i32 => "os_error/is_EACCES";
+
+    ported os_error::is_econnrefused(errno: i32) -> i32 => "os_error/is_ECONNREFUSED";
+
+    ported os_error::is_error_notify_enum_dir(errno: i32) -> i32 => "os_error/is_ERROR_NOTIFY_ENUM_DIR";
+
+    ported os_error::get_enotdir() -> i32 => "os_error/get_ENOTDIR";
+
+    helper os_error::errno_to_string_len(errno: i32) -> i32 => "os_error/errno_to_string_len";
+
+    ported os_error::errno_to_string(errno: i32, ptr: i32, len: i32) -> i32 => "os_error/errno_to_string";
+
+    // Decode host-native strings into guest-owned MoonBit String storage.
+    helper os_string::decode_len(ptr: u64, len: i32) -> i32 => "os_string/decode_len";
+
+    helper os_string::decode(ptr: u64, len: i32, out: i32, out_len: i32) -> void => "os_string/decode";
+
+    helper fs::close_fd(fd: u64) -> i32 => "fd_util/close_fd";
+
+    helper fd_util::invalid_fd() -> u64 => "fd_util/invalid_fd";
+
+    #[cfg(unix)]
+    ported fd_util::pipe(
+        dst: i32,
+        len: i32,
+        read_end_is_async: i32,
+        write_end_is_async: i32,
+    ) -> i32 => "fd_util/pipe";
+
+    #[cfg(windows)]
+    helper fd_util::pipe(
+        dst: i32,
+        len: i32,
+        read_end_is_async: i32,
+        write_end_is_async: i32,
+    ) -> i32 => "fd_util/pipe";
+
+    #[cfg(unix)]
+    ported fd_util::set_nonblocking(fd: u64) -> i32 => "fd_util/set_nonblocking/unix";
+
+    #[cfg(windows)]
+    fake fd_util::set_nonblocking(fd: u64) -> i32 => "fd_util/set_nonblocking/unix";
+
+    helper fd_util::sizeof_file_time() -> i32 => "fd_util/sizeof_file_time";
+
+    ported fd_util::get_atime_sec(ptr: i32) -> i64 => "fd_util/get_atime_sec";
+
+    ported fd_util::get_atime_nsec(ptr: i32) -> i32 => "fd_util/get_atime_nsec";
+
+    ported fd_util::get_mtime_sec(ptr: i32) -> i64 => "fd_util/get_mtime_sec";
+
+    ported fd_util::get_mtime_nsec(ptr: i32) -> i32 => "fd_util/get_mtime_nsec";
+
+    ported fd_util::get_ctime_sec(ptr: i32) -> i64 => "fd_util/get_ctime_sec";
+
+    ported fd_util::get_ctime_nsec(ptr: i32) -> i32 => "fd_util/get_ctime_nsec";
+
+    // Small internal utility stubs.
+    ported env_util::getpid() -> i32 => "env_util/getpid";
+
+    #[cfg(unix)]
+    ported io::read(fd: u64, dst: i32, offset: i32, len: i32) -> i32 => "io/read/unix";
+
+    #[cfg(windows)]
+    fake io::read(fd: u64, dst: i32, offset: i32, len: i32) -> i32 => "io/read/unix";
+
+    #[cfg(unix)]
+    ported io::write(fd: u64, src: i32, offset: i32, len: i32) -> i32 => "io/write/unix";
+
+    #[cfg(windows)]
+    fake io::write(fd: u64, src: i32, offset: i32, len: i32) -> i32 => "io/write/unix";
+
+    #[cfg(windows)]
+    ported io::make_file_io_result(
+        events: i32,
+        buf: i32,
+        offset: i32,
+        len: i32,
+        position: i64,
+    ) -> u64 => "io/make_file_io_result/windows";
+
+    #[cfg(not(windows))]
+    fake io::make_file_io_result(
+        events: i32,
+        buf: i32,
+        offset: i32,
+        len: i32,
+        position: i64,
+    ) -> u64 => "io/make_file_io_result/windows";
+
+    #[cfg(windows)]
+    ported io::free_io_result(result: u64) -> void => "io/free_io_result/windows";
+
+    #[cfg(not(windows))]
+    fake io::free_io_result(result: u64) -> void => "io/free_io_result/windows";
+
+    #[cfg(windows)]
+    ported io::io_result_get_event(result: u64) -> i32 => "io/io_result_get_event/windows";
+
+    #[cfg(not(windows))]
+    fake io::io_result_get_event(result: u64) -> i32 => "io/io_result_get_event/windows";
+
+    #[cfg(windows)]
+    ported io::cancel_io_result(result: u64, fd: u64) -> i32 => "io/cancel_io_result/windows";
+
+    #[cfg(not(windows))]
+    fake io::cancel_io_result(result: u64, fd: u64) -> i32 => "io/cancel_io_result/windows";
+
+    #[cfg(windows)]
+    ported io::io_result_get_status(result: u64, fd: u64) -> i32 => "io/io_result_get_status/windows";
+
+    #[cfg(not(windows))]
+    fake io::io_result_get_status(result: u64, fd: u64) -> i32 => "io/io_result_get_status/windows";
+
+    #[cfg(windows)]
+    ported io::read_io_result(fd: u64, result: u64) -> i32 => "io/read/windows";
+
+    #[cfg(not(windows))]
+    fake io::read_io_result(fd: u64, result: u64) -> i32 => "io/read/windows";
+
+    #[cfg(windows)]
+    ported io::write_io_result(fd: u64, result: u64) -> i32 => "io/write/windows";
+
+    #[cfg(not(windows))]
+    fake io::write_io_result(fd: u64, result: u64) -> i32 => "io/write/windows";
+
+    #[cfg(windows)]
+    ported io::errno_is_read_eof(errno: i32) -> i32 => "io/errno_is_read_EOF/windows";
+
+    #[cfg(not(windows))]
+    fake io::errno_is_read_eof(errno: i32) -> i32 => "io/errno_is_read_EOF/windows";
+
+    helper c_buffer::is_null(ptr: u64) -> i32 => "c_buffer/is_null";
+
+    ported c_buffer::blit_to_c(dst: u64, src: i32, offset: i32, len: i32) -> void => "c_buffer/blit_to_c";
+
+    ported c_buffer::blit_from_c(src: u64, dst: i32, offset: i32, len: i32) -> void => "c_buffer/blit_from_c";
+
+    ported c_buffer::c_buffer_get(buf: u64, index: i32) -> i32 => "c_buffer/c_buffer_get";
+
+    ported c_buffer::strlen(buf: u64) -> i32 => "c_buffer/strlen";
+
+    helper c_buffer::free(ptr: u64) -> void => "c_buffer/free";
+
+    // fs/stub.c and fs/dir.c.
+    ported fs::errno_is_lock_violation(errno: i32) -> i32 => "fs/errno_is_lock_violation";
+
+    ported fs::try_lock_file(fd: u64, exclusive: i32) -> i32 => "fs/try_lock_file";
+
+    ported fs::unlock_file(fd: u64) -> i32 => "fs/unlock_file";
+
+    // Returns the UTF-16 code-unit length that the guest must allocate for
+    // `fs/get_tmp_path`.
+    helper fs::get_tmp_path_len() -> i32 => "fs/get_tmp_path_len";
+
+    // Writes the native temporary directory as UTF-16 code units into a
+    // guest-allocated MoonBit String.
+    ported fs::get_tmp_path(ptr: i32, len: i32) -> i32 => "fs/get_tmp_path";
+
+    ported fs::dir_buffer_min_size() -> i32 => "fs/dir_buffer_min_size";
+
+    ported fs::dir_entry_length(buf: i32, offset: i32) -> i32 => "fs/dir_entry_length";
+
+    ported fs::dir_entry_name_len(buf: i32, offset: i32) -> i32 => "fs/dir_entry_get_name_len";
+
+    ported fs::dir_entry_name(buf: i32, offset: i32) -> u64 => "fs/dir_entry_get_name";
+
+    ported fs::dir_entry_is_dir(buf: i32, offset: i32) -> i32 => "fs/dir_entry_is_dir";
+
+    ported fs::dir_entry_is_hidden(buf: i32, offset: i32) -> i32 => "fs/dir_entry_is_hidden";
+
+    ported fs::dir_entry_file_id(buf: i32, offset: i32) -> i64 => "fs/dir_entry_get_file_id";
+
+    // thread_pool.c FS jobs. Path-taking jobs use the Guest String Path ABI:
+    // MoonBit String pointer plus UTF-16 code-unit length.
+    ported thread_pool::make_open_job(
+        path_ptr: i32,
+        path_len: i32,
+        access: i32,
+        create_mode: i32,
+        append: i32,
+        sync: i32,
+        mode: i32,
+    ) -> u64 => "thread_pool/make_open_job";
+
+    ported thread_pool::open_job_get_fd(job: u64) -> u64 => "thread_pool/open_job_get_fd";
+
+    ported thread_pool::open_job_get_kind(job: u64) -> i32 => "thread_pool/open_job_get_kind";
+
+    ported thread_pool::open_job_get_dev_id(job: u64) -> u64 => "thread_pool/open_job_get_dev_id";
+
+    ported thread_pool::open_job_get_file_id(job: u64) -> u64 => "thread_pool/open_job_get_file_id";
+
+    ported thread_pool::make_read_job(fd: u64, len: i32, position: i64) -> u64 => "thread_pool/make_read_job";
+
+    ported thread_pool::make_write_job(fd: u64, ptr: i32, offset: i32, len: i32, position: i64) -> u64 => "thread_pool/make_write_job";
+
+    helper thread_pool::get_read_result(job: u64, dst: i32, offset: i32, len: i32) -> void => "thread_pool/get_read_result";
+
+    ported thread_pool::make_file_kind_by_path_job(
+        parent: u64,
+        path_ptr: i32,
+        path_len: i32,
+        follow_symlink: i32,
+    ) -> u64 => "thread_pool/make_file_kind_by_path_job";
+
+    ported thread_pool::make_file_size_job(fd: u64) -> u64 => "thread_pool/make_file_size_job";
+
+    ported thread_pool::get_file_size_result(job: u64) -> i64 => "thread_pool/get_file_size_result";
+
+    ported thread_pool::make_file_time_job(fd: u64) -> u64 => "thread_pool/make_file_time_job";
+
+    ported thread_pool::make_file_time_by_path_job(
+        path_ptr: i32,
+        path_len: i32,
+        follow_symlink: i32,
+    ) -> u64 => "thread_pool/make_file_time_by_path_job";
+
+    helper thread_pool::get_file_time_result(job: u64, out: i32) -> void => "thread_pool/get_file_time_result";
+
+    ported thread_pool::make_access_job(path_ptr: i32, path_len: i32, access: i32) -> u64 => "thread_pool/make_access_job";
+
+    ported thread_pool::make_chmod_job(path_ptr: i32, path_len: i32, mode: i32) -> u64 => "thread_pool/make_chmod_job";
+
+    ported thread_pool::make_fsync_job(fd: u64, only_data: i32) -> u64 => "thread_pool/make_fsync_job";
+
+    ported thread_pool::make_flock_job(fd: u64, exclusive: i32) -> u64 => "thread_pool/make_flock_job";
+
+    ported thread_pool::make_remove_job(path_ptr: i32, path_len: i32) -> u64 => "thread_pool/make_remove_job";
+
+    ported thread_pool::make_rename_job(
+        old_path_ptr: i32,
+        old_path_len: i32,
+        new_path_ptr: i32,
+        new_path_len: i32,
+        replace: i32,
+    ) -> u64 => "thread_pool/make_rename_job";
+
+    ported thread_pool::make_symlink_job(
+        target_ptr: i32,
+        target_len: i32,
+        path_ptr: i32,
+        path_len: i32,
+        force_symlink: i32,
+    ) -> u64 => "thread_pool/make_symlink_job";
+
+    ported thread_pool::make_mkdir_job(path_ptr: i32, path_len: i32, mode: i32) -> u64 => "thread_pool/make_mkdir_job";
+
+    ported thread_pool::make_rmdir_job(path_ptr: i32, path_len: i32) -> u64 => "thread_pool/make_rmdir_job";
+
+    ported thread_pool::make_readdir_job(dir: u64, len: i32, restart: i32) -> u64 => "thread_pool/make_readdir_job";
+
+    helper thread_pool::get_readdir_result(job: u64, dst: i32, len: i32) -> void => "thread_pool/get_readdir_result";
+}
+
+#[cfg(test)]
+fn async_api_ported_imports() -> Vec<PortedImport> {
+    let mut imports = Vec::new();
+    imports.extend_from_slice(event_loop::PORTED_IMPORTS);
+    imports.extend_from_slice(event_bus::PORTED_IMPORTS);
+    imports.extend_from_slice(thread_pool::PORTED_IMPORTS);
+    imports.extend_from_slice(os_error::PORTED_IMPORTS);
+    imports.extend_from_slice(fs::PORTED_IMPORTS);
+    imports.extend_from_slice(fd_util::PORTED_IMPORTS);
+    imports.extend_from_slice(io::PORTED_IMPORTS);
+    imports.extend_from_slice(env_util::PORTED_IMPORTS);
+    imports.extend_from_slice(c_buffer::PORTED_IMPORTS);
+    imports
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-    use std::path::{Path, PathBuf};
+    use std::{collections::BTreeSet, fs, path::Path};
 
     use super::*;
 
-    fn repo_root() -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    fn repo_root() -> &'static Path {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
-            .and_then(|path| path.parent())
-            .unwrap()
-            .to_path_buf()
+            .and_then(Path::parent)
+            .expect("moonrun crate must live under crates/moonrun")
     }
 
-    fn source_path(source: SourceLocation) -> PathBuf {
+    fn source_path(source: SourceLocation) -> std::path::PathBuf {
         match source.root {
             SourceRoot::MoonbitAsync => repo_root()
                 .join("third_party/moonbitlang_async")
                 .join(source.path),
-            SourceRoot::Moonrun => repo_root().join(source.path),
         }
     }
 
-    fn collect_moonbit_files(dir: &Path, files: &mut Vec<PathBuf>) {
-        for entry in std::fs::read_dir(dir).unwrap() {
-            let path = entry.unwrap().path();
-            if path.is_dir() {
-                collect_moonbit_files(&path, files);
-            } else if path.extension().is_some_and(|extension| extension == "mbt") {
-                files.push(path);
-            }
-        }
+    fn native_symbol(import: &AsyncImport) -> String {
+        let segments = import.wasm_symbol.split('/').collect::<Vec<_>>();
+        let leaf = match segments.as_slice() {
+            [.., symbol, "linux" | "macos" | "unix" | "windows"] => symbol,
+            [.., symbol] => symbol,
+            [] => import.callback_symbol,
+        };
+        format!("{NATIVE_ASYNC_PREFIX}{leaf}")
     }
 
-    fn moonbit_v0_imports() -> HashSet<String> {
-        let marker = "\"moonbit_v0\" \"";
-        let mut files = Vec::new();
-        collect_moonbit_files(
-            &repo_root().join("third_party/moonbitlang_async/src"),
-            &mut files,
-        );
+    fn native_symbol_for(import: &AsyncImport, ported_import: &PortedImport) -> String {
+        ported_import
+            .native_symbol
+            .map(str::to_string)
+            .unwrap_or_else(|| native_symbol(import))
+    }
 
-        let mut imports = HashSet::new();
-        for file in files {
-            let contents = std::fs::read_to_string(file).unwrap();
-            for line in contents.lines() {
-                let mut rest = line;
-                while let Some(start) = rest.find(marker) {
-                    let symbol_start = start + marker.len();
-                    rest = &rest[symbol_start..];
-                    if let Some(end) = rest.find('"') {
-                        imports.insert(rest[..end].to_owned());
-                        rest = &rest[end..];
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
-        imports
+    fn module_leaf(module_path: &str) -> Option<&str> {
+        module_path.rsplit("::").next()
+    }
+
+    fn registered_import_for_ported(ported_import: &PortedImport) -> Option<&'static AsyncImport> {
+        ASYNC_IMPORTS.iter().find(|import| {
+            module_leaf(ported_import.rust_module) == Some(import.callback_module)
+                && ported_import.rust_symbol == import.callback_symbol
+        })
     }
 
     #[test]
-    fn import_names_are_unique() {
-        let mut names = HashSet::new();
+    fn wasm_import_names_are_unique() {
+        let mut seen = BTreeSet::new();
         for import in ASYNC_IMPORTS {
             assert!(
-                names.insert(import.wasm_symbol),
+                seen.insert(import.wasm_symbol),
                 "duplicate async import {}",
                 import.wasm_symbol
             );
@@ -434,146 +687,177 @@ mod tests {
     }
 
     #[test]
-    fn registry_covers_async_wasm_imports() {
-        let declared = ASYNC_IMPORTS
+    fn runtime_exit_is_part_of_moonbit_async() {
+        assert!(
+            ASYNC_IMPORTS.iter().any(|import| {
+                import.kind == AsyncImportKind::Helper && import.wasm_symbol == "runtime/exit"
+            }),
+            "async wasm integration must not depend on older runtime namespaces for exit"
+        );
+    }
+
+    #[test]
+    fn event_bus_imports_are_the_event_loop_boundary() {
+        let imports = ASYNC_IMPORTS
             .iter()
             .map(|import| import.wasm_symbol)
-            .collect::<HashSet<_>>();
-        let actual = moonbit_v0_imports();
-        for import in actual {
+            .collect::<BTreeSet<_>>();
+        assert!(
+            !imports.contains("runtime/wait_for_event"),
+            "async wasm event loop must not use runtime/wait_for_event"
+        );
+        for wasm_symbol in [
+            "event_bus/create",
+            "event_bus/destroy",
+            "event_bus/register",
+            "event_bus/wait",
+            "event_bus/get_event",
+            "event_bus/event_fd",
+            "event_bus/event_events/unix",
+            "event_bus/event_io_result/windows",
+            "event_bus/event_bytes_transferred/windows",
+        ] {
             assert!(
-                declared.contains(import.as_str()),
-                "missing moonbit_v0 async import registration for {import}"
+                imports.contains(wasm_symbol),
+                "missing async wasm event bus import {wasm_symbol}"
             );
         }
     }
 
     #[test]
-    fn source_locations_exist() {
+    fn wasm_import_names_are_namespaced() {
         for import in ASYNC_IMPORTS {
-            for source in import.sources {
-                let path = source_path(*source);
+            let Some((_namespace, _)) = import.wasm_symbol.split_once('/') else {
+                panic!("async import {} must be namespaced", import.wasm_symbol);
+            };
+            for segment in import.wasm_symbol.split('/') {
                 assert!(
-                    path.exists(),
-                    "source for {} does not exist: {}",
-                    import.wasm_symbol,
-                    path.display()
+                    !segment.is_empty(),
+                    "empty path segment for {}",
+                    import.wasm_symbol
+                );
+            }
+            let leaf = import
+                .wasm_symbol
+                .rsplit('/')
+                .next()
+                .expect("split must produce at least one segment");
+            assert!(!leaf.starts_with("async_"));
+        }
+    }
+
+    #[test]
+    fn declared_sources_exist_and_contain_native_symbols() {
+        for ported_import in async_api_ported_imports() {
+            let registered_import = registered_import_for_ported(&ported_import)
+                .expect("ported import must have a registered wasm import");
+            let native_symbol = native_symbol_for(registered_import, &ported_import);
+            for source in ported_import.sources {
+                let source_path = source_path(*source);
+                let contents = fs::read_to_string(&source_path)
+                    .unwrap_or_else(|error| panic!("failed to read {:?}: {error}", source_path));
+                assert!(
+                    contents.contains(&native_symbol),
+                    "{:?} does not contain native symbol {} for wasm import {}",
+                    source_path,
+                    native_symbol,
+                    registered_import.wasm_symbol
                 );
             }
         }
     }
 
     #[test]
-    fn native_symbols_are_traceable_to_async_sources() {
+    fn ported_provenance_entries_are_registered_imports() {
+        for ported_import in async_api_ported_imports() {
+            assert!(
+                registered_import_for_ported(&ported_import).is_some(),
+                "ported provenance for {:?}::{:?} has no registered import",
+                ported_import.rust_module,
+                ported_import.rust_symbol
+            );
+        }
+    }
+
+    #[test]
+    fn fake_imports_do_not_have_active_provenance() {
+        let api_ported_imports = async_api_ported_imports();
         for import in ASYNC_IMPORTS {
-            let Some(native_symbol) = import.native_symbol else {
+            if import.kind != AsyncImportKind::Fake {
                 continue;
-            };
+            }
             assert!(
-                native_symbol.starts_with(NATIVE_ASYNC_PREFIX),
-                "native symbol for {} should use {NATIVE_ASYNC_PREFIX}: {native_symbol}",
-                import.wasm_symbol
-            );
-
-            let found = import
-                .sources
-                .iter()
-                .filter(|source| source.root == SourceRoot::MoonbitAsync)
-                .map(|source| std::fs::read_to_string(source_path(*source)).unwrap())
-                .any(|contents| contents.contains(native_symbol));
-            assert!(
-                found,
-                "native symbol {native_symbol} for {} is not present in its async sources",
+                api_ported_imports.iter().all(|ported_import| {
+                    module_leaf(ported_import.rust_module) != Some(import.callback_module)
+                        || ported_import.rust_symbol != import.callback_symbol
+                }),
+                "fake import {} has active ported provenance",
                 import.wasm_symbol
             );
         }
     }
 
     #[test]
-    fn pr1_surface_stays_event_loop_timer_only() {
+    fn ported_imports_have_ported_implementations() {
+        let api_ported_imports = async_api_ported_imports();
+        let ported_symbols = crate::async_sys::ported_symbols();
+
         for import in ASYNC_IMPORTS {
+            if import.kind != AsyncImportKind::Ported {
+                continue;
+            }
+
+            let ported_import = api_ported_imports
+                .iter()
+                .find(|ported_import| {
+                    module_leaf(ported_import.rust_module) == Some(import.callback_module)
+                        && ported_import.rust_symbol == import.callback_symbol
+                })
+                .unwrap_or_else(|| {
+                    panic!(
+                        "async import {} has no ported provenance",
+                        import.wasm_symbol
+                    )
+                });
+            let native_symbol = native_symbol_for(import, ported_import);
             assert!(
-                !import.wasm_symbol.starts_with("fs/")
-                    && !import.wasm_symbol.starts_with("process/")
-                    && !import.wasm_symbol.starts_with("socket/")
-                    && !import.wasm_symbol.starts_with("tls/")
-                    && !import.wasm_symbol.starts_with("fd_util/")
-                    && !import.wasm_symbol.starts_with("c_buffer/"),
-                "PR1 should not register broader async host import {}",
+                ported_import.sources.iter().any(|source| {
+                    source.root == SourceRoot::MoonbitAsync
+                        && ported_symbols.iter().any(|ported| {
+                            ported.native_symbol == native_symbol && ported.source == source.path
+                        })
+                }),
+                "async import {} has no Rust port origin",
                 import.wasm_symbol
             );
         }
     }
 
     #[test]
-    fn native_poll_imports_are_explicit_unsupported_entries() {
-        let wait_for_event = ASYNC_IMPORTS
-            .iter()
-            .find(|import| import.wasm_symbol == "runtime/wait_for_event")
-            .expect("runtime/wait_for_event should be registered");
-        assert_eq!(wait_for_event.kind, AsyncImportKind::WasmSupport);
-        assert_eq!(wait_for_event.native_symbol, None);
-
-        for (wasm_symbol, native_symbol) in [
-            ("poll/poll_create", "moonbitlang_async_poll_create"),
-            ("poll/poll_destroy", "moonbitlang_async_poll_destroy"),
-            ("poll/poll_register", "moonbitlang_async_poll_register"),
-            (
-                "poll/support_wait_pid_via_poll",
-                "moonbitlang_async_support_wait_pid_via_poll",
-            ),
-            (
-                "poll/poll_register_pid",
-                "moonbitlang_async_poll_register_pid",
-            ),
-            ("poll/poll_remove", "moonbitlang_async_poll_remove"),
-            ("poll/poll_remove_pid", "moonbitlang_async_poll_remove_pid"),
-            ("poll/poll_wait", "moonbitlang_async_poll_wait"),
-            ("poll/event_list_get", "moonbitlang_async_event_list_get"),
-            ("poll/event_get_fd", "moonbitlang_async_event_get_fd"),
-            (
-                "poll/event_get_events",
-                "moonbitlang_async_event_get_events",
-            ),
-            (
-                "poll/event_get_io_result",
-                "moonbitlang_async_event_get_io_result",
-            ),
-            (
-                "poll/event_get_bytes_transferred",
-                "moonbitlang_async_event_get_bytes_transferred",
-            ),
-        ] {
-            let import = ASYNC_IMPORTS
-                .iter()
-                .find(|import| import.wasm_symbol == wasm_symbol)
-                .unwrap_or_else(|| panic!("{wasm_symbol} should be registered"));
-            assert_eq!(import.kind, AsyncImportKind::UnsupportedMvp);
-            assert_eq!(import.native_symbol, Some(native_symbol));
-        }
-    }
-
-    #[test]
-    fn worker_job_imports_are_link_stubs() {
-        let unsupported = ASYNC_IMPORTS
-            .iter()
-            .filter(|import| import.kind == AsyncImportKind::UnsupportedMvp)
-            .map(|import| import.wasm_symbol)
-            .collect::<HashSet<_>>();
-        for symbol in [
-            "thread_pool/spawn_worker",
-            "thread_pool/free_worker",
-            "thread_pool/wake_worker",
-            "thread_pool/worker_enter_idle",
-            "thread_pool/cancel_worker",
-            "thread_pool/free_job",
-            "thread_pool/run_job",
-            "thread_pool/job_get_ret",
-            "thread_pool/job_get_err",
-        ] {
+    fn ported_implementations_are_registered_imports() {
+        let api_ported_imports = async_api_ported_imports();
+        for ported in crate::async_sys::ported_symbols() {
             assert!(
-                unsupported.contains(symbol),
-                "{symbol} should be unsupported in PR1"
+                api_ported_imports.iter().any(|ported_import| {
+                    let Some(registered_import) = registered_import_for_ported(ported_import)
+                    else {
+                        return false;
+                    };
+                    let native_symbol = native_symbol_for(registered_import, ported_import);
+                    ASYNC_IMPORTS
+                        .iter()
+                        .any(|import| import.wasm_symbol == registered_import.wasm_symbol)
+                        && ported_import.sources.iter().any(|source| {
+                            native_symbol == ported.native_symbol
+                                && source.root == SourceRoot::MoonbitAsync
+                                && source.path == ported.source
+                        })
+                }),
+                "ported symbol {}::{} from {} / {} is not registered",
+                ported.rust_module,
+                ported.rust_symbol,
+                ported.source,
+                ported.native_symbol
             );
         }
     }

--- a/crates/moonrun/src/async_api/runtime.rs
+++ b/crates/moonrun/src/async_api/runtime.rs
@@ -16,67 +16,8 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-pub(super) fn exit(
-    scope: &mut v8::HandleScope,
-    args: v8::FunctionCallbackArguments,
-    _ret: v8::ReturnValue,
-) {
-    let code = args.get(0).int32_value(scope).unwrap_or(1);
-    std::process::exit(code);
-}
+use super::context::ImportContext;
 
-pub(super) fn wait_for_event(
-    scope: &mut v8::HandleScope,
-    args: v8::FunctionCallbackArguments,
-    mut ret: v8::ReturnValue,
-) {
-    let timeout_ms = args.get(0).int32_value(scope).unwrap_or(-1);
-    match wait_for_event_impl(timeout_ms) {
-        Ok(()) => {
-            super::set_last_errno(0);
-            ret.set_int32(0);
-        }
-        Err(errno) => {
-            super::set_last_errno(errno);
-            ret.set_int32(-1);
-        }
-    }
-}
-
-#[cfg(unix)]
-fn wait_for_event_impl(timeout_ms: i32) -> Result<(), i32> {
-    let timeout = if timeout_ms < 0 { -1 } else { timeout_ms };
-    if unsafe { libc::poll(std::ptr::null_mut(), 0, timeout) } < 0 {
-        return Err(last_errno());
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn last_errno() -> i32 {
-    #[cfg(target_os = "linux")]
-    {
-        unsafe { *libc::__errno_location() }
-    }
-    #[cfg(target_os = "macos")]
-    {
-        unsafe { *libc::__error() }
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    {
-        std::io::Error::last_os_error().raw_os_error().unwrap_or(1)
-    }
-}
-
-#[cfg(windows)]
-fn wait_for_event_impl(timeout_ms: i32) -> Result<(), i32> {
-    let timeout = if timeout_ms < 0 {
-        windows_sys::Win32::System::Threading::INFINITE
-    } else {
-        timeout_ms as u32
-    };
-    unsafe {
-        windows_sys::Win32::System::Threading::Sleep(timeout);
-    }
-    Ok(())
+pub(super) fn exit(_context: &mut ImportContext, code: i32) {
+    std::process::exit(code)
 }

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -16,10 +16,470 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use std::ffi::OsString;
+
+use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory, read_u16};
+use crate::async_sys::internal::event_loop::thread_pool;
+
+use super::context::ImportContext;
+use super::provenance::ported_imports;
+
+ported_imports! {
+pub(super) fn free_job(context: &mut ImportContext, job: u64) -> AsyncHostResult<()> {
+    context.host.free_job(job)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn job_get_ret(context: &mut ImportContext, job: u64) -> AsyncHostResult<i32> {
+    context.host.job_get_ret(job).map(|value| value as i32)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn job_get_err(context: &mut ImportContext, job: u64) -> AsyncHostResult<i32> {
+    context.host.job_get_err(job)
+}
+
+pub(super) fn run_job(context: &mut ImportContext, job: u64) -> AsyncHostResult<()> {
+    context.host.run_job(job)
+}
+
+pub(super) fn init_thread_pool(context: &mut ImportContext, poll: u64) -> AsyncHostResult<u64> {
+    context.host.init_thread_pool(poll)
+}
+
+pub(super) fn destroy_thread_pool(context: &mut ImportContext) {
+    context.host.destroy_thread_pool();
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn spawn_worker(
+    context: &mut ImportContext,
+    worker_id: i32,
+    waiting_worker_id: u64,
+) -> AsyncHostResult<u64> {
+    context.host.spawn_worker(worker_id, waiting_worker_id)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn free_worker(context: &mut ImportContext, worker: u64) -> AsyncHostResult<()> {
+    context.host.free_worker(worker)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn wake_worker(
+    context: &mut ImportContext,
+    worker: u64,
+    job_id: i32,
+    job: u64,
+) -> AsyncHostResult<()> {
+    context.host.wake_worker(worker, job_id, job)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn worker_enter_idle(context: &mut ImportContext, worker: u64) -> AsyncHostResult<()> {
+    context.host.worker_enter_idle(worker)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn cancel_worker(context: &mut ImportContext, worker: u64) -> AsyncHostResult<i32> {
+    context.host.cancel_worker(worker)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[cfg(unix)]
 pub(super) fn fetch_completion(
-    _scope: &mut v8::HandleScope,
-    _args: v8::FunctionCallbackArguments,
-    mut ret: v8::ReturnValue,
-) {
-    ret.set_int32(0);
+    context: &mut ImportContext,
+    source_fd: u64,
+    dst: i32,
+    max_jobs: i32,
+) -> i32 {
+    let host = context.host;
+    match context.with_memory_mut(|memory| host.fetch_completion(memory, source_fd, dst, max_jobs))
+    {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_sleep_job(
+    context: &mut ImportContext,
+    duration_ms: i32,
+) -> AsyncHostResult<u64> {
+    context
+        .host
+        .insert_job(thread_pool::make_sleep_job(duration_ms))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn make_open_job(
+    context: &mut ImportContext,
+    path_ptr: i32,
+    path_len: i32,
+    access: i32,
+    create_mode: i32,
+    append: i32,
+    sync: i32,
+    mode: i32,
+) -> AsyncHostResult<u64> {
+    let filename = read_guest_path(context, path_ptr, path_len)?;
+
+    context.host.insert_job(thread_pool::make_open_job(
+        filename,
+        access,
+        create_mode,
+        append != 0,
+        sync,
+        mode,
+    ))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_read_job(
+    context: &mut ImportContext,
+    fd: u64,
+    len: i32,
+    position: i64,
+) -> AsyncHostResult<u64> {
+    context
+        .host
+        .insert_job(thread_pool::make_read_job(fd, len, position))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_write_job(
+    context: &mut ImportContext,
+    fd: u64,
+    ptr: i32,
+    offset: i32,
+    len: i32,
+    position: i64,
+) -> AsyncHostResult<u64> {
+    let offset_ptr = ptr.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+    let data =
+        context.with_memory_mut(|memory| Ok(memory.read_exact(offset_ptr, len)?.to_vec()))?;
+
+    context
+        .host
+        .insert_job(thread_pool::make_write_job(fd, data, position))
+}
+
+pub(super) fn get_read_result(
+    context: &mut ImportContext,
+    job: u64,
+    dst: i32,
+    offset: i32,
+    len: i32,
+) -> AsyncHostResult<()> {
+    let host = context.host;
+    context.with_memory_mut(|memory| host.get_read_result(memory, job, dst, offset, len))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_file_kind_by_path_job(
+    context: &mut ImportContext,
+    parent: u64,
+    path_ptr: i32,
+    path_len: i32,
+    follow_symlink: i32,
+) -> AsyncHostResult<u64> {
+    let path = read_guest_path(context, path_ptr, path_len)?;
+
+    context
+        .host
+        .insert_job(thread_pool::make_file_kind_by_path_job(
+            parent,
+            path,
+            follow_symlink != 0,
+        ))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_file_size_job(context: &mut ImportContext, fd: u64) -> AsyncHostResult<u64> {
+    context.host.insert_job(thread_pool::make_file_size_job(fd))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn get_file_size_result(context: &mut ImportContext, job: u64) -> AsyncHostResult<i64> {
+    context.host.get_file_size_result(job)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_file_time_job(
+    context: &mut ImportContext,
+    fd: u64,
+) -> AsyncHostResult<u64> {
+    context
+        .host
+        .insert_job(thread_pool::make_file_time_job(fd))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_file_time_by_path_job(
+    context: &mut ImportContext,
+    path_ptr: i32,
+    path_len: i32,
+    follow_symlink: i32,
+) -> AsyncHostResult<u64> {
+    let path = read_guest_path(context, path_ptr, path_len)?;
+
+    context
+        .host
+        .insert_job(thread_pool::make_file_time_by_path_job(
+            path,
+            follow_symlink != 0,
+        ))
+}
+
+pub(super) fn get_file_time_result(
+    context: &mut ImportContext,
+    job: u64,
+    out: i32,
+) -> AsyncHostResult<()> {
+    let host = context.host;
+    context.with_memory_mut(|memory| host.get_file_time_result(memory, job, out))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_access_job(
+    context: &mut ImportContext,
+    path_ptr: i32,
+    path_len: i32,
+    access: i32,
+) -> AsyncHostResult<u64> {
+    let path = read_guest_path(context, path_ptr, path_len)?;
+
+    context
+        .host
+        .insert_job(thread_pool::make_access_job(path, access))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_chmod_job(
+    context: &mut ImportContext,
+    path_ptr: i32,
+    path_len: i32,
+    mode: i32,
+) -> AsyncHostResult<u64> {
+    let path = read_guest_path(context, path_ptr, path_len)?;
+
+    context
+        .host
+        .insert_job(thread_pool::make_chmod_job(path, mode))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_fsync_job(
+    context: &mut ImportContext,
+    fd: u64,
+    only_data: i32,
+) -> AsyncHostResult<u64> {
+    context
+        .host
+        .insert_job(thread_pool::make_fsync_job(fd, only_data != 0))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_flock_job(
+    context: &mut ImportContext,
+    fd: u64,
+    exclusive: i32,
+) -> AsyncHostResult<u64> {
+    context
+        .host
+        .insert_job(thread_pool::make_flock_job(fd, exclusive != 0))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_remove_job(
+    context: &mut ImportContext,
+    path_ptr: i32,
+    path_len: i32,
+) -> AsyncHostResult<u64> {
+    let path = read_guest_path(context, path_ptr, path_len)?;
+    context.host.insert_job(thread_pool::make_remove_job(path))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_rename_job(
+    context: &mut ImportContext,
+    old_path_ptr: i32,
+    old_path_len: i32,
+    new_path_ptr: i32,
+    new_path_len: i32,
+    replace: i32,
+) -> AsyncHostResult<u64> {
+    let old_path = read_guest_path(context, old_path_ptr, old_path_len)?;
+    let new_path = read_guest_path(context, new_path_ptr, new_path_len)?;
+
+    context.host.insert_job(thread_pool::make_rename_job(
+        old_path,
+        new_path,
+        replace != 0,
+    ))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_symlink_job(
+    context: &mut ImportContext,
+    target_ptr: i32,
+    target_len: i32,
+    path_ptr: i32,
+    path_len: i32,
+    force_symlink: i32,
+) -> AsyncHostResult<u64> {
+    let target = read_guest_path(context, target_ptr, target_len)?;
+    let path = read_guest_path(context, path_ptr, path_len)?;
+
+    context.host.insert_job(thread_pool::make_symlink_job(
+        target,
+        path,
+        force_symlink != 0,
+    ))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_mkdir_job(
+    context: &mut ImportContext,
+    path_ptr: i32,
+    path_len: i32,
+    mode: i32,
+) -> AsyncHostResult<u64> {
+    let path = read_guest_path(context, path_ptr, path_len)?;
+
+    context
+        .host
+        .insert_job(thread_pool::make_mkdir_job(path, mode))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_rmdir_job(
+    context: &mut ImportContext,
+    path_ptr: i32,
+    path_len: i32,
+) -> AsyncHostResult<u64> {
+    let path = read_guest_path(context, path_ptr, path_len)?;
+    context.host.insert_job(thread_pool::make_rmdir_job(path))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_readdir_job(
+    context: &mut ImportContext,
+    dir: u64,
+    len: i32,
+    restart: i32,
+) -> AsyncHostResult<u64> {
+    context
+        .host
+        .insert_job(thread_pool::make_readdir_job(dir, len, restart != 0))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn open_job_get_fd(context: &mut ImportContext, job: u64) -> AsyncHostResult<u64> {
+    context.host.open_job_get_fd(job)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn open_job_get_kind(context: &mut ImportContext, job: u64) -> AsyncHostResult<i32> {
+    context.host.open_job_get_kind(job)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn open_job_get_dev_id(context: &mut ImportContext, job: u64) -> AsyncHostResult<u64> {
+    context.host.open_job_get_dev_id(job)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn open_job_get_file_id(context: &mut ImportContext, job: u64) -> AsyncHostResult<u64> {
+    context.host.open_job_get_file_id(job)
+}
+
+pub(super) fn get_readdir_result(
+    context: &mut ImportContext,
+    job: u64,
+    dst: i32,
+    len: i32,
+) -> AsyncHostResult<()> {
+    let host = context.host;
+    context.with_memory_mut(|memory| host.get_readdir_result(memory, job, dst, len))
+}
+
+fn read_guest_path(context: &mut ImportContext, ptr: i32, len: i32) -> AsyncHostResult<OsString> {
+    // Async path imports pass MoonBit String data, so `len` is UTF-16 code
+    // units. Do not treat this as UTF-8 bytes or a native C string.
+    context.with_memory_mut(|memory| {
+        let units = read_u16(memory, ptr, len)?;
+        Ok(decode_guest_path(units))
+    })
+}
+
+#[cfg(unix)]
+fn decode_guest_path(units: &[u16]) -> OsString {
+    use std::os::unix::ffi::OsStringExt;
+
+    let path = char::decode_utf16(units.iter().copied())
+        .map(Result::unwrap)
+        .collect::<String>();
+    OsString::from_vec(path.into_bytes())
+}
+
+#[cfg(windows)]
+fn decode_guest_path(units: &[u16]) -> OsString {
+    use std::os::windows::ffi::OsStringExt;
+
+    OsString::from_wide(units)
+}
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn guest_path_decodes_utf16_to_unix_bytes() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let units = guest_string_units("async-fs-smoke-\u{1f600}.txt");
+        let path = decode_guest_path(&units);
+
+        assert_eq!(
+            path.as_os_str().as_bytes(),
+            "async-fs-smoke-\u{1f600}.txt".as_bytes()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn guest_path_decodes_utf16_on_windows() {
+        use std::os::windows::ffi::OsStrExt;
+
+        let units = guest_string_units("async-fs-smoke-\u{1f600}.txt");
+        let path = decode_guest_path(&units);
+
+        assert_eq!(
+            path.as_os_str().encode_wide().collect::<Vec<_>>(),
+            "async-fs-smoke-\u{1f600}.txt"
+                .encode_utf16()
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn guest_path_length_is_utf16_code_units_on_windows() {
+        let units = guest_string_units("a.txt");
+        let path = decode_guest_path(&units);
+
+        assert_eq!(path, OsString::from("a.txt"));
+    }
+
+    fn guest_string_units(path: &str) -> Vec<u16> {
+        path.encode_utf16().collect()
+    }
 }

--- a/crates/moonrun/src/async_api/time.rs
+++ b/crates/moonrun/src/async_api/time.rs
@@ -16,17 +16,10 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::sync::OnceLock;
-use std::time::Instant;
+use crate::async_sys::internal::time::clock;
 
-static MONOTONIC_CLOCK_ORIGIN: OnceLock<Instant> = OnceLock::new();
+use super::context::ImportContext;
 
-pub(super) fn get_ms_since_epoch(
-    scope: &mut v8::HandleScope,
-    _args: v8::FunctionCallbackArguments,
-    mut ret: v8::ReturnValue,
-) {
-    let origin = MONOTONIC_CLOCK_ORIGIN.get_or_init(Instant::now);
-    let millis = i64::try_from(origin.elapsed().as_millis()).unwrap_or(i64::MAX);
-    ret.set(v8::BigInt::new_from_i64(scope, millis).into());
+pub(super) fn get_ms_since_epoch(_context: &mut ImportContext) -> u64 {
+    clock::get_ms_since_epoch()
 }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -1,0 +1,1715 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Moonrun-owned async wasm host state.
+//!
+//! This module owns one V8 host instance's runtime state: handle tables, host
+//! workers, guest memory helpers, and host poll instances.
+//!
+//! Native async multiplexes pollable IO through epoll, kqueue, or IOCP, with
+//! thread-pool completions as one registered event
+//! source. The wasm ABI exposes that same shape: MoonBit owns event-loop
+//! scheduling and Rust owns the OS poller behind opaque poll handles.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use slotmap::{Key, KeyData, SlotMap, new_key_type};
+
+#[cfg(unix)]
+use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
+use crate::async_sys::internal::event_loop::{
+    poll::{self, PollInstance},
+    thread_pool::{
+        self, HostFile, HostFileTable, HostHandle, HostWorkerHandle, HostWorkerJob, Job,
+    },
+};
+use crate::async_sys::internal::fd_util::stub::RawFd;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+compile_error!("moonrun async wasm host currently supports only Linux, macOS, and Windows hosts");
+
+#[cfg(not(target_endian = "little"))]
+compile_error!("moonrun async wasm host requires little-endian host memory");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AsyncHostError {
+    Fault,
+    Inval,
+    Badf,
+    Native(i32),
+}
+
+pub(crate) type AsyncHostResult<T> = Result<T, AsyncHostError>;
+pub(crate) const INVALID_HOST_HANDLE: u64 = 0;
+
+#[cfg(unix)]
+mod native_errno {
+    pub(crate) const BADF: i32 = libc::EBADF;
+    pub(crate) const FAULT: i32 = libc::EFAULT;
+    pub(crate) const INVAL: i32 = libc::EINVAL;
+}
+
+#[cfg(windows)]
+mod native_errno {
+    use windows_sys::Win32::Foundation::{
+        ERROR_INVALID_ADDRESS, ERROR_INVALID_HANDLE, ERROR_INVALID_PARAMETER,
+    };
+
+    pub(crate) const BADF: i32 = ERROR_INVALID_HANDLE as i32;
+    pub(crate) const FAULT: i32 = ERROR_INVALID_ADDRESS as i32;
+    pub(crate) const INVAL: i32 = ERROR_INVALID_PARAMETER as i32;
+}
+
+impl AsyncHostError {
+    pub(crate) fn errno(self) -> i32 {
+        match self {
+            Self::Fault => native_errno::FAULT,
+            Self::Inval => native_errno::INVAL,
+            Self::Badf => native_errno::BADF,
+            Self::Native(errno) => errno,
+        }
+    }
+}
+
+pub(crate) trait GuestMemory {
+    fn bytes(&self) -> &[u8];
+
+    fn bytes_mut(&mut self) -> &mut [u8];
+
+    fn read_exact(&self, offset: i32, len: i32) -> AsyncHostResult<&[u8]> {
+        let (offset, end) = guest_bounds(offset, len)?;
+        self.bytes().get(offset..end).ok_or(AsyncHostError::Fault)
+    }
+
+    fn read_exact_mut(&mut self, offset: i32, len: i32) -> AsyncHostResult<&mut [u8]> {
+        let (offset, end) = guest_bounds(offset, len)?;
+        self.bytes_mut()
+            .get_mut(offset..end)
+            .ok_or(AsyncHostError::Fault)
+    }
+
+    fn write_exact(&mut self, offset: i32, data: &[u8]) -> AsyncHostResult<()> {
+        let len = i32::try_from(data.len()).map_err(|_| AsyncHostError::Fault)?;
+        let dst = self.read_exact_mut(offset, len)?;
+        dst.copy_from_slice(data);
+        Ok(())
+    }
+
+    fn write_with_capacity(
+        &mut self,
+        offset: i32,
+        capacity: i32,
+        data: &[u8],
+    ) -> AsyncHostResult<()> {
+        let data_len = i32::try_from(data.len()).map_err(|_| AsyncHostError::Fault)?;
+        if data_len > capacity {
+            return Err(AsyncHostError::Fault);
+        }
+        let dst = self.read_exact_mut(offset, capacity)?;
+        dst[..data.len()].copy_from_slice(data);
+        Ok(())
+    }
+
+    fn write_u64_le(&mut self, offset: i32, value: u64) -> AsyncHostResult<()> {
+        self.write_exact(offset, &value.to_le_bytes())
+    }
+}
+
+fn guest_bounds(offset: i32, len: i32) -> AsyncHostResult<(usize, usize)> {
+    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+    let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+    let end = offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
+    Ok((offset, end))
+}
+
+pub(crate) fn read_u16(memory: &[u8], offset: i32, len: i32) -> AsyncHostResult<&[u16]> {
+    let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+    let (offset, _) = u16_bounds(memory.len(), offset, len)?;
+    if len == 0 {
+        return Ok(&[]);
+    }
+    let ptr = unsafe { memory.as_ptr().add(offset).cast::<u16>() };
+    Ok(unsafe { std::slice::from_raw_parts(ptr, len) })
+}
+
+pub(crate) fn write_u16(memory: &mut [u8], offset: i32, data: &[u16]) -> AsyncHostResult<()> {
+    let (offset, _) = u16_bounds(memory.len(), offset, data.len())?;
+    if data.is_empty() {
+        return Ok(());
+    }
+    let ptr = unsafe { memory.as_mut_ptr().add(offset).cast::<u16>() };
+    let dst = unsafe { std::slice::from_raw_parts_mut(ptr, data.len()) };
+    dst.copy_from_slice(data);
+    Ok(())
+}
+
+fn u16_bounds(memory_len: usize, offset: i32, len: usize) -> AsyncHostResult<(usize, usize)> {
+    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+    if len != 0 && offset % std::mem::align_of::<u16>() != 0 {
+        return Err(AsyncHostError::Fault);
+    }
+    let byte_len = len
+        .checked_mul(std::mem::size_of::<u16>())
+        .ok_or(AsyncHostError::Fault)?;
+    let end = offset.checked_add(byte_len).ok_or(AsyncHostError::Fault)?;
+    if end > memory_len {
+        return Err(AsyncHostError::Fault);
+    }
+    Ok((offset, end))
+}
+
+impl GuestMemory for [u8] {
+    fn bytes(&self) -> &[u8] {
+        self
+    }
+
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        self
+    }
+}
+
+impl<const N: usize> GuestMemory for [u8; N] {
+    fn bytes(&self) -> &[u8] {
+        self.as_slice()
+    }
+
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        self.as_mut_slice()
+    }
+}
+
+impl HostFileTable for SlotMap<HostFileKey, HostFile> {
+    fn insert_file(&mut self, file: RawFd) -> AsyncHostResult<u64> {
+        Ok(handle_from_key(self.insert(HostFile::new(file))))
+    }
+
+    fn is_invalid_file_handle(&self, handle: HostHandle) -> bool {
+        self.get(key_from_handle::<HostFileKey>(handle))
+            .is_some_and(HostFile::is_invalid)
+    }
+
+    #[cfg(windows)]
+    fn borrowed_raw_file(&mut self, handle: HostHandle) -> AsyncHostResult<RawFd> {
+        let file = self
+            .get(key_from_handle::<HostFileKey>(handle))
+            .ok_or(AsyncHostError::Badf)?;
+        if file.is_invalid() {
+            return Err(AsyncHostError::Badf);
+        }
+        Ok(file.raw_fd())
+    }
+
+    fn with_raw_file<U>(
+        &mut self,
+        handle: u64,
+        f: impl FnOnce(RawFd) -> AsyncHostResult<U>,
+    ) -> AsyncHostResult<U> {
+        let file = self
+            .get_mut(key_from_handle::<HostFileKey>(handle))
+            .ok_or(AsyncHostError::Badf)?;
+        if file.is_invalid() {
+            return Err(AsyncHostError::Badf);
+        }
+        f(file.raw_fd())
+    }
+
+    fn with_host_file_mut<U>(
+        &mut self,
+        handle: u64,
+        f: impl FnOnce(&mut HostFile) -> AsyncHostResult<U>,
+    ) -> AsyncHostResult<U> {
+        let file = self
+            .get_mut(key_from_handle::<HostFileKey>(handle))
+            .ok_or(AsyncHostError::Badf)?;
+        if file.is_invalid() {
+            return Err(AsyncHostError::Badf);
+        }
+        f(file)
+    }
+}
+
+new_key_type! {
+    pub(crate) struct HostCBufferKey;
+    pub(crate) struct HostEventKey;
+    pub(crate) struct HostFileKey;
+    pub(crate) struct HostIoResultKey;
+    pub(crate) struct HostJobKey;
+    pub(crate) struct HostPollKey;
+    pub(crate) struct HostWorkerKey;
+}
+
+fn handle_from_key(key: impl Key) -> u64 {
+    key.data().as_ffi()
+}
+
+fn key_from_handle<K: Key>(handle: u64) -> K {
+    KeyData::from_ffi(handle).into()
+}
+
+struct AsyncHostState {
+    errno: i32,
+    c_buffers: SlotMap<HostCBufferKey, Vec<u8>>,
+    #[cfg(windows)]
+    io_results: SlotMap<HostIoResultKey, Box<HostIoResult>>,
+    #[cfg(windows)]
+    io_results_by_overlapped: HashMap<usize, HostIoResultKey>,
+    events: SlotMap<HostEventKey, HostEvent>,
+    jobs: SlotMap<HostJobKey, Option<Job>>,
+    polls: SlotMap<HostPollKey, Arc<Mutex<HostPoll>>>,
+    files: SlotMap<HostFileKey, HostFile>,
+    invalid_file: HostFileKey,
+    workers: SlotMap<HostWorkerKey, HostWorkerHandle>,
+    #[cfg(unix)]
+    completion_notifier: Option<Arc<ThreadPoolCompletionNotifier>>,
+    #[cfg(unix)]
+    completion_source: Option<HostHandle>,
+    #[cfg(windows)]
+    completion_port: Option<poll::CompletionPort>,
+}
+
+impl Default for AsyncHostState {
+    fn default() -> Self {
+        let mut files = SlotMap::with_key();
+        let invalid_file = files.insert(HostFile::invalid());
+        Self {
+            errno: 0,
+            c_buffers: SlotMap::with_key(),
+            #[cfg(windows)]
+            io_results: SlotMap::with_key(),
+            #[cfg(windows)]
+            io_results_by_overlapped: HashMap::new(),
+            events: SlotMap::with_key(),
+            jobs: SlotMap::with_key(),
+            polls: SlotMap::with_key(),
+            files,
+            invalid_file,
+            workers: SlotMap::with_key(),
+            #[cfg(unix)]
+            completion_notifier: None,
+            #[cfg(unix)]
+            completion_source: None,
+            #[cfg(windows)]
+            completion_port: None,
+        }
+    }
+}
+
+impl AsyncHostState {
+    fn invalid_fd(&self) -> HostHandle {
+        handle_from_key(self.invalid_file)
+    }
+
+    fn file(&self, handle: HostHandle) -> AsyncHostResult<&HostFile> {
+        let file = self
+            .files
+            .get(key_from_handle::<HostFileKey>(handle))
+            .ok_or(AsyncHostError::Badf)?;
+        if file.is_invalid() {
+            return Err(AsyncHostError::Badf);
+        }
+        Ok(file)
+    }
+
+    fn file_mut(&mut self, handle: HostHandle) -> AsyncHostResult<&mut HostFile> {
+        let file = self
+            .files
+            .get_mut(key_from_handle::<HostFileKey>(handle))
+            .ok_or(AsyncHostError::Badf)?;
+        if file.is_invalid() {
+            return Err(AsyncHostError::Badf);
+        }
+        Ok(file)
+    }
+
+    fn remove_file(&mut self, handle: HostHandle) -> AsyncHostResult<HostFile> {
+        let key = key_from_handle::<HostFileKey>(handle);
+        if key == self.invalid_file {
+            return Err(AsyncHostError::Badf);
+        }
+        self.files.remove(key).ok_or(AsyncHostError::Badf)
+    }
+}
+
+#[derive(Debug)]
+struct HostPoll {
+    instance: PollInstance,
+    registered_fds: HashMap<isize, HostHandle>,
+    #[cfg(unix)]
+    completion_notifier: Option<Arc<ThreadPoolCompletionNotifier>>,
+    event_generation: u64,
+    event_handles: Vec<HostEventKey>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HostEvent {
+    poll: HostPollKey,
+    generation: u64,
+    index: i32,
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostIoDirection {
+    Read,
+    Write,
+}
+
+#[cfg(windows)]
+struct HostIoResult {
+    overlapped: windows_sys::Win32::System::IO::OVERLAPPED,
+    event: i32,
+    // Native async retains the MoonBit buffer object. The V8 host instead keeps
+    // a stable host buffer and copies at explicit FFI submit/complete points.
+    buffer: Vec<u8>,
+    guest_offset: i32,
+    direction: Option<HostIoDirection>,
+}
+
+#[cfg(windows)]
+unsafe impl Send for HostIoResult {}
+
+#[cfg(windows)]
+impl HostIoResult {
+    fn for_file(event: i32, buffer: Vec<u8>, guest_offset: i32, position: i64) -> Self {
+        let overlapped =
+            std::mem::MaybeUninit::<windows_sys::Win32::System::IO::OVERLAPPED>::zeroed();
+        let mut overlapped = unsafe { overlapped.assume_init() };
+        overlapped.Anonymous.Anonymous.Offset = position as u32;
+        overlapped.Anonymous.Anonymous.OffsetHigh = (position >> 32) as u32;
+        Self {
+            overlapped,
+            event,
+            buffer,
+            guest_offset,
+            direction: None,
+        }
+    }
+
+    fn overlapped_ptr(&mut self) -> *mut windows_sys::Win32::System::IO::OVERLAPPED {
+        &mut self.overlapped
+    }
+
+    fn copy_read_result(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        bytes_transferred: i32,
+    ) -> AsyncHostResult<()> {
+        if self.direction != Some(HostIoDirection::Read) {
+            return Ok(());
+        }
+        let len = usize::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)?;
+        let data = self.buffer.get(..len).ok_or(AsyncHostError::Fault)?;
+        memory.write_exact(self.guest_offset, data)
+    }
+}
+
+pub(crate) struct AsyncHost {
+    state: Arc<Mutex<AsyncHostState>>,
+}
+
+impl Default for AsyncHost {
+    fn default() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(AsyncHostState::default())),
+        }
+    }
+}
+
+impl AsyncHost {
+    pub(crate) fn invalid_fd(&self) -> HostHandle {
+        self.state.lock().unwrap().invalid_fd()
+    }
+
+    pub(crate) fn get_errno(&self) -> i32 {
+        self.state.lock().unwrap().errno
+    }
+
+    pub(crate) fn set_errno(&self, errno: i32) {
+        self.state.lock().unwrap().errno = errno;
+    }
+
+    pub(crate) fn record_error(&self, error: AsyncHostError) -> i32 {
+        let errno = error.errno();
+        self.set_errno(errno);
+        errno
+    }
+
+    pub(crate) fn poll_create(&self) -> AsyncHostResult<u64> {
+        let instance = poll::poll_create()?;
+        let mut state = self.state.lock().unwrap();
+        let key = state.polls.insert(Arc::new(Mutex::new(HostPoll {
+            instance,
+            registered_fds: HashMap::new(),
+            #[cfg(unix)]
+            completion_notifier: None,
+            event_generation: 0,
+            event_handles: Vec::new(),
+        })));
+        Ok(handle_from_key(key))
+    }
+
+    pub(crate) fn poll_destroy(&self, handle: u64) -> AsyncHostResult<()> {
+        let mut state = self.state.lock().unwrap();
+        let poll = state
+            .polls
+            .remove(key_from_handle::<HostPollKey>(handle))
+            .ok_or(AsyncHostError::Badf)?;
+        let poll = Arc::try_unwrap(poll).map_err(|_| AsyncHostError::Inval)?;
+        let mut poll = poll.into_inner().unwrap();
+        for event in poll.event_handles.drain(..) {
+            state.events.remove(event);
+        }
+        #[cfg(unix)]
+        {
+            if let Some(notifier) = &poll.completion_notifier
+                && state
+                    .completion_notifier
+                    .as_ref()
+                    .is_some_and(|active| Arc::ptr_eq(active, notifier))
+            {
+                state.completion_notifier = None;
+                if let Some(source) = state.completion_source.take() {
+                    let _ = state.remove_file(source);
+                }
+            }
+        }
+        #[cfg(windows)]
+        {
+            if state.completion_port == Some(poll::CompletionPort::from_poll(&poll.instance)) {
+                state.completion_port = None;
+            }
+        }
+        poll::poll_destroy(poll.instance);
+        Ok(())
+    }
+
+    pub(crate) fn poll_register(
+        &self,
+        poll_handle: u64,
+        fd_handle: HostHandle,
+        read_only: bool,
+    ) -> AsyncHostResult<()> {
+        let (raw_fd, poll) = {
+            let state = self.state.lock().unwrap();
+            let raw_fd = state.file(fd_handle)?.raw_fd();
+            let poll = Arc::clone(
+                state
+                    .polls
+                    .get(key_from_handle::<HostPollKey>(poll_handle))
+                    .ok_or(AsyncHostError::Badf)?,
+            );
+            (raw_fd, poll)
+        };
+        let mut poll = poll.lock().unwrap();
+        poll::poll_register(&poll.instance, raw_fd, read_only)?;
+        poll.registered_fds.insert(raw_fd_key(raw_fd), fd_handle);
+        Ok(())
+    }
+
+    pub(crate) fn poll_wait(&self, poll_handle: u64, timeout_ms: i32) -> AsyncHostResult<i32> {
+        let poll = {
+            let state = self.state.lock().unwrap();
+            Arc::clone(
+                state
+                    .polls
+                    .get(key_from_handle::<HostPollKey>(poll_handle))
+                    .ok_or(AsyncHostError::Badf)?,
+            )
+        };
+        let mut poll = poll.lock().unwrap();
+        let result = poll::poll_wait(&mut poll.instance, timeout_ms);
+        if result.is_ok() {
+            poll.event_generation = poll.event_generation.wrapping_add(1);
+            let old_events = std::mem::take(&mut poll.event_handles);
+            drop(poll);
+            if !old_events.is_empty() {
+                let mut state = self.state.lock().unwrap();
+                for event in old_events {
+                    state.events.remove(event);
+                }
+            }
+        }
+        result
+    }
+
+    pub(crate) fn poll_get_event(&self, poll_handle: u64, index: i32) -> AsyncHostResult<u64> {
+        let poll_key = key_from_handle::<HostPollKey>(poll_handle);
+        let mut state = self.state.lock().unwrap();
+        let poll = Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?);
+        let mut poll = poll.lock().unwrap();
+        poll::event_list_get(&poll.instance, index)?;
+        let key = state.events.insert(HostEvent {
+            poll: poll_key,
+            generation: poll.event_generation,
+            index,
+        });
+        poll.event_handles.push(key);
+        Ok(handle_from_key(key))
+    }
+
+    fn with_event<T>(
+        &self,
+        event_handle: u64,
+        f: impl FnOnce(&HostPoll, &poll::PollEvent) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
+        let event = key_from_handle::<HostEventKey>(event_handle);
+        let (event, poll) = {
+            let state = self.state.lock().unwrap();
+            let event = *state.events.get(event).ok_or(AsyncHostError::Badf)?;
+            let poll = Arc::clone(state.polls.get(event.poll).ok_or(AsyncHostError::Badf)?);
+            (event, poll)
+        };
+        let poll = poll.lock().unwrap();
+        if poll.event_generation != event.generation {
+            return Err(AsyncHostError::Badf);
+        }
+        let poll_event = poll::event_list_get(&poll.instance, event.index)?;
+        f(&poll, poll_event)
+    }
+
+    pub(crate) fn poll_event_fd(&self, event_handle: u64) -> AsyncHostResult<HostHandle> {
+        self.with_event(event_handle, |poll, event| {
+            let raw_fd = poll::event_get_fd(event);
+            poll.registered_fds
+                .get(&raw_fd_key(raw_fd))
+                .copied()
+                .map(Ok)
+                .unwrap_or_else(|| raw_fd_to_guest(raw_fd))
+        })
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn poll_event_events(&self, event_handle: u64) -> AsyncHostResult<i32> {
+        self.with_event(event_handle, |_, event| Ok(poll::event_get_events(event)))
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn poll_event_io_result(&self, event_handle: u64) -> AsyncHostResult<u64> {
+        let overlapped = self.with_event(event_handle, |_, event| {
+            Ok(poll::event_get_io_result(event) as usize)
+        })?;
+        let state = self.state.lock().unwrap();
+        state
+            .io_results_by_overlapped
+            .get(&overlapped)
+            .copied()
+            .map(handle_from_key)
+            .ok_or(AsyncHostError::Badf)
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn poll_event_bytes_transferred(&self, event_handle: u64) -> AsyncHostResult<i32> {
+        self.with_event(event_handle, |_, event| {
+            Ok(poll::event_get_bytes_transferred(event))
+        })
+    }
+
+    pub(crate) fn init_thread_pool(&self, poll_handle: u64) -> AsyncHostResult<HostHandle> {
+        let poll = {
+            let state = self.state.lock().unwrap();
+            #[cfg(unix)]
+            if state.completion_source.is_some() {
+                return Err(AsyncHostError::Inval);
+            }
+            Arc::clone(
+                state
+                    .polls
+                    .get(key_from_handle::<HostPollKey>(poll_handle))
+                    .ok_or(AsyncHostError::Badf)?,
+            )
+        };
+        #[cfg(unix)]
+        {
+            let (completion_notifier, event_fd) = {
+                let poll = poll.lock().unwrap();
+                ThreadPoolCompletionNotifier::new(&poll.instance)?
+            };
+            let completion_notifier = Arc::new(completion_notifier);
+            let source = {
+                let mut state = self.state.lock().unwrap();
+                let source = handle_from_key(state.files.insert(HostFile::new(event_fd)));
+                state.completion_notifier = Some(Arc::clone(&completion_notifier));
+                state.completion_source = Some(source);
+                source
+            };
+            let mut poll = poll.lock().unwrap();
+            poll.registered_fds.insert(raw_fd_key(event_fd), source);
+            poll.completion_notifier = Some(completion_notifier);
+            Ok(source)
+        }
+        #[cfg(windows)]
+        {
+            let completion_port = poll::CompletionPort::from_poll(&poll.lock().unwrap().instance);
+            self.state.lock().unwrap().completion_port = Some(completion_port);
+            raw_fd_to_guest(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE)
+        }
+    }
+
+    pub(crate) fn destroy_thread_pool(&self) {
+        let mut state = self.state.lock().unwrap();
+        #[cfg(unix)]
+        {
+            if let Some(source) = state.completion_source.take()
+                && let Ok(file) = state.remove_file(source)
+            {
+                let raw_fd = file.raw_fd();
+                for poll in state.polls.values_mut() {
+                    poll.lock()
+                        .unwrap()
+                        .registered_fds
+                        .remove(&raw_fd_key(raw_fd));
+                }
+            }
+            state.completion_notifier = None;
+            for poll in state.polls.values_mut() {
+                poll.lock().unwrap().completion_notifier = None;
+            }
+        }
+        #[cfg(windows)]
+        {
+            state.completion_port = None;
+        }
+    }
+
+    pub(crate) fn insert_c_buffer(&self, buffer: Vec<u8>) -> u64 {
+        let key = self.state.lock().unwrap().c_buffers.insert(buffer);
+        handle_from_key(key)
+    }
+
+    pub(crate) fn free_c_buffer(&self, handle: u64) -> AsyncHostResult<()> {
+        if handle == INVALID_HOST_HANDLE {
+            return Ok(());
+        }
+        self.state
+            .lock()
+            .unwrap()
+            .c_buffers
+            .remove(key_from_handle::<HostCBufferKey>(handle))
+            .map(|_| ())
+            .ok_or(AsyncHostError::Badf)
+    }
+
+    pub(crate) fn with_c_buffer<T>(
+        &self,
+        handle: u64,
+        f: impl FnOnce(&[u8]) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
+        if handle == INVALID_HOST_HANDLE {
+            return Err(AsyncHostError::Badf);
+        }
+        let state = self.state.lock().unwrap();
+        let buffer = state
+            .c_buffers
+            .get(key_from_handle::<HostCBufferKey>(handle))
+            .ok_or(AsyncHostError::Badf)?;
+        f(buffer)
+    }
+
+    pub(crate) fn with_c_buffer_mut<T>(
+        &self,
+        handle: u64,
+        f: impl FnOnce(&mut [u8]) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
+        if handle == INVALID_HOST_HANDLE {
+            return Err(AsyncHostError::Badf);
+        }
+        let mut state = self.state.lock().unwrap();
+        let buffer = state
+            .c_buffers
+            .get_mut(key_from_handle::<HostCBufferKey>(handle))
+            .ok_or(AsyncHostError::Badf)?;
+        f(buffer)
+    }
+
+    pub(crate) fn insert_job(&self, job: Job) -> AsyncHostResult<u64> {
+        let key = self.state.lock().unwrap().jobs.insert(Some(job));
+        Ok(handle_from_key(key))
+    }
+
+    pub(crate) fn free_job(&self, handle: u64) -> AsyncHostResult<()> {
+        self.state
+            .lock()
+            .unwrap()
+            .jobs
+            .remove(key_from_handle::<HostJobKey>(handle))
+            .map(|_| ())
+            .ok_or(AsyncHostError::Badf)
+    }
+
+    pub(crate) fn job_get_ret(&self, handle: u64) -> AsyncHostResult<i64> {
+        let state = self.state.lock().unwrap();
+        let job = state
+            .jobs
+            .get(key_from_handle::<HostJobKey>(handle))
+            .and_then(Option::as_ref)
+            .ok_or(AsyncHostError::Badf)?;
+        Ok(crate::async_sys::internal::event_loop::thread_pool::job_get_ret(job))
+    }
+
+    pub(crate) fn job_get_err(&self, handle: u64) -> AsyncHostResult<i32> {
+        let state = self.state.lock().unwrap();
+        let job = state
+            .jobs
+            .get(key_from_handle::<HostJobKey>(handle))
+            .and_then(Option::as_ref)
+            .ok_or(AsyncHostError::Badf)?;
+        Ok(crate::async_sys::internal::event_loop::thread_pool::job_get_err(job))
+    }
+
+    pub(crate) fn open_job_get_fd(&self, handle: u64) -> AsyncHostResult<HostHandle> {
+        let state = self.state.lock().unwrap();
+        let job = state
+            .jobs
+            .get(key_from_handle::<HostJobKey>(handle))
+            .and_then(Option::as_ref)
+            .ok_or(AsyncHostError::Badf)?;
+        let result = thread_pool::open_job_result(job)?;
+        Ok(thread_pool::open_job_get_fd(result))
+    }
+
+    pub(crate) fn open_job_get_kind(&self, handle: u64) -> AsyncHostResult<i32> {
+        let state = self.state.lock().unwrap();
+        let job = state
+            .jobs
+            .get(key_from_handle::<HostJobKey>(handle))
+            .and_then(Option::as_ref)
+            .ok_or(AsyncHostError::Badf)?;
+        let result = thread_pool::open_job_result(job)?;
+        Ok(thread_pool::open_job_get_kind(result))
+    }
+
+    pub(crate) fn open_job_get_dev_id(&self, handle: u64) -> AsyncHostResult<u64> {
+        let state = self.state.lock().unwrap();
+        let job = state
+            .jobs
+            .get(key_from_handle::<HostJobKey>(handle))
+            .and_then(Option::as_ref)
+            .ok_or(AsyncHostError::Badf)?;
+        let result = thread_pool::open_job_result(job)?;
+        Ok(thread_pool::open_job_get_dev_id(result))
+    }
+
+    pub(crate) fn open_job_get_file_id(&self, handle: u64) -> AsyncHostResult<u64> {
+        let state = self.state.lock().unwrap();
+        let job = state
+            .jobs
+            .get(key_from_handle::<HostJobKey>(handle))
+            .and_then(Option::as_ref)
+            .ok_or(AsyncHostError::Badf)?;
+        let result = thread_pool::open_job_result(job)?;
+        Ok(thread_pool::open_job_get_file_id(result))
+    }
+
+    pub(crate) fn get_file_size_result(&self, handle: u64) -> AsyncHostResult<i64> {
+        let state = self.state.lock().unwrap();
+        let job = state
+            .jobs
+            .get(key_from_handle::<HostJobKey>(handle))
+            .and_then(Option::as_ref)
+            .ok_or(AsyncHostError::Badf)?;
+        crate::async_sys::internal::event_loop::thread_pool::get_file_size_result(job)
+    }
+
+    pub(crate) fn close_fd(&self, handle: HostHandle) -> AsyncHostResult<()> {
+        let mut state = self.state.lock().unwrap();
+        let raw_fd = state.file(handle)?.raw_fd();
+        #[cfg(unix)]
+        if state.completion_source == Some(handle) {
+            state.completion_source = None;
+            state.completion_notifier = None;
+            for poll in state.polls.values_mut() {
+                poll.lock().unwrap().completion_notifier = None;
+            }
+        }
+        state.remove_file(handle)?;
+        for poll in state.polls.values() {
+            poll.lock()
+                .unwrap()
+                .registered_fds
+                .remove(&raw_fd_key(raw_fd));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn pipe(
+        &self,
+        read_end_is_async: bool,
+        write_end_is_async: bool,
+    ) -> AsyncHostResult<[HostHandle; 2]> {
+        crate::async_sys::internal::fd_util::stub::pipe_host_files(
+            &mut self.state.lock().unwrap().files,
+            read_end_is_async,
+            write_end_is_async,
+        )
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn set_nonblocking(&self, handle: HostHandle) -> AsyncHostResult<()> {
+        let state = self.state.lock().unwrap();
+        let raw_fd = state.file(handle)?.raw_fd();
+        crate::async_sys::internal::fd_util::stub::set_nonblocking(raw_fd)
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn read_fd(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        handle: HostHandle,
+        dst: i32,
+        offset: i32,
+        len: i32,
+    ) -> AsyncHostResult<i32> {
+        let offset_dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        let dst = memory.read_exact_mut(offset_dst, len)?;
+        let state = self.state.lock().unwrap();
+        let raw_fd = state.file(handle)?.raw_fd();
+        crate::async_sys::internal::event_loop::io::read(raw_fd, dst)
+            .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn write_fd(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        handle: HostHandle,
+        src: i32,
+        offset: i32,
+        len: i32,
+    ) -> AsyncHostResult<i32> {
+        let offset_src = src.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        let src = memory.read_exact(offset_src, len)?;
+        let state = self.state.lock().unwrap();
+        let raw_fd = state.file(handle)?.raw_fd();
+        crate::async_sys::internal::event_loop::io::write(raw_fd, src)
+            .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn make_file_io_result(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        event: i32,
+        buf: i32,
+        offset: i32,
+        len: i32,
+        position: i64,
+    ) -> AsyncHostResult<u64> {
+        let guest_offset = buf.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        memory.read_exact(guest_offset, len)?;
+        let buffer = vec![0; usize::try_from(len).map_err(|_| AsyncHostError::Fault)?];
+        let result = Box::new(HostIoResult::for_file(
+            event,
+            buffer,
+            guest_offset,
+            position,
+        ));
+
+        let mut state = self.state.lock().unwrap();
+        let key = state.io_results.insert(result);
+        let overlapped = state
+            .io_results
+            .get_mut(key)
+            .ok_or(AsyncHostError::Badf)?
+            .overlapped_ptr() as usize;
+        state.io_results_by_overlapped.insert(overlapped, key);
+        Ok(handle_from_key(key))
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn free_io_result(&self, handle: u64) -> AsyncHostResult<()> {
+        let key = key_from_handle::<HostIoResultKey>(handle);
+        let mut state = self.state.lock().unwrap();
+        let mut result = state.io_results.remove(key).ok_or(AsyncHostError::Badf)?;
+        state
+            .io_results_by_overlapped
+            .remove(&(result.overlapped_ptr() as usize));
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn io_result_get_event(&self, handle: u64) -> AsyncHostResult<i32> {
+        let state = self.state.lock().unwrap();
+        let result = state
+            .io_results
+            .get(key_from_handle::<HostIoResultKey>(handle))
+            .ok_or(AsyncHostError::Badf)?;
+        Ok(result.event)
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn cancel_io_result(
+        &self,
+        result_handle: u64,
+        fd_handle: HostHandle,
+    ) -> AsyncHostResult<i32> {
+        use windows_sys::Win32::Foundation::{ERROR_IO_INCOMPLETE, ERROR_NOT_FOUND};
+        use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult};
+
+        let mut state = self.state.lock().unwrap();
+        let raw_fd = state.file(fd_handle)?.raw_fd();
+        let result = state
+            .io_results
+            .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
+            .ok_or(AsyncHostError::Badf)?;
+        let overlapped = result.overlapped_ptr();
+        let cancelled = unsafe { CancelIoEx(raw_fd, overlapped) };
+        if cancelled == 0 {
+            let errno = last_errno();
+            return if errno == ERROR_NOT_FOUND as i32 {
+                Ok(0)
+            } else {
+                Err(AsyncHostError::Native(errno))
+            };
+        }
+
+        let mut bytes_transferred = 0;
+        if unsafe { GetOverlappedResult(raw_fd, overlapped, &mut bytes_transferred, 0) } != 0 {
+            return Ok(0);
+        }
+        if last_errno() == ERROR_IO_INCOMPLETE as i32 {
+            Ok(1)
+        } else {
+            Ok(0)
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn io_result_get_status(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        result_handle: u64,
+        fd_handle: HostHandle,
+    ) -> AsyncHostResult<i32> {
+        use windows_sys::Win32::System::IO::GetOverlappedResult;
+
+        let mut state = self.state.lock().unwrap();
+        let raw_fd = state.file(fd_handle)?.raw_fd();
+        let result = state
+            .io_results
+            .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
+            .ok_or(AsyncHostError::Badf)?;
+        let mut bytes_transferred = 0;
+        if unsafe {
+            GetOverlappedResult(raw_fd, result.overlapped_ptr(), &mut bytes_transferred, 0)
+        } == 0
+        {
+            return Err(last_native_error());
+        }
+        let bytes_transferred =
+            i32::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)?;
+        result.copy_read_result(memory, bytes_transferred)?;
+        Ok(bytes_transferred)
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn read_io_result(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        fd_handle: HostHandle,
+        result_handle: u64,
+    ) -> AsyncHostResult<i32> {
+        use windows_sys::Win32::Foundation::ERROR_HANDLE_EOF;
+        use windows_sys::Win32::Storage::FileSystem::ReadFile;
+
+        let mut state = self.state.lock().unwrap();
+        let raw_fd = state.file(fd_handle)?.raw_fd();
+        let result = state
+            .io_results
+            .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
+            .ok_or(AsyncHostError::Badf)?;
+        result.direction = Some(HostIoDirection::Read);
+        let len = u32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
+        let mut bytes_transferred = 0;
+        let success = unsafe {
+            ReadFile(
+                raw_fd,
+                result.buffer.as_mut_ptr().cast(),
+                len,
+                &mut bytes_transferred,
+                result.overlapped_ptr(),
+            )
+        };
+        if success != 0 {
+            let bytes_transferred =
+                i32::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)?;
+            result.copy_read_result(memory, bytes_transferred)?;
+            return Ok(bytes_transferred);
+        }
+        let errno = last_errno();
+        if errno == ERROR_HANDLE_EOF as i32 {
+            Ok(0)
+        } else {
+            Err(AsyncHostError::Native(errno))
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn write_io_result(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        fd_handle: HostHandle,
+        result_handle: u64,
+    ) -> AsyncHostResult<i32> {
+        use windows_sys::Win32::Storage::FileSystem::WriteFile;
+
+        let mut state = self.state.lock().unwrap();
+        let raw_fd = state.file(fd_handle)?.raw_fd();
+        let result = state
+            .io_results
+            .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
+            .ok_or(AsyncHostError::Badf)?;
+        result.direction = Some(HostIoDirection::Write);
+        let len_i32 = i32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
+        let data = memory.read_exact(result.guest_offset, len_i32)?;
+        result.buffer.copy_from_slice(data);
+        let len = u32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
+        let mut bytes_transferred = 0;
+        let success = unsafe {
+            WriteFile(
+                raw_fd,
+                result.buffer.as_ptr().cast(),
+                len,
+                &mut bytes_transferred,
+                result.overlapped_ptr(),
+            )
+        };
+        if success != 0 {
+            i32::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
+        } else {
+            Err(last_native_error())
+        }
+    }
+
+    pub(crate) fn try_lock_file(&self, handle: HostHandle, exclusive: bool) -> AsyncHostResult<()> {
+        let mut state = self.state.lock().unwrap();
+        let file = state.file_mut(handle)?;
+        crate::async_sys::fs::stub::try_lock_host_file(file, exclusive)
+    }
+
+    pub(crate) fn unlock_file(&self, handle: HostHandle) -> AsyncHostResult<()> {
+        let mut state = self.state.lock().unwrap();
+        let file = state.file_mut(handle)?;
+        crate::async_sys::fs::stub::unlock_host_file(file)
+    }
+
+    pub(crate) fn run_job(&self, handle: u64) -> AsyncHostResult<()> {
+        let key = key_from_handle::<HostJobKey>(handle);
+        let mut job = self
+            .state
+            .lock()
+            .unwrap()
+            .jobs
+            .get_mut(key)
+            .and_then(Option::take)
+            .ok_or(AsyncHostError::Badf)?;
+        let mut files = SharedFileTable {
+            state: Arc::clone(&self.state),
+        };
+        thread_pool::run_host_job(&mut job, &mut files);
+        let mut state = self.state.lock().unwrap();
+        let slot = state.jobs.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        if slot.is_some() {
+            return Err(AsyncHostError::Badf);
+        }
+        *slot = Some(job);
+        Ok(())
+    }
+
+    pub(crate) fn spawn_worker(&self, job_id: i32, job_handle: u64) -> AsyncHostResult<u64> {
+        #[cfg(unix)]
+        let worker = {
+            let completion_notifier = self
+                .state
+                .lock()
+                .unwrap()
+                .completion_notifier
+                .clone()
+                .ok_or(AsyncHostError::Badf)?;
+            self.spawn_worker_thread(HostWorkerJob { job_id, job_handle }, move |worker_job| {
+                completion_notifier
+                    .notify(worker_job.job_id)
+                    .expect("failed to notify async host completion pipe");
+            })
+        };
+        #[cfg(windows)]
+        let worker = {
+            let completion_port = self
+                .state
+                .lock()
+                .unwrap()
+                .completion_port
+                .ok_or(AsyncHostError::Badf)?;
+            self.spawn_worker_thread(HostWorkerJob { job_id, job_handle }, move |worker_job| {
+                poll::post_thread_pool_completion(completion_port, worker_job.job_id)
+                    .expect("failed to post async host completion packet");
+            })
+        };
+        let key = self.state.lock().unwrap().workers.insert(worker);
+        Ok(handle_from_key(key))
+    }
+
+    pub(crate) fn wake_worker(
+        &self,
+        worker_handle: u64,
+        job_id: i32,
+        job_handle: u64,
+    ) -> AsyncHostResult<()> {
+        let state = self.state.lock().unwrap();
+        let worker = state
+            .workers
+            .get(key_from_handle::<HostWorkerKey>(worker_handle))
+            .ok_or(AsyncHostError::Badf)?;
+        thread_pool::wake_worker(worker, HostWorkerJob { job_id, job_handle });
+        Ok(())
+    }
+
+    pub(crate) fn worker_enter_idle(&self, worker_handle: u64) -> AsyncHostResult<()> {
+        let state = self.state.lock().unwrap();
+        let worker = state
+            .workers
+            .get(key_from_handle::<HostWorkerKey>(worker_handle))
+            .ok_or(AsyncHostError::Badf)?;
+        thread_pool::worker_enter_idle(worker);
+        Ok(())
+    }
+
+    pub(crate) fn free_worker(&self, worker_handle: u64) -> AsyncHostResult<()> {
+        let worker = self
+            .state
+            .lock()
+            .unwrap()
+            .workers
+            .remove(key_from_handle::<HostWorkerKey>(worker_handle))
+            .ok_or(AsyncHostError::Badf)?;
+        thread_pool::free_worker(worker);
+        Ok(())
+    }
+
+    pub(crate) fn cancel_worker(&self, worker_handle: u64) -> AsyncHostResult<i32> {
+        let state = self.state.lock().unwrap();
+        let worker = state
+            .workers
+            .get(key_from_handle::<HostWorkerKey>(worker_handle))
+            .ok_or(AsyncHostError::Badf)?;
+        Ok(thread_pool::cancel_worker(worker))
+    }
+
+    pub(crate) fn get_read_result(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        handle: u64,
+        dst: i32,
+        offset: i32,
+        len: i32,
+    ) -> AsyncHostResult<()> {
+        let state = self.state.lock().unwrap();
+        let job = state
+            .jobs
+            .get(key_from_handle::<HostJobKey>(handle))
+            .and_then(Option::as_ref)
+            .ok_or(AsyncHostError::Badf)?;
+        thread_pool::get_read_result(job, memory, dst, offset, len)
+    }
+
+    pub(crate) fn get_readdir_result(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        handle: u64,
+        dst: i32,
+        len: i32,
+    ) -> AsyncHostResult<()> {
+        let state = self.state.lock().unwrap();
+        let job = state
+            .jobs
+            .get(key_from_handle::<HostJobKey>(handle))
+            .and_then(Option::as_ref)
+            .ok_or(AsyncHostError::Badf)?;
+        thread_pool::get_readdir_result(job, memory, dst, len)
+    }
+
+    pub(crate) fn get_file_time_result(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        handle: u64,
+        dst: i32,
+    ) -> AsyncHostResult<()> {
+        let state = self.state.lock().unwrap();
+        let job = state
+            .jobs
+            .get(key_from_handle::<HostJobKey>(handle))
+            .and_then(Option::as_ref)
+            .ok_or(AsyncHostError::Badf)?;
+        thread_pool::get_file_time_result(job, memory, dst)
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn fetch_completion(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        source_fd: HostHandle,
+        dst: i32,
+        max_jobs: i32,
+    ) -> AsyncHostResult<i32> {
+        let (completion_notifier, completion_source) = {
+            let state = self.state.lock().unwrap();
+            (
+                state
+                    .completion_notifier
+                    .clone()
+                    .ok_or(AsyncHostError::Badf)?,
+                state.completion_source.ok_or(AsyncHostError::Badf)?,
+            )
+        };
+        if completion_source != source_fd {
+            return Err(AsyncHostError::Badf);
+        }
+
+        let max_jobs = usize::try_from(max_jobs).map_err(|_| AsyncHostError::Fault)?;
+        if max_jobs == 0 {
+            return Ok(0);
+        }
+        let max_bytes = max_jobs
+            .checked_mul(std::mem::size_of::<i32>())
+            .ok_or(AsyncHostError::Fault)?;
+        let max_bytes_i32 = i32::try_from(max_bytes).map_err(|_| AsyncHostError::Fault)?;
+        memory.read_exact(dst, max_bytes_i32)?;
+
+        let mut completions = vec![0; max_bytes];
+        let bytes = completion_notifier.fetch(&mut completions)?;
+        debug_assert_eq!(bytes % std::mem::size_of::<i32>(), 0);
+        let bytes_i32 = i32::try_from(bytes).map_err(|_| AsyncHostError::Fault)?;
+        memory.write_exact(dst, &completions[..bytes])?;
+        Ok(bytes_i32)
+    }
+
+    fn spawn_worker_thread(
+        &self,
+        init_job: HostWorkerJob,
+        mut complete_job: impl FnMut(HostWorkerJob) + Send + 'static,
+    ) -> HostWorkerHandle {
+        let state = Arc::clone(&self.state);
+        let run_state = Arc::clone(&state);
+        thread_pool::spawn_worker(
+            init_job,
+            move |worker_job| {
+                let key = key_from_handle::<HostJobKey>(worker_job.job_handle);
+                let Some(mut job) = run_state
+                    .lock()
+                    .unwrap()
+                    .jobs
+                    .get_mut(key)
+                    .and_then(Option::take)
+                else {
+                    return;
+                };
+
+                let mut files = SharedFileTable {
+                    state: Arc::clone(&run_state),
+                };
+                thread_pool::run_host_job(&mut job, &mut files);
+
+                let mut state = run_state.lock().unwrap();
+                if let Some(slot) = state.jobs.get_mut(key)
+                    && slot.is_none()
+                {
+                    *slot = Some(job);
+                }
+            },
+            move |worker_job| {
+                // Even if cancellation discarded the job handle, the event loop
+                // still needs the completion to move the worker out of running.
+                complete_job(worker_job);
+            },
+        )
+    }
+}
+
+struct SharedFileTable {
+    state: Arc<Mutex<AsyncHostState>>,
+}
+
+impl HostFileTable for SharedFileTable {
+    fn insert_file(&mut self, file: RawFd) -> AsyncHostResult<HostHandle> {
+        Ok(handle_from_key(
+            self.state.lock().unwrap().files.insert(HostFile::new(file)),
+        ))
+    }
+
+    fn is_invalid_file_handle(&self, handle: HostHandle) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .files
+            .get(key_from_handle::<HostFileKey>(handle))
+            .is_some_and(HostFile::is_invalid)
+    }
+
+    #[cfg(windows)]
+    fn borrowed_raw_file(&mut self, handle: HostHandle) -> AsyncHostResult<RawFd> {
+        let state = self.state.lock().unwrap();
+        Ok(state.file(handle)?.raw_fd())
+    }
+
+    fn with_raw_file<U>(
+        &mut self,
+        handle: HostHandle,
+        f: impl FnOnce(RawFd) -> AsyncHostResult<U>,
+    ) -> AsyncHostResult<U> {
+        let file = {
+            let mut state = self.state.lock().unwrap();
+            state.file_mut(handle)?.duplicate()?
+        };
+        f(file.raw_fd())
+    }
+
+    fn with_host_file_mut<U>(
+        &mut self,
+        handle: HostHandle,
+        f: impl FnOnce(&mut HostFile) -> AsyncHostResult<U>,
+    ) -> AsyncHostResult<U> {
+        // TODO(async-wasm): keep this path for handle-state mutations only.
+        // Blocking job bodies should clone/take the OS handle before running so
+        // worker threads do not serialize on the host table lock.
+        let mut state = self.state.lock().unwrap();
+        let file = state.file_mut(handle)?;
+        f(file)
+    }
+}
+
+#[cfg(windows)]
+fn last_errno() -> i32 {
+    std::io::Error::last_os_error()
+        .raw_os_error()
+        .unwrap_or_else(|| AsyncHostError::Inval.errno())
+}
+
+#[cfg(windows)]
+fn last_native_error() -> AsyncHostError {
+    AsyncHostError::Native(last_errno())
+}
+
+#[cfg(unix)]
+fn raw_fd_to_guest(fd: RawFd) -> AsyncHostResult<HostHandle> {
+    u64::try_from(fd).map_err(|_| AsyncHostError::Fault)
+}
+
+#[cfg(windows)]
+fn raw_fd_to_guest(fd: RawFd) -> AsyncHostResult<HostHandle> {
+    Ok(fd as usize as u64)
+}
+
+#[cfg(unix)]
+fn raw_fd_key(fd: RawFd) -> isize {
+    fd as isize
+}
+
+#[cfg(windows)]
+fn raw_fd_key(fd: RawFd) -> isize {
+    fd as isize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guest_memory_read_exact_accepts_in_bounds_access() {
+        let memory = [1, 2, 3, 4];
+
+        assert_eq!(memory.read_exact(1, 2).unwrap(), &[2, 3]);
+        assert!(memory.read_exact(4, 0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn guest_memory_read_exact_rejects_out_of_bounds_access() {
+        let memory = [0; 4];
+
+        for (offset, len) in [(-1, 1), (0, -1), (3, 2), (i32::MAX, 1), (2, i32::MAX)] {
+            assert_eq!(memory.read_exact(offset, len), Err(AsyncHostError::Fault));
+        }
+    }
+
+    #[test]
+    fn guest_memory_read_exact_mut_accepts_in_bounds_access() {
+        let mut memory = [1, 2, 3, 4];
+
+        memory.read_exact_mut(1, 2).unwrap().fill(9);
+
+        assert_eq!(memory, [1, 9, 9, 4]);
+    }
+
+    #[test]
+    fn guest_memory_read_exact_mut_rejects_out_of_bounds_access() {
+        let mut memory = [0; 4];
+
+        for (offset, len) in [(-1, 1), (0, -1), (3, 2), (i32::MAX, 1), (2, i32::MAX)] {
+            assert_eq!(
+                memory.read_exact_mut(offset, len),
+                Err(AsyncHostError::Fault)
+            );
+        }
+    }
+
+    #[test]
+    fn guest_memory_helpers_read_and_write_u16_units() {
+        let mut memory = [0; 8];
+
+        write_u16(&mut memory, 2, &[0x1234, 0x5678]).unwrap();
+
+        assert_eq!(read_u16(&memory, 2, 2).unwrap(), &[0x1234, 0x5678]);
+        assert_eq!(read_u16(&memory, 1, 1), Err(AsyncHostError::Fault));
+        assert_eq!(
+            write_u16(&mut memory, 6, &[1, 2]),
+            Err(AsyncHostError::Fault)
+        );
+        assert_eq!(&memory[2..6], &[0x34, 0x12, 0x78, 0x56]);
+    }
+
+    #[test]
+    fn guest_memory_helpers_allow_empty_u16_access_on_empty_memory() {
+        let mut memory = [];
+
+        assert!(read_u16(&memory, 0, 0).unwrap().is_empty());
+        write_u16(&mut memory, 0, &[]).unwrap();
+    }
+
+    #[test]
+    fn guest_memory_writes_fixed_little_endian_words() {
+        let mut memory = [0; 16];
+
+        memory.write_u64_le(2, 0x1020_3040_5060_7080).unwrap();
+
+        assert_eq!(
+            &memory[2..10],
+            &[0x80, 0x70, 0x60, 0x50, 0x40, 0x30, 0x20, 0x10]
+        );
+        assert_eq!(memory.write_u64_le(10, 1), Err(AsyncHostError::Fault));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn completion_source_is_host_file_handle() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let completion_source = host.init_thread_pool(poll).unwrap();
+        let raw_completion_fd = {
+            let state = host.state.lock().unwrap();
+            state.file(completion_source).unwrap().raw_fd()
+        };
+        {
+            let state = host.state.lock().unwrap();
+            let poll = state
+                .polls
+                .get(key_from_handle::<HostPollKey>(poll))
+                .unwrap()
+                .lock()
+                .unwrap();
+            assert_eq!(
+                poll.registered_fds
+                    .get(&raw_fd_key(raw_completion_fd))
+                    .copied(),
+                Some(completion_source)
+            );
+        }
+
+        {
+            let state = host.state.lock().unwrap();
+            state
+                .completion_notifier
+                .as_ref()
+                .unwrap()
+                .notify(17)
+                .unwrap();
+        }
+        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+        let event = host.poll_get_event(poll, 0).unwrap();
+        assert_eq!(host.poll_event_fd(event).unwrap(), completion_source);
+
+        let mut memory = [0; 4];
+        assert_eq!(
+            host.fetch_completion(memory.as_mut_slice(), completion_source, 0, 1)
+                .unwrap(),
+            4
+        );
+        assert_eq!(i32::from_le_bytes(memory), 17);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fetch_completion_publishes_job_id_without_copying_payload() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let completion_notifier = host.init_thread_pool(poll).unwrap();
+        let job = thread_pool::make_read_job(0, 3, -1);
+        let job_handle = host.insert_job(job).unwrap();
+        {
+            let mut state = host.state.lock().unwrap();
+            let job = state
+                .jobs
+                .get_mut(key_from_handle::<HostJobKey>(job_handle))
+                .and_then(Option::as_mut)
+                .unwrap();
+            let thread_pool::JobPayload::Read { result, .. } = job.payload_mut() else {
+                panic!("expected read job");
+            };
+            *result = Some(b"abc".to_vec());
+            state
+                .completion_notifier
+                .as_ref()
+                .unwrap()
+                .notify(42)
+                .unwrap();
+        }
+
+        let mut memory = vec![0; 16];
+        let bytes = host
+            .fetch_completion(memory.as_mut_slice(), completion_notifier, 0, 1)
+            .unwrap();
+
+        assert_eq!(bytes, 4);
+        assert_eq!(i32::from_le_bytes(memory[0..4].try_into().unwrap()), 42);
+        assert_eq!(&memory[8..11], &[0, 0, 0]);
+
+        host.get_read_result(memory.as_mut_slice(), job_handle, 8, 0, 3)
+            .unwrap();
+
+        assert_eq!(&memory[8..11], b"abc");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fetch_completion_leaves_unfetched_job_ids_in_os_source() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let completion_notifier = host.init_thread_pool(poll).unwrap();
+        {
+            let state = host.state.lock().unwrap();
+            let notifier = state.completion_notifier.as_ref().unwrap();
+            notifier.notify(41).unwrap();
+            notifier.notify(42).unwrap();
+        }
+
+        let mut memory = vec![0; 8];
+        let bytes = host
+            .fetch_completion(memory.as_mut_slice(), completion_notifier, 0, 0)
+            .unwrap();
+        assert_eq!(bytes, 0);
+
+        let bytes = host
+            .fetch_completion(memory.as_mut_slice(), completion_notifier, 0, 1)
+            .unwrap();
+        assert_eq!(bytes, 4);
+        assert_eq!(i32::from_le_bytes(memory[0..4].try_into().unwrap()), 41);
+
+        let bytes = host
+            .fetch_completion(memory.as_mut_slice(), completion_notifier, 4, 1)
+            .unwrap();
+        assert_eq!(bytes, 4);
+        assert_eq!(i32::from_le_bytes(memory[4..8].try_into().unwrap()), 42);
+    }
+
+    #[test]
+    fn stale_job_handle_is_rejected_after_free() {
+        let host = AsyncHost::default();
+        let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
+
+        host.free_job(job).unwrap();
+
+        assert_eq!(host.job_get_ret(job), Err(AsyncHostError::Badf));
+        assert_eq!(host.free_job(job), Err(AsyncHostError::Badf));
+    }
+
+    #[test]
+    fn stale_worker_handle_is_rejected_after_free() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let completion_notifier = host.init_thread_pool(poll).unwrap();
+        let job = host
+            .insert_job(thread_pool::make_read_job(0, 1, -1))
+            .unwrap();
+        let worker = host.spawn_worker(42, job).unwrap();
+        host.poll_wait(poll, 1000).unwrap();
+        #[cfg(unix)]
+        {
+            let mut memory = [0; 4];
+            host.fetch_completion(memory.as_mut_slice(), completion_notifier, 0, 1)
+                .unwrap();
+        }
+        #[cfg(windows)]
+        {
+            let event = host.poll_get_event(poll, 0).unwrap();
+            assert_eq!(host.poll_event_fd(event).unwrap(), completion_notifier);
+            assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 42);
+        }
+
+        host.free_worker(worker).unwrap();
+
+        assert_eq!(host.free_worker(worker), Err(AsyncHostError::Badf));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn poll_reports_registered_pipe_readiness_as_guest_fd() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let [read, write] = host.pipe(true, true).unwrap();
+        host.poll_register(poll, read, true).unwrap();
+
+        {
+            let mut state = host.state.lock().unwrap();
+            state
+                .files
+                .with_raw_file(write, |fd| {
+                    let byte = b"x";
+                    let ret = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
+                    if ret < 0 {
+                        Err(AsyncHostError::Native(
+                            std::io::Error::last_os_error()
+                                .raw_os_error()
+                                .unwrap_or_else(|| AsyncHostError::Inval.errno()),
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                })
+                .unwrap();
+        }
+
+        assert_eq!(host.poll_wait(poll, 100).unwrap(), 1);
+        let event = host.poll_get_event(poll, 0).unwrap();
+        assert_eq!(host.poll_event_fd(event).unwrap(), read);
+        assert_eq!(
+            host.poll_event_events(event).unwrap() & poll::READ_EVENT,
+            poll::READ_EVENT
+        );
+        host.close_fd(read).unwrap();
+        host.close_fd(write).unwrap();
+    }
+
+    #[test]
+    fn stale_file_handle_is_rejected_after_close() {
+        let host = AsyncHost::default();
+        let [read, write] = host.pipe(true, true).unwrap();
+
+        host.close_fd(read).unwrap();
+
+        assert_eq!(host.close_fd(read), Err(AsyncHostError::Badf));
+        host.close_fd(write).unwrap();
+    }
+}

--- a/crates/moonrun/src/async_sys/fs/dir.rs
+++ b/crates/moonrun/src/async_sys/fs/dir.rs
@@ -1,0 +1,422 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::ported_fns;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const NAME_MAX: usize = 255;
+
+#[cfg(target_os = "linux")]
+const LINUX_DIRENT_SIZE: usize = 24;
+#[cfg(target_os = "linux")]
+const LINUX_D_INO_OFFSET: usize = 0;
+#[cfg(target_os = "linux")]
+const LINUX_D_RECLEN_OFFSET: usize = 16;
+#[cfg(target_os = "linux")]
+const LINUX_D_TYPE_OFFSET: usize = 18;
+#[cfg(target_os = "linux")]
+const LINUX_D_NAME_OFFSET: usize = 19;
+
+#[cfg(target_os = "macos")]
+const MAC_DIRENT_SIZE: usize = 44;
+#[cfg(target_os = "macos")]
+const MAC_D_RECLEN_OFFSET: usize = 0;
+#[cfg(target_os = "macos")]
+const MAC_D_ATTRS_OFFSET: usize = 4;
+#[cfg(target_os = "macos")]
+const MAC_D_NAME_OFFSET: usize = 24;
+#[cfg(target_os = "macos")]
+const MAC_D_NAME_LENGTH_OFFSET: usize = 28;
+#[cfg(target_os = "macos")]
+const MAC_D_TYPE_OFFSET: usize = 32;
+#[cfg(target_os = "macos")]
+const MAC_D_FILEID_OFFSET: usize = 36;
+
+ported_fns! {
+    #[ported(
+        source = "src/fs/dir.c",
+        original = "moonbitlang_async_dir_buffer_min_size"
+    )]
+    pub(crate) fn buffer_min_size() -> i32 {
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::MAX_PATH;
+            use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
+
+            (std::mem::size_of::<FILE_ID_BOTH_DIR_INFO>() + MAX_PATH as usize) as i32
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            (MAC_DIRENT_SIZE + NAME_MAX) as i32
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            (LINUX_DIRENT_SIZE + NAME_MAX) as i32
+        }
+    }
+
+    #[ported(
+        source = "src/fs/dir.c",
+        original = "moonbitlang_async_dir_entry_length"
+    )]
+    pub(crate) fn entry_length(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<i32> {
+        #[cfg(windows)]
+        {
+            let entry = windows_entry(buf, buf_ptr, offset)?;
+            i32::try_from(entry.NextEntryOffset).map_err(|_| AsyncHostError::Fault)
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let entry = entry_offset(buf_ptr, offset)?;
+            i32::try_from(read_u32_ne(buf, entry + MAC_D_RECLEN_OFFSET)?)
+                .map_err(|_| AsyncHostError::Fault)
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let entry = entry_offset(buf_ptr, offset)?;
+            Ok(i32::from(read_u16_ne(buf, entry + LINUX_D_RECLEN_OFFSET)?))
+        }
+    }
+
+    #[ported(
+        source = "src/fs/dir.c",
+        original = "moonbitlang_async_dir_entry_get_name_len"
+    )]
+    pub(crate) fn entry_name_len(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<i32> {
+        #[cfg(windows)]
+        {
+            let entry = windows_entry(buf, buf_ptr, offset)?;
+            i32::try_from(entry.FileNameLength).map_err(|_| AsyncHostError::Fault)
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let (_, len) = mac_name_range(buf, buf_ptr, offset)?;
+            i32::try_from(len).map_err(|_| AsyncHostError::Fault)
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let (_, len) = linux_name_range(buf, buf_ptr, offset)?;
+            i32::try_from(len).map_err(|_| AsyncHostError::Fault)
+        }
+    }
+
+    #[ported(
+        source = "src/fs/dir.c",
+        original = "moonbitlang_async_dir_entry_get_name"
+    )]
+    pub(crate) fn entry_name(
+        buf: &[u8],
+        buf_ptr: i32,
+        offset: i32,
+    ) -> AsyncHostResult<&[u8]> {
+        #[cfg(windows)]
+        {
+            let (start, len) = windows_name_range(buf, buf_ptr, offset)?;
+            buf
+                .get(start..start.checked_add(len).ok_or(AsyncHostError::Fault)?)
+                .ok_or(AsyncHostError::Fault)
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let (start, len) = mac_name_range(buf, buf_ptr, offset)?;
+            buf
+                .get(start..start.checked_add(len).ok_or(AsyncHostError::Fault)?)
+                .ok_or(AsyncHostError::Fault)
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let (start, len) = linux_name_range(buf, buf_ptr, offset)?;
+            buf
+                .get(start..start.checked_add(len).ok_or(AsyncHostError::Fault)?)
+                .ok_or(AsyncHostError::Fault)
+        }
+    }
+
+    #[ported(
+        source = "src/fs/dir.c",
+        original = "moonbitlang_async_dir_entry_is_dir"
+    )]
+    pub(crate) fn entry_is_dir(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<i32> {
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Storage::FileSystem::{
+                FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+            };
+
+            let entry = windows_entry(buf, buf_ptr, offset)?;
+            Ok(((entry.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) == 0
+                && (entry.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) as i32)
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let entry = entry_offset(buf_ptr, offset)?;
+            let attrs = read_u32_ne(buf, entry + MAC_D_ATTRS_OFFSET)?;
+            if (attrs & libc::ATTR_CMN_OBJTYPE) == 0 {
+                return Ok(-1);
+            }
+
+            match read_i32_ne(buf, entry + MAC_D_TYPE_OFFSET)? {
+                // vnode.h defines VNON = 0 and VDIR = 2. libc does not expose
+                // these macOS constants on every supported Rust target.
+                0 => Ok(-1),
+                2 => Ok(1),
+                _ => Ok(0),
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let entry = entry_offset(buf_ptr, offset)?;
+            match read_u8(buf, entry + LINUX_D_TYPE_OFFSET)? {
+                libc::DT_UNKNOWN => Ok(-1),
+                libc::DT_DIR => Ok(1),
+                _ => Ok(0),
+            }
+        }
+    }
+
+    #[ported(
+        source = "src/fs/dir.c",
+        original = "moonbitlang_async_dir_entry_is_hidden"
+    )]
+    pub(crate) fn entry_is_hidden(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<bool> {
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_HIDDEN;
+
+            let entry = windows_entry(buf, buf_ptr, offset)?;
+            Ok((entry.FileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0)
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let (start, _) = mac_name_range(buf, buf_ptr, offset)?;
+            Ok(read_u8(buf, start)? == b'.')
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let (start, _) = linux_name_range(buf, buf_ptr, offset)?;
+            Ok(read_u8(buf, start)? == b'.')
+        }
+    }
+
+    #[ported(
+        source = "src/fs/dir.c",
+        original = "moonbitlang_async_dir_entry_get_file_id"
+    )]
+    pub(crate) fn entry_file_id(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<u64> {
+        #[cfg(windows)]
+        {
+            let entry = windows_entry(buf, buf_ptr, offset)?;
+            Ok(entry.FileId as u64)
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let entry = entry_offset(buf_ptr, offset)?;
+            read_u64_ne(buf, entry + MAC_D_FILEID_OFFSET)
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let entry = entry_offset(buf_ptr, offset)?;
+            read_u64_ne(buf, entry + LINUX_D_INO_OFFSET)
+        }
+    }
+}
+
+fn entry_offset(buf_ptr: i32, offset: i32) -> AsyncHostResult<usize> {
+    let ptr = buf_ptr.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+    usize::try_from(ptr).map_err(|_| AsyncHostError::Fault)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn read_u8(buf: &[u8], offset: usize) -> AsyncHostResult<u8> {
+    buf.get(offset).copied().ok_or(AsyncHostError::Fault)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn read_array<const N: usize>(buf: &[u8], offset: usize) -> AsyncHostResult<[u8; N]> {
+    let end = offset.checked_add(N).ok_or(AsyncHostError::Fault)?;
+    buf.get(offset..end)
+        .ok_or(AsyncHostError::Fault)?
+        .try_into()
+        .map_err(|_| AsyncHostError::Fault)
+}
+
+#[cfg(target_os = "linux")]
+fn read_u16_ne(buf: &[u8], offset: usize) -> AsyncHostResult<u16> {
+    Ok(u16::from_ne_bytes(read_array(buf, offset)?))
+}
+
+#[cfg(target_os = "macos")]
+fn read_u32_ne(buf: &[u8], offset: usize) -> AsyncHostResult<u32> {
+    Ok(u32::from_ne_bytes(read_array(buf, offset)?))
+}
+
+#[cfg(target_os = "macos")]
+fn read_i32_ne(buf: &[u8], offset: usize) -> AsyncHostResult<i32> {
+    Ok(i32::from_ne_bytes(read_array(buf, offset)?))
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn read_u64_ne(buf: &[u8], offset: usize) -> AsyncHostResult<u64> {
+    Ok(u64::from_ne_bytes(read_array(buf, offset)?))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_name_range(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<(usize, usize)> {
+    let entry = entry_offset(buf_ptr, offset)?;
+    let reclen = usize::from(read_u16_ne(buf, entry + LINUX_D_RECLEN_OFFSET)?);
+    let name_start = entry
+        .checked_add(LINUX_D_NAME_OFFSET)
+        .ok_or(AsyncHostError::Fault)?;
+    let record_end = entry.checked_add(reclen).ok_or(AsyncHostError::Fault)?;
+    let name = buf
+        .get(name_start..record_end)
+        .ok_or(AsyncHostError::Fault)?;
+    let name_len = name
+        .iter()
+        .position(|byte| *byte == 0)
+        .ok_or(AsyncHostError::Fault)?;
+    Ok((name_start, name_len))
+}
+
+#[cfg(target_os = "macos")]
+fn mac_name_range(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<(usize, usize)> {
+    let entry = entry_offset(buf_ptr, offset)?;
+    let reclen = usize::try_from(read_u32_ne(buf, entry + MAC_D_RECLEN_OFFSET)?)
+        .map_err(|_| AsyncHostError::Fault)?;
+    let name_offset = usize::try_from(read_i32_ne(buf, entry + MAC_D_NAME_OFFSET)?)
+        .map_err(|_| AsyncHostError::Fault)?;
+    let name_len = usize::try_from(read_u32_ne(buf, entry + MAC_D_NAME_LENGTH_OFFSET)?)
+        .map_err(|_| AsyncHostError::Fault)?;
+    let name_len = name_len.checked_sub(1).ok_or(AsyncHostError::Fault)?;
+    let name_start = entry
+        .checked_add(MAC_D_NAME_OFFSET)
+        .and_then(|offset| offset.checked_add(name_offset))
+        .ok_or(AsyncHostError::Fault)?;
+    let name_end = name_start
+        .checked_add(name_len)
+        .ok_or(AsyncHostError::Fault)?;
+    let record_end = entry.checked_add(reclen).ok_or(AsyncHostError::Fault)?;
+    if name_end > record_end {
+        return Err(AsyncHostError::Fault);
+    }
+    Ok((name_start, name_len))
+}
+
+#[cfg(windows)]
+fn windows_entry(
+    buf: &[u8],
+    buf_ptr: i32,
+    offset: i32,
+) -> AsyncHostResult<windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO> {
+    use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
+
+    let entry = entry_offset(buf_ptr, offset)?;
+    let end = entry
+        .checked_add(std::mem::size_of::<FILE_ID_BOTH_DIR_INFO>())
+        .ok_or(AsyncHostError::Fault)?;
+    if end > buf.len() {
+        return Err(AsyncHostError::Fault);
+    }
+    Ok(unsafe { std::ptr::read_unaligned(buf.as_ptr().add(entry).cast()) })
+}
+
+#[cfg(windows)]
+fn windows_name_range(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<(usize, usize)> {
+    use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
+
+    let entry = windows_entry(buf, buf_ptr, offset)?;
+    let entry_start = entry_offset(buf_ptr, offset)?;
+    let name_start = entry_start
+        .checked_add(std::mem::offset_of!(FILE_ID_BOTH_DIR_INFO, FileName))
+        .ok_or(AsyncHostError::Fault)?;
+    let name_len = usize::try_from(entry.FileNameLength).map_err(|_| AsyncHostError::Fault)?;
+    let name_end = name_start
+        .checked_add(name_len)
+        .ok_or(AsyncHostError::Fault)?;
+    if name_end > buf.len() {
+        return Err(AsyncHostError::Fault);
+    }
+    Ok((name_start, name_len))
+}
+
+#[cfg(test)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_entry_accessors_read_native_getdents64_layout() {
+        let base = 100usize;
+        let mut buf = vec![0; 200];
+        buf[base..base + 8].copy_from_slice(&0x0102_0304_0506_0708_u64.to_ne_bytes());
+        buf[base + LINUX_D_RECLEN_OFFSET..base + LINUX_D_RECLEN_OFFSET + 2]
+            .copy_from_slice(&24_u16.to_ne_bytes());
+        buf[base + LINUX_D_TYPE_OFFSET] = libc::DT_DIR;
+        buf[base + LINUX_D_NAME_OFFSET..base + LINUX_D_NAME_OFFSET + 4].copy_from_slice(b"abc\0");
+
+        assert_eq!(entry_length(&buf, 100, 0), Ok(24));
+        assert_eq!(entry_name_len(&buf, 100, 0), Ok(3));
+        assert_eq!(entry_name(&buf, 100, 0), Ok(b"abc".as_slice()));
+        assert_eq!(entry_is_dir(&buf, 100, 0), Ok(1));
+        assert_eq!(entry_is_hidden(&buf, 100, 0), Ok(false));
+        assert_eq!(entry_file_id(&buf, 100, 0), Ok(0x0102_0304_0506_0708));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_entry_accessors_read_native_getattrlistbulk_layout() {
+        let base = 100usize;
+        let mut buf = vec![0; 200];
+        buf[base + MAC_D_RECLEN_OFFSET..base + MAC_D_RECLEN_OFFSET + 4]
+            .copy_from_slice(&52_u32.to_ne_bytes());
+        buf[base + MAC_D_ATTRS_OFFSET..base + MAC_D_ATTRS_OFFSET + 4]
+            .copy_from_slice(&libc::ATTR_CMN_OBJTYPE.to_ne_bytes());
+        buf[base + MAC_D_NAME_OFFSET..base + MAC_D_NAME_OFFSET + 4]
+            .copy_from_slice(&20_i32.to_ne_bytes());
+        buf[base + MAC_D_NAME_LENGTH_OFFSET..base + MAC_D_NAME_LENGTH_OFFSET + 4]
+            .copy_from_slice(&4_u32.to_ne_bytes());
+        buf[base + MAC_D_TYPE_OFFSET..base + MAC_D_TYPE_OFFSET + 4]
+            .copy_from_slice(&2_i32.to_ne_bytes());
+        buf[base + MAC_D_FILEID_OFFSET..base + MAC_D_FILEID_OFFSET + 8]
+            .copy_from_slice(&0x0102_0304_0506_0708_u64.to_ne_bytes());
+        buf[base + 44..base + 48].copy_from_slice(b"abc\0");
+
+        assert_eq!(entry_length(&buf, 100, 0), Ok(52));
+        assert_eq!(entry_name_len(&buf, 100, 0), Ok(3));
+        assert_eq!(entry_name(&buf, 100, 0), Ok(b"abc".as_slice()));
+        assert_eq!(entry_is_dir(&buf, 100, 0), Ok(1));
+        assert_eq!(entry_is_hidden(&buf, 100, 0), Ok(false));
+        assert_eq!(entry_file_id(&buf, 100, 0), Ok(0x0102_0304_0506_0708));
+    }
+}

--- a/crates/moonrun/src/async_sys/fs/mod.rs
+++ b/crates/moonrun/src/async_sys/fs/mod.rs
@@ -16,13 +16,5 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::v8_builder::ScopeExt;
-
-pub(super) fn fail(
-    scope: &mut v8::HandleScope,
-    _args: v8::FunctionCallbackArguments,
-    _ret: v8::ReturnValue,
-) {
-    let message = scope.string("moonbit_v0 async worker jobs are not supported in this PR");
-    scope.throw_exception(message.into());
-}
+pub(crate) mod dir;
+pub(crate) mod stub;

--- a/crates/moonrun/src/async_sys/fs/stub.rs
+++ b/crates/moonrun/src/async_sys/fs/stub.rs
@@ -1,0 +1,289 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::ffi::OsString;
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::internal::event_loop::thread_pool::HostFile;
+use crate::async_sys::ported_fns;
+
+#[cfg(unix)]
+pub(crate) type RawFileHandle = std::os::fd::RawFd;
+
+#[cfg(windows)]
+pub(crate) type RawFileHandle = windows_sys::Win32::Foundation::HANDLE;
+
+ported_fns! {
+    #[ported(
+        source = "src/fs/stub.c",
+        original = "moonbitlang_async_errno_is_lock_violation"
+    )]
+    pub(crate) fn errno_is_lock_violation(errno: i32) -> bool {
+        #[cfg(unix)]
+        {
+            errno == libc::EWOULDBLOCK
+        }
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::ERROR_LOCK_VIOLATION;
+            errno == ERROR_LOCK_VIOLATION as i32
+        }
+    }
+
+    #[ported(
+        source = "src/fs/stub.c",
+        original = "moonbitlang_async_get_tmp_path"
+    )]
+    pub(crate) fn get_tmp_path() -> AsyncHostResult<OsString> {
+        #[cfg(unix)]
+        {
+            Ok(tmp_path_from_native_stub())
+        }
+        #[cfg(windows)]
+        {
+            tmp_path_from_native_stub()
+        }
+    }
+
+    #[ported(
+        source = "src/fs/stub.c",
+        original = "moonbitlang_async_try_lock_file"
+    )]
+    pub(crate) fn try_lock_file(handle: RawFileHandle, exclusive: bool) -> AsyncHostResult<()> {
+        try_lock_file_from_native_stub(handle, exclusive)
+    }
+
+    #[ported(
+        source = "src/fs/stub.c",
+        original = "moonbitlang_async_unlock_file"
+    )]
+    pub(crate) fn unlock_file(handle: RawFileHandle) -> AsyncHostResult<()> {
+        unlock_file_from_native_stub(handle)
+    }
+}
+
+#[cfg(unix)]
+fn try_lock_file_from_native_stub(fd: RawFileHandle, exclusive: bool) -> AsyncHostResult<()> {
+    let operation = libc::LOCK_NB
+        | if exclusive {
+            libc::LOCK_EX
+        } else {
+            libc::LOCK_SH
+        };
+    if unsafe { libc::flock(fd, operation) } == 0 {
+        Ok(())
+    } else {
+        Err(last_native_error())
+    }
+}
+
+#[cfg(unix)]
+fn unlock_file_from_native_stub(fd: RawFileHandle) -> AsyncHostResult<()> {
+    if unsafe { libc::flock(fd, libc::LOCK_UN) } == 0 {
+        Ok(())
+    } else {
+        Err(last_native_error())
+    }
+}
+
+#[cfg(windows)]
+fn try_lock_file_from_native_stub(handle: RawFileHandle, exclusive: bool) -> AsyncHostResult<()> {
+    use std::mem::zeroed;
+    use windows_sys::Win32::Storage::FileSystem::{
+        LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
+    };
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let mut overlapped: OVERLAPPED = unsafe { zeroed() };
+    // Keep parity with async's native stub: lock a one-byte sentinel range at
+    // the end of the 64-bit file-position space.
+    overlapped.Anonymous.Anonymous.Offset = 0xfffffffe;
+    overlapped.Anonymous.Anonymous.OffsetHigh = 0xffffffff;
+    let flags = LOCKFILE_FAIL_IMMEDIATELY
+        | if exclusive {
+            LOCKFILE_EXCLUSIVE_LOCK
+        } else {
+            0
+        };
+
+    if unsafe { LockFileEx(handle, flags, 0, 1, 0, &mut overlapped) } != 0 {
+        Ok(())
+    } else {
+        Err(last_native_error())
+    }
+}
+
+#[cfg(windows)]
+fn unlock_file_from_native_stub(handle: RawFileHandle) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Storage::FileSystem::UnlockFile;
+
+    if unsafe { UnlockFile(handle, 0xfffffffe, 0xffffffff, 1, 0) } != 0 {
+        Ok(())
+    } else {
+        Err(last_native_error())
+    }
+}
+
+pub(crate) fn try_lock_host_file(file: &mut HostFile, exclusive: bool) -> AsyncHostResult<()> {
+    try_lock_file(file.raw_fd(), exclusive)
+}
+
+pub(crate) fn unlock_host_file(file: &mut HostFile) -> AsyncHostResult<()> {
+    unlock_file(file.raw_fd())
+}
+
+fn last_native_error() -> AsyncHostError {
+    AsyncHostError::Native(
+        std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
+    )
+}
+
+#[cfg(unix)]
+fn tmp_path_from_native_stub() -> OsString {
+    // POSIX reserves TMPDIR for temporary-file placement. The async tmpdir
+    // layer concatenates this base path with a generated name, so the host
+    // normalizes the Unix base to include the separator.
+    std::env::var_os("TMPDIR")
+        .and_then(separator_terminated_unix_path)
+        .unwrap_or_else(default_unix_tmp_path)
+}
+
+#[cfg(all(unix, target_os = "android"))]
+fn default_unix_tmp_path() -> OsString {
+    OsString::from("/data/local/tmp/")
+}
+
+#[cfg(all(unix, not(target_os = "android")))]
+fn default_unix_tmp_path() -> OsString {
+    OsString::from("/tmp/")
+}
+
+#[cfg(unix)]
+fn separator_terminated_unix_path(path: OsString) -> Option<OsString> {
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    let bytes = path.as_os_str().as_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+    if bytes.ends_with(b"/") {
+        return Some(path);
+    }
+
+    let mut bytes = path.into_vec();
+    bytes.push(b'/');
+    Some(OsString::from_vec(bytes))
+}
+
+#[cfg(windows)]
+fn tmp_path_from_native_stub() -> AsyncHostResult<OsString> {
+    use crate::async_host::AsyncHostError;
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::Foundation::{GetLastError, MAX_PATH};
+    use windows_sys::Win32::Storage::FileSystem::GetTempPath2W;
+
+    let mut buffer = [0u16; MAX_PATH as usize + 1];
+    let len = unsafe { GetTempPath2W(buffer.len() as u32, buffer.as_mut_ptr()) };
+    if len == 0 {
+        return Err(AsyncHostError::Native(unsafe { GetLastError() as i32 }));
+    }
+
+    let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+    Ok(OsString::from_wide(&buffer[..len]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tmp_path_is_non_empty_and_separator_terminated() {
+        let path = get_tmp_path().unwrap();
+
+        assert!(!path.as_os_str().is_empty());
+        let path = path.to_string_lossy();
+        assert!(path.ends_with('/') || path.ends_with('\\'));
+    }
+
+    #[cfg(all(unix, not(target_os = "android")))]
+    #[test]
+    fn default_unix_tmp_path_matches_async_stub_fallback() {
+        use std::os::unix::ffi::OsStrExt;
+
+        assert_eq!(default_unix_tmp_path().as_os_str().as_bytes(), b"/tmp/");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tmpdir_env_value_is_separator_terminated() {
+        use std::os::unix::ffi::OsStrExt;
+
+        assert_eq!(
+            separator_terminated_unix_path(OsString::from("/var/tmp"))
+                .unwrap()
+                .as_os_str()
+                .as_bytes(),
+            b"/var/tmp/"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn empty_tmpdir_env_value_is_ignored() {
+        assert_eq!(separator_terminated_unix_path(OsString::from("")), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_lock_violation_matches_async_stub() {
+        assert!(errno_is_lock_violation(libc::EWOULDBLOCK));
+        assert!(!errno_is_lock_violation(libc::EINVAL));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_try_lock_and_unlock_file_match_async_stub() {
+        use std::os::fd::AsRawFd;
+
+        let path =
+            std::env::temp_dir().join(format!("moonrun-async-lock-test-{}", std::process::id()));
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+
+        try_lock_file(file.as_raw_fd(), true).unwrap();
+        unlock_file(file.as_raw_fd()).unwrap();
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_invalid_lock_file_records_native_errno() {
+        assert_eq!(
+            try_lock_file(-1, true),
+            Err(AsyncHostError::Native(libc::EBADF))
+        );
+        assert_eq!(unlock_file(-1), Err(AsyncHostError::Native(libc::EBADF)));
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/c_buffer/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/c_buffer/mod.rs
@@ -1,0 +1,19 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+pub(crate) mod stub;

--- a/crates/moonrun/src/async_sys/internal/c_buffer/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/c_buffer/stub.rs
@@ -1,0 +1,104 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::ported_fns;
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/c_buffer/stub.c",
+        original = "moonbitlang_async_blit_to_c"
+    )]
+    pub(crate) fn blit_to_c(dst: &mut [u8], src: &[u8], offset: i32, len: i32) -> AsyncHostResult<()> {
+        let src = checked_range(src, offset, len)?;
+        let dst = dst.get_mut(..src.len()).ok_or(AsyncHostError::Fault)?;
+        dst.copy_from_slice(src);
+        Ok(())
+    }
+
+    #[ported(
+        source = "src/internal/c_buffer/stub.c",
+        original = "moonbitlang_async_blit_from_c"
+    )]
+    pub(crate) fn blit_from_c(src: &[u8], dst: &mut [u8], offset: i32, len: i32) -> AsyncHostResult<()> {
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        let src = src.get(..len).ok_or(AsyncHostError::Fault)?;
+        let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+        let end = offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
+        let dst = dst.get_mut(offset..end).ok_or(AsyncHostError::Fault)?;
+        dst.copy_from_slice(src);
+        Ok(())
+    }
+
+    #[ported(
+        source = "src/internal/c_buffer/stub.c",
+        original = "moonbitlang_async_c_buffer_get"
+    )]
+    pub(crate) fn c_buffer_get(buf: &[u8], index: i32) -> AsyncHostResult<u8> {
+        let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
+        buf.get(index).copied().ok_or(AsyncHostError::Fault)
+    }
+
+    #[ported(
+        source = "src/internal/c_buffer/stub.c",
+        original = "moonbitlang_async_strlen"
+    )]
+    pub(crate) fn strlen(buf: &[u8]) -> AsyncHostResult<i32> {
+        let len = buf
+            .iter()
+            .position(|byte| *byte == 0)
+            .ok_or(AsyncHostError::Fault)?;
+        i32::try_from(len).map_err(|_| AsyncHostError::Fault)
+    }
+
+}
+
+fn checked_range(src: &[u8], offset: i32, len: i32) -> AsyncHostResult<&[u8]> {
+    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+    let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+    let end = offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
+    src.get(offset..end).ok_or(AsyncHostError::Fault)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blit_to_c_copies_from_source_offset() {
+        let mut dst = [0; 3];
+
+        blit_to_c(&mut dst, b"abcdef", 2, 3).unwrap();
+
+        assert_eq!(&dst, b"cde");
+    }
+
+    #[test]
+    fn blit_from_c_copies_to_destination_offset() {
+        let mut dst = *b"abcdef";
+
+        blit_from_c(b"XY", &mut dst, 2, 2).unwrap();
+
+        assert_eq!(&dst, b"abXYef");
+    }
+
+    #[test]
+    fn strlen_stops_at_first_nul() {
+        assert_eq!(strlen(b"abc\0def").unwrap(), 3);
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/env_util/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/env_util/mod.rs
@@ -1,0 +1,19 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+pub(crate) mod stub;

--- a/crates/moonrun/src/async_sys/internal/env_util/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/env_util/stub.rs
@@ -1,0 +1,39 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_sys::ported_fns;
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/env_util/stub.c",
+        original = "moonbitlang_async_getpid"
+    )]
+    pub(crate) fn get_pid() -> u32 {
+        std::process::id()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_pid_matches_current_process() {
+        assert_eq!(get_pid(), std::process::id());
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
@@ -1,0 +1,162 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+#[cfg(unix)]
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+#[cfg(unix)]
+use crate::async_sys::internal::event_loop::poll;
+#[cfg(unix)]
+use crate::async_sys::internal::fd_util::stub as fd_util;
+#[cfg(unix)]
+use crate::async_sys::internal::fd_util::stub::RawFd;
+
+#[cfg(unix)]
+#[derive(Debug)]
+pub(crate) struct ThreadPoolCompletionNotifier {
+    notify_recv: RawFd,
+    notify_send: RawFd,
+}
+
+#[cfg(unix)]
+impl ThreadPoolCompletionNotifier {
+    pub(crate) fn new(poll: &poll::PollInstance) -> AsyncHostResult<(Self, RawFd)> {
+        let fds = fd_util::pipe()?;
+
+        if let Err(error) = fd_util::set_nonblocking(fds[0]) {
+            close_fds(fds);
+            return Err(error);
+        }
+
+        if let Err(error) = poll::poll_register(poll, fds[0], true) {
+            close_fds(fds);
+            return Err(error);
+        }
+
+        // The read end is transferred to AsyncHost's HostFile table so poll
+        // events report the same handle space as ordinary pipe/file fds.
+        Ok((
+            Self {
+                notify_recv: fds[0],
+                notify_send: fds[1],
+            },
+            fds[0],
+        ))
+    }
+
+    pub(crate) fn notify(&self, job_id: i32) -> AsyncHostResult<()> {
+        let bytes = job_id.to_ne_bytes();
+        let mut offset = 0;
+        loop {
+            let n = unsafe {
+                libc::write(
+                    self.notify_send,
+                    bytes[offset..].as_ptr().cast(),
+                    bytes.len() - offset,
+                )
+            };
+            if n > 0 {
+                offset += n as usize;
+                if offset == bytes.len() {
+                    return Ok(());
+                }
+                continue;
+            }
+            if n == 0 {
+                return Err(AsyncHostError::Inval);
+            }
+            let errno = last_errno();
+            if errno == libc::EINTR {
+                continue;
+            }
+            return Err(AsyncHostError::Native(errno));
+        }
+    }
+
+    pub(crate) fn fetch(&self, dst: &mut [u8]) -> AsyncHostResult<usize> {
+        if dst.is_empty() {
+            return Ok(0);
+        }
+        loop {
+            let n = unsafe { libc::read(self.notify_recv, dst.as_mut_ptr().cast(), dst.len()) };
+            if n > 0 {
+                return usize::try_from(n).map_err(|_| AsyncHostError::Fault);
+            }
+            if n == 0 {
+                return Ok(0);
+            }
+            let errno = last_errno();
+            if errno == libc::EINTR {
+                continue;
+            }
+            if would_block(errno) {
+                return Ok(0);
+            }
+            return Err(AsyncHostError::Native(errno));
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ThreadPoolCompletionNotifier {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.notify_send);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn close_fds(fds: [RawFd; 2]) {
+    unsafe {
+        libc::close(fds[0]);
+        libc::close(fds[1]);
+    }
+}
+
+#[cfg(unix)]
+fn last_errno() -> i32 {
+    std::io::Error::last_os_error()
+        .raw_os_error()
+        .unwrap_or_else(|| AsyncHostError::Inval.errno())
+}
+
+#[cfg(unix)]
+fn would_block(errno: i32) -> bool {
+    errno == libc::EAGAIN || errno == libc::EWOULDBLOCK
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completion_pipe_is_close_on_exec() {
+        let poll = poll::poll_create().unwrap();
+        let (notifier, notify_recv) = ThreadPoolCompletionNotifier::new(&poll).unwrap();
+
+        for fd in [notify_recv, notifier.notify_send] {
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+            assert!(flags >= 0);
+            assert_ne!(flags & libc::FD_CLOEXEC, 0);
+        }
+
+        unsafe {
+            libc::close(notify_recv);
+        }
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/io.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/io.rs
@@ -1,0 +1,118 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+#[cfg(unix)]
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+#[cfg(unix)]
+use crate::async_sys::internal::fd_util::stub::RawFd;
+use crate::async_sys::ported_fns;
+
+#[cfg(unix)]
+fn last_native_error() -> AsyncHostError {
+    AsyncHostError::Native(
+        std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
+    )
+}
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/event_loop/io_unix.c",
+        original = "moonbitlang_async_read"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn read(fd: RawFd, buf: &mut [u8]) -> AsyncHostResult<usize> {
+        let ret = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+        if ret < 0 {
+            Err(last_native_error())
+        } else {
+            usize::try_from(ret).map_err(|_| AsyncHostError::Fault)
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/io_unix.c",
+        original = "moonbitlang_async_write"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn write(fd: RawFd, buf: &[u8]) -> AsyncHostResult<usize> {
+        let ret = unsafe { libc::write(fd, buf.as_ptr().cast(), buf.len()) };
+        if ret < 0 {
+            Err(last_native_error())
+        } else {
+            usize::try_from(ret).map_err(|_| AsyncHostError::Fault)
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/io_windows.c",
+        original = "moonbitlang_async_errno_is_read_EOF"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn errno_is_read_eof(errno: i32) -> bool {
+        use windows_sys::Win32::Foundation::{ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF};
+
+        errno == ERROR_HANDLE_EOF as i32 || errno == ERROR_BROKEN_PIPE as i32
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
+    #[cfg(not(windows))]
+    {
+        PORTED_SYMBOLS.to_vec()
+    }
+
+    #[cfg(windows)]
+    {
+        let mut symbols = PORTED_SYMBOLS.to_vec();
+        symbols.extend_from_slice(&[
+            ported_windows_symbol(
+                "make_file_io_result",
+                "moonbitlang_async_make_file_io_result",
+            ),
+            ported_windows_symbol("free_io_result", "moonbitlang_async_free_io_result"),
+            ported_windows_symbol(
+                "io_result_get_event",
+                "moonbitlang_async_io_result_get_event",
+            ),
+            ported_windows_symbol("cancel_io_result", "moonbitlang_async_cancel_io_result"),
+            ported_windows_symbol(
+                "io_result_get_status",
+                "moonbitlang_async_io_result_get_status",
+            ),
+            ported_windows_symbol("read_io_result", "moonbitlang_async_read"),
+            ported_windows_symbol("write_io_result", "moonbitlang_async_write"),
+        ]);
+        symbols
+    }
+}
+
+#[cfg(all(test, windows))]
+fn ported_windows_symbol(
+    rust_symbol: &'static str,
+    native_symbol: &'static str,
+) -> crate::async_sys::PortedSymbol {
+    crate::async_sys::PortedSymbol {
+        rust_module: module_path!(),
+        rust_symbol,
+        native_symbol,
+        source: "src/internal/event_loop/io_windows.c",
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/mod.rs
@@ -1,0 +1,25 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+mod completion;
+pub(crate) mod io;
+pub(crate) mod poll;
+pub(crate) mod thread_pool;
+
+#[cfg(unix)]
+pub(crate) use completion::ThreadPoolCompletionNotifier;

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -1,0 +1,162 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::internal::fd_util::stub::RawFd;
+use crate::async_sys::ported_fns;
+
+use super::{
+    EVENT_BUFFER_SIZE, PollEvent, PollInstance, READ_EVENT, WRITE_EVENT, last_native_error,
+};
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/event_loop/epoll.c",
+        original = "moonbitlang_async_event_bus_create"
+    )]
+    pub(crate) fn poll_create() -> AsyncHostResult<PollInstance> {
+        let fd = unsafe { libc::epoll_create1(0) };
+        if fd < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(PollInstance {
+                fd,
+                events: Vec::new(),
+            })
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/epoll.c",
+        original = "moonbitlang_async_event_bus_destroy"
+    )]
+    pub(crate) fn poll_destroy(instance: PollInstance) {
+        drop(instance);
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/epoll.c",
+        original = "moonbitlang_async_event_bus_register"
+    )]
+    pub(crate) fn poll_register(
+        instance: &PollInstance,
+        fd: RawFd,
+        read_only: bool,
+    ) -> AsyncHostResult<()> {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags >= 0 && (flags & libc::O_NONBLOCK) == 0 {
+            unsafe {
+                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+        }
+        let events = if read_only {
+            READ_EVENT
+        } else {
+            READ_EVENT | WRITE_EVENT
+        };
+        let mut event = libc::epoll_event {
+            events: epoll_event_mask(events)?,
+            u64: fd as u64,
+        };
+        if unsafe { libc::epoll_ctl(instance.fd, libc::EPOLL_CTL_ADD, fd, &mut event) } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/epoll.c",
+        original = "moonbitlang_async_event_bus_wait"
+    )]
+    pub(crate) fn poll_wait(instance: &mut PollInstance, timeout: i32) -> AsyncHostResult<i32> {
+        let mut events = vec![libc::epoll_event { events: 0, u64: 0 }; EVENT_BUFFER_SIZE];
+        let count = unsafe {
+            libc::epoll_wait(
+                instance.fd,
+                events.as_mut_ptr(),
+                EVENT_BUFFER_SIZE as i32,
+                timeout,
+            )
+        };
+        if count < 0 {
+            return Err(last_native_error());
+        }
+        instance.events = events
+            .into_iter()
+            .take(count as usize)
+            .map(|event| PollEvent {
+                fd: event.u64 as RawFd,
+                events: epoll_result_events(event.events),
+            })
+            .collect();
+        Ok(count)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/epoll.c",
+        original = "moonbitlang_async_event_list_get"
+    )]
+    pub(crate) fn event_list_get(instance: &PollInstance, index: i32) -> AsyncHostResult<&PollEvent> {
+        let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
+        instance.events.get(index).ok_or(AsyncHostError::Fault)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/epoll.c",
+        original = "moonbitlang_async_event_get_fd"
+    )]
+    pub(crate) fn event_get_fd(event: &PollEvent) -> RawFd {
+        event.fd
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/epoll.c",
+        original = "moonbitlang_async_event_get_events"
+    )]
+    pub(crate) fn event_get_events(event: &PollEvent) -> i32 {
+        event.events
+    }
+}
+
+fn epoll_event_mask(events: i32) -> AsyncHostResult<u32> {
+    let mut mask = match events {
+        READ_EVENT => libc::EPOLLIN,
+        WRITE_EVENT => libc::EPOLLOUT,
+        events if events == (READ_EVENT | WRITE_EVENT) => libc::EPOLLIN | libc::EPOLLOUT,
+        _ => return Err(AsyncHostError::Inval),
+    };
+    mask |= libc::EPOLLET;
+    mask |= libc::EPOLLRDHUP;
+    Ok(mask as u32)
+}
+
+fn epoll_result_events(events: u32) -> i32 {
+    if (events & (libc::EPOLLERR | libc::EPOLLHUP | libc::EPOLLRDHUP) as u32) != 0 {
+        return READ_EVENT | WRITE_EVENT;
+    }
+
+    let mut result = 0;
+    if (events & libc::EPOLLIN as u32) != 0 {
+        result |= READ_EVENT;
+    }
+    if (events & libc::EPOLLOUT as u32) != 0 {
+        result |= WRITE_EVENT;
+    }
+    result
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
@@ -1,0 +1,194 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::internal::fd_util::stub::RawFd;
+use crate::async_sys::ported_fns;
+
+use super::{EVENT_BUFFER_SIZE, PollEvent, PollInstance, last_errno, last_native_error};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompletionPort(RawFd);
+
+// A completion port handle may be used from worker threads to post completion
+// packets. PollInstance owns the actual handle lifetime; this value is only a
+// typed copy used while the owning poll instance remains registered in AsyncHost.
+unsafe impl Send for CompletionPort {}
+
+impl CompletionPort {
+    pub(crate) fn from_poll(poll: &PollInstance) -> Self {
+        Self(poll.raw_fd())
+    }
+}
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/event_loop/iocp.c",
+        original = "moonbitlang_async_event_bus_create"
+    )]
+    pub(crate) fn poll_create() -> AsyncHostResult<PollInstance> {
+        use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+        use windows_sys::Win32::System::IO::CreateIoCompletionPort;
+
+        let fd = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, std::ptr::null_mut(), 0, 0) };
+        if fd.is_null() {
+            Err(last_native_error())
+        } else {
+            Ok(PollInstance {
+                fd,
+                events: Vec::new(),
+            })
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/iocp.c",
+        original = "moonbitlang_async_event_bus_destroy"
+    )]
+    pub(crate) fn poll_destroy(instance: PollInstance) {
+        drop(instance);
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/iocp.c",
+        original = "moonbitlang_async_event_bus_register"
+    )]
+    pub(crate) fn poll_register(
+        instance: &PollInstance,
+        fd: RawFd,
+        read_only: bool,
+    ) -> AsyncHostResult<()> {
+        use windows_sys::Win32::Storage::FileSystem::SetFileCompletionNotificationModes;
+        use windows_sys::Win32::System::IO::CreateIoCompletionPort;
+        use windows_sys::Win32::System::WindowsProgramming::FILE_SKIP_COMPLETION_PORT_ON_SUCCESS;
+
+        let _ = read_only;
+        if unsafe { SetFileCompletionNotificationModes(fd, FILE_SKIP_COMPLETION_PORT_ON_SUCCESS as u8) } == 0 {
+            return Err(last_native_error());
+        }
+        let registered = unsafe { CreateIoCompletionPort(fd, instance.fd, fd as usize, 0) };
+        if registered.is_null() {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/iocp.c",
+        original = "moonbitlang_async_event_bus_wait"
+    )]
+    pub(crate) fn poll_wait(instance: &mut PollInstance, timeout: i32) -> AsyncHostResult<i32> {
+        use windows_sys::Win32::Foundation::WAIT_TIMEOUT;
+        use windows_sys::Win32::System::IO::GetQueuedCompletionStatusEx;
+        use windows_sys::Win32::System::Threading::INFINITE;
+
+        let mut entries = vec![empty_overlapped_entry(); EVENT_BUFFER_SIZE];
+        let mut count = 0;
+        let ok = unsafe {
+            GetQueuedCompletionStatusEx(
+                instance.fd,
+                entries.as_mut_ptr(),
+                EVENT_BUFFER_SIZE as u32,
+                &mut count,
+                if timeout < 0 { INFINITE } else { timeout as u32 },
+                0,
+            )
+        };
+        if ok == 0 {
+            if last_errno() == WAIT_TIMEOUT as i32 {
+                instance.events.clear();
+                return Ok(0);
+            }
+            return Err(last_native_error());
+        }
+        instance.events = entries
+            .into_iter()
+            .take(count as usize)
+            .map(|entry| PollEvent {
+                fd: entry.lpCompletionKey as RawFd,
+                events: 0,
+                io_result: entry.lpOverlapped,
+                bytes_transferred: entry.dwNumberOfBytesTransferred as i32,
+            })
+            .collect();
+        i32::try_from(count).map_err(|_| AsyncHostError::Fault)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/iocp.c",
+        original = "moonbitlang_async_event_list_get"
+    )]
+    pub(crate) fn event_list_get(instance: &PollInstance, index: i32) -> AsyncHostResult<&PollEvent> {
+        let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
+        instance.events.get(index).ok_or(AsyncHostError::Fault)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/iocp.c",
+        original = "moonbitlang_async_event_get_fd"
+    )]
+    pub(crate) fn event_get_fd(event: &PollEvent) -> RawFd {
+        event.fd
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/iocp.c",
+        original = "moonbitlang_async_event_get_io_result"
+    )]
+    pub(crate) fn event_get_io_result(
+        event: &PollEvent,
+    ) -> *mut windows_sys::Win32::System::IO::OVERLAPPED {
+        event.io_result
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/iocp.c",
+        original = "moonbitlang_async_event_get_bytes_transferred"
+    )]
+    pub(crate) fn event_get_bytes_transferred(event: &PollEvent) -> i32 {
+        event.bytes_transferred
+    }
+}
+
+pub(crate) fn post_thread_pool_completion(
+    completion_port: CompletionPort,
+    job_id: i32,
+) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Foundation::{GetLastError, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
+
+    // Native thread_pool.c posts worker completions to the event bus IOCP with
+    // INVALID_HANDLE_VALUE as the completion key and the job id as transferred bytes.
+    if unsafe {
+        PostQueuedCompletionStatus(
+            completion_port.0,
+            job_id as u32,
+            INVALID_HANDLE_VALUE as usize,
+            std::ptr::null_mut(),
+        )
+    } == 0
+    {
+        return Err(AsyncHostError::Native(unsafe { GetLastError() } as i32));
+    }
+    Ok(())
+}
+
+fn empty_overlapped_entry() -> windows_sys::Win32::System::IO::OVERLAPPED_ENTRY {
+    unsafe { std::mem::zeroed() }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
@@ -1,0 +1,190 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::internal::fd_util::stub::RawFd;
+use crate::async_sys::ported_fns;
+
+use super::{
+    EVENT_BUFFER_SIZE, PROCESS_EVENT, PollEvent, PollInstance, READ_EVENT, WRITE_EVENT,
+    last_native_error,
+};
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/event_loop/kqueue.c",
+        original = "moonbitlang_async_event_bus_create"
+    )]
+    pub(crate) fn poll_create() -> AsyncHostResult<PollInstance> {
+        let fd = unsafe { libc::kqueue() };
+        if fd < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(PollInstance {
+                fd,
+                events: Vec::new(),
+            })
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/kqueue.c",
+        original = "moonbitlang_async_event_bus_destroy"
+    )]
+    pub(crate) fn poll_destroy(instance: PollInstance) {
+        drop(instance);
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/kqueue.c",
+        original = "moonbitlang_async_event_bus_register"
+    )]
+    pub(crate) fn poll_register(
+        instance: &PollInstance,
+        fd: RawFd,
+        read_only: bool,
+    ) -> AsyncHostResult<()> {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags >= 0 && (flags & libc::O_NONBLOCK) == 0 {
+            unsafe {
+                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+        }
+
+        let flags = libc::EV_ADD | libc::EV_CLEAR;
+        let events = [
+            new_kevent(fd as libc::uintptr_t, libc::EVFILT_READ, flags, 0, 0),
+            new_kevent(fd as libc::uintptr_t, libc::EVFILT_WRITE, flags, 0, 0),
+        ];
+        if unsafe {
+            libc::kevent(
+                instance.fd,
+                events.as_ptr(),
+                if read_only { 1 } else { 2 },
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null(),
+            )
+        } < 0
+        {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/kqueue.c",
+        original = "moonbitlang_async_event_bus_wait"
+    )]
+    pub(crate) fn poll_wait(instance: &mut PollInstance, timeout: i32) -> AsyncHostResult<i32> {
+        let timeout_spec = libc::timespec {
+            tv_sec: (timeout / 1000) as libc::time_t,
+            tv_nsec: ((timeout % 1000) * 1_000_000) as libc::c_long,
+        };
+        let mut events = vec![empty_kevent(); EVENT_BUFFER_SIZE];
+        let count = unsafe {
+            libc::kevent(
+                instance.fd,
+                std::ptr::null(),
+                0,
+                events.as_mut_ptr(),
+                EVENT_BUFFER_SIZE as i32,
+                if timeout < 0 {
+                    std::ptr::null()
+                } else {
+                    &timeout_spec
+                },
+            )
+        };
+        if count < 0 {
+            return Err(last_native_error());
+        }
+        instance.events = events
+            .into_iter()
+            .take(count as usize)
+            .map(|event| PollEvent {
+                fd: event.ident as RawFd,
+                events: kqueue_result_events(&event),
+            })
+            .collect();
+        Ok(count)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/kqueue.c",
+        original = "moonbitlang_async_event_list_get"
+    )]
+    pub(crate) fn event_list_get(instance: &PollInstance, index: i32) -> AsyncHostResult<&PollEvent> {
+        let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
+        instance.events.get(index).ok_or(AsyncHostError::Fault)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/kqueue.c",
+        original = "moonbitlang_async_event_get_fd"
+    )]
+    pub(crate) fn event_get_fd(event: &PollEvent) -> RawFd {
+        event.fd
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/kqueue.c",
+        original = "moonbitlang_async_event_get_events"
+    )]
+    pub(crate) fn event_get_events(event: &PollEvent) -> i32 {
+        event.events
+    }
+}
+
+fn kqueue_result_events(event: &libc::kevent) -> i32 {
+    if event.filter == libc::EVFILT_READ {
+        return READ_EVENT;
+    }
+    if event.filter == libc::EVFILT_WRITE {
+        return WRITE_EVENT;
+    }
+    if event.filter == libc::EVFILT_PROC {
+        return PROCESS_EVENT;
+    }
+    if (event.flags & libc::EV_ERROR) != 0 {
+        return READ_EVENT | WRITE_EVENT;
+    }
+    0
+}
+
+fn new_kevent(
+    ident: libc::uintptr_t,
+    filter: i16,
+    flags: u16,
+    fflags: u32,
+    data: libc::intptr_t,
+) -> libc::kevent {
+    let mut event = empty_kevent();
+    event.ident = ident;
+    event.filter = filter;
+    event.flags = flags;
+    event.fflags = fflags;
+    event.data = data;
+    event.udata = std::ptr::null_mut();
+    event
+}
+
+fn empty_kevent() -> libc::kevent {
+    unsafe { std::mem::zeroed() }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
@@ -1,0 +1,183 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Ports of `moonbitlang/async/src/internal/event_loop/{epoll,kqueue,iocp}.c`.
+//! The native C surface calls this abstraction the event bus.
+
+use crate::async_host::AsyncHostError;
+use crate::async_sys::internal::fd_util::stub::RawFd;
+
+#[cfg(target_os = "linux")]
+mod epoll;
+#[cfg(windows)]
+mod iocp;
+#[cfg(target_os = "macos")]
+mod kqueue;
+
+#[cfg(target_os = "linux")]
+pub(crate) use epoll::*;
+#[cfg(windows)]
+pub(crate) use iocp::*;
+#[cfg(target_os = "macos")]
+pub(crate) use kqueue::*;
+
+pub(super) const EVENT_BUFFER_SIZE: usize = 1024;
+#[cfg(unix)]
+pub(crate) const READ_EVENT: i32 = 1;
+#[cfg(unix)]
+pub(crate) const WRITE_EVENT: i32 = 2;
+#[cfg(target_os = "macos")]
+pub(crate) const PROCESS_EVENT: i32 = 4;
+
+#[derive(Debug)]
+pub(crate) struct PollInstance {
+    fd: RawFd,
+    events: Vec<PollEvent>,
+}
+
+#[cfg(windows)]
+unsafe impl Send for PollInstance {}
+
+#[cfg(windows)]
+unsafe impl Sync for PollInstance {}
+
+impl PollInstance {
+    #[cfg(windows)]
+    pub(crate) fn raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PollEvent {
+    fd: RawFd,
+    events: i32,
+    #[cfg(windows)]
+    io_result: *mut windows_sys::Win32::System::IO::OVERLAPPED,
+    #[cfg(windows)]
+    bytes_transferred: i32,
+}
+
+impl Drop for PollInstance {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        unsafe {
+            libc::close(self.fd);
+        }
+        #[cfg(windows)]
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.fd);
+        }
+    }
+}
+
+pub(super) fn last_errno() -> i32 {
+    std::io::Error::last_os_error()
+        .raw_os_error()
+        .unwrap_or_else(|| AsyncHostError::Inval.errno())
+}
+
+pub(super) fn last_native_error() -> AsyncHostError {
+    AsyncHostError::Native(last_errno())
+}
+
+#[cfg(test)]
+pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
+    let mut symbols = Vec::new();
+    #[cfg(target_os = "linux")]
+    symbols.extend_from_slice(epoll::PORTED_SYMBOLS);
+    #[cfg(target_os = "macos")]
+    symbols.extend_from_slice(kqueue::PORTED_SYMBOLS);
+    #[cfg(windows)]
+    symbols.extend_from_slice(iocp::PORTED_SYMBOLS);
+    symbols.retain(|symbol| {
+        matches!(
+            symbol.native_symbol,
+            "moonbitlang_async_event_bus_create"
+                | "moonbitlang_async_event_bus_destroy"
+                | "moonbitlang_async_event_bus_register"
+                | "moonbitlang_async_event_bus_wait"
+                | "moonbitlang_async_event_list_get"
+                | "moonbitlang_async_event_get_fd"
+                | "moonbitlang_async_event_get_events"
+                | "moonbitlang_async_event_get_io_result"
+                | "moonbitlang_async_event_get_bytes_transferred"
+        )
+    });
+    symbols
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_list_get_rejects_missing_event() {
+        let poll = poll_create().unwrap();
+
+        assert_eq!(
+            event_list_get(&poll, 0).copied(),
+            Err(AsyncHostError::Fault)
+        );
+    }
+
+    #[test]
+    fn event_bus_wait_reports_pipe_readiness() {
+        let mut fds = [0; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let read_fd = fds[0];
+        let write_fd = fds[1];
+
+        let mut poll = poll_create().unwrap();
+        poll_register(&poll, read_fd, true).unwrap();
+        let byte = b"x";
+        assert_eq!(
+            unsafe { libc::write(write_fd, byte.as_ptr().cast(), byte.len()) },
+            1
+        );
+
+        let count = poll_wait(&mut poll, 100).unwrap();
+        assert_eq!(count, 1);
+        let event = *event_list_get(&poll, 0).unwrap();
+        assert_eq!(event_get_fd(&event), read_fd);
+        assert_eq!(event_get_events(&event) & READ_EVENT, READ_EVENT);
+
+        unsafe {
+            libc::close(read_fd);
+            libc::close(write_fd);
+        }
+    }
+
+    #[test]
+    fn ported_symbols_reference_native_sources() {
+        let async_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../third_party/moonbitlang_async");
+        for symbol in PORTED_SYMBOLS {
+            let source_path = async_root.join(symbol.source);
+            let contents = std::fs::read_to_string(&source_path)
+                .unwrap_or_else(|error| panic!("failed to read {:?}: {error}", source_path));
+            assert!(
+                contents.contains(symbol.native_symbol),
+                "{:?} does not contain native symbol {}",
+                source_path,
+                symbol.native_symbol
+            );
+        }
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -1,0 +1,1632 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Concrete filesystem job executors ported from
+//! `moonbitlang/async/src/internal/event_loop/thread_pool.c`.
+
+use std::ffi::OsString;
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::internal::fd_util;
+use crate::async_sys::ported_fns;
+
+use super::{FileTimeResult, HostFile, HostFileTable, HostHandle, OpenJobResult};
+
+type RawFile = fd_util::stub::RawFd;
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "open_job_worker"
+    )]
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn run_open_job(
+        files: &mut impl HostFileTable,
+        result: &mut Option<OpenJobResult>,
+        filename: OsString,
+        access: i32,
+        create_mode: i32,
+        append: bool,
+        sync: i32,
+        mode: i32,
+    ) -> AsyncHostResult<i64> {
+        let OpenedFile {
+            file,
+            kind,
+            dev_id,
+            file_id,
+        } = open_native_file(filename, access, create_mode, append, sync, mode)?;
+        let fd = files.insert_file(file)?;
+        *result = Some(OpenJobResult {
+            fd,
+            kind,
+            dev_id,
+            file_id,
+        });
+        Ok(0)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "read_job_worker"
+    )]
+    pub(super) fn run_read_job(
+        files: &mut impl HostFileTable,
+        fd: HostHandle,
+        len: i32,
+        position: i64,
+        result: &mut Option<Vec<u8>>,
+    ) -> AsyncHostResult<i64> {
+        files.with_raw_file(fd, |file| {
+            let mut buf = vec![0; usize::try_from(len).map_err(|_| AsyncHostError::Fault)?];
+            let n = read_from_native_file(file, &mut buf, position)?;
+            buf.truncate(n);
+            *result = Some(buf);
+            Ok(n as i64)
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "write_job_worker"
+    )]
+    pub(super) fn run_write_job(
+        files: &mut impl HostFileTable,
+        fd: HostHandle,
+        data: &[u8],
+        position: i64,
+    ) -> AsyncHostResult<i64> {
+        files.with_raw_file(fd, |file| {
+            let n = write_to_native_file(file, data, position)?;
+            Ok(n as i64)
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "file_kind_by_path_job_worker"
+    )]
+    pub(super) fn run_file_kind_by_path_job(
+        files: &mut impl HostFileTable,
+        parent: HostHandle,
+        path: OsString,
+        follow_symlink: bool,
+    ) -> AsyncHostResult<i64> {
+        file_kind_by_path(files, parent, path, follow_symlink).map(i64::from)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "file_size_job_worker"
+    )]
+    pub(super) fn run_file_size_job(
+        files: &mut impl HostFileTable,
+        fd: HostHandle,
+        result: &mut i64,
+    ) -> AsyncHostResult<i64> {
+        files.with_raw_file(fd, |file| {
+            *result = file_size(file)?;
+            Ok(0)
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "file_time_job_worker"
+    )]
+    pub(super) fn run_file_time_job(
+        files: &mut impl HostFileTable,
+        fd: HostHandle,
+        result: &mut Option<FileTimeResult>,
+    ) -> AsyncHostResult<i64> {
+        files.with_raw_file(fd, |file| {
+            *result = Some(FileTimeResult::new(file_time(file)?));
+            Ok(0)
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "file_time_by_path_job_worker"
+    )]
+    pub(super) fn run_file_time_by_path_job(
+        path: OsString,
+        follow_symlink: bool,
+        result: &mut Option<FileTimeResult>,
+    ) -> AsyncHostResult<i64> {
+        *result = Some(FileTimeResult::new(file_time_by_path(
+            path,
+            follow_symlink,
+        )?));
+        Ok(0)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "access_job_worker"
+    )]
+    pub(super) fn run_access_job(path: OsString, access: i32) -> AsyncHostResult<i64> {
+        access_native_path(path, access)?;
+        Ok(0)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "chmod_job_worker"
+    )]
+    pub(super) fn run_chmod_job(path: OsString, mode: i32) -> AsyncHostResult<i64> {
+        chmod_native_path(path, mode)?;
+        Ok(0)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "fsync_job_worker"
+    )]
+    pub(super) fn run_fsync_job(
+        files: &mut impl HostFileTable,
+        fd: HostHandle,
+        only_data: bool,
+    ) -> AsyncHostResult<i64> {
+        files.with_raw_file(fd, |file| {
+            sync_native_file(file, only_data)?;
+            Ok(0)
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "flock_job_worker"
+    )]
+    pub(super) fn run_flock_job(
+        files: &mut impl HostFileTable,
+        fd: HostHandle,
+        exclusive: bool,
+    ) -> AsyncHostResult<i64> {
+        #[cfg(windows)]
+        {
+            // Windows byte-range locks are tied to the handle used for
+            // LockFileEx/UnlockFile. Native async passes the same HANDLE to the
+            // flock worker and unlock stub, so the wasm host must not duplicate
+            // the handle here or it creates a separate lock identity.
+            let file = files.borrowed_raw_file(fd)?;
+            lock_native_file(file, exclusive)?;
+            Ok(0)
+        }
+
+        #[cfg(not(windows))]
+        files.with_raw_file(fd, |file| {
+            lock_native_file(file, exclusive)?;
+            Ok(0)
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "remove_job_worker"
+    )]
+    pub(super) fn run_remove_job(path: OsString) -> AsyncHostResult<i64> {
+        remove_native_path(path)?;
+        Ok(0)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "rename_job_worker"
+    )]
+    pub(super) fn run_rename_job(
+        old_path: OsString,
+        new_path: OsString,
+        replace: bool,
+    ) -> AsyncHostResult<i64> {
+        rename_native_path(old_path, new_path, replace)?;
+        Ok(0)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "symlink_job_worker"
+    )]
+    pub(super) fn run_symlink_job(
+        target: OsString,
+        path: OsString,
+        force_symlink: bool,
+    ) -> AsyncHostResult<i64> {
+        symlink_native_path(target, path, force_symlink)?;
+        Ok(0)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "mkdir_job_worker"
+    )]
+    pub(super) fn run_mkdir_job(path: OsString, mode: i32) -> AsyncHostResult<i64> {
+        mkdir_native_path(path, mode)?;
+        Ok(0)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "rmdir_job_worker"
+    )]
+    pub(super) fn run_rmdir_job(path: OsString) -> AsyncHostResult<i64> {
+        rmdir_native_path(path)?;
+        Ok(0)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "readdir_job_worker"
+    )]
+    pub(super) fn run_readdir_job(
+        files: &mut impl HostFileTable,
+        dir: HostHandle,
+        len: i32,
+        restart: bool,
+        result: &mut Option<Vec<u8>>,
+    ) -> AsyncHostResult<i64> {
+        files.with_host_file_mut(dir, |file| {
+            let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+            let (ret, native) = read_native_dir(file, len, restart)?;
+            *result = Some(native);
+            Ok(ret)
+        })
+    }
+}
+
+#[cfg(unix)]
+#[allow(clippy::unnecessary_cast)]
+fn open_native_file(
+    filename: OsString,
+    access: i32,
+    create_mode: i32,
+    append: bool,
+    sync: i32,
+    mode: i32,
+) -> AsyncHostResult<OpenedFile> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let access_flag = match access {
+        0 | 3 => libc::O_RDONLY,
+        1 => libc::O_WRONLY,
+        2 => libc::O_RDWR,
+        _ => return Err(AsyncHostError::Inval),
+    };
+    let create_flag = match create_mode {
+        0 => 0,
+        1 => libc::O_TRUNC,
+        2 => libc::O_CREAT,
+        3 => libc::O_CREAT | libc::O_TRUNC,
+        4 => libc::O_CREAT | libc::O_EXCL,
+        _ => return Err(AsyncHostError::Inval),
+    };
+    let sync_flag = match sync {
+        0 => 0,
+        1 => libc::O_DSYNC,
+        2 => libc::O_SYNC,
+        _ => return Err(AsyncHostError::Inval),
+    };
+    let append_flag = if append { libc::O_APPEND } else { 0 };
+    let filename = CString::new(filename.into_vec()).map_err(|_| AsyncHostError::Inval)?;
+    let fd = unsafe {
+        libc::open(
+            filename.as_ptr(),
+            access_flag | sync_flag | create_flag | append_flag | libc::O_CLOEXEC,
+            mode as libc::c_uint,
+        )
+    };
+    if fd < 0 {
+        return Err(last_native_error());
+    }
+
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } < 0 {
+        let error = last_native_error();
+        unsafe {
+            libc::close(fd);
+        }
+        return Err(error);
+    }
+    let stat = unsafe { stat.assume_init() };
+    Ok(OpenedFile {
+        file: fd,
+        kind: file_kind_from_stat(&stat),
+        dev_id: stat.st_dev as u64,
+        file_id: stat.st_ino as u64,
+    })
+}
+
+#[cfg(unix)]
+fn file_kind_from_stat(stat: &libc::stat) -> i32 {
+    match stat.st_mode & libc::S_IFMT {
+        libc::S_IFREG => 1,
+        libc::S_IFDIR => 2,
+        libc::S_IFLNK => 3,
+        libc::S_IFSOCK => 4,
+        libc::S_IFIFO => 5,
+        libc::S_IFBLK => 6,
+        libc::S_IFCHR => 7,
+        _ => 0,
+    }
+}
+
+#[cfg(windows)]
+fn open_native_file(
+    filename: OsString,
+    access: i32,
+    create_mode: i32,
+    append: bool,
+    sync: i32,
+    _mode: i32,
+) -> AsyncHostResult<OpenedFile> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, ERROR_PIPE_BUSY, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, CREATE_ALWAYS, CREATE_NEW, CreateFileW, FILE_APPEND_DATA,
+        FILE_ATTRIBUTE_NORMAL, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OVERLAPPED,
+        FILE_LIST_DIRECTORY, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        GetFileInformationByHandle, OPEN_ALWAYS, OPEN_EXISTING, TRUNCATE_EXISTING,
+    };
+    use windows_sys::Win32::System::Pipes::{NMPWAIT_WAIT_FOREVER, WaitNamedPipeW};
+
+    if !(0..=2).contains(&sync) {
+        return Err(AsyncHostError::Inval);
+    }
+    let mut access_flag = match access {
+        0 => GENERIC_READ,
+        1 => GENERIC_WRITE,
+        2 => GENERIC_READ | GENERIC_WRITE,
+        3 => FILE_LIST_DIRECTORY,
+        _ => return Err(AsyncHostError::Inval),
+    };
+    let create_mode = match create_mode {
+        0 => OPEN_EXISTING,
+        1 => TRUNCATE_EXISTING,
+        2 => OPEN_ALWAYS,
+        3 => CREATE_ALWAYS,
+        4 => CREATE_NEW,
+        _ => return Err(AsyncHostError::Inval),
+    };
+    if append {
+        access_flag = (access_flag ^ GENERIC_WRITE) | FILE_APPEND_DATA;
+    }
+    let mut flags = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS;
+    if access == 3 {
+        flags |= FILE_FLAG_OVERLAPPED;
+    }
+
+    let filename = filename
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let handle: HANDLE = loop {
+        let handle = unsafe {
+            CreateFileW(
+                filename.as_ptr(),
+                access_flag,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                std::ptr::null(),
+                create_mode,
+                flags,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle != INVALID_HANDLE_VALUE {
+            break handle;
+        }
+        let error = std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or_else(|| AsyncHostError::Inval.errno());
+        if error != ERROR_PIPE_BUSY as i32 {
+            return Err(AsyncHostError::Native(error));
+        }
+        if unsafe { WaitNamedPipeW(filename.as_ptr(), NMPWAIT_WAIT_FOREVER) } == 0 {
+            return Err(last_native_error());
+        }
+    };
+
+    let mut info = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+    if unsafe { GetFileInformationByHandle(handle, info.as_mut_ptr()) } == 0 {
+        let error = last_native_error();
+        unsafe {
+            CloseHandle(handle);
+        }
+        return Err(error);
+    }
+    let info = unsafe { info.assume_init() };
+    Ok(OpenedFile {
+        file: handle,
+        kind: file_kind_from_attr(info.dwFileAttributes),
+        dev_id: u64::from(info.dwVolumeSerialNumber),
+        file_id: (u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow),
+    })
+}
+
+#[cfg(windows)]
+fn file_kind_from_attr(attrs: u32) -> i32 {
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+    };
+
+    if (attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+        3
+    } else if (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0 {
+        2
+    } else {
+        1
+    }
+}
+
+struct OpenedFile {
+    file: RawFile,
+    kind: i32,
+    dev_id: u64,
+    file_id: u64,
+}
+
+#[cfg(unix)]
+fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHostResult<usize> {
+    let ret = if position < 0 {
+        unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) }
+    } else {
+        unsafe {
+            libc::pread(
+                fd,
+                buf.as_mut_ptr().cast(),
+                buf.len(),
+                position as libc::off_t,
+            )
+        }
+    };
+    native_io_result(ret)
+}
+
+#[cfg(unix)]
+fn write_to_native_file(fd: RawFile, data: &[u8], position: i64) -> AsyncHostResult<usize> {
+    let ret = if position < 0 {
+        unsafe { libc::write(fd, data.as_ptr().cast(), data.len()) }
+    } else {
+        unsafe {
+            libc::pwrite(
+                fd,
+                data.as_ptr().cast(),
+                data.len(),
+                position as libc::off_t,
+            )
+        }
+    };
+    native_io_result(ret)
+}
+
+#[cfg(unix)]
+fn file_kind_by_path(
+    files: &mut impl HostFileTable,
+    parent: HostHandle,
+    path: OsString,
+    follow_symlink: bool,
+) -> AsyncHostResult<i32> {
+    let path = path_to_cstring(path)?;
+    let flags = if follow_symlink {
+        0
+    } else {
+        libc::AT_SYMLINK_NOFOLLOW
+    };
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    let ret = if files.is_invalid_file_handle(parent) {
+        unsafe { libc::fstatat(libc::AT_FDCWD, path.as_ptr(), stat.as_mut_ptr(), flags) }
+    } else {
+        files.with_raw_file(parent, |fd| {
+            Ok(unsafe { libc::fstatat(fd, path.as_ptr(), stat.as_mut_ptr(), flags) })
+        })?
+    };
+    if ret < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(file_kind_from_stat(&unsafe { stat.assume_init() }))
+    }
+}
+
+#[cfg(unix)]
+#[allow(clippy::unnecessary_cast)]
+fn file_size(fd: RawFile) -> AsyncHostResult<i64> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } < 0 {
+        return Err(last_native_error());
+    }
+    Ok(unsafe { stat.assume_init() }.st_size as i64)
+}
+
+#[cfg(unix)]
+fn file_time(fd: RawFile) -> AsyncHostResult<fd_util::stub::FileTime> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } < 0 {
+        return Err(last_native_error());
+    }
+    Ok(unsafe { stat.assume_init() })
+}
+
+#[cfg(unix)]
+fn file_time_by_path(
+    path: OsString,
+    follow_symlink: bool,
+) -> AsyncHostResult<fd_util::stub::FileTime> {
+    let path = path_to_cstring(path)?;
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    let ret = if follow_symlink {
+        unsafe { libc::stat(path.as_ptr(), stat.as_mut_ptr()) }
+    } else {
+        unsafe { libc::lstat(path.as_ptr(), stat.as_mut_ptr()) }
+    };
+    if ret < 0 {
+        return Err(last_native_error());
+    }
+    Ok(unsafe { stat.assume_init() })
+}
+
+#[cfg(unix)]
+fn access_native_path(path: OsString, access: i32) -> AsyncHostResult<()> {
+    let path = path_to_cstring(path)?;
+    let mode = match access {
+        0 => libc::F_OK,
+        1 => libc::R_OK,
+        2 => libc::W_OK,
+        3 => libc::X_OK,
+        _ => return Err(AsyncHostError::Inval),
+    };
+    if unsafe { libc::access(path.as_ptr(), mode) } < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn chmod_native_path(path: OsString, mode: i32) -> AsyncHostResult<()> {
+    let path = path_to_cstring(path)?;
+    if unsafe { libc::chmod(path.as_ptr(), mode as libc::mode_t) } < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn sync_native_file(fd: RawFile, only_data: bool) -> AsyncHostResult<()> {
+    #[cfg(target_os = "macos")]
+    let ret = {
+        let _ = only_data;
+        unsafe { libc::fsync(fd) }
+    };
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let ret = unsafe {
+        if only_data {
+            libc::fdatasync(fd)
+        } else {
+            libc::fsync(fd)
+        }
+    };
+
+    if ret < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn lock_native_file(fd: RawFile, exclusive: bool) -> AsyncHostResult<()> {
+    let operation = if exclusive {
+        libc::LOCK_EX
+    } else {
+        libc::LOCK_SH
+    };
+    if unsafe { libc::flock(fd, operation) } < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn remove_native_path(path: OsString) -> AsyncHostResult<()> {
+    let path = path_to_cstring(path)?;
+    if unsafe { libc::remove(path.as_ptr()) } < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn symlink_native_path(
+    target: OsString,
+    path: OsString,
+    _force_symlink: bool,
+) -> AsyncHostResult<()> {
+    let target = path_to_cstring(target)?;
+    let path = path_to_cstring(path)?;
+    if unsafe { libc::symlink(target.as_ptr(), path.as_ptr()) } < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn mkdir_native_path(path: OsString, mode: i32) -> AsyncHostResult<()> {
+    let path = path_to_cstring(path)?;
+    if unsafe { libc::mkdir(path.as_ptr(), mode as libc::mode_t) } < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn rmdir_native_path(path: OsString) -> AsyncHostResult<()> {
+    let path = path_to_cstring(path)?;
+    if unsafe { libc::rmdir(path.as_ptr()) } < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn read_native_dir(
+    file: &mut HostFile,
+    len: usize,
+    restart: bool,
+) -> AsyncHostResult<(i64, Vec<u8>)> {
+    let fd = file.raw_fd();
+    if restart && unsafe { libc::lseek(fd, 0, libc::SEEK_SET) } < 0 {
+        return Err(last_native_error());
+    }
+
+    let mut native = vec![0; len];
+    let ret = unsafe { libc::syscall(libc::SYS_getdents64, fd, native.as_mut_ptr(), native.len()) };
+    if ret < 0 {
+        return Err(last_native_error());
+    }
+    #[cfg(not(target_pointer_width = "64"))]
+    let ret = i64::from(ret);
+    native.truncate(usize::try_from(ret).map_err(|_| AsyncHostError::Fault)?);
+    Ok((ret, native))
+}
+
+#[cfg(all(unix, target_os = "macos"))]
+fn read_native_dir(
+    file: &mut HostFile,
+    len: usize,
+    restart: bool,
+) -> AsyncHostResult<(i64, Vec<u8>)> {
+    let fd = file.raw_fd();
+    if restart && unsafe { libc::lseek(fd, 0, libc::SEEK_SET) } < 0 {
+        return Err(last_native_error());
+    }
+
+    let mut attr_spec = libc::attrlist {
+        bitmapcount: libc::ATTR_BIT_MAP_COUNT,
+        reserved: 0,
+        commonattr: libc::ATTR_CMN_RETURNED_ATTRS
+            | libc::ATTR_CMN_NAME
+            | libc::ATTR_CMN_OBJTYPE
+            | libc::ATTR_CMN_FILEID,
+        volattr: 0,
+        dirattr: 0,
+        fileattr: 0,
+        forkattr: 0,
+    };
+    let mut native = vec![0; len];
+    let ret = unsafe {
+        libc::getattrlistbulk(
+            fd,
+            (&mut attr_spec as *mut libc::attrlist).cast(),
+            native.as_mut_ptr().cast(),
+            native.len(),
+            0,
+        )
+    };
+    if ret < 0 {
+        return Err(last_native_error());
+    }
+    if ret == 0 {
+        native.clear();
+    }
+    Ok((i64::from(ret), native))
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn rename_native_path(
+    old_path: OsString,
+    new_path: OsString,
+    replace: bool,
+) -> AsyncHostResult<()> {
+    let old_path = path_to_cstring(old_path)?;
+    let new_path = path_to_cstring(new_path)?;
+    let flags = if replace { 0 } else { libc::RENAME_NOREPLACE };
+    let ret = unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
+            libc::AT_FDCWD,
+            old_path.as_ptr(),
+            libc::AT_FDCWD,
+            new_path.as_ptr(),
+            flags,
+        )
+    };
+    if ret < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(all(unix, target_os = "macos"))]
+fn rename_native_path(
+    old_path: OsString,
+    new_path: OsString,
+    replace: bool,
+) -> AsyncHostResult<()> {
+    let old_path = path_to_cstring(old_path)?;
+    let new_path = path_to_cstring(new_path)?;
+    let flags = if replace { 0 } else { libc::RENAME_EXCL };
+    let ret = unsafe {
+        libc::renameatx_np(
+            libc::AT_FDCWD,
+            old_path.as_ptr(),
+            libc::AT_FDCWD,
+            new_path.as_ptr(),
+            flags,
+        )
+    };
+    if ret < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn path_to_cstring(path: OsString) -> AsyncHostResult<std::ffi::CString> {
+    use std::os::unix::ffi::OsStringExt;
+
+    std::ffi::CString::new(path.into_vec()).map_err(|_| AsyncHostError::Inval)
+}
+
+#[cfg(unix)]
+fn native_io_result(ret: libc::ssize_t) -> AsyncHostResult<usize> {
+    if ret < 0 {
+        Err(last_native_error())
+    } else {
+        usize::try_from(ret).map_err(|_| AsyncHostError::Fault)
+    }
+}
+
+#[cfg(windows)]
+fn read_from_native_file(handle: RawFile, buf: &mut [u8], position: i64) -> AsyncHostResult<usize> {
+    use windows_sys::Win32::Foundation::{ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF, HANDLE};
+    use windows_sys::Win32::Storage::FileSystem::ReadFile;
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let overlapped = std::mem::MaybeUninit::<OVERLAPPED>::zeroed();
+    let overlapped = unsafe {
+        let mut overlapped = overlapped.assume_init();
+        if position > 0 {
+            overlapped.Anonymous.Anonymous.Offset = position as u32;
+            overlapped.Anonymous.Anonymous.OffsetHigh = (position >> 32) as u32;
+        }
+        overlapped
+    };
+    let mut overlapped = overlapped;
+    let mut bytes_transferred = 0;
+    let overlapped_ptr = if position < 0 {
+        std::ptr::null_mut()
+    } else {
+        &mut overlapped
+    };
+    let handle = handle as HANDLE;
+    // Synchronous Windows file handles can advance the current file pointer
+    // even when ReadFile receives an OVERLAPPED offset. Keep read_at/pread
+    // semantics by restoring the original pointer before returning.
+    let saved_position = if position < 0 {
+        None
+    } else {
+        Some(current_file_pointer(handle)?)
+    };
+    let result = unsafe {
+        ReadFile(
+            handle,
+            buf.as_mut_ptr().cast(),
+            u32::try_from(buf.len()).map_err(|_| AsyncHostError::Fault)?,
+            &mut bytes_transferred,
+            overlapped_ptr,
+        )
+    };
+    let result = if result != 0 {
+        usize::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
+    } else {
+        let error = std::io::Error::last_os_error();
+        let is_eof = matches!(
+            error.raw_os_error(),
+            Some(errno) if errno == ERROR_HANDLE_EOF as i32 || errno == ERROR_BROKEN_PIPE as i32
+        );
+        if is_eof {
+            Ok(0)
+        } else {
+            Err(native_io_error(error))
+        }
+    };
+    if let Some(saved_position) = saved_position
+        && let Err(restore_error) = restore_file_pointer(handle, saved_position)
+    {
+        return match result {
+            Ok(_) => Err(restore_error),
+            Err(error) => Err(error),
+        };
+    }
+    result
+}
+
+#[cfg(windows)]
+fn write_to_native_file(handle: RawFile, data: &[u8], position: i64) -> AsyncHostResult<usize> {
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Storage::FileSystem::WriteFile;
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let overlapped = std::mem::MaybeUninit::<OVERLAPPED>::zeroed();
+    let overlapped = unsafe {
+        let mut overlapped = overlapped.assume_init();
+        if position > 0 {
+            overlapped.Anonymous.Anonymous.Offset = position as u32;
+            overlapped.Anonymous.Anonymous.OffsetHigh = (position >> 32) as u32;
+        }
+        overlapped
+    };
+    let mut overlapped = overlapped;
+    let mut bytes_transferred = 0;
+    let overlapped_ptr = if position < 0 {
+        std::ptr::null_mut()
+    } else {
+        &mut overlapped
+    };
+    let handle = handle as HANDLE;
+    // See read_from_native_file: positioned writes must not alter the stream
+    // offset seen by following non-positioned writes.
+    let saved_position = if position < 0 {
+        None
+    } else {
+        Some(current_file_pointer(handle)?)
+    };
+    let result = unsafe {
+        WriteFile(
+            handle,
+            data.as_ptr().cast(),
+            u32::try_from(data.len()).map_err(|_| AsyncHostError::Fault)?,
+            &mut bytes_transferred,
+            overlapped_ptr,
+        )
+    };
+    let result = if result != 0 {
+        usize::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
+    } else {
+        Err(last_native_error())
+    };
+    if let Some(saved_position) = saved_position
+        && let Err(restore_error) = restore_file_pointer(handle, saved_position)
+    {
+        return match result {
+            Ok(_) => Err(restore_error),
+            Err(error) => Err(error),
+        };
+    }
+    result
+}
+
+#[cfg(windows)]
+fn current_file_pointer(handle: windows_sys::Win32::Foundation::HANDLE) -> AsyncHostResult<i64> {
+    use windows_sys::Win32::Storage::FileSystem::{FILE_CURRENT, SetFilePointerEx};
+
+    let mut current = 0;
+    if unsafe { SetFilePointerEx(handle, 0, &mut current, FILE_CURRENT) } == 0 {
+        Err(last_native_error())
+    } else {
+        Ok(current)
+    }
+}
+
+#[cfg(windows)]
+fn restore_file_pointer(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    position: i64,
+) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Storage::FileSystem::{FILE_BEGIN, SetFilePointerEx};
+
+    if unsafe { SetFilePointerEx(handle, position, std::ptr::null_mut(), FILE_BEGIN) } == 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn file_kind_by_path(
+    files: &mut impl HostFileTable,
+    parent: HostHandle,
+    path: OsString,
+    follow_symlink: bool,
+) -> AsyncHostResult<i32> {
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, GetFileInformationByHandle, OPEN_EXISTING,
+    };
+
+    let mut flags = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS;
+    if !follow_symlink {
+        flags |= FILE_FLAG_OPEN_REPARSE_POINT;
+    }
+    let path = resolve_windows_path_for_parent(files, parent, path)?;
+    let path = path_to_wide(path);
+    let handle: HANDLE = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            flags,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(last_native_error());
+    }
+    let mut info = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+    if unsafe { GetFileInformationByHandle(handle, info.as_mut_ptr()) } == 0 {
+        let error = last_native_error();
+        unsafe {
+            CloseHandle(handle);
+        }
+        return Err(error);
+    }
+    unsafe {
+        CloseHandle(handle);
+    }
+    Ok(file_kind_from_attr(
+        unsafe { info.assume_init() }.dwFileAttributes,
+    ))
+}
+
+#[cfg(windows)]
+fn resolve_windows_path_for_parent(
+    files: &mut impl HostFileTable,
+    parent: HostHandle,
+    path: OsString,
+) -> AsyncHostResult<OsString> {
+    if files.is_invalid_file_handle(parent) || std::path::Path::new(&path).is_absolute() {
+        return Ok(path);
+    }
+
+    files.with_raw_file(parent, |file| {
+        let mut parent_path = std::path::PathBuf::from(final_path_from_handle(file)?);
+        parent_path.push(path);
+        Ok(parent_path.into_os_string())
+    })
+}
+
+#[cfg(windows)]
+fn final_path_from_handle(handle: RawFile) -> AsyncHostResult<OsString> {
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_NAME_NORMALIZED, GetFinalPathNameByHandleW, VOLUME_NAME_DOS,
+    };
+
+    let mut buffer = vec![0u16; 260];
+    loop {
+        let len = unsafe {
+            GetFinalPathNameByHandleW(
+                handle,
+                buffer.as_mut_ptr(),
+                u32::try_from(buffer.len()).map_err(|_| AsyncHostError::Fault)?,
+                FILE_NAME_NORMALIZED | VOLUME_NAME_DOS,
+            )
+        };
+        if len == 0 {
+            return Err(last_native_error());
+        }
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        if len < buffer.len() {
+            buffer.truncate(len);
+            return Ok(OsString::from_wide(&buffer));
+        }
+        buffer.resize(len + 1, 0);
+    }
+}
+
+#[cfg(windows)]
+fn file_size(file: RawFile) -> AsyncHostResult<i64> {
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Storage::FileSystem::GetFileSizeEx;
+
+    let mut size = std::mem::MaybeUninit::<i64>::uninit();
+    let result = unsafe { GetFileSizeEx(file as HANDLE, size.as_mut_ptr()) };
+    if result == 0 {
+        Err(last_native_error())
+    } else {
+        Ok(unsafe { size.assume_init() })
+    }
+}
+
+#[cfg(windows)]
+fn file_time(file: RawFile) -> AsyncHostResult<fd_util::stub::FileTime> {
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_BASIC_INFO, FileBasicInfo, GetFileInformationByHandleEx,
+    };
+
+    let mut info = std::mem::MaybeUninit::<FILE_BASIC_INFO>::uninit();
+    let ok = unsafe {
+        GetFileInformationByHandleEx(
+            file as HANDLE,
+            FileBasicInfo,
+            info.as_mut_ptr().cast(),
+            std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+        )
+    };
+    if ok == 0 {
+        return Err(last_native_error());
+    }
+    Ok(unsafe { info.assume_init() })
+}
+
+#[cfg(windows)]
+fn file_time_by_path(
+    path: OsString,
+    follow_symlink: bool,
+) -> AsyncHostResult<fd_util::stub::FileTime> {
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_BASIC_INFO, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, FileBasicInfo, GetFileInformationByHandleEx, OPEN_EXISTING,
+    };
+
+    let mut flags = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS;
+    if !follow_symlink {
+        flags |= FILE_FLAG_OPEN_REPARSE_POINT;
+    }
+    let path = path_to_wide(path);
+    let handle: HANDLE = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            flags,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(last_native_error());
+    }
+
+    let mut info = std::mem::MaybeUninit::<FILE_BASIC_INFO>::uninit();
+    let ok = unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileBasicInfo,
+            info.as_mut_ptr().cast(),
+            std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+        )
+    };
+    unsafe {
+        CloseHandle(handle);
+    }
+    if ok == 0 {
+        return Err(last_native_error());
+    }
+    Ok(unsafe { info.assume_init() })
+}
+
+#[cfg(windows)]
+fn access_native_path(path: OsString, access: i32) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_EXECUTE, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+
+    let access_mode = match access {
+        0 => 0,
+        1 => GENERIC_READ,
+        2 => GENERIC_WRITE,
+        3 => FILE_EXECUTE,
+        _ => return Err(AsyncHostError::Inval),
+    };
+    let path = path_to_wide(path);
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            access_mode,
+            FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        Err(last_native_error())
+    } else {
+        unsafe {
+            CloseHandle(handle);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn chmod_native_path(_path: OsString, _mode: i32) -> AsyncHostResult<()> {
+    Err(AsyncHostError::Native(
+        windows_sys::Win32::Foundation::ERROR_CALL_NOT_IMPLEMENTED as i32,
+    ))
+}
+
+#[cfg(windows)]
+fn sync_native_file(file: RawFile, _only_data: bool) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Storage::FileSystem::FlushFileBuffers;
+
+    if unsafe { FlushFileBuffers(file as HANDLE) } == 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn lock_native_file(file: RawFile, exclusive: bool) -> AsyncHostResult<()> {
+    use std::mem::zeroed;
+    use windows_sys::Win32::Storage::FileSystem::{LOCKFILE_EXCLUSIVE_LOCK, LockFileEx};
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let mut overlapped: OVERLAPPED = unsafe { zeroed() };
+    // Keep parity with thread_pool.c: lock a one-byte sentinel range beyond
+    // ordinary file data so Windows mandatory locks approximate advisory locks.
+    overlapped.Anonymous.Anonymous.Offset = 0xfffffffe;
+    overlapped.Anonymous.Anonymous.OffsetHigh = 0xffffffff;
+    let flags = if exclusive {
+        LOCKFILE_EXCLUSIVE_LOCK
+    } else {
+        0
+    };
+    if unsafe { LockFileEx(file, flags, 0, 1, 0, &mut overlapped) } == 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn remove_native_path(path: OsString) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        DeleteFileW, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT, GetFileAttributesW,
+        INVALID_FILE_ATTRIBUTES, RemoveDirectoryW,
+    };
+
+    let path = path_to_wide(path);
+    let attrs = unsafe { GetFileAttributesW(path.as_ptr()) };
+    if attrs == INVALID_FILE_ATTRIBUTES {
+        return Err(last_native_error());
+    }
+
+    let is_directory_link =
+        (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0 && (attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+    let ok = if is_directory_link {
+        // Windows removes directory symlinks and junctions through RemoveDirectoryW,
+        // not DeleteFileW, even though they are reparse points rather than real dirs.
+        unsafe { RemoveDirectoryW(path.as_ptr()) }
+    } else {
+        unsafe { DeleteFileW(path.as_ptr()) }
+    };
+    if ok == 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn symlink_native_path(
+    target: OsString,
+    path: OsString,
+    force_symlink: bool,
+) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Foundation::ERROR_INVALID_PARAMETER;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateSymbolicLinkW, FILE_ATTRIBUTE_DIRECTORY, GetFileAttributesW, INVALID_FILE_ATTRIBUTES,
+        SYMBOLIC_LINK_FLAG_DIRECTORY,
+    };
+
+    let target_wide = path_to_wide(target.clone());
+    let path_wide = path_to_wide(path.clone());
+    let attrs = unsafe { GetFileAttributesW(target_wide.as_ptr()) };
+    let is_directory = attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+
+    if !force_symlink && is_directory && std::path::Path::new(target.as_os_str()).is_absolute() {
+        match create_junction_native_path(target.clone(), path.clone()) {
+            Ok(()) => return Ok(()),
+            Err(AsyncHostError::Native(error)) if error == ERROR_INVALID_PARAMETER as i32 => {}
+            Err(error) => return Err(error),
+        }
+    }
+
+    let flags = if is_directory {
+        SYMBOLIC_LINK_FLAG_DIRECTORY
+    } else {
+        0
+    };
+    if unsafe { CreateSymbolicLinkW(path_wide.as_ptr(), target_wide.as_ptr(), flags) } != 0 {
+        Ok(())
+    } else {
+        Err(last_native_error())
+    }
+}
+
+#[cfg(windows)]
+fn create_junction_native_path(target: OsString, path: OsString) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateDirectoryW, CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_WRITE_ATTRIBUTES, OPEN_EXISTING,
+        RemoveDirectoryW,
+    };
+    use windows_sys::Win32::System::IO::DeviceIoControl;
+    use windows_sys::Win32::System::Ioctl::FSCTL_SET_REPARSE_POINT;
+
+    let data = junction_reparse_buffer(target)?;
+    let path_wide = path_to_wide(path);
+    if unsafe { CreateDirectoryW(path_wide.as_ptr(), std::ptr::null()) } == 0 {
+        return Err(last_native_error());
+    }
+
+    let handle = unsafe {
+        CreateFileW(
+            path_wide.as_ptr(),
+            FILE_WRITE_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        let error = last_native_error();
+        unsafe {
+            RemoveDirectoryW(path_wide.as_ptr());
+        }
+        return Err(error);
+    }
+
+    let mut bytes_returned = 0;
+    let ok = unsafe {
+        DeviceIoControl(
+            handle,
+            FSCTL_SET_REPARSE_POINT,
+            data.as_ptr().cast(),
+            data.len() as u32,
+            std::ptr::null_mut(),
+            0,
+            &mut bytes_returned,
+            std::ptr::null_mut(),
+        )
+    };
+    unsafe {
+        CloseHandle(handle);
+    }
+    if ok == 0 {
+        let error = last_native_error();
+        unsafe {
+            RemoveDirectoryW(path_wide.as_ptr());
+        }
+        Err(error)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn junction_reparse_buffer(target: OsString) -> AsyncHostResult<Vec<u8>> {
+    use windows_sys::Win32::System::SystemServices::IO_REPARSE_TAG_MOUNT_POINT;
+
+    const MOUNT_POINT_HEADER_LEN: usize = 8;
+    const WCHAR_SIZE: usize = 2;
+    const UNICODE_NULL_SIZE: usize = WCHAR_SIZE;
+    const NON_INTERPRETED_PATH_PREFIX: [u16; 4] =
+        ['\\' as u16, '?' as u16, '?' as u16, '\\' as u16];
+
+    let mut print_name = os_string_to_wide(target);
+    if print_name.starts_with(&NON_INTERPRETED_PATH_PREFIX)
+        || print_name.starts_with(&['\\' as u16, '\\' as u16, '?' as u16, '\\' as u16])
+    {
+        print_name.drain(0..NON_INTERPRETED_PATH_PREFIX.len());
+    }
+    for code_unit in &mut print_name {
+        if *code_unit == '/' as u16 {
+            *code_unit = '\\' as u16;
+        }
+    }
+
+    let mut substitute = Vec::from(NON_INTERPRETED_PATH_PREFIX);
+    substitute.extend(print_name.iter().copied());
+    let substitute_len = substitute
+        .len()
+        .checked_mul(WCHAR_SIZE)
+        .ok_or(AsyncHostError::Inval)?;
+    let substitute_len = u16::try_from(substitute_len).map_err(|_| AsyncHostError::Inval)?;
+    let print_name_len = print_name
+        .len()
+        .checked_mul(WCHAR_SIZE)
+        .ok_or(AsyncHostError::Inval)?;
+    let print_name_len = u16::try_from(print_name_len).map_err(|_| AsyncHostError::Inval)?;
+    let print_name_offset = substitute_len
+        .checked_add(UNICODE_NULL_SIZE as u16)
+        .ok_or(AsyncHostError::Inval)?;
+    let reparse_data_len = (MOUNT_POINT_HEADER_LEN as u16)
+        .checked_add(print_name_offset)
+        .and_then(|len| len.checked_add(print_name_len))
+        .and_then(|len| len.checked_add(UNICODE_NULL_SIZE as u16))
+        .ok_or(AsyncHostError::Inval)?;
+
+    let mut data = Vec::with_capacity(8 + usize::from(reparse_data_len));
+    data.extend_from_slice(&IO_REPARSE_TAG_MOUNT_POINT.to_le_bytes());
+    data.extend_from_slice(&reparse_data_len.to_le_bytes());
+    data.extend_from_slice(&0u16.to_le_bytes());
+    data.extend_from_slice(&0u16.to_le_bytes());
+    data.extend_from_slice(&substitute_len.to_le_bytes());
+    data.extend_from_slice(&print_name_offset.to_le_bytes());
+    data.extend_from_slice(&print_name_len.to_le_bytes());
+    for code_unit in substitute {
+        data.extend_from_slice(&code_unit.to_le_bytes());
+    }
+    data.extend_from_slice(&0u16.to_le_bytes());
+    for code_unit in print_name {
+        data.extend_from_slice(&code_unit.to_le_bytes());
+    }
+    data.extend_from_slice(&0u16.to_le_bytes());
+    Ok(data)
+}
+
+#[cfg(windows)]
+fn mkdir_native_path(path: OsString, _mode: i32) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Storage::FileSystem::CreateDirectoryW;
+
+    let path = path_to_wide(path);
+    if unsafe { CreateDirectoryW(path.as_ptr(), std::ptr::null()) } == 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn rmdir_native_path(path: OsString) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Storage::FileSystem::RemoveDirectoryW;
+
+    let path = path_to_wide(path);
+    if unsafe { RemoveDirectoryW(path.as_ptr()) } == 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn read_native_dir(
+    file: &mut HostFile,
+    len: usize,
+    restart: bool,
+) -> AsyncHostResult<(i64, Vec<u8>)> {
+    use windows_sys::Win32::Foundation::{ERROR_NO_MORE_FILES, HANDLE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileIdBothDirectoryInfo, FileIdBothDirectoryRestartInfo, GetFileInformationByHandleEx,
+    };
+
+    let mut native = vec![0; len];
+    let info_class = if restart {
+        FileIdBothDirectoryRestartInfo
+    } else {
+        FileIdBothDirectoryInfo
+    };
+    let ok = unsafe {
+        GetFileInformationByHandleEx(
+            file.raw_fd() as HANDLE,
+            info_class,
+            native.as_mut_ptr().cast(),
+            u32::try_from(native.len()).map_err(|_| AsyncHostError::Fault)?,
+        )
+    };
+    if ok == 0 {
+        let error = std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or_else(|| AsyncHostError::Inval.errno());
+        if error == ERROR_NO_MORE_FILES as i32 {
+            return Ok((0, Vec::new()));
+        }
+        return Err(AsyncHostError::Native(error));
+    }
+
+    Ok((
+        i64::try_from(len).map_err(|_| AsyncHostError::Fault)?,
+        native,
+    ))
+}
+
+#[cfg(windows)]
+fn rename_native_path(
+    old_path: OsString,
+    new_path: OsString,
+    replace: bool,
+) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, ERROR_INVALID_PARAMETER, HANDLE, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, DELETE, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_BACKUP_SEMANTICS, FILE_RENAME_INFO,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileRenameInfoEx,
+        MOVEFILE_COPY_ALLOWED, MOVEFILE_REPLACE_EXISTING, MoveFileExW, OPEN_EXISTING,
+        SetFileInformationByHandle,
+    };
+
+    let old_path = path_to_wide(old_path);
+    let new_path = path_to_wide(new_path);
+    let handle: HANDLE = unsafe {
+        CreateFileW(
+            old_path.as_ptr(),
+            DELETE,
+            FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(last_native_error());
+    }
+
+    let filename_len = new_path.len().checked_sub(1).ok_or(AsyncHostError::Inval)?;
+    let buffer_size = std::mem::size_of::<FILE_RENAME_INFO>()
+        .checked_add(filename_len * std::mem::size_of::<u16>())
+        .ok_or(AsyncHostError::Fault)?;
+    let mut buffer = vec![0u8; buffer_size];
+    let info = buffer.as_mut_ptr().cast::<FILE_RENAME_INFO>();
+    unsafe {
+        (*info).Anonymous.Flags = if replace { 3 } else { 0 };
+        (*info).RootDirectory = std::ptr::null_mut();
+        (*info).FileNameLength = u32::try_from(filename_len * std::mem::size_of::<u16>())
+            .map_err(|_| AsyncHostError::Fault)?;
+        std::ptr::copy_nonoverlapping(
+            new_path.as_ptr(),
+            (*info).FileName.as_mut_ptr(),
+            filename_len,
+        );
+    }
+
+    let ret = unsafe {
+        SetFileInformationByHandle(handle, FileRenameInfoEx, info.cast(), buffer_size as u32)
+    };
+    unsafe {
+        CloseHandle(handle);
+    }
+    if ret != 0 {
+        return Ok(());
+    }
+
+    let error = std::io::Error::last_os_error()
+        .raw_os_error()
+        .unwrap_or_else(|| AsyncHostError::Inval.errno());
+    if error != ERROR_INVALID_PARAMETER as i32 {
+        return Err(AsyncHostError::Native(error));
+    }
+
+    let flags = MOVEFILE_COPY_ALLOWED
+        | if replace {
+            MOVEFILE_REPLACE_EXISTING
+        } else {
+            0
+        };
+    if unsafe { MoveFileExW(old_path.as_ptr(), new_path.as_ptr(), flags) } == 0 {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn path_to_wide(path: OsString) -> Vec<u16> {
+    os_string_to_wide(path)
+        .into_iter()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+#[cfg(windows)]
+fn os_string_to_wide(path: OsString) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+
+    path.as_os_str().encode_wide().collect()
+}
+
+fn last_native_error() -> AsyncHostError {
+    AsyncHostError::Native(
+        std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
+    )
+}
+
+#[cfg(windows)]
+fn native_io_error(error: std::io::Error) -> AsyncHostError {
+    AsyncHostError::Native(
+        error
+            .raw_os_error()
+            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
+    )
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn junction_reparse_buffer_encodes_substitute_and_print_names() {
+        let data = junction_reparse_buffer(OsString::from("C:/target")).unwrap();
+        let reparse_data_len = u16::from_le_bytes([data[4], data[5]]) as usize;
+        let substitute_len = u16::from_le_bytes([data[10], data[11]]) as usize;
+        let print_name_offset = u16::from_le_bytes([data[12], data[13]]) as usize;
+        let print_name_len = u16::from_le_bytes([data[14], data[15]]) as usize;
+
+        assert_eq!(data.len(), 8 + reparse_data_len);
+        assert_eq!(print_name_offset, substitute_len + 2);
+
+        let path_buffer = &data[16..];
+        let substitute = path_buffer[..substitute_len]
+            .chunks_exact(2)
+            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .collect::<Vec<_>>();
+        let print_name = path_buffer[print_name_offset..print_name_offset + print_name_len]
+            .chunks_exact(2)
+            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .collect::<Vec<_>>();
+
+        assert_eq!(String::from_utf16(&substitute).unwrap(), r"\??\C:\target");
+        assert_eq!(String::from_utf16(&print_name).unwrap(), r"C:\target");
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -1,0 +1,432 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::ffi::OsString;
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::ported_fns;
+
+use super::types::{HostHandle, Job, JobPayload, OpenJobResult, platform};
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_get_platform"
+    )]
+    pub(crate) fn get_platform() -> i32 {
+        platform()
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_job_get_ret"
+    )]
+    pub(crate) fn job_get_ret(job: &Job) -> i64 {
+        job.ret()
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_job_get_err"
+    )]
+    pub(crate) fn job_get_err(job: &Job) -> i32 {
+        job.err()
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_errno_is_cancelled"
+    )]
+    pub(crate) fn errno_is_cancelled(errno: i32) -> bool {
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::ERROR_OPERATION_ABORTED;
+            errno == ERROR_OPERATION_ABORTED as i32
+        }
+        #[cfg(unix)]
+        {
+            errno == libc::EINTR
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_sleep_job"
+    )]
+    pub(crate) fn make_sleep_job(ms: i32) -> Job {
+        Job::new(JobPayload::Sleep { duration_ms: ms })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_read_job"
+    )]
+    pub(crate) fn make_read_job(
+        fd: HostHandle,
+        len: i32,
+        position: i64,
+    ) -> Job {
+        Job::new(JobPayload::Read {
+            fd,
+            len,
+            position,
+            result: None,
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_write_job"
+    )]
+    pub(crate) fn make_write_job(fd: HostHandle, data: Vec<u8>, position: i64) -> Job {
+        Job::new(JobPayload::Write { fd, data, position })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_open_job"
+    )]
+    pub(crate) fn make_open_job(
+        filename: OsString,
+        access: i32,
+        create_mode: i32,
+        append: bool,
+        sync: i32,
+        mode: i32,
+    ) -> Job {
+        Job::new(JobPayload::Open {
+            filename,
+            access,
+            create_mode,
+            append,
+            sync,
+            mode,
+            result: None,
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_file_kind_by_path_job"
+    )]
+    pub(crate) fn make_file_kind_by_path_job(
+        parent: HostHandle,
+        path: OsString,
+        follow_symlink: bool,
+    ) -> Job {
+        Job::new(JobPayload::FileKindByPath {
+            parent,
+            path,
+            follow_symlink,
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_open_job_get_fd"
+    )]
+    pub(crate) fn open_job_get_fd(result: &OpenJobResult) -> HostHandle {
+        result.fd
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_open_job_get_kind"
+    )]
+    pub(crate) fn open_job_get_kind(result: &OpenJobResult) -> i32 {
+        result.kind
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_open_job_get_dev_id"
+    )]
+    pub(crate) fn open_job_get_dev_id(result: &OpenJobResult) -> u64 {
+        result.dev_id
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_open_job_get_file_id"
+    )]
+    pub(crate) fn open_job_get_file_id(result: &OpenJobResult) -> u64 {
+        result.file_id
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_file_size_job"
+    )]
+    pub(crate) fn make_file_size_job(fd: HostHandle) -> Job {
+        Job::new(JobPayload::FileSize { fd, result: 0 })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_file_time_job"
+    )]
+    pub(crate) fn make_file_time_job(fd: HostHandle) -> Job {
+        Job::new(JobPayload::FileTime {
+            fd,
+            result: None,
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_file_time_by_path_job"
+    )]
+    pub(crate) fn make_file_time_by_path_job(
+        path: OsString,
+        follow_symlink: bool,
+    ) -> Job {
+        Job::new(JobPayload::FileTimeByPath {
+            path,
+            follow_symlink,
+            result: None,
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_access_job"
+    )]
+    pub(crate) fn make_access_job(path: OsString, access: i32) -> Job {
+        Job::new(JobPayload::Access { path, access })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_chmod_job"
+    )]
+    pub(crate) fn make_chmod_job(path: OsString, mode: i32) -> Job {
+        Job::new(JobPayload::Chmod { path, mode })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_get_file_size_result"
+    )]
+    pub(crate) fn get_file_size_result(job: &Job) -> AsyncHostResult<i64> {
+        match job.payload() {
+            JobPayload::FileSize { result, .. } => Ok(*result),
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_fsync_job"
+    )]
+    pub(crate) fn make_fsync_job(fd: HostHandle, only_data: bool) -> Job {
+        Job::new(JobPayload::Fsync { fd, only_data })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_flock_job"
+    )]
+    pub(crate) fn make_flock_job(fd: HostHandle, exclusive: bool) -> Job {
+        Job::new(JobPayload::Flock { fd, exclusive })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_remove_job"
+    )]
+    pub(crate) fn make_remove_job(path: OsString) -> Job {
+        Job::new(JobPayload::Remove { path })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_rename_job"
+    )]
+    pub(crate) fn make_rename_job(old_path: OsString, new_path: OsString, replace: bool) -> Job {
+        Job::new(JobPayload::Rename {
+            old_path,
+            new_path,
+            replace,
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_symlink_job"
+    )]
+    pub(crate) fn make_symlink_job(target: OsString, path: OsString, force_symlink: bool) -> Job {
+        Job::new(JobPayload::Symlink {
+            target,
+            path,
+            force_symlink,
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_mkdir_job"
+    )]
+    pub(crate) fn make_mkdir_job(path: OsString, mode: i32) -> Job {
+        Job::new(JobPayload::Mkdir { path, mode })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_rmdir_job"
+    )]
+    pub(crate) fn make_rmdir_job(path: OsString) -> Job {
+        Job::new(JobPayload::Rmdir { path })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_readdir_job"
+    )]
+    pub(crate) fn make_readdir_job(dir: HostHandle, len: i32, restart: bool) -> Job {
+        Job::new(JobPayload::Readdir {
+            dir,
+            len,
+            restart,
+            result: None,
+        })
+    }
+
+}
+
+pub(crate) fn open_job_result(job: &Job) -> AsyncHostResult<&OpenJobResult> {
+    match job.payload() {
+        JobPayload::Open {
+            result: Some(result),
+            ..
+        } => Ok(result),
+        JobPayload::Open { .. } => Err(AsyncHostError::Inval),
+        _ => Err(AsyncHostError::Badf),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::async_sys::internal::event_loop::thread_pool::{
+        HostFile, HostFileTable, run_host_job,
+    };
+    use crate::async_sys::internal::fd_util::stub::RawFd;
+
+    struct NoFiles;
+
+    impl HostFileTable for NoFiles {
+        fn insert_file(&mut self, _file: RawFd) -> AsyncHostResult<HostHandle> {
+            unreachable!("sleep jobs do not access files")
+        }
+
+        fn is_invalid_file_handle(&self, _handle: HostHandle) -> bool {
+            unreachable!("sleep jobs do not access files")
+        }
+
+        #[cfg(windows)]
+        fn borrowed_raw_file(&mut self, _handle: HostHandle) -> AsyncHostResult<RawFd> {
+            unreachable!("sleep jobs do not access files")
+        }
+
+        fn with_raw_file<T>(
+            &mut self,
+            _handle: HostHandle,
+            _f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
+        ) -> AsyncHostResult<T> {
+            unreachable!("sleep jobs do not access files")
+        }
+
+        fn with_host_file_mut<T>(
+            &mut self,
+            _handle: HostHandle,
+            _f: impl FnOnce(&mut HostFile) -> AsyncHostResult<T>,
+        ) -> AsyncHostResult<T> {
+            unreachable!("sleep jobs do not access files")
+        }
+    }
+
+    #[test]
+    fn sleep_job_initial_result_matches_native_job_header() {
+        let job = make_sleep_job(0);
+
+        assert_eq!(job_get_ret(&job), 0);
+        assert_eq!(job_get_err(&job), 0);
+    }
+
+    #[test]
+    fn read_job_carries_host_handle_and_length_payload() {
+        let job = make_read_job(7, 8, -1);
+
+        match job.payload() {
+            JobPayload::Read {
+                fd,
+                len,
+                position,
+                result: None,
+            } => {
+                assert_eq!(*fd, 7);
+                assert_eq!(*len, 8);
+                assert_eq!(*position, -1);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_job_carries_owned_path_and_open_flags() {
+        let job = make_open_job(OsString::from("/tmp/example"), 2, 3, true, 1, 0o644);
+
+        match job.payload() {
+            JobPayload::Open {
+                filename,
+                access,
+                create_mode,
+                append,
+                sync,
+                mode,
+                result: None,
+            } => {
+                assert_eq!(filename, &OsString::from("/tmp/example"));
+                assert_eq!(*access, 2);
+                assert_eq!(*create_mode, 3);
+                assert!(*append);
+                assert_eq!(*sync, 1);
+                assert_eq!(*mode, 0o644);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sleep_job_runs_without_error() {
+        let mut job = make_sleep_job(0);
+        let mut files = NoFiles;
+
+        run_host_job(&mut job, &mut files);
+
+        assert_eq!(job_get_ret(&job), 0);
+        assert_eq!(job_get_err(&job), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_errno_is_cancelled_matches_async_stub() {
+        assert!(errno_is_cancelled(libc::EINTR));
+        assert!(!errno_is_cancelled(libc::EINVAL));
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -1,0 +1,79 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+mod fs;
+mod jobs;
+mod runner;
+mod sleep;
+mod types;
+mod worker;
+
+pub(crate) use jobs::{
+    errno_is_cancelled, get_file_size_result, get_platform, job_get_err, job_get_ret,
+    make_access_job, make_chmod_job, make_file_kind_by_path_job, make_file_size_job,
+    make_file_time_by_path_job, make_file_time_job, make_flock_job, make_fsync_job, make_mkdir_job,
+    make_open_job, make_read_job, make_readdir_job, make_remove_job, make_rename_job,
+    make_rmdir_job, make_sleep_job, make_symlink_job, make_write_job, open_job_get_dev_id,
+    open_job_get_fd, open_job_get_file_id, open_job_get_kind, open_job_result,
+};
+pub(crate) use runner::{get_file_time_result, get_read_result, get_readdir_result, run_host_job};
+#[cfg(all(test, unix))]
+pub(crate) use types::JobPayload;
+pub(crate) use types::{FileTimeResult, HostFile, HostFileTable, HostHandle, Job, OpenJobResult};
+pub(crate) use worker::{
+    HostWorkerHandle, HostWorkerJob, cancel_worker, free_worker, spawn_worker, wake_worker,
+    worker_enter_idle,
+};
+
+#[cfg(test)]
+pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
+    let mut symbols = Vec::new();
+    symbols.extend_from_slice(jobs::PORTED_SYMBOLS);
+    symbols.extend_from_slice(worker::PORTED_SYMBOLS);
+    symbols
+}
+
+#[cfg(test)]
+fn job_executor_ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
+    let mut symbols = Vec::new();
+    symbols.extend_from_slice(fs::PORTED_SYMBOLS);
+    symbols.extend_from_slice(sleep::PORTED_SYMBOLS);
+    symbols
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn job_executors_reference_native_worker_symbols() {
+        let async_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../third_party/moonbitlang_async");
+        for symbol in super::job_executor_ported_symbols() {
+            let source_path = async_root.join(symbol.source);
+            let contents = std::fs::read_to_string(&source_path)
+                .unwrap_or_else(|error| panic!("failed to read {:?}: {error}", source_path));
+            assert!(
+                contents.contains(symbol.native_symbol),
+                "{:?} does not contain native worker symbol {} for {}::{}",
+                source_path,
+                symbol.native_symbol,
+                symbol.rust_module,
+                symbol.rust_symbol
+            );
+        }
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -1,0 +1,177 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory};
+use crate::async_sys::internal::fd_util;
+
+use super::fs::{
+    run_access_job, run_chmod_job, run_file_kind_by_path_job, run_file_size_job,
+    run_file_time_by_path_job, run_file_time_job, run_flock_job, run_fsync_job, run_mkdir_job,
+    run_open_job, run_read_job, run_readdir_job, run_remove_job, run_rename_job, run_rmdir_job,
+    run_symlink_job, run_write_job,
+};
+use super::sleep::run_sleep_job;
+use super::types::{HostFileTable, Job, JobPayload};
+
+pub(crate) fn run_host_job(job: &mut Job, files: &mut impl HostFileTable) {
+    job.set_ret(0);
+
+    let result = match job.payload_mut() {
+        JobPayload::Sleep { duration_ms } => {
+            run_sleep_job(*duration_ms);
+            Ok(0)
+        }
+        JobPayload::Open {
+            filename,
+            access,
+            create_mode,
+            append,
+            sync,
+            mode,
+            result,
+        } => run_open_job(
+            files,
+            result,
+            filename.clone(),
+            *access,
+            *create_mode,
+            *append,
+            *sync,
+            *mode,
+        ),
+        JobPayload::Read {
+            fd,
+            len,
+            position,
+            result,
+        } => run_read_job(files, *fd, *len, *position, result),
+        JobPayload::Write { fd, data, position } => run_write_job(files, *fd, data, *position),
+        JobPayload::FileKindByPath {
+            parent,
+            path,
+            follow_symlink,
+        } => run_file_kind_by_path_job(files, *parent, path.clone(), *follow_symlink),
+        JobPayload::FileSize { fd, result } => run_file_size_job(files, *fd, result),
+        JobPayload::FileTime { fd, result, .. } => run_file_time_job(files, *fd, result),
+        JobPayload::FileTimeByPath {
+            path,
+            follow_symlink,
+            result,
+            ..
+        } => run_file_time_by_path_job(path.clone(), *follow_symlink, result),
+        JobPayload::Access { path, access } => run_access_job(path.clone(), *access),
+        JobPayload::Chmod { path, mode } => run_chmod_job(path.clone(), *mode),
+        JobPayload::Fsync { fd, only_data } => run_fsync_job(files, *fd, *only_data),
+        JobPayload::Flock { fd, exclusive } => run_flock_job(files, *fd, *exclusive),
+        JobPayload::Remove { path } => run_remove_job(path.clone()),
+        JobPayload::Rename {
+            old_path,
+            new_path,
+            replace,
+        } => run_rename_job(old_path.clone(), new_path.clone(), *replace),
+        JobPayload::Symlink {
+            target,
+            path,
+            force_symlink,
+        } => run_symlink_job(target.clone(), path.clone(), *force_symlink),
+        JobPayload::Mkdir { path, mode } => run_mkdir_job(path.clone(), *mode),
+        JobPayload::Rmdir { path } => run_rmdir_job(path.clone()),
+        JobPayload::Readdir {
+            dir,
+            len,
+            restart,
+            result,
+        } => run_readdir_job(files, *dir, *len, *restart, result),
+    };
+
+    match result {
+        Ok(ret) => job.set_ret(ret),
+        Err(error) => job.set_err(error.errno()),
+    }
+}
+
+pub(crate) fn get_read_result(
+    job: &Job,
+    memory: &mut (impl GuestMemory + ?Sized),
+    dst: i32,
+    offset: i32,
+    len: i32,
+) -> AsyncHostResult<()> {
+    if job.err() != 0 {
+        return Ok(());
+    }
+    let JobPayload::Read {
+        result: Some(result),
+        ..
+    } = job.payload()
+    else {
+        return Err(AsyncHostError::Badf);
+    };
+    let dst_offset = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+    memory.write_with_capacity(dst_offset, len, result)
+}
+
+pub(crate) fn get_readdir_result(
+    job: &Job,
+    memory: &mut (impl GuestMemory + ?Sized),
+    dst: i32,
+    len: i32,
+) -> AsyncHostResult<()> {
+    if job.err() != 0 {
+        return Ok(());
+    }
+    let JobPayload::Readdir {
+        result: Some(result),
+        ..
+    } = job.payload()
+    else {
+        return Err(AsyncHostError::Badf);
+    };
+    memory.write_with_capacity(dst, len, result)
+}
+
+pub(crate) fn get_file_time_result(
+    job: &Job,
+    memory: &mut (impl GuestMemory + ?Sized),
+    dst: i32,
+) -> AsyncHostResult<()> {
+    if job.err() != 0 {
+        return Ok(());
+    }
+    let result = match job.payload() {
+        JobPayload::FileTime {
+            result: Some(result),
+            ..
+        }
+        | JobPayload::FileTimeByPath {
+            result: Some(result),
+            ..
+        } => result,
+        _ => return Err(AsyncHostError::Badf),
+    };
+
+    let file_time = result.as_native();
+    let mut record = [0; 48];
+    record[0..8].copy_from_slice(&fd_util::stub::get_atime_sec(file_time).to_le_bytes());
+    record[8..12].copy_from_slice(&fd_util::stub::get_atime_nsec(file_time).to_le_bytes());
+    record[16..24].copy_from_slice(&fd_util::stub::get_mtime_sec(file_time).to_le_bytes());
+    record[24..28].copy_from_slice(&fd_util::stub::get_mtime_nsec(file_time).to_le_bytes());
+    record[32..40].copy_from_slice(&fd_util::stub::get_ctime_sec(file_time).to_le_bytes());
+    record[40..44].copy_from_slice(&fd_util::stub::get_ctime_nsec(file_time).to_le_bytes());
+    memory.write_exact(dst, &record)
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/sleep.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/sleep.rs
@@ -1,0 +1,74 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Sleep job executor ported from
+//! `moonbitlang/async/src/internal/event_loop/thread_pool.c`.
+
+use crate::async_sys::ported_fns;
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "sleep_job_worker"
+    )]
+    pub(super) fn run_sleep_job(duration_ms: i32) {
+        #[cfg(windows)]
+        {
+            // Match the native stub's `Sleep(((struct sleep_job*)job)->duration)`.
+            unsafe { windows_sys::Win32::System::Threading::Sleep(duration_ms as u32) };
+        }
+        #[cfg(all(unix, target_os = "macos"))]
+        {
+            run_sleep_job_with_kqueue(duration_ms);
+        }
+        #[cfg(all(unix, not(target_os = "macos")))]
+        {
+            run_sleep_job_with_nanosleep(duration_ms);
+        }
+    }
+}
+
+#[cfg(all(unix, target_os = "macos"))]
+fn run_sleep_job_with_kqueue(duration_ms: i32) {
+    let kqfd = unsafe { libc::kqueue() };
+    let duration = sleep_job_timespec(duration_ms);
+    let mut event = std::mem::MaybeUninit::<libc::kevent>::uninit();
+
+    // Native async intentionally uses kqueue as a timeout-only sleeper on
+    // macOS because nanosleep was too imprecise on CI runners.
+    unsafe {
+        libc::kevent(kqfd, std::ptr::null(), 0, event.as_mut_ptr(), 1, &duration);
+        libc::close(kqfd);
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn run_sleep_job_with_nanosleep(duration_ms: i32) {
+    let duration = sleep_job_timespec(duration_ms);
+    unsafe {
+        libc::nanosleep(&duration, std::ptr::null_mut());
+    }
+}
+
+#[cfg(unix)]
+fn sleep_job_timespec(duration_ms: i32) -> libc::timespec {
+    libc::timespec {
+        tv_sec: (duration_ms / 1000) as libc::time_t,
+        tv_nsec: ((duration_ms % 1000) * 1_000_000) as libc::c_long,
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -1,0 +1,330 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::ffi::OsString;
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::internal::fd_util;
+
+pub(crate) type HostHandle = u64;
+
+#[derive(Debug)]
+pub(crate) struct HostFile {
+    raw: fd_util::stub::RawFd,
+}
+
+#[cfg(windows)]
+unsafe impl Send for HostFile {}
+
+impl HostFile {
+    pub(crate) fn new(raw: fd_util::stub::RawFd) -> Self {
+        Self { raw }
+    }
+
+    pub(crate) fn invalid() -> Self {
+        Self::new(invalid_raw_file())
+    }
+
+    pub(crate) fn is_invalid(&self) -> bool {
+        is_invalid_raw_file(self.raw)
+    }
+
+    pub(crate) fn raw_fd(&self) -> fd_util::stub::RawFd {
+        self.raw
+    }
+
+    pub(crate) fn duplicate(&self) -> AsyncHostResult<Self> {
+        if self.is_invalid() {
+            return Err(AsyncHostError::Badf);
+        }
+        duplicate_raw_file(self.raw).map(Self::new)
+    }
+}
+
+impl Drop for HostFile {
+    fn drop(&mut self) {
+        if !self.is_invalid() {
+            close_raw_file(self.raw);
+            self.raw = invalid_raw_file();
+        }
+    }
+}
+
+#[cfg(unix)]
+fn invalid_raw_file() -> fd_util::stub::RawFd {
+    -1
+}
+
+#[cfg(windows)]
+fn invalid_raw_file() -> fd_util::stub::RawFd {
+    windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE
+}
+
+fn is_invalid_raw_file(raw: fd_util::stub::RawFd) -> bool {
+    raw == invalid_raw_file()
+}
+
+#[cfg(unix)]
+fn close_raw_file(raw: fd_util::stub::RawFd) {
+    unsafe {
+        libc::close(raw);
+    }
+}
+
+#[cfg(windows)]
+fn close_raw_file(raw: fd_util::stub::RawFd) {
+    unsafe {
+        windows_sys::Win32::Foundation::CloseHandle(raw);
+    }
+}
+
+#[cfg(unix)]
+fn duplicate_raw_file(raw: fd_util::stub::RawFd) -> AsyncHostResult<fd_util::stub::RawFd> {
+    let fd = unsafe { libc::fcntl(raw, libc::F_DUPFD_CLOEXEC, 0) };
+    if fd < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(fd)
+    }
+}
+
+#[cfg(windows)]
+fn duplicate_raw_file(raw: fd_util::stub::RawFd) -> AsyncHostResult<fd_util::stub::RawFd> {
+    use windows_sys::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE};
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    let process = unsafe { GetCurrentProcess() };
+    let mut duplicate: HANDLE = std::ptr::null_mut();
+    if unsafe {
+        DuplicateHandle(
+            process,
+            raw,
+            process,
+            &mut duplicate,
+            0,
+            0,
+            DUPLICATE_SAME_ACCESS,
+        )
+    } == 0
+    {
+        Err(last_native_error())
+    } else {
+        Ok(duplicate)
+    }
+}
+
+fn last_native_error() -> AsyncHostError {
+    AsyncHostError::Native(
+        std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OpenJobResult {
+    pub(crate) fd: HostHandle,
+    pub(crate) kind: i32,
+    pub(crate) dev_id: u64,
+    pub(crate) file_id: u64,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct FileTimeResult(fd_util::stub::FileTime);
+
+impl FileTimeResult {
+    pub(crate) fn new(file_time: fd_util::stub::FileTime) -> Self {
+        Self(file_time)
+    }
+
+    pub(crate) fn as_native(&self) -> &fd_util::stub::FileTime {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for FileTimeResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("FileTimeResult").finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Job {
+    ret: i64,
+    err: i32,
+    payload: JobPayload,
+}
+
+impl Job {
+    pub(super) fn new(payload: JobPayload) -> Self {
+        Self {
+            ret: 0,
+            err: 0,
+            payload,
+        }
+    }
+
+    pub(crate) fn payload(&self) -> &JobPayload {
+        &self.payload
+    }
+
+    pub(crate) fn payload_mut(&mut self) -> &mut JobPayload {
+        &mut self.payload
+    }
+
+    pub(crate) fn ret(&self) -> i64 {
+        self.ret
+    }
+
+    pub(crate) fn err(&self) -> i32 {
+        self.err
+    }
+
+    pub(crate) fn set_ret(&mut self, ret: i64) {
+        self.ret = ret;
+        self.err = 0;
+    }
+
+    pub(crate) fn set_err(&mut self, err: i32) {
+        self.ret = -1;
+        self.err = err;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum JobPayload {
+    Sleep {
+        duration_ms: i32,
+    },
+    Read {
+        fd: HostHandle,
+        len: i32,
+        position: i64,
+        result: Option<Vec<u8>>,
+    },
+    Write {
+        fd: HostHandle,
+        data: Vec<u8>,
+        position: i64,
+    },
+    Open {
+        filename: OsString,
+        access: i32,
+        create_mode: i32,
+        append: bool,
+        sync: i32,
+        mode: i32,
+        result: Option<OpenJobResult>,
+    },
+    FileKindByPath {
+        parent: HostHandle,
+        path: OsString,
+        follow_symlink: bool,
+    },
+    FileSize {
+        fd: HostHandle,
+        result: i64,
+    },
+    FileTime {
+        fd: HostHandle,
+        result: Option<FileTimeResult>,
+    },
+    FileTimeByPath {
+        path: OsString,
+        follow_symlink: bool,
+        result: Option<FileTimeResult>,
+    },
+    Access {
+        path: OsString,
+        access: i32,
+    },
+    Chmod {
+        path: OsString,
+        mode: i32,
+    },
+    Fsync {
+        fd: HostHandle,
+        only_data: bool,
+    },
+    Flock {
+        fd: HostHandle,
+        exclusive: bool,
+    },
+    Remove {
+        path: OsString,
+    },
+    Rename {
+        old_path: OsString,
+        new_path: OsString,
+        replace: bool,
+    },
+    Symlink {
+        target: OsString,
+        path: OsString,
+        force_symlink: bool,
+    },
+    Mkdir {
+        path: OsString,
+        mode: i32,
+    },
+    Rmdir {
+        path: OsString,
+    },
+    Readdir {
+        dir: HostHandle,
+        len: i32,
+        restart: bool,
+        result: Option<Vec<u8>>,
+    },
+}
+
+pub(crate) trait HostFileTable {
+    fn insert_file(&mut self, file: fd_util::stub::RawFd) -> AsyncHostResult<HostHandle>;
+
+    fn is_invalid_file_handle(&self, handle: HostHandle) -> bool;
+
+    #[cfg(windows)]
+    fn borrowed_raw_file(&mut self, handle: HostHandle) -> AsyncHostResult<fd_util::stub::RawFd>;
+
+    fn with_raw_file<T>(
+        &mut self,
+        handle: HostHandle,
+        f: impl FnOnce(fd_util::stub::RawFd) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T>;
+
+    fn with_host_file_mut<T>(
+        &mut self,
+        handle: HostHandle,
+        f: impl FnOnce(&mut HostFile) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T>;
+}
+
+pub(crate) fn platform() -> i32 {
+    #[cfg(windows)]
+    {
+        2
+    }
+    #[cfg(target_os = "macos")]
+    {
+        1
+    }
+    #[cfg(target_os = "linux")]
+    {
+        0
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -1,0 +1,389 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::JoinHandle;
+
+use crate::async_sys::ported_fns;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HostWorkerJob {
+    pub(crate) job_id: i32,
+    pub(crate) job_handle: u64,
+}
+
+#[derive(Debug)]
+struct HostWorkerState {
+    job: Option<HostWorkerJob>,
+    waiting: bool,
+    terminating: bool,
+}
+
+#[derive(Debug)]
+struct HostWorkerShared {
+    state: Mutex<HostWorkerState>,
+    wakeup: Condvar,
+}
+
+// MoonBit owns the pool scheduler. Each host worker handle owns one long-lived
+// OS thread and follows thread_pool.c's worker state machine: run current job,
+// publish completion, wait until MoonBit either assigns another job or parks it.
+pub(crate) struct HostWorkerHandle {
+    shared: Arc<HostWorkerShared>,
+    thread: Option<JoinHandle<()>>,
+    #[cfg(unix)]
+    thread_id: Arc<Mutex<Option<libc::pthread_t>>>,
+}
+
+impl std::fmt::Debug for HostWorkerHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HostWorkerHandle")
+            .field(
+                "alive",
+                &self
+                    .thread
+                    .as_ref()
+                    .is_some_and(|thread| !thread.is_finished()),
+            )
+            .field("state", &self.shared.state.lock().ok())
+            .finish()
+    }
+}
+
+#[cfg(unix)]
+fn init_worker_signal_handler() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+
+    extern "C" fn nop_signal_handler(_: i32) {}
+
+    INIT.call_once(|| unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+        let mut action = std::mem::zeroed::<libc::sigaction>();
+        action.sa_sigaction = nop_signal_handler as usize;
+        libc::sigemptyset(&mut action.sa_mask);
+        action.sa_flags = 0;
+        libc::sigaction(libc::SIGUSR2, &action, std::ptr::null_mut());
+    });
+}
+
+impl HostWorkerHandle {
+    pub(crate) fn spawn(
+        init_job: HostWorkerJob,
+        mut run_job: impl FnMut(HostWorkerJob) + Send + 'static,
+        mut complete_job: impl FnMut(HostWorkerJob) + Send + 'static,
+    ) -> Self {
+        #[cfg(unix)]
+        init_worker_signal_handler();
+
+        let shared = Arc::new(HostWorkerShared {
+            state: Mutex::new(HostWorkerState {
+                job: Some(init_job),
+                waiting: false,
+                terminating: false,
+            }),
+            wakeup: Condvar::new(),
+        });
+        let worker_shared = Arc::clone(&shared);
+        #[cfg(unix)]
+        let thread_id = Arc::new(Mutex::new(None));
+        #[cfg(unix)]
+        let worker_thread_id = Arc::clone(&thread_id);
+        let thread = std::thread::spawn(move || {
+            #[cfg(unix)]
+            {
+                *worker_thread_id.lock().unwrap() = Some(unsafe { libc::pthread_self() });
+            }
+
+            loop {
+                let job = {
+                    let state = worker_shared.state.lock().unwrap();
+                    if state.terminating { None } else { state.job }
+                };
+                let Some(job) = job else {
+                    break;
+                };
+                run_job(job);
+
+                let terminating = {
+                    let mut state = worker_shared.state.lock().unwrap();
+                    if state.terminating {
+                        true
+                    } else {
+                        state.waiting = true;
+                        false
+                    }
+                };
+                complete_job(job);
+                if terminating {
+                    break;
+                }
+
+                let mut state = worker_shared.state.lock().unwrap();
+                while state.waiting && !state.terminating {
+                    state = worker_shared.wakeup.wait(state).unwrap();
+                }
+                if state.terminating {
+                    break;
+                }
+            }
+
+            #[cfg(unix)]
+            {
+                *worker_thread_id.lock().unwrap() = None;
+            }
+        });
+        Self {
+            shared,
+            thread: Some(thread),
+            #[cfg(unix)]
+            thread_id,
+        }
+    }
+
+    pub(crate) fn wake(&self, job: Option<HostWorkerJob>) {
+        let mut state = self.shared.state.lock().unwrap();
+        // A missing job is only used by `free_worker`; keep it as an explicit
+        // termination state so a wake sent during `run_job` is still observed.
+        if job.is_none() {
+            state.terminating = true;
+        }
+        state.job = job;
+        state.waiting = false;
+        self.shared.wakeup.notify_one();
+    }
+
+    pub(crate) fn enter_idle(&self) {
+        self.shared.state.lock().unwrap().job = None;
+    }
+
+    pub(crate) fn cancel(&self) -> i32 {
+        if self.shared.state.lock().unwrap().waiting {
+            return 1;
+        }
+
+        #[cfg(unix)]
+        {
+            if let Some(thread_id) = *self.thread_id.lock().unwrap() {
+                unsafe {
+                    libc::pthread_kill(thread_id, libc::SIGUSR2);
+                }
+            }
+            0
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+            use windows_sys::Win32::Foundation::{ERROR_NOT_FOUND, GetLastError};
+            use windows_sys::Win32::System::IO::CancelSynchronousIo;
+
+            let Some(thread) = &self.thread else {
+                return -1;
+            };
+            if unsafe { CancelSynchronousIo(thread.as_raw_handle()) } != 0 {
+                1
+            } else if unsafe { GetLastError() } == ERROR_NOT_FOUND {
+                0
+            } else {
+                -1
+            }
+        }
+    }
+
+    pub(crate) fn join(&mut self) {
+        if let Some(thread) = self.thread.take() {
+            self.wake(None);
+            let _ = thread.join();
+        }
+    }
+}
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_spawn_worker"
+    )]
+    pub(crate) fn spawn_worker(
+        init_job: HostWorkerJob,
+        run_job: impl FnMut(HostWorkerJob) + Send + 'static,
+        complete_job: impl FnMut(HostWorkerJob) + Send + 'static,
+    ) -> HostWorkerHandle {
+        HostWorkerHandle::spawn(init_job, run_job, complete_job)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_wake_worker"
+    )]
+    pub(crate) fn wake_worker(worker: &HostWorkerHandle, job: HostWorkerJob) {
+        worker.wake(Some(job));
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_worker_enter_idle"
+    )]
+    pub(crate) fn worker_enter_idle(worker: &HostWorkerHandle) {
+        worker.enter_idle();
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_cancel_worker"
+    )]
+    pub(crate) fn cancel_worker(worker: &HostWorkerHandle) -> i32 {
+        worker.cancel()
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_free_worker"
+    )]
+    pub(crate) fn free_worker(mut worker: HostWorkerHandle) {
+        worker.join();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    #[test]
+    fn host_worker_runs_initial_job_then_waits_for_wake() {
+        let (sender, receiver) = mpsc::channel();
+        let (completion_sender, completion_receiver) = mpsc::channel();
+        let worker = spawn_worker(
+            HostWorkerJob {
+                job_id: 7,
+                job_handle: 11,
+            },
+            move |job| sender.send(job).unwrap(),
+            move |job| completion_sender.send(job).unwrap(),
+        );
+
+        assert_eq!(
+            receiver.recv().unwrap(),
+            HostWorkerJob {
+                job_id: 7,
+                job_handle: 11
+            }
+        );
+        assert_eq!(
+            completion_receiver.recv().unwrap(),
+            HostWorkerJob {
+                job_id: 7,
+                job_handle: 11
+            }
+        );
+        assert_eq!(cancel_worker(&worker), 1);
+
+        wake_worker(
+            &worker,
+            HostWorkerJob {
+                job_id: 13,
+                job_handle: 17,
+            },
+        );
+        assert_eq!(
+            receiver.recv().unwrap(),
+            HostWorkerJob {
+                job_id: 13,
+                job_handle: 17
+            }
+        );
+        assert_eq!(
+            completion_receiver.recv().unwrap(),
+            HostWorkerJob {
+                job_id: 13,
+                job_handle: 17
+            }
+        );
+        free_worker(worker);
+    }
+
+    #[test]
+    fn worker_enter_idle_parks_until_next_wake() {
+        let (sender, receiver) = mpsc::channel();
+        let (completion_sender, completion_receiver) = mpsc::channel();
+        let worker = spawn_worker(
+            HostWorkerJob {
+                job_id: 1,
+                job_handle: 2,
+            },
+            move |job| sender.send(job).unwrap(),
+            move |job| completion_sender.send(job).unwrap(),
+        );
+
+        assert_eq!(receiver.recv().unwrap().job_id, 1);
+        assert_eq!(completion_receiver.recv().unwrap().job_id, 1);
+
+        worker_enter_idle(&worker);
+        wake_worker(
+            &worker,
+            HostWorkerJob {
+                job_id: 3,
+                job_handle: 4,
+            },
+        );
+
+        assert_eq!(receiver.recv().unwrap().job_id, 3);
+        assert_eq!(completion_receiver.recv().unwrap().job_id, 3);
+        free_worker(worker);
+    }
+
+    #[test]
+    fn termination_wake_during_job_exits_after_completion() {
+        let (started_sender, started_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let (completion_sender, completion_receiver) = mpsc::channel();
+        let worker = spawn_worker(
+            HostWorkerJob {
+                job_id: 21,
+                job_handle: 34,
+            },
+            move |job| {
+                started_sender.send(job).unwrap();
+                release_receiver.recv().unwrap();
+            },
+            move |job| completion_sender.send(job).unwrap(),
+        );
+
+        assert_eq!(started_receiver.recv().unwrap().job_id, 21);
+        worker.wake(None);
+        release_sender.send(()).unwrap();
+        assert_eq!(completion_receiver.recv().unwrap().job_id, 21);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        while worker
+            .thread
+            .as_ref()
+            .is_some_and(|thread| !thread.is_finished())
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::yield_now();
+        }
+        assert!(
+            worker
+                .thread
+                .as_ref()
+                .is_some_and(|thread| thread.is_finished())
+        );
+        free_worker(worker);
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/fd_util/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/fd_util/mod.rs
@@ -1,0 +1,19 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+pub(crate) mod stub;

--- a/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
@@ -1,0 +1,323 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::internal::event_loop::thread_pool::{HostFileTable, HostHandle};
+use crate::async_sys::ported_fns;
+
+#[cfg(unix)]
+pub(crate) type RawFd = std::os::fd::RawFd;
+
+#[cfg(windows)]
+pub(crate) type RawFd = windows_sys::Win32::Foundation::HANDLE;
+
+#[cfg(windows)]
+pub(crate) type FileTime = windows_sys::Win32::Storage::FileSystem::FILE_BASIC_INFO;
+
+#[cfg(unix)]
+pub(crate) type FileTime = libc::stat;
+
+#[cfg(windows)]
+const WINDOWS_TICKS_PER_SECOND: i64 = 10_000_000;
+#[cfg(windows)]
+const WINDOWS_TO_UNIX_EPOCH_SECONDS: i64 = 11_644_473_600;
+
+#[cfg(windows)]
+fn windows_filetime_to_unix_seconds(ticks: i64) -> i64 {
+    ticks / WINDOWS_TICKS_PER_SECOND - WINDOWS_TO_UNIX_EPOCH_SECONDS
+}
+
+#[cfg(windows)]
+fn windows_filetime_to_nanoseconds(ticks: i64) -> i32 {
+    ((ticks % WINDOWS_TICKS_PER_SECOND) * 100) as i32
+}
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/fd_util/stub.c",
+        original = "moonbitlang_async_pipe"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn pipe() -> AsyncHostResult<[RawFd; 2]> {
+        let mut fds = [0, 0];
+        if unsafe { libc::pipe(fds.as_mut_ptr()) } < 0 {
+            return Err(last_native_error());
+        }
+        for fd in fds {
+            if let Err(error) = set_cloexec(fd) {
+                unsafe {
+                    libc::close(fds[0]);
+                    libc::close(fds[1]);
+                }
+                return Err(error);
+            }
+        }
+        Ok(fds)
+    }
+
+    #[ported(
+        source = "src/internal/fd_util/stub.c",
+        original = "moonbitlang_async_set_nonblocking"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn set_nonblocking(fd: RawFd) -> AsyncHostResult<()> {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags < 0 {
+            return Err(last_native_error());
+        }
+        if (flags & libc::O_NONBLOCK) == 0 {
+            let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+            if ret < 0 {
+                return Err(last_native_error());
+            }
+        }
+        Ok(())
+    }
+
+    #[ported(
+        source = "src/internal/fd_util/stub.c",
+        original = "moonbitlang_async_get_atime_sec"
+    )]
+    #[allow(clippy::unnecessary_cast)]
+    pub(crate) fn get_atime_sec(file_time: &FileTime) -> i64 {
+        #[cfg(windows)]
+        {
+            windows_filetime_to_unix_seconds(file_time.LastAccessTime)
+        }
+        #[cfg(unix)]
+        {
+            file_time.st_atime as i64
+        }
+    }
+
+    #[ported(
+        source = "src/internal/fd_util/stub.c",
+        original = "moonbitlang_async_get_atime_nsec"
+    )]
+    pub(crate) fn get_atime_nsec(file_time: &FileTime) -> i32 {
+        #[cfg(windows)]
+        {
+            windows_filetime_to_nanoseconds(file_time.LastAccessTime)
+        }
+        #[cfg(unix)]
+        {
+            file_time.st_atime_nsec as i32
+        }
+    }
+
+    #[ported(
+        source = "src/internal/fd_util/stub.c",
+        original = "moonbitlang_async_get_mtime_sec"
+    )]
+    #[allow(clippy::unnecessary_cast)]
+    pub(crate) fn get_mtime_sec(file_time: &FileTime) -> i64 {
+        #[cfg(windows)]
+        {
+            windows_filetime_to_unix_seconds(file_time.LastWriteTime)
+        }
+        #[cfg(unix)]
+        {
+            file_time.st_mtime as i64
+        }
+    }
+
+    #[ported(
+        source = "src/internal/fd_util/stub.c",
+        original = "moonbitlang_async_get_mtime_nsec"
+    )]
+    pub(crate) fn get_mtime_nsec(file_time: &FileTime) -> i32 {
+        #[cfg(windows)]
+        {
+            windows_filetime_to_nanoseconds(file_time.LastWriteTime)
+        }
+        #[cfg(unix)]
+        {
+            file_time.st_mtime_nsec as i32
+        }
+    }
+
+    #[ported(
+        source = "src/internal/fd_util/stub.c",
+        original = "moonbitlang_async_get_ctime_sec"
+    )]
+    #[allow(clippy::unnecessary_cast)]
+    pub(crate) fn get_ctime_sec(file_time: &FileTime) -> i64 {
+        #[cfg(windows)]
+        {
+            windows_filetime_to_unix_seconds(file_time.ChangeTime)
+        }
+        #[cfg(unix)]
+        {
+            file_time.st_ctime as i64
+        }
+    }
+
+    #[ported(
+        source = "src/internal/fd_util/stub.c",
+        original = "moonbitlang_async_get_ctime_nsec"
+    )]
+    pub(crate) fn get_ctime_nsec(file_time: &FileTime) -> i32 {
+        #[cfg(windows)]
+        {
+            windows_filetime_to_nanoseconds(file_time.ChangeTime)
+        }
+        #[cfg(unix)]
+        {
+            file_time.st_ctime_nsec as i32
+        }
+    }
+}
+
+#[cfg(unix)]
+fn set_cloexec(fd: RawFd) -> AsyncHostResult<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(last_native_error());
+    }
+    if (flags & libc::FD_CLOEXEC) == 0 {
+        let ret = unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) };
+        if ret < 0 {
+            return Err(last_native_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn create_named_pipe_server(name: &std::ffi::OsStr, is_async: bool) -> RawFd {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED, PIPE_ACCESS_OUTBOUND,
+    };
+    use windows_sys::Win32::System::Pipes::{
+        CreateNamedPipeW, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_UNLIMITED_INSTANCES, PIPE_WAIT,
+    };
+
+    let mut name: Vec<u16> = name.encode_wide().collect();
+    name.push(0);
+    let flags = PIPE_ACCESS_OUTBOUND
+        | FILE_FLAG_FIRST_PIPE_INSTANCE
+        | if is_async { FILE_FLAG_OVERLAPPED } else { 0 };
+    unsafe {
+        CreateNamedPipeW(
+            name.as_ptr(),
+            flags,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+            PIPE_UNLIMITED_INSTANCES,
+            1024,
+            1024,
+            0,
+            std::ptr::null(),
+        )
+    }
+}
+
+#[cfg(windows)]
+fn create_named_pipe_client(name: &std::ffi::OsStr, is_async: bool) -> RawFd {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::GENERIC_READ;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAG_OVERLAPPED, OPEN_EXISTING,
+    };
+
+    let mut name: Vec<u16> = name.encode_wide().collect();
+    name.push(0);
+    unsafe {
+        CreateFileW(
+            name.as_ptr(),
+            GENERIC_READ,
+            0,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            if is_async { FILE_FLAG_OVERLAPPED } else { 0 },
+            std::ptr::null_mut(),
+        )
+    }
+}
+
+pub(crate) fn pipe_host_files(
+    files: &mut impl HostFileTable,
+    read_end_is_async: bool,
+    write_end_is_async: bool,
+) -> AsyncHostResult<[HostHandle; 2]> {
+    #[cfg(unix)]
+    {
+        let _ = (read_end_is_async, write_end_is_async);
+        let fds = pipe()?;
+        let read = files.insert_file(fds[0])?;
+        let write = files.insert_file(fds[1])?;
+        Ok([read, write])
+    }
+
+    #[cfg(windows)]
+    {
+        use std::ffi::OsString;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+        use windows_sys::Win32::System::Threading::GetCurrentProcessId;
+
+        static PIPE_ID: AtomicU64 = AtomicU64::new(0);
+
+        let pipe_id = PIPE_ID.fetch_add(1, Ordering::Relaxed) + 1;
+        let name = OsString::from(format!(
+            r"\\.\pipe\moonbitlang_async.{}.{}",
+            unsafe { GetCurrentProcessId() },
+            pipe_id
+        ));
+        let write = create_named_pipe_server(&name, write_end_is_async);
+        if write == INVALID_HANDLE_VALUE {
+            return Err(last_native_error());
+        }
+        let read = create_named_pipe_client(&name, read_end_is_async);
+        if read == INVALID_HANDLE_VALUE {
+            unsafe {
+                CloseHandle(write);
+            }
+            return Err(last_native_error());
+        }
+
+        let read = files.insert_file(read)?;
+        let write = files.insert_file(write)?;
+        Ok([read, write])
+    }
+}
+
+fn last_native_error() -> AsyncHostError {
+    AsyncHostError::Native(
+        std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
+    )
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_filetime_seconds_use_unix_epoch() {
+        let unix_epoch = WINDOWS_TO_UNIX_EPOCH_SECONDS * WINDOWS_TICKS_PER_SECOND;
+
+        assert_eq!(windows_filetime_to_unix_seconds(unix_epoch), 0);
+        assert_eq!(
+            windows_filetime_to_unix_seconds(unix_epoch + WINDOWS_TICKS_PER_SECOND),
+            1
+        );
+        assert_eq!(windows_filetime_to_nanoseconds(unix_epoch + 123), 12_300);
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/mod.rs
@@ -1,0 +1,23 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+pub(crate) mod c_buffer;
+pub(crate) mod env_util;
+pub(crate) mod event_loop;
+pub(crate) mod fd_util;
+pub(crate) mod time;

--- a/crates/moonrun/src/async_sys/internal/time/clock.rs
+++ b/crates/moonrun/src/async_sys/internal/time/clock.rs
@@ -1,0 +1,44 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(crate) fn get_ms_since_epoch() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clock_is_monotonic() {
+        let first = get_ms_since_epoch();
+        let second = get_ms_since_epoch();
+
+        assert!(second >= first);
+    }
+
+    #[test]
+    fn clock_uses_unix_epoch_milliseconds() {
+        assert!(get_ms_since_epoch() > 1_600_000_000_000);
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/time/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/time/mod.rs
@@ -1,0 +1,19 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+pub(crate) mod clock;

--- a/crates/moonrun/src/async_sys/mod.rs
+++ b/crates/moonrun/src/async_sys/mod.rs
@@ -1,0 +1,122 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! V8-free async host operations ported from `moonbitlang/async` native stubs.
+//!
+//! Files under this module follow the async package's source layout where a
+//! wasm import has a live implementation. The provenance macros record the
+//! native source path and symbol so the adapter registry can stay aligned with
+//! the C implementation. Moonrun-only runtime state stays in `async_host`.
+
+pub(crate) mod fs;
+pub(crate) mod internal;
+pub(crate) mod os_error;
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct PortedSymbol {
+    pub(crate) rust_module: &'static str,
+    pub(crate) rust_symbol: &'static str,
+    pub(crate) native_symbol: &'static str,
+    pub(crate) source: &'static str,
+}
+
+macro_rules! ported_fns {
+    (@collect [$($entries:tt)*] [$($out:tt)*]) => {
+        #[cfg(test)]
+        pub(crate) const PORTED_SYMBOLS: &[crate::async_sys::PortedSymbol] = &[
+            $($entries)*
+        ];
+
+        $($out)*
+    };
+    (
+        @collect [$($entries:tt)*] [$($out:tt)*]
+        #[ported(source = $source:literal, original = $original:literal)]
+        #[cfg($($cfg:tt)*)]
+        $(#[$meta:meta])*
+        $vis:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+        $($rest:tt)*
+    ) => {
+        ported_fns!(
+            @collect [
+                $($entries)*
+                #[cfg($($cfg)*)]
+                crate::async_sys::PortedSymbol {
+                    rust_module: module_path!(),
+                    rust_symbol: stringify!($name),
+                    native_symbol: $original,
+                    source: $source,
+                },
+            ] [
+                $($out)*
+                #[cfg($($cfg)*)]
+                $(#[$meta])*
+                $vis fn $name($($args)*) $(-> $ret)? $body
+            ]
+            $($rest)*
+        );
+    };
+    (
+        @collect [$($entries:tt)*] [$($out:tt)*]
+        #[ported(source = $source:literal, original = $original:literal)]
+        $(#[$meta:meta])*
+        $vis:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+        $($rest:tt)*
+    ) => {
+        ported_fns!(
+            @collect [
+                $($entries)*
+                crate::async_sys::PortedSymbol {
+                    rust_module: module_path!(),
+                    rust_symbol: stringify!($name),
+                    native_symbol: $original,
+                    source: $source,
+                },
+            ] [
+                $($out)*
+                $(#[$meta])*
+                $vis fn $name($($args)*) $(-> $ret)? $body
+            ]
+            $($rest)*
+        );
+    };
+    (@collect [$($entries:tt)*] [$($out:tt)*] $item:item $($rest:tt)*) => {
+        ported_fns!(@collect [$($entries)*] [$($out)* $item] $($rest)*);
+    };
+    ($($items:tt)*) => {
+        ported_fns!(@collect [] [] $($items)*);
+    };
+}
+
+pub(crate) use ported_fns;
+
+#[cfg(test)]
+pub(crate) fn ported_symbols() -> Vec<PortedSymbol> {
+    let mut symbols = Vec::new();
+    symbols.extend_from_slice(internal::c_buffer::stub::PORTED_SYMBOLS);
+    symbols.extend_from_slice(internal::env_util::stub::PORTED_SYMBOLS);
+    symbols.extend_from_slice(internal::fd_util::stub::PORTED_SYMBOLS);
+    symbols.extend(internal::event_loop::io::ported_symbols());
+    symbols.extend(internal::event_loop::poll::ported_symbols());
+    symbols.extend(internal::event_loop::thread_pool::ported_symbols());
+    symbols.extend_from_slice(fs::dir::PORTED_SYMBOLS);
+    symbols.extend_from_slice(fs::stub::PORTED_SYMBOLS);
+    symbols.extend_from_slice(os_error::stub::PORTED_SYMBOLS);
+    symbols
+}

--- a/crates/moonrun/src/async_sys/os_error/mod.rs
+++ b/crates/moonrun/src/async_sys/os_error/mod.rs
@@ -1,0 +1,19 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+pub(crate) mod stub;

--- a/crates/moonrun/src/async_sys/os_error/stub.rs
+++ b/crates/moonrun/src/async_sys/os_error/stub.rs
@@ -1,0 +1,209 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::AsyncHost;
+use crate::async_sys::ported_fns;
+
+ported_fns! {
+    #[ported(
+        source = "src/os_error/stub.c",
+        original = "moonbitlang_async_get_errno"
+    )]
+    pub(crate) fn get_errno(host: &AsyncHost) -> i32 {
+        host.get_errno()
+    }
+
+    #[ported(
+        source = "src/os_error/stub.c",
+        original = "moonbitlang_async_is_nonblocking_io_error"
+    )]
+    pub(crate) fn is_nonblocking_io_error(errno: i32) -> bool {
+        #[cfg(unix)]
+        {
+            errno == libc::EAGAIN || errno == libc::EINPROGRESS || errno == libc::EWOULDBLOCK
+        }
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::{ERROR_IO_INCOMPLETE, ERROR_IO_PENDING};
+            errno == ERROR_IO_INCOMPLETE as i32 || errno == ERROR_IO_PENDING as i32
+        }
+    }
+
+    #[ported(
+        source = "src/os_error/stub.c",
+        original = "moonbitlang_async_is_EINTR"
+    )]
+    pub(crate) fn is_eintr(errno: i32) -> bool {
+        #[cfg(unix)]
+        {
+            errno == libc::EINTR
+        }
+        #[cfg(windows)]
+        {
+            let _ = errno;
+            false
+        }
+    }
+
+    #[ported(
+        source = "src/os_error/stub.c",
+        original = "moonbitlang_async_is_ENOENT"
+    )]
+    pub(crate) fn is_enoent(errno: i32) -> bool {
+        #[cfg(unix)]
+        {
+            errno == libc::ENOENT
+        }
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND};
+            errno == ERROR_FILE_NOT_FOUND as i32 || errno == ERROR_PATH_NOT_FOUND as i32
+        }
+    }
+
+    #[ported(
+        source = "src/os_error/stub.c",
+        original = "moonbitlang_async_is_EEXIST"
+    )]
+    pub(crate) fn is_eexist(errno: i32) -> bool {
+        #[cfg(unix)]
+        {
+            errno == libc::EEXIST
+        }
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::{ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS};
+            errno == ERROR_FILE_EXISTS as i32 || errno == ERROR_ALREADY_EXISTS as i32
+        }
+    }
+
+    #[ported(
+        source = "src/os_error/stub.c",
+        original = "moonbitlang_async_is_EACCES"
+    )]
+    pub(crate) fn is_eacces(errno: i32) -> bool {
+        #[cfg(unix)]
+        {
+            errno == libc::EACCES
+        }
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED;
+            errno == ERROR_ACCESS_DENIED as i32
+        }
+    }
+
+    #[ported(
+        source = "src/os_error/stub.c",
+        original = "moonbitlang_async_is_ECONNREFUSED"
+    )]
+    pub(crate) fn is_econnrefused(errno: i32) -> bool {
+        #[cfg(unix)]
+        {
+            errno == libc::ECONNREFUSED
+        }
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::ERROR_CONNECTION_REFUSED;
+            errno == ERROR_CONNECTION_REFUSED as i32
+        }
+    }
+
+    #[ported(
+        source = "src/os_error/stub.c",
+        original = "moonbitlang_async_is_ERROR_NOTIFY_ENUM_DIR"
+    )]
+    pub(crate) fn is_error_notify_enum_dir(errno: i32) -> bool {
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::ERROR_NOTIFY_ENUM_DIR;
+            errno == ERROR_NOTIFY_ENUM_DIR as i32
+        }
+        #[cfg(unix)]
+        {
+            let _ = errno;
+            false
+        }
+    }
+
+    #[ported(
+        source = "src/os_error/stub.c",
+        original = "moonbitlang_async_get_ENOTDIR"
+    )]
+    pub(crate) fn get_enotdir() -> i32 {
+        #[cfg(unix)]
+        {
+            libc::ENOTDIR
+        }
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::ERROR_DIRECTORY;
+            ERROR_DIRECTORY as i32
+        }
+    }
+
+    #[ported(
+        source = "src/os_error/stub.c",
+        original = "moonbitlang_async_errno_to_string"
+    )]
+    pub(crate) fn errno_to_string(errno: i32) -> String {
+        errno_to_string_sys(errno)
+    }
+}
+
+#[cfg(unix)]
+fn errno_to_string_sys(errno: i32) -> String {
+    use std::ffi::CStr;
+
+    let message = unsafe { libc::strerror(errno) };
+    if message.is_null() {
+        return format!("errno {errno}");
+    }
+
+    unsafe { CStr::from_ptr(message) }
+        .to_string_lossy()
+        .trim_end_matches(['\r', '\n'])
+        .to_owned()
+}
+
+#[cfg(windows)]
+fn errno_to_string_sys(errno: i32) -> String {
+    use windows_sys::Win32::System::Diagnostics::Debug::{
+        FORMAT_MESSAGE_FROM_SYSTEM, FORMAT_MESSAGE_IGNORE_INSERTS, FormatMessageW,
+    };
+
+    let mut buffer = [0u16; 2048];
+    let len = unsafe {
+        FormatMessageW(
+            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            std::ptr::null(),
+            errno as u32,
+            0x409,
+            buffer.as_mut_ptr(),
+            buffer.len() as u32,
+            std::ptr::null(),
+        )
+    };
+    if len == 0 {
+        return format!("errno {errno}");
+    }
+
+    String::from_utf16_lossy(&buffer[..len as usize])
+        .trim_end_matches(['\r', '\n'])
+        .to_owned()
+}

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -24,6 +24,8 @@ use std::{cell::Cell, io::Read, path::PathBuf, time::Instant};
 use v8::V8::set_flags_from_string;
 
 mod async_api;
+mod async_host;
+mod async_sys;
 mod backtrace_api;
 mod demangle_js_template;
 mod fs_api_temp;
@@ -385,8 +387,8 @@ fn init_env(
     }
 
     {
-        let async_runtime = global_proxy.child(scope, async_api::MOONBIT_V0_MODULE);
-        async_api::init_env(async_runtime, scope);
+        let async_runtime = global_proxy.child(scope, async_api::MOONBIT_ASYNC_MODULE);
+        async_api::init_env(async_runtime, scope, dtors);
     }
 
     {

--- a/crates/moonrun/src/template/js_glue.js
+++ b/crates/moonrun/src/template/js_glue.js
@@ -143,7 +143,7 @@ const __moonbit_backtrace_runtime = globalThis.__moonbit_backtrace_runtime || {
 })(__moonbit_fs_unstable, __moonbit_run_env);
 
 const __moonbit_wasi_unstable = globalThis.__moonbit_wasi_unstable || {};
-const moonbit_v0 = globalThis.moonbit_v0 || {};
+const moonbitlang_async = globalThis["moonbitlang/async"] || {};
 
 delete globalThis.__moonbit_run_env;
 delete globalThis.__moonbit_backtrace_runtime;
@@ -437,7 +437,7 @@ const spectest = {
     __moonbit_io_unstable: __moonbit_io_unstable,
     __moonbit_sys_unstable: __moonbit_sys_unstable,
     __moonbit_time_unstable: __moonbit_time_unstable,
-    moonbit_v0: moonbit_v0,
+    "moonbitlang/async": moonbitlang_async,
     wasi_snapshot_preview1: wasi_snapshot_preview1,
     moonbit: {
         string_to_js_string() {
@@ -504,6 +504,13 @@ function setWasiMemory(memory) {
     wasiMemoryInitialized = true;
 }
 
+function setAsyncMemory(memory) {
+    if (!(memory instanceof WebAssembly.Memory)) {
+        throw new Error("moonbitlang/async requires an exported `memory`");
+    }
+    moonbitlang_async.memory = memory;
+}
+
 try {
     if (typeof bytes === 'undefined') {
         bytes = read_file_to_bytes(module_name);
@@ -516,10 +523,18 @@ try {
     const moduleExports = WebAssembly.Module.exports(module);
     const usesWasiSnapshotPreview1 = moduleImports
         .some(importItem => importItem.module === "wasi_snapshot_preview1");
+    const usesMoonBitAsync = moduleImports
+        .some(importItem => importItem.module === "moonbitlang/async");
     if (usesWasiSnapshotPreview1) {
         const importedMemory = findImportedMemory(moduleImports, moduleExports, spectest);
         if (importedMemory instanceof WebAssembly.Memory) {
             setWasiMemory(importedMemory);
+        }
+    }
+    if (usesMoonBitAsync) {
+        const importedMemory = findImportedMemory(moduleImports, moduleExports, spectest);
+        if (importedMemory instanceof WebAssembly.Memory) {
+            setAsyncMemory(importedMemory);
         }
     }
     let instance = new WebAssembly.Instance(module, spectest);
@@ -530,6 +545,16 @@ try {
         } else if (!wasiMemoryInitialized) {
             throw new Error(
                 "wasi_snapshot_preview1 requires an exported or imported WebAssembly.Memory"
+            );
+        }
+    }
+    if (usesMoonBitAsync) {
+        const memory = instance.exports.memory;
+        if (memory instanceof WebAssembly.Memory) {
+            setAsyncMemory(memory);
+        } else if (!(moonbitlang_async.memory instanceof WebAssembly.Memory)) {
+            throw new Error(
+                "moonbitlang/async requires an exported or imported WebAssembly.Memory"
             );
         }
     }

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -327,6 +327,47 @@ fn test_moon_run_with_is_windows() {
 }
 
 #[test]
+fn test_moon_run_with_async_host_imports() {
+    let dir = TestDir::new("test_async_host.in");
+
+    moon_cmd()
+        .current_dir(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success();
+
+    let wasm_file = dir.join("_build/wasm/debug/build/main/main.wasm");
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(&wasm_file)
+        .assert()
+        .success()
+        .stdout_eq("ok\n");
+}
+
+#[test]
+fn test_moon_run_with_async_host_invalid_c_buffer_traps() {
+    let dir = TestDir::new("test_async_host_invalid_c_buffer.in");
+
+    moon_cmd()
+        .current_dir(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success();
+
+    let wasm_file = dir.join("_build/wasm/debug/build/main/main.wasm");
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(&wasm_file)
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: moonbitlang/async.c_buffer/c_buffer_get failed: Badf
+[..]
+"#]]);
+}
+
+#[test]
 fn test_moon_fmt_skips_prebuild_output() {
     // Prepare a temp copy of the test case
     let dir = TestDir::new("test_fmt_skip_prebuild_output");

--- a/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
@@ -1,0 +1,168 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+fn get_platform() -> Int = "moonbitlang/async" "runtime/get_platform"
+
+///|
+fn invalid_fd() -> UInt64 = "moonbitlang/async" "fd_util/invalid_fd"
+
+///|
+fn ms_since_epoch() -> UInt64 = "moonbitlang/async" "time/get_ms_since_epoch"
+
+///|
+fn event_bus_create() -> UInt64 = "moonbitlang/async" "event_bus/create"
+
+///|
+fn event_bus_destroy(bus : UInt64) -> Unit = "moonbitlang/async" "event_bus/destroy"
+
+///|
+fn event_bus_wait(bus : UInt64, timeout_ms : Int) -> Int = "moonbitlang/async" "event_bus/wait"
+
+///|
+fn event_bus_get_event(bus : UInt64, index : Int) -> UInt64 = "moonbitlang/async" "event_bus/get_event"
+
+///|
+fn event_bus_event_fd(event : UInt64) -> UInt64 = "moonbitlang/async" "event_bus/event_fd"
+
+///|
+fn event_bus_event_events(event : UInt64) -> Int = "moonbitlang/async" "event_bus/event_events/unix"
+
+///|
+fn event_bus_event_bytes_transferred(event : UInt64) -> Int = "moonbitlang/async" "event_bus/event_bytes_transferred/windows"
+
+///|
+fn init_thread_pool(bus : UInt64) -> UInt64 = "moonbitlang/async" "thread_pool/init_thread_pool"
+
+///|
+fn destroy_thread_pool() -> Unit = "moonbitlang/async" "thread_pool/destroy_thread_pool"
+
+///|
+fn make_read_job(fd : UInt64, len : Int, position : Int64) -> UInt64 = "moonbitlang/async" "thread_pool/make_read_job"
+
+///|
+fn free_job(job : UInt64) -> Unit = "moonbitlang/async" "thread_pool/free_job"
+
+///|
+fn spawn_worker(worker_id : Int, job : UInt64) -> UInt64 = "moonbitlang/async" "thread_pool/spawn_worker"
+
+///|
+fn free_worker(worker : UInt64) -> Unit = "moonbitlang/async" "thread_pool/free_worker"
+
+///|
+#unsafe_skip_stub_check
+#borrow(completed_jobs)
+fn fetch_completion(
+  source_fd : UInt64,
+  completed_jobs : FixedArray[Int],
+  max_jobs : Int,
+) -> Int = "moonbitlang/async" "thread_pool/fetch_completion/unix"
+
+///|
+fn errno_to_string_len(errno : Int) -> Int = "moonbitlang/async" "os_error/errno_to_string_len"
+
+///|
+fn errno_to_string(errno : Int, dst : Int, len : Int) -> Int = "moonbitlang/async" "os_error/errno_to_string"
+
+///|
+fn get_tmp_path_len() -> Int = "moonbitlang/async" "fs/get_tmp_path_len"
+
+///|
+fn get_tmp_path(dst : Int, len : Int) -> Int = "moonbitlang/async" "fs/get_tmp_path"
+
+///|
+#borrow(str)
+extern "wasm" fn string_to_ptr(str : String) -> Int =
+  #|(func (param i32) (result i32) local.get 0)
+
+///|
+fn errno_is_lock_violation(errno : Int) -> Bool = "moonbitlang/async" "fs/errno_is_lock_violation"
+
+///|
+fn assert_true(cond : Bool, message : String) -> Unit {
+  if !cond {
+    abort(message)
+  }
+}
+
+///|
+fn main {
+  let platform = get_platform()
+  assert_true(platform >= 0 && platform <= 2, "invalid platform")
+  let before = ms_since_epoch()
+  assert_true(before > 1_600_000_000_000, "time is not Unix epoch milliseconds")
+  let after = ms_since_epoch()
+  assert_true(after >= before, "time moved backwards")
+  let message_len = errno_to_string_len(2)
+  assert_true(message_len > 0, "errno string size query failed")
+  let message = String::make(message_len, '\u{0}')
+  assert_true(
+    errno_to_string(2, string_to_ptr(message), message_len) == 0,
+    "errno string fill failed",
+  )
+  assert_true(
+    message != String::make(message_len, '\u{0}'),
+    "errno string fill wrote an empty message",
+  )
+  let tmp_path_len = get_tmp_path_len()
+  assert_true(tmp_path_len > 0, "tmp path size query failed")
+  assert_true(get_tmp_path(0, 0) == -1, "tmp path fill accepted a missing buffer")
+  let tmp_path = String::make(tmp_path_len, '\u{0}')
+  let tmp_path_ptr = string_to_ptr(tmp_path)
+  assert_true(get_tmp_path(tmp_path_ptr, tmp_path_len) == 0, "tmp path fill failed")
+  assert_true(tmp_path != String::make(tmp_path_len, '\u{0}'), "tmp path fill wrote an empty path")
+  assert_true(!errno_is_lock_violation(0), "zero errno is a lock violation")
+  let bus = event_bus_create()
+  assert_true(event_bus_wait(bus, 0) == 0, "empty event bus did not time out")
+  let completion_source = init_thread_pool(bus)
+  let job = make_read_job(invalid_fd(), 1, -1)
+  let worker = spawn_worker(17, job)
+  let event_count = event_bus_wait(bus, 1000)
+  assert_true(event_count > 0, "worker completion did not wake event bus")
+  let mut saw_completion = false
+  for i in 0..<event_count {
+    let event = event_bus_get_event(bus, i)
+    let event_fd = event_bus_event_fd(event)
+    if event_fd == completion_source {
+      if platform == 2 {
+        assert_true(
+          event_bus_event_bytes_transferred(event) == 17,
+          "IOCP completion did not carry job id",
+        )
+      } else {
+        event_bus_event_events(event) |> ignore
+      }
+      saw_completion = true
+    }
+  }
+  assert_true(saw_completion, "event bus did not report worker completion source")
+  // Windows carries the completed job id in the IOCP event; Unix drains ids
+  // from the readable completion pipe.
+  if platform != 2 {
+    let completed_jobs = FixedArray::make(4, 0)
+    assert_true(
+      fetch_completion(completion_source, completed_jobs, completed_jobs.length()) == 4,
+      "completion drain returned wrong byte count",
+    )
+    assert_true(completed_jobs[0] == 17, "completion drain returned wrong job id")
+  }
+  free_worker(worker)
+  free_job(job)
+  destroy_thread_pool()
+  event_bus_destroy(bus)
+  println("ok")
+}

--- a/crates/moonrun/tests/test_cases/test_async_host.in/main/moon.pkg.json
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moonrun/tests/test_cases/test_async_host.in/moon.mod.json
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/moon.mod.json
@@ -1,0 +1,3 @@
+{
+  "name": "username/async-host"
+}

--- a/crates/moonrun/tests/test_cases/test_async_host_invalid_c_buffer.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host_invalid_c_buffer.in/main/main.mbt
@@ -1,0 +1,24 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+fn c_buffer_get(buf : UInt64, index : Int) -> Byte = "moonbitlang/async" "c_buffer/c_buffer_get"
+
+///|
+fn main {
+  ignore(c_buffer_get(2147483647UL, 0))
+}

--- a/crates/moonrun/tests/test_cases/test_async_host_invalid_c_buffer.in/main/moon.pkg.json
+++ b/crates/moonrun/tests/test_cases/test_async_host_invalid_c_buffer.in/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moonrun/tests/test_cases/test_async_host_invalid_c_buffer.in/moon.mod.json
+++ b/crates/moonrun/tests/test_cases/test_async_host_invalid_c_buffer.in/moon.mod.json
@@ -1,0 +1,3 @@
+{
+  "name": "username/async-host-invalid-c-buffer"
+}

--- a/docs/adr/0001-async-wasm-host-boundary.md
+++ b/docs/adr/0001-async-wasm-host-boundary.md
@@ -1,53 +1,37 @@
 # Async Wasm Host Boundary
 
-We will support `moonbitlang/async` on the wasm backend through
-`#cfg(target="wasm")` bindings to a `moonbit_v0` host module in `moonrun`,
-without compiler changes or JS backend changes. The host follows the semantic
-contract of async's native C stubs, while this first split only implements the
-event-loop and timer foundation needed by the root async, async queue, and
-semaphore tests.
+We will support `moonbitlang/async` on the wasm backend through `#cfg(target="wasm")` bindings to a `moonbit_v0` host module in `moonrun`, without compiler changes or JS backend changes. The host follows the semantic contract of async's native C stubs, but wasm resources are represented as host handles and guest-memory ranges rather than native MoonBit runtime objects or pinned pointers; this keeps V8 as the first adapter while allowing the V8-free host core to be reused by future wasm runtimes.
 
 ## Decisions
 
-- Use a semantic C-stub boundary: `moonbit_v0` symbols map from
-  `moonbitlang_async_*` symbols by stripping that prefix and placing the leaf
-  name under an async namespace.
-- Keep the first split limited to event-loop and timer support. Filesystem,
-  process, socket, TLS, raw-fd, c-buffer, and real worker-job behavior remain
-  follow-up work.
-- Use monotonic elapsed milliseconds with an unspecified process-local origin
-  for wasm async time. The async timer contract uses differences between
-  readings; the absolute epoch is not meaningful.
-- Support Unix-family and Windows hosts first. Other host families are
-  deliberately compile-time unsupported until the async C-stub parity target is
-  defined for them.
-- Keep link-required worker symbols registered when the wasm event-loop module
-  references them, but make real worker/job operations fail loudly in this
-  split instead of causing missing-import instantiation failures.
+- Use a semantic C-stub boundary: `moonbit_v0` symbols map from `moonbitlang_async_*` symbols by stripping that prefix.
+- Keep source provenance next to import registration and V8-free host implementation. Each mapped import declares the async source file and native symbol it tracks, each active Rust port declares the same origin through the port provenance macro, and tests verify the registry and implementation entries stay in sync. V8 callback modules are adapters only and should not own port provenance.
+- Keep `AsyncHost` focused on shared runtime state, resource tables, guest-memory helpers, and shared ABI representation types. Ported operation behavior belongs in `async_sys`, with `AsyncHost` passed in only when the operation needs shared state.
+- Use monotonic elapsed milliseconds with an unspecified process-local origin for wasm async time. The async timer contract uses differences between readings; the absolute epoch is not meaningful.
+- Support Unix-family and Windows hosts first. Other host families are deliberately compile-time unsupported until the async C-stub parity target is defined for them.
+- Store wasm memory as `moonbit_v0.memory` in the JS glue. The Rust adapter reads that property on each memory-using import instead of registering a separate async `set_memory` callback.
+- Never retain raw wasm-memory pointers after an import returns. Host state may store handles, guest offsets, lengths, and host-owned buffers.
+- Pass async path arguments as borrowed MoonBit `String` pointers plus UTF-16 code-unit lengths. The guest must not encode `OsString` paths to UTF-8 `Bytes` before calling `moonbit_v0`; `moonrun` owns conversion from MoonBit string data into Rust `OsString` and then into the native OS call form.
+- Treat V8 memory growth as a reason to reacquire memory every call. OS APIs that need stable pointers must use host-owned memory and copy to or from wasm memory.
+- Keep worker threads out of wasm guest memory. Worker jobs may compute host-owned results, but guest-memory writes happen only during guest-thread imports such as `fetch_completion`, where the V8 adapter can reacquire the current memory view while notifying MoonBit that jobs are ready.
+- Treat wasm `FileTime` as a portable 48-byte record, not as a native `stat` or `FILE_BASIC_INFO` buffer. The wasm layout is little-endian `{ atime_sec: i64, atime_nsec: i32, mtime_sec: i64, mtime_nsec: i32, ctime_sec: i64, ctime_nsec: i32 }` with 4 bytes of padding after each nanosecond field, matching the WIT canonical record layout for those fields on wasm32.
+- Make `poll` the wasm event-loop ABI. MoonBit owns scheduling and dispatch; moonrun owns the OS poller and returns readiness/completion events through `poll/create`, `poll/wait`, `poll/event_fd`, and related imports. `runtime/wait_for_event` is not part of the async wasm boundary.
+- Register only the imports produced by the current wasm async implementation. Do not add deferred C-host symbols as placeholder unsupported imports; add future sockets, TLS, direct I/O, or file-watching surfaces only when wasm bindings import them and the implementation can be wired end to end.
 
-## PR1 Correspondence
+## Module Boundaries
 
-| `moonbit_v0` import | Native async correspondence | PR1 status |
-| --- | --- | --- |
-| `runtime/exit` | wasm support glue | implemented |
-| `runtime/get_platform` | `moonbitlang_async_get_platform` | implemented |
-| `runtime/wait_for_event` | wasm support glue | implemented |
-| `time/get_ms_since_epoch` | `moonbitlang_async_get_ms_since_epoch` | implemented with monotonic local origin |
-| `os_error/get_errno` | `moonbitlang_async_get_errno` | implemented for host callback errno |
-| `thread_pool/errno_is_cancelled` | `moonbitlang_async_errno_is_cancelled` | deterministic no-worker stub |
-| `thread_pool/fetch_completion` | `moonbitlang_async_fetch_completion` | deterministic no-completion stub |
-| `thread_pool/spawn_worker` | `moonbitlang_async_spawn_worker` | link-only unsupported stub |
-| `thread_pool/free_worker` | `moonbitlang_async_free_worker` | link-only unsupported stub |
-| `thread_pool/wake_worker` | `moonbitlang_async_wake_worker` | link-only unsupported stub |
-| `thread_pool/worker_enter_idle` | `moonbitlang_async_worker_enter_idle` | link-only unsupported stub |
-| `thread_pool/cancel_worker` | `moonbitlang_async_cancel_worker` | link-only unsupported stub |
-| `thread_pool/free_job` | wasm support glue | link-only unsupported stub |
-| `thread_pool/run_job` | wasm support glue | link-only unsupported stub |
-| `thread_pool/job_get_ret` | `moonbitlang_async_job_get_ret` | link-only unsupported stub |
-| `thread_pool/job_get_err` | `moonbitlang_async_job_get_err` | link-only unsupported stub |
+- `async_api` is the V8-facing `moonbit_v0` adapter. It declares and registers imports, decodes wasm ABI values from V8 callback arguments, reacquires guest memory, sets return values, and turns host failures into return values or traps.
+- `async_host` is moonrun-owned runtime state for one V8 `moonbit_v0` host instance. It owns handle tables, host workers, completion queues, guest-memory helper types, and opaque poll instances. It intentionally does not mirror `moonbitlang/async`.
+- `async_sys` is the V8-free native-stub port layer. Its implemented files follow the `moonbitlang/async` source layout where the wasm backend imports that behavior, and each ported operation records the native source path and symbol it tracks. The platform poll files are direct ports behind the wasm `poll/*` imports.
+
+## Event Loop Scope
+
+Native `moonbitlang/async` has a platform poller: epoll on Linux, kqueue on macOS/BSD, and IOCP on Windows. Thread-pool completions are only one event source in that poller: Unix workers write completed job ids to a notify pipe registered with the poller, and Windows workers post completed job ids to the IOCP.
+
+The wasm host exposes the same event-loop concept through opaque poll handles. `poll/register` and `poll/remove` operate on moonrun host fd handles, so pipes and future pollable handles stay opaque to the guest while Rust resolves them to the platform fd or HANDLE. The thread-pool completion source is created inside a poll instance, returned as an fd-like event key, and drained through `thread_pool/fetch_completion` when `poll/event_fd` reports that key.
+
+Current filesystem reads and writes still run as worker jobs; socket, HTTP, and process work should extend the same poll facade instead of adding another wait shortcut. A Rust `Barrier` or completion-only `Condvar` is not enough because neither can wait on thousands of OS readiness events.
 
 ## Deferred
 
-Executor design, cancellation semantics, broad core FS, sockets, process, TLS,
-file watching, arbitrary external fd/HANDLE adoption, Wasmtime/WasmEdge
-adapters, and wasm-gc support remain follow-up work.
+Executor design, cancellation semantics, broad core FS, sockets, process readiness, TLS, file watching, arbitrary external fd/HANDLE adoption, Wasmtime/WasmEdge adapters, and wasm-gc support remain follow-up work.

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -44,6 +44,7 @@ excludes = [
     "crates/moon/tests/test_cases/**",
     "!crates/moon/tests/test_cases/mod.rs",
     "crates/moonbuild/template/**",
+    "third_party/**",
     ".justfile",
     "moon.test",
     "*.js",


### PR DESCRIPTION
## Why

This brings the async wasm host runtime onto current `main` using PR 1772 as the reference, while aligning the implementation with the current `moonbitlang/async` event-loop architecture. The wasm runtime needs the same durable shape as native async: MoonBit owns scheduling and event dispatch, and moonrun owns the host poller, worker threads, host handles, and explicit guest-memory copy boundaries.

## What Changed

- Added the async host/sys split for moonrun:
  - `async_api` registers the V8-facing wasm imports.
  - `async_host` owns per-host runtime state, handle tables, guest-memory helpers, poll instances, and worker orchestration.
  - `async_sys` contains V8-free Rust ports of the native async C stubs with provenance tracking.
- Registered the wasm ABI under `moonbitlang/async`, with `pkg/func` import names and OS-qualified names where the guest dispatches by platform.
- Added a native-shaped event bus boundary backed by epoll, kqueue, or IOCP, including event accessors and platform-specific IO result handling.
- Kept thread-pool completion as an event-bus source: Unix uses a host-owned completion pipe handle, while Windows posts completions through IOCP.
- Ported the filesystem-oriented worker jobs, file/dir metadata helpers, c-buffer support, errno helpers, os-string decoding, and temporary-path handling used by the wasm async packages.
- Added pollable pipe/direct IO support so pipe read/write goes through the event-loop path instead of being treated like regular filesystem jobs.
- Kept process/socket/TLS outside the active wasm ABI until those packages are implemented end to end.
- Updated the async submodule pointer and wasm package fixtures/tests for timer, fs, shared async packages, and pipe coverage.

## Why This Is Correct

The host ABI now follows the shape of native async rather than exposing a filesystem-only shortcut. Regular file work is still scheduled through worker jobs, while pollable descriptors such as pipes are registered with the event bus and serviced through readiness/completion events.

The Rust implementation keeps provenance for active ports back to the corresponding `moonbitlang/async` native C source and symbol, and separates ported imports from wasm-only helpers and platform-dispatched fake link entries. Unsupported future surfaces are not registered as broad placeholders.

The completion source uses the same host-handle namespace as ordinary fd handles, so event dispatch can compare the event fd against the MoonBit-owned completion handle without mixing raw OS fd values with host table keys.

## Scope

This PR intentionally focuses on the wasm async runtime needed for timer, filesystem, synchronization primitives, and pipe/event-loop coverage. Process, socket, HTTP, and TLS remain follow-up work and should be added through the same event-bus/host-handle shape rather than new ad hoc host APIs.