### PR TITLE
Cache workspace binaries in integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "escargot"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11c3aea32bc97b500c9ca6a72b768a26e558264303d101d3409cf6d57a9ed0cf"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "expect-test"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1562,7 @@ dependencies = [
  "derive_builder",
  "dialoguer",
  "dunce",
+ "escargot",
  "expect-test",
  "home",
  "ignore",
@@ -1724,6 +1736,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "escargot",
  "libc",
  "moon-test-util",
  "moonutil",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ clap = { version = "4.5.4", features = ["derive", "string", "env"] }
 colored = "2.1.0"
 ctrlc = { version = "3.4.4", features = ["termination"] }
 dunce = "1.0.4"
+escargot = "0.5.15"
 expect-test = "1.5.0"
 snapbox = "0.6.23"
 futures = { version = "0.3.29", features = ["std"], default-features = false }

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -85,6 +85,7 @@ junction = "1"
 tempfile = "3.6.0"
 snapbox.workspace = true
 expect-test.workspace = true
+escargot.workspace = true
 clap-markdown = "0.1.4"
 similar.workspace = true
 colored.workspace = true

--- a/crates/moon/tests/support/util.rs
+++ b/crates/moon/tests/support/util.rs
@@ -16,10 +16,15 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
 
 use expect_test::Expect;
 use moonutil::{common::StringExt, compiler_flags};
