### PR TITLE
Fix async wasm host resource handling

### DIFF
--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -345,6 +345,28 @@ impl AsyncHostState {
         }
         self.files.remove(key).ok_or(AsyncHostError::Badf)
     }
+
+    fn take_workers(&mut self) -> Vec<HostWorkerHandle> {
+        std::mem::take(&mut self.workers)
+            .into_iter()
+            .map(|(_, worker)| worker)
+            .collect()
+    }
+
+    #[cfg(windows)]
+    fn drain_pending_io_for_raw_fd(&mut self, raw_fd: RawFd) -> AsyncHostResult<()> {
+        let pending: Vec<_> = self
+            .io_results
+            .iter()
+            .filter_map(|(key, result)| (result.pending_raw_fd() == Some(raw_fd)).then_some(key))
+            .collect();
+        for key in pending {
+            if let Some(result) = self.io_results.get_mut(key) {
+                result.cancel_and_drain_pending()?;
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -362,6 +384,7 @@ struct HostEvent {
     poll: HostPollKey,
     generation: u64,
     index: i32,
+    fd_handle: Option<HostHandle>,
 }
 
 #[cfg(windows)]
@@ -380,6 +403,7 @@ struct HostIoResult {
     buffer: Vec<u8>,
     guest_offset: i32,
     direction: Option<HostIoDirection>,
+    pending_raw_fd: Option<RawFd>,
 }
 
 #[cfg(windows)]
@@ -399,6 +423,7 @@ impl HostIoResult {
             buffer,
             guest_offset,
             direction: None,
+            pending_raw_fd: None,
         }
     }
 
@@ -417,6 +442,85 @@ impl HostIoResult {
         let len = usize::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)?;
         let data = self.buffer.get(..len).ok_or(AsyncHostError::Fault)?;
         memory.write_exact(self.guest_offset, data)
+    }
+
+    fn pending_raw_fd(&self) -> Option<RawFd> {
+        self.pending_raw_fd
+    }
+
+    fn mark_pending(&mut self, raw_fd: RawFd) -> AsyncHostResult<()> {
+        if self.pending_raw_fd.is_some() {
+            return Err(AsyncHostError::Inval);
+        }
+        self.pending_raw_fd = Some(raw_fd);
+        Ok(())
+    }
+
+    fn clear_pending(&mut self) {
+        self.pending_raw_fd = None;
+    }
+
+    fn cancel_pending(&mut self) -> AsyncHostResult<i32> {
+        use windows_sys::Win32::Foundation::{ERROR_IO_INCOMPLETE, ERROR_NOT_FOUND};
+        use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult};
+
+        let Some(raw_fd) = self.pending_raw_fd else {
+            return Ok(0);
+        };
+        let overlapped = self.overlapped_ptr();
+        if unsafe { CancelIoEx(raw_fd, overlapped) } == 0 {
+            let errno = last_errno();
+            if errno != ERROR_NOT_FOUND as i32 {
+                return Err(AsyncHostError::Native(errno));
+            }
+            self.clear_pending();
+            return Ok(0);
+        }
+
+        let mut bytes_transferred = 0;
+        if unsafe { GetOverlappedResult(raw_fd, overlapped, &mut bytes_transferred, 0) } != 0 {
+            self.clear_pending();
+            return Ok(0);
+        }
+        if last_errno() == ERROR_IO_INCOMPLETE as i32 {
+            Ok(1)
+        } else {
+            self.clear_pending();
+            Ok(0)
+        }
+    }
+
+    fn cancel_and_drain_pending(&mut self) -> AsyncHostResult<()> {
+        use windows_sys::Win32::Foundation::{ERROR_NOT_FOUND, ERROR_OPERATION_ABORTED};
+        use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult};
+
+        let Some(raw_fd) = self.pending_raw_fd else {
+            return Ok(());
+        };
+        let overlapped = self.overlapped_ptr();
+        if unsafe { CancelIoEx(raw_fd, overlapped) } == 0 {
+            let errno = last_errno();
+            if errno != ERROR_NOT_FOUND as i32 {
+                return Err(AsyncHostError::Native(errno));
+            }
+        }
+
+        let mut bytes_transferred = 0;
+        if unsafe { GetOverlappedResult(raw_fd, overlapped, &mut bytes_transferred, 1) } == 0 {
+            let errno = last_errno();
+            if errno != ERROR_OPERATION_ABORTED as i32 && errno != ERROR_NOT_FOUND as i32 {
+                return Err(AsyncHostError::Native(errno));
+            }
+        }
+        self.clear_pending();
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+impl Drop for HostIoResult {
+    fn drop(&mut self) {
+        let _ = self.cancel_and_drain_pending();
     }
 }
 
@@ -554,11 +658,18 @@ impl AsyncHost {
         let mut state = self.state.lock().unwrap();
         let poll = Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?);
         let mut poll = poll.lock().unwrap();
-        poll::event_list_get(&poll.instance, index)?;
+        let event = poll::event_list_get(&poll.instance, index)?;
+        let raw_fd = poll::event_get_fd(event);
+        let fd_handle = poll
+            .registered_fds
+            .get(&raw_fd_key(raw_fd))
+            .copied()
+            .or_else(|| completion_event_fd(raw_fd));
         let key = state.events.insert(HostEvent {
             poll: poll_key,
             generation: poll.event_generation,
             index,
+            fd_handle,
         });
         poll.event_handles.push(key);
         Ok(handle_from_key(key))
@@ -585,14 +696,18 @@ impl AsyncHost {
     }
 
     pub(crate) fn poll_event_fd(&self, event_handle: u64) -> AsyncHostResult<HostHandle> {
-        self.with_event(event_handle, |poll, event| {
-            let raw_fd = poll::event_get_fd(event);
-            poll.registered_fds
-                .get(&raw_fd_key(raw_fd))
-                .copied()
-                .map(Ok)
-                .unwrap_or_else(|| raw_fd_to_guest(raw_fd))
-        })
+        let event = key_from_handle::<HostEventKey>(event_handle);
+        let (event, poll) = {
+            let state = self.state.lock().unwrap();
+            let event = *state.events.get(event).ok_or(AsyncHostError::Badf)?;
+            let poll = Arc::clone(state.polls.get(event.poll).ok_or(AsyncHostError::Badf)?);
+            (event, poll)
+        };
+        let poll = poll.lock().unwrap();
+        if poll.event_generation != event.generation {
+            return Err(AsyncHostError::Badf);
+        }
+        event.fd_handle.ok_or(AsyncHostError::Badf)
     }
 
     #[cfg(unix)]
