### PR TITLE
Refactor moonrun async resources behind handles

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -24,6 +24,10 @@ _Avoid_: Notify pipe, callback queue
 The wasm linear memory owned by the guest program.
 _Avoid_: Wasm buffer, V8 memory
 
+**Untrusted Guest**:
+A wasm program that may call the async boundary outside the sequencing and ownership discipline expected from MoonBit async code.
+_Avoid_: Random wasm, malicious MoonBit
+
 **Guest String Path**:
 A MoonBit `String` pointer plus UTF-16 code-unit length used for async path arguments crossing `moonbitlang/async`.
 Moonrun converts this directly into `OsString`; guest code must not send UTF-8 `Bytes` for paths.
@@ -33,9 +37,22 @@ _Avoid_: Guest UTF-8 path buffer
 Memory owned by moonrun while servicing guest jobs.
 _Avoid_: Native buffer, temporary buffer
 
+**Resource**:
+A moonrun-owned OS or runtime resource exposed to MoonBit through an opaque async boundary value.
+_Avoid_: Capability, Host Resource, Guest Resource, raw fd, pointer, id
+
+**Resource Handle**:
+An opaque value held by MoonBit code that names a resource at the async boundary.
+_Avoid_: Host Handle, Guest Handle, raw fd, pointer, id
+
 **Native-Shaped Async Boundary**:
 The wasm async host boundary that keeps MoonBit-facing concepts aligned with `moonbitlang/async` native concepts even when moonrun uses different host representations.
 _Avoid_: Wasm-specific async API, shortcut API
+
+**Native Behavior**:
+The observable behavior of `moonbitlang/async` native execution that moonrun should match byte-for-byte unless that behavior is questionable or not user facing.
+For normal MoonBit async paths, moonrun should stay strictly native-shaped and avoid adding observable intermediate states. Extra validation exists at the async boundary to reject stale or unexpected calls from an Untrusted Guest before they can violate moonrun's Rust or OS ownership invariants.
+_Avoid_: Conceptual parity, best-effort compatibility
 
 **Async API**:
 The V8-facing `moonbitlang/async` adapter that registers imports, decodes wasm ABI values, reacquires guest memory, sets return values, and reports traps.

--- a/crates/moonrun/docs/adr/0008-own-resources-behind-boundary-handles.md
+++ b/crates/moonrun/docs/adr/0008-own-resources-behind-boundary-handles.md
@@ -1,0 +1,5 @@
+# Own Resources Behind Boundary Handles
+
+Moonrun will keep MoonBit ABI values as opaque Resource Handles, resolve them at the async import boundary into Rust-owned Resources, and let Jobs carry `Arc<Resource>` rather than guest `u64` handles or duplicated OS fd/HANDLE values. This preserves Native Behavior for valid MoonBit async programs while protecting moonrun from Untrusted Guests: closing a Resource Handle removes future guest reachability immediately, and any already-submitted Job may finish through the Resource it already acquired.
+
+The guiding rule is strict native behavior on the normal path, with defensive checks only at the boundary. Valid MoonBit async code should observe the same behavior as native execution; unexpected guest calls may be rejected before they can turn opaque ABI handles into stale, duplicated, or lifetime-less host access.

