### PR TITLE
Simplify moonrun async import context

### DIFF
--- a/crates/moonrun/src/async_api/c_buffer.rs
+++ b/crates/moonrun/src/async_api/c_buffer.rs
@@ -23,13 +23,13 @@ use super::context::ImportContext;
 use super::provenance::ported_imports;
 
 ported_imports! {
-pub(super) fn is_null(_context: &mut ImportContext, ptr: u64) -> i32 {
+pub(super) fn is_null(_context: &mut ImportContext<'_, '_>, ptr: u64) -> i32 {
     i32::from(ptr == crate::async_host::INVALID_HOST_HANDLE)
 }
 
 #[ported(source = "src/internal/c_buffer/stub.c")]
 pub(super) fn blit_to_c(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     dst: u64,
     dst_offset: i32,
     src: i32,
@@ -37,8 +37,7 @@ pub(super) fn blit_to_c(
     len: i32,
 ) -> AsyncHostResult<()> {
     let src_len = checked_add_i32(src_offset, len)?;
-    let host = context.host;
-    context.with_memory_mut(|memory| {
+    context.with_host_and_memory_mut(|host, memory| {
         let src = memory.read_exact(src, src_len)?;
         host.with_c_buffer_mut(dst, |dst| {
             stub::blit_to_c(dst, dst_offset, src, src_offset, len)
@@ -48,7 +47,7 @@ pub(super) fn blit_to_c(
 
 #[ported(source = "src/internal/c_buffer/stub.c")]
 pub(super) fn blit_from_c(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     src: u64,
     src_offset: i32,
     dst: i32,
@@ -56,8 +55,7 @@ pub(super) fn blit_from_c(
     len: i32,
 ) -> AsyncHostResult<()> {
     let dst_len = checked_add_i32(dst_offset, len)?;
-    let host = context.host;
-    context.with_memory_mut(|memory| {
+    context.with_host_and_memory_mut(|host, memory| {
         let dst = memory.read_exact_mut(dst, dst_len)?;
         host.with_c_buffer(src, |src| {
             stub::blit_from_c(src, src_offset, dst, dst_offset, len)
@@ -67,21 +65,20 @@ pub(super) fn blit_from_c(
 
 #[ported(source = "src/internal/c_buffer/stub.c")]
 pub(super) fn c_buffer_get(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     buf: u64,
     index: i32,
 ) -> AsyncHostResult<i32> {
-    context
-        .host
+    context.host
         .with_c_buffer(buf, |buf| stub::c_buffer_get(buf, index).map(i32::from))
 }
 
 #[ported(source = "src/internal/c_buffer/stub.c")]
-pub(super) fn strlen(context: &mut ImportContext, buf: u64) -> AsyncHostResult<i32> {
+pub(super) fn strlen(context: &mut ImportContext<'_, '_>, buf: u64) -> AsyncHostResult<i32> {
     context.host.with_c_buffer(buf, stub::strlen)
 }
 
-pub(super) fn free(context: &mut ImportContext, ptr: u64) -> AsyncHostResult<()> {
+pub(super) fn free(context: &mut ImportContext<'_, '_>, ptr: u64) -> AsyncHostResult<()> {
     context.host.free_c_buffer(ptr)
 }
 
@@ -89,7 +86,7 @@ pub(super) fn free(context: &mut ImportContext, ptr: u64) -> AsyncHostResult<()>
     source = "src/internal/c_buffer/stub.c",
     original = "moonbitlang_async_make_c_buffer"
 )]
-pub(super) fn new(context: &mut ImportContext, size: i32) -> AsyncHostResult<u64> {
+pub(super) fn new(context: &mut ImportContext<'_, '_>, size: i32) -> AsyncHostResult<u64> {
     Ok(context.host.insert_c_buffer(stub::make_c_buffer(size)?))
 }
 

--- a/crates/moonrun/src/async_api/context.rs
+++ b/crates/moonrun/src/async_api/context.rs
@@ -61,10 +61,11 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
         }
     }
 
-    pub(super) fn with_memory_mut<T>(
+    pub(super) fn with_host_and_memory_mut<T>(
         &mut self,
-        f: impl FnOnce(&mut [u8]) -> AsyncHostResult<T>,
+        f: impl FnOnce(&AsyncHost, &mut [u8]) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
+        let host = self.host;
         let memory_object = memory_object(self.scope, self.imports)?;
         let buffer = memory_object.buffer();
         let len = buffer.byte_length();
@@ -76,7 +77,14 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
         };
 
         let memory = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), len) };
-        f(memory)
+        f(host, memory)
+    }
+
+    pub(super) fn with_memory_mut<T>(
+        &mut self,
+        f: impl FnOnce(&mut [u8]) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
+        self.with_host_and_memory_mut(|_, memory| f(memory))
     }
 }
 

--- a/crates/moonrun/src/async_api/env_util.rs
+++ b/crates/moonrun/src/async_api/env_util.rs
@@ -23,7 +23,7 @@ use super::provenance::ported_imports;
 
 ported_imports! {
 #[ported(source = "src/internal/env_util/stub.c")]
-pub(super) fn getpid(_context: &mut ImportContext) -> i32 {
+pub(super) fn getpid(_context: &mut ImportContext<'_, '_>) -> i32 {
     stub::get_pid() as i32
 }
 }

--- a/crates/moonrun/src/async_api/event_bus.rs
+++ b/crates/moonrun/src/async_api/event_bus.rs
@@ -107,19 +107,24 @@ const fn ported_from(
     }
 }
 
-pub(super) fn create(context: &mut ImportContext) -> AsyncHostResult<u64> {
+pub(super) fn create(context: &mut ImportContext<'_, '_>) -> AsyncHostResult<u64> {
     context.host.poll_create()
 }
 
-pub(super) fn destroy(context: &mut ImportContext, bus: u64) -> AsyncHostResult<()> {
+pub(super) fn destroy(context: &mut ImportContext<'_, '_>, bus: u64) -> AsyncHostResult<()> {
     context.host.poll_destroy(bus)
 }
 
-pub(super) fn register(context: &mut ImportContext, bus: u64, fd: u64, read_only: i32) -> i32 {
+pub(super) fn register(
+    context: &mut ImportContext<'_, '_>,
+    bus: u64,
+    fd: u64,
+    read_only: i32,
+) -> i32 {
     poll_errno_result(context, context.host.poll_register(bus, fd, read_only != 0))
 }
 
-pub(super) fn wait(context: &mut ImportContext, bus: u64, timeout_ms: i32) -> i32 {
+pub(super) fn wait(context: &mut ImportContext<'_, '_>, bus: u64, timeout_ms: i32) -> i32 {
     match context.host.poll_wait(bus, timeout_ms) {
         Ok(n) => n,
         Err(error) => {
@@ -129,33 +134,43 @@ pub(super) fn wait(context: &mut ImportContext, bus: u64, timeout_ms: i32) -> i3
     }
 }
 
-pub(super) fn get_event(context: &mut ImportContext, bus: u64, index: i32) -> AsyncHostResult<u64> {
+pub(super) fn get_event(
+    context: &mut ImportContext<'_, '_>,
+    bus: u64,
+    index: i32,
+) -> AsyncHostResult<u64> {
     context.host.poll_get_event(bus, index)
 }
 
-pub(super) fn event_fd(context: &mut ImportContext, event: u64) -> AsyncHostResult<u64> {
+pub(super) fn event_fd(context: &mut ImportContext<'_, '_>, event: u64) -> AsyncHostResult<u64> {
     context.host.poll_event_fd(event)
 }
 
 #[cfg(unix)]
-pub(super) fn event_events(context: &mut ImportContext, event: u64) -> AsyncHostResult<i32> {
+pub(super) fn event_events(
+    context: &mut ImportContext<'_, '_>,
+    event: u64,
+) -> AsyncHostResult<i32> {
     context.host.poll_event_events(event)
 }
 
 #[cfg(windows)]
-pub(super) fn event_io_result(context: &mut ImportContext, event: u64) -> AsyncHostResult<u64> {
+pub(super) fn event_io_result(
+    context: &mut ImportContext<'_, '_>,
+    event: u64,
+) -> AsyncHostResult<u64> {
     context.host.poll_event_io_result(event)
 }
 
 #[cfg(windows)]
 pub(super) fn event_bytes_transferred(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     event: u64,
 ) -> AsyncHostResult<i32> {
     context.host.poll_event_bytes_transferred(event)
 }
 
-fn poll_errno_result(context: &ImportContext, result: AsyncHostResult<()>) -> i32 {
+fn poll_errno_result(context: &ImportContext<'_, '_>, result: AsyncHostResult<()>) -> i32 {
     match result {
         Ok(()) => 0,
         Err(error) => {

--- a/crates/moonrun/src/async_api/event_loop.rs
+++ b/crates/moonrun/src/async_api/event_loop.rs
@@ -23,12 +23,12 @@ use super::provenance::ported_imports;
 
 ported_imports! {
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn get_platform(_context: &mut ImportContext) -> i32 {
+pub(super) fn get_platform(_context: &mut ImportContext<'_, '_>) -> i32 {
     thread_pool::get_platform()
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn errno_is_cancelled(_context: &mut ImportContext, errno: i32) -> i32 {
+pub(super) fn errno_is_cancelled(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if thread_pool::errno_is_cancelled(errno) {
         1
     } else {

--- a/crates/moonrun/src/async_api/fd_util.rs
+++ b/crates/moonrun/src/async_api/fd_util.rs
@@ -30,47 +30,47 @@ const MTIME_NSEC_OFFSET: i32 = 24;
 const CTIME_SEC_OFFSET: i32 = 32;
 const CTIME_NSEC_OFFSET: i32 = 40;
 
-pub(super) fn invalid_fd(context: &mut ImportContext) -> u64 {
+pub(super) fn invalid_fd(context: &mut ImportContext<'_, '_>) -> u64 {
     context.host.invalid_fd()
 }
 
-pub(super) fn sizeof_file_time(_context: &mut ImportContext) -> i32 {
+pub(super) fn sizeof_file_time(_context: &mut ImportContext<'_, '_>) -> i32 {
     FILE_TIME_RECORD_LEN
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_atime_sec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i64> {
+pub(super) fn get_atime_sec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i64> {
     file_time_i64(context, ptr, ATIME_SEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_atime_nsec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i32> {
+pub(super) fn get_atime_nsec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i32> {
     file_time_i32(context, ptr, ATIME_NSEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_mtime_sec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i64> {
+pub(super) fn get_mtime_sec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i64> {
     file_time_i64(context, ptr, MTIME_SEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_mtime_nsec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i32> {
+pub(super) fn get_mtime_nsec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i32> {
     file_time_i32(context, ptr, MTIME_NSEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_ctime_sec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i64> {
+pub(super) fn get_ctime_sec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i64> {
     file_time_i64(context, ptr, CTIME_SEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_ctime_nsec(context: &mut ImportContext, ptr: i32) -> AsyncHostResult<i32> {
+pub(super) fn get_ctime_nsec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i32> {
     file_time_i32(context, ptr, CTIME_NSEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
 pub(super) fn pipe(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     dst: i32,
     len: i32,
     read_end_is_async: i32,
@@ -81,8 +81,7 @@ pub(super) fn pipe(
             return Err(AsyncHostError::Fault);
         }
         context.with_memory_mut(|memory| memory.read_exact_mut(dst, 16).map(|_| ()))?;
-        let fds = context
-            .host
+        let fds = context.host
             .pipe(read_end_is_async != 0, write_end_is_async != 0)?;
         context.with_memory_mut(|memory| {
             memory.write_u64_le(dst, fds[0])?;
@@ -100,7 +99,7 @@ pub(super) fn pipe(
 
 #[ported(source = "src/internal/fd_util/stub.c")]
 #[cfg(unix)]
-pub(super) fn set_nonblocking(context: &mut ImportContext, fd: u64) -> i32 {
+pub(super) fn set_nonblocking(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
     match context.host.set_nonblocking(fd) {
         Ok(()) => 0,
         Err(error) => {
@@ -110,18 +109,18 @@ pub(super) fn set_nonblocking(context: &mut ImportContext, fd: u64) -> i32 {
     }
 }
 
-fn file_time_i64(context: &mut ImportContext, ptr: i32, field_offset: i32) -> AsyncHostResult<i64> {
+fn file_time_i64(context: &mut ImportContext<'_, '_>, ptr: i32, field_offset: i32) -> AsyncHostResult<i64> {
     read_field(context, ptr, field_offset, 8)
         .map(|bytes| i64::from_le_bytes(bytes.as_slice().try_into().unwrap()))
 }
 
-fn file_time_i32(context: &mut ImportContext, ptr: i32, field_offset: i32) -> AsyncHostResult<i32> {
+fn file_time_i32(context: &mut ImportContext<'_, '_>, ptr: i32, field_offset: i32) -> AsyncHostResult<i32> {
     read_field(context, ptr, field_offset, 4)
         .map(|bytes| i32::from_le_bytes(bytes.as_slice().try_into().unwrap()))
 }
 
 fn read_field(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     ptr: i32,
     field_offset: i32,
     len: i32,

--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -24,7 +24,7 @@ use super::context::ImportContext;
 use super::provenance::ported_imports;
 
 ported_imports! {
-pub(super) fn get_tmp_path_len(context: &mut ImportContext) -> i32 {
+pub(super) fn get_tmp_path_len(context: &mut ImportContext<'_, '_>) -> i32 {
     match tmp_path_utf16_units()
         .and_then(|units| i32::try_from(units.len()).map_err(|_| AsyncHostError::Fault))
     {
@@ -37,7 +37,7 @@ pub(super) fn get_tmp_path_len(context: &mut ImportContext) -> i32 {
 }
 
 #[ported(source = "src/fs/stub.c")]
-pub(super) fn get_tmp_path(context: &mut ImportContext, ptr: i32, len: i32) -> i32 {
+pub(super) fn get_tmp_path(context: &mut ImportContext<'_, '_>, ptr: i32, len: i32) -> i32 {
     let result = (|| {
         let units = tmp_path_utf16_units()?;
         let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
@@ -50,79 +50,73 @@ pub(super) fn get_tmp_path(context: &mut ImportContext, ptr: i32, len: i32) -> i
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn close_fd(context: &mut ImportContext, fd: u64) -> i32 {
+pub(super) fn close_fd(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
     zero_or_minus_one(context, context.host.close_fd(fd))
 }
 
 #[ported(source = "src/fs/dir.c")]
-pub(super) fn dir_buffer_min_size(_context: &mut ImportContext) -> i32 {
+pub(super) fn dir_buffer_min_size(_context: &mut ImportContext<'_, '_>) -> i32 {
     dir::buffer_min_size()
 }
 
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_length(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     buf: u64,
     offset: i32,
 ) -> AsyncHostResult<i32> {
-    context
-        .host
+    context.host
         .with_c_buffer(buf, |buf| dir::entry_length(buf, 0, offset))
 }
 
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_name_len(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     buf: u64,
     offset: i32,
 ) -> AsyncHostResult<i32> {
-    context
-        .host
+    context.host
         .with_c_buffer(buf, |buf| dir::entry_name_len(buf, 0, offset))
 }
 
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_name_offset(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     buf: u64,
     offset: i32,
 ) -> AsyncHostResult<i32> {
-    context
-        .host
+    context.host
         .with_c_buffer(buf, |buf| dir::entry_name_offset(buf, 0, offset))
 }
 
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_is_dir(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     buf: u64,
     offset: i32,
 ) -> AsyncHostResult<i32> {
-    context
-        .host
+    context.host
         .with_c_buffer(buf, |buf| dir::entry_is_dir(buf, 0, offset))
 }
 
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_is_hidden(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     buf: u64,
     offset: i32,
 ) -> AsyncHostResult<i32> {
-    context
-        .host
+    context.host
         .with_c_buffer(buf, |buf| dir::entry_is_hidden(buf, 0, offset))
         .map(|value| if value { 1 } else { 0 })
 }
 
 #[ported(source = "src/fs/dir.c")]
 pub(super) fn dir_entry_file_id(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     buf: u64,
     offset: i32,
 ) -> AsyncHostResult<u64> {
-    context
-        .host
+    context.host
         .with_c_buffer(buf, |buf| dir::entry_file_id(buf, 0, offset))
 }
 
@@ -146,7 +140,7 @@ fn os_string_to_utf16_units(path: std::ffi::OsString) -> AsyncHostResult<Vec<u16
 }
 
 #[ported(source = "src/fs/stub.c")]
-pub(super) fn errno_is_lock_violation(_context: &mut ImportContext, errno: i32) -> i32 {
+pub(super) fn errno_is_lock_violation(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::errno_is_lock_violation(errno) {
         1
     } else {
@@ -155,16 +149,16 @@ pub(super) fn errno_is_lock_violation(_context: &mut ImportContext, errno: i32) 
 }
 
 #[ported(source = "src/fs/stub.c")]
-pub(super) fn try_lock_file(context: &mut ImportContext, fd: u64, exclusive: i32) -> i32 {
+pub(super) fn try_lock_file(context: &mut ImportContext<'_, '_>, fd: u64, exclusive: i32) -> i32 {
     zero_or_minus_one(context, context.host.try_lock_file(fd, exclusive != 0))
 }
 
 #[ported(source = "src/fs/stub.c")]
-pub(super) fn unlock_file(context: &mut ImportContext, fd: u64) -> i32 {
+pub(super) fn unlock_file(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
     zero_or_minus_one(context, context.host.unlock_file(fd))
 }
 
-fn zero_or_minus_one(context: &ImportContext, result: AsyncHostResult<()>) -> i32 {
+fn zero_or_minus_one(context: &ImportContext<'_, '_>, result: AsyncHostResult<()>) -> i32 {
     match result {
         Ok(()) => 0,
         Err(error) => {

--- a/crates/moonrun/src/async_api/io.rs
+++ b/crates/moonrun/src/async_api/io.rs
@@ -23,19 +23,20 @@ ported_imports! {
 #[ported(source = "src/internal/event_loop/io_unix.c")]
 #[cfg(unix)]
 pub(super) fn read(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     fd: u64,
     dst: i32,
     offset: i32,
     len: i32,
 ) -> i32 {
-    let host = context.host;
     // Unix io/read is the pollable nonblocking path. Regular files are routed
     // through worker jobs, so this borrowed guest slice must not outlive the syscall.
-    match context.with_memory_mut(|memory| host.read_fd(memory, fd, dst, offset, len)) {
+    match context
+        .with_host_and_memory_mut(|host, memory| host.read_fd(memory, fd, dst, offset, len))
+    {
         Ok(bytes) => bytes,
         Err(error) => {
-            host.record_error(error);
+            context.host.record_error(error);
             -1
         }
     }
@@ -44,19 +45,20 @@ pub(super) fn read(
 #[ported(source = "src/internal/event_loop/io_unix.c")]
 #[cfg(unix)]
 pub(super) fn write(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     fd: u64,
     src: i32,
     offset: i32,
     len: i32,
 ) -> i32 {
-    let host = context.host;
     // See io/read: this import is for pollable nonblocking handles, not
     // regular files, and the borrowed guest slice is used only for the syscall.
-    match context.with_memory_mut(|memory| host.write_fd(memory, fd, src, offset, len)) {
+    match context
+        .with_host_and_memory_mut(|host, memory| host.write_fd(memory, fd, src, offset, len))
+    {
         Ok(bytes) => bytes,
         Err(error) => {
-            host.record_error(error);
+            context.host.record_error(error);
             -1
         }
     }
@@ -68,15 +70,14 @@ pub(super) fn write(
 )]
 #[cfg(windows)]
 pub(super) fn make_file_io_result(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     events: i32,
     buf: i32,
     offset: i32,
     len: i32,
     position: i64,
 ) -> crate::async_host::AsyncHostResult<u64> {
-    let host = context.host;
-    context.with_memory_mut(|memory| {
+    context.with_host_and_memory_mut(|host, memory| {
         host.make_file_io_result(memory, events, buf, offset, len, position)
     })
 }
@@ -87,7 +88,7 @@ pub(super) fn make_file_io_result(
 )]
 #[cfg(windows)]
 pub(super) fn free_io_result(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     result: u64,
 ) -> crate::async_host::AsyncHostResult<()> {
     context.host.free_io_result(result)
@@ -99,7 +100,7 @@ pub(super) fn free_io_result(
 )]
 #[cfg(windows)]
 pub(super) fn io_result_get_event(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     result: u64,
 ) -> crate::async_host::AsyncHostResult<i32> {
     context.host.io_result_get_event(result)
@@ -110,7 +111,7 @@ pub(super) fn io_result_get_event(
     original = "moonbitlang_async_cancel_io_result"
 )]
 #[cfg(windows)]
-pub(super) fn cancel_io_result(context: &mut ImportContext, result: u64, fd: u64) -> i32 {
+pub(super) fn cancel_io_result(context: &mut ImportContext<'_, '_>, result: u64, fd: u64) -> i32 {
     match context.host.cancel_io_result(result, fd) {
         Ok(status) => status,
         Err(error) => {
@@ -125,12 +126,13 @@ pub(super) fn cancel_io_result(context: &mut ImportContext, result: u64, fd: u64
     original = "moonbitlang_async_io_result_get_status"
 )]
 #[cfg(windows)]
-pub(super) fn io_result_get_status(context: &mut ImportContext, result: u64, fd: u64) -> i32 {
-    let host = context.host;
-    match context.with_memory_mut(|memory| host.io_result_get_status(memory, result, fd)) {
+pub(super) fn io_result_get_status(context: &mut ImportContext<'_, '_>, result: u64, fd: u64) -> i32 {
+    match context
+        .with_host_and_memory_mut(|host, memory| host.io_result_get_status(memory, result, fd))
+    {
         Ok(bytes) => bytes,
         Err(error) => {
-            host.record_error(error);
+            context.host.record_error(error);
             -1
         }
     }
@@ -141,12 +143,11 @@ pub(super) fn io_result_get_status(context: &mut ImportContext, result: u64, fd:
     original = "moonbitlang_async_read"
 )]
 #[cfg(windows)]
-pub(super) fn read_io_result(context: &mut ImportContext, fd: u64, result: u64) -> i32 {
-    let host = context.host;
-    match context.with_memory_mut(|memory| host.read_io_result(memory, fd, result)) {
+pub(super) fn read_io_result(context: &mut ImportContext<'_, '_>, fd: u64, result: u64) -> i32 {
+    match context.with_host_and_memory_mut(|host, memory| host.read_io_result(memory, fd, result)) {
         Ok(bytes) => bytes,
         Err(error) => {
-            host.record_error(error);
+            context.host.record_error(error);
             -1
         }
     }
@@ -157,12 +158,12 @@ pub(super) fn read_io_result(context: &mut ImportContext, fd: u64, result: u64) 
     original = "moonbitlang_async_write"
 )]
 #[cfg(windows)]
-pub(super) fn write_io_result(context: &mut ImportContext, fd: u64, result: u64) -> i32 {
-    let host = context.host;
-    match context.with_memory_mut(|memory| host.write_io_result(memory, fd, result)) {
+pub(super) fn write_io_result(context: &mut ImportContext<'_, '_>, fd: u64, result: u64) -> i32 {
+    match context.with_host_and_memory_mut(|host, memory| host.write_io_result(memory, fd, result))
+    {
         Ok(bytes) => bytes,
         Err(error) => {
-            host.record_error(error);
+            context.host.record_error(error);
             -1
         }
     }
@@ -173,7 +174,7 @@ pub(super) fn write_io_result(context: &mut ImportContext, fd: u64, result: u64)
     original = "moonbitlang_async_errno_is_read_EOF"
 )]
 #[cfg(windows)]
-pub(super) fn errno_is_read_eof(_context: &mut ImportContext, errno: i32) -> i32 {
+pub(super) fn errno_is_read_eof(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if crate::async_sys::internal::event_loop::io::errno_is_read_eof(errno) {
         1
     } else {

--- a/crates/moonrun/src/async_api/mod.rs
+++ b/crates/moonrun/src/async_api/mod.rs
@@ -16,10 +16,12 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! V8-facing `moonbitlang/async` import adapter.
+//! Runtime-facing `moonbitlang/async` import adapter.
 //!
-//! This layer registers wasm imports, decodes wasm ABI values from V8 callback
-//! arguments, acquires guest memory, sets return values, and reports traps.
+//! This layer owns the canonical wasm import list, decodes wasm ABI values from
+//! callback arguments, acquires guest memory, sets return values, and reports
+//! traps. Callback implementations are written against `ImportContext` so the
+//! host behavior stays separate from runtime-specific memory access.
 //! Ported native-stub behavior belongs in `async_sys`; shared runtime state
 //! belongs in `async_host`.
 

--- a/crates/moonrun/src/async_api/os_error.rs
+++ b/crates/moonrun/src/async_api/os_error.rs
@@ -24,12 +24,12 @@ use super::provenance::ported_imports;
 
 ported_imports! {
 #[ported(source = "src/os_error/stub.c")]
-pub(super) fn get_errno(context: &mut ImportContext) -> i32 {
+pub(super) fn get_errno(context: &mut ImportContext<'_, '_>) -> i32 {
     stub::get_errno(context.host)
 }
 
 #[ported(source = "src/os_error/stub.c")]
-pub(super) fn is_nonblocking_io_error(_context: &mut ImportContext, errno: i32) -> i32 {
+pub(super) fn is_nonblocking_io_error(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_nonblocking_io_error(errno) {
         1
     } else {
@@ -38,32 +38,32 @@ pub(super) fn is_nonblocking_io_error(_context: &mut ImportContext, errno: i32) 
 }
 
 #[ported(source = "src/os_error/stub.c")]
-pub(super) fn is_eintr(_context: &mut ImportContext, errno: i32) -> i32 {
+pub(super) fn is_eintr(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_eintr(errno) { 1 } else { 0 }
 }
 
 #[ported(source = "src/os_error/stub.c")]
-pub(super) fn is_enoent(_context: &mut ImportContext, errno: i32) -> i32 {
+pub(super) fn is_enoent(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_enoent(errno) { 1 } else { 0 }
 }
 
 #[ported(source = "src/os_error/stub.c")]
-pub(super) fn is_eexist(_context: &mut ImportContext, errno: i32) -> i32 {
+pub(super) fn is_eexist(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_eexist(errno) { 1 } else { 0 }
 }
 
 #[ported(source = "src/os_error/stub.c")]
-pub(super) fn is_eacces(_context: &mut ImportContext, errno: i32) -> i32 {
+pub(super) fn is_eacces(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_eacces(errno) { 1 } else { 0 }
 }
 
 #[ported(source = "src/os_error/stub.c")]
-pub(super) fn is_econnrefused(_context: &mut ImportContext, errno: i32) -> i32 {
+pub(super) fn is_econnrefused(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_econnrefused(errno) { 1 } else { 0 }
 }
 
 #[ported(source = "src/os_error/stub.c")]
-pub(super) fn is_error_notify_enum_dir(_context: &mut ImportContext, errno: i32) -> i32 {
+pub(super) fn is_error_notify_enum_dir(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::is_error_notify_enum_dir(errno) {
         1
     } else {
@@ -72,16 +72,16 @@ pub(super) fn is_error_notify_enum_dir(_context: &mut ImportContext, errno: i32)
 }
 
 #[ported(source = "src/os_error/stub.c")]
-pub(super) fn errno_to_string(context: &mut ImportContext, errno: i32) -> u64 {
+pub(super) fn errno_to_string(context: &mut ImportContext<'_, '_>, errno: i32) -> u64 {
     context.host.insert_c_buffer(stub::errno_to_string(errno))
 }
 
-pub(super) fn free_errno_str(context: &mut ImportContext, ptr: u64) -> AsyncHostResult<()> {
+pub(super) fn free_errno_str(context: &mut ImportContext<'_, '_>, ptr: u64) -> AsyncHostResult<()> {
     context.host.free_c_buffer(ptr)
 }
 
 #[ported(source = "src/os_error/stub.c")]
-pub(super) fn get_enotdir(_context: &mut ImportContext) -> i32 {
+pub(super) fn get_enotdir(_context: &mut ImportContext<'_, '_>) -> i32 {
     stub::get_enotdir()
 }
 

--- a/crates/moonrun/src/async_api/os_string.rs
+++ b/crates/moonrun/src/async_api/os_string.rs
@@ -21,7 +21,7 @@ use crate::async_host::{AsyncHostError, AsyncHostResult, write_u16};
 use super::context::ImportContext;
 
 pub(super) fn decode_len(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     ptr: u64,
     offset: i32,
     len: i32,
@@ -33,7 +33,7 @@ pub(super) fn decode_len(
 }
 
 pub(super) fn decode(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     ptr: u64,
     offset: i32,
     len: i32,

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -18,16 +18,15 @@
 
 use crate::v8_builder::ObjectExt;
 
+use super::context::{
+    AsyncContext, FinishI32, FinishI64, FinishVoid, ImportArgs, ImportContext, callback_context,
+    throw_import_error,
+};
 #[cfg(test)]
 use super::provenance::{PortedImport, SourceLocation, SourceRoot};
 use super::{
-    c_buffer,
-    context::{
-        AsyncContext, FinishI32, FinishI64, FinishVoid, ImportArgs, ImportContext,
-        callback_context, throw_import_error,
-    },
-    env_util, event_bus, event_loop, fd_util, fs, io, os_error, os_string, runtime, thread_pool,
-    time,
+    c_buffer, env_util, event_bus, event_loop, fd_util, fs, io, os_error, os_string, runtime,
+    thread_pool, time,
 };
 
 pub(crate) const MOONBIT_ASYNC_MODULE: &str = "moonbitlang/async";

--- a/crates/moonrun/src/async_api/runtime.rs
+++ b/crates/moonrun/src/async_api/runtime.rs
@@ -18,6 +18,6 @@
 
 use super::context::ImportContext;
 
-pub(super) fn exit(_context: &mut ImportContext, code: i32) {
+pub(super) fn exit(_context: &mut ImportContext<'_, '_>, code: i32) {
     std::process::exit(code)
 }

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -25,35 +25,35 @@ use super::context::ImportContext;
 use super::provenance::ported_imports;
 
 ported_imports! {
-pub(super) fn free_job(context: &mut ImportContext, job: u64) -> AsyncHostResult<()> {
+pub(super) fn free_job(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<()> {
     context.host.free_job(job)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn job_get_ret(context: &mut ImportContext, job: u64) -> AsyncHostResult<i32> {
+pub(super) fn job_get_ret(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<i32> {
     context.host.job_get_ret(job).map(|value| value as i32)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn job_get_err(context: &mut ImportContext, job: u64) -> AsyncHostResult<i32> {
+pub(super) fn job_get_err(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<i32> {
     context.host.job_get_err(job)
 }
 
-pub(super) fn run_job(context: &mut ImportContext, job: u64) -> AsyncHostResult<()> {
+pub(super) fn run_job(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<()> {
     context.host.run_job(job)
 }
 
-pub(super) fn init_thread_pool(context: &mut ImportContext, poll: u64) -> AsyncHostResult<u64> {
+pub(super) fn init_thread_pool(context: &mut ImportContext<'_, '_>, poll: u64) -> AsyncHostResult<u64> {
     context.host.init_thread_pool(poll)
 }
 
-pub(super) fn destroy_thread_pool(context: &mut ImportContext) {
+pub(super) fn destroy_thread_pool(context: &mut ImportContext<'_, '_>) {
     context.host.destroy_thread_pool();
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn spawn_worker(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     worker_id: i32,
     waiting_worker_id: u64,
 ) -> AsyncHostResult<u64> {
@@ -61,13 +61,13 @@ pub(super) fn spawn_worker(
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn free_worker(context: &mut ImportContext, worker: u64) -> AsyncHostResult<()> {
+pub(super) fn free_worker(context: &mut ImportContext<'_, '_>, worker: u64) -> AsyncHostResult<()> {
     context.host.free_worker(worker)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn wake_worker(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     worker: u64,
     job_id: i32,
     job: u64,
@@ -76,29 +76,30 @@ pub(super) fn wake_worker(
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn worker_enter_idle(context: &mut ImportContext, worker: u64) -> AsyncHostResult<()> {
+pub(super) fn worker_enter_idle(context: &mut ImportContext<'_, '_>, worker: u64) -> AsyncHostResult<()> {
     context.host.worker_enter_idle(worker)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn cancel_worker(context: &mut ImportContext, worker: u64) -> AsyncHostResult<i32> {
+pub(super) fn cancel_worker(context: &mut ImportContext<'_, '_>, worker: u64) -> AsyncHostResult<i32> {
     context.host.cancel_worker(worker)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 #[cfg(unix)]
 pub(super) fn fetch_completion(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     source_fd: u64,
     dst: i32,
     max_jobs: i32,
 ) -> i32 {
-    let host = context.host;
-    match context.with_memory_mut(|memory| host.fetch_completion(memory, source_fd, dst, max_jobs))
+    match context.with_host_and_memory_mut(|host, memory| {
+        host.fetch_completion(memory, source_fd, dst, max_jobs)
+    })
     {
         Ok(bytes) => bytes,
         Err(error) => {
-            host.record_error(error);
+            context.host.record_error(error);
             -1
         }
     }
@@ -106,18 +107,17 @@ pub(super) fn fetch_completion(
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_sleep_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     duration_ms: i32,
 ) -> AsyncHostResult<u64> {
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_sleep_job(duration_ms))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_open_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
     path_len: i32,
     access: i32,
@@ -140,19 +140,18 @@ pub(super) fn make_open_job(
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_read_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     fd: u64,
     len: i32,
     position: i64,
 ) -> AsyncHostResult<u64> {
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_read_job(fd, len, position))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_write_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     fd: u64,
     ptr: i32,
     offset: i32,
@@ -163,25 +162,25 @@ pub(super) fn make_write_job(
     let data =
         context.with_memory_mut(|memory| Ok(memory.read_exact(offset_ptr, len)?.to_vec()))?;
 
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_write_job(fd, data, position))
 }
 
 pub(super) fn get_read_result(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     job: u64,
     dst: i32,
     offset: i32,
     len: i32,
 ) -> AsyncHostResult<()> {
-    let host = context.host;
-    context.with_memory_mut(|memory| host.get_read_result(memory, job, dst, offset, len))
+    context.with_host_and_memory_mut(|host, memory| {
+        host.get_read_result(memory, job, dst, offset, len)
+    })
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_file_kind_by_path_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     parent: u64,
     path_ptr: i32,
     path_len: i32,
@@ -189,8 +188,7 @@ pub(super) fn make_file_kind_by_path_job(
 ) -> AsyncHostResult<u64> {
     let path = read_guest_path(context, path_ptr, path_len)?;
 
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_file_kind_by_path_job(
             parent,
             path,
@@ -199,36 +197,34 @@ pub(super) fn make_file_kind_by_path_job(
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn make_file_size_job(context: &mut ImportContext, fd: u64) -> AsyncHostResult<u64> {
+pub(super) fn make_file_size_job(context: &mut ImportContext<'_, '_>, fd: u64) -> AsyncHostResult<u64> {
     context.host.insert_job(thread_pool::make_file_size_job(fd))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn get_file_size_result(context: &mut ImportContext, job: u64) -> AsyncHostResult<i64> {
+pub(super) fn get_file_size_result(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<i64> {
     context.host.get_file_size_result(job)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_file_time_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     fd: u64,
 ) -> AsyncHostResult<u64> {
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_file_time_job(fd))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_file_time_by_path_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
     path_len: i32,
     follow_symlink: i32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_path(context, path_ptr, path_len)?;
 
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_file_time_by_path_job(
             path,
             follow_symlink != 0,
@@ -236,67 +232,64 @@ pub(super) fn make_file_time_by_path_job(
 }
 
 pub(super) fn get_file_time_result(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     job: u64,
     out: i32,
 ) -> AsyncHostResult<()> {
-    let host = context.host;
-    context.with_memory_mut(|memory| host.get_file_time_result(memory, job, out))
+    context.with_host_and_memory_mut(|host, memory| {
+        host.get_file_time_result(memory, job, out)
+    })
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_access_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
     path_len: i32,
     access: i32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_path(context, path_ptr, path_len)?;
 
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_access_job(path, access))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_chmod_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
     path_len: i32,
     mode: i32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_path(context, path_ptr, path_len)?;
 
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_chmod_job(path, mode))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_fsync_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     fd: u64,
     only_data: i32,
 ) -> AsyncHostResult<u64> {
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_fsync_job(fd, only_data != 0))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_flock_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     fd: u64,
     exclusive: i32,
 ) -> AsyncHostResult<u64> {
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_flock_job(fd, exclusive != 0))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_remove_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
     path_len: i32,
 ) -> AsyncHostResult<u64> {
@@ -306,7 +299,7 @@ pub(super) fn make_remove_job(
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_rename_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     old_path_ptr: i32,
     old_path_len: i32,
     new_path_ptr: i32,
@@ -325,7 +318,7 @@ pub(super) fn make_rename_job(
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_symlink_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     target_ptr: i32,
     target_len: i32,
     path_ptr: i32,
@@ -344,21 +337,20 @@ pub(super) fn make_symlink_job(
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_mkdir_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
     path_len: i32,
     mode: i32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_path(context, path_ptr, path_len)?;
 
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_mkdir_job(path, mode))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_rmdir_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
     path_len: i32,
 ) -> AsyncHostResult<u64> {
@@ -368,15 +360,14 @@ pub(super) fn make_rmdir_job(
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_readdir_job(
-    context: &mut ImportContext,
+    context: &mut ImportContext<'_, '_>,
     dir: u64,
     buf: u64,
     len: i32,
     restart: i32,
 ) -> AsyncHostResult<u64> {
     let buffer = context.host.c_buffer(buf)?;
-    context
-        .host
+    context.host
         .insert_job(thread_pool::make_readdir_job(
             dir,
             buffer,
@@ -386,26 +377,26 @@ pub(super) fn make_readdir_job(
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn open_job_get_fd(context: &mut ImportContext, job: u64) -> AsyncHostResult<u64> {
+pub(super) fn open_job_get_fd(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_fd(job)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn open_job_get_kind(context: &mut ImportContext, job: u64) -> AsyncHostResult<i32> {
+pub(super) fn open_job_get_kind(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<i32> {
     context.host.open_job_get_kind(job)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn open_job_get_dev_id(context: &mut ImportContext, job: u64) -> AsyncHostResult<u64> {
+pub(super) fn open_job_get_dev_id(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_dev_id(job)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn open_job_get_file_id(context: &mut ImportContext, job: u64) -> AsyncHostResult<u64> {
+pub(super) fn open_job_get_file_id(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_file_id(job)
 }
 
-fn read_guest_path(context: &mut ImportContext, ptr: i32, len: i32) -> AsyncHostResult<OsString> {
+fn read_guest_path(context: &mut ImportContext<'_, '_>, ptr: i32, len: i32) -> AsyncHostResult<OsString> {
     // Async path imports pass MoonBit String data, so `len` is UTF-16 code
     // units. Do not treat this as UTF-8 bytes or a native C string.
     context.with_memory_mut(|memory| {

--- a/crates/moonrun/src/async_api/time.rs
+++ b/crates/moonrun/src/async_api/time.rs
@@ -20,6 +20,6 @@ use crate::async_sys::internal::time::clock;
 
 use super::context::ImportContext;
 
-pub(super) fn get_ms_since_epoch(_context: &mut ImportContext) -> u64 {
+pub(super) fn get_ms_since_epoch(_context: &mut ImportContext<'_, '_>) -> u64 {
     clock::get_ms_since_epoch()
 }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -1883,6 +1883,34 @@ mod tests {
     }
 
     #[test]
+    fn drop_destroys_pool_even_when_worker_holds_state() {
+        let host = AsyncHost::default();
+        let state = Arc::downgrade(&host.state);
+        let poll = host.poll_create().unwrap();
+        let completion_notifier = host.init_thread_pool(poll).unwrap();
+        let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
+        host.spawn_worker(42, job).unwrap();
+
+        host.poll_wait(poll, 1000).unwrap();
+        #[cfg(unix)]
+        {
+            let mut memory = [0; 4];
+            host.fetch_completion(memory.as_mut_slice(), completion_notifier, 0, 1)
+                .unwrap();
+        }
+        #[cfg(windows)]
+        {
+            let event = host.poll_get_event(poll, 0).unwrap();
+            assert_eq!(host.poll_event_fd(event).unwrap(), completion_notifier);
+            assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 42);
+        }
+
+        drop(host);
+
+        assert!(state.upgrade().is_none());
+    }
+
+    #[test]
     fn worker_handles_stay_stale_after_thread_pool_reinit() {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();


### PR DESCRIPTION
## Why

This refactor keeps the `moonbitlang/async` import callbacks focused on the per-call context they actually use instead of introducing a separate import-context trait. The host state and guest memory access remain available through one concrete `ImportContext`, which matches the current single-runtime upstream surface while still keeping runtime-owned memory access out of `AsyncHost`.

The host teardown path also needs to clean up internal worker state when the runtime-owned host is dropped. Worker threads hold internal `AsyncHostState` references, so teardown must not use the state `Arc`'s strong count as a proxy for host ownership.

## What Changed

- Removed the extra async import context trait and use concrete `ImportContext` directly.
- Added concrete `ImportContext` helpers for combined host + guest-memory access.
- Simplified shared async imports to use the context's host field directly.
- Made `AsyncHost` drop always destroy the thread pool.
- Added a regression test covering drop while a worker still holds internal state.

## Why This Is Minimal

This does not add Wasmtime support, runtime feature flags, new binaries, or dependency changes. It only keeps the runtime-neutral cleanup and the host lifecycle fix that are useful independently of any future backend work.