### PR TITLE
Remove stale async submodule branch override

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,3 @@
 [submodule "third_party/moonbitlang_async"]
 	path = third_party/moonbitlang_async
 	url = https://github.com/moonbitlang/async.git
-	branch = codex/wasm-async-fs-host-upstream


### PR DESCRIPTION
## Summary

Remove the `branch` override from the `third_party/moonbitlang_async` submodule configuration.

## Why

The override pointed at an old codex branch instead of the upstream default branch. That makes any checkout path using submodule remote updates depend on a stale feature branch name.

## Correctness

The submodule URL and recorded gitlink remain unchanged. Without a branch override, normal submodule checkout continues to use the recorded commit, while `--remote` style updates follow the upstream repository default branch instead of a stale codex branch.