--- a/crates/moonrun/src/async_api/socket.rs
+++ b/crates/moonrun/src/async_api/socket.rs
@@ -215,7 +215,7 @@ pub(super) fn addrinfo_free(context: &mut ImportContext<'_, '_>, addrinfo: u64) 
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn make_tcp_socket(context: &mut ImportContext<'_, '_>, family: i32) -> u64 {
     match sys::make_tcp_socket(family) {
-        Ok(fd) => context.host.insert_host_file(fd),
+        Ok(fd) => context.host.insert_socket_resource(fd),
         Err(error) => {
             context.host.record_error(error);
             context.host.invalid_fd()
@@ -226,7 +226,7 @@ pub(super) fn make_tcp_socket(context: &mut ImportContext<'_, '_>, family: i32) 
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn make_udp_socket(context: &mut ImportContext<'_, '_>, family: i32, multicast: i32) -> u64 {
     match sys::make_udp_socket(family, multicast != 0) {
-        Ok(fd) => context.host.insert_host_file(fd),
+        Ok(fd) => context.host.insert_socket_resource(fd),
         Err(error) => {
             context.host.record_error(error);
             context.host.invalid_fd()
@@ -390,7 +390,7 @@ pub(super) fn getsockname(context: &mut ImportContext<'_, '_>, fd: u64, addr: i3
 pub(super) fn if_nametoindex(context: &mut ImportContext<'_, '_>, name: i32, name_len: i32) -> i32 {
     let result = context.with_memory_mut(|memory| {
         let name = read_u16(memory, name, name_len)?;
-        sys::if_nametoindex(name)
+        sys::if_nametoindex(&name)
     });
     match result {
         Ok(index) => index,
@@ -545,7 +545,7 @@ pub(super) fn accept(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, ad
         host.with_raw_file(fd, |fd| sys::accept(fd, addr))
     });
     match result {
-        Ok(fd) => context.host.insert_host_file(fd),
+        Ok(fd) => context.host.insert_socket_resource(fd),
         Err(error) => {
             context.host.record_error(error);
             context.host.invalid_fd()

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -145,8 +145,9 @@ pub(super) fn make_read_job(
     len: i32,
     position: i64,
 ) -> AsyncHostResult<u64> {
+    let file = context.host.file_resource(fd)?;
     context.host
-        .insert_job(thread_pool::make_read_job(fd, len, position))
+        .insert_job(thread_pool::make_read_job(file, len, position))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
@@ -158,12 +159,13 @@ pub(super) fn make_write_job(
     len: i32,
     position: i64,
 ) -> AsyncHostResult<u64> {
+    let file = context.host.file_resource(fd)?;
     let offset_ptr = ptr.checked_add(offset).ok_or(AsyncHostError::Fault)?;
     let data =
         context.with_memory_mut(|memory| Ok(memory.read_exact(offset_ptr, len)?.to_vec()))?;
 
     context.host
-        .insert_job(thread_pool::make_write_job(fd, data, position))
+        .insert_job(thread_pool::make_write_job(file, data, position))
 }
 
 pub(super) fn get_read_result(
@@ -186,6 +188,11 @@ pub(super) fn make_file_kind_by_path_job(
     path_len: i32,
     follow_symlink: i32,
 ) -> AsyncHostResult<u64> {
+    let parent = if parent == context.host.invalid_fd() {
+        None
+    } else {
+        Some(context.host.file_resource(parent)?)
+    };
     let path = read_guest_os_string(context, path_ptr, path_len)?;
 
     context.host
@@ -198,7 +205,8 @@ pub(super) fn make_file_kind_by_path_job(
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_file_size_job(context: &mut ImportContext<'_, '_>, fd: u64) -> AsyncHostResult<u64> {
-    context.host.insert_job(thread_pool::make_file_size_job(fd))
+    let file = context.host.file_resource(fd)?;
+    context.host.insert_job(thread_pool::make_file_size_job(file))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
@@ -211,8 +219,9 @@ pub(super) fn make_file_time_job(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
 ) -> AsyncHostResult<u64> {
+    let file = context.host.file_resource(fd)?;
     context.host
-        .insert_job(thread_pool::make_file_time_job(fd))
+        .insert_job(thread_pool::make_file_time_job(file))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
@@ -273,8 +282,9 @@ pub(super) fn make_fsync_job(
     fd: u64,
     only_data: i32,
 ) -> AsyncHostResult<u64> {
+    let file = context.host.file_resource(fd)?;
     context.host
-        .insert_job(thread_pool::make_fsync_job(fd, only_data != 0))
+        .insert_job(thread_pool::make_fsync_job(file, only_data != 0))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
@@ -283,8 +293,9 @@ pub(super) fn make_flock_job(
     fd: u64,
     exclusive: i32,
 ) -> AsyncHostResult<u64> {
+    let file = context.host.file_resource(fd)?;
     context.host
-        .insert_job(thread_pool::make_flock_job(fd, exclusive != 0))
+        .insert_job(thread_pool::make_flock_job(file, exclusive != 0))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
@@ -366,6 +377,7 @@ pub(super) fn make_readdir_job(
     len: i32,
     restart: i32,
 ) -> AsyncHostResult<u64> {
+    let dir = context.host.file_resource(dir)?;
     let buffer = context.host.c_buffer(buf)?;
     context.host
         .insert_job(thread_pool::make_readdir_job(
@@ -383,6 +395,7 @@ pub(super) fn make_bind_job(
     addr: i32,
     addr_len: i32,
 ) -> AsyncHostResult<u64> {
+    let socket = context.host.file_resource(socket)?;
     let addr = context.with_memory_mut(|memory| Ok(memory.read_exact(addr, addr_len)?.to_vec()))?;
     context
         .host
@@ -438,7 +451,7 @@ fn read_guest_os_string(context: &mut ImportContext<'_, '_>, ptr: i32, len: i32)
         {
             use std::os::unix::ffi::OsStringExt;
 
-            let path = char::decode_utf16(units.iter().copied())
+            let path = char::decode_utf16(units)
                 .map(Result::unwrap)
                 .collect::<String>();
             Ok(OsString::from_vec(path.into_bytes()))
@@ -448,7 +461,7 @@ fn read_guest_os_string(context: &mut ImportContext<'_, '_>, ptr: i32, len: i32)
         {
             use std::os::windows::ffi::OsStringExt;
 
-            Ok(OsString::from_wide(units))
+            Ok(OsString::from_wide(&units))
         }
     })
 }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -335,6 +335,28 @@ impl AsyncHostState {
         self.files.remove(key).ok_or(AsyncHostError::Badf)
     }
 
+    fn restore_completed_job(&mut self, key: HostJobKey, mut job: Job) -> AsyncHostResult<()> {
+        let can_restore = match self.jobs.get(key) {
+            Some(slot) => slot.is_none(),
+            None => {
+                self.discard_job_results(&mut job);
+                return Err(AsyncHostError::Badf);
+            }
+        };
+        if !can_restore {
+            self.discard_job_results(&mut job);
+            return Err(AsyncHostError::Badf);
+        }
+        *self.jobs.get_mut(key).ok_or(AsyncHostError::Badf)? = Some(job);
+        Ok(())
+    }
+
+    fn discard_job_results(&mut self, job: &mut Job) {
+        if let Some(result) = thread_pool::take_open_job_result(job) {
+            let _ = self.remove_file(result.fd);
+        }
+    }
+
     fn take_workers(&mut self) -> Vec<HostWorkerHandle> {
         let keys: Vec<_> = self.workers.keys().collect();
         keys.into_iter()
@@ -949,14 +971,32 @@ impl AsyncHost {
             let poll_key = state.current_event_poll.ok_or(AsyncHostError::Badf)?;
             Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
         };
-        let poll = poll.lock().unwrap();
-        poll::event_list_get(&poll.instance, index)?;
-        let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
-        poll.event_fd_handles
-            .get(index)
-            .copied()
-            .flatten()
-            .ok_or(AsyncHostError::Badf)
+        let fd = {
+            let poll = poll.lock().unwrap();
+            poll::event_list_get(&poll.instance, index)?;
+            let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
+            poll.event_fd_handles
+                .get(index)
+                .copied()
+                .flatten()
+                .ok_or(AsyncHostError::Badf)?
+        };
+        let state = self.state.lock().unwrap();
+        #[cfg(windows)]
+        let is_thread_pool_completion =
+            fd == raw_fd_to_guest(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE)?;
+        #[cfg(not(windows))]
+        let is_thread_pool_completion = false;
+        if fd == state.invalid_fd()
+            || is_thread_pool_completion
+            || state
+                .files
+                .contains_key(key_from_handle::<FileResourceKey>(fd))
+        {
+            Ok(fd)
+        } else {
+            Err(AsyncHostError::Badf)
+        }
     }
 
     #[cfg(unix)]
@@ -1010,15 +1050,22 @@ impl AsyncHost {
             let completion_notifier = Arc::new(completion_notifier);
             let source = {
                 let mut state = self.state.lock().unwrap();
+                if state.completion_source.is_some() {
+                    drop(state);
+                    let poll = poll.lock().unwrap();
+                    let _ = poll::poll_unregister(&poll.instance, event_fd);
+                    drop(FileResource::new(event_fd));
+                    return Err(AsyncHostError::Inval);
+                }
                 let source =
                     handle_from_key(state.files.insert(Arc::new(FileResource::new(event_fd))));
                 state.completion_notifier = Some(Arc::clone(&completion_notifier));
                 state.completion_source = Some(source);
+                let mut poll = poll.lock().unwrap();
+                poll.registered_fds.insert(raw_fd_key(event_fd), source);
+                poll.completion_notifier = Some(completion_notifier);
                 source
             };
-            let mut poll = poll.lock().unwrap();
-            poll.registered_fds.insert(raw_fd_key(event_fd), source);
-            poll.completion_notifier = Some(completion_notifier);
             Ok(source)
         }
         #[cfg(windows)]
@@ -1055,10 +1102,11 @@ impl AsyncHost {
             {
                 let raw_fd = file.raw_fd();
                 for poll in state.polls.values_mut() {
-                    poll.lock()
-                        .unwrap()
-                        .registered_fds
-                        .remove(&raw_fd_key(raw_fd));
+                    let mut poll = poll.lock().unwrap();
+                    if poll.registered_fds.contains_key(&raw_fd_key(raw_fd)) {
+                        let _ = poll::poll_unregister(&poll.instance, raw_fd);
+                    }
+                    poll.registered_fds.remove(&raw_fd_key(raw_fd));
                 }
             }
             state.completion_notifier = None;
@@ -1291,10 +1339,12 @@ impl AsyncHost {
             }
         }
         for poll in state.polls.values() {
-            poll.lock()
-                .unwrap()
-                .registered_fds
-                .remove(&raw_fd_key(raw_fd));
+            let mut poll = poll.lock().unwrap();
+            if poll.registered_fds.contains_key(&raw_fd_key(raw_fd)) {
+                #[cfg(unix)]
+                poll::poll_unregister(&poll.instance, raw_fd)?;
+            }
+            poll.registered_fds.remove(&raw_fd_key(raw_fd));
         }
         state.remove_file(handle)?;
         Ok(())
@@ -1958,12 +2008,7 @@ impl AsyncHost {
         };
         thread_pool::run_host_job(&mut job, &mut files);
         let mut state = self.state.lock().unwrap();
-        let slot = state.jobs.get_mut(key).ok_or(AsyncHostError::Badf)?;
-        if slot.is_some() {
-            return Err(AsyncHostError::Badf);
-        }
-        *slot = Some(job);
-        Ok(())
+        state.restore_completed_job(key, job)
     }
 
     pub(crate) fn spawn_worker(&self, job_id: i32, job_handle: u64) -> AsyncHostResult<u64> {
@@ -2145,11 +2190,7 @@ impl AsyncHost {
                 thread_pool::run_host_job(&mut job, &mut files);
 
                 let mut state = run_state.lock().unwrap();
-                if let Some(slot) = state.jobs.get_mut(key)
-                    && slot.is_none()
-                {
-                    *slot = Some(job);
-                }
+                let _ = state.restore_completed_job(key, job);
             },
             move |worker_job| {
                 // Even if cancellation discarded the job handle, the event loop
@@ -2592,6 +2633,53 @@ mod tests {
     }
 
     #[test]
+    fn discarded_completed_open_job_removes_opened_resource() {
+        let host = AsyncHost::default();
+        let path =
+            std::env::temp_dir().join(format!("moonrun-discarded-open-job-{}", std::process::id()));
+        let job_handle = host
+            .insert_job(thread_pool::make_open_job(
+                path.as_os_str().to_os_string(),
+                2,
+                3,
+                false,
+                0,
+                0o600,
+            ))
+            .unwrap();
+        let key = key_from_handle::<HostJobKey>(job_handle);
+        let mut job = host
+            .state
+            .lock()
+            .unwrap()
+            .jobs
+            .get_mut(key)
+            .and_then(Option::take)
+            .unwrap();
+        let mut files = SharedFileTable {
+            state: Arc::clone(&host.state),
+        };
+
+        thread_pool::run_host_job(&mut job, &mut files);
+
+        assert_eq!(job.err(), 0);
+        let opened = thread_pool::open_job_get_fd(thread_pool::open_job_result(&job).unwrap());
+        assert!(host.state.lock().unwrap().file(opened).is_ok());
+        host.state.lock().unwrap().jobs.remove(key);
+
+        {
+            let mut state = host.state.lock().unwrap();
+            assert_eq!(
+                state.restore_completed_job(key, job),
+                Err(AsyncHostError::Badf)
+            );
+            assert!(matches!(state.file(opened), Err(AsyncHostError::Badf)));
+        }
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn drop_destroys_pool_even_when_worker_holds_state() {
         let host = AsyncHost::default();
         let state = Arc::downgrade(&host.state);
@@ -2706,6 +2794,22 @@ mod tests {
         assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 43);
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn thread_pool_completion_reports_native_sentinel() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let completion_notifier = host.init_thread_pool(poll).unwrap();
+        let completion = host.state.lock().unwrap().completion_port.unwrap();
+
+        poll::post_thread_pool_completion(completion.port, 42, completion.generation).unwrap();
+
+        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+        let event = host.poll_get_event(poll, 0).unwrap();
+        assert_eq!(host.poll_event_fd(event).unwrap(), completion_notifier);
+        assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 42);
+    }
+
     #[test]
     fn stale_worker_handle_is_rejected_after_free() {
         let host = AsyncHost::default();
@@ -2755,6 +2859,33 @@ mod tests {
 
         assert_eq!(output[0], b'x');
         assert_eq!(host.close_fd(read), Err(AsyncHostError::Badf));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn close_fd_unregisters_poll_when_job_still_holds_resource() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let [read, write] = host.pipe(true, true).unwrap();
+        host.poll_register(poll, read, true).unwrap();
+        let job = host
+            .insert_job(thread_pool::make_read_job(
+                host.file_resource(read).unwrap(),
+                1,
+                -1,
+            ))
+            .unwrap();
+
+        host.close_fd(read).unwrap();
+        let fd = host.file_resource(write).unwrap().raw_fd();
+        let byte = b"x";
+        let ret = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
+        assert_eq!(ret, 1);
+
+        assert_eq!(host.poll_wait(poll, 0).unwrap(), 0);
+
+        host.free_job(job).unwrap();
+        host.close_fd(write).unwrap();
     }
 
     #[cfg(windows)]
@@ -3050,6 +3181,27 @@ mod tests {
             poll::READ_EVENT
         );
         host.close_fd(read).unwrap();
+        host.close_fd(write).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn close_fd_invalidates_cached_poll_event_fd() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let [read, write] = host.pipe(true, true).unwrap();
+        host.poll_register(poll, read, true).unwrap();
+
+        let fd = host.file_resource(write).unwrap().raw_fd();
+        let byte = b"x";
+        let ret = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
+        assert_eq!(ret, 1);
+        assert_eq!(host.poll_wait(poll, 100).unwrap(), 1);
+        let event = host.poll_get_event(poll, 0).unwrap();
+
+        host.close_fd(read).unwrap();
+
+        assert_eq!(host.poll_event_fd(event), Err(AsyncHostError::Badf));
         host.close_fd(write).unwrap();
     }
 

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -36,10 +36,12 @@ use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 use crate::async_sys::internal::event_loop::{
     poll::{self, PollInstance},
     thread_pool::{
-        self, HostFile, HostFileTable, HostHandle, HostWorkerHandle, HostWorkerJob, Job,
+        self, FileResource, FileResourceRef, FileResourceTable, HostHandle, HostWorkerHandle,
+        HostWorkerJob, Job,
     },
 };
 use crate::async_sys::internal::fd_util::stub::RawFd;
+use crate::async_sys::socket::RawSocket;
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 compile_error!("moonrun async wasm host currently supports only Linux, macOS, and Windows hosts");
@@ -140,32 +142,23 @@ fn guest_bounds(offset: i32, len: i32) -> AsyncHostResult<(usize, usize)> {
     Ok((offset, end))
 }
 
-pub(crate) fn read_u16(memory: &[u8], offset: i32, len: i32) -> AsyncHostResult<&[u16]> {
+pub(crate) fn read_u16(memory: &[u8], offset: i32, len: i32) -> AsyncHostResult<Vec<u16>> {
     let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
-    let (offset, _) = u16_bounds(memory.len(), offset, len)?;
-    if len == 0 {
-        return Ok(&[]);
-    }
-    let ptr = unsafe { memory.as_ptr().add(offset) };
-    if !(ptr as usize).is_multiple_of(std::mem::align_of::<u16>()) {
-        return Err(AsyncHostError::Fault);
-    }
-    let ptr = ptr.cast::<u16>();
-    Ok(unsafe { std::slice::from_raw_parts(ptr, len) })
+    let (offset, end) = u16_bounds(memory.len(), offset, len)?;
+    Ok(memory[offset..end]
+        .chunks_exact(std::mem::size_of::<u16>())
+        .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+        .collect())
 }
 
 pub(crate) fn write_u16(memory: &mut [u8], offset: i32, data: &[u16]) -> AsyncHostResult<()> {
-    let (offset, _) = u16_bounds(memory.len(), offset, data.len())?;
-    if data.is_empty() {
-        return Ok(());
+    let (offset, end) = u16_bounds(memory.len(), offset, data.len())?;
+    for (dst, value) in memory[offset..end]
+        .chunks_exact_mut(std::mem::size_of::<u16>())
+        .zip(data.iter().copied())
+    {
+        dst.copy_from_slice(&value.to_le_bytes());
     }
-    let ptr = unsafe { memory.as_mut_ptr().add(offset) };
-    if !(ptr as usize).is_multiple_of(std::mem::align_of::<u16>()) {
-        return Err(AsyncHostError::Fault);
-    }
-    let ptr = ptr.cast::<u16>();
-    let dst = unsafe { std::slice::from_raw_parts_mut(ptr, data.len()) };
-    dst.copy_from_slice(data);
     Ok(())
 }
 
@@ -204,64 +197,18 @@ impl<const N: usize> GuestMemory for [u8; N] {
     }
 }
 
-impl HostFileTable for SlotMap<HostFileKey, HostFile> {
+impl FileResourceTable for SlotMap<FileResourceKey, FileResourceRef> {
     fn insert_file(&mut self, file: RawFd) -> AsyncHostResult<u64> {
-        Ok(handle_from_key(self.insert(HostFile::new(file))))
-    }
-
-    fn is_invalid_file_handle(&self, handle: HostHandle) -> bool {
-        self.get(key_from_handle::<HostFileKey>(handle))
-            .is_some_and(HostFile::is_invalid)
-    }
-
-    #[cfg(windows)]
-    fn with_borrowed_raw_file<T>(
-        &mut self,
-        handle: HostHandle,
-        f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
-    ) -> AsyncHostResult<T> {
-        let file = self
-            .get(key_from_handle::<HostFileKey>(handle))
-            .ok_or(AsyncHostError::Badf)?;
-        if file.is_invalid() {
-            return Err(AsyncHostError::Badf);
-        }
-        f(file.raw_fd())
-    }
-
-    fn with_raw_file<U>(
-        &mut self,
-        handle: u64,
-        f: impl FnOnce(RawFd) -> AsyncHostResult<U>,
-    ) -> AsyncHostResult<U> {
-        let file = self
-            .get_mut(key_from_handle::<HostFileKey>(handle))
-            .ok_or(AsyncHostError::Badf)?;
-        if file.is_invalid() {
-            return Err(AsyncHostError::Badf);
-        }
-        f(file.raw_fd())
-    }
-
-    fn with_host_file_mut<U>(
-        &mut self,
-        handle: u64,
-        f: impl FnOnce(&mut HostFile) -> AsyncHostResult<U>,
-    ) -> AsyncHostResult<U> {
-        let file = self
-            .get_mut(key_from_handle::<HostFileKey>(handle))
-            .ok_or(AsyncHostError::Badf)?;
-        if file.is_invalid() {
-            return Err(AsyncHostError::Badf);
-        }
-        f(file)
+        Ok(handle_from_key(
+            self.insert(Arc::new(FileResource::new(file))),
+        ))
     }
 }
 
 new_key_type! {
     pub(crate) struct HostAddrInfoKey;
     pub(crate) struct HostCBufferKey;
-    pub(crate) struct HostFileKey;
+    pub(crate) struct FileResourceKey;
     pub(crate) struct HostIoResultKey;
     pub(crate) struct HostJobKey;
     pub(crate) struct HostPollKey;
@@ -293,8 +240,8 @@ struct AsyncHostState {
     jobs: SlotMap<HostJobKey, Option<Job>>,
     polls: SlotMap<HostPollKey, Arc<Mutex<HostPoll>>>,
     current_event_poll: Option<HostPollKey>,
-    files: SlotMap<HostFileKey, HostFile>,
-    invalid_file: HostFileKey,
+    files: SlotMap<FileResourceKey, FileResourceRef>,
+    invalid_file: FileResourceKey,
     workers: SlotMap<HostWorkerKey, HostWorkerHandle>,
     #[cfg(unix)]
     completion_notifier: Option<Arc<ThreadPoolCompletionNotifier>>,
@@ -328,7 +275,7 @@ impl OverlappedAddr {
 impl Default for AsyncHostState {
     fn default() -> Self {
         let mut files = SlotMap::with_key();
-        let invalid_file = files.insert(HostFile::invalid());
+        let invalid_file = files.insert(Arc::new(FileResource::invalid()));
         Self {
             errno: 0,
             addr_infos: SlotMap::with_key(),
@@ -369,30 +316,19 @@ impl AsyncHostState {
         handle_from_key(self.invalid_file)
     }
 
-    fn file(&self, handle: HostHandle) -> AsyncHostResult<&HostFile> {
+    fn file(&self, handle: HostHandle) -> AsyncHostResult<FileResourceRef> {
         let file = self
             .files
-            .get(key_from_handle::<HostFileKey>(handle))
+            .get(key_from_handle::<FileResourceKey>(handle))
             .ok_or(AsyncHostError::Badf)?;
         if file.is_invalid() {
             return Err(AsyncHostError::Badf);
         }
-        Ok(file)
+        Ok(Arc::clone(file))
     }
 
-    fn file_mut(&mut self, handle: HostHandle) -> AsyncHostResult<&mut HostFile> {
-        let file = self
-            .files
-            .get_mut(key_from_handle::<HostFileKey>(handle))
-            .ok_or(AsyncHostError::Badf)?;
-        if file.is_invalid() {
-            return Err(AsyncHostError::Badf);
-        }
-        Ok(file)
-    }
-
-    fn remove_file(&mut self, handle: HostHandle) -> AsyncHostResult<HostFile> {
-        let key = key_from_handle::<HostFileKey>(handle);
+    fn remove_file(&mut self, handle: HostHandle) -> AsyncHostResult<FileResourceRef> {
+        let key = key_from_handle::<FileResourceKey>(handle);
         if key == self.invalid_file {
             return Err(AsyncHostError::Badf);
         }
@@ -1074,7 +1010,8 @@ impl AsyncHost {
             let completion_notifier = Arc::new(completion_notifier);
             let source = {
                 let mut state = self.state.lock().unwrap();
-                let source = handle_from_key(state.files.insert(HostFile::new(event_fd)));
+                let source =
+                    handle_from_key(state.files.insert(Arc::new(FileResource::new(event_fd))));
                 state.completion_notifier = Some(Arc::clone(&completion_notifier));
                 state.completion_source = Some(source);
                 source
@@ -1363,12 +1300,12 @@ impl AsyncHost {
         Ok(())
     }
 
-    pub(crate) fn insert_host_file(&self, raw_fd: RawFd) -> HostHandle {
+    pub(crate) fn insert_socket_resource(&self, raw_socket: RawSocket) -> HostHandle {
         #[cfg(unix)]
-        let file = HostFile::new(raw_fd);
+        let file = FileResource::new(raw_socket);
         #[cfg(windows)]
-        let file = HostFile::new_socket(raw_fd);
-        handle_from_key(self.state.lock().unwrap().files.insert(file))
+        let file = FileResource::new_socket(raw_socket);
+        handle_from_key(self.state.lock().unwrap().files.insert(Arc::new(file)))
     }
 
     pub(crate) fn with_raw_file<T>(
@@ -1380,12 +1317,16 @@ impl AsyncHost {
         f(state.file(handle)?.raw_fd())
     }
 
+    pub(crate) fn file_resource(&self, handle: HostHandle) -> AsyncHostResult<FileResourceRef> {
+        self.state.lock().unwrap().file(handle)
+    }
+
     pub(crate) fn pipe(
         &self,
         read_end_is_async: bool,
         write_end_is_async: bool,
     ) -> AsyncHostResult<[HostHandle; 2]> {
-        crate::async_sys::internal::fd_util::stub::pipe_host_files(
+        crate::async_sys::internal::fd_util::stub::pipe_file_resources(
             &mut self.state.lock().unwrap().files,
             read_end_is_async,
             write_end_is_async,
@@ -1991,15 +1932,15 @@ impl AsyncHost {
     }
 
     pub(crate) fn try_lock_file(&self, handle: HostHandle, exclusive: bool) -> AsyncHostResult<()> {
-        let mut state = self.state.lock().unwrap();
-        let file = state.file_mut(handle)?;
-        crate::async_sys::fs::stub::try_lock_host_file(file, exclusive)
+        let state = self.state.lock().unwrap();
+        let file = state.file(handle)?;
+        crate::async_sys::fs::stub::try_lock_file_resource(&file, exclusive)
     }
 
     pub(crate) fn unlock_file(&self, handle: HostHandle) -> AsyncHostResult<()> {
-        let mut state = self.state.lock().unwrap();
-        let file = state.file_mut(handle)?;
-        crate::async_sys::fs::stub::unlock_host_file(file)
+        let state = self.state.lock().unwrap();
+        let file = state.file(handle)?;
+        crate::async_sys::fs::stub::unlock_file_resource(&file)
     }
 
     pub(crate) fn run_job(&self, handle: u64) -> AsyncHostResult<()> {
@@ -2229,54 +2170,15 @@ struct SharedFileTable {
     state: Arc<Mutex<AsyncHostState>>,
 }
 
-impl HostFileTable for SharedFileTable {
+impl FileResourceTable for SharedFileTable {
     fn insert_file(&mut self, file: RawFd) -> AsyncHostResult<HostHandle> {
         Ok(handle_from_key(
-            self.state.lock().unwrap().files.insert(HostFile::new(file)),
+            self.state
+                .lock()
+                .unwrap()
+                .files
+                .insert(Arc::new(FileResource::new(file))),
         ))
-    }
-
-    fn is_invalid_file_handle(&self, handle: HostHandle) -> bool {
-        self.state
-            .lock()
-            .unwrap()
-            .files
-            .get(key_from_handle::<HostFileKey>(handle))
-            .is_some_and(HostFile::is_invalid)
-    }
-
-    #[cfg(windows)]
-    fn with_borrowed_raw_file<T>(
-        &mut self,
-        handle: HostHandle,
-        f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
-    ) -> AsyncHostResult<T> {
-        let state = self.state.lock().unwrap();
-        f(state.file(handle)?.raw_fd())
-    }
-
-    fn with_raw_file<U>(
-        &mut self,
-        handle: HostHandle,
-        f: impl FnOnce(RawFd) -> AsyncHostResult<U>,
-    ) -> AsyncHostResult<U> {
-        let file = {
-            let mut state = self.state.lock().unwrap();
-            state.file_mut(handle)?.duplicate()?
-        };
-        f(file.raw_fd())
-    }
-
-    fn with_host_file_mut<U>(
-        &mut self,
-        handle: HostHandle,
-        f: impl FnOnce(&mut HostFile) -> AsyncHostResult<U>,
-    ) -> AsyncHostResult<U> {
-        // Keep this path for host-owned file state operations such as readdir
-        // where duplicating the fd would change the directory cursor.
-        let mut state = self.state.lock().unwrap();
-        let file = state.file_mut(handle)?;
-        f(file)
     }
 }
 
@@ -2505,19 +2407,11 @@ mod tests {
     }
 
     #[test]
-    fn guest_memory_helpers_reject_unaligned_u16_storage() {
+    fn guest_memory_helpers_reject_odd_u16_offsets() {
         let mut memory = [0; 8];
-        let start = if (memory.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>()) {
-            1
-        } else {
-            0
-        };
 
-        assert_eq!(read_u16(&memory[start..], 0, 1), Err(AsyncHostError::Fault));
-        assert_eq!(
-            write_u16(&mut memory[start..], 0, &[1]),
-            Err(AsyncHostError::Fault)
-        );
+        assert_eq!(read_u16(&memory, 1, 1), Err(AsyncHostError::Fault));
+        assert_eq!(write_u16(&mut memory, 1, &[1]), Err(AsyncHostError::Fault));
     }
 
     #[test]
@@ -2543,7 +2437,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn completion_source_is_host_file_handle() {
+    fn completion_source_is_file_resource_handle() {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let completion_source = host.init_thread_pool(poll).unwrap();
@@ -2595,7 +2489,7 @@ mod tests {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
-        let job = thread_pool::make_read_job(0, 3, -1);
+        let job = thread_pool::make_read_job(Arc::new(FileResource::invalid()), 3, -1);
         let job_handle = host.insert_job(job).unwrap();
         {
             let mut state = host.state.lock().unwrap();
@@ -2731,7 +2625,11 @@ mod tests {
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let first_job = host
-            .insert_job(thread_pool::make_read_job(0, 1, -1))
+            .insert_job(thread_pool::make_read_job(
+                Arc::new(FileResource::invalid()),
+                1,
+                -1,
+            ))
             .unwrap();
         let old_worker = host.spawn_worker(42, first_job).unwrap();
         host.poll_wait(poll, 1000).unwrap();
@@ -2752,7 +2650,11 @@ mod tests {
 
         host.init_thread_pool(poll).unwrap();
         let second_job = host
-            .insert_job(thread_pool::make_read_job(0, 1, -1))
+            .insert_job(thread_pool::make_read_job(
+                Arc::new(FileResource::invalid()),
+                1,
+                -1,
+            ))
             .unwrap();
         let new_worker = host.spawn_worker(43, second_job).unwrap();
         let wake_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
@@ -2810,7 +2712,11 @@ mod tests {
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let job = host
-            .insert_job(thread_pool::make_read_job(0, 1, -1))
+            .insert_job(thread_pool::make_read_job(
+                Arc::new(FileResource::invalid()),
+                1,
+                -1,
+            ))
             .unwrap();
         let worker = host.spawn_worker(42, job).unwrap();
         host.poll_wait(poll, 1000).unwrap();
@@ -2834,35 +2740,20 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn shared_worker_file_survives_guest_close() {
+    fn acquired_file_resource_survives_guest_close() {
         let host = AsyncHost::default();
         let [read, write] = host.pipe(false, false).unwrap();
-        let mut files = SharedFileTable {
-            state: Arc::clone(&host.state),
-        };
+        let file = host.file_resource(read).unwrap();
 
-        let byte = files
-            .with_raw_file(read, |raw_read| {
-                host.close_fd(read)?;
-                let mut input = *b"x";
-                host.write_fd(&mut input, write, 0, 0, 1)?;
+        host.close_fd(read).unwrap();
+        let mut input = *b"x";
+        host.write_fd(&mut input, write, 0, 0, 1).unwrap();
 
-                let mut output = [0];
-                let ret = unsafe { libc::read(raw_read, output.as_mut_ptr().cast(), output.len()) };
-                if ret < 0 {
-                    Err(AsyncHostError::Native(
-                        std::io::Error::last_os_error()
-                            .raw_os_error()
-                            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
-                    ))
-                } else {
-                    assert_eq!(ret, 1);
-                    Ok(output[0])
-                }
-            })
-            .unwrap();
+        let mut output = [0];
+        let ret = unsafe { libc::read(file.raw_fd(), output.as_mut_ptr().cast(), output.len()) };
+        assert_eq!(ret, 1);
 
-        assert_eq!(byte, b'x');
+        assert_eq!(output[0], b'x');
         assert_eq!(host.close_fd(read), Err(AsyncHostError::Badf));
     }
 
@@ -3144,25 +3035,10 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         host.poll_register(poll, read, true).unwrap();
 
-        {
-            let mut state = host.state.lock().unwrap();
-            state
-                .files
-                .with_raw_file(write, |fd| {
-                    let byte = b"x";
-                    let ret = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
-                    if ret < 0 {
-                        Err(AsyncHostError::Native(
-                            std::io::Error::last_os_error()
-                                .raw_os_error()
-                                .unwrap_or_else(|| AsyncHostError::Inval.errno()),
-                        ))
-                    } else {
-                        Ok(())
-                    }
-                })
-                .unwrap();
-        }
+        let fd = host.file_resource(write).unwrap().raw_fd();
+        let byte = b"x";
+        let ret = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
+        assert_eq!(ret, 1);
 
         assert_eq!(host.poll_wait(poll, 100).unwrap(), 1);
         let event = host.poll_get_event(poll, 0).unwrap();

--- a/crates/moonrun/src/async_sys/fs/stub.rs
+++ b/crates/moonrun/src/async_sys/fs/stub.rs
@@ -19,7 +19,7 @@
 use std::ffi::OsString;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
-use crate::async_sys::internal::event_loop::thread_pool::HostFile;
+use crate::async_sys::internal::event_loop::thread_pool::FileResource;
 use crate::async_sys::ported_fns;
 
 #[cfg(unix)]
@@ -163,11 +163,11 @@ fn unlock_file_from_native_stub(handle: RawFileHandle) -> AsyncHostResult<()> {
     }
 }
 
-pub(crate) fn try_lock_host_file(file: &mut HostFile, exclusive: bool) -> AsyncHostResult<()> {
+pub(crate) fn try_lock_file_resource(file: &FileResource, exclusive: bool) -> AsyncHostResult<()> {
     try_lock_file(file.raw_fd(), exclusive)
 }
 
-pub(crate) fn unlock_host_file(file: &mut HostFile) -> AsyncHostResult<()> {
+pub(crate) fn unlock_file_resource(file: &FileResource) -> AsyncHostResult<()> {
     unlock_file(file.raw_fd())
 }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
@@ -47,7 +47,7 @@ impl ThreadPoolCompletionNotifier {
             return Err(error);
         }
 
-        // The read end is transferred to AsyncHost's HostFile table so poll
+        // The read end is transferred to AsyncHost's file table so poll
         // events report the same handle space as ordinary pipe/file fds.
         Ok((
             Self {

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -134,6 +134,19 @@ ported_fns! {
     }
 }
 
+pub(crate) fn poll_unregister(instance: &PollInstance, fd: RawFd) -> AsyncHostResult<()> {
+    if unsafe { libc::epoll_ctl(instance.fd, libc::EPOLL_CTL_DEL, fd, std::ptr::null_mut()) } < 0 {
+        let errno = super::last_errno();
+        if errno == libc::ENOENT {
+            Ok(())
+        } else {
+            Err(AsyncHostError::Native(errno))
+        }
+    } else {
+        Ok(())
+    }
+}
+
 fn epoll_event_mask(events: i32) -> AsyncHostResult<u32> {
     let mut mask = match events {
         READ_EVENT => libc::EPOLLIN,

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
@@ -21,7 +21,7 @@ use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::ported_fns;
 
 use super::{
-    EVENT_BUFFER_SIZE, PROCESS_EVENT, PollEvent, PollInstance, READ_EVENT, WRITE_EVENT,
+    EVENT_BUFFER_SIZE, PROCESS_EVENT, PollEvent, PollInstance, READ_EVENT, WRITE_EVENT, last_errno,
     last_native_error,
 };
 
@@ -150,6 +150,29 @@ ported_fns! {
     pub(crate) fn event_get_events(event: &PollEvent) -> i32 {
         event.events
     }
+}
+
+pub(crate) fn poll_unregister(instance: &PollInstance, fd: RawFd) -> AsyncHostResult<()> {
+    for filter in [libc::EVFILT_READ, libc::EVFILT_WRITE] {
+        let event = new_kevent(fd as libc::uintptr_t, filter, libc::EV_DELETE, 0, 0);
+        if unsafe {
+            libc::kevent(
+                instance.fd,
+                &event,
+                1,
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null(),
+            )
+        } < 0
+        {
+            let errno = last_errno();
+            if errno != libc::ENOENT {
+                return Err(AsyncHostError::Native(errno));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn kqueue_result_events(event: &libc::kevent) -> i32 {

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
@@ -167,6 +167,30 @@ mod tests {
     }
 
     #[test]
+    fn event_bus_unregister_removes_pipe_readiness() {
+        let mut fds = [0; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let read_fd = fds[0];
+        let write_fd = fds[1];
+
+        let mut poll = poll_create().unwrap();
+        poll_register(&poll, read_fd, true).unwrap();
+        poll_unregister(&poll, read_fd).unwrap();
+        let byte = b"x";
+        assert_eq!(
+            unsafe { libc::write(write_fd, byte.as_ptr().cast(), byte.len()) },
+            1
+        );
+
+        assert_eq!(poll_wait(&mut poll, 0).unwrap(), 0);
+
+        unsafe {
+            libc::close(read_fd);
+            libc::close(write_fd);
+        }
+    }
+
+    #[test]
     fn ported_symbols_reference_native_sources() {
         let async_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../third_party/moonbitlang_async");

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -249,6 +249,7 @@ ported_fns! {
         restart: bool,
     ) -> AsyncHostResult<i64> {
         let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        let _directory_cursor = dir.lock_directory_cursor();
         let mut buffer = buffer.lock().unwrap();
         let buffer = buffer.get_mut(..len).ok_or(AsyncHostError::Fault)?;
         read_native_dir(dir, buffer, restart)

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -25,7 +25,7 @@ use crate::async_host::{AsyncHostError, AsyncHostResult, HostCBuffer};
 use crate::async_sys::internal::fd_util;
 use crate::async_sys::ported_fns;
 
-use super::{FileTimeResult, HostFile, HostFileTable, HostHandle, OpenJobResult};
+use super::{FileResource, FileResourceTable, FileTimeResult, OpenJobResult};
 
 type RawFile = fd_util::stub::RawFd;
 
@@ -36,7 +36,7 @@ ported_fns! {
     )]
     #[allow(clippy::too_many_arguments)]
     pub(super) fn run_open_job(
-        files: &mut impl HostFileTable,
+        files: &mut impl FileResourceTable,
         result: &mut Option<OpenJobResult>,
         filename: OsString,
         access: i32,
@@ -66,19 +66,16 @@ ported_fns! {
         original = "read_job_worker"
     )]
     pub(super) fn run_read_job(
-        files: &mut impl HostFileTable,
-        fd: HostHandle,
+        file: &FileResource,
         len: i32,
         position: i64,
         result: &mut Option<Vec<u8>>,
     ) -> AsyncHostResult<i64> {
-        files.with_raw_file(fd, |file| {
-            let mut buf = vec![0; usize::try_from(len).map_err(|_| AsyncHostError::Fault)?];
-            let n = read_from_native_file(file, &mut buf, position)?;
-            buf.truncate(n);
-            *result = Some(buf);
-            Ok(n as i64)
-        })
+        let mut buf = vec![0; usize::try_from(len).map_err(|_| AsyncHostError::Fault)?];
+        let n = read_from_native_file(file.raw_fd(), &mut buf, position)?;
+        buf.truncate(n);
+        *result = Some(buf);
+        Ok(n as i64)
     }
 
     #[ported(
@@ -86,15 +83,12 @@ ported_fns! {
         original = "write_job_worker"
     )]
     pub(super) fn run_write_job(
-        files: &mut impl HostFileTable,
-        fd: HostHandle,
+        file: &FileResource,
         data: &[u8],
         position: i64,
     ) -> AsyncHostResult<i64> {
-        files.with_raw_file(fd, |file| {
-            let n = write_to_native_file(file, data, position)?;
-            Ok(n as i64)
-        })
+        let n = write_to_native_file(file.raw_fd(), data, position)?;
+        Ok(n as i64)
     }
 
     #[ported(
@@ -102,12 +96,11 @@ ported_fns! {
         original = "file_kind_by_path_job_worker"
     )]
     pub(super) fn run_file_kind_by_path_job(
-        files: &mut impl HostFileTable,
-        parent: HostHandle,
+        parent: Option<&FileResource>,
         path: OsString,
         follow_symlink: bool,
     ) -> AsyncHostResult<i64> {
-        file_kind_by_path(files, parent, path, follow_symlink).map(i64::from)
+        file_kind_by_path(parent, path, follow_symlink).map(i64::from)
     }
 
     #[ported(
@@ -115,14 +108,11 @@ ported_fns! {
         original = "file_size_job_worker"
     )]
     pub(super) fn run_file_size_job(
-        files: &mut impl HostFileTable,
-        fd: HostHandle,
+        file: &FileResource,
         result: &mut i64,
     ) -> AsyncHostResult<i64> {
-        files.with_raw_file(fd, |file| {
-            *result = file_size(file)?;
-            Ok(0)
-        })
+        *result = file_size(file.raw_fd())?;
+        Ok(0)
     }
 
     #[ported(
@@ -130,14 +120,11 @@ ported_fns! {
         original = "file_time_job_worker"
     )]
     pub(super) fn run_file_time_job(
-        files: &mut impl HostFileTable,
-        fd: HostHandle,
+        file: &FileResource,
         result: &mut Option<FileTimeResult>,
     ) -> AsyncHostResult<i64> {
-        files.with_raw_file(fd, |file| {
-            *result = Some(FileTimeResult::new(file_time(file)?));
-            Ok(0)
-        })
+        *result = Some(FileTimeResult::new(file_time(file.raw_fd())?));
+        Ok(0)
     }
 
     #[ported(
@@ -179,14 +166,11 @@ ported_fns! {
         original = "fsync_job_worker"
     )]
     pub(super) fn run_fsync_job(
-        files: &mut impl HostFileTable,
-        fd: HostHandle,
+        file: &FileResource,
         only_data: bool,
     ) -> AsyncHostResult<i64> {
-        files.with_raw_file(fd, |file| {
-            sync_native_file(file, only_data)?;
-            Ok(0)
-        })
+        sync_native_file(file.raw_fd(), only_data)?;
+        Ok(0)
     }
 
     #[ported(
@@ -194,27 +178,11 @@ ported_fns! {
         original = "flock_job_worker"
     )]
     pub(super) fn run_flock_job(
-        files: &mut impl HostFileTable,
-        fd: HostHandle,
+        file: &FileResource,
         exclusive: bool,
     ) -> AsyncHostResult<i64> {
-        #[cfg(windows)]
-        {
-            // Windows byte-range locks are tied to the handle used for
-            // LockFileEx/UnlockFile. Native async passes the same HANDLE to the
-            // flock worker and unlock stub, so the wasm host must not duplicate
-            // the handle here or it creates a separate lock identity.
-            files.with_borrowed_raw_file(fd, |file| {
-                lock_native_file(file, exclusive)?;
-                Ok(0)
-            })
-        }
-
-        #[cfg(not(windows))]
-        files.with_raw_file(fd, |file| {
-            lock_native_file(file, exclusive)?;
-            Ok(0)
-        })
+        lock_native_file(file.raw_fd(), exclusive)?;
+        Ok(0)
     }
 
     #[ported(
@@ -275,8 +243,7 @@ ported_fns! {
         original = "readdir_job_worker"
     )]
     pub(super) fn run_readdir_job(
-        files: &mut impl HostFileTable,
-        dir: HostHandle,
+        dir: &FileResource,
         buffer: &HostCBuffer,
         len: i32,
         restart: bool,
@@ -284,9 +251,7 @@ ported_fns! {
         let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
         let mut buffer = buffer.lock().unwrap();
         let buffer = buffer.get_mut(..len).ok_or(AsyncHostError::Fault)?;
-        files.with_host_file_mut(dir, |file| {
-            read_native_dir(file, buffer, restart)
-        })
+        read_native_dir(dir, buffer, restart)
     }
 }
 
@@ -607,8 +572,7 @@ fn write_to_native_file(fd: RawFile, data: &[u8], position: i64) -> AsyncHostRes
 
 #[cfg(unix)]
 fn file_kind_by_path(
-    files: &mut impl HostFileTable,
-    parent: HostHandle,
+    parent: Option<&FileResource>,
     path: OsString,
     follow_symlink: bool,
 ) -> AsyncHostResult<i32> {
@@ -619,13 +583,8 @@ fn file_kind_by_path(
         libc::AT_SYMLINK_NOFOLLOW
     };
     let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-    let ret = if files.is_invalid_file_handle(parent) {
-        unsafe { libc::fstatat(libc::AT_FDCWD, path.as_ptr(), stat.as_mut_ptr(), flags) }
-    } else {
-        files.with_raw_file(parent, |fd| {
-            Ok(unsafe { libc::fstatat(fd, path.as_ptr(), stat.as_mut_ptr(), flags) })
-        })?
-    };
+    let parent = parent.map(FileResource::raw_fd).unwrap_or(libc::AT_FDCWD);
+    let ret = unsafe { libc::fstatat(parent, path.as_ptr(), stat.as_mut_ptr(), flags) };
     if ret < 0 {
         Err(last_native_error())
     } else {
@@ -781,7 +740,7 @@ fn rmdir_native_path(path: OsString) -> AsyncHostResult<()> {
 }
 
 #[cfg(all(unix, target_os = "linux"))]
-fn read_native_dir(file: &mut HostFile, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
+fn read_native_dir(file: &FileResource, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
     let fd = file.raw_fd();
     if restart && unsafe { libc::lseek(fd, 0, libc::SEEK_SET) } < 0 {
         return Err(last_native_error());
@@ -797,7 +756,7 @@ fn read_native_dir(file: &mut HostFile, out: &mut [u8], restart: bool) -> AsyncH
 }
 
 #[cfg(all(unix, target_os = "macos"))]
-fn read_native_dir(file: &mut HostFile, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
+fn read_native_dir(file: &FileResource, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
     let fd = file.raw_fd();
     if restart && unsafe { libc::lseek(fd, 0, libc::SEEK_SET) } < 0 {
         return Err(last_native_error());
@@ -1045,8 +1004,7 @@ fn restore_file_pointer(
 
 #[cfg(windows)]
 fn file_kind_by_path(
-    files: &mut impl HostFileTable,
-    parent: HostHandle,
+    parent: Option<&FileResource>,
     path: OsString,
     follow_symlink: bool,
 ) -> AsyncHostResult<i32> {
@@ -1061,7 +1019,7 @@ fn file_kind_by_path(
     if !follow_symlink {
         flags |= FILE_FLAG_OPEN_REPARSE_POINT;
     }
-    let path = resolve_windows_path_for_parent(files, parent, path)?;
+    let path = resolve_windows_path_for_parent(parent, path)?;
     let path = path_to_wide(path);
     let handle: HANDLE = unsafe {
         CreateFileW(
@@ -1086,19 +1044,19 @@ fn file_kind_by_path(
 
 #[cfg(windows)]
 fn resolve_windows_path_for_parent(
-    files: &mut impl HostFileTable,
-    parent: HostHandle,
+    parent: Option<&FileResource>,
     path: OsString,
 ) -> AsyncHostResult<OsString> {
-    if files.is_invalid_file_handle(parent) || std::path::Path::new(&path).is_absolute() {
+    let Some(parent) = parent else {
+        return Ok(path);
+    };
+    if std::path::Path::new(&path).is_absolute() {
         return Ok(path);
     }
 
-    files.with_raw_file(parent, |file| {
-        let mut parent_path = std::path::PathBuf::from(final_path_from_handle(file)?);
-        parent_path.push(path);
-        Ok(parent_path.into_os_string())
-    })
+    let mut parent_path = std::path::PathBuf::from(final_path_from_handle(parent.raw_fd())?);
+    parent_path.push(path);
+    Ok(parent_path.into_os_string())
 }
 
 #[cfg(windows)]
@@ -1534,7 +1492,7 @@ fn rmdir_native_path(path: OsString) -> AsyncHostResult<()> {
 }
 
 #[cfg(windows)]
-fn read_native_dir(file: &mut HostFile, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
+fn read_native_dir(file: &FileResource, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
     use windows_sys::Win32::Foundation::{ERROR_NO_MORE_FILES, HANDLE};
     use windows_sys::Win32::Storage::FileSystem::{
         FileIdBothDirectoryInfo, FileIdBothDirectoryRestartInfo, GetFileInformationByHandleEx,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -82,7 +82,7 @@ ported_fns! {
         position: i64,
     ) -> Job {
         Job::new(JobPayload::Read {
-            file,
+            file: Some(file),
             len,
             position,
             result: None,
@@ -94,7 +94,11 @@ ported_fns! {
         original = "moonbitlang_async_make_write_job"
     )]
     pub(crate) fn make_write_job(file: FileResourceRef, data: Vec<u8>, position: i64) -> Job {
-        Job::new(JobPayload::Write { file, data, position })
+        Job::new(JobPayload::Write {
+            file: Some(file),
+            data,
+            position,
+        })
     }
 
     #[ported(
@@ -173,7 +177,10 @@ ported_fns! {
         original = "moonbitlang_async_make_file_size_job"
     )]
     pub(crate) fn make_file_size_job(file: FileResourceRef) -> Job {
-        Job::new(JobPayload::FileSize { file, result: 0 })
+        Job::new(JobPayload::FileSize {
+            file: Some(file),
+            result: 0,
+        })
     }
 
     #[ported(
@@ -182,7 +189,7 @@ ported_fns! {
     )]
     pub(crate) fn make_file_time_job(file: FileResourceRef) -> Job {
         Job::new(JobPayload::FileTime {
-            file,
+            file: Some(file),
             result: None,
         })
     }
@@ -234,7 +241,10 @@ ported_fns! {
         original = "moonbitlang_async_make_fsync_job"
     )]
     pub(crate) fn make_fsync_job(file: FileResourceRef, only_data: bool) -> Job {
-        Job::new(JobPayload::Fsync { file, only_data })
+        Job::new(JobPayload::Fsync {
+            file: Some(file),
+            only_data,
+        })
     }
 
     #[ported(
@@ -242,7 +252,10 @@ ported_fns! {
         original = "moonbitlang_async_make_flock_job"
     )]
     pub(crate) fn make_flock_job(file: FileResourceRef, exclusive: bool) -> Job {
-        Job::new(JobPayload::Flock { file, exclusive })
+        Job::new(JobPayload::Flock {
+            file: Some(file),
+            exclusive,
+        })
     }
 
     #[ported(
@@ -304,7 +317,7 @@ ported_fns! {
         restart: bool,
     ) -> Job {
         Job::new(JobPayload::Readdir {
-            dir,
+            dir: Some(dir),
             buffer,
             len,
             restart,
@@ -316,7 +329,10 @@ ported_fns! {
         original = "moonbitlang_async_make_bind_job"
     )]
     pub(crate) fn make_bind_job(socket: FileResourceRef, addr: Vec<u8>) -> Job {
-        Job::new(JobPayload::Bind { socket, addr })
+        Job::new(JobPayload::Bind {
+            socket: Some(socket),
+            addr,
+        })
     }
 
     #[ported(
@@ -337,6 +353,13 @@ pub(crate) fn open_job_result(job: &Job) -> AsyncHostResult<&OpenJobResult> {
         } => Ok(result),
         JobPayload::Open { .. } => Err(AsyncHostError::Inval),
         _ => Err(AsyncHostError::Badf),
+    }
+}
+
+pub(crate) fn take_open_job_result(job: &mut Job) -> Option<OpenJobResult> {
+    match job.payload_mut() {
+        JobPayload::Open { result, .. } => result.take(),
+        _ => None,
     }
 }
 
@@ -383,7 +406,7 @@ mod tests {
 
         match job.payload() {
             JobPayload::Read {
-                file: actual_file,
+                file: Some(actual_file),
                 len,
                 position,
                 result: None,
@@ -430,6 +453,19 @@ mod tests {
 
         assert_eq!(job_get_ret(&job), 0);
         assert_eq!(job_get_err(&job), 0);
+    }
+
+    #[test]
+    fn resource_job_releases_file_when_worker_finishes() {
+        let file = Arc::new(FileResource::invalid());
+        let file_ref = Arc::downgrade(&file);
+        let mut job = make_flock_job(Arc::clone(&file), true);
+        let mut files = NoFiles;
+        drop(file);
+
+        run_host_job(&mut job, &mut files);
+
+        assert!(file_ref.upgrade().is_none());
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -21,7 +21,7 @@ use std::ffi::OsString;
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::ported_fns;
 
-use super::types::{HostHandle, Job, JobPayload, OpenJobResult, platform};
+use super::types::{FileResourceRef, HostHandle, Job, JobPayload, OpenJobResult, platform};
 
 ported_fns! {
     #[ported(
@@ -77,12 +77,12 @@ ported_fns! {
         original = "moonbitlang_async_make_read_job"
     )]
     pub(crate) fn make_read_job(
-        fd: HostHandle,
+        file: FileResourceRef,
         len: i32,
         position: i64,
     ) -> Job {
         Job::new(JobPayload::Read {
-            fd,
+            file,
             len,
             position,
             result: None,
@@ -93,8 +93,8 @@ ported_fns! {
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_make_write_job"
     )]
-    pub(crate) fn make_write_job(fd: HostHandle, data: Vec<u8>, position: i64) -> Job {
-        Job::new(JobPayload::Write { fd, data, position })
+    pub(crate) fn make_write_job(file: FileResourceRef, data: Vec<u8>, position: i64) -> Job {
+        Job::new(JobPayload::Write { file, data, position })
     }
 
     #[ported(
@@ -125,7 +125,7 @@ ported_fns! {
         original = "moonbitlang_async_make_file_kind_by_path_job"
     )]
     pub(crate) fn make_file_kind_by_path_job(
-        parent: HostHandle,
+        parent: Option<FileResourceRef>,
         path: OsString,
         follow_symlink: bool,
     ) -> Job {
@@ -172,17 +172,17 @@ ported_fns! {
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_make_file_size_job"
     )]
-    pub(crate) fn make_file_size_job(fd: HostHandle) -> Job {
-        Job::new(JobPayload::FileSize { fd, result: 0 })
+    pub(crate) fn make_file_size_job(file: FileResourceRef) -> Job {
+        Job::new(JobPayload::FileSize { file, result: 0 })
     }
 
     #[ported(
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_make_file_time_job"
     )]
-    pub(crate) fn make_file_time_job(fd: HostHandle) -> Job {
+    pub(crate) fn make_file_time_job(file: FileResourceRef) -> Job {
         Job::new(JobPayload::FileTime {
-            fd,
+            file,
             result: None,
         })
     }
@@ -233,16 +233,16 @@ ported_fns! {
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_make_fsync_job"
     )]
-    pub(crate) fn make_fsync_job(fd: HostHandle, only_data: bool) -> Job {
-        Job::new(JobPayload::Fsync { fd, only_data })
+    pub(crate) fn make_fsync_job(file: FileResourceRef, only_data: bool) -> Job {
+        Job::new(JobPayload::Fsync { file, only_data })
     }
 
     #[ported(
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_make_flock_job"
     )]
-    pub(crate) fn make_flock_job(fd: HostHandle, exclusive: bool) -> Job {
-        Job::new(JobPayload::Flock { fd, exclusive })
+    pub(crate) fn make_flock_job(file: FileResourceRef, exclusive: bool) -> Job {
+        Job::new(JobPayload::Flock { file, exclusive })
     }
 
     #[ported(
@@ -298,7 +298,7 @@ ported_fns! {
         original = "moonbitlang_async_make_readdir_job"
     )]
     pub(crate) fn make_readdir_job(
-        dir: HostHandle,
+        dir: FileResourceRef,
         buffer: crate::async_host::HostCBuffer,
         len: i32,
         restart: bool,
@@ -315,7 +315,7 @@ ported_fns! {
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_make_bind_job"
     )]
-    pub(crate) fn make_bind_job(socket: HostHandle, addr: Vec<u8>) -> Job {
+    pub(crate) fn make_bind_job(socket: FileResourceRef, addr: Vec<u8>) -> Job {
         Job::new(JobPayload::Bind { socket, addr })
     }
 
@@ -355,43 +355,15 @@ pub(crate) fn getaddrinfo_job_result(job: &Job) -> AsyncHostResult<&[Box<[u8]>]>
 mod tests {
     use super::*;
     use crate::async_sys::internal::event_loop::thread_pool::{
-        HostFile, HostFileTable, run_host_job,
+        FileResource, FileResourceTable, run_host_job,
     };
     use crate::async_sys::internal::fd_util::stub::RawFd;
+    use std::sync::Arc;
 
     struct NoFiles;
 
-    impl HostFileTable for NoFiles {
+    impl FileResourceTable for NoFiles {
         fn insert_file(&mut self, _file: RawFd) -> AsyncHostResult<HostHandle> {
-            unreachable!("sleep jobs do not access files")
-        }
-
-        fn is_invalid_file_handle(&self, _handle: HostHandle) -> bool {
-            unreachable!("sleep jobs do not access files")
-        }
-
-        #[cfg(windows)]
-        fn with_borrowed_raw_file<T>(
-            &mut self,
-            _handle: HostHandle,
-            _f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
-        ) -> AsyncHostResult<T> {
-            unreachable!("sleep jobs do not access files")
-        }
-
-        fn with_raw_file<T>(
-            &mut self,
-            _handle: HostHandle,
-            _f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
-        ) -> AsyncHostResult<T> {
-            unreachable!("sleep jobs do not access files")
-        }
-
-        fn with_host_file_mut<T>(
-            &mut self,
-            _handle: HostHandle,
-            _f: impl FnOnce(&mut HostFile) -> AsyncHostResult<T>,
-        ) -> AsyncHostResult<T> {
             unreachable!("sleep jobs do not access files")
         }
     }
@@ -405,17 +377,18 @@ mod tests {
     }
 
     #[test]
-    fn read_job_carries_host_handle_and_length_payload() {
-        let job = make_read_job(7, 8, -1);
+    fn read_job_carries_file_resource_and_length_payload() {
+        let file = Arc::new(FileResource::invalid());
+        let job = make_read_job(Arc::clone(&file), 8, -1);
 
         match job.payload() {
             JobPayload::Read {
-                fd,
+                file: actual_file,
                 len,
                 position,
                 result: None,
             } => {
-                assert_eq!(*fd, 7);
+                assert!(Arc::ptr_eq(actual_file, &file));
                 assert_eq!(*len, 8);
                 assert_eq!(*position, -1);
             }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use jobs::{
     make_fsync_job, make_getaddrinfo_job, make_mkdir_job, make_open_job, make_read_job,
     make_readdir_job, make_remove_job, make_rename_job, make_rmdir_job, make_sleep_job,
     make_symlink_job, make_write_job, open_job_get_dev_id, open_job_get_fd, open_job_get_file_id,
-    open_job_get_kind, open_job_result,
+    open_job_get_kind, open_job_result, take_open_job_result,
 };
 pub(crate) use runner::{get_file_time_result, get_read_result, run_host_job};
 #[cfg(all(test, unix))]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -36,7 +36,10 @@ pub(crate) use jobs::{
 pub(crate) use runner::{get_file_time_result, get_read_result, run_host_job};
 #[cfg(all(test, unix))]
 pub(crate) use types::JobPayload;
-pub(crate) use types::{FileTimeResult, HostFile, HostFileTable, HostHandle, Job, OpenJobResult};
+pub(crate) use types::{
+    FileResource, FileResourceRef, FileResourceTable, FileTimeResult, HostHandle, Job,
+    OpenJobResult,
+};
 pub(crate) use worker::{
     HostWorkerHandle, HostWorkerJob, cancel_worker, free_worker, spawn_worker, wake_worker,
     worker_enter_idle,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -60,19 +60,34 @@ pub(crate) fn run_host_job(job: &mut Job, files: &mut impl FileResourceTable) {
             len,
             position,
             result,
-        } => run_read_job(file, *len, *position, result),
+        } => match file.take() {
+            Some(file) => run_read_job(&file, *len, *position, result),
+            None => Err(AsyncHostError::Badf),
+        },
         JobPayload::Write {
             file,
             data,
             position,
-        } => run_write_job(file, data, *position),
+        } => match file.take() {
+            Some(file) => run_write_job(&file, data, *position),
+            None => Err(AsyncHostError::Badf),
+        },
         JobPayload::FileKindByPath {
             parent,
             path,
             follow_symlink,
-        } => run_file_kind_by_path_job(parent.as_deref(), path.clone(), *follow_symlink),
-        JobPayload::FileSize { file, result } => run_file_size_job(file, result),
-        JobPayload::FileTime { file, result, .. } => run_file_time_job(file, result),
+        } => {
+            let parent = parent.take();
+            run_file_kind_by_path_job(parent.as_deref(), path.clone(), *follow_symlink)
+        }
+        JobPayload::FileSize { file, result } => match file.take() {
+            Some(file) => run_file_size_job(&file, result),
+            None => Err(AsyncHostError::Badf),
+        },
+        JobPayload::FileTime { file, result, .. } => match file.take() {
+            Some(file) => run_file_time_job(&file, result),
+            None => Err(AsyncHostError::Badf),
+        },
         JobPayload::FileTimeByPath {
             path,
             follow_symlink,
@@ -81,8 +96,14 @@ pub(crate) fn run_host_job(job: &mut Job, files: &mut impl FileResourceTable) {
         } => run_file_time_by_path_job(path.clone(), *follow_symlink, result),
         JobPayload::Access { path, access } => run_access_job(path.clone(), *access),
         JobPayload::Chmod { path, mode } => run_chmod_job(path.clone(), *mode),
-        JobPayload::Fsync { file, only_data } => run_fsync_job(file, *only_data),
-        JobPayload::Flock { file, exclusive } => run_flock_job(file, *exclusive),
+        JobPayload::Fsync { file, only_data } => match file.take() {
+            Some(file) => run_fsync_job(&file, *only_data),
+            None => Err(AsyncHostError::Badf),
+        },
+        JobPayload::Flock { file, exclusive } => match file.take() {
+            Some(file) => run_flock_job(&file, *exclusive),
+            None => Err(AsyncHostError::Badf),
+        },
         JobPayload::Remove { path } => run_remove_job(path.clone()),
         JobPayload::Rename {
             old_path,
@@ -101,8 +122,14 @@ pub(crate) fn run_host_job(job: &mut Job, files: &mut impl FileResourceTable) {
             buffer,
             len,
             restart,
-        } => run_readdir_job(dir, buffer, *len, *restart),
-        JobPayload::Bind { socket, addr } => run_bind_job(socket, addr),
+        } => match dir.take() {
+            Some(dir) => run_readdir_job(&dir, buffer, *len, *restart),
+            None => Err(AsyncHostError::Badf),
+        },
+        JobPayload::Bind { socket, addr } => match socket.take() {
+            Some(socket) => run_bind_job(&socket, addr),
+            None => Err(AsyncHostError::Badf),
+        },
         JobPayload::GetAddrInfo { host, result } => run_getaddrinfo_job(host.clone(), result),
     };
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -27,9 +27,9 @@ use super::fs::{
 };
 use super::sleep::run_sleep_job;
 use super::socket::{run_bind_job, run_getaddrinfo_job};
-use super::types::{HostFileTable, Job, JobPayload};
+use super::types::{FileResourceTable, Job, JobPayload};
 
-pub(crate) fn run_host_job(job: &mut Job, files: &mut impl HostFileTable) {
+pub(crate) fn run_host_job(job: &mut Job, files: &mut impl FileResourceTable) {
     job.set_ret(0);
 
     let result = match job.payload_mut() {
@@ -56,19 +56,23 @@ pub(crate) fn run_host_job(job: &mut Job, files: &mut impl HostFileTable) {
             *mode,
         ),
         JobPayload::Read {
-            fd,
+            file,
             len,
             position,
             result,
-        } => run_read_job(files, *fd, *len, *position, result),
-        JobPayload::Write { fd, data, position } => run_write_job(files, *fd, data, *position),
+        } => run_read_job(file, *len, *position, result),
+        JobPayload::Write {
+            file,
+            data,
+            position,
+        } => run_write_job(file, data, *position),
         JobPayload::FileKindByPath {
             parent,
             path,
             follow_symlink,
-        } => run_file_kind_by_path_job(files, *parent, path.clone(), *follow_symlink),
-        JobPayload::FileSize { fd, result } => run_file_size_job(files, *fd, result),
-        JobPayload::FileTime { fd, result, .. } => run_file_time_job(files, *fd, result),
+        } => run_file_kind_by_path_job(parent.as_deref(), path.clone(), *follow_symlink),
+        JobPayload::FileSize { file, result } => run_file_size_job(file, result),
+        JobPayload::FileTime { file, result, .. } => run_file_time_job(file, result),
         JobPayload::FileTimeByPath {
             path,
             follow_symlink,
@@ -77,8 +81,8 @@ pub(crate) fn run_host_job(job: &mut Job, files: &mut impl HostFileTable) {
         } => run_file_time_by_path_job(path.clone(), *follow_symlink, result),
         JobPayload::Access { path, access } => run_access_job(path.clone(), *access),
         JobPayload::Chmod { path, mode } => run_chmod_job(path.clone(), *mode),
-        JobPayload::Fsync { fd, only_data } => run_fsync_job(files, *fd, *only_data),
-        JobPayload::Flock { fd, exclusive } => run_flock_job(files, *fd, *exclusive),
+        JobPayload::Fsync { file, only_data } => run_fsync_job(file, *only_data),
+        JobPayload::Flock { file, exclusive } => run_flock_job(file, *exclusive),
         JobPayload::Remove { path } => run_remove_job(path.clone()),
         JobPayload::Rename {
             old_path,
@@ -97,8 +101,8 @@ pub(crate) fn run_host_job(job: &mut Job, files: &mut impl HostFileTable) {
             buffer,
             len,
             restart,
-        } => run_readdir_job(files, *dir, buffer, *len, *restart),
-        JobPayload::Bind { socket, addr } => run_bind_job(files, *socket, addr),
+        } => run_readdir_job(dir, buffer, *len, *restart),
+        JobPayload::Bind { socket, addr } => run_bind_job(socket, addr),
         JobPayload::GetAddrInfo { host, result } => run_getaddrinfo_job(host.clone(), result),
     };
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/socket.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/socket.rs
@@ -21,7 +21,7 @@ use std::ffi::OsString;
 use crate::async_host::AsyncHostResult;
 use crate::async_sys::ported_fns;
 
-use super::{HostFileTable, HostHandle};
+use super::FileResource;
 
 ported_fns! {
     #[ported(
@@ -29,26 +29,11 @@ ported_fns! {
         original = "bind_job_worker"
     )]
         pub(super) fn run_bind_job(
-        files: &mut impl HostFileTable,
-        socket: HostHandle,
+        socket: &FileResource,
         addr: &[u8],
     ) -> AsyncHostResult<i64> {
-        #[cfg(unix)]
-        {
-            files.with_raw_file(socket, |socket| {
-                crate::async_sys::socket::bind(socket, addr)?;
-                Ok(0)
-            })
-        }
-        #[cfg(windows)]
-        {
-            // `with_raw_file` duplicates with DuplicateHandle on Windows, which
-            // does not produce a valid duplicate Winsock SOCKET.
-            files.with_borrowed_raw_file(socket, |socket| {
-                crate::async_sys::socket::bind(socket, addr)?;
-                Ok(0)
-            })
-        }
+        crate::async_sys::socket::bind(socket.raw_fd(), addr)?;
+        Ok(0)
     }
 
     #[ported(
@@ -62,60 +47,5 @@ ported_fns! {
         let (ret, addrs) = crate::async_sys::socket::copy_sockaddrs_from_getaddrinfo(host)?;
         *result = Some(addrs);
         Ok(i64::from(ret))
-    }
-}
-
-#[cfg(all(test, windows))]
-mod tests {
-    use super::*;
-    use crate::async_host::AsyncHostResult;
-    use crate::async_sys::internal::event_loop::thread_pool::HostFile;
-    use crate::async_sys::internal::fd_util::stub::RawFd;
-
-    struct TrackingFiles {
-        borrowed: bool,
-    }
-
-    impl HostFileTable for TrackingFiles {
-        fn insert_file(&mut self, _file: RawFd) -> AsyncHostResult<HostHandle> {
-            unreachable!("bind job test does not insert files")
-        }
-
-        fn is_invalid_file_handle(&self, _handle: HostHandle) -> bool {
-            unreachable!("bind job test does not query file validity")
-        }
-
-        fn with_borrowed_raw_file<T>(
-            &mut self,
-            _handle: HostHandle,
-            f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
-        ) -> AsyncHostResult<T> {
-            self.borrowed = true;
-            f(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE)
-        }
-
-        fn with_raw_file<T>(
-            &mut self,
-            _handle: HostHandle,
-            _f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
-        ) -> AsyncHostResult<T> {
-            panic!("Windows socket bind jobs must not duplicate SOCKET handles")
-        }
-
-        fn with_host_file_mut<T>(
-            &mut self,
-            _handle: HostHandle,
-            _f: impl FnOnce(&mut HostFile) -> AsyncHostResult<T>,
-        ) -> AsyncHostResult<T> {
-            unreachable!("bind job test does not mutate host files")
-        }
-    }
-
-    #[test]
-    fn windows_bind_job_borrows_socket_handle() {
-        let mut files = TrackingFiles { borrowed: false };
-        let result = run_bind_job(&mut files, 1, &[]);
-        assert!(result.is_err());
-        assert!(files.borrowed);
     }
 }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -17,7 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use std::ffi::OsString;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use crate::async_host::{AsyncHostResult, HostCBuffer};
 use crate::async_sys::internal::fd_util;
@@ -41,6 +41,8 @@ type OwnedRawFile = OwnedHandle;
 #[derive(Debug)]
 pub(crate) struct FileResource {
     raw: RawFileResource,
+    // Native directory enumeration mutates cursor state on the opened resource.
+    directory_cursor: Mutex<()>,
 }
 
 #[derive(Debug)]
@@ -58,6 +60,7 @@ impl FileResource {
         }
         Self {
             raw: RawFileResource::File(owned_raw_file(raw)),
+            directory_cursor: Mutex::new(()),
         }
     }
 
@@ -68,12 +71,14 @@ impl FileResource {
         }
         Self {
             raw: RawFileResource::Socket(owned_raw_socket(raw)),
+            directory_cursor: Mutex::new(()),
         }
     }
 
     pub(crate) fn invalid() -> Self {
         Self {
             raw: RawFileResource::Invalid,
+            directory_cursor: Mutex::new(()),
         }
     }
 
@@ -88,6 +93,10 @@ impl FileResource {
             #[cfg(windows)]
             RawFileResource::Socket(raw) => raw_socket(raw),
         }
+    }
+
+    pub(crate) fn lock_directory_cursor(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.directory_cursor.lock().unwrap()
     }
 }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -17,72 +17,76 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use std::ffi::OsString;
+use std::sync::Arc;
 
-use crate::async_host::{AsyncHostError, AsyncHostResult, HostCBuffer};
+use crate::async_host::{AsyncHostResult, HostCBuffer};
 use crate::async_sys::internal::fd_util;
 
-pub(crate) type HostHandle = u64;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+#[cfg(windows)]
+use std::os::windows::io::{
+    AsRawHandle, AsRawSocket, FromRawHandle, FromRawSocket, OwnedHandle, OwnedSocket, RawSocket,
+};
+
+pub(crate) type ResourceHandle = u64;
+pub(crate) type HostHandle = ResourceHandle;
+pub(crate) type FileResourceRef = Arc<FileResource>;
+
+#[cfg(unix)]
+type OwnedRawFile = OwnedFd;
+#[cfg(windows)]
+type OwnedRawFile = OwnedHandle;
 
 #[derive(Debug)]
-pub(crate) struct HostFile {
-    raw: fd_util::stub::RawFd,
-    close_kind: HostFileCloseKind,
+pub(crate) struct FileResource {
+    raw: RawFileResource,
 }
 
-#[cfg(windows)]
-unsafe impl Send for HostFile {}
-
-#[derive(Debug, Clone, Copy)]
-enum HostFileCloseKind {
-    File,
+#[derive(Debug)]
+enum RawFileResource {
+    Invalid,
+    File(OwnedRawFile),
     #[cfg(windows)]
-    Socket,
+    Socket(OwnedSocket),
 }
 
-impl HostFile {
+impl FileResource {
     pub(crate) fn new(raw: fd_util::stub::RawFd) -> Self {
+        if raw == invalid_raw_file() {
+            return Self::invalid();
+        }
         Self {
-            raw,
-            close_kind: HostFileCloseKind::File,
+            raw: RawFileResource::File(owned_raw_file(raw)),
         }
     }
 
     #[cfg(windows)]
-    pub(crate) fn new_socket(raw: fd_util::stub::RawFd) -> Self {
+    pub(crate) fn new_socket(raw: RawSocket) -> Self {
+        if raw == invalid_raw_socket() {
+            return Self::invalid();
+        }
         Self {
-            raw,
-            close_kind: HostFileCloseKind::Socket,
+            raw: RawFileResource::Socket(owned_raw_socket(raw)),
         }
     }
 
     pub(crate) fn invalid() -> Self {
-        Self::new(invalid_raw_file())
+        Self {
+            raw: RawFileResource::Invalid,
+        }
     }
 
     pub(crate) fn is_invalid(&self) -> bool {
-        is_invalid_raw_file(self.raw)
+        matches!(self.raw, RawFileResource::Invalid)
     }
 
     pub(crate) fn raw_fd(&self) -> fd_util::stub::RawFd {
-        self.raw
-    }
-
-    pub(crate) fn duplicate(&self) -> AsyncHostResult<Self> {
-        if self.is_invalid() {
-            return Err(AsyncHostError::Badf);
-        }
-        duplicate_raw_file(self.raw).map(|raw| Self {
-            raw,
-            close_kind: self.close_kind,
-        })
-    }
-}
-
-impl Drop for HostFile {
-    fn drop(&mut self) {
-        if !self.is_invalid() {
-            close_raw_file(self.raw, self.close_kind);
-            self.raw = invalid_raw_file();
+        match &self.raw {
+            RawFileResource::Invalid => invalid_raw_file(),
+            RawFileResource::File(raw) => raw_file(raw),
+            #[cfg(windows)]
+            RawFileResource::Socket(raw) => raw_socket(raw),
         }
     }
 }
@@ -97,70 +101,42 @@ fn invalid_raw_file() -> fd_util::stub::RawFd {
     windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE
 }
 
-fn is_invalid_raw_file(raw: fd_util::stub::RawFd) -> bool {
-    raw == invalid_raw_file()
+#[cfg(windows)]
+fn invalid_raw_socket() -> RawSocket {
+    windows_sys::Win32::Networking::WinSock::INVALID_SOCKET as RawSocket
 }
 
 #[cfg(unix)]
-fn close_raw_file(raw: fd_util::stub::RawFd, _close_kind: HostFileCloseKind) {
-    unsafe {
-        libc::close(raw);
-    }
+fn owned_raw_file(raw: fd_util::stub::RawFd) -> OwnedRawFile {
+    // FileResource takes ownership of handles returned by platform APIs.
+    unsafe { OwnedFd::from_raw_fd(raw) }
 }
 
 #[cfg(windows)]
-fn close_raw_file(raw: fd_util::stub::RawFd, close_kind: HostFileCloseKind) {
-    match close_kind {
-        HostFileCloseKind::File => unsafe {
-            windows_sys::Win32::Foundation::CloseHandle(raw);
-        },
-        HostFileCloseKind::Socket => unsafe {
-            windows_sys::Win32::Networking::WinSock::closesocket(raw as usize);
-        },
-    }
+fn owned_raw_file(raw: fd_util::stub::RawFd) -> OwnedRawFile {
+    // FileResource takes ownership of handles returned by platform APIs.
+    unsafe { OwnedHandle::from_raw_handle(raw) }
+}
+
+#[cfg(windows)]
+fn owned_raw_socket(raw: RawSocket) -> OwnedSocket {
+    // FileResource takes ownership of sockets returned by platform APIs.
+    unsafe { OwnedSocket::from_raw_socket(raw) }
 }
 
 #[cfg(unix)]
-fn duplicate_raw_file(raw: fd_util::stub::RawFd) -> AsyncHostResult<fd_util::stub::RawFd> {
-    let fd = unsafe { libc::fcntl(raw, libc::F_DUPFD_CLOEXEC, 0) };
-    if fd < 0 {
-        Err(last_native_error())
-    } else {
-        Ok(fd)
-    }
+fn raw_file(raw: &OwnedRawFile) -> fd_util::stub::RawFd {
+    raw.as_raw_fd()
 }
 
 #[cfg(windows)]
-fn duplicate_raw_file(raw: fd_util::stub::RawFd) -> AsyncHostResult<fd_util::stub::RawFd> {
-    use windows_sys::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE};
-    use windows_sys::Win32::System::Threading::GetCurrentProcess;
-
-    let process = unsafe { GetCurrentProcess() };
-    let mut duplicate: HANDLE = std::ptr::null_mut();
-    if unsafe {
-        DuplicateHandle(
-            process,
-            raw,
-            process,
-            &mut duplicate,
-            0,
-            0,
-            DUPLICATE_SAME_ACCESS,
-        )
-    } == 0
-    {
-        Err(last_native_error())
-    } else {
-        Ok(duplicate)
-    }
+fn raw_file(raw: &OwnedRawFile) -> fd_util::stub::RawFd {
+    raw.as_raw_handle()
 }
 
-fn last_native_error() -> AsyncHostError {
-    AsyncHostError::Native(
-        std::io::Error::last_os_error()
-            .raw_os_error()
-            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
-    )
+#[cfg(windows)]
+fn raw_socket(raw: &OwnedSocket) -> fd_util::stub::RawFd {
+    raw.as_raw_socket() as fd_util::stub::RawFd
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -239,13 +215,13 @@ pub(crate) enum JobPayload {
         duration_ms: i32,
     },
     Read {
-        fd: HostHandle,
+        file: FileResourceRef,
         len: i32,
         position: i64,
         result: Option<Vec<u8>>,
     },
     Write {
-        fd: HostHandle,
+        file: FileResourceRef,
         data: Vec<u8>,
         position: i64,
     },
@@ -259,16 +235,16 @@ pub(crate) enum JobPayload {
         result: Option<OpenJobResult>,
     },
     FileKindByPath {
-        parent: HostHandle,
+        parent: Option<FileResourceRef>,
         path: OsString,
         follow_symlink: bool,
     },
     FileSize {
-        fd: HostHandle,
+        file: FileResourceRef,
         result: i64,
     },
     FileTime {
-        fd: HostHandle,
+        file: FileResourceRef,
         result: Option<FileTimeResult>,
     },
     FileTimeByPath {
@@ -285,11 +261,11 @@ pub(crate) enum JobPayload {
         mode: i32,
     },
     Fsync {
-        fd: HostHandle,
+        file: FileResourceRef,
         only_data: bool,
     },
     Flock {
-        fd: HostHandle,
+        file: FileResourceRef,
         exclusive: bool,
     },
     Remove {
@@ -313,13 +289,13 @@ pub(crate) enum JobPayload {
         path: OsString,
     },
     Readdir {
-        dir: HostHandle,
+        dir: FileResourceRef,
         buffer: HostCBuffer,
         len: i32,
         restart: bool,
     },
     Bind {
-        socket: HostHandle,
+        socket: FileResourceRef,
         addr: Vec<u8>,
     },
     GetAddrInfo {
@@ -328,29 +304,8 @@ pub(crate) enum JobPayload {
     },
 }
 
-pub(crate) trait HostFileTable {
+pub(crate) trait FileResourceTable {
     fn insert_file(&mut self, file: fd_util::stub::RawFd) -> AsyncHostResult<HostHandle>;
-
-    fn is_invalid_file_handle(&self, handle: HostHandle) -> bool;
-
-    #[cfg(windows)]
-    fn with_borrowed_raw_file<T>(
-        &mut self,
-        handle: HostHandle,
-        f: impl FnOnce(fd_util::stub::RawFd) -> AsyncHostResult<T>,
-    ) -> AsyncHostResult<T>;
-
-    fn with_raw_file<T>(
-        &mut self,
-        handle: HostHandle,
-        f: impl FnOnce(fd_util::stub::RawFd) -> AsyncHostResult<T>,
-    ) -> AsyncHostResult<T>;
-
-    fn with_host_file_mut<T>(
-        &mut self,
-        handle: HostHandle,
-        f: impl FnOnce(&mut HostFile) -> AsyncHostResult<T>,
-    ) -> AsyncHostResult<T>;
 }
 
 pub(crate) fn platform() -> i32 {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -224,13 +224,13 @@ pub(crate) enum JobPayload {
         duration_ms: i32,
     },
     Read {
-        file: FileResourceRef,
+        file: Option<FileResourceRef>,
         len: i32,
         position: i64,
         result: Option<Vec<u8>>,
     },
     Write {
-        file: FileResourceRef,
+        file: Option<FileResourceRef>,
         data: Vec<u8>,
         position: i64,
     },
@@ -249,11 +249,11 @@ pub(crate) enum JobPayload {
         follow_symlink: bool,
     },
     FileSize {
-        file: FileResourceRef,
+        file: Option<FileResourceRef>,
         result: i64,
     },
     FileTime {
-        file: FileResourceRef,
+        file: Option<FileResourceRef>,
         result: Option<FileTimeResult>,
     },
     FileTimeByPath {
@@ -270,11 +270,11 @@ pub(crate) enum JobPayload {
         mode: i32,
     },
     Fsync {
-        file: FileResourceRef,
+        file: Option<FileResourceRef>,
         only_data: bool,
     },
     Flock {
-        file: FileResourceRef,
+        file: Option<FileResourceRef>,
         exclusive: bool,
     },
     Remove {
@@ -298,13 +298,13 @@ pub(crate) enum JobPayload {
         path: OsString,
     },
     Readdir {
-        dir: FileResourceRef,
+        dir: Option<FileResourceRef>,
         buffer: HostCBuffer,
         len: i32,
         restart: bool,
     },
     Bind {
-        socket: FileResourceRef,
+        socket: Option<FileResourceRef>,
         addr: Vec<u8>,
     },
     GetAddrInfo {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -122,18 +122,23 @@ impl HostWorkerHandle {
                 };
                 run_job(job);
 
-                let terminating = {
+                let (terminating, should_wait) = {
                     let mut state = worker_shared.state.lock().unwrap();
                     if state.terminating {
-                        true
-                    } else {
+                        (true, false)
+                    } else if state.job == Some(job) {
                         state.waiting = true;
-                        false
+                        (false, true)
+                    } else {
+                        (false, false)
                     }
                 };
                 complete_job(job);
                 if terminating {
                     break;
+                }
+                if !should_wait {
+                    continue;
                 }
 
                 let mut state = worker_shared.state.lock().unwrap();
@@ -349,6 +354,47 @@ mod tests {
         );
 
         assert_eq!(receiver.recv().unwrap().job_id, 3);
+        assert_eq!(completion_receiver.recv().unwrap().job_id, 3);
+        free_worker(worker);
+    }
+
+    #[test]
+    fn wake_during_running_job_is_not_lost() {
+        let (started_sender, started_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let (completion_sender, completion_receiver) = mpsc::channel();
+        let worker = spawn_worker(
+            HostWorkerJob {
+                job_id: 1,
+                job_handle: 2,
+            },
+            move |job| {
+                started_sender.send(job).unwrap();
+                if job.job_id == 1 {
+                    release_receiver.recv().unwrap();
+                }
+            },
+            move |job| completion_sender.send(job).unwrap(),
+        );
+
+        assert_eq!(started_receiver.recv().unwrap().job_id, 1);
+        wake_worker(
+            &worker,
+            HostWorkerJob {
+                job_id: 3,
+                job_handle: 4,
+            },
+        );
+        release_sender.send(()).unwrap();
+
+        assert_eq!(completion_receiver.recv().unwrap().job_id, 1);
+        assert_eq!(
+            started_receiver
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .unwrap()
+                .job_id,
+            3
+        );
         assert_eq!(completion_receiver.recv().unwrap().job_id, 3);
         free_worker(worker);
     }

--- a/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
@@ -17,7 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
-use crate::async_sys::internal::event_loop::thread_pool::{HostFileTable, HostHandle};
+use crate::async_sys::internal::event_loop::thread_pool::{FileResourceTable, HostHandle};
 use crate::async_sys::ported_fns;
 
 #[cfg(unix)]
@@ -250,8 +250,8 @@ fn create_named_pipe_client(name: &std::ffi::OsStr, is_async: bool) -> RawFd {
     }
 }
 
-pub(crate) fn pipe_host_files(
-    files: &mut impl HostFileTable,
+pub(crate) fn pipe_file_resources(
+    files: &mut impl FileResourceTable,
     read_end_is_async: bool,
     write_end_is_async: bool,
 ) -> AsyncHostResult<[HostHandle; 2]> {

--- a/crates/moonrun/src/async_sys/socket.rs
+++ b/crates/moonrun/src/async_sys/socket.rs
@@ -28,6 +28,11 @@ use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::ported_fns;
 
 #[cfg(unix)]
+pub(crate) type RawSocket = RawFd;
+#[cfg(windows)]
+pub(crate) type RawSocket = std::os::windows::io::RawSocket;
+
+#[cfg(unix)]
 fn last_native_error() -> AsyncHostError {
     AsyncHostError::Native(
         std::io::Error::last_os_error()
@@ -144,14 +149,14 @@ mod win {
     use windows_sys::Win32::NetworkManagement::Ndis::{IfOperStatusUp, NET_LUID_LH};
     use windows_sys::Win32::Networking::WinSock as ws;
 
-    use super::{AsyncHostError, AsyncHostResult, RawFd};
+    use super::{AsyncHostError, AsyncHostResult, RawFd, RawSocket};
 
     fn socket(fd: RawFd) -> ws::SOCKET {
         fd as usize
     }
 
-    fn raw_socket(socket: ws::SOCKET) -> RawFd {
-        socket as RawFd
+    fn raw_socket(socket: ws::SOCKET) -> RawSocket {
+        socket as RawSocket
     }
 
     fn last_wsa_error() -> AsyncHostError {
@@ -363,7 +368,7 @@ mod win {
         Ok(unsafe { read_sockaddr_in6(addr)?.sin6_addr.u.Byte } == [0; 16])
     }
 
-    pub(super) fn make_tcp_socket(family: i32) -> AsyncHostResult<RawFd> {
+    pub(super) fn make_tcp_socket(family: i32) -> AsyncHostResult<RawSocket> {
         let socket = unsafe {
             ws::WSASocketW(
                 domain(family)?,
@@ -377,17 +382,18 @@ mod win {
         if socket == ws::INVALID_SOCKET {
             return Err(last_wsa_error());
         }
-        let raw = raw_socket(socket);
-        if let Err(error) = set_socket_int(raw, ws::SOL_SOCKET, ws::SO_EXCLUSIVEADDRUSE, 0) {
+        if let Err(error) =
+            set_socket_int(socket as RawFd, ws::SOL_SOCKET, ws::SO_EXCLUSIVEADDRUSE, 0)
+        {
             unsafe {
                 ws::closesocket(socket);
             }
             return Err(error);
         }
-        Ok(raw)
+        Ok(raw_socket(socket))
     }
 
-    pub(super) fn make_udp_socket(family: i32, multicast: bool) -> AsyncHostResult<RawFd> {
+    pub(super) fn make_udp_socket(family: i32, multicast: bool) -> AsyncHostResult<RawSocket> {
         let socket = unsafe {
             ws::WSASocketW(
                 domain(family)?,
@@ -401,11 +407,15 @@ mod win {
         if socket == ws::INVALID_SOCKET {
             return Err(last_wsa_error());
         }
-        let raw = raw_socket(socket);
         let result = if multicast {
-            set_socket_int(raw, ws::SOL_SOCKET, ws::SO_REUSE_MULTICASTPORT, 1)
+            set_socket_int(
+                socket as RawFd,
+                ws::SOL_SOCKET,
+                ws::SO_REUSE_MULTICASTPORT,
+                1,
+            )
         } else {
-            set_socket_int(raw, ws::SOL_SOCKET, ws::SO_EXCLUSIVEADDRUSE, 0)
+            set_socket_int(socket as RawFd, ws::SOL_SOCKET, ws::SO_EXCLUSIVEADDRUSE, 0)
         };
         if let Err(error) = result {
             unsafe {
@@ -413,7 +423,7 @@ mod win {
             }
             return Err(error);
         }
-        Ok(raw)
+        Ok(raw_socket(socket))
     }
 
     pub(super) fn join_multicast_group(
@@ -953,7 +963,7 @@ ported_fns! {
         original = "moonbitlang_async_make_tcp_socket"
     )]
     #[cfg(unix)]
-    pub(crate) fn make_tcp_socket(family: i32) -> AsyncHostResult<RawFd> {
+    pub(crate) fn make_tcp_socket(family: i32) -> AsyncHostResult<RawSocket> {
         let domain = match family {
             4 => libc::AF_INET,
             6 => libc::AF_INET6,
@@ -971,7 +981,7 @@ ported_fns! {
         original = "moonbitlang_async_make_tcp_socket"
     )]
     #[cfg(windows)]
-    pub(crate) fn make_tcp_socket(family: i32) -> AsyncHostResult<RawFd> {
+    pub(crate) fn make_tcp_socket(family: i32) -> AsyncHostResult<RawSocket> {
         win::make_tcp_socket(family)
     }
 
@@ -980,7 +990,7 @@ ported_fns! {
         original = "moonbitlang_async_make_udp_socket"
     )]
     #[cfg(unix)]
-    pub(crate) fn make_udp_socket(family: i32, multicast: bool) -> AsyncHostResult<RawFd> {
+    pub(crate) fn make_udp_socket(family: i32, multicast: bool) -> AsyncHostResult<RawSocket> {
         let domain = match family {
             4 => libc::AF_INET,
             6 => libc::AF_INET6,
@@ -1021,7 +1031,7 @@ ported_fns! {
         original = "moonbitlang_async_make_udp_socket"
     )]
     #[cfg(windows)]
-    pub(crate) fn make_udp_socket(family: i32, multicast: bool) -> AsyncHostResult<RawFd> {
+    pub(crate) fn make_udp_socket(family: i32, multicast: bool) -> AsyncHostResult<RawSocket> {
         win::make_udp_socket(family, multicast)
     }
 
@@ -1661,7 +1671,7 @@ ported_fns! {
         original = "moonbitlang_async_accept"
     )]
     #[cfg(unix)]
-    pub(crate) fn accept(fd: RawFd, addr: &mut [u8]) -> AsyncHostResult<RawFd> {
+    pub(crate) fn accept(fd: RawFd, addr: &mut [u8]) -> AsyncHostResult<RawSocket> {
         let mut len = sockaddr_len(addr)?;
         let conn = unsafe { libc::accept(fd, addr.as_mut_ptr().cast::<libc::sockaddr>(), &mut len) };
         if conn < 0 {

--- a/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
@@ -20,9 +20,6 @@
 fn get_platform() -> Int = "moonbitlang/async" "runtime/get_platform"
 
 ///|
-fn invalid_fd() -> UInt64 = "moonbitlang/async" "fd_util/invalid_fd"
-
-///|
 fn ms_since_epoch() -> UInt64 = "moonbitlang/async" "time/get_ms_since_epoch"
 
 ///|
@@ -53,7 +50,7 @@ fn init_thread_pool(bus : UInt64) -> UInt64 = "moonbitlang/async" "thread_pool/i
 fn destroy_thread_pool() -> Unit = "moonbitlang/async" "thread_pool/destroy_thread_pool"
 
 ///|
-fn make_read_job(fd : UInt64, len : Int, position : Int64) -> UInt64 = "moonbitlang/async" "thread_pool/make_read_job"
+fn make_sleep_job(ms : Int) -> UInt64 = "moonbitlang/async" "thread_pool/make_sleep_job"
 
 ///|
 fn free_job(job : UInt64) -> Unit = "moonbitlang/async" "thread_pool/free_job"
@@ -176,7 +173,7 @@ fn main {
   let bus = event_bus_create()
   assert_true(event_bus_wait(bus, 0) == 0, "empty event bus did not time out")
   let completion_source = init_thread_pool(bus)
-  let job = make_read_job(invalid_fd(), 1, -1)
+  let job = make_sleep_job(0)
   let worker = spawn_worker(17, job)
   let event_count = event_bus_wait(bus, 1000)
   assert_true(event_count > 0, "worker completion did not wake event bus")


### PR DESCRIPTION
## Why

Moonrun's async host should preserve native `moonbitlang/async` behavior for valid MoonBit code while still defending itself at the wasm boundary. Carrying guest handles or duplicated OS handles into worker jobs makes that boundary harder to reason about and weakens Rust's ownership model.

## What changed

- Resolve async resource handles at the import boundary into Rust-owned `FileResource` references.
- Let thread-pool jobs carry acquired `Arc<FileResource>` values instead of guest `u64` handles or duplicated raw fd/HANDLE values.
- Remove the `HostFile` alias and align internal naming around `FileResource`.
- Document the design principle: strict native behavior on the normal path, defensive rejection of stale or unexpected guest calls at the boundary.

## Why this is correct

Valid MoonBit async code still observes the native-shaped close behavior: closing a resource handle removes future guest reachability, while jobs that already acquired the resource can finish through their Rust-owned reference. Unexpected guest calls are rejected before opaque ABI handles are lowered back into raw OS access.

## Scope

This is intentionally the first slice: file/socket resources used by the async thread pool plus the ADR/glossary updates. Broader handle-table unification can follow separately.