### PR TITLE
Align async Wasm host offset ABI

### DIFF
--- a/crates/moonrun/src/async_api/c_buffer.rs
+++ b/crates/moonrun/src/async_api/c_buffer.rs
@@ -31,15 +31,18 @@ pub(super) fn is_null(_context: &mut ImportContext, ptr: u64) -> i32 {
 pub(super) fn blit_to_c(
     context: &mut ImportContext,
     dst: u64,
+    dst_offset: i32,
     src: i32,
-    offset: i32,
+    src_offset: i32,
     len: i32,
 ) -> AsyncHostResult<()> {
-    let src_len = checked_add_i32(offset, len)?;
+    let src_len = checked_add_i32(src_offset, len)?;
     let host = context.host;
     context.with_memory_mut(|memory| {
         let src = memory.read_exact(src, src_len)?;
-        host.with_c_buffer_mut(dst, |dst| stub::blit_to_c(dst, src, offset, len))
+        host.with_c_buffer_mut(dst, |dst| {
+            stub::blit_to_c(dst, dst_offset, src, src_offset, len)
+        })
     })
 }
 
@@ -47,15 +50,18 @@ pub(super) fn blit_to_c(
 pub(super) fn blit_from_c(
     context: &mut ImportContext,
     src: u64,
+    src_offset: i32,
     dst: i32,
-    offset: i32,
+    dst_offset: i32,
     len: i32,
 ) -> AsyncHostResult<()> {
-    let dst_len = checked_add_i32(offset, len)?;
+    let dst_len = checked_add_i32(dst_offset, len)?;
     let host = context.host;
     context.with_memory_mut(|memory| {
         let dst = memory.read_exact_mut(dst, dst_len)?;
-        host.with_c_buffer(src, |src| stub::blit_from_c(src, dst, offset, len))
+        host.with_c_buffer(src, |src| {
+            stub::blit_from_c(src, src_offset, dst, dst_offset, len)
+        })
     })
 }
 

--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -82,14 +82,14 @@ pub(super) fn dir_entry_name_len(
 }
 
 #[ported(source = "src/fs/dir.c")]
-pub(super) fn dir_entry_name(
+pub(super) fn dir_entry_name_offset(
     context: &mut ImportContext,
     buf: u64,
     offset: i32,
-) -> AsyncHostResult<u64> {
+) -> AsyncHostResult<i32> {
     context
         .host
-        .with_c_buffer(buf, |buf| Ok(dir::entry_name(buf, 0, offset)?.as_ptr() as u64))
+        .with_c_buffer(buf, |buf| dir::entry_name_offset(buf, 0, offset))
 }
 
 #[ported(source = "src/fs/dir.c")]

--- a/crates/moonrun/src/async_api/os_string.rs
+++ b/crates/moonrun/src/async_api/os_string.rs
@@ -20,23 +20,29 @@ use crate::async_host::{AsyncHostError, AsyncHostResult, write_u16};
 
 use super::context::ImportContext;
 
-pub(super) fn decode_len(context: &mut ImportContext, ptr: u64, len: i32) -> AsyncHostResult<i32> {
+pub(super) fn decode_len(
+    context: &mut ImportContext,
+    ptr: u64,
+    offset: i32,
+    len: i32,
+) -> AsyncHostResult<i32> {
     let string = context
         .host
-        .with_c_buffer(ptr, |buffer| decode_native_string(buffer, len))?;
+        .with_c_buffer(ptr, |buffer| decode_native_string(buffer, offset, len))?;
     utf16_len(&string)
 }
 
 pub(super) fn decode(
     context: &mut ImportContext,
     ptr: u64,
+    offset: i32,
     len: i32,
     out: i32,
     out_len: i32,
 ) -> AsyncHostResult<()> {
     let string = context
         .host
-        .with_c_buffer(ptr, |buffer| decode_native_string(buffer, len))?;
+        .with_c_buffer(ptr, |buffer| decode_native_string(buffer, offset, len))?;
     let units = string.encode_utf16().collect::<Vec<_>>();
     let actual_len = i32::try_from(units.len()).map_err(|_| AsyncHostError::Fault)?;
     if actual_len != out_len {
@@ -49,14 +55,39 @@ fn utf16_len(string: &str) -> AsyncHostResult<i32> {
     i32::try_from(string.encode_utf16().count()).map_err(|_| AsyncHostError::Fault)
 }
 
-fn decode_native_string(bytes: &[u8], len: i32) -> AsyncHostResult<String> {
-    let bytes = if len == -1 {
-        bytes
-    } else {
-        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
-        bytes.get(..len).ok_or(AsyncHostError::Fault)?
-    };
+fn decode_native_string(bytes: &[u8], offset: i32, len: i32) -> AsyncHostResult<String> {
+    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+    let bytes = bytes.get(offset..).ok_or(AsyncHostError::Fault)?;
+    let bytes = native_string_bytes(bytes, len)?;
     decode_native_string_bytes(bytes)
+}
+
+fn native_string_bytes(bytes: &[u8], len: i32) -> AsyncHostResult<&[u8]> {
+    if len == -1 {
+        return native_string_bytes_until_terminator(bytes);
+    }
+
+    let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+    bytes.get(..len).ok_or(AsyncHostError::Fault)
+}
+
+#[cfg(unix)]
+fn native_string_bytes_until_terminator(bytes: &[u8]) -> AsyncHostResult<&[u8]> {
+    let len = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .ok_or(AsyncHostError::Fault)?;
+    Ok(&bytes[..len])
+}
+
+#[cfg(windows)]
+fn native_string_bytes_until_terminator(bytes: &[u8]) -> AsyncHostResult<&[u8]> {
+    let len = bytes
+        .chunks_exact(std::mem::size_of::<u16>())
+        .position(|chunk| chunk == [0, 0])
+        .ok_or(AsyncHostError::Fault)?
+        * std::mem::size_of::<u16>();
+    Ok(&bytes[..len])
 }
 
 #[cfg(unix)]
@@ -83,19 +114,37 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn unix_decode_native_string_uses_the_whole_owned_buffer() {
+    fn unix_decode_native_string_uses_offset_and_explicit_length() {
         assert_eq!(
-            decode_native_string(b"abc\0def", -1),
-            Ok("abc\0def".to_string())
+            decode_native_string(b"zzabc\0def", 2, 3),
+            Ok("abc".to_string())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_decode_native_string_stops_at_nul_after_offset() {
+        assert_eq!(
+            decode_native_string(b"zzabc\0def", 2, -1),
+            Ok("abc".to_string())
         );
     }
 
     #[cfg(windows)]
     #[test]
-    fn windows_decode_native_string_uses_the_whole_owned_buffer() {
+    fn windows_decode_native_string_uses_offset_and_explicit_byte_length() {
         assert_eq!(
-            decode_native_string(&[b'a', 0, b'b', 0, 0, 0], -1),
-            Ok("ab\0".to_string())
+            decode_native_string(&[0xff, 0xff, b'a', 0, b'b', 0, 0, 0], 2, 4),
+            Ok("ab".to_string())
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_decode_native_string_stops_at_wide_nul_after_offset() {
+        assert_eq!(
+            decode_native_string(&[0xff, 0xff, b'a', 0, b'b', 0, 0, 0], 2, -1),
+            Ok("ab".to_string())
         );
     }
 

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -368,9 +368,9 @@ declare_async_imports! {
     helper os_error::free_errno_str(ptr: u64) -> void => "os_error/free_errno_str";
 
     // Decode host-native strings into guest-owned MoonBit String storage.
-    helper os_string::decode_len(ptr: u64, len: i32) -> i32 => "os_string/decode_len";
+    helper os_string::decode_len(ptr: u64, offset: i32, len: i32) -> i32 => "os_string/decode_len";
 
-    helper os_string::decode(ptr: u64, len: i32, out: i32, out_len: i32) -> void => "os_string/decode";
+    helper os_string::decode(ptr: u64, offset: i32, len: i32, out: i32, out_len: i32) -> void => "os_string/decode";
 
     helper fs::close_fd(fd: u64) -> i32 => "fd_util/close_fd";
 
@@ -489,9 +489,9 @@ declare_async_imports! {
 
     helper c_buffer::is_null(ptr: u64) -> i32 => "c_buffer/is_null";
 
-    ported c_buffer::blit_to_c(dst: u64, src: i32, offset: i32, len: i32) -> void => "c_buffer/blit_to_c";
+    ported c_buffer::blit_to_c(dst: u64, dst_offset: i32, src: i32, src_offset: i32, len: i32) -> void => "c_buffer/blit_to_c";
 
-    ported c_buffer::blit_from_c(src: u64, dst: i32, offset: i32, len: i32) -> void => "c_buffer/blit_from_c";
+    ported c_buffer::blit_from_c(src: u64, src_offset: i32, dst: i32, dst_offset: i32, len: i32) -> void => "c_buffer/blit_from_c";
 
     ported c_buffer::c_buffer_get(buf: u64, index: i32) -> i32 => "c_buffer/c_buffer_get";
 
@@ -522,7 +522,7 @@ declare_async_imports! {
 
     ported fs::dir_entry_name_len(buf: u64, offset: i32) -> i32 => "fs/dir_entry_get_name_len";
 
-    ported fs::dir_entry_name(buf: u64, offset: i32) -> u64 => "fs/dir_entry_get_name";
+    ported fs::dir_entry_name_offset(buf: u64, offset: i32) -> i32 => "fs/dir_entry_get_name_offset";
 
     ported fs::dir_entry_is_dir(buf: u64, offset: i32) -> i32 => "fs/dir_entry_is_dir";
 

--- a/crates/moonrun/src/async_sys/fs/dir.rs
+++ b/crates/moonrun/src/async_sys/fs/dir.rs
@@ -124,35 +124,37 @@ ported_fns! {
 
     #[ported(
         source = "src/fs/dir.c",
-        original = "moonbitlang_async_dir_entry_get_name"
+        original = "moonbitlang_async_dir_entry_get_name_offset"
     )]
-    pub(crate) fn entry_name(
+    pub(crate) fn entry_name_offset(
         buf: &[u8],
         buf_ptr: i32,
         offset: i32,
-    ) -> AsyncHostResult<&[u8]> {
+    ) -> AsyncHostResult<i32> {
         #[cfg(windows)]
         {
-            let (start, len) = windows_name_range(buf, buf_ptr, offset)?;
-            buf
-                .get(start..start.checked_add(len).ok_or(AsyncHostError::Fault)?)
-                .ok_or(AsyncHostError::Fault)
+            use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
+
+            windows_name_range(buf, buf_ptr, offset)?;
+            i32::try_from(std::mem::offset_of!(FILE_ID_BOTH_DIR_INFO, FileName))
+                .map_err(|_| AsyncHostError::Fault)
         }
 
         #[cfg(target_os = "macos")]
         {
-            let (start, len) = mac_name_range(buf, buf_ptr, offset)?;
-            buf
-                .get(start..start.checked_add(len).ok_or(AsyncHostError::Fault)?)
-                .ok_or(AsyncHostError::Fault)
+            let name_offset = mac_name_offset(buf, buf_ptr, offset)?;
+            i32::try_from(
+                MAC_D_NAME_OFFSET
+                    .checked_add(name_offset)
+                    .ok_or(AsyncHostError::Fault)?,
+            )
+            .map_err(|_| AsyncHostError::Fault)
         }
 
         #[cfg(target_os = "linux")]
         {
-            let (start, len) = linux_name_range(buf, buf_ptr, offset)?;
-            buf
-                .get(start..start.checked_add(len).ok_or(AsyncHostError::Fault)?)
-                .ok_or(AsyncHostError::Fault)
+            linux_name_range(buf, buf_ptr, offset)?;
+            i32::try_from(LINUX_D_NAME_OFFSET).map_err(|_| AsyncHostError::Fault)
         }
     }
 
@@ -313,8 +315,7 @@ fn mac_name_range(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<(usi
     let entry = entry_offset(buf_ptr, offset)?;
     let reclen = usize::try_from(read_u32_ne(buf, entry + MAC_D_RECLEN_OFFSET)?)
         .map_err(|_| AsyncHostError::Fault)?;
-    let name_offset = usize::try_from(read_i32_ne(buf, entry + MAC_D_NAME_OFFSET)?)
-        .map_err(|_| AsyncHostError::Fault)?;
+    let name_offset = mac_name_offset(buf, buf_ptr, offset)?;
     let name_len = usize::try_from(read_u32_ne(buf, entry + MAC_D_NAME_LENGTH_OFFSET)?)
         .map_err(|_| AsyncHostError::Fault)?;
     let name_len = name_len.checked_sub(1).ok_or(AsyncHostError::Fault)?;
@@ -330,6 +331,12 @@ fn mac_name_range(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<(usi
         return Err(AsyncHostError::Fault);
     }
     Ok((name_start, name_len))
+}
+
+#[cfg(target_os = "macos")]
+fn mac_name_offset(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<usize> {
+    let entry = entry_offset(buf_ptr, offset)?;
+    usize::try_from(read_i32_ne(buf, entry + MAC_D_NAME_OFFSET)?).map_err(|_| AsyncHostError::Fault)
 }
 
 #[cfg(windows)]
@@ -387,7 +394,7 @@ mod tests {
 
         assert_eq!(entry_length(&buf, 100, 0), Ok(24));
         assert_eq!(entry_name_len(&buf, 100, 0), Ok(3));
-        assert_eq!(entry_name(&buf, 100, 0), Ok(b"abc".as_slice()));
+        assert_eq!(entry_name_offset(&buf, 100, 0), Ok(19));
         assert_eq!(entry_is_dir(&buf, 100, 0), Ok(1));
         assert_eq!(entry_is_hidden(&buf, 100, 0), Ok(false));
         assert_eq!(entry_file_id(&buf, 100, 0), Ok(0x0102_0304_0506_0708));
@@ -414,7 +421,7 @@ mod tests {
 
         assert_eq!(entry_length(&buf, 100, 0), Ok(52));
         assert_eq!(entry_name_len(&buf, 100, 0), Ok(3));
-        assert_eq!(entry_name(&buf, 100, 0), Ok(b"abc".as_slice()));
+        assert_eq!(entry_name_offset(&buf, 100, 0), Ok(44));
         assert_eq!(entry_is_dir(&buf, 100, 0), Ok(1));
         assert_eq!(entry_is_hidden(&buf, 100, 0), Ok(false));
         assert_eq!(entry_file_id(&buf, 100, 0), Ok(0x0102_0304_0506_0708));

--- a/crates/moonrun/src/async_sys/internal/c_buffer/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/c_buffer/stub.rs
@@ -24,9 +24,15 @@ ported_fns! {
         source = "src/internal/c_buffer/stub.c",
         original = "moonbitlang_async_blit_to_c"
     )]
-    pub(crate) fn blit_to_c(dst: &mut [u8], src: &[u8], offset: i32, len: i32) -> AsyncHostResult<()> {
-        let src = checked_range(src, offset, len)?;
-        let dst = dst.get_mut(..src.len()).ok_or(AsyncHostError::Fault)?;
+    pub(crate) fn blit_to_c(
+        dst: &mut [u8],
+        dst_offset: i32,
+        src: &[u8],
+        src_offset: i32,
+        len: i32,
+    ) -> AsyncHostResult<()> {
+        let src = checked_range(src, src_offset, len)?;
+        let dst = checked_range_mut(dst, dst_offset, len)?;
         dst.copy_from_slice(src);
         Ok(())
     }
@@ -35,12 +41,15 @@ ported_fns! {
         source = "src/internal/c_buffer/stub.c",
         original = "moonbitlang_async_blit_from_c"
     )]
-    pub(crate) fn blit_from_c(src: &[u8], dst: &mut [u8], offset: i32, len: i32) -> AsyncHostResult<()> {
-        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
-        let src = src.get(..len).ok_or(AsyncHostError::Fault)?;
-        let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
-        let end = offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
-        let dst = dst.get_mut(offset..end).ok_or(AsyncHostError::Fault)?;
+    pub(crate) fn blit_from_c(
+        src: &[u8],
+        src_offset: i32,
+        dst: &mut [u8],
+        dst_offset: i32,
+        len: i32,
+    ) -> AsyncHostResult<()> {
+        let src = checked_range(src, src_offset, len)?;
+        let dst = checked_range_mut(dst, dst_offset, len)?;
         dst.copy_from_slice(src);
         Ok(())
     }
@@ -84,26 +93,33 @@ fn checked_range(src: &[u8], offset: i32, len: i32) -> AsyncHostResult<&[u8]> {
     src.get(offset..end).ok_or(AsyncHostError::Fault)
 }
 
+fn checked_range_mut(src: &mut [u8], offset: i32, len: i32) -> AsyncHostResult<&mut [u8]> {
+    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+    let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+    let end = offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
+    src.get_mut(offset..end).ok_or(AsyncHostError::Fault)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn blit_to_c_copies_from_source_offset() {
-        let mut dst = [0; 3];
+    fn blit_to_c_copies_between_offsets() {
+        let mut dst = *b"abcdef";
 
-        blit_to_c(&mut dst, b"abcdef", 2, 3).unwrap();
+        blit_to_c(&mut dst, 2, b"XYZ123", 1, 3).unwrap();
 
-        assert_eq!(&dst, b"cde");
+        assert_eq!(&dst, b"abYZ1f");
     }
 
     #[test]
-    fn blit_from_c_copies_to_destination_offset() {
+    fn blit_from_c_copies_between_offsets() {
         let mut dst = *b"abcdef";
 
-        blit_from_c(b"XY", &mut dst, 2, 2).unwrap();
+        blit_from_c(b"XYZ123", 1, &mut dst, 2, 3).unwrap();
 
-        assert_eq!(&dst, b"abXYef");
+        assert_eq!(&dst, b"abYZ1f");
     }
 
     #[test]

--- a/crates/moonrun/src/async_sys/os_error/stub.rs
+++ b/crates/moonrun/src/async_sys/os_error/stub.rs
@@ -172,13 +172,10 @@ fn errno_to_string_sys(errno: i32) -> Box<[u8]> {
 
     let message = unsafe { libc::strerror(errno) };
     if message.is_null() {
-        return format!("errno {errno}").into_bytes().into_boxed_slice();
+        return nul_terminated_bytes(format!("errno {errno}").into_bytes());
     }
 
-    unsafe { CStr::from_ptr(message) }
-        .to_bytes()
-        .to_vec()
-        .into_boxed_slice()
+    nul_terminated_bytes(unsafe { CStr::from_ptr(message) }.to_bytes().to_vec())
 }
 
 #[cfg(windows)]
@@ -200,10 +197,10 @@ fn errno_to_string_sys(errno: i32) -> Box<[u8]> {
         )
     };
     if len == 0 {
-        return wide_bytes(format!("errno {errno}").encode_utf16());
+        return nul_terminated_wide_bytes(format!("errno {errno}").encode_utf16());
     }
 
-    wide_bytes(buffer[..len as usize].iter().copied())
+    nul_terminated_wide_bytes(buffer[..len as usize].iter().copied())
 }
 
 #[cfg(windows)]
@@ -215,22 +212,36 @@ fn wide_bytes(units: impl IntoIterator<Item = u16>) -> Box<[u8]> {
         .into_boxed_slice()
 }
 
+#[cfg(unix)]
+fn nul_terminated_bytes(mut bytes: Vec<u8>) -> Box<[u8]> {
+    bytes.push(0);
+    bytes.into_boxed_slice()
+}
+
+#[cfg(windows)]
+fn nul_terminated_wide_bytes(units: impl IntoIterator<Item = u16>) -> Box<[u8]> {
+    wide_bytes(units.into_iter().chain(std::iter::once(0)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn errno_to_string_returns_exact_owned_message_bytes() {
+    fn errno_to_string_returns_native_string_buffer() {
         let buffer = errno_to_string(get_enotdir());
         assert!(!buffer.is_empty());
 
         #[cfg(unix)]
-        assert_ne!(buffer.last(), Some(&0));
+        {
+            assert_eq!(buffer.last(), Some(&0));
+            assert!(buffer.len() > 1);
+        }
 
         #[cfg(windows)]
         {
             assert!(buffer.len().is_multiple_of(std::mem::size_of::<u16>()));
-            assert_ne!(
+            assert_eq!(
                 buffer.get(buffer.len().saturating_sub(2)..),
                 Some(&[0, 0][..])
             );

--- a/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
@@ -76,10 +76,20 @@ fn fetch_completion(
 fn errno_to_string(errno : Int) -> UInt64 = "moonbitlang/async" "os_error/errno_to_string"
 
 ///|
-fn os_string_decode_len(ptr : UInt64, len : Int) -> Int = "moonbitlang/async" "os_string/decode_len"
+fn os_string_decode_len(
+  ptr : UInt64,
+  offset : Int,
+  len : Int,
+) -> Int = "moonbitlang/async" "os_string/decode_len"
 
 ///|
-fn os_string_decode(ptr : UInt64, len : Int, out : Int, out_len : Int) -> Unit = "moonbitlang/async" "os_string/decode"
+fn os_string_decode(
+  ptr : UInt64,
+  offset : Int,
+  len : Int,
+  out : Int,
+  out_len : Int,
+) -> Unit = "moonbitlang/async" "os_string/decode"
 
 ///|
 fn free_errno_str(ptr : UInt64) -> Unit = "moonbitlang/async" "os_error/free_errno_str"
@@ -114,10 +124,10 @@ fn main {
   let after = ms_since_epoch()
   assert_true(after >= before, "time moved backwards")
   let message_buf = errno_to_string(2)
-  let message_len = os_string_decode_len(message_buf, -1)
+  let message_len = os_string_decode_len(message_buf, 0, -1)
   assert_true(message_len > 0, "errno string size query failed")
   let message = String::make(message_len, '\u{0}')
-  os_string_decode(message_buf, -1, string_to_ptr(message), message_len)
+  os_string_decode(message_buf, 0, -1, string_to_ptr(message), message_len)
   free_errno_str(message_buf)
   assert_true(
     message != String::make(message_len, '\u{0}'),


### PR DESCRIPTION
## Why

`moonbitlang/async` changed the directory entry path to decode names from a c-buffer using an entry-relative offset. The Wasm-support async branch also needs to sit on top of that upstream refactor, otherwise it still imports the old raw directory-name and no-offset string/c-buffer host shapes.

## What changed

- Rebase `moonbitlang/async` branch `codex/wasm-async-fs-host-upstream` onto async `main` and point the submodule at its new head.
- Keep `.gitmodules` tracking `codex/wasm-async-fs-host-upstream`, not `main`.
- Replace the raw directory name ABI with `fs/dir_entry_get_name_offset`.
- Align `c_buffer/blit_to_c` and `c_buffer/blit_from_c` with upstream's source/destination offset signatures.
- Keep the Rust `os_string` host adapter, but update it to decode `(buffer, offset, len)` instead of the old no-offset shape.
- Keep `errno_to_string` buffers shaped like native C strings so offset-aware `@os_string.decode` can use `len = -1` safely.

## Why this is correct

The async submodule branch remains the Wasm-support branch, now rebased over upstream's offset refactor. The Rust host exposes the ABI that the rebased Wasm branch imports: directory names are read by offset, c-buffer copies accept both source and destination offsets, and native string decoding remains host-owned for platform-specific UTF-8/UTF-16 handling.

## Scope

The change is limited to the Rust async host ABI adaptation, the rebased async submodule pointer/tracking metadata, and the existing moonrun async-host fixture.