### PR TITLE
feat(moonrun): support wasm sockets

### DIFF
--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -786,6 +786,16 @@ fn test_async_wasm_upstream_pipe_package() {
 }
 
 #[test]
+fn test_async_wasm_upstream_socket_package() {
+    check(
+        run_upstream_async_wasm_package("moonbitlang/async/socket"),
+        expect![[r#"
+            Total tests: 24, passed: 24, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
 fn test_max_concurrent_tests() {
     let dir = TestDir::new("moon_test");
     let out1 = get_stdout(

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -41,6 +41,8 @@ libc.workspace = true
 version = "0.59.0"
 features = [
     "Win32_Foundation",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",
     "Win32_Security",
     "Win32_Storage_FileSystem",

--- a/crates/moonrun/src/async_api/event_loop.rs
+++ b/crates/moonrun/src/async_api/event_loop.rs
@@ -16,6 +16,8 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+#[cfg(windows)]
+use crate::async_sys::internal::event_loop::io;
 use crate::async_sys::internal::event_loop::thread_pool;
 
 use super::context::ImportContext;
@@ -34,5 +36,23 @@ pub(super) fn errno_is_cancelled(_context: &mut ImportContext<'_, '_>, errno: i3
     } else {
         0
     }
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_init_WSA"
+)]
+#[cfg(windows)]
+pub(super) fn init_wsa(_context: &mut ImportContext<'_, '_>) -> i32 {
+    io::init_wsa()
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_cleanup_WSA"
+)]
+#[cfg(windows)]
+pub(super) fn cleanup_wsa(_context: &mut ImportContext<'_, '_>) -> i32 {
+    io::cleanup_wsa()
 }
 }

--- a/crates/moonrun/src/async_api/fd_util.rs
+++ b/crates/moonrun/src/async_api/fd_util.rs
@@ -109,6 +109,16 @@ pub(super) fn set_nonblocking(context: &mut ImportContext<'_, '_>, fd: u64) -> i
     }
 }
 
+pub(super) fn set_cloexec(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
+    match context.host.set_cloexec(fd) {
+        Ok(()) => 0,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
 fn file_time_i64(context: &mut ImportContext<'_, '_>, ptr: i32, field_offset: i32) -> AsyncHostResult<i64> {
     read_field(context, ptr, field_offset, 8)
         .map(|bytes| i64::from_le_bytes(bytes.as_slice().try_into().unwrap()))

--- a/crates/moonrun/src/async_api/io.rs
+++ b/crates/moonrun/src/async_api/io.rs
@@ -84,6 +84,71 @@ pub(super) fn make_file_io_result(
 
 #[ported(
     source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_make_socket_io_result"
+)]
+#[cfg(windows)]
+pub(super) fn make_socket_io_result(
+    context: &mut ImportContext<'_, '_>,
+    events: i32,
+    buf: i32,
+    offset: i32,
+    len: i32,
+    flags: i32,
+) -> crate::async_host::AsyncHostResult<u64> {
+    context.with_host_and_memory_mut(|host, memory| {
+        host.make_socket_io_result(memory, events, buf, offset, len, flags)
+    })
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_make_socket_with_addr_io_result"
+)]
+#[cfg(windows)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn make_socket_with_addr_io_result(
+    context: &mut ImportContext<'_, '_>,
+    events: i32,
+    buf: i32,
+    offset: i32,
+    len: i32,
+    flags: i32,
+    addr: i32,
+    addr_len: i32,
+) -> crate::async_host::AsyncHostResult<u64> {
+    context.with_host_and_memory_mut(|host, memory| {
+        host.make_socket_with_addr_io_result(memory, events, buf, offset, len, flags, addr, addr_len)
+    })
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_make_connect_io_result"
+)]
+#[cfg(windows)]
+pub(super) fn make_connect_io_result(
+    context: &mut ImportContext<'_, '_>,
+    addr: i32,
+    addr_len: i32,
+) -> crate::async_host::AsyncHostResult<u64> {
+    context.with_host_and_memory_mut(|host, memory| {
+        host.make_connect_io_result(memory, addr, addr_len)
+    })
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_make_accept_io_result"
+)]
+#[cfg(windows)]
+pub(super) fn make_accept_io_result(
+    context: &mut ImportContext<'_, '_>,
+) -> crate::async_host::AsyncHostResult<u64> {
+    context.host.make_accept_io_result()
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
     original = "moonbitlang_async_free_io_result"
 )]
 #[cfg(windows)]

--- a/crates/moonrun/src/async_api/mod.rs
+++ b/crates/moonrun/src/async_api/mod.rs
@@ -38,6 +38,7 @@ mod os_string;
 mod provenance;
 mod registry;
 mod runtime;
