### PR TITLE
Avoid repeated package manifest probes

### DIFF
--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -31,9 +31,7 @@ pub mod special_case;
 pub mod synth;
 
 pub use model::{DiscoverError, DiscoverResult, DiscoveredLocalProject, DiscoveredPackage};
-use moonutil::common::{
-    PackageSourceFileKind, is_moon_mod, is_moon_pkg_exist, package_source_file_kind,
-};
+use moonutil::common::{PackageSourceFileKind, is_moon_mod, package_source_file_kind};
 
 use std::{
     path::{Path, PathBuf},
@@ -52,7 +50,8 @@ use moonutil::{
     common::{
         IGNORE_DIRS, MBTI_USER_WRITTEN, MOON_MOD, MOON_MOD_JSON, MOON_PKG, MOON_PKG_JSON,
         MOONBITLANG_ABORT, read_module_desc_file_in_dir,
-        read_package_desc_file_in_dir_with_supported_targets_decl, warn_if_shadowed_manifest,
+        read_package_desc_file_from_path_with_supported_targets_decl, warn_if_shadowed_manifest,
+        warn_known_shadowed_manifest,
     },
     mooncakes::ModuleSourceKind,
     package::resolve_supported_targets,
@@ -289,14 +288,28 @@ pub(crate) fn discover_packages_for_mod(
             continue;
         }
 
-        // Check if this directory is a package
-        if !is_moon_pkg_exist(abs_path) {
+        // Check if this directory is a package.
+        let moon_pkg_path = abs_path.join(MOON_PKG);
+        let moon_pkg_json_path = abs_path.join(MOON_PKG_JSON);
+        let pkg_manifest_path = if moon_pkg_path.exists() {
+            if moon_pkg_json_path.exists() {
+                warn_known_shadowed_manifest(
+                    abs_path,
+                    MOON_PKG_JSON,
+                    MOON_PKG,
+                    &format!("at package root '{}'", abs_path.display()),
+                );
+            }
+            moon_pkg_path
+        } else if moon_pkg_json_path.exists() {
+            moon_pkg_json_path
+        } else {
             debug!(
                 "Skipping {} because it does not contain a package configuration file",
                 abs_path.display()
             );
             continue;
-        }
+        };
 
         // Begin discovering the package
         debug!("Discovering package at {}", abs_path.display());
@@ -304,11 +317,11 @@ pub(crate) fn discover_packages_for_mod(
         let pkg = discover_one_package(
             id,
             module_source,
-            abs_path,
             &rel_path,
             is_core,
             is_stdlib_pkg,
             &module_supported_targets,
+            &pkg_manifest_path,
         )?;
         debug!(
             "Found package: {} with {} source files",
@@ -323,36 +336,33 @@ pub(crate) fn discover_packages_for_mod(
 
 /// Discover one package and get its basic information. This does *not* create
 /// e.g. subpackages.
-#[instrument(level = Level::DEBUG, skip(m, abs, rel))]
+#[instrument(level = Level::DEBUG, skip(m, rel, pkg_manifest_path))]
 fn discover_one_package(
     mid: ModuleId,
     m: &ModuleSource,
-    abs: &Path,
     rel: &RelativePath,
     is_core: bool, // We have a couple of special cases for core packages. is_core is true when building the core module.
     pkg_is_stdlib: bool, // Whether the package being discovered is inside the stdlib (core) module.
     module_supported_targets: &IndexSet<TargetBackend>,
+    pkg_manifest_path: &Path,
 ) -> Result<DiscoveredPackage, DiscoverError> {
+    let abs = pkg_manifest_path
+        .parent()
+        .expect("package manifest path should be inside package root");
     let pkg_path = PackagePath::new_from_rel_path(rel)
         .expect("Generation of package path from relative path should not error");
     let fqn = PackageFQN::new(m.clone(), pkg_path);
 
     // Discover the package config
-    warn_if_shadowed_manifest(
-        abs,
-        MOON_PKG_JSON,
-        MOON_PKG,
-        &format!("at package root '{}'", abs.display()),
-    );
     let (pkg_json, supported_targets_decl) =
-        read_package_desc_file_in_dir_with_supported_targets_decl(abs).map_err(|e| {
-            DiscoverError::CantReadPackageFile {
+        read_package_desc_file_from_path_with_supported_targets_decl(pkg_manifest_path).map_err(
+            |e| DiscoverError::CantReadPackageFile {
                 module: m.clone(),
                 package: fqn.package().clone(),
                 path: abs.to_path_buf(),
                 inner: e,
-            }
-        })?;
+            },
+        )?;
     let pkg_json = if is_core {
         add_prelude_as_import_for_core(pkg_json)
     } else {
@@ -450,6 +460,7 @@ fn discover_one_package(
         module: mid,
         fqn,
         is_single_file: false,
+        manifest_path: Some(pkg_manifest_path.to_owned()),
         raw: Box::new(pkg_json),
         supported_targets_decl,
         effective_supported_targets,

--- a/crates/moonbuild-rupes-recta/src/discover/model.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/model.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use moonbuild::expect::PackageSrcResolver;
-use moonutil::common::{MOON_PKG, MOON_PKG_JSON, TargetBackend};
+use moonutil::common::{MOON_PKG_JSON, TargetBackend};
 use moonutil::module::MoonModRule;
 use moonutil::mooncakes::{ModuleId, ModuleSource, result::ResolvedRootModules};
 use moonutil::package::{MoonPkg, SupportedTargetsDeclKind};
@@ -51,6 +51,11 @@ pub struct DiscoveredPackage {
     /// Single-file packages behave differently in certain aspects, such as
     /// file determination and import resolution.
     pub is_single_file: bool,
+
+    /// The selected package manifest path for normal package layouts.
+    ///
+    /// Synthetic single-file packages do not have a real package manifest.
+    pub manifest_path: Option<PathBuf>,
 
     /// The raw `moon.pkg.json` of this package.
     pub raw: Box<MoonPkg>,
@@ -98,17 +103,11 @@ pub struct DiscoveredPackage {
 }
 
 impl DiscoveredPackage {
-    /// Get the configuration file `moon.pkg.json` or `moon.pkg` of this package
-    ///
-    /// This function assumes regular project layout.
-    /// Prefers `moon.pkg` (DSL format) if it exists, otherwise falls back to `moon.pkg.json`.
+    /// Get the configuration file `moon.pkg.json` or `moon.pkg` of this package.
     pub fn config_path(&self) -> PathBuf {
-        if self.root_path.join(MOON_PKG).exists() {
-            self.root_path.join(MOON_PKG)
-        } else {
-            // Default to JSON format (for backward compatibility and single-file scenarios)
-            self.root_path.join(MOON_PKG_JSON)
-        }
+        self.manifest_path
+            .clone()
+            .unwrap_or_else(|| self.root_path.join(MOON_PKG_JSON))
     }
 
     /// Get whether if the package is a virtual package

--- a/crates/moonbuild-rupes-recta/src/discover/synth.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/synth.rs
@@ -155,6 +155,7 @@ pub fn build_synth_single_file_package(
         module: mid,
         fqn: PackageFQN::new(module_src, pkg_path.clone()),
         is_single_file: true,
+        manifest_path: None,
         raw: Box::new(moon_pkg),
         supported_targets_decl: SupportedTargetsDeclKind::Omitted,
         effective_supported_targets: supported,

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -1140,6 +1140,7 @@ mod tests {
             module: module_id,
             fqn: PackageFQN::new(module_source, package_path.clone()),
             is_single_file: false,
+            manifest_path: Some(PathBuf::from(package_path.as_str()).join("moon.pkg.json")),
             raw: Box::new(moon_pkg(supported_targets.clone())),
             supported_targets_decl: SupportedTargetsDeclKind::Omitted,
             effective_supported_targets: supported_targets,

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -555,8 +555,7 @@ pub fn preferred_manifest_in_dir(
     let new_path = dir.join(new_manifest);
     let legacy_path = dir.join(legacy_manifest);
     match (new_path.exists(), legacy_path.exists()) {
-        (true, true) => Some((new_path, ManifestFormat::New)),
-        (true, false) => Some((new_path, ManifestFormat::New)),
+        (true, _) => Some((new_path, ManifestFormat::New)),
         (false, true) => Some((legacy_path, ManifestFormat::Legacy)),
         (false, false) => None,
     }
@@ -568,10 +567,18 @@ pub fn warn_if_shadowed_manifest(
     new_manifest: &'static str,
     location: &str,
 ) {
-    if !should_warn_manifest(dir)
-        || !dir.join(new_manifest).exists()
-        || !dir.join(legacy_manifest).exists()
-    {
+    if dir.join(new_manifest).exists() && dir.join(legacy_manifest).exists() {
+        warn_known_shadowed_manifest(dir, legacy_manifest, new_manifest, location);
+    }
+}
+
+pub fn warn_known_shadowed_manifest(
+    dir: &Path,
+    legacy_manifest: &'static str,
+    new_manifest: &'static str,
+    location: &str,
+) {
+    if !should_warn_manifest(dir) {
         return;
     }
 
@@ -662,18 +669,32 @@ pub fn read_package_desc_file_in_dir_with_supported_targets_decl(
     dir: &Path,
 ) -> anyhow::Result<(MoonPkg, SupportedTargetsDeclKind)> {
     match preferred_manifest_in_dir(dir, MOON_PKG, MOON_PKG_JSON) {
-        Some((path, ManifestFormat::New)) => {
-            read_package_from_dsl_with_supported_targets_decl(&path)
-        }
-        Some((path, ManifestFormat::Legacy)) => {
-            read_package_from_json_with_supported_targets_decl(&path)
-                .context(format!("Failed to load {:?}", path))
-        }
+        Some((path, _)) => read_package_desc_file_from_path_with_supported_targets_decl(&path),
         None => bail!(
             "Failed to find `{}` or `{}` for package at path `{}`",
             MOON_PKG,
             MOON_PKG_JSON,
             dir.display()
+        ),
+    }
+}
+
+pub fn read_package_desc_file_from_path_with_supported_targets_decl(
+    path: &Path,
+) -> anyhow::Result<(MoonPkg, SupportedTargetsDeclKind)> {
+    match path.file_name() {
+        Some(filename) if filename == OsStr::new(MOON_PKG) => {
+            read_package_from_dsl_with_supported_targets_decl(path)
+        }
+        Some(filename) if filename == OsStr::new(MOON_PKG_JSON) => {
+            read_package_from_json_with_supported_targets_decl(path)
+                .context(format!("Failed to load {:?}", path))
+        }
+        _ => bail!(
+            "Unsupported package manifest path `{}`; expected `{}` or `{}`",
+            path.display(),
+            MOON_PKG,
+            MOON_PKG_JSON
         ),
     }
 }


### PR DESCRIPTION
## Summary

- Remember the selected package manifest path during Rupes Recta package discovery.
- Read package config from that selected path instead of probing the manifest pair again.
- Reuse the recorded manifest path for later package config inputs.

## Rationale

Normal package discovery was repeatedly checking the same `moon.pkg` / `moon.pkg.json` pair across detection, shadowed-manifest warnings, manifest reading, and later `config_path()` calls. This adds redundant filesystem probes on no-op builds, where discovery and graph construction still run before the build cache is consulted.

## Correctness

The manifest selection rule is unchanged: `moon.pkg` remains preferred over `moon.pkg.json`, and JSON remains the fallback. The shadowed-manifest warning is still emitted when both files exist, while the existing warning suppression for cached dependency paths is preserved. Synthetic single-file packages keep their previous fallback config path behavior because they do not have a real package manifest.

## Scope

The change is limited to package manifest selection and propagation through discovered package metadata. Module manifest handling is left unchanged.