### PR TITLE
feat(config): allow formatter/source configurations in top-level

### DIFF
--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -342,6 +342,7 @@ pub fn read_module_from_dsl(path: &Path) -> anyhow::Result<MoonMod> {
         ("license", false),
         ("keywords", false),
         ("description", false),
+        ("source", false),
         ("supported_targets", false),
         ("preferred_target", false),
     ]);

--- a/crates/moonutil/src/package.rs
+++ b/crates/moonutil/src/package.rs
@@ -725,6 +725,7 @@ pub fn convert_pkg_dsl_to_package_with_supported_targets_decl(
         ("options", false),
         ("warnings", false),
         ("dev_build", true),
+        ("formatter", false),
         ("rule", true),
         ("supported_targets", false),
     ]);

--- a/crates/moonutil/tests/expect_moon_mod.rs
+++ b/crates/moonutil/tests/expect_moon_mod.rs
@@ -171,6 +171,7 @@ fn read_module_desc_supports_new_toplevel_fields_from_fixture() {
         Some(["moonbit".to_string(), "dsl".to_string()].as_slice())
     );
     assert_eq!(module.description.as_deref(), Some("Module metadata"));
+    assert_eq!(module.source.as_deref(), Some("src"));
     assert_eq!(module.preferred_target, Some(TargetBackend::Js));
     match module.supported_targets {
         Some(SupportedTargetsConfig::Expr(expr)) => assert_eq!(expr, "js"),

--- a/crates/moonutil/tests/expect_moon_pkg.rs
+++ b/crates/moonutil/tests/expect_moon_pkg.rs
@@ -156,9 +156,7 @@ fn expect_is_main() {
 #[test]
 fn expect_formatter() {
     let actual = run(r#"
-    options(
-      formatter: { "ignore": ["file1.mbt", "file2.mbt", "file3.mbt"] }
-    )
+    formatter(ignore: ["file1.mbt", "file2.mbt", "file3.mbt"])
     "#);
     expect_test::expect![[r#"
         MoonPkg {
@@ -199,6 +197,13 @@ fn expect_formatter() {
             local_rules: None,
         }"#]]
     .assert_eq(&actual);
+
+    let legacy_actual = run(r#"
+    options(
+      formatter: { "ignore": ["file1.mbt", "file2.mbt", "file3.mbt"] }
+    )
+    "#);
+    assert_eq!(legacy_actual, actual);
 }
 
 #[test]

--- a/crates/moonutil/tests/fixtures/module_dsl_toplevel/moon.mod
+++ b/crates/moonutil/tests/fixtures/module_dsl_toplevel/moon.mod
@@ -7,5 +7,6 @@ repository = "https://example.com/toplevel"
 license = "Apache-2.0"
 keywords = ["moonbit", "dsl"]
 description = "Module metadata"
+source = "src"
 preferred_target = "js"
 supported_targets = "js"


### PR DESCRIPTION
- Related issues: None
- PR kind: feature

## Summary

Support top-level DSL fields emitted by moonfmt for manifest migration:

- Allow `source = ...` as a top-level field in `moon.mod`
- Allow `formatter(...)` as a top-level field in `moon.pkg`
- Keep existing `options(formatter: ...)`，options(source: ...)  behavior compatible

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
