### PR TITLE
ci: parallelize core tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,14 +206,15 @@ jobs:
       - name: Test core (Unix)
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target wasm-gc
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target js
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target wasm
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target native
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target wasm-gc
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target js
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target wasm
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target native
+          test_jobs=$(sysctl -n hw.logicalcpu 2>/dev/null || nproc 2>/dev/null || echo 1)
+          cargo run --bin moon -- -C ~/.moon/lib/core test --target wasm-gc -j "$test_jobs"
+          cargo run --bin moon -- -C ~/.moon/lib/core test --target js -j "$test_jobs"
+          cargo run --bin moon -- -C ~/.moon/lib/core test --target wasm -j "$test_jobs"
+          cargo run --bin moon -- -C ~/.moon/lib/core test --target native -j "$test_jobs"
+          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target wasm-gc -j "$test_jobs"
+          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target js -j "$test_jobs"
+          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target wasm -j "$test_jobs"
+          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target native -j "$test_jobs"
 
       # LLVM is currently disabled because it doesn't exist on non-bleeding channels.
       # TODO: Add this back when we add LLVM to nightly
@@ -265,14 +266,15 @@ jobs:
 
       - name: Test core (Windows)
         run: |
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target wasm-gc
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target js
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target wasm
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target native
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm-gc
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target js
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target native
+          $testJobs = [Environment]::ProcessorCount
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target wasm-gc -j $testJobs
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target js -j $testJobs
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target wasm -j $testJobs
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target native -j $testJobs
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm-gc -j $testJobs
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target js -j $testJobs
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm -j $testJobs
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target native -j $testJobs
 
       # LLVM is currently disabled because it doesn't exist on non-bleeding channels.
       # TODO: Add this back when we add LLVM to nightly


### PR DESCRIPTION
## Summary

- Pass the runner CPU count to `moon test -j` for core tests on Unix and Windows.
- Keep using `cargo run --bin moon` for the core test commands.

## Motivation

The core test CI step spends a significant part of its time running compiled test executables sequentially. Build execution already uses available parallelism when `-j` is omitted, but the test executable runner defaults to one job unless `-j` is supplied.

## Correctness

This keeps the same targets, profiles, and command shape, while supplying an explicit numeric job limit from the current CI runner. The build phase may receive the same explicit limit, and the test execution phase now uses it instead of the sequential default.

## Minimality

This is a workflow-only change. It does not change CLI semantics or split the build/test parallelism flags; that can remain a separate design discussion.