### PR TITLE
Add tracing instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ dependencies = [
  "thiserror 1.0.63",
  "tokio",
  "toml",
+ "tracing",
  "walkdir",
  "which 6.0.2",
  "zip",
@@ -1713,6 +1714,7 @@ dependencies = [
  "sha2",
  "test-log",
  "thiserror 1.0.63",
+ "tracing",
  "walkdir",
  "zip",
 ]

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -821,6 +821,7 @@ fn check_command_args_without_executable(args: &[String]) -> Option<Vec<String>>
         .then(|| command_args.to_vec())
 }
 
+#[instrument(level = Level::DEBUG, skip_all)]
 pub fn generate_all_pkgs_json(build_meta: &BuildMeta) -> anyhow::Result<()> {
     let all_pkgs_path = build_meta
         .artifact_paths
@@ -986,7 +987,11 @@ type WantFileFn<'b> = dyn for<'a> FnOnce(&'a mut n2::work::Work) -> anyhow::Resu
 ///
 /// This function is primarily used for rebuilding tests after snapshot test
 /// promotion.
-#[instrument(skip_all)]
+#[instrument(
+    level = Level::DEBUG,
+    skip_all,
+    fields(parallelism = ?cfg.parallelism, n2_explain = cfg.n2_explain)
+)]
 pub fn execute_build_partial(
     cfg: &BuildConfig,
     input: BuildInput,
@@ -1015,8 +1020,10 @@ pub fn execute_build_partial(
     // Generate n2 state
 
     let mut hashes = n2::graph::Hashes::default();
+    let n2_open_db_span = tracing::debug_span!("n2_open_db").entered();
     let n2_db = n2::db::open(&db_path, &mut build_graph, &mut hashes)
         .with_context(|| format!("Failed to open build cache DB at {}", db_path.display()))?;
+    drop(n2_open_db_span);
 
     let parallelism = cfg
         .parallelism
@@ -1038,6 +1045,7 @@ pub fn execute_build_partial(
             cfg.suppress_progress,
         ),
     };
+    let n2_create_work_span = tracing::debug_span!("n2_create_work", parallelism).entered();
     let mut work = n2::work::Work::new(
         build_graph,
         hashes,
@@ -1052,10 +1060,15 @@ pub fn execute_build_partial(
         &mut *prog_console,
         n2::smallmap::SmallMap::default(),
     );
+    drop(n2_create_work_span);
+    let n2_select_targets_span = tracing::debug_span!("n2_select_targets").entered();
     want_files(&mut work).context("Failed to determine the files to be built")?;
+    drop(n2_select_targets_span);
 
     // The actual execution done by the n2 executor
+    let n2_run_span = tracing::debug_span!("n2_run", parallelism).entered();
     let res = work.run().context("Failed to run n2 graph");
+    drop(n2_run_span);
     drop(work);
     drop(prog_console); // Ensure the progress bar won't mess with diagnostic output
     let res = res?;

--- a/crates/moon/src/run/child.rs
+++ b/crates/moon/src/run/child.rs
@@ -42,6 +42,11 @@ use tracing::warn;
 /// `captures` uses a list of [`SectionCapture`] to capture part of the `stdout`
 /// output since the running process might not have any other method to interact
 /// with the host `moon` process.
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(capture, capture_count = captures.len())
+)]
 pub(crate) async fn run<'a>(
     captures: &mut [&mut SectionCapture<'a>],
     capture: bool,

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -216,7 +216,14 @@ impl<'a> LoweringContext<'a> {
         self.packages.get_package(target.package)
     }
 
-    #[instrument(level = Level::DEBUG, skip(self))]
+    #[instrument(
+        level = Level::DEBUG,
+        skip(self),
+        fields(
+            action = %self.plan.human_desc(id, self.modules, self.packages),
+            package = %self.plan.package_for_error(id).map(|target| self.packages.fqn(target.package).to_string()).unwrap_or_else(|| "none".to_string())
+        )
+    )]
     pub(super) fn lower_action(&mut self, id: BuildActionId) -> Result<(), LoweringError> {
         let action = self.plan.action(id);
         if self.is_action_noop(action) {

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -371,7 +371,11 @@ impl<'a> BuildPlanConstructor<'a> {
         Ok(())
     }
 
-    #[instrument(level = Level::DEBUG, skip(self))]
+    #[instrument(
+        level = Level::DEBUG,
+        skip(self),
+        fields(package = %self.input.pkg_dirs.fqn(target.package), kind = ?target.kind)
+    )]
     pub(super) fn build_check(
         &mut self,
         node: BuildPlanNode,

--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -336,7 +336,11 @@ pub(crate) fn discover_packages_for_mod(
 
 /// Discover one package and get its basic information. This does *not* create
 /// e.g. subpackages.
-#[instrument(level = Level::DEBUG, skip(m, rel, pkg_manifest_path))]
+#[instrument(
+    level = Level::DEBUG,
+    skip(m, rel, pkg_manifest_path),
+    fields(module = %m.name(), package_path = %PackagePath::new_from_rel_path(rel).expect("valid package path"))
+)]
 fn discover_one_package(
     mid: ModuleId,
     m: &ModuleSource,

--- a/crates/moonbuild-rupes-recta/src/pkg_solve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/pkg_solve/mod.rs
@@ -45,10 +45,17 @@ pub fn solve(
 ) -> Result<DepRelationship, SolveError> {
     info!("Starting dependency resolution");
 
+    let solve_only_span = tracing::debug_span!("solve_package_dependencies").entered();
     let (mut res, mut solve_warnings) = solve_only(modules, packages, enable_coverage)?;
+    drop(solve_only_span);
     user_warnings.append(&mut solve_warnings);
+    let verify_span = tracing::debug_span!("verify_package_dependencies").entered();
     verify(&res, packages, user_warnings)?;
+    drop(verify_span);
+    let supported_targets_span =
+        tracing::debug_span!("compute_realizable_supported_targets").entered();
     res.realizable_supported_targets = compute_realizable_supported_targets(&res, packages);
+    drop(supported_targets_span);
 
     info!("Dependency resolution completed successfully");
     Ok(res)

--- a/crates/moonbuild-rupes-recta/src/prebuild.rs
+++ b/crates/moonbuild-rupes-recta/src/prebuild.rs
@@ -77,6 +77,7 @@ pub fn run_prebuild_config(
     Ok(output)
 }
 
+#[instrument(level = "debug", skip_all, fields(module = %ms.name()))]
 fn run_prebuild_for_module(
     m: ModuleId,
     ms: &ModuleSource,

--- a/crates/moonbuild/Cargo.toml
+++ b/crates/moonbuild/Cargo.toml
@@ -67,6 +67,7 @@ regex.workspace = true
 ariadne.workspace = true
 handlebars = { version = "6.3.2", default-features = false }
 toml = { workspace = true, features = ["parse", "serde", "std"] }
+tracing.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/crates/moonbuild/src/build_script.rs
+++ b/crates/moonbuild/src/build_script.rs
@@ -66,6 +66,7 @@ fn run_script_cmd(prebuild: &String, m: &ModuleName) -> anyhow::Result<Command> 
     }
 }
 
+#[tracing::instrument(level = "debug", skip_all, fields(module = %module.name()))]
 pub fn run_build_script_for_module(
     module: &moonutil::mooncakes::ModuleSource,
     dir: &Path,
@@ -79,6 +80,7 @@ pub fn run_build_script_for_module(
         "Running external prebuild config at `{}`. The script can execute arbitrary code.",
         prebuild
     );
+    let spawn_span = tracing::debug_span!("spawn_prebuild_script").entered();
     let mut cmd = run_script_cmd(prebuild, module.name())?
         .current_dir(dir)
         .stdin(Stdio::piped())
@@ -88,15 +90,18 @@ pub fn run_build_script_for_module(
         .with_context(|| {
             format!("failed to spawn prebuild script `{prebuild}` for module `{module}`")
         })?;
+    drop(spawn_span);
     let stdin = cmd.stdin.take().expect("Didn't get stdin");
     let join = std::thread::spawn(move || {
         let mut stdin = stdin;
         let input = serde_json::to_string(&input).expect("failed to serialize input");
         let _ = stdin.write_all(input.as_bytes());
     });
+    let wait_span = tracing::debug_span!("wait_prebuild_script").entered();
     let output = cmd.wait_with_output().with_context(|| {
         format!("failed to run prebuild script `{prebuild}` for module `{module}`")
     })?;
+    drop(wait_span);
     join.join().map_err(|_| {
         anyhow::anyhow!(
             "failed to join prebuild script `{}` for module `{}`",
@@ -111,10 +116,12 @@ pub fn run_build_script_for_module(
             module
         );
     }
+    let parse_span = tracing::debug_span!("parse_prebuild_script_output").entered();
     let output =
         serde_json::from_slice::<BuildScriptOutput>(&output.stdout).with_context(|| {
             format!("failed to deserialize prebuild script `{prebuild}` for module `{module}`")
         })?;
+    drop(parse_span);
 
     Ok(output)
 }

--- a/crates/mooncake/Cargo.toml
+++ b/crates/mooncake/Cargo.toml
@@ -46,6 +46,7 @@ indexmap.workspace = true
 petgraph.workspace = true
 thiserror.workspace = true
 dunce.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/crates/mooncake/src/dep_dir.rs
+++ b/crates/mooncake/src/dep_dir.rs
@@ -195,6 +195,7 @@ fn diff_dep_dir_state<'a>(
 /// If `frozen` is true, the function will not change anything in the current
 /// dependency directory. If the desired dependency list cannot be created
 /// from the current directory, this function will return an error.
+#[tracing::instrument(level = "debug", skip_all, fields(quiet, frozen, verbose))]
 pub(crate) fn sync_deps(
     dep_dir: &DepDir,
     registry: &dyn Registry,

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -105,6 +105,11 @@ pub fn install(
     .map(|_| 0)
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(root_count = roots.len(), verbose, dont_sync, no_std)
+)]
 pub(crate) fn install_impl(
     mooncakes_dir: &Path,
     roots: ResolvedRootModules,
@@ -125,9 +130,12 @@ pub(crate) fn install_impl(
         inject_std: !includes_core && !no_std,
     };
 
+    let resolve_span = tracing::debug_span!("resolve_dependencies").entered();
     let res = resolve_with_default_env_and_resolver(&resolve_config, roots)?;
+    drop(resolve_span);
     let dep_dir = crate::dep_dir::DepDir::new(mooncakes_dir.to_path_buf());
 
+    let sync_span = tracing::debug_span!("sync_dependency_directory").entered();
     crate::dep_dir::sync_deps(
         &dep_dir,
         resolve_config.registry.as_ref(),
@@ -137,14 +145,18 @@ pub(crate) fn install_impl(
         output_options.verbose(),
     )
     .context("When installing packages")?;
+    drop(sync_span);
 
+    let resolve_dirs_span = tracing::debug_span!("resolve_dependency_directories").entered();
     let dir_sync_result = resolve_dep_dirs(&dep_dir, &res);
+    drop(resolve_dirs_span);
 
     install_bin_deps(verbose, &res, &dir_sync_result)?;
 
     Ok((res, dir_sync_result))
 }
 
+#[tracing::instrument(level = "debug", skip_all, fields(verbose))]
 fn install_bin_deps(
     verbose: bool,
     res: &ResolvedEnv,

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -57,6 +57,7 @@ impl OnlineRegistry {
 }
 
 impl super::Registry for OnlineRegistry {
+    #[tracing::instrument(level = "debug", skip_all, fields(module = %name))]
     fn all_versions_of(
         &self,
         name: &ModuleName,
@@ -163,6 +164,11 @@ impl OnlineRegistry {
         );
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(module = %name, version = %version)
+    )]
     fn download_or_using_cache(
         &self,
         name: &ModuleName,
@@ -211,6 +217,11 @@ impl OnlineRegistry {
         Ok(data)
     }
 
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(module = %name, version = %version)
+    )]
     pub fn install_to_impl(
         &self,
         name: &ModuleName,

--- a/crates/mooncake/src/resolver.rs
+++ b/crates/mooncake/src/resolver.rs
@@ -237,6 +237,11 @@ pub(crate) struct ResolveConfig {
     pub(crate) inject_std: bool,
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(root_count = root.len(), inject_std = config.inject_std)
+)]
 pub(crate) fn resolve_with_default_env(
     config: &ResolveConfig,
     resolver: &mut dyn Resolver,

--- a/crates/mooncake/src/resolver/mvs.rs
+++ b/crates/mooncake/src/resolver/mvs.rs
@@ -233,6 +233,11 @@ fn workspace_version_override_warning(
     ))
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(root_count = res.input_module_ids().len())
+)]
 fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv) -> bool {
     let workspace_roots = res
         .input_module_ids()


### PR DESCRIPTION
## Summary

This PR adds tracing spans around MoonBuild-owned work that is currently hard to break down in trace output. It covers dependency sync and resolution, package solving, package discovery labels, build planning/lowering labels, prebuild script execution, child process waits, metadata generation, and n2 setup/run phases.

## Why

The existing trace output makes it possible to see broad command time, but several important sections are too coarse when investigating cache-hit checks or build planning overhead. Adding spans at those boundaries makes it easier to distinguish MoonBuild work from compiler subprocess work and to identify whether time is spent in discovery, solving, planning, lowering, metadata, or n2 cache validation.

## Correctness

The change is instrumentation-only. It uses existing `tracing` macros and keeps the existing control flow intact, with explicit scoped span guards only around important middle sections such as n2 setup/run and prebuild subprocess phases. The added fields use stable labels such as module names, package names, action descriptions, booleans, and counts.

## Scope

The patch avoids restructuring the build flow and keeps the added instrumentation close to existing function boundaries. Follow-up performance work can use these spans to decide where optimization is actually warranted.