### PR TITLE
fix(moonrun): align async runtime portability fixes

### DIFF
--- a/crates/moonrun/src/async_sys/fs/dir.rs
+++ b/crates/moonrun/src/async_sys/fs/dir.rs
@@ -59,7 +59,8 @@ ported_fns! {
             use windows_sys::Win32::Foundation::MAX_PATH;
             use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
 
-            (std::mem::size_of::<FILE_ID_BOTH_DIR_INFO>() + MAX_PATH as usize) as i32
+            (std::mem::size_of::<FILE_ID_BOTH_DIR_INFO>()
+                + MAX_PATH as usize * std::mem::size_of::<u16>()) as i32
         }
 
         #[cfg(target_os = "macos")]

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -30,7 +30,7 @@ ported_fns! {
         original = "moonbitlang_async_event_bus_create"
     )]
     pub(crate) fn poll_create() -> AsyncHostResult<PollInstance> {
-        let fd = unsafe { libc::epoll_create1(0) };
+        let fd = unsafe { libc::epoll_create1(libc::EPOLL_CLOEXEC) };
         if fd < 0 {
             Err(last_native_error())
         } else {


### PR DESCRIPTION
## Why

The Rust async host port still had two portability behaviors that were already fixed in the native async runtime followups from moonbitlang/async#442:

- Linux epoll descriptors were created without close-on-exec.
- The Windows directory buffer minimum treated `MAX_PATH` as bytes even though `FILE_ID_BOTH_DIR_INFO::FileNameLength` and the `GetFileInformationByHandleEx` buffer length contract are byte-based while Windows filenames are UTF-16 code units.

## What Changed

- Create epoll descriptors with `EPOLL_CLOEXEC`.
- Size the Windows directory entry filename portion as `MAX_PATH * size_of::<u16>()` bytes.

## Why This Is Correct

The Rust port now matches the corrected native runtime behavior. `EPOLL_CLOEXEC` prevents event-loop descriptors from leaking into spawned children, and the Windows directory buffer calculation now preserves the byte-count contract used by the OS API and the existing Rust entry accessors.

## Scope

This is intentionally limited to the two parity fixes in the Rust async host port. No unrelated async behavior or public API is changed.