### PR TITLE
Fix deny-warn warning list ordering

### DIFF
--- a/crates/moon/tests/test_cases/warns/mod.rs
+++ b/crates/moon/tests/test_cases/warns/mod.rs
@@ -1,5 +1,37 @@
 use super::*;
 
+fn assert_deny_warn_appended_to_custom_warn_list(stdout: &str, command_prefix: &str) {
+    let mut checked_commands = 0;
+
+    for command in stdout
+        .lines()
+        .filter(|line| line.starts_with(command_prefix))
+    {
+        let args = command.split_whitespace().collect::<Vec<_>>();
+        let warn_lists = args
+            .windows(2)
+            .filter_map(|pair| (pair[0] == "-w").then_some(pair[1]))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            warn_lists.len(),
+            1,
+            "expected a single warning list in command:\n{command}"
+        );
+        let warn_list = warn_lists[0];
+        assert!(
+            warn_list.ends_with("@a") && warn_list.len() > "@a".len(),
+            "deny warning token should be appended after custom warning list:\n{command}"
+        );
+        checked_commands += 1;
+    }
+
+    assert!(
+        checked_commands > 0,
+        "expected at least one `{command_prefix}` command in dry-run output:\n{stdout}"
+    );
+}
+
 #[test]
 fn test_warn_list_dry_run() {
     let dir = TestDir::new("warns/warn_list");
@@ -32,6 +64,18 @@ fn test_warn_list_dry_run() {
             moonc link-core '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/core.core' ./_build/wasm-gc/debug/build/lib/lib.core ./_build/wasm-gc/debug/build/lib1/lib1.core ./_build/wasm-gc/debug/build/main/main.core -main username/hello/main -o ./_build/wasm-gc/debug/build/main/main.wasm -pkg-config-path ./main/moon.pkg.json -pkg-sources username/hello/lib:./lib -pkg-sources username/hello/lib1:./lib1 -pkg-sources username/hello/main:./main -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target wasm-gc -g -O0 -source-map
         "#]],
     );
+
+    let build_deny_warn_stdout = get_stdout(
+        &dir,
+        [
+            "build",
+            "--deny-warn",
+            "--sort-input",
+            "--no-render",
+            "--dry-run",
+        ],
+    );
+    assert_deny_warn_appended_to_custom_warn_list(&build_deny_warn_stdout, "moonc build-package");
 
     check(
         get_stdout(&dir, ["test", "--sort-input"]),
@@ -85,6 +129,18 @@ fn test_warn_list_dry_run() {
             moonc check ./lib/hello_test.mbt -doctest-only ./lib/hello.mbt -include-doctests -w -2-29 -o ./_build/wasm-gc/debug/check/lib/lib.blackbox_test.mi -pkg username/hello/lib_blackbox_test -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/lib/lib.mi:lib -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/hello/lib_blackbox_test:./lib -target wasm-gc -blackbox-test -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
         "#]],
     );
+
+    let check_deny_warn_stdout = get_stdout(
+        &dir,
+        [
+            "check",
+            "--deny-warn",
+            "--sort-input",
+            "--no-render",
+            "--dry-run",
+        ],
+    );
+    assert_deny_warn_appended_to_custom_warn_list(&check_deny_warn_stdout, "moonc check");
 }
 
 #[test]

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/build_common.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/build_common.rs
@@ -225,12 +225,21 @@ impl<'a> BuildCommonConfig<'a> {
         }
     }
 
-    /// Add custom warning list arguments
-    pub(crate) fn add_custom_warn_list(&self, args: &mut Vec<String>) {
-        if let WarnAlertConfig::List(warn_list) = &self.warn_config
-            && !warn_list.is_empty()
-        {
-            args.extend(["-w".to_string(), warn_list.to_string()]);
+    /// Add the warning selection expression, with deny promotion appended last
+    /// when `--deny-warn` is enabled.
+    pub(crate) fn add_warning_options(&self, args: &mut Vec<String>) {
+        let mut warn_list = match &self.warn_config {
+            WarnAlertConfig::Default => String::new(),
+            WarnAlertConfig::List(warn_list) => warn_list.to_string(),
+            WarnAlertConfig::Suppress => MOONC_SUPPRESS_WARNING_SET.to_string(),
+        };
+        if self.deny_warn {
+            // `moonc -w` parses the list left-to-right. `@a` promotes active
+            // warnings to errors, so it must come after opt-ins like `+missing_doc`.
+            warn_list.push_str(MOONC_DENY_WARNING_SET);
+        }
+        if !warn_list.is_empty() {
+            args.extend(["-w".to_string(), warn_list]);
         }
     }
 
@@ -252,20 +261,6 @@ impl<'a> BuildCommonConfig<'a> {
     pub(crate) fn add_virtual_package_check(&self, args: &mut Vec<String>) {
         if let Some(check_mi_path) = &self.check_mi {
             args.extend(["-check-mi".to_string(), check_mi_path.display().to_string()]);
-        }
-    }
-
-    /// Add warning/alert deny all arguments (combined)
-    pub(crate) fn add_deny_all(&self, args: &mut Vec<String>) {
-        if self.deny_warn {
-            args.extend(["-w".to_string(), MOONC_DENY_WARNING_SET.to_string()]);
-        }
-    }
-
-    /// Add warning/alert allow all arguments
-    pub(crate) fn add_warn_alert_allow_all(&self, args: &mut Vec<String>) {
-        if matches!(self.warn_config, WarnAlertConfig::Suppress) {
-            args.extend(["-w".to_string(), MOONC_SUPPRESS_WARNING_SET.into()]);
         }
     }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/build_package.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/build_package.rs
@@ -63,19 +63,13 @@ impl<'a> CmdlineAbstraction for MooncBuildPackage<'a> {
         // Error format
         self.defaults.add_error_format(args);
 
-        // Warning and alert handling
-        self.defaults.add_deny_all(args);
-
         // Input files
         self.required.add_mbt_sources(args);
         // Additional inputs in stable ordering
         self.required.add_doctest_only_sources(args);
 
-        // Custom warning list
-        self.defaults.add_custom_warn_list(args);
-
-        // Third-party package handling (allow all)
-        self.defaults.add_warn_alert_allow_all(args);
+        // Warning selection and deny handling
+        self.defaults.add_warning_options(args);
 
         // Output
         args.extend(["-o".to_string(), self.core_out.display().to_string()]);

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/check.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/check.rs
@@ -60,9 +60,6 @@ impl<'a> CmdlineAbstraction for MooncCheck<'a> {
         // Error format
         self.defaults.add_error_format(args);
 
-        // Warning and alert handling (deny all combined)
-        self.defaults.add_deny_all(args);
-
         // MBT source files
         self.required.add_mbt_sources(args);
 
@@ -72,9 +69,8 @@ impl<'a> CmdlineAbstraction for MooncCheck<'a> {
         // Include doctests for blackbox
         self.required.add_include_doctests_if_blackbox(args);
 
-        // Custom warning list
-        self.defaults.add_custom_warn_list(args);
-        self.defaults.add_warn_alert_allow_all(args);
+        // Warning selection and deny handling
+        self.defaults.add_warning_options(args);
 
         // Output
         if !self.defaults.no_mi {

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/prove.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/prove.rs
@@ -44,12 +44,10 @@ impl<'a> CmdlineAbstraction for MooncProve<'a> {
 
         self.defaults.add_patch_file_moonc(args);
         self.defaults.add_error_format(args);
-        self.defaults.add_deny_all(args);
         self.required.add_mbt_sources(args);
         self.required.add_doctest_only_sources(args);
         self.required.add_include_doctests_if_blackbox(args);
-        self.defaults.add_custom_warn_list(args);
-        self.defaults.add_warn_alert_allow_all(args);
+        self.defaults.add_warning_options(args);
         args.extend([
             "-whyml-output-path".to_string(),
             self.whyml_out.display().to_string(),


### PR DESCRIPTION
## Summary

This fixes `--deny-warn` handling when a package or module warning list enables warnings that are disabled by the compiler default, such as `+missing_doc`.

Previously MoonBuild emitted `-w @a` before the custom warning list. Since `moonc` applies warning-list operations left to right and `@a` only promotes currently active warnings, later opt-ins could remain warnings instead of becoming errors.

## Why this is correct

The warning list is already built as one ordered expression from module, package, proof, and command-line fragments. This change appends `@a` to that same expression after warning selection, so the compiler sees the final active warning set before promotion. Suppressed warnings remain suppressed because compiler `@a` does not reactivate disabled warnings.

## Scope

The change is limited to `moonc` command argument construction for `check`, `build-package`, and `prove`, plus a dry-run regression covering the generated warning-list shape.