### PR TITLE
Implement async realpath host support

### DIFF
--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -997,6 +997,10 @@ declare_async_imports! {
 
     helper thread_pool::get_getaddrinfo_result(job: u64) -> u64 => "thread_pool/get_getaddrinfo_result";
 
+    ported thread_pool::make_realpath_job(path_ptr: i32, path_len: i32) -> u64 => "thread_pool/make_realpath_job";
+
+    ported thread_pool::get_realpath_result(job: u64) -> u64 => "thread_pool/get_realpath_result";
+
     #[cfg(unix)]
     ported thread_pool::make_spawn_job_unix(
         path: i32,

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -589,6 +589,26 @@ fn read_i32_array(
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn make_realpath_job(
+    context: &mut ImportContext<'_, '_>,
+    path_ptr: i32,
+    path_len: i32,
+) -> AsyncHostResult<u64> {
+    let path = read_guest_os_string(context, path_ptr, path_len)?;
+    context
+        .host
+        .insert_job(thread_pool::make_realpath_job(path))
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
+pub(super) fn get_realpath_result(
+    context: &mut ImportContext<'_, '_>,
+    job: u64,
+) -> AsyncHostResult<u64> {
+    context.host.get_realpath_result(job)
+}
+
+#[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn open_job_get_fd(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_fd(job)
 }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -2271,6 +2271,17 @@ impl AsyncHost {
             | HostJobState::Queued(job)
             | HostJobState::ResultReady(job) => {
                 Self::revoke_unclaimed_spawn(self.process_policy_state.as_deref(), &job);
+
+                // Native realpath frees its resolved path from the job finalizer.
+                // After get_realpath_result exposes that path as a host c_buffer,
+                // freeing the job must also release the c_buffer slot.
+                if let thread_pool::JobPayload::Realpath {
+                    result_handle: Some(buffer_handle),
+                    ..
+                } = job.payload()
+                {
+                    let _ = self.free_c_buffer(*buffer_handle);
+                }
             }
             HostJobState::Running => {}
         }
@@ -3799,6 +3810,28 @@ impl AsyncHost {
         thread_pool::get_file_time_result(job, memory, dst)
     }
 
+    pub(crate) fn get_realpath_result(&self, handle: u64) -> AsyncHostResult<u64> {
+        let key = self.handles.lock().unwrap().job(handle)?;
+        {
+            let jobs = self.jobs.lock().unwrap();
+            let job = jobs.visible_job(key)?;
+            if let Some(handle) = thread_pool::get_realpath_result_handle(job)? {
+                return Ok(handle);
+            }
+        }
+
+        let buffer = {
+            let mut jobs = self.jobs.lock().unwrap();
+            let job = jobs.visible_job_mut(key)?;
+            thread_pool::take_realpath_result_buffer(job)?
+        };
+        let buffer_handle = self.insert_c_buffer(buffer);
+        let mut jobs = self.jobs.lock().unwrap();
+        let job = jobs.visible_job_mut(key)?;
+        thread_pool::set_realpath_result_handle(job, buffer_handle)?;
+        Ok(buffer_handle)
+    }
+
     #[cfg(unix)]
     pub(crate) fn thread_pool_notifier(
         &self,
@@ -4972,6 +5005,46 @@ mod tests {
         assert_eq!(
             host.with_c_buffer_mut(interior_ptr, |_| Ok(()))
                 .unwrap_err(),
+            AsyncHostError::Badf
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn realpath_result_is_registered_c_buffer_cleaned_up_with_job() {
+        let host = AsyncHost::default();
+        let job_handle = host
+            .insert_job(thread_pool::make_realpath_job(std::ffi::OsString::from(
+                "/tmp/example",
+            )))
+            .unwrap();
+        {
+            let mut jobs = host.jobs.lock().unwrap();
+            let job = jobs.visible_job_mut(job_key(&host, job_handle)).unwrap();
+            let thread_pool::JobPayload::Realpath {
+                result,
+                result_handle,
+                ..
+            } = job.payload_mut()
+            else {
+                panic!("expected realpath job");
+            };
+            *result = Some(b"/tmp/example\0".to_vec().into_boxed_slice());
+            assert_eq!(*result_handle, None);
+        }
+
+        let buffer_handle = host.get_realpath_result(job_handle).unwrap();
+        assert_eq!(host.get_realpath_result(job_handle).unwrap(), buffer_handle);
+        host.with_c_buffer(buffer_handle, |buffer| {
+            assert_eq!(buffer, b"/tmp/example\0");
+            Ok(())
+        })
+        .unwrap();
+
+        host.free_job(job_handle).unwrap();
+
+        assert_eq!(
+            host.with_c_buffer(buffer_handle, |_| Ok(())).unwrap_err(),
             AsyncHostError::Badf
         );
     }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -1196,7 +1196,7 @@ pub(crate) struct AsyncHost {
     // table is the only guest-visible namespace, but most payload storage stays
     // in narrower tables until moving it improves locality.
     // Keep nested table locks short and in the existing directions:
-    // jobs -> handles for publishing open-job results,
+    // jobs -> handles for publishing open and realpath job results,
     // handles -> io_results for Windows overlapped-IO submission/close; submit
     // paths keep handles held until io_results is locked so close_fd cannot
     // miss an operation that is about to become pending,
@@ -2276,7 +2276,7 @@ impl AsyncHost {
                 // After get_realpath_result exposes that path as a host c_buffer,
                 // freeing the job must also release the c_buffer slot.
                 if let thread_pool::JobPayload::Realpath {
-                    result_handle: Some(buffer_handle),
+                    result: Some(thread_pool::RealpathJobResult::Published(buffer_handle)),
                     ..
                 } = job.payload()
                 {
@@ -3455,6 +3455,9 @@ impl AsyncHost {
                 path,
                 *follow_symlink,
             ),
+            JobPayload::Realpath { path, .. } => {
+                policy.stat_path(RuntimePathBase::CurrentDirectory, path)
+            }
             JobPayload::Access { path, access } => policy.access_path(path, *access),
             JobPayload::Chmod { path, .. } => policy.chmod_path(path),
             JobPayload::Flock { file, exclusive } => {
@@ -3812,24 +3815,18 @@ impl AsyncHost {
 
     pub(crate) fn get_realpath_result(&self, handle: u64) -> AsyncHostResult<u64> {
         let key = self.handles.lock().unwrap().job(handle)?;
-        {
-            let jobs = self.jobs.lock().unwrap();
-            let job = jobs.visible_job(key)?;
-            if let Some(handle) = thread_pool::get_realpath_result_handle(job)? {
-                return Ok(handle);
-            }
-        }
-
-        let buffer = {
-            let mut jobs = self.jobs.lock().unwrap();
-            let job = jobs.visible_job_mut(key)?;
-            thread_pool::take_realpath_result_buffer(job)?
-        };
-        let buffer_handle = self.insert_c_buffer(buffer);
         let mut jobs = self.jobs.lock().unwrap();
         let job = jobs.visible_job_mut(key)?;
-        thread_pool::set_realpath_result_handle(job, buffer_handle)?;
-        Ok(buffer_handle)
+        // Keep the job locked through publication so free_job either observes
+        // and cleans up the c_buffer or removes the job before publication.
+        thread_pool::publish_realpath_result(job, |buffer| {
+            let buffer_key = self.handles.lock().unwrap().insert(HandleKind::CBuffer);
+            self.c_buffers
+                .lock()
+                .unwrap()
+                .insert(buffer_key, Arc::new(Mutex::new(buffer)));
+            handle_from_key(buffer_key)
+        })
     }
 
     #[cfg(unix)]
@@ -5021,16 +5018,12 @@ mod tests {
         {
             let mut jobs = host.jobs.lock().unwrap();
             let job = jobs.visible_job_mut(job_key(&host, job_handle)).unwrap();
-            let thread_pool::JobPayload::Realpath {
-                result,
-                result_handle,
-                ..
-            } = job.payload_mut()
-            else {
+            let thread_pool::JobPayload::Realpath { result, .. } = job.payload_mut() else {
                 panic!("expected realpath job");
             };
-            *result = Some(b"/tmp/example\0".to_vec().into_boxed_slice());
-            assert_eq!(*result_handle, None);
+            *result = Some(thread_pool::RealpathJobResult::Unpublished(
+                b"/tmp/example\0".to_vec().into_boxed_slice(),
+            ));
         }
 
         let buffer_handle = host.get_realpath_result(job_handle).unwrap();
@@ -5142,6 +5135,34 @@ mod tests {
                 false,
                 0,
                 0,
+            ))
+            .unwrap();
+
+        host.run_job(job).unwrap();
+
+        assert_eq!(host.job_get_ret(job).unwrap(), -1);
+        assert_eq!(
+            host.job_get_err(job).unwrap(),
+            AsyncHostError::PermissionDenied.errno()
+        );
+        host.free_job(job).unwrap();
+    }
+
+    #[test]
+    fn run_job_checks_realpath_policy_at_execution() {
+        let tmp = tempfile::tempdir().unwrap();
+        let allowed = tmp.path().join("allowed");
+        let denied = tmp.path().join("denied");
+        std::fs::create_dir(&allowed).unwrap();
+        std::fs::create_dir(&denied).unwrap();
+        let denied_file = denied.join("secret.txt");
+        std::fs::write(&denied_file, "secret").unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(&policy_file, "[fs]\nread = [\"allowed\"]\n").unwrap();
+        let host = host_with_policy(&policy_file);
+        let job = host
+            .insert_job(thread_pool::make_realpath_job(
+                denied_file.as_os_str().to_os_string(),
             ))
             .unwrap();
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -29,7 +29,7 @@ use crate::async_host::{AsyncHostError, AsyncHostResult, HostCBuffer};
 use crate::async_sys::internal::fd_util;
 use crate::async_sys::ported_fns;
 
-use super::{FileTimeResult, OpenJobResource, OpenJobResult, Resource};
+use super::{FileTimeResult, OpenJobResource, OpenJobResult, RealpathJobResult, Resource};
 
 type RawFile = fd_util::stub::RawFd;
 
@@ -278,9 +278,9 @@ ported_fns! {
     )]
     pub(super) fn run_realpath_job(
         path: OsString,
-        result: &mut Option<Box<[u8]>>,
+        result: &mut Option<RealpathJobResult>,
     ) -> AsyncHostResult<i64> {
-        *result = Some(realpath_native_path(path)?);
+        *result = Some(RealpathJobResult::Unpublished(realpath_native_path(path)?));
         Ok(0)
     }
 }
@@ -1781,7 +1781,7 @@ fn os_string_to_wide(path: OsString) -> Vec<u16> {
 
 #[cfg(windows)]
 fn copy_windows_realpath_c_string_bytes(units: &[u16]) -> Box<[u8]> {
-    const VERBATIM_PREFIX_LEN: usize = 4;
+    const VERBATIM_PREFIX: [u16; 4] = ['\\' as u16, '\\' as u16, '?' as u16, '\\' as u16];
     const VERBATIM_UNC_PREFIX: [u16; 8] = [
         '\\' as u16,
         '\\' as u16,
@@ -1793,46 +1793,33 @@ fn copy_windows_realpath_c_string_bytes(units: &[u16]) -> Box<[u8]> {
         '\\' as u16,
     ];
 
+    // GetFinalPathNameByHandleW with VOLUME_NAME_DOS returns a `\\?\` path.
+    // Match async's user-facing realpath result by normalizing `\\?\C:\...`
+    // to `C:\...` and `\\?\UNC\server\...` to `\\server\...`. Checking
+    // each complete prefix establishes the slice bounds before rewriting it.
+    // The returned string therefore uses conventional rather than verbatim
+    // Windows path syntax.
     if units.starts_with(&VERBATIM_UNC_PREFIX) {
-        let units = &units[6..];
-        let byte_len = std::mem::size_of_val(units);
-        let mut buffer = Box::<[u8]>::new_uninit_slice(byte_len + std::mem::size_of::<u16>());
-        let first_unit = ('\\' as u16).to_ne_bytes();
-        buffer[0].write(first_unit[0]);
-        buffer[1].write(first_unit[1]);
-        if units.len() > 1 {
-            unsafe {
-                std::ptr::copy_nonoverlapping(
-                    units[1..].as_ptr().cast::<u8>(),
-                    buffer.as_mut_ptr().add(std::mem::size_of::<u16>()).cast(),
-                    byte_len - std::mem::size_of::<u16>(),
-                );
-            }
-        }
-        buffer[byte_len].write(0);
-        buffer[byte_len + 1].write(0);
-        unsafe { buffer.assume_init() }
-    } else if units.len() >= VERBATIM_PREFIX_LEN {
-        copy_wide_c_string_bytes(&units[VERBATIM_PREFIX_LEN..])
+        let mut normalized = units[6..].to_vec();
+        normalized[0] = '\\' as u16;
+        copy_wide_c_string_bytes(&normalized)
+    } else if units.starts_with(&VERBATIM_PREFIX) {
+        copy_wide_c_string_bytes(&units[VERBATIM_PREFIX.len()..])
     } else {
+        // Preserve an unexpected API result rather than dropping arbitrary
+        // leading code units.
         copy_wide_c_string_bytes(units)
     }
 }
 
 #[cfg(windows)]
 fn copy_wide_c_string_bytes(units: &[u16]) -> Box<[u8]> {
-    let byte_len = std::mem::size_of_val(units);
-    let mut buffer = Box::<[u8]>::new_uninit_slice(byte_len + std::mem::size_of::<u16>());
-    unsafe {
-        std::ptr::copy_nonoverlapping(
-            units.as_ptr().cast::<u8>(),
-            buffer.as_mut_ptr().cast(),
-            byte_len,
-        );
+    let mut buffer = Vec::with_capacity(std::mem::size_of_val(units) + std::mem::size_of::<u16>());
+    for unit in units {
+        buffer.extend_from_slice(&unit.to_ne_bytes());
     }
-    buffer[byte_len].write(0);
-    buffer[byte_len + 1].write(0);
-    unsafe { buffer.assume_init() }
+    buffer.extend_from_slice(&0u16.to_ne_bytes());
+    buffer.into_boxed_slice()
 }
 
 fn last_native_error() -> AsyncHostError {
@@ -1855,6 +1842,27 @@ fn native_io_error(error: std::io::Error) -> AsyncHostError {
 #[cfg(all(test, windows))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn realpath_normalizes_only_windows_verbatim_prefixes() {
+        let normalize = |path: &str| {
+            let units = path.encode_utf16().collect::<Vec<_>>();
+            let bytes = copy_windows_realpath_c_string_bytes(&units);
+            let units = bytes
+                .chunks_exact(std::mem::size_of::<u16>())
+                .map(|bytes| u16::from_ne_bytes([bytes[0], bytes[1]]))
+                .collect::<Vec<_>>();
+            assert_eq!(units.last(), Some(&0));
+            String::from_utf16(&units[..units.len() - 1]).unwrap()
+        };
+
+        assert_eq!(normalize(r"\\?\C:\dir\file"), r"C:\dir\file");
+        assert_eq!(
+            normalize(r"\\?\UNC\server\share\file"),
+            r"\\server\share\file"
+        );
+        assert_eq!(normalize(r"C:\already-normal"), r"C:\already-normal");
+    }
 
     #[test]
     fn junction_reparse_buffer_encodes_substitute_and_print_names() {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -271,6 +271,18 @@ ported_fns! {
         let buffer = buffer.get_mut(..len).ok_or(AsyncHostError::Fault)?;
         read_native_dir(dir, buffer, restart)
     }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "realpath_job_worker"
+    )]
+    pub(super) fn run_realpath_job(
+        path: OsString,
+        result: &mut Option<Box<[u8]>>,
+    ) -> AsyncHostResult<i64> {
+        *result = Some(realpath_native_path(path)?);
+        Ok(0)
+    }
 }
 
 #[cfg(unix)]
@@ -799,6 +811,24 @@ fn rmdir_native_path(path: OsString) -> AsyncHostResult<()> {
     } else {
         Ok(())
     }
+}
+
+#[cfg(unix)]
+fn realpath_native_path(path: OsString) -> AsyncHostResult<Box<[u8]>> {
+    let path = path_to_cstring(path)?;
+    let resolved = unsafe { libc::realpath(path.as_ptr(), std::ptr::null_mut()) };
+    if resolved.is_null() {
+        return Err(last_native_error());
+    }
+
+    let bytes = unsafe { std::ffi::CStr::from_ptr(resolved) }
+        .to_bytes_with_nul()
+        .to_vec()
+        .into_boxed_slice();
+    unsafe {
+        libc::free(resolved.cast());
+    }
+    Ok(bytes)
 }
 
 #[cfg(all(unix, target_os = "linux"))]
@@ -1555,6 +1585,72 @@ fn rmdir_native_path(path: OsString) -> AsyncHostResult<()> {
 }
 
 #[cfg(windows)]
+fn realpath_native_path(path: OsString) -> AsyncHostResult<Box<[u8]>> {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_BACKUP_SEMANTICS, FILE_NAME_NORMALIZED,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, GetFinalPathNameByHandleW,
+        OPEN_EXISTING, VOLUME_NAME_DOS,
+    };
+
+    const BUFFER_LEN: usize = 1024;
+
+    let path = path_to_wide(path);
+    let file = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
+            std::ptr::null_mut(),
+        )
+    };
+    if file == INVALID_HANDLE_VALUE {
+        return Err(last_native_error());
+    }
+
+    let result = (|| {
+        let flags = FILE_NAME_NORMALIZED | VOLUME_NAME_DOS;
+        let mut stack_buffer = [0u16; BUFFER_LEN];
+        let len = unsafe {
+            GetFinalPathNameByHandleW(file, stack_buffer.as_mut_ptr(), BUFFER_LEN as u32, flags)
+        };
+        if len == 0 {
+            return Err(last_native_error());
+        }
+
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        if len < stack_buffer.len() {
+            return Ok(copy_windows_realpath_c_string_bytes(&stack_buffer[..len]));
+        }
+
+        let buffer_len = len.checked_add(1).ok_or(AsyncHostError::Fault)?;
+        let mut heap_buffer = vec![0u16; buffer_len];
+        let len = unsafe {
+            GetFinalPathNameByHandleW(
+                file,
+                heap_buffer.as_mut_ptr(),
+                u32::try_from(heap_buffer.len()).map_err(|_| AsyncHostError::Fault)?,
+                flags,
+            )
+        };
+        if len == 0 {
+            return Err(last_native_error());
+        }
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        let units = heap_buffer.get(..len).ok_or(AsyncHostError::Fault)?;
+        Ok(copy_windows_realpath_c_string_bytes(units))
+    })();
+
+    unsafe {
+        CloseHandle(file);
+    }
+    result
+}
+
+#[cfg(windows)]
 fn read_native_dir(file: &Resource, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
     use windows_sys::Win32::Foundation::{ERROR_NO_MORE_FILES, HANDLE};
     use windows_sys::Win32::Storage::FileSystem::{
@@ -1681,6 +1777,62 @@ fn os_string_to_wide(path: OsString) -> Vec<u16> {
     use std::os::windows::ffi::OsStrExt;
 
     path.as_os_str().encode_wide().collect()
+}
+
+#[cfg(windows)]
+fn copy_windows_realpath_c_string_bytes(units: &[u16]) -> Box<[u8]> {
+    const VERBATIM_PREFIX_LEN: usize = 4;
+    const VERBATIM_UNC_PREFIX: [u16; 8] = [
+        '\\' as u16,
+        '\\' as u16,
+        '?' as u16,
+        '\\' as u16,
+        'U' as u16,
+        'N' as u16,
+        'C' as u16,
+        '\\' as u16,
+    ];
+
+    if units.starts_with(&VERBATIM_UNC_PREFIX) {
+        let units = &units[6..];
+        let byte_len = std::mem::size_of_val(units);
+        let mut buffer = Box::<[u8]>::new_uninit_slice(byte_len + std::mem::size_of::<u16>());
+        let first_unit = ('\\' as u16).to_ne_bytes();
+        buffer[0].write(first_unit[0]);
+        buffer[1].write(first_unit[1]);
+        if units.len() > 1 {
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    units[1..].as_ptr().cast::<u8>(),
+                    buffer.as_mut_ptr().add(std::mem::size_of::<u16>()).cast(),
+                    byte_len - std::mem::size_of::<u16>(),
+                );
+            }
+        }
+        buffer[byte_len].write(0);
+        buffer[byte_len + 1].write(0);
+        unsafe { buffer.assume_init() }
+    } else if units.len() >= VERBATIM_PREFIX_LEN {
+        copy_wide_c_string_bytes(&units[VERBATIM_PREFIX_LEN..])
+    } else {
+        copy_wide_c_string_bytes(units)
+    }
+}
+
+#[cfg(windows)]
+fn copy_wide_c_string_bytes(units: &[u16]) -> Box<[u8]> {
+    let byte_len = std::mem::size_of_val(units);
+    let mut buffer = Box::<[u8]>::new_uninit_slice(byte_len + std::mem::size_of::<u16>());
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            units.as_ptr().cast::<u8>(),
+            buffer.as_mut_ptr().cast(),
+            byte_len,
+        );
+    }
+    buffer[byte_len].write(0);
+    buffer[byte_len + 1].write(0);
+    unsafe { buffer.assume_init() }
 }
 
 fn last_native_error() -> AsyncHostError {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -359,6 +359,18 @@ ported_fns! {
 
     #[ported(
         source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_make_realpath_job"
+    )]
+    pub(crate) fn make_realpath_job(path: OsString) -> Job {
+        Job::new(JobPayload::Realpath {
+            path,
+            result: None,
+            result_handle: None,
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_make_spawn_job"
     )]
     #[allow(clippy::too_many_arguments)]
@@ -382,6 +394,26 @@ ported_fns! {
             cwd,
             result: None,
         })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_get_realpath_result"
+    )]
+    pub(crate) fn get_realpath_result_handle(job: &Job) -> AsyncHostResult<Option<HostHandle>> {
+        match job.payload() {
+            JobPayload::Realpath {
+                result_handle: Some(handle),
+                ..
+            } => Ok(Some(*handle)),
+            JobPayload::Realpath {
+                result: Some(_),
+                result_handle: None,
+                ..
+            } => Ok(None),
+            JobPayload::Realpath { .. } => Err(AsyncHostError::Inval),
+            _ => Err(AsyncHostError::Badf),
+        }
     }
 
     #[ported(
@@ -557,6 +589,28 @@ pub(crate) fn getaddrinfo_job_result(job: &Job) -> AsyncHostResult<(&OsStr, &[Bo
     }
 }
 
+pub(crate) fn take_realpath_result_buffer(job: &mut Job) -> AsyncHostResult<Box<[u8]>> {
+    match job.payload_mut() {
+        JobPayload::Realpath {
+            result,
+            result_handle: None,
+            ..
+        } => result.take().ok_or(AsyncHostError::Inval),
+        JobPayload::Realpath { .. } => Err(AsyncHostError::Inval),
+        _ => Err(AsyncHostError::Badf),
+    }
+}
+
+pub(crate) fn set_realpath_result_handle(job: &mut Job, handle: HostHandle) -> AsyncHostResult<()> {
+    match job.payload_mut() {
+        JobPayload::Realpath { result_handle, .. } => {
+            *result_handle = Some(handle);
+            Ok(())
+        }
+        _ => Err(AsyncHostError::Badf),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -614,6 +668,52 @@ mod tests {
             }
             other => panic!("unexpected payload: {other:?}"),
         }
+    }
+
+    #[test]
+    fn realpath_job_carries_owned_path() {
+        let job = make_realpath_job(OsString::from("/tmp/example"));
+
+        match job.payload() {
+            JobPayload::Realpath {
+                path,
+                result: None,
+                result_handle: None,
+            } => {
+                assert_eq!(path, &OsString::from("/tmp/example"));
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn realpath_job_resolves_to_nul_terminated_c_buffer() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        let link = tmp.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let mut job = make_realpath_job(link.into_os_string());
+
+        run_host_job(&mut job);
+
+        assert_eq!(job_get_ret(&job), 0);
+        assert_eq!(job_get_err(&job), 0);
+        let JobPayload::Realpath {
+            result: Some(buffer),
+            result_handle: None,
+            ..
+        } = job.payload()
+        else {
+            panic!("expected completed realpath job");
+        };
+        let realpath = std::ffi::CStr::from_bytes_with_nul(buffer.as_ref()).unwrap();
+        let expected = std::fs::canonicalize(target).unwrap();
+        assert_eq!(realpath.to_bytes(), expected.as_os_str().as_bytes());
     }
 
     #[test]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -26,8 +26,8 @@ use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 use crate::async_sys::ported_fns;
 
 use super::types::{
-    HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult, ResourceRef, SpawnOptions,
-    platform,
+    HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult, RealpathJobResult, ResourceRef,
+    SpawnOptions, platform,
 };
 
 pub(crate) fn make_failed_job(errno: i32) -> Job {
@@ -362,11 +362,32 @@ ported_fns! {
         original = "moonbitlang_async_make_realpath_job"
     )]
     pub(crate) fn make_realpath_job(path: OsString) -> Job {
-        Job::new(JobPayload::Realpath {
-            path,
-            result: None,
-            result_handle: None,
-        })
+        Job::new(JobPayload::Realpath { path, result: None })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_get_realpath_result"
+    )]
+    pub(crate) fn publish_realpath_result(
+        job: &mut Job,
+        publish: impl FnOnce(Box<[u8]>) -> HostHandle,
+    ) -> AsyncHostResult<HostHandle> {
+        match job.payload_mut() {
+            JobPayload::Realpath {
+                result: Some(RealpathJobResult::Published(handle)),
+                ..
+            } => Ok(*handle),
+            JobPayload::Realpath { result, .. } => {
+                let Some(RealpathJobResult::Unpublished(buffer)) = result.take() else {
+                    return Err(AsyncHostError::Inval);
+                };
+                let handle = publish(buffer);
+                *result = Some(RealpathJobResult::Published(handle));
+                Ok(handle)
+            }
+            _ => Err(AsyncHostError::Badf),
+        }
     }
 
     #[ported(
@@ -394,26 +415,6 @@ ported_fns! {
             cwd,
             result: None,
         })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_get_realpath_result"
-    )]
-    pub(crate) fn get_realpath_result_handle(job: &Job) -> AsyncHostResult<Option<HostHandle>> {
-        match job.payload() {
-            JobPayload::Realpath {
-                result_handle: Some(handle),
-                ..
-            } => Ok(Some(*handle)),
-            JobPayload::Realpath {
-                result: Some(_),
-                result_handle: None,
-                ..
-            } => Ok(None),
-            JobPayload::Realpath { .. } => Err(AsyncHostError::Inval),
-            _ => Err(AsyncHostError::Badf),
-        }
     }
 
     #[ported(
@@ -589,28 +590,6 @@ pub(crate) fn getaddrinfo_job_result(job: &Job) -> AsyncHostResult<(&OsStr, &[Bo
     }
 }
 
-pub(crate) fn take_realpath_result_buffer(job: &mut Job) -> AsyncHostResult<Box<[u8]>> {
-    match job.payload_mut() {
-        JobPayload::Realpath {
-            result,
-            result_handle: None,
-            ..
-        } => result.take().ok_or(AsyncHostError::Inval),
-        JobPayload::Realpath { .. } => Err(AsyncHostError::Inval),
-        _ => Err(AsyncHostError::Badf),
-    }
-}
-
-pub(crate) fn set_realpath_result_handle(job: &mut Job, handle: HostHandle) -> AsyncHostResult<()> {
-    match job.payload_mut() {
-        JobPayload::Realpath { result_handle, .. } => {
-            *result_handle = Some(handle);
-            Ok(())
-        }
-        _ => Err(AsyncHostError::Badf),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -675,11 +654,7 @@ mod tests {
         let job = make_realpath_job(OsString::from("/tmp/example"));
 
         match job.payload() {
-            JobPayload::Realpath {
-                path,
-                result: None,
-                result_handle: None,
-            } => {
+            JobPayload::Realpath { path, result: None } => {
                 assert_eq!(path, &OsString::from("/tmp/example"));
             }
             other => panic!("unexpected payload: {other:?}"),
@@ -704,8 +679,7 @@ mod tests {
         assert_eq!(job_get_ret(&job), 0);
         assert_eq!(job_get_err(&job), 0);
         let JobPayload::Realpath {
-            result: Some(buffer),
-            result_handle: None,
+            result: Some(RealpathJobResult::Unpublished(buffer)),
             ..
         } = job.payload()
         else {
@@ -714,6 +688,30 @@ mod tests {
         let realpath = std::ffi::CStr::from_bytes_with_nul(buffer.as_ref()).unwrap();
         let expected = std::fs::canonicalize(target).unwrap();
         assert_eq!(realpath.to_bytes(), expected.as_os_str().as_bytes());
+    }
+
+    #[test]
+    fn realpath_result_is_published_once() {
+        let mut job = make_realpath_job(OsString::from("unused"));
+        let JobPayload::Realpath { result, .. } = job.payload_mut() else {
+            unreachable!();
+        };
+        *result = Some(RealpathJobResult::Unpublished(
+            b"resolved\0".to_vec().into_boxed_slice(),
+        ));
+
+        let handle = publish_realpath_result(&mut job, |buffer| {
+            assert_eq!(&*buffer, b"resolved\0");
+            42
+        })
+        .unwrap();
+        let same_handle = publish_realpath_result(&mut job, |_| {
+            panic!("a published realpath result must not be published again")
+        })
+        .unwrap();
+
+        assert_eq!(handle, 42);
+        assert_eq!(same_handle, handle);
     }
 
     #[test]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -36,21 +36,20 @@ pub(crate) use jobs::make_spawn_job_windows;
 #[cfg(windows)]
 pub(crate) use jobs::{cancel_job_resource, job_cancel_resource};
 pub(crate) use jobs::{
-    errno_is_cancelled, get_file_size_result, get_platform, get_realpath_result_handle,
-    get_spawn_job_result_handle, getaddrinfo_job_result, job_get_err, job_get_ret, make_access_job,
-    make_bind_job, make_chmod_job, make_failed_job, make_file_kind_by_path_job, make_file_size_job,
+    errno_is_cancelled, get_file_size_result, get_platform, get_spawn_job_result_handle,
+    getaddrinfo_job_result, job_get_err, job_get_ret, make_access_job, make_bind_job,
+    make_chmod_job, make_failed_job, make_file_kind_by_path_job, make_file_size_job,
     make_file_time_by_path_job, make_file_time_job, make_flock_job, make_fsync_job,
     make_getaddrinfo_job, make_mkdir_job, make_open_job, make_read_job, make_readdir_job,
     make_realpath_job, make_remove_job, make_rename_job, make_rmdir_job, make_sleep_job,
     make_symlink_job, make_wait_for_process_job, make_write_job, open_job_get_dev_id,
     open_job_get_fd, open_job_get_file_id, open_job_get_kind, open_job_result, open_job_result_mut,
-    set_realpath_result_handle, set_spawn_job_result, take_realpath_result_buffer,
-    take_spawn_job_result,
+    publish_realpath_result, set_spawn_job_result, take_spawn_job_result,
 };
 pub(crate) use runner::{get_file_time_result, get_read_result, run_host_job};
 pub(crate) use types::{
-    FileRef, FileTimeResult, HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult, Resource,
-    ResourceClass, ResourceRef, ResourceTable, SpawnOptions,
+    FileRef, FileTimeResult, HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult,
+    RealpathJobResult, Resource, ResourceClass, ResourceRef, ResourceTable, SpawnOptions,
 };
 #[cfg(windows)]
 pub(crate) use worker::worker_cancellable_job;

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -36,15 +36,16 @@ pub(crate) use jobs::make_spawn_job_windows;
 #[cfg(windows)]
 pub(crate) use jobs::{cancel_job_resource, job_cancel_resource};
 pub(crate) use jobs::{
-    errno_is_cancelled, get_file_size_result, get_platform, get_spawn_job_result_handle,
-    getaddrinfo_job_result, job_get_err, job_get_ret, make_access_job, make_bind_job,
-    make_chmod_job, make_failed_job, make_file_kind_by_path_job, make_file_size_job,
+    errno_is_cancelled, get_file_size_result, get_platform, get_realpath_result_handle,
+    get_spawn_job_result_handle, getaddrinfo_job_result, job_get_err, job_get_ret, make_access_job,
+    make_bind_job, make_chmod_job, make_failed_job, make_file_kind_by_path_job, make_file_size_job,
     make_file_time_by_path_job, make_file_time_job, make_flock_job, make_fsync_job,
     make_getaddrinfo_job, make_mkdir_job, make_open_job, make_read_job, make_readdir_job,
-    make_remove_job, make_rename_job, make_rmdir_job, make_sleep_job, make_symlink_job,
-    make_wait_for_process_job, make_write_job, open_job_get_dev_id, open_job_get_fd,
-    open_job_get_file_id, open_job_get_kind, open_job_result, open_job_result_mut,
-    set_spawn_job_result, take_spawn_job_result,
+    make_realpath_job, make_remove_job, make_rename_job, make_rmdir_job, make_sleep_job,
+    make_symlink_job, make_wait_for_process_job, make_write_job, open_job_get_dev_id,
+    open_job_get_fd, open_job_get_file_id, open_job_get_kind, open_job_result, open_job_result_mut,
+    set_realpath_result_handle, set_spawn_job_result, take_realpath_result_buffer,
+    take_spawn_job_result,
 };
 pub(crate) use runner::{get_file_time_result, get_read_result, run_host_job};
 pub(crate) use types::{

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -22,8 +22,8 @@ use crate::async_sys::internal::fd_util;
 use super::fs::{
     run_access_job, run_chmod_job, run_file_kind_by_path_job, run_file_size_job,
     run_file_time_by_path_job, run_file_time_job, run_flock_job, run_fsync_job, run_mkdir_job,
-    run_open_job, run_read_job, run_readdir_job, run_remove_job, run_rename_job, run_rmdir_job,
-    run_symlink_job, run_write_job,
+    run_open_job, run_read_job, run_readdir_job, run_realpath_job, run_remove_job, run_rename_job,
+    run_rmdir_job, run_symlink_job, run_write_job,
 };
 #[cfg(unix)]
 use super::process::run_spawn_job_unix;
@@ -138,6 +138,7 @@ pub(crate) fn run_host_job(job: &mut Job) {
             None => Err(AsyncHostError::Badf),
         },
         JobPayload::GetAddrInfo { host, result } => run_getaddrinfo_job(host.clone(), result),
+        JobPayload::Realpath { path, result, .. } => run_realpath_job(path.clone(), result),
         #[cfg(unix)]
         JobPayload::SpawnUnix {
             path,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -397,6 +397,14 @@ impl Job {
 }
 
 #[derive(Debug)]
+pub(crate) enum RealpathJobResult {
+    // The completed job owns the native path until the guest requests it.
+    Unpublished(Box<[u8]>),
+    // The host c_buffer table owns the path and the job finalizer releases it.
+    Published(HostHandle),
+}
+
+#[derive(Debug)]
 pub(crate) enum JobPayload {
     Failed {
         errno: i32,
@@ -494,8 +502,7 @@ pub(crate) enum JobPayload {
     },
     Realpath {
         path: OsString,
-        result: Option<Box<[u8]>>,
-        result_handle: Option<HostHandle>,
+        result: Option<RealpathJobResult>,
     },
     #[cfg(unix)]
     SpawnUnix {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -492,6 +492,11 @@ pub(crate) enum JobPayload {
         host: OsString,
         result: Option<Vec<Box<[u8]>>>,
     },
+    Realpath {
+        path: OsString,
+        result: Option<Box<[u8]>>,
+        result_handle: Option<HostHandle>,
+    },
     #[cfg(unix)]
     SpawnUnix {
         path: OsString,


### PR DESCRIPTION
## Summary

This PR implements the `realpath` async host imports in `moonrun` and updates the async submodule pointer to the companion wasm binding change.

Companion async PR: https://github.com/moonbitlang/async/pull/459

## Why

The async package exposes `realpath`, but the wasm host side did not implement the corresponding thread-pool job and result import. That left the package API without an end-to-end host implementation.

## Why this is correct

The worker checks filesystem read policy when the job executes, resolves the native path, and keeps the resulting buffer in an explicit unpublished state. The event loop publishes that buffer once as a whole-buffer `c_buffer` handle while the job is locked, so concurrent job cleanup cannot miss or leak the published buffer.

On Windows, `GetFinalPathNameByHandleW` results are normalized to the conventional DOS or UNC form used by upstream async. The implementation validates complete verbatim prefixes before slicing and constructs the UTF-16 buffer without raw byte copies.

## Scope

The change is limited to `moonrun` async host/thread-pool plumbing, platform-specific native path resolution, focused regression coverage, and the async submodule pointer update.
