### PR TITLE
Check moonrun async host leaks

### DIFF
--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -38,6 +38,7 @@ fn repo_root() -> std::path::PathBuf {
 // Upstream async has tick-sensitive tests; keep wasm package runs isolated
 // from the Rust test harness's package-level concurrency.
 static ASYNC_WASM_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+const MOONBIT_ASYNC_CHECK_FD_LEAK: &str = "MOONBIT_ASYNC_CHECK_FD_LEAK";
 
 fn prepare_async_wasm_workspace(dir: &TestDir) -> std::path::PathBuf {
     let repo_root = repo_root();
@@ -89,6 +90,7 @@ fn run_async_wasm_package(dir: &TestDir, package: &str) -> String {
     let output = moon_cmd(dir)
         .env("MOON_OVERRIDE", moon_bin())
         .env("MOONRUN_OVERRIDE", &moonrun)
+        .env(MOONBIT_ASYNC_CHECK_FD_LEAK, "1")
         .args([
             "-C",
             "app/main",
@@ -117,6 +119,7 @@ fn run_upstream_async_wasm_package(package: &str) -> String {
     let output = moon_cmd(&async_dir)
         .env("MOON_OVERRIDE", moon_bin())
         .env("MOONRUN_OVERRIDE", &moonrun)
+        .env(MOONBIT_ASYNC_CHECK_FD_LEAK, "1")
         .args([
             "test",
             "--target",

--- a/crates/moonrun/src/async_api/context.rs
+++ b/crates/moonrun/src/async_api/context.rs
@@ -38,6 +38,12 @@ impl AsyncContext {
     }
 }
 
+impl Drop for AsyncContext {
+    fn drop(&mut self) {
+        self.host.assert_no_leaked_handles_if_enabled();
+    }
+}
+
 pub(super) fn callback_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s AsyncContext {
     let data = args.data();
     assert!(data.is_external());

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -615,9 +615,6 @@ impl AsyncHost {
                     ));
                 }
             }
-            if !state.events.is_empty() {
-                leaks.push(format!("events={}", state.events.len()));
-            }
             if !state.jobs.is_empty() {
                 leaks.push(format!("jobs={}", state.jobs.len()));
             }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -57,6 +57,7 @@ pub(crate) enum AsyncHostError {
 
 pub(crate) type AsyncHostResult<T> = Result<T, AsyncHostError>;
 pub(crate) const INVALID_HOST_HANDLE: u64 = 0;
+pub(crate) const CHECK_FD_LEAK_ENV: &str = "MOONBIT_ASYNC_CHECK_FD_LEAK";
 pub(crate) type HostCBuffer = Arc<Mutex<Box<[u8]>>>;
 
 #[cfg(unix)]
@@ -588,6 +589,80 @@ impl AsyncHost {
         let errno = error.errno();
         self.set_errno(errno);
         errno
+    }
+
+    pub(crate) fn assert_no_leaked_handles_if_enabled(&self) {
+        if std::thread::panicking() || std::env::var_os(CHECK_FD_LEAK_ENV).is_none() {
+            return;
+        }
+
+        let summary = {
+            let state = self.state.lock().unwrap();
+            let mut leaks = Vec::new();
+
+            if state.c_buffers.len() != 0 {
+                leaks.push(format!("c_buffers={}", state.c_buffers.len()));
+            }
+            #[cfg(windows)]
+            {
+                if state.io_results.len() != 0 {
+                    leaks.push(format!("io_results={}", state.io_results.len()));
+                }
+                if !state.io_results_by_overlapped.is_empty() {
+                    leaks.push(format!(
+                        "io_results_by_overlapped={}",
+                        state.io_results_by_overlapped.len()
+                    ));
+                }
+            }
+            if state.events.len() != 0 {
+                leaks.push(format!("events={}", state.events.len()));
+            }
+            if state.jobs.len() != 0 {
+                leaks.push(format!("jobs={}", state.jobs.len()));
+            }
+            if state.polls.len() != 0 {
+                leaks.push(format!("polls={}", state.polls.len()));
+            }
+            let leaked_files = match state.files.get(state.invalid_file) {
+                Some(file) if file.is_invalid() => state.files.len().saturating_sub(1),
+                Some(_) => {
+                    leaks.push("invalid_file=valid".to_string());
+                    state.files.len()
+                }
+                None => {
+                    leaks.push("invalid_file=missing".to_string());
+                    state.files.len()
+                }
+            };
+            if leaked_files != 0 {
+                leaks.push(format!("files={leaked_files}"));
+            }
+            if state.workers.len() != 0 {
+                leaks.push(format!("workers={}", state.workers.len()));
+            }
+            #[cfg(unix)]
+            {
+                if state.completion_notifier.is_some() {
+                    leaks.push("completion_notifier=1".to_string());
+                }
+                if state.completion_source.is_some() {
+                    leaks.push("completion_source=1".to_string());
+                }
+            }
+            #[cfg(windows)]
+            {
+                if state.completion_port.is_some() {
+                    leaks.push("completion_port=1".to_string());
+                }
+            }
+
+            (!leaks.is_empty()).then(|| leaks.join(", "))
+        };
+
+        if let Some(summary) = summary {
+            panic!("moonrun async host leaked handles: {summary}");
+        }
     }
 
     pub(crate) fn poll_create(&self) -> AsyncHostResult<u64> {

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -600,12 +600,12 @@ impl AsyncHost {
             let state = self.state.lock().unwrap();
             let mut leaks = Vec::new();
 
-            if state.c_buffers.len() != 0 {
+            if !state.c_buffers.is_empty() {
                 leaks.push(format!("c_buffers={}", state.c_buffers.len()));
             }
             #[cfg(windows)]
             {
-                if state.io_results.len() != 0 {
+                if !state.io_results.is_empty() {
                     leaks.push(format!("io_results={}", state.io_results.len()));
                 }
                 if !state.io_results_by_overlapped.is_empty() {
@@ -615,13 +615,13 @@ impl AsyncHost {
                     ));
                 }
             }
-            if state.events.len() != 0 {
+            if !state.events.is_empty() {
                 leaks.push(format!("events={}", state.events.len()));
             }
-            if state.jobs.len() != 0 {
+            if !state.jobs.is_empty() {
                 leaks.push(format!("jobs={}", state.jobs.len()));
             }
-            if state.polls.len() != 0 {
+            if !state.polls.is_empty() {
                 leaks.push(format!("polls={}", state.polls.len()));
             }
             let leaked_files = match state.files.get(state.invalid_file) {
@@ -638,7 +638,7 @@ impl AsyncHost {
             if leaked_files != 0 {
                 leaks.push(format!("files={leaked_files}"));
             }
-            if state.workers.len() != 0 {
+            if !state.workers.is_empty() {
                 leaks.push(format!("workers={}", state.workers.len()));
             }
             #[cfg(unix)]

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -18,6 +18,8 @@
 
 use std::path::PathBuf;
 
+const MOONBIT_ASYNC_CHECK_FD_LEAK: &str = "MOONBIT_ASYNC_CHECK_FD_LEAK";
+
 fn moon_cmd() -> snapbox::cmd::Command {
     let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../moon/Cargo.toml");
     snapbox::cmd::Command::new("cargo")
@@ -339,10 +341,45 @@ fn test_moon_run_with_async_host_imports() {
     let wasm_file = dir.join("_build/wasm/debug/build/main/main.wasm");
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .env(MOONBIT_ASYNC_CHECK_FD_LEAK, "1")
         .arg(&wasm_file)
         .assert()
         .success()
         .stdout_eq("ok\n");
+}
+
+#[test]
+fn test_moon_run_async_host_leak_check_env() {
+    let dir = TestDir::new("test_async_host_leak_check.in");
+
+    moon_cmd()
+        .current_dir(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success();
+
+    let wasm_file = dir.join("_build/wasm/debug/build/main/main.wasm");
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .env_remove(MOONBIT_ASYNC_CHECK_FD_LEAK)
+        .arg(&wasm_file)
+        .assert()
+        .success()
+        .stdout_eq("leaked\n")
+        .stderr_eq("");
+
+    let assert = snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .env(MOONBIT_ASYNC_CHECK_FD_LEAK, "1")
+        .env("RUST_BACKTRACE", "0")
+        .arg(&wasm_file)
+        .assert()
+        .failure()
+        .stdout_eq("leaked\n");
+    let stderr = std::str::from_utf8(&assert.get_output().stderr).unwrap();
+    assert!(
+        stderr.contains("moonrun async host leaked handles: polls=1"),
+        "expected async host leak assertion in stderr, got:\n{stderr}"
+    );
 }
 
 #[test]

--- a/crates/moonrun/tests/test_cases/test_async_host_leak_check.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host_leak_check.in/main/main.mbt
@@ -1,0 +1,25 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+fn event_bus_create() -> UInt64 = "moonbitlang/async" "event_bus/create"
+
+///|
+fn main {
+  ignore(event_bus_create())
+  println("leaked")
+}

--- a/crates/moonrun/tests/test_cases/test_async_host_leak_check.in/main/moon.pkg.json
+++ b/crates/moonrun/tests/test_cases/test_async_host_leak_check.in/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moonrun/tests/test_cases/test_async_host_leak_check.in/moon.mod.json
+++ b/crates/moonrun/tests/test_cases/test_async_host_leak_check.in/moon.mod.json
@@ -1,0 +1,3 @@
+{
+  "name": "username/async-host-leak-check"
+}


### PR DESCRIPTION
## Summary
- Add an env-gated moonrun async host handle-table leak assertion keyed by `MOONBIT_ASYNC_CHECK_FD_LEAK`, matching `moonbitlang/async`.
- Enable that check for async wasm package tests.
- Add a regression fixture that intentionally leaks an event-bus handle to prove the assertion catches host-table leaks.

## Rationale
`moonbitlang/async` already has an FD leak check for guest-level descriptors. moonrun also owns host-side tables for async resources, so the same upstream test knob should verify those tables are empty when async tests finish.

## Correctness
The assertion runs only when `MOONBIT_ASYNC_CHECK_FD_LEAK` is present and is skipped during unwinding to avoid masking an existing panic. The leak summary checks the async host-owned resource tables while preserving the expected invalid file sentinel. The regression fixture demonstrates both disabled and enabled behavior.

## Minimality
The change is limited to moonrun's async host cleanup assertion, async wasm test env wiring, and one focused leak-check fixture.