### PR TITLE
Refactor moonrun async host locks

### DIFF
--- a/crates/moonrun/docs/adr/0002-preserve-native-shaped-worker-boundary.md
+++ b/crates/moonrun/docs/adr/0002-preserve-native-shaped-worker-boundary.md
@@ -1,3 +1,11 @@
 # Preserve Native-Shaped Worker Boundary
 
 Moonrun will preserve the `moonbitlang/async` native-shaped `Worker` and `Job` boundary for wasm instead of exposing a separate wasm-specific scheduler API to MoonBit. In wasm, worker handles may represent scheduler resources rather than raw OS threads, but the MoonBit-facing structure should stay close to the native async implementation to reduce maintenance drift.
+
+When checking parity with native behavior, evaluate the native C stubs together
+with the MoonBit code that wraps them. The compatibility target is the behavior
+reachable through the `moonbitlang/async` MoonBit API, not every possible misuse
+of a raw C symbol. If the MoonBit layer constrains ownership or lifecycle, such
+as creating a private `Job`, submitting it once, reading the result, and freeing
+it, the wasm host should model that contract explicitly and document any
+deliberately stricter checks against raw C misuse.

--- a/crates/moonrun/docs/adr/0002-preserve-native-shaped-worker-boundary.md
+++ b/crates/moonrun/docs/adr/0002-preserve-native-shaped-worker-boundary.md
@@ -9,3 +9,13 @@ of a raw C symbol. If the MoonBit layer constrains ownership or lifecycle, such
 as creating a private `Job`, submitting it once, reading the result, and freeing
 it, the wasm host should model that contract explicitly and document any
 deliberately stricter checks against raw C misuse.
+
+For worker jobs, the wasm host treats a job handle as a one-shot result handle.
+A newly-created job is ready to submit once. Submitting it to a worker moves the
+payload out of the guest-visible table and leaves a reservation slot while the
+host worker runs. Completion restores the payload as result-readable, so
+`job_get_ret`, `job_get_err`, and payload-specific result accessors remain valid
+until `free_job`, but `run_job`, `spawn_worker`, and `wake_worker` reject the
+completed handle. Queued jobs remain cancellable or displaceable until a worker
+takes them; freeing a queued or running job discards the result payload when the
+worker later reports completion.

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -280,8 +280,16 @@ impl FileTable {
     }
 }
 