+mod socket;
 mod thread_pool;
 mod time;
 

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -26,7 +26,7 @@ use super::context::{
 use super::provenance::{PortedImport, SourceLocation, SourceRoot};
 use super::{
     c_buffer, env_util, event_bus, event_loop, fd_util, fs, io, os_error, os_string, runtime,
-    thread_pool, time,
+    socket, thread_pool, time,
 };
 
 pub(crate) const MOONBIT_ASYNC_MODULE: &str = "moonbitlang/async";
@@ -274,6 +274,18 @@ declare_async_imports! {
 
     ported event_loop::get_platform() -> i32 => "runtime/get_platform";
 
+    #[cfg(windows)]
+    ported event_loop::init_wsa() -> i32 => "runtime/init_WSA";
+
+    #[cfg(not(windows))]
+    fake event_loop::init_wsa() -> i32 => "runtime/init_WSA";
+
+    #[cfg(windows)]
+    ported event_loop::cleanup_wsa() -> i32 => "runtime/cleanup_WSA";
+
+    #[cfg(not(windows))]
+    fake event_loop::cleanup_wsa() -> i32 => "runtime/cleanup_WSA";
+
     ported event_bus::create() -> u64 => "event_bus/create";
 
     ported event_bus::destroy(bus: u64) -> void => "event_bus/destroy";
@@ -397,6 +409,8 @@ declare_async_imports! {
     #[cfg(windows)]
     fake fd_util::set_nonblocking(fd: u64) -> i32 => "fd_util/set_nonblocking/unix";
 
+    helper fd_util::set_cloexec(fd: u64) -> i32 => "fd_util/set_cloexec";
+
     helper fd_util::sizeof_file_time() -> i32 => "fd_util/sizeof_file_time";
 
     ported fd_util::get_atime_sec(ptr: i32) -> i64 => "fd_util/get_atime_sec";
@@ -426,6 +440,138 @@ declare_async_imports! {
     #[cfg(windows)]
     fake io::write(fd: u64, src: i32, offset: i32, len: i32) -> i32 => "io/write/unix";
 
+    ported socket::ipv4_addr_size() -> i32 => "socket/ipv4_addr_size";
+
+    ported socket::ipv6_addr_size() -> i32 => "socket/ipv6_addr_size";
+
+    ported socket::init_ip_addr(addr: i32, ip: i32, port: i32) -> void => "socket/init_ip_addr";
+
+    ported socket::init_ipv6_addr(addr: i32, ip: i32, port: i32, scope_id: i32) -> void => "socket/init_ipv6_addr";
+
+    #[cfg(unix)]
+    ported socket::gai_strerror(code: i32) -> u64 => "socket/gai_strerror";
+
+    #[cfg(windows)]
+    fake socket::gai_strerror(code: i32) -> u64 => "socket/gai_strerror";
+
+    ported socket::ip_addr_get_ip(addr: i32, addr_len: i32) -> i32 => "socket/ip_addr_get_ip";
+
+    ported socket::ip_addr_get_port(addr: i32, addr_len: i32) -> i32 => "socket/ip_addr_get_port";
+
+    ported socket::addr_is_ipv6(addr: i32, addr_len: i32) -> i32 => "socket/addr_is_ipv6";
+
+    ported socket::addr_is_multicast(addr: i32, addr_len: i32) -> i32 => "socket/addr_is_multicast";
+
+    ported socket::addr_copy_ipv6_bytes(addr: i32, out: i32, addr_len: i32, len: i32) -> void => "socket/addr_copy_ipv6_bytes";
+
+    ported socket::addr_get_ipv6_scope_id(addr: i32, addr_len: i32) -> i32 => "socket/addr_get_ipv6_scope_id";
+
+    ported socket::addr_is_ipv6_wildcard(addr: i32, addr_len: i32) -> i32 => "socket/addr_is_ipv6_wildcard";
+
+    helper socket::addrinfo_is_null(addrinfo: u64) -> i32 => "socket/addrinfo_is_null";
+
+    helper socket::addrinfo_get_next(addrinfo: u64) -> u64 => "socket/addrinfo_get_next";
+
+    ported socket::addrinfo_addr_size(addrinfo: u64) -> i32 => "socket/addrinfo_addr_size";
+
+    ported socket::addrinfo_fill_addr(addrinfo: u64, out: i32, port: i32, out_len: i32) -> void => "socket/addrinfo_fill_addr";
+
+    helper socket::addrinfo_free(addrinfo: u64) -> void => "socket/addrinfo_free";
+
+    ported socket::make_tcp_socket(family: i32) -> u64 => "socket/make_tcp_socket";
+
+    ported socket::make_udp_socket(family: i32, multicast: i32) -> u64 => "socket/make_udp_socket";
+
+    ported socket::join_multicast_group(fd: u64, multi_addr: i32, local_addr: i32, multi_addr_len: i32, local_addr_len: i32) -> i32 => "socket/join_multicast_group";
+
+    ported socket::join_multicast_group_v6(fd: u64, multi_addr: i32, interface_index: i32, multi_addr_len: i32) -> i32 => "socket/join_multicast_group_v6";
+
+    ported socket::set_multicast_interface(fd: u64, local_addr: i32, local_addr_len: i32) -> i32 => "socket/set_multicast_interface";
+
+    ported socket::set_multicast_interface_v6(fd: u64, interface_index: i32) -> i32 => "socket/set_multicast_interface_v6";
+
+    ported socket::set_multicast_ttl(fd: u64, ttl: i32, family: i32) -> i32 => "socket/set_multicast_ttl";
+
+    ported socket::set_multicast_loopback(fd: u64, enable: i32, family: i32) -> i32 => "socket/set_multicast_loopback";
+
+    ported socket::disable_nagle(fd: u64) -> i32 => "socket/disable_nagle";
+
+    ported socket::allow_reuse_addr(fd: u64) -> i32 => "socket/allow_reuse_addr";
+
+    ported socket::set_ipv6_only(fd: u64, ipv6_only: i32) -> i32 => "socket/set_ipv6_only";
+
+    ported socket::listen(fd: u64) -> i32 => "socket/listen";
+
+    ported socket::enable_keepalive(fd: u64, keep_idle: i32, keep_count: i32, keep_intvl: i32) -> i32 => "socket/enable_keepalive";
+
+    ported socket::getsockname(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/getsockname";
+
+    ported socket::getpeername(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/getpeername";
+
+    ported socket::if_nametoindex(name: i32, name_len: i32) -> i32 => "socket/if_nametoindex";
+
+    ported socket::if_indextoname(index: i32) -> u64 => "socket/if_indextoname";
+
+    ported socket::find_ipv6_test_interface() -> i32 => "socket/find_ipv6_test_interface";
+
+    ported socket::udp_client_connect(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/udp_client_connect";
+
+    helper socket::bind(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/bind";
+
+    #[cfg(unix)]
+    ported socket::recvfrom(fd: u64, buf: i32, offset: i32, len: i32, addr: i32, addr_len: i32) -> i32 => "socket/recvfrom/unix";
+
+    #[cfg(windows)]
+    fake socket::recvfrom(fd: u64, buf: i32, offset: i32, len: i32, addr: i32, addr_len: i32) -> i32 => "socket/recvfrom/unix";
+
+    #[cfg(unix)]
+    ported socket::sendto(fd: u64, buf: i32, offset: i32, len: i32, addr: i32, addr_len: i32) -> i32 => "socket/sendto/unix";
+
+    #[cfg(windows)]
+    fake socket::sendto(fd: u64, buf: i32, offset: i32, len: i32, addr: i32, addr_len: i32) -> i32 => "socket/sendto/unix";
+
+    #[cfg(unix)]
+    ported socket::connect(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/connect/unix";
+
+    #[cfg(windows)]
+    fake socket::connect(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/connect/unix";
+
+    #[cfg(unix)]
+    ported socket::getsockerr(fd: u64) -> i32 => "socket/getsockerr/unix";
+
+    #[cfg(windows)]
+    fake socket::getsockerr(fd: u64) -> i32 => "socket/getsockerr/unix";
+
+    #[cfg(unix)]
+    ported socket::accept(fd: u64, addr: i32, addr_len: i32) -> u64 => "socket/accept/unix";
+
+    #[cfg(windows)]
+    fake socket::accept(fd: u64, addr: i32, addr_len: i32) -> u64 => "socket/accept/unix";
+
+    #[cfg(windows)]
+    ported socket::connect_io_result(fd: u64, result: u64) -> i32 => "socket/connect/windows";
+
+    #[cfg(not(windows))]
+    fake socket::connect_io_result(fd: u64, result: u64) -> i32 => "socket/connect/windows";
+
+    #[cfg(windows)]
+    ported socket::setup_connected_socket(fd: u64) -> i32 => "socket/setup_connected_socket/windows";
+
+    #[cfg(not(windows))]
+    fake socket::setup_connected_socket(fd: u64) -> i32 => "socket/setup_connected_socket/windows";
+
+    #[cfg(windows)]
+    ported socket::accept_io_result(server_fd: u64, conn_fd: u64, result: u64) -> i32 => "socket/accept/windows";
+
+    #[cfg(not(windows))]
+    fake socket::accept_io_result(server_fd: u64, conn_fd: u64, result: u64) -> i32 => "socket/accept/windows";
+
+    #[cfg(windows)]
+    ported socket::setup_accepted_socket(listen_fd: u64, accept_fd: u64) -> i32 => "socket/setup_accepted_socket/windows";
+
+    #[cfg(not(windows))]
+    fake socket::setup_accepted_socket(listen_fd: u64, accept_fd: u64) -> i32 => "socket/setup_accepted_socket/windows";
+
     #[cfg(windows)]
     ported io::make_file_io_result(
         events: i32,
@@ -443,6 +589,58 @@ declare_async_imports! {
         len: i32,
         position: i64,
     ) -> u64 => "io/make_file_io_result/windows";
+
+    #[cfg(windows)]
+    ported io::make_socket_io_result(
+        events: i32,
+        buf: i32,
+        offset: i32,
+        len: i32,
+        flags: i32,
+    ) -> u64 => "io/make_socket_io_result/windows";
+
+    #[cfg(not(windows))]
+    fake io::make_socket_io_result(
+        events: i32,
+        buf: i32,
+        offset: i32,
+        len: i32,
+        flags: i32,
+    ) -> u64 => "io/make_socket_io_result/windows";
+
+    #[cfg(windows)]
+    ported io::make_socket_with_addr_io_result(
+        events: i32,
+        buf: i32,
+        offset: i32,
+        len: i32,
+        flags: i32,
+        addr: i32,
+        addr_len: i32,
+    ) -> u64 => "io/make_socket_with_addr_io_result/windows";
+
+    #[cfg(not(windows))]
+    fake io::make_socket_with_addr_io_result(
+        events: i32,
+        buf: i32,
+        offset: i32,
+        len: i32,
+        flags: i32,
+        addr: i32,
+        addr_len: i32,
+    ) -> u64 => "io/make_socket_with_addr_io_result/windows";
+
+    #[cfg(windows)]
+    ported io::make_connect_io_result(addr: i32, addr_len: i32) -> u64 => "io/make_connect_io_result/windows";
+
+    #[cfg(not(windows))]
+    fake io::make_connect_io_result(addr: i32, addr_len: i32) -> u64 => "io/make_connect_io_result/windows";
+
+    #[cfg(windows)]
+    ported io::make_accept_io_result() -> u64 => "io/make_accept_io_result/windows";
+
+    #[cfg(not(windows))]
+    fake io::make_accept_io_result() -> u64 => "io/make_accept_io_result/windows";
 
     #[cfg(windows)]
     ported io::free_io_result(result: u64) -> void => "io/free_io_result/windows";
@@ -609,6 +807,12 @@ declare_async_imports! {
     ported thread_pool::make_rmdir_job(path_ptr: i32, path_len: i32) -> u64 => "thread_pool/make_rmdir_job";
 
     ported thread_pool::make_readdir_job(dir: u64, buf: u64, len: i32, restart: i32) -> u64 => "thread_pool/make_readdir_job";
+
+    ported thread_pool::make_bind_job(socket: u64, addr: i32, addr_len: i32) -> u64 => "thread_pool/make_bind_job";
+
+    ported thread_pool::make_getaddrinfo_job(host: i32, host_len: i32) -> u64 => "thread_pool/make_getaddrinfo_job";
+
+    helper thread_pool::get_getaddrinfo_result(job: u64) -> u64 => "thread_pool/get_getaddrinfo_result";
 }
 
 #[cfg(test)]
@@ -623,6 +827,7 @@ fn async_api_ported_imports() -> Vec<PortedImport> {
     imports.extend_from_slice(io::PORTED_IMPORTS);
     imports.extend_from_slice(env_util::PORTED_IMPORTS);
     imports.extend_from_slice(c_buffer::PORTED_IMPORTS);
+    imports.extend_from_slice(socket::PORTED_IMPORTS);
     imports
 }
 

--- a/crates/moonrun/src/async_api/socket.rs
+++ b/crates/moonrun/src/async_api/socket.rs
@@ -1,0 +1,640 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+#[cfg(unix)]
+use crate::async_host::AsyncHostError;
+use crate::async_host::{AsyncHostResult, GuestMemory, read_u16};
+use crate::async_sys::socket as sys;
+
+use super::context::ImportContext;
+use super::provenance::ported_imports;
+
+ported_imports! {
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn ipv4_addr_size(_context: &mut ImportContext<'_, '_>) -> i32 {
+    sys::ipv4_addr_size()
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn ipv6_addr_size(_context: &mut ImportContext<'_, '_>) -> i32 {
+    sys::ipv6_addr_size()
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn init_ip_addr(
+    context: &mut ImportContext<'_, '_>,
+    addr: i32,
+    ip: i32,
+    port: i32,
+) -> AsyncHostResult<()> {
+    context.with_memory_mut(|memory| {
+        let addr_len = sys::ipv4_addr_size();
+        let addr = memory.read_exact_mut(addr, addr_len)?;
+        sys::init_ip_addr(addr, ip, port)
+    })
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn init_ipv6_addr(
+    context: &mut ImportContext<'_, '_>,
+    addr: i32,
+    ip: i32,
+    port: i32,
+    scope_id: i32,
+) -> AsyncHostResult<()> {
+    context.with_memory_mut(|memory| {
+        let ip = memory.read_exact(ip, 16)?.to_vec();
+        let addr_len = sys::ipv6_addr_size();
+        let addr = memory.read_exact_mut(addr, addr_len)?;
+        sys::init_ipv6_addr(addr, &ip, port, scope_id)
+    })
+}
+
+#[ported(source = "src/internal/event_loop/network.mbt", original = "gai_strerror")]
+#[cfg(unix)]
+pub(super) fn gai_strerror(context: &mut ImportContext<'_, '_>, code: i32) -> u64 {
+    context.host.insert_c_buffer(sys::gai_strerror(code))
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn ip_addr_get_ip(
+    context: &mut ImportContext<'_, '_>,
+    addr: i32,
+    addr_len: i32,
+) -> AsyncHostResult<i32> {
+    context.with_memory_mut(|memory| {
+        let addr = memory.read_exact(addr, addr_len)?;
+        sys::ip_addr_get_ip(addr)
+    })
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn ip_addr_get_port(
+    context: &mut ImportContext<'_, '_>,
+    addr: i32,
+    addr_len: i32,
+) -> AsyncHostResult<i32> {
+    context.with_memory_mut(|memory| {
+        let addr = memory.read_exact(addr, addr_len)?;
+        sys::ip_addr_get_port(addr)
+    })
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn addr_is_ipv6(
+    context: &mut ImportContext<'_, '_>,
+    addr: i32,
+    addr_len: i32,
+) -> AsyncHostResult<i32> {
+    context
+        .with_memory_mut(|memory| {
+            let addr = memory.read_exact(addr, addr_len)?;
+            sys::addr_is_ipv6(addr)
+        })
+        .map(i32::from)
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn addr_is_multicast(
+    context: &mut ImportContext<'_, '_>,
+    addr: i32,
+    addr_len: i32,
+) -> AsyncHostResult<i32> {
+    context
+        .with_memory_mut(|memory| {
+            let addr = memory.read_exact(addr, addr_len)?;
+            sys::addr_is_multicast(addr)
+        })
+        .map(i32::from)
+}
+
+#[ported(
+    source = "src/socket/socket.c",
+    original = "moonbitlang_async_addr_get_ipv6_bytes"
+)]
+pub(super) fn addr_copy_ipv6_bytes(
+    context: &mut ImportContext<'_, '_>,
+    addr: i32,
+    out: i32,
+    addr_len: i32,
+    len: i32,
+) -> AsyncHostResult<()> {
+    context.with_memory_mut(|memory| {
+        let addr = memory.read_exact(addr, addr_len)?.to_vec();
+        let out = memory.read_exact_mut(out, len)?;
+        sys::addr_copy_ipv6_bytes(&addr, out)
+    })
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn addr_get_ipv6_scope_id(
+    context: &mut ImportContext<'_, '_>,
+    addr: i32,
+    addr_len: i32,
+) -> AsyncHostResult<i32> {
+    context.with_memory_mut(|memory| {
+        let addr = memory.read_exact(addr, addr_len)?;
+        sys::addr_get_ipv6_scope_id(addr)
+    })
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn addr_is_ipv6_wildcard(
+    context: &mut ImportContext<'_, '_>,
+    addr: i32,
+    addr_len: i32,
+) -> AsyncHostResult<i32> {
+    context
+        .with_memory_mut(|memory| {
+            let addr = memory.read_exact(addr, addr_len)?;
+            sys::addr_is_ipv6_wildcard(addr)
+        })
+        .map(i32::from)
+}
+
+pub(super) fn addrinfo_is_null(_context: &mut ImportContext<'_, '_>, addrinfo: u64) -> i32 {
+    i32::from(addrinfo == crate::async_host::INVALID_HOST_HANDLE)
+}
+
+pub(super) fn addrinfo_get_next(
+    context: &mut ImportContext<'_, '_>,
+    addrinfo: u64,
+) -> AsyncHostResult<u64> {
+    context.host.addrinfo_next(addrinfo)
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn addrinfo_addr_size(
+    context: &mut ImportContext<'_, '_>,
+    addrinfo: u64,
+) -> AsyncHostResult<i32> {
+    if addrinfo == crate::async_host::INVALID_HOST_HANDLE {
+        return Ok(0);
+    }
+    let addr = context.host.addrinfo_addr(addrinfo)?;
+    Ok(sys::addrinfo_addr_size(&addr))
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn addrinfo_fill_addr(
+    context: &mut ImportContext<'_, '_>,
+    addrinfo: u64,
+    out: i32,
+    port: i32,
+    out_len: i32,
+) -> AsyncHostResult<()> {
+    if addrinfo == crate::async_host::INVALID_HOST_HANDLE {
+        return Ok(());
+    }
+    let addr = context.host.addrinfo_addr(addrinfo)?;
+    context.with_memory_mut(|memory| {
+        let out = memory.read_exact_mut(out, out_len)?;
+        sys::addrinfo_fill_addr(&addr, out, port)
+    })
+}
+
+pub(super) fn addrinfo_free(context: &mut ImportContext<'_, '_>, addrinfo: u64) -> AsyncHostResult<()> {
+    context.host.free_addrinfo(addrinfo)
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn make_tcp_socket(context: &mut ImportContext<'_, '_>, family: i32) -> u64 {
+    match sys::make_tcp_socket(family) {
+        Ok(fd) => context.host.insert_host_file(fd),
+        Err(error) => {
+            context.host.record_error(error);
+            context.host.invalid_fd()
+        }
+    }
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn make_udp_socket(context: &mut ImportContext<'_, '_>, family: i32, multicast: i32) -> u64 {
+    match sys::make_udp_socket(family, multicast != 0) {
+        Ok(fd) => context.host.insert_host_file(fd),
+        Err(error) => {
+            context.host.record_error(error);
+            context.host.invalid_fd()
+        }
+    }
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn join_multicast_group(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    multi_addr: i32,
+    local_addr: i32,
+    multi_addr_len: i32,
+    local_addr_len: i32,
+) -> i32 {
+    let host = context.host;
+    let result = context.with_memory_mut(|memory| {
+        let multi_addr = memory.read_exact(multi_addr, multi_addr_len)?.to_vec();
+        let local_addr = memory.read_exact(local_addr, local_addr_len)?.to_vec();
+        host.with_raw_file(fd, |fd| {
+            sys::join_multicast_group(fd, &multi_addr, &local_addr)
+        })
+    });
+    zero_or_minus_one(context, result)
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn join_multicast_group_v6(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    multi_addr: i32,
+    interface_index: i32,
+    multi_addr_len: i32,
+) -> i32 {
+    let host = context.host;
+    let result = context.with_memory_mut(|memory| {
+        let multi_addr = memory.read_exact(multi_addr, multi_addr_len)?.to_vec();
+        host.with_raw_file(fd, |fd| {
+            sys::join_multicast_group_v6(fd, &multi_addr, interface_index)
+        })
+    });
+    zero_or_minus_one(context, result)
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn set_multicast_interface(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    local_addr: i32,
+    local_addr_len: i32,
+) -> i32 {
+    let host = context.host;
+    let result = context.with_memory_mut(|memory| {
+        let local_addr = memory.read_exact(local_addr, local_addr_len)?.to_vec();
+        host.with_raw_file(fd, |fd| sys::set_multicast_interface(fd, &local_addr))
+    });
+    zero_or_minus_one(context, result)
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn set_multicast_interface_v6(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    interface_index: i32,
+) -> i32 {
+    let host = context.host;
+    zero_or_minus_one(
+        context,
+        host.with_raw_file(fd, |fd| {
+            sys::set_multicast_interface_v6(fd, interface_index)
+        }),
+    )
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn set_multicast_ttl(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    ttl: i32,
+    family: i32,
+) -> i32 {
+    let host = context.host;
+    zero_or_minus_one(
+        context,
+        host.with_raw_file(fd, |fd| sys::set_multicast_ttl(fd, ttl, family)),
+    )
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn set_multicast_loopback(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    enable: i32,
+    family: i32,
+) -> i32 {
+    let host = context.host;
+    zero_or_minus_one(
+        context,
+        host.with_raw_file(fd, |fd| {
+            sys::set_multicast_loopback(fd, enable != 0, family)
+        }),
+    )
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn disable_nagle(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
+    let host = context.host;
+    zero_or_minus_one(context, host.with_raw_file(fd, sys::disable_nagle))
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn allow_reuse_addr(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
+    let host = context.host;
+    zero_or_minus_one(context, host.with_raw_file(fd, sys::allow_reuse_addr))
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn set_ipv6_only(context: &mut ImportContext<'_, '_>, fd: u64, ipv6_only: i32) -> i32 {
+    let host = context.host;
+    zero_or_minus_one(
+        context,
+        host.with_raw_file(fd, |fd| sys::set_ipv6_only(fd, ipv6_only != 0)),
+    )
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn listen(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
+    let host = context.host;
+    zero_or_minus_one(context, host.with_raw_file(fd, sys::listen))
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn enable_keepalive(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    keep_idle: i32,
+    keep_count: i32,
+    keep_intvl: i32,
+) -> i32 {
+    let host = context.host;
+    zero_or_minus_one(
+        context,
+        host.with_raw_file(fd, |fd| {
+            sys::enable_keepalive(fd, keep_idle, keep_count, keep_intvl)
+        }),
+    )
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn getsockname(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, addr_len: i32) -> i32 {
+    let host = context.host;
+    let result = context.with_memory_mut(|memory| {
+        let addr = memory.read_exact_mut(addr, addr_len)?;
+        host.with_raw_file(fd, |fd| sys::getsockname(fd, addr))
+    });
+    zero_or_minus_one(context, result)
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn getpeername(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, addr_len: i32) -> i32 {
+    let host = context.host;
+    let result = context.with_memory_mut(|memory| {
+        let addr = memory.read_exact_mut(addr, addr_len)?;
+        host.with_raw_file(fd, |fd| sys::getpeername(fd, addr))
+    });
+    zero_or_minus_one(context, result)
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn if_nametoindex(context: &mut ImportContext<'_, '_>, name: i32, name_len: i32) -> i32 {
+    let result = context.with_memory_mut(|memory| {
+        let name = read_u16(memory, name, name_len)?;
+        sys::if_nametoindex(name)
+    });
+    match result {
+        Ok(index) => index,
+        Err(error) => {
+            context.host.record_error(error);
+            0
+        }
+    }
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn if_indextoname(context: &mut ImportContext<'_, '_>, index: i32) -> u64 {
+    match sys::if_indextoname(index) {
+        Ok(name) => context.host.insert_c_buffer(name.into_boxed_slice()),
+        Err(error) => {
+            context.host.record_error(error);
+            crate::async_host::INVALID_HOST_HANDLE
+        }
+    }
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn find_ipv6_test_interface(_context: &mut ImportContext<'_, '_>) -> i32 {
+    sys::find_ipv6_test_interface()
+}
+
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn udp_client_connect(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    addr: i32,
+    addr_len: i32,
+) -> i32 {
+    let host = context.host;
+    let result = context.with_memory_mut(|memory| {
+        let addr = memory.read_exact(addr, addr_len)?.to_vec();
+        host.with_raw_file(fd, |fd| sys::udp_client_connect(fd, &addr))
+    });
+    zero_or_minus_one(context, result)
+}
+
+pub(super) fn bind(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, addr_len: i32) -> i32 {
+    let host = context.host;
+    let result = context.with_memory_mut(|memory| {
+        let addr = memory.read_exact(addr, addr_len)?.to_vec();
+        host.with_raw_file(fd, |fd| sys::bind(fd, &addr))
+    });
+    zero_or_minus_one(context, result)
+}
+
+#[ported(source = "src/internal/event_loop/io_unix.c")]
+#[cfg(unix)]
+pub(super) fn recvfrom(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    buf: i32,
+    offset: i32,
+    len: i32,
+    addr: i32,
+    addr_len: i32,
+) -> i32 {
+    let offset_buf = match checked_add_i32(buf, offset) {
+        Ok(offset_buf) => offset_buf,
+        Err(error) => {
+            context.host.record_error(error);
+            return -1;
+        }
+    };
+    let host = context.host;
+    let result = context.with_memory_mut(|memory| {
+        memory.read_exact(offset_buf, len)?;
+        let mut data = vec![0; usize::try_from(len).map_err(|_| AsyncHostError::Fault)?];
+        let mut addr_data = memory.read_exact(addr, addr_len)?.to_vec();
+        let n = host.with_raw_file(fd, |fd| sys::recvfrom(fd, &mut data, &mut addr_data))?;
+        memory.write_exact(offset_buf, &data[..n])?;
+        memory.write_exact(addr, &addr_data)?;
+        i32::try_from(n).map_err(|_| AsyncHostError::Fault)
+    });
+    match result {
+        Ok(n) => n,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(source = "src/internal/event_loop/io_unix.c")]
+#[cfg(unix)]
+pub(super) fn sendto(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    buf: i32,
+    offset: i32,
+    len: i32,
+    addr: i32,
+    addr_len: i32,
+) -> i32 {
+    let offset_buf = match checked_add_i32(buf, offset) {
+        Ok(offset_buf) => offset_buf,
+        Err(error) => {
+            context.host.record_error(error);
+            return -1;
+        }
+    };
+    let host = context.host;
+    let result = context.with_memory_mut(|memory| {
+        let data = memory.read_exact(offset_buf, len)?.to_vec();
+        let addr = memory.read_exact(addr, addr_len)?.to_vec();
+        host.with_raw_file(fd, |fd| sys::sendto(fd, &data, &addr))
+            .and_then(|n| i32::try_from(n).map_err(|_| AsyncHostError::Fault))
+    });
+    match result {
+        Ok(n) => n,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(source = "src/internal/event_loop/io_unix.c")]
+#[cfg(unix)]
+pub(super) fn connect(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, addr_len: i32) -> i32 {
+    let host = context.host;
+    let result = context.with_memory_mut(|memory| {
+        let addr = memory.read_exact(addr, addr_len)?;
+        host.with_raw_file(fd, |fd| sys::connect(fd, addr))
+    });
+    zero_or_minus_one(context, result)
+}
+
+#[ported(source = "src/internal/event_loop/io_unix.c")]
+#[cfg(unix)]
+pub(super) fn getsockerr(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
+    let host = context.host;
+    match host.with_raw_file(fd, sys::getsockerr) {
+        Ok(err) => err,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(source = "src/internal/event_loop/io_unix.c")]
+#[cfg(unix)]
+pub(super) fn accept(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, addr_len: i32) -> u64 {
+    let host = context.host;
+    let result = context.with_memory_mut(|memory| {
+        let addr = memory.read_exact_mut(addr, addr_len)?;
+        host.with_raw_file(fd, |fd| sys::accept(fd, addr))
+    });
+    match result {
+        Ok(fd) => context.host.insert_host_file(fd),
+        Err(error) => {
+            context.host.record_error(error);
+            context.host.invalid_fd()
+        }
+    }
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_connect"
+)]
+#[cfg(windows)]
+pub(super) fn connect_io_result(context: &mut ImportContext<'_, '_>, fd: u64, result: u64) -> i32 {
+    match context.host.connect_io_result(fd, result) {
+        Ok(ret) => ret,
+        Err(error) => {
+            context.host.record_error(error);
+            0
+        }
+    }
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_setup_connected_socket"
+)]
+#[cfg(windows)]
+pub(super) fn setup_connected_socket(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
+    zero_or_minus_one(context, context.host.setup_connected_socket(fd))
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_accept"
+)]
+#[cfg(windows)]
+pub(super) fn accept_io_result(
+    context: &mut ImportContext<'_, '_>,
+    server_fd: u64,
+    conn_fd: u64,
+    result: u64,
+) -> i32 {
+    match context.host.accept_io_result(server_fd, conn_fd, result) {
+        Ok(ret) => ret,
+        Err(error) => {
+            context.host.record_error(error);
+            0
+        }
+    }
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_setup_accepted_socket"
+)]
+#[cfg(windows)]
+pub(super) fn setup_accepted_socket(
+    context: &mut ImportContext<'_, '_>,
+    listen_fd: u64,
+    accept_fd: u64,
+) -> i32 {
+    zero_or_minus_one(
+        context,
+        context.host.setup_accepted_socket(listen_fd, accept_fd),
+    )
+}
+
+fn zero_or_minus_one(context: &mut ImportContext<'_, '_>, result: AsyncHostResult<()>) -> i32 {
+    match result {
+        Ok(()) => 0,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[cfg(unix)]
+fn checked_add_i32(lhs: i32, rhs: i32) -> AsyncHostResult<i32> {
+    lhs.checked_add(rhs).ok_or(AsyncHostError::Fault)
+}
+}

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -126,7 +126,7 @@ pub(super) fn make_open_job(
     sync: i32,
     mode: i32,
 ) -> AsyncHostResult<u64> {
-    let filename = read_guest_path(context, path_ptr, path_len)?;
+    let filename = read_guest_os_string(context, path_ptr, path_len)?;
 
     context.host.insert_job(thread_pool::make_open_job(
         filename,
@@ -186,7 +186,7 @@ pub(super) fn make_file_kind_by_path_job(
     path_len: i32,
     follow_symlink: i32,
 ) -> AsyncHostResult<u64> {
-    let path = read_guest_path(context, path_ptr, path_len)?;
+    let path = read_guest_os_string(context, path_ptr, path_len)?;
 
     context.host
         .insert_job(thread_pool::make_file_kind_by_path_job(
@@ -222,7 +222,7 @@ pub(super) fn make_file_time_by_path_job(
     path_len: i32,
     follow_symlink: i32,
 ) -> AsyncHostResult<u64> {
-    let path = read_guest_path(context, path_ptr, path_len)?;
+    let path = read_guest_os_string(context, path_ptr, path_len)?;
 
     context.host
         .insert_job(thread_pool::make_file_time_by_path_job(
@@ -248,7 +248,7 @@ pub(super) fn make_access_job(
     path_len: i32,
     access: i32,
 ) -> AsyncHostResult<u64> {
-    let path = read_guest_path(context, path_ptr, path_len)?;
+    let path = read_guest_os_string(context, path_ptr, path_len)?;
 
     context.host
         .insert_job(thread_pool::make_access_job(path, access))
@@ -261,7 +261,7 @@ pub(super) fn make_chmod_job(
     path_len: i32,
     mode: i32,
 ) -> AsyncHostResult<u64> {
-    let path = read_guest_path(context, path_ptr, path_len)?;
+    let path = read_guest_os_string(context, path_ptr, path_len)?;
 
     context.host
         .insert_job(thread_pool::make_chmod_job(path, mode))
@@ -293,7 +293,7 @@ pub(super) fn make_remove_job(
     path_ptr: i32,
     path_len: i32,
 ) -> AsyncHostResult<u64> {
-    let path = read_guest_path(context, path_ptr, path_len)?;
+    let path = read_guest_os_string(context, path_ptr, path_len)?;
     context.host.insert_job(thread_pool::make_remove_job(path))
 }
 
@@ -306,8 +306,8 @@ pub(super) fn make_rename_job(
     new_path_len: i32,
     replace: i32,
 ) -> AsyncHostResult<u64> {
-    let old_path = read_guest_path(context, old_path_ptr, old_path_len)?;
-    let new_path = read_guest_path(context, new_path_ptr, new_path_len)?;
+    let old_path = read_guest_os_string(context, old_path_ptr, old_path_len)?;
+    let new_path = read_guest_os_string(context, new_path_ptr, new_path_len)?;
 
     context.host.insert_job(thread_pool::make_rename_job(
         old_path,
@@ -325,8 +325,8 @@ pub(super) fn make_symlink_job(
     path_len: i32,
     force_symlink: i32,
 ) -> AsyncHostResult<u64> {
-    let target = read_guest_path(context, target_ptr, target_len)?;
-    let path = read_guest_path(context, path_ptr, path_len)?;
+    let target = read_guest_os_string(context, target_ptr, target_len)?;
+    let path = read_guest_os_string(context, path_ptr, path_len)?;
 
     context.host.insert_job(thread_pool::make_symlink_job(
         target,
@@ -342,7 +342,7 @@ pub(super) fn make_mkdir_job(
     path_len: i32,
     mode: i32,
 ) -> AsyncHostResult<u64> {
-    let path = read_guest_path(context, path_ptr, path_len)?;
+    let path = read_guest_os_string(context, path_ptr, path_len)?;
 
     context.host
         .insert_job(thread_pool::make_mkdir_job(path, mode))
@@ -354,7 +354,7 @@ pub(super) fn make_rmdir_job(
     path_ptr: i32,
     path_len: i32,
 ) -> AsyncHostResult<u64> {
-    let path = read_guest_path(context, path_ptr, path_len)?;
+    let path = read_guest_os_string(context, path_ptr, path_len)?;
     context.host.insert_job(thread_pool::make_rmdir_job(path))
 }
 
@@ -377,6 +377,38 @@ pub(super) fn make_readdir_job(
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_bind_job(
+    context: &mut ImportContext<'_, '_>,
+    socket: u64,
+    addr: i32,
+    addr_len: i32,
+) -> AsyncHostResult<u64> {
+    let addr = context.with_memory_mut(|memory| Ok(memory.read_exact(addr, addr_len)?.to_vec()))?;
+    context
+        .host
+        .insert_job(thread_pool::make_bind_job(socket, addr))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_getaddrinfo_job(
+    context: &mut ImportContext<'_, '_>,
+    host: i32,
+    host_len: i32,
+) -> AsyncHostResult<u64> {
+    let host = read_guest_os_string(context, host, host_len)?;
+    context
+        .host
+        .insert_job(thread_pool::make_getaddrinfo_job(host))
+}
+
+pub(super) fn get_getaddrinfo_result(
+    context: &mut ImportContext<'_, '_>,
+    job: u64,
+) -> AsyncHostResult<u64> {
+    context.host.get_getaddrinfo_result(job)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn open_job_get_fd(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_fd(job)
 }
@@ -396,78 +428,29 @@ pub(super) fn open_job_get_file_id(context: &mut ImportContext<'_, '_>, job: u64
     context.host.open_job_get_file_id(job)
 }
 
-fn read_guest_path(context: &mut ImportContext<'_, '_>, ptr: i32, len: i32) -> AsyncHostResult<OsString> {
-    // Async path imports pass MoonBit String data, so `len` is UTF-16 code
+fn read_guest_os_string(context: &mut ImportContext<'_, '_>, ptr: i32, len: i32) -> AsyncHostResult<OsString> {
+    // Async OsString imports pass MoonBit String data, so `len` is UTF-16 code
     // units. Do not treat this as UTF-8 bytes or a native C string.
     context.with_memory_mut(|memory| {
         let units = read_u16(memory, ptr, len)?;
-        Ok(decode_guest_path(units))
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+
+            let path = char::decode_utf16(units.iter().copied())
+                .map(Result::unwrap)
+                .collect::<String>();
+            Ok(OsString::from_vec(path.into_bytes()))
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::ffi::OsStringExt;
+
+            Ok(OsString::from_wide(units))
+        }
     })
 }
 
-#[cfg(unix)]
-fn decode_guest_path(units: &[u16]) -> OsString {
-    use std::os::unix::ffi::OsStringExt;
-
-    let path = char::decode_utf16(units.iter().copied())
-        .map(Result::unwrap)
-        .collect::<String>();
-    OsString::from_vec(path.into_bytes())
-}
-
-#[cfg(windows)]
-fn decode_guest_path(units: &[u16]) -> OsString {
-    use std::os::windows::ffi::OsStringExt;
-
-    OsString::from_wide(units)
-}
-
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[cfg(unix)]
-    #[test]
-    fn guest_path_decodes_utf16_to_unix_bytes() {
-        use std::os::unix::ffi::OsStrExt;
-
-        let units = guest_string_units("async-fs-smoke-\u{1f600}.txt");
-        let path = decode_guest_path(&units);
-
-        assert_eq!(
-            path.as_os_str().as_bytes(),
-            "async-fs-smoke-\u{1f600}.txt".as_bytes()
-        );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn guest_path_decodes_utf16_on_windows() {
-        use std::os::windows::ffi::OsStrExt;
-
-        let units = guest_string_units("async-fs-smoke-\u{1f600}.txt");
-        let path = decode_guest_path(&units);
-
-        assert_eq!(
-            path.as_os_str().encode_wide().collect::<Vec<_>>(),
-            "async-fs-smoke-\u{1f600}.txt"
-                .encode_utf16()
-                .collect::<Vec<_>>()
-        );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn guest_path_length_is_utf16_code_units_on_windows() {
-        let units = guest_string_units("a.txt");
-        let path = decode_guest_path(&units);
-
-        assert_eq!(path, OsString::from("a.txt"));
-    }
-
-    fn guest_string_units(path: &str) -> Vec<u16> {
-        path.encode_utf16().collect()
-    }
 }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -146,7 +146,11 @@ pub(crate) fn read_u16(memory: &[u8], offset: i32, len: i32) -> AsyncHostResult<
     if len == 0 {
         return Ok(&[]);
     }
-    let ptr = unsafe { memory.as_ptr().add(offset).cast::<u16>() };
+    let ptr = unsafe { memory.as_ptr().add(offset) };
+    if !(ptr as usize).is_multiple_of(std::mem::align_of::<u16>()) {
+        return Err(AsyncHostError::Fault);
+    }
+    let ptr = ptr.cast::<u16>();
     Ok(unsafe { std::slice::from_raw_parts(ptr, len) })
 }
 
@@ -155,7 +159,11 @@ pub(crate) fn write_u16(memory: &mut [u8], offset: i32, data: &[u16]) -> AsyncHo
     if data.is_empty() {
         return Ok(());
     }
-    let ptr = unsafe { memory.as_mut_ptr().add(offset).cast::<u16>() };
+    let ptr = unsafe { memory.as_mut_ptr().add(offset) };
+    if !(ptr as usize).is_multiple_of(std::mem::align_of::<u16>()) {
+        return Err(AsyncHostError::Fault);
+    }
+    let ptr = ptr.cast::<u16>();
     let dst = unsafe { std::slice::from_raw_parts_mut(ptr, data.len()) };
     dst.copy_from_slice(data);
     Ok(())
@@ -207,14 +215,18 @@ impl HostFileTable for SlotMap<HostFileKey, HostFile> {
     }
 
     #[cfg(windows)]
-    fn borrowed_raw_file(&mut self, handle: HostHandle) -> AsyncHostResult<RawFd> {
+    fn with_borrowed_raw_file<T>(
+        &mut self,
+        handle: HostHandle,
+        f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
         let file = self
             .get(key_from_handle::<HostFileKey>(handle))
             .ok_or(AsyncHostError::Badf)?;
         if file.is_invalid() {
             return Err(AsyncHostError::Badf);
         }
-        Ok(file.raw_fd())
+        f(file.raw_fd())
     }
 
     fn with_raw_file<U>(
@@ -247,12 +259,19 @@ impl HostFileTable for SlotMap<HostFileKey, HostFile> {
 }
 
 new_key_type! {
+    pub(crate) struct HostAddrInfoKey;
     pub(crate) struct HostCBufferKey;
     pub(crate) struct HostFileKey;
     pub(crate) struct HostIoResultKey;
     pub(crate) struct HostJobKey;
     pub(crate) struct HostPollKey;
     pub(crate) struct HostWorkerKey;
+}
+
+#[derive(Debug)]
+struct HostAddrInfo {
+    addr: Box<[u8]>,
+    next: Option<HostAddrInfoKey>,
 }
 
 fn handle_from_key(key: impl Key) -> u64 {
@@ -265,6 +284,7 @@ fn key_from_handle<K: Key>(handle: u64) -> K {
 
 struct AsyncHostState {
     errno: i32,
+    addr_infos: SlotMap<HostAddrInfoKey, HostAddrInfo>,
     c_buffers: SlotMap<HostCBufferKey, HostCBuffer>,
     #[cfg(windows)]
     io_results: SlotMap<HostIoResultKey, Box<HostIoResult>>,
@@ -311,6 +331,7 @@ impl Default for AsyncHostState {
         let invalid_file = files.insert(HostFile::invalid());
         Self {
             errno: 0,
+            addr_infos: SlotMap::with_key(),
             c_buffers: SlotMap::with_key(),
             #[cfg(windows)]
             io_results: SlotMap::with_key(),
@@ -389,7 +410,7 @@ impl AsyncHostState {
     fn has_pending_io_for_raw_fd(&self, raw_fd: RawFd) -> bool {
         self.io_results
             .values()
-            .any(|result| result.pending_raw_fd() == Some(raw_fd))
+            .any(|result| result.protects_pending_raw_fd(raw_fd))
     }
 }
 
@@ -410,19 +431,46 @@ enum HostIoDirection {
 }
 
 #[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostIoKind {
+    File,
+    Socket,
+    SocketWithAddr,
+    Connect,
+    Accept,
+}
+
+#[cfg(windows)]
 struct HostIoResult {
     overlapped: windows_sys::Win32::System::IO::OVERLAPPED,
+    kind: HostIoKind,
     event: i32,
     // Native async retains the MoonBit buffer object. The V8 host instead keeps
     // a stable host buffer and copies at explicit FFI submit/complete points.
     buffer: Vec<u8>,
     guest_offset: i32,
+    socket_flags: u32,
+    addr_buffer: Vec<u8>,
+    // WSARecvFrom may complete asynchronously and write through lpFromlen later.
+    // Keep that storage with the overlapped result, not on the submitter stack.
+    addr_len: i32,
+    guest_addr_offset: Option<i32>,
+    accept_buffer: Vec<u8>,
+    accept_bytes_received: u32,
     direction: Option<HostIoDirection>,
     pending_raw_fd: Option<RawFd>,
+    // AcceptEx submits one overlapped operation with both the listening socket
+    // and a pre-created accepted socket. Cancel/status use pending_raw_fd, but
+    // close protection must cover the accepted socket as well until completion.
+    extra_pending_close_raw_fd: Option<RawFd>,
 }
 
 #[cfg(windows)]
 unsafe impl Send for HostIoResult {}
+
+#[cfg(windows)]
+const ACCEPTEX_ADDR_LEN: usize =
+    std::mem::size_of::<windows_sys::Win32::Networking::WinSock::SOCKADDR_STORAGE>() + 16;
 
 #[cfg(windows)]
 impl HostIoResult {
@@ -434,11 +482,111 @@ impl HostIoResult {
         overlapped.Anonymous.Anonymous.OffsetHigh = (position >> 32) as u32;
         Self {
             overlapped,
+            kind: HostIoKind::File,
             event,
             buffer,
             guest_offset,
+            socket_flags: 0,
+            addr_buffer: Vec::new(),
+            addr_len: 0,
+            guest_addr_offset: None,
+            accept_buffer: Vec::new(),
+            accept_bytes_received: 0,
             direction: None,
             pending_raw_fd: None,
+            extra_pending_close_raw_fd: None,
+        }
+    }
+
+    fn for_socket(event: i32, buffer: Vec<u8>, guest_offset: i32, flags: i32) -> Self {
+        let overlapped =
+            std::mem::MaybeUninit::<windows_sys::Win32::System::IO::OVERLAPPED>::zeroed();
+        Self {
+            overlapped: unsafe { overlapped.assume_init() },
+            kind: HostIoKind::Socket,
+            event,
+            buffer,
+            guest_offset,
+            socket_flags: flags as u32,
+            addr_buffer: Vec::new(),
+            addr_len: 0,
+            guest_addr_offset: None,
+            accept_buffer: Vec::new(),
+            accept_bytes_received: 0,
+            direction: None,
+            pending_raw_fd: None,
+            extra_pending_close_raw_fd: None,
+        }
+    }
+
+    fn for_socket_with_addr(
+        event: i32,
+        buffer: Vec<u8>,
+        guest_offset: i32,
+        flags: i32,
+        addr_buffer: Vec<u8>,
+        addr_len: i32,
+        guest_addr_offset: i32,
+    ) -> Self {
+        let overlapped =
+            std::mem::MaybeUninit::<windows_sys::Win32::System::IO::OVERLAPPED>::zeroed();
+        Self {
+            overlapped: unsafe { overlapped.assume_init() },
+            kind: HostIoKind::SocketWithAddr,
+            event,
+            buffer,
+            guest_offset,
+            socket_flags: flags as u32,
+            addr_len,
+            addr_buffer,
+            guest_addr_offset: Some(guest_addr_offset),
+            accept_buffer: Vec::new(),
+            accept_bytes_received: 0,
+            direction: None,
+            pending_raw_fd: None,
+            extra_pending_close_raw_fd: None,
+        }
+    }
+
+    fn for_connect(addr_buffer: Vec<u8>) -> Self {
+        let overlapped =
+            std::mem::MaybeUninit::<windows_sys::Win32::System::IO::OVERLAPPED>::zeroed();
+        Self {
+            overlapped: unsafe { overlapped.assume_init() },
+            kind: HostIoKind::Connect,
+            event: 2,
+            buffer: Vec::new(),
+            guest_offset: 0,
+            socket_flags: 0,
+            addr_buffer,
+            addr_len: 0,
+            guest_addr_offset: None,
+            accept_buffer: Vec::new(),
+            accept_bytes_received: 0,
+            direction: None,
+            pending_raw_fd: None,
+            extra_pending_close_raw_fd: None,
+        }
+    }
+
+    fn for_accept() -> Self {
+        let overlapped =
+            std::mem::MaybeUninit::<windows_sys::Win32::System::IO::OVERLAPPED>::zeroed();
+        Self {
+            overlapped: unsafe { overlapped.assume_init() },
+            kind: HostIoKind::Accept,
+            event: 1,
+            buffer: Vec::new(),
+            guest_offset: 0,
+            socket_flags: 0,
+            addr_buffer: Vec::new(),
+            addr_len: 0,
+            guest_addr_offset: None,
+            accept_buffer: vec![0; ACCEPTEX_ADDR_LEN * 2],
+            accept_bytes_received: 0,
+            direction: None,
+            pending_raw_fd: None,
+            extra_pending_close_raw_fd: None,
         }
     }
 
@@ -460,23 +608,49 @@ impl HostIoResult {
         }
         let len = usize::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)?;
         let data = self.buffer.get(..len).ok_or(AsyncHostError::Fault)?;
-        memory.write_exact(self.guest_offset, data)
+        memory.write_exact(self.guest_offset, data)?;
+        if self.kind == HostIoKind::SocketWithAddr
+            && let Some(guest_addr_offset) = self.guest_addr_offset
+        {
+            memory.write_exact(guest_addr_offset, &self.addr_buffer)?;
+        }
+        Ok(())
     }
 
+    #[cfg(test)]
     fn pending_raw_fd(&self) -> Option<RawFd> {
         self.pending_raw_fd
     }
 
+    fn is_pending(&self) -> bool {
+        self.pending_raw_fd.is_some() || self.extra_pending_close_raw_fd.is_some()
+    }
+
+    fn protects_pending_raw_fd(&self, raw_fd: RawFd) -> bool {
+        self.pending_raw_fd == Some(raw_fd) || self.extra_pending_close_raw_fd == Some(raw_fd)
+    }
+
     fn mark_pending(&mut self, raw_fd: RawFd) -> AsyncHostResult<()> {
-        if self.pending_raw_fd.is_some() {
+        if self.is_pending() {
             return Err(AsyncHostError::Inval);
         }
         self.pending_raw_fd = Some(raw_fd);
         Ok(())
     }
 
+    fn mark_pending_with_close_guard(
+        &mut self,
+        raw_fd: RawFd,
+        close_guard_raw_fd: RawFd,
+    ) -> AsyncHostResult<()> {
+        self.mark_pending(raw_fd)?;
+        self.extra_pending_close_raw_fd = Some(close_guard_raw_fd);
+        Ok(())
+    }
+
     fn clear_pending(&mut self) {
         self.pending_raw_fd = None;
+        self.extra_pending_close_raw_fd = None;
     }
 
     fn validate_pending_handle(&self, raw_fd: RawFd) -> AsyncHostResult<()> {
@@ -499,8 +673,8 @@ impl HostIoResult {
     }
 
     fn cancel_pending(&mut self) -> AsyncHostResult<i32> {
-        use windows_sys::Win32::Foundation::{ERROR_IO_INCOMPLETE, ERROR_NOT_FOUND};
-        use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult};
+        use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
+        use windows_sys::Win32::System::IO::CancelIoEx;
 
         let Some(raw_fd) = self.pending_raw_fd else {
             return Ok(0);
@@ -511,21 +685,11 @@ impl HostIoResult {
             if errno != ERROR_NOT_FOUND as i32 {
                 return Err(AsyncHostError::Native(errno));
             }
-            self.clear_pending();
-            return Ok(0);
+            // The operation may have completed after the cancellation request
+            // raced with IOCP delivery. Keep the result pending until the
+            // completion packet is consumed through poll_event_io_result.
         }
-
-        let mut bytes_transferred = 0;
-        if unsafe { GetOverlappedResult(raw_fd, overlapped, &mut bytes_transferred, 0) } != 0 {
-            self.clear_pending();
-            return Ok(0);
-        }
-        if last_errno() == ERROR_IO_INCOMPLETE as i32 {
-            Ok(1)
-        } else {
-            self.clear_pending();
-            Ok(0)
-        }
+        Ok(1)
     }
 
     fn cancel_and_drain_pending(&mut self) -> AsyncHostResult<()> {
@@ -602,6 +766,9 @@ impl AsyncHost {
 
             if !state.c_buffers.is_empty() {
                 leaks.push(format!("c_buffers={}", state.c_buffers.len()));
+            }
+            if !state.addr_infos.is_empty() {
+                leaks.push(format!("addr_infos={}", state.addr_infos.len()));
             }
             #[cfg(windows)]
             {
@@ -1113,6 +1280,61 @@ impl AsyncHost {
         crate::async_sys::internal::event_loop::thread_pool::get_file_size_result(job)
     }
 
+    pub(crate) fn get_getaddrinfo_result(&self, handle: u64) -> AsyncHostResult<u64> {
+        let mut state = self.state.lock().unwrap();
+        let addrs: Vec<Box<[u8]>> = {
+            let job = state
+                .jobs
+                .get(key_from_handle::<HostJobKey>(handle))
+                .and_then(Option::as_ref)
+                .ok_or(AsyncHostError::Badf)?;
+            thread_pool::getaddrinfo_job_result(job)?.to_vec()
+        };
+        let mut next = None;
+        for addr in addrs.into_iter().rev() {
+            let key = state.addr_infos.insert(HostAddrInfo { addr, next });
+            next = Some(key);
+        }
+        Ok(next.map(handle_from_key).unwrap_or(INVALID_HOST_HANDLE))
+    }
+
+    pub(crate) fn addrinfo_next(&self, handle: u64) -> AsyncHostResult<u64> {
+        if handle == INVALID_HOST_HANDLE {
+            return Ok(INVALID_HOST_HANDLE);
+        }
+        let state = self.state.lock().unwrap();
+        let addrinfo = state
+            .addr_infos
+            .get(key_from_handle::<HostAddrInfoKey>(handle))
+            .ok_or(AsyncHostError::Badf)?;
+        Ok(addrinfo
+            .next
+            .map(handle_from_key)
+            .unwrap_or(INVALID_HOST_HANDLE))
+    }
+
+    pub(crate) fn addrinfo_addr(&self, handle: u64) -> AsyncHostResult<Box<[u8]>> {
+        let state = self.state.lock().unwrap();
+        let addrinfo = state
+            .addr_infos
+            .get(key_from_handle::<HostAddrInfoKey>(handle))
+            .ok_or(AsyncHostError::Badf)?;
+        Ok(addrinfo.addr.clone())
+    }
+
+    pub(crate) fn free_addrinfo(&self, handle: u64) -> AsyncHostResult<()> {
+        if handle == INVALID_HOST_HANDLE {
+            return Ok(());
+        }
+        let mut state = self.state.lock().unwrap();
+        let mut current = Some(key_from_handle::<HostAddrInfoKey>(handle));
+        while let Some(key) = current {
+            let addrinfo = state.addr_infos.remove(key).ok_or(AsyncHostError::Badf)?;
+            current = addrinfo.next;
+        }
+        Ok(())
+    }
+
     pub(crate) fn close_fd(&self, handle: HostHandle) -> AsyncHostResult<()> {
         let mut state = self.state.lock().unwrap();
         let raw_fd = state.file(handle)?.raw_fd();
@@ -1138,6 +1360,23 @@ impl AsyncHost {
         Ok(())
     }
 
+    pub(crate) fn insert_host_file(&self, raw_fd: RawFd) -> HostHandle {
+        #[cfg(unix)]
+        let file = HostFile::new(raw_fd);
+        #[cfg(windows)]
+        let file = HostFile::new_socket(raw_fd);
+        handle_from_key(self.state.lock().unwrap().files.insert(file))
+    }
+
+    pub(crate) fn with_raw_file<T>(
+        &self,
+        handle: HostHandle,
+        f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
+        let state = self.state.lock().unwrap();
+        f(state.file(handle)?.raw_fd())
+    }
+
     pub(crate) fn pipe(
         &self,
         read_end_is_async: bool,
@@ -1155,6 +1394,20 @@ impl AsyncHost {
         let state = self.state.lock().unwrap();
         let raw_fd = state.file(handle)?.raw_fd();
         crate::async_sys::internal::fd_util::stub::set_nonblocking(raw_fd)
+    }
+
+    pub(crate) fn set_cloexec(&self, handle: HostHandle) -> AsyncHostResult<()> {
+        let state = self.state.lock().unwrap();
+        let raw_fd = state.file(handle)?.raw_fd();
+        #[cfg(unix)]
+        {
+            crate::async_sys::internal::fd_util::stub::set_cloexec(raw_fd)
+        }
+        #[cfg(windows)]
+        {
+            let _ = raw_fd;
+            Ok(())
+        }
     }
 
     #[cfg(unix)]
@@ -1223,11 +1476,84 @@ impl AsyncHost {
     }
 
     #[cfg(windows)]
+    pub(crate) fn make_socket_io_result(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        event: i32,
+        buf: i32,
+        offset: i32,
+        len: i32,
+        flags: i32,
+    ) -> AsyncHostResult<u64> {
+        let guest_offset = buf.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        memory.read_exact(guest_offset, len)?;
+        let buffer = vec![0; usize::try_from(len).map_err(|_| AsyncHostError::Fault)?];
+        self.insert_io_result(HostIoResult::for_socket(event, buffer, guest_offset, flags))
+    }
+
+    #[cfg(windows)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn make_socket_with_addr_io_result(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        event: i32,
+        buf: i32,
+        offset: i32,
+        len: i32,
+        flags: i32,
+        addr: i32,
+        addr_len: i32,
+    ) -> AsyncHostResult<u64> {
+        let guest_offset = buf.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        memory.read_exact(guest_offset, len)?;
+        let buffer = vec![0; usize::try_from(len).map_err(|_| AsyncHostError::Fault)?];
+        let addr_buffer = memory.read_exact(addr, addr_len)?.to_vec();
+        self.insert_io_result(HostIoResult::for_socket_with_addr(
+            event,
+            buffer,
+            guest_offset,
+            flags,
+            addr_buffer,
+            addr_len,
+            addr,
+        ))
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn make_connect_io_result(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        addr: i32,
+        addr_len: i32,
+    ) -> AsyncHostResult<u64> {
+        let addr_buffer = memory.read_exact(addr, addr_len)?.to_vec();
+        self.insert_io_result(HostIoResult::for_connect(addr_buffer))
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn make_accept_io_result(&self) -> AsyncHostResult<u64> {
+        self.insert_io_result(HostIoResult::for_accept())
+    }
+
+    #[cfg(windows)]
+    fn insert_io_result(&self, result: HostIoResult) -> AsyncHostResult<u64> {
+        let mut state = self.state.lock().unwrap();
+        let key = state.io_results.insert(Box::new(result));
+        let overlapped = state
+            .io_results
+            .get_mut(key)
+            .ok_or(AsyncHostError::Badf)?
+            .overlapped_addr();
+        state.io_results_by_overlapped.insert(overlapped, key);
+        Ok(handle_from_key(key))
+    }
+
+    #[cfg(windows)]
     pub(crate) fn free_io_result(&self, handle: u64) -> AsyncHostResult<()> {
         let key = key_from_handle::<HostIoResultKey>(handle);
         let mut state = self.state.lock().unwrap();
         let result = state.io_results.get_mut(key).ok_or(AsyncHostError::Badf)?;
-        if result.pending_raw_fd().is_some() {
+        if result.is_pending() {
             return Err(AsyncHostError::Inval);
         }
         let mut result = state.io_results.remove(key).ok_or(AsyncHostError::Badf)?;
@@ -1308,6 +1634,7 @@ impl AsyncHost {
         result_handle: u64,
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Foundation::{ERROR_HANDLE_EOF, ERROR_IO_PENDING};
+        use windows_sys::Win32::Networking::WinSock as ws;
         use windows_sys::Win32::Storage::FileSystem::ReadFile;
 
         let mut state = self.state.lock().unwrap();
@@ -1316,20 +1643,65 @@ impl AsyncHost {
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
-        if result.pending_raw_fd().is_some() {
+        if result.is_pending() {
             return Err(AsyncHostError::Inval);
         }
         result.direction = Some(HostIoDirection::Read);
-        let len = u32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
         let mut bytes_transferred = 0;
-        let success = unsafe {
-            ReadFile(
-                raw_fd,
-                result.buffer.as_mut_ptr().cast(),
-                len,
-                &mut bytes_transferred,
-                result.overlapped_ptr(),
-            )
+        let success = match result.kind {
+            HostIoKind::File => {
+                let len = u32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
+                unsafe {
+                    ReadFile(
+                        raw_fd,
+                        result.buffer.as_mut_ptr().cast(),
+                        len,
+                        &mut bytes_transferred,
+                        result.overlapped_ptr(),
+                    )
+                }
+            }
+            HostIoKind::Socket => {
+                let buffer = socket_buffer(&mut result.buffer)?;
+                unsafe {
+                    i32::from(
+                        ws::WSARecv(
+                            raw_fd as usize,
+                            &buffer,
+                            1,
+                            &mut bytes_transferred,
+                            &mut result.socket_flags,
+                            result.overlapped_ptr(),
+                            None,
+                        ) == 0,
+                    )
+                }
+            }
+            HostIoKind::SocketWithAddr => {
+                let buffer = socket_buffer(&mut result.buffer)?;
+                result.addr_len =
+                    i32::try_from(result.addr_buffer.len()).map_err(|_| AsyncHostError::Fault)?;
+                let addr_len = std::ptr::addr_of_mut!(result.addr_len);
+                let flags = std::ptr::addr_of_mut!(result.socket_flags);
+                let addr = result.addr_buffer.as_mut_ptr().cast::<ws::SOCKADDR>();
+                let overlapped = result.overlapped_ptr();
+                unsafe {
+                    i32::from(
+                        ws::WSARecvFrom(
+                            raw_fd as usize,
+                            &buffer,
+                            1,
+                            &mut bytes_transferred,
+                            flags,
+                            addr,
+                            addr_len,
+                            overlapped,
+                            None,
+                        ) == 0,
+                    )
+                }
+            }
+            HostIoKind::Connect | HostIoKind::Accept => return Err(AsyncHostError::Inval),
         };
         if success != 0 {
             let bytes_transferred =
@@ -1337,7 +1709,10 @@ impl AsyncHost {
             result.copy_read_result(memory, bytes_transferred)?;
             return Ok(bytes_transferred);
         }
-        let errno = last_errno();
+        let errno = match result.kind {
+            HostIoKind::Socket | HostIoKind::SocketWithAddr => last_wsa_errno(),
+            _ => last_errno(),
+        };
         if errno == ERROR_HANDLE_EOF as i32 {
             Ok(0)
         } else if errno == ERROR_IO_PENDING as i32 {
@@ -1356,6 +1731,7 @@ impl AsyncHost {
         result_handle: u64,
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Foundation::ERROR_IO_PENDING;
+        use windows_sys::Win32::Networking::WinSock as ws;
         use windows_sys::Win32::Storage::FileSystem::WriteFile;
 
         let mut state = self.state.lock().unwrap();
@@ -1364,32 +1740,223 @@ impl AsyncHost {
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
-        if result.pending_raw_fd().is_some() {
+        if result.is_pending() {
             return Err(AsyncHostError::Inval);
         }
         result.direction = Some(HostIoDirection::Write);
         let len_i32 = i32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
-        let data = memory.read_exact(result.guest_offset, len_i32)?;
-        result.buffer.copy_from_slice(data);
-        let len = u32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
+        if matches!(
+            result.kind,
+            HostIoKind::File | HostIoKind::Socket | HostIoKind::SocketWithAddr
+        ) {
+            let data = memory.read_exact(result.guest_offset, len_i32)?;
+            result.buffer.copy_from_slice(data);
+        }
         let mut bytes_transferred = 0;
-        let success = unsafe {
-            WriteFile(
-                raw_fd,
-                result.buffer.as_ptr().cast(),
-                len,
-                &mut bytes_transferred,
-                result.overlapped_ptr(),
-            )
+        let success = match result.kind {
+            HostIoKind::File => {
+                let len = u32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
+                unsafe {
+                    WriteFile(
+                        raw_fd,
+                        result.buffer.as_ptr().cast(),
+                        len,
+                        &mut bytes_transferred,
+                        result.overlapped_ptr(),
+                    )
+                }
+            }
+            HostIoKind::Socket => {
+                let buffer = socket_buffer(&mut result.buffer)?;
+                unsafe {
+                    i32::from(
+                        ws::WSASend(
+                            raw_fd as usize,
+                            &buffer,
+                            1,
+                            &mut bytes_transferred,
+                            result.socket_flags,
+                            result.overlapped_ptr(),
+                            None,
+                        ) == 0,
+                    )
+                }
+            }
+            HostIoKind::SocketWithAddr => {
+                let buffer = socket_buffer(&mut result.buffer)?;
+                let addr_len =
+                    i32::try_from(result.addr_buffer.len()).map_err(|_| AsyncHostError::Fault)?;
+                unsafe {
+                    i32::from(
+                        ws::WSASendTo(
+                            raw_fd as usize,
+                            &buffer,
+                            1,
+                            &mut bytes_transferred,
+                            result.socket_flags,
+                            result.addr_buffer.as_ptr().cast::<ws::SOCKADDR>(),
+                            addr_len,
+                            result.overlapped_ptr(),
+                            None,
+                        ) == 0,
+                    )
+                }
+            }
+            HostIoKind::Connect | HostIoKind::Accept => return Err(AsyncHostError::Inval),
         };
         if success != 0 {
             i32::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
         } else {
-            let error = last_native_error();
+            let errno = match result.kind {
+                HostIoKind::Socket | HostIoKind::SocketWithAddr => last_wsa_errno(),
+                _ => last_errno(),
+            };
+            let error = AsyncHostError::Native(errno);
             if matches!(error, AsyncHostError::Native(errno) if errno == ERROR_IO_PENDING as i32) {
                 result.mark_pending(raw_fd)?;
             }
             Err(error)
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn connect_io_result(
+        &self,
+        fd_handle: HostHandle,
+        result_handle: u64,
+    ) -> AsyncHostResult<i32> {
+        use windows_sys::Win32::Networking::WinSock as ws;
+
+        let mut state = self.state.lock().unwrap();
+        let raw_fd = state.file(fd_handle)?.raw_fd();
+        let result = state
+            .io_results
+            .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
+            .ok_or(AsyncHostError::Badf)?;
+        if result.kind != HostIoKind::Connect || result.is_pending() {
+            return Err(AsyncHostError::Inval);
+        }
+
+        bind_any_for_connect(raw_fd, &result.addr_buffer)?;
+        let connect_ex = get_wsa_extension::<ws::LPFN_CONNECTEX>(raw_fd, &ws::WSAID_CONNECTEX)?
+            .ok_or(AsyncHostError::Inval)?;
+        let addr_len = socket_addr_len(&result.addr_buffer)?;
+        let success = unsafe {
+            connect_ex(
+                raw_fd as usize,
+                result.addr_buffer.as_ptr().cast::<ws::SOCKADDR>(),
+                addr_len,
+                std::ptr::null(),
+                0,
+                std::ptr::null_mut(),
+                result.overlapped_ptr(),
+            )
+        };
+        if success != 0 {
+            Ok(1)
+        } else {
+            let errno = last_wsa_errno();
+            if errno == windows_sys::Win32::Foundation::ERROR_IO_PENDING as i32 {
+                result.mark_pending(raw_fd)?;
+            }
+            Err(AsyncHostError::Native(errno))
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn setup_connected_socket(&self, fd_handle: HostHandle) -> AsyncHostResult<()> {
+        use windows_sys::Win32::Networking::WinSock as ws;
+
+        let state = self.state.lock().unwrap();
+        let raw_fd = state.file(fd_handle)?.raw_fd();
+        let yes: u32 = 1;
+        if unsafe {
+            ws::setsockopt(
+                raw_fd as usize,
+                ws::SOL_SOCKET,
+                ws::SO_UPDATE_CONNECT_CONTEXT,
+                (&yes as *const u32).cast(),
+                std::mem::size_of_val(&yes) as i32,
+            )
+        } == ws::SOCKET_ERROR
+        {
+            Err(AsyncHostError::Native(last_wsa_errno()))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn accept_io_result(
+        &self,
+        server_fd_handle: HostHandle,
+        conn_fd_handle: HostHandle,
+        result_handle: u64,
+    ) -> AsyncHostResult<i32> {
+        use windows_sys::Win32::Networking::WinSock as ws;
+
+        let mut state = self.state.lock().unwrap();
+        let server_fd = state.file(server_fd_handle)?.raw_fd();
+        let conn_fd = state.file(conn_fd_handle)?.raw_fd();
+        let result = state
+            .io_results
+            .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
+            .ok_or(AsyncHostError::Badf)?;
+        if result.kind != HostIoKind::Accept || result.is_pending() {
+            return Err(AsyncHostError::Inval);
+        }
+
+        let accept_ex = get_wsa_extension::<ws::LPFN_ACCEPTEX>(server_fd, &ws::WSAID_ACCEPTEX)?
+            .ok_or(AsyncHostError::Inval)?;
+        let addr_len = u32::try_from(ACCEPTEX_ADDR_LEN).map_err(|_| AsyncHostError::Fault)?;
+        let success = unsafe {
+            accept_ex(
+                server_fd as usize,
+                conn_fd as usize,
+                result.accept_buffer.as_mut_ptr().cast(),
+                0,
+                addr_len,
+                addr_len,
+                &mut result.accept_bytes_received,
+                result.overlapped_ptr(),
+            )
+        };
+        if success != 0 {
+            Ok(1)
+        } else {
+            let errno = last_wsa_errno();
+            if errno == windows_sys::Win32::Foundation::ERROR_IO_PENDING as i32 {
+                result.mark_pending_with_close_guard(server_fd, conn_fd)?;
+            }
+            Err(AsyncHostError::Native(errno))
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn setup_accepted_socket(
+        &self,
+        listen_fd_handle: HostHandle,
+        accept_fd_handle: HostHandle,
+    ) -> AsyncHostResult<()> {
+        use windows_sys::Win32::Networking::WinSock as ws;
+
+        let state = self.state.lock().unwrap();
+        let listen_fd = state.file(listen_fd_handle)?.raw_fd();
+        let accept_fd = state.file(accept_fd_handle)?.raw_fd();
+        let listen_socket = listen_fd as usize;
+        if unsafe {
+            ws::setsockopt(
+                accept_fd as usize,
+                ws::SOL_SOCKET,
+                ws::SO_UPDATE_ACCEPT_CONTEXT,
+                (&listen_socket as *const usize).cast(),
+                std::mem::size_of_val(&listen_socket) as i32,
+            )
+        } == ws::SOCKET_ERROR
+        {
+            Err(AsyncHostError::Native(last_wsa_errno()))
+        } else {
+            Ok(())
         }
     }
 
@@ -1649,9 +2216,13 @@ impl HostFileTable for SharedFileTable {
     }
 
     #[cfg(windows)]
-    fn borrowed_raw_file(&mut self, handle: HostHandle) -> AsyncHostResult<RawFd> {
+    fn with_borrowed_raw_file<T>(
+        &mut self,
+        handle: HostHandle,
+        f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
         let state = self.state.lock().unwrap();
-        Ok(state.file(handle)?.raw_fd())
+        f(state.file(handle)?.raw_fd())
     }
 
     fn with_raw_file<U>(
@@ -1692,6 +2263,125 @@ fn last_native_error() -> AsyncHostError {
 }
 
 #[cfg(windows)]
+fn last_wsa_errno() -> i32 {
+    use windows_sys::Win32::Foundation::{SetLastError, WIN32_ERROR};
+    use windows_sys::Win32::Networking::WinSock;
+
+    let errno = unsafe { WinSock::WSAGetLastError() };
+    unsafe {
+        SetLastError(errno as WIN32_ERROR);
+    }
+    errno
+}
+
+#[cfg(windows)]
+fn socket_buffer(
+    buffer: &mut [u8],
+) -> AsyncHostResult<windows_sys::Win32::Networking::WinSock::WSABUF> {
+    Ok(windows_sys::Win32::Networking::WinSock::WSABUF {
+        len: u32::try_from(buffer.len()).map_err(|_| AsyncHostError::Fault)?,
+        buf: buffer.as_mut_ptr().cast(),
+    })
+}
+
+#[cfg(windows)]
+fn socket_addr_family(addr: &[u8]) -> AsyncHostResult<u16> {
+    use windows_sys::Win32::Networking::WinSock;
+
+    if addr.len() < std::mem::size_of::<WinSock::SOCKADDR>() {
+        return Err(AsyncHostError::Fault);
+    }
+    Ok(unsafe { addr.as_ptr().cast::<WinSock::SOCKADDR>().read_unaligned() }.sa_family)
+}
+
+#[cfg(windows)]
+fn socket_addr_len(addr: &[u8]) -> AsyncHostResult<i32> {
+    use windows_sys::Win32::Networking::WinSock;
+
+    let len = match socket_addr_family(addr)? {
+        WinSock::AF_INET => std::mem::size_of::<WinSock::SOCKADDR_IN>(),
+        WinSock::AF_INET6 => std::mem::size_of::<WinSock::SOCKADDR_IN6>(),
+        _ => return Err(AsyncHostError::Inval),
+    };
+    if addr.len() < len {
+        return Err(AsyncHostError::Fault);
+    }
+    i32::try_from(len).map_err(|_| AsyncHostError::Fault)
+}
+
+#[cfg(windows)]
+fn bind_any_for_connect(raw_fd: RawFd, remote_addr: &[u8]) -> AsyncHostResult<()> {
+    use windows_sys::Win32::Networking::WinSock;
+
+    let result = match socket_addr_family(remote_addr)? {
+        WinSock::AF_INET => {
+            let mut addr = unsafe { std::mem::zeroed::<WinSock::SOCKADDR_IN>() };
+            addr.sin_family = WinSock::AF_INET;
+            unsafe {
+                WinSock::bind(
+                    raw_fd as usize,
+                    (&addr as *const WinSock::SOCKADDR_IN).cast::<WinSock::SOCKADDR>(),
+                    std::mem::size_of_val(&addr) as i32,
+                )
+            }
+        }
+        WinSock::AF_INET6 => {
+            let mut addr = unsafe { std::mem::zeroed::<WinSock::SOCKADDR_IN6>() };
+            addr.sin6_family = WinSock::AF_INET6;
+            unsafe {
+                WinSock::bind(
+                    raw_fd as usize,
+                    (&addr as *const WinSock::SOCKADDR_IN6).cast::<WinSock::SOCKADDR>(),
+                    std::mem::size_of_val(&addr) as i32,
+                )
+            }
+        }
+        _ => return Err(AsyncHostError::Inval),
+    };
+    if result == WinSock::SOCKET_ERROR {
+        let errno = last_wsa_errno();
+        if errno == WinSock::WSAEINVAL {
+            unreachable!(
+                "moonbitlang/async Tcp::connect creates a fresh unbound socket before ConnectEx"
+            );
+        }
+        Err(AsyncHostError::Native(errno))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn get_wsa_extension<T: Copy>(raw_fd: RawFd, guid: &windows_sys::core::GUID) -> AsyncHostResult<T> {
+    use windows_sys::Win32::Networking::WinSock;
+
+    debug_assert_eq!(
+        std::mem::size_of::<T>(),
+        std::mem::size_of::<*mut std::ffi::c_void>()
+    );
+    let mut extension = std::ptr::null_mut::<std::ffi::c_void>();
+    let mut bytes_returned = 0;
+    let ret = unsafe {
+        WinSock::WSAIoctl(
+            raw_fd as usize,
+            WinSock::SIO_GET_EXTENSION_FUNCTION_POINTER,
+            (guid as *const windows_sys::core::GUID).cast(),
+            std::mem::size_of_val(guid) as u32,
+            (&mut extension as *mut *mut std::ffi::c_void).cast(),
+            std::mem::size_of_val(&extension) as u32,
+            &mut bytes_returned,
+            std::ptr::null_mut(),
+            None,
+        )
+    };
+    if ret == WinSock::SOCKET_ERROR {
+        Err(AsyncHostError::Native(last_wsa_errno()))
+    } else {
+        Ok(unsafe { std::mem::transmute_copy(&extension) })
+    }
+}
+
+#[cfg(windows)]
 fn raw_fd_to_guest(fd: RawFd) -> AsyncHostResult<HostHandle> {
     Ok(fd as usize as u64)
 }
@@ -1727,6 +2417,9 @@ fn raw_fd_key(fd: RawFd) -> isize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[repr(align(2))]
+    struct AlignedBytes<const N: usize>([u8; N]);
 
     #[test]
     fn guest_memory_read_exact_accepts_in_bounds_access() {
@@ -1768,17 +2461,33 @@ mod tests {
 
     #[test]
     fn guest_memory_helpers_read_and_write_u16_units() {
-        let mut memory = [0; 8];
+        let mut memory = AlignedBytes([0; 8]);
 
-        write_u16(&mut memory, 2, &[0x1234, 0x5678]).unwrap();
+        write_u16(&mut memory.0, 2, &[0x1234, 0x5678]).unwrap();
 
-        assert_eq!(read_u16(&memory, 2, 2).unwrap(), &[0x1234, 0x5678]);
-        assert_eq!(read_u16(&memory, 1, 1), Err(AsyncHostError::Fault));
+        assert_eq!(read_u16(&memory.0, 2, 2).unwrap(), &[0x1234, 0x5678]);
+        assert_eq!(read_u16(&memory.0, 1, 1), Err(AsyncHostError::Fault));
         assert_eq!(
-            write_u16(&mut memory, 6, &[1, 2]),
+            write_u16(&mut memory.0, 6, &[1, 2]),
             Err(AsyncHostError::Fault)
         );
-        assert_eq!(&memory[2..6], &[0x34, 0x12, 0x78, 0x56]);
+        assert_eq!(&memory.0[2..6], &[0x34, 0x12, 0x78, 0x56]);
+    }
+
+    #[test]
+    fn guest_memory_helpers_reject_unaligned_u16_storage() {
+        let mut memory = [0; 8];
+        let start = if (memory.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>()) {
+            1
+        } else {
+            0
+        };
+
+        assert_eq!(read_u16(&memory[start..], 0, 1), Err(AsyncHostError::Fault));
+        assert_eq!(
+            write_u16(&mut memory[start..], 0, &[1]),
+            Err(AsyncHostError::Fault)
+        );
     }
 
     #[test]
@@ -2182,6 +2891,42 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn cancel_io_result_keeps_pending_until_completion_is_delivered() {
+        let host = AsyncHost::default();
+        let [read, write] = host.pipe(true, true).unwrap();
+        let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
+        let raw_read = {
+            let mut state = host.state.lock().unwrap();
+            let raw_read = state.file(read).unwrap().raw_fd();
+            state
+                .io_results
+                .get_mut(key_from_handle::<HostIoResultKey>(result))
+                .unwrap()
+                .mark_pending(raw_read)
+                .unwrap();
+            raw_read
+        };
+
+        assert_eq!(host.cancel_io_result(result, read), Ok(1));
+        assert_eq!(host.free_io_result(result), Err(AsyncHostError::Inval));
+        assert_eq!(host.close_fd(read), Err(AsyncHostError::Inval));
+        {
+            let mut state = host.state.lock().unwrap();
+            let result = state
+                .io_results
+                .get_mut(key_from_handle::<HostIoResultKey>(result))
+                .unwrap();
+            assert_eq!(result.pending_raw_fd(), Some(raw_read));
+            result.clear_pending();
+        }
+
+        host.free_io_result(result).unwrap();
+        host.close_fd(read).unwrap();
+        host.close_fd(write).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn close_fd_rejects_pending_io_result() {
         let host = AsyncHost::default();
         let [read, write] = host.pipe(true, true).unwrap();
@@ -2207,6 +2952,49 @@ mod tests {
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap();
             assert_eq!(result.pending_raw_fd(), Some(raw_read));
+            result.clear_pending();
+        }
+
+        host.free_io_result(result).unwrap();
+        host.close_fd(read).unwrap();
+        host.close_fd(write).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn close_fd_rejects_extra_pending_close_guard() {
+        let host = AsyncHost::default();
+        let [read, write] = host.pipe(true, true).unwrap();
+        let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
+        let (raw_read, raw_write) = {
+            let mut state = host.state.lock().unwrap();
+            let raw_read = state.file(read).unwrap().raw_fd();
+            let raw_write = state.file(write).unwrap().raw_fd();
+            state
+                .io_results
+                .get_mut(key_from_handle::<HostIoResultKey>(result))
+                .unwrap()
+                .mark_pending_with_close_guard(raw_read, raw_write)
+                .unwrap();
+            (raw_read, raw_write)
+        };
+
+        assert_eq!(host.close_fd(write), Err(AsyncHostError::Inval));
+        assert_eq!(
+            host.cancel_io_result(result, write),
+            Err(AsyncHostError::Badf)
+        );
+        assert_eq!(host.close_fd(read), Err(AsyncHostError::Inval));
+        {
+            let mut state = host.state.lock().unwrap();
+            assert!(state.file(read).is_ok());
+            assert!(state.file(write).is_ok());
+            let result = state
+                .io_results
+                .get_mut(key_from_handle::<HostIoResultKey>(result))
+                .unwrap();
+            assert_eq!(result.pending_raw_fd(), Some(raw_read));
+            assert!(result.protects_pending_raw_fd(raw_write));
             result.clear_pending();
         }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/io.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/io.rs
@@ -33,6 +33,27 @@ fn last_native_error() -> AsyncHostError {
 
 ported_fns! {
     #[ported(
+        source = "src/internal/event_loop/io_windows.c",
+        original = "moonbitlang_async_init_WSA"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn init_wsa() -> i32 {
+        use windows_sys::Win32::Networking::WinSock::{WSADATA, WSAStartup};
+
+        let mut data = std::mem::MaybeUninit::<WSADATA>::uninit();
+        unsafe { WSAStartup(0x0202, data.as_mut_ptr()) }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/io_windows.c",
+        original = "moonbitlang_async_cleanup_WSA"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn cleanup_wsa() -> i32 {
+        unsafe { windows_sys::Win32::Networking::WinSock::WSACleanup() }
+    }
+
+    #[ported(
         source = "src/internal/event_loop/io_unix.c",
         original = "moonbitlang_async_read"
     )]
@@ -87,6 +108,22 @@ pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
                 "make_file_io_result",
                 "moonbitlang_async_make_file_io_result",
             ),
+            ported_windows_symbol(
+                "make_socket_io_result",
+                "moonbitlang_async_make_socket_io_result",
+            ),
+            ported_windows_symbol(
+                "make_socket_with_addr_io_result",
+                "moonbitlang_async_make_socket_with_addr_io_result",
+            ),
+            ported_windows_symbol(
+                "make_connect_io_result",
+                "moonbitlang_async_make_connect_io_result",
+            ),
+            ported_windows_symbol(
+                "make_accept_io_result",
+                "moonbitlang_async_make_accept_io_result",
+            ),
             ported_windows_symbol("free_io_result", "moonbitlang_async_free_io_result"),
             ported_windows_symbol(
                 "io_result_get_event",
@@ -99,6 +136,16 @@ pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
             ),
             ported_windows_symbol("read_io_result", "moonbitlang_async_read"),
             ported_windows_symbol("write_io_result", "moonbitlang_async_write"),
+            ported_windows_symbol("connect_io_result", "moonbitlang_async_connect"),
+            ported_windows_symbol(
+                "setup_connected_socket",
+                "moonbitlang_async_setup_connected_socket",
+            ),
+            ported_windows_symbol("accept_io_result", "moonbitlang_async_accept"),
+            ported_windows_symbol(
+                "setup_accepted_socket",
+                "moonbitlang_async_setup_accepted_socket",
+            ),
         ]);
         symbols
     }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -204,9 +204,10 @@ ported_fns! {
             // LockFileEx/UnlockFile. Native async passes the same HANDLE to the
             // flock worker and unlock stub, so the wasm host must not duplicate
             // the handle here or it creates a separate lock identity.
-            let file = files.borrowed_raw_file(fd)?;
-            lock_native_file(file, exclusive)?;
-            Ok(0)
+            files.with_borrowed_raw_file(fd, |file| {
+                lock_native_file(file, exclusive)?;
+                Ok(0)
+            })
         }
 
         #[cfg(not(windows))]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -311,6 +311,22 @@ ported_fns! {
         })
     }
 
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_bind_job"
+    )]
+    pub(crate) fn make_bind_job(socket: HostHandle, addr: Vec<u8>) -> Job {
+        Job::new(JobPayload::Bind { socket, addr })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_getaddrinfo_job"
+    )]
+    pub(crate) fn make_getaddrinfo_job(host: OsString) -> Job {
+        Job::new(JobPayload::GetAddrInfo { host, result: None })
+    }
+
 }
 
 pub(crate) fn open_job_result(job: &Job) -> AsyncHostResult<&OpenJobResult> {
@@ -320,6 +336,17 @@ pub(crate) fn open_job_result(job: &Job) -> AsyncHostResult<&OpenJobResult> {
             ..
         } => Ok(result),
         JobPayload::Open { .. } => Err(AsyncHostError::Inval),
+        _ => Err(AsyncHostError::Badf),
+    }
+}
+
+pub(crate) fn getaddrinfo_job_result(job: &Job) -> AsyncHostResult<&[Box<[u8]>]> {
+    match job.payload() {
+        JobPayload::GetAddrInfo {
+            result: Some(result),
+            ..
+        } => Ok(result),
+        JobPayload::GetAddrInfo { .. } => Err(AsyncHostError::Inval),
         _ => Err(AsyncHostError::Badf),
     }
 }
@@ -344,7 +371,11 @@ mod tests {
         }
 
         #[cfg(windows)]
-        fn borrowed_raw_file(&mut self, _handle: HostHandle) -> AsyncHostResult<RawFd> {
+        fn with_borrowed_raw_file<T>(
+            &mut self,
+            _handle: HostHandle,
+            _f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
+        ) -> AsyncHostResult<T> {
             unreachable!("sleep jobs do not access files")
         }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -20,16 +20,18 @@ mod fs;
 mod jobs;
 mod runner;
 mod sleep;
+mod socket;
 mod types;
 mod worker;
 
 pub(crate) use jobs::{
-    errno_is_cancelled, get_file_size_result, get_platform, job_get_err, job_get_ret,
-    make_access_job, make_chmod_job, make_file_kind_by_path_job, make_file_size_job,
-    make_file_time_by_path_job, make_file_time_job, make_flock_job, make_fsync_job, make_mkdir_job,
-    make_open_job, make_read_job, make_readdir_job, make_remove_job, make_rename_job,
-    make_rmdir_job, make_sleep_job, make_symlink_job, make_write_job, open_job_get_dev_id,
-    open_job_get_fd, open_job_get_file_id, open_job_get_kind, open_job_result,
+    errno_is_cancelled, get_file_size_result, get_platform, getaddrinfo_job_result, job_get_err,
+    job_get_ret, make_access_job, make_bind_job, make_chmod_job, make_file_kind_by_path_job,
+    make_file_size_job, make_file_time_by_path_job, make_file_time_job, make_flock_job,
+    make_fsync_job, make_getaddrinfo_job, make_mkdir_job, make_open_job, make_read_job,
+    make_readdir_job, make_remove_job, make_rename_job, make_rmdir_job, make_sleep_job,
+    make_symlink_job, make_write_job, open_job_get_dev_id, open_job_get_fd, open_job_get_file_id,
+    open_job_get_kind, open_job_result,
 };
 pub(crate) use runner::{get_file_time_result, get_read_result, run_host_job};
 #[cfg(all(test, unix))]
@@ -53,6 +55,7 @@ fn job_executor_ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
     let mut symbols = Vec::new();
     symbols.extend_from_slice(fs::PORTED_SYMBOLS);
     symbols.extend_from_slice(sleep::PORTED_SYMBOLS);
+    symbols.extend_from_slice(socket::PORTED_SYMBOLS);
     symbols
 }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -26,6 +26,7 @@ use super::fs::{
     run_symlink_job, run_write_job,
 };
 use super::sleep::run_sleep_job;
+use super::socket::{run_bind_job, run_getaddrinfo_job};
 use super::types::{HostFileTable, Job, JobPayload};
 
 pub(crate) fn run_host_job(job: &mut Job, files: &mut impl HostFileTable) {
@@ -97,6 +98,8 @@ pub(crate) fn run_host_job(job: &mut Job, files: &mut impl HostFileTable) {
             len,
             restart,
         } => run_readdir_job(files, *dir, buffer, *len, *restart),
+        JobPayload::Bind { socket, addr } => run_bind_job(files, *socket, addr),
+        JobPayload::GetAddrInfo { host, result } => run_getaddrinfo_job(host.clone(), result),
     };
 
     match result {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/socket.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/socket.rs
@@ -1,0 +1,121 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::ffi::OsString;
+
+use crate::async_host::AsyncHostResult;
+use crate::async_sys::ported_fns;
+
+use super::{HostFileTable, HostHandle};
+
+ported_fns! {
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "bind_job_worker"
+    )]
+        pub(super) fn run_bind_job(
+        files: &mut impl HostFileTable,
+        socket: HostHandle,
+        addr: &[u8],
+    ) -> AsyncHostResult<i64> {
+        #[cfg(unix)]
+        {
+            files.with_raw_file(socket, |socket| {
+                crate::async_sys::socket::bind(socket, addr)?;
+                Ok(0)
+            })
+        }
+        #[cfg(windows)]
+        {
+            // `with_raw_file` duplicates with DuplicateHandle on Windows, which
+            // does not produce a valid duplicate Winsock SOCKET.
+            files.with_borrowed_raw_file(socket, |socket| {
+                crate::async_sys::socket::bind(socket, addr)?;
+                Ok(0)
+            })
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "getaddrinfo_job_worker"
+    )]
+        pub(super) fn run_getaddrinfo_job(
+        host: OsString,
+        result: &mut Option<Vec<Box<[u8]>>>,
+    ) -> AsyncHostResult<i64> {
+        let (ret, addrs) = crate::async_sys::socket::copy_sockaddrs_from_getaddrinfo(host)?;
+        *result = Some(addrs);
+        Ok(i64::from(ret))
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use crate::async_host::AsyncHostResult;
+    use crate::async_sys::internal::event_loop::thread_pool::HostFile;
+    use crate::async_sys::internal::fd_util::stub::RawFd;
+
+    struct TrackingFiles {
+        borrowed: bool,
+    }
+
+    impl HostFileTable for TrackingFiles {
+        fn insert_file(&mut self, _file: RawFd) -> AsyncHostResult<HostHandle> {
+            unreachable!("bind job test does not insert files")
+        }
+
+        fn is_invalid_file_handle(&self, _handle: HostHandle) -> bool {
+            unreachable!("bind job test does not query file validity")
+        }
+
+        fn with_borrowed_raw_file<T>(
+            &mut self,
+            _handle: HostHandle,
+            f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
+        ) -> AsyncHostResult<T> {
+            self.borrowed = true;
+            f(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE)
+        }
+
+        fn with_raw_file<T>(
+            &mut self,
+            _handle: HostHandle,
+            _f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
+        ) -> AsyncHostResult<T> {
+            panic!("Windows socket bind jobs must not duplicate SOCKET handles")
+        }
+
+        fn with_host_file_mut<T>(
+            &mut self,
+            _handle: HostHandle,
+            _f: impl FnOnce(&mut HostFile) -> AsyncHostResult<T>,
+        ) -> AsyncHostResult<T> {
+            unreachable!("bind job test does not mutate host files")
+        }
+    }
+
+    #[test]
+    fn windows_bind_job_borrows_socket_handle() {
+        let mut files = TrackingFiles { borrowed: false };
+        let result = run_bind_job(&mut files, 1, &[]);
+        assert!(result.is_err());
+        assert!(files.borrowed);
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -26,14 +26,33 @@ pub(crate) type HostHandle = u64;
 #[derive(Debug)]
 pub(crate) struct HostFile {
     raw: fd_util::stub::RawFd,
+    close_kind: HostFileCloseKind,
 }
 
 #[cfg(windows)]
 unsafe impl Send for HostFile {}
 
+#[derive(Debug, Clone, Copy)]
+enum HostFileCloseKind {
+    File,
+    #[cfg(windows)]
+    Socket,
+}
+
 impl HostFile {
     pub(crate) fn new(raw: fd_util::stub::RawFd) -> Self {
-        Self { raw }
+        Self {
+            raw,
+            close_kind: HostFileCloseKind::File,
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn new_socket(raw: fd_util::stub::RawFd) -> Self {
+        Self {
+            raw,
+            close_kind: HostFileCloseKind::Socket,
+        }
     }
 
     pub(crate) fn invalid() -> Self {
@@ -52,14 +71,17 @@ impl HostFile {
         if self.is_invalid() {
             return Err(AsyncHostError::Badf);
         }
-        duplicate_raw_file(self.raw).map(Self::new)
+        duplicate_raw_file(self.raw).map(|raw| Self {
+            raw,
+            close_kind: self.close_kind,
+        })
     }
 }
 
 impl Drop for HostFile {
     fn drop(&mut self) {
         if !self.is_invalid() {
-            close_raw_file(self.raw);
+            close_raw_file(self.raw, self.close_kind);
             self.raw = invalid_raw_file();
         }
     }
@@ -80,16 +102,21 @@ fn is_invalid_raw_file(raw: fd_util::stub::RawFd) -> bool {
 }
 
 #[cfg(unix)]
-fn close_raw_file(raw: fd_util::stub::RawFd) {
+fn close_raw_file(raw: fd_util::stub::RawFd, _close_kind: HostFileCloseKind) {
     unsafe {
         libc::close(raw);
     }
 }
 
 #[cfg(windows)]
-fn close_raw_file(raw: fd_util::stub::RawFd) {
-    unsafe {
-        windows_sys::Win32::Foundation::CloseHandle(raw);
+fn close_raw_file(raw: fd_util::stub::RawFd, close_kind: HostFileCloseKind) {
+    match close_kind {
+        HostFileCloseKind::File => unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(raw);
+        },
+        HostFileCloseKind::Socket => unsafe {
+            windows_sys::Win32::Networking::WinSock::closesocket(raw as usize);
+        },
     }
 }
 
@@ -291,6 +318,14 @@ pub(crate) enum JobPayload {
         len: i32,
         restart: bool,
     },
+    Bind {
+        socket: HostHandle,
+        addr: Vec<u8>,
+    },
+    GetAddrInfo {
+        host: OsString,
+        result: Option<Vec<Box<[u8]>>>,
+    },
 }
 
 pub(crate) trait HostFileTable {
@@ -299,7 +334,11 @@ pub(crate) trait HostFileTable {
     fn is_invalid_file_handle(&self, handle: HostHandle) -> bool;
 
     #[cfg(windows)]
-    fn borrowed_raw_file(&mut self, handle: HostHandle) -> AsyncHostResult<fd_util::stub::RawFd>;
+    fn with_borrowed_raw_file<T>(
+        &mut self,
+        handle: HostHandle,
+        f: impl FnOnce(fd_util::stub::RawFd) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T>;
 
     fn with_raw_file<T>(
         &mut self,

--- a/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
@@ -184,7 +184,7 @@ ported_fns! {
 }
 
 #[cfg(unix)]
-fn set_cloexec(fd: RawFd) -> AsyncHostResult<()> {
+pub(crate) fn set_cloexec(fd: RawFd) -> AsyncHostResult<()> {
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
     if flags < 0 {
         return Err(last_native_error());

--- a/crates/moonrun/src/async_sys/mod.rs
+++ b/crates/moonrun/src/async_sys/mod.rs
@@ -26,6 +26,7 @@
 pub(crate) mod fs;
 pub(crate) mod internal;
 pub(crate) mod os_error;
+pub(crate) mod socket;
 
 #[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -118,5 +119,6 @@ pub(crate) fn ported_symbols() -> Vec<PortedSymbol> {
     symbols.extend_from_slice(fs::dir::PORTED_SYMBOLS);
     symbols.extend_from_slice(fs::stub::PORTED_SYMBOLS);
     symbols.extend_from_slice(os_error::stub::PORTED_SYMBOLS);
+    symbols.extend_from_slice(socket::PORTED_SYMBOLS);
     symbols
 }

--- a/crates/moonrun/src/async_sys/os_error/stub.rs
+++ b/crates/moonrun/src/async_sys/os_error/stub.rs
@@ -119,8 +119,11 @@ ported_fns! {
         }
         #[cfg(windows)]
         {
-            use windows_sys::Win32::Foundation::ERROR_CONNECTION_REFUSED;
-            errno == ERROR_CONNECTION_REFUSED as i32
+            use windows_sys::Win32::{
+                Foundation::ERROR_CONNECTION_REFUSED,
+                Networking::WinSock::WSAECONNREFUSED,
+            };
+            errno == ERROR_CONNECTION_REFUSED as i32 || errno == WSAECONNREFUSED
         }
     }
 

--- a/crates/moonrun/src/async_sys/socket.rs
+++ b/crates/moonrun/src/async_sys/socket.rs
@@ -1,0 +1,1834 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+#[cfg(unix)]
+use std::ffi::CStr;
+#[cfg(unix)]
+use std::ffi::CString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::internal::fd_util::stub::RawFd;
+use crate::async_sys::ported_fns;
+
+#[cfg(unix)]
+fn last_native_error() -> AsyncHostError {
+    AsyncHostError::Native(
+        std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
+    )
+}
+
+#[cfg(unix)]
+fn sockaddr_len(addr: &[u8]) -> AsyncHostResult<libc::socklen_t> {
+    let len = match sockaddr_family(addr)? {
+        libc::AF_INET => std::mem::size_of::<libc::sockaddr_in>(),
+        libc::AF_INET6 => std::mem::size_of::<libc::sockaddr_in6>(),
+        _ => return Err(AsyncHostError::Inval),
+    };
+    if addr.len() < len {
+        return Err(AsyncHostError::Fault);
+    }
+    libc::socklen_t::try_from(len).map_err(|_| AsyncHostError::Fault)
+}
+
+#[cfg(unix)]
+fn sockaddr_family(addr: &[u8]) -> AsyncHostResult<i32> {
+    if addr.len() < std::mem::size_of::<libc::sockaddr>() {
+        return Err(AsyncHostError::Fault);
+    }
+    let family = unsafe { addr.as_ptr().cast::<libc::sockaddr>().read_unaligned() }.sa_family;
+    Ok(i32::from(family))
+}
+
+#[cfg(unix)]
+fn read_sockaddr_in(addr: &[u8]) -> AsyncHostResult<libc::sockaddr_in> {
+    if addr.len() < std::mem::size_of::<libc::sockaddr_in>() {
+        return Err(AsyncHostError::Fault);
+    }
+    Ok(unsafe { addr.as_ptr().cast::<libc::sockaddr_in>().read_unaligned() })
+}
+
+#[cfg(unix)]
+fn read_sockaddr_in6(addr: &[u8]) -> AsyncHostResult<libc::sockaddr_in6> {
+    if addr.len() < std::mem::size_of::<libc::sockaddr_in6>() {
+        return Err(AsyncHostError::Fault);
+    }
+    Ok(unsafe { addr.as_ptr().cast::<libc::sockaddr_in6>().read_unaligned() })
+}
+
+#[cfg(unix)]
+pub(crate) fn copy_sockaddrs_from_getaddrinfo(
+    hostname: std::ffi::OsString,
+) -> AsyncHostResult<(i32, Vec<Box<[u8]>>)> {
+    let hostname = CString::new(hostname.into_vec()).map_err(|_| AsyncHostError::Inval)?;
+    let mut hints = unsafe { std::mem::zeroed::<libc::addrinfo>() };
+    hints.ai_flags = libc::AI_ADDRCONFIG;
+    hints.ai_family = libc::AF_UNSPEC;
+
+    let mut result = std::ptr::null_mut();
+    let ret =
+        unsafe { libc::getaddrinfo(hostname.as_ptr(), std::ptr::null(), &hints, &mut result) };
+    if ret != 0 {
+        if ret == libc::EAI_SYSTEM {
+            return Err(last_native_error());
+        }
+        return Ok((ret, Vec::new()));
+    }
+
+    let mut addrs = Vec::new();
+    let mut current = result;
+    while !current.is_null() {
+        let addrinfo = unsafe { &*current };
+        let len = match addrinfo.ai_family {
+            libc::AF_INET => std::mem::size_of::<libc::sockaddr_in>(),
+            libc::AF_INET6 => std::mem::size_of::<libc::sockaddr_in6>(),
+            _ => {
+                current = addrinfo.ai_next;
+                continue;
+            }
+        };
+        if !addrinfo.ai_addr.is_null() && addrinfo.ai_addrlen as usize >= len {
+            let addr = unsafe { std::slice::from_raw_parts(addrinfo.ai_addr.cast::<u8>(), len) };
+            addrs.push(addr.into());
+        }
+        current = addrinfo.ai_next;
+    }
+    unsafe {
+        libc::freeaddrinfo(result);
+    }
+    Ok((0, addrs))
+}
+
+#[cfg(unix)]
+fn write_struct<T>(dst: &mut [u8], value: &T) -> AsyncHostResult<()> {
+    let len = std::mem::size_of::<T>();
+    if dst.len() < len {
+        return Err(AsyncHostError::Fault);
+    }
+    let src = unsafe { std::slice::from_raw_parts((value as *const T).cast::<u8>(), len) };
+    dst[..len].copy_from_slice(src);
+    Ok(())
+}
+
+#[cfg(windows)]
+mod win {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Foundation::{
+        ERROR_BUFFER_OVERFLOW, NO_ERROR, SetLastError, WIN32_ERROR,
+    };
+    use windows_sys::Win32::NetworkManagement::IpHelper::{
+        ConvertInterfaceAliasToLuid, ConvertInterfaceIndexToLuid, ConvertInterfaceLuidToAlias,
+        ConvertInterfaceLuidToIndex, GAA_FLAG_SKIP_ANYCAST, GAA_FLAG_SKIP_DNS_SERVER,
+        GAA_FLAG_SKIP_MULTICAST, GetAdaptersAddresses, IP_ADAPTER_NO_MULTICAST,
+    };
+    use windows_sys::Win32::NetworkManagement::Ndis::{IfOperStatusUp, NET_LUID_LH};
+    use windows_sys::Win32::Networking::WinSock as ws;
+
+    use super::{AsyncHostError, AsyncHostResult, RawFd};
+
+    fn socket(fd: RawFd) -> ws::SOCKET {
+        fd as usize
+    }
+
+    fn raw_socket(socket: ws::SOCKET) -> RawFd {
+        socket as RawFd
+    }
+
+    fn last_wsa_error() -> AsyncHostError {
+        let errno = unsafe { ws::WSAGetLastError() };
+        unsafe {
+            SetLastError(errno as WIN32_ERROR);
+        }
+        AsyncHostError::Native(errno)
+    }
+
+    fn win32_error(errno: WIN32_ERROR) -> AsyncHostError {
+        unsafe {
+            SetLastError(errno);
+        }
+        AsyncHostError::Native(errno as i32)
+    }
+
+    fn socket_error(ret: i32) -> AsyncHostResult<()> {
+        if ret == ws::SOCKET_ERROR {
+            Err(last_wsa_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn domain(family: i32) -> AsyncHostResult<i32> {
+        match family {
+            4 => Ok(ws::AF_INET as i32),
+            6 => Ok(ws::AF_INET6 as i32),
+            _ => Err(AsyncHostError::Inval),
+        }
+    }
+
+    fn sockaddr_family(addr: &[u8]) -> AsyncHostResult<i32> {
+        if addr.len() < std::mem::size_of::<ws::SOCKADDR>() {
+            return Err(AsyncHostError::Fault);
+        }
+        let family = unsafe { addr.as_ptr().cast::<ws::SOCKADDR>().read_unaligned() }.sa_family;
+        Ok(i32::from(family))
+    }
+
+    fn sockaddr_len(addr: &[u8]) -> AsyncHostResult<i32> {
+        let len = match sockaddr_family(addr)? as u16 {
+            ws::AF_INET => std::mem::size_of::<ws::SOCKADDR_IN>(),
+            ws::AF_INET6 => std::mem::size_of::<ws::SOCKADDR_IN6>(),
+            _ => return Err(AsyncHostError::Inval),
+        };
+        if addr.len() < len {
+            return Err(AsyncHostError::Fault);
+        }
+        i32::try_from(len).map_err(|_| AsyncHostError::Fault)
+    }
+
+    fn read_sockaddr_in(addr: &[u8]) -> AsyncHostResult<ws::SOCKADDR_IN> {
+        if addr.len() < std::mem::size_of::<ws::SOCKADDR_IN>() {
+            return Err(AsyncHostError::Fault);
+        }
+        Ok(unsafe { addr.as_ptr().cast::<ws::SOCKADDR_IN>().read_unaligned() })
+    }
+
+    fn read_sockaddr_in6(addr: &[u8]) -> AsyncHostResult<ws::SOCKADDR_IN6> {
+        if addr.len() < std::mem::size_of::<ws::SOCKADDR_IN6>() {
+            return Err(AsyncHostError::Fault);
+        }
+        Ok(unsafe { addr.as_ptr().cast::<ws::SOCKADDR_IN6>().read_unaligned() })
+    }
+
+    fn write_struct<T>(dst: &mut [u8], value: &T) -> AsyncHostResult<()> {
+        let len = std::mem::size_of::<T>();
+        if dst.len() < len {
+            return Err(AsyncHostError::Fault);
+        }
+        let src = unsafe { std::slice::from_raw_parts((value as *const T).cast::<u8>(), len) };
+        dst[..len].copy_from_slice(src);
+        Ok(())
+    }
+
+    fn set_socket_int(fd: RawFd, level: i32, option: i32, value: i32) -> AsyncHostResult<()> {
+        socket_error(unsafe {
+            ws::setsockopt(
+                socket(fd),
+                level,
+                option,
+                (&value as *const i32).cast(),
+                std::mem::size_of_val(&value) as i32,
+            )
+        })
+    }
+
+    pub(super) fn copy_sockaddrs_from_getaddrinfo(
+        hostname: OsString,
+    ) -> AsyncHostResult<(i32, Vec<Box<[u8]>>)> {
+        let hostname: Vec<u16> = hostname.encode_wide().chain(std::iter::once(0)).collect();
+        let mut hints = unsafe { std::mem::zeroed::<ws::ADDRINFOW>() };
+        hints.ai_flags = ws::AI_ADDRCONFIG as i32;
+        hints.ai_family = ws::AF_UNSPEC as i32;
+
+        let mut result = std::ptr::null_mut();
+        let ret =
+            unsafe { ws::GetAddrInfoW(hostname.as_ptr(), std::ptr::null(), &hints, &mut result) };
+        if ret != 0 {
+            return match ret {
+                ws::WSATRY_AGAIN
+                | ws::WSANO_RECOVERY
+                | ws::WSAEAFNOSUPPORT
+                | ws::WSAHOST_NOT_FOUND
+                | ws::WSATYPE_NOT_FOUND
+                | ws::WSAESOCKTNOSUPPORT => Ok((ret, Vec::new())),
+                _ => Err(AsyncHostError::Native(ret)),
+            };
+        }
+
+        let mut addrs = Vec::new();
+        let mut current = result;
+        while !current.is_null() {
+            let addrinfo = unsafe { &*current };
+            let len = match addrinfo.ai_family as u16 {
+                ws::AF_INET => std::mem::size_of::<ws::SOCKADDR_IN>(),
+                ws::AF_INET6 => std::mem::size_of::<ws::SOCKADDR_IN6>(),
+                _ => {
+                    current = addrinfo.ai_next;
+                    continue;
+                }
+            };
+            if !addrinfo.ai_addr.is_null() && addrinfo.ai_addrlen >= len {
+                let addr =
+                    unsafe { std::slice::from_raw_parts(addrinfo.ai_addr.cast::<u8>(), len) };
+                addrs.push(addr.into());
+            }
+            current = addrinfo.ai_next;
+        }
+        unsafe {
+            ws::FreeAddrInfoW(result);
+        }
+        Ok((0, addrs))
+    }
+
+    pub(super) fn ipv4_addr_size() -> i32 {
+        std::mem::size_of::<ws::SOCKADDR_IN>() as i32
+    }
+
+    pub(super) fn ipv6_addr_size() -> i32 {
+        std::mem::size_of::<ws::SOCKADDR_IN6>() as i32
+    }
+
+    pub(super) fn init_ip_addr(addr: &mut [u8], ip: i32, port: i32) -> AsyncHostResult<()> {
+        let mut sockaddr = unsafe { std::mem::zeroed::<ws::SOCKADDR_IN>() };
+        sockaddr.sin_family = ws::AF_INET;
+        sockaddr.sin_port = (port as u16).to_be();
+        sockaddr.sin_addr.S_un.S_addr = (ip as u32).to_be();
+        write_struct(addr, &sockaddr)
+    }
+
+    pub(super) fn init_ipv6_addr(
+        addr: &mut [u8],
+        ip: &[u8],
+        port: i32,
+        scope_id: i32,
+    ) -> AsyncHostResult<()> {
+        let ip: [u8; 16] = ip
+            .get(..16)
+            .ok_or(AsyncHostError::Fault)?
+            .try_into()
+            .map_err(|_| AsyncHostError::Fault)?;
+        let mut sockaddr = unsafe { std::mem::zeroed::<ws::SOCKADDR_IN6>() };
+        sockaddr.sin6_family = ws::AF_INET6;
+        sockaddr.sin6_port = (port as u16).to_be();
+        sockaddr.sin6_addr.u.Byte = ip;
+        sockaddr.Anonymous.sin6_scope_id = scope_id as u32;
+        write_struct(addr, &sockaddr)
+    }
+
+    pub(super) fn ip_addr_get_ip(addr: &[u8]) -> AsyncHostResult<i32> {
+        Ok(u32::from_be(unsafe { read_sockaddr_in(addr)?.sin_addr.S_un.S_addr }) as i32)
+    }
+
+    pub(super) fn ip_addr_get_port(addr: &[u8]) -> AsyncHostResult<i32> {
+        Ok(i32::from(u16::from_be(read_sockaddr_in(addr)?.sin_port)))
+    }
+
+    pub(super) fn addr_is_ipv6(addr: &[u8]) -> AsyncHostResult<bool> {
+        Ok(sockaddr_family(addr)? as u16 == ws::AF_INET6)
+    }
+
+    pub(super) fn addr_is_multicast(addr: &[u8]) -> AsyncHostResult<bool> {
+        match sockaddr_family(addr)? as u16 {
+            ws::AF_INET => {
+                let first_octet =
+                    u32::from_be(unsafe { read_sockaddr_in(addr)?.sin_addr.S_un.S_addr }) >> 24;
+                Ok((224..240).contains(&first_octet))
+            }
+            ws::AF_INET6 => Ok(unsafe { read_sockaddr_in6(addr)?.sin6_addr.u.Byte[0] } == 0xff),
+            _ => Ok(false),
+        }
+    }
+
+    pub(super) fn addr_copy_ipv6_bytes(addr: &[u8], out: &mut [u8]) -> AsyncHostResult<()> {
+        let addr = read_sockaddr_in6(addr)?;
+        let out = out.get_mut(..16).ok_or(AsyncHostError::Fault)?;
+        out.copy_from_slice(unsafe { &addr.sin6_addr.u.Byte });
+        Ok(())
+    }
+
+    pub(super) fn addr_get_ipv6_scope_id(addr: &[u8]) -> AsyncHostResult<i32> {
+        Ok(unsafe { read_sockaddr_in6(addr)?.Anonymous.sin6_scope_id } as i32)
+    }
+
+    pub(super) fn addr_is_ipv6_wildcard(addr: &[u8]) -> AsyncHostResult<bool> {
+        Ok(unsafe { read_sockaddr_in6(addr)?.sin6_addr.u.Byte } == [0; 16])
+    }
+
+    pub(super) fn make_tcp_socket(family: i32) -> AsyncHostResult<RawFd> {
+        let socket = unsafe {
+            ws::WSASocketW(
+                domain(family)?,
+                ws::SOCK_STREAM,
+                0,
+                std::ptr::null(),
+                0,
+                ws::WSA_FLAG_OVERLAPPED | ws::WSA_FLAG_NO_HANDLE_INHERIT,
+            )
+        };
+        if socket == ws::INVALID_SOCKET {
+            return Err(last_wsa_error());
+        }
+        let raw = raw_socket(socket);
+        if let Err(error) = set_socket_int(raw, ws::SOL_SOCKET, ws::SO_EXCLUSIVEADDRUSE, 0) {
+            unsafe {
+                ws::closesocket(socket);
+            }
+            return Err(error);
+        }
+        Ok(raw)
+    }
+
+    pub(super) fn make_udp_socket(family: i32, multicast: bool) -> AsyncHostResult<RawFd> {
+        let socket = unsafe {
+            ws::WSASocketW(
+                domain(family)?,
+                ws::SOCK_DGRAM,
+                0,
+                std::ptr::null(),
+                0,
+                ws::WSA_FLAG_OVERLAPPED | ws::WSA_FLAG_NO_HANDLE_INHERIT,
+            )
+        };
+        if socket == ws::INVALID_SOCKET {
+            return Err(last_wsa_error());
+        }
+        let raw = raw_socket(socket);
+        let result = if multicast {
+            set_socket_int(raw, ws::SOL_SOCKET, ws::SO_REUSE_MULTICASTPORT, 1)
+        } else {
+            set_socket_int(raw, ws::SOL_SOCKET, ws::SO_EXCLUSIVEADDRUSE, 0)
+        };
+        if let Err(error) = result {
+            unsafe {
+                ws::closesocket(socket);
+            }
+            return Err(error);
+        }
+        Ok(raw)
+    }
+
+    pub(super) fn join_multicast_group(
+        fd: RawFd,
+        multi_addr: &[u8],
+        local_addr: &[u8],
+    ) -> AsyncHostResult<()> {
+        let multi_addr = read_sockaddr_in(multi_addr)?;
+        let local_addr = read_sockaddr_in(local_addr)?;
+        let mreq = ws::IP_MREQ {
+            imr_multiaddr: multi_addr.sin_addr,
+            imr_interface: local_addr.sin_addr,
+        };
+        socket_error(unsafe {
+            ws::setsockopt(
+                socket(fd),
+                ws::IPPROTO_IP,
+                ws::IP_ADD_MEMBERSHIP,
+                (&mreq as *const ws::IP_MREQ).cast(),
+                std::mem::size_of_val(&mreq) as i32,
+            )
+        })
+    }
+
+    pub(super) fn join_multicast_group_v6(
+        fd: RawFd,
+        multi_addr: &[u8],
+        interface_index: i32,
+    ) -> AsyncHostResult<()> {
+        let multi_addr = read_sockaddr_in6(multi_addr)?;
+        let mreq = ws::IPV6_MREQ {
+            ipv6mr_multiaddr: multi_addr.sin6_addr,
+            ipv6mr_interface: interface_index as u32,
+        };
+        socket_error(unsafe {
+            ws::setsockopt(
+                socket(fd),
+                ws::IPPROTO_IPV6,
+                ws::IPV6_ADD_MEMBERSHIP,
+                (&mreq as *const ws::IPV6_MREQ).cast(),
+                std::mem::size_of_val(&mreq) as i32,
+            )
+        })
+    }
+
+    pub(super) fn set_multicast_interface(fd: RawFd, local_addr: &[u8]) -> AsyncHostResult<()> {
+        let local_addr = read_sockaddr_in(local_addr)?;
+        socket_error(unsafe {
+            ws::setsockopt(
+                socket(fd),
+                ws::IPPROTO_IP,
+                ws::IP_MULTICAST_IF,
+                (&local_addr.sin_addr as *const ws::IN_ADDR).cast(),
+                std::mem::size_of::<ws::IN_ADDR>() as i32,
+            )
+        })
+    }
+
+    pub(super) fn set_multicast_interface_v6(
+        fd: RawFd,
+        interface_index: i32,
+    ) -> AsyncHostResult<()> {
+        let interface_index = interface_index as u32;
+        socket_error(unsafe {
+            ws::setsockopt(
+                socket(fd),
+                ws::IPPROTO_IPV6,
+                ws::IPV6_MULTICAST_IF,
+                (&interface_index as *const u32).cast(),
+                std::mem::size_of_val(&interface_index) as i32,
+            )
+        })
+    }
+
+    pub(super) fn set_multicast_ttl(fd: RawFd, ttl: i32, family: i32) -> AsyncHostResult<()> {
+        let (level, option) = match family {
+            4 => (ws::IPPROTO_IP, ws::IP_MULTICAST_TTL),
+            6 => (ws::IPPROTO_IPV6, ws::IPV6_MULTICAST_HOPS),
+            _ => return Err(AsyncHostError::Inval),
+        };
+        set_socket_int(fd, level, option, ttl)
+    }
+
+    pub(super) fn set_multicast_loopback(
+        fd: RawFd,
+        enable: bool,
+        family: i32,
+    ) -> AsyncHostResult<()> {
+        let (level, option) = match family {
+            4 => (ws::IPPROTO_IP, ws::IP_MULTICAST_LOOP),
+            6 => (ws::IPPROTO_IPV6, ws::IPV6_MULTICAST_LOOP),
+            _ => return Err(AsyncHostError::Inval),
+        };
+        set_socket_int(fd, level, option, i32::from(enable))
+    }
+
+    pub(super) fn disable_nagle(fd: RawFd) -> AsyncHostResult<()> {
+        set_socket_int(fd, ws::IPPROTO_TCP, ws::TCP_NODELAY, 1)
+    }
+
+    pub(super) fn allow_reuse_addr(fd: RawFd) -> AsyncHostResult<()> {
+        set_socket_int(fd, ws::SOL_SOCKET, ws::SO_REUSEADDR, 1)
+    }
+
+    pub(super) fn set_ipv6_only(fd: RawFd, ipv6_only: bool) -> AsyncHostResult<()> {
+        set_socket_int(fd, ws::IPPROTO_IPV6, ws::IPV6_V6ONLY, i32::from(ipv6_only))
+    }
+
+    pub(super) fn listen(fd: RawFd) -> AsyncHostResult<()> {
+        socket_error(unsafe { ws::listen(socket(fd), ws::SOMAXCONN as i32) })
+    }
+
+    pub(super) fn enable_keepalive(
+        fd: RawFd,
+        keep_idle: i32,
+        keep_count: i32,
+        keep_intvl: i32,
+    ) -> AsyncHostResult<()> {
+        set_socket_int(fd, ws::SOL_SOCKET, ws::SO_KEEPALIVE, 1)?;
+        if keep_count > 0 {
+            set_socket_int(fd, ws::IPPROTO_TCP, ws::TCP_KEEPCNT, keep_count)?;
+        }
+        if keep_idle > 0 {
+            set_socket_int(fd, ws::IPPROTO_TCP, ws::TCP_KEEPIDLE, keep_idle)?;
+        }
+        if keep_intvl > 0 {
+            set_socket_int(fd, ws::IPPROTO_TCP, ws::TCP_KEEPINTVL, keep_intvl)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn getsockname(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
+        let mut len = i32::try_from(addr_out.len()).map_err(|_| AsyncHostError::Fault)?;
+        socket_error(unsafe {
+            ws::getsockname(
+                socket(fd),
+                addr_out.as_mut_ptr().cast::<ws::SOCKADDR>(),
+                &mut len,
+            )
+        })
+    }
+
+    pub(super) fn getpeername(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
+        let mut len = i32::try_from(addr_out.len()).map_err(|_| AsyncHostError::Fault)?;
+        socket_error(unsafe {
+            ws::getpeername(
+                socket(fd),
+                addr_out.as_mut_ptr().cast::<ws::SOCKADDR>(),
+                &mut len,
+            )
+        })
+    }
+
+    pub(super) fn if_nametoindex(name: &[u16]) -> AsyncHostResult<i32> {
+        let name: Vec<u16> = name.iter().copied().chain(std::iter::once(0)).collect();
+        let mut luid = unsafe { std::mem::zeroed::<NET_LUID_LH>() };
+        let mut errno = unsafe { ConvertInterfaceAliasToLuid(name.as_ptr(), &mut luid) };
+        if errno != NO_ERROR {
+            return Err(win32_error(errno));
+        }
+        let mut index = 0;
+        errno = unsafe { ConvertInterfaceLuidToIndex(&luid, &mut index) };
+        if errno != NO_ERROR {
+            return Err(win32_error(errno));
+        }
+        i32::try_from(index).map_err(|_| AsyncHostError::Fault)
+    }
+
+    pub(super) fn if_indextoname(index: i32) -> AsyncHostResult<Vec<u8>> {
+        let mut luid = unsafe { std::mem::zeroed::<NET_LUID_LH>() };
+        let mut errno = unsafe { ConvertInterfaceIndexToLuid(index as u32, &mut luid) };
+        if errno != NO_ERROR {
+            return Err(win32_error(errno));
+        }
+        let mut name = vec![0u16; 257];
+        errno = unsafe { ConvertInterfaceLuidToAlias(&luid, name.as_mut_ptr(), name.len()) };
+        if errno != NO_ERROR {
+            return Err(win32_error(errno));
+        }
+        let len = name
+            .iter()
+            .position(|unit| *unit == 0)
+            .ok_or(AsyncHostError::Fault)?;
+        let mut bytes = Vec::with_capacity((len + 1) * std::mem::size_of::<u16>());
+        for unit in &name[..=len] {
+            bytes.extend_from_slice(&unit.to_le_bytes());
+        }
+        Ok(bytes)
+    }
+
+    pub(super) fn find_ipv6_test_interface() -> i32 {
+        let flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER;
+        let mut buf_len = 16 * 1024u32;
+        for _ in 0..3 {
+            let word_len = (buf_len as usize).div_ceil(std::mem::size_of::<usize>());
+            let mut storage = vec![0usize; word_len];
+            let addrs = storage
+                .as_mut_ptr()
+                .cast::<windows_sys::Win32::NetworkManagement::IpHelper::IP_ADAPTER_ADDRESSES_LH>(
+            );
+            let err = unsafe {
+                GetAdaptersAddresses(
+                    ws::AF_INET6 as u32,
+                    flags,
+                    std::ptr::null(),
+                    addrs,
+                    &mut buf_len,
+                )
+            };
+            if err == ERROR_BUFFER_OVERFLOW {
+                continue;
+            }
+            if err != NO_ERROR {
+                return 0;
+            }
+            let mut adapter = addrs;
+            while !adapter.is_null() {
+                let adapter_ref = unsafe { &*adapter };
+                let adapter_flags = unsafe { adapter_ref.Anonymous2.Flags };
+                if adapter_ref.OperStatus == IfOperStatusUp
+                    && adapter_ref.Ipv6IfIndex != 0
+                    && (adapter_flags & IP_ADAPTER_NO_MULTICAST) == 0
+                {
+                    let mut unicast = adapter_ref.FirstUnicastAddress;
+                    while !unicast.is_null() {
+                        let address = unsafe { (*unicast).Address };
+                        if !address.lpSockaddr.is_null()
+                            && unsafe { (*address.lpSockaddr).sa_family } == ws::AF_INET6
+                        {
+                            let sockaddr =
+                                unsafe { &*(address.lpSockaddr.cast::<ws::SOCKADDR_IN6>()) };
+                            let bytes = unsafe { sockaddr.sin6_addr.u.Byte };
+                            if bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80 {
+                                return adapter_ref.Ipv6IfIndex as i32;
+                            }
+                        }
+                        unicast = unsafe { (*unicast).Next };
+                    }
+                }
+                adapter = adapter_ref.Next;
+            }
+            return 0;
+        }
+        0
+    }
+
+    pub(super) fn udp_client_connect(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+        connect(fd, addr)
+    }
+
+    pub(super) fn bind(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+        let len = sockaddr_len(addr)?;
+        socket_error(unsafe { ws::bind(socket(fd), addr.as_ptr().cast::<ws::SOCKADDR>(), len) })
+    }
+
+    pub(super) fn connect(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+        let len = sockaddr_len(addr)?;
+        socket_error(unsafe { ws::connect(socket(fd), addr.as_ptr().cast::<ws::SOCKADDR>(), len) })
+    }
+
+    pub(super) fn addrinfo_addr_size(addr: &[u8]) -> i32 {
+        if addr.is_empty() {
+            return 0;
+        }
+        i32::try_from(addr.len()).unwrap_or(0)
+    }
+
+    pub(super) fn addrinfo_fill_addr(
+        addr: &[u8],
+        out: &mut [u8],
+        port: i32,
+    ) -> AsyncHostResult<()> {
+        match sockaddr_family(addr)? as u16 {
+            ws::AF_INET => {
+                let mut sockaddr = read_sockaddr_in(addr)?;
+                sockaddr.sin_port = (port as u16).to_be();
+                write_struct(out, &sockaddr)?;
+            }
+            ws::AF_INET6 => {
+                let mut sockaddr = read_sockaddr_in6(addr)?;
+                sockaddr.sin6_port = (port as u16).to_be();
+                write_struct(out, &sockaddr)?;
+            }
+            _ => return Err(AsyncHostError::Inval),
+        }
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn copy_sockaddrs_from_getaddrinfo(
+    hostname: std::ffi::OsString,
+) -> AsyncHostResult<(i32, Vec<Box<[u8]>>)> {
+    win::copy_sockaddrs_from_getaddrinfo(hostname)
+}
+
+ported_fns! {
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_ipv4_addr_size"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn ipv4_addr_size() -> i32 {
+        std::mem::size_of::<libc::sockaddr_in>() as i32
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_ipv4_addr_size"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn ipv4_addr_size() -> i32 {
+        win::ipv4_addr_size()
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_ipv6_addr_size"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn ipv6_addr_size() -> i32 {
+        std::mem::size_of::<libc::sockaddr_in6>() as i32
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_ipv6_addr_size"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn ipv6_addr_size() -> i32 {
+        win::ipv6_addr_size()
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_init_ip_addr"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn init_ip_addr(addr: &mut [u8], ip: i32, port: i32) -> AsyncHostResult<()> {
+        let sockaddr = libc::sockaddr_in {
+            sin_family: libc::AF_INET as libc::sa_family_t,
+            sin_port: (port as u16).to_be(),
+            sin_addr: libc::in_addr {
+                s_addr: (ip as u32).to_be(),
+            },
+            ..unsafe { std::mem::zeroed() }
+        };
+        write_struct(addr, &sockaddr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_init_ip_addr"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn init_ip_addr(addr: &mut [u8], ip: i32, port: i32) -> AsyncHostResult<()> {
+        win::init_ip_addr(addr, ip, port)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_init_ipv6_addr"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn init_ipv6_addr(
+        addr: &mut [u8],
+        ip: &[u8],
+        port: i32,
+        scope_id: i32,
+    ) -> AsyncHostResult<()> {
+        let ip: [u8; 16] = ip
+            .get(..16)
+            .ok_or(AsyncHostError::Fault)?
+            .try_into()
+            .map_err(|_| AsyncHostError::Fault)?;
+        let sockaddr = libc::sockaddr_in6 {
+            sin6_family: libc::AF_INET6 as libc::sa_family_t,
+            sin6_port: (port as u16).to_be(),
+            sin6_addr: libc::in6_addr { s6_addr: ip },
+            sin6_scope_id: scope_id as u32,
+            ..unsafe { std::mem::zeroed() }
+        };
+        write_struct(addr, &sockaddr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_init_ipv6_addr"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn init_ipv6_addr(
+        addr: &mut [u8],
+        ip: &[u8],
+        port: i32,
+        scope_id: i32,
+    ) -> AsyncHostResult<()> {
+        win::init_ipv6_addr(addr, ip, port, scope_id)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/network.mbt",
+        original = "gai_strerror"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn gai_strerror(code: i32) -> Box<[u8]> {
+        let ptr = unsafe { libc::gai_strerror(code) };
+        unsafe { CStr::from_ptr(ptr) }.to_bytes_with_nul().into()
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_ip_addr_get_ip"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn ip_addr_get_ip(addr: &[u8]) -> AsyncHostResult<i32> {
+        Ok(u32::from_be(read_sockaddr_in(addr)?.sin_addr.s_addr) as i32)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_ip_addr_get_ip"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn ip_addr_get_ip(addr: &[u8]) -> AsyncHostResult<i32> {
+        win::ip_addr_get_ip(addr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_ip_addr_get_port"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn ip_addr_get_port(addr: &[u8]) -> AsyncHostResult<i32> {
+        Ok(i32::from(u16::from_be(read_sockaddr_in(addr)?.sin_port)))
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_ip_addr_get_port"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn ip_addr_get_port(addr: &[u8]) -> AsyncHostResult<i32> {
+        win::ip_addr_get_port(addr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addr_is_ipv6"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn addr_is_ipv6(addr: &[u8]) -> AsyncHostResult<bool> {
+        Ok(sockaddr_family(addr)? == libc::AF_INET6)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addr_is_ipv6"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn addr_is_ipv6(addr: &[u8]) -> AsyncHostResult<bool> {
+        win::addr_is_ipv6(addr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addr_is_multicast"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn addr_is_multicast(addr: &[u8]) -> AsyncHostResult<bool> {
+        match sockaddr_family(addr)? {
+            libc::AF_INET => {
+                let first_octet = u32::from_be(read_sockaddr_in(addr)?.sin_addr.s_addr) >> 24;
+                Ok((224..240).contains(&first_octet))
+            }
+            libc::AF_INET6 => Ok(read_sockaddr_in6(addr)?.sin6_addr.s6_addr[0] == 0xff),
+            _ => Ok(false),
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addr_is_multicast"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn addr_is_multicast(addr: &[u8]) -> AsyncHostResult<bool> {
+        win::addr_is_multicast(addr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addr_get_ipv6_bytes"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn addr_copy_ipv6_bytes(addr: &[u8], out: &mut [u8]) -> AsyncHostResult<()> {
+        let addr = read_sockaddr_in6(addr)?;
+        let out = out.get_mut(..16).ok_or(AsyncHostError::Fault)?;
+        out.copy_from_slice(&addr.sin6_addr.s6_addr);
+        Ok(())
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addr_get_ipv6_bytes"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn addr_copy_ipv6_bytes(addr: &[u8], out: &mut [u8]) -> AsyncHostResult<()> {
+        win::addr_copy_ipv6_bytes(addr, out)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addr_get_ipv6_scope_id"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn addr_get_ipv6_scope_id(addr: &[u8]) -> AsyncHostResult<i32> {
+        Ok(read_sockaddr_in6(addr)?.sin6_scope_id as i32)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addr_get_ipv6_scope_id"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn addr_get_ipv6_scope_id(addr: &[u8]) -> AsyncHostResult<i32> {
+        win::addr_get_ipv6_scope_id(addr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addr_is_ipv6_wildcard"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn addr_is_ipv6_wildcard(addr: &[u8]) -> AsyncHostResult<bool> {
+        Ok(read_sockaddr_in6(addr)?.sin6_addr.s6_addr == [0; 16])
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addr_is_ipv6_wildcard"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn addr_is_ipv6_wildcard(addr: &[u8]) -> AsyncHostResult<bool> {
+        win::addr_is_ipv6_wildcard(addr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_make_tcp_socket"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn make_tcp_socket(family: i32) -> AsyncHostResult<RawFd> {
+        let domain = match family {
+            4 => libc::AF_INET,
+            6 => libc::AF_INET6,
+            _ => return Err(AsyncHostError::Inval),
+        };
+        let fd = unsafe { libc::socket(domain, libc::SOCK_STREAM, 0) };
+        if fd < 0 {
+            return Err(last_native_error());
+        }
+        Ok(fd)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_make_tcp_socket"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn make_tcp_socket(family: i32) -> AsyncHostResult<RawFd> {
+        win::make_tcp_socket(family)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_make_udp_socket"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn make_udp_socket(family: i32, multicast: bool) -> AsyncHostResult<RawFd> {
+        let domain = match family {
+            4 => libc::AF_INET,
+            6 => libc::AF_INET6,
+            _ => return Err(AsyncHostError::Inval),
+        };
+        let fd = unsafe { libc::socket(domain, libc::SOCK_DGRAM, 0) };
+        if fd < 0 {
+            return Err(last_native_error());
+        }
+        if multicast {
+            let enable: libc::c_int = 1;
+            #[cfg(target_os = "linux")]
+            let option = libc::SO_REUSEADDR;
+            #[cfg(target_os = "macos")]
+            let option = libc::SO_REUSEPORT;
+            if unsafe {
+                libc::setsockopt(
+                    fd,
+                    libc::SOL_SOCKET,
+                    option,
+                    (&enable as *const libc::c_int).cast(),
+                    std::mem::size_of_val(&enable) as libc::socklen_t,
+                )
+            } < 0
+            {
+                let error = last_native_error();
+                unsafe {
+                    libc::close(fd);
+                }
+                return Err(error);
+            }
+        }
+        Ok(fd)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_make_udp_socket"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn make_udp_socket(family: i32, multicast: bool) -> AsyncHostResult<RawFd> {
+        win::make_udp_socket(family, multicast)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_join_multicast_group"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn join_multicast_group(
+        fd: RawFd,
+        multi_addr: &[u8],
+        local_addr: &[u8],
+    ) -> AsyncHostResult<()> {
+        let multi_addr = read_sockaddr_in(multi_addr)?;
+        let local_addr = read_sockaddr_in(local_addr)?;
+        let mreq = libc::ip_mreq {
+            imr_multiaddr: multi_addr.sin_addr,
+            imr_interface: local_addr.sin_addr,
+        };
+        if unsafe {
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_IP,
+                libc::IP_ADD_MEMBERSHIP,
+                (&mreq as *const libc::ip_mreq).cast(),
+                std::mem::size_of_val(&mreq) as libc::socklen_t,
+            )
+        } < 0
+        {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_join_multicast_group"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn join_multicast_group(
+        fd: RawFd,
+        multi_addr: &[u8],
+        local_addr: &[u8],
+    ) -> AsyncHostResult<()> {
+        win::join_multicast_group(fd, multi_addr, local_addr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_join_multicast_group_v6"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn join_multicast_group_v6(
+        fd: RawFd,
+        multi_addr: &[u8],
+        interface_index: i32,
+    ) -> AsyncHostResult<()> {
+        let multi_addr = read_sockaddr_in6(multi_addr)?;
+        let mreq = libc::ipv6_mreq {
+            ipv6mr_multiaddr: multi_addr.sin6_addr,
+            ipv6mr_interface: interface_index as libc::c_uint,
+        };
+        #[cfg(target_os = "linux")]
+        let option = libc::IPV6_ADD_MEMBERSHIP;
+        #[cfg(target_os = "macos")]
+        let option = libc::IPV6_JOIN_GROUP;
+        if unsafe {
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_IPV6,
+                option,
+                (&mreq as *const libc::ipv6_mreq).cast(),
+                std::mem::size_of_val(&mreq) as libc::socklen_t,
+            )
+        } < 0
+        {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_join_multicast_group_v6"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn join_multicast_group_v6(
+        fd: RawFd,
+        multi_addr: &[u8],
+        interface_index: i32,
+    ) -> AsyncHostResult<()> {
+        win::join_multicast_group_v6(fd, multi_addr, interface_index)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_set_multicast_interface"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn set_multicast_interface(fd: RawFd, local_addr: &[u8]) -> AsyncHostResult<()> {
+        let local_addr = read_sockaddr_in(local_addr)?;
+        if unsafe {
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_IP,
+                libc::IP_MULTICAST_IF,
+                (&local_addr.sin_addr as *const libc::in_addr).cast(),
+                std::mem::size_of::<libc::in_addr>() as libc::socklen_t,
+            )
+        } < 0
+        {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_set_multicast_interface"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn set_multicast_interface(fd: RawFd, local_addr: &[u8]) -> AsyncHostResult<()> {
+        win::set_multicast_interface(fd, local_addr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_set_multicast_interface_v6"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn set_multicast_interface_v6(
+        fd: RawFd,
+        interface_index: i32,
+    ) -> AsyncHostResult<()> {
+        let interface_index = interface_index as libc::c_uint;
+        if unsafe {
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_IPV6,
+                libc::IPV6_MULTICAST_IF,
+                (&interface_index as *const libc::c_uint).cast(),
+                std::mem::size_of_val(&interface_index) as libc::socklen_t,
+            )
+        } < 0
+        {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_set_multicast_interface_v6"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn set_multicast_interface_v6(
+        fd: RawFd,
+        interface_index: i32,
+    ) -> AsyncHostResult<()> {
+        win::set_multicast_interface_v6(fd, interface_index)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_set_multicast_ttl"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn set_multicast_ttl(fd: RawFd, ttl: i32, family: i32) -> AsyncHostResult<()> {
+        let (level, option) = match family {
+            4 => (libc::IPPROTO_IP, libc::IP_MULTICAST_TTL),
+            6 => (libc::IPPROTO_IPV6, libc::IPV6_MULTICAST_HOPS),
+            _ => return Err(AsyncHostError::Inval),
+        };
+        let ttl: libc::c_int = ttl;
+        if unsafe {
+            libc::setsockopt(
+                fd,
+                level,
+                option,
+                (&ttl as *const libc::c_int).cast(),
+                std::mem::size_of_val(&ttl) as libc::socklen_t,
+            )
+        } < 0
+        {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_set_multicast_ttl"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn set_multicast_ttl(fd: RawFd, ttl: i32, family: i32) -> AsyncHostResult<()> {
+        win::set_multicast_ttl(fd, ttl, family)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_set_multicast_loopback"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn set_multicast_loopback(
+        fd: RawFd,
+        enable: bool,
+        family: i32,
+    ) -> AsyncHostResult<()> {
+        let (level, option) = match family {
+            4 => (libc::IPPROTO_IP, libc::IP_MULTICAST_LOOP),
+            6 => (libc::IPPROTO_IPV6, libc::IPV6_MULTICAST_LOOP),
+            _ => return Err(AsyncHostError::Inval),
+        };
+        let enable: libc::c_int = i32::from(enable);
+        if unsafe {
+            libc::setsockopt(
+                fd,
+                level,
+                option,
+                (&enable as *const libc::c_int).cast(),
+                std::mem::size_of_val(&enable) as libc::socklen_t,
+            )
+        } < 0
+        {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_set_multicast_loopback"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn set_multicast_loopback(
+        fd: RawFd,
+        enable: bool,
+        family: i32,
+    ) -> AsyncHostResult<()> {
+        win::set_multicast_loopback(fd, enable, family)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_disable_nagle"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn disable_nagle(fd: RawFd) -> AsyncHostResult<()> {
+        let enable: libc::c_int = 1;
+        if unsafe {
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_TCP,
+                libc::TCP_NODELAY,
+                (&enable as *const libc::c_int).cast(),
+                std::mem::size_of_val(&enable) as libc::socklen_t,
+            )
+        } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_disable_nagle"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn disable_nagle(fd: RawFd) -> AsyncHostResult<()> {
+        win::disable_nagle(fd)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_allow_reuse_addr"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn allow_reuse_addr(fd: RawFd) -> AsyncHostResult<()> {
+        let enable: libc::c_int = 1;
+        if unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_REUSEADDR,
+                (&enable as *const libc::c_int).cast(),
+                std::mem::size_of_val(&enable) as libc::socklen_t,
+            )
+        } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_allow_reuse_addr"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn allow_reuse_addr(fd: RawFd) -> AsyncHostResult<()> {
+        win::allow_reuse_addr(fd)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_set_ipv6_only"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn set_ipv6_only(fd: RawFd, ipv6_only: bool) -> AsyncHostResult<()> {
+        let value: libc::c_int = i32::from(ipv6_only);
+        if unsafe {
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_IPV6,
+                libc::IPV6_V6ONLY,
+                (&value as *const libc::c_int).cast(),
+                std::mem::size_of_val(&value) as libc::socklen_t,
+            )
+        } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_set_ipv6_only"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn set_ipv6_only(fd: RawFd, ipv6_only: bool) -> AsyncHostResult<()> {
+        win::set_ipv6_only(fd, ipv6_only)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_listen"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn listen(fd: RawFd) -> AsyncHostResult<()> {
+        if unsafe { libc::listen(fd, libc::SOMAXCONN) } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_listen"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn listen(fd: RawFd) -> AsyncHostResult<()> {
+        win::listen(fd)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_enable_keepalive"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn enable_keepalive(
+        fd: RawFd,
+        keep_idle: i32,
+        keep_count: i32,
+        keep_intvl: i32,
+    ) -> AsyncHostResult<()> {
+        let enable: libc::c_int = 1;
+        if unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_KEEPALIVE,
+                (&enable as *const libc::c_int).cast(),
+                std::mem::size_of_val(&enable) as libc::socklen_t,
+            )
+        } < 0 {
+            return Err(last_native_error());
+        }
+
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            if keep_count > 0 {
+                set_tcp_int(fd, libc::TCP_KEEPCNT, keep_count)?;
+            }
+            if keep_idle > 0 {
+                set_tcp_int(fd, libc::TCP_KEEPIDLE, keep_idle)?;
+            }
+            if keep_intvl > 0 {
+                set_tcp_int(fd, libc::TCP_KEEPINTVL, keep_intvl)?;
+            }
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            if keep_count > 0 {
+                set_tcp_int(fd, libc::TCP_KEEPCNT, keep_count)?;
+            }
+            if keep_idle > 0 {
+                set_tcp_int(fd, libc::TCP_KEEPALIVE, keep_idle)?;
+            }
+            if keep_intvl > 0 {
+                set_tcp_int(fd, libc::TCP_KEEPINTVL, keep_intvl)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_enable_keepalive"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn enable_keepalive(
+        fd: RawFd,
+        keep_idle: i32,
+        keep_count: i32,
+        keep_intvl: i32,
+    ) -> AsyncHostResult<()> {
+        win::enable_keepalive(fd, keep_idle, keep_count, keep_intvl)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_getsockname"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn getsockname(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
+        let mut len = libc::socklen_t::try_from(addr_out.len()).map_err(|_| AsyncHostError::Fault)?;
+        if unsafe {
+            libc::getsockname(fd, addr_out.as_mut_ptr().cast::<libc::sockaddr>(), &mut len)
+        } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_getsockname"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn getsockname(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
+        win::getsockname(fd, addr_out)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_if_nametoindex"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn if_nametoindex(name: &[u16]) -> AsyncHostResult<i32> {
+        let name = char::decode_utf16(name.iter().copied())
+            .map(Result::unwrap)
+            .collect::<String>();
+        let name = std::ffi::CString::new(name).map_err(|_| AsyncHostError::Inval)?;
+        let index = unsafe { libc::if_nametoindex(name.as_ptr()) };
+        if index == 0 {
+            Err(last_native_error())
+        } else {
+            Ok(index as i32)
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_if_nametoindex"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn if_nametoindex(name: &[u16]) -> AsyncHostResult<i32> {
+        win::if_nametoindex(name)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_if_indextoname"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn if_indextoname(index: i32) -> AsyncHostResult<Vec<u8>> {
+        let mut name = vec![0; libc::IF_NAMESIZE + 1];
+        let ptr = unsafe { libc::if_indextoname(index as u32, name.as_mut_ptr().cast()) };
+        if ptr.is_null() {
+            return Err(last_native_error());
+        }
+        let bytes = unsafe { CStr::from_ptr(ptr) }.to_bytes_with_nul();
+        name.truncate(bytes.len());
+        Ok(name)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_if_indextoname"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn if_indextoname(index: i32) -> AsyncHostResult<Vec<u8>> {
+        win::if_indextoname(index)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_find_ipv6_test_interface"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn find_ipv6_test_interface() -> i32 {
+        let mut ifaddrs = std::ptr::null_mut();
+        if unsafe { libc::getifaddrs(&mut ifaddrs) } < 0 {
+            return 0;
+        }
+        let mut current = ifaddrs;
+        let mut result = 0;
+        while !current.is_null() {
+            let ifaddr = unsafe { &*current };
+            if !ifaddr.ifa_addr.is_null() {
+                let sockaddr = unsafe { &*ifaddr.ifa_addr };
+                let flags = ifaddr.ifa_flags as libc::c_uint;
+                #[cfg(target_os = "linux")]
+                let loopback_ok = (flags & libc::IFF_LOOPBACK as libc::c_uint) == 0;
+                #[cfg(target_os = "macos")]
+                let loopback_ok = (flags & libc::IFF_LOOPBACK as libc::c_uint) != 0;
+                if i32::from(sockaddr.sa_family) == libc::AF_INET6
+                    && loopback_ok
+                    && (flags & libc::IFF_UP as libc::c_uint) != 0
+                    && (flags & libc::IFF_RUNNING as libc::c_uint) != 0
+                    && (flags & libc::IFF_MULTICAST as libc::c_uint) != 0
+                {
+                    let sockaddr_in6 =
+                        unsafe { &*(ifaddr.ifa_addr.cast::<libc::sockaddr_in6>()) };
+                    let addr = sockaddr_in6.sin6_addr.s6_addr;
+                    let is_link_local = addr[0] == 0xfe && (addr[1] & 0xc0) == 0x80;
+                    if is_link_local {
+                        let index = unsafe { libc::if_nametoindex(ifaddr.ifa_name) };
+                        if index != 0 {
+                            result = index as i32;
+                            break;
+                        }
+                    }
+                }
+            }
+            current = ifaddr.ifa_next;
+        }
+        unsafe {
+            libc::freeifaddrs(ifaddrs);
+        }
+        result
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_find_ipv6_test_interface"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn find_ipv6_test_interface() -> i32 {
+        win::find_ipv6_test_interface()
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_udp_client_connect"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn udp_client_connect(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+        connect(fd, addr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_udp_client_connect"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn udp_client_connect(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+        win::udp_client_connect(fd, addr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_getpeername"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn getpeername(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
+        let mut len = libc::socklen_t::try_from(addr_out.len()).map_err(|_| AsyncHostError::Fault)?;
+        if unsafe {
+            libc::getpeername(fd, addr_out.as_mut_ptr().cast::<libc::sockaddr>(), &mut len)
+        } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_getpeername"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn getpeername(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
+        win::getpeername(fd, addr_out)
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn bind(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+        let len = sockaddr_len(addr)?;
+        if unsafe { libc::bind(fd, addr.as_ptr().cast::<libc::sockaddr>(), len) } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn bind(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+        win::bind(fd, addr)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/io_unix.c",
+        original = "moonbitlang_async_connect"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn connect(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+        let len = sockaddr_len(addr)?;
+        if unsafe { libc::connect(fd, addr.as_ptr().cast::<libc::sockaddr>(), len) } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/io_unix.c",
+        original = "moonbitlang_async_getsockerr"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn getsockerr(fd: RawFd) -> AsyncHostResult<i32> {
+        let mut err = 0;
+        let mut len = std::mem::size_of_val(&err) as libc::socklen_t;
+        if unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_ERROR,
+                (&mut err as *mut libc::c_int).cast(),
+                &mut len,
+            )
+        } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(err)
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/io_unix.c",
+        original = "moonbitlang_async_accept"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn accept(fd: RawFd, addr: &mut [u8]) -> AsyncHostResult<RawFd> {
+        let mut len = sockaddr_len(addr)?;
+        let conn = unsafe { libc::accept(fd, addr.as_mut_ptr().cast::<libc::sockaddr>(), &mut len) };
+        if conn < 0 {
+            return Err(last_native_error());
+        }
+        Ok(conn)
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/io_unix.c",
+        original = "moonbitlang_async_recvfrom"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn recvfrom(
+        fd: RawFd,
+        buf: &mut [u8],
+        addr: &mut [u8],
+    ) -> AsyncHostResult<usize> {
+        let mut len = sockaddr_len(addr)?;
+        let ret = unsafe {
+            libc::recvfrom(
+                fd,
+                buf.as_mut_ptr().cast(),
+                buf.len(),
+                0,
+                addr.as_mut_ptr().cast::<libc::sockaddr>(),
+                &mut len,
+            )
+        };
+        if ret < 0 {
+            Err(last_native_error())
+        } else {
+            usize::try_from(ret).map_err(|_| AsyncHostError::Fault)
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/io_unix.c",
+        original = "moonbitlang_async_sendto"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn sendto(fd: RawFd, buf: &[u8], addr: &[u8]) -> AsyncHostResult<usize> {
+        let len = sockaddr_len(addr)?;
+        let ret = unsafe {
+            libc::sendto(
+                fd,
+                buf.as_ptr().cast(),
+                buf.len(),
+                0,
+                addr.as_ptr().cast::<libc::sockaddr>(),
+                len,
+            )
+        };
+        if ret < 0 {
+            Err(last_native_error())
+        } else {
+            usize::try_from(ret).map_err(|_| AsyncHostError::Fault)
+        }
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addrinfo_addr_size"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn addrinfo_addr_size(addr: &[u8]) -> i32 {
+        if addr.is_empty() {
+            return 0;
+        }
+        i32::try_from(addr.len()).unwrap_or(0)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addrinfo_addr_size"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn addrinfo_addr_size(addr: &[u8]) -> i32 {
+        win::addrinfo_addr_size(addr)
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addrinfo_fill_addr"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn addrinfo_fill_addr(addr: &[u8], out: &mut [u8], port: i32) -> AsyncHostResult<()> {
+        match sockaddr_family(addr)? {
+            libc::AF_INET => {
+                let mut sockaddr = read_sockaddr_in(addr)?;
+                sockaddr.sin_port = (port as u16).to_be();
+                write_struct(out, &sockaddr)?;
+            }
+            libc::AF_INET6 => {
+                let mut sockaddr = read_sockaddr_in6(addr)?;
+                sockaddr.sin6_port = (port as u16).to_be();
+                write_struct(out, &sockaddr)?;
+            }
+            _ => return Err(AsyncHostError::Inval),
+        }
+        Ok(())
+    }
+
+    #[ported(
+        source = "src/socket/socket.c",
+        original = "moonbitlang_async_addrinfo_fill_addr"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn addrinfo_fill_addr(addr: &[u8], out: &mut [u8], port: i32) -> AsyncHostResult<()> {
+        win::addrinfo_fill_addr(addr, out, port)
+    }
+}
+
+#[cfg(all(
+    unix,
+    any(target_os = "linux", target_os = "android", target_os = "macos")
+))]
+fn set_tcp_int(fd: RawFd, option: libc::c_int, value: i32) -> AsyncHostResult<()> {
+    let value: libc::c_int = value;
+    if unsafe {
+        libc::setsockopt(
+            fd,
+            libc::IPPROTO_TCP,
+            option,
+            (&value as *const libc::c_int).cast(),
+            std::mem::size_of_val(&value) as libc::socklen_t,
+        )
+    } < 0
+    {
+        Err(last_native_error())
+    } else {
+        Ok(())
+    }
+}

--- a/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
@@ -16,6 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+///|
 fn get_platform() -> Int = "moonbitlang/async" "runtime/get_platform"
 
 ///|
@@ -157,11 +158,20 @@ fn main {
   )
   let tmp_path_len = get_tmp_path_len()
   assert_true(tmp_path_len > 0, "tmp path size query failed")
-  assert_true(get_tmp_path(0, 0) == -1, "tmp path fill accepted a missing buffer")
+  assert_true(
+    get_tmp_path(0, 0) == -1,
+    "tmp path fill accepted a missing buffer",
+  )
   let tmp_path = String::make(tmp_path_len, '\u{0}')
   let tmp_path_ptr = string_to_ptr(tmp_path)
-  assert_true(get_tmp_path(tmp_path_ptr, tmp_path_len) == 0, "tmp path fill failed")
-  assert_true(tmp_path != String::make(tmp_path_len, '\u{0}'), "tmp path fill wrote an empty path")
+  assert_true(
+    get_tmp_path(tmp_path_ptr, tmp_path_len) == 0,
+    "tmp path fill failed",
+  )
+  assert_true(
+    tmp_path != String::make(tmp_path_len, '\u{0}'),
+    "tmp path fill wrote an empty path",
+  )
   assert_true(!errno_is_lock_violation(0), "zero errno is a lock violation")
   let bus = event_bus_create()
   assert_true(event_bus_wait(bus, 0) == 0, "empty event bus did not time out")
@@ -186,16 +196,26 @@ fn main {
       saw_completion = true
     }
   }
-  assert_true(saw_completion, "event bus did not report worker completion source")
+  assert_true(
+    saw_completion, "event bus did not report worker completion source",
+  )
   // Windows carries the completed job id in the IOCP event; Unix drains ids
   // from the readable completion pipe.
   if platform != 2 {
     let completed_jobs = FixedArray::make(4, 0)
     assert_true(
-      fetch_completion(completion_source, completed_jobs, completed_jobs.length()) == 4,
+      fetch_completion(
+        completion_source,
+        completed_jobs,
+        completed_jobs.length(),
+      ) ==
+      4,
       "completion drain returned wrong byte count",
     )
-    assert_true(completed_jobs[0] == 17, "completion drain returned wrong job id")
+    assert_true(
+      completed_jobs[0] == 17,
+      "completion drain returned wrong job id",
+    )
   }
   free_worker(worker)
   free_job(job)


### PR DESCRIPTION
## Why

Wasm async socket programs need moonrun host support so the async socket package can use TCP and UDP from the wasm backend.

## What changed

- Adds moonrun async host APIs for socket operations, address helpers, interface-name helpers, and fd utility support used by the wasm socket backend.
- Wires socket imports into the async API registry and host syscall layer.
- Updates the async submodule pointer to the wasm socket backend work in moonbitlang/async#451.
- Adds socket benchmark coverage comparing native and wasm backend TCP server behavior.

## Why this is correct

The host layer follows the native socket behavior closely while keeping platform differences explicit. Guest memory access is bounds-checked at the host boundary, and wasm-specific APIs pass raw handles through host-managed objects instead of exposing native pointers to guest code.

## Scope

This PR is scoped to moonrun support required by the wasm socket backend and the submodule pointer. HTTP support is intentionally left for a separate PR.