### PR TITLE
Refactor moonrun workers to own async jobs

### DIFF
--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -330,11 +330,11 @@ declare_async_imports! {
 
     helper thread_pool::run_job(job: u64) -> void => "thread_pool/run_job";
 
-    ported thread_pool::spawn_worker(worker_id: i32, waiting_worker_id: u64) -> u64 => "thread_pool/spawn_worker";
+    ported thread_pool::spawn_worker(completion_id: i32, job: u64) -> u64 => "thread_pool/spawn_worker";
 
     ported thread_pool::free_worker(worker: u64) -> void => "thread_pool/free_worker";
 
-    ported thread_pool::wake_worker(worker: u64, job_id: i32, job: u64) -> void => "thread_pool/wake_worker";
+    ported thread_pool::wake_worker(worker: u64, completion_id: i32, job: u64) -> void => "thread_pool/wake_worker";
 
     ported thread_pool::worker_enter_idle(worker: u64) -> void => "thread_pool/worker_enter_idle";
 

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -54,10 +54,10 @@ pub(super) fn destroy_thread_pool(context: &mut ImportContext<'_, '_>) {
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn spawn_worker(
     context: &mut ImportContext<'_, '_>,
-    worker_id: i32,
-    waiting_worker_id: u64,
+    completion_id: i32,
+    job: u64,
 ) -> AsyncHostResult<u64> {
-    context.host.spawn_worker(worker_id, waiting_worker_id)
+    context.host.spawn_worker(completion_id, job)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
@@ -69,10 +69,10 @@ pub(super) fn free_worker(context: &mut ImportContext<'_, '_>, worker: u64) -> A
 pub(super) fn wake_worker(
     context: &mut ImportContext<'_, '_>,
     worker: u64,
-    job_id: i32,
+    completion_id: i32,
     job: u64,
 ) -> AsyncHostResult<()> {
-    context.host.wake_worker(worker, job_id, job)
+    context.host.wake_worker(worker, completion_id, job)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -37,7 +37,7 @@ use crate::async_sys::internal::event_loop::{
     poll::{self, PollInstance},
     thread_pool::{
         self, FileResource, FileResourceRef, FileResourceTable, HostHandle, HostWorkerHandle,
-        HostWorkerJob, Job, OpenJobResource,
+        HostWorkerJob, Job, OpenJobResource, WorkerCompletionId,
     },
 };
 use crate::async_sys::internal::fd_util::stub::RawFd;
@@ -221,6 +221,12 @@ struct HostAddrInfo {
     next: Option<HostAddrInfoKey>,
 }
 
+#[derive(Debug)]
+struct CompletedJob {
+    key: HostJobKey,
+    job: Job,
+}
+
 fn handle_from_key(key: impl Key) -> u64 {
     key.data().as_ffi()
 }
@@ -367,7 +373,14 @@ impl AsyncHostState {
         thread_pool::open_job_get_fd(result)
     }
 
-    fn restore_completed_job(&mut self, key: HostJobKey, mut job: Job) -> AsyncHostResult<()> {
+    fn take_job(&mut self, key: HostJobKey) -> AsyncHostResult<Job> {
+        self.jobs
+            .get_mut(key)
+            .and_then(Option::take)
+            .ok_or(AsyncHostError::Badf)
+    }
+
+    fn restore_job(&mut self, key: HostJobKey, mut job: Job) -> AsyncHostResult<()> {
         let can_restore = match self.jobs.get(key) {
             Some(slot) => slot.is_none(),
             None => {
@@ -721,12 +734,14 @@ impl Drop for HostIoResult {
 
 pub(crate) struct AsyncHost {
     state: Arc<Mutex<AsyncHostState>>,
+    completed_jobs: Arc<Mutex<Vec<CompletedJob>>>,
 }
 
 impl Default for AsyncHost {
     fn default() -> Self {
         Self {
             state: Arc::new(Mutex::new(AsyncHostState::default())),
+            completed_jobs: Arc::new(Mutex::new(Vec::new())),
         }
     }
 }
@@ -734,6 +749,21 @@ impl Default for AsyncHost {
 impl AsyncHost {
     pub(crate) fn invalid_fd(&self) -> HostHandle {
         self.state.lock().unwrap().invalid_fd()
+    }
+
+    fn restore_completed_jobs(&self) {
+        let completed_jobs = {
+            let mut completed_jobs = self.completed_jobs.lock().unwrap();
+            if completed_jobs.is_empty() {
+                return;
+            }
+            std::mem::take(&mut *completed_jobs)
+        };
+
+        let mut state = self.state.lock().unwrap();
+        for CompletedJob { key, job } in completed_jobs {
+            let _ = state.restore_job(key, job);
+        }
     }
 
     pub(crate) fn get_errno(&self) -> i32 {
@@ -754,6 +784,7 @@ impl AsyncHost {
         if std::thread::panicking() || std::env::var_os(CHECK_FD_LEAK_ENV).is_none() {
             return;
         }
+        self.restore_completed_jobs();
 
         let summary = {
             let state = self.state.lock().unwrap();
@@ -965,6 +996,7 @@ impl AsyncHost {
             let mut state = self.state.lock().unwrap();
             state.current_event_poll = Some(poll_key);
         }
+        self.restore_completed_jobs();
         Ok(result)
     }
 
@@ -1125,8 +1157,12 @@ impl AsyncHost {
             state.take_workers()
         };
         for worker in workers {
-            thread_pool::free_worker(worker);
+            if let Some(worker_job) = thread_pool::free_worker(worker) {
+                let mut state = self.state.lock().unwrap();
+                let _ = state.restore_job(worker_job.job_key, worker_job.job);
+            }
         }
+        self.restore_completed_jobs();
 
         let mut state = self.state.lock().unwrap();
         #[cfg(unix)]
@@ -1219,6 +1255,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn free_job(&self, handle: u64) -> AsyncHostResult<()> {
+        self.restore_completed_jobs();
         self.state
             .lock()
             .unwrap()
@@ -1229,6 +1266,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn job_get_ret(&self, handle: u64) -> AsyncHostResult<i64> {
+        self.restore_completed_jobs();
         let state = self.state.lock().unwrap();
         let job = state
             .jobs
@@ -1239,6 +1277,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn job_get_err(&self, handle: u64) -> AsyncHostResult<i32> {
+        self.restore_completed_jobs();
         let state = self.state.lock().unwrap();
         let job = state
             .jobs
@@ -1249,6 +1288,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn open_job_get_fd(&self, handle: u64) -> AsyncHostResult<HostHandle> {
+        self.restore_completed_jobs();
         self.state
             .lock()
             .unwrap()
@@ -1256,6 +1296,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn open_job_get_kind(&self, handle: u64) -> AsyncHostResult<i32> {
+        self.restore_completed_jobs();
         let state = self.state.lock().unwrap();
         let job = state
             .jobs
@@ -1267,6 +1308,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn open_job_get_dev_id(&self, handle: u64) -> AsyncHostResult<u64> {
+        self.restore_completed_jobs();
         let state = self.state.lock().unwrap();
         let job = state
             .jobs
@@ -1278,6 +1320,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn open_job_get_file_id(&self, handle: u64) -> AsyncHostResult<u64> {
+        self.restore_completed_jobs();
         let state = self.state.lock().unwrap();
         let job = state
             .jobs
@@ -1289,6 +1332,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn get_file_size_result(&self, handle: u64) -> AsyncHostResult<i64> {
+        self.restore_completed_jobs();
         let state = self.state.lock().unwrap();
         let job = state
             .jobs
@@ -1299,6 +1343,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn get_getaddrinfo_result(&self, handle: u64) -> AsyncHostResult<u64> {
+        self.restore_completed_jobs();
         let mut state = self.state.lock().unwrap();
         let addrs: Vec<Box<[u8]>> = {
             let job = state
@@ -2025,48 +2070,60 @@ impl AsyncHost {
 
     pub(crate) fn run_job(&self, handle: u64) -> AsyncHostResult<()> {
         let key = key_from_handle::<HostJobKey>(handle);
-        let mut job = self
-            .state
-            .lock()
-            .unwrap()
-            .jobs
-            .get_mut(key)
-            .and_then(Option::take)
-            .ok_or(AsyncHostError::Badf)?;
+        let mut job = self.state.lock().unwrap().take_job(key)?;
         thread_pool::run_host_job(&mut job);
         let mut state = self.state.lock().unwrap();
-        state.restore_completed_job(key, job)
+        state.restore_job(key, job)
     }
 
-    pub(crate) fn spawn_worker(&self, job_id: i32, job_handle: u64) -> AsyncHostResult<u64> {
+    pub(crate) fn spawn_worker(&self, completion_id: i32, job_handle: u64) -> AsyncHostResult<u64> {
+        self.restore_completed_jobs();
+        let completion_id = WorkerCompletionId::from_abi(completion_id);
+        let job_key = key_from_handle::<HostJobKey>(job_handle);
         #[cfg(unix)]
         let worker = {
-            let completion_notifier = self
-                .state
-                .lock()
-                .unwrap()
-                .completion_notifier
-                .clone()
-                .ok_or(AsyncHostError::Badf)?;
-            self.spawn_worker_thread(HostWorkerJob { job_id, job_handle }, move |worker_job| {
-                let _ = completion_notifier.notify(worker_job.job_id);
-            })
+            let (completion_notifier, job) = {
+                let mut state = self.state.lock().unwrap();
+                let completion_notifier = state
+                    .completion_notifier
+                    .clone()
+                    .ok_or(AsyncHostError::Badf)?;
+                let job = state.take_job(job_key)?;
+                (completion_notifier, job)
+            };
+            self.spawn_worker_thread(
+                HostWorkerJob {
+                    completion_id,
+                    job_key,
+                    job,
+                },
+                move |completion_id| {
+                    let _ = completion_notifier.notify(completion_id.as_i32());
+                },
+            )
         };
         #[cfg(windows)]
         let worker = {
-            let completion_target = self
-                .state
-                .lock()
-                .unwrap()
-                .completion_port
-                .ok_or(AsyncHostError::Badf)?;
-            self.spawn_worker_thread(HostWorkerJob { job_id, job_handle }, move |worker_job| {
-                let _ = poll::post_thread_pool_completion(
-                    completion_target.port,
-                    worker_job.job_id,
-                    completion_target.generation,
-                );
-            })
+            let (completion_target, job) = {
+                let mut state = self.state.lock().unwrap();
+                let completion_target = state.completion_port.ok_or(AsyncHostError::Badf)?;
+                let job = state.take_job(job_key)?;
+                (completion_target, job)
+            };
+            self.spawn_worker_thread(
+                HostWorkerJob {
+                    completion_id,
+                    job_key,
+                    job,
+                },
+                move |completion_id| {
+                    let _ = poll::post_thread_pool_completion(
+                        completion_target.port,
+                        completion_id.as_i32(),
+                        completion_target.generation,
+                    );
+                },
+            )
         };
         let key = self.state.lock().unwrap().workers.insert(worker);
         Ok(handle_from_key(key))
@@ -2075,29 +2132,53 @@ impl AsyncHost {
     pub(crate) fn wake_worker(
         &self,
         worker_handle: u64,
-        job_id: i32,
+        completion_id: i32,
         job_handle: u64,
     ) -> AsyncHostResult<()> {
-        let state = self.state.lock().unwrap();
-        let worker = state
-            .workers
-            .get(key_from_handle::<HostWorkerKey>(worker_handle))
-            .ok_or(AsyncHostError::Badf)?;
-        thread_pool::wake_worker(worker, HostWorkerJob { job_id, job_handle });
+        self.restore_completed_jobs();
+        let completion_id = WorkerCompletionId::from_abi(completion_id);
+        let worker_key = key_from_handle::<HostWorkerKey>(worker_handle);
+        let job_key = key_from_handle::<HostJobKey>(job_handle);
+        let mut state = self.state.lock().unwrap();
+        if state.workers.get(worker_key).is_none() {
+            return Err(AsyncHostError::Badf);
+        }
+        let job = state.take_job(job_key)?;
+        let replaced_job = {
+            let worker = state.workers.get(worker_key).ok_or(AsyncHostError::Badf)?;
+            thread_pool::wake_worker(
+                worker,
+                HostWorkerJob {
+                    completion_id,
+                    job_key,
+                    job,
+                },
+            )
+        };
+        if let Some(HostWorkerJob { job_key, job, .. }) = replaced_job {
+            let _ = state.restore_job(job_key, job);
+        }
         Ok(())
     }
 
     pub(crate) fn worker_enter_idle(&self, worker_handle: u64) -> AsyncHostResult<()> {
-        let state = self.state.lock().unwrap();
-        let worker = state
-            .workers
-            .get(key_from_handle::<HostWorkerKey>(worker_handle))
-            .ok_or(AsyncHostError::Badf)?;
-        thread_pool::worker_enter_idle(worker);
+        self.restore_completed_jobs();
+        let mut state = self.state.lock().unwrap();
+        let replaced_job = {
+            let worker = state
+                .workers
+                .get(key_from_handle::<HostWorkerKey>(worker_handle))
+                .ok_or(AsyncHostError::Badf)?;
+            thread_pool::worker_enter_idle(worker)
+        };
+        if let Some(HostWorkerJob { job_key, job, .. }) = replaced_job {
+            let _ = state.restore_job(job_key, job);
+        }
         Ok(())
     }
 
     pub(crate) fn free_worker(&self, worker_handle: u64) -> AsyncHostResult<()> {
+        self.restore_completed_jobs();
         let worker = self
             .state
             .lock()
@@ -2105,7 +2186,11 @@ impl AsyncHost {
             .workers
             .remove(key_from_handle::<HostWorkerKey>(worker_handle))
             .ok_or(AsyncHostError::Badf)?;
-        thread_pool::free_worker(worker);
+        if let Some(HostWorkerJob { job_key, job, .. }) = thread_pool::free_worker(worker) {
+            let mut state = self.state.lock().unwrap();
+            let _ = state.restore_job(job_key, job);
+        }
+        self.restore_completed_jobs();
         Ok(())
     }
 
@@ -2126,6 +2211,7 @@ impl AsyncHost {
         offset: i32,
         len: i32,
     ) -> AsyncHostResult<()> {
+        self.restore_completed_jobs();
         let state = self.state.lock().unwrap();
         let job = state
             .jobs
@@ -2141,6 +2227,7 @@ impl AsyncHost {
         handle: u64,
         dst: i32,
     ) -> AsyncHostResult<()> {
+        self.restore_completed_jobs();
         let state = self.state.lock().unwrap();
         let job = state
             .jobs
@@ -2158,6 +2245,7 @@ impl AsyncHost {
         dst: i32,
         max_jobs: i32,
     ) -> AsyncHostResult<i32> {
+        self.restore_completed_jobs();
         let (completion_notifier, completion_source) = {
             let state = self.state.lock().unwrap();
             (
@@ -2193,33 +2281,23 @@ impl AsyncHost {
     fn spawn_worker_thread(
         &self,
         init_job: HostWorkerJob,
-        mut complete_job: impl FnMut(HostWorkerJob) + Send + 'static,
+        mut complete_job: impl FnMut(WorkerCompletionId) + Send + 'static,
     ) -> HostWorkerHandle {
-        let state = Arc::clone(&self.state);
-        let run_state = Arc::clone(&state);
+        let completed_jobs = Arc::clone(&self.completed_jobs);
         thread_pool::spawn_worker(
             init_job,
             move |worker_job| {
-                let key = key_from_handle::<HostJobKey>(worker_job.job_handle);
-                let Some(mut job) = run_state
-                    .lock()
-                    .unwrap()
-                    .jobs
-                    .get_mut(key)
-                    .and_then(Option::take)
-                else {
-                    return;
-                };
-
-                thread_pool::run_host_job(&mut job);
-
-                let mut state = run_state.lock().unwrap();
-                let _ = state.restore_completed_job(key, job);
+                thread_pool::run_host_job(&mut worker_job.job);
             },
             move |worker_job| {
                 // Even if cancellation discarded the job handle, the event loop
                 // still needs the completion to move the worker out of running.
-                complete_job(worker_job);
+                let completion_id = worker_job.completion_id;
+                completed_jobs.lock().unwrap().push(CompletedJob {
+                    key: worker_job.job_key,
+                    job: worker_job.job,
+                });
+                complete_job(completion_id);
             },
         )
     }
@@ -2534,7 +2612,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn fetch_completion_publishes_job_id_without_copying_payload() {
+    fn fetch_completion_publishes_completion_id_without_copying_payload() {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
@@ -2599,7 +2677,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn fetch_completion_leaves_unfetched_job_ids_in_os_source() {
+    fn fetch_completion_leaves_unfetched_completion_ids_in_os_source() {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
@@ -2712,10 +2790,7 @@ mod tests {
 
         {
             let mut state = host.state.lock().unwrap();
-            assert_eq!(
-                state.restore_completed_job(key, job),
-                Err(AsyncHostError::Badf)
-            );
+            assert_eq!(state.restore_job(key, job), Err(AsyncHostError::Badf));
             assert_eq!(state.files.len(), 1);
         }
 
@@ -2748,6 +2823,36 @@ mod tests {
         drop(host);
 
         assert!(state.upgrade().is_none());
+    }
+
+    #[test]
+    fn worker_result_is_available_after_completion_event() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let completion_source = host.init_thread_pool(poll).unwrap();
+        let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
+        let worker = host.spawn_worker(42, job).unwrap();
+
+        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+        assert_eq!(host.job_get_ret(job).unwrap(), 0);
+
+        #[cfg(unix)]
+        {
+            let mut memory = [0; 4];
+            host.fetch_completion(memory.as_mut_slice(), completion_source, 0, 1)
+                .unwrap();
+            assert_eq!(i32::from_le_bytes(memory), 42);
+        }
+        #[cfg(windows)]
+        {
+            let event = host.poll_get_event(poll, 0).unwrap();
+            assert_eq!(host.poll_event_fd(event).unwrap(), completion_source);
+            assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 42);
+        }
+
+        host.free_worker(worker).unwrap();
+        host.free_job(job).unwrap();
+        host.destroy_thread_pool();
     }
 
     #[test]
@@ -2796,6 +2901,7 @@ mod tests {
             host.wake_worker(old_worker, 44, wake_job),
             Err(AsyncHostError::Badf)
         );
+        host.free_job(wake_job).unwrap();
         assert_eq!(host.free_worker(old_worker), Err(AsyncHostError::Badf));
 
         host.destroy_thread_pool();
@@ -2811,10 +2917,10 @@ mod tests {
         let stale_completion = host.state.lock().unwrap().completion_port.unwrap();
         // Fill the current IOCP batch so a valid completion can sit behind
         // stale completions from the destroyed pool generation.
-        for job_id in 0..1024 {
+        for completion_id in 0..1024 {
             poll::post_thread_pool_completion(
                 stale_completion.port,
-                job_id,
+                completion_id,
                 stale_completion.generation,
             )
             .unwrap();

--- a/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
@@ -58,8 +58,8 @@ impl ThreadPoolCompletionNotifier {
         ))
     }
 
-    pub(crate) fn notify(&self, job_id: i32) -> AsyncHostResult<()> {
-        let bytes = job_id.to_ne_bytes();
+    pub(crate) fn notify(&self, completion_id: i32) -> AsyncHostResult<()> {
+        let bytes = completion_id.to_ne_bytes();
         let mut offset = 0;
         loop {
             let n = unsafe {

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
@@ -184,7 +184,7 @@ ported_fns! {
 
 pub(crate) fn post_thread_pool_completion(
     completion_port: CompletionPort,
-    job_id: i32,
+    completion_id: i32,
     generation: usize,
 ) -> AsyncHostResult<()> {
     use windows_sys::Win32::Foundation::{GetLastError, INVALID_HANDLE_VALUE};
@@ -192,11 +192,12 @@ pub(crate) fn post_thread_pool_completion(
 
     debug_assert_ne!(generation, 0);
     // Native thread_pool.c posts worker completions to the event bus IOCP with
-    // INVALID_HANDLE_VALUE as the completion key and the job id as transferred bytes.
+    // INVALID_HANDLE_VALUE as the completion key and the native job id as
+    // transferred bytes. Rust treats that value as an opaque completion id.
     if unsafe {
         PostQueuedCompletionStatus(
             completion_port.0,
-            job_id as u32,
+            completion_id as u32,
             INVALID_HANDLE_VALUE as usize,
             worker_generation_to_overlapped(generation),
         )

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -41,8 +41,8 @@ pub(crate) use types::{
     OpenJobResource, OpenJobResult,
 };
 pub(crate) use worker::{
-    HostWorkerHandle, HostWorkerJob, cancel_worker, free_worker, spawn_worker, wake_worker,
-    worker_enter_idle,
+    HostWorkerHandle, HostWorkerJob, WorkerCompletionId, cancel_worker, free_worker, spawn_worker,
+    wake_worker, worker_enter_idle,
 };
 
 #[cfg(test)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -21,13 +21,29 @@ use std::thread::JoinHandle;
 
 #[cfg(windows)]
 use crate::async_host::AsyncHostError;
-use crate::async_host::AsyncHostResult;
+use crate::async_host::{AsyncHostResult, HostJobKey};
 use crate::async_sys::ported_fns;
 
+use super::Job;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WorkerCompletionId(i32);
+
+impl WorkerCompletionId {
+    pub(crate) fn from_abi(value: i32) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn as_i32(self) -> i32 {
+        self.0
+    }
+}
+
+#[derive(Debug)]
 pub(crate) struct HostWorkerJob {
-    pub(crate) job_id: i32,
-    pub(crate) job_handle: u64,
+    pub(crate) completion_id: WorkerCompletionId,
+    pub(crate) job_key: HostJobKey,
+    pub(crate) job: Job,
 }
 
 #[derive(Debug)]
@@ -87,7 +103,7 @@ fn init_worker_signal_handler() {
 impl HostWorkerHandle {
     pub(crate) fn spawn(
         init_job: HostWorkerJob,
-        mut run_job: impl FnMut(HostWorkerJob) + Send + 'static,
+        mut run_job: impl FnMut(&mut HostWorkerJob) + Send + 'static,
         mut complete_job: impl FnMut(HostWorkerJob) + Send + 'static,
     ) -> Self {
         #[cfg(unix)]
@@ -114,38 +130,27 @@ impl HostWorkerHandle {
 
             loop {
                 let job = {
-                    let state = worker_shared.state.lock().unwrap();
-                    if state.terminating { None } else { state.job }
+                    let mut state = worker_shared.state.lock().unwrap();
+                    while state.job.is_none() && !state.terminating {
+                        state.waiting = true;
+                        state = worker_shared.wakeup.wait(state).unwrap();
+                    }
+                    (!state.terminating).then(|| state.job.take()).flatten()
                 };
-                let Some(job) = job else {
+                let Some(mut job) = job else {
                     break;
                 };
-                run_job(job);
+                run_job(&mut job);
 
-                let (terminating, should_wait) = {
+                let terminating = {
                     let mut state = worker_shared.state.lock().unwrap();
-                    if state.terminating {
-                        (true, false)
-                    } else if state.job == Some(job) {
+                    if !state.terminating && state.job.is_none() {
                         state.waiting = true;
-                        (false, true)
-                    } else {
-                        (false, false)
                     }
+                    state.terminating
                 };
                 complete_job(job);
                 if terminating {
-                    break;
-                }
-                if !should_wait {
-                    continue;
-                }
-
-                let mut state = worker_shared.state.lock().unwrap();
-                while state.waiting && !state.terminating {
-                    state = worker_shared.wakeup.wait(state).unwrap();
-                }
-                if state.terminating {
                     break;
                 }
             }
@@ -163,20 +168,22 @@ impl HostWorkerHandle {
         }
     }
 
-    pub(crate) fn wake(&self, job: Option<HostWorkerJob>) {
+    pub(crate) fn wake(&self, job: Option<HostWorkerJob>) -> Option<HostWorkerJob> {
         let mut state = self.shared.state.lock().unwrap();
         // A missing job is only used by `free_worker`; keep it as an explicit
         // termination state so a wake sent during `run_job` is still observed.
         if job.is_none() {
             state.terminating = true;
         }
+        let previous_job = state.job.take();
         state.job = job;
         state.waiting = false;
         self.shared.wakeup.notify_one();
+        previous_job
     }
 
-    pub(crate) fn enter_idle(&self) {
-        self.shared.state.lock().unwrap().job = None;
+    pub(crate) fn enter_idle(&self) -> Option<HostWorkerJob> {
+        self.shared.state.lock().unwrap().job.take()
     }
 
     pub(crate) fn cancel(&self) -> AsyncHostResult<i32> {
@@ -216,11 +223,16 @@ impl HostWorkerHandle {
         }
     }
 
-    pub(crate) fn join(&mut self) {
+    pub(crate) fn join(&mut self) -> Option<HostWorkerJob> {
+        let previous_job = if self.thread.is_some() {
+            self.wake(None)
+        } else {
+            None
+        };
         if let Some(thread) = self.thread.take() {
-            self.wake(None);
             let _ = thread.join();
         }
+        previous_job
     }
 }
 
@@ -231,7 +243,7 @@ ported_fns! {
     )]
     pub(crate) fn spawn_worker(
         init_job: HostWorkerJob,
-        run_job: impl FnMut(HostWorkerJob) + Send + 'static,
+        run_job: impl FnMut(&mut HostWorkerJob) + Send + 'static,
         complete_job: impl FnMut(HostWorkerJob) + Send + 'static,
     ) -> HostWorkerHandle {
         HostWorkerHandle::spawn(init_job, run_job, complete_job)
@@ -241,16 +253,19 @@ ported_fns! {
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_wake_worker"
     )]
-    pub(crate) fn wake_worker(worker: &HostWorkerHandle, job: HostWorkerJob) {
-        worker.wake(Some(job));
+    pub(crate) fn wake_worker(
+        worker: &HostWorkerHandle,
+        job: HostWorkerJob,
+    ) -> Option<HostWorkerJob> {
+        worker.wake(Some(job))
     }
 
     #[ported(
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_worker_enter_idle"
     )]
-    pub(crate) fn worker_enter_idle(worker: &HostWorkerHandle) {
-        worker.enter_idle();
+    pub(crate) fn worker_enter_idle(worker: &HostWorkerHandle) -> Option<HostWorkerJob> {
+        worker.enter_idle()
     }
 
     #[ported(
@@ -265,67 +280,64 @@ ported_fns! {
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_free_worker"
     )]
-    pub(crate) fn free_worker(mut worker: HostWorkerHandle) {
-        worker.join();
+    pub(crate) fn free_worker(mut worker: HostWorkerHandle) -> Option<HostWorkerJob> {
+        worker.join()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::async_sys::internal::event_loop::thread_pool::make_sleep_job;
+    use slotmap::KeyData;
     use std::sync::mpsc;
+
+    fn make_job_key(value: u64) -> HostJobKey {
+        KeyData::from_ffi(value).into()
+    }
+
+    fn worker_job_summary(job: &HostWorkerJob) -> (WorkerCompletionId, HostJobKey) {
+        (job.completion_id, job.job_key)
+    }
+
+    fn make_worker_job(completion_id: i32, job_key: u64) -> HostWorkerJob {
+        HostWorkerJob {
+            completion_id: WorkerCompletionId::from_abi(completion_id),
+            job_key: make_job_key(job_key),
+            job: make_sleep_job(0),
+        }
+    }
 
     #[test]
     fn host_worker_runs_initial_job_then_waits_for_wake() {
         let (sender, receiver) = mpsc::channel();
         let (completion_sender, completion_receiver) = mpsc::channel();
         let worker = spawn_worker(
-            HostWorkerJob {
-                job_id: 7,
-                job_handle: 11,
-            },
-            move |job| sender.send(job).unwrap(),
-            move |job| completion_sender.send(job).unwrap(),
+            make_worker_job(7, 11),
+            move |job| sender.send(worker_job_summary(job)).unwrap(),
+            move |job| completion_sender.send(worker_job_summary(&job)).unwrap(),
         );
 
         assert_eq!(
             receiver.recv().unwrap(),
-            HostWorkerJob {
-                job_id: 7,
-                job_handle: 11
-            }
+            (WorkerCompletionId::from_abi(7), make_job_key(11))
         );
         assert_eq!(
             completion_receiver.recv().unwrap(),
-            HostWorkerJob {
-                job_id: 7,
-                job_handle: 11
-            }
+            (WorkerCompletionId::from_abi(7), make_job_key(11))
         );
         assert_eq!(cancel_worker(&worker), Ok(1));
 
-        wake_worker(
-            &worker,
-            HostWorkerJob {
-                job_id: 13,
-                job_handle: 17,
-            },
-        );
+        assert!(wake_worker(&worker, make_worker_job(13, 17)).is_none());
         assert_eq!(
             receiver.recv().unwrap(),
-            HostWorkerJob {
-                job_id: 13,
-                job_handle: 17
-            }
+            (WorkerCompletionId::from_abi(13), make_job_key(17))
         );
         assert_eq!(
             completion_receiver.recv().unwrap(),
-            HostWorkerJob {
-                job_id: 13,
-                job_handle: 17
-            }
+            (WorkerCompletionId::from_abi(13), make_job_key(17))
         );
-        free_worker(worker);
+        assert!(free_worker(worker).is_none());
     }
 
     #[test]
@@ -333,29 +345,26 @@ mod tests {
         let (sender, receiver) = mpsc::channel();
         let (completion_sender, completion_receiver) = mpsc::channel();
         let worker = spawn_worker(
-            HostWorkerJob {
-                job_id: 1,
-                job_handle: 2,
-            },
-            move |job| sender.send(job).unwrap(),
-            move |job| completion_sender.send(job).unwrap(),
+            make_worker_job(1, 2),
+            move |job| sender.send(worker_job_summary(job)).unwrap(),
+            move |job| completion_sender.send(worker_job_summary(&job)).unwrap(),
         );
 
-        assert_eq!(receiver.recv().unwrap().job_id, 1);
-        assert_eq!(completion_receiver.recv().unwrap().job_id, 1);
-
-        worker_enter_idle(&worker);
-        wake_worker(
-            &worker,
-            HostWorkerJob {
-                job_id: 3,
-                job_handle: 4,
-            },
+        assert_eq!(receiver.recv().unwrap().0, WorkerCompletionId::from_abi(1));
+        assert_eq!(
+            completion_receiver.recv().unwrap().0,
+            WorkerCompletionId::from_abi(1)
         );
 
-        assert_eq!(receiver.recv().unwrap().job_id, 3);
-        assert_eq!(completion_receiver.recv().unwrap().job_id, 3);
-        free_worker(worker);
+        assert!(worker_enter_idle(&worker).is_none());
+        assert!(wake_worker(&worker, make_worker_job(3, 4)).is_none());
+
+        assert_eq!(receiver.recv().unwrap().0, WorkerCompletionId::from_abi(3));
+        assert_eq!(
+            completion_receiver.recv().unwrap().0,
+            WorkerCompletionId::from_abi(3)
+        );
+        assert!(free_worker(worker).is_none());
     }
 
     #[test]
@@ -364,39 +373,97 @@ mod tests {
         let (release_sender, release_receiver) = mpsc::channel();
         let (completion_sender, completion_receiver) = mpsc::channel();
         let worker = spawn_worker(
-            HostWorkerJob {
-                job_id: 1,
-                job_handle: 2,
-            },
+            make_worker_job(1, 2),
             move |job| {
-                started_sender.send(job).unwrap();
-                if job.job_id == 1 {
+                started_sender.send(worker_job_summary(job)).unwrap();
+                if job.completion_id == WorkerCompletionId::from_abi(1) {
                     release_receiver.recv().unwrap();
                 }
             },
-            move |job| completion_sender.send(job).unwrap(),
+            move |job| completion_sender.send(worker_job_summary(&job)).unwrap(),
         );
 
-        assert_eq!(started_receiver.recv().unwrap().job_id, 1);
-        wake_worker(
-            &worker,
-            HostWorkerJob {
-                job_id: 3,
-                job_handle: 4,
-            },
+        assert_eq!(
+            started_receiver.recv().unwrap().0,
+            WorkerCompletionId::from_abi(1)
         );
+        assert!(wake_worker(&worker, make_worker_job(3, 4)).is_none());
         release_sender.send(()).unwrap();
 
-        assert_eq!(completion_receiver.recv().unwrap().job_id, 1);
+        assert_eq!(
+            completion_receiver.recv().unwrap().0,
+            WorkerCompletionId::from_abi(1)
+        );
         assert_eq!(
             started_receiver
                 .recv_timeout(std::time::Duration::from_secs(1))
                 .unwrap()
-                .job_id,
-            3
+                .0,
+            WorkerCompletionId::from_abi(3)
         );
-        assert_eq!(completion_receiver.recv().unwrap().job_id, 3);
-        free_worker(worker);
+        assert_eq!(
+            completion_receiver.recv().unwrap().0,
+            WorkerCompletionId::from_abi(3)
+        );
+        assert!(free_worker(worker).is_none());
+    }
+
+    #[test]
+    fn completion_receives_job_mutated_by_runner() {
+        let (completion_sender, completion_receiver) = mpsc::channel();
+        let worker = spawn_worker(
+            make_worker_job(1, 2),
+            move |job| job.job.set_ret(123),
+            move |job| completion_sender.send(job.job.ret()).unwrap(),
+        );
+
+        assert_eq!(completion_receiver.recv().unwrap(), 123);
+        assert!(free_worker(worker).is_none());
+    }
+
+    #[test]
+    fn worker_enter_idle_returns_queued_job() {
+        let (started_sender, started_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let (completion_sender, completion_receiver) = mpsc::channel();
+        let worker = spawn_worker(
+            make_worker_job(1, 2),
+            move |job| {
+                started_sender.send(worker_job_summary(job)).unwrap();
+                release_receiver.recv().unwrap();
+            },
+            move |job| completion_sender.send(worker_job_summary(&job)).unwrap(),
+        );
+
+        assert_eq!(
+            started_receiver.recv().unwrap(),
+            (WorkerCompletionId::from_abi(1), make_job_key(2))
+        );
+        assert!(wake_worker(&worker, make_worker_job(3, 4)).is_none());
+        let displaced = worker_enter_idle(&worker).unwrap();
+        assert_eq!(
+            worker_job_summary(&displaced),
+            (WorkerCompletionId::from_abi(3), make_job_key(4))
+        );
+
+        release_sender.send(()).unwrap();
+        assert_eq!(
+            completion_receiver.recv().unwrap(),
+            (WorkerCompletionId::from_abi(1), make_job_key(2))
+        );
+        assert!(wake_worker(&worker, make_worker_job(5, 6)).is_none());
+        assert_eq!(
+            started_receiver
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .unwrap(),
+            (WorkerCompletionId::from_abi(5), make_job_key(6))
+        );
+        release_sender.send(()).unwrap();
+        assert_eq!(
+            completion_receiver.recv().unwrap(),
+            (WorkerCompletionId::from_abi(5), make_job_key(6))
+        );
+        assert!(free_worker(worker).is_none());
     }
 
     #[test]
@@ -405,21 +472,24 @@ mod tests {
         let (release_sender, release_receiver) = mpsc::channel();
         let (completion_sender, completion_receiver) = mpsc::channel();
         let worker = spawn_worker(
-            HostWorkerJob {
-                job_id: 21,
-                job_handle: 34,
-            },
+            make_worker_job(21, 34),
             move |job| {
-                started_sender.send(job).unwrap();
+                started_sender.send(worker_job_summary(job)).unwrap();
                 release_receiver.recv().unwrap();
             },
-            move |job| completion_sender.send(job).unwrap(),
+            move |job| completion_sender.send(worker_job_summary(&job)).unwrap(),
         );
 
-        assert_eq!(started_receiver.recv().unwrap().job_id, 21);
-        worker.wake(None);
+        assert_eq!(
+            started_receiver.recv().unwrap().0,
+            WorkerCompletionId::from_abi(21)
+        );
+        assert!(worker.wake(None).is_none());
         release_sender.send(()).unwrap();
-        assert_eq!(completion_receiver.recv().unwrap().job_id, 21);
+        assert_eq!(
+            completion_receiver.recv().unwrap().0,
+            WorkerCompletionId::from_abi(21)
+        );
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
         while worker
@@ -436,6 +506,6 @@ mod tests {
                 .as_ref()
                 .is_some_and(|thread| thread.is_finished())
         );
-        free_worker(worker);
+        assert!(free_worker(worker).is_none());
     }
 }


### PR DESCRIPTION
## Why

The previous Rust worker path still reached back into `AsyncHostState.jobs` from the worker thread to take and restore jobs. That kept the worker tied to the global async host state and drifted from the native model, where a worker owns the current `struct job *` while it runs.

## Why this is correct

This moves the job ownership transition to the event-loop boundary: `spawn_worker` and `wake_worker` take the `Job` out of the guest-visible job slot before handing it to the worker, and the worker runs that owned job directly. When the worker completes, it pushes the finished job into a completed-job queue and posts the same completion event as before. The event-loop side drains that queue before polling/result/free paths observe jobs, restoring the original job handle slot.

Normal worker scheduling therefore mirrors the native pointer shape more closely: the worker owns the current job while it runs, and the event loop owns publication of completed results. For malformed guest calls that displace a queued job before it starts, the displaced job is returned to the table or discarded if its handle is already gone, so Rust ownership does not silently drop guest-visible state.

## Why this is minimal

This PR only changes the async job handoff between `AsyncHost` and thread-pool workers. It does not restructure the file/resource table, poll table, or broader host locking model; those can remain separate follow-up slices.