### PR TITLE
fix: align async host native buffers

### DIFF
--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -49,6 +49,10 @@ pub(super) fn get_tmp_path(context: &mut ImportContext<'_, '_>, ptr: i32, len: i
     zero_or_minus_one(context, result)
 }
 
+pub(super) fn get_tmp_path_buffer(context: &mut ImportContext<'_, '_>) -> AsyncHostResult<u64> {
+    Ok(context.host.insert_c_buffer(stub::get_tmp_path_buffer()?))
+}
+
 #[ported(source = "src/internal/fd_util/stub.c")]
 pub(super) fn close_fd(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
     zero_or_minus_one(context, context.host.close_fd(fd))

--- a/crates/moonrun/src/async_api/os_error.rs
+++ b/crates/moonrun/src/async_api/os_error.rs
@@ -77,7 +77,7 @@ pub(super) fn errno_to_string(context: &mut ImportContext<'_, '_>, errno: i32) -
 }
 
 pub(super) fn free_errno_str(context: &mut ImportContext<'_, '_>, ptr: u64) -> AsyncHostResult<()> {
-    context.host.free_c_buffer(ptr)
+    super::c_buffer::free(context, ptr)
 }
 
 #[ported(source = "src/os_error/stub.c")]

--- a/crates/moonrun/src/async_api/os_string.rs
+++ b/crates/moonrun/src/async_api/os_string.rs
@@ -123,10 +123,25 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn unix_decode_native_string_uses_explicit_length_without_nul() {
+        assert_eq!(decode_native_string(b"abc", 0, 3), Ok("abc".to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn unix_decode_native_string_stops_at_nul_after_offset() {
         assert_eq!(
             decode_native_string(b"zzabc\0def", 2, -1),
             Ok("abc".to_string())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_decode_native_string_rejects_implicit_length_without_nul() {
+        assert_eq!(
+            decode_native_string(b"abc", 0, -1),
+            Err(AsyncHostError::Fault)
         );
     }
 
@@ -141,10 +156,28 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn windows_decode_native_string_uses_explicit_length_without_wide_nul() {
+        assert_eq!(
+            decode_native_string(&[b'a', 0, b'b', 0], 0, 4),
+            Ok("ab".to_string())
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn windows_decode_native_string_stops_at_wide_nul_after_offset() {
         assert_eq!(
             decode_native_string(&[0xff, 0xff, b'a', 0, b'b', 0, 0, 0], 2, -1),
             Ok("ab".to_string())
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_decode_native_string_rejects_implicit_length_without_wide_nul() {
+        assert_eq!(
+            decode_native_string(&[b'a', 0, b'b', 0], 0, -1),
+            Err(AsyncHostError::Fault)
         );
     }
 

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -515,6 +515,8 @@ declare_async_imports! {
     // guest-allocated MoonBit String.
     ported fs::get_tmp_path(ptr: i32, len: i32) -> i32 => "fs/get_tmp_path";
 
+    helper fs::get_tmp_path_buffer() -> u64 => "fs/get_tmp_path_buffer";
+
     ported fs::dir_buffer_min_size() -> i32 => "fs/dir_buffer_min_size";
 
     ported fs::dir_entry_length(buf: u64, offset: i32) -> i32 => "fs/dir_entry_length";

--- a/crates/moonrun/src/async_sys/fs/stub.rs
+++ b/crates/moonrun/src/async_sys/fs/stub.rs
@@ -60,6 +60,30 @@ ported_fns! {
         }
     }
 
+    #[cfg(unix)]
+    pub(crate) fn get_tmp_path_buffer() -> AsyncHostResult<Box<[u8]>> {
+        use std::os::unix::ffi::OsStrExt;
+
+        let path = tmp_path_from_native_stub();
+        Ok(copy_c_string_bytes(path.as_os_str().as_bytes()))
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn get_tmp_path_buffer() -> AsyncHostResult<Box<[u8]>> {
+        use windows_sys::Win32::Foundation::{GetLastError, MAX_PATH};
+        use windows_sys::Win32::Storage::FileSystem::GetTempPath2W;
+
+        let mut wide_buffer = [0u16; MAX_PATH as usize + 1];
+        let len = unsafe { GetTempPath2W(wide_buffer.len() as u32, wide_buffer.as_mut_ptr()) };
+        if len == 0 {
+            return Err(AsyncHostError::Native(unsafe { GetLastError() as i32 }));
+        }
+
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        let units = wide_buffer.get(..len).ok_or(AsyncHostError::Fault)?;
+        Ok(copy_wide_c_string_bytes(units))
+    }
+
     #[ported(
         source = "src/fs/stub.c",
         original = "moonbitlang_async_try_lock_file"
@@ -209,6 +233,32 @@ fn tmp_path_from_native_stub() -> AsyncHostResult<OsString> {
     Ok(OsString::from_wide(&buffer[..len]))
 }
 
+#[cfg(unix)]
+fn copy_c_string_bytes(bytes: &[u8]) -> Box<[u8]> {
+    let mut buffer = Box::<[u8]>::new_uninit_slice(bytes.len() + 1);
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), buffer.as_mut_ptr().cast(), bytes.len());
+    }
+    buffer[bytes.len()].write(0);
+    unsafe { buffer.assume_init() }
+}
+
+#[cfg(windows)]
+fn copy_wide_c_string_bytes(units: &[u16]) -> Box<[u8]> {
+    let byte_len = std::mem::size_of_val(units);
+    let mut buffer = Box::<[u8]>::new_uninit_slice(byte_len + std::mem::size_of::<u16>());
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            units.as_ptr().cast::<u8>(),
+            buffer.as_mut_ptr().cast(),
+            byte_len,
+        );
+    }
+    buffer[byte_len].write(0);
+    buffer[byte_len + 1].write(0);
+    unsafe { buffer.assume_init() }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -220,6 +270,20 @@ mod tests {
         assert!(!path.as_os_str().is_empty());
         let path = path.to_string_lossy();
         assert!(path.ends_with('/') || path.ends_with('\\'));
+    }
+
+    #[test]
+    fn tmp_path_buffer_is_non_empty() {
+        let buffer = get_tmp_path_buffer().unwrap();
+
+        assert!(!buffer.is_empty());
+        #[cfg(unix)]
+        assert_eq!(buffer.last(), Some(&0));
+        #[cfg(windows)]
+        assert_eq!(
+            buffer.get(buffer.len().saturating_sub(2)..),
+            Some(&[0, 0][..])
+        );
     }
 
     #[cfg(all(unix, not(target_os = "android")))]

--- a/crates/moonrun/src/async_sys/os_error/stub.rs
+++ b/crates/moonrun/src/async_sys/os_error/stub.rs
@@ -172,55 +172,83 @@ fn errno_to_string_sys(errno: i32) -> Box<[u8]> {
 
     let message = unsafe { libc::strerror(errno) };
     if message.is_null() {
-        return nul_terminated_bytes(format!("errno {errno}").into_bytes());
+        return fallback_errno_bytes(errno);
     }
 
-    nul_terminated_bytes(unsafe { CStr::from_ptr(message) }.to_bytes().to_vec())
+    copy_c_string_bytes(unsafe { CStr::from_ptr(message) }.to_bytes())
 }
 
 #[cfg(windows)]
 fn errno_to_string_sys(errno: i32) -> Box<[u8]> {
+    use windows_sys::Win32::Foundation::LocalFree;
     use windows_sys::Win32::System::Diagnostics::Debug::{
-        FORMAT_MESSAGE_FROM_SYSTEM, FORMAT_MESSAGE_IGNORE_INSERTS, FormatMessageW,
+        FORMAT_MESSAGE_ALLOCATE_BUFFER, FORMAT_MESSAGE_FROM_SYSTEM, FORMAT_MESSAGE_IGNORE_INSERTS,
+        FormatMessageW,
     };
 
-    let mut buffer = [0u16; 2048];
+    let mut message = std::ptr::null_mut::<u16>();
     let len = unsafe {
         FormatMessageW(
-            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            FORMAT_MESSAGE_ALLOCATE_BUFFER
+                | FORMAT_MESSAGE_FROM_SYSTEM
+                | FORMAT_MESSAGE_IGNORE_INSERTS,
             std::ptr::null(),
             errno as u32,
-            0x409,
-            buffer.as_mut_ptr(),
-            buffer.len() as u32,
+            0,
+            std::ptr::addr_of_mut!(message).cast(),
+            0,
             std::ptr::null(),
         )
     };
     if len == 0 {
-        return nul_terminated_wide_bytes(format!("errno {errno}").encode_utf16());
+        return fallback_errno_wide_bytes(errno);
     }
 
-    nul_terminated_wide_bytes(buffer[..len as usize].iter().copied())
-}
-
-#[cfg(windows)]
-fn wide_bytes(units: impl IntoIterator<Item = u16>) -> Box<[u8]> {
-    units
-        .into_iter()
-        .flat_map(u16::to_le_bytes)
-        .collect::<Vec<_>>()
-        .into_boxed_slice()
+    let buffer = unsafe { std::slice::from_raw_parts(message, len as usize) };
+    let bytes = copy_wide_c_string_bytes(buffer);
+    unsafe {
+        let _ = LocalFree(message.cast());
+    }
+    bytes
 }
 
 #[cfg(unix)]
-fn nul_terminated_bytes(mut bytes: Vec<u8>) -> Box<[u8]> {
-    bytes.push(0);
-    bytes.into_boxed_slice()
+fn fallback_errno_bytes(errno: i32) -> Box<[u8]> {
+    let message = format!("errno {errno}");
+    copy_c_string_bytes(message.as_bytes())
 }
 
 #[cfg(windows)]
-fn nul_terminated_wide_bytes(units: impl IntoIterator<Item = u16>) -> Box<[u8]> {
-    wide_bytes(units.into_iter().chain(std::iter::once(0)))
+fn fallback_errno_wide_bytes(errno: i32) -> Box<[u8]> {
+    let message = format!("errno {errno}");
+    let units = message.encode_utf16().collect::<Box<[_]>>();
+    copy_wide_c_string_bytes(&units)
+}
+
+#[cfg(unix)]
+fn copy_c_string_bytes(bytes: &[u8]) -> Box<[u8]> {
+    let mut buffer = Box::<[u8]>::new_uninit_slice(bytes.len() + 1);
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), buffer.as_mut_ptr().cast(), bytes.len());
+    }
+    buffer[bytes.len()].write(0);
+    unsafe { buffer.assume_init() }
+}
+
+#[cfg(windows)]
+fn copy_wide_c_string_bytes(units: &[u16]) -> Box<[u8]> {
+    let byte_len = std::mem::size_of_val(units);
+    let mut buffer = Box::<[u8]>::new_uninit_slice(byte_len + std::mem::size_of::<u16>());
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            units.as_ptr().cast::<u8>(),
+            buffer.as_mut_ptr().cast(),
+            byte_len,
+        );
+    }
+    buffer[byte_len].write(0);
+    buffer[byte_len + 1].write(0);
+    unsafe { buffer.assume_init() }
 }
 
 #[cfg(test)]

--- a/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
@@ -95,10 +95,16 @@ fn os_string_decode(
 fn free_errno_str(ptr : UInt64) -> Unit = "moonbitlang/async" "os_error/free_errno_str"
 
 ///|
+fn c_buffer_free(ptr : UInt64) -> Unit = "moonbitlang/async" "c_buffer/free"
+
+///|
 fn get_tmp_path_len() -> Int = "moonbitlang/async" "fs/get_tmp_path_len"
 
 ///|
 fn get_tmp_path(dst : Int, len : Int) -> Int = "moonbitlang/async" "fs/get_tmp_path"
+
+///|
+fn get_tmp_path_buffer() -> UInt64 = "moonbitlang/async" "fs/get_tmp_path_buffer"
 
 ///|
 #borrow(str)
@@ -132,6 +138,22 @@ fn main {
   assert_true(
     message != String::make(message_len, '\u{0}'),
     "errno string fill wrote an empty message",
+  )
+  let tmp_path_buf = get_tmp_path_buffer()
+  let tmp_path_from_buf_len = os_string_decode_len(tmp_path_buf, 0, -1)
+  assert_true(tmp_path_from_buf_len > 0, "tmp path buffer size query failed")
+  let tmp_path_from_buf = String::make(tmp_path_from_buf_len, '\u{0}')
+  os_string_decode(
+    tmp_path_buf,
+    0,
+    -1,
+    string_to_ptr(tmp_path_from_buf),
+    tmp_path_from_buf_len,
+  )
+  c_buffer_free(tmp_path_buf)
+  assert_true(
+    tmp_path_from_buf != String::make(tmp_path_from_buf_len, '\u{0}'),
+    "tmp path buffer decode wrote an empty path",
   )
   let tmp_path_len = get_tmp_path_len()
   assert_true(tmp_path_len > 0, "tmp path size query failed")


### PR DESCRIPTION
## Why

The async host native-string helpers should match the native stub behavior more closely. Errno formatting on Windows should let the system allocate the message buffer, and temporary-directory lookup should expose a host C buffer without forcing an extra `OsString` and UTF-16 re-encoding round trip.

## What Changed

- Use Windows `FormatMessageW` with system allocation for errno strings before copying the native wide contents into the host C buffer.
- Add a `fs/get_tmp_path_buffer` import that returns the native temporary directory as a host C buffer.
- Implement the Windows tmpdir buffer path directly from `GetTempPath2W` output, avoiding the previous `OsString`/`encode_wide` path.
- Add decoder coverage for explicit native string lengths without terminators, while preserving the existing `-1` terminator-based decode contract.
- Bump `third_party/moonbitlang_async` to its `origin/main` tip.

## Correctness

The returned buffers remain native encoded and continue to satisfy the existing MoonBit decode path. The Windows tmpdir path copies from the native wide buffer directly into the byte-backed host C buffer, which keeps the conversion boundary explicit and avoids relying on misaligned byte storage as `u16` storage.

## Minimality

The change is limited to the async host native-string/temporary-directory boundary, the import registry entry, focused tests, and the requested submodule pointer update.