### PR TITLE
fix: use FSEvents for macOS watch

### DIFF
--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -48,6 +48,7 @@ which.workspace = true
 chrono.workspace = true
 log.workspace = true
 walkdir.workspace = true
+notify = "6.1.1"
 tokio = { workspace = true, features = ["rt", "signal"] }
 tokio-util.workspace = true
 clap_complete.workspace = true
@@ -76,12 +77,6 @@ features = [
     "Win32_System_Threading",
 ]
 version = "0.59.0"
-
-[target."cfg(not(target_os = \"macos\"))".dependencies]
-notify = "6.1.1"
-
-[target."cfg(target_os = \"macos\")".dependencies]
-notify = { version = "6.1.1", default-features = false, features = ["macos_fsevent"] }
 
 [target."cfg(windows)".dependencies]
 junction = "1"

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -81,7 +81,7 @@ version = "0.59.0"
 notify = "6.1.1"
 
 [target."cfg(target_os = \"macos\")".dependencies]
-notify = { version = "6.1.1", default-features = false, features = ["crossbeam-channel", "macos_kqueue"] }
+notify = { version = "6.1.1", default-features = false, features = ["macos_fsevent"] }
 
 [target."cfg(windows)".dependencies]
 junction = "1"

--- a/crates/moon/src/watch/mod.rs
+++ b/crates/moon/src/watch/mod.rs
@@ -67,7 +67,10 @@ pub(crate) fn watching(
 
     // Setup watcher
     let (tx, rx) = std::sync::mpsc::channel();
-    debug!("Creating file watcher with default config");
+    debug!(
+        backend = ?RecommendedWatcher::kind(),
+        "Creating file watcher with default config"
+    );
     let mut watcher = RecommendedWatcher::new(tx, Config::default())
         .context("Failed to create a directory watcher")?;
 
@@ -96,23 +99,40 @@ pub(crate) fn watching(
         watcher
             .watch(watch_dir, RecursiveMode::Recursive)
             .with_context(|| format!("Failed to watch directory: '{}'", watch_dir.display()))?;
+        info!(
+            backend = ?RecommendedWatcher::kind(),
+            "Using file watcher backend"
+        );
 
         // in watch mode, moon is a long-running process that should handle errors as much as possible rather than throwing them up and then exiting.
         const DEBOUNCE_TIME: Duration = Duration::from_millis(300);
         debug!("Watcher loop started (debounce = {:?})", DEBOUNCE_TIME);
         while let Ok(res) = rx.recv() {
-            let Ok(evt) = res else {
-                warn!(?res, "Watcher event channel returned an error");
-                continue;
+            let evt = match res {
+                Ok(evt) => {
+                    log_watch_event(&evt);
+                    evt
+                }
+                Err(err) => {
+                    warn!(error = ?err, "Watcher event channel returned an error");
+                    continue;
+                }
             };
 
             // Debounce events
             let mut evt_list = vec![evt];
             let start = std::time::Instant::now();
             while start.elapsed() < DEBOUNCE_TIME {
-                if let Ok(Ok(evt)) = rx.recv_timeout(DEBOUNCE_TIME.saturating_sub(start.elapsed()))
-                {
-                    evt_list.push(evt);
+                match rx.recv_timeout(DEBOUNCE_TIME.saturating_sub(start.elapsed())) {
+                    Ok(Ok(evt)) => {
+                        log_watch_event(&evt);
+                        evt_list.push(evt);
+                    }
+                    Ok(Err(err)) => {
+                        warn!(error = ?err, "Watcher event channel returned an error");
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
                 }
             }
 
@@ -139,6 +159,10 @@ pub(crate) fn watching(
         }
     }
     Ok(0)
+}
+
+fn log_watch_event(event: &notify::Event) {
+    debug!(event = ?event, "Received filesystem event");
 }
 
 /// Check if the event kind is relevant for a rebuild/rerun.


### PR DESCRIPTION
## Summary

Switch macOS watch mode back to the FSEvents backend and add debug logging for raw filesystem events and watcher errors.

## Why

The kqueue backend recursively registers individual file descriptors for the watched tree. Since Moon currently watches the source root and filters generated output after events arrive, volatile build output under `_build` can still be registered by kqueue and trigger backend bookkeeping failures when files are deleted or recreated quickly.

## Correctness

FSEvents is the default macOS backend in `notify` and better matches Moon's current watch model: subscribe to the project tree, then apply Moon-specific filtering for generated output and irrelevant files. The added logs make it easier to tell whether the backend emitted events or Moon filtered them.

## How to Validate

On macOS, run watch mode with watcher debug logs enabled from a MoonBit project:

```sh
RUST_LOG=moon::watch=debug moon check --watch
```

When running from a source checkout, the equivalent command is:

```sh
RUST_LOG=moon::watch=debug cargo run -p moon -- check --watch
```

Useful signals in the log:

- `Using file watcher backend` should report `Fsevent`.
- Source edits should produce `Received filesystem event`, then either `Triggered by path ...` and a rerun, or an ignore/filtering log explaining why no rerun happened.
- Build-output churn under `_build` may still be seen by the backend, but should be filtered by Moon and should not trigger an endless rebuild loop.
- `Watcher event channel returned an error` means `notify` reported an error instead of a normal event; keep the error payload.
- Events containing `Rescan` or `rescan:` are especially useful follow-up signals. This PR logs them but intentionally does not change rerun policy for them.

If a source edit does not produce any `Received filesystem event`, the backend did not report the change. If the event appears but no rerun happens, the issue is likely in Moon's filtering or relevance logic.

## Scope

This is intentionally limited to the backend selection and diagnostics. It does not change rerun filtering policy or rescan/metadata handling.