### PR TITLE
Update coverage snapshot for tabbed snippets

### DIFF
--- a/crates/moon/tests/test_cases/moon_coverage.rs
+++ b/crates/moon/tests/test_cases/moon_coverage.rs
@@ -36,46 +36,46 @@ fn test_moon_coverage_analyze() {
                 "-f=caret",
             ],
         ),
-        expect![[r#"
+        expect![["
             warning: this line has no test coverage
              --> lib2/hello.mbt:2
-            1 | fn hello_uncovered_1() -> String {
-            2 |   "Hello, world!"
-              |   ^^^^^^^^^^^^^^^
-            3 | }
-            4 | 
-            5 | fn hello_uncovered_2() -> String {
+            1\tfn hello_uncovered_1() -> String {
+            2\t  \"Hello, world!\"
+             \t  ^^^^^^^^^^^^^^^
+            3\t}
+            4\t
+            5\tfn hello_uncovered_2() -> String {
 
 
             warning: this line has no test coverage
              --> lib2/hello.mbt:6
-            4 | 
-            5 | fn hello_uncovered_2() -> String {
-            6 |   "Hello, world!"
-              |   ^^^^^^^^^^^^^^^
-            7 | }
-            8 | 
+            4\t
+            5\tfn hello_uncovered_2() -> String {
+            6\t  \"Hello, world!\"
+             \t  ^^^^^^^^^^^^^^^
+            7\t}
+            8\t
 
 
             warning: this line has no test coverage
              --> lib2/hello.mbt:10
-             7 | }
-             8 | 
-             9 | fn hello_uncovered_3() -> String {
-            10 |   "Hello, world!"
-               |   ^^^^^^^^^^^^^^^
-            11 | }
+             7\t}
+             8\t
+             9\tfn hello_uncovered_3() -> String {
+            10\t  \"Hello, world!\"
+              \t  ^^^^^^^^^^^^^^^
+            11\t}
 
 
             warning: this line has no test coverage
              --> main/main.mbt:2
-            1 | fn main {
-            2 |   println("main")
-              |   ^^^^^^^^^^^^^^^
-            3 | }
+            1\tfn main {
+            2\t  println(\"main\")
+             \t  ^^^^^^^^^^^^^^^
+            3\t}
 
 
-        "#]],
+        "]],
     );
 }
 


### PR DESCRIPTION
## Summary

Updates the `moon coverage analyze` snapshot to match the tab-separated source snippets emitted by the current `moon_cove_report`.

## Rationale

The latest MoonBit coverage reporter changed caret snippets from pipe-separated source lines to tab-separated source lines. MoonBuild delegates report rendering to `moon_cove_report`, so the existing snapshot no longer matches the toolchain output.

## Minimality

This only updates the affected inline snapshot. Runtime coverage behavior is unchanged.