+
+static MOONRUN_BIN: OnceLock<PathBuf> = OnceLock::new();
 
 pub(crate) fn check<S: AsRef<str>>(actual: S, expect: Expect) {
     expect.assert_eq(actual.as_ref())
@@ -27,6 +32,24 @@ pub(crate) fn check<S: AsRef<str>>(actual: S, expect: Expect) {
 
 pub(crate) fn moon_bin() -> PathBuf {
     snapbox::cargo_bin!("moon").to_owned()
+}
+
+pub(crate) fn moonrun_bin() -> PathBuf {
+    MOONRUN_BIN
+        .get_or_init(|| {
+            escargot::CargoBuild::new()
+                .manifest_path(
+                    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../moonrun/Cargo.toml"),
+                )
+                .bin("moonrun")
+                .current_release()
+                .current_target()
+                .run()
+                .expect("failed to build moonrun")
+                .path()
+                .to_owned()
+        })
+        .clone()
 }
 
 pub(crate) fn toolchain_root_for_tests() -> PathBuf {
@@ -60,6 +83,13 @@ pub(crate) fn replace_dir(s: &str, dir: impl AsRef<std::path::Path>) -> String {
             };
             s.replace(path.to_string_lossy().as_ref(), name)
         });
+    let s = if let Some(path) = MOONRUN_BIN.get() {
+        let path = path.to_string_lossy();
+        let s = s.replace(path.as_ref(), "moonrun");
+        s.replace(path.replace('\\', "/").as_str(), "moonrun")
+    } else {
+        s
+    };
     let path_str1 = dunce::canonicalize(dir)
         .unwrap()
         .to_str()

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -1168,7 +1168,7 @@ fn no_main_just_init() {
     let file = dir.join("_build/wasm-gc/debug/build/lib/lib.wasm");
     assert!(file.exists());
 
-    let out = snapbox::cmd::Command::new("moonrun")
+    let out = snapbox::cmd::Command::new(moonrun_bin())
         .current_dir(&dir)
         .args(["./_build/wasm-gc/debug/build/lib/lib.wasm"])
         .assert()

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -171,19 +171,6 @@ fn test_test_with_explicit_target_fails_on_test_executable_exit_code() {
     );
 }
 
-fn moonrun_bin() -> std::path::PathBuf {
-    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_moonrun") {
-        return path.into();
-    }
-
-    let mut path = std::env::current_exe().unwrap();
-    path.pop();
-    if path.ends_with("deps") {
-        path.pop();
-    }
-    path.join(format!("moonrun{}", std::env::consts::EXE_SUFFIX))
-}
-
 #[test]
 fn test_runwasm_exits_with_guest_exit_code() {
     let dir = TestDir::new("moon_run_with_cli_args.in");

--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -59,34 +59,11 @@ fn prepare_async_wasm_workspace(dir: &TestDir) -> std::path::PathBuf {
     async_dir
 }
 
-fn build_moonrun() -> std::path::PathBuf {
-    let repo_root = repo_root();
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut build_moonrun = std::process::Command::new(cargo);
-    build_moonrun
-        .current_dir(&repo_root)
-        .args(["build", "--quiet", "-p", "moonrun"]);
-    if !cfg!(debug_assertions) {
-        build_moonrun.arg("--release");
-    }
-    let status = build_moonrun
-        .status()
-        .expect("failed to spawn cargo build for moonrun");
-    assert!(status.success(), "failed to build moonrun");
-
-    let mut path = std::env::current_exe().unwrap();
-    path.pop();
-    if path.ends_with("deps") {
-        path.pop();
-    }
-    path.join(format!("moonrun{}", std::env::consts::EXE_SUFFIX))
-}
-
 fn run_async_wasm_package(dir: &TestDir, package: &str) -> String {
     let _guard = ASYNC_WASM_TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let moonrun = build_moonrun();
+    let moonrun = moonrun_bin();
     let output = moon_cmd(dir)
         .env("MOON_OVERRIDE", moon_bin())
         .env("MOONRUN_OVERRIDE", &moonrun)
@@ -114,7 +91,7 @@ fn run_upstream_async_wasm_package(package: &str) -> String {
     let _guard = ASYNC_WASM_TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let moonrun = build_moonrun();
+    let moonrun = moonrun_bin();
     let async_dir = repo_root().join("third_party/moonbitlang_async");
     let output = moon_cmd(&async_dir)
         .env("MOON_OVERRIDE", moon_bin())

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -59,9 +59,10 @@ vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
 chrono.workspace = true
 
 [dev-dependencies]
-snapbox.workspace = true
+escargot.workspace = true
 moon-test-util = { path = "../moon-test-util" }
 moonutil.workspace = true
+snapbox.workspace = true
 tempfile.workspace = true
 
 [[bin]]

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -16,20 +16,28 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::OnceLock};
 
 const MOONBIT_ASYNC_CHECK_FD_LEAK: &str = "MOONBIT_ASYNC_CHECK_FD_LEAK";
 
 fn moon_cmd() -> snapbox::cmd::Command {
-    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../moon/Cargo.toml");
-    snapbox::cmd::Command::new("cargo")
-        .arg("run")
-        .arg("--quiet")
-        .arg("--manifest-path")
-        .arg(manifest_path)
-        .arg("--bin")
-        .arg("moon")
-        .arg("--")
+    snapbox::cmd::Command::new(moon_bin())
+}
+
+fn moon_bin() -> &'static PathBuf {
+    static MOON_BIN: OnceLock<PathBuf> = OnceLock::new();
+    MOON_BIN.get_or_init(|| {
+        let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../moon/Cargo.toml");
+        escargot::CargoBuild::new()
+            .manifest_path(manifest_path)
+            .bin("moon")
+            .current_release()
+            .current_target()
+            .run()
+            .expect("failed to build moon")
+            .path()
+            .to_owned()
+    })
 }
 
 struct TestDir(moon_test_util::test_dir::TestDir);


### PR DESCRIPTION
## Why

Some integration tests shell out to workspace binaries from inside other test crates. The previous setup repeatedly invoked Cargo for the same binaries, which adds avoidable overhead in test runs, especially in the moonrun fixture-building path and async wasm E2E tests.

## What Changed

- Cache the workspace `moon` binary once for `moonrun` integration tests via `escargot`.
- Add a shared cached `moonrun` helper for `moon` E2E tests that need the workspace `moonrun` binary.
- Reuse that helper in async wasm, runwasm exit-code, and direct moonrun invocation tests.

## Why This Is Correct

The tests still execute the same workspace binaries; the change only replaces repeated Cargo command invocation or duplicated target-path reconstruction with one cached build artifact path per test process.

## Scope

This is limited to Rust integration-test infrastructure and dev-dependency wiring. It does not change moon or moonrun runtime behavior.