### PR TITLE
Align async host buffer ownership

### DIFF
--- a/crates/moonrun/src/async_api/c_buffer.rs
+++ b/crates/moonrun/src/async_api/c_buffer.rs
@@ -79,6 +79,14 @@ pub(super) fn free(context: &mut ImportContext, ptr: u64) -> AsyncHostResult<()>
     context.host.free_c_buffer(ptr)
 }
 
+#[ported(
+    source = "src/internal/c_buffer/stub.c",
+    original = "moonbitlang_async_make_c_buffer"
+)]
+pub(super) fn new(context: &mut ImportContext, size: i32) -> AsyncHostResult<u64> {
+    Ok(context.host.insert_c_buffer(stub::make_c_buffer(size)?))
+}
+
 fn checked_add_i32(lhs: i32, rhs: i32) -> AsyncHostResult<i32> {
     lhs.checked_add(rhs).ok_or(AsyncHostError::Fault)
 }

--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory, write_u16};
+use crate::async_host::{AsyncHostError, AsyncHostResult, write_u16};
 use crate::async_sys::fs::dir;
 use crate::async_sys::fs::stub;
 
@@ -62,64 +62,68 @@ pub(super) fn dir_buffer_min_size(_context: &mut ImportContext) -> i32 {
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_length(
     context: &mut ImportContext,
-    buf: i32,
+    buf: u64,
     offset: i32,
 ) -> AsyncHostResult<i32> {
-    context.with_memory_mut(|memory| dir::entry_length(memory.bytes(), buf, offset))
+    context
+        .host
+        .with_c_buffer(buf, |buf| dir::entry_length(buf, 0, offset))
 }
 
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_name_len(
     context: &mut ImportContext,
-    buf: i32,
+    buf: u64,
     offset: i32,
 ) -> AsyncHostResult<i32> {
-    context.with_memory_mut(|memory| dir::entry_name_len(memory.bytes(), buf, offset))
+    context
+        .host
+        .with_c_buffer(buf, |buf| dir::entry_name_len(buf, 0, offset))
 }
 
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_name(
     context: &mut ImportContext,
-    buf: i32,
+    buf: u64,
     offset: i32,
 ) -> AsyncHostResult<u64> {
-    let name = context.with_memory_mut(|memory| {
-        Ok(Box::<[u8]>::from(dir::entry_name(
-            memory.bytes(),
-            buf,
-            offset,
-        )?))
-    })?;
-    Ok(context.host.insert_c_buffer(name))
+    context
+        .host
+        .with_c_buffer(buf, |buf| Ok(dir::entry_name(buf, 0, offset)?.as_ptr() as u64))
 }
 
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_is_dir(
     context: &mut ImportContext,
-    buf: i32,
+    buf: u64,
     offset: i32,
 ) -> AsyncHostResult<i32> {
-    context.with_memory_mut(|memory| dir::entry_is_dir(memory.bytes(), buf, offset))
+    context
+        .host
+        .with_c_buffer(buf, |buf| dir::entry_is_dir(buf, 0, offset))
 }
 
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_is_hidden(
     context: &mut ImportContext,
-    buf: i32,
+    buf: u64,
     offset: i32,
 ) -> AsyncHostResult<i32> {
     context
-        .with_memory_mut(|memory| dir::entry_is_hidden(memory.bytes(), buf, offset))
+        .host
+        .with_c_buffer(buf, |buf| dir::entry_is_hidden(buf, 0, offset))
         .map(|value| if value { 1 } else { 0 })
 }
 
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_file_id(
     context: &mut ImportContext,
-    buf: i32,
+    buf: u64,
     offset: i32,
 ) -> AsyncHostResult<u64> {
-    context.with_memory_mut(|memory| dir::entry_file_id(memory.bytes(), buf, offset))
+    context
+        .host
+        .with_c_buffer(buf, |buf| dir::entry_file_id(buf, 0, offset))
 }
 
 fn tmp_path_utf16_units() -> AsyncHostResult<Vec<u16>> {

--- a/crates/moonrun/src/async_api/os_error.rs
+++ b/crates/moonrun/src/async_api/os_error.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::async_host::{AsyncHostError, write_u16};
+use crate::async_host::AsyncHostResult;
 use crate::async_sys::os_error::stub;
 
 use super::context::ImportContext;
@@ -71,35 +71,13 @@ pub(super) fn is_error_notify_enum_dir(_context: &mut ImportContext, errno: i32)
     }
 }
 
