### PR TITLE
Narrow registry index parsing

### DIFF
--- a/crates/moon/src/cli/fetch.rs
+++ b/crates/moon/src/cli/fetch.rs
@@ -96,10 +96,7 @@ pub(crate) fn fetch_cli(cli: UniversalFlags, cmd: FetchSubcommand) -> anyhow::Re
                         "Could not find the latest published version of `{pkg_name}` in the registry. Please consider running `moon update` to update the index."
                     )
                 }
-            })?
-            .version
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("latest registry entry for `{pkg_name}` has no version"))?;
+            })?;
         if !cli.quiet {
             println!("Latest version of {pkg_name} is {latest_version}");
         }

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -258,14 +258,9 @@ pub(super) fn install_binary(
     let version = if let Some(v) = &spec.version {
         v.clone()
     } else {
-        let module_info = registry
+        registry
             .get_latest_version(&spec.module_name)
-            .ok_or_else(|| {
-                anyhow::anyhow!("Module `{}` not found in registry", spec.module_name)
-            })?;
-        module_info.version.clone().ok_or_else(|| {
-            anyhow::anyhow!("Module `{}` has no version information", spec.module_name)
-        })?
+            .ok_or_else(|| anyhow::anyhow!("Module `{}` not found in registry", spec.module_name))?
     };
 
     output.info(format!("Installing {}@{}", spec.module_name, version));

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -110,7 +110,7 @@ pub(crate) fn run_build_binary_dep(
     let &[main_module_id] = resolve_output.local_modules() else {
         panic!("Expected exactly one main module when building all packages");
     };
-    let main_module_ref = resolve_output.module_rel.module_info(main_module_id);
+    let main_module_ref = resolve_output.module_info(main_module_id);
     let default_backend = main_module_ref.preferred_target.unwrap_or_default();
 
     // Okay let's filter the packages

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -326,7 +326,6 @@ pub(crate) fn preferred_target_backend_for_package(
 ) -> TargetBackend {
     let module_id = resolve_output.pkg_dirs.get_package(pkg_id).module;
     resolve_output
-        .module_rel
         .module_info(module_id)
         .preferred_target
         .unwrap_or_default()

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -166,12 +166,7 @@ fn local_modules_preferred_target(
     let preferred = resolve_output
         .local_modules()
         .iter()
-        .filter_map(|&module_id| {
-            resolve_output
-                .module_rel
-                .module_info(module_id)
-                .preferred_target
-        })
+        .filter_map(|&module_id| resolve_output.module_info(module_id).preferred_target)
         .collect::<BTreeSet<_>>();
 
     if preferred.len() > 1 {
@@ -532,7 +527,7 @@ pub(crate) fn prepare_resolved_build(
     // Preferred backend
     info!("Checking local modules and backend");
     let main_module = match resolve_output.local_modules() {
-        &[module_id] => Some(resolve_output.module_rel.module_info(module_id)),
+        &[module_id] => Some(resolve_output.module_info(module_id)),
         _ => None,
     };
     let preferred_target = if preconfig.target_backend.is_some() {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -340,7 +340,7 @@ impl<'a> LoweringContext<'a> {
         info: &BuildTargetInfo,
     ) -> BuildCommand {
         let package = self.get_package(target);
-        let module = self.modules.module_info(package.module);
+        let module = self.packages.module_info(package.module);
 
         let mi_output = products
             .optional_single_output_path_matching(|product| {
@@ -429,7 +429,7 @@ impl<'a> LoweringContext<'a> {
         info: &BuildTargetInfo,
     ) -> BuildCommand {
         let package = self.get_package(target);
-        let module = self.modules.module_info(package.module);
+        let module = self.packages.module_info(package.module);
         let mi_inputs = self.prove_mi_inputs_of(target);
 
         let files_vec = self.compiler_source_files(info);
@@ -490,7 +490,7 @@ impl<'a> LoweringContext<'a> {
         info: &BuildTargetInfo,
     ) -> BuildCommand {
         let package = self.get_package(target);
-        let module = self.modules.module_info(package.module);
+        let module = self.packages.module_info(package.module);
         let mi_inputs = self.prove_mi_inputs_of(target);
 
         let files_vec = self.compiler_source_files(info);
@@ -570,7 +570,7 @@ impl<'a> LoweringContext<'a> {
         info: &BuildTargetInfo,
     ) -> BuildCommand {
         let package = self.get_package(target);
-        let module = self.modules.module_info(package.module);
+        let module = self.packages.module_info(package.module);
 
         let core_output = products.single_output_path_matching(|product| {
             matches!(
@@ -680,7 +680,7 @@ impl<'a> LoweringContext<'a> {
         let _ = make_executable_info;
 
         let package = self.get_package(target);
-        let module = self.modules.module_info(package.module);
+        let module = self.packages.module_info(package.module);
 
         let mut core_input_files = Vec::new();
         // Add core for the standard library

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -608,7 +608,7 @@ impl<'a> BuildPlanConstructor<'a> {
         };
 
         let pkg = self.input.pkg_dirs.get_package(target.package);
-        let module = self.input.module_rel.module_info(pkg.module);
+        let module = self.input.module_info(pkg.module);
 
         // Populate `warn_list` by concatenating module-level, package-level,
         // and command-line settings.
@@ -1461,7 +1461,7 @@ impl<'a> BuildPlanConstructor<'a> {
         let command = match prebuild_cmd {
             MoonPkgGenerate::Direct { command, .. } => Cow::Borrowed(command.as_str()),
             MoonPkgGenerate::Rule { rule, .. } => {
-                let module_info = self.input.module_rel.module_info(pkg.module);
+                let module_info = self.input.module_info(pkg.module);
                 Cow::Owned(resolve_prebuild_rule_command(
                     pkg.local_rules(),
                     module_info,

--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -231,9 +231,9 @@ pub(crate) fn discover_packages_for_mod(
         });
     }
 
-    let source_dir_name = m.source.as_deref().unwrap_or("");
+    let source_dir_name = m.source.clone().unwrap_or_default();
     let scan_source_root = {
-        let p = dir.join(source_dir_name);
+        let p = dir.join(&source_dir_name);
         dunce::canonicalize(p).map_err(|e| DiscoverError::CantReadModulePackages {
             module: module_source.clone(),
             inner: e.into(),
@@ -246,6 +246,7 @@ pub(crate) fn discover_packages_for_mod(
             path: dir.to_owned(),
             inner: e,
         })?;
+    res.set_module_info(id, Arc::new(m));
 
     // Recursively walk through the module's directories
     let mut walkdir = WalkDir::new(&scan_source_root)
@@ -504,4 +505,80 @@ fn discover_virtual_mbti(
     };
 
     Ok(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use moonutil::{
+        module::MoonMod,
+        mooncakes::{DirSyncResult, ModuleSource, result::ResolvedEnv},
+    };
+
+    use super::discover_packages;
+
+    fn temp_dir(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "moonbuild-rupes-recta-discover-{name}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("failed to create temporary module directory");
+        dir
+    }
+
+    #[test]
+    fn discover_packages_keeps_installed_module_manifest() {
+        let dir = temp_dir("module-info");
+        std::fs::write(
+            dir.join("moon.mod.json"),
+            r#"{
+  "name": "example/pkg",
+  "version": "0.2.1",
+  "compile-flags": ["-DREGISTRY"],
+  "link-flags": ["-lregistry"],
+  "warn-list": "+a",
+  "--moonbit-unstable-prebuild": "prebuild.py",
+  "rule": [
+    { "name": "gen", "command": "tool $input -o $output" }
+  ]
+}
+"#,
+        )
+        .expect("failed to write test moon.mod.json");
+
+        let source: ModuleSource = "example/pkg@0.2.1"
+            .parse()
+            .expect("failed to parse test module source");
+        let stub = MoonMod {
+            name: "example/pkg".to_string(),
+            version: Some(source.version().clone()),
+            ..Default::default()
+        };
+        let (resolved_env, id) = ResolvedEnv::only_one_module(source, stub);
+        let mut dirs = DirSyncResult::default();
+        dirs.insert(id, dir.clone());
+
+        let discovered =
+            discover_packages(&resolved_env, &dirs).expect("failed to discover test packages");
+
+        let module = discovered.module_info(id);
+        assert_eq!(
+            module.compile_flags.as_deref(),
+            Some(&["-DREGISTRY".into()][..])
+        );
+        assert_eq!(
+            module.link_flags.as_deref(),
+            Some(&["-lregistry".into()][..])
+        );
+        assert_eq!(module.warn_list.as_deref(), Some("+a"));
+        assert_eq!(
+            module.__moonbit_unstable_prebuild.as_deref(),
+            Some("prebuild.py")
+        );
+        let rule = module.rule.as_ref().expect("expected test rule to be kept");
+        assert_eq!(rule.len(), 1);
+        assert_eq!(rule[0].name, "gen");
+        assert_eq!(rule[0].command, "tool $input -o $output");
+        let _ = std::fs::remove_dir_all(dir);
+    }
 }

--- a/crates/moonbuild-rupes-recta/src/discover/model.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/model.rs
@@ -21,11 +21,12 @@
 use std::{
     collections::{BTreeMap, HashMap},
     path::PathBuf,
+    sync::Arc,
 };
 
 use moonbuild::expect::PackageSrcResolver;
 use moonutil::common::{MOON_PKG_JSON, TargetBackend};
-use moonutil::module::MoonModRule;
+use moonutil::module::{MoonMod, MoonModRule};
 use moonutil::mooncakes::{ModuleId, ModuleSource, result::ResolvedRootModules};
 use moonutil::package::{MoonPkg, SupportedTargetsDeclKind};
 use slotmap::{SecondaryMap, SlotMap};
@@ -149,6 +150,9 @@ impl DiscoveredPackage {
 /// The result of a package discovery process.
 #[derive(Debug, Clone, Default)]
 pub struct DiscoverResult {
+    /// Module manifests read from the resolved source directories.
+    module_infos: SecondaryMap<ModuleId, Arc<MoonMod>>,
+
     /// The directory of all discovered packages
     packages: SlotMap<PackageId, DiscoveredPackage>,
 
@@ -185,6 +189,17 @@ pub struct DiscoveredLocalProject {
 }
 
 impl DiscoverResult {
+    pub(super) fn set_module_info(&mut self, module: ModuleId, info: Arc<MoonMod>) {
+        self.module_infos.insert(module, info);
+    }
+
+    pub fn module_info(&self, module: ModuleId) -> &MoonMod {
+        self.module_infos
+            .get(module)
+            .expect("module info should be discovered before use")
+            .as_ref()
+    }
+
     /// Add a discovered package to the result.
     ///
     /// If a package with the same fully-qualified name already exists, an error

--- a/crates/moonbuild-rupes-recta/src/discover/synth.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/synth.rs
@@ -28,7 +28,7 @@
 //! This mirrors the legacy path in `moon/src/cli/test.rs:get_module_for_single_file`
 //! where it programmatically enumerates imports for the synthetic single-file package.
 
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 use indexmap::IndexSet;
 use moonutil::common::TargetBackend;
@@ -58,6 +58,7 @@ pub fn build_synth_single_file_package(
     let &[mid] = env.input_module_ids() else {
         panic!("No multiple main modules are supported")
     };
+    discovered.set_module_info(mid, Arc::clone(env.module_info(mid)));
 
     // Resolve ModuleSource for the ModuleId
     let module_src = env

--- a/crates/moonbuild-rupes-recta/src/metadata.rs
+++ b/crates/moonbuild-rupes-recta/src/metadata.rs
@@ -56,7 +56,7 @@ pub fn gen_metadata_json(
     let (name, deps, source) = match ctx.local_modules() {
         &[main_module_id] => {
             let main_module = ctx.module_rel.module_source(main_module_id);
-            let main_module_json = ctx.module_rel.module_info(main_module_id);
+            let main_module_json = ctx.module_info(main_module_id);
             (
                 main_module.name().to_string(),
                 main_module_json.deps.keys().cloned().collect(),
@@ -70,7 +70,7 @@ pub fn gen_metadata_json(
             let deps = ctx
                 .local_modules()
                 .iter()
-                .flat_map(|&module_id| ctx.module_rel.module_info(module_id).deps.keys().cloned())
+                .flat_map(|&module_id| ctx.module_info(module_id).deps.keys().cloned())
                 .collect::<BTreeSet<_>>()
                 .into_iter()
                 .collect();

--- a/crates/moonbuild-rupes-recta/src/prebuild.rs
+++ b/crates/moonbuild-rupes-recta/src/prebuild.rs
@@ -84,7 +84,7 @@ fn run_prebuild_for_module(
     environment: &PrebuildEnvironment,
     ret: &mut PrebuildOutput,
 ) -> anyhow::Result<()> {
-    let m_info = &**resolve_output.module_rel.module_info(m);
+    let m_info = resolve_output.module_info(m);
     let m_dir = resolve_output.module_dirs.get(m).expect("module not found");
     let Some(prebuild) = &m_info.__moonbit_unstable_prebuild else {
         return Ok(());

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -40,6 +40,7 @@ use moonutil::{
     },
     dependency::SourceDependencyInfo,
     dirs::WorkspaceEnv,
+    module::MoonMod,
     mooncakes::{DirSyncResult, ModuleId, result::ResolvedEnv, sync::AutoSyncFlags},
     package::{Import, PkgJSONImport, pkg_json_imports_to_imports},
 };
@@ -77,6 +78,10 @@ impl ResolveOutput {
     /// `ModuleSourceKind::Local`.
     pub fn local_modules(&self) -> &[ModuleId] {
         self.module_rel.input_module_ids()
+    }
+
+    pub fn module_info(&self, id: ModuleId) -> &MoonMod {
+        self.pkg_dirs.module_info(id)
     }
 }
 

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -90,10 +90,7 @@ pub fn add_latest(
                     pkg_name_str
                 )
             }
-        })?
-        .version
-        .clone()
-        .unwrap();
+        })?;
     add(
         project_root,
         module_dir,

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -23,22 +23,23 @@ pub mod path;
 
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 
-use moonutil::module::MoonMod;
+use indexmap::IndexMap;
+use moonutil::dependency::SourceDependencyInfo;
 use moonutil::mooncakes::ModuleName;
 pub use online::*;
 use semver::Version;
+
+#[derive(Debug, Clone, Default)]
+pub struct RegistryVersionInfo {
+    pub deps: IndexMap<String, SourceDependencyInfo>,
+}
 
 pub trait Registry {
     /// Get all versions of a module.
     fn all_versions_of(
         &self,
         name: &ModuleName,
-    ) -> anyhow::Result<Arc<BTreeMap<Version, Arc<MoonMod>>>>;
-
-    fn get_module_version(&self, name: &ModuleName, version: &Version) -> Option<Arc<MoonMod>> {
-        let all_versions = self.all_versions_of(name).ok()?;
-        all_versions.get(version).cloned()
-    }
+    ) -> anyhow::Result<Arc<BTreeMap<Version, RegistryVersionInfo>>>;
 
     /// Resolve an unversioned import-style path into:
     /// - module path
@@ -62,9 +63,11 @@ pub trait Registry {
         })
     }
 
-    fn get_latest_version(&self, name: &ModuleName) -> Option<Arc<MoonMod>> {
+    fn get_latest_version(&self, name: &ModuleName) -> Option<Version> {
         let all_versions = self.all_versions_of(name).ok()?;
-        all_versions.values().last().cloned()
+        all_versions
+            .last_key_value()
+            .map(|(version, _)| version.clone())
     }
 
     fn install_to(
@@ -83,7 +86,7 @@ where
     fn all_versions_of(
         &self,
         name: &ModuleName,
-    ) -> anyhow::Result<Arc<BTreeMap<Version, Arc<MoonMod>>>> {
+    ) -> anyhow::Result<Arc<BTreeMap<Version, RegistryVersionInfo>>> {
         (**self).all_versions_of(name)
     }
 
@@ -97,11 +100,7 @@ where
         (**self).install_to(name, version, to, quiet)
     }
 
-    fn get_module_version(&self, name: &ModuleName, version: &Version) -> Option<Arc<MoonMod>> {
-        (**self).get_module_version(name, version)
-    }
-
-    fn get_latest_version(&self, name: &ModuleName) -> Option<Arc<MoonMod>> {
+    fn get_latest_version(&self, name: &ModuleName) -> Option<Version> {
         (**self).get_latest_version(name)
     }
 
@@ -117,7 +116,7 @@ where
     fn all_versions_of(
         &self,
         name: &ModuleName,
-    ) -> anyhow::Result<Arc<BTreeMap<Version, Arc<MoonMod>>>> {
+    ) -> anyhow::Result<Arc<BTreeMap<Version, RegistryVersionInfo>>> {
         (**self).all_versions_of(name)
     }
 
@@ -131,11 +130,7 @@ where
         (**self).install_to(name, version, to, quiet)
     }
 
-    fn get_module_version(&self, name: &ModuleName, version: &Version) -> Option<Arc<MoonMod>> {
-        (**self).get_module_version(name, version)
-    }
-
-    fn get_latest_version(&self, name: &ModuleName) -> Option<Arc<MoonMod>> {
+    fn get_latest_version(&self, name: &ModuleName) -> Option<Version> {
         (**self).get_latest_version(name)
     }
 

--- a/crates/mooncake/src/registry/mock.rs
+++ b/crates/mooncake/src/registry/mock.rs
@@ -26,7 +26,7 @@ use std::{
 use moonutil::{dependency::SourceDependencyInfo, module::MoonMod, mooncakes::ModuleName};
 use semver::Version;
 
-use super::Registry;
+use super::{Registry, RegistryVersionInfo};
 
 /// A mock registry, primarily used in tests.
 pub struct MockRegistry {
@@ -150,11 +150,24 @@ impl Registry for MockRegistry {
     fn all_versions_of(
         &self,
         name: &ModuleName,
-    ) -> anyhow::Result<Arc<BTreeMap<Version, Arc<MoonMod>>>> {
+    ) -> anyhow::Result<Arc<BTreeMap<Version, RegistryVersionInfo>>> {
         self.modules
             .get(name)
+            .map(|versions| {
+                versions
+                    .iter()
+                    .map(|(version, module)| {
+                        (
+                            version.clone(),
+                            RegistryVersionInfo {
+                                deps: module.deps.clone(),
+                            },
+                        )
+                    })
+                    .collect()
+            })
             .ok_or_else(|| anyhow::anyhow!("module not found in mock registry"))
-            .cloned()
+            .map(Arc::new)
     }
 
     fn install_to(

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -25,18 +25,28 @@ use std::{
 };
 
 use anyhow::bail;
-use moonutil::module::{MoonMod, MoonModJSON};
-use moonutil::{common::execute_postadd_script, mooncakes::ModuleName};
+use indexmap::map::IndexMap;
+use moonutil::{
+    common::execute_postadd_script, dependency::SourceDependencyInfo, mooncakes::ModuleName,
+};
 use reqwest::header::USER_AGENT;
 use semver::Version;
+use serde::Deserialize;
 
-use crate::zip_util::extract_zip_to_dir;
+use crate::{registry::RegistryVersionInfo, zip_util::extract_zip_to_dir};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct RegistryIndexEntry {
+    version: Option<String>,
+    deps: Option<IndexMap<String, SourceDependencyInfo>>,
+    checksum: Option<String>,
+}
 
 pub struct OnlineRegistry {
     index: std::path::PathBuf,
     url_base: String, // TODO: add download feature to registry interface
-    #[allow(clippy::type_complexity)] // Isn't it still pretty clear?
-    cache: RefCell<HashMap<ModuleName, Arc<BTreeMap<Version, Arc<MoonMod>>>>>,
+    cache: RefCell<HashMap<ModuleName, Arc<BTreeMap<Version, RegistryVersionInfo>>>>,
 }
 
 impl OnlineRegistry {
@@ -60,7 +70,7 @@ impl super::Registry for OnlineRegistry {
     fn all_versions_of(
         &self,
         name: &ModuleName,
-    ) -> anyhow::Result<Arc<BTreeMap<Version, Arc<MoonMod>>>> {
+    ) -> anyhow::Result<Arc<BTreeMap<Version, RegistryVersionInfo>>> {
         // check cache
         if let Some(v) = self.cache.borrow().get(name) {
             return Ok(Arc::clone(v));
@@ -75,16 +85,20 @@ impl super::Registry for OnlineRegistry {
         let mut res = BTreeMap::new();
         for line in lines {
             let line = line?;
-            let module: MoonModJSON = match serde_json_lenient::from_str(&line) {
+            let entry = match serde_json_lenient::from_str::<RegistryIndexEntry>(&line) {
                 Ok(m) => m,
                 Err(e) => {
                     log::warn!("Error when reading index file of {}: {}", name, e);
                     continue;
                 }
             };
-            let module: MoonMod = module.try_into()?;
-            if let Some(v) = &module.version {
-                res.insert(v.clone(), Arc::new(module));
+            if let Some(v) = entry.version.as_deref() {
+                res.insert(
+                    Version::parse(v)?,
+                    RegistryVersionInfo {
+                        deps: entry.deps.unwrap_or_default(),
+                    },
+                );
             }
         }
 
@@ -143,9 +157,9 @@ impl OnlineRegistry {
         let lines = reader.lines().collect::<std::io::Result<Vec<String>>>()?;
         let version_str = version.to_string();
         for line in lines.iter().rev() {
-            let j: MoonModJSON = serde_json_lenient::from_str(line)?;
-            if j.version.as_ref() == Some(&version_str) {
-                if let Some(checksum) = j.checksum {
+            let entry = serde_json_lenient::from_str::<RegistryIndexEntry>(line)?;
+            if entry.version.as_deref() == Some(version_str.as_str()) {
+                if let Some(checksum) = entry.checksum {
                     return Ok(checksum);
                 } else {
                     bail!(
@@ -250,4 +264,65 @@ fn test_urlencode() {
         .append_key_only("0.1.2+3")
         .finish();
     assert_eq!(s, "0.1.2%2B3");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+    use crate::registry::Registry;
+
+    fn temp_index_dir() -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "mooncake-registry-index-test-{}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn all_versions_accepts_single_rule_object_from_index_jsonl() {
+        let index = temp_index_dir();
+        let index_file = index.join("user").join("bobzhang").join("openseek.index");
+        std::fs::create_dir_all(index_file.parent().unwrap()).unwrap();
+        std::fs::write(
+            &index_file,
+            r#"{"name":"bobzhang/openseek","version":"0.2.1","deps":{"bobzhang/jsonl":"0.2.0"},"preferred_target":"native","checksum":"abc123","rule":{"name":"md_to_mbt_string","command":"moon run --quiet --target native scripts/md_to_mbt_string -- \"$input\" \"$output\""}}
+"#,
+        )
+        .unwrap();
+
+        let registry = OnlineRegistry {
+            index: index.clone(),
+            url_base: String::new(),
+            cache: RefCell::new(HashMap::new()),
+        };
+        let versions = registry
+            .all_versions_of(&ModuleName {
+                username: "bobzhang".into(),
+                unqual: "openseek".into(),
+            })
+            .unwrap();
+
+        let version = Version::parse("0.2.1").unwrap();
+        assert!(versions.contains_key(&version));
+        assert_eq!(
+            registry
+                .read_checksum_from_index_file(
+                    &ModuleName {
+                        username: "bobzhang".into(),
+                        unqual: "openseek".into(),
+                    },
+                    &version,
+                )
+                .unwrap(),
+            "abc123"
+        );
+
+        let _ = std::fs::remove_dir_all(index);
+    }
 }

--- a/crates/mooncake/src/resolver/env.rs
+++ b/crates/mooncake/src/resolver/env.rs
@@ -29,7 +29,7 @@ use moonutil::{
 };
 use semver::Version;
 
-use crate::registry::Registry;
+use crate::registry::{Registry, RegistryVersionInfo};
 
 use super::ResolverError;
 
@@ -65,21 +65,22 @@ impl<'a> ResolverEnv<'a> {
     pub(crate) fn all_versions_of(
         &mut self,
         name: &ModuleName,
-    ) -> Option<Arc<BTreeMap<Version, Arc<MoonMod>>>> {
+    ) -> Option<Arc<BTreeMap<Version, RegistryVersionInfo>>> {
         self.registry.all_versions_of(name).ok()
-    }
-
-    pub(crate) fn get_module_version(
-        &mut self,
-        name: &ModuleName,
-        version: &Version,
-    ) -> Option<Arc<MoonMod>> {
-        self.registry.get_module_version(name, version)
     }
 
     pub(crate) fn get(&mut self, ms: &ModuleSource) -> Option<Arc<MoonMod>> {
         match ms.source() {
-            ModuleSourceKind::Registry => self.get_module_version(ms.name(), ms.version()),
+            ModuleSourceKind::Registry => {
+                let version_info = self.registry.all_versions_of(ms.name()).ok()?;
+                let deps = version_info.get(ms.version())?.deps.clone();
+                Some(Arc::new(MoonMod {
+                    name: ms.name().to_string(),
+                    version: Some(ms.version().clone()),
+                    deps,
+                    ..Default::default()
+                }))
+            }
             ModuleSourceKind::Git(_) => todo!("Resolve git module"),
             ModuleSourceKind::Local(path) => self.resolve_local_module(path).ok(),
             ModuleSourceKind::Stdlib(_) => self.stdlib.clone(),

--- a/crates/mooncake/src/resolver/mvs.rs
+++ b/crates/mooncake/src/resolver/mvs.rs
@@ -118,7 +118,13 @@ fn select_min_version_satisfying_in_env(
         select_min_version_satisfying(dependency, dependant, req, all_versions.keys());
     match min_version_satisfying {
         Ok(version) => {
-            let module = Arc::clone(&all_versions[&version]);
+            let source = ModuleSource::from_version(dependency.clone(), version.clone());
+            let module = env
+                .get(&source)
+                .ok_or_else(|| ResolverError::ModuleMissing {
+                    dependency: dependency.clone(),
+                    dependant: dependant.clone(),
+                })?;
             Ok((version, module))
         }
         Err(err) => Err(err),
@@ -597,7 +603,11 @@ mod test {
         let module_name: ModuleName = "dep/three".parse().unwrap();
         let version: Version = "0.1.0".parse().unwrap();
         let root_ms = ModuleSource::from_version(module_name.clone(), version.clone());
-        let root = registry.get_module_version(&module_name, &version).unwrap();
+        let root = Arc::new(create_mock_module(
+            "dep/three",
+            "0.1.0",
+            [("dep/two", "0.1.0")],
+        ));
         let (roots, _) = ResolvedModule::only_one_module(root_ms.clone(), root);
         let mut env = ResolverEnv::new(registry.as_ref());
         let mut result_env = ResolvedEnv::from_root_modules(roots);


### PR DESCRIPTION
## Why

Registry index parsing was coupled to the full `moon.mod.json` shape by deserializing each JSONL entry through `MoonModJSON`. That made unrelated manifest fields part of dependency resolution and latest-version lookup. In particular, index entries can contain `rule` metadata that is not needed for cache/index resolution.

## What

This introduces a cache-specific `RegistryIndexEntry` containing only the index fields the current code uses: `version`, `deps`, and `checksum`.

The registry cache now stores version keys with `RegistryVersionInfo` values instead of synthetic `MoonMod` values. MVS still selects versions from the map keys and reads regular dependency metadata from the selected version info. Checksum validation continues to read the checksum from the same index entry shape.

## Why This Split Is Minimal

MVS needs regular dependency edges from the registry index to resolve transitive dependencies before packages are downloaded. Other manifest fields such as `rule`, `bin-deps`, target preferences, and scripts stay outside the cache/index boundary. The separate `moon.mod.json` schema/parser cleanup remains a follow-up change.