@@ -626,6 +741,10 @@ impl AsyncHost {
             let state = self.state.lock().unwrap();
             #[cfg(unix)]
             if state.completion_source.is_some() {
+                return Err(AsyncHostError::Inval);
+            }
+            #[cfg(windows)]
+            if state.completion_port.is_some() {
                 return Err(AsyncHostError::Inval);
             }
             Arc::clone(
@@ -663,6 +782,14 @@ impl AsyncHost {
     }
 
     pub(crate) fn destroy_thread_pool(&self) {
+        let workers = {
+            let mut state = self.state.lock().unwrap();
+            state.take_workers()
+        };
+        for worker in workers {
+            thread_pool::free_worker(worker);
+        }
+
         let mut state = self.state.lock().unwrap();
         #[cfg(unix)]
         {
@@ -858,6 +985,8 @@ impl AsyncHost {
     pub(crate) fn close_fd(&self, handle: HostHandle) -> AsyncHostResult<()> {
         let mut state = self.state.lock().unwrap();
         let raw_fd = state.file(handle)?.raw_fd();
+        #[cfg(windows)]
+        state.drain_pending_io_for_raw_fd(raw_fd)?;
         #[cfg(unix)]
         if state.completion_source == Some(handle) {
             state.completion_source = None;
@@ -866,13 +995,13 @@ impl AsyncHost {
                 poll.lock().unwrap().completion_notifier = None;
             }
         }
-        state.remove_file(handle)?;
         for poll in state.polls.values() {
             poll.lock()
                 .unwrap()
                 .registered_fds
                 .remove(&raw_fd_key(raw_fd));
         }
+        state.remove_file(handle)?;
         Ok(())
     }
 
@@ -964,6 +1093,8 @@ impl AsyncHost {
     pub(crate) fn free_io_result(&self, handle: u64) -> AsyncHostResult<()> {
         let key = key_from_handle::<HostIoResultKey>(handle);
         let mut state = self.state.lock().unwrap();
+        let result = state.io_results.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        result.cancel_and_drain_pending()?;
         let mut result = state.io_results.remove(key).ok_or(AsyncHostError::Badf)?;
         state
             .io_results_by_overlapped
@@ -987,35 +1118,13 @@ impl AsyncHost {
         result_handle: u64,
         fd_handle: HostHandle,
     ) -> AsyncHostResult<i32> {
-        use windows_sys::Win32::Foundation::{ERROR_IO_INCOMPLETE, ERROR_NOT_FOUND};
-        use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult};
-
         let mut state = self.state.lock().unwrap();
-        let raw_fd = state.file(fd_handle)?.raw_fd();
+        state.file(fd_handle)?;
         let result = state
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
-        let overlapped = result.overlapped_ptr();
-        let cancelled = unsafe { CancelIoEx(raw_fd, overlapped) };
-        if cancelled == 0 {
-            let errno = last_errno();
-            return if errno == ERROR_NOT_FOUND as i32 {
-                Ok(0)
-            } else {
-                Err(AsyncHostError::Native(errno))
-            };
-        }
-
-        let mut bytes_transferred = 0;
-        if unsafe { GetOverlappedResult(raw_fd, overlapped, &mut bytes_transferred, 0) } != 0 {
-            return Ok(0);
-        }
-        if last_errno() == ERROR_IO_INCOMPLETE as i32 {
-            Ok(1)
-        } else {
-            Ok(0)
-        }
+        result.cancel_pending()
     }
 
     #[cfg(windows)]
@@ -1038,8 +1147,17 @@ impl AsyncHost {
             GetOverlappedResult(raw_fd, result.overlapped_ptr(), &mut bytes_transferred, 0)
         } == 0
         {
-            return Err(last_native_error());
+            let error = last_native_error();
+            if !matches!(
+                error,
+                AsyncHostError::Native(errno)
+                    if errno == windows_sys::Win32::Foundation::ERROR_IO_INCOMPLETE as i32
+            ) {
+                result.clear_pending();
+            }
+            return Err(error);
         }
+        result.clear_pending();
         let bytes_transferred =
             i32::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)?;
         result.copy_read_result(memory, bytes_transferred)?;
@@ -1053,7 +1171,7 @@ impl AsyncHost {
         fd_handle: HostHandle,
         result_handle: u64,
     ) -> AsyncHostResult<i32> {
-        use windows_sys::Win32::Foundation::ERROR_HANDLE_EOF;
+        use windows_sys::Win32::Foundation::{ERROR_HANDLE_EOF, ERROR_IO_PENDING};
         use windows_sys::Win32::Storage::FileSystem::ReadFile;
 
         let mut state = self.state.lock().unwrap();
@@ -1062,6 +1180,9 @@ impl AsyncHost {
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
+        if result.pending_raw_fd().is_some() {
+            return Err(AsyncHostError::Inval);
+        }
         result.direction = Some(HostIoDirection::Read);
         let len = u32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
         let mut bytes_transferred = 0;
@@ -1083,6 +1204,9 @@ impl AsyncHost {
         let errno = last_errno();
         if errno == ERROR_HANDLE_EOF as i32 {
             Ok(0)
+        } else if errno == ERROR_IO_PENDING as i32 {
+            result.mark_pending(raw_fd)?;
+            Err(AsyncHostError::Native(errno))
         } else {
             Err(AsyncHostError::Native(errno))
         }
@@ -1095,6 +1219,7 @@ impl AsyncHost {
         fd_handle: HostHandle,
         result_handle: u64,
     ) -> AsyncHostResult<i32> {
+        use windows_sys::Win32::Foundation::ERROR_IO_PENDING;
         use windows_sys::Win32::Storage::FileSystem::WriteFile;
 
         let mut state = self.state.lock().unwrap();
@@ -1103,6 +1228,9 @@ impl AsyncHost {
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
+        if result.pending_raw_fd().is_some() {
+            return Err(AsyncHostError::Inval);
+        }
         result.direction = Some(HostIoDirection::Write);
         let len_i32 = i32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
         let data = memory.read_exact(result.guest_offset, len_i32)?;
@@ -1121,7 +1249,11 @@ impl AsyncHost {
         if success != 0 {
             i32::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
         } else {
-            Err(last_native_error())
+            let error = last_native_error();
+            if matches!(error, AsyncHostError::Native(errno) if errno == ERROR_IO_PENDING as i32) {
+                result.mark_pending(raw_fd)?;
+            }
+            Err(error)
         }
     }
 
@@ -1171,9 +1303,7 @@ impl AsyncHost {
                 .clone()
                 .ok_or(AsyncHostError::Badf)?;
             self.spawn_worker_thread(HostWorkerJob { job_id, job_handle }, move |worker_job| {
-                completion_notifier
-                    .notify(worker_job.job_id)
-                    .expect("failed to notify async host completion pipe");
+                let _ = completion_notifier.notify(worker_job.job_id);
             })
         };
         #[cfg(windows)]
@@ -1185,8 +1315,7 @@ impl AsyncHost {
                 .completion_port
                 .ok_or(AsyncHostError::Badf)?;
             self.spawn_worker_thread(HostWorkerJob { job_id, job_handle }, move |worker_job| {
-                poll::post_thread_pool_completion(completion_port, worker_job.job_id)
-                    .expect("failed to post async host completion packet");
+                let _ = poll::post_thread_pool_completion(completion_port, worker_job.job_id);
             })
         };
         let key = self.state.lock().unwrap().workers.insert(worker);
@@ -1236,7 +1365,7 @@ impl AsyncHost {
             .workers
             .get(key_from_handle::<HostWorkerKey>(worker_handle))
             .ok_or(AsyncHostError::Badf)?;
-        Ok(thread_pool::cancel_worker(worker))
+        thread_pool::cancel_worker(worker)
     }
 
     pub(crate) fn get_read_result(
@@ -1353,6 +1482,12 @@ impl AsyncHost {
     }
 }
 
+impl Drop for AsyncHost {
+    fn drop(&mut self) {
+        self.destroy_thread_pool();
+    }
+}
+
 struct SharedFileTable {
     state: Arc<Mutex<AsyncHostState>>,
 }
@@ -1384,11 +1519,11 @@ impl HostFileTable for SharedFileTable {
         handle: HostHandle,
         f: impl FnOnce(RawFd) -> AsyncHostResult<U>,
     ) -> AsyncHostResult<U> {
-        let file = {
-            let mut state = self.state.lock().unwrap();
-            state.file_mut(handle)?.duplicate()?
+        let raw_fd = {
+            let state = self.state.lock().unwrap();
+            state.file(handle)?.raw_fd()
         };
-        f(file.raw_fd())
+        f(raw_fd)
     }
 
     fn with_host_file_mut<U>(
@@ -1396,9 +1531,9 @@ impl HostFileTable for SharedFileTable {
         handle: HostHandle,
         f: impl FnOnce(&mut HostFile) -> AsyncHostResult<U>,
     ) -> AsyncHostResult<U> {
-        // TODO(async-wasm): keep this path for handle-state mutations only.
-        // Blocking job bodies should clone/take the OS handle before running so
-        // worker threads do not serialize on the host table lock.
+        // Keep this path for host-owned file state operations such as readdir.
+        // Ordinary worker jobs should use with_raw_file and mirror native async
+        // by operating on the raw fd value without duplicating the OS handle.
         let mut state = self.state.lock().unwrap();
         let file = state.file_mut(handle)?;
         f(file)
@@ -1417,14 +1552,23 @@ fn last_native_error() -> AsyncHostError {
     AsyncHostError::Native(last_errno())
 }
 
-#[cfg(unix)]
-fn raw_fd_to_guest(fd: RawFd) -> AsyncHostResult<HostHandle> {
-    u64::try_from(fd).map_err(|_| AsyncHostError::Fault)
-}
-
 #[cfg(windows)]
 fn raw_fd_to_guest(fd: RawFd) -> AsyncHostResult<HostHandle> {
     Ok(fd as usize as u64)
+}
+
+#[cfg(unix)]
+fn completion_event_fd(_fd: RawFd) -> Option<HostHandle> {
+    None
+}
+
+#[cfg(windows)]
+fn completion_event_fd(fd: RawFd) -> Option<HostHandle> {
+    if fd == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
+        raw_fd_to_guest(fd).ok()
+    } else {
+        None
+    }
 }
 
 #[cfg(unix)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -1519,11 +1519,11 @@ impl HostFileTable for SharedFileTable {
         handle: HostHandle,
         f: impl FnOnce(RawFd) -> AsyncHostResult<U>,
     ) -> AsyncHostResult<U> {
-        let raw_fd = {
-            let state = self.state.lock().unwrap();
-            state.file(handle)?.raw_fd()
+        let file = {
+            let mut state = self.state.lock().unwrap();
+            state.file_mut(handle)?.duplicate()?
         };
-        f(raw_fd)
+        f(file.raw_fd())
     }
 
     fn with_host_file_mut<U>(
@@ -1531,9 +1531,8 @@ impl HostFileTable for SharedFileTable {
         handle: HostHandle,
         f: impl FnOnce(&mut HostFile) -> AsyncHostResult<U>,
     ) -> AsyncHostResult<U> {
-        // Keep this path for host-owned file state operations such as readdir.
-        // Ordinary worker jobs should use with_raw_file and mirror native async
-        // by operating on the raw fd value without duplicating the OS handle.
+        // Keep this path for host-owned file state operations such as readdir
+        // where duplicating the fd would change the directory cursor.
         let mut state = self.state.lock().unwrap();
         let file = state.file_mut(handle)?;
         f(file)
@@ -1818,6 +1817,40 @@ mod tests {
         host.free_worker(worker).unwrap();
 
         assert_eq!(host.free_worker(worker), Err(AsyncHostError::Badf));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_worker_file_survives_guest_close() {
+        let host = AsyncHost::default();
+        let [read, write] = host.pipe(false, false).unwrap();
+        let mut files = SharedFileTable {
+            state: Arc::clone(&host.state),
+        };
+
+        let byte = files
+            .with_raw_file(read, |raw_read| {
+                host.close_fd(read)?;
+                let mut input = *b"x";
+                host.write_fd(&mut input, write, 0, 0, 1)?;
+
+                let mut output = [0];
+                let ret = unsafe { libc::read(raw_read, output.as_mut_ptr().cast(), output.len()) };
+                if ret < 0 {
+                    Err(AsyncHostError::Native(
+                        std::io::Error::last_os_error()
+                            .raw_os_error()
+                            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
+                    ))
+                } else {
+                    assert_eq!(ret, 1);
+                    Ok(output[0])
+                }
+            })
+            .unwrap();
+
+        assert_eq!(byte, b'x');
+        assert_eq!(host.close_fd(read), Err(AsyncHostError::Badf));
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -460,6 +460,25 @@ impl HostIoResult {
         self.pending_raw_fd = None;
     }
 
+    fn validate_status_handle(&self, raw_fd: RawFd) -> AsyncHostResult<()> {
+        // The import boundary may receive malformed/stale fd handles. Validate
+        // before asserting the internal "pending status uses submitter fd"
+        // invariant so debug builds do not panic on bad guest input.
+        if let Some(pending_raw_fd) = self.pending_raw_fd
+            && pending_raw_fd != raw_fd
+        {
+            return Err(AsyncHostError::Badf);
+        }
+        debug_assert!(
+            match self.pending_raw_fd {
+                Some(pending_raw_fd) => pending_raw_fd == raw_fd,
+                None => true,
+            },
+            "pending IO status must be queried with the submitting handle"
+        );
+        Ok(())
+    }
+
     fn cancel_pending(&mut self) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Foundation::{ERROR_IO_INCOMPLETE, ERROR_NOT_FOUND};
         use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult};
@@ -491,7 +510,7 @@ impl HostIoResult {
     }
 
     fn cancel_and_drain_pending(&mut self) -> AsyncHostResult<()> {
-        use windows_sys::Win32::Foundation::{ERROR_NOT_FOUND, ERROR_OPERATION_ABORTED};
+        use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
         use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult};
 
         let Some(raw_fd) = self.pending_raw_fd else {
@@ -506,12 +525,10 @@ impl HostIoResult {
         }
 
         let mut bytes_transferred = 0;
-        if unsafe { GetOverlappedResult(raw_fd, overlapped, &mut bytes_transferred, 1) } == 0 {
-            let errno = last_errno();
-            if errno != ERROR_OPERATION_ABORTED as i32 && errno != ERROR_NOT_FOUND as i32 {
-                return Err(AsyncHostError::Native(errno));
-            }
-        }
+        // With bWait=TRUE the operation has reached a final status when this
+        // returns, even if the final status is an error such as EOF or broken
+        // pipe. At that point the OVERLAPPED storage can be released.
+        let _ = unsafe { GetOverlappedResult(raw_fd, overlapped, &mut bytes_transferred, 1) };
         self.clear_pending();
         Ok(())
     }
@@ -1142,6 +1159,7 @@ impl AsyncHost {
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
+        result.validate_status_handle(raw_fd)?;
         let mut bytes_transferred = 0;
         if unsafe {
             GetOverlappedResult(raw_fd, result.overlapped_ptr(), &mut bytes_transferred, 0)
@@ -1851,6 +1869,22 @@ mod tests {
 
         assert_eq!(byte, b'x');
         assert_eq!(host.close_fd(read), Err(AsyncHostError::Badf));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn io_result_status_rejects_wrong_fd_without_clearing_pending() {
+        let mut result = HostIoResult::for_file(0, Vec::new(), 0, 0);
+        let pending_fd = 1usize as RawFd;
+        let other_fd = 2usize as RawFd;
+
+        result.mark_pending(pending_fd).unwrap();
+
+        assert_eq!(
+            result.validate_status_handle(other_fd),
+            Err(AsyncHostError::Badf)
+        );
+        assert_eq!(result.pending_raw_fd(), Some(pending_fd));
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -281,7 +281,17 @@ struct AsyncHostState {
     #[cfg(unix)]
     completion_source: Option<HostHandle>,
     #[cfg(windows)]
-    completion_port: Option<poll::CompletionPort>,
+    completion_port: Option<ThreadPoolCompletionTarget>,
+    #[cfg(windows)]
+    thread_pool_generation: usize,
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ThreadPoolCompletionTarget {
+    poll: HostPollKey,
+    port: poll::CompletionPort,
+    generation: usize,
 }
 
 #[cfg(windows)]
@@ -318,11 +328,22 @@ impl Default for AsyncHostState {
             completion_source: None,
             #[cfg(windows)]
             completion_port: None,
+            #[cfg(windows)]
+            thread_pool_generation: 0,
         }
     }
 }
 
 impl AsyncHostState {
+    #[cfg(windows)]
+    fn next_thread_pool_generation(&mut self) -> usize {
+        self.thread_pool_generation = self.thread_pool_generation.wrapping_add(1);
+        if self.thread_pool_generation == 0 {
+            self.thread_pool_generation = 1;
+        }
+        self.thread_pool_generation
+    }
+
     fn invalid_fd(&self) -> HostHandle {
         handle_from_key(self.invalid_file)
     }
@@ -358,9 +379,9 @@ impl AsyncHostState {
     }
 
     fn take_workers(&mut self) -> Vec<HostWorkerHandle> {
-        std::mem::take(&mut self.workers)
-            .into_iter()
-            .map(|(_, worker)| worker)
+        let keys: Vec<_> = self.workers.keys().collect();
+        keys.into_iter()
+            .filter_map(|key| self.workers.remove(key))
             .collect()
     }
 
@@ -620,7 +641,10 @@ impl AsyncHost {
         }
         #[cfg(windows)]
         {
-            if state.completion_port == Some(poll::CompletionPort::from_poll(&poll.instance)) {
+            if state
+                .completion_port
+                .is_some_and(|target| target.poll == key_from_handle::<HostPollKey>(handle))
+            {
                 state.completion_port = None;
             }
         }
@@ -652,18 +676,53 @@ impl AsyncHost {
     }
 
     pub(crate) fn poll_wait(&self, poll_handle: u64, timeout_ms: i32) -> AsyncHostResult<i32> {
+        let poll_key = key_from_handle::<HostPollKey>(poll_handle);
+        #[cfg(windows)]
+        let (poll, thread_pool_generation) = {
+            let state = self.state.lock().unwrap();
+            let poll = Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?);
+            let thread_pool_generation = state
+                .completion_port
+                .filter(|target| target.poll == poll_key)
+                .map(|target| target.generation);
+            (poll, thread_pool_generation)
+        };
+        #[cfg(not(windows))]
         let poll = {
             let state = self.state.lock().unwrap();
-            Arc::clone(
-                state
-                    .polls
-                    .get(key_from_handle::<HostPollKey>(poll_handle))
-                    .ok_or(AsyncHostError::Badf)?,
-            )
+            Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
         };
         let (result, old_events) = {
             let mut poll_guard = poll.lock().unwrap();
+            #[cfg(not(windows))]
             let result = poll::poll_wait(&mut poll_guard.instance, timeout_ms)?;
+            #[cfg(windows)]
+            let result = {
+                let deadline = (timeout_ms >= 0).then(|| {
+                    std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms as u64)
+                });
+                let mut next_timeout = timeout_ms;
+                loop {
+                    poll::poll_wait(&mut poll_guard.instance, next_timeout)?;
+                    let result = poll::retain_current_thread_pool_completions(
+                        &mut poll_guard.instance,
+                        thread_pool_generation,
+                    )?;
+                    if result != 0 || timeout_ms == 0 {
+                        break result;
+                    }
+                    let Some(deadline) = deadline else {
+                        continue;
+                    };
+                    let now = std::time::Instant::now();
+                    if now >= deadline {
+                        break 0;
+                    }
+                    next_timeout = i32::try_from(deadline.duration_since(now).as_millis())
+                        .unwrap_or(i32::MAX)
+                        .max(1);
+                }
+            };
             poll_guard.event_generation = poll_guard.event_generation.wrapping_add(1);
             let old_events = std::mem::take(&mut poll_guard.event_handles);
             (result, old_events)
@@ -771,6 +830,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn init_thread_pool(&self, poll_handle: u64) -> AsyncHostResult<HostHandle> {
+        let poll_key = key_from_handle::<HostPollKey>(poll_handle);
         let poll = {
             let state = self.state.lock().unwrap();
             #[cfg(unix)]
@@ -781,12 +841,7 @@ impl AsyncHost {
             if state.completion_port.is_some() {
                 return Err(AsyncHostError::Inval);
             }
-            Arc::clone(
-                state
-                    .polls
-                    .get(key_from_handle::<HostPollKey>(poll_handle))
-                    .ok_or(AsyncHostError::Badf)?,
-            )
+            Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
         };
         #[cfg(unix)]
         {
@@ -810,7 +865,16 @@ impl AsyncHost {
         #[cfg(windows)]
         {
             let completion_port = poll::CompletionPort::from_poll(&poll.lock().unwrap().instance);
-            self.state.lock().unwrap().completion_port = Some(completion_port);
+            let mut state = self.state.lock().unwrap();
+            if state.completion_port.is_some() {
+                return Err(AsyncHostError::Inval);
+            }
+            let generation = state.next_thread_pool_generation();
+            state.completion_port = Some(ThreadPoolCompletionTarget {
+                poll: poll_key,
+                port: completion_port,
+                generation,
+            });
             raw_fd_to_guest(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE)
         }
     }
@@ -1347,14 +1411,18 @@ impl AsyncHost {
         };
         #[cfg(windows)]
         let worker = {
-            let completion_port = self
+            let completion_target = self
                 .state
                 .lock()
                 .unwrap()
                 .completion_port
                 .ok_or(AsyncHostError::Badf)?;
             self.spawn_worker_thread(HostWorkerJob { job_id, job_handle }, move |worker_job| {
-                let _ = poll::post_thread_pool_completion(completion_port, worker_job.job_id);
+                let _ = poll::post_thread_pool_completion(
+                    completion_target.port,
+                    worker_job.job_id,
+                    completion_target.generation,
+                );
             })
         };
         let key = self.state.lock().unwrap().workers.insert(worker);
@@ -1828,6 +1896,85 @@ mod tests {
 
         assert_eq!(host.job_get_ret(job), Err(AsyncHostError::Badf));
         assert_eq!(host.free_job(job), Err(AsyncHostError::Badf));
+    }
+
+    #[test]
+    fn worker_handles_stay_stale_after_thread_pool_reinit() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let completion_notifier = host.init_thread_pool(poll).unwrap();
+        let first_job = host
+            .insert_job(thread_pool::make_read_job(0, 1, -1))
+            .unwrap();
+        let old_worker = host.spawn_worker(42, first_job).unwrap();
+        host.poll_wait(poll, 1000).unwrap();
+        #[cfg(unix)]
+        {
+            let mut memory = [0; 4];
+            host.fetch_completion(memory.as_mut_slice(), completion_notifier, 0, 1)
+                .unwrap();
+        }
+        #[cfg(windows)]
+        {
+            let event = host.poll_get_event(poll, 0).unwrap();
+            assert_eq!(host.poll_event_fd(event).unwrap(), completion_notifier);
+            assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 42);
+        }
+
+        host.destroy_thread_pool();
+
+        host.init_thread_pool(poll).unwrap();
+        let second_job = host
+            .insert_job(thread_pool::make_read_job(0, 1, -1))
+            .unwrap();
+        let new_worker = host.spawn_worker(43, second_job).unwrap();
+        let wake_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
+
+        assert_ne!(old_worker, new_worker);
+        assert_eq!(host.cancel_worker(old_worker), Err(AsyncHostError::Badf));
+        assert_eq!(
+            host.wake_worker(old_worker, 44, wake_job),
+            Err(AsyncHostError::Badf)
+        );
+        assert_eq!(host.free_worker(old_worker), Err(AsyncHostError::Badf));
+
+        host.destroy_thread_pool();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn stale_thread_pool_completions_are_ignored_after_reinit() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+
+        host.init_thread_pool(poll).unwrap();
+        let stale_completion = host.state.lock().unwrap().completion_port.unwrap();
+        // Fill the current IOCP batch so a valid completion can sit behind
+        // stale completions from the destroyed pool generation.
+        for job_id in 0..1024 {
+            poll::post_thread_pool_completion(
+                stale_completion.port,
+                job_id,
+                stale_completion.generation,
+            )
+            .unwrap();
+        }
+        host.destroy_thread_pool();
+
+        let completion_notifier = host.init_thread_pool(poll).unwrap();
+        let current_completion = host.state.lock().unwrap().completion_port.unwrap();
+        assert_ne!(stale_completion.generation, current_completion.generation);
+
+        poll::post_thread_pool_completion(
+            current_completion.port,
+            43,
+            current_completion.generation,
+        )
+        .unwrap();
+        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+        let event = host.poll_get_event(poll, 0).unwrap();
+        assert_eq!(host.poll_event_fd(event).unwrap(), completion_notifier);
+        assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 43);
     }
 
     #[test]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -269,7 +269,7 @@ struct AsyncHostState {
     #[cfg(windows)]
     io_results: SlotMap<HostIoResultKey, Box<HostIoResult>>,
     #[cfg(windows)]
-    io_results_by_overlapped: HashMap<usize, HostIoResultKey>,
+    io_results_by_overlapped: HashMap<OverlappedAddr, HostIoResultKey>,
     events: SlotMap<HostEventKey, HostEvent>,
     jobs: SlotMap<HostJobKey, Option<Job>>,
     polls: SlotMap<HostPollKey, Arc<Mutex<HostPoll>>>,
@@ -282,6 +282,17 @@ struct AsyncHostState {
     completion_source: Option<HostHandle>,
     #[cfg(windows)]
     completion_port: Option<poll::CompletionPort>,
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct OverlappedAddr(usize);
+
+#[cfg(windows)]
+impl OverlappedAddr {
+    fn from_ptr(ptr: *mut windows_sys::Win32::System::IO::OVERLAPPED) -> Self {
+        Self(ptr as usize)
+    }
 }
 
 impl Default for AsyncHostState {
@@ -354,18 +365,10 @@ impl AsyncHostState {
     }
 
     #[cfg(windows)]
-    fn drain_pending_io_for_raw_fd(&mut self, raw_fd: RawFd) -> AsyncHostResult<()> {
-        let pending: Vec<_> = self
-            .io_results
-            .iter()
-            .filter_map(|(key, result)| (result.pending_raw_fd() == Some(raw_fd)).then_some(key))
-            .collect();
-        for key in pending {
-            if let Some(result) = self.io_results.get_mut(key) {
-                result.cancel_and_drain_pending()?;
-            }
-        }
-        Ok(())
+    fn has_pending_io_for_raw_fd(&self, raw_fd: RawFd) -> bool {
+        self.io_results
+            .values()
+            .any(|result| result.pending_raw_fd() == Some(raw_fd))
     }
 }
 
@@ -431,6 +434,10 @@ impl HostIoResult {
         &mut self.overlapped
     }
 
+    fn overlapped_addr(&mut self) -> OverlappedAddr {
+        OverlappedAddr::from_ptr(self.overlapped_ptr())
+    }
+
     fn copy_read_result(
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
@@ -460,9 +467,9 @@ impl HostIoResult {
         self.pending_raw_fd = None;
     }
 
-    fn validate_status_handle(&self, raw_fd: RawFd) -> AsyncHostResult<()> {
+    fn validate_pending_handle(&self, raw_fd: RawFd) -> AsyncHostResult<()> {
         // The import boundary may receive malformed/stale fd handles. Validate
-        // before asserting the internal "pending status uses submitter fd"
+        // before asserting the internal "pending operation uses submitter fd"
         // invariant so debug builds do not panic on bad guest input.
         if let Some(pending_raw_fd) = self.pending_raw_fd
             && pending_raw_fd != raw_fd
@@ -474,7 +481,7 @@ impl HostIoResult {
                 Some(pending_raw_fd) => pending_raw_fd == raw_fd,
                 None => true,
             },
-            "pending IO status must be queried with the submitting handle"
+            "pending IO operation must use the submitting handle"
         );
         Ok(())
     }
@@ -527,7 +534,7 @@ impl HostIoResult {
         let mut bytes_transferred = 0;
         // With bWait=TRUE the operation has reached a final status when this
         // returns, even if the final status is an error such as EOF or broken
-        // pipe. At that point the OVERLAPPED storage can be released.
+        // pipe. At that point the host no longer treats the result as pending.
         let _ = unsafe { GetOverlappedResult(raw_fd, overlapped, &mut bytes_transferred, 1) };
         self.clear_pending();
         Ok(())
@@ -654,20 +661,20 @@ impl AsyncHost {
                     .ok_or(AsyncHostError::Badf)?,
             )
         };
-        let mut poll = poll.lock().unwrap();
-        let result = poll::poll_wait(&mut poll.instance, timeout_ms);
-        if result.is_ok() {
-            poll.event_generation = poll.event_generation.wrapping_add(1);
-            let old_events = std::mem::take(&mut poll.event_handles);
-            drop(poll);
-            if !old_events.is_empty() {
-                let mut state = self.state.lock().unwrap();
-                for event in old_events {
-                    state.events.remove(event);
-                }
+        let (result, old_events) = {
+            let mut poll_guard = poll.lock().unwrap();
+            let result = poll::poll_wait(&mut poll_guard.instance, timeout_ms)?;
+            poll_guard.event_generation = poll_guard.event_generation.wrapping_add(1);
+            let old_events = std::mem::take(&mut poll_guard.event_handles);
+            (result, old_events)
+        };
+        if !old_events.is_empty() {
+            let mut state = self.state.lock().unwrap();
+            for event in old_events {
+                state.events.remove(event);
             }
         }
-        result
+        Ok(result)
     }
 
     pub(crate) fn poll_get_event(&self, poll_handle: u64, index: i32) -> AsyncHostResult<u64> {
@@ -677,6 +684,14 @@ impl AsyncHost {
         let mut poll = poll.lock().unwrap();
         let event = poll::event_list_get(&poll.instance, index)?;
         let raw_fd = poll::event_get_fd(event);
+        #[cfg(windows)]
+        let fd_handle = poll
+            .registered_fds
+            .get(&raw_fd_key(raw_fd))
+            .copied()
+            .or_else(|| completion_event_fd(raw_fd))
+            .or_else(|| Some(state.invalid_fd()));
+        #[cfg(unix)]
         let fd_handle = poll
             .registered_fds
             .get(&raw_fd_key(raw_fd))
@@ -735,15 +750,17 @@ impl AsyncHost {
     #[cfg(windows)]
     pub(crate) fn poll_event_io_result(&self, event_handle: u64) -> AsyncHostResult<u64> {
         let overlapped = self.with_event(event_handle, |_, event| {
-            Ok(poll::event_get_io_result(event) as usize)
+            Ok(OverlappedAddr::from_ptr(poll::event_get_io_result(event)))
         })?;
-        let state = self.state.lock().unwrap();
-        state
+        let mut state = self.state.lock().unwrap();
+        let key = state
             .io_results_by_overlapped
             .get(&overlapped)
             .copied()
-            .map(handle_from_key)
-            .ok_or(AsyncHostError::Badf)
+            .ok_or(AsyncHostError::Badf)?;
+        let result = state.io_results.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        result.clear_pending();
+        Ok(handle_from_key(key))
     }
 
     #[cfg(windows)]
@@ -1003,7 +1020,9 @@ impl AsyncHost {
         let mut state = self.state.lock().unwrap();
         let raw_fd = state.file(handle)?.raw_fd();
         #[cfg(windows)]
-        state.drain_pending_io_for_raw_fd(raw_fd)?;
+        if state.has_pending_io_for_raw_fd(raw_fd) {
+            return Err(AsyncHostError::Inval);
+        }
         #[cfg(unix)]
         if state.completion_source == Some(handle) {
             state.completion_source = None;
@@ -1101,7 +1120,7 @@ impl AsyncHost {
             .io_results
             .get_mut(key)
             .ok_or(AsyncHostError::Badf)?
-            .overlapped_ptr() as usize;
+            .overlapped_addr();
         state.io_results_by_overlapped.insert(overlapped, key);
         Ok(handle_from_key(key))
     }
@@ -1111,11 +1130,12 @@ impl AsyncHost {
         let key = key_from_handle::<HostIoResultKey>(handle);
         let mut state = self.state.lock().unwrap();
         let result = state.io_results.get_mut(key).ok_or(AsyncHostError::Badf)?;
-        result.cancel_and_drain_pending()?;
+        if result.pending_raw_fd().is_some() {
+            return Err(AsyncHostError::Inval);
+        }
         let mut result = state.io_results.remove(key).ok_or(AsyncHostError::Badf)?;
-        state
-            .io_results_by_overlapped
-            .remove(&(result.overlapped_ptr() as usize));
+        let overlapped = result.overlapped_addr();
+        state.io_results_by_overlapped.remove(&overlapped);
         Ok(())
     }
 
@@ -1136,11 +1156,12 @@ impl AsyncHost {
         fd_handle: HostHandle,
     ) -> AsyncHostResult<i32> {
         let mut state = self.state.lock().unwrap();
-        state.file(fd_handle)?;
+        let raw_fd = state.file(fd_handle)?.raw_fd();
         let result = state
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
+        result.validate_pending_handle(raw_fd)?;
         result.cancel_pending()
     }
 
@@ -1159,7 +1180,7 @@ impl AsyncHost {
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
-        result.validate_status_handle(raw_fd)?;
+        result.validate_pending_handle(raw_fd)?;
         let mut bytes_transferred = 0;
         if unsafe {
             GetOverlappedResult(raw_fd, result.overlapped_ptr(), &mut bytes_transferred, 0)
@@ -1881,10 +1902,185 @@ mod tests {
         result.mark_pending(pending_fd).unwrap();
 
         assert_eq!(
-            result.validate_status_handle(other_fd),
+            result.validate_pending_handle(other_fd),
             Err(AsyncHostError::Badf)
         );
         assert_eq!(result.pending_raw_fd(), Some(pending_fd));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn cancel_io_result_rejects_wrong_fd_without_clearing_pending() {
+        let host = AsyncHost::default();
+        let [read, write] = host.pipe(true, true).unwrap();
+        let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
+        let raw_read = {
+            let mut state = host.state.lock().unwrap();
+            let raw_read = state.file(read).unwrap().raw_fd();
+            state
+                .io_results
+                .get_mut(key_from_handle::<HostIoResultKey>(result))
+                .unwrap()
+                .mark_pending(raw_read)
+                .unwrap();
+            raw_read
+        };
+
+        assert_eq!(
+            host.cancel_io_result(result, write),
+            Err(AsyncHostError::Badf)
+        );
+        {
+            let mut state = host.state.lock().unwrap();
+            let result = state
+                .io_results
+                .get_mut(key_from_handle::<HostIoResultKey>(result))
+                .unwrap();
+            assert_eq!(result.pending_raw_fd(), Some(raw_read));
+            result.clear_pending();
+        }
+
+        host.free_io_result(result).unwrap();
+        host.close_fd(read).unwrap();
+        host.close_fd(write).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn close_fd_rejects_pending_io_result() {
+        let host = AsyncHost::default();
+        let [read, write] = host.pipe(true, true).unwrap();
+        let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
+        let raw_read = {
+            let mut state = host.state.lock().unwrap();
+            let raw_read = state.file(read).unwrap().raw_fd();
+            state
+                .io_results
+                .get_mut(key_from_handle::<HostIoResultKey>(result))
+                .unwrap()
+                .mark_pending(raw_read)
+                .unwrap();
+            raw_read
+        };
+
+        assert_eq!(host.close_fd(read), Err(AsyncHostError::Inval));
+        {
+            let mut state = host.state.lock().unwrap();
+            assert!(state.file(read).is_ok());
+            let result = state
+                .io_results
+                .get_mut(key_from_handle::<HostIoResultKey>(result))
+                .unwrap();
+            assert_eq!(result.pending_raw_fd(), Some(raw_read));
+            result.clear_pending();
+        }
+
+        host.free_io_result(result).unwrap();
+        host.close_fd(read).unwrap();
+        host.close_fd(write).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn free_io_result_rejects_pending_result() {
+        let host = AsyncHost::default();
+        let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
+        {
+            let mut state = host.state.lock().unwrap();
+            state
+                .io_results
+                .get_mut(key_from_handle::<HostIoResultKey>(result))
+                .unwrap()
+                .mark_pending(1usize as RawFd)
+                .unwrap();
+        }
+
+        assert_eq!(host.free_io_result(result), Err(AsyncHostError::Inval));
+        assert!(
+            host.state
+                .lock()
+                .unwrap()
+                .io_results
+                .contains_key(key_from_handle::<HostIoResultKey>(result))
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn poll_event_io_result_marks_pending_result_delivered() {
+        use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
+
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let completion_port = {
+            let state = host.state.lock().unwrap();
+            let poll = state
+                .polls
+                .get(key_from_handle::<HostPollKey>(poll))
+                .unwrap()
+                .lock()
+                .unwrap();
+            poll.instance.raw_fd()
+        };
+        let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
+        let raw_fd = 0x1234usize as RawFd;
+        let overlapped = {
+            let mut state = host.state.lock().unwrap();
+            let result = state
+                .io_results
+                .get_mut(key_from_handle::<HostIoResultKey>(result))
+                .unwrap();
+            result.mark_pending(raw_fd).unwrap();
+            result.overlapped_ptr()
+        };
+        let posted =
+            unsafe { PostQueuedCompletionStatus(completion_port, 0, raw_fd as usize, overlapped) };
+        assert_ne!(posted, 0);
+
+        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+        let event = host.poll_get_event(poll, 0).unwrap();
+
+        assert_eq!(host.poll_event_io_result(event).unwrap(), result);
+        assert_eq!(
+            host.state
+                .lock()
+                .unwrap()
+                .io_results
+                .get(key_from_handle::<HostIoResultKey>(result))
+                .unwrap()
+                .pending_raw_fd(),
+            None
+        );
+        host.free_io_result(result).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn unregistered_iocp_completion_reports_invalid_fd() {
+        use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
+
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let completion_port = {
+            let state = host.state.lock().unwrap();
+            let poll = state
+                .polls
+                .get(key_from_handle::<HostPollKey>(poll))
+                .unwrap()
+                .lock()
+                .unwrap();
+            poll.instance.raw_fd()
+        };
+        let raw_fd = 0x1234usize as RawFd;
+        let posted = unsafe {
+            PostQueuedCompletionStatus(completion_port, 0, raw_fd as usize, std::ptr::null_mut())
+        };
+        assert_ne!(posted, 0);
+
+        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+        let event = host.poll_get_event(poll, 0).unwrap();
+
+        assert_eq!(host.poll_event_fd(event).unwrap(), host.invalid_fd());
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
@@ -120,11 +120,27 @@ ported_fns! {
         instance.events = entries
             .into_iter()
             .take(count as usize)
-            .map(|entry| PollEvent {
-                fd: entry.lpCompletionKey as RawFd,
-                events: 0,
-                io_result: entry.lpOverlapped,
-                bytes_transferred: entry.dwNumberOfBytesTransferred as i32,
+            .map(|entry| {
+                let fd = entry.lpCompletionKey as RawFd;
+                let worker_generation = if is_thread_pool_completion(fd) {
+                    worker_generation_from_overlapped(entry.lpOverlapped)
+                } else {
+                    None
+                };
+                PollEvent {
+                    fd,
+                    events: 0,
+                    // Worker completion packets use lpOverlapped only as a
+                    // host generation token; guest-visible worker events match
+                    // native and expose no IO result.
+                    io_result: if worker_generation.is_some() {
+                        std::ptr::null_mut()
+                    } else {
+                        entry.lpOverlapped
+                    },
+                    bytes_transferred: entry.dwNumberOfBytesTransferred as i32,
+                    worker_generation,
+                }
             })
             .collect();
         i32::try_from(count).map_err(|_| AsyncHostError::Fault)
@@ -169,10 +185,12 @@ ported_fns! {
 pub(crate) fn post_thread_pool_completion(
     completion_port: CompletionPort,
     job_id: i32,
+    generation: usize,
 ) -> AsyncHostResult<()> {
     use windows_sys::Win32::Foundation::{GetLastError, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
+    debug_assert_ne!(generation, 0);
     // Native thread_pool.c posts worker completions to the event bus IOCP with
     // INVALID_HANDLE_VALUE as the completion key and the job id as transferred bytes.
     if unsafe {
@@ -180,13 +198,42 @@ pub(crate) fn post_thread_pool_completion(
             completion_port.0,
             job_id as u32,
             INVALID_HANDLE_VALUE as usize,
-            std::ptr::null_mut(),
+            worker_generation_to_overlapped(generation),
         )
     } == 0
     {
         return Err(AsyncHostError::Native(unsafe { GetLastError() } as i32));
     }
     Ok(())
+}
+
+pub(crate) fn retain_current_thread_pool_completions(
+    instance: &mut PollInstance,
+    generation: Option<usize>,
+) -> AsyncHostResult<i32> {
+    instance.events.retain(|event| {
+        event
+            .worker_generation
+            .is_none_or(|event_generation| Some(event_generation) == generation)
+    });
+    i32::try_from(instance.events.len()).map_err(|_| AsyncHostError::Fault)
+}
+
+fn is_thread_pool_completion(fd: RawFd) -> bool {
+    fd == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE
+}
+
+fn worker_generation_to_overlapped(
+    generation: usize,
+) -> *mut windows_sys::Win32::System::IO::OVERLAPPED {
+    generation as *mut windows_sys::Win32::System::IO::OVERLAPPED
+}
+
+fn worker_generation_from_overlapped(
+    overlapped: *mut windows_sys::Win32::System::IO::OVERLAPPED,
+) -> Option<usize> {
+    let generation = overlapped as usize;
+    (generation != 0).then_some(generation)
 }
 
 fn empty_overlapped_entry() -> windows_sys::Win32::System::IO::OVERLAPPED_ENTRY {

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
@@ -71,6 +71,8 @@ pub(crate) struct PollEvent {
     io_result: *mut windows_sys::Win32::System::IO::OVERLAPPED,
     #[cfg(windows)]
     bytes_transferred: i32,
+    #[cfg(windows)]
+    worker_generation: Option<usize>,
 }
 
 impl Drop for PollInstance {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -47,13 +47,6 @@ impl HostFile {
     pub(crate) fn raw_fd(&self) -> fd_util::stub::RawFd {
         self.raw
     }
-
-    pub(crate) fn duplicate(&self) -> AsyncHostResult<Self> {
-        if self.is_invalid() {
-            return Err(AsyncHostError::Badf);
-        }
-        duplicate_raw_file(self.raw).map(Self::new)
-    }
 }
 
 impl Drop for HostFile {
@@ -91,49 +84,6 @@ fn close_raw_file(raw: fd_util::stub::RawFd) {
     unsafe {
         windows_sys::Win32::Foundation::CloseHandle(raw);
     }
-}
-
-#[cfg(unix)]
-fn duplicate_raw_file(raw: fd_util::stub::RawFd) -> AsyncHostResult<fd_util::stub::RawFd> {
-    let fd = unsafe { libc::fcntl(raw, libc::F_DUPFD_CLOEXEC, 0) };
-    if fd < 0 {
-        Err(last_native_error())
-    } else {
-        Ok(fd)
-    }
-}
-
-#[cfg(windows)]
-fn duplicate_raw_file(raw: fd_util::stub::RawFd) -> AsyncHostResult<fd_util::stub::RawFd> {
-    use windows_sys::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE};
-    use windows_sys::Win32::System::Threading::GetCurrentProcess;
-
-    let process = unsafe { GetCurrentProcess() };
-    let mut duplicate: HANDLE = std::ptr::null_mut();
-    if unsafe {
-        DuplicateHandle(
-            process,
-            raw,
-            process,
-            &mut duplicate,
-            0,
-            0,
-            DUPLICATE_SAME_ACCESS,
-        )
-    } == 0
-    {
-        Err(last_native_error())
-    } else {
-        Ok(duplicate)
-    }
-}
-
-fn last_native_error() -> AsyncHostError {
-    AsyncHostError::Native(
-        std::io::Error::last_os_error()
-            .raw_os_error()
-            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
-    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -47,6 +47,13 @@ impl HostFile {
     pub(crate) fn raw_fd(&self) -> fd_util::stub::RawFd {
         self.raw
     }
+
+    pub(crate) fn duplicate(&self) -> AsyncHostResult<Self> {
+        if self.is_invalid() {
+            return Err(AsyncHostError::Badf);
+        }
+        duplicate_raw_file(self.raw).map(Self::new)
+    }
 }
 
 impl Drop for HostFile {
@@ -84,6 +91,49 @@ fn close_raw_file(raw: fd_util::stub::RawFd) {
     unsafe {
         windows_sys::Win32::Foundation::CloseHandle(raw);
     }
+}
+
+#[cfg(unix)]
+fn duplicate_raw_file(raw: fd_util::stub::RawFd) -> AsyncHostResult<fd_util::stub::RawFd> {
+    let fd = unsafe { libc::fcntl(raw, libc::F_DUPFD_CLOEXEC, 0) };
+    if fd < 0 {
+        Err(last_native_error())
+    } else {
+        Ok(fd)
+    }
+}
+
+#[cfg(windows)]
+fn duplicate_raw_file(raw: fd_util::stub::RawFd) -> AsyncHostResult<fd_util::stub::RawFd> {
+    use windows_sys::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE};
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    let process = unsafe { GetCurrentProcess() };
+    let mut duplicate: HANDLE = std::ptr::null_mut();
+    if unsafe {
+        DuplicateHandle(
+            process,
+            raw,
+            process,
+            &mut duplicate,
+            0,
+            0,
+            DUPLICATE_SAME_ACCESS,
+        )
+    } == 0
+    {
+        Err(last_native_error())
+    } else {
+        Ok(duplicate)
+    }
+}
+
+fn last_native_error() -> AsyncHostError {
+    AsyncHostError::Native(
+        std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -19,6 +19,9 @@
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
 
+#[cfg(windows)]
+use crate::async_host::AsyncHostError;
+use crate::async_host::AsyncHostResult;
 use crate::async_sys::ported_fns;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -171,9 +174,9 @@ impl HostWorkerHandle {
         self.shared.state.lock().unwrap().job = None;
     }
 
-    pub(crate) fn cancel(&self) -> i32 {
+    pub(crate) fn cancel(&self) -> AsyncHostResult<i32> {
         if self.shared.state.lock().unwrap().waiting {
-            return 1;
+            return Ok(1);
         }
 
         #[cfg(unix)]
@@ -183,7 +186,7 @@ impl HostWorkerHandle {
                     libc::pthread_kill(thread_id, libc::SIGUSR2);
                 }
             }
-            0
+            Ok(0)
         }
 
         #[cfg(windows)]
@@ -193,14 +196,17 @@ impl HostWorkerHandle {
             use windows_sys::Win32::System::IO::CancelSynchronousIo;
 
             let Some(thread) = &self.thread else {
-                return -1;
+                return Err(AsyncHostError::Badf);
             };
             if unsafe { CancelSynchronousIo(thread.as_raw_handle()) } != 0 {
-                1
-            } else if unsafe { GetLastError() } == ERROR_NOT_FOUND {
-                0
+                Ok(1)
             } else {
-                -1
+                let error = unsafe { GetLastError() };
+                if error == ERROR_NOT_FOUND {
+                    Ok(0)
+                } else {
+                    Err(AsyncHostError::Native(error as i32))
+                }
             }
         }
     }
@@ -246,7 +252,7 @@ ported_fns! {
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_cancel_worker"
     )]
-    pub(crate) fn cancel_worker(worker: &HostWorkerHandle) -> i32 {
+    pub(crate) fn cancel_worker(worker: &HostWorkerHandle) -> AsyncHostResult<i32> {
         worker.cancel()
     }
 
@@ -291,7 +297,7 @@ mod tests {
                 job_handle: 11
             }
         );
-        assert_eq!(cancel_worker(&worker), 1);
+        assert_eq!(cancel_worker(&worker), Ok(1));
 
         wake_worker(
             &worker,


### PR DESCRIPTION
## Why

After the async wasm host runtime landed, the remaining resource-lifetime issues are in the Rust host boundary: poll events can outlive raw fd mappings, Windows overlapped I/O can outlive its Rust `OVERLAPPED` storage, worker teardown can race with completion shutdown, and thread-pool jobs need an owned OS handle while running.

## What changed

This PR hardens the Rust host by resolving poll event fds to guest handles when events are created, separating the thread-pool completion marker from normal host-file handles, tracking pending Windows I/O ownership until completion/cancellation is drained, making worker teardown tolerant of completion shutdown, and keeping ordinary worker jobs on duplicated OS handles while preserving the original-handle path for Windows byte-range locks.

## Why this is correct

The host keeps raw OS fd values and SlotMap guest handles separate. Pending Windows I/O now records the submitting raw handle, rejects status checks through another fd without clearing ownership, and treats any final overlapped status as drained before freeing the Rust allocation. Worker jobs duplicate ordinary fds before releasing the host state lock, so guest close/reopen cannot invalidate or redirect an in-flight job.

## Scope

This PR is stacked on the smaller ABI/filesystem parity PR. Directory-entry name ownership and other upstream MoonBit contract questions are intentionally left out.