-pub(super) fn errno_to_string_len(context: &mut ImportContext, errno: i32) -> i32 {
-    match i32::try_from(errno_to_string_utf16(errno).len()).map_err(|_| AsyncHostError::Fault) {
-        Ok(len) => len,
-        Err(error) => {
-            context.host.record_error(error);
-            -1
-        }
-    }
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn errno_to_string(context: &mut ImportContext, errno: i32) -> u64 {
+    context.host.insert_c_buffer(stub::errno_to_string(errno))
 }
 
-#[ported(source = "src/os_error/stub.c")]
-pub(super) fn errno_to_string(context: &mut ImportContext, errno: i32, ptr: i32, len: i32) -> i32 {
-    let result = (|| {
-        let units = errno_to_string_utf16(errno);
-        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
-        if len != units.len() {
-            return Err(AsyncHostError::Inval);
-        }
-
-        context.with_memory_mut(|memory| write_u16(memory, ptr, &units))
-    })();
-
-    match result {
-        Ok(()) => 0,
-        Err(error) => {
-            context.host.record_error(error);
-            -1
-        }
-    }
+pub(super) fn free_errno_str(context: &mut ImportContext, ptr: u64) -> AsyncHostResult<()> {
+    context.host.free_c_buffer(ptr)
 }
 
 #[ported(source = "src/os_error/stub.c")]
@@ -107,17 +85,4 @@ pub(super) fn get_enotdir(_context: &mut ImportContext) -> i32 {
     stub::get_enotdir()
 }
 
-fn errno_to_string_utf16(errno: i32) -> Vec<u16> {
-    stub::errno_to_string(errno).encode_utf16().collect()
-}
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn errno_to_string_utf16_returns_message_units() {
-        assert!(!errno_to_string_utf16(stub::get_enotdir()).is_empty());
-    }
 }

--- a/crates/moonrun/src/async_api/os_string.rs
+++ b/crates/moonrun/src/async_api/os_string.rs
@@ -51,32 +51,12 @@ fn utf16_len(string: &str) -> AsyncHostResult<i32> {
 
 fn decode_native_string(bytes: &[u8], len: i32) -> AsyncHostResult<String> {
     let bytes = if len == -1 {
-        native_string_bytes(bytes)?
+        bytes
     } else {
         let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
         bytes.get(..len).ok_or(AsyncHostError::Fault)?
     };
     decode_native_string_bytes(bytes)
-}
-
-#[cfg(unix)]
-fn native_string_bytes(bytes: &[u8]) -> AsyncHostResult<&[u8]> {
-    let len = crate::async_sys::internal::c_buffer::stub::strlen(bytes)?;
-    let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
-    Ok(&bytes[..len])
-}
-
-#[cfg(windows)]
-fn native_string_bytes(bytes: &[u8]) -> AsyncHostResult<&[u8]> {
-    for (index, chunk) in bytes.chunks_exact(2).enumerate() {
-        if chunk == [0, 0] {
-            let len = index
-                .checked_mul(std::mem::size_of::<u16>())
-                .ok_or(AsyncHostError::Fault)?;
-            return Ok(&bytes[..len]);
-        }
-    }
-    Err(AsyncHostError::Fault)
 }
 
 #[cfg(unix)]
@@ -103,16 +83,19 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn unix_decode_native_string_stops_at_nul_byte() {
-        assert_eq!(decode_native_string(b"abc\0def", -1), Ok("abc".to_string()));
+    fn unix_decode_native_string_uses_the_whole_owned_buffer() {
+        assert_eq!(
+            decode_native_string(b"abc\0def", -1),
+            Ok("abc\0def".to_string())
+        );
     }
 
     #[cfg(windows)]
     #[test]
-    fn windows_decode_native_string_stops_at_nul_wchar() {
+    fn windows_decode_native_string_uses_the_whole_owned_buffer() {
         assert_eq!(
             decode_native_string(&[b'a', 0, b'b', 0, 0, 0], -1),
-            Ok("ab".to_string())
+            Ok("ab\0".to_string())
         );
     }
 

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -363,9 +363,9 @@ declare_async_imports! {
 
     ported os_error::get_enotdir() -> i32 => "os_error/get_ENOTDIR";
 
-    helper os_error::errno_to_string_len(errno: i32) -> i32 => "os_error/errno_to_string_len";
+    ported os_error::errno_to_string(errno: i32) -> u64 => "os_error/errno_to_string";
 
-    ported os_error::errno_to_string(errno: i32, ptr: i32, len: i32) -> i32 => "os_error/errno_to_string";
+    helper os_error::free_errno_str(ptr: u64) -> void => "os_error/free_errno_str";
 
     // Decode host-native strings into guest-owned MoonBit String storage.
     helper os_string::decode_len(ptr: u64, len: i32) -> i32 => "os_string/decode_len";
@@ -497,6 +497,8 @@ declare_async_imports! {
 
     ported c_buffer::strlen(buf: u64) -> i32 => "c_buffer/strlen";
 
+    ported c_buffer::new(size: i32) -> u64 => "c_buffer/new";
+
     helper c_buffer::free(ptr: u64) -> void => "c_buffer/free";
 
     // fs/stub.c and fs/dir.c.
@@ -516,17 +518,17 @@ declare_async_imports! {
 
     ported fs::dir_buffer_min_size() -> i32 => "fs/dir_buffer_min_size";
 
-    ported fs::dir_entry_length(buf: i32, offset: i32) -> i32 => "fs/dir_entry_length";
+    ported fs::dir_entry_length(buf: u64, offset: i32) -> i32 => "fs/dir_entry_length";
 
-    ported fs::dir_entry_name_len(buf: i32, offset: i32) -> i32 => "fs/dir_entry_get_name_len";
+    ported fs::dir_entry_name_len(buf: u64, offset: i32) -> i32 => "fs/dir_entry_get_name_len";
 
-    ported fs::dir_entry_name(buf: i32, offset: i32) -> u64 => "fs/dir_entry_get_name";
+    ported fs::dir_entry_name(buf: u64, offset: i32) -> u64 => "fs/dir_entry_get_name";
 
-    ported fs::dir_entry_is_dir(buf: i32, offset: i32) -> i32 => "fs/dir_entry_is_dir";
+    ported fs::dir_entry_is_dir(buf: u64, offset: i32) -> i32 => "fs/dir_entry_is_dir";
 
-    ported fs::dir_entry_is_hidden(buf: i32, offset: i32) -> i32 => "fs/dir_entry_is_hidden";
+    ported fs::dir_entry_is_hidden(buf: u64, offset: i32) -> i32 => "fs/dir_entry_is_hidden";
 
-    ported fs::dir_entry_file_id(buf: i32, offset: i32) -> u64 => "fs/dir_entry_get_file_id";
+    ported fs::dir_entry_file_id(buf: u64, offset: i32) -> u64 => "fs/dir_entry_get_file_id";
 
     // thread_pool.c FS jobs. Path-taking jobs use the Guest String Path ABI:
     // MoonBit String pointer plus UTF-16 code-unit length.
@@ -605,9 +607,7 @@ declare_async_imports! {
 
     ported thread_pool::make_rmdir_job(path_ptr: i32, path_len: i32) -> u64 => "thread_pool/make_rmdir_job";
 
-    ported thread_pool::make_readdir_job(dir: u64, len: i32, restart: i32) -> u64 => "thread_pool/make_readdir_job";
-
-    helper thread_pool::get_readdir_result(job: u64, dst: i32, len: i32) -> void => "thread_pool/get_readdir_result";
+    ported thread_pool::make_readdir_job(dir: u64, buf: u64, len: i32, restart: i32) -> u64 => "thread_pool/make_readdir_job";
 }
 
 #[cfg(test)]

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -370,12 +370,19 @@ pub(super) fn make_rmdir_job(
 pub(super) fn make_readdir_job(
     context: &mut ImportContext,
     dir: u64,
+    buf: u64,
     len: i32,
     restart: i32,
 ) -> AsyncHostResult<u64> {
+    let buffer = context.host.c_buffer(buf)?;
     context
         .host
-        .insert_job(thread_pool::make_readdir_job(dir, len, restart != 0))
+        .insert_job(thread_pool::make_readdir_job(
+            dir,
+            buffer,
+            len,
+            restart != 0,
+        ))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
@@ -396,16 +403,6 @@ pub(super) fn open_job_get_dev_id(context: &mut ImportContext, job: u64) -> Asyn
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn open_job_get_file_id(context: &mut ImportContext, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_file_id(job)
-}
-
-pub(super) fn get_readdir_result(
-    context: &mut ImportContext,
-    job: u64,
-    dst: i32,
-    len: i32,
-) -> AsyncHostResult<()> {
-    let host = context.host;
-    context.with_memory_mut(|memory| host.get_readdir_result(memory, job, dst, len))
 }
 
 fn read_guest_path(context: &mut ImportContext, ptr: i32, len: i32) -> AsyncHostResult<OsString> {

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -57,6 +57,7 @@ pub(crate) enum AsyncHostError {
 
 pub(crate) type AsyncHostResult<T> = Result<T, AsyncHostError>;
 pub(crate) const INVALID_HOST_HANDLE: u64 = 0;
+pub(crate) type HostCBuffer = Arc<Mutex<Box<[u8]>>>;
 
 #[cfg(unix)]
 mod native_errno {
@@ -264,7 +265,7 @@ fn key_from_handle<K: Key>(handle: u64) -> K {
 
 struct AsyncHostState {
     errno: i32,
-    c_buffers: SlotMap<HostCBufferKey, Box<[u8]>>,
+    c_buffers: SlotMap<HostCBufferKey, HostCBuffer>,
     #[cfg(windows)]
     io_results: SlotMap<HostIoResultKey, Box<HostIoResult>>,
     #[cfg(windows)]
@@ -688,7 +689,12 @@ impl AsyncHost {
     }
 
     pub(crate) fn insert_c_buffer(&self, buffer: Box<[u8]>) -> u64 {
-        let key = self.state.lock().unwrap().c_buffers.insert(buffer);
+        let key = self
+            .state
+            .lock()
+            .unwrap()
+            .c_buffers
+            .insert(Arc::new(Mutex::new(buffer)));
         handle_from_key(key)
     }
 
@@ -710,15 +716,10 @@ impl AsyncHost {
         handle: u64,
         f: impl FnOnce(&[u8]) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
-        if handle == INVALID_HOST_HANDLE {
-            return Err(AsyncHostError::Badf);
-        }
-        let state = self.state.lock().unwrap();
-        let buffer = state
-            .c_buffers
-            .get(key_from_handle::<HostCBufferKey>(handle))
-            .ok_or(AsyncHostError::Badf)?;
-        f(buffer.as_ref())
+        let (buffer, offset) = self.c_buffer_slice(handle)?;
+        let buffer = buffer.lock().unwrap();
+        let buffer = buffer.get(offset..).ok_or(AsyncHostError::Badf)?;
+        f(buffer)
     }
 
     pub(crate) fn with_c_buffer_mut<T>(
@@ -726,15 +727,43 @@ impl AsyncHost {
         handle: u64,
         f: impl FnOnce(&mut [u8]) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
+        let (buffer, offset) = self.c_buffer_slice(handle)?;
+        let mut buffer = buffer.lock().unwrap();
+        let buffer = buffer.get_mut(offset..).ok_or(AsyncHostError::Badf)?;
+        f(buffer)
+    }
+
+    pub(crate) fn c_buffer(&self, handle: u64) -> AsyncHostResult<HostCBuffer> {
         if handle == INVALID_HOST_HANDLE {
             return Err(AsyncHostError::Badf);
         }
-        let mut state = self.state.lock().unwrap();
-        let buffer = state
+        self.state
+            .lock()
+            .unwrap()
             .c_buffers
-            .get_mut(key_from_handle::<HostCBufferKey>(handle))
-            .ok_or(AsyncHostError::Badf)?;
-        f(buffer.as_mut())
+            .get(key_from_handle::<HostCBufferKey>(handle))
+            .cloned()
+            .ok_or(AsyncHostError::Badf)
+    }
+
+    fn c_buffer_slice(&self, handle: u64) -> AsyncHostResult<(HostCBuffer, usize)> {
+        if let Ok(buffer) = self.c_buffer(handle) {
+            return Ok((buffer, 0));
+        }
+
+        let ptr = usize::try_from(handle).map_err(|_| AsyncHostError::Badf)?;
+        let state = self.state.lock().unwrap();
+        for buffer in state.c_buffers.values() {
+            let guard = buffer.lock().unwrap();
+            let start = guard.as_ptr() as usize;
+            let Some(end) = start.checked_add(guard.len()) else {
+                continue;
+            };
+            if (start..end).contains(&ptr) {
+                return Ok((Arc::clone(buffer), ptr - start));
+            }
+        }
+        Err(AsyncHostError::Badf)
     }
 
     pub(crate) fn insert_job(&self, job: Job) -> AsyncHostResult<u64> {
@@ -1225,22 +1254,6 @@ impl AsyncHost {
             .and_then(Option::as_ref)
             .ok_or(AsyncHostError::Badf)?;
         thread_pool::get_read_result(job, memory, dst, offset, len)
-    }
-
-    pub(crate) fn get_readdir_result(
-        &self,
-        memory: &mut (impl GuestMemory + ?Sized),
-        handle: u64,
-        dst: i32,
-        len: i32,
-    ) -> AsyncHostResult<()> {
-        let state = self.state.lock().unwrap();
-        let job = state
-            .jobs
-            .get(key_from_handle::<HostJobKey>(handle))
-            .and_then(Option::as_ref)
-            .ok_or(AsyncHostError::Badf)?;
-        thread_pool::get_readdir_result(job, memory, dst, len)
     }
 
     pub(crate) fn get_file_time_result(

--- a/crates/moonrun/src/async_sys/internal/c_buffer/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/c_buffer/stub.rs
@@ -66,6 +66,15 @@ ported_fns! {
         i32::try_from(len).map_err(|_| AsyncHostError::Fault)
     }
 
+    #[ported(
+        source = "src/internal/c_buffer/stub.c",
+        original = "moonbitlang_async_make_c_buffer"
+    )]
+    pub(crate) fn make_c_buffer(size: i32) -> AsyncHostResult<Box<[u8]>> {
+        let size = usize::try_from(size).map_err(|_| AsyncHostError::Fault)?;
+        Ok(vec![0; size].into_boxed_slice())
+    }
+
 }
 
 fn checked_range(src: &[u8], offset: i32, len: i32) -> AsyncHostResult<&[u8]> {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -21,7 +21,7 @@
 
 use std::ffi::OsString;
 
-use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_host::{AsyncHostError, AsyncHostResult, HostCBuffer};
 use crate::async_sys::internal::fd_util;
 use crate::async_sys::ported_fns;
 
@@ -276,15 +276,15 @@ ported_fns! {
     pub(super) fn run_readdir_job(
         files: &mut impl HostFileTable,
         dir: HostHandle,
+        buffer: &HostCBuffer,
         len: i32,
         restart: bool,
-        result: &mut Option<Vec<u8>>,
     ) -> AsyncHostResult<i64> {
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        let mut buffer = buffer.lock().unwrap();
+        let buffer = buffer.get_mut(..len).ok_or(AsyncHostError::Fault)?;
         files.with_host_file_mut(dir, |file| {
-            let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
-            let (ret, native) = read_native_dir(file, len, restart)?;
-            *result = Some(native);
-            Ok(ret)
+            read_native_dir(file, buffer, restart)
         })
     }
 }
@@ -780,33 +780,23 @@ fn rmdir_native_path(path: OsString) -> AsyncHostResult<()> {
 }
 
 #[cfg(all(unix, target_os = "linux"))]
-fn read_native_dir(
-    file: &mut HostFile,
-    len: usize,
-    restart: bool,
-) -> AsyncHostResult<(i64, Vec<u8>)> {
+fn read_native_dir(file: &mut HostFile, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
     let fd = file.raw_fd();
     if restart && unsafe { libc::lseek(fd, 0, libc::SEEK_SET) } < 0 {
         return Err(last_native_error());
     }
 
-    let mut native = vec![0; len];
-    let ret = unsafe { libc::syscall(libc::SYS_getdents64, fd, native.as_mut_ptr(), native.len()) };
+    let ret = unsafe { libc::syscall(libc::SYS_getdents64, fd, out.as_mut_ptr(), out.len()) };
     if ret < 0 {
         return Err(last_native_error());
     }
     #[cfg(not(target_pointer_width = "64"))]
     let ret = i64::from(ret);
-    native.truncate(usize::try_from(ret).map_err(|_| AsyncHostError::Fault)?);
-    Ok((ret, native))
+    Ok(ret)
 }
 
 #[cfg(all(unix, target_os = "macos"))]
-fn read_native_dir(
-    file: &mut HostFile,
-    len: usize,
-    restart: bool,
-) -> AsyncHostResult<(i64, Vec<u8>)> {
+fn read_native_dir(file: &mut HostFile, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
     let fd = file.raw_fd();
     if restart && unsafe { libc::lseek(fd, 0, libc::SEEK_SET) } < 0 {
         return Err(last_native_error());
@@ -824,23 +814,19 @@ fn read_native_dir(
         fileattr: 0,
         forkattr: 0,
     };
-    let mut native = vec![0; len];
     let ret = unsafe {
         libc::getattrlistbulk(
             fd,
             (&mut attr_spec as *mut libc::attrlist).cast(),
-            native.as_mut_ptr().cast(),
-            native.len(),
+            out.as_mut_ptr().cast(),
+            out.len(),
             0,
         )
     };
     if ret < 0 {
         return Err(last_native_error());
     }
-    if ret == 0 {
-        native.clear();
-    }
-    Ok((i64::from(ret), native))
+    Ok(i64::from(ret))
 }
 
 #[cfg(all(unix, target_os = "linux"))]
@@ -1547,17 +1533,12 @@ fn rmdir_native_path(path: OsString) -> AsyncHostResult<()> {
 }
 
 #[cfg(windows)]
-fn read_native_dir(
-    file: &mut HostFile,
-    len: usize,
-    restart: bool,
-) -> AsyncHostResult<(i64, Vec<u8>)> {
+fn read_native_dir(file: &mut HostFile, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
     use windows_sys::Win32::Foundation::{ERROR_NO_MORE_FILES, HANDLE};
     use windows_sys::Win32::Storage::FileSystem::{
         FileIdBothDirectoryInfo, FileIdBothDirectoryRestartInfo, GetFileInformationByHandleEx,
     };
 
-    let mut native = vec![0; len];
     let info_class = if restart {
         FileIdBothDirectoryRestartInfo
     } else {
@@ -1567,8 +1548,8 @@ fn read_native_dir(
         GetFileInformationByHandleEx(
             file.raw_fd() as HANDLE,
             info_class,
-            native.as_mut_ptr().cast(),
-            u32::try_from(native.len()).map_err(|_| AsyncHostError::Fault)?,
+            out.as_mut_ptr().cast(),
+            u32::try_from(out.len()).map_err(|_| AsyncHostError::Fault)?,
         )
     };
     if ok == 0 {
@@ -1576,15 +1557,12 @@ fn read_native_dir(
             .raw_os_error()
             .unwrap_or_else(|| AsyncHostError::Inval.errno());
         if error == ERROR_NO_MORE_FILES as i32 {
-            return Ok((0, Vec::new()));
+            return Ok(0);
         }
         return Err(AsyncHostError::Native(error));
     }
 
-    Ok((
-        i64::try_from(len).map_err(|_| AsyncHostError::Fault)?,
-        native,
-    ))
+    i64::try_from(out.len()).map_err(|_| AsyncHostError::Fault)
 }
 
 #[cfg(windows)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -297,12 +297,17 @@ ported_fns! {
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_make_readdir_job"
     )]
-    pub(crate) fn make_readdir_job(dir: HostHandle, len: i32, restart: bool) -> Job {
+    pub(crate) fn make_readdir_job(
+        dir: HostHandle,
+        buffer: crate::async_host::HostCBuffer,
+        len: i32,
+        restart: bool,
+    ) -> Job {
         Job::new(JobPayload::Readdir {
             dir,
+            buffer,
             len,
             restart,
-            result: None,
         })
     }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use jobs::{
     make_rmdir_job, make_sleep_job, make_symlink_job, make_write_job, open_job_get_dev_id,
     open_job_get_fd, open_job_get_file_id, open_job_get_kind, open_job_result,
 };
-pub(crate) use runner::{get_file_time_result, get_read_result, get_readdir_result, run_host_job};
+pub(crate) use runner::{get_file_time_result, get_read_result, run_host_job};
 #[cfg(all(test, unix))]
 pub(crate) use types::JobPayload;
 pub(crate) use types::{FileTimeResult, HostFile, HostFileTable, HostHandle, Job, OpenJobResult};

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -93,10 +93,10 @@ pub(crate) fn run_host_job(job: &mut Job, files: &mut impl HostFileTable) {
         JobPayload::Rmdir { path } => run_rmdir_job(path.clone()),
         JobPayload::Readdir {
             dir,
+            buffer,
             len,
             restart,
-            result,
-        } => run_readdir_job(files, *dir, *len, *restart, result),
+        } => run_readdir_job(files, *dir, buffer, *len, *restart),
     };
 
     match result {
@@ -124,25 +124,6 @@ pub(crate) fn get_read_result(
     };
     let dst_offset = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
     memory.write_with_capacity(dst_offset, len, result)
-}
-
-pub(crate) fn get_readdir_result(
-    job: &Job,
-    memory: &mut (impl GuestMemory + ?Sized),
-    dst: i32,
-    len: i32,
-) -> AsyncHostResult<()> {
-    if job.err() != 0 {
-        return Ok(());
-    }
-    let JobPayload::Readdir {
-        result: Some(result),
-        ..
-    } = job.payload()
-    else {
-        return Err(AsyncHostError::Badf);
-    };
-    memory.write_with_capacity(dst, len, result)
 }
 
 pub(crate) fn get_file_time_result(

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -18,7 +18,7 @@
 
 use std::ffi::OsString;
 
-use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_host::{AsyncHostError, AsyncHostResult, HostCBuffer};
 use crate::async_sys::internal::fd_util;
 
 pub(crate) type HostHandle = u64;
@@ -287,9 +287,9 @@ pub(crate) enum JobPayload {
     },
     Readdir {
         dir: HostHandle,
+        buffer: HostCBuffer,
         len: i32,
         restart: bool,
-        result: Option<Vec<u8>>,
     },
 }
 

--- a/crates/moonrun/src/async_sys/os_error/stub.rs
+++ b/crates/moonrun/src/async_sys/os_error/stub.rs
@@ -161,28 +161,28 @@ ported_fns! {
         source = "src/os_error/stub.c",
         original = "moonbitlang_async_errno_to_string"
     )]
-    pub(crate) fn errno_to_string(errno: i32) -> String {
+    pub(crate) fn errno_to_string(errno: i32) -> Box<[u8]> {
         errno_to_string_sys(errno)
     }
 }
 
 #[cfg(unix)]
-fn errno_to_string_sys(errno: i32) -> String {
+fn errno_to_string_sys(errno: i32) -> Box<[u8]> {
     use std::ffi::CStr;
 
     let message = unsafe { libc::strerror(errno) };
     if message.is_null() {
-        return format!("errno {errno}");
+        return format!("errno {errno}").into_bytes().into_boxed_slice();
     }
 
     unsafe { CStr::from_ptr(message) }
-        .to_string_lossy()
-        .trim_end_matches(['\r', '\n'])
-        .to_owned()
+        .to_bytes()
+        .to_vec()
+        .into_boxed_slice()
 }
 
 #[cfg(windows)]
-fn errno_to_string_sys(errno: i32) -> String {
+fn errno_to_string_sys(errno: i32) -> Box<[u8]> {
     use windows_sys::Win32::System::Diagnostics::Debug::{
         FORMAT_MESSAGE_FROM_SYSTEM, FORMAT_MESSAGE_IGNORE_INSERTS, FormatMessageW,
     };
@@ -200,10 +200,40 @@ fn errno_to_string_sys(errno: i32) -> String {
         )
     };
     if len == 0 {
-        return format!("errno {errno}");
+        return wide_bytes(format!("errno {errno}").encode_utf16());
     }
 
-    String::from_utf16_lossy(&buffer[..len as usize])
-        .trim_end_matches(['\r', '\n'])
-        .to_owned()
+    wide_bytes(buffer[..len as usize].iter().copied())
+}
+
+#[cfg(windows)]
+fn wide_bytes(units: impl IntoIterator<Item = u16>) -> Box<[u8]> {
+    units
+        .into_iter()
+        .flat_map(u16::to_le_bytes)
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn errno_to_string_returns_exact_owned_message_bytes() {
+        let buffer = errno_to_string(get_enotdir());
+        assert!(!buffer.is_empty());
+
+        #[cfg(unix)]
+        assert_ne!(buffer.last(), Some(&0));
+
+        #[cfg(windows)]
+        {
+            assert!(buffer.len().is_multiple_of(std::mem::size_of::<u16>()));
+            assert_ne!(
+                buffer.get(buffer.len().saturating_sub(2)..),
+                Some(&[0, 0][..])
+            );
+        }
+    }
 }

--- a/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
@@ -73,10 +73,16 @@ fn fetch_completion(
 ) -> Int = "moonbitlang/async" "thread_pool/fetch_completion/unix"
 
 ///|
-fn errno_to_string_len(errno : Int) -> Int = "moonbitlang/async" "os_error/errno_to_string_len"
+fn errno_to_string(errno : Int) -> UInt64 = "moonbitlang/async" "os_error/errno_to_string"
 
 ///|
-fn errno_to_string(errno : Int, dst : Int, len : Int) -> Int = "moonbitlang/async" "os_error/errno_to_string"
+fn os_string_decode_len(ptr : UInt64, len : Int) -> Int = "moonbitlang/async" "os_string/decode_len"
+
+///|
+fn os_string_decode(ptr : UInt64, len : Int, out : Int, out_len : Int) -> Unit = "moonbitlang/async" "os_string/decode"
+
+///|
+fn free_errno_str(ptr : UInt64) -> Unit = "moonbitlang/async" "os_error/free_errno_str"
 
 ///|
 fn get_tmp_path_len() -> Int = "moonbitlang/async" "fs/get_tmp_path_len"
@@ -107,13 +113,12 @@ fn main {
   assert_true(before > 1_600_000_000_000, "time is not Unix epoch milliseconds")
   let after = ms_since_epoch()
   assert_true(after >= before, "time moved backwards")
-  let message_len = errno_to_string_len(2)
+  let message_buf = errno_to_string(2)
+  let message_len = os_string_decode_len(message_buf, -1)
   assert_true(message_len > 0, "errno string size query failed")
   let message = String::make(message_len, '\u{0}')
-  assert_true(
-    errno_to_string(2, string_to_ptr(message), message_len) == 0,
-    "errno string fill failed",
-  )
+  os_string_decode(message_buf, -1, string_to_ptr(message), message_len)
+  free_errno_str(message_buf)
   assert_true(
     message != String::make(message_len, '\u{0}'),
     "errno string fill wrote an empty message",


### PR DESCRIPTION
## Why

This keeps MoonBuild's wasm async host boundary aligned with the rebased `moonbitlang/async` wasm host branch. The previous error ABI forced the host to materialize the errno string more than once, and the directory ABI copied readdir output through an extra job-owned buffer with unclear ownership.

## What changed

- `os_error/errno_to_string` now returns an owned C-buffer, and `os_error/free_errno_str` releases it after guest decoding.
- Host-owned C-buffers can be decoded directly from the recorded buffer length when the guest does not pass an explicit length.
- The wasm host exposes `c_buffer/new` so async can allocate the directory buffer explicitly.
- Readdir jobs now write into the caller-owned directory buffer, and directory entry helpers read from that C-buffer handle.
- The async submodule pointer is updated to the rebased async branch that carries the matching bindings.

## Why this is correct

This mirrors the native async ownership model: errno messages have one owned buffer that is freed after decoding, and directory iteration parses entries from the caller-managed directory buffer. Directory entry names are borrowed views into that buffer instead of separate host allocations, so the third-buffer path is removed.

## Scope

The change is limited to the wasm async host ABI, its Rust host implementations, the direct async-host fixture, and the async submodule pointer. The corresponding async bindings remain split in `moonbitlang/async#440`.