+// A job stays in the table while queued or running so its guest handle can
+// cancel it without making the payload available for duplicate execution.
+enum HostJobState {
+    Ready(Job),
+    Queued(Job),
+    Running,
+}
+
 struct JobTable {
-    jobs: SlotMap<HostJobKey, Option<Job>>,
+    jobs: SlotMap<HostJobKey, HostJobState>,
 }
 
 impl Default for JobTable {
@@ -293,11 +301,82 @@ impl Default for JobTable {
 }
 
 impl JobTable {
-    fn take_job(&mut self, key: HostJobKey) -> AsyncHostResult<Job> {
-        self.jobs
-            .get_mut(key)
-            .and_then(Option::take)
-            .ok_or(AsyncHostError::Badf)
+    fn insert_job(&mut self, job: Job) -> HostJobKey {
+        self.jobs.insert(HostJobState::Ready(job))
+    }
+
+    fn ready_job(&self, key: HostJobKey) -> AsyncHostResult<&Job> {
+        match self.jobs.get(key) {
+            Some(HostJobState::Ready(job)) => Ok(job),
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    fn ready_job_mut(&mut self, key: HostJobKey) -> AsyncHostResult<&mut Job> {
+        match self.jobs.get_mut(key) {
+            Some(HostJobState::Ready(job)) => Ok(job),
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    fn take_ready_job(&mut self, key: HostJobKey) -> AsyncHostResult<Job> {
+        let slot = self.jobs.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        match std::mem::replace(slot, HostJobState::Running) {
+            HostJobState::Ready(job) => Ok(job),
+            other => {
+                *slot = other;
+                Err(AsyncHostError::Badf)
+            }
+        }
+    }
+
+    fn queue_job(&mut self, key: HostJobKey) -> AsyncHostResult<()> {
+        let slot = self.jobs.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        match std::mem::replace(slot, HostJobState::Running) {
+            HostJobState::Ready(job) => {
+                *slot = HostJobState::Queued(job);
+                Ok(())
+            }
+            other => {
+                *slot = other;
+                Err(AsyncHostError::Badf)
+            }
+        }
+    }
+
+    fn take_queued_job(&mut self, key: HostJobKey) -> AsyncHostResult<Job> {
+        let slot = self.jobs.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        match std::mem::replace(slot, HostJobState::Running) {
+            HostJobState::Queued(job) => Ok(job),
+            other => {
+                *slot = other;
+                Err(AsyncHostError::Badf)
+            }
+        }
+    }
+
+    fn unqueue_job(&mut self, key: HostJobKey) -> AsyncHostResult<()> {
+        let slot = self.jobs.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        match std::mem::replace(slot, HostJobState::Running) {
+            HostJobState::Queued(job) => {
+                *slot = HostJobState::Ready(job);
+                Ok(())
+            }
+            other => {
+                *slot = other;
+                Err(AsyncHostError::Badf)
+            }
+        }
+    }
+
+    fn restore_job(&mut self, key: HostJobKey, job: &mut Option<Job>) -> bool {
+        match self.jobs.get_mut(key) {
+            Some(slot @ HostJobState::Running) => {
+                *slot = HostJobState::Ready(job.take().expect("job is restored at most once"));
+                true
+            }
+            _ => false,
+        }
     }
 }
 
@@ -776,20 +855,9 @@ impl AsyncHost {
 
     fn restore_job(&self, key: HostJobKey, job: Job) -> AsyncHostResult<()> {
         let mut job = Some(job);
-        let restored = {
-            let mut jobs = self.jobs.lock().unwrap();
-            match jobs.jobs.get_mut(key) {
-                Some(slot) if slot.is_none() => {
-                    *slot = job.take();
-                    true
-                }
-                _ => false,
-            }
-        };
-        if restored {
+        if self.jobs.lock().unwrap().restore_job(key, &mut job) {
             return Ok(());
         }
-
         let mut job = job.expect("job is only taken after being restored");
         self.discard_job_results(&mut job);
         Err(AsyncHostError::Badf)
@@ -807,11 +875,7 @@ impl AsyncHost {
         let mut jobs = self.jobs.lock().unwrap();
         let placeholder = OpenJobResource::Published(self.invalid_fd());
         let file = {
-            let job = jobs
-                .jobs
-                .get_mut(key)
-                .and_then(Option::as_mut)
-                .ok_or(AsyncHostError::Badf)?;
+            let job = jobs.ready_job_mut(key)?;
             let result = thread_pool::open_job_result_mut(job)?;
             match std::mem::replace(&mut result.resource, placeholder) {
                 OpenJobResource::Published(fd) => {
@@ -823,11 +887,7 @@ impl AsyncHost {
         };
 
         let fd = self.files.lock().unwrap().insert_file_resource(file);
-        let job = jobs
-            .jobs
-            .get_mut(key)
-            .and_then(Option::as_mut)
-            .ok_or(AsyncHostError::Badf)?;
+        let job = jobs.ready_job_mut(key)?;
         let result = thread_pool::open_job_result_mut(job)?;
         result.resource = OpenJobResource::Published(fd);
         thread_pool::open_job_get_fd(result)
@@ -1282,7 +1342,9 @@ impl AsyncHost {
                 .collect::<Vec<_>>()
         };
         for worker in workers {
-            let _ = thread_pool::free_worker(worker);
+            if let Some(replaced_job) = thread_pool::free_worker(worker) {
+                let _ = self.jobs.lock().unwrap().unqueue_job(replaced_job.job_key);
+            }
         }
         self.restore_completed_jobs();
 
@@ -1381,7 +1443,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn insert_job(&self, job: Job) -> AsyncHostResult<u64> {
-        let key = self.jobs.lock().unwrap().jobs.insert(Some(job));
+        let key = self.jobs.lock().unwrap().insert_job(job);
         Ok(handle_from_key(key))
     }
 
@@ -1399,22 +1461,14 @@ impl AsyncHost {
     pub(crate) fn job_get_ret(&self, handle: u64) -> AsyncHostResult<i64> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs
-            .jobs
-            .get(key_from_handle::<HostJobKey>(handle))
-            .and_then(Option::as_ref)
-            .ok_or(AsyncHostError::Badf)?;
+        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
         Ok(crate::async_sys::internal::event_loop::thread_pool::job_get_ret(job))
     }
 
     pub(crate) fn job_get_err(&self, handle: u64) -> AsyncHostResult<i32> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs
-            .jobs
-            .get(key_from_handle::<HostJobKey>(handle))
-            .and_then(Option::as_ref)
-            .ok_or(AsyncHostError::Badf)?;
+        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
         Ok(crate::async_sys::internal::event_loop::thread_pool::job_get_err(job))
     }
 
@@ -1426,11 +1480,7 @@ impl AsyncHost {
     pub(crate) fn open_job_get_kind(&self, handle: u64) -> AsyncHostResult<i32> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs
-            .jobs
-            .get(key_from_handle::<HostJobKey>(handle))
-            .and_then(Option::as_ref)
-            .ok_or(AsyncHostError::Badf)?;
+        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
         let result = thread_pool::open_job_result(job)?;
         Ok(thread_pool::open_job_get_kind(result))
     }
@@ -1438,11 +1488,7 @@ impl AsyncHost {
     pub(crate) fn open_job_get_dev_id(&self, handle: u64) -> AsyncHostResult<u64> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs
-            .jobs
-            .get(key_from_handle::<HostJobKey>(handle))
-            .and_then(Option::as_ref)
-            .ok_or(AsyncHostError::Badf)?;
+        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
         let result = thread_pool::open_job_result(job)?;
         Ok(thread_pool::open_job_get_dev_id(result))
     }
@@ -1450,11 +1496,7 @@ impl AsyncHost {
     pub(crate) fn open_job_get_file_id(&self, handle: u64) -> AsyncHostResult<u64> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs
-            .jobs
-            .get(key_from_handle::<HostJobKey>(handle))
-            .and_then(Option::as_ref)
-            .ok_or(AsyncHostError::Badf)?;
+        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
         let result = thread_pool::open_job_result(job)?;
         Ok(thread_pool::open_job_get_file_id(result))
     }
@@ -1462,11 +1504,7 @@ impl AsyncHost {
     pub(crate) fn get_file_size_result(&self, handle: u64) -> AsyncHostResult<i64> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs
-            .jobs
-            .get(key_from_handle::<HostJobKey>(handle))
-            .and_then(Option::as_ref)
-            .ok_or(AsyncHostError::Badf)?;
+        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
         crate::async_sys::internal::event_loop::thread_pool::get_file_size_result(job)
     }
 
@@ -1474,11 +1512,7 @@ impl AsyncHost {
         self.restore_completed_jobs();
         let addrs: Vec<Box<[u8]>> = {
             let jobs = self.jobs.lock().unwrap();
-            let job = jobs
-                .jobs
-                .get(key_from_handle::<HostJobKey>(handle))
-                .and_then(Option::as_ref)
-                .ok_or(AsyncHostError::Badf)?;
+            let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
             thread_pool::getaddrinfo_job_result(job)?.to_vec()
         };
         let mut addr_infos = self.addr_infos.lock().unwrap();
@@ -2229,7 +2263,7 @@ impl AsyncHost {
 
     pub(crate) fn run_job(&self, handle: u64) -> AsyncHostResult<()> {
         let key = key_from_handle::<HostJobKey>(handle);
-        let mut job = self.jobs.lock().unwrap().take_job(key)?;
+        let mut job = self.jobs.lock().unwrap().take_ready_job(key)?;
         thread_pool::run_host_job(&mut job);
         self.restore_job(key, job)
     }
@@ -2238,13 +2272,6 @@ impl AsyncHost {
         self.restore_completed_jobs();
         let completion_id = WorkerCompletionId::from_abi(completion_id);
         let job_key = key_from_handle::<HostJobKey>(job_handle);
-        {
-            let jobs = self.jobs.lock().unwrap();
-            jobs.jobs
-                .get(job_key)
-                .and_then(Option::as_ref)
-                .ok_or(AsyncHostError::Badf)?;
-        }
         #[cfg(unix)]
         let worker = {
             let completion_notifier = self
@@ -2254,6 +2281,7 @@ impl AsyncHost {
                 .notifier
                 .clone()
                 .ok_or(AsyncHostError::Badf)?;
+            self.jobs.lock().unwrap().queue_job(job_key)?;
             self.spawn_worker_thread(
                 HostWorkerJob {
                     completion_id,
@@ -2272,6 +2300,7 @@ impl AsyncHost {
                 .unwrap()
                 .target
                 .ok_or(AsyncHostError::Badf)?;
+            self.jobs.lock().unwrap().queue_job(job_key)?;
             self.spawn_worker_thread(
                 HostWorkerJob {
                     completion_id,
@@ -2300,28 +2329,12 @@ impl AsyncHost {
         let completion_id = WorkerCompletionId::from_abi(completion_id);
         let worker_key = key_from_handle::<HostWorkerKey>(worker_handle);
         let job_key = key_from_handle::<HostJobKey>(job_handle);
-        if self
-            .workers
-            .lock()
-            .unwrap()
-            .workers
-            .get(worker_key)
-            .is_none()
-        {
-            return Err(AsyncHostError::Badf);
-        }
-        {
-            let jobs = self.jobs.lock().unwrap();
-            jobs.jobs
-                .get(job_key)
-                .and_then(Option::as_ref)
-                .ok_or(AsyncHostError::Badf)?;
-        }
         let replaced_job = {
             let workers = self.workers.lock().unwrap();
             let Some(worker) = workers.workers.get(worker_key) else {
                 return Err(AsyncHostError::Badf);
             };
+            self.jobs.lock().unwrap().queue_job(job_key)?;
             thread_pool::wake_worker(
                 worker,
                 HostWorkerJob {
@@ -2330,13 +2343,15 @@ impl AsyncHost {
                 },
             )
         };
-        let _ = replaced_job;
+        if let Some(replaced_job) = replaced_job {
+            let _ = self.jobs.lock().unwrap().unqueue_job(replaced_job.job_key);
+        }
         Ok(())
     }
 
     pub(crate) fn worker_enter_idle(&self, worker_handle: u64) -> AsyncHostResult<()> {
         self.restore_completed_jobs();
-        let _ = {
+        let replaced_job = {
             let workers = self.workers.lock().unwrap();
             let worker = workers
                 .workers
@@ -2344,6 +2359,9 @@ impl AsyncHost {
                 .ok_or(AsyncHostError::Badf)?;
             thread_pool::worker_enter_idle(worker)
         };
+        if let Some(replaced_job) = replaced_job {
+            let _ = self.jobs.lock().unwrap().unqueue_job(replaced_job.job_key);
+        }
         Ok(())
     }
 
@@ -2356,7 +2374,9 @@ impl AsyncHost {
             .workers
             .remove(key_from_handle::<HostWorkerKey>(worker_handle))
             .ok_or(AsyncHostError::Badf)?;
-        let _ = thread_pool::free_worker(worker);
+        if let Some(replaced_job) = thread_pool::free_worker(worker) {
+            let _ = self.jobs.lock().unwrap().unqueue_job(replaced_job.job_key);
+        }
         self.restore_completed_jobs();
         Ok(())
     }
@@ -2380,11 +2400,7 @@ impl AsyncHost {
     ) -> AsyncHostResult<()> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs
-            .jobs
-            .get(key_from_handle::<HostJobKey>(handle))
-            .and_then(Option::as_ref)
-            .ok_or(AsyncHostError::Badf)?;
+        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
         thread_pool::get_read_result(job, memory, dst, offset, len)
     }
 
@@ -2396,11 +2412,7 @@ impl AsyncHost {
     ) -> AsyncHostResult<()> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs
-            .jobs
-            .get(key_from_handle::<HostJobKey>(handle))
-            .and_then(Option::as_ref)
-            .ok_or(AsyncHostError::Badf)?;
+        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
         thread_pool::get_file_time_result(job, memory, dst)
     }
 
@@ -2452,7 +2464,7 @@ impl AsyncHost {
         thread_pool::spawn_worker(
             init_job,
             move |worker_job| {
-                let Ok(mut job) = jobs.lock().unwrap().take_job(worker_job.job_key) else {
+                let Ok(mut job) = jobs.lock().unwrap().take_queued_job(worker_job.job_key) else {
                     return None;
                 };
                 thread_pool::run_host_job(&mut job);
@@ -2787,9 +2799,7 @@ mod tests {
         {
             let mut jobs = host.jobs.lock().unwrap();
             let job = jobs
-                .jobs
-                .get_mut(key_from_handle::<HostJobKey>(job_handle))
-                .and_then(Option::as_mut)
+                .ready_job_mut(key_from_handle::<HostJobKey>(job_handle))
                 .unwrap();
             let thread_pool::JobPayload::Read { result, .. } = job.payload_mut() else {
                 panic!("expected read job");
@@ -2937,14 +2947,7 @@ mod tests {
             ))
             .unwrap();
         let key = key_from_handle::<HostJobKey>(job_handle);
-        let mut job = host
-            .jobs
-            .lock()
-            .unwrap()
-            .jobs
-            .get_mut(key)
-            .and_then(Option::take)
-            .unwrap();
+        let mut job = host.jobs.lock().unwrap().take_ready_job(key).unwrap();
 
         thread_pool::run_host_job(&mut job);
 
@@ -3033,13 +3036,15 @@ mod tests {
         let worker = {
             let jobs = Arc::clone(&host.jobs);
             let completed_jobs = Arc::clone(&host.completed_jobs);
+            host.jobs.lock().unwrap().queue_job(first_key).unwrap();
             thread_pool::spawn_worker(
                 HostWorkerJob {
                     completion_id: WorkerCompletionId::from_abi(1),
                     job_key: first_key,
                 },
                 move |worker_job| {
-                    let Ok(mut job) = jobs.lock().unwrap().take_job(worker_job.job_key) else {
+                    let Ok(mut job) = jobs.lock().unwrap().take_queued_job(worker_job.job_key)
+                    else {
                         return None;
                     };
                     started_sender.send(worker_job.completion_id).unwrap();
@@ -3070,19 +3075,35 @@ mod tests {
             WorkerCompletionId::from_abi(1)
         );
 
-        let path = std::env::temp_dir().join(format!(
+        let displaced_path = std::env::temp_dir().join(format!(
+            "moonrun-displaced-queued-worker-job-{}",
+            std::process::id()
+        ));
+        std::fs::write(&displaced_path, b"displaced").unwrap();
+        let displaced_job = host
+            .insert_job(thread_pool::make_remove_job(
+                displaced_path.as_os_str().to_os_string(),
+            ))
+            .unwrap();
+        let queued_path = std::env::temp_dir().join(format!(
             "moonrun-cancelled-queued-worker-job-{}",
             std::process::id()
         ));
-        std::fs::write(&path, b"queued").unwrap();
+        std::fs::write(&queued_path, b"queued").unwrap();
         let queued_job = host
             .insert_job(thread_pool::make_remove_job(
-                path.as_os_str().to_os_string(),
+                queued_path.as_os_str().to_os_string(),
             ))
             .unwrap();
 
-        host.wake_worker(worker, 2, queued_job).unwrap();
-        assert_eq!(host.job_get_ret(queued_job).unwrap(), 0);
+        host.wake_worker(worker, 2, displaced_job).unwrap();
+        host.wake_worker(worker, 3, queued_job).unwrap();
+        host.run_job(displaced_job).unwrap();
+        assert!(!displaced_path.exists());
+        host.free_job(displaced_job).unwrap();
+        assert_eq!(host.job_get_ret(queued_job), Err(AsyncHostError::Badf));
+        assert_eq!(host.run_job(queued_job), Err(AsyncHostError::Badf));
+        assert_eq!(host.spawn_worker(4, queued_job), Err(AsyncHostError::Badf));
         host.free_job(queued_job).unwrap();
 
         release_sender.send(()).unwrap();
@@ -3096,12 +3117,13 @@ mod tests {
             completion_receiver
                 .recv_timeout(std::time::Duration::from_secs(1))
                 .unwrap(),
-            (WorkerCompletionId::from_abi(2), false)
+            (WorkerCompletionId::from_abi(3), false)
         );
-        assert!(path.exists());
+        assert!(queued_path.exists());
 
         host.free_worker(worker).unwrap();
-        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(displaced_path);
+        let _ = std::fs::remove_file(queued_path);
     }
 
     #[test]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -304,14 +304,6 @@ impl JobTable {
 struct PollTable {
     polls: SlotMap<HostPollKey, Arc<Mutex<HostPoll>>>,
     current_event_poll: Option<HostPollKey>,
-    #[cfg(unix)]
-    completion_notifier: Option<Arc<ThreadPoolCompletionNotifier>>,
-    #[cfg(unix)]
-    completion_source: Option<HostHandle>,
-    #[cfg(windows)]
-    completion_port: Option<ThreadPoolCompletionTarget>,
-    #[cfg(windows)]
-    thread_pool_generation: usize,
 }
 
 impl Default for PollTable {
@@ -319,26 +311,30 @@ impl Default for PollTable {
         Self {
             polls: SlotMap::with_key(),
             current_event_poll: None,
-            #[cfg(unix)]
-            completion_notifier: None,
-            #[cfg(unix)]
-            completion_source: None,
-            #[cfg(windows)]
-            completion_port: None,
-            #[cfg(windows)]
-            thread_pool_generation: 0,
         }
     }
 }
 
-impl PollTable {
+#[derive(Default)]
+struct ThreadPoolCompletions {
+    #[cfg(unix)]
+    notifier: Option<Arc<ThreadPoolCompletionNotifier>>,
+    #[cfg(unix)]
+    source: Option<HostHandle>,
     #[cfg(windows)]
-    fn next_thread_pool_generation(&mut self) -> usize {
-        self.thread_pool_generation = self.thread_pool_generation.wrapping_add(1);
-        if self.thread_pool_generation == 0 {
-            self.thread_pool_generation = 1;
+    target: Option<ThreadPoolCompletionTarget>,
+    #[cfg(windows)]
+    generation_counter: usize,
+}
+
+impl ThreadPoolCompletions {
+    #[cfg(windows)]
+    fn advance_generation(&mut self) -> usize {
+        self.generation_counter = self.generation_counter.wrapping_add(1);
+        if self.generation_counter == 0 {
+            self.generation_counter = 1;
         }
-        self.thread_pool_generation
+        self.generation_counter
     }
 }
 
@@ -721,6 +717,7 @@ pub(crate) struct AsyncHost {
     io_results: Mutex<IoResultTable>,
     jobs: Arc<Mutex<JobTable>>,
     polls: Mutex<PollTable>,
+    thread_pool_completions: Mutex<ThreadPoolCompletions>,
     files: Mutex<FileTable>,
     workers: Mutex<WorkerTable>,
     completed_jobs: Arc<Mutex<Vec<CompletedJob>>>,
@@ -736,6 +733,7 @@ impl Default for AsyncHost {
             io_results: Mutex::new(IoResultTable::default()),
             jobs: Arc::new(Mutex::new(JobTable::default())),
             polls: Mutex::new(PollTable::default()),
+            thread_pool_completions: Mutex::new(ThreadPoolCompletions::default()),
             files: Mutex::new(FileTable::default()),
             workers: Mutex::new(WorkerTable::default()),
             completed_jobs: Arc::new(Mutex::new(Vec::new())),
@@ -880,18 +878,21 @@ impl AsyncHost {
                 if !polls.polls.is_empty() {
                     leaks.push(format!("polls={}", polls.polls.len()));
                 }
+            }
+            {
+                let completions = self.thread_pool_completions.lock().unwrap();
                 #[cfg(unix)]
                 {
-                    if polls.completion_notifier.is_some() {
+                    if completions.notifier.is_some() {
                         leaks.push("completion_notifier=1".to_string());
                     }
-                    if polls.completion_source.is_some() {
+                    if completions.source.is_some() {
                         leaks.push("completion_source=1".to_string());
                     }
                 }
                 #[cfg(windows)]
                 {
-                    if polls.completion_port.is_some() {
+                    if completions.target.is_some() {
                         leaks.push("completion_port=1".to_string());
                     }
                 }
@@ -954,20 +955,24 @@ impl AsyncHost {
         let poll = Arc::try_unwrap(poll).map_err(|_| AsyncHostError::Inval)?;
         let poll = poll.into_inner().unwrap();
 
-        #[cfg(unix)]
-        let completion_source = {
+        {
             let mut polls = self.polls.lock().unwrap();
             if polls.current_event_poll == Some(poll_key) {
                 polls.current_event_poll = None;
             }
+        }
+
+        #[cfg(unix)]
+        let completion_source = {
+            let mut completions = self.thread_pool_completions.lock().unwrap();
             if let Some(notifier) = &poll.completion_notifier
-                && polls
-                    .completion_notifier
+                && completions
+                    .notifier
                     .as_ref()
                     .is_some_and(|active| Arc::ptr_eq(active, notifier))
             {
-                polls.completion_notifier = None;
-                polls.completion_source.take()
+                completions.notifier = None;
+                completions.source.take()
             } else {
                 None
             }
@@ -980,15 +985,12 @@ impl AsyncHost {
         }
         #[cfg(windows)]
         {
-            let mut polls = self.polls.lock().unwrap();
-            if polls.current_event_poll == Some(poll_key) {
-                polls.current_event_poll = None;
-            }
-            if polls
-                .completion_port
+            let mut completions = self.thread_pool_completions.lock().unwrap();
+            if completions
+                .target
                 .is_some_and(|target| target.poll == poll_key)
             {
-                polls.completion_port = None;
+                completions.target = None;
             }
         }
         poll::poll_destroy(poll.instance);
@@ -1020,10 +1022,19 @@ impl AsyncHost {
         let poll_key = key_from_handle::<HostPollKey>(poll_handle);
         #[cfg(windows)]
         let (poll, thread_pool_generation, invalid_fd) = {
-            let polls = self.polls.lock().unwrap();
-            let poll = Arc::clone(polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?);
-            let thread_pool_generation = polls
-                .completion_port
+            let poll = Arc::clone(
+                self.polls
+                    .lock()
+                    .unwrap()
+                    .polls
+                    .get(poll_key)
+                    .ok_or(AsyncHostError::Badf)?,
+            );
+            let thread_pool_generation = self
+                .thread_pool_completions
+                .lock()
+                .unwrap()
+                .target
                 .filter(|target| target.poll == poll_key)
                 .map(|target| target.generation);
             (poll, thread_pool_generation, self.invalid_fd())
@@ -1192,16 +1203,28 @@ impl AsyncHost {
         let poll_key = key_from_handle::<HostPollKey>(poll_handle);
         let poll = {
             let polls = self.polls.lock().unwrap();
-            #[cfg(unix)]
-            if polls.completion_source.is_some() {
-                return Err(AsyncHostError::Inval);
-            }
-            #[cfg(windows)]
-            if polls.completion_port.is_some() {
-                return Err(AsyncHostError::Inval);
-            }
             Arc::clone(polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
         };
+        #[cfg(unix)]
+        if self
+            .thread_pool_completions
+            .lock()
+            .unwrap()
+            .source
+            .is_some()
+        {
+            return Err(AsyncHostError::Inval);
+        }
+        #[cfg(windows)]
+        if self
+            .thread_pool_completions
+            .lock()
+            .unwrap()
+            .target
+            .is_some()
+        {
+            return Err(AsyncHostError::Inval);
+        }
         #[cfg(unix)]
         {
             let (completion_notifier, event_fd) = {
@@ -1210,9 +1233,9 @@ impl AsyncHost {
             };
             let completion_notifier = Arc::new(completion_notifier);
             let source = {
-                let mut polls = self.polls.lock().unwrap();
-                if polls.completion_source.is_some() {
-                    drop(polls);
+                let mut completions = self.thread_pool_completions.lock().unwrap();
+                if completions.source.is_some() {
+                    drop(completions);
                     let poll = poll.lock().unwrap();
                     let _ = poll::poll_unregister(&poll.instance, event_fd);
                     drop(FileResource::new(event_fd));
@@ -1223,9 +1246,9 @@ impl AsyncHost {
                     .lock()
                     .unwrap()
                     .insert_file_resource(FileResource::new(event_fd));
-                polls.completion_notifier = Some(Arc::clone(&completion_notifier));
-                polls.completion_source = Some(source);
-                drop(polls);
+                completions.notifier = Some(Arc::clone(&completion_notifier));
+                completions.source = Some(source);
+                drop(completions);
                 let mut poll = poll.lock().unwrap();
                 poll.registered_fds.insert(raw_fd_key(event_fd), source);
                 poll.completion_notifier = Some(completion_notifier);
@@ -1236,12 +1259,12 @@ impl AsyncHost {
         #[cfg(windows)]
         {
             let completion_port = poll::CompletionPort::from_poll(&poll.lock().unwrap().instance);
-            let mut polls = self.polls.lock().unwrap();
-            if polls.completion_port.is_some() {
+            let mut completions = self.thread_pool_completions.lock().unwrap();
+            if completions.target.is_some() {
                 return Err(AsyncHostError::Inval);
             }
-            let generation = polls.next_thread_pool_generation();
-            polls.completion_port = Some(ThreadPoolCompletionTarget {
+            let generation = completions.advance_generation();
+            completions.target = Some(ThreadPoolCompletionTarget {
                 poll: poll_key,
                 port: completion_port,
                 generation,
@@ -1265,13 +1288,20 @@ impl AsyncHost {
 
         #[cfg(unix)]
         {
-            let (completion_source, polls) = {
-                let mut polls = self.polls.lock().unwrap();
-                let completion_source = polls.completion_source.take();
-                polls.completion_notifier = None;
-                let poll_entries = polls.polls.values().cloned().collect::<Vec<_>>();
-                (completion_source, poll_entries)
+            let completion_source = {
+                let mut completions = self.thread_pool_completions.lock().unwrap();
+                let completion_source = completions.source.take();
+                completions.notifier = None;
+                completion_source
             };
+            let polls = self
+                .polls
+                .lock()
+                .unwrap()
+                .polls
+                .values()
+                .cloned()
+                .collect::<Vec<_>>();
             if let Some(source) = completion_source
                 && let Ok(file) = self.files.lock().unwrap().remove_file(source)
             {
@@ -1290,7 +1320,7 @@ impl AsyncHost {
         }
         #[cfg(windows)]
         {
-            self.polls.lock().unwrap().completion_port = None;
+            self.thread_pool_completions.lock().unwrap().target = None;
         }
     }
 
@@ -1508,17 +1538,25 @@ impl AsyncHost {
         }
         #[cfg(unix)]
         {
-            let completion_source_polls = {
-                let mut polls = self.polls.lock().unwrap();
-                if polls.completion_source == Some(handle) {
-                    polls.completion_source = None;
-                    polls.completion_notifier = None;
-                    Some(polls.polls.values().cloned().collect::<Vec<_>>())
+            let completion_source_closed = {
+                let mut completions = self.thread_pool_completions.lock().unwrap();
+                if completions.source == Some(handle) {
+                    completions.source = None;
+                    completions.notifier = None;
+                    true
                 } else {
-                    None
+                    false
                 }
             };
-            if let Some(polls) = completion_source_polls {
+            if completion_source_closed {
+                let polls = self
+                    .polls
+                    .lock()
+                    .unwrap()
+                    .polls
+                    .values()
+                    .cloned()
+                    .collect::<Vec<_>>();
                 for poll in polls {
                     poll.lock().unwrap().completion_notifier = None;
                 }
@@ -2210,10 +2248,10 @@ impl AsyncHost {
         #[cfg(unix)]
         let worker = {
             let completion_notifier = self
-                .polls
+                .thread_pool_completions
                 .lock()
                 .unwrap()
-                .completion_notifier
+                .notifier
                 .clone()
                 .ok_or(AsyncHostError::Badf)?;
             self.spawn_worker_thread(
@@ -2229,10 +2267,10 @@ impl AsyncHost {
         #[cfg(windows)]
         let worker = {
             let completion_target = self
-                .polls
+                .thread_pool_completions
                 .lock()
                 .unwrap()
-                .completion_port
+                .target
                 .ok_or(AsyncHostError::Badf)?;
             self.spawn_worker_thread(
                 HostWorkerJob {
@@ -2376,13 +2414,10 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         self.restore_completed_jobs();
         let (completion_notifier, completion_source) = {
-            let polls = self.polls.lock().unwrap();
+            let completions = self.thread_pool_completions.lock().unwrap();
             (
-                polls
-                    .completion_notifier
-                    .clone()
-                    .ok_or(AsyncHostError::Badf)?,
-                polls.completion_source.ok_or(AsyncHostError::Badf)?,
+                completions.notifier.clone().ok_or(AsyncHostError::Badf)?,
+                completions.source.ok_or(AsyncHostError::Badf)?,
             )
         };
         if completion_source != source_fd {
@@ -2725,13 +2760,8 @@ mod tests {
         }
 
         {
-            let polls = host.polls.lock().unwrap();
-            polls
-                .completion_notifier
-                .as_ref()
-                .unwrap()
-                .notify(17)
-                .unwrap();
+            let completions = host.thread_pool_completions.lock().unwrap();
+            completions.notifier.as_ref().unwrap().notify(17).unwrap();
         }
         assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
         let event = host.poll_get_event(poll, 0).unwrap();
@@ -2765,10 +2795,10 @@ mod tests {
                 panic!("expected read job");
             };
             *result = Some(b"abc".to_vec());
-            host.polls
+            host.thread_pool_completions
                 .lock()
                 .unwrap()
-                .completion_notifier
+                .notifier
                 .as_ref()
                 .unwrap()
                 .notify(42)
@@ -2820,8 +2850,8 @@ mod tests {
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         {
-            let polls = host.polls.lock().unwrap();
-            let notifier = polls.completion_notifier.as_ref().unwrap();
+            let completions = host.thread_pool_completions.lock().unwrap();
+            let notifier = completions.notifier.as_ref().unwrap();
             notifier.notify(41).unwrap();
             notifier.notify(42).unwrap();
         }
@@ -3133,7 +3163,7 @@ mod tests {
         let poll = host.poll_create().unwrap();
 
         host.init_thread_pool(poll).unwrap();
-        let stale_completion = host.polls.lock().unwrap().completion_port.unwrap();
+        let stale_completion = host.thread_pool_completions.lock().unwrap().target.unwrap();
         // Fill the current IOCP batch so a valid completion can sit behind
         // stale completions from the destroyed pool generation.
         for completion_id in 0..1024 {
@@ -3147,7 +3177,7 @@ mod tests {
         host.destroy_thread_pool();
 
         let completion_notifier = host.init_thread_pool(poll).unwrap();
-        let current_completion = host.polls.lock().unwrap().completion_port.unwrap();
+        let current_completion = host.thread_pool_completions.lock().unwrap().target.unwrap();
         assert_ne!(stale_completion.generation, current_completion.generation);
 
         poll::post_thread_pool_completion(
@@ -3168,7 +3198,7 @@ mod tests {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
-        let completion = host.polls.lock().unwrap().completion_port.unwrap();
+        let completion = host.thread_pool_completions.lock().unwrap().target.unwrap();
 
         poll::post_thread_pool_completion(completion.port, 42, completion.generation).unwrap();
 

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -280,12 +280,14 @@ impl FileTable {
     }
 }
 
-// A job stays in the table while queued or running so its guest handle can
-// cancel it without making the payload available for duplicate execution.
+// Jobs are one-shot work items with result handles. Queued jobs stay cancellable
+// by handle, running jobs keep only a reservation slot, and finished jobs become
+// result-readable but cannot be submitted again.
 enum HostJobState {
     Ready(Job),
     Queued(Job),
     Running,
+    ResultReady(Job),
 }
 
 struct JobTable {
@@ -305,16 +307,16 @@ impl JobTable {
         self.jobs.insert(HostJobState::Ready(job))
     }
 
-    fn ready_job(&self, key: HostJobKey) -> AsyncHostResult<&Job> {
+    fn visible_job(&self, key: HostJobKey) -> AsyncHostResult<&Job> {
         match self.jobs.get(key) {
-            Some(HostJobState::Ready(job)) => Ok(job),
+            Some(HostJobState::Ready(job) | HostJobState::ResultReady(job)) => Ok(job),
             _ => Err(AsyncHostError::Badf),
         }
     }
 
-    fn ready_job_mut(&mut self, key: HostJobKey) -> AsyncHostResult<&mut Job> {
+    fn visible_job_mut(&mut self, key: HostJobKey) -> AsyncHostResult<&mut Job> {
         match self.jobs.get_mut(key) {
-            Some(HostJobState::Ready(job)) => Ok(job),
+            Some(HostJobState::Ready(job) | HostJobState::ResultReady(job)) => Ok(job),
             _ => Err(AsyncHostError::Badf),
         }
     }
@@ -372,7 +374,8 @@ impl JobTable {
     fn restore_job(&mut self, key: HostJobKey, job: &mut Option<Job>) -> bool {
         match self.jobs.get_mut(key) {
             Some(slot @ HostJobState::Running) => {
-                *slot = HostJobState::Ready(job.take().expect("job is restored at most once"));
+                *slot =
+                    HostJobState::ResultReady(job.take().expect("job is restored at most once"));
                 true
             }
             _ => false,
@@ -447,10 +450,10 @@ impl Default for IoResultTable {
 
 #[cfg(windows)]
 impl IoResultTable {
-    fn has_pending_io_for_raw_fd(&self, raw_fd: RawFd) -> bool {
+    fn has_pending_io_for_file(&self, file: &FileResourceRef) -> bool {
         self.io_results
             .values()
-            .any(|result| result.protects_pending_raw_fd(raw_fd))
+            .any(|result| result.protects_pending_file(file))
     }
 }
 
@@ -474,9 +477,15 @@ impl OverlappedAddr {
 }
 
 #[derive(Debug)]
+struct RegisteredFd {
+    handle: HostHandle,
+    file: FileResourceRef,
+}
+
+#[derive(Debug)]
 struct HostPoll {
     instance: PollInstance,
-    registered_fds: HashMap<isize, HostHandle>,
+    registered_fds: HashMap<isize, RegisteredFd>,
     #[cfg(unix)]
     completion_notifier: Option<Arc<ThreadPoolCompletionNotifier>>,
     event_fd_handles: Vec<Option<HostHandle>>,
@@ -517,11 +526,11 @@ struct HostIoResult {
     accept_buffer: Vec<u8>,
     accept_bytes_received: u32,
     direction: Option<HostIoDirection>,
-    pending_raw_fd: Option<RawFd>,
+    pending_file: Option<FileResourceRef>,
     // AcceptEx submits one overlapped operation with both the listening socket
-    // and a pre-created accepted socket. Cancel/status use pending_raw_fd, but
+    // and a pre-created accepted socket. Cancel/status use pending_file, but
     // close protection must cover the accepted socket as well until completion.
-    extra_pending_close_raw_fd: Option<RawFd>,
+    extra_pending_close_file: Option<FileResourceRef>,
 }
 
 #[cfg(windows)]
@@ -548,8 +557,8 @@ impl HostIoResult {
             accept_buffer: Vec::new(),
             accept_bytes_received: 0,
             direction: None,
-            pending_raw_fd: None,
-            extra_pending_close_raw_fd: None,
+            pending_file: None,
+            extra_pending_close_file: None,
         }
     }
 
@@ -569,8 +578,8 @@ impl HostIoResult {
             accept_buffer: Vec::new(),
             accept_bytes_received: 0,
             direction: None,
-            pending_raw_fd: None,
-            extra_pending_close_raw_fd: None,
+            pending_file: None,
+            extra_pending_close_file: None,
         }
     }
 
@@ -598,8 +607,8 @@ impl HostIoResult {
             accept_buffer: Vec::new(),
             accept_bytes_received: 0,
             direction: None,
-            pending_raw_fd: None,
-            extra_pending_close_raw_fd: None,
+            pending_file: None,
+            extra_pending_close_file: None,
         }
     }
 
@@ -619,8 +628,8 @@ impl HostIoResult {
             accept_buffer: Vec::new(),
             accept_bytes_received: 0,
             direction: None,
-            pending_raw_fd: None,
-            extra_pending_close_raw_fd: None,
+            pending_file: None,
+            extra_pending_close_file: None,
         }
     }
 
@@ -647,8 +656,8 @@ impl HostIoResult {
             accept_buffer: vec![0; accept_buffer_len],
             accept_bytes_received: 0,
             direction: None,
-            pending_raw_fd: None,
-            extra_pending_close_raw_fd: None,
+            pending_file: None,
+            extra_pending_close_file: None,
         })
     }
 
@@ -681,52 +690,58 @@ impl HostIoResult {
 
     #[cfg(test)]
     fn pending_raw_fd(&self) -> Option<RawFd> {
-        self.pending_raw_fd
+        self.pending_file.as_ref().map(|file| file.raw_fd())
     }
 
     fn is_pending(&self) -> bool {
-        self.pending_raw_fd.is_some() || self.extra_pending_close_raw_fd.is_some()
+        self.pending_file.is_some() || self.extra_pending_close_file.is_some()
     }
 
-    fn protects_pending_raw_fd(&self, raw_fd: RawFd) -> bool {
-        self.pending_raw_fd == Some(raw_fd) || self.extra_pending_close_raw_fd == Some(raw_fd)
+    fn protects_pending_file(&self, file: &FileResourceRef) -> bool {
+        self.pending_file
+            .as_ref()
+            .is_some_and(|pending| Arc::ptr_eq(pending, file))
+            || self
+                .extra_pending_close_file
+                .as_ref()
+                .is_some_and(|pending| Arc::ptr_eq(pending, file))
     }
 
-    fn mark_pending(&mut self, raw_fd: RawFd) -> AsyncHostResult<()> {
+    fn mark_pending(&mut self, file: FileResourceRef) -> AsyncHostResult<()> {
         if self.is_pending() {
             return Err(AsyncHostError::Inval);
         }
-        self.pending_raw_fd = Some(raw_fd);
+        self.pending_file = Some(file);
         Ok(())
     }
 
     fn mark_pending_with_close_guard(
         &mut self,
-        raw_fd: RawFd,
-        close_guard_raw_fd: RawFd,
+        file: FileResourceRef,
+        close_guard: FileResourceRef,
     ) -> AsyncHostResult<()> {
-        self.mark_pending(raw_fd)?;
-        self.extra_pending_close_raw_fd = Some(close_guard_raw_fd);
+        self.mark_pending(file)?;
+        self.extra_pending_close_file = Some(close_guard);
         Ok(())
     }
 
     fn clear_pending(&mut self) {
-        self.pending_raw_fd = None;
-        self.extra_pending_close_raw_fd = None;
+        self.pending_file = None;
+        self.extra_pending_close_file = None;
     }
 
-    fn validate_pending_handle(&self, raw_fd: RawFd) -> AsyncHostResult<()> {
+    fn validate_pending_file(&self, file: &FileResourceRef) -> AsyncHostResult<()> {
         // The import boundary may receive malformed/stale fd handles. Validate
         // before asserting the internal "pending operation uses submitter fd"
         // invariant so debug builds do not panic on bad guest input.
-        if let Some(pending_raw_fd) = self.pending_raw_fd
-            && pending_raw_fd != raw_fd
+        if let Some(pending_file) = &self.pending_file
+            && !Arc::ptr_eq(pending_file, file)
         {
             return Err(AsyncHostError::Badf);
         }
         debug_assert!(
-            match self.pending_raw_fd {
-                Some(pending_raw_fd) => pending_raw_fd == raw_fd,
+            match &self.pending_file {
+                Some(pending_file) => Arc::ptr_eq(pending_file, file),
                 None => true,
             },
             "pending IO operation must use the submitting handle"
@@ -738,9 +753,10 @@ impl HostIoResult {
         use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
         use windows_sys::Win32::System::IO::CancelIoEx;
 
-        let Some(raw_fd) = self.pending_raw_fd else {
+        let Some(file) = &self.pending_file else {
             return Ok(0);
         };
+        let raw_fd = file.raw_fd();
         let overlapped = self.overlapped_ptr();
         if unsafe { CancelIoEx(raw_fd, overlapped) } == 0 {
             let errno = last_errno();
@@ -758,9 +774,10 @@ impl HostIoResult {
         use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
         use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult};
 
-        let Some(raw_fd) = self.pending_raw_fd else {
+        let Some(file) = &self.pending_file else {
             return Ok(());
         };
+        let raw_fd = file.raw_fd();
         let overlapped = self.overlapped_ptr();
         if unsafe { CancelIoEx(raw_fd, overlapped) } == 0 {
             let errno = last_errno();
@@ -875,7 +892,7 @@ impl AsyncHost {
         let mut jobs = self.jobs.lock().unwrap();
         let placeholder = OpenJobResource::Published(self.invalid_fd());
         let file = {
-            let job = jobs.ready_job_mut(key)?;
+            let job = jobs.visible_job_mut(key)?;
             let result = thread_pool::open_job_result_mut(job)?;
             match std::mem::replace(&mut result.resource, placeholder) {
                 OpenJobResource::Published(fd) => {
@@ -887,7 +904,7 @@ impl AsyncHost {
         };
 
         let fd = self.files.lock().unwrap().insert_file_resource(file);
-        let job = jobs.ready_job_mut(key)?;
+        let job = jobs.visible_job_mut(key)?;
         let result = thread_pool::open_job_result_mut(job)?;
         result.resource = OpenJobResource::Published(fd);
         thread_pool::open_job_get_fd(result)
@@ -1063,7 +1080,8 @@ impl AsyncHost {
         fd_handle: HostHandle,
         read_only: bool,
     ) -> AsyncHostResult<()> {
-        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let file = self.file_resource(fd_handle)?;
+        let raw_fd = file.raw_fd();
         let poll = Arc::clone(
             self.polls
                 .lock()
@@ -1072,9 +1090,30 @@ impl AsyncHost {
                 .get(key_from_handle::<HostPollKey>(poll_handle))
                 .ok_or(AsyncHostError::Badf)?,
         );
+        {
+            let poll = poll.lock().unwrap();
+            poll::poll_register(&poll.instance, raw_fd, read_only)?;
+        }
+        let files = self.files.lock().unwrap();
+        if !files
+            .files
+            .get(key_from_handle::<FileResourceKey>(fd_handle))
+            .is_some_and(|current| Arc::ptr_eq(current, &file))
+        {
+            drop(files);
+            let poll = poll.lock().unwrap();
+            #[cfg(unix)]
+            poll::poll_unregister(&poll.instance, raw_fd)?;
+            return Err(AsyncHostError::Badf);
+        }
         let mut poll = poll.lock().unwrap();
-        poll::poll_register(&poll.instance, raw_fd, read_only)?;
-        poll.registered_fds.insert(raw_fd_key(raw_fd), fd_handle);
+        poll.registered_fds.insert(
+            raw_fd_key(raw_fd),
+            RegisteredFd {
+                handle: fd_handle,
+                file,
+            },
+        );
         Ok(())
     }
 
@@ -1148,7 +1187,7 @@ impl AsyncHost {
                 let fd_handle = poll_guard
                     .registered_fds
                     .get(&raw_fd_key(raw_fd))
-                    .copied()
+                    .map(|registered| registered.handle)
                     .or_else(|| completion_event_fd(raw_fd));
                 #[cfg(windows)]
                 let fd_handle = fd_handle.or(Some(invalid_fd));
@@ -1200,15 +1239,22 @@ impl AsyncHost {
             let poll_key = polls.current_event_poll.ok_or(AsyncHostError::Badf)?;
             Arc::clone(polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
         };
-        let fd = {
+        let (fd, registered_file) = {
             let poll = poll.lock().unwrap();
-            poll::event_list_get(&poll.instance, index)?;
+            let event = poll::event_list_get(&poll.instance, index)?;
+            let raw_fd = poll::event_get_fd(event);
+            let registered_file = poll
+                .registered_fds
+                .get(&raw_fd_key(raw_fd))
+                .map(|registered| Arc::clone(&registered.file));
             let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
-            poll.event_fd_handles
+            let fd = poll
+                .event_fd_handles
                 .get(index)
                 .copied()
                 .flatten()
-                .ok_or(AsyncHostError::Badf)?
+                .ok_or(AsyncHostError::Badf)?;
+            (fd, registered_file)
         };
         #[cfg(windows)]
         let is_thread_pool_completion =
@@ -1216,15 +1262,26 @@ impl AsyncHost {
         #[cfg(not(windows))]
         let is_thread_pool_completion = false;
         let files = self.files.lock().unwrap();
-        if fd == files.invalid_fd()
-            || is_thread_pool_completion
-            || files
-                .files
-                .contains_key(key_from_handle::<FileResourceKey>(fd))
-        {
+        if fd == files.invalid_fd() || is_thread_pool_completion {
             Ok(fd)
+        } else if let Some(registered_file) = registered_file {
+            let key = key_from_handle::<FileResourceKey>(fd);
+            if files
+                .files
+                .get(key)
+                .is_some_and(|current| Arc::ptr_eq(current, &registered_file))
+            {
+                Ok(fd)
+            } else {
+                Err(AsyncHostError::Badf)
+            }
         } else {
-            Err(AsyncHostError::Badf)
+            let key = key_from_handle::<FileResourceKey>(fd);
+            files
+                .files
+                .contains_key(key)
+                .then_some(fd)
+                .ok_or(AsyncHostError::Badf)
         }
     }
 
@@ -1301,16 +1358,21 @@ impl AsyncHost {
                     drop(FileResource::new(event_fd));
                     return Err(AsyncHostError::Inval);
                 }
-                let source = self
-                    .files
-                    .lock()
-                    .unwrap()
-                    .insert_file_resource(FileResource::new(event_fd));
+                let mut files = self.files.lock().unwrap();
+                let source = files.insert_file_resource(FileResource::new(event_fd));
+                let source_file = files.file(source)?;
+                drop(files);
                 completions.notifier = Some(Arc::clone(&completion_notifier));
                 completions.source = Some(source);
                 drop(completions);
                 let mut poll = poll.lock().unwrap();
-                poll.registered_fds.insert(raw_fd_key(event_fd), source);
+                poll.registered_fds.insert(
+                    raw_fd_key(event_fd),
+                    RegisteredFd {
+                        handle: source,
+                        file: source_file,
+                    },
+                );
                 poll.completion_notifier = Some(completion_notifier);
                 source
             };
@@ -1461,14 +1523,14 @@ impl AsyncHost {
     pub(crate) fn job_get_ret(&self, handle: u64) -> AsyncHostResult<i64> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
+        let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         Ok(crate::async_sys::internal::event_loop::thread_pool::job_get_ret(job))
     }
 
     pub(crate) fn job_get_err(&self, handle: u64) -> AsyncHostResult<i32> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
+        let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         Ok(crate::async_sys::internal::event_loop::thread_pool::job_get_err(job))
     }
 
@@ -1480,7 +1542,7 @@ impl AsyncHost {
     pub(crate) fn open_job_get_kind(&self, handle: u64) -> AsyncHostResult<i32> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
+        let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         let result = thread_pool::open_job_result(job)?;
         Ok(thread_pool::open_job_get_kind(result))
     }
@@ -1488,7 +1550,7 @@ impl AsyncHost {
     pub(crate) fn open_job_get_dev_id(&self, handle: u64) -> AsyncHostResult<u64> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
+        let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         let result = thread_pool::open_job_result(job)?;
         Ok(thread_pool::open_job_get_dev_id(result))
     }
@@ -1496,7 +1558,7 @@ impl AsyncHost {
     pub(crate) fn open_job_get_file_id(&self, handle: u64) -> AsyncHostResult<u64> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
+        let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         let result = thread_pool::open_job_result(job)?;
         Ok(thread_pool::open_job_get_file_id(result))
     }
@@ -1504,7 +1566,7 @@ impl AsyncHost {
     pub(crate) fn get_file_size_result(&self, handle: u64) -> AsyncHostResult<i64> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
+        let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         crate::async_sys::internal::event_loop::thread_pool::get_file_size_result(job)
     }
 
@@ -1512,7 +1574,7 @@ impl AsyncHost {
         self.restore_completed_jobs();
         let addrs: Vec<Box<[u8]>> = {
             let jobs = self.jobs.lock().unwrap();
-            let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
+            let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
             thread_pool::getaddrinfo_job_result(job)?.to_vec()
         };
         let mut addr_infos = self.addr_infos.lock().unwrap();
@@ -1560,16 +1622,23 @@ impl AsyncHost {
     }
 
     pub(crate) fn close_fd(&self, handle: HostHandle) -> AsyncHostResult<()> {
-        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
-        #[cfg(windows)]
-        if self
-            .io_results
-            .lock()
-            .unwrap()
-            .has_pending_io_for_raw_fd(raw_fd)
-        {
-            return Err(AsyncHostError::Inval);
-        }
+        let file = {
+            let mut files = self.files.lock().unwrap();
+            #[cfg(windows)]
+            {
+                let file = files.file(handle)?;
+                if self
+                    .io_results
+                    .lock()
+                    .unwrap()
+                    .has_pending_io_for_file(&file)
+                {
+                    return Err(AsyncHostError::Inval);
+                }
+            }
+            files.remove_file(handle)?
+        };
+        let raw_fd = file.raw_fd();
         #[cfg(unix)]
         {
             let completion_source_closed = {
@@ -1612,7 +1681,6 @@ impl AsyncHost {
             }
             poll.registered_fds.remove(&raw_fd_key(raw_fd));
         }
-        self.files.lock().unwrap().remove_file(handle)?;
         Ok(())
     }
 
@@ -1629,8 +1697,8 @@ impl AsyncHost {
         handle: HostHandle,
         f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
-        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
-        f(raw_fd)
+        let file = self.file_resource(handle)?;
+        f(file.raw_fd())
     }
 
     pub(crate) fn file_resource(&self, handle: HostHandle) -> AsyncHostResult<FileResourceRef> {
@@ -1652,12 +1720,13 @@ impl AsyncHost {
 
     #[cfg(unix)]
     pub(crate) fn set_nonblocking(&self, handle: HostHandle) -> AsyncHostResult<()> {
-        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
-        crate::async_sys::internal::fd_util::stub::set_nonblocking(raw_fd)
+        let file = self.file_resource(handle)?;
+        crate::async_sys::internal::fd_util::stub::set_nonblocking(file.raw_fd())
     }
 
     pub(crate) fn set_cloexec(&self, handle: HostHandle) -> AsyncHostResult<()> {
-        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
+        let file = self.file_resource(handle)?;
+        let raw_fd = file.raw_fd();
         #[cfg(unix)]
         {
             crate::async_sys::internal::fd_util::stub::set_cloexec(raw_fd)
@@ -1680,8 +1749,8 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         let offset_dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
         let dst = memory.read_exact_mut(offset_dst, len)?;
-        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
-        crate::async_sys::internal::event_loop::io::read(raw_fd, dst)
+        let file = self.file_resource(handle)?;
+        crate::async_sys::internal::event_loop::io::read(file.raw_fd(), dst)
             .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
     }
 
@@ -1696,8 +1765,8 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         let offset_src = src.checked_add(offset).ok_or(AsyncHostError::Fault)?;
         let src = memory.read_exact(offset_src, len)?;
-        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
-        crate::async_sys::internal::event_loop::io::write(raw_fd, src)
+        let file = self.file_resource(handle)?;
+        crate::async_sys::internal::event_loop::io::write(file.raw_fd(), src)
             .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
     }
 
@@ -1841,13 +1910,13 @@ impl AsyncHost {
         result_handle: u64,
         fd_handle: HostHandle,
     ) -> AsyncHostResult<i32> {
-        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let file = self.file_resource(fd_handle)?;
         let mut io_results = self.io_results.lock().unwrap();
         let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
-        result.validate_pending_handle(raw_fd)?;
+        result.validate_pending_file(&file)?;
         result.cancel_pending()
     }
 
@@ -1860,13 +1929,14 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::System::IO::GetOverlappedResult;
 
-        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let file = self.file_resource(fd_handle)?;
+        let raw_fd = file.raw_fd();
         let mut io_results = self.io_results.lock().unwrap();
         let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
-        result.validate_pending_handle(raw_fd)?;
+        result.validate_pending_file(&file)?;
         let mut bytes_transferred = 0;
         if unsafe {
             GetOverlappedResult(raw_fd, result.overlapped_ptr(), &mut bytes_transferred, 0)
@@ -1900,7 +1970,8 @@ impl AsyncHost {
         use windows_sys::Win32::Networking::WinSock as ws;
         use windows_sys::Win32::Storage::FileSystem::ReadFile;
 
-        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let file = self.file_resource(fd_handle)?;
+        let raw_fd = file.raw_fd();
         let mut io_results = self.io_results.lock().unwrap();
         let result = io_results
             .io_results
@@ -1979,7 +2050,7 @@ impl AsyncHost {
         if errno == ERROR_HANDLE_EOF as i32 {
             Ok(0)
         } else if errno == ERROR_IO_PENDING as i32 {
-            result.mark_pending(raw_fd)?;
+            result.mark_pending(file)?;
             Err(AsyncHostError::Native(errno))
         } else {
             Err(AsyncHostError::Native(errno))
@@ -1997,7 +2068,8 @@ impl AsyncHost {
         use windows_sys::Win32::Networking::WinSock as ws;
         use windows_sys::Win32::Storage::FileSystem::WriteFile;
 
-        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let file = self.file_resource(fd_handle)?;
+        let raw_fd = file.raw_fd();
         let mut io_results = self.io_results.lock().unwrap();
         let result = io_results
             .io_results
@@ -2076,7 +2148,7 @@ impl AsyncHost {
             };
             let error = AsyncHostError::Native(errno);
             if matches!(error, AsyncHostError::Native(errno) if errno == ERROR_IO_PENDING as i32) {
-                result.mark_pending(raw_fd)?;
+                result.mark_pending(file)?;
             }
             Err(error)
         }
@@ -2090,7 +2162,8 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let file = self.file_resource(fd_handle)?;
+        let raw_fd = file.raw_fd();
         let mut io_results = self.io_results.lock().unwrap();
         let result = io_results
             .io_results
@@ -2120,7 +2193,7 @@ impl AsyncHost {
         } else {
             let errno = last_wsa_errno();
             if errno == windows_sys::Win32::Foundation::ERROR_IO_PENDING as i32 {
-                result.mark_pending(raw_fd)?;
+                result.mark_pending(file)?;
             }
             Err(AsyncHostError::Native(errno))
         }
@@ -2130,11 +2203,11 @@ impl AsyncHost {
     pub(crate) fn setup_connected_socket(&self, fd_handle: HostHandle) -> AsyncHostResult<()> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let file = self.file_resource(fd_handle)?;
         let yes: u32 = 1;
         if unsafe {
             ws::setsockopt(
-                raw_fd as usize,
+                file.raw_fd() as usize,
                 ws::SOL_SOCKET,
                 ws::SO_UPDATE_CONNECT_CONTEXT,
                 (&yes as *const u32).cast(),
@@ -2157,10 +2230,10 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let files = self.files.lock().unwrap();
-        let server_fd = files.file(server_fd_handle)?.raw_fd();
-        let conn_fd = files.file(conn_fd_handle)?.raw_fd();
-        drop(files);
+        let server_file = self.file_resource(server_fd_handle)?;
+        let conn_file = self.file_resource(conn_fd_handle)?;
+        let server_fd = server_file.raw_fd();
+        let conn_fd = conn_file.raw_fd();
         let mut io_results = self.io_results.lock().unwrap();
         let result = io_results
             .io_results
@@ -2191,7 +2264,7 @@ impl AsyncHost {
         } else {
             let errno = last_wsa_errno();
             if errno == windows_sys::Win32::Foundation::ERROR_IO_PENDING as i32 {
-                result.mark_pending_with_close_guard(server_fd, conn_fd)?;
+                result.mark_pending_with_close_guard(server_file, conn_file)?;
             }
             Err(AsyncHostError::Native(errno))
         }
@@ -2231,13 +2304,12 @@ impl AsyncHost {
     ) -> AsyncHostResult<()> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let files = self.files.lock().unwrap();
-        let listen_fd = files.file(listen_fd_handle)?.raw_fd();
-        let accept_fd = files.file(accept_fd_handle)?.raw_fd();
-        let listen_socket = listen_fd as usize;
+        let listen_file = self.file_resource(listen_fd_handle)?;
+        let accept_file = self.file_resource(accept_fd_handle)?;
+        let listen_socket = listen_file.raw_fd() as usize;
         if unsafe {
             ws::setsockopt(
-                accept_fd as usize,
+                accept_file.raw_fd() as usize,
                 ws::SOL_SOCKET,
                 ws::SO_UPDATE_ACCEPT_CONTEXT,
                 (&listen_socket as *const usize).cast(),
@@ -2400,7 +2472,7 @@ impl AsyncHost {
     ) -> AsyncHostResult<()> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
+        let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         thread_pool::get_read_result(job, memory, dst, offset, len)
     }
 
@@ -2412,7 +2484,7 @@ impl AsyncHost {
     ) -> AsyncHostResult<()> {
         self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
-        let job = jobs.ready_job(key_from_handle::<HostJobKey>(handle))?;
+        let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         thread_pool::get_file_time_result(job, memory, dst)
     }
 
@@ -2766,7 +2838,7 @@ mod tests {
             assert_eq!(
                 poll.registered_fds
                     .get(&raw_fd_key(raw_completion_fd))
-                    .copied(),
+                    .map(|registered| registered.handle),
                 Some(completion_source)
             );
         }
@@ -2799,7 +2871,7 @@ mod tests {
         {
             let mut jobs = host.jobs.lock().unwrap();
             let job = jobs
-                .ready_job_mut(key_from_handle::<HostJobKey>(job_handle))
+                .visible_job_mut(key_from_handle::<HostJobKey>(job_handle))
                 .unwrap();
             let thread_pool::JobPayload::Read { result, .. } = job.payload_mut() else {
                 panic!("expected read job");
@@ -2920,6 +2992,7 @@ mod tests {
 
         let opened = host.open_job_get_fd(job).unwrap();
         assert_eq!(host.open_job_get_fd(job).unwrap(), opened);
+        assert_eq!(host.run_job(job), Err(AsyncHostError::Badf));
         {
             let files = host.files.lock().unwrap();
             assert_eq!(files.files.len(), 2);
@@ -3005,6 +3078,9 @@ mod tests {
 
         assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
         assert_eq!(host.job_get_ret(job).unwrap(), 0);
+        assert_eq!(host.run_job(job), Err(AsyncHostError::Badf));
+        assert_eq!(host.spawn_worker(43, job), Err(AsyncHostError::Badf));
+        assert_eq!(host.wake_worker(worker, 44, job), Err(AsyncHostError::Badf));
 
         #[cfg(unix)]
         {
@@ -3022,6 +3098,64 @@ mod tests {
 
         host.free_worker(worker).unwrap();
         host.free_job(job).unwrap();
+        host.destroy_thread_pool();
+    }
+
+    #[test]
+    fn freed_running_worker_job_is_not_restored_after_completion() {
+        let host = AsyncHost::default();
+        let first_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
+        let first_key = key_from_handle::<HostJobKey>(first_job);
+        let (started_sender, started_receiver) = std::sync::mpsc::channel();
+        let (release_sender, release_receiver) = std::sync::mpsc::channel();
+        let (completion_sender, completion_receiver) = std::sync::mpsc::channel();
+        let worker = {
+            let jobs = Arc::clone(&host.jobs);
+            let completed_jobs = Arc::clone(&host.completed_jobs);
+            host.jobs.lock().unwrap().queue_job(first_key).unwrap();
+            thread_pool::spawn_worker(
+                HostWorkerJob {
+                    completion_id: WorkerCompletionId::from_abi(1),
+                    job_key: first_key,
+                },
+                move |worker_job| {
+                    let Ok(mut job) = jobs.lock().unwrap().take_queued_job(worker_job.job_key)
+                    else {
+                        return None;
+                    };
+                    started_sender.send(worker_job.completion_id).unwrap();
+                    release_receiver.recv().unwrap();
+                    thread_pool::run_host_job(&mut job);
+                    Some(job)
+                },
+                move |worker_job| {
+                    if let Some(job) = worker_job.job {
+                        completed_jobs.lock().unwrap().push(CompletedJob {
+                            key: worker_job.job_key,
+                            job,
+                        });
+                    }
+                    completion_sender.send(worker_job.completion_id).unwrap();
+                },
+            )
+        };
+        let worker = handle_from_key(host.workers.lock().unwrap().workers.insert(worker));
+
+        assert_eq!(
+            started_receiver.recv().unwrap(),
+            WorkerCompletionId::from_abi(1)
+        );
+        host.free_job(first_job).unwrap();
+
+        release_sender.send(()).unwrap();
+        assert_eq!(
+            completion_receiver.recv().unwrap(),
+            WorkerCompletionId::from_abi(1)
+        );
+        assert_eq!(host.job_get_ret(first_job), Err(AsyncHostError::Badf));
+        assert_eq!(host.run_job(first_job), Err(AsyncHostError::Badf));
+
+        host.free_worker(worker).unwrap();
         host.destroy_thread_pool();
     }
 
@@ -3312,13 +3446,14 @@ mod tests {
     #[test]
     fn io_result_status_rejects_wrong_fd_without_clearing_pending() {
         let mut result = HostIoResult::for_file(0, Vec::new(), 0, 0);
-        let pending_fd = 1usize as RawFd;
-        let other_fd = 2usize as RawFd;
+        let pending_file = Arc::new(FileResource::invalid());
+        let other_file = Arc::new(FileResource::invalid());
+        let pending_fd = pending_file.raw_fd();
 
-        result.mark_pending(pending_fd).unwrap();
+        result.mark_pending(pending_file).unwrap();
 
         assert_eq!(
-            result.validate_pending_handle(other_fd),
+            result.validate_pending_file(&other_file),
             Err(AsyncHostError::Badf)
         );
         assert_eq!(result.pending_raw_fd(), Some(pending_fd));
@@ -3331,14 +3466,15 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
         let raw_read = {
-            let raw_read = host.files.lock().unwrap().file(read).unwrap().raw_fd();
+            let read_file = host.file_resource(read).unwrap();
+            let raw_read = read_file.raw_fd();
             host.io_results
                 .lock()
                 .unwrap()
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap()
-                .mark_pending(raw_read)
+                .mark_pending(read_file)
                 .unwrap();
             raw_read
         };
@@ -3369,14 +3505,15 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
         let raw_read = {
-            let raw_read = host.files.lock().unwrap().file(read).unwrap().raw_fd();
+            let read_file = host.file_resource(read).unwrap();
+            let raw_read = read_file.raw_fd();
             host.io_results
                 .lock()
                 .unwrap()
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap()
-                .mark_pending(raw_read)
+                .mark_pending(read_file)
                 .unwrap();
             raw_read
         };
@@ -3406,14 +3543,15 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
         let raw_read = {
-            let raw_read = host.files.lock().unwrap().file(read).unwrap().raw_fd();
+            let read_file = host.file_resource(read).unwrap();
+            let raw_read = read_file.raw_fd();
             host.io_results
                 .lock()
                 .unwrap()
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap()
-                .mark_pending(raw_read)
+                .mark_pending(read_file)
                 .unwrap();
             raw_read
         };
@@ -3442,17 +3580,17 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
         let (raw_read, raw_write) = {
-            let files = host.files.lock().unwrap();
-            let raw_read = files.file(read).unwrap().raw_fd();
-            let raw_write = files.file(write).unwrap().raw_fd();
-            drop(files);
+            let read_file = host.file_resource(read).unwrap();
+            let write_file = host.file_resource(write).unwrap();
+            let raw_read = read_file.raw_fd();
+            let raw_write = write_file.raw_fd();
             host.io_results
                 .lock()
                 .unwrap()
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap()
-                .mark_pending_with_close_guard(raw_read, raw_write)
+                .mark_pending_with_close_guard(read_file, write_file)
                 .unwrap();
             (raw_read, raw_write)
         };
@@ -3474,7 +3612,14 @@ mod tests {
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap();
             assert_eq!(result.pending_raw_fd(), Some(raw_read));
-            assert!(result.protects_pending_raw_fd(raw_write));
+            assert!(result.protects_pending_file(&host.file_resource(write).unwrap()));
+            assert_eq!(
+                result
+                    .extra_pending_close_file
+                    .as_ref()
+                    .map(|file| file.raw_fd()),
+                Some(raw_write)
+            );
             result.clear_pending();
         }
 
@@ -3487,15 +3632,17 @@ mod tests {
     #[test]
     fn free_io_result_rejects_pending_result() {
         let host = AsyncHost::default();
+        let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
         {
+            let read_file = host.file_resource(read).unwrap();
             host.io_results
                 .lock()
                 .unwrap()
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap()
-                .mark_pending(1usize as RawFd)
+                .mark_pending(read_file)
                 .unwrap();
         }
 
@@ -3507,6 +3654,16 @@ mod tests {
                 .io_results
                 .contains_key(key_from_handle::<HostIoResultKey>(result))
         );
+        host.io_results
+            .lock()
+            .unwrap()
+            .io_results
+            .get_mut(key_from_handle::<HostIoResultKey>(result))
+            .unwrap()
+            .clear_pending();
+        host.free_io_result(result).unwrap();
+        host.close_fd(read).unwrap();
+        host.close_fd(write).unwrap();
     }
 
     #[cfg(windows)]
@@ -3527,14 +3684,16 @@ mod tests {
             poll.instance.raw_fd()
         };
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
-        let raw_fd = 0x1234usize as RawFd;
+        let [read, write] = host.pipe(true, true).unwrap();
+        let read_file = host.file_resource(read).unwrap();
+        let raw_fd = read_file.raw_fd();
         let overlapped = {
             let mut io_results = host.io_results.lock().unwrap();
             let result = io_results
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap();
-            result.mark_pending(raw_fd).unwrap();
+            result.mark_pending(read_file).unwrap();
             result.overlapped_ptr()
         };
         let posted =
@@ -3556,6 +3715,8 @@ mod tests {
             None
         );
         host.free_io_result(result).unwrap();
+        host.close_fd(read).unwrap();
+        host.close_fd(write).unwrap();
     }
 
     #[cfg(windows)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -1345,9 +1345,8 @@ impl AsyncHost {
                 let source = files.insert_file_resource(FileResource::new(event_fd));
                 let source_file = files.file(source)?;
                 drop(files);
-                completions.notifier = Some(Arc::clone(&completion_notifier));
-                completions.source = Some(source);
-                drop(completions);
+                // Publish the poll-side mapping before exposing the notifier:
+                // workers can notify as soon as completions.notifier is visible.
                 let mut poll = poll.lock().unwrap();
                 poll.registered_fds.insert(
                     raw_fd_key(event_fd),
@@ -1356,7 +1355,10 @@ impl AsyncHost {
                         file: source_file,
                     },
                 );
-                poll.completion_notifier = Some(completion_notifier);
+                poll.completion_notifier = Some(Arc::clone(&completion_notifier));
+                drop(poll);
+                completions.notifier = Some(completion_notifier);
+                completions.source = Some(source);
                 source
             };
             Ok(source)

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -221,12 +221,6 @@ struct HostAddrInfo {
     next: Option<HostAddrInfoKey>,
 }
 
-#[derive(Debug)]
-struct CompletedJob {
-    key: HostJobKey,
-    job: Job,
-}
-
 fn handle_from_key(key: impl Key) -> u64 {
     key.data().as_ffi()
 }
@@ -371,14 +365,13 @@ impl JobTable {
         }
     }
 
-    fn restore_job(&mut self, key: HostJobKey, job: &mut Option<Job>) -> bool {
+    fn restore_job(&mut self, key: HostJobKey, job: Job) -> Option<Job> {
         match self.jobs.get_mut(key) {
             Some(slot @ HostJobState::Running) => {
-                *slot =
-                    HostJobState::ResultReady(job.take().expect("job is restored at most once"));
-                true
+                *slot = HostJobState::ResultReady(job);
+                None
             }
-            _ => false,
+            _ => Some(job),
         }
     }
 }
@@ -417,18 +410,6 @@ impl ThreadPoolCompletions {
             self.generation_counter = 1;
         }
         self.generation_counter
-    }
-}
-
-struct WorkerTable {
-    workers: SlotMap<HostWorkerKey, HostWorkerHandle>,
-}
-
-impl Default for WorkerTable {
-    fn default() -> Self {
-        Self {
-            workers: SlotMap::with_key(),
-        }
     }
 }
 
@@ -806,6 +787,11 @@ impl Drop for HostIoResult {
 pub(crate) struct AsyncHost {
     // These cells split synchronization by native-shaped owner. They are not
     // separate guest concepts: resource handles and ABI values stay unchanged.
+    // Keep nested table locks short and in the existing directions:
+    // jobs -> files for publishing open-job results,
+    // completions -> files -> polls for completion-source init, and
+    // workers -> jobs -> worker state for worker assignment.
+    // Do not hold table locks while running worker jobs or blocking I/O.
     errno: Mutex<i32>,
     addr_infos: Mutex<SlotMap<HostAddrInfoKey, HostAddrInfo>>,
     c_buffers: Mutex<SlotMap<HostCBufferKey, HostCBuffer>>,
@@ -815,8 +801,7 @@ pub(crate) struct AsyncHost {
     polls: Mutex<PollTable>,
     thread_pool_completions: Mutex<ThreadPoolCompletions>,
     files: Mutex<FileTable>,
-    workers: Mutex<WorkerTable>,
-    completed_jobs: Arc<Mutex<Vec<CompletedJob>>>,
+    workers: Mutex<SlotMap<HostWorkerKey, HostWorkerHandle>>,
 }
 
 impl Default for AsyncHost {
@@ -831,8 +816,7 @@ impl Default for AsyncHost {
             polls: Mutex::new(PollTable::default()),
             thread_pool_completions: Mutex::new(ThreadPoolCompletions::default()),
             files: Mutex::new(FileTable::default()),
-            workers: Mutex::new(WorkerTable::default()),
-            completed_jobs: Arc::new(Mutex::new(Vec::new())),
+            workers: Mutex::new(SlotMap::with_key()),
         }
     }
 }
@@ -840,20 +824,6 @@ impl Default for AsyncHost {
 impl AsyncHost {
     pub(crate) fn invalid_fd(&self) -> HostHandle {
         self.files.lock().unwrap().invalid_fd()
-    }
-
-    fn restore_completed_jobs(&self) {
-        let completed_jobs = {
-            let mut completed_jobs = self.completed_jobs.lock().unwrap();
-            if completed_jobs.is_empty() {
-                return;
-            }
-            std::mem::take(&mut *completed_jobs)
-        };
-
-        for CompletedJob { key, job } in completed_jobs {
-            let _ = self.restore_job(key, job);
-        }
     }
 
     pub(crate) fn get_errno(&self) -> i32 {
@@ -871,13 +841,13 @@ impl AsyncHost {
     }
 
     fn restore_job(&self, key: HostJobKey, job: Job) -> AsyncHostResult<()> {
-        let mut job = Some(job);
-        if self.jobs.lock().unwrap().restore_job(key, &mut job) {
-            return Ok(());
+        let result = { self.jobs.lock().unwrap().restore_job(key, job) };
+        if let Some(mut job) = result {
+            self.discard_job_results(&mut job);
+            Err(AsyncHostError::Badf)
+        } else {
+            Ok(())
         }
-        let mut job = job.expect("job is only taken after being restored");
-        self.discard_job_results(&mut job);
-        Err(AsyncHostError::Badf)
     }
 
     fn discard_job_results(&self, job: &mut Job) {
@@ -914,8 +884,6 @@ impl AsyncHost {
         if std::thread::panicking() || std::env::var_os(CHECK_FD_LEAK_ENV).is_none() {
             return;
         }
-        self.restore_completed_jobs();
-
         let summary = {
             let mut leaks = Vec::new();
 
@@ -993,8 +961,8 @@ impl AsyncHost {
             }
             {
                 let workers = self.workers.lock().unwrap();
-                if !workers.workers.is_empty() {
-                    leaks.push(format!("workers={}", workers.workers.len()));
+                if !workers.is_empty() {
+                    leaks.push(format!("workers={}", workers.len()));
                 }
             }
 
@@ -1198,7 +1166,6 @@ impl AsyncHost {
         {
             self.polls.lock().unwrap().current_event_poll = Some(poll_key);
         }
-        self.restore_completed_jobs();
         Ok(result)
     }
 
@@ -1398,9 +1365,9 @@ impl AsyncHost {
     pub(crate) fn destroy_thread_pool(&self) {
         let workers = {
             let mut workers = self.workers.lock().unwrap();
-            let keys: Vec<_> = workers.workers.keys().collect();
+            let keys: Vec<_> = workers.keys().collect();
             keys.into_iter()
-                .filter_map(|key| workers.workers.remove(key))
+                .filter_map(|key| workers.remove(key))
                 .collect::<Vec<_>>()
         };
         for worker in workers {
@@ -1408,8 +1375,6 @@ impl AsyncHost {
                 let _ = self.jobs.lock().unwrap().unqueue_job(replaced_job.job_key);
             }
         }
-        self.restore_completed_jobs();
-
         #[cfg(unix)]
         {
             let completion_source = {
@@ -1510,7 +1475,6 @@ impl AsyncHost {
     }
 
     pub(crate) fn free_job(&self, handle: u64) -> AsyncHostResult<()> {
-        self.restore_completed_jobs();
         self.jobs
             .lock()
             .unwrap()
@@ -1521,26 +1485,22 @@ impl AsyncHost {
     }
 
     pub(crate) fn job_get_ret(&self, handle: u64) -> AsyncHostResult<i64> {
-        self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
         let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         Ok(crate::async_sys::internal::event_loop::thread_pool::job_get_ret(job))
     }
 
     pub(crate) fn job_get_err(&self, handle: u64) -> AsyncHostResult<i32> {
-        self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
         let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         Ok(crate::async_sys::internal::event_loop::thread_pool::job_get_err(job))
     }
 
     pub(crate) fn open_job_get_fd(&self, handle: u64) -> AsyncHostResult<HostHandle> {
-        self.restore_completed_jobs();
         self.publish_open_job_result(key_from_handle::<HostJobKey>(handle))
     }
 
     pub(crate) fn open_job_get_kind(&self, handle: u64) -> AsyncHostResult<i32> {
-        self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
         let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         let result = thread_pool::open_job_result(job)?;
@@ -1548,7 +1508,6 @@ impl AsyncHost {
     }
 
     pub(crate) fn open_job_get_dev_id(&self, handle: u64) -> AsyncHostResult<u64> {
-        self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
         let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         let result = thread_pool::open_job_result(job)?;
@@ -1556,7 +1515,6 @@ impl AsyncHost {
     }
 
     pub(crate) fn open_job_get_file_id(&self, handle: u64) -> AsyncHostResult<u64> {
-        self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
         let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         let result = thread_pool::open_job_result(job)?;
@@ -1564,14 +1522,12 @@ impl AsyncHost {
     }
 
     pub(crate) fn get_file_size_result(&self, handle: u64) -> AsyncHostResult<i64> {
-        self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
         let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         crate::async_sys::internal::event_loop::thread_pool::get_file_size_result(job)
     }
 
     pub(crate) fn get_getaddrinfo_result(&self, handle: u64) -> AsyncHostResult<u64> {
-        self.restore_completed_jobs();
         let addrs: Vec<Box<[u8]>> = {
             let jobs = self.jobs.lock().unwrap();
             let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
@@ -1623,10 +1579,10 @@ impl AsyncHost {
 
     pub(crate) fn close_fd(&self, handle: HostHandle) -> AsyncHostResult<()> {
         let file = {
-            let mut files = self.files.lock().unwrap();
+            let files = self.files.lock().unwrap();
+            let file = files.file(handle)?;
             #[cfg(windows)]
             {
-                let file = files.file(handle)?;
                 if self
                     .io_results
                     .lock()
@@ -1636,9 +1592,25 @@ impl AsyncHost {
                     return Err(AsyncHostError::Inval);
                 }
             }
-            files.remove_file(handle)?
+            file
         };
         let raw_fd = file.raw_fd();
+        let polls = self
+            .polls
+            .lock()
+            .unwrap()
+            .polls
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for poll in polls {
+            let mut poll = poll.lock().unwrap();
+            if poll.registered_fds.contains_key(&raw_fd_key(raw_fd)) {
+                #[cfg(unix)]
+                poll::poll_unregister(&poll.instance, raw_fd)?;
+            }
+            poll.registered_fds.remove(&raw_fd_key(raw_fd));
+        }
         #[cfg(unix)]
         {
             let completion_source_closed = {
@@ -1665,22 +1637,7 @@ impl AsyncHost {
                 }
             }
         }
-        let polls = self
-            .polls
-            .lock()
-            .unwrap()
-            .polls
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        for poll in polls {
-            let mut poll = poll.lock().unwrap();
-            if poll.registered_fds.contains_key(&raw_fd_key(raw_fd)) {
-                #[cfg(unix)]
-                poll::poll_unregister(&poll.instance, raw_fd)?;
-            }
-            poll.registered_fds.remove(&raw_fd_key(raw_fd));
-        }
+        self.files.lock().unwrap().remove_file(handle)?;
         Ok(())
     }
 
@@ -2341,7 +2298,6 @@ impl AsyncHost {
     }
 
     pub(crate) fn spawn_worker(&self, completion_id: i32, job_handle: u64) -> AsyncHostResult<u64> {
-        self.restore_completed_jobs();
         let completion_id = WorkerCompletionId::from_abi(completion_id);
         let job_key = key_from_handle::<HostJobKey>(job_handle);
         #[cfg(unix)]
@@ -2387,7 +2343,7 @@ impl AsyncHost {
                 },
             )
         };
-        let key = self.workers.lock().unwrap().workers.insert(worker);
+        let key = self.workers.lock().unwrap().insert(worker);
         Ok(handle_from_key(key))
     }
 
@@ -2397,13 +2353,12 @@ impl AsyncHost {
         completion_id: i32,
         job_handle: u64,
     ) -> AsyncHostResult<()> {
-        self.restore_completed_jobs();
         let completion_id = WorkerCompletionId::from_abi(completion_id);
         let worker_key = key_from_handle::<HostWorkerKey>(worker_handle);
         let job_key = key_from_handle::<HostJobKey>(job_handle);
         let replaced_job = {
             let workers = self.workers.lock().unwrap();
-            let Some(worker) = workers.workers.get(worker_key) else {
+            let Some(worker) = workers.get(worker_key) else {
                 return Err(AsyncHostError::Badf);
             };
             self.jobs.lock().unwrap().queue_job(job_key)?;
@@ -2422,11 +2377,9 @@ impl AsyncHost {
     }
 
     pub(crate) fn worker_enter_idle(&self, worker_handle: u64) -> AsyncHostResult<()> {
-        self.restore_completed_jobs();
         let replaced_job = {
             let workers = self.workers.lock().unwrap();
             let worker = workers
-                .workers
                 .get(key_from_handle::<HostWorkerKey>(worker_handle))
                 .ok_or(AsyncHostError::Badf)?;
             thread_pool::worker_enter_idle(worker)
@@ -2438,25 +2391,21 @@ impl AsyncHost {
     }
 
     pub(crate) fn free_worker(&self, worker_handle: u64) -> AsyncHostResult<()> {
-        self.restore_completed_jobs();
         let worker = self
             .workers
             .lock()
             .unwrap()
-            .workers
             .remove(key_from_handle::<HostWorkerKey>(worker_handle))
             .ok_or(AsyncHostError::Badf)?;
         if let Some(replaced_job) = thread_pool::free_worker(worker) {
             let _ = self.jobs.lock().unwrap().unqueue_job(replaced_job.job_key);
         }
-        self.restore_completed_jobs();
         Ok(())
     }
 
     pub(crate) fn cancel_worker(&self, worker_handle: u64) -> AsyncHostResult<i32> {
         let workers = self.workers.lock().unwrap();
         let worker = workers
-            .workers
             .get(key_from_handle::<HostWorkerKey>(worker_handle))
             .ok_or(AsyncHostError::Badf)?;
         thread_pool::cancel_worker(worker)
@@ -2470,7 +2419,6 @@ impl AsyncHost {
         offset: i32,
         len: i32,
     ) -> AsyncHostResult<()> {
-        self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
         let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         thread_pool::get_read_result(job, memory, dst, offset, len)
@@ -2482,7 +2430,6 @@ impl AsyncHost {
         handle: u64,
         dst: i32,
     ) -> AsyncHostResult<()> {
-        self.restore_completed_jobs();
         let jobs = self.jobs.lock().unwrap();
         let job = jobs.visible_job(key_from_handle::<HostJobKey>(handle))?;
         thread_pool::get_file_time_result(job, memory, dst)
@@ -2496,7 +2443,6 @@ impl AsyncHost {
         dst: i32,
         max_jobs: i32,
     ) -> AsyncHostResult<i32> {
-        self.restore_completed_jobs();
         let (completion_notifier, completion_source) = {
             let completions = self.thread_pool_completions.lock().unwrap();
             (
@@ -2531,27 +2477,31 @@ impl AsyncHost {
         init_job: HostWorkerJob,
         mut complete_job: impl FnMut(WorkerCompletionId) + Send + 'static,
     ) -> HostWorkerHandle {
-        let jobs = Arc::clone(&self.jobs);
-        let completed_jobs = Arc::clone(&self.completed_jobs);
+        let jobs_for_runner = Arc::clone(&self.jobs);
+        let jobs_for_completion = Arc::clone(&self.jobs);
         thread_pool::spawn_worker(
             init_job,
             move |worker_job| {
-                let Ok(mut job) = jobs.lock().unwrap().take_queued_job(worker_job.job_key) else {
+                let Ok(mut job) = jobs_for_runner
+                    .lock()
+                    .unwrap()
+                    .take_queued_job(worker_job.job_key)
+                else {
                     return None;
                 };
                 thread_pool::run_host_job(&mut job);
                 Some(job)
             },
             move |worker_job| {
-                // Even if cancellation discarded the job handle, the event loop
-                // still needs the completion to move the worker out of running.
                 let completion_id = worker_job.completion_id;
                 if let Some(job) = worker_job.job {
-                    completed_jobs.lock().unwrap().push(CompletedJob {
-                        key: worker_job.job_key,
-                        job,
-                    });
+                    let _ = jobs_for_completion
+                        .lock()
+                        .unwrap()
+                        .restore_job(worker_job.job_key, job);
                 }
+                // Even if cancellation discarded the job handle, the event loop
+                // still needs the completion to move the worker out of running.
                 complete_job(completion_id);
             },
         )
@@ -3043,7 +2993,7 @@ mod tests {
     #[test]
     fn drop_destroys_pool_even_when_worker_holds_state() {
         let host = AsyncHost::default();
-        let completed_jobs = Arc::downgrade(&host.completed_jobs);
+        let jobs = Arc::downgrade(&host.jobs);
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
@@ -3065,7 +3015,7 @@ mod tests {
 
         drop(host);
 
-        assert!(completed_jobs.upgrade().is_none());
+        assert!(jobs.upgrade().is_none());
     }
 
     #[test]
@@ -3110,8 +3060,8 @@ mod tests {
         let (release_sender, release_receiver) = std::sync::mpsc::channel();
         let (completion_sender, completion_receiver) = std::sync::mpsc::channel();
         let worker = {
-            let jobs = Arc::clone(&host.jobs);
-            let completed_jobs = Arc::clone(&host.completed_jobs);
+            let jobs_for_runner = Arc::clone(&host.jobs);
+            let jobs_for_completion = Arc::clone(&host.jobs);
             host.jobs.lock().unwrap().queue_job(first_key).unwrap();
             thread_pool::spawn_worker(
                 HostWorkerJob {
@@ -3119,7 +3069,10 @@ mod tests {
                     job_key: first_key,
                 },
                 move |worker_job| {
-                    let Ok(mut job) = jobs.lock().unwrap().take_queued_job(worker_job.job_key)
+                    let Ok(mut job) = jobs_for_runner
+                        .lock()
+                        .unwrap()
+                        .take_queued_job(worker_job.job_key)
                     else {
                         return None;
                     };
@@ -3130,16 +3083,16 @@ mod tests {
                 },
                 move |worker_job| {
                     if let Some(job) = worker_job.job {
-                        completed_jobs.lock().unwrap().push(CompletedJob {
-                            key: worker_job.job_key,
-                            job,
-                        });
+                        let _ = jobs_for_completion
+                            .lock()
+                            .unwrap()
+                            .restore_job(worker_job.job_key, job);
                     }
                     completion_sender.send(worker_job.completion_id).unwrap();
                 },
             )
         };
-        let worker = handle_from_key(host.workers.lock().unwrap().workers.insert(worker));
+        let worker = handle_from_key(host.workers.lock().unwrap().insert(worker));
 
         assert_eq!(
             started_receiver.recv().unwrap(),
@@ -3168,8 +3121,8 @@ mod tests {
         let (release_sender, release_receiver) = std::sync::mpsc::channel();
         let (completion_sender, completion_receiver) = std::sync::mpsc::channel();
         let worker = {
-            let jobs = Arc::clone(&host.jobs);
-            let completed_jobs = Arc::clone(&host.completed_jobs);
+            let jobs_for_runner = Arc::clone(&host.jobs);
+            let jobs_for_completion = Arc::clone(&host.jobs);
             host.jobs.lock().unwrap().queue_job(first_key).unwrap();
             thread_pool::spawn_worker(
                 HostWorkerJob {
@@ -3177,7 +3130,10 @@ mod tests {
                     job_key: first_key,
                 },
                 move |worker_job| {
-                    let Ok(mut job) = jobs.lock().unwrap().take_queued_job(worker_job.job_key)
+                    let Ok(mut job) = jobs_for_runner
+                        .lock()
+                        .unwrap()
+                        .take_queued_job(worker_job.job_key)
                     else {
                         return None;
                     };
@@ -3191,10 +3147,10 @@ mod tests {
                 move |worker_job| {
                     let completed = worker_job.job.is_some();
                     if let Some(job) = worker_job.job {
-                        completed_jobs.lock().unwrap().push(CompletedJob {
-                            key: worker_job.job_key,
-                            job,
-                        });
+                        let _ = jobs_for_completion
+                            .lock()
+                            .unwrap()
+                            .restore_job(worker_job.job_key, job);
                     }
                     completion_sender
                         .send((worker_job.completion_id, completed))
@@ -3202,7 +3158,7 @@ mod tests {
                 },
             )
         };
-        let worker = handle_from_key(host.workers.lock().unwrap().workers.insert(worker));
+        let worker = handle_from_key(host.workers.lock().unwrap().insert(worker));
 
         assert_eq!(
             started_receiver.recv().unwrap(),
@@ -3245,7 +3201,6 @@ mod tests {
             completion_receiver.recv().unwrap(),
             (WorkerCompletionId::from_abi(1), true)
         );
-        host.restore_completed_jobs();
         host.free_job(first_job).unwrap();
         assert_eq!(
             completion_receiver

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -719,7 +719,7 @@ pub(crate) struct AsyncHost {
     c_buffers: Mutex<SlotMap<HostCBufferKey, HostCBuffer>>,
     #[cfg(windows)]
     io_results: Mutex<IoResultTable>,
-    jobs: Mutex<JobTable>,
+    jobs: Arc<Mutex<JobTable>>,
     polls: Mutex<PollTable>,
     files: Mutex<FileTable>,
     workers: Mutex<WorkerTable>,
@@ -734,7 +734,7 @@ impl Default for AsyncHost {
             c_buffers: Mutex::new(SlotMap::with_key()),
             #[cfg(windows)]
             io_results: Mutex::new(IoResultTable::default()),
-            jobs: Mutex::new(JobTable::default()),
+            jobs: Arc::new(Mutex::new(JobTable::default())),
             polls: Mutex::new(PollTable::default()),
             files: Mutex::new(FileTable::default()),
             workers: Mutex::new(WorkerTable::default()),
@@ -1259,9 +1259,7 @@ impl AsyncHost {
                 .collect::<Vec<_>>()
         };
         for worker in workers {
-            if let Some(worker_job) = thread_pool::free_worker(worker) {
-                let _ = self.restore_job(worker_job.job_key, worker_job.job);
-            }
+            let _ = thread_pool::free_worker(worker);
         }
         self.restore_completed_jobs();
 
@@ -2202,6 +2200,13 @@ impl AsyncHost {
         self.restore_completed_jobs();
         let completion_id = WorkerCompletionId::from_abi(completion_id);
         let job_key = key_from_handle::<HostJobKey>(job_handle);
+        {
+            let jobs = self.jobs.lock().unwrap();
+            jobs.jobs
+                .get(job_key)
+                .and_then(Option::as_ref)
+                .ok_or(AsyncHostError::Badf)?;
+        }
         #[cfg(unix)]
         let worker = {
             let completion_notifier = self
@@ -2211,15 +2216,10 @@ impl AsyncHost {
                 .completion_notifier
                 .clone()
                 .ok_or(AsyncHostError::Badf)?;
-            let job = {
-                let mut jobs = self.jobs.lock().unwrap();
-                jobs.take_job(job_key)?
-            };
             self.spawn_worker_thread(
                 HostWorkerJob {
                     completion_id,
                     job_key,
-                    job,
                 },
                 move |completion_id| {
                     let _ = completion_notifier.notify(completion_id.as_i32());
@@ -2234,15 +2234,10 @@ impl AsyncHost {
                 .unwrap()
                 .completion_port
                 .ok_or(AsyncHostError::Badf)?;
-            let job = {
-                let mut jobs = self.jobs.lock().unwrap();
-                jobs.take_job(job_key)?
-            };
             self.spawn_worker_thread(
                 HostWorkerJob {
                     completion_id,
                     job_key,
-                    job,
                 },
                 move |completion_id| {
                     let _ = poll::post_thread_pool_completion(
@@ -2277,12 +2272,16 @@ impl AsyncHost {
         {
             return Err(AsyncHostError::Badf);
         }
-        let job = self.jobs.lock().unwrap().take_job(job_key)?;
+        {
+            let jobs = self.jobs.lock().unwrap();
+            jobs.jobs
+                .get(job_key)
+                .and_then(Option::as_ref)
+                .ok_or(AsyncHostError::Badf)?;
+        }
         let replaced_job = {
             let workers = self.workers.lock().unwrap();
             let Some(worker) = workers.workers.get(worker_key) else {
-                drop(workers);
-                let _ = self.restore_job(job_key, job);
                 return Err(AsyncHostError::Badf);
             };
             thread_pool::wake_worker(
@@ -2290,19 +2289,16 @@ impl AsyncHost {
                 HostWorkerJob {
                     completion_id,
                     job_key,
-                    job,
                 },
             )
         };
-        if let Some(HostWorkerJob { job_key, job, .. }) = replaced_job {
-            let _ = self.restore_job(job_key, job);
-        }
+        let _ = replaced_job;
         Ok(())
     }
 
     pub(crate) fn worker_enter_idle(&self, worker_handle: u64) -> AsyncHostResult<()> {
         self.restore_completed_jobs();
-        let replaced_job = {
+        let _ = {
             let workers = self.workers.lock().unwrap();
             let worker = workers
                 .workers
@@ -2310,9 +2306,6 @@ impl AsyncHost {
                 .ok_or(AsyncHostError::Badf)?;
             thread_pool::worker_enter_idle(worker)
         };
-        if let Some(HostWorkerJob { job_key, job, .. }) = replaced_job {
-            let _ = self.restore_job(job_key, job);
-        }
         Ok(())
     }
 
@@ -2325,9 +2318,7 @@ impl AsyncHost {
             .workers
             .remove(key_from_handle::<HostWorkerKey>(worker_handle))
             .ok_or(AsyncHostError::Badf)?;
-        if let Some(HostWorkerJob { job_key, job, .. }) = thread_pool::free_worker(worker) {
-            let _ = self.restore_job(job_key, job);
-        }
+        let _ = thread_pool::free_worker(worker);
         self.restore_completed_jobs();
         Ok(())
     }
@@ -2421,20 +2412,27 @@ impl AsyncHost {
         init_job: HostWorkerJob,
         mut complete_job: impl FnMut(WorkerCompletionId) + Send + 'static,
     ) -> HostWorkerHandle {
+        let jobs = Arc::clone(&self.jobs);
         let completed_jobs = Arc::clone(&self.completed_jobs);
         thread_pool::spawn_worker(
             init_job,
             move |worker_job| {
-                thread_pool::run_host_job(&mut worker_job.job);
+                let Ok(mut job) = jobs.lock().unwrap().take_job(worker_job.job_key) else {
+                    return None;
+                };
+                thread_pool::run_host_job(&mut job);
+                Some(job)
             },
             move |worker_job| {
                 // Even if cancellation discarded the job handle, the event loop
                 // still needs the completion to move the worker out of running.
                 let completion_id = worker_job.completion_id;
-                completed_jobs.lock().unwrap().push(CompletedJob {
-                    key: worker_job.job_key,
-                    job: worker_job.job,
-                });
+                if let Some(job) = worker_job.job {
+                    completed_jobs.lock().unwrap().push(CompletedJob {
+                        key: worker_job.job_key,
+                        job,
+                    });
+                }
                 complete_job(completion_id);
             },
         )
@@ -2992,6 +2990,88 @@ mod tests {
         host.free_worker(worker).unwrap();
         host.free_job(job).unwrap();
         host.destroy_thread_pool();
+    }
+
+    #[test]
+    fn queued_worker_job_can_be_freed_before_worker_runs_it() {
+        let host = AsyncHost::default();
+        let first_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
+        let first_key = key_from_handle::<HostJobKey>(first_job);
+        let (started_sender, started_receiver) = std::sync::mpsc::channel();
+        let (release_sender, release_receiver) = std::sync::mpsc::channel();
+        let (completion_sender, completion_receiver) = std::sync::mpsc::channel();
+        let worker = {
+            let jobs = Arc::clone(&host.jobs);
+            let completed_jobs = Arc::clone(&host.completed_jobs);
+            thread_pool::spawn_worker(
+                HostWorkerJob {
+                    completion_id: WorkerCompletionId::from_abi(1),
+                    job_key: first_key,
+                },
+                move |worker_job| {
+                    let Ok(mut job) = jobs.lock().unwrap().take_job(worker_job.job_key) else {
+                        return None;
+                    };
+                    started_sender.send(worker_job.completion_id).unwrap();
+                    if worker_job.job_key == first_key {
+                        release_receiver.recv().unwrap();
+                    }
+                    thread_pool::run_host_job(&mut job);
+                    Some(job)
+                },
+                move |worker_job| {
+                    let completed = worker_job.job.is_some();
+                    if let Some(job) = worker_job.job {
+                        completed_jobs.lock().unwrap().push(CompletedJob {
+                            key: worker_job.job_key,
+                            job,
+                        });
+                    }
+                    completion_sender
+                        .send((worker_job.completion_id, completed))
+                        .unwrap();
+                },
+            )
+        };
+        let worker = handle_from_key(host.workers.lock().unwrap().workers.insert(worker));
+
+        assert_eq!(
+            started_receiver.recv().unwrap(),
+            WorkerCompletionId::from_abi(1)
+        );
+
+        let path = std::env::temp_dir().join(format!(
+            "moonrun-cancelled-queued-worker-job-{}",
+            std::process::id()
+        ));
+        std::fs::write(&path, b"queued").unwrap();
+        let queued_job = host
+            .insert_job(thread_pool::make_remove_job(
+                path.as_os_str().to_os_string(),
+            ))
+            .unwrap();
+
+        host.wake_worker(worker, 2, queued_job).unwrap();
+        assert_eq!(host.job_get_ret(queued_job).unwrap(), 0);
+        host.free_job(queued_job).unwrap();
+
+        release_sender.send(()).unwrap();
+        assert_eq!(
+            completion_receiver.recv().unwrap(),
+            (WorkerCompletionId::from_abi(1), true)
+        );
+        host.restore_completed_jobs();
+        host.free_job(first_job).unwrap();
+        assert_eq!(
+            completion_receiver
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .unwrap(),
+            (WorkerCompletionId::from_abi(2), false)
+        );
+        assert!(path.exists());
+
+        host.free_worker(worker).unwrap();
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -235,89 +235,23 @@ fn key_from_handle<K: Key>(handle: u64) -> K {
     KeyData::from_ffi(handle).into()
 }
 
-struct AsyncHostState {
-    errno: i32,
-    addr_infos: SlotMap<HostAddrInfoKey, HostAddrInfo>,
-    c_buffers: SlotMap<HostCBufferKey, HostCBuffer>,
-    #[cfg(windows)]
-    io_results: SlotMap<HostIoResultKey, Box<HostIoResult>>,
-    #[cfg(windows)]
-    io_results_by_overlapped: HashMap<OverlappedAddr, HostIoResultKey>,
-    jobs: SlotMap<HostJobKey, Option<Job>>,
-    polls: SlotMap<HostPollKey, Arc<Mutex<HostPoll>>>,
-    current_event_poll: Option<HostPollKey>,
+struct FileTable {
     files: SlotMap<FileResourceKey, FileResourceRef>,
     invalid_file: FileResourceKey,
-    workers: SlotMap<HostWorkerKey, HostWorkerHandle>,
-    #[cfg(unix)]
-    completion_notifier: Option<Arc<ThreadPoolCompletionNotifier>>,
-    #[cfg(unix)]
-    completion_source: Option<HostHandle>,
-    #[cfg(windows)]
-    completion_port: Option<ThreadPoolCompletionTarget>,
-    #[cfg(windows)]
-    thread_pool_generation: usize,
 }
 
-#[cfg(windows)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ThreadPoolCompletionTarget {
-    poll: HostPollKey,
-    port: poll::CompletionPort,
-    generation: usize,
-}
-
-#[cfg(windows)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct OverlappedAddr(usize);
-
-#[cfg(windows)]
-impl OverlappedAddr {
-    fn from_ptr(ptr: *mut windows_sys::Win32::System::IO::OVERLAPPED) -> Self {
-        Self(ptr as usize)
-    }
-}
-
-impl Default for AsyncHostState {
+impl Default for FileTable {
     fn default() -> Self {
         let mut files = SlotMap::with_key();
         let invalid_file = files.insert(Arc::new(FileResource::invalid()));
         Self {
-            errno: 0,
-            addr_infos: SlotMap::with_key(),
-            c_buffers: SlotMap::with_key(),
-            #[cfg(windows)]
-            io_results: SlotMap::with_key(),
-            #[cfg(windows)]
-            io_results_by_overlapped: HashMap::new(),
-            jobs: SlotMap::with_key(),
-            polls: SlotMap::with_key(),
-            current_event_poll: None,
             files,
             invalid_file,
-            workers: SlotMap::with_key(),
-            #[cfg(unix)]
-            completion_notifier: None,
-            #[cfg(unix)]
-            completion_source: None,
-            #[cfg(windows)]
-            completion_port: None,
-            #[cfg(windows)]
-            thread_pool_generation: 0,
         }
     }
 }
 
-impl AsyncHostState {
-    #[cfg(windows)]
-    fn next_thread_pool_generation(&mut self) -> usize {
-        self.thread_pool_generation = self.thread_pool_generation.wrapping_add(1);
-        if self.thread_pool_generation == 0 {
-            self.thread_pool_generation = 1;
-        }
-        self.thread_pool_generation
-    }
-
+impl FileTable {
     fn invalid_fd(&self) -> HostHandle {
         handle_from_key(self.invalid_file)
     }
@@ -344,78 +278,123 @@ impl AsyncHostState {
     fn insert_file_resource(&mut self, file: FileResource) -> HostHandle {
         handle_from_key(self.files.insert(Arc::new(file)))
     }
+}
 
-    fn publish_open_job_result(&mut self, key: HostJobKey) -> AsyncHostResult<HostHandle> {
-        let placeholder = OpenJobResource::Published(self.invalid_fd());
-        let file = {
-            let job = self
-                .jobs
-                .get_mut(key)
-                .and_then(Option::as_mut)
-                .ok_or(AsyncHostError::Badf)?;
-            let result = thread_pool::open_job_result_mut(job)?;
-            match std::mem::replace(&mut result.resource, placeholder) {
-                OpenJobResource::Published(fd) => {
-                    result.resource = OpenJobResource::Published(fd);
-                    return Ok(fd);
-                }
-                OpenJobResource::Unpublished(file) => file,
-            }
-        };
-        let fd = self.insert_file_resource(file);
-        let job = self
-            .jobs
-            .get_mut(key)
-            .and_then(Option::as_mut)
-            .ok_or(AsyncHostError::Badf)?;
-        let result = thread_pool::open_job_result_mut(job)?;
-        result.resource = OpenJobResource::Published(fd);
-        thread_pool::open_job_get_fd(result)
+struct JobTable {
+    jobs: SlotMap<HostJobKey, Option<Job>>,
+}
+
+impl Default for JobTable {
+    fn default() -> Self {
+        Self {
+            jobs: SlotMap::with_key(),
+        }
     }
+}
 
+impl JobTable {
     fn take_job(&mut self, key: HostJobKey) -> AsyncHostResult<Job> {
         self.jobs
             .get_mut(key)
             .and_then(Option::take)
             .ok_or(AsyncHostError::Badf)
     }
+}
 
-    fn restore_job(&mut self, key: HostJobKey, mut job: Job) -> AsyncHostResult<()> {
-        let can_restore = match self.jobs.get(key) {
-            Some(slot) => slot.is_none(),
-            None => {
-                self.discard_job_results(&mut job);
-                return Err(AsyncHostError::Badf);
-            }
-        };
-        if !can_restore {
-            self.discard_job_results(&mut job);
-            return Err(AsyncHostError::Badf);
-        }
-        *self.jobs.get_mut(key).ok_or(AsyncHostError::Badf)? = Some(job);
-        Ok(())
-    }
-
-    fn discard_job_results(&mut self, job: &mut Job) {
-        if let Some(result) = thread_pool::take_open_job_result(job)
-            && let OpenJobResource::Published(fd) = result.resource
-        {
-            let _ = self.remove_file(fd);
-        }
-    }
-
-    fn take_workers(&mut self) -> Vec<HostWorkerHandle> {
-        let keys: Vec<_> = self.workers.keys().collect();
-        keys.into_iter()
-            .filter_map(|key| self.workers.remove(key))
-            .collect()
-    }
-
+struct PollTable {
+    polls: SlotMap<HostPollKey, Arc<Mutex<HostPoll>>>,
+    current_event_poll: Option<HostPollKey>,
+    #[cfg(unix)]
+    completion_notifier: Option<Arc<ThreadPoolCompletionNotifier>>,
+    #[cfg(unix)]
+    completion_source: Option<HostHandle>,
     #[cfg(windows)]
+    completion_port: Option<ThreadPoolCompletionTarget>,
+    #[cfg(windows)]
+    thread_pool_generation: usize,
+}
+
+impl Default for PollTable {
+    fn default() -> Self {
+        Self {
+            polls: SlotMap::with_key(),
+            current_event_poll: None,
+            #[cfg(unix)]
+            completion_notifier: None,
+            #[cfg(unix)]
+            completion_source: None,
+            #[cfg(windows)]
+            completion_port: None,
+            #[cfg(windows)]
+            thread_pool_generation: 0,
+        }
+    }
+}
+
+impl PollTable {
+    #[cfg(windows)]
+    fn next_thread_pool_generation(&mut self) -> usize {
+        self.thread_pool_generation = self.thread_pool_generation.wrapping_add(1);
+        if self.thread_pool_generation == 0 {
+            self.thread_pool_generation = 1;
+        }
+        self.thread_pool_generation
+    }
+}
+
+struct WorkerTable {
+    workers: SlotMap<HostWorkerKey, HostWorkerHandle>,
+}
+
+impl Default for WorkerTable {
+    fn default() -> Self {
+        Self {
+            workers: SlotMap::with_key(),
+        }
+    }
+}
+
+#[cfg(windows)]
+struct IoResultTable {
+    io_results: SlotMap<HostIoResultKey, Box<HostIoResult>>,
+    io_results_by_overlapped: HashMap<OverlappedAddr, HostIoResultKey>,
+}
+
+#[cfg(windows)]
+impl Default for IoResultTable {
+    fn default() -> Self {
+        Self {
+            io_results: SlotMap::with_key(),
+            io_results_by_overlapped: HashMap::new(),
+        }
+    }
+}
+
+#[cfg(windows)]
+impl IoResultTable {
     fn has_pending_io_for_raw_fd(&self, raw_fd: RawFd) -> bool {
         self.io_results
             .values()
             .any(|result| result.protects_pending_raw_fd(raw_fd))
+    }
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ThreadPoolCompletionTarget {
+    poll: HostPollKey,
+    port: poll::CompletionPort,
+    generation: usize,
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct OverlappedAddr(usize);
+
+#[cfg(windows)]
+impl OverlappedAddr {
+    fn from_ptr(ptr: *mut windows_sys::Win32::System::IO::OVERLAPPED) -> Self {
+        Self(ptr as usize)
     }
 }
 
@@ -733,14 +712,32 @@ impl Drop for HostIoResult {
 }
 
 pub(crate) struct AsyncHost {
-    state: Arc<Mutex<AsyncHostState>>,
+    // These cells split synchronization by native-shaped owner. They are not
+    // separate guest concepts: resource handles and ABI values stay unchanged.
+    errno: Mutex<i32>,
+    addr_infos: Mutex<SlotMap<HostAddrInfoKey, HostAddrInfo>>,
+    c_buffers: Mutex<SlotMap<HostCBufferKey, HostCBuffer>>,
+    #[cfg(windows)]
+    io_results: Mutex<IoResultTable>,
+    jobs: Mutex<JobTable>,
+    polls: Mutex<PollTable>,
+    files: Mutex<FileTable>,
+    workers: Mutex<WorkerTable>,
     completed_jobs: Arc<Mutex<Vec<CompletedJob>>>,
 }
 
 impl Default for AsyncHost {
     fn default() -> Self {
         Self {
-            state: Arc::new(Mutex::new(AsyncHostState::default())),
+            errno: Mutex::new(0),
+            addr_infos: Mutex::new(SlotMap::with_key()),
+            c_buffers: Mutex::new(SlotMap::with_key()),
+            #[cfg(windows)]
+            io_results: Mutex::new(IoResultTable::default()),
+            jobs: Mutex::new(JobTable::default()),
+            polls: Mutex::new(PollTable::default()),
+            files: Mutex::new(FileTable::default()),
+            workers: Mutex::new(WorkerTable::default()),
             completed_jobs: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -748,7 +745,7 @@ impl Default for AsyncHost {
 
 impl AsyncHost {
     pub(crate) fn invalid_fd(&self) -> HostHandle {
-        self.state.lock().unwrap().invalid_fd()
+        self.files.lock().unwrap().invalid_fd()
     }
 
     fn restore_completed_jobs(&self) {
@@ -760,24 +757,82 @@ impl AsyncHost {
             std::mem::take(&mut *completed_jobs)
         };
 
-        let mut state = self.state.lock().unwrap();
         for CompletedJob { key, job } in completed_jobs {
-            let _ = state.restore_job(key, job);
+            let _ = self.restore_job(key, job);
         }
     }
 
     pub(crate) fn get_errno(&self) -> i32 {
-        self.state.lock().unwrap().errno
+        *self.errno.lock().unwrap()
     }
 
     pub(crate) fn set_errno(&self, errno: i32) {
-        self.state.lock().unwrap().errno = errno;
+        *self.errno.lock().unwrap() = errno;
     }
 
     pub(crate) fn record_error(&self, error: AsyncHostError) -> i32 {
         let errno = error.errno();
         self.set_errno(errno);
         errno
+    }
+
+    fn restore_job(&self, key: HostJobKey, job: Job) -> AsyncHostResult<()> {
+        let mut job = Some(job);
+        let restored = {
+            let mut jobs = self.jobs.lock().unwrap();
+            match jobs.jobs.get_mut(key) {
+                Some(slot) if slot.is_none() => {
+                    *slot = job.take();
+                    true
+                }
+                _ => false,
+            }
+        };
+        if restored {
+            return Ok(());
+        }
+
+        let mut job = job.expect("job is only taken after being restored");
+        self.discard_job_results(&mut job);
+        Err(AsyncHostError::Badf)
+    }
+
+    fn discard_job_results(&self, job: &mut Job) {
+        if let Some(result) = thread_pool::take_open_job_result(job)
+            && let OpenJobResource::Published(fd) = result.resource
+        {
+            let _ = self.files.lock().unwrap().remove_file(fd);
+        }
+    }
+
+    fn publish_open_job_result(&self, key: HostJobKey) -> AsyncHostResult<HostHandle> {
+        let mut jobs = self.jobs.lock().unwrap();
+        let placeholder = OpenJobResource::Published(self.invalid_fd());
+        let file = {
+            let job = jobs
+                .jobs
+                .get_mut(key)
+                .and_then(Option::as_mut)
+                .ok_or(AsyncHostError::Badf)?;
+            let result = thread_pool::open_job_result_mut(job)?;
+            match std::mem::replace(&mut result.resource, placeholder) {
+                OpenJobResource::Published(fd) => {
+                    result.resource = OpenJobResource::Published(fd);
+                    return Ok(fd);
+                }
+                OpenJobResource::Unpublished(file) => file,
+            }
+        };
+
+        let fd = self.files.lock().unwrap().insert_file_resource(file);
+        let job = jobs
+            .jobs
+            .get_mut(key)
+            .and_then(Option::as_mut)
+            .ok_or(AsyncHostError::Badf)?;
+        let result = thread_pool::open_job_result_mut(job)?;
+        result.resource = OpenJobResource::Published(fd);
+        thread_pool::open_job_get_fd(result)
     }
 
     pub(crate) fn assert_no_leaked_handles_if_enabled(&self) {
@@ -787,63 +842,81 @@ impl AsyncHost {
         self.restore_completed_jobs();
 
         let summary = {
-            let state = self.state.lock().unwrap();
             let mut leaks = Vec::new();
 
-            if !state.c_buffers.is_empty() {
-                leaks.push(format!("c_buffers={}", state.c_buffers.len()));
+            {
+                let c_buffers = self.c_buffers.lock().unwrap();
+                if !c_buffers.is_empty() {
+                    leaks.push(format!("c_buffers={}", c_buffers.len()));
+                }
             }
-            if !state.addr_infos.is_empty() {
-                leaks.push(format!("addr_infos={}", state.addr_infos.len()));
+            {
+                let addr_infos = self.addr_infos.lock().unwrap();
+                if !addr_infos.is_empty() {
+                    leaks.push(format!("addr_infos={}", addr_infos.len()));
+                }
             }
             #[cfg(windows)]
             {
-                if !state.io_results.is_empty() {
-                    leaks.push(format!("io_results={}", state.io_results.len()));
+                let io_results = self.io_results.lock().unwrap();
+                if !io_results.io_results.is_empty() {
+                    leaks.push(format!("io_results={}", io_results.io_results.len()));
                 }
-                if !state.io_results_by_overlapped.is_empty() {
+                if !io_results.io_results_by_overlapped.is_empty() {
                     leaks.push(format!(
                         "io_results_by_overlapped={}",
-                        state.io_results_by_overlapped.len()
+                        io_results.io_results_by_overlapped.len()
                     ));
                 }
             }
-            if !state.jobs.is_empty() {
-                leaks.push(format!("jobs={}", state.jobs.len()));
-            }
-            if !state.polls.is_empty() {
-                leaks.push(format!("polls={}", state.polls.len()));
-            }
-            let leaked_files = match state.files.get(state.invalid_file) {
-                Some(file) if file.is_invalid() => state.files.len().saturating_sub(1),
-                Some(_) => {
-                    leaks.push("invalid_file=valid".to_string());
-                    state.files.len()
-                }
-                None => {
-                    leaks.push("invalid_file=missing".to_string());
-                    state.files.len()
-                }
-            };
-            if leaked_files != 0 {
-                leaks.push(format!("files={leaked_files}"));
-            }
-            if !state.workers.is_empty() {
-                leaks.push(format!("workers={}", state.workers.len()));
-            }
-            #[cfg(unix)]
             {
-                if state.completion_notifier.is_some() {
-                    leaks.push("completion_notifier=1".to_string());
-                }
-                if state.completion_source.is_some() {
-                    leaks.push("completion_source=1".to_string());
+                let jobs = self.jobs.lock().unwrap();
+                if !jobs.jobs.is_empty() {
+                    leaks.push(format!("jobs={}", jobs.jobs.len()));
                 }
             }
-            #[cfg(windows)]
             {
-                if state.completion_port.is_some() {
-                    leaks.push("completion_port=1".to_string());
+                let polls = self.polls.lock().unwrap();
+                if !polls.polls.is_empty() {
+                    leaks.push(format!("polls={}", polls.polls.len()));
+                }
+                #[cfg(unix)]
+                {
+                    if polls.completion_notifier.is_some() {
+                        leaks.push("completion_notifier=1".to_string());
+                    }
+                    if polls.completion_source.is_some() {
+                        leaks.push("completion_source=1".to_string());
+                    }
+                }
+                #[cfg(windows)]
+                {
+                    if polls.completion_port.is_some() {
+                        leaks.push("completion_port=1".to_string());
+                    }
+                }
+            }
+            {
+                let files = self.files.lock().unwrap();
+                let leaked_files = match files.files.get(files.invalid_file) {
+                    Some(file) if file.is_invalid() => files.files.len().saturating_sub(1),
+                    Some(_) => {
+                        leaks.push("invalid_file=valid".to_string());
+                        files.files.len()
+                    }
+                    None => {
+                        leaks.push("invalid_file=missing".to_string());
+                        files.files.len()
+                    }
+                };
+                if leaked_files != 0 {
+                    leaks.push(format!("files={leaked_files}"));
+                }
+            }
+            {
+                let workers = self.workers.lock().unwrap();
+                if !workers.workers.is_empty() {
+                    leaks.push(format!("workers={}", workers.workers.len()));
                 }
             }
 
@@ -857,49 +930,65 @@ impl AsyncHost {
 
     pub(crate) fn poll_create(&self) -> AsyncHostResult<u64> {
         let instance = poll::poll_create()?;
-        let mut state = self.state.lock().unwrap();
-        let key = state.polls.insert(Arc::new(Mutex::new(HostPoll {
-            instance,
-            registered_fds: HashMap::new(),
-            #[cfg(unix)]
-            completion_notifier: None,
-            event_fd_handles: Vec::new(),
-        })));
+        let key = self
+            .polls
+            .lock()
+            .unwrap()
+            .polls
+            .insert(Arc::new(Mutex::new(HostPoll {
+                instance,
+                registered_fds: HashMap::new(),
+                #[cfg(unix)]
+                completion_notifier: None,
+                event_fd_handles: Vec::new(),
+            })));
         Ok(handle_from_key(key))
     }
 
     pub(crate) fn poll_destroy(&self, handle: u64) -> AsyncHostResult<()> {
-        let mut state = self.state.lock().unwrap();
-        let poll = state
-            .polls
-            .remove(key_from_handle::<HostPollKey>(handle))
-            .ok_or(AsyncHostError::Badf)?;
+        let poll_key = key_from_handle::<HostPollKey>(handle);
+        let poll = {
+            let mut polls = self.polls.lock().unwrap();
+            polls.polls.remove(poll_key).ok_or(AsyncHostError::Badf)?
+        };
         let poll = Arc::try_unwrap(poll).map_err(|_| AsyncHostError::Inval)?;
         let poll = poll.into_inner().unwrap();
-        if state.current_event_poll == Some(key_from_handle::<HostPollKey>(handle)) {
-            state.current_event_poll = None;
-        }
+
         #[cfg(unix)]
-        {
+        let completion_source = {
+            let mut polls = self.polls.lock().unwrap();
+            if polls.current_event_poll == Some(poll_key) {
+                polls.current_event_poll = None;
+            }
             if let Some(notifier) = &poll.completion_notifier
-                && state
+                && polls
                     .completion_notifier
                     .as_ref()
                     .is_some_and(|active| Arc::ptr_eq(active, notifier))
             {
-                state.completion_notifier = None;
-                if let Some(source) = state.completion_source.take() {
-                    let _ = state.remove_file(source);
-                }
+                polls.completion_notifier = None;
+                polls.completion_source.take()
+            } else {
+                None
+            }
+        };
+        #[cfg(unix)]
+        {
+            if let Some(source) = completion_source {
+                let _ = self.files.lock().unwrap().remove_file(source);
             }
         }
         #[cfg(windows)]
         {
-            if state
+            let mut polls = self.polls.lock().unwrap();
+            if polls.current_event_poll == Some(poll_key) {
+                polls.current_event_poll = None;
+            }
+            if polls
                 .completion_port
-                .is_some_and(|target| target.poll == key_from_handle::<HostPollKey>(handle))
+                .is_some_and(|target| target.poll == poll_key)
             {
-                state.completion_port = None;
+                polls.completion_port = None;
             }
         }
         poll::poll_destroy(poll.instance);
@@ -912,17 +1001,15 @@ impl AsyncHost {
         fd_handle: HostHandle,
         read_only: bool,
     ) -> AsyncHostResult<()> {
-        let (raw_fd, poll) = {
-            let state = self.state.lock().unwrap();
-            let raw_fd = state.file(fd_handle)?.raw_fd();
-            let poll = Arc::clone(
-                state
-                    .polls
-                    .get(key_from_handle::<HostPollKey>(poll_handle))
-                    .ok_or(AsyncHostError::Badf)?,
-            );
-            (raw_fd, poll)
-        };
+        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let poll = Arc::clone(
+            self.polls
+                .lock()
+                .unwrap()
+                .polls
+                .get(key_from_handle::<HostPollKey>(poll_handle))
+                .ok_or(AsyncHostError::Badf)?,
+        );
         let mut poll = poll.lock().unwrap();
         poll::poll_register(&poll.instance, raw_fd, read_only)?;
         poll.registered_fds.insert(raw_fd_key(raw_fd), fd_handle);
@@ -933,18 +1020,24 @@ impl AsyncHost {
         let poll_key = key_from_handle::<HostPollKey>(poll_handle);
         #[cfg(windows)]
         let (poll, thread_pool_generation, invalid_fd) = {
-            let state = self.state.lock().unwrap();
-            let poll = Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?);
-            let thread_pool_generation = state
+            let polls = self.polls.lock().unwrap();
+            let poll = Arc::clone(polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?);
+            let thread_pool_generation = polls
                 .completion_port
                 .filter(|target| target.poll == poll_key)
                 .map(|target| target.generation);
-            (poll, thread_pool_generation, state.invalid_fd())
+            (poll, thread_pool_generation, self.invalid_fd())
         };
         #[cfg(not(windows))]
         let poll = {
-            let state = self.state.lock().unwrap();
-            Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
+            Arc::clone(
+                self.polls
+                    .lock()
+                    .unwrap()
+                    .polls
+                    .get(poll_key)
+                    .ok_or(AsyncHostError::Badf)?,
+            )
         };
         let result = {
             let mut poll_guard = poll.lock().unwrap();
@@ -993,8 +1086,7 @@ impl AsyncHost {
             result
         };
         {
-            let mut state = self.state.lock().unwrap();
-            state.current_event_poll = Some(poll_key);
+            self.polls.lock().unwrap().current_event_poll = Some(poll_key);
         }
         self.restore_completed_jobs();
         Ok(result)
@@ -1003,11 +1095,11 @@ impl AsyncHost {
     pub(crate) fn poll_get_event(&self, poll_handle: u64, index: i32) -> AsyncHostResult<u64> {
         let poll_key = key_from_handle::<HostPollKey>(poll_handle);
         let poll = {
-            let state = self.state.lock().unwrap();
-            if state.current_event_poll != Some(poll_key) {
+            let polls = self.polls.lock().unwrap();
+            if polls.current_event_poll != Some(poll_key) {
                 return Err(AsyncHostError::Badf);
             }
-            Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
+            Arc::clone(polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
         };
         let poll = poll.lock().unwrap();
         poll::event_list_get(&poll.instance, index)?;
@@ -1021,9 +1113,9 @@ impl AsyncHost {
     ) -> AsyncHostResult<T> {
         let index = event_index(event_handle)?;
         let poll = {
-            let state = self.state.lock().unwrap();
-            let poll_key = state.current_event_poll.ok_or(AsyncHostError::Badf)?;
-            Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
+            let polls = self.polls.lock().unwrap();
+            let poll_key = polls.current_event_poll.ok_or(AsyncHostError::Badf)?;
+            Arc::clone(polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
         };
         let poll = poll.lock().unwrap();
         let poll_event = poll::event_list_get(&poll.instance, index)?;
@@ -1033,9 +1125,9 @@ impl AsyncHost {
     pub(crate) fn poll_event_fd(&self, event_handle: u64) -> AsyncHostResult<HostHandle> {
         let index = event_index(event_handle)?;
         let poll = {
-            let state = self.state.lock().unwrap();
-            let poll_key = state.current_event_poll.ok_or(AsyncHostError::Badf)?;
-            Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
+            let polls = self.polls.lock().unwrap();
+            let poll_key = polls.current_event_poll.ok_or(AsyncHostError::Badf)?;
+            Arc::clone(polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
         };
         let fd = {
             let poll = poll.lock().unwrap();
@@ -1047,15 +1139,15 @@ impl AsyncHost {
                 .flatten()
                 .ok_or(AsyncHostError::Badf)?
         };
-        let state = self.state.lock().unwrap();
         #[cfg(windows)]
         let is_thread_pool_completion =
             fd == raw_fd_to_guest(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE)?;
         #[cfg(not(windows))]
         let is_thread_pool_completion = false;
-        if fd == state.invalid_fd()
+        let files = self.files.lock().unwrap();
+        if fd == files.invalid_fd()
             || is_thread_pool_completion
-            || state
+            || files
                 .files
                 .contains_key(key_from_handle::<FileResourceKey>(fd))
         {
@@ -1075,13 +1167,16 @@ impl AsyncHost {
         let overlapped = self.with_event(event_handle, |_, event| {
             Ok(OverlappedAddr::from_ptr(poll::event_get_io_result(event)))
         })?;
-        let mut state = self.state.lock().unwrap();
-        let key = state
+        let mut io_results = self.io_results.lock().unwrap();
+        let key = io_results
             .io_results_by_overlapped
             .get(&overlapped)
             .copied()
             .ok_or(AsyncHostError::Badf)?;
-        let result = state.io_results.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        let result = io_results
+            .io_results
+            .get_mut(key)
+            .ok_or(AsyncHostError::Badf)?;
         result.clear_pending();
         Ok(handle_from_key(key))
     }
@@ -1096,16 +1191,16 @@ impl AsyncHost {
     pub(crate) fn init_thread_pool(&self, poll_handle: u64) -> AsyncHostResult<HostHandle> {
         let poll_key = key_from_handle::<HostPollKey>(poll_handle);
         let poll = {
-            let state = self.state.lock().unwrap();
+            let polls = self.polls.lock().unwrap();
             #[cfg(unix)]
-            if state.completion_source.is_some() {
+            if polls.completion_source.is_some() {
                 return Err(AsyncHostError::Inval);
             }
             #[cfg(windows)]
-            if state.completion_port.is_some() {
+            if polls.completion_port.is_some() {
                 return Err(AsyncHostError::Inval);
             }
-            Arc::clone(state.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
+            Arc::clone(polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?)
         };
         #[cfg(unix)]
         {
@@ -1115,18 +1210,22 @@ impl AsyncHost {
             };
             let completion_notifier = Arc::new(completion_notifier);
             let source = {
-                let mut state = self.state.lock().unwrap();
-                if state.completion_source.is_some() {
-                    drop(state);
+                let mut polls = self.polls.lock().unwrap();
+                if polls.completion_source.is_some() {
+                    drop(polls);
                     let poll = poll.lock().unwrap();
                     let _ = poll::poll_unregister(&poll.instance, event_fd);
                     drop(FileResource::new(event_fd));
                     return Err(AsyncHostError::Inval);
                 }
-                let source =
-                    handle_from_key(state.files.insert(Arc::new(FileResource::new(event_fd))));
-                state.completion_notifier = Some(Arc::clone(&completion_notifier));
-                state.completion_source = Some(source);
+                let source = self
+                    .files
+                    .lock()
+                    .unwrap()
+                    .insert_file_resource(FileResource::new(event_fd));
+                polls.completion_notifier = Some(Arc::clone(&completion_notifier));
+                polls.completion_source = Some(source);
+                drop(polls);
                 let mut poll = poll.lock().unwrap();
                 poll.registered_fds.insert(raw_fd_key(event_fd), source);
                 poll.completion_notifier = Some(completion_notifier);
@@ -1137,12 +1236,12 @@ impl AsyncHost {
         #[cfg(windows)]
         {
             let completion_port = poll::CompletionPort::from_poll(&poll.lock().unwrap().instance);
-            let mut state = self.state.lock().unwrap();
-            if state.completion_port.is_some() {
+            let mut polls = self.polls.lock().unwrap();
+            if polls.completion_port.is_some() {
                 return Err(AsyncHostError::Inval);
             }
-            let generation = state.next_thread_pool_generation();
-            state.completion_port = Some(ThreadPoolCompletionTarget {
+            let generation = polls.next_thread_pool_generation();
+            polls.completion_port = Some(ThreadPoolCompletionTarget {
                 poll: poll_key,
                 port: completion_port,
                 generation,
@@ -1153,25 +1252,33 @@ impl AsyncHost {
 
     pub(crate) fn destroy_thread_pool(&self) {
         let workers = {
-            let mut state = self.state.lock().unwrap();
-            state.take_workers()
+            let mut workers = self.workers.lock().unwrap();
+            let keys: Vec<_> = workers.workers.keys().collect();
+            keys.into_iter()
+                .filter_map(|key| workers.workers.remove(key))
+                .collect::<Vec<_>>()
         };
         for worker in workers {
             if let Some(worker_job) = thread_pool::free_worker(worker) {
-                let mut state = self.state.lock().unwrap();
-                let _ = state.restore_job(worker_job.job_key, worker_job.job);
+                let _ = self.restore_job(worker_job.job_key, worker_job.job);
             }
         }
         self.restore_completed_jobs();
 
-        let mut state = self.state.lock().unwrap();
         #[cfg(unix)]
         {
-            if let Some(source) = state.completion_source.take()
-                && let Ok(file) = state.remove_file(source)
+            let (completion_source, polls) = {
+                let mut polls = self.polls.lock().unwrap();
+                let completion_source = polls.completion_source.take();
+                polls.completion_notifier = None;
+                let poll_entries = polls.polls.values().cloned().collect::<Vec<_>>();
+                (completion_source, poll_entries)
+            };
+            if let Some(source) = completion_source
+                && let Ok(file) = self.files.lock().unwrap().remove_file(source)
             {
                 let raw_fd = file.raw_fd();
-                for poll in state.polls.values_mut() {
+                for poll in &polls {
                     let mut poll = poll.lock().unwrap();
                     if poll.registered_fds.contains_key(&raw_fd_key(raw_fd)) {
                         let _ = poll::poll_unregister(&poll.instance, raw_fd);
@@ -1179,23 +1286,21 @@ impl AsyncHost {
                     poll.registered_fds.remove(&raw_fd_key(raw_fd));
                 }
             }
-            state.completion_notifier = None;
-            for poll in state.polls.values_mut() {
+            for poll in polls {
                 poll.lock().unwrap().completion_notifier = None;
             }
         }
         #[cfg(windows)]
         {
-            state.completion_port = None;
+            self.polls.lock().unwrap().completion_port = None;
         }
     }
 
     pub(crate) fn insert_c_buffer(&self, buffer: Box<[u8]>) -> u64 {
         let key = self
-            .state
+            .c_buffers
             .lock()
             .unwrap()
-            .c_buffers
             .insert(Arc::new(Mutex::new(buffer)));
         handle_from_key(key)
     }
@@ -1204,10 +1309,9 @@ impl AsyncHost {
         if handle == INVALID_HOST_HANDLE {
             return Ok(());
         }
-        self.state
+        self.c_buffers
             .lock()
             .unwrap()
-            .c_buffers
             .remove(key_from_handle::<HostCBufferKey>(handle))
             .map(|_| ())
             .ok_or(AsyncHostError::Badf)
@@ -1240,23 +1344,22 @@ impl AsyncHost {
         if handle == INVALID_HOST_HANDLE {
             return Err(AsyncHostError::Badf);
         }
-        self.state
+        self.c_buffers
             .lock()
             .unwrap()
-            .c_buffers
             .get(key_from_handle::<HostCBufferKey>(handle))
             .cloned()
             .ok_or(AsyncHostError::Badf)
     }
 
     pub(crate) fn insert_job(&self, job: Job) -> AsyncHostResult<u64> {
-        let key = self.state.lock().unwrap().jobs.insert(Some(job));
+        let key = self.jobs.lock().unwrap().jobs.insert(Some(job));
         Ok(handle_from_key(key))
     }
 
     pub(crate) fn free_job(&self, handle: u64) -> AsyncHostResult<()> {
         self.restore_completed_jobs();
-        self.state
+        self.jobs
             .lock()
             .unwrap()
             .jobs
@@ -1267,8 +1370,8 @@ impl AsyncHost {
 
     pub(crate) fn job_get_ret(&self, handle: u64) -> AsyncHostResult<i64> {
         self.restore_completed_jobs();
-        let state = self.state.lock().unwrap();
-        let job = state
+        let jobs = self.jobs.lock().unwrap();
+        let job = jobs
             .jobs
             .get(key_from_handle::<HostJobKey>(handle))
             .and_then(Option::as_ref)
@@ -1278,8 +1381,8 @@ impl AsyncHost {
 
     pub(crate) fn job_get_err(&self, handle: u64) -> AsyncHostResult<i32> {
         self.restore_completed_jobs();
-        let state = self.state.lock().unwrap();
-        let job = state
+        let jobs = self.jobs.lock().unwrap();
+        let job = jobs
             .jobs
             .get(key_from_handle::<HostJobKey>(handle))
             .and_then(Option::as_ref)
@@ -1289,16 +1392,13 @@ impl AsyncHost {
 
     pub(crate) fn open_job_get_fd(&self, handle: u64) -> AsyncHostResult<HostHandle> {
         self.restore_completed_jobs();
-        self.state
-            .lock()
-            .unwrap()
-            .publish_open_job_result(key_from_handle::<HostJobKey>(handle))
+        self.publish_open_job_result(key_from_handle::<HostJobKey>(handle))
     }
 
     pub(crate) fn open_job_get_kind(&self, handle: u64) -> AsyncHostResult<i32> {
         self.restore_completed_jobs();
-        let state = self.state.lock().unwrap();
-        let job = state
+        let jobs = self.jobs.lock().unwrap();
+        let job = jobs
             .jobs
             .get(key_from_handle::<HostJobKey>(handle))
             .and_then(Option::as_ref)
@@ -1309,8 +1409,8 @@ impl AsyncHost {
 
     pub(crate) fn open_job_get_dev_id(&self, handle: u64) -> AsyncHostResult<u64> {
         self.restore_completed_jobs();
-        let state = self.state.lock().unwrap();
-        let job = state
+        let jobs = self.jobs.lock().unwrap();
+        let job = jobs
             .jobs
             .get(key_from_handle::<HostJobKey>(handle))
             .and_then(Option::as_ref)
@@ -1321,8 +1421,8 @@ impl AsyncHost {
 
     pub(crate) fn open_job_get_file_id(&self, handle: u64) -> AsyncHostResult<u64> {
         self.restore_completed_jobs();
-        let state = self.state.lock().unwrap();
-        let job = state
+        let jobs = self.jobs.lock().unwrap();
+        let job = jobs
             .jobs
             .get(key_from_handle::<HostJobKey>(handle))
             .and_then(Option::as_ref)
@@ -1333,8 +1433,8 @@ impl AsyncHost {
 
     pub(crate) fn get_file_size_result(&self, handle: u64) -> AsyncHostResult<i64> {
         self.restore_completed_jobs();
-        let state = self.state.lock().unwrap();
-        let job = state
+        let jobs = self.jobs.lock().unwrap();
+        let job = jobs
             .jobs
             .get(key_from_handle::<HostJobKey>(handle))
             .and_then(Option::as_ref)
@@ -1344,18 +1444,19 @@ impl AsyncHost {
 
     pub(crate) fn get_getaddrinfo_result(&self, handle: u64) -> AsyncHostResult<u64> {
         self.restore_completed_jobs();
-        let mut state = self.state.lock().unwrap();
         let addrs: Vec<Box<[u8]>> = {
-            let job = state
+            let jobs = self.jobs.lock().unwrap();
+            let job = jobs
                 .jobs
                 .get(key_from_handle::<HostJobKey>(handle))
                 .and_then(Option::as_ref)
                 .ok_or(AsyncHostError::Badf)?;
             thread_pool::getaddrinfo_job_result(job)?.to_vec()
         };
+        let mut addr_infos = self.addr_infos.lock().unwrap();
         let mut next = None;
         for addr in addrs.into_iter().rev() {
-            let key = state.addr_infos.insert(HostAddrInfo { addr, next });
+            let key = addr_infos.insert(HostAddrInfo { addr, next });
             next = Some(key);
         }
         Ok(next.map(handle_from_key).unwrap_or(INVALID_HOST_HANDLE))
@@ -1365,9 +1466,8 @@ impl AsyncHost {
         if handle == INVALID_HOST_HANDLE {
             return Ok(INVALID_HOST_HANDLE);
         }
-        let state = self.state.lock().unwrap();
-        let addrinfo = state
-            .addr_infos
+        let addr_infos = self.addr_infos.lock().unwrap();
+        let addrinfo = addr_infos
             .get(key_from_handle::<HostAddrInfoKey>(handle))
             .ok_or(AsyncHostError::Badf)?;
         Ok(addrinfo
@@ -1377,9 +1477,8 @@ impl AsyncHost {
     }
 
     pub(crate) fn addrinfo_addr(&self, handle: u64) -> AsyncHostResult<Box<[u8]>> {
-        let state = self.state.lock().unwrap();
-        let addrinfo = state
-            .addr_infos
+        let addr_infos = self.addr_infos.lock().unwrap();
+        let addrinfo = addr_infos
             .get(key_from_handle::<HostAddrInfoKey>(handle))
             .ok_or(AsyncHostError::Badf)?;
         Ok(addrinfo.addr.clone())
@@ -1389,31 +1488,53 @@ impl AsyncHost {
         if handle == INVALID_HOST_HANDLE {
             return Ok(());
         }
-        let mut state = self.state.lock().unwrap();
+        let mut addr_infos = self.addr_infos.lock().unwrap();
         let mut current = Some(key_from_handle::<HostAddrInfoKey>(handle));
         while let Some(key) = current {
-            let addrinfo = state.addr_infos.remove(key).ok_or(AsyncHostError::Badf)?;
+            let addrinfo = addr_infos.remove(key).ok_or(AsyncHostError::Badf)?;
             current = addrinfo.next;
         }
         Ok(())
     }
 
     pub(crate) fn close_fd(&self, handle: HostHandle) -> AsyncHostResult<()> {
-        let mut state = self.state.lock().unwrap();
-        let raw_fd = state.file(handle)?.raw_fd();
+        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
         #[cfg(windows)]
-        if state.has_pending_io_for_raw_fd(raw_fd) {
+        if self
+            .io_results
+            .lock()
+            .unwrap()
+            .has_pending_io_for_raw_fd(raw_fd)
+        {
             return Err(AsyncHostError::Inval);
         }
         #[cfg(unix)]
-        if state.completion_source == Some(handle) {
-            state.completion_source = None;
-            state.completion_notifier = None;
-            for poll in state.polls.values_mut() {
-                poll.lock().unwrap().completion_notifier = None;
+        {
+            let completion_source_polls = {
+                let mut polls = self.polls.lock().unwrap();
+                if polls.completion_source == Some(handle) {
+                    polls.completion_source = None;
+                    polls.completion_notifier = None;
+                    Some(polls.polls.values().cloned().collect::<Vec<_>>())
+                } else {
+                    None
+                }
+            };
+            if let Some(polls) = completion_source_polls {
+                for poll in polls {
+                    poll.lock().unwrap().completion_notifier = None;
+                }
             }
         }
-        for poll in state.polls.values() {
+        let polls = self
+            .polls
+            .lock()
+            .unwrap()
+            .polls
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for poll in polls {
             let mut poll = poll.lock().unwrap();
             if poll.registered_fds.contains_key(&raw_fd_key(raw_fd)) {
                 #[cfg(unix)]
@@ -1421,7 +1542,7 @@ impl AsyncHost {
             }
             poll.registered_fds.remove(&raw_fd_key(raw_fd));
         }
-        state.remove_file(handle)?;
+        self.files.lock().unwrap().remove_file(handle)?;
         Ok(())
     }
 
@@ -1430,7 +1551,7 @@ impl AsyncHost {
         let file = FileResource::new(raw_socket);
         #[cfg(windows)]
         let file = FileResource::new_socket(raw_socket);
-        handle_from_key(self.state.lock().unwrap().files.insert(Arc::new(file)))
+        self.files.lock().unwrap().insert_file_resource(file)
     }
 
     pub(crate) fn with_raw_file<T>(
@@ -1438,12 +1559,12 @@ impl AsyncHost {
         handle: HostHandle,
         f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
-        let state = self.state.lock().unwrap();
-        f(state.file(handle)?.raw_fd())
+        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
+        f(raw_fd)
     }
 
     pub(crate) fn file_resource(&self, handle: HostHandle) -> AsyncHostResult<FileResourceRef> {
-        self.state.lock().unwrap().file(handle)
+        self.files.lock().unwrap().file(handle)
     }
 
     pub(crate) fn pipe(
@@ -1451,8 +1572,9 @@ impl AsyncHost {
         read_end_is_async: bool,
         write_end_is_async: bool,
     ) -> AsyncHostResult<[HostHandle; 2]> {
+        let mut files = self.files.lock().unwrap();
         crate::async_sys::internal::fd_util::stub::pipe_file_resources(
-            &mut self.state.lock().unwrap().files,
+            &mut files.files,
             read_end_is_async,
             write_end_is_async,
         )
@@ -1460,14 +1582,12 @@ impl AsyncHost {
 
     #[cfg(unix)]
     pub(crate) fn set_nonblocking(&self, handle: HostHandle) -> AsyncHostResult<()> {
-        let state = self.state.lock().unwrap();
-        let raw_fd = state.file(handle)?.raw_fd();
+        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
         crate::async_sys::internal::fd_util::stub::set_nonblocking(raw_fd)
     }
 
     pub(crate) fn set_cloexec(&self, handle: HostHandle) -> AsyncHostResult<()> {
-        let state = self.state.lock().unwrap();
-        let raw_fd = state.file(handle)?.raw_fd();
+        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
         #[cfg(unix)]
         {
             crate::async_sys::internal::fd_util::stub::set_cloexec(raw_fd)
@@ -1490,8 +1610,7 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         let offset_dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
         let dst = memory.read_exact_mut(offset_dst, len)?;
-        let state = self.state.lock().unwrap();
-        let raw_fd = state.file(handle)?.raw_fd();
+        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
         crate::async_sys::internal::event_loop::io::read(raw_fd, dst)
             .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
     }
@@ -1507,8 +1626,7 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         let offset_src = src.checked_add(offset).ok_or(AsyncHostError::Fault)?;
         let src = memory.read_exact(offset_src, len)?;
-        let state = self.state.lock().unwrap();
-        let raw_fd = state.file(handle)?.raw_fd();
+        let raw_fd = self.files.lock().unwrap().file(handle)?.raw_fd();
         crate::async_sys::internal::event_loop::io::write(raw_fd, src)
             .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
     }
@@ -1533,14 +1651,14 @@ impl AsyncHost {
             position,
         ));
 
-        let mut state = self.state.lock().unwrap();
-        let key = state.io_results.insert(result);
-        let overlapped = state
+        let mut io_results = self.io_results.lock().unwrap();
+        let key = io_results.io_results.insert(result);
+        let overlapped = io_results
             .io_results
             .get_mut(key)
             .ok_or(AsyncHostError::Badf)?
             .overlapped_addr();
-        state.io_results_by_overlapped.insert(overlapped, key);
+        io_results.io_results_by_overlapped.insert(overlapped, key);
         Ok(handle_from_key(key))
     }
 
@@ -1606,35 +1724,41 @@ impl AsyncHost {
 
     #[cfg(windows)]
     fn insert_io_result(&self, result: HostIoResult) -> AsyncHostResult<u64> {
-        let mut state = self.state.lock().unwrap();
-        let key = state.io_results.insert(Box::new(result));
-        let overlapped = state
+        let mut io_results = self.io_results.lock().unwrap();
+        let key = io_results.io_results.insert(Box::new(result));
+        let overlapped = io_results
             .io_results
             .get_mut(key)
             .ok_or(AsyncHostError::Badf)?
             .overlapped_addr();
-        state.io_results_by_overlapped.insert(overlapped, key);
+        io_results.io_results_by_overlapped.insert(overlapped, key);
         Ok(handle_from_key(key))
     }
 
     #[cfg(windows)]
     pub(crate) fn free_io_result(&self, handle: u64) -> AsyncHostResult<()> {
         let key = key_from_handle::<HostIoResultKey>(handle);
-        let mut state = self.state.lock().unwrap();
-        let result = state.io_results.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        let mut io_results = self.io_results.lock().unwrap();
+        let result = io_results
+            .io_results
+            .get_mut(key)
+            .ok_or(AsyncHostError::Badf)?;
         if result.is_pending() {
             return Err(AsyncHostError::Inval);
         }
-        let mut result = state.io_results.remove(key).ok_or(AsyncHostError::Badf)?;
+        let mut result = io_results
+            .io_results
+            .remove(key)
+            .ok_or(AsyncHostError::Badf)?;
         let overlapped = result.overlapped_addr();
-        state.io_results_by_overlapped.remove(&overlapped);
+        io_results.io_results_by_overlapped.remove(&overlapped);
         Ok(())
     }
 
     #[cfg(windows)]
     pub(crate) fn io_result_get_event(&self, handle: u64) -> AsyncHostResult<i32> {
-        let state = self.state.lock().unwrap();
-        let result = state
+        let io_results = self.io_results.lock().unwrap();
+        let result = io_results
             .io_results
             .get(key_from_handle::<HostIoResultKey>(handle))
             .ok_or(AsyncHostError::Badf)?;
@@ -1647,9 +1771,9 @@ impl AsyncHost {
         result_handle: u64,
         fd_handle: HostHandle,
     ) -> AsyncHostResult<i32> {
-        let mut state = self.state.lock().unwrap();
-        let raw_fd = state.file(fd_handle)?.raw_fd();
-        let result = state
+        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let mut io_results = self.io_results.lock().unwrap();
+        let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
@@ -1666,9 +1790,9 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::System::IO::GetOverlappedResult;
 
-        let mut state = self.state.lock().unwrap();
-        let raw_fd = state.file(fd_handle)?.raw_fd();
-        let result = state
+        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let mut io_results = self.io_results.lock().unwrap();
+        let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
@@ -1706,9 +1830,9 @@ impl AsyncHost {
         use windows_sys::Win32::Networking::WinSock as ws;
         use windows_sys::Win32::Storage::FileSystem::ReadFile;
 
-        let mut state = self.state.lock().unwrap();
-        let raw_fd = state.file(fd_handle)?.raw_fd();
-        let result = state
+        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let mut io_results = self.io_results.lock().unwrap();
+        let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
@@ -1803,9 +1927,9 @@ impl AsyncHost {
         use windows_sys::Win32::Networking::WinSock as ws;
         use windows_sys::Win32::Storage::FileSystem::WriteFile;
 
-        let mut state = self.state.lock().unwrap();
-        let raw_fd = state.file(fd_handle)?.raw_fd();
-        let result = state
+        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let mut io_results = self.io_results.lock().unwrap();
+        let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
@@ -1896,9 +2020,9 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let mut state = self.state.lock().unwrap();
-        let raw_fd = state.file(fd_handle)?.raw_fd();
-        let result = state
+        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
+        let mut io_results = self.io_results.lock().unwrap();
+        let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
@@ -1936,8 +2060,7 @@ impl AsyncHost {
     pub(crate) fn setup_connected_socket(&self, fd_handle: HostHandle) -> AsyncHostResult<()> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let state = self.state.lock().unwrap();
-        let raw_fd = state.file(fd_handle)?.raw_fd();
+        let raw_fd = self.files.lock().unwrap().file(fd_handle)?.raw_fd();
         let yes: u32 = 1;
         if unsafe {
             ws::setsockopt(
@@ -1964,10 +2087,12 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let mut state = self.state.lock().unwrap();
-        let server_fd = state.file(server_fd_handle)?.raw_fd();
-        let conn_fd = state.file(conn_fd_handle)?.raw_fd();
-        let result = state
+        let files = self.files.lock().unwrap();
+        let server_fd = files.file(server_fd_handle)?.raw_fd();
+        let conn_fd = files.file(conn_fd_handle)?.raw_fd();
+        drop(files);
+        let mut io_results = self.io_results.lock().unwrap();
+        let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
@@ -2010,8 +2135,8 @@ impl AsyncHost {
         dst: i32,
         dst_len: i32,
     ) -> AsyncHostResult<()> {
-        let state = self.state.lock().unwrap();
-        let result = state
+        let io_results = self.io_results.lock().unwrap();
+        let result = io_results
             .io_results
             .get(key_from_handle::<HostIoResultKey>(result_handle))
             .ok_or(AsyncHostError::Badf)?;
@@ -2036,9 +2161,9 @@ impl AsyncHost {
     ) -> AsyncHostResult<()> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let state = self.state.lock().unwrap();
-        let listen_fd = state.file(listen_fd_handle)?.raw_fd();
-        let accept_fd = state.file(accept_fd_handle)?.raw_fd();
+        let files = self.files.lock().unwrap();
+        let listen_fd = files.file(listen_fd_handle)?.raw_fd();
+        let accept_fd = files.file(accept_fd_handle)?.raw_fd();
         let listen_socket = listen_fd as usize;
         if unsafe {
             ws::setsockopt(
@@ -2057,23 +2182,20 @@ impl AsyncHost {
     }
 
     pub(crate) fn try_lock_file(&self, handle: HostHandle, exclusive: bool) -> AsyncHostResult<()> {
-        let state = self.state.lock().unwrap();
-        let file = state.file(handle)?;
+        let file = self.files.lock().unwrap().file(handle)?;
         crate::async_sys::fs::stub::try_lock_file_resource(&file, exclusive)
     }
 
     pub(crate) fn unlock_file(&self, handle: HostHandle) -> AsyncHostResult<()> {
-        let state = self.state.lock().unwrap();
-        let file = state.file(handle)?;
+        let file = self.files.lock().unwrap().file(handle)?;
         crate::async_sys::fs::stub::unlock_file_resource(&file)
     }
 
     pub(crate) fn run_job(&self, handle: u64) -> AsyncHostResult<()> {
         let key = key_from_handle::<HostJobKey>(handle);
-        let mut job = self.state.lock().unwrap().take_job(key)?;
+        let mut job = self.jobs.lock().unwrap().take_job(key)?;
         thread_pool::run_host_job(&mut job);
-        let mut state = self.state.lock().unwrap();
-        state.restore_job(key, job)
+        self.restore_job(key, job)
     }
 
     pub(crate) fn spawn_worker(&self, completion_id: i32, job_handle: u64) -> AsyncHostResult<u64> {
@@ -2082,14 +2204,16 @@ impl AsyncHost {
         let job_key = key_from_handle::<HostJobKey>(job_handle);
         #[cfg(unix)]
         let worker = {
-            let (completion_notifier, job) = {
-                let mut state = self.state.lock().unwrap();
-                let completion_notifier = state
-                    .completion_notifier
-                    .clone()
-                    .ok_or(AsyncHostError::Badf)?;
-                let job = state.take_job(job_key)?;
-                (completion_notifier, job)
+            let completion_notifier = self
+                .polls
+                .lock()
+                .unwrap()
+                .completion_notifier
+                .clone()
+                .ok_or(AsyncHostError::Badf)?;
+            let job = {
+                let mut jobs = self.jobs.lock().unwrap();
+                jobs.take_job(job_key)?
             };
             self.spawn_worker_thread(
                 HostWorkerJob {
@@ -2104,11 +2228,15 @@ impl AsyncHost {
         };
         #[cfg(windows)]
         let worker = {
-            let (completion_target, job) = {
-                let mut state = self.state.lock().unwrap();
-                let completion_target = state.completion_port.ok_or(AsyncHostError::Badf)?;
-                let job = state.take_job(job_key)?;
-                (completion_target, job)
+            let completion_target = self
+                .polls
+                .lock()
+                .unwrap()
+                .completion_port
+                .ok_or(AsyncHostError::Badf)?;
+            let job = {
+                let mut jobs = self.jobs.lock().unwrap();
+                jobs.take_job(job_key)?
             };
             self.spawn_worker_thread(
                 HostWorkerJob {
@@ -2125,7 +2253,7 @@ impl AsyncHost {
                 },
             )
         };
-        let key = self.state.lock().unwrap().workers.insert(worker);
+        let key = self.workers.lock().unwrap().workers.insert(worker);
         Ok(handle_from_key(key))
     }
 
@@ -2139,13 +2267,24 @@ impl AsyncHost {
         let completion_id = WorkerCompletionId::from_abi(completion_id);
         let worker_key = key_from_handle::<HostWorkerKey>(worker_handle);
         let job_key = key_from_handle::<HostJobKey>(job_handle);
-        let mut state = self.state.lock().unwrap();
-        if state.workers.get(worker_key).is_none() {
+        if self
+            .workers
+            .lock()
+            .unwrap()
+            .workers
+            .get(worker_key)
+            .is_none()
+        {
             return Err(AsyncHostError::Badf);
         }
-        let job = state.take_job(job_key)?;
+        let job = self.jobs.lock().unwrap().take_job(job_key)?;
         let replaced_job = {
-            let worker = state.workers.get(worker_key).ok_or(AsyncHostError::Badf)?;
+            let workers = self.workers.lock().unwrap();
+            let Some(worker) = workers.workers.get(worker_key) else {
+                drop(workers);
+                let _ = self.restore_job(job_key, job);
+                return Err(AsyncHostError::Badf);
+            };
             thread_pool::wake_worker(
                 worker,
                 HostWorkerJob {
@@ -2156,23 +2295,23 @@ impl AsyncHost {
             )
         };
         if let Some(HostWorkerJob { job_key, job, .. }) = replaced_job {
-            let _ = state.restore_job(job_key, job);
+            let _ = self.restore_job(job_key, job);
         }
         Ok(())
     }
 
     pub(crate) fn worker_enter_idle(&self, worker_handle: u64) -> AsyncHostResult<()> {
         self.restore_completed_jobs();
-        let mut state = self.state.lock().unwrap();
         let replaced_job = {
-            let worker = state
+            let workers = self.workers.lock().unwrap();
+            let worker = workers
                 .workers
                 .get(key_from_handle::<HostWorkerKey>(worker_handle))
                 .ok_or(AsyncHostError::Badf)?;
             thread_pool::worker_enter_idle(worker)
         };
         if let Some(HostWorkerJob { job_key, job, .. }) = replaced_job {
-            let _ = state.restore_job(job_key, job);
+            let _ = self.restore_job(job_key, job);
         }
         Ok(())
     }
@@ -2180,23 +2319,22 @@ impl AsyncHost {
     pub(crate) fn free_worker(&self, worker_handle: u64) -> AsyncHostResult<()> {
         self.restore_completed_jobs();
         let worker = self
-            .state
+            .workers
             .lock()
             .unwrap()
             .workers
             .remove(key_from_handle::<HostWorkerKey>(worker_handle))
             .ok_or(AsyncHostError::Badf)?;
         if let Some(HostWorkerJob { job_key, job, .. }) = thread_pool::free_worker(worker) {
-            let mut state = self.state.lock().unwrap();
-            let _ = state.restore_job(job_key, job);
+            let _ = self.restore_job(job_key, job);
         }
         self.restore_completed_jobs();
         Ok(())
     }
 
     pub(crate) fn cancel_worker(&self, worker_handle: u64) -> AsyncHostResult<i32> {
-        let state = self.state.lock().unwrap();
-        let worker = state
+        let workers = self.workers.lock().unwrap();
+        let worker = workers
             .workers
             .get(key_from_handle::<HostWorkerKey>(worker_handle))
             .ok_or(AsyncHostError::Badf)?;
@@ -2212,8 +2350,8 @@ impl AsyncHost {
         len: i32,
     ) -> AsyncHostResult<()> {
         self.restore_completed_jobs();
-        let state = self.state.lock().unwrap();
-        let job = state
+        let jobs = self.jobs.lock().unwrap();
+        let job = jobs
             .jobs
             .get(key_from_handle::<HostJobKey>(handle))
             .and_then(Option::as_ref)
@@ -2228,8 +2366,8 @@ impl AsyncHost {
         dst: i32,
     ) -> AsyncHostResult<()> {
         self.restore_completed_jobs();
-        let state = self.state.lock().unwrap();
-        let job = state
+        let jobs = self.jobs.lock().unwrap();
+        let job = jobs
             .jobs
             .get(key_from_handle::<HostJobKey>(handle))
             .and_then(Option::as_ref)
@@ -2247,13 +2385,13 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         self.restore_completed_jobs();
         let (completion_notifier, completion_source) = {
-            let state = self.state.lock().unwrap();
+            let polls = self.polls.lock().unwrap();
             (
-                state
+                polls
                     .completion_notifier
                     .clone()
                     .ok_or(AsyncHostError::Badf)?,
-                state.completion_source.ok_or(AsyncHostError::Badf)?,
+                polls.completion_source.ok_or(AsyncHostError::Badf)?,
             )
         };
         if completion_source != source_fd {
@@ -2569,12 +2707,12 @@ mod tests {
         let poll = host.poll_create().unwrap();
         let completion_source = host.init_thread_pool(poll).unwrap();
         let raw_completion_fd = {
-            let state = host.state.lock().unwrap();
-            state.file(completion_source).unwrap().raw_fd()
+            let files = host.files.lock().unwrap();
+            files.file(completion_source).unwrap().raw_fd()
         };
         {
-            let state = host.state.lock().unwrap();
-            let poll = state
+            let polls = host.polls.lock().unwrap();
+            let poll = polls
                 .polls
                 .get(key_from_handle::<HostPollKey>(poll))
                 .unwrap()
@@ -2589,8 +2727,8 @@ mod tests {
         }
 
         {
-            let state = host.state.lock().unwrap();
-            state
+            let polls = host.polls.lock().unwrap();
+            polls
                 .completion_notifier
                 .as_ref()
                 .unwrap()
@@ -2619,8 +2757,8 @@ mod tests {
         let job = thread_pool::make_read_job(Arc::new(FileResource::invalid()), 3, -1);
         let job_handle = host.insert_job(job).unwrap();
         {
-            let mut state = host.state.lock().unwrap();
-            let job = state
+            let mut jobs = host.jobs.lock().unwrap();
+            let job = jobs
                 .jobs
                 .get_mut(key_from_handle::<HostJobKey>(job_handle))
                 .and_then(Option::as_mut)
@@ -2629,7 +2767,9 @@ mod tests {
                 panic!("expected read job");
             };
             *result = Some(b"abc".to_vec());
-            state
+            host.polls
+                .lock()
+                .unwrap()
                 .completion_notifier
                 .as_ref()
                 .unwrap()
@@ -2682,8 +2822,8 @@ mod tests {
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         {
-            let state = host.state.lock().unwrap();
-            let notifier = state.completion_notifier.as_ref().unwrap();
+            let polls = host.polls.lock().unwrap();
+            let notifier = polls.completion_notifier.as_ref().unwrap();
             notifier.notify(41).unwrap();
             notifier.notify(42).unwrap();
         }
@@ -2736,16 +2876,16 @@ mod tests {
 
         host.run_job(job).unwrap();
         {
-            let state = host.state.lock().unwrap();
-            assert_eq!(state.files.len(), 1);
+            let files = host.files.lock().unwrap();
+            assert_eq!(files.files.len(), 1);
         }
 
         let opened = host.open_job_get_fd(job).unwrap();
         assert_eq!(host.open_job_get_fd(job).unwrap(), opened);
         {
-            let state = host.state.lock().unwrap();
-            assert_eq!(state.files.len(), 2);
-            assert!(state.file(opened).is_ok());
+            let files = host.files.lock().unwrap();
+            assert_eq!(files.files.len(), 2);
+            assert!(files.file(opened).is_ok());
         }
 
         host.close_fd(opened).unwrap();
@@ -2770,7 +2910,7 @@ mod tests {
             .unwrap();
         let key = key_from_handle::<HostJobKey>(job_handle);
         let mut job = host
-            .state
+            .jobs
             .lock()
             .unwrap()
             .jobs
@@ -2785,13 +2925,12 @@ mod tests {
             thread_pool::open_job_result(&job).unwrap().resource,
             OpenJobResource::Unpublished(_)
         ));
-        assert_eq!(host.state.lock().unwrap().files.len(), 1);
-        host.state.lock().unwrap().jobs.remove(key);
+        assert_eq!(host.files.lock().unwrap().files.len(), 1);
+        host.jobs.lock().unwrap().jobs.remove(key);
 
         {
-            let mut state = host.state.lock().unwrap();
-            assert_eq!(state.restore_job(key, job), Err(AsyncHostError::Badf));
-            assert_eq!(state.files.len(), 1);
+            assert_eq!(host.restore_job(key, job), Err(AsyncHostError::Badf));
+            assert_eq!(host.files.lock().unwrap().files.len(), 1);
         }
 
         let _ = std::fs::remove_file(path);
@@ -2800,7 +2939,7 @@ mod tests {
     #[test]
     fn drop_destroys_pool_even_when_worker_holds_state() {
         let host = AsyncHost::default();
-        let state = Arc::downgrade(&host.state);
+        let completed_jobs = Arc::downgrade(&host.completed_jobs);
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
@@ -2822,7 +2961,7 @@ mod tests {
 
         drop(host);
 
-        assert!(state.upgrade().is_none());
+        assert!(completed_jobs.upgrade().is_none());
     }
 
     #[test]
@@ -2914,7 +3053,7 @@ mod tests {
         let poll = host.poll_create().unwrap();
 
         host.init_thread_pool(poll).unwrap();
-        let stale_completion = host.state.lock().unwrap().completion_port.unwrap();
+        let stale_completion = host.polls.lock().unwrap().completion_port.unwrap();
         // Fill the current IOCP batch so a valid completion can sit behind
         // stale completions from the destroyed pool generation.
         for completion_id in 0..1024 {
@@ -2928,7 +3067,7 @@ mod tests {
         host.destroy_thread_pool();
 
         let completion_notifier = host.init_thread_pool(poll).unwrap();
-        let current_completion = host.state.lock().unwrap().completion_port.unwrap();
+        let current_completion = host.polls.lock().unwrap().completion_port.unwrap();
         assert_ne!(stale_completion.generation, current_completion.generation);
 
         poll::post_thread_pool_completion(
@@ -2949,7 +3088,7 @@ mod tests {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
-        let completion = host.state.lock().unwrap().completion_port.unwrap();
+        let completion = host.polls.lock().unwrap().completion_port.unwrap();
 
         poll::post_thread_pool_completion(completion.port, 42, completion.generation).unwrap();
 
@@ -3060,9 +3199,10 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
         let raw_read = {
-            let mut state = host.state.lock().unwrap();
-            let raw_read = state.file(read).unwrap().raw_fd();
-            state
+            let raw_read = host.files.lock().unwrap().file(read).unwrap().raw_fd();
+            host.io_results
+                .lock()
+                .unwrap()
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap()
@@ -3076,8 +3216,8 @@ mod tests {
             Err(AsyncHostError::Badf)
         );
         {
-            let mut state = host.state.lock().unwrap();
-            let result = state
+            let mut io_results = host.io_results.lock().unwrap();
+            let result = io_results
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap();
@@ -3097,9 +3237,10 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
         let raw_read = {
-            let mut state = host.state.lock().unwrap();
-            let raw_read = state.file(read).unwrap().raw_fd();
-            state
+            let raw_read = host.files.lock().unwrap().file(read).unwrap().raw_fd();
+            host.io_results
+                .lock()
+                .unwrap()
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap()
@@ -3112,8 +3253,8 @@ mod tests {
         assert_eq!(host.free_io_result(result), Err(AsyncHostError::Inval));
         assert_eq!(host.close_fd(read), Err(AsyncHostError::Inval));
         {
-            let mut state = host.state.lock().unwrap();
-            let result = state
+            let mut io_results = host.io_results.lock().unwrap();
+            let result = io_results
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap();
@@ -3133,9 +3274,10 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
         let raw_read = {
-            let mut state = host.state.lock().unwrap();
-            let raw_read = state.file(read).unwrap().raw_fd();
-            state
+            let raw_read = host.files.lock().unwrap().file(read).unwrap().raw_fd();
+            host.io_results
+                .lock()
+                .unwrap()
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap()
@@ -3146,9 +3288,9 @@ mod tests {
 
         assert_eq!(host.close_fd(read), Err(AsyncHostError::Inval));
         {
-            let mut state = host.state.lock().unwrap();
-            assert!(state.file(read).is_ok());
-            let result = state
+            assert!(host.files.lock().unwrap().file(read).is_ok());
+            let mut io_results = host.io_results.lock().unwrap();
+            let result = io_results
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap();
@@ -3168,10 +3310,13 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
         let (raw_read, raw_write) = {
-            let mut state = host.state.lock().unwrap();
-            let raw_read = state.file(read).unwrap().raw_fd();
-            let raw_write = state.file(write).unwrap().raw_fd();
-            state
+            let files = host.files.lock().unwrap();
+            let raw_read = files.file(read).unwrap().raw_fd();
+            let raw_write = files.file(write).unwrap().raw_fd();
+            drop(files);
+            host.io_results
+                .lock()
+                .unwrap()
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap()
@@ -3187,10 +3332,12 @@ mod tests {
         );
         assert_eq!(host.close_fd(read), Err(AsyncHostError::Inval));
         {
-            let mut state = host.state.lock().unwrap();
-            assert!(state.file(read).is_ok());
-            assert!(state.file(write).is_ok());
-            let result = state
+            let files = host.files.lock().unwrap();
+            assert!(files.file(read).is_ok());
+            assert!(files.file(write).is_ok());
+            drop(files);
+            let mut io_results = host.io_results.lock().unwrap();
+            let result = io_results
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap();
@@ -3210,8 +3357,9 @@ mod tests {
         let host = AsyncHost::default();
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
         {
-            let mut state = host.state.lock().unwrap();
-            state
+            host.io_results
+                .lock()
+                .unwrap()
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap()
@@ -3221,7 +3369,7 @@ mod tests {
 
         assert_eq!(host.free_io_result(result), Err(AsyncHostError::Inval));
         assert!(
-            host.state
+            host.io_results
                 .lock()
                 .unwrap()
                 .io_results
@@ -3237,8 +3385,8 @@ mod tests {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let completion_port = {
-            let state = host.state.lock().unwrap();
-            let poll = state
+            let polls = host.polls.lock().unwrap();
+            let poll = polls
                 .polls
                 .get(key_from_handle::<HostPollKey>(poll))
                 .unwrap()
@@ -3249,8 +3397,8 @@ mod tests {
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
         let raw_fd = 0x1234usize as RawFd;
         let overlapped = {
-            let mut state = host.state.lock().unwrap();
-            let result = state
+            let mut io_results = host.io_results.lock().unwrap();
+            let result = io_results
                 .io_results
                 .get_mut(key_from_handle::<HostIoResultKey>(result))
                 .unwrap();
@@ -3266,7 +3414,7 @@ mod tests {
 
         assert_eq!(host.poll_event_io_result(event).unwrap(), result);
         assert_eq!(
-            host.state
+            host.io_results
                 .lock()
                 .unwrap()
                 .io_results
@@ -3286,8 +3434,8 @@ mod tests {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let completion_port = {
-            let state = host.state.lock().unwrap();
-            let poll = state
+            let polls = host.polls.lock().unwrap();
+            let poll = polls
                 .polls
                 .get(key_from_handle::<HostPollKey>(poll))
                 .unwrap()

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -1069,9 +1069,11 @@ impl AsyncHost {
             .is_some_and(|current| Arc::ptr_eq(current, &file))
         {
             drop(files);
-            let poll = poll.lock().unwrap();
             #[cfg(unix)]
-            poll::poll_unregister(&poll.instance, raw_fd)?;
+            {
+                let poll = poll.lock().unwrap();
+                poll::poll_unregister(&poll.instance, raw_fd)?;
+            }
             return Err(AsyncHostError::Badf);
         }
         let mut poll = poll.lock().unwrap();
@@ -1579,10 +1581,10 @@ impl AsyncHost {
 
     pub(crate) fn close_fd(&self, handle: HostHandle) -> AsyncHostResult<()> {
         let file = {
-            let files = self.files.lock().unwrap();
-            let file = files.file(handle)?;
+            let mut files = self.files.lock().unwrap();
             #[cfg(windows)]
             {
+                let file = files.file(handle)?;
                 if self
                     .io_results
                     .lock()
@@ -1592,7 +1594,7 @@ impl AsyncHost {
                     return Err(AsyncHostError::Inval);
                 }
             }
-            file
+            files.remove_file(handle)?
         };
         let raw_fd = file.raw_fd();
         let polls = self
@@ -1607,7 +1609,7 @@ impl AsyncHost {
             let mut poll = poll.lock().unwrap();
             if poll.registered_fds.contains_key(&raw_fd_key(raw_fd)) {
                 #[cfg(unix)]
-                poll::poll_unregister(&poll.instance, raw_fd)?;
+                let _ = poll::poll_unregister(&poll.instance, raw_fd);
             }
             poll.registered_fds.remove(&raw_fd_key(raw_fd));
         }
@@ -1637,7 +1639,6 @@ impl AsyncHost {
                 }
             }
         }
-        self.files.lock().unwrap().remove_file(handle)?;
         Ok(())
     }
 

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -731,8 +731,8 @@ impl HostIoResult {
     }
 
     fn cancel_pending(&mut self) -> AsyncHostResult<i32> {
-        use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
-        use windows_sys::Win32::System::IO::CancelIoEx;
+        use windows_sys::Win32::Foundation::{ERROR_IO_INCOMPLETE, ERROR_NOT_FOUND};
+        use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult};
 
         let Some(file) = &self.pending_file else {
             return Ok(0);
@@ -744,11 +744,22 @@ impl HostIoResult {
             if errno != ERROR_NOT_FOUND as i32 {
                 return Err(AsyncHostError::Native(errno));
             }
-            // The operation may have completed after the cancellation request
-            // raced with IOCP delivery. Keep the result pending until the
-            // completion packet is consumed through poll_event_io_result.
         }
-        Ok(1)
+
+        let mut bytes_transferred = 0;
+        if unsafe { GetOverlappedResult(raw_fd, overlapped, &mut bytes_transferred, 0) } != 0 {
+            self.clear_pending();
+            return Ok(0);
+        }
+        let errno = last_errno();
+        if errno == ERROR_IO_INCOMPLETE as i32 {
+            // Native leaves the result pending here so MoonBit waits for the
+            // completion packet before freeing the IO result.
+            Ok(1)
+        } else {
+            self.clear_pending();
+            Ok(0)
+        }
     }
 
     fn cancel_and_drain_pending(&mut self) -> AsyncHostResult<()> {
@@ -789,6 +800,9 @@ pub(crate) struct AsyncHost {
     // separate guest concepts: resource handles and ABI values stay unchanged.
     // Keep nested table locks short and in the existing directions:
     // jobs -> files for publishing open-job results,
+    // files -> io_results for Windows overlapped-IO submission/close; submit
+    // paths keep files held until io_results is locked so close_fd cannot miss
+    // an operation that is about to become pending,
     // completions -> files -> polls for completion-source init, and
     // workers -> jobs -> worker state for worker assignment.
     // Do not hold table locks while running worker jobs or blocking I/O.
@@ -1928,9 +1942,13 @@ impl AsyncHost {
         use windows_sys::Win32::Networking::WinSock as ws;
         use windows_sys::Win32::Storage::FileSystem::ReadFile;
 
-        let file = self.file_resource(fd_handle)?;
+        // Keep the fd handle reserved until io_results is locked. close_fd uses
+        // the same order before removing the handle from files.
+        let files = self.files.lock().unwrap();
+        let file = files.file(fd_handle)?;
         let raw_fd = file.raw_fd();
         let mut io_results = self.io_results.lock().unwrap();
+        drop(files);
         let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
@@ -2026,9 +2044,13 @@ impl AsyncHost {
         use windows_sys::Win32::Networking::WinSock as ws;
         use windows_sys::Win32::Storage::FileSystem::WriteFile;
 
-        let file = self.file_resource(fd_handle)?;
+        // Keep the fd handle reserved until io_results is locked. close_fd uses
+        // the same order before removing the handle from files.
+        let files = self.files.lock().unwrap();
+        let file = files.file(fd_handle)?;
         let raw_fd = file.raw_fd();
         let mut io_results = self.io_results.lock().unwrap();
+        drop(files);
         let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
@@ -2120,9 +2142,13 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let file = self.file_resource(fd_handle)?;
+        // Keep the fd handle reserved until io_results is locked. close_fd uses
+        // the same order before removing the handle from files.
+        let files = self.files.lock().unwrap();
+        let file = files.file(fd_handle)?;
         let raw_fd = file.raw_fd();
         let mut io_results = self.io_results.lock().unwrap();
+        drop(files);
         let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
@@ -2188,11 +2214,15 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let server_file = self.file_resource(server_fd_handle)?;
-        let conn_file = self.file_resource(conn_fd_handle)?;
+        // Keep both fd handles reserved until io_results is locked. close_fd
+        // uses the same order before removing either handle from files.
+        let files = self.files.lock().unwrap();
+        let server_file = files.file(server_fd_handle)?;
+        let conn_file = files.file(conn_fd_handle)?;
         let server_fd = server_file.raw_fd();
         let conn_fd = conn_file.raw_fd();
         let mut io_results = self.io_results.lock().unwrap();
+        drop(files);
         let result = io_results
             .io_results
             .get_mut(key_from_handle::<HostIoResultKey>(result_handle))
@@ -3456,13 +3486,12 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn cancel_io_result_keeps_pending_until_completion_is_delivered() {
+    fn cancel_io_result_clears_pending_result_when_no_wait_is_needed() {
         let host = AsyncHost::default();
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
-        let raw_read = {
+        {
             let read_file = host.file_resource(read).unwrap();
-            let raw_read = read_file.raw_fd();
             host.io_results
                 .lock()
                 .unwrap()
@@ -3471,6 +3500,39 @@ mod tests {
                 .unwrap()
                 .mark_pending(read_file)
                 .unwrap();
+        }
+
+        assert_eq!(host.cancel_io_result(result, read), Ok(0));
+        {
+            let io_results = host.io_results.lock().unwrap();
+            let result = io_results
+                .io_results
+                .get(key_from_handle::<HostIoResultKey>(result))
+                .unwrap();
+            assert_eq!(result.pending_raw_fd(), None);
+        }
+
+        host.free_io_result(result).unwrap();
+        host.close_fd(read).unwrap();
+        host.close_fd(write).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn cancel_io_result_keeps_pending_result_when_wait_is_needed() {
+        let host = AsyncHost::default();
+        let [read, write] = host.pipe(true, true).unwrap();
+        let result = host.make_file_io_result(&mut [], 0, 0, 0, 0, 0).unwrap();
+        let raw_read = {
+            let read_file = host.file_resource(read).unwrap();
+            let raw_read = read_file.raw_fd();
+            let mut io_results = host.io_results.lock().unwrap();
+            let result = io_results
+                .io_results
+                .get_mut(key_from_handle::<HostIoResultKey>(result))
+                .unwrap();
+            result.overlapped.Internal = windows_sys::Win32::Foundation::STATUS_PENDING as usize;
+            result.mark_pending(read_file).unwrap();
             raw_read
         };
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -446,6 +446,44 @@ mod tests {
     }
 
     #[test]
+    fn completion_reports_missing_job_and_worker_continues() {
+        let (started_sender, started_receiver) = mpsc::channel();
+        let (completion_sender, completion_receiver) = mpsc::channel();
+        let worker = spawn_worker(
+            make_worker_job(1, 2),
+            move |job| {
+                started_sender.send(worker_job_summary(&job)).unwrap();
+                None
+            },
+            move |job| {
+                completion_sender
+                    .send((worker_result_summary(&job), job.job.is_some()))
+                    .unwrap()
+            },
+        );
+
+        assert_eq!(
+            started_receiver.recv().unwrap(),
+            (WorkerCompletionId::from_abi(1), make_job_key(2))
+        );
+        assert_eq!(
+            completion_receiver.recv().unwrap(),
+            ((WorkerCompletionId::from_abi(1), make_job_key(2)), false)
+        );
+
+        assert!(wake_worker(&worker, make_worker_job(3, 4)).is_none());
+        assert_eq!(
+            started_receiver.recv().unwrap(),
+            (WorkerCompletionId::from_abi(3), make_job_key(4))
+        );
+        assert_eq!(
+            completion_receiver.recv().unwrap(),
+            ((WorkerCompletionId::from_abi(3), make_job_key(4)), false)
+        );
+        assert!(free_worker(worker).is_none());
+    }
+
+    #[test]
     fn worker_enter_idle_returns_queued_job() {
         let (started_sender, started_receiver) = mpsc::channel();
         let (release_sender, release_receiver) = mpsc::channel();

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -39,11 +39,17 @@ impl WorkerCompletionId {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct HostWorkerJob {
     pub(crate) completion_id: WorkerCompletionId,
     pub(crate) job_key: HostJobKey,
-    pub(crate) job: Job,
+}
+
+#[derive(Debug)]
+pub(crate) struct HostWorkerJobResult {
+    pub(crate) completion_id: WorkerCompletionId,
+    pub(crate) job_key: HostJobKey,
+    pub(crate) job: Option<Job>,
 }
 
 #[derive(Debug)]
@@ -103,8 +109,8 @@ fn init_worker_signal_handler() {
 impl HostWorkerHandle {
     pub(crate) fn spawn(
         init_job: HostWorkerJob,
-        mut run_job: impl FnMut(&mut HostWorkerJob) + Send + 'static,
-        mut complete_job: impl FnMut(HostWorkerJob) + Send + 'static,
+        mut run_job: impl FnMut(HostWorkerJob) -> Option<Job> + Send + 'static,
+        mut complete_job: impl FnMut(HostWorkerJobResult) + Send + 'static,
     ) -> Self {
         #[cfg(unix)]
         init_worker_signal_handler();
@@ -137,10 +143,10 @@ impl HostWorkerHandle {
                     }
                     (!state.terminating).then(|| state.job.take()).flatten()
                 };
-                let Some(mut job) = job else {
+                let Some(job) = job else {
                     break;
                 };
-                run_job(&mut job);
+                let result = run_job(job);
 
                 let terminating = {
                     let mut state = worker_shared.state.lock().unwrap();
@@ -149,7 +155,11 @@ impl HostWorkerHandle {
                     }
                     state.terminating
                 };
-                complete_job(job);
+                complete_job(HostWorkerJobResult {
+                    completion_id: job.completion_id,
+                    job_key: job.job_key,
+                    job: result,
+                });
                 if terminating {
                     break;
                 }
@@ -243,8 +253,8 @@ ported_fns! {
     )]
     pub(crate) fn spawn_worker(
         init_job: HostWorkerJob,
-        run_job: impl FnMut(&mut HostWorkerJob) + Send + 'static,
-        complete_job: impl FnMut(HostWorkerJob) + Send + 'static,
+        run_job: impl FnMut(HostWorkerJob) -> Option<Job> + Send + 'static,
+        complete_job: impl FnMut(HostWorkerJobResult) + Send + 'static,
     ) -> HostWorkerHandle {
         HostWorkerHandle::spawn(init_job, run_job, complete_job)
     }
@@ -300,11 +310,14 @@ mod tests {
         (job.completion_id, job.job_key)
     }
 
+    fn worker_result_summary(job: &HostWorkerJobResult) -> (WorkerCompletionId, HostJobKey) {
+        (job.completion_id, job.job_key)
+    }
+
     fn make_worker_job(completion_id: i32, job_key: u64) -> HostWorkerJob {
         HostWorkerJob {
             completion_id: WorkerCompletionId::from_abi(completion_id),
             job_key: make_job_key(job_key),
-            job: make_sleep_job(0),
         }
     }
 
@@ -314,8 +327,11 @@ mod tests {
         let (completion_sender, completion_receiver) = mpsc::channel();
         let worker = spawn_worker(
             make_worker_job(7, 11),
-            move |job| sender.send(worker_job_summary(job)).unwrap(),
-            move |job| completion_sender.send(worker_job_summary(&job)).unwrap(),
+            move |job| {
+                sender.send(worker_job_summary(&job)).unwrap();
+                Some(make_sleep_job(0))
+            },
+            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
         );
 
         assert_eq!(
@@ -346,8 +362,11 @@ mod tests {
         let (completion_sender, completion_receiver) = mpsc::channel();
         let worker = spawn_worker(
             make_worker_job(1, 2),
-            move |job| sender.send(worker_job_summary(job)).unwrap(),
-            move |job| completion_sender.send(worker_job_summary(&job)).unwrap(),
+            move |job| {
+                sender.send(worker_job_summary(&job)).unwrap();
+                Some(make_sleep_job(0))
+            },
+            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
         );
 
         assert_eq!(receiver.recv().unwrap().0, WorkerCompletionId::from_abi(1));
@@ -375,12 +394,13 @@ mod tests {
         let worker = spawn_worker(
             make_worker_job(1, 2),
             move |job| {
-                started_sender.send(worker_job_summary(job)).unwrap();
+                started_sender.send(worker_job_summary(&job)).unwrap();
                 if job.completion_id == WorkerCompletionId::from_abi(1) {
                     release_receiver.recv().unwrap();
                 }
+                Some(make_sleep_job(0))
             },
-            move |job| completion_sender.send(worker_job_summary(&job)).unwrap(),
+            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
         );
 
         assert_eq!(
@@ -413,8 +433,12 @@ mod tests {
         let (completion_sender, completion_receiver) = mpsc::channel();
         let worker = spawn_worker(
             make_worker_job(1, 2),
-            move |job| job.job.set_ret(123),
-            move |job| completion_sender.send(job.job.ret()).unwrap(),
+            move |_| {
+                let mut job = make_sleep_job(0);
+                job.set_ret(123);
+                Some(job)
+            },
+            move |job| completion_sender.send(job.job.unwrap().ret()).unwrap(),
         );
 
         assert_eq!(completion_receiver.recv().unwrap(), 123);
@@ -429,10 +453,11 @@ mod tests {
         let worker = spawn_worker(
             make_worker_job(1, 2),
             move |job| {
-                started_sender.send(worker_job_summary(job)).unwrap();
+                started_sender.send(worker_job_summary(&job)).unwrap();
                 release_receiver.recv().unwrap();
+                Some(make_sleep_job(0))
             },
-            move |job| completion_sender.send(worker_job_summary(&job)).unwrap(),
+            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
         );
 
         assert_eq!(
@@ -474,10 +499,11 @@ mod tests {
         let worker = spawn_worker(
             make_worker_job(21, 34),
             move |job| {
-                started_sender.send(worker_job_summary(job)).unwrap();
+                started_sender.send(worker_job_summary(&job)).unwrap();
                 release_receiver.recv().unwrap();
+                Some(make_sleep_job(0))
             },
-            move |job| completion_sender.send(worker_job_summary(&job)).unwrap(),
+            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
         );
 
         assert_eq!(

--- a/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
@@ -56,6 +56,9 @@ fn make_sleep_job(ms : Int) -> UInt64 = "moonbitlang/async" "thread_pool/make_sl
 fn free_job(job : UInt64) -> Unit = "moonbitlang/async" "thread_pool/free_job"
 
 ///|
+fn job_get_ret(job : UInt64) -> Int = "moonbitlang/async" "thread_pool/job_get_ret"
+
+///|
 fn spawn_worker(worker_id : Int, job : UInt64) -> UInt64 = "moonbitlang/async" "thread_pool/spawn_worker"
 
 ///|
@@ -214,6 +217,10 @@ fn main {
       "completion drain returned wrong job id",
     )
   }
+  assert_true(
+    job_get_ret(job) == 0,
+    "completed worker job result was not readable",
+  )
   free_worker(worker)
   free_job(job)
   destroy_thread_pool()


### PR DESCRIPTION
## Why this is necessary

PR #1837 removed worker-thread dependence on the global async host state lock, but it also made queued worker jobs non-cancellable by moving the queued `Job` out of the job table before the worker started it. This PR fixes that by keeping worker assignments as completion-token plus job-key entries until execution.

The PR also addresses lifecycle races exposed while splitting async host state behind narrower locks. MoonBit observes these host tables as one native-shaped async runtime, even though the Rust host stores them separately:

- guest fd/HANDLE validity
- poll registrations
- thread-pool completion sources
- Windows overlapped IO results

The split must preserve publication order:

- a handle must not remain externally usable while `close_fd` is tearing down poll state;
- pending Windows IO must be visible before `close_fd` can remove its handle;
- a Unix completion notifier must not be visible before its poll fd mapping exists.

## Why this is correct

The guest-visible ABI and typed `SlotMap` handles stay unchanged. A worker only takes ownership of a `Job` when it starts running that assignment. If the guest frees a queued job first, the worker sees the missing slot, skips the operation, and still publishes the completion token so the event loop can move the worker state forward. Running jobs remain worker-owned until completion, and completed payloads are restored on the event-loop side.

The lifecycle ordering now matches the MoonBit-facing native model:

- `close_fd` invalidates the guest handle before walking poll registrations, while keeping the underlying file resource alive long enough to clean up host poll state.
- Windows overlapped submit paths keep the fd handle reserved until the IO-result table is locked, matching close's pending-IO check order.
- Windows cancellation status follows the native `CancelIoEx` plus `GetOverlappedResult(..., FALSE)` behavior, returning `NeedWait` only while the operation is still incomplete.
- Unix thread-pool completion initialization installs the poll-side fd mapping before publishing the notifier/source that workers can use.

## Why this is minimal

This does not collapse all handle tables into one resource table and does not change import signatures. The PR keeps the native-shaped worker and event-loop flow while limiting the synchronization split to async host state groups that were previously behind one mutex.

The follow-up fixes are local lifecycle-ordering changes, not a new fd abstraction. Each change keeps the existing tables and only moves publication/removal to the point where the MoonBit-facing state is already coherent.
