### PR TITLE
Remove moon check no-mi flag

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -58,7 +58,6 @@ use super::BuildFlags;
 #[derive(Debug, Clone)]
 struct ResolvedCheckSelection {
     packages: Vec<PackageId>,
-    no_mi: bool,
     patch_file: Option<PathBuf>,
 }
 
@@ -66,17 +65,13 @@ impl ResolvedCheckSelection {
     fn from_command(packages: Vec<PackageId>, cmd: &CheckSubcommand) -> Self {
         Self {
             packages,
-            no_mi: cmd.no_mi,
             patch_file: cmd.patch_file.clone(),
         }
     }
 
     fn into_user_intent(self) -> anyhow::Result<CalcUserIntentOutput> {
-        let directive = build_directive_for_selected_packages(
-            &self.packages,
-            self.no_mi,
-            self.patch_file.as_deref(),
-        )?;
+        let directive =
+            build_directive_for_selected_packages(&self.packages, self.patch_file.as_deref())?;
         Ok((
             self.packages.into_iter().map(UserIntent::Check).collect(),
             directive,
@@ -117,10 +112,6 @@ pub(crate) struct CheckSubcommand {
     #[clap(long, requires = "package_selector")]
     pub patch_file: Option<PathBuf>,
 
-    /// Whether to skip the mi generation. Only valid when the selector resolves to a single package.
-    #[clap(long, requires = "package_selector")]
-    pub no_mi: bool,
-
     /// Whether to explain the error code with details.
     #[clap(long)]
     pub explain: bool,
@@ -137,9 +128,6 @@ pub(crate) struct CheckSubcommand {
 #[instrument(skip_all)]
 pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::Result<i32> {
     let output = UserDiagnostics::from_flags(cli);
-    if cmd.no_mi {
-        output.warn("`moon check --no-mi` is deprecated");
-    }
     if cmd.fmt {
         let mut cli_for_fmt = cli.clone();
         cli_for_fmt.quiet = true;
@@ -289,9 +277,6 @@ fn run_check_for_single_file_rr(
     mooncakes_dir: &Path,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
-    if cmd.no_mi {
-        anyhow::bail!("standalone single-file `moon check` does not support `--no-mi`");
-    }
     if cmd.patch_file.is_some() {
         anyhow::bail!("standalone single-file `moon check` does not support `--patch-file`");
     }
@@ -615,15 +600,12 @@ fn validate_selector_flags_before_split(
     target_backend: Option<TargetBackend>,
     output: UserDiagnostics,
 ) -> anyhow::Result<()> {
-    if !cmd.no_mi && cmd.patch_file.is_none() {
+    if cmd.patch_file.is_none() {
         return Ok(());
     }
 
     let selected =
         resolve_selected_packages(resolve_output, cmd, source_dir, target_backend, output)?;
-    if cmd.no_mi && selected.len() != 1 {
-        anyhow::bail!("`--no-mi` requires the selector to resolve to a single package");
-    }
     if cmd.patch_file.is_some() && selected.len() != 1 {
         anyhow::bail!("`--patch-file` requires the selector to resolve to a single package");
     }
@@ -663,7 +645,6 @@ pub(crate) fn plan_check_rr_from_resolved(
             source_dir,
             filter_path,
             planning_context.target_backend(),
-            cmd.no_mi,
             cmd.patch_file.as_deref(),
         )?
     } else {
@@ -671,7 +652,6 @@ pub(crate) fn plan_check_rr_from_resolved(
             &resolve_output,
             &cmd.path,
             planning_context.target_backend(),
-            cmd.no_mi,
             cmd.patch_file.as_deref(),
             output,
         )?
@@ -852,14 +832,13 @@ fn calc_user_intent_from_package_path(
     source_dir: &Path,
     filter_path: &Path,
     target_backend: TargetBackend,
-    no_mi: bool,
     patch_file: Option<&Path>,
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
     let (dir, _) = canonicalize_with_filename(&source_dir.join(filter_path))?;
     let pkg = filter_pkg_by_dir(resolve_output, &dir)?;
     ensure_package_supports_backend(resolve_output, pkg, target_backend)?;
     let directive =
-        rr_build::build_patch_directive_for_package(pkg, no_mi, None, patch_file, false)?;
+        rr_build::build_patch_directive_for_package(pkg, false, None, patch_file, false)?;
     Ok((vec![UserIntent::Check(pkg)], directive).into())
 }
 
@@ -868,13 +847,12 @@ fn calc_user_intent(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     paths: &[PathBuf],
     target_backend: TargetBackend,
-    no_mi: bool,
     patch_file: Option<&Path>,
     output: UserDiagnostics,
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
     if !paths.is_empty() {
         let selected = select_supported_packages(resolve_output, paths, target_backend, output)?;
-        let directive = build_directive_for_selected_packages(&selected, no_mi, patch_file)?;
+        let directive = build_directive_for_selected_packages(&selected, patch_file)?;
         Ok((
             selected.into_iter().map(UserIntent::Check).collect(),
             directive,
@@ -891,16 +869,12 @@ fn calc_user_intent(
 
 fn build_directive_for_selected_packages(
     selected: &[moonbuild_rupes_recta::model::PackageId],
-    no_mi: bool,
     patch_file: Option<&Path>,
 ) -> anyhow::Result<moonbuild_rupes_recta::build_plan::InputDirective> {
     if let [pkg] = selected {
-        return rr_build::build_patch_directive_for_package(*pkg, no_mi, None, patch_file, false);
+        return rr_build::build_patch_directive_for_package(*pkg, false, None, patch_file, false);
     }
 
-    if no_mi {
-        anyhow::bail!("`--no-mi` requires the selector to resolve to a single package");
-    }
     if patch_file.is_some() {
         anyhow::bail!("`--patch-file` requires the selector to resolve to a single package");
     }

--- a/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
@@ -631,7 +631,7 @@ _moon() {
             return 0
             ;;
         moon__check)
-            opts="-g -d -j -w -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --frozen --watch --package-path --patch-file --no-mi --explain --fmt --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
+            opts="-g -d -j -w -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --frozen --watch --package-path --patch-file --explain --fmt --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
@@ -192,7 +192,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --frozen 'Do not sync dependencies, assuming local dependencies are up-to-date'
             cand -w 'Monitor the file system and automatically check files'
             cand --watch 'Monitor the file system and automatically check files'
-            cand --no-mi 'Whether to skip the mi generation. Only valid when the selector resolves to a single package'
             cand --explain 'Whether to explain the error code with details'
             cand --fmt 'Check whether the code is properly formatted'
             cand -q 'Suppress output'

--- a/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
@@ -165,7 +165,6 @@ complete -c moon -n "__fish_moon_using_subcommand check" -l output-json -d 'Outp
 complete -c moon -n "__fish_moon_using_subcommand check" -l enable-value-tracing -d 'Enable value tracing'
 complete -c moon -n "__fish_moon_using_subcommand check" -l frozen -d 'Do not sync dependencies, assuming local dependencies are up-to-date'
 complete -c moon -n "__fish_moon_using_subcommand check" -s w -l watch -d 'Monitor the file system and automatically check files'
-complete -c moon -n "__fish_moon_using_subcommand check" -l no-mi -d 'Whether to skip the mi generation. Only valid when the selector resolves to a single package'
 complete -c moon -n "__fish_moon_using_subcommand check" -l explain -d 'Whether to explain the error code with details'
 complete -c moon -n "__fish_moon_using_subcommand check" -l fmt -d 'Check whether the code is properly formatted'
 complete -c moon -n "__fish_moon_using_subcommand check" -s q -l quiet -d 'Suppress output'

--- a/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
@@ -199,7 +199,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--frozen', 'frozen', [CompletionResultType]::ParameterName, 'Do not sync dependencies, assuming local dependencies are up-to-date')
             [CompletionResult]::new('-w', 'w', [CompletionResultType]::ParameterName, 'Monitor the file system and automatically check files')
             [CompletionResult]::new('--watch', 'watch', [CompletionResultType]::ParameterName, 'Monitor the file system and automatically check files')
-            [CompletionResult]::new('--no-mi', 'no-mi', [CompletionResultType]::ParameterName, 'Whether to skip the mi generation. Only valid when the selector resolves to a single package')
             [CompletionResult]::new('--explain', 'explain', [CompletionResultType]::ParameterName, 'Whether to explain the error code with details')
             [CompletionResult]::new('--fmt', 'fmt', [CompletionResultType]::ParameterName, 'Check whether the code is properly formatted')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -170,7 +170,6 @@ _arguments "${_arguments_options[@]}" : \
 '--frozen[Do not sync dependencies, assuming local dependencies are up-to-date]' \
 '-w[Monitor the file system and automatically check files]' \
 '--watch[Monitor the file system and automatically check files]' \
-'--no-mi[Whether to skip the mi generation. Only valid when the selector resolves to a single package]' \
 '--explain[Whether to explain the error code with details]' \
 '--fmt[Check whether the code is properly formatted]' \
 '-q[Suppress output]' \

--- a/crates/moon/tests/test_cases/debug_flag_test/mod.rs
+++ b/crates/moon/tests/test_cases/debug_flag_test/mod.rs
@@ -144,7 +144,7 @@ fn cli_reports_selector_conflicts_before_planning() {
 #[test]
 fn check_path_selector_smoke() {
     let dir = TestDir::new("debug_flag_test");
-    let check_with_path_selector = get_stdout(&dir, ["check", "lib", "--no-mi", "--dry-run"]);
+    let check_with_path_selector = get_stdout(&dir, ["check", "lib", "--dry-run"]);
     assert!(
         check_with_path_selector.contains("moonc check"),
         "stdout: {check_with_path_selector}"
@@ -152,18 +152,6 @@ fn check_path_selector_smoke() {
 
     #[cfg(unix)]
     {
-        let stderr = get_err_stderr(&dir, ["check", "lib", "main", "--no-mi", "--dry-run"]);
-        assert!(
-            stderr.contains("`--no-mi` requires the selector to resolve to a single package"),
-            "stderr: {stderr}"
-        );
-
-        let stderr = get_err_stderr(&dir, ["check", "notes", "--no-mi", "--dry-run"]);
-        assert!(
-            stderr.contains("`--no-mi` requires the selector to resolve to a single package"),
-            "stderr: {stderr}"
-        );
-
         let stderr = get_err_stderr(
             &dir,
             ["check", "notes", "--patch-file", "patch.json", "--dry-run"],

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -1709,7 +1709,6 @@ fn test_moon_check_package_with_patch() {
                 "main",
                 "--patch-file",
                 "/path/to/patch.json",
-                "--no-mi",
                 "--dry-run",
                 "--sort-input",
             ],
@@ -1717,8 +1716,8 @@ fn test_moon_check_package_with_patch() {
         expect![[r#"
             moonc check ./lib2/lib.mbt -o ./_build/wasm-gc/debug/check/lib2/lib2.mi -pkg username/hello/lib2 -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/hello/lib2:./lib2 -target wasm-gc -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
             moonc check ./lib/hello.mbt -o ./_build/wasm-gc/debug/check/lib/lib.mi -pkg username/hello/lib -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/lib2/lib2.mi:lib2 -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/hello/lib:./lib -target wasm-gc -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
-            moonc check -patch-file /path/to/patch.json -no-mi ./main/main.mbt -pkg username/hello/main -is-main -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/lib/lib.mi:lib -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/hello/main:./main -target wasm-gc -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
-            moonc check -no-mi -doctest-only ./main/main.mbt -include-doctests -pkg username/hello/main_blackbox_test -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/lib/lib.mi:lib -i ./_build/wasm-gc/debug/check/main/main.mi:main -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/hello/main_blackbox_test:./main -target wasm-gc -blackbox-test -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
+            moonc check -patch-file /path/to/patch.json ./main/main.mbt -o ./_build/wasm-gc/debug/check/main/main.mi -pkg username/hello/main -is-main -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/lib/lib.mi:lib -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/hello/main:./main -target wasm-gc -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
+            moonc check -doctest-only ./main/main.mbt -include-doctests -o ./_build/wasm-gc/debug/check/main/main.blackbox_test.mi -pkg username/hello/main_blackbox_test -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/lib/lib.mi:lib -i ./_build/wasm-gc/debug/check/main/main.mi:main -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/hello/main_blackbox_test:./main -target wasm-gc -blackbox-test -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
         "#]],
     );
 }

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -70,14 +70,8 @@ fn test_single_file_mbtx_run_block_import() {
 }
 
 #[test]
-fn test_single_file_check_rejects_unsupported_selector_flags() {
+fn test_single_file_check_rejects_patch_file() {
     let dir = TestDir::new("moon_test_single_file.in");
-
-    let no_mi_stderr = get_err_stderr(&dir, ["check", "front_matter_import_ok.mbt.md", "--no-mi"]);
-    assert!(
-        no_mi_stderr.contains("does not support `--no-mi`"),
-        "stderr: {no_mi_stderr}"
-    );
 
     let patch_stderr = get_err_stderr(
         &dir,

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -612,24 +612,6 @@ fn test_workspace_member_path_selector_uses_workspace_context() {
         !fmt_stderr.contains("skipping path `../liba/src/lib`"),
         "stderr: {fmt_stderr}"
     );
-
-    let check_no_mi_stderr = get_err_stderr(
-        &dir,
-        [
-            "-C",
-            "app",
-            "check",
-            "src/main",
-            "../liba/src/lib",
-            "--no-mi",
-            "--dry-run",
-        ],
-    );
-    assert!(
-        check_no_mi_stderr
-            .contains("`--no-mi` requires the selector to resolve to a single package"),
-        "stderr: {check_no_mi_stderr}"
-    );
 }
 
 #[test]

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -176,7 +176,6 @@ Check the current package, but don't build object files
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `-w`, `--watch` — Monitor the file system and automatically check files
 * `--patch-file <PATCH_FILE>` — The patch file to check. Only valid when the selector resolves to a single package
-* `--no-mi` — Whether to skip the mi generation. Only valid when the selector resolves to a single package
 * `--explain` — Whether to explain the error code with details
 * `--fmt` — Check whether the code is properly formatted
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -176,7 +176,6 @@ Check the current package, but don't build object files
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `-w`, `--watch` — Monitor the file system and automatically check files
 * `--patch-file <PATCH_FILE>` — The patch file to check. Only valid when the selector resolves to a single package
-* `--no-mi` — Whether to skip the mi generation. Only valid when the selector resolves to a single package
 * `--explain` — Whether to explain the error code with details
 * `--fmt` — Check whether the code is properly formatted
 


### PR DESCRIPTION
## Summary

- Remove the deprecated `moon check --no-mi` public flag and the code paths that forwarded it from the check CLI.
- Update command docs and shell completion snapshots generated from the CLI.
- Drop tests that asserted `--no-mi` selector validation, and update the affected check dry-run expectation to emit `.mi` output normally.

## Rationale

`--no-mi` exposed an internal compiler-detail escape hatch on `moon check`, but check actions are expected to produce package interfaces. Removing the public flag keeps `moon check` behavior aligned with that contract.

This change is intentionally scoped to the public check command surface. The existing internal compiler `-no-mi` plumbing for non-check build-package cases is left unchanged.