### PR TITLE
fix: batch wasm async tests in driver

### DIFF
--- a/crates/moonbuild/template/test_driver_project/entry.mbt
+++ b/crates/moonbuild/template/test_driver_project/entry.mbt
@@ -71,7 +71,23 @@ pub fn moonbit_test_driver_internal_execute(
 }
 
 ///|
-#cfg(any(target="wasm", target="wasm-gc"))
+#cfg(target="wasm")
+let moonbit_test_driver_internal_wasm_async_tests : Array[async () -> Unit] = []
+
+///|
+#cfg(target="wasm")
+pub fn moonbit_test_driver_internal_execute(
+  filename : MoonbitTestDriverInternalExternString,
+  index : Int,
+) -> Unit {
+  let filename = moonbit_test_driver_internal_get_file_name(filename)
+  moonbit_test_driver_internal_do_execute(
+    moonbit_test_driver_internal_wasm_async_tests, filename, index,
+  )
+}
+
+///|
+#cfg(target="wasm-gc")
 pub fn moonbit_test_driver_internal_execute(
   filename : MoonbitTestDriverInternalExternString,
   index : Int,
@@ -83,7 +99,16 @@ pub fn moonbit_test_driver_internal_execute(
 }
 
 ///|
-#cfg(not(any(target="native", target="llvm")))
+#cfg(target="wasm")
+pub fn moonbit_test_driver_finish() -> Unit {
+  MoonBit_Async_Test_Driver_Impl::run_async_tests(
+    moonbit_test_driver_internal_wasm_async_tests,
+  )
+  // {COVERAGE_END}
+}
+
+///|
+#cfg(any(target="js", target="wasm-gc"))
 pub fn moonbit_test_driver_finish() -> Unit {
   // {COVERAGE_END}
 }

--- a/crates/moonbuild/template/test_driver_project/template_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_async.mbt
@@ -2,7 +2,7 @@
 // This also introduces the dependency on async package
 
 ///|
-#cfg(not(any(target="wasm", target="wasm-gc")))
+#cfg(not(target="wasm-gc"))
 impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with fn run_async_tests(
   tests,
 ) {
@@ -22,17 +22,6 @@ impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with fn run_as
     })
     // {COVERAGE_END}
   })
-}
-
-///|
-#cfg(target="wasm")
-impl MoonBit_Async_Test_Driver for MoonBit_Async_Test_Driver_Impl with fn run_async_tests(
-  tests,
-) {
-  for f in tests {
-    @moonbitlang/async.run_async_main(f)
-  }
-  // {COVERAGE_END}
 }
 
 ///|


### PR DESCRIPTION
## Why

Wasm async tests were dispatched one selected test at a time, and each dispatch ran its own async event loop. Packages with many sleep-heavy async tests therefore serialized sleep time across test cases even though the native and JS test drivers batch async tests and run them with the configured concurrency.

## What Changed

This changes the wasm test driver to collect async tests during per-test dispatch and run the collected batch once from `moonbit_test_driver_finish`. The wasm async runtime now reuses the same concurrent async test runner used by the other supported non-wasm-gc backends.

## Why This Is Correct

The external wasm driver still reports each selected test through the existing per-test dispatch path, but async test execution is delayed until finish so the generated test driver can apply the existing max-concurrent scheduling logic. This preserves the wasm host boundary and avoids changing moonrun's async FFI implementation.

## Scope

The change is limited to the generated test-driver templates. The wasm-gc path keeps its existing behavior because the async wasm host support is for the wasm backend.