### PR TITLE
Cache package file classification in build plan

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,47 @@
+# MoonBuild
+
+MoonBuild turns MoonBit project declarations and package files into build targets, dependency relationships, and executable build commands.
+
+## Language
+
+**Package Declaration**:
+The declaration-level representation of a package: its identity, root, manifest configuration, and package-level declared capabilities.
+_Avoid_: Discovered package, package discovery result, package facts
+
+**Package File Set**:
+The set of MoonBuild-relevant file paths observed under an already known package root before target-specific selection.
+_Avoid_: Package file inventory, package file facts, source file discovery, package source files
+
+**File Content**:
+The bytes or text read from a file after it has been identified as relevant.
+_Avoid_: File facts
+
+**File Interpretation**:
+The meaning MoonBuild derives from a file path or file content before applying target-specific projection.
+_Avoid_: File facts, parsed file
+
+**Build Rule**:
+A declared or built-in rule that constrains how declarations, file sets, and file interpretations participate in a build.
+_Avoid_: Build fact
+
+**Build Target Projection**:
+The target-specific view produced by applying build rules to package declarations, package file sets, and file interpretations. It is not the source of truth for package content.
+_Avoid_: Build target facts, target file facts
+
+**Command Information Demand**:
+The level of package information a MoonBuild command needs before it can produce its result.
+_Avoid_: Always-full package model, eager package facts
+
+**Lightweight Command**:
+A MoonBuild command whose information demand stops before full dependency resolution and build target projection.
+_Avoid_: Partial resolve, incomplete build command
+
+## Naming
+
+**Process Name**:
+A verb or verb phrase used for operations that locate, read, scan, parse, resolve, project, or lower build information.
+_Avoid_: Using process names for durable data entities
+
+**Entity Name**:
+A noun or noun phrase used for stable MoonBuild concepts produced or consumed by build stages. A distinct entity name does not require a distinct data container.
+_Avoid_: Using entity names for operations, adding containers only to mirror vocabulary

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -44,7 +44,7 @@ use tracing::{Level, debug, instrument, trace, warn};
 
 use crate::{
     build_plan::{BuildBundleInfo, FileDependencyKind, PlanArtifactNeed, PrebuildInfo},
-    cond_comp::{self, CompileCondition},
+    cond_comp,
     discover::DiscoveredPackage,
     model::{BuildPlanNode, BuildTarget, PackageId, TargetKind},
     pkg_name::PackageFQNWithSource,
@@ -53,7 +53,7 @@ use crate::{
 
 use super::{
     BuildCStubsInfo, BuildPlanConstructError, BuildTargetInfo, LinkCoreInfo, MakeExecutableInfo,
-    constructor::BuildPlanConstructor,
+    constructor::{BuildPlanConstructor, PackageFileSet},
 };
 
 static BUILD_VAR_REGEX: LazyLock<Regex> =
@@ -470,23 +470,21 @@ impl<'a> BuildPlanConstructor<'a> {
         Ok(())
     }
 
+    fn package_file_set(&mut self, package: PackageId) -> &PackageFileSet {
+        if !self.package_file_sets.contains_key(&package) {
+            let file_set = self.collect_package_file_set(package);
+            self.package_file_sets.insert(package, file_set);
+        }
+        self.package_file_sets
+            .get(&package)
+            .expect("package file set should be cached after collection")
+    }
+
     #[instrument(level = Level::DEBUG, skip(self))]
-    pub(super) fn resolve_mbt_files_for_node(&self, target: BuildTarget) -> BuildTargetInfo {
+    fn collect_package_file_set(&self, package: PackageId) -> PackageFileSet {
         use crate::cond_comp::FileTestKind::*;
-        use TargetKind::*;
 
-        let pkg = self.input.pkg_dirs.get_package(target.package);
-        let module = self.input.module_rel.module_info(pkg.module);
-
-        // FIXME: Should we resolve test drivers' paths, or should we leave it
-        // in the lowering phase? The path to the test driver depends on the
-        // artifact layout, so we might not be able to do that here, unless we
-        // add some kind of `SpecialFile::TestDriver` or something.
-        let compile_condition = CompileCondition {
-            optlevel: self.build_env.opt_level,
-            test_kind: target.kind.into(),
-            backend: self.build_env.target_backend.into(),
-        };
+        let pkg = self.input.pkg_dirs.get_package(package);
 
         // Iterator of all existing source files in the package
         let source_iter = pkg.source_files.iter().map(|x| Cow::Borrowed(x.as_path()));
@@ -526,75 +524,91 @@ impl<'a> BuildPlanConstructor<'a> {
             .iter()
             .map(|x| Cow::Owned(x.with_extension("mbt")));
 
-        // Filter source files
-        let source_files = cond_comp::filter_files(
+        let mut no_test_files = IndexSet::new();
+        let mut whitebox_files = IndexSet::new();
+        let mut blackbox_files = IndexSet::new();
+
+        let _classify_span = tracing::debug_span!("classifying_package_files").entered();
+        for (file, file_kind) in cond_comp::classify_files(
             &pkg.raw,
             source_iter
                 .chain(prebuild_output_iter)
                 .chain(mbtlex_iter)
                 .chain(mbtyacc_iter),
-            &compile_condition,
-        );
-
-        // Include files
-        //
-        // Source and prebuild might emit duplicated files if the prebuilt file
-        // already exist in the source directory. We dedup it here.
-        let mut regular_files = IndexSet::new();
-        let mut whitebox_files = IndexSet::new();
-        let mut doctest_files = IndexSet::new();
-        let _filter_span = tracing::debug_span!("filtering_files").entered();
-        for (file, file_kind) in source_files {
-            match (target.kind, file_kind) {
-                (Source | SubPackage | InlineTest, NoTest) => {
-                    regular_files.insert(file.into_owned())
-                }
-
-                (WhiteboxTest, NoTest) => regular_files.insert(file.into_owned()),
-                (WhiteboxTest, Whitebox) => whitebox_files.insert(file.into_owned()),
-
-                (BlackboxTest, Blackbox) => regular_files.insert(file.into_owned()),
-                (BlackboxTest, NoTest) => doctest_files.insert(file.into_owned()),
-
-                _ => panic!(
-                    "Unexpected file kind {:?} for target {:?} in package {}, \
-                    this is a bug in the build system!",
-                    file_kind, target, pkg.fqn
-                ),
+            self.build_env.opt_level,
+            self.build_env.target_backend.into(),
+        ) {
+            match file_kind {
+                NoTest => no_test_files.insert(file.into_owned()),
+                Whitebox => whitebox_files.insert(file.into_owned()),
+                Blackbox => blackbox_files.insert(file.into_owned()),
             };
         }
-        if target.kind == BlackboxTest {
-            // mbt.md files are also part of regular files
-            for md_file in &pkg.mbt_md_files {
-                regular_files.insert(md_file.clone());
-            }
-        }
-        let mbtp_files = match target.kind {
-            Source | SubPackage | InlineTest | WhiteboxTest => {
-                // `.mbtp` files are threaded into all moonc-based compilation
-                // and checking commands for this package.
-                //
-                // Blackbox targets import the checked package interface, so
-                // threading `.mbtp` through as regular sources there would
-                // redeclare proof-side APIs against the imported package.
-                //
-                // We intentionally ignore prebuild-generated `.mbtp` files for
-                // now until their semantics are designed explicitly.
-                pkg.mbtp_files.clone()
-            }
-            BlackboxTest => Vec::new(),
-        };
-        drop(_filter_span);
+        drop(_classify_span);
 
         // Sort the input, or the different order may cause n2 to view the input
         // file set as different than original.
         //
         // FIXME: we have already sorted them on discover, should we omit that?
-        let _sort_span = tracing::debug_span!("sorting_files").entered();
-        regular_files.sort();
+        let _sort_span = tracing::debug_span!("sorting_package_files").entered();
+        no_test_files.sort();
         whitebox_files.sort();
-        doctest_files.sort();
+        blackbox_files.sort();
         drop(_sort_span);
+
+        PackageFileSet {
+            no_test_files: no_test_files.into_iter().collect(),
+            whitebox_files: whitebox_files.into_iter().collect(),
+            blackbox_files: blackbox_files.into_iter().collect(),
+            mbt_md_files: pkg.mbt_md_files.clone(),
+            mbtp_files: pkg.mbtp_files.clone(),
+        }
+    }
+
+    #[instrument(level = Level::DEBUG, skip(self))]
+    pub(super) fn resolve_mbt_files_for_node(&mut self, target: BuildTarget) -> BuildTargetInfo {
+        use TargetKind::*;
+
+        // FIXME: Should we resolve test drivers' paths, or should we leave it
+        // in the lowering phase? The path to the test driver depends on the
+        // artifact layout, so we might not be able to do that here, unless we
+        // add some kind of `SpecialFile::TestDriver` or something.
+        let (regular_files, mbtp_files, whitebox_files, doctest_files) = {
+            let file_set = self.package_file_set(target.package);
+            match target.kind {
+                Source | SubPackage | InlineTest => (
+                    file_set.no_test_files.clone(),
+                    file_set.mbtp_files.clone(),
+                    Vec::new(),
+                    Vec::new(),
+                ),
+                WhiteboxTest => (
+                    file_set.no_test_files.clone(),
+                    file_set.mbtp_files.clone(),
+                    file_set.whitebox_files.clone(),
+                    Vec::new(),
+                ),
+                BlackboxTest => {
+                    // `.mbt.md` files are also part of blackbox regular files.
+                    let mut regular_files = file_set
+                        .blackbox_files
+                        .iter()
+                        .cloned()
+                        .collect::<IndexSet<_>>();
+                    regular_files.extend(file_set.mbt_md_files.iter().cloned());
+                    regular_files.sort();
+                    (
+                        regular_files.into_iter().collect(),
+                        Vec::new(),
+                        Vec::new(),
+                        file_set.no_test_files.clone(),
+                    )
+                }
+            }
+        };
+
+        let pkg = self.input.pkg_dirs.get_package(target.package);
+        let module = self.input.module_rel.module_info(pkg.module);
 
         // Populate `warn_list` by concatenating module-level, package-level,
         // and command-line settings.
@@ -622,10 +636,10 @@ impl<'a> BuildPlanConstructor<'a> {
         let mi_check_target = self.mi_check_target(target, pkg);
 
         BuildTargetInfo {
-            regular_files: regular_files.into_iter().collect(),
+            regular_files,
             mbtp_files,
-            whitebox_files: whitebox_files.into_iter().collect(),
-            doctest_files: doctest_files.into_iter().collect(),
+            whitebox_files,
+            doctest_files,
             warn_list,
             specified_no_mi,
             patch_file,
@@ -641,7 +655,7 @@ impl<'a> BuildPlanConstructor<'a> {
     pub(super) fn warn_if_main_package_uses_blackbox_inputs(
         &mut self,
         pkg: &DiscoveredPackage,
-        regular_files: &IndexSet<PathBuf>,
+        regular_files: &[PathBuf],
     ) {
         if !pkg.raw.is_main {
             return;

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -18,9 +18,10 @@
 
 //! Core build plan construction logic.
 
-#[cfg(debug_assertions)]
-use std::collections::HashMap;
-use std::{collections::HashSet, path::Path};
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
 
 use crate::{
     ResolveOutput,
@@ -52,12 +53,22 @@ pub(super) struct BuildPlanConstructor<'a> {
     pub(super) pending: Vec<BuildPlanNode>,
     pub(super) resolved: HashSet<BuildPlanNode>,
     pub(super) warned_missing_supported_targets: HashSet<PackageId>,
+    pub(super) package_file_sets: HashMap<PackageId, PackageFileSet>,
 
     /// Debug-only: record call-sites that requested each node via `need_node`.
     /// Used to improve diagnostics when dependency construction panics.
     /// Only compiled in debug builds (cfg(debug_assertions)).
     #[cfg(debug_assertions)]
     pub(super) need_node_sources: HashMap<BuildPlanNode, Vec<(&'static str, u32, u32)>>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct PackageFileSet {
+    pub(super) no_test_files: Vec<PathBuf>,
+    pub(super) whitebox_files: Vec<PathBuf>,
+    pub(super) blackbox_files: Vec<PathBuf>,
+    pub(super) mbt_md_files: Vec<PathBuf>,
+    pub(super) mbtp_files: Vec<PathBuf>,
 }
 
 fn merge_edge_kind(dst: &mut FileDependencyKind, src: FileDependencyKind) {
@@ -138,6 +149,7 @@ impl<'a> BuildPlanConstructor<'a> {
             pending: Vec::new(),
             resolved: HashSet::new(),
             warned_missing_supported_targets: HashSet::new(),
+            package_file_sets: HashMap::new(),
             #[cfg(debug_assertions)]
             need_node_sources: HashMap::new(),
         }
@@ -525,8 +537,7 @@ impl<'a> BuildPlanConstructor<'a> {
         let info = self.resolve_mbt_files_for_node(target);
         if target.kind == crate::model::TargetKind::BlackboxTest {
             let pkg = self.input.pkg_dirs.get_package(target.package);
-            let regular_files = info.regular_files.iter().cloned().collect();
-            self.warn_if_main_package_uses_blackbox_inputs(pkg, &regular_files);
+            self.warn_if_main_package_uses_blackbox_inputs(pkg, &info.regular_files);
         }
         self.res.build_target_infos.insert(target, info);
     }

--- a/crates/moonbuild-rupes-recta/src/cond_comp.rs
+++ b/crates/moonbuild-rupes-recta/src/cond_comp.rs
@@ -26,46 +26,15 @@ use moonutil::{
     package::MoonPkg,
 };
 
-use crate::model;
-
-/// Which kind of test (if any) are we compiling the current package for.
-#[derive(Clone, Copy)]
-pub enum TestKind {
-    Inline,
-    Whitebox,
-    Blackbox,
-}
-
-impl From<model::TargetKind> for Option<TestKind> {
-    fn from(value: model::TargetKind) -> Self {
-        match value {
-            model::TargetKind::Source => None,
-            model::TargetKind::WhiteboxTest => Some(TestKind::Whitebox),
-            model::TargetKind::BlackboxTest => Some(TestKind::Blackbox),
-            model::TargetKind::InlineTest => Some(TestKind::Inline),
-            model::TargetKind::SubPackage => None,
-        }
-    }
-}
-
-/// A collection of conditions that affect compilation behavior.
-pub(crate) struct CompileCondition {
-    pub optlevel: OptLevel,
-    pub test_kind: Option<TestKind>,
-    pub backend: TargetBackend,
-}
-
-/// Get the list of files that should get included in the compile list under
-/// the given condition.
-///
-/// Note: `pkg_file_path` is purely for error reporting, as required by
-/// [`moonutil::cond_expr::parse_cond_expr`].
-pub(crate) fn filter_files<'a, P: AsRef<Path> + 'a>(
+/// Classify files that are available for the current backend and optimization
+/// level, without projecting them into a specific target kind.
+pub(crate) fn classify_files<'a, P: AsRef<Path> + 'a>(
     pkg: &'a MoonPkg,
     files: impl Iterator<Item = P> + 'a,
-    cond: &'a CompileCondition,
+    optlevel: OptLevel,
+    backend: TargetBackend,
 ) -> impl Iterator<Item = (P, FileTestKind)> + 'a {
-    files.filter_map(|file| {
+    files.filter_map(move |file| {
         let filename = file
             .as_ref()
             .file_name()
@@ -77,11 +46,14 @@ pub(crate) fn filter_files<'a, P: AsRef<Path> + 'a>(
             .as_ref()
             .and_then(|targets| targets.get(&*str_filename))
         {
-            // We have a condition for this file
-            should_compile_using_pkg_cond_expr(&str_filename, expect_cond, cond)
+            should_compile_using_pkg_cond_expr_without_test_kind(
+                &str_filename,
+                expect_cond,
+                optlevel,
+                backend,
+            )
         } else {
-            // We don't, evaluate file name
-            should_compile_using_filename(&str_filename, cond)
+            should_compile_using_filename_without_test_kind(&str_filename, backend)
         };
 
         should_include.map(|kind| (file, kind))
@@ -132,17 +104,16 @@ pub(crate) fn file_metadatas<'a>(
     })
 }
 
-fn should_compile_using_pkg_cond_expr(
+fn should_compile_using_pkg_cond_expr_without_test_kind(
     name: &str,
     cond_expr: &CondExpr,
-    actual: &CompileCondition,
+    optlevel: OptLevel,
+    backend: TargetBackend,
 ) -> Option<FileTestKind> {
-    if !cond_expr.eval(actual.optlevel, actual.backend) {
-        None // Fails the condition in pkg.json
+    if !cond_expr.eval(optlevel, backend) {
+        None
     } else if let Some(stripped) = name.strip_suffix(".mbt") {
-        let spec = get_file_test_kind(stripped);
-        let include = check_test_suffix(spec, actual.test_kind);
-        if include { Some(spec) } else { None }
+        Some(get_file_test_kind(stripped))
     } else {
         panic!("File name '{}' does not end with '.mbt'", name);
     }
@@ -160,9 +131,10 @@ pub fn get_file_target_backend(stripped_filename: &str) -> (Option<TargetBackend
     }
 }
 
-/// Check the file name to determine if it should be included. If true,
-/// returns `Some(file_test_kind)`, otherwise `None`.
-fn should_compile_using_filename(name: &str, actual: &CompileCondition) -> Option<FileTestKind> {
+fn should_compile_using_filename_without_test_kind(
+    name: &str,
+    actual_backend: TargetBackend,
+) -> Option<FileTestKind> {
     let filename = if let Some(mbt_stripped) = name.strip_suffix(".mbt") {
         mbt_stripped
     } else if let Some(mbt_md_stripped) = name.strip_suffix(DOT_MBT_DOT_MD) {
@@ -171,17 +143,14 @@ fn should_compile_using_filename(name: &str, actual: &CompileCondition) -> Optio
         panic!("File name '{}' does not end with '.mbt' or '.mbt.md'", name);
     };
 
-    // Target backend checking -- check the suffix of the file name
     let (backend, remaining) = get_file_target_backend(filename);
     if let Some(backend) = backend
-        && backend != actual.backend
+        && backend != actual_backend
     {
-        return None; // Wrong backend, returning
+        return None;
     }
 
-    let spec = get_file_test_kind(remaining);
-    let include = check_test_suffix(spec, actual.test_kind);
-    if include { Some(spec) } else { None }
+    Some(get_file_test_kind(remaining))
 }
 
 /// Get the test kind of the file by checking its suffix, and also handles if
@@ -207,23 +176,6 @@ pub fn get_file_test_kind(stripped_name: &str) -> FileTestKind {
         FileTestKind::Blackbox
     } else {
         FileTestKind::NoTest
-    }
-}
-
-/// Check the suffix of the stripped filename against the actual test condition
-fn check_test_suffix(file_test_spec: FileTestKind, test_kind: Option<TestKind>) -> bool {
-    use FileTestKind::*;
-
-    // White box tests are implemented with compiling with source code, and
-    // black box tests are implemented without
-    #[allow(clippy::match_like_matches_macro)] // This is more readable
-    match (test_kind, file_test_spec) {
-        (None, NoTest) => true,
-        (Some(TestKind::Inline), NoTest) => true,
-        (Some(TestKind::Whitebox), NoTest | Whitebox) => true,
-        // Black box tests return no test files for doctest compilation
-        (Some(TestKind::Blackbox), NoTest | Blackbox) => true,
-        _ => false,
     }
 }
 


### PR DESCRIPTION
## Why

Blackbox test targets and source targets repeatedly classified the same package file list while constructing build target information. That repeated work made the build-plan phase harder to reason about and added avoidable cost on no-op checks.

## What Changed

This PR introduces a package-level file set cache inside build-plan construction. Each package's backend/profile-filtered files are classified once, then projected into source, whitebox, and blackbox target views as needed.

It also documents the naming split between package declarations, package file sets, file interpretation, and build target projection so later refactors have a shared vocabulary.

## Why This Is Correct

The cached file set is still derived from the same discovered package files, prebuild outputs, generated lexer/parser outputs, backend suffix rules, and package target conditions. Target-specific behavior remains in the projection step: source and whitebox targets keep proof files, blackbox targets keep doctest inputs and omit proof files, and `.mbt.md` files remain blackbox regular inputs.

The change is intentionally local to build-plan construction. It does not change lowering, n2 registration, compiler command shape, or package discovery semantics.

## Scope

This is the small package file classification cache only. Later tracing and metadata experiments are intentionally not included.