### PR TITLE
Deprecate workspace preferred target

### DIFF
--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -329,7 +329,6 @@ pub(crate) fn preferred_target_backend_for_package(
         .module_rel
         .module_info(module_id)
         .preferred_target
-        .or(resolve_output.workspace_preferred_target)
         .unwrap_or_default()
 }
 

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -159,14 +159,10 @@ pub(crate) fn local_packages(
         })
 }
 
-fn workspace_preferred_target(
+fn local_modules_preferred_target(
     resolve_output: &ResolveOutput,
     output: UserDiagnostics,
 ) -> Option<TargetBackend> {
-    if let Some(preferred_target) = resolve_output.workspace_preferred_target {
-        return Some(preferred_target);
-    }
-
     let preferred = resolve_output
         .local_modules()
         .iter()
@@ -542,7 +538,7 @@ pub(crate) fn prepare_resolved_build(
     let preferred_target = if preconfig.target_backend.is_some() {
         None
     } else {
-        workspace_preferred_target(resolve_output, output)
+        local_modules_preferred_target(resolve_output, output)
     };
     info!("Preferred backend: {:?}", preferred_target);
 

--- a/crates/moon/tests/test_cases/workspace_basic.in/moon.work
+++ b/crates/moon/tests/test_cases/workspace_basic.in/moon.work
@@ -2,4 +2,3 @@ members = [
   "./app",
   "./liba",
 ]
-preferred_target = "wasm-gc"

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -46,7 +46,6 @@ fn same_root_workspace_dir() -> TestDir {
   ".",
   "./dep",
 ]
-preferred_target = "wasm-gc"
 "#,
     );
     write_file(
@@ -125,7 +124,6 @@ fn nested_workspace_under_unrelated_module_dir() -> TestDir {
         r#"members = [
   "./app",
 ]
-preferred_target = "wasm-gc"
 "#,
     );
     write_file(
@@ -382,6 +380,56 @@ fn test_empty_workspace_fmt_formats_workspace_manifest() {
 }
 
 #[test]
+fn test_workspace_preferred_target_warns() {
+    let dir = TestDir::new("workspace_basic.in");
+    std::fs::write(
+        dir.join("moon.work"),
+        r#"members = [
+  "./app",
+  "./liba",
+]
+preferred_target = "wasm-gc"
+"#,
+    )
+    .unwrap();
+
+    check(
+        get_stderr(&dir, ["build", "--dry-run", "--sort-input"]),
+        expect![[r#"
+            Warning: `preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.
+        "#]],
+    );
+}
+
+#[test]
+fn test_workspace_fmt_removes_deprecated_preferred_target() {
+    let dir = TestDir::new("fmt_moon_work_existing.in");
+
+    check(
+        get_stderr(&dir, ["fmt", "--dry-run", "--sort-input"]),
+        expect![[r#"
+            Warning: `preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.
+            Warning: Migrating to moon.mod at module root '$ROOT/app', deprecated moon.mod.json is removed.
+        "#]],
+    );
+
+    snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .args(["fmt"])
+        .assert()
+        .success();
+
+    check(
+        std::fs::read_to_string(dir.join("moon.work")).unwrap(),
+        expect![[r#"
+            members = [
+              "./app",
+            ]
+        "#]],
+    );
+}
+
+#[test]
 fn test_workspace_fmt_places_moon_mod_under_module_name() {
     let dir = TestDir::new("workspace_basic.in");
     std::fs::remove_file(dir.join("app/moon.mod.json")).unwrap();
@@ -604,7 +652,7 @@ fn test_work_init_creates_empty_workspace() {
 }
 
 #[test]
-fn test_work_use_updates_workspace_and_preserves_preferred_target() {
+fn test_work_use_updates_workspace_and_preserves_deprecated_preferred_target() {
     let dir = TestDir::new("workspace_basic.in");
 
     std::fs::write(
@@ -624,8 +672,17 @@ preferred_target = "wasm-gc"
         "#]],
     );
 
+    let moon_work = std::fs::read_to_string(dir.join("moon.work")).unwrap();
+    let preferred_target = moon_work
+        .lines()
+        .find(|line| line.starts_with("preferred_target"))
+        .unwrap_or("");
     check(
-        std::fs::read_to_string(dir.join("moon.work")).unwrap(),
+        preferred_target,
+        expect![[r#"preferred_target = "wasm-gc""#]],
+    );
+    check(
+        moon_work,
         expect![[r#"
             members = [
               "./liba",
@@ -690,7 +747,6 @@ fn test_work_use_ignores_unrelated_ancestor_workspace() {
               "./app",
               "./liba",
             ]
-            preferred_target = "wasm-gc"
         "#]],
     );
 }
@@ -1279,7 +1335,6 @@ fn test_pinned_workspace_path_selects_outer_module_when_listed() {
         r#"members = [
   "../",
 ]
-preferred_target = "wasm-gc"
 "#,
     );
 

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -66,8 +66,6 @@ pub struct ResolveOutput {
     pub pkg_dirs: DiscoverResult,
     /// Package dependency relationship
     pub pkg_rel: DepRelationship,
-    /// Explicit preferred target from `moon.work`, if any.
-    pub workspace_preferred_target: Option<TargetBackend>,
     /// User-facing warnings discovered during resolve.
     pub user_warnings: Vec<UserWarning>,
 }
@@ -331,14 +329,14 @@ pub fn sync_dependencies(
     source_dir: &Path,
     mooncakes_dir: &Path,
     project_manifest_path: Option<&Path>,
-) -> Result<(ResolvedEnv, DirSyncResult, Option<TargetBackend>), ResolveError> {
+) -> Result<(ResolvedEnv, DirSyncResult), ResolveError> {
     info!(
         "Starting dependency sync for source directory: {}",
         source_dir.display()
     );
     debug!("Resolve config: sync_flags={:?}", cfg.sync_flags);
 
-    let (resolved_env, dir_sync_result, workspace) = auto_sync(
+    let (resolved_env, dir_sync_result, _) = auto_sync(
         source_dir,
         mooncakes_dir,
         &cfg.sync_flags,
@@ -351,20 +349,16 @@ pub fn sync_dependencies(
     info!("Module dependency resolution completed successfully");
     debug!("Resolved {} modules", resolved_env.module_count());
 
-    Ok((
-        resolved_env,
-        dir_sync_result,
-        workspace.and_then(|workspace| workspace.preferred_target),
-    ))
+    Ok((resolved_env, dir_sync_result))
 }
 
 /// Resolves packages and package relationships from already synced dependencies.
 #[instrument(skip_all)]
 pub fn resolve_synced_project(
     cfg: &ResolveConfig,
-    synced_dependencies: (ResolvedEnv, DirSyncResult, Option<TargetBackend>),
+    synced_dependencies: (ResolvedEnv, DirSyncResult),
 ) -> Result<ResolveOutput, ResolveError> {
-    let (resolved_env, dir_sync_result, workspace_preferred_target) = synced_dependencies;
+    let (resolved_env, dir_sync_result) = synced_dependencies;
 
     let mut discover_result = discover_packages(&resolved_env, &dir_sync_result)?;
     let main_is_core = {
@@ -408,7 +402,6 @@ pub fn resolve_synced_project(
         module_dirs: dir_sync_result,
         pkg_dirs: discover_result,
         pkg_rel: dep_relationship,
-        workspace_preferred_target,
         user_warnings,
     })
 }
@@ -517,7 +510,6 @@ Use moonbit.import with 'username/module@version[/package]' entries to opt in to
         module_dirs: dir_sync_result,
         pkg_dirs: discover_result,
         pkg_rel: dep_relationship,
-        workspace_preferred_target: None,
         user_warnings,
     };
     Ok((res, backend))

--- a/crates/mooncake/src/pkg/work.rs
+++ b/crates/mooncake/src/pkg/work.rs
@@ -88,10 +88,9 @@ pub fn init_workspace(
 
 pub fn use_workspace(workspace_root: &Path, paths: &[PathBuf], quiet: bool) -> anyhow::Result<i32> {
     let existing = read_workspace(workspace_root)?;
-    let preferred_target = match existing.as_ref() {
-        Some(workspace) => workspace.preferred_target,
-        None => None,
-    };
+    let preferred_target = existing
+        .as_ref()
+        .and_then(|workspace| workspace.preferred_target);
 
     let mut use_paths = Vec::new();
     let mut member_dirs = BTreeSet::new();

--- a/crates/moonutil/src/workspace.rs
+++ b/crates/moonutil/src/workspace.rs
@@ -31,6 +31,8 @@ use crate::{
     moon_pkg,
 };
 
+const PREFERRED_TARGET_DEPRECATION_WARNING: &str = "Warning: `preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.";
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MoonWork {
@@ -83,20 +85,33 @@ pub fn read_workspace(dir: &Path) -> anyhow::Result<Option<MoonWork>> {
 pub fn read_workspace_file(path: &Path) -> anyhow::Result<MoonWork> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read workspace file `{}`", path.display()))?;
-    let workspace = match path.file_name().and_then(|name| name.to_str()) {
-        Some(MOON_WORK) => parse_workspace_dsl(&content),
+    let workspace = parse_workspace_file_content(path, &content)?;
+    if workspace.preferred_target.is_some() {
+        eprintln!("{PREFERRED_TARGET_DEPRECATION_WARNING}");
+    }
+    Ok(workspace)
+}
+
+pub fn format_workspace_file(path: &Path) -> anyhow::Result<String> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read workspace file `{}`", path.display()))?;
+    let workspace = parse_workspace_file_content(path, &content)?;
+    if workspace.preferred_target.is_some() {
+        eprintln!("{PREFERRED_TARGET_DEPRECATION_WARNING}");
+    }
+    format_workspace_dsl_for_moon_fmt(&workspace)
+}
+
+fn parse_workspace_file_content(path: &Path, content: &str) -> anyhow::Result<MoonWork> {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some(MOON_WORK) => parse_workspace_dsl(content),
         _ => anyhow::bail!(
             "expected workspace file to be `{}`, got `{}`",
             MOON_WORK,
             path.display()
         ),
-    };
-    workspace.with_context(|| format!("failed to parse workspace file `{}`", path.display()))
-}
-
-pub fn format_workspace_file(path: &Path) -> anyhow::Result<String> {
-    let workspace = read_workspace_file(path)?;
-    format_workspace_dsl(&workspace)
+    }
+    .with_context(|| format!("failed to parse workspace file `{}`", path.display()))
 }
 
 pub fn write_workspace(dir: &Path, work: &MoonWork) -> anyhow::Result<()> {
@@ -144,7 +159,7 @@ fn parse_workspace_dsl(content: &str) -> anyhow::Result<MoonWork> {
     Ok(workspace)
 }
 
-fn format_workspace_dsl(work: &MoonWork) -> anyhow::Result<String> {
+fn format_workspace_members(work: &MoonWork) -> anyhow::Result<String> {
     let mut out = String::new();
 
     if work.use_paths.is_empty() {
@@ -161,6 +176,12 @@ fn format_workspace_dsl(work: &MoonWork) -> anyhow::Result<String> {
         out.push_str("]\n");
     }
 
+    Ok(out)
+}
+
+fn format_workspace_dsl(work: &MoonWork) -> anyhow::Result<String> {
+    let mut out = format_workspace_members(work)?;
+
     if let Some(preferred_target) = work.preferred_target {
         out.push_str("preferred_target = ");
         out.push_str(&serde_json_lenient::to_string(preferred_target.to_flag())?);
@@ -168,6 +189,10 @@ fn format_workspace_dsl(work: &MoonWork) -> anyhow::Result<String> {
     }
 
     Ok(out)
+}
+
+fn format_workspace_dsl_for_moon_fmt(work: &MoonWork) -> anyhow::Result<String> {
+    format_workspace_members(work)
 }
 
 fn write_text_with_trailing_newline(writer: &mut impl Write, content: &str) -> anyhow::Result<()> {
@@ -219,6 +244,17 @@ mod tests {
             json,
             "members = [\n  \"./app/main\",\n]\npreferred_target = \"wasm-gc\"\n"
         );
+    }
+
+    #[test]
+    fn format_for_moon_fmt_removes_deprecated_preferred_target() {
+        let workspace = MoonWork {
+            use_paths: vec![PathBuf::from(".").join("app").join("main")],
+            preferred_target: Some(TargetBackend::WasmGC),
+        };
+
+        let json = format_workspace_dsl_for_moon_fmt(&workspace).unwrap();
+        assert_eq!(json, "members = [\n  \"./app/main\",\n]\n");
     }
 
     #[cfg(windows)]

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -142,8 +142,8 @@ forward instead of letting later phases infer it again. In particular:
 Source directory, `.mooncakes` directory, target directory, and optional project
 manifest path are user/config facts from project discovery. The synced
 dependency result is derived data: it contains the resolved module
-relationships, module source directories, and workspace preferred target
-produced by dependency sync. `ResolveOutput` should contain resolved
+relationships and module source directories produced by dependency sync.
+`ResolveOutput` should contain resolved
 build-model data derived from those inputs, not repeat the captured discovery
 paths.
 
@@ -202,7 +202,10 @@ explicit workspace root via `moon.work`, following the same discovery precedence
 The workspace manifest is intentionally small. `moon.work` currently supports:
 
 - `members = ["./app", "./lib"]` to list workspace roots.
-- `preferred_target = "wasm-gc"` to set the preferred default target for the workspace.
+
+`preferred_target` in `moon.work` is deprecated. Commands warn when they read
+it, but they do not use it for backend selection. `moon fmt` removes it. Set
+`preferred_target` in each module manifest instead.
 
 When Moon writes `use` entries, relative paths are normalized with `/` separators. Absolute paths
 are kept as absolute OS-specific paths and are not made portable.
@@ -361,7 +364,7 @@ If the package is virtual, then a list of virtual package checking nodes will be
 
 For `moon check` and `moon build` without an explicit `--target`, CLI planning
 may first split selected packages into multiple backend groups using
-`module preferred_target -> workspace preferred_target -> default backend`,
+`module preferred_target -> default backend`,
 then emit intents separately for each backend group.
 
 This mapping is also on a migration path for main packages: release N keeps the

--- a/docs/dev/reference/workspace.md
+++ b/docs/dev/reference/workspace.md
@@ -37,10 +37,11 @@ A workspace manifest defines:
 
 - `members`
   - the module directories contained by the workspace
-- `preferred_target`
-  - an optional default backend for the workspace
 
 Workspace members are canonicalized relative to the workspace root and deduped.
+`preferred_target` in `moon.work` is deprecated: commands warn when they read
+it, but they do not use it for backend selection. `moon fmt` removes it. Use
+module-level `preferred_target` instead.
 
 The workspace root may or may not also contain a `moon.mod.json`.
 
@@ -112,8 +113,8 @@ All of them operate on the selected project rather than a single member, but
 - they accept package/path selectors across the selected project,
 - they may split one invocation into multiple backend-specific runs when
   `--target` is omitted,
-- and they use `module preferred_target -> workspace preferred_target ->
-  default backend` to decide those runs.
+- and they use `module preferred_target -> default backend` to decide those
+  runs.
 
 That makes them more than just "project-scoped"; they are the current
 workspace-wide target-planning commands.


### PR DESCRIPTION
## Summary

Deprecates `preferred_target` in `moon.work` while preserving compatibility for existing workspaces.

## Why

Workspace-level target selection is being replaced by module-level `preferred_target`. Existing `moon.work` files should warn when they still use the deprecated field, but ordinary workspace maintenance commands should not unexpectedly rewrite it away.

## Correctness

The parser still accepts the deprecated field and build planning continues to honor it as a compatibility fallback. Warnings are emitted when the field is observed, and the only path that removes it is workspace formatting through `moon fmt`.

## Scope

The change is limited to workspace manifest formatting, warning emission, targeted workspace command behavior, tests, and the developer reference docs.