### PR TITLE
Refactor moonrun open resource publication

### DIFF
--- a/crates/moonrun/docs/adr/0009-main-owned-resource-table.md
+++ b/crates/moonrun/docs/adr/0009-main-owned-resource-table.md
@@ -1,0 +1,5 @@
+# Keep The Resource Table On The Event Loop Side
+
+Moonrun will move toward a single Resource Handle table owned by the event-loop side of the async host, while workers own only the Job they are running and return completed host-owned payloads. Workers may acquire Resources before running and may create new OS Resources such as open-file results, but publishing guest-visible handles belongs to the event-loop side; this mirrors `moonbitlang/async`'s structure more closely than letting worker threads mutate guest handle tables.
+
+The first migration step should not be collapsing every SlotMap at once. We should first remove worker-side table mutation from async job completion paths, especially `Open`, so a worker returns a completed Job containing the created Resource and the event-loop side inserts it into the Resource table when the result is observed. After that, the separate handle tables can be folded into one typed table one resource family at a time without holding a global registry lock across native syscalls.

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -37,7 +37,7 @@ use crate::async_sys::internal::event_loop::{
     poll::{self, PollInstance},
     thread_pool::{
         self, FileResource, FileResourceRef, FileResourceTable, HostHandle, HostWorkerHandle,
-        HostWorkerJob, Job,
+        HostWorkerJob, Job, OpenJobResource,
     },
 };
 use crate::async_sys::internal::fd_util::stub::RawFd;
@@ -335,6 +335,38 @@ impl AsyncHostState {
         self.files.remove(key).ok_or(AsyncHostError::Badf)
     }
 
+    fn insert_file_resource(&mut self, file: FileResource) -> HostHandle {
+        handle_from_key(self.files.insert(Arc::new(file)))
+    }
+
+    fn publish_open_job_result(&mut self, key: HostJobKey) -> AsyncHostResult<HostHandle> {
+        let placeholder = OpenJobResource::Published(self.invalid_fd());
+        let file = {
+            let job = self
+                .jobs
+                .get_mut(key)
+                .and_then(Option::as_mut)
+                .ok_or(AsyncHostError::Badf)?;
+            let result = thread_pool::open_job_result_mut(job)?;
+            match std::mem::replace(&mut result.resource, placeholder) {
+                OpenJobResource::Published(fd) => {
+                    result.resource = OpenJobResource::Published(fd);
+                    return Ok(fd);
+                }
+                OpenJobResource::Unpublished(file) => file,
+            }
+        };
+        let fd = self.insert_file_resource(file);
+        let job = self
+            .jobs
+            .get_mut(key)
+            .and_then(Option::as_mut)
+            .ok_or(AsyncHostError::Badf)?;
+        let result = thread_pool::open_job_result_mut(job)?;
+        result.resource = OpenJobResource::Published(fd);
+        thread_pool::open_job_get_fd(result)
+    }
+
     fn restore_completed_job(&mut self, key: HostJobKey, mut job: Job) -> AsyncHostResult<()> {
         let can_restore = match self.jobs.get(key) {
             Some(slot) => slot.is_none(),
@@ -352,8 +384,10 @@ impl AsyncHostState {
     }
 
     fn discard_job_results(&mut self, job: &mut Job) {
-        if let Some(result) = thread_pool::take_open_job_result(job) {
-            let _ = self.remove_file(result.fd);
+        if let Some(result) = thread_pool::take_open_job_result(job)
+            && let OpenJobResource::Published(fd) = result.resource
+        {
+            let _ = self.remove_file(fd);
         }
     }
 
@@ -1215,14 +1249,10 @@ impl AsyncHost {
     }
 
     pub(crate) fn open_job_get_fd(&self, handle: u64) -> AsyncHostResult<HostHandle> {
-        let state = self.state.lock().unwrap();
-        let job = state
-            .jobs
-            .get(key_from_handle::<HostJobKey>(handle))
-            .and_then(Option::as_ref)
-            .ok_or(AsyncHostError::Badf)?;
-        let result = thread_pool::open_job_result(job)?;
-        Ok(thread_pool::open_job_get_fd(result))
+        self.state
+            .lock()
+            .unwrap()
+            .publish_open_job_result(key_from_handle::<HostJobKey>(handle))
     }
 
     pub(crate) fn open_job_get_kind(&self, handle: u64) -> AsyncHostResult<i32> {
@@ -2003,10 +2033,7 @@ impl AsyncHost {
             .get_mut(key)
             .and_then(Option::take)
             .ok_or(AsyncHostError::Badf)?;
-        let mut files = SharedFileTable {
-            state: Arc::clone(&self.state),
-        };
-        thread_pool::run_host_job(&mut job, &mut files);
+        thread_pool::run_host_job(&mut job);
         let mut state = self.state.lock().unwrap();
         state.restore_completed_job(key, job)
     }
@@ -2184,10 +2211,7 @@ impl AsyncHost {
                     return;
                 };
 
-                let mut files = SharedFileTable {
-                    state: Arc::clone(&run_state),
-                };
-                thread_pool::run_host_job(&mut job, &mut files);
+                thread_pool::run_host_job(&mut job);
 
                 let mut state = run_state.lock().unwrap();
                 let _ = state.restore_completed_job(key, job);
@@ -2204,22 +2228,6 @@ impl AsyncHost {
 impl Drop for AsyncHost {
     fn drop(&mut self) {
         self.destroy_thread_pool();
-    }
-}
-
-struct SharedFileTable {
-    state: Arc<Mutex<AsyncHostState>>,
-}
-
-impl FileResourceTable for SharedFileTable {
-    fn insert_file(&mut self, file: RawFd) -> AsyncHostResult<HostHandle> {
-        Ok(handle_from_key(
-            self.state
-                .lock()
-                .unwrap()
-                .files
-                .insert(Arc::new(FileResource::new(file))),
-        ))
     }
 }
 
@@ -2633,7 +2641,42 @@ mod tests {
     }
 
     #[test]
-    fn discarded_completed_open_job_removes_opened_resource() {
+    fn open_job_get_fd_publishes_opened_resource_once() {
+        let host = AsyncHost::default();
+        let path =
+            std::env::temp_dir().join(format!("moonrun-published-open-job-{}", std::process::id()));
+        let job = host
+            .insert_job(thread_pool::make_open_job(
+                path.as_os_str().to_os_string(),
+                2,
+                3,
+                false,
+                0,
+                0o600,
+            ))
+            .unwrap();
+
+        host.run_job(job).unwrap();
+        {
+            let state = host.state.lock().unwrap();
+            assert_eq!(state.files.len(), 1);
+        }
+
+        let opened = host.open_job_get_fd(job).unwrap();
+        assert_eq!(host.open_job_get_fd(job).unwrap(), opened);
+        {
+            let state = host.state.lock().unwrap();
+            assert_eq!(state.files.len(), 2);
+            assert!(state.file(opened).is_ok());
+        }
+
+        host.close_fd(opened).unwrap();
+        host.free_job(job).unwrap();
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn discarded_completed_open_job_drops_unpublished_resource() {
         let host = AsyncHost::default();
         let path =
             std::env::temp_dir().join(format!("moonrun-discarded-open-job-{}", std::process::id()));
@@ -2656,15 +2699,15 @@ mod tests {
             .get_mut(key)
             .and_then(Option::take)
             .unwrap();
-        let mut files = SharedFileTable {
-            state: Arc::clone(&host.state),
-        };
 
-        thread_pool::run_host_job(&mut job, &mut files);
+        thread_pool::run_host_job(&mut job);
 
         assert_eq!(job.err(), 0);
-        let opened = thread_pool::open_job_get_fd(thread_pool::open_job_result(&job).unwrap());
-        assert!(host.state.lock().unwrap().file(opened).is_ok());
+        assert!(matches!(
+            thread_pool::open_job_result(&job).unwrap().resource,
+            OpenJobResource::Unpublished(_)
+        ));
+        assert_eq!(host.state.lock().unwrap().files.len(), 1);
         host.state.lock().unwrap().jobs.remove(key);
 
         {
@@ -2673,7 +2716,7 @@ mod tests {
                 state.restore_completed_job(key, job),
                 Err(AsyncHostError::Badf)
             );
-            assert!(matches!(state.file(opened), Err(AsyncHostError::Badf)));
+            assert_eq!(state.files.len(), 1);
         }
 
         let _ = std::fs::remove_file(path);

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -25,7 +25,7 @@ use crate::async_host::{AsyncHostError, AsyncHostResult, HostCBuffer};
 use crate::async_sys::internal::fd_util;
 use crate::async_sys::ported_fns;
 
-use super::{FileResource, FileResourceTable, FileTimeResult, OpenJobResult};
+use super::{FileResource, FileTimeResult, OpenJobResource, OpenJobResult};
 
 type RawFile = fd_util::stub::RawFd;
 
@@ -36,7 +36,6 @@ ported_fns! {
     )]
     #[allow(clippy::too_many_arguments)]
     pub(super) fn run_open_job(
-        files: &mut impl FileResourceTable,
         result: &mut Option<OpenJobResult>,
         filename: OsString,
         access: i32,
@@ -51,9 +50,8 @@ ported_fns! {
             dev_id,
             file_id,
         } = open_native_file(filename, access, create_mode, append, sync, mode)?;
-        let fd = files.insert_file(file)?;
         *result = Some(OpenJobResult {
-            fd,
+            resource: OpenJobResource::Unpublished(FileResource::new(file)),
             kind,
             dev_id,
             file_id,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -21,7 +21,9 @@ use std::ffi::OsString;
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::ported_fns;
 
-use super::types::{FileResourceRef, HostHandle, Job, JobPayload, OpenJobResult, platform};
+use super::types::{
+    FileResourceRef, HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult, platform,
+};
 
 ported_fns! {
     #[ported(
@@ -144,8 +146,11 @@ ported_fns! {
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_open_job_get_fd"
     )]
-    pub(crate) fn open_job_get_fd(result: &OpenJobResult) -> HostHandle {
-        result.fd
+    pub(crate) fn open_job_get_fd(result: &OpenJobResult) -> AsyncHostResult<HostHandle> {
+        match &result.resource {
+            OpenJobResource::Published(fd) => Ok(*fd),
+            OpenJobResource::Unpublished(_) => Err(AsyncHostError::Inval),
+        }
     }
 
     #[ported(
@@ -356,6 +361,17 @@ pub(crate) fn open_job_result(job: &Job) -> AsyncHostResult<&OpenJobResult> {
     }
 }
 
+pub(crate) fn open_job_result_mut(job: &mut Job) -> AsyncHostResult<&mut OpenJobResult> {
+    match job.payload_mut() {
+        JobPayload::Open {
+            result: Some(result),
+            ..
+        } => Ok(result),
+        JobPayload::Open { .. } => Err(AsyncHostError::Inval),
+        _ => Err(AsyncHostError::Badf),
+    }
+}
+
 pub(crate) fn take_open_job_result(job: &mut Job) -> Option<OpenJobResult> {
     match job.payload_mut() {
         JobPayload::Open { result, .. } => result.take(),
@@ -377,19 +393,8 @@ pub(crate) fn getaddrinfo_job_result(job: &Job) -> AsyncHostResult<&[Box<[u8]>]>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::async_sys::internal::event_loop::thread_pool::{
-        FileResource, FileResourceTable, run_host_job,
-    };
-    use crate::async_sys::internal::fd_util::stub::RawFd;
+    use crate::async_sys::internal::event_loop::thread_pool::{FileResource, run_host_job};
     use std::sync::Arc;
-
-    struct NoFiles;
-
-    impl FileResourceTable for NoFiles {
-        fn insert_file(&mut self, _file: RawFd) -> AsyncHostResult<HostHandle> {
-            unreachable!("sleep jobs do not access files")
-        }
-    }
 
     #[test]
     fn sleep_job_initial_result_matches_native_job_header() {
@@ -447,9 +452,8 @@ mod tests {
     #[test]
     fn sleep_job_runs_without_error() {
         let mut job = make_sleep_job(0);
-        let mut files = NoFiles;
 
-        run_host_job(&mut job, &mut files);
+        run_host_job(&mut job);
 
         assert_eq!(job_get_ret(&job), 0);
         assert_eq!(job_get_err(&job), 0);
@@ -460,10 +464,9 @@ mod tests {
         let file = Arc::new(FileResource::invalid());
         let file_ref = Arc::downgrade(&file);
         let mut job = make_flock_job(Arc::clone(&file), true);
-        let mut files = NoFiles;
         drop(file);
 
-        run_host_job(&mut job, &mut files);
+        run_host_job(&mut job);
 
         assert!(file_ref.upgrade().is_none());
     }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -31,14 +31,14 @@ pub(crate) use jobs::{
     make_fsync_job, make_getaddrinfo_job, make_mkdir_job, make_open_job, make_read_job,
     make_readdir_job, make_remove_job, make_rename_job, make_rmdir_job, make_sleep_job,
     make_symlink_job, make_write_job, open_job_get_dev_id, open_job_get_fd, open_job_get_file_id,
-    open_job_get_kind, open_job_result, take_open_job_result,
+    open_job_get_kind, open_job_result, open_job_result_mut, take_open_job_result,
 };
 pub(crate) use runner::{get_file_time_result, get_read_result, run_host_job};
 #[cfg(all(test, unix))]
 pub(crate) use types::JobPayload;
 pub(crate) use types::{
     FileResource, FileResourceRef, FileResourceTable, FileTimeResult, HostHandle, Job,
-    OpenJobResult,
+    OpenJobResource, OpenJobResult,
 };
 pub(crate) use worker::{
     HostWorkerHandle, HostWorkerJob, cancel_worker, free_worker, spawn_worker, wake_worker,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -27,9 +27,9 @@ use super::fs::{
 };
 use super::sleep::run_sleep_job;
 use super::socket::{run_bind_job, run_getaddrinfo_job};
-use super::types::{FileResourceTable, Job, JobPayload};
+use super::types::{Job, JobPayload};
 
-pub(crate) fn run_host_job(job: &mut Job, files: &mut impl FileResourceTable) {
+pub(crate) fn run_host_job(job: &mut Job) {
     job.set_ret(0);
 
     let result = match job.payload_mut() {
@@ -46,7 +46,6 @@ pub(crate) fn run_host_job(job: &mut Job, files: &mut impl FileResourceTable) {
             mode,
             result,
         } => run_open_job(
-            files,
             result,
             filename.clone(),
             *access,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -148,12 +148,18 @@ fn raw_socket(raw: &OwnedSocket) -> fd_util::stub::RawFd {
     raw.as_raw_socket() as fd_util::stub::RawFd
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct OpenJobResult {
-    pub(crate) fd: HostHandle,
+    pub(crate) resource: OpenJobResource,
     pub(crate) kind: i32,
     pub(crate) dev_id: u64,
     pub(crate) file_id: u64,
+}
+
+#[derive(Debug)]
+pub(crate) enum OpenJobResource {
+    Unpublished(FileResource),
+    Published(HostHandle),
 }
 
 #[derive(Clone, Copy)]
@@ -175,7 +181,7 @@ impl std::fmt::Debug for FileTimeResult {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct Job {
     ret: i64,
     err: i32,
@@ -218,7 +224,7 @@ impl Job {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) enum JobPayload {
     Sleep {
         duration_ms: i32,


### PR DESCRIPTION
## Why

Moonrun is moving toward a resource table owned by the event-loop side of the async host. Worker threads should perform blocking native work and return completed job payloads, but they should not publish guest-visible resource handles by mutating the handle table.

## What changed

- Add an ADR recording the target shape: event-loop-owned Resource Handle publication, with workers owning only running jobs and completed payloads.
- Change async `Open` jobs to store an opened `FileResource` as an unpublished result.
- Publish the opened resource into the file table exactly once when `open_job_get_fd` is observed.
- Remove the worker-side file-table adapter from thread-pool job execution.

## Why this is correct

The MoonBit-facing ABI stays unchanged: successful open jobs still expose their handle through `thread_pool/open_job_get_fd`. Normal MoonBit async open waits for completion, asks for the fd, then builds the returned IO handle. Repeated fd reads return the same published handle, and unpublished open results are dropped with the job instead of leaving unreachable table entries.

## Scope

This is the first slice toward a single resource table. It intentionally changes only open-result publication before folding the existing handle tables into one typed table in later PRs.