### PR TITLE
Scope moon run preferred target to selected module

### DIFF
--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -516,6 +516,22 @@ pub(crate) fn plan_run_rr_from_resolved(
     resolve_output: ResolveOutput,
     try_tcc_run: bool,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
+    let input_path = cmd
+        .package_or_mbt_file
+        .clone()
+        .expect("package run planning requires a positional input");
+    let selection = resolve_run_selection(&input_path, &resolve_output)?;
+    let package = resolve_output.pkg_dirs.get_package(selection.package);
+    let selected_target_backend = Some(
+        selected_target_backend
+            .or_else(|| {
+                resolve_output
+                    .module_rel
+                    .module_info(package.module)
+                    .preferred_target
+            })
+            .unwrap_or_default(),
+    );
     let mut preconfig = preconfig_compile(
         &cmd.auto_sync_flags,
         cli,
@@ -526,13 +542,8 @@ pub(crate) fn plan_run_rr_from_resolved(
     );
     preconfig.try_tcc_run = try_tcc_run;
 
-    let input_path = cmd
-        .package_or_mbt_file
-        .clone()
-        .expect("package run planning requires a positional input");
     let value_tracing = cmd.build_flags.enable_value_tracing;
 
-    let selection = resolve_run_selection(&input_path, &resolve_output)?;
     let output = UserDiagnostics::from_flags(cli);
     let planning_context = rr_build::prepare_resolved_build(
         &preconfig,

--- a/crates/moon/src/tests/planner/target_backend_planning.rs
+++ b/crates/moon/src/tests/planner/target_backend_planning.rs
@@ -546,6 +546,49 @@ fn mixed_backend_run_planning_is_target_aware() {
 }
 
 #[test]
+fn conflicting_workspace_preferred_targets_run_selection_uses_selected_module_backend() {
+    let fixture = PlanningFixture::new("workspace_conflicting_run_preferred_targets.in")
+        .expect("fixture should resolve");
+
+    let (cli, cmd) =
+        parse_run_command(&["run", "js_preferred/src/main", "--dry-run", "--sort-input"]);
+    let run_js = fixture
+        .plan_run_graph_with_cli(&cli, &cmd)
+        .expect("js preferred run graph should plan");
+    assert_target_backend_runs(vec![run_js], &[TargetBackend::Js]);
+
+    let (cli, cmd) = parse_run_command(&[
+        "run",
+        "native_preferred/src/main",
+        "--dry-run",
+        "--sort-input",
+    ]);
+    let run_native = fixture
+        .plan_run_graph_with_cli(&cli, &cmd)
+        .expect("native preferred run graph should plan");
+    assert_target_backend_runs(vec![run_native], &[TargetBackend::Native]);
+}
+
+#[test]
+fn run_selection_without_module_preference_uses_default_backend() {
+    let fixture = PlanningFixture::new("workspace_run_default_target_with_unrelated_preference.in")
+        .expect("fixture should resolve");
+
+    let (cli, cmd) = parse_run_command(&["run", "app/src/main", "--dry-run", "--sort-input"]);
+    let run_app = fixture
+        .plan_run_graph_with_cli(&cli, &cmd)
+        .expect("default backend run graph should plan");
+    assert_target_backend_runs(vec![run_app], &[TargetBackend::WasmGC]);
+
+    let (cli, cmd) =
+        parse_run_command(&["run", "js_preferred/src/main", "--dry-run", "--sort-input"]);
+    let run_js = fixture
+        .plan_run_graph_with_cli(&cli, &cmd)
+        .expect("js preferred run graph should plan");
+    assert_target_backend_runs(vec![run_js], &[TargetBackend::Js]);
+}
+
+#[test]
 fn supported_targets_empty_packages_are_skipped_in_check_planning() {
     let fixture =
         PlanningFixture::new("supported_targets_empty.in").expect("fixture should resolve");

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -424,6 +424,93 @@ fn test_supported_targets_transitive_mismatch_fails_fast() {
 }
 
 #[test]
+fn test_run_conflicting_workspace_preferred_targets_uses_selected_module_backend() {
+    let dir = TestDir::new("workspace_conflicting_run_preferred_targets.in");
+
+    let js_stdout = get_stdout(
+        &dir,
+        [
+            "run",
+            "js_preferred/src/main",
+            "--dry-run",
+            "--sort-input",
+            "--nostd",
+        ],
+    );
+    let js_stderr = get_stderr(
+        &dir,
+        [
+            "run",
+            "js_preferred/src/main",
+            "--dry-run",
+            "--sort-input",
+            "--nostd",
+        ],
+    );
+    assert!(
+        !js_stderr.contains(PREFERRED_TARGET_CONFLICT_WARNING),
+        "stderr: {js_stderr}"
+    );
+    assert_contains_and_absent(
+        &js_stdout,
+        &["./_build/js/", "-target js"],
+        &["./_build/wasm-gc/", "./_build/native/", "-target wasm-gc"],
+    );
+
+    let native_stdout = get_stdout(
+        &dir,
+        [
+            "run",
+            "native_preferred/src/main",
+            "--dry-run",
+            "--sort-input",
+            "--nostd",
+        ],
+    );
+    let native_stderr = get_stderr(
+        &dir,
+        [
+            "run",
+            "native_preferred/src/main",
+            "--dry-run",
+            "--sort-input",
+            "--nostd",
+        ],
+    );
+    assert!(
+        !native_stderr.contains(PREFERRED_TARGET_CONFLICT_WARNING),
+        "stderr: {native_stderr}"
+    );
+    assert_contains_and_absent(
+        &native_stdout,
+        &["./_build/native/", "-target native"],
+        &["./_build/wasm-gc/", "./_build/js/", "-target wasm-gc"],
+    );
+}
+
+#[test]
+fn test_run_without_module_preference_ignores_unrelated_module_preference() {
+    let dir = TestDir::new("workspace_run_default_target_with_unrelated_preference.in");
+
+    let stdout = get_stdout(
+        &dir,
+        [
+            "run",
+            "app/src/main",
+            "--dry-run",
+            "--sort-input",
+            "--nostd",
+        ],
+    );
+
+    assert_contains_and_absent(
+        &stdout,
+        &["./_build/wasm-gc/", "-target wasm-gc"],
+        &["./_build/js/", "-target js"],
+    );
+}
+
+#[test]
 fn test_supported_targets_virtual_root_dep_mismatch_fails_fast() {
     let dir = TestDir::new("supported_targets_virtual_root_mismatch.in");
 

--- a/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/js_preferred/moon.mod.json
+++ b/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/js_preferred/moon.mod.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace/js_preferred",
+  "version": "0.1.0",
+  "source": "src",
+  "preferred-target": "js"
+}

--- a/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/js_preferred/src/main/main.mbt
+++ b/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/js_preferred/src/main/main.mbt
@@ -1,0 +1,3 @@
+fn main {
+  println("js")
+}

--- a/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/js_preferred/src/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/js_preferred/src/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/moon.work
+++ b/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/moon.work
@@ -1,0 +1,4 @@
+members = [
+  "./js_preferred",
+  "./native_preferred",
+]

--- a/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/native_preferred/moon.mod.json
+++ b/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/native_preferred/moon.mod.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace/native_preferred",
+  "version": "0.1.0",
+  "source": "src",
+  "preferred-target": "native"
+}

--- a/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/native_preferred/src/main/main.mbt
+++ b/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/native_preferred/src/main/main.mbt
@@ -1,0 +1,3 @@
+fn main {
+  println("native")
+}

--- a/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/native_preferred/src/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/workspace_conflicting_run_preferred_targets.in/native_preferred/src/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/app/moon.mod.json
+++ b/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/app/moon.mod.json
@@ -1,0 +1,5 @@
+{
+  "name": "workspace/app",
+  "version": "0.1.0",
+  "source": "src"
+}

--- a/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/app/src/main/main.mbt
+++ b/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/app/src/main/main.mbt
@@ -1,0 +1,3 @@
+fn main {
+  println("app")
+}

--- a/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/app/src/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/app/src/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/js_preferred/moon.mod.json
+++ b/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/js_preferred/moon.mod.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace/js_preferred",
+  "version": "0.1.0",
+  "source": "src",
+  "preferred-target": "js"
+}

--- a/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/js_preferred/src/main/main.mbt
+++ b/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/js_preferred/src/main/main.mbt
@@ -1,0 +1,3 @@
+fn main {
+  println("js")
+}

--- a/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/js_preferred/src/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/js_preferred/src/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/moon.work
+++ b/crates/moon/tests/test_cases/workspace_run_default_target_with_unrelated_preference.in/moon.work
@@ -1,0 +1,4 @@
+members = [
+  "./app",
+  "./js_preferred",
+]


### PR DESCRIPTION
## Why

`moon run` resolves a single package to execute, but its implicit target selection still considered preferred targets from every local workspace module. In a workspace whose modules prefer different targets, running a package from one module could fall back to the default target and emit a conflict warning even though the selected package's module has an unambiguous preference.

## What changed

This changes package `moon run` planning to resolve the run package before preparing the build target. When no explicit `--target` is provided, the planner now seeds the effective target from the selected package's containing module.

## Why this is correct

`moon run` has a single selected package, so the relevant implicit target preference is the selected package's module preference. Explicit `--target` still takes precedence, and other workspace-wide commands keep their existing split/default behavior.

## Scope

The change is limited to package `moon run` planning plus regression coverage for conflicting workspace module preferences.