### PR TITLE
fix(moonrun): align wasm AcceptEx host ABI

### DIFF
--- a/crates/moonrun/src/async_api/io.rs
+++ b/crates/moonrun/src/async_api/io.rs
@@ -143,8 +143,25 @@ pub(super) fn make_connect_io_result(
 #[cfg(windows)]
 pub(super) fn make_accept_io_result(
     context: &mut ImportContext<'_, '_>,
+    addr_len: i32,
 ) -> crate::async_host::AsyncHostResult<u64> {
-    context.host.make_accept_io_result()
+    context.host.make_accept_io_result(addr_len)
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_get_accept_peer_addr"
+)]
+#[cfg(windows)]
+pub(super) fn get_accept_peer_addr(
+    context: &mut ImportContext<'_, '_>,
+    result: u64,
+    dst: i32,
+    dst_len: i32,
+) -> crate::async_host::AsyncHostResult<()> {
+    context.with_host_and_memory_mut(|host, memory| {
+        host.get_accept_peer_addr(memory, result, dst, dst_len)
+    })
 }
 
 #[ported(

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -506,8 +506,6 @@ declare_async_imports! {
 
     ported socket::getsockname(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/getsockname";
 
-    ported socket::getpeername(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/getpeername";
-
     ported socket::if_nametoindex(name: i32, name_len: i32) -> i32 => "socket/if_nametoindex";
 
     ported socket::if_indextoname(index: i32) -> u64 => "socket/if_indextoname";
@@ -637,10 +635,16 @@ declare_async_imports! {
     fake io::make_connect_io_result(addr: i32, addr_len: i32) -> u64 => "io/make_connect_io_result/windows";
 
     #[cfg(windows)]
-    ported io::make_accept_io_result() -> u64 => "io/make_accept_io_result/windows";
+    ported io::make_accept_io_result(addr_len: i32) -> u64 => "io/make_accept_io_result/windows";
 
     #[cfg(not(windows))]
-    fake io::make_accept_io_result() -> u64 => "io/make_accept_io_result/windows";
+    fake io::make_accept_io_result(addr_len: i32) -> u64 => "io/make_accept_io_result/windows";
+
+    #[cfg(windows)]
+    ported io::get_accept_peer_addr(result: u64, dst: i32, dst_len: i32) -> void => "io/get_accept_peer_addr/windows";
+
+    #[cfg(not(windows))]
+    fake io::get_accept_peer_addr(result: u64, dst: i32, dst_len: i32) -> void => "io/get_accept_peer_addr/windows";
 
     #[cfg(windows)]
     ported io::free_io_result(result: u64) -> void => "io/free_io_result/windows";

--- a/crates/moonrun/src/async_api/socket.rs
+++ b/crates/moonrun/src/async_api/socket.rs
@@ -387,16 +387,6 @@ pub(super) fn getsockname(context: &mut ImportContext<'_, '_>, fd: u64, addr: i3
 }
 
 #[ported(source = "src/socket/socket.c")]
-pub(super) fn getpeername(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, addr_len: i32) -> i32 {
-    let host = context.host;
-    let result = context.with_memory_mut(|memory| {
-        let addr = memory.read_exact_mut(addr, addr_len)?;
-        host.with_raw_file(fd, |fd| sys::getpeername(fd, addr))
-    });
-    zero_or_minus_one(context, result)
-}
-
-#[ported(source = "src/socket/socket.c")]
 pub(super) fn if_nametoindex(context: &mut ImportContext<'_, '_>, name: i32, name_len: i32) -> i32 {
     let result = context.with_memory_mut(|memory| {
         let name = read_u16(memory, name, name_len)?;

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -469,10 +469,6 @@ struct HostIoResult {
 unsafe impl Send for HostIoResult {}
 
 #[cfg(windows)]
-const ACCEPTEX_ADDR_LEN: usize =
-    std::mem::size_of::<windows_sys::Win32::Networking::WinSock::SOCKADDR_STORAGE>() + 16;
-
-#[cfg(windows)]
 impl HostIoResult {
     fn for_file(event: i32, buffer: Vec<u8>, guest_offset: i32, position: i64) -> Self {
         let overlapped =
@@ -569,10 +565,17 @@ impl HostIoResult {
         }
     }
 
-    fn for_accept() -> Self {
+    fn for_accept(addr_len: i32) -> AsyncHostResult<Self> {
         let overlapped =
             std::mem::MaybeUninit::<windows_sys::Win32::System::IO::OVERLAPPED>::zeroed();
-        Self {
+        let addr_len_usize = usize::try_from(addr_len).map_err(|_| AsyncHostError::Fault)?;
+        let accept_addr_len = addr_len_usize
+            .checked_add(16)
+            .ok_or(AsyncHostError::Fault)?;
+        let accept_buffer_len = accept_addr_len
+            .checked_mul(2)
+            .ok_or(AsyncHostError::Fault)?;
+        Ok(Self {
             overlapped: unsafe { overlapped.assume_init() },
             kind: HostIoKind::Accept,
             event: 1,
@@ -580,14 +583,14 @@ impl HostIoResult {
             guest_offset: 0,
             socket_flags: 0,
             addr_buffer: Vec::new(),
-            addr_len: 0,
+            addr_len,
             guest_addr_offset: None,
-            accept_buffer: vec![0; ACCEPTEX_ADDR_LEN * 2],
+            accept_buffer: vec![0; accept_buffer_len],
             accept_bytes_received: 0,
             direction: None,
             pending_raw_fd: None,
             extra_pending_close_raw_fd: None,
-        }
+        })
     }
 
     fn overlapped_ptr(&mut self) -> *mut windows_sys::Win32::System::IO::OVERLAPPED {
@@ -1531,8 +1534,8 @@ impl AsyncHost {
     }
 
     #[cfg(windows)]
-    pub(crate) fn make_accept_io_result(&self) -> AsyncHostResult<u64> {
-        self.insert_io_result(HostIoResult::for_accept())
+    pub(crate) fn make_accept_io_result(&self, addr_len: i32) -> AsyncHostResult<u64> {
+        self.insert_io_result(HostIoResult::for_accept(addr_len)?)
     }
 
     #[cfg(windows)]
@@ -1908,15 +1911,16 @@ impl AsyncHost {
 
         let accept_ex = get_wsa_extension::<ws::LPFN_ACCEPTEX>(server_fd, &ws::WSAID_ACCEPTEX)?
             .ok_or(AsyncHostError::Inval)?;
-        let addr_len = u32::try_from(ACCEPTEX_ADDR_LEN).map_err(|_| AsyncHostError::Fault)?;
+        let addr_len = u32::try_from(result.addr_len).map_err(|_| AsyncHostError::Fault)?;
+        let accept_addr_len = addr_len.checked_add(16).ok_or(AsyncHostError::Fault)?;
         let success = unsafe {
             accept_ex(
                 server_fd as usize,
                 conn_fd as usize,
                 result.accept_buffer.as_mut_ptr().cast(),
                 0,
-                addr_len,
-                addr_len,
+                accept_addr_len,
+                accept_addr_len,
                 &mut result.accept_bytes_received,
                 result.overlapped_ptr(),
             )
@@ -1930,6 +1934,32 @@ impl AsyncHost {
             }
             Err(AsyncHostError::Native(errno))
         }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn get_accept_peer_addr(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        result_handle: u64,
+        dst: i32,
+        dst_len: i32,
+    ) -> AsyncHostResult<()> {
+        let state = self.state.lock().unwrap();
+        let result = state
+            .io_results
+            .get(key_from_handle::<HostIoResultKey>(result_handle))
+            .ok_or(AsyncHostError::Badf)?;
+        if result.kind != HostIoKind::Accept || result.is_pending() {
+            return Err(AsyncHostError::Inval);
+        }
+        let addr_len = usize::try_from(result.addr_len).map_err(|_| AsyncHostError::Fault)?;
+        let offset = addr_len.checked_add(16).ok_or(AsyncHostError::Fault)?;
+        let end = offset.checked_add(addr_len).ok_or(AsyncHostError::Fault)?;
+        let addr = result
+            .accept_buffer
+            .get(offset..end)
+            .ok_or(AsyncHostError::Fault)?;
+        memory.write_with_capacity(dst, dst_len, addr)
     }
 
     #[cfg(windows)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/io.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/io.rs
@@ -143,6 +143,10 @@ pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
             ),
             ported_windows_symbol("accept_io_result", "moonbitlang_async_accept"),
             ported_windows_symbol(
+                "get_accept_peer_addr",
+                "moonbitlang_async_get_accept_peer_addr",
+            ),
+            ported_windows_symbol(
                 "setup_accepted_socket",
                 "moonbitlang_async_setup_accepted_socket",
             ),

--- a/crates/moonrun/src/async_sys/socket.rs
+++ b/crates/moonrun/src/async_sys/socket.rs
@@ -556,17 +556,6 @@ mod win {
         })
     }
 
-    pub(super) fn getpeername(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
-        let mut len = i32::try_from(addr_out.len()).map_err(|_| AsyncHostError::Fault)?;
-        socket_error(unsafe {
-            ws::getpeername(
-                socket(fd),
-                addr_out.as_mut_ptr().cast::<ws::SOCKADDR>(),
-                &mut len,
-            )
-        })
-    }
-
     pub(super) fn if_nametoindex(name: &[u16]) -> AsyncHostResult<i32> {
         let name: Vec<u16> = name.iter().copied().chain(std::iter::once(0)).collect();
         let mut luid = unsafe { std::mem::zeroed::<NET_LUID_LH>() };
@@ -1613,31 +1602,6 @@ ported_fns! {
     #[cfg(windows)]
     pub(crate) fn udp_client_connect(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
         win::udp_client_connect(fd, addr)
-    }
-
-    #[ported(
-        source = "src/socket/socket.c",
-        original = "moonbitlang_async_getpeername"
-    )]
-    #[cfg(unix)]
-    pub(crate) fn getpeername(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
-        let mut len = libc::socklen_t::try_from(addr_out.len()).map_err(|_| AsyncHostError::Fault)?;
-        if unsafe {
-            libc::getpeername(fd, addr_out.as_mut_ptr().cast::<libc::sockaddr>(), &mut len)
-        } < 0 {
-            Err(last_native_error())
-        } else {
-            Ok(())
-        }
-    }
-
-    #[ported(
-        source = "src/socket/socket.c",
-        original = "moonbitlang_async_getpeername"
-    )]
-    #[cfg(windows)]
-    pub(crate) fn getpeername(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
-        win::getpeername(fd, addr_out)
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Why

`moonbitlang/async` changed the Windows `AcceptEx` flow to size the accept result by address family and copy the peer address directly from the `AcceptEx` output buffer. The wasm host imports in moonrun need to match that updated async-side ABI.

## What changed

- Updates the wasm accept IO-result import to accept an address length.
- Adds the host import that copies the accepted peer address from the `AcceptEx` result buffer.
- Removes the obsolete `getpeername` wasm import now that upstream no longer uses the post-accept lookup.
- Updates the async submodule pointer to the rebased socket branch.

## Why this is correct

The moonrun host now mirrors the upstream native `AcceptEx` contract: allocate `(addr_len + 16) * 2`, pass `addr_len + 16` for each address slot, and copy the remote address from the second slot after completion.

## Scope

This is limited to the host ABI adjustment needed by the rebased async socket PR after the upstream `AcceptEx` refactor.