### PR TITLE
Avoid c_buffer blit copies in moonrun

### DIFF
--- a/crates/moonrun/src/async_api/c_buffer.rs
+++ b/crates/moonrun/src/async_api/c_buffer.rs
@@ -36,10 +36,11 @@ pub(super) fn blit_to_c(
     len: i32,
 ) -> AsyncHostResult<()> {
     let src_len = checked_add_i32(offset, len)?;
-    let src = context.with_memory_mut(|memory| Ok(memory.read_exact(src, src_len)?.to_vec()))?;
-    context
-        .host
-        .with_c_buffer_mut(dst, |dst| stub::blit_to_c(dst, &src, offset, len))
+    let host = context.host;
+    context.with_memory_mut(|memory| {
+        let src = memory.read_exact(src, src_len)?;
+        host.with_c_buffer_mut(dst, |dst| stub::blit_to_c(dst, src, offset, len))
+    })
 }
 
 #[ported(source = "src/internal/c_buffer/stub.c")]
@@ -51,13 +52,10 @@ pub(super) fn blit_from_c(
     len: i32,
 ) -> AsyncHostResult<()> {
     let dst_len = checked_add_i32(offset, len)?;
-    let src = context.host.with_c_buffer(src, |src| {
-        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
-        Ok(src.get(..len).ok_or(AsyncHostError::Fault)?.to_vec())
-    })?;
+    let host = context.host;
     context.with_memory_mut(|memory| {
         let dst = memory.read_exact_mut(dst, dst_len)?;
-        stub::blit_from_c(&src, dst, offset, len)
+        host.with_c_buffer(src, |src| stub::blit_from_c(src, dst, offset, len))
     })
 }
 

--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -84,7 +84,11 @@ pub(super) fn dir_entry_name(
     offset: i32,
 ) -> AsyncHostResult<u64> {
     let name = context.with_memory_mut(|memory| {
-        Ok(dir::entry_name(memory.bytes(), buf, offset)?.to_vec())
+        Ok(Box::<[u8]>::from(dir::entry_name(
+            memory.bytes(),
+            buf,
+            offset,
+        )?))
     })?;
     Ok(context.host.insert_c_buffer(name))
 }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -264,7 +264,7 @@ fn key_from_handle<K: Key>(handle: u64) -> K {
 
 struct AsyncHostState {
     errno: i32,
-    c_buffers: SlotMap<HostCBufferKey, Vec<u8>>,
+    c_buffers: SlotMap<HostCBufferKey, Box<[u8]>>,
     #[cfg(windows)]
     io_results: SlotMap<HostIoResultKey, Box<HostIoResult>>,
     #[cfg(windows)]
@@ -687,7 +687,7 @@ impl AsyncHost {
         }
     }
 
-    pub(crate) fn insert_c_buffer(&self, buffer: Vec<u8>) -> u64 {
+    pub(crate) fn insert_c_buffer(&self, buffer: Box<[u8]>) -> u64 {
         let key = self.state.lock().unwrap().c_buffers.insert(buffer);
         handle_from_key(key)
     }
@@ -718,7 +718,7 @@ impl AsyncHost {
             .c_buffers
             .get(key_from_handle::<HostCBufferKey>(handle))
             .ok_or(AsyncHostError::Badf)?;
-        f(buffer)
+        f(buffer.as_ref())
     }
 
     pub(crate) fn with_c_buffer_mut<T>(
@@ -734,7 +734,7 @@ impl AsyncHost {
             .c_buffers
             .get_mut(key_from_handle::<HostCBufferKey>(handle))
             .ok_or(AsyncHostError::Badf)?;
-        f(buffer)
+        f(buffer.as_mut())
     }
 
     pub(crate) fn insert_job(&self, job: Job) -> AsyncHostResult<u64> {


### PR DESCRIPTION
## Summary

This PR stores host `c_buffer` entries as boxed slices and removes temporary `Vec` allocations from the `blit_to_c` and `blit_from_c` import paths.

## Rationale

`c_buffer` handles must still own their bytes because they can outlive a single import call, but the host table does not need `Vec` capacity or resizing semantics. The blit imports can borrow guest memory and host buffers for the duration of the call instead of materializing temporary vectors before copying.

## Correctness

The guest ABI and observable behavior are unchanged: handles remain `u64`, import names stay the same, and c-buffers still provide owned mutable byte storage. The borrowed slices are used only within the import call, so no guest-memory or host-buffer reference escapes its valid lifetime.

## Scope

The change is limited to `moonrun` c-buffer storage and the adjacent import shims. Creation of a c-buffer from directory-entry data still performs an owned allocation because that handle must outlive the source slice.