### PR TITLE
chore: bump n2 to head

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "n2"
 version = "0.1.5"
-source = "git+https://github.com/moonbitlang/n2.git?rev=113d577c65f9ebf350f1f9f7359a242e64883b37#113d577c65f9ebf350f1f9f7359a242e64883b37"
+source = "git+https://github.com/moonbitlang/n2.git?rev=3f3eb821ba064a91076aa42042b2d376a2a11bce#3f3eb821ba064a91076aa42042b2d376a2a11bce"
 dependencies = [
  "anyhow",
  "argh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.90"
 edition = "2024"
 
 [workspace.dependencies]
-n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "113d577c65f9ebf350f1f9f7359a242e64883b37" }
+n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "3f3eb821ba064a91076aa42042b2d376a2a11bce" }
 arcstr = { version = "1.2", features = ["serde"] }
 moonbuild = { path = "./crates/moonbuild", version = "*" }
 moonbuild-rupes-recta = { path = "./crates/moonbuild-rupes-recta", version = "*" }


### PR DESCRIPTION
## Why

Update the pinned `moonbitlang/n2` dependency to the current upstream HEAD so MoonBuild tracks the latest executor changes.

## Upstream n2 changelog

Range: `113d577c` -> `3f3eb821` ([compare](https://github.com/moonbitlang/n2/compare/113d577c65f9ebf350f1f9f7359a242e64883b37...3f3eb821ba064a91076aa42042b2d376a2a11bce))

Notable changes in this bump:

- Makes `jemalloc` opt-in instead of part of the default build.
- Adds build working-directory support and resolves task files relative to that cwd.
- Avoids the Linux `addchdir` spawn dependency.
- Disables fancy progress when `TERM=dumb`, including the Windows terminal path.
- Decodes Windows process errors as UTF-16.
- Cleans up trace and signal internals by removing an unused async trace scope, avoiding trace-state borrows across callbacks, and removing an unnecessary `static mut` interrupt flag.

## Correctness

`Cargo.toml` and `Cargo.lock` now point to the same `n2` commit, keeping dependency resolution consistent. No source changes were needed for the bump.

## Scope

This PR is limited to the workspace dependency pin and lockfile entry.