### PR TITLE
Support wasm async HTTP and TLS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          apt update && apt install -y software-properties-common curl unzip build-essential git sudo coreutils
+          apt update && apt install -y software-properties-common curl unzip build-essential git sudo coreutils pkg-config libssl-dev
 
       - name: Configure git
         run: git config --global core.autocrlf false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -803,6 +803,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1740,6 +1755,8 @@ dependencies = [
  "libc",
  "moon-test-util",
  "moonutil",
+ "openssl",
+ "openssl-probe",
  "rand 0.8.5",
  "serde",
  "serde_json_lenient",
@@ -1944,10 +1961,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "paste"
@@ -2026,6 +2090,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "powerfmt"
@@ -2359,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.34"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "once_cell",
  "ring",
@@ -3240,6 +3310,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ reqwest = { version = "0.12.24", default-features = false, features = [
     "http2",
     "system-proxy",
 ] }
+openssl = { version = "0.10.75", features = ["vendored"] }
+openssl-probe = "0.2.0"
 petgraph = { version = "0.6.4", features = [
     "graphmap",
 ], default-features = false }

--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -804,6 +804,26 @@ fn test_async_wasm_upstream_socket_package() {
 }
 
 #[test]
+fn test_async_wasm_upstream_tls_package() {
+    check(
+        run_upstream_async_wasm_package("moonbitlang/async/tls"),
+        expect![[r#"
+            Total tests: 7, passed: 7, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
+fn test_async_wasm_upstream_http_package() {
+    check(
+        run_upstream_async_wasm_package("moonbitlang/async/http"),
+        expect![[r#"
+            Total tests: 49, passed: 49, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
 fn test_max_concurrent_tests() {
     let dir = TestDir::new("moon_test");
     let out1 = get_stdout(

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -35,6 +35,10 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 v8 = "0.106.0"
 
+[target."cfg(not(windows))".dependencies]
+openssl.workspace = true
+openssl-probe.workspace = true
+
 [target."cfg(unix)".dependencies]
 libc.workspace = true
 
@@ -46,6 +50,9 @@ features = [
     "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",
     "Win32_Security",
+    "Win32_Security_Authentication_Identity",
+    "Win32_Security_Credentials",
+    "Win32_Security_Cryptography",
     "Win32_Storage_FileSystem",
     "Win32_System_Console",
     "Win32_System_Diagnostics_Debug",

--- a/crates/moonrun/src/async_api/c_buffer.rs
+++ b/crates/moonrun/src/async_api/c_buffer.rs
@@ -78,6 +78,12 @@ pub(super) fn strlen(context: &mut ImportContext<'_, '_>, buf: u64) -> AsyncHost
     context.host.with_c_buffer(buf, stub::strlen)
 }
 
+pub(super) fn length(context: &mut ImportContext<'_, '_>, buf: u64) -> AsyncHostResult<i32> {
+    context
+        .host
+        .with_c_buffer(buf, |buf| i32::try_from(buf.len()).map_err(|_| AsyncHostError::Fault))
+}
+
 pub(super) fn free(context: &mut ImportContext<'_, '_>, ptr: u64) -> AsyncHostResult<()> {
     context.host.free_c_buffer(ptr)
 }

--- a/crates/moonrun/src/async_api/io.rs
+++ b/crates/moonrun/src/async_api/io.rs
@@ -66,7 +66,7 @@ pub(super) fn write(
 
 #[ported(
     source = "src/internal/event_loop/io_windows.c",
-    original = "moonbitlang_async_make_file_io_result"
+    original = "moonbitlang_async_make_file_read_io_result"
 )]
 #[cfg(windows)]
 pub(super) fn make_file_read_io_result(
@@ -79,7 +79,7 @@ pub(super) fn make_file_read_io_result(
 
 #[ported(
     source = "src/internal/event_loop/io_windows.c",
-    original = "moonbitlang_async_make_file_io_result"
+    original = "moonbitlang_async_make_file_write_io_result"
 )]
 #[cfg(windows)]
 pub(super) fn make_file_write_io_result(
@@ -96,7 +96,7 @@ pub(super) fn make_file_write_io_result(
 
 #[ported(
     source = "src/internal/event_loop/io_windows.c",
-    original = "moonbitlang_async_make_socket_io_result"
+    original = "moonbitlang_async_make_socket_read_io_result"
 )]
 #[cfg(windows)]
 pub(super) fn make_socket_read_io_result(
@@ -109,7 +109,7 @@ pub(super) fn make_socket_read_io_result(
 
 #[ported(
     source = "src/internal/event_loop/io_windows.c",
-    original = "moonbitlang_async_make_socket_io_result"
+    original = "moonbitlang_async_make_socket_write_io_result"
 )]
 #[cfg(windows)]
 pub(super) fn make_socket_write_io_result(
@@ -126,7 +126,7 @@ pub(super) fn make_socket_write_io_result(
 
 #[ported(
     source = "src/internal/event_loop/io_windows.c",
-    original = "moonbitlang_async_make_socket_with_addr_io_result"
+    original = "moonbitlang_async_make_socket_with_addr_read_io_result"
 )]
 #[cfg(windows)]
 #[allow(clippy::too_many_arguments)]
@@ -144,7 +144,7 @@ pub(super) fn make_socket_with_addr_read_io_result(
 
 #[ported(
     source = "src/internal/event_loop/io_windows.c",
-    original = "moonbitlang_async_make_socket_with_addr_io_result"
+    original = "moonbitlang_async_make_socket_with_addr_write_io_result"
 )]
 #[cfg(windows)]
 #[allow(clippy::too_many_arguments)]

--- a/crates/moonrun/src/async_api/mod.rs
+++ b/crates/moonrun/src/async_api/mod.rs
@@ -41,6 +41,7 @@ mod runtime;
 mod socket;
 mod thread_pool;
 mod time;
+mod tls;
 
 use std::any::Any;
 use std::sync::Arc;

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -26,7 +26,7 @@ use super::context::{
 use super::provenance::{PortedImport, SourceLocation, SourceRoot};
 use super::{
     c_buffer, env_util, event_bus, event_loop, fd_util, fs, io, os_error, os_string, runtime,
-    socket, thread_pool, time,
+    socket, thread_pool, time, tls,
 };
 
 pub(crate) const MOONBIT_ASYNC_MODULE: &str = "moonbitlang/async";
@@ -263,9 +263,9 @@ fn register_func_impl<'s>(
 //   kind callback maps to "namespace/wasm_symbol".
 //
 // Kind legend:
-// - ported: imports that have Rust ports corresponding to native async C stubs.
-//   Tests require separate native provenance entries for these imports.
-// - helper: wasm-only support import or host-control glue.
+// - ported: imports that have Rust ports corresponding to moonbitlang/async
+//   implementations. Tests require separate provenance entries for these imports.
+// - helper: auxiliary glue around ported ABI.
 // - fake: link-only import for runtime-dispatched wasm; the generated callback is unreachable.
 declare_async_imports! {
 
@@ -463,6 +463,8 @@ declare_async_imports! {
     ported socket::addr_is_multicast(addr: i32, addr_len: i32) -> i32 => "socket/addr_is_multicast";
 
     ported socket::addr_get_ipv6_bytes_offset() -> i32 => "socket/addr_get_ipv6_bytes_offset";
+
+    helper socket::addr_copy_ipv6_bytes(addr: i32, out: i32, addr_len: i32, len: i32) -> void => "socket/addr_copy_ipv6_bytes";
 
     ported socket::addr_get_ipv6_scope_id(addr: i32, addr_len: i32) -> i32 => "socket/addr_get_ipv6_scope_id";
 
@@ -744,9 +746,113 @@ declare_async_imports! {
 
     ported c_buffer::strlen(buf: u64) -> i32 => "c_buffer/strlen";
 
+    helper c_buffer::length(buf: u64) -> i32 => "c_buffer/length";
+
     ported c_buffer::new(size: i32) -> u64 => "c_buffer/new";
 
     helper c_buffer::free(ptr: u64) -> void => "c_buffer/free";
+
+    // Host-backed TLS state machine. MoonBit owns async transport IO and
+    // feeds/drains encrypted bytes through these host-side TLS handles.
+    ported tls::new() -> u64 => "tls/connection/new";
+
+    ported tls::set_client(
+        tls: u64,
+        host: i32,
+        host_len: i32,
+        sni: i32,
+        trust: i32,
+    ) -> i32 => "tls/connection/set_client";
+
+    ported tls::add_root_certificate(
+        tls: u64,
+        root: i32,
+        root_len: i32,
+    ) -> i32 => "tls/connection/add_root_certificate";
+
+    ported tls::set_server_files(
+        tls: u64,
+        private_key_file: i32,
+        private_key_file_len: i32,
+        private_key_type_abi: i32,
+        certificate_file: i32,
+        certificate_file_len: i32,
+        certificate_type_abi: i32,
+    ) -> i32 => "tls/connection/set_server_files";
+
+    ported tls::set_server_pfx(
+        tls: u64,
+        pfx_content: i32,
+        pfx_content_len: i32,
+    ) -> i32 => "tls/connection/set_server_pfx";
+
+    ported tls::free(tls: u64) -> void => "tls/connection/free";
+
+    ported tls::take_error(tls: u64) -> u64 => "tls/connection/take_error";
+
+    ported tls::take_global_error() -> u64 => "tls/error/take_global";
+
+    ported tls::read_plain(
+        tls: u64,
+        in_buffer: i32,
+        in_buffer_offset: i32,
+        in_buffer_len: i32,
+        out_buffer: i32,
+        out_buffer_offset: i32,
+        out_buffer_len: i32,
+        plain_buffer: i32,
+        plain_buffer_offset: i32,
+        plain_buffer_len: i32,
+    ) -> i32 => "tls/connection/read_plain";
+
+    ported tls::write_plain(
+        tls: u64,
+        in_buffer: i32,
+        in_buffer_offset: i32,
+        in_buffer_len: i32,
+        out_buffer: i32,
+        out_buffer_offset: i32,
+        out_buffer_len: i32,
+        plain_buffer: i32,
+        plain_buffer_offset: i32,
+        plain_buffer_len: i32,
+    ) -> i32 => "tls/connection/write_plain";
+
+    ported tls::connect(
+        tls: u64,
+        in_buffer: i32,
+        in_buffer_offset: i32,
+        in_buffer_len: i32,
+        out_buffer: i32,
+        out_buffer_offset: i32,
+        out_buffer_len: i32,
+    ) -> i32 => "tls/connection/connect";
+
+    ported tls::accept(
+        tls: u64,
+        in_buffer: i32,
+        in_buffer_offset: i32,
+        in_buffer_len: i32,
+        out_buffer: i32,
+        out_buffer_offset: i32,
+        out_buffer_len: i32,
+    ) -> i32 => "tls/connection/accept";
+
+    ported tls::bytes_read(tls: u64) -> i32 => "tls/connection/bytes_read";
+
+    ported tls::bytes_to_write(tls: u64) -> i32 => "tls/connection/bytes_to_write";
+
+    ported tls::wants_read(tls: u64) -> i32 => "tls/connection/wants_read";
+
+    ported tls::wants_write(tls: u64) -> i32 => "tls/connection/wants_write";
+
+    ported tls::shutdown(tls: u64) -> i32 => "tls/connection/shutdown";
+
+    ported tls::peer_certificate(tls: u64) -> u64 => "tls/connection/peer_certificate";
+
+    ported tls::unique_channel_binding(tls: u64) -> u64 => "tls/connection/unique_channel_binding";
+
+    ported tls::server_endpoint_channel_binding(tls: u64) -> u64 => "tls/connection/server_endpoint_channel_binding";
 
     // fs/stub.c and fs/dir.c.
     ported fs::errno_is_lock_violation(errno: i32) -> i32 => "fs/errno_is_lock_violation";
@@ -878,6 +984,7 @@ fn async_api_ported_imports() -> Vec<PortedImport> {
     imports.extend_from_slice(env_util::PORTED_IMPORTS);
     imports.extend_from_slice(c_buffer::PORTED_IMPORTS);
     imports.extend_from_slice(socket::PORTED_IMPORTS);
+    imports.extend_from_slice(tls::PORTED_IMPORTS);
     imports
 }
 
@@ -930,6 +1037,12 @@ mod tests {
         })
     }
 
+    fn rust_ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
+        let mut symbols = crate::async_sys::ported_symbols();
+        symbols.extend(tls::ported_symbols());
+        symbols
+    }
+
     #[test]
     fn wasm_import_names_are_unique() {
         let mut seen = BTreeSet::new();
@@ -950,6 +1063,21 @@ mod tests {
             }),
             "async wasm integration must not depend on older runtime namespaces for exit"
         );
+    }
+
+    #[test]
+    fn tls_imports_are_ported_abi() {
+        for import in ASYNC_IMPORTS
+            .iter()
+            .filter(|import| import.wasm_symbol.starts_with("tls/"))
+        {
+            assert_eq!(
+                import.kind,
+                AsyncImportKind::Ported,
+                "TLS import {} must be classified as ported ABI",
+                import.wasm_symbol
+            );
+        }
     }
 
     #[test]
@@ -1056,7 +1184,7 @@ mod tests {
     #[test]
     fn ported_imports_have_ported_implementations() {
         let api_ported_imports = async_api_ported_imports();
-        let ported_symbols = crate::async_sys::ported_symbols();
+        let ported_symbols = rust_ported_symbols();
 
         for import in ASYNC_IMPORTS {
             if import.kind != AsyncImportKind::Ported {
@@ -1092,7 +1220,7 @@ mod tests {
     #[test]
     fn ported_implementations_are_registered_imports() {
         let api_ported_imports = async_api_ported_imports();
-        for ported in crate::async_sys::ported_symbols() {
+        for ported in rust_ported_symbols() {
             assert!(
                 api_ported_imports.iter().any(|ported_import| {
                     let Some(registered_import) = registered_import_for_ported(ported_import)

--- a/crates/moonrun/src/async_api/socket.rs
+++ b/crates/moonrun/src/async_api/socket.rs
@@ -16,8 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::async_host::AsyncHostError;
-use crate::async_host::{AsyncHostResult, GuestMemory, read_u16};
+use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory, read_u16};
 use crate::async_policy::AsyncPolicy;
 use crate::async_sys::internal::event_loop::thread_pool::{ResourceClass, ResourceRef};
 use crate::async_sys::socket as sys;
@@ -66,7 +65,7 @@ pub(super) fn init_ipv6_addr(
     })
 }
 
-#[ported(source = "src/internal/event_loop/network.mbt", original = "gai_strerror")]
+#[ported(source = "src/internal/event_loop/network.wasm.mbt", original = "gai_strerror")]
 #[cfg(unix)]
 pub(super) fn gai_strerror(context: &mut ImportContext<'_, '_>, code: i32) -> u64 {
     context.host.insert_c_buffer(sys::gai_strerror(code))
@@ -127,6 +126,30 @@ pub(super) fn addr_is_multicast(
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn addr_get_ipv6_bytes_offset(_context: &mut ImportContext<'_, '_>) -> i32 {
     sys::addr_get_ipv6_bytes_offset()
+}
+
+pub(super) fn addr_copy_ipv6_bytes(
+    context: &mut ImportContext<'_, '_>,
+    addr: i32,
+    out: i32,
+    addr_len: i32,
+    len: i32,
+) -> AsyncHostResult<()> {
+    context.with_memory_mut(|memory| {
+        let addr = memory.read_exact(addr, addr_len)?;
+        let offset =
+            usize::try_from(sys::addr_get_ipv6_bytes_offset()).map_err(|_| AsyncHostError::Fault)?;
+        let ip = addr
+            .get(offset..offset + 16)
+            .ok_or(AsyncHostError::Fault)?
+            .to_vec();
+        let out = memory
+            .read_exact_mut(out, len)?
+            .get_mut(..16)
+            .ok_or(AsyncHostError::Fault)?;
+        out.copy_from_slice(&ip);
+        Ok(())
+    })
 }
 
 #[ported(source = "src/socket/socket.c")]

--- a/crates/moonrun/src/async_api/tls.rs
+++ b/crates/moonrun/src/async_api/tls.rs
@@ -1,0 +1,472 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::path::PathBuf;
+
+use crate::async_host::{
+    AsyncHostError, AsyncHostResult, GuestMemory, read_u16,
+    tls::{TlsFileType, TlsTrust},
+};
+
+use super::context::ImportContext;
+use super::provenance::ported_imports;
+
+ported_imports! {
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/new")]
+pub(super) fn new(context: &mut ImportContext<'_, '_>) -> u64 {
+    context.host.tls_new()
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/set_client")]
+pub(super) fn set_client(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+    host: i32,
+    host_len: i32,
+    sni: i32,
+    trust_abi: i32,
+) -> AsyncHostResult<i32> {
+    context.with_host_and_memory_mut(|host_state, memory| {
+        let hostname = read_guest_string(memory, host, host_len)?;
+        let trust = TlsTrust::from_abi(trust_abi)?;
+        host_state.tls_set_client(tls, hostname, sni != 0, trust)
+    })
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/add_root_certificate")]
+pub(super) fn add_root_certificate(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+    root: i32,
+    root_len: i32,
+) -> AsyncHostResult<i32> {
+    context.with_host_and_memory_mut(|host, memory| {
+        let root = memory.read_exact(root, root_len)?;
+        host.tls_add_root_certificate(tls, root)
+    })
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/set_server_files")]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn set_server_files(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+    private_key_file: i32,
+    private_key_file_len: i32,
+    private_key_type_abi: i32,
+    certificate_file: i32,
+    certificate_file_len: i32,
+    certificate_type_abi: i32,
+) -> AsyncHostResult<i32> {
+    context.with_host_and_memory_mut(|host, memory| {
+        let private_key_file = read_guest_os_path(memory, private_key_file, private_key_file_len)?;
+        let certificate_file = read_guest_os_path(memory, certificate_file, certificate_file_len)?;
+        host.tls_set_server_files(
+            tls,
+            private_key_file,
+            TlsFileType::from_abi(private_key_type_abi)?,
+            certificate_file,
+            TlsFileType::from_abi(certificate_type_abi)?,
+        )
+    })
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/set_server_pfx")]
+pub(super) fn set_server_pfx(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+    pfx_content: i32,
+    pfx_content_len: i32,
+) -> AsyncHostResult<i32> {
+    context.with_host_and_memory_mut(|host, memory| {
+        host.tls_set_server_pfx(
+            tls,
+            memory.read_exact(pfx_content, pfx_content_len)?.to_vec(),
+        )
+    })
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/free")]
+pub(super) fn free(context: &mut ImportContext<'_, '_>, tls: u64) -> AsyncHostResult<()> {
+    context.host.tls_free(tls)
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/take_error")]
+pub(super) fn take_error(context: &mut ImportContext<'_, '_>, tls: u64) -> AsyncHostResult<u64> {
+    context.host.tls_take_error(tls)
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/error/take_global")]
+pub(super) fn take_global_error(context: &mut ImportContext<'_, '_>) -> u64 {
+    context.host.tls_take_global_error()
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/read_plain")]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn read_plain(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+    in_buffer: i32,
+    in_buffer_offset: i32,
+    in_buffer_len: i32,
+    out_buffer: i32,
+    out_buffer_offset: i32,
+    out_buffer_len: i32,
+    plain_buffer: i32,
+    plain_buffer_offset: i32,
+    plain_buffer_len: i32,
+) -> AsyncHostResult<i32> {
+    context.with_host_and_memory_mut(|host, memory| {
+        let (input, output, plain) = read_guest_buffers3_mut(
+            memory,
+            guest_offset(in_buffer, in_buffer_offset)?,
+            in_buffer_len,
+            guest_offset(out_buffer, out_buffer_offset)?,
+            out_buffer_len,
+            guest_offset(plain_buffer, plain_buffer_offset)?,
+            plain_buffer_len,
+        )?;
+        host.tls_read_plain(tls, input, plain, output)
+    })
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/write_plain")]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn write_plain(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+    in_buffer: i32,
+    in_buffer_offset: i32,
+    in_buffer_len: i32,
+    out_buffer: i32,
+    out_buffer_offset: i32,
+    out_buffer_len: i32,
+    plain_buffer: i32,
+    plain_buffer_offset: i32,
+    plain_buffer_len: i32,
+) -> AsyncHostResult<i32> {
+    context.with_host_and_memory_mut(|host, memory| {
+        let (input, output, plain) = read_guest_buffers3_mut(
+            memory,
+            guest_offset(in_buffer, in_buffer_offset)?,
+            in_buffer_len,
+            guest_offset(out_buffer, out_buffer_offset)?,
+            out_buffer_len,
+            guest_offset(plain_buffer, plain_buffer_offset)?,
+            plain_buffer_len,
+        )?;
+        host.tls_write_plain(tls, input, plain, output)
+    })
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/connect")]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn connect(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+    in_buffer: i32,
+    in_buffer_offset: i32,
+    in_buffer_len: i32,
+    out_buffer: i32,
+    out_buffer_offset: i32,
+    out_buffer_len: i32,
+) -> AsyncHostResult<i32> {
+    context.with_host_and_memory_mut(|host, memory| {
+        let (input, output) = read_guest_input_output_mut(
+            memory,
+            guest_offset(in_buffer, in_buffer_offset)?,
+            in_buffer_len,
+            guest_offset(out_buffer, out_buffer_offset)?,
+            out_buffer_len,
+        )?;
+        host.tls_connect(tls, input, output)
+    })
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/accept")]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn accept(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+    in_buffer: i32,
+    in_buffer_offset: i32,
+    in_buffer_len: i32,
+    out_buffer: i32,
+    out_buffer_offset: i32,
+    out_buffer_len: i32,
+) -> AsyncHostResult<i32> {
+    context.with_host_and_memory_mut(|host, memory| {
+        let (input, output) = read_guest_input_output_mut(
+            memory,
+            guest_offset(in_buffer, in_buffer_offset)?,
+            in_buffer_len,
+            guest_offset(out_buffer, out_buffer_offset)?,
+            out_buffer_len,
+        )?;
+        host.tls_accept(tls, input, output)
+    })
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/bytes_read")]
+pub(super) fn bytes_read(context: &mut ImportContext<'_, '_>, tls: u64) -> AsyncHostResult<i32> {
+    context.host.tls_bytes_read(tls)
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/bytes_to_write")]
+pub(super) fn bytes_to_write(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+) -> AsyncHostResult<i32> {
+    context.host.tls_bytes_to_write(tls)
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/wants_read")]
+pub(super) fn wants_read(context: &mut ImportContext<'_, '_>, tls: u64) -> AsyncHostResult<i32> {
+    context.host.tls_wants_read(tls)
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/wants_write")]
+pub(super) fn wants_write(context: &mut ImportContext<'_, '_>, tls: u64) -> AsyncHostResult<i32> {
+    context.host.tls_wants_write(tls)
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/shutdown")]
+pub(super) fn shutdown(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+) -> AsyncHostResult<i32> {
+    context.host.tls_shutdown(tls)
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/peer_certificate")]
+pub(super) fn peer_certificate(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+) -> AsyncHostResult<u64> {
+    context.host.tls_peer_certificate(tls)
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/unique_channel_binding")]
+pub(super) fn unique_channel_binding(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+) -> AsyncHostResult<u64> {
+    context.host.tls_unique_channel_binding(tls)
+}
+
+#[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/server_endpoint_channel_binding")]
+pub(super) fn server_endpoint_channel_binding(
+    context: &mut ImportContext<'_, '_>,
+    tls: u64,
+) -> AsyncHostResult<u64> {
+    context.host.tls_server_endpoint_channel_binding(tls)
+}
+}
+
+fn guest_offset(ptr: i32, offset: i32) -> AsyncHostResult<i32> {
+    if offset < 0 {
+        return Err(AsyncHostError::Fault);
+    }
+    ptr.checked_add(offset).ok_or(AsyncHostError::Fault)
+}
+
+fn read_guest_input_output_mut(
+    memory: &mut (impl GuestMemory + ?Sized),
+    input_offset: i32,
+    input_len: i32,
+    output_offset: i32,
+    output_len: i32,
+) -> AsyncHostResult<(&mut [u8], &mut [u8])> {
+    let input = guest_range(memory.bytes().len(), input_offset, input_len)?;
+    let output = guest_range(memory.bytes().len(), output_offset, output_len)?;
+    if input.end <= output.start {
+        let (before_output, output_and_after) = memory.bytes_mut().split_at_mut(output.start);
+        Ok((
+            &mut before_output[input],
+            &mut output_and_after[..output_len as usize],
+        ))
+    } else if output.end <= input.start {
+        let (before_input, input_and_after) = memory.bytes_mut().split_at_mut(input.start);
+        Ok((
+            &mut input_and_after[..input_len as usize],
+            &mut before_input[output],
+        ))
+    } else {
+        Err(AsyncHostError::Fault)
+    }
+}
+
+fn read_guest_buffers3_mut(
+    memory: &mut (impl GuestMemory + ?Sized),
+    first_offset: i32,
+    first_len: i32,
+    second_offset: i32,
+    second_len: i32,
+    third_offset: i32,
+    third_len: i32,
+) -> AsyncHostResult<(&mut [u8], &mut [u8], &mut [u8])> {
+    let memory_len = memory.bytes().len();
+    let first = guest_range(memory_len, first_offset, first_len)?;
+    let second = guest_range(memory_len, second_offset, second_len)?;
+    let third = guest_range(memory_len, third_offset, third_len)?;
+    if ranges_overlap(&first, &second)
+        || ranges_overlap(&first, &third)
+        || ranges_overlap(&second, &third)
+    {
+        return Err(AsyncHostError::Fault);
+    }
+
+    let bytes = memory.bytes_mut();
+    let ptr = bytes.as_mut_ptr();
+    // SAFETY: all three ranges were bounds-checked against `bytes` and
+    // pairwise overlap was rejected, so the returned mutable slices are
+    // disjoint views into the same guest memory allocation.
+    unsafe {
+        Ok((
+            std::slice::from_raw_parts_mut(ptr.add(first.start), first.len()),
+            std::slice::from_raw_parts_mut(ptr.add(second.start), second.len()),
+            std::slice::from_raw_parts_mut(ptr.add(third.start), third.len()),
+        ))
+    }
+}
+
+fn ranges_overlap(first: &std::ops::Range<usize>, second: &std::ops::Range<usize>) -> bool {
+    first.start < second.end && second.start < first.end
+}
+
+fn guest_range(
+    memory_len: usize,
+    offset: i32,
+    len: i32,
+) -> AsyncHostResult<std::ops::Range<usize>> {
+    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+    let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+    let end = offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
+    if end > memory_len {
+        return Err(AsyncHostError::Fault);
+    }
+    Ok(offset..end)
+}
+
+fn read_guest_string(memory: &[u8], ptr: i32, len: i32) -> AsyncHostResult<String> {
+    let units = read_u16(memory, ptr, len)?;
+    Ok(std::char::decode_utf16(units)
+        .map(|unit| unit.unwrap_or(std::char::REPLACEMENT_CHARACTER))
+        .collect())
+}
+
+fn read_guest_os_path(memory: &[u8], ptr: i32, len: i32) -> AsyncHostResult<PathBuf> {
+    let units = read_u16(memory, ptr, len)?;
+
+    #[cfg(unix)]
+    {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = std::char::decode_utf16(units)
+            .map(|unit| unit.unwrap_or(std::char::REPLACEMENT_CHARACTER))
+            .collect::<String>();
+        Ok(PathBuf::from(OsString::from_vec(path.into_bytes())))
+    }
+
+    #[cfg(windows)]
+    {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStringExt;
+
+        Ok(PathBuf::from(OsString::from_wide(&units)))
+    }
+}
+
+#[cfg(test)]
+pub(super) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
+    PORTED_IMPORTS
+        .iter()
+        .flat_map(|import| {
+            import
+                .sources
+                .iter()
+                .map(move |source| crate::async_sys::PortedSymbol {
+                    rust_module: import.rust_module,
+                    rust_symbol: import.rust_symbol,
+                    native_symbol: import
+                        .native_symbol
+                        .expect("TLS ABI provenance uses explicit wasm import symbols"),
+                    source: source.path,
+                })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_output_split_allows_input_before_output() {
+        let mut memory = [0, 1, 2, 3, 4, 5];
+        {
+            let (input, output) = read_guest_input_output_mut(&mut memory, 1, 2, 4, 2).unwrap();
+            assert_eq!(input, &[1, 2]);
+            output.copy_from_slice(&[9, 8]);
+        }
+        assert_eq!(memory, [0, 1, 2, 3, 9, 8]);
+    }
+
+    #[test]
+    fn input_output_split_allows_output_before_input() {
+        let mut memory = [0, 1, 2, 3, 4, 5];
+        {
+            let (input, output) = read_guest_input_output_mut(&mut memory, 4, 2, 1, 2).unwrap();
+            assert_eq!(input, &[4, 5]);
+            output.copy_from_slice(&[9, 8]);
+        }
+        assert_eq!(memory, [0, 9, 8, 3, 4, 5]);
+    }
+
+    #[test]
+    fn input_output_split_rejects_overlapping_ranges() {
+        let mut memory = [0, 1, 2, 3, 4, 5];
+        assert_eq!(
+            read_guest_input_output_mut(&mut memory, 1, 3, 2, 2).unwrap_err(),
+            AsyncHostError::Fault,
+        );
+    }
+
+    #[test]
+    fn buffers3_split_allows_disjoint_ranges() {
+        let mut memory = [0, 1, 2, 3, 4, 5, 6, 7];
+        {
+            let (first, second, third) =
+                read_guest_buffers3_mut(&mut memory, 0, 2, 3, 2, 6, 2).unwrap();
+            assert_eq!(first, &[0, 1]);
+            second.copy_from_slice(&[9, 8]);
+            third.copy_from_slice(&[7, 6]);
+        }
+        assert_eq!(memory, [0, 1, 2, 9, 8, 5, 7, 6]);
+    }
+
+    #[test]
+    fn buffers3_split_rejects_overlap() {
+        let mut memory = [0, 1, 2, 3, 4, 5];
+        assert_eq!(
+            read_guest_buffers3_mut(&mut memory, 0, 3, 3, 2, 2, 2).unwrap_err(),
+            AsyncHostError::Fault,
+        );
+    }
+}

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -50,6 +50,8 @@ compile_error!("moonrun async wasm host currently supports only Linux, macOS, an
 #[cfg(not(target_endian = "little"))]
 compile_error!("moonrun async wasm host requires little-endian host memory");
 
+pub(crate) mod tls;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AsyncHostError {
     Fault,
@@ -220,6 +222,23 @@ fn key_from_handle(handle: u64) -> HandleKey {
     KeyData::from_ffi(handle).into()
 }
 
+#[cfg(unix)]
+fn error_message_buffer(message: String) -> Box<[u8]> {
+    let mut bytes = message.into_bytes();
+    bytes.push(0);
+    bytes.into_boxed_slice()
+}
+
+#[cfg(windows)]
+fn error_message_buffer(message: String) -> Box<[u8]> {
+    let mut bytes = Vec::with_capacity((message.len() + 1) * std::mem::size_of::<u16>());
+    for unit in message.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    bytes.extend_from_slice(&0u16.to_le_bytes());
+    bytes.into_boxed_slice()
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum HandleKind {
     Resource,
@@ -228,6 +247,7 @@ enum HandleKind {
     Worker,
     CBuffer,
     AddrInfo,
+    TlsConnection,
     #[cfg(windows)]
     IoResult,
 }
@@ -367,6 +387,14 @@ impl HandleTable {
 
     fn remove_addrinfo(&mut self, handle: HostHandle) -> AsyncHostResult<HandleKey> {
         self.remove(handle, HandleKind::AddrInfo)
+    }
+
+    fn tls_connection(&self, handle: HostHandle) -> AsyncHostResult<HandleKey> {
+        self.key(handle, HandleKind::TlsConnection)
+    }
+
+    fn remove_tls_connection(&mut self, handle: HostHandle) -> AsyncHostResult<HandleKey> {
+        self.remove(handle, HandleKind::TlsConnection)
     }
 
     #[cfg(windows)]
@@ -1018,6 +1046,8 @@ pub(crate) struct AsyncHost {
     polls: Mutex<PollTable>,
     thread_pool_completions: Mutex<ThreadPoolCompletions>,
     handles: Mutex<HandleTable>,
+    tls_connections: Mutex<SecondaryMap<HandleKey, tls::TlsHandleRef>>,
+    tls_error: Mutex<Option<String>>,
     workers: Mutex<SecondaryMap<HandleKey, HostWorkerHandle>>,
 }
 
@@ -1040,6 +1070,8 @@ impl AsyncHost {
             polls: Mutex::new(PollTable::default()),
             thread_pool_completions: Mutex::new(ThreadPoolCompletions::default()),
             handles: Mutex::new(HandleTable::default()),
+            tls_connections: Mutex::new(SecondaryMap::new()),
+            tls_error: Mutex::new(None),
             workers: Mutex::new(SecondaryMap::new()),
         }
     }
@@ -1162,6 +1194,12 @@ impl AsyncHost {
                     if completions.target.is_some() {
                         leaks.push("completion_port=1".to_string());
                     }
+                }
+            }
+            {
+                let tls_connections = self.tls_connections.lock().unwrap();
+                if !tls_connections.is_empty() {
+                    leaks.push(format!("tls_connections={}", tls_connections.len()));
                 }
             }
             {
@@ -2947,6 +2985,302 @@ impl AsyncHost {
         Ok(bytes_i32)
     }
 
+    pub(crate) fn tls_take_error(&self, handle: HostHandle) -> AsyncHostResult<HostHandle> {
+        let tls = self.tls_connection(handle)?;
+        let message = match &mut *tls.lock().unwrap() {
+            tls::TlsHandle::Connection(tls) => tls
+                .take_error()
+                .unwrap_or_else(|| "unknown TLS error".to_string()),
+            tls::TlsHandle::Empty(pending) => pending
+                .take_error()
+                .unwrap_or_else(|| "unknown TLS error".to_string()),
+        };
+        Ok(self.insert_c_buffer(error_message_buffer(message)))
+    }
+
+    pub(crate) fn tls_take_global_error(&self) -> HostHandle {
+        let message = self
+            .tls_error
+            .lock()
+            .unwrap()
+            .take()
+            .unwrap_or_else(|| "unknown TLS error".to_string());
+        self.insert_c_buffer(error_message_buffer(message))
+    }
+
+    pub(crate) fn tls_new(&self) -> HostHandle {
+        self.insert_tls_handle(tls::TlsHandle::Empty(tls::TlsPending::new()))
+    }
+
+    pub(crate) fn tls_set_client(
+        &self,
+        handle: HostHandle,
+        host: String,
+        sni: bool,
+        trust: tls::TlsTrust,
+    ) -> AsyncHostResult<i32> {
+        let tls = self.tls_connection(handle)?;
+        let mut handle = tls.lock().unwrap();
+        match &mut *handle {
+            tls::TlsHandle::Empty(pending) => {
+                match tls::TlsConnection::client(&host, sni, pending.client_config(trust)) {
+                    Ok(connection) => {
+                        *handle = tls::TlsHandle::Connection(Box::new(connection));
+                        Ok(0)
+                    }
+                    Err(message) => Ok(pending.set_error(message)),
+                }
+            }
+            tls::TlsHandle::Connection(_) => Err(AsyncHostError::Inval),
+        }
+    }
+
+    pub(crate) fn tls_add_root_certificate(
+        &self,
+        handle: HostHandle,
+        root: &[u8],
+    ) -> AsyncHostResult<i32> {
+        self.with_tls_pending_mut(handle, |pending| pending.add_root_certificate(root))
+    }
+
+    pub(crate) fn tls_set_server_files(
+        &self,
+        handle: HostHandle,
+        private_key_file: std::path::PathBuf,
+        private_key_type: tls::TlsFileType,
+        certificate_file: std::path::PathBuf,
+        certificate_type: tls::TlsFileType,
+    ) -> AsyncHostResult<i32> {
+        for (label, path) in [
+            ("TLS private key", private_key_file.as_path()),
+            ("TLS certificate", certificate_file.as_path()),
+        ] {
+            if let Err(error) = self.policy.open_path(
+                RuntimePathBase::CurrentDirectory,
+                path.as_os_str(),
+                0,
+                0,
+                false,
+            ) {
+                return self.with_tls_pending_mut(handle, |pending| {
+                    pending.set_error(format!("failed to access {label} file: {error:?}"))
+                });
+            }
+        }
+        let tls = self.tls_connection(handle)?;
+        let mut handle = tls.lock().unwrap();
+        match &mut *handle {
+            tls::TlsHandle::Empty(pending) => {
+                if pending.has_root_certificates() {
+                    return Ok(pending.set_error(
+                        "TLS root certificates require client custom root trust".to_string(),
+                    ));
+                }
+                match tls::TlsConnection::server(tls::TlsConfig::ServerFiles {
+                    private_key_file,
+                    private_key_type,
+                    certificate_file,
+                    certificate_type,
+                }) {
+                    Ok(connection) => {
+                        *handle = tls::TlsHandle::Connection(Box::new(connection));
+                        Ok(0)
+                    }
+                    Err(message) => Ok(pending.set_error(message)),
+                }
+            }
+            tls::TlsHandle::Connection(_) => Err(AsyncHostError::Inval),
+        }
+    }
+
+    pub(crate) fn tls_set_server_pfx(
+        &self,
+        handle: HostHandle,
+        pfx_content: Vec<u8>,
+    ) -> AsyncHostResult<i32> {
+        let tls = self.tls_connection(handle)?;
+        let mut handle = tls.lock().unwrap();
+        match &mut *handle {
+            tls::TlsHandle::Empty(pending) => {
+                if pending.has_root_certificates() {
+                    return Ok(pending.set_error(
+                        "TLS root certificates require client custom root trust".to_string(),
+                    ));
+                }
+                match tls::TlsConnection::server(tls::TlsConfig::ServerPfx { pfx_content }) {
+                    Ok(connection) => {
+                        *handle = tls::TlsHandle::Connection(Box::new(connection));
+                        Ok(0)
+                    }
+                    Err(message) => Ok(pending.set_error(message)),
+                }
+            }
+            tls::TlsHandle::Connection(_) => Err(AsyncHostError::Inval),
+        }
+    }
+
+    fn insert_tls_handle(&self, handle: tls::TlsHandle) -> HostHandle {
+        let handle = Arc::new(Mutex::new(handle));
+        let key = self
+            .handles
+            .lock()
+            .unwrap()
+            .insert(HandleKind::TlsConnection);
+        self.tls_connections.lock().unwrap().insert(key, handle);
+        handle_from_key(key)
+    }
+
+    pub(crate) fn tls_free(&self, handle: HostHandle) -> AsyncHostResult<()> {
+        if handle == INVALID_HOST_HANDLE {
+            return Ok(());
+        }
+        let key = self.handles.lock().unwrap().remove_tls_connection(handle)?;
+        self.tls_connections
+            .lock()
+            .unwrap()
+            .remove(key)
+            .map(|_| ())
+            .ok_or(AsyncHostError::Badf)
+    }
+
+    pub(crate) fn tls_read_plain(
+        &self,
+        handle: HostHandle,
+        input: &mut [u8],
+        plain: &mut [u8],
+        output: &mut [u8],
+    ) -> AsyncHostResult<i32> {
+        self.with_tls_connection_mut(handle, tls::TLS_ERROR_STATUS, |tls| {
+            tls.read_plain(input, plain, output)
+        })
+    }
+
+    pub(crate) fn tls_write_plain(
+        &self,
+        handle: HostHandle,
+        input: &mut [u8],
+        plain: &[u8],
+        output: &mut [u8],
+    ) -> AsyncHostResult<i32> {
+        self.with_tls_connection_mut(handle, tls::TLS_ERROR_STATUS, |tls| {
+            tls.write_plain(input, plain, output)
+        })
+    }
+
+    pub(crate) fn tls_connect(
+        &self,
+        handle: HostHandle,
+        input: &mut [u8],
+        output: &mut [u8],
+    ) -> AsyncHostResult<i32> {
+        self.with_tls_connection_mut(handle, tls::TlsState::Error.code(), |tls| {
+            let status = tls.connect(input, output);
+            tls::TlsState::from_status(status, tls.wants_read(), tls.wants_write()).code()
+        })
+    }
+
+    pub(crate) fn tls_accept(
+        &self,
+        handle: HostHandle,
+        input: &mut [u8],
+        output: &mut [u8],
+    ) -> AsyncHostResult<i32> {
+        self.with_tls_connection_mut(handle, tls::TlsState::Error.code(), |tls| {
+            let status = tls.accept(input, output);
+            tls::TlsState::from_status(status, tls.wants_read(), tls.wants_write()).code()
+        })
+    }
+
+    pub(crate) fn tls_bytes_read(&self, handle: HostHandle) -> AsyncHostResult<i32> {
+        self.with_tls_connection_mut(handle, 0, |tls| tls.bytes_read())
+    }
+
+    pub(crate) fn tls_bytes_to_write(&self, handle: HostHandle) -> AsyncHostResult<i32> {
+        self.with_tls_connection_mut(handle, 0, |tls| tls.bytes_to_write())
+    }
+
+    pub(crate) fn tls_wants_read(&self, handle: HostHandle) -> AsyncHostResult<i32> {
+        self.with_tls_connection_mut(handle, 0, |tls| i32::from(tls.wants_read()))
+    }
+
+    pub(crate) fn tls_wants_write(&self, handle: HostHandle) -> AsyncHostResult<i32> {
+        self.with_tls_connection_mut(handle, 0, |tls| i32::from(tls.wants_write()))
+    }
+
+    pub(crate) fn tls_shutdown(&self, handle: HostHandle) -> AsyncHostResult<i32> {
+        self.with_tls_connection_mut(handle, tls::TLS_ERROR_STATUS, |tls| tls.shutdown())
+    }
+
+    pub(crate) fn tls_peer_certificate(&self, handle: HostHandle) -> AsyncHostResult<HostHandle> {
+        self.tls_c_buffer(handle, |tls| tls.peer_certificate())
+    }
+
+    pub(crate) fn tls_unique_channel_binding(
+        &self,
+        handle: HostHandle,
+    ) -> AsyncHostResult<HostHandle> {
+        self.tls_c_buffer(handle, |tls| tls.unique_channel_binding())
+    }
+
+    pub(crate) fn tls_server_endpoint_channel_binding(
+        &self,
+        handle: HostHandle,
+    ) -> AsyncHostResult<HostHandle> {
+        self.tls_c_buffer(handle, |tls| tls.server_endpoint_channel_binding())
+    }
+
+    fn tls_c_buffer(
+        &self,
+        handle: HostHandle,
+        f: impl FnOnce(&mut tls::TlsConnection) -> Result<Option<Vec<u8>>, ()>,
+    ) -> AsyncHostResult<HostHandle> {
+        match self.with_tls_connection_mut(handle, Err(()), f)? {
+            Ok(Some(buffer)) => Ok(self.insert_c_buffer(buffer.into_boxed_slice())),
+            Ok(None) => Ok(INVALID_HOST_HANDLE),
+            Err(()) => Ok(INVALID_HOST_HANDLE),
+        }
+    }
+
+    fn with_tls_connection_mut<T>(
+        &self,
+        handle: HostHandle,
+        unconfigured_value: T,
+        f: impl FnOnce(&mut tls::TlsConnection) -> T,
+    ) -> AsyncHostResult<T> {
+        let connection = self.tls_connection(handle)?;
+        let mut handle = connection.lock().unwrap();
+        match &mut *handle {
+            tls::TlsHandle::Connection(connection) => Ok(f(connection)),
+            tls::TlsHandle::Empty(pending) => {
+                pending.set_error("TLS handle is not configured".to_string());
+                Ok(unconfigured_value)
+            }
+        }
+    }
+
+    fn with_tls_pending_mut<T>(
+        &self,
+        handle: HostHandle,
+        f: impl FnOnce(&mut tls::TlsPending) -> T,
+    ) -> AsyncHostResult<T> {
+        let tls = self.tls_connection(handle)?;
+        let mut handle = tls.lock().unwrap();
+        match &mut *handle {
+            tls::TlsHandle::Empty(pending) => Ok(f(pending)),
+            tls::TlsHandle::Connection(_) => Err(AsyncHostError::Inval),
+        }
+    }
+
+    fn tls_connection(&self, handle: HostHandle) -> AsyncHostResult<tls::TlsHandleRef> {
+        let key = self.handles.lock().unwrap().tls_connection(handle)?;
+        self.tls_connections
+            .lock()
+            .unwrap()
+            .get(key)
+            .map(Arc::clone)
+            .ok_or(AsyncHostError::Badf)
+    }
+
     fn spawn_worker_thread(
         &self,
         init_job: HostWorkerJob,
@@ -3178,6 +3512,21 @@ mod tests {
 
     fn host_with_policy(path: &std::path::Path) -> AsyncHost {
         AsyncHost::new(Arc::new(AsyncPolicy::from_file(path).unwrap()))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn error_message_buffer_uses_native_string_encoding_on_unix() {
+        assert_eq!(error_message_buffer("ab".to_string()).as_ref(), b"ab\0");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn error_message_buffer_uses_native_string_encoding_on_windows() {
+        assert_eq!(
+            error_message_buffer("ab".to_string()).as_ref(),
+            &[b'a', 0, b'b', 0, 0, 0]
+        );
     }
 
     #[cfg(windows)]
@@ -3917,6 +4266,46 @@ mod tests {
         host.free_job(flock_job).unwrap();
         host.close_fd(fd).unwrap();
         host.free_job(open_job).unwrap();
+    }
+
+    #[test]
+    fn tls_set_server_files_checks_file_policy_before_backend_load() {
+        let tmp = tempfile::tempdir().unwrap();
+        let allowed = tmp.path().join("allowed");
+        let denied = tmp.path().join("denied");
+        std::fs::create_dir(&allowed).unwrap();
+        std::fs::create_dir(&denied).unwrap();
+        let key_file = denied.join("key.pem");
+        let cert_file = allowed.join("cert.pem");
+        std::fs::write(&key_file, "key").unwrap();
+        std::fs::write(&cert_file, "cert").unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(&policy_file, "[fs]\nread = [\"allowed\"]\n").unwrap();
+        let host = host_with_policy(&policy_file);
+
+        let handle = host.tls_new();
+        let status = host
+            .tls_set_server_files(
+                handle,
+                key_file,
+                tls::TlsFileType::Pem,
+                cert_file,
+                tls::TlsFileType::Pem,
+            )
+            .unwrap();
+
+        assert_eq!(status, tls::TLS_ERROR_STATUS);
+        let error = host.tls_take_error(handle).unwrap();
+        host.with_c_buffer(error, |buffer| {
+            let expected = error_message_buffer(
+                "failed to access TLS private key file: PermissionDenied".to_string(),
+            );
+            assert_eq!(buffer, &*expected);
+            Ok(())
+        })
+        .unwrap();
+        host.free_c_buffer(error).unwrap();
+        host.tls_free(handle).unwrap();
     }
 
     #[test]

--- a/crates/moonrun/src/async_host/tls/mod.rs
+++ b/crates/moonrun/src/async_host/tls/mod.rs
@@ -1,0 +1,268 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use super::{AsyncHostError, AsyncHostResult};
+
+#[cfg(not(windows))]
+mod openssl;
+#[cfg(windows)]
+mod schannel;
+
+#[cfg(not(windows))]
+pub(crate) use self::openssl::TlsConnection;
+#[cfg(windows)]
+pub(crate) use self::schannel::TlsConnection;
+
+// MoonBit owns the transport loop for the wasm TLS API. Every TLS step takes
+// the current encrypted input and output buffers directly, then reports how
+// many encrypted bytes were consumed or produced through `bytes_read` and
+// `bytes_to_write`.
+#[cfg(windows)]
+const TLS_PLAINTEXT_INPUT_LIMIT: usize = 256 * 1024;
+
+pub(crate) const TLS_ERROR_STATUS: i32 = -1;
+pub(super) const TLS_CLOSED_STATUS: i32 = -2;
+pub(super) const TLS_WOULD_BLOCK_STATUS: i32 = -3;
+pub(super) const TLS_RENEGOTIATION_STATUS: i32 = -4;
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TlsState {
+    Completed = 0,
+    WantRead = 1,
+    WantWrite = 2,
+    Error = 3,
+    Eof = 4,
+    ReNegotiation = 5,
+}
+
+impl TlsState {
+    pub(crate) fn code(self) -> i32 {
+        self as i32
+    }
+
+    pub(crate) fn from_status(status: i32, _wants_read: bool, wants_write: bool) -> Self {
+        match status {
+            0 => Self::Completed,
+            TLS_WOULD_BLOCK_STATUS => {
+                if wants_write {
+                    Self::WantWrite
+                } else {
+                    Self::WantRead
+                }
+            }
+            TLS_CLOSED_STATUS => Self::Eof,
+            TLS_RENEGOTIATION_STATUS => Self::ReNegotiation,
+            _ => Self::Error,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TlsFileType {
+    Pem,
+    Asn1,
+}
+
+impl TlsFileType {
+    const PEM_ABI: i32 = 1;
+    const ASN1_ABI: i32 = 2;
+
+    pub(crate) fn from_abi(value: i32) -> AsyncHostResult<Self> {
+        match value {
+            Self::PEM_ABI => Ok(Self::Pem),
+            Self::ASN1_ABI => Ok(Self::Asn1),
+            _ => Err(AsyncHostError::Inval),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TlsTrust {
+    NoVerification,
+    SystemRoot,
+    CustomRoot,
+}
+
+impl TlsTrust {
+    const NO_VERIFICATION_ABI: i32 = 0;
+    const SYSTEM_ROOT_ABI: i32 = 1;
+    const CUSTOM_ROOT_ABI: i32 = 2;
+
+    pub(crate) fn from_abi(value: i32) -> AsyncHostResult<Self> {
+        match value {
+            Self::NO_VERIFICATION_ABI => Ok(Self::NoVerification),
+            Self::SYSTEM_ROOT_ABI => Ok(Self::SystemRoot),
+            Self::CUSTOM_ROOT_ABI => Ok(Self::CustomRoot),
+            _ => Err(AsyncHostError::Inval),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum TlsConfig {
+    Client {
+        trust: TlsTrust,
+        root_certificates: Vec<Vec<u8>>,
+    },
+    ServerFiles {
+        private_key_file: PathBuf,
+        private_key_type: TlsFileType,
+        certificate_file: PathBuf,
+        certificate_type: TlsFileType,
+    },
+    ServerPfx {
+        pfx_content: Vec<u8>,
+    },
+}
+
+pub(crate) type TlsHandleRef = Arc<Mutex<TlsHandle>>;
+
+// The wasm ABI exposes one TLS handle. New handles start empty and become a
+// live connection as soon as a client/server setter has enough data.
+pub(crate) enum TlsHandle {
+    Empty(TlsPending),
+    Connection(Box<TlsConnection>),
+}
+
+#[derive(Debug)]
+pub(crate) struct TlsPending {
+    root_certificates: Vec<Vec<u8>>,
+    last_error: Option<String>,
+}
+
+impl TlsPending {
+    pub(crate) fn new() -> Self {
+        Self {
+            root_certificates: Vec::new(),
+            last_error: None,
+        }
+    }
+
+    pub(crate) fn take_error(&mut self) -> Option<String> {
+        self.last_error.take()
+    }
+
+    pub(crate) fn set_error(&mut self, message: String) -> i32 {
+        self.last_error = Some(message);
+        TLS_ERROR_STATUS
+    }
+
+    pub(crate) fn add_root_certificate(&mut self, root: &[u8]) -> i32 {
+        self.last_error = None;
+        self.root_certificates.push(root.to_vec());
+        0
+    }
+
+    pub(crate) fn client_config(&self, trust: TlsTrust) -> TlsConfig {
+        TlsConfig::Client {
+            trust,
+            root_certificates: self.root_certificates.clone(),
+        }
+    }
+
+    pub(crate) fn has_root_certificates(&self) -> bool {
+        !self.root_certificates.is_empty()
+    }
+}
+
+#[derive(Debug)]
+#[cfg(any(windows, test))]
+struct RingBuffer {
+    buf: Box<[u8]>,
+    start: usize,
+    len: usize,
+}
+
+#[cfg(any(windows, test))]
+impl RingBuffer {
+    fn new(capacity: usize) -> Self {
+        Self {
+            buf: vec![0; capacity].into_boxed_slice(),
+            start: 0,
+            len: 0,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    fn remaining(&self) -> usize {
+        self.buf.len() - self.len
+    }
+
+    fn push(&mut self, src: &[u8]) {
+        debug_assert!(src.len() <= self.remaining());
+        let tail = (self.start + self.len) % self.buf.len();
+        let first_len = src.len().min(self.buf.len() - tail);
+        let second_len = src.len() - first_len;
+        self.buf[tail..tail + first_len].copy_from_slice(&src[..first_len]);
+        self.buf[..second_len].copy_from_slice(&src[first_len..]);
+        self.len += src.len();
+    }
+
+    fn pop(&mut self, dst: &mut [u8]) -> usize {
+        let len = dst.len().min(self.len);
+        let first_len = len.min(self.buf.len() - self.start);
+        let second_len = len - first_len;
+        dst[..first_len].copy_from_slice(&self.buf[self.start..self.start + first_len]);
+        dst[first_len..len].copy_from_slice(&self.buf[..second_len]);
+        self.start = (self.start + len) % self.buf.len();
+        self.len -= len;
+        len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_buffer_preserves_order_across_wraparound() {
+        let mut buffer = RingBuffer::new(5);
+        buffer.push(&[1, 2, 3, 4]);
+
+        let mut first = [0; 2];
+        assert_eq!(buffer.pop(&mut first), 2);
+        assert_eq!(first, [1, 2]);
+
+        buffer.push(&[5, 6, 7]);
+        assert_eq!(buffer.remaining(), 0);
+
+        let mut second = [0; 5];
+        assert_eq!(buffer.pop(&mut second), 5);
+        assert_eq!(second, [3, 4, 5, 6, 7]);
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.remaining(), 5);
+    }
+
+    #[test]
+    fn ring_buffer_pop_is_limited_to_available_bytes() {
+        let mut buffer = RingBuffer::new(4);
+        buffer.push(&[9, 8]);
+
+        let mut dst = [0; 4];
+        assert_eq!(buffer.pop(&mut dst), 2);
+        assert_eq!(dst, [9, 8, 0, 0]);
+        assert!(buffer.is_empty());
+    }
+}

--- a/crates/moonrun/src/async_host/tls/openssl.rs
+++ b/crates/moonrun/src/async_host/tls/openssl.rs
@@ -1,0 +1,801 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::io::{self, Read, Write};
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+
+use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
+use openssl::ssl::{
+    Error as SslError, ErrorCode, Ssl, SslContextBuilder, SslFiletype, SslMethod, SslMode,
+    SslStream, SslVerifyMode,
+};
+use openssl::x509::{X509, X509Ref, store::X509StoreBuilder, verify::X509CheckFlags};
+
+use super::{
+    TLS_CLOSED_STATUS, TLS_ERROR_STATUS, TLS_RENEGOTIATION_STATUS, TLS_WOULD_BLOCK_STATUS,
+    TlsConfig, TlsFileType, TlsTrust,
+};
+
+pub(crate) struct TlsConnection {
+    stream: Option<SslStream<QueueStream>>,
+    pending_ssl: Option<Ssl>,
+    state: Arc<Mutex<BioState>>,
+    mode: TlsMode,
+    shutdown_started: bool,
+    shutdown_complete: bool,
+    last_error: Option<String>,
+    last_want_read: bool,
+    last_want_write: bool,
+    last_bytes_read: usize,
+    last_bytes_to_write: usize,
+}
+
+impl TlsConnection {
+    pub(crate) fn client(host: &str, sni: bool, config: TlsConfig) -> Result<Self, String> {
+        let TlsConfig::Client {
+            trust,
+            root_certificates,
+        } = config
+        else {
+            return Err("TLS client requires client configuration".to_string());
+        };
+        if trust != TlsTrust::CustomRoot && !root_certificates.is_empty() {
+            return Err("TLS root certificates require custom root trust".to_string());
+        }
+        let mut ctx = SslContextBuilder::new(SslMethod::tls())
+            .map_err(|error| format!("failed to create TLS client context: {error}"))?;
+        ctx.set_mode(SslMode::ENABLE_PARTIAL_WRITE | SslMode::ACCEPT_MOVING_WRITE_BUFFER);
+        match trust {
+            TlsTrust::NoVerification => ctx.set_verify(SslVerifyMode::NONE),
+            TlsTrust::SystemRoot => {
+                ctx.set_verify(SslVerifyMode::PEER);
+                load_system_root_paths(&mut ctx)
+                    .map_err(|error| format!("failed to load system TLS roots: {error}"))?;
+            }
+            TlsTrust::CustomRoot => {
+                ctx.set_verify(SslVerifyMode::PEER);
+            }
+        }
+
+        let mut ssl = Ssl::new(&ctx.build())
+            .map_err(|error| format!("failed to create TLS client: {error}"))?;
+        if trust == TlsTrust::CustomRoot {
+            configure_custom_root_store(&mut ssl, &root_certificates)?;
+        }
+        ssl.set_connect_state();
+        if !host.is_empty() {
+            if sni {
+                ssl.set_hostname(host)
+                    .map_err(|error| format!("failed to configure TLS SNI: {error}"))?;
+            }
+            if trust != TlsTrust::NoVerification {
+                configure_hostname_verification(&mut ssl, host).map_err(|error| {
+                    format!("failed to configure TLS host verification: {error}")
+                })?;
+            }
+        }
+
+        Self::new(ssl, TlsMode::Client)
+    }
+
+    pub(crate) fn server(config: TlsConfig) -> Result<Self, String> {
+        let (private_key_file, private_key_type, certificate_file, certificate_type) = match config
+        {
+            TlsConfig::ServerFiles {
+                private_key_file,
+                private_key_type,
+                certificate_file,
+                certificate_type,
+            } => (
+                private_key_file,
+                private_key_type,
+                certificate_file,
+                certificate_type,
+            ),
+            TlsConfig::ServerPfx {
+                pfx_content: _pfx_content,
+            } => {
+                return Err(
+                    "TLS PFX server certificates are supported only by SChannel on Windows"
+                        .to_string(),
+                );
+            }
+            TlsConfig::Client { .. } => {
+                return Err("TLS server requires server configuration".to_string());
+            }
+        };
+        let mut ctx = SslContextBuilder::new(SslMethod::tls())
+            .map_err(|error| format!("failed to create TLS server context: {error}"))?;
+        ctx.set_mode(SslMode::ENABLE_PARTIAL_WRITE | SslMode::ACCEPT_MOVING_WRITE_BUFFER);
+        if certificate_type == TlsFileType::Pem {
+            ctx.set_certificate_chain_file(&certificate_file)
+                .map_err(|error| format!("failed to load TLS certificate chain: {error}"))?;
+        } else {
+            ctx.set_certificate_file(&certificate_file, openssl_file_type(certificate_type))
+                .map_err(|error| format!("failed to load TLS certificate: {error}"))?;
+        }
+        ctx.set_private_key_file(&private_key_file, openssl_file_type(private_key_type))
+            .map_err(|error| format!("failed to load TLS private key: {error}"))?;
+
+        let mut ssl = Ssl::new(&ctx.build())
+            .map_err(|error| format!("failed to create TLS server: {error}"))?;
+        ssl.set_accept_state();
+        Self::new(ssl, TlsMode::Server)
+    }
+
+    fn new(ssl: Ssl, mode: TlsMode) -> Result<Self, String> {
+        let state = Arc::new(Mutex::new(BioState::new()));
+        Ok(Self {
+            stream: None,
+            pending_ssl: Some(ssl),
+            state,
+            mode,
+            shutdown_started: false,
+            shutdown_complete: false,
+            last_error: None,
+            last_want_read: false,
+            last_want_write: true,
+            last_bytes_read: 0,
+            last_bytes_to_write: 0,
+        })
+    }
+
+    pub(crate) fn read_plain(
+        &mut self,
+        input: &mut [u8],
+        dst: &mut [u8],
+        output: &mut [u8],
+    ) -> i32 {
+        self.with_scoped_io(input, output, |tls| tls.read_plain_scoped(dst))
+    }
+
+    fn read_plain_scoped(&mut self, dst: &mut [u8]) -> i32 {
+        if dst.is_empty() {
+            return 0;
+        }
+        if !self.is_init_finished() {
+            self.last_want_read = !self.output_pending();
+            self.last_want_write = self.output_pending();
+            return TLS_RENEGOTIATION_STATUS;
+        }
+        let result = match self.stream_mut() {
+            Ok(stream) => stream.ssl_read(dst),
+            Err(error) => return self.error(error),
+        };
+        match result {
+            Ok(0) => TLS_CLOSED_STATUS,
+            Ok(read) => i32::try_from(read)
+                .unwrap_or_else(|_| self.error("TLS plaintext read size overflow".to_string())),
+            Err(error) => self.handle_ssl_data_error(error, "TLS plaintext read failed"),
+        }
+    }
+
+    pub(crate) fn write_plain(&mut self, input: &mut [u8], src: &[u8], output: &mut [u8]) -> i32 {
+        self.with_scoped_io(input, output, |tls| tls.write_plain_scoped(src))
+    }
+
+    fn write_plain_scoped(&mut self, src: &[u8]) -> i32 {
+        if src.is_empty() {
+            return 0;
+        }
+        if self.shutdown_started {
+            self.last_want_read = false;
+            self.last_want_write = self.output_pending();
+            return TLS_CLOSED_STATUS;
+        }
+        if !self.is_init_finished() {
+            self.last_want_read = false;
+            self.last_want_write = self.output_pending();
+            return TLS_RENEGOTIATION_STATUS;
+        }
+        let result = match self.stream_mut() {
+            Ok(stream) => stream.ssl_write(src),
+            Err(error) => return self.error(error),
+        };
+        match result {
+            Ok(written) => {
+                self.last_want_read = false;
+                self.last_want_write = self.output_pending();
+                i32::try_from(written)
+                    .unwrap_or_else(|_| self.error("TLS plaintext write size overflow".to_string()))
+            }
+            Err(error) => self.handle_ssl_data_error(error, "TLS plaintext write failed"),
+        }
+    }
+
+    pub(crate) fn wants_read(&self) -> bool {
+        self.last_want_read
+    }
+
+    pub(crate) fn wants_write(&self) -> bool {
+        self.last_want_write
+    }
+
+    pub(crate) fn is_handshaking(&self) -> bool {
+        !self.is_init_finished()
+    }
+
+    pub(crate) fn shutdown(&mut self) -> i32 {
+        self.shutdown_started = true;
+        0
+    }
+
+    pub(crate) fn connect(&mut self, input: &mut [u8], output: &mut [u8]) -> i32 {
+        if self.mode != TlsMode::Client {
+            return self.error("TLS connect requires a client handle".to_string());
+        }
+        self.advance_state(input, output)
+    }
+
+    pub(crate) fn accept(&mut self, input: &mut [u8], output: &mut [u8]) -> i32 {
+        if self.mode != TlsMode::Server {
+            return self.error("TLS accept requires a server handle".to_string());
+        }
+        self.advance_state(input, output)
+    }
+
+    pub(crate) fn bytes_read(&self) -> i32 {
+        self.last_bytes_read as i32
+    }
+
+    pub(crate) fn bytes_to_write(&self) -> i32 {
+        self.last_bytes_to_write as i32
+    }
+
+    fn advance_state(&mut self, input: &mut [u8], output: &mut [u8]) -> i32 {
+        self.with_scoped_io(input, output, |tls| {
+            if tls.shutdown_started {
+                tls.advance_shutdown()
+            } else {
+                tls.advance_handshake()
+            }
+        })
+    }
+
+    fn with_scoped_io(
+        &mut self,
+        input: &mut [u8],
+        output: &mut [u8],
+        f: impl FnOnce(&mut Self) -> i32,
+    ) -> i32 {
+        self.last_bytes_read = 0;
+        self.last_bytes_to_write = 0;
+        let scoped = self
+            .state
+            .lock()
+            .map_err(|_| "TLS BIO state lock poisoned".to_string())
+            .and_then(|mut state| state.begin_scoped(input, output));
+        if let Err(error) = scoped {
+            return self.error(error);
+        }
+
+        let status = f(self);
+
+        let counters = self
+            .state
+            .lock()
+            .map_err(|_| "TLS BIO state lock poisoned".to_string())
+            .and_then(|mut state| state.end_scoped());
+        match counters {
+            Ok((bytes_read, bytes_to_write)) => {
+                self.last_bytes_read = bytes_read;
+                self.last_bytes_to_write = bytes_to_write;
+                if bytes_to_write > 0
+                    && (status == TLS_WOULD_BLOCK_STATUS || status == TLS_RENEGOTIATION_STATUS)
+                {
+                    self.last_want_write = true;
+                }
+                status
+            }
+            Err(error) => self.error(error),
+        }
+    }
+
+    fn advance_shutdown(&mut self) -> i32 {
+        if self.shutdown_complete {
+            self.last_want_read = false;
+            self.last_want_write = self.output_pending();
+            return 0;
+        }
+        let result = match self.stream_mut() {
+            Ok(stream) => stream.shutdown(),
+            Err(error) => return self.error(error),
+        };
+        match result {
+            Ok(_) => {
+                self.shutdown_complete = true;
+                self.last_want_read = false;
+                self.last_want_write = self.output_pending();
+                0
+            }
+            Err(error) => self.handle_ssl_error(error, "TLS shutdown failed"),
+        }
+    }
+
+    pub(crate) fn peer_certificate(&mut self) -> Result<Option<Vec<u8>>, ()> {
+        match self.peer_certificate_der() {
+            Ok(certificate) => Ok(certificate),
+            Err(error) => {
+                self.error(error);
+                Err(())
+            }
+        }
+    }
+
+    pub(crate) fn unique_channel_binding(&mut self) -> Result<Option<Vec<u8>>, ()> {
+        match self.unique_channel_binding_bytes() {
+            Ok(binding) => Ok(binding),
+            Err(error) => {
+                self.error(error);
+                Err(())
+            }
+        }
+    }
+
+    pub(crate) fn server_endpoint_channel_binding(&mut self) -> Result<Option<Vec<u8>>, ()> {
+        match self.server_endpoint_channel_binding_bytes() {
+            Ok(binding) => Ok(binding),
+            Err(error) => {
+                self.error(error);
+                Err(())
+            }
+        }
+    }
+
+    pub(crate) fn take_error(&mut self) -> Option<String> {
+        self.last_error.take()
+    }
+
+    fn advance_handshake(&mut self) -> i32 {
+        if self.is_init_finished() {
+            self.last_want_read = false;
+            self.last_want_write = self.output_pending();
+            return 0;
+        }
+        let mode = self.mode;
+        let result = match self.stream_mut() {
+            Ok(stream) => match mode {
+                TlsMode::Client => stream.connect(),
+                TlsMode::Server => stream.accept(),
+            },
+            Err(error) => return self.error(error),
+        };
+        match result {
+            Ok(()) => {
+                self.last_want_read = false;
+                self.last_want_write = self.output_pending();
+                0
+            }
+            Err(error) => self.handle_ssl_error(error, "TLS handshake failed"),
+        }
+    }
+
+    fn handle_ssl_data_error(&mut self, error: SslError, context: &str) -> i32 {
+        let status = self.handle_ssl_error(error, context);
+        if status == TLS_WOULD_BLOCK_STATUS && self.is_handshaking() {
+            TLS_RENEGOTIATION_STATUS
+        } else {
+            status
+        }
+    }
+
+    fn handle_ssl_error(&mut self, error: SslError, context: &str) -> i32 {
+        match error.code() {
+            ErrorCode::WANT_READ => {
+                self.last_want_read = true;
+                self.last_want_write = self.output_pending();
+                TLS_WOULD_BLOCK_STATUS
+            }
+            ErrorCode::WANT_WRITE => {
+                self.last_want_read = false;
+                self.last_want_write = true;
+                TLS_WOULD_BLOCK_STATUS
+            }
+            ErrorCode::ZERO_RETURN => {
+                self.last_want_read = false;
+                self.last_want_write = self.output_pending();
+                TLS_CLOSED_STATUS
+            }
+            ErrorCode::SYSCALL
+                if error
+                    .io_error()
+                    .is_some_and(|io| io.kind() == io::ErrorKind::WouldBlock) =>
+            {
+                match self.last_bio_blocked() {
+                    Some(BioBlocked::Write) => {
+                        self.last_want_read = false;
+                        self.last_want_write = true;
+                    }
+                    Some(BioBlocked::Read) | None => {
+                        self.last_want_read = true;
+                        self.last_want_write = self.output_pending();
+                    }
+                }
+                TLS_WOULD_BLOCK_STATUS
+            }
+            _ => self.error(format!("{context}: {error}")),
+        }
+    }
+
+    fn peer_certificate_der(&self) -> Result<Option<Vec<u8>>, String> {
+        let Some(stream) = &self.stream else {
+            return Ok(None);
+        };
+        stream
+            .ssl()
+            .peer_certificate()
+            .map(|certificate| {
+                certificate
+                    .to_der()
+                    .map_err(|error| format!("failed to encode TLS peer certificate: {error}"))
+            })
+            .transpose()
+    }
+
+    fn unique_channel_binding_bytes(&self) -> Result<Option<Vec<u8>>, String> {
+        let Some(stream) = &self.stream else {
+            return Ok(None);
+        };
+        let ssl = stream.ssl();
+        let len = match self.mode {
+            TlsMode::Client => ssl.finished(&mut []),
+            TlsMode::Server => ssl.peer_finished(&mut []),
+        };
+        if len == 0 {
+            return Ok(None);
+        }
+        let mut binding = vec![0; len];
+        let actual_len = match self.mode {
+            TlsMode::Client => ssl.finished(&mut binding),
+            TlsMode::Server => ssl.peer_finished(&mut binding),
+        };
+        if actual_len != len {
+            return Err("TLS channel binding size changed while copying".to_string());
+        }
+        Ok(Some(binding))
+    }
+
+    fn server_endpoint_channel_binding_bytes(&self) -> Result<Option<Vec<u8>>, String> {
+        let Some(stream) = &self.stream else {
+            return Ok(None);
+        };
+        match self.mode {
+            TlsMode::Client => stream
+                .ssl()
+                .peer_certificate()
+                .as_deref()
+                .map(server_endpoint_certificate_hash)
+                .transpose(),
+            TlsMode::Server => stream
+                .ssl()
+                .certificate()
+                .map(server_endpoint_certificate_hash)
+                .transpose(),
+        }
+    }
+
+    fn is_init_finished(&self) -> bool {
+        self.stream
+            .as_ref()
+            .is_some_and(|stream| stream.ssl().is_init_finished())
+    }
+
+    fn stream_mut(&mut self) -> Result<&mut SslStream<QueueStream>, String> {
+        if self.stream.is_none() {
+            let ssl = self
+                .pending_ssl
+                .take()
+                .ok_or_else(|| "TLS stream is not initialized".to_string())?;
+            let stream = QueueStream {
+                state: Arc::clone(&self.state),
+            };
+            self.stream = Some(
+                SslStream::new(ssl, stream)
+                    .map_err(|error| format!("failed to create TLS stream: {error}"))?,
+            );
+        }
+        self.stream
+            .as_mut()
+            .ok_or_else(|| "TLS stream is not initialized".to_string())
+    }
+
+    fn output_pending(&self) -> bool {
+        false
+    }
+
+    fn error(&mut self, message: String) -> i32 {
+        self.last_error = Some(message);
+        TLS_ERROR_STATUS
+    }
+
+    fn last_bio_blocked(&self) -> Option<BioBlocked> {
+        self.state
+            .lock()
+            .ok()
+            .and_then(|state| state.last_blocked())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TlsMode {
+    Client,
+    Server,
+}
+
+#[derive(Debug)]
+struct BioState {
+    scoped: Option<ScopedBio>,
+    last_blocked: Option<BioBlocked>,
+}
+
+impl BioState {
+    fn new() -> Self {
+        Self {
+            scoped: None,
+            last_blocked: None,
+        }
+    }
+
+    fn begin_scoped(&mut self, input: &mut [u8], output: &mut [u8]) -> Result<(), String> {
+        if self.scoped.is_some() {
+            return Err("TLS BIO state already has scoped buffers".to_string());
+        }
+        self.last_blocked = None;
+        self.scoped = Some(ScopedBio::new(input, output));
+        Ok(())
+    }
+
+    fn end_scoped(&mut self) -> Result<(usize, usize), String> {
+        self.scoped
+            .take()
+            .map(|scoped| (scoped.input_pos, scoped.output_pos))
+            .ok_or_else(|| "TLS BIO state has no scoped buffers".to_string())
+    }
+
+    fn read_input(&mut self, dst: &mut [u8]) -> usize {
+        if let Some(scoped) = &mut self.scoped
+            && scoped.input_pos < scoped.input_len
+        {
+            self.last_blocked = None;
+            return scoped.read_input(dst);
+        }
+        0
+    }
+
+    fn input_pending(&self) -> bool {
+        self.scoped
+            .as_ref()
+            .is_some_and(|scoped| scoped.input_pos < scoped.input_len)
+    }
+
+    fn write_output(&mut self, src: &[u8]) -> usize {
+        if let Some(scoped) = &mut self.scoped {
+            let len = scoped.write_output(src);
+            if len > 0 || src.is_empty() {
+                self.last_blocked = None;
+            }
+            return len;
+        }
+        0
+    }
+
+    fn block_on_read(&mut self) {
+        self.last_blocked = Some(BioBlocked::Read);
+    }
+
+    fn block_on_write(&mut self) {
+        self.last_blocked = Some(BioBlocked::Write);
+    }
+
+    fn last_blocked(&self) -> Option<BioBlocked> {
+        self.last_blocked
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BioBlocked {
+    Read,
+    Write,
+}
+
+#[derive(Debug)]
+struct ScopedBio {
+    input_ptr: *const u8,
+    input_len: usize,
+    input_pos: usize,
+    output_ptr: *mut u8,
+    output_len: usize,
+    output_pos: usize,
+}
+
+// The raw pointers are borrowed guest-memory slices registered only while a
+// single synchronous OpenSSL call is active. `QueueStream` reaches them through
+// the same mutex and `advance_state` always clears them before returning.
+unsafe impl Send for ScopedBio {}
+
+impl ScopedBio {
+    fn new(input: &mut [u8], output: &mut [u8]) -> Self {
+        Self {
+            input_ptr: input.as_ptr(),
+            input_len: input.len(),
+            input_pos: 0,
+            output_ptr: output.as_mut_ptr(),
+            output_len: output.len(),
+            output_pos: 0,
+        }
+    }
+
+    fn read_input(&mut self, dst: &mut [u8]) -> usize {
+        let len = dst.len().min(self.input_len - self.input_pos);
+        if len > 0 {
+            // SAFETY: `input_ptr` points to the scoped input slice registered
+            // by `begin_scoped`; `input_pos + len` is bounded above.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    self.input_ptr.add(self.input_pos),
+                    dst.as_mut_ptr(),
+                    len,
+                );
+            }
+            self.input_pos += len;
+        }
+        len
+    }
+
+    fn write_output(&mut self, src: &[u8]) -> usize {
+        let len = src.len().min(self.output_len - self.output_pos);
+        if len > 0 {
+            // SAFETY: `output_ptr` points to the scoped output slice registered
+            // by `begin_scoped`; `output_pos + len` is bounded above.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    src.as_ptr(),
+                    self.output_ptr.add(self.output_pos),
+                    len,
+                );
+            }
+            self.output_pos += len;
+        }
+        len
+    }
+}
+
+#[derive(Debug, Clone)]
+struct QueueStream {
+    state: Arc<Mutex<BioState>>,
+}
+
+impl Read for QueueStream {
+    fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        if dst.is_empty() {
+            return Ok(0);
+        }
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| io::Error::other("TLS BIO state lock poisoned"))?;
+        if !state.input_pending() {
+            state.block_on_read();
+            Err(io::Error::from(io::ErrorKind::WouldBlock))
+        } else {
+            Ok(state.read_input(dst))
+        }
+    }
+}
+
+impl Write for QueueStream {
+    fn write(&mut self, src: &[u8]) -> io::Result<usize> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| io::Error::other("TLS BIO state lock poisoned"))?;
+        let written = state.write_output(src);
+        if written == 0 && !src.is_empty() {
+            state.block_on_write();
+            Err(io::Error::from(io::ErrorKind::WouldBlock))
+        } else {
+            Ok(written)
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn configure_hostname_verification(
+    ssl: &mut Ssl,
+    host: &str,
+) -> Result<(), openssl::error::ErrorStack> {
+    let param = ssl.param_mut();
+    param.set_hostflags(X509CheckFlags::NO_PARTIAL_WILDCARDS);
+    match host.parse::<IpAddr>() {
+        Ok(ip) => param.set_ip(ip),
+        Err(_) => param.set_host(host),
+    }
+}
+
+fn load_system_root_paths(ctx: &mut SslContextBuilder) -> Result<(), openssl::error::ErrorStack> {
+    let mut loaded = false;
+    let probe = openssl_probe::probe();
+
+    #[cfg(target_os = "macos")]
+    let cert_file = probe.cert_file.or_else(|| {
+        let cert_file = std::path::PathBuf::from("/etc/ssl/cert.pem");
+        cert_file.exists().then_some(cert_file)
+    });
+
+    #[cfg(not(target_os = "macos"))]
+    let cert_file = probe.cert_file;
+
+    if let Some(cert_file) = cert_file {
+        ctx.set_ca_file(&cert_file)?;
+        loaded = true;
+    }
+    for cert_dir in probe.cert_dir {
+        ctx.load_verify_locations(None, Some(&cert_dir))?;
+        loaded = true;
+    }
+
+    if loaded {
+        Ok(())
+    } else {
+        ctx.set_default_verify_paths()
+    }
+}
+
+fn configure_custom_root_store(ssl: &mut Ssl, roots: &[Vec<u8>]) -> Result<(), String> {
+    let mut store = X509StoreBuilder::new()
+        .map_err(|error| format!("failed to create TLS root store: {error}"))?;
+    for root in roots {
+        let cert = X509::from_der(root)
+            .map_err(|error| format!("failed to parse TLS root certificate: {error}"))?;
+        store
+            .add_cert(cert)
+            .map_err(|error| format!("failed to add TLS root certificate: {error}"))?;
+    }
+    ssl.set_verify_cert_store(store.build())
+        .map_err(|error| format!("failed to configure TLS root store: {error}"))
+}
+
+fn openssl_file_type(file_type: TlsFileType) -> SslFiletype {
+    match file_type {
+        TlsFileType::Pem => SslFiletype::PEM,
+        TlsFileType::Asn1 => SslFiletype::ASN1,
+    }
+}
+
+fn server_endpoint_certificate_hash(certificate: &X509Ref) -> Result<Vec<u8>, String> {
+    let signature_nid = certificate.signature_algorithm().object().nid();
+    let digest_nid = signature_nid
+        .signature_algorithms()
+        .map(|algorithms| algorithms.digest)
+        .ok_or_else(|| "tls-server-endpoint channel binding unavailable".to_string())?;
+    let digest = if matches!(digest_nid, Nid::MD5 | Nid::SHA1) {
+        MessageDigest::sha256()
+    } else {
+        MessageDigest::from_nid(digest_nid)
+            .ok_or_else(|| "tls-server-endpoint channel binding unavailable".to_string())?
+    };
+    certificate
+        .digest(digest)
+        .map(|digest| digest.to_vec())
+        .map_err(|error| format!("failed to hash TLS server endpoint certificate: {error}"))
+}

--- a/crates/moonrun/src/async_host/tls/schannel.rs
+++ b/crates/moonrun/src/async_host/tls/schannel.rs
@@ -1,0 +1,1430 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::io;
+
+use crate::async_sys::ported_fns;
+
+use windows_sys::Win32::Foundation::{
+    SEC_E_INCOMPLETE_MESSAGE, SEC_E_NO_CREDENTIALS, SEC_E_OK, SEC_I_CONTEXT_EXPIRED,
+    SEC_I_CONTINUE_NEEDED, SEC_I_RENEGOTIATE,
+};
+use windows_sys::Win32::Security::Authentication::Identity::SECPKG_ATTR_ENDPOINT_BINDINGS;
+use windows_sys::Win32::Security::Authentication::Identity::{
+    ASC_REQ_CONFIDENTIALITY, ASC_REQ_INTEGRITY, AcceptSecurityContext, AcquireCredentialsHandleW,
+    ApplyControlToken, DecryptMessage, DeleteSecurityContext, EncryptMessage, FreeContextBuffer,
+    FreeCredentialsHandle, ISC_REQ_CONFIDENTIALITY, ISC_REQ_INTEGRITY, InitializeSecurityContextW,
+    QueryContextAttributesW, SCH_CRED_FORMAT_CERT_HASH_STORE, SCH_CRED_IGNORE_NO_REVOCATION_CHECK,
+    SCH_CRED_MANUAL_CRED_VALIDATION, SCH_CRED_NO_DEFAULT_CREDS, SCH_CREDENTIALS,
+    SCH_CREDENTIALS_VERSION, SCH_USE_STRONG_CRYPTO, SCHANNEL_SHUTDOWN, SEC_CHANNEL_BINDINGS,
+    SECBUFFER_DATA, SECBUFFER_EMPTY, SECBUFFER_EXTRA, SECBUFFER_STREAM_HEADER,
+    SECBUFFER_STREAM_TRAILER, SECBUFFER_TOKEN, SECBUFFER_VERSION, SECPKG_ATTR_REMOTE_CERT_CONTEXT,
+    SECPKG_ATTR_STREAM_SIZES, SECPKG_ATTR_UNIQUE_BINDINGS, SECPKG_CRED_INBOUND,
+    SECPKG_CRED_OUTBOUND, SecBuffer, SecBufferDesc, SecPkgContext_Bindings,
+    SecPkgContext_StreamSizes, TLS_PARAMETERS, UNISP_NAME,
+};
+use windows_sys::Win32::Security::Credentials::SecHandle;
+use windows_sys::Win32::Security::Cryptography::{
+    AUTHTYPE_SERVER, CERT_CHAIN_CONTEXT, CERT_CHAIN_ENGINE_CONFIG,
+    CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG, CERT_CHAIN_PARA, CERT_CHAIN_POLICY_PARA,
+    CERT_CHAIN_POLICY_SSL, CERT_CHAIN_POLICY_STATUS, CERT_CONTEXT, CERT_FIND_HAS_PRIVATE_KEY,
+    CERT_STORE_ADD_USE_EXISTING, CERT_STORE_CREATE_NEW_FLAG, CERT_STORE_PROV_MEMORY,
+    CRYPT_INTEGER_BLOB, CertAddCertificateContextToStore, CertCloseStore,
+    CertCreateCertificateChainEngine, CertCreateCertificateContext, CertFindCertificateInStore,
+    CertFreeCertificateChain, CertFreeCertificateChainEngine, CertFreeCertificateContext,
+    CertGetCertificateChain, CertOpenStore, CertVerifyCertificateChainPolicy, HCERTCHAINENGINE,
+    HCERTSTORE, HTTPSPolicyCallbackData, PFXImportCertStore, PKCS_7_ASN_ENCODING,
+    X509_ASN_ENCODING,
+};
+
+use super::{
+    RingBuffer, TLS_CLOSED_STATUS, TLS_ERROR_STATUS, TLS_PLAINTEXT_INPUT_LIMIT,
+    TLS_RENEGOTIATION_STATUS, TLS_WOULD_BLOCK_STATUS, TlsConfig, TlsTrust,
+};
+
+pub(crate) struct TlsConnection {
+    schannel: SchannelContext,
+    plain_input: RingBuffer,
+    custom_root_verifier_host: Option<String>,
+    peer_verified: bool,
+    phase: SchannelPhase,
+    // TLS close_notify is a half-close: plaintext writes stop immediately,
+    // while reads may still drain the peer's close_notify.
+    local_shutdown_started: bool,
+    local_shutdown_complete: bool,
+    last_error: Option<String>,
+    last_want_read: bool,
+    last_want_write: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchannelContextState {
+    Uninitialized,
+    HandleInitialized,
+    ContextInitialized,
+}
+
+enum SchannelMode {
+    Client { host: Option<Vec<u16>> },
+    Server,
+}
+
+// Native SChannel keeps these fields in `struct Context`; keep the same
+// boundary here so state transitions and byte accounting stay reviewable
+// against third_party/moonbitlang_async/src/tls/schannel.c.
+struct SchannelContext {
+    state: SchannelContextState,
+    handle: SecHandle,
+    context: SecHandle,
+    context_attrs: u32,
+    bytes_read: usize,
+    bytes_to_write: usize,
+    stream_sizes: Option<SecPkgContext_StreamSizes>,
+    custom_root_store: Option<CertStoreHandle>,
+    custom_root_chain_engine: Option<CertChainEngine>,
+    mode: SchannelMode,
+}
+
+impl Drop for SchannelContext {
+    fn drop(&mut self) {
+        // Match the native SChannel shim: custom trust state belongs to the
+        // context and is released before the security handles.
+        drop(self.custom_root_chain_engine.take());
+        drop(self.custom_root_store.take());
+        unsafe {
+            if self.state == SchannelContextState::ContextInitialized {
+                DeleteSecurityContext(&self.context);
+            }
+            if self.state != SchannelContextState::Uninitialized {
+                FreeCredentialsHandle(&self.handle);
+            }
+        }
+    }
+}
+
+enum SchannelStep {
+    Complete,
+    NeedMoreInput,
+    Continue,
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchannelPhase {
+    Handshaking,
+    Open,
+    Closed,
+}
+
+impl TlsConnection {
+    pub(crate) fn client(host: &str, _sni: bool, config: TlsConfig) -> Result<Self, String> {
+        let TlsConfig::Client {
+            trust,
+            root_certificates,
+        } = config
+        else {
+            return Err("TLS client requires client configuration".to_string());
+        };
+        if trust != TlsTrust::CustomRoot && !root_certificates.is_empty() {
+            return Err("TLS root certificates require custom root trust".to_string());
+        }
+        // Native Windows currently ignores `sni=false`; the target name is
+        // passed to SChannel whenever a host is available.
+        let target_host = (!host.is_empty()).then_some(host);
+        let mut schannel = SchannelContext::client(target_host, trust == TlsTrust::SystemRoot)?;
+        if trust == TlsTrust::CustomRoot {
+            for root in &root_certificates {
+                schannel
+                    .add_root_certificate(root)
+                    .map_err(|error| format!("failed to add TLS root certificate: {error}"))?;
+            }
+        }
+        let custom_root_verifier_host = (trust == TlsTrust::CustomRoot).then(|| host.to_string());
+        Ok(Self::new(schannel, custom_root_verifier_host))
+    }
+
+    pub(crate) fn server(config: TlsConfig) -> Result<Self, String> {
+        let pfx_content = match config {
+            TlsConfig::ServerPfx { pfx_content } => pfx_content,
+            TlsConfig::ServerFiles {
+                private_key_file: _private_key_file,
+                private_key_type: _private_key_type,
+                certificate_file: _certificate_file,
+                certificate_type: _certificate_type,
+            } => {
+                return Err(
+                    "SChannel TLS servers require a PKCS#12/PFX certificate context on Windows"
+                        .to_string(),
+                );
+            }
+            TlsConfig::Client { .. } => {
+                return Err("TLS server requires server configuration".to_string());
+            }
+        };
+        let schannel = SchannelContext::server(&pfx_content)?;
+        Ok(Self::new(schannel, None))
+    }
+
+    fn new(schannel: SchannelContext, custom_root_verifier_host: Option<String>) -> Self {
+        Self {
+            schannel,
+            plain_input: RingBuffer::new(TLS_PLAINTEXT_INPUT_LIMIT),
+            custom_root_verifier_host,
+            peer_verified: false,
+            phase: SchannelPhase::Handshaking,
+            local_shutdown_started: false,
+            local_shutdown_complete: false,
+            last_error: None,
+            last_want_read: false,
+            last_want_write: false,
+        }
+    }
+
+    pub(crate) fn read_plain(
+        &mut self,
+        input: &mut [u8],
+        dst: &mut [u8],
+        _output: &mut [u8],
+    ) -> i32 {
+        self.schannel.bytes_read = 0;
+        self.schannel.bytes_to_write = 0;
+        if dst.is_empty() {
+            return 0;
+        }
+        if !self.plain_input.is_empty() {
+            return self.pop_plain_input(dst);
+        }
+        if self.phase == SchannelPhase::Closed {
+            return TLS_CLOSED_STATUS;
+        }
+        if self.is_handshaking() {
+            self.last_want_read = !self.output_pending();
+            self.last_want_write = self.output_pending();
+            return TLS_RENEGOTIATION_STATUS;
+        }
+        match self.decrypt_plain(input, dst) {
+            Ok(read) if read > 0 => read,
+            Ok(status) if status == TLS_CLOSED_STATUS => TLS_CLOSED_STATUS,
+            Ok(status) if status == TLS_WOULD_BLOCK_STATUS => TLS_WOULD_BLOCK_STATUS,
+            Ok(status) if status == TLS_RENEGOTIATION_STATUS => TLS_RENEGOTIATION_STATUS,
+            Ok(status) if status == TLS_ERROR_STATUS => {
+                unreachable!("TLS errors are returned through Err")
+            }
+            Ok(status) => status,
+            Err(error) => self.error(error),
+        }
+    }
+
+    fn decrypt_plain(&mut self, input: &mut [u8], dst: &mut [u8]) -> Result<i32, String> {
+        if input.is_empty() {
+            self.last_want_read = true;
+            self.last_want_write = self.output_pending();
+            return Ok(TLS_WOULD_BLOCK_STATUS);
+        }
+
+        let input_len = input.len();
+        let mut buffers = [
+            sec_buffer(SECBUFFER_DATA, input),
+            empty_sec_buffer(),
+            empty_sec_buffer(),
+            empty_sec_buffer(),
+        ];
+        let desc = sec_buffer_desc(&mut buffers);
+        let status =
+            unsafe { DecryptMessage(&self.schannel.context, &desc, 0, std::ptr::null_mut()) };
+        match status {
+            SEC_E_OK => {
+                self.schannel.bytes_read = consumed_len(input_len, &buffers);
+                let plain = sec_buffer_slice(&buffers, SECBUFFER_DATA, input).unwrap_or(&[]);
+                let plain_is_empty = plain.is_empty();
+                let read = plain.len().min(dst.len());
+                dst[..read].copy_from_slice(&plain[..read]);
+                self.append_plain_input(&plain[read..])?;
+                // A zero-length TLS application record is legal. If no
+                // plaintext was produced, MoonBit first drops consumed
+                // transport bytes and then retries or reads more input.
+                self.last_want_read = plain_is_empty
+                    && (self.schannel.bytes_read == 0 || self.schannel.bytes_read == input_len);
+                self.last_want_write = self.output_pending();
+                if read > 0 {
+                    i32::try_from(read).map_err(|_| "TLS plaintext read size overflow".to_string())
+                } else {
+                    Ok(TLS_WOULD_BLOCK_STATUS)
+                }
+            }
+            SEC_E_INCOMPLETE_MESSAGE => {
+                self.schannel.bytes_read = 0;
+                self.last_want_read = true;
+                self.last_want_write = self.output_pending();
+                Ok(TLS_WOULD_BLOCK_STATUS)
+            }
+            SEC_I_CONTEXT_EXPIRED => {
+                self.phase = SchannelPhase::Closed;
+                self.last_want_read = false;
+                self.last_want_write = self.output_pending();
+                Ok(TLS_CLOSED_STATUS)
+            }
+            SEC_I_RENEGOTIATE => {
+                self.schannel.bytes_read = 0;
+                self.phase = SchannelPhase::Handshaking;
+                self.last_want_read = true;
+                self.last_want_write = self.output_pending();
+                Ok(TLS_RENEGOTIATION_STATUS)
+            }
+            error => Err(schannel_status_error("TLS plaintext read failed", error)),
+        }
+    }
+
+    pub(crate) fn write_plain(&mut self, _input: &mut [u8], src: &[u8], output: &mut [u8]) -> i32 {
+        self.schannel.bytes_read = 0;
+        self.schannel.bytes_to_write = 0;
+        if src.is_empty() {
+            return 0;
+        }
+        if self.is_handshaking() {
+            self.last_want_read = false;
+            self.last_want_write = self.output_pending();
+            return TLS_RENEGOTIATION_STATUS;
+        }
+        if self.phase == SchannelPhase::Closed || self.local_shutdown_started {
+            return TLS_CLOSED_STATUS;
+        }
+        match self.encrypt_plain(src, output) {
+            Ok(written) => i32::try_from(written)
+                .unwrap_or_else(|_| self.error("TLS plaintext write size overflow".to_string())),
+            Err(SchannelIoError {
+                kind: SchannelIoKind::WouldBlock,
+                ..
+            }) => {
+                self.last_want_read = false;
+                self.last_want_write = true;
+                TLS_WOULD_BLOCK_STATUS
+            }
+            Err(error) => self.error(error.message),
+        }
+    }
+
+    pub(crate) fn wants_read(&self) -> bool {
+        self.last_want_read
+    }
+
+    pub(crate) fn wants_write(&self) -> bool {
+        self.last_want_write
+    }
+
+    pub(crate) fn is_handshaking(&self) -> bool {
+        self.phase == SchannelPhase::Handshaking
+    }
+
+    pub(crate) fn shutdown(&mut self) -> i32 {
+        if self.local_shutdown_complete {
+            return 0;
+        }
+        if !self.local_shutdown_started {
+            if let Err(error) = self.apply_schannel_shutdown() {
+                return self.error(error);
+            }
+            self.local_shutdown_started = true;
+        }
+        0
+    }
+
+    pub(crate) fn connect(&mut self, input: &mut [u8], output: &mut [u8]) -> i32 {
+        if !self.schannel.is_client() {
+            return self.error("TLS connect requires a client handle".to_string());
+        }
+        self.advance_state(input, output)
+    }
+
+    pub(crate) fn accept(&mut self, input: &mut [u8], output: &mut [u8]) -> i32 {
+        if self.schannel.is_client() {
+            return self.error("TLS accept requires a server handle".to_string());
+        }
+        self.advance_state(input, output)
+    }
+
+    pub(crate) fn bytes_read(&self) -> i32 {
+        self.schannel.bytes_read as i32
+    }
+
+    pub(crate) fn bytes_to_write(&self) -> i32 {
+        self.schannel.bytes_to_write as i32
+    }
+
+    pub(crate) fn peer_certificate(&mut self) -> Result<Option<Vec<u8>>, ()> {
+        match self.peer_certificate_der() {
+            Ok(certificate) => Ok(certificate),
+            Err(error) => {
+                self.error(error);
+                Err(())
+            }
+        }
+    }
+
+    pub(crate) fn unique_channel_binding(&mut self) -> Result<Option<Vec<u8>>, ()> {
+        match self.unique_channel_binding_bytes() {
+            Ok(binding) => Ok(binding),
+            Err(error) => {
+                self.error(error);
+                Err(())
+            }
+        }
+    }
+
+    pub(crate) fn server_endpoint_channel_binding(&mut self) -> Result<Option<Vec<u8>>, ()> {
+        match self.server_endpoint_channel_binding_bytes() {
+            Ok(binding) => Ok(binding),
+            Err(error) => {
+                self.error(error);
+                Err(())
+            }
+        }
+    }
+
+    pub(crate) fn take_error(&mut self) -> Option<String> {
+        self.last_error.take()
+    }
+
+    fn advance_state(&mut self, input: &mut [u8], output: &mut [u8]) -> i32 {
+        self.schannel.bytes_read = 0;
+        self.schannel.bytes_to_write = 0;
+        if self.local_shutdown_started && !self.local_shutdown_complete {
+            return match self.drive_shutdown(input, output) {
+                Ok(true) => 0,
+                Ok(false) => TLS_WOULD_BLOCK_STATUS,
+                Err(error) => self.error(error),
+            };
+        }
+        if self.phase == SchannelPhase::Open {
+            self.last_want_read = false;
+            self.last_want_write = self.generated_output_pending();
+            return 0;
+        }
+        if self.phase == SchannelPhase::Closed {
+            self.last_want_read = false;
+            self.last_want_write = self.generated_output_pending();
+            return if self.local_shutdown_complete {
+                0
+            } else {
+                TLS_CLOSED_STATUS
+            };
+        }
+        match self.step_handshake(input, output) {
+            Ok(SchannelStep::Complete) => {
+                self.last_want_read = false;
+                self.last_want_write = self.generated_output_pending();
+                if let Err(error) = self.verify_peer_if_needed() {
+                    return self.error(error);
+                }
+                self.phase = SchannelPhase::Open;
+                0
+            }
+            Ok(SchannelStep::NeedMoreInput) => {
+                self.phase = SchannelPhase::Handshaking;
+                self.last_want_read = true;
+                self.last_want_write = self.generated_output_pending();
+                TLS_WOULD_BLOCK_STATUS
+            }
+            Ok(SchannelStep::Continue) => {
+                self.phase = SchannelPhase::Handshaking;
+                self.last_want_write = self.generated_output_pending();
+                self.last_want_read = !self.last_want_write;
+                TLS_WOULD_BLOCK_STATUS
+            }
+            Ok(SchannelStep::Closed) => {
+                self.phase = SchannelPhase::Closed;
+                self.last_want_read = false;
+                self.last_want_write = self.generated_output_pending();
+                TLS_CLOSED_STATUS
+            }
+            Err(error) => self.error(error),
+        }
+    }
+
+    fn peer_certificate_der(&mut self) -> Result<Option<Vec<u8>>, String> {
+        self.peer_certificate_context()
+            .map(|certificate| certificate.map(|certificate| certificate.to_der().to_vec()))
+    }
+
+    fn unique_channel_binding_bytes(&self) -> Result<Option<Vec<u8>>, String> {
+        self.schannel.unique_channel_binding()
+    }
+
+    fn server_endpoint_channel_binding_bytes(&self) -> Result<Option<Vec<u8>>, String> {
+        self.schannel.server_endpoint_channel_binding()
+    }
+
+    fn verify_peer_if_needed(&mut self) -> Result<(), String> {
+        if self.peer_verified {
+            return Ok(());
+        }
+        let Some(host) = self.custom_root_verifier_host.clone() else {
+            self.peer_verified = true;
+            return Ok(());
+        };
+        self.schannel.verify_peer_certificate(&host)?;
+        self.peer_verified = true;
+        Ok(())
+    }
+
+    fn step_handshake(
+        &mut self,
+        guest_input: &mut [u8],
+        output: &mut [u8],
+    ) -> Result<SchannelStep, String> {
+        let input_len = guest_input.len();
+        // Native SChannel receives a pointer into a buffer even when the
+        // logical input length is zero.
+        let mut empty_input = [0];
+        let input = if guest_input.is_empty() {
+            &mut empty_input[..]
+        } else {
+            guest_input
+        };
+
+        let mut output_buffers = [sec_buffer(SECBUFFER_TOKEN, output)];
+        let mut output_desc = sec_buffer_desc(&mut output_buffers);
+
+        let (status, bytes_read, bytes_to_write, is_client_step) = match &self.schannel.mode {
+            SchannelMode::Client { host } => {
+                let mut input_buffers = [
+                    sec_buffer_with_len(SECBUFFER_TOKEN, input, input_len),
+                    empty_sec_buffer(),
+                ];
+                let input_desc = sec_buffer_desc(&mut input_buffers);
+                let context_ptr = if self.schannel.is_context_initialized() {
+                    &self.schannel.context as *const _
+                } else {
+                    std::ptr::null()
+                };
+                let input_desc_ptr = if self.schannel.is_context_initialized() {
+                    &input_desc as *const _
+                } else {
+                    std::ptr::null()
+                };
+                let status = unsafe {
+                    InitializeSecurityContextW(
+                        &self.schannel.handle,
+                        context_ptr,
+                        host.as_ref()
+                            .map(|host| host.as_ptr())
+                            .unwrap_or(std::ptr::null()),
+                        ISC_REQ_CONFIDENTIALITY | ISC_REQ_INTEGRITY,
+                        0,
+                        0,
+                        input_desc_ptr,
+                        0,
+                        &mut self.schannel.context,
+                        &mut output_desc,
+                        &mut self.schannel.context_attrs,
+                        std::ptr::null_mut(),
+                    )
+                };
+                (
+                    status,
+                    consumed_len(input_len, &input_buffers),
+                    sec_buffer_slice(&output_buffers, SECBUFFER_TOKEN, output)
+                        .map(|output| output.len())
+                        .unwrap_or(0),
+                    true,
+                )
+            }
+            SchannelMode::Server => {
+                let mut input_buffers = [
+                    sec_buffer_with_len(SECBUFFER_TOKEN, input, input_len),
+                    empty_sec_buffer(),
+                ];
+                let input_desc = sec_buffer_desc(&mut input_buffers);
+                let context_ptr = if self.schannel.is_context_initialized() {
+                    &self.schannel.context as *const _
+                } else {
+                    std::ptr::null()
+                };
+                let status = unsafe {
+                    AcceptSecurityContext(
+                        &self.schannel.handle,
+                        context_ptr,
+                        &input_desc,
+                        ASC_REQ_CONFIDENTIALITY | ASC_REQ_INTEGRITY,
+                        0,
+                        &mut self.schannel.context,
+                        &mut output_desc,
+                        &mut self.schannel.context_attrs,
+                        std::ptr::null_mut(),
+                    )
+                };
+                (
+                    status,
+                    consumed_len(input_len, &input_buffers),
+                    sec_buffer_slice(&output_buffers, SECBUFFER_TOKEN, output)
+                        .map(|output| output.len())
+                        .unwrap_or(0),
+                    false,
+                )
+            }
+        };
+        self.finish_handshake_step(status, bytes_read, bytes_to_write, is_client_step)
+    }
+
+    fn finish_handshake_step(
+        &mut self,
+        status: i32,
+        bytes_read: usize,
+        bytes_to_write: usize,
+        is_client_step: bool,
+    ) -> Result<SchannelStep, String> {
+        match status {
+            SEC_E_OK | SEC_I_CONTINUE_NEEDED | SEC_I_CONTEXT_EXPIRED => {
+                self.mark_context_initialized_after_handshake_step(is_client_step);
+                self.schannel.bytes_read = bytes_read;
+                self.schannel.bytes_to_write = if status == SEC_I_CONTEXT_EXPIRED && !is_client_step
+                {
+                    0
+                } else {
+                    bytes_to_write
+                };
+                if status == SEC_E_OK {
+                    self.schannel.stream_sizes = Some(query_stream_sizes(&self.schannel.context)?);
+                    Ok(SchannelStep::Complete)
+                } else if status == SEC_I_CONTEXT_EXPIRED {
+                    Ok(SchannelStep::Closed)
+                } else {
+                    Ok(SchannelStep::Continue)
+                }
+            }
+            SEC_E_INCOMPLETE_MESSAGE => {
+                self.mark_context_initialized_after_handshake_step(is_client_step);
+                self.schannel.bytes_read = 0;
+                self.schannel.bytes_to_write = 0;
+                Ok(SchannelStep::NeedMoreInput)
+            }
+            error => Err(schannel_status_error(
+                if is_client_step {
+                    "TLS client handshake failed"
+                } else {
+                    "TLS server handshake failed"
+                },
+                error,
+            )),
+        }
+    }
+
+    fn mark_context_initialized_after_handshake_step(&mut self, is_client_step: bool) {
+        // Match the native SChannel shim: clients transition after any
+        // non-error step, while servers wait until AcceptSecurityContext
+        // publishes a real context handle for an incomplete ClientHello.
+        if self.schannel.state == SchannelContextState::HandleInitialized
+            && (is_client_step
+                || self.schannel.context.dwLower != 0
+                || self.schannel.context.dwUpper != 0)
+        {
+            self.schannel.state = SchannelContextState::ContextInitialized;
+        }
+    }
+
+    fn encrypt_plain(&mut self, src: &[u8], output: &mut [u8]) -> Result<usize, SchannelIoError> {
+        if src.is_empty() {
+            return Ok(0);
+        }
+        let sizes = self.schannel.stream_sizes.ok_or_else(|| {
+            SchannelIoError::fatal("TLS plaintext write attempted before handshake completed")
+        })?;
+        let overhead = sizes.cbHeader as usize + sizes.cbTrailer as usize;
+        let output_remaining = output.len();
+        if output_remaining <= overhead {
+            return Err(SchannelIoError::would_block());
+        }
+        let len = src
+            .len()
+            .min(sizes.cbMaximumMessage as usize)
+            .min(output_remaining - overhead);
+        output[sizes.cbHeader as usize..sizes.cbHeader as usize + len].copy_from_slice(&src[..len]);
+        let header_len = sizes.cbHeader as usize;
+        let trailer_start = header_len + len;
+        let mut buffers = [
+            SecBuffer {
+                cbBuffer: sizes.cbHeader,
+                BufferType: SECBUFFER_STREAM_HEADER,
+                pvBuffer: output.as_mut_ptr().cast(),
+            },
+            SecBuffer {
+                cbBuffer: u32::try_from(len)
+                    .map_err(|_| SchannelIoError::fatal("TLS plaintext write size overflow"))?,
+                BufferType: SECBUFFER_DATA,
+                pvBuffer: unsafe { output.as_mut_ptr().add(header_len) }.cast(),
+            },
+            SecBuffer {
+                cbBuffer: sizes.cbTrailer,
+                BufferType: SECBUFFER_STREAM_TRAILER,
+                pvBuffer: unsafe { output.as_mut_ptr().add(trailer_start) }.cast(),
+            },
+            empty_sec_buffer(),
+        ];
+        let desc = sec_buffer_desc(&mut buffers);
+        let status = unsafe { EncryptMessage(&self.schannel.context, 0, &desc, 0) };
+        if status != SEC_E_OK {
+            return Err(SchannelIoError::fatal(schannel_status_error(
+                "TLS plaintext write failed",
+                status,
+            )));
+        }
+        let encrypted_len = buffers[0].cbBuffer as usize
+            + buffers[1].cbBuffer as usize
+            + buffers[2].cbBuffer as usize;
+        self.schannel.bytes_to_write = encrypted_len;
+        self.last_want_read = false;
+        self.last_want_write = true;
+        Ok(len)
+    }
+
+    fn apply_schannel_shutdown(&mut self) -> Result<(), String> {
+        if !self.schannel.is_context_initialized() {
+            self.local_shutdown_complete = true;
+            return Ok(());
+        }
+        let mut shutdown = SCHANNEL_SHUTDOWN;
+        let mut buffers = [SecBuffer {
+            cbBuffer: std::mem::size_of::<u32>() as u32,
+            BufferType: SECBUFFER_TOKEN,
+            pvBuffer: (&mut shutdown as *mut u32).cast(),
+        }];
+        let desc = sec_buffer_desc(&mut buffers);
+        let status = unsafe { ApplyControlToken(&self.schannel.context, &desc) };
+        if status != SEC_E_OK {
+            return Err(schannel_status_error("TLS shutdown failed", status));
+        }
+        Ok(())
+    }
+
+    fn drive_shutdown(&mut self, input: &mut [u8], output: &mut [u8]) -> Result<bool, String> {
+        match self.step_handshake(input, output)? {
+            SchannelStep::Complete => {
+                self.phase = SchannelPhase::Open;
+                self.local_shutdown_complete = true;
+                self.last_want_read = false;
+                self.last_want_write = self.generated_output_pending();
+                Ok(true)
+            }
+            SchannelStep::Closed => {
+                self.phase = SchannelPhase::Closed;
+                self.local_shutdown_complete = true;
+                self.last_want_read = false;
+                self.last_want_write = self.generated_output_pending();
+                Ok(true)
+            }
+            SchannelStep::NeedMoreInput => {
+                self.phase = SchannelPhase::Handshaking;
+                self.last_want_read = true;
+                self.last_want_write = self.generated_output_pending();
+                Ok(false)
+            }
+            SchannelStep::Continue => {
+                self.phase = SchannelPhase::Handshaking;
+                self.last_want_write = self.generated_output_pending();
+                self.last_want_read = !self.last_want_write;
+                Ok(false)
+            }
+        }
+    }
+
+    fn peer_certificate_context(&self) -> Result<Option<CertContextHandle>, String> {
+        self.schannel.peer_certificate_context()
+    }
+
+    fn append_plain_input(&mut self, plain: &[u8]) -> Result<(), String> {
+        if plain.len() > self.plain_input.remaining() {
+            return Err("TLS plaintext input buffer limit exceeded".to_string());
+        }
+        self.plain_input.push(plain);
+        Ok(())
+    }
+
+    fn pop_plain_input(&mut self, dst: &mut [u8]) -> i32 {
+        let read = self.plain_input.pop(dst);
+        i32::try_from(read)
+            .unwrap_or_else(|_| self.error("TLS plaintext read size overflow".to_string()))
+    }
+
+    fn output_pending(&self) -> bool {
+        false
+    }
+
+    fn generated_output_pending(&self) -> bool {
+        self.output_pending() || self.schannel.bytes_to_write > 0
+    }
+
+    fn error(&mut self, message: String) -> i32 {
+        self.last_error = Some(message);
+        TLS_ERROR_STATUS
+    }
+}
+
+impl SchannelContext {
+    fn new(mode: SchannelMode) -> Self {
+        schannel_new(mode)
+    }
+
+    fn client(host: Option<&str>, verify: bool) -> Result<Self, String> {
+        let mut context = Self::new(SchannelMode::Client {
+            host: host.map(|host| host.encode_utf16().chain(Some(0)).collect()),
+        });
+        context.init_client(verify)?;
+        Ok(context)
+    }
+
+    fn init_client(&mut self, verify: bool) -> Result<(), String> {
+        schannel_init_client(self, verify)
+    }
+
+    fn server(pfx_content: &[u8]) -> Result<Self, String> {
+        let mut context = Self::new(SchannelMode::Server);
+        context.init_server(pfx_content)?;
+        Ok(context)
+    }
+
+    fn init_server(&mut self, pfx_content: &[u8]) -> Result<(), String> {
+        schannel_init_server(self, pfx_content)
+    }
+
+    fn is_context_initialized(&self) -> bool {
+        self.state == SchannelContextState::ContextInitialized
+    }
+
+    fn is_client(&self) -> bool {
+        matches!(self.mode, SchannelMode::Client { .. })
+    }
+
+    fn add_root_certificate(&mut self, der: &[u8]) -> io::Result<()> {
+        schannel_add_root_certificate(self, der)
+    }
+
+    fn verify_peer_certificate(&mut self, host_name: &str) -> Result<(), String> {
+        schannel_verify_peer_certificate(self, host_name)
+    }
+
+    fn peer_certificate_context(&self) -> Result<Option<CertContextHandle>, String> {
+        if !self.is_context_initialized() {
+            return Ok(None);
+        }
+        let mut certificate: *mut CERT_CONTEXT = std::ptr::null_mut();
+        let status = unsafe {
+            QueryContextAttributesW(
+                &self.context,
+                SECPKG_ATTR_REMOTE_CERT_CONTEXT,
+                &mut certificate as *mut _ as _,
+            )
+        };
+        match status {
+            SEC_E_OK if certificate.is_null() => Ok(None),
+            SEC_E_OK => Ok(Some(CertContextHandle(certificate))),
+            SEC_E_NO_CREDENTIALS => Ok(None),
+            error => Err(schannel_status_error(
+                "failed to get TLS peer certificate",
+                error,
+            )),
+        }
+    }
+
+    fn unique_channel_binding(&self) -> Result<Option<Vec<u8>>, String> {
+        self.channel_binding(
+            SECPKG_ATTR_UNIQUE_BINDINGS,
+            "failed to get TLS unique channel binding",
+        )
+    }
+
+    fn server_endpoint_channel_binding(&self) -> Result<Option<Vec<u8>>, String> {
+        self.channel_binding(
+            SECPKG_ATTR_ENDPOINT_BINDINGS,
+            "failed to get TLS server endpoint channel binding",
+        )
+    }
+
+    fn channel_binding(
+        &self,
+        attribute: u32,
+        error_context: &str,
+    ) -> Result<Option<Vec<u8>>, String> {
+        if !self.is_context_initialized() {
+            return Ok(None);
+        }
+        let mut bindings = SecPkgContext_Bindings {
+            BindingsLength: 0,
+            Bindings: std::ptr::null_mut(),
+        };
+        let status = unsafe {
+            QueryContextAttributesW(&self.context, attribute, &mut bindings as *mut _ as _)
+        };
+        if status != SEC_E_OK {
+            return Err(schannel_status_error(error_context, status));
+        }
+        if bindings.Bindings.is_null() {
+            return Ok(None);
+        }
+
+        let bindings = ChannelBindingsHandle {
+            bindings: bindings.Bindings,
+            len: bindings.BindingsLength as usize,
+        };
+        let binding = unsafe { bindings.application_data() }?;
+        Ok(Some(binding.to_vec()))
+    }
+}
+
+ported_fns! {
+    #[ported(source = "src/tls/schannel.c", original = "moonbitlang_async_schannel_new")]
+    fn schannel_new(mode: SchannelMode) -> SchannelContext {
+        SchannelContext {
+            state: SchannelContextState::Uninitialized,
+            handle: zeroed_sec_handle(),
+            context: zeroed_sec_handle(),
+            context_attrs: 0,
+            bytes_read: 0,
+            bytes_to_write: 0,
+            stream_sizes: None,
+            custom_root_store: None,
+            custom_root_chain_engine: None,
+            mode,
+        }
+    }
+
+    #[ported(source = "src/tls/schannel.c", original = "moonbitlang_async_schannel_init_client")]
+    fn schannel_init_client(ctx: &mut SchannelContext, verify: bool) -> Result<(), String> {
+        let mut tls_param: TLS_PARAMETERS = unsafe { std::mem::zeroed() };
+        tls_param.grbitDisabledProtocols =
+            windows_sys::Win32::Security::Authentication::Identity::SP_PROT_TLS1_CLIENT;
+
+        let mut auth_data: SCH_CREDENTIALS = unsafe { std::mem::zeroed() };
+        auth_data.dwVersion = SCH_CREDENTIALS_VERSION;
+        auth_data.dwFlags = SCH_CRED_IGNORE_NO_REVOCATION_CHECK | SCH_CRED_NO_DEFAULT_CREDS;
+        if !verify {
+            auth_data.dwFlags |= SCH_CRED_MANUAL_CRED_VALIDATION;
+        }
+        auth_data.cTlsParameters = 1;
+        auth_data.pTlsParameters = &mut tls_param;
+        let mut handle = zeroed_sec_handle();
+        let status = unsafe {
+            AcquireCredentialsHandleW(
+                std::ptr::null(),
+                UNISP_NAME,
+                SECPKG_CRED_OUTBOUND,
+                std::ptr::null(),
+                &mut auth_data as *mut _ as _,
+                None,
+                std::ptr::null(),
+                &mut handle,
+                std::ptr::null_mut(),
+            )
+        };
+        if status == SEC_E_OK {
+            ctx.handle = handle;
+            ctx.state = SchannelContextState::HandleInitialized;
+            Ok(())
+        } else {
+            Err(schannel_status_error(
+                "failed to create TLS client credentials",
+                status,
+            ))
+        }
+    }
+
+    #[ported(source = "src/tls/schannel.c", original = "moonbitlang_async_schannel_init_server")]
+    fn schannel_init_server(ctx: &mut SchannelContext, pfx_content: &[u8]) -> Result<(), String> {
+        const ENCODING_TYPE: u32 = PKCS_7_ASN_ENCODING | X509_ASN_ENCODING;
+
+        let pfx_len = u32::try_from(pfx_content.len())
+            .map_err(|_| "TLS PFX file is too large".to_string())?;
+        let pfx_store = CRYPT_INTEGER_BLOB {
+            cbData: pfx_len,
+            pbData: pfx_content.as_ptr().cast_mut(),
+        };
+        let cert_store = unsafe { PFXImportCertStore(&pfx_store, std::ptr::null(), 0) };
+        if cert_store.is_null() {
+            return Err(format!(
+                "failed to import TLS PFX certificate: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        let cert_store = CertStoreHandle(cert_store);
+
+        let cert = unsafe {
+            CertFindCertificateInStore(
+                cert_store.as_ptr(),
+                ENCODING_TYPE,
+                0,
+                CERT_FIND_HAS_PRIVATE_KEY,
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        };
+        if cert.is_null() {
+            return Err(format!(
+                "no certificate with private key found in TLS PFX file: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        let certificate = CertContextHandle(cert);
+        let mut certificate_ptr = certificate.as_ptr();
+
+        let mut tls_param: TLS_PARAMETERS = unsafe { std::mem::zeroed() };
+        tls_param.grbitDisabledProtocols =
+            windows_sys::Win32::Security::Authentication::Identity::SP_PROT_TLS1_0_SERVER
+                | windows_sys::Win32::Security::Authentication::Identity::SP_PROT_TLS1_1_SERVER;
+
+        let mut auth_data: SCH_CREDENTIALS = unsafe { std::mem::zeroed() };
+        auth_data.dwVersion = SCH_CREDENTIALS_VERSION;
+        // Keep the same credential format as the native SChannel shim.
+        auth_data.cCreds = 1;
+        auth_data.dwCredFormat = SCH_CRED_FORMAT_CERT_HASH_STORE;
+        auth_data.paCred = &mut certificate_ptr;
+        auth_data.dwFlags = SCH_USE_STRONG_CRYPTO;
+        auth_data.cTlsParameters = 1;
+        auth_data.pTlsParameters = &mut tls_param;
+        let mut handle = zeroed_sec_handle();
+        let status = unsafe {
+            AcquireCredentialsHandleW(
+                std::ptr::null(),
+                UNISP_NAME,
+                SECPKG_CRED_INBOUND,
+                std::ptr::null(),
+                &mut auth_data as *mut _ as _,
+                None,
+                std::ptr::null(),
+                &mut handle,
+                std::ptr::null_mut(),
+            )
+        };
+        drop(certificate);
+        drop(cert_store);
+        if status == SEC_E_OK {
+            ctx.handle = handle;
+            ctx.state = SchannelContextState::HandleInitialized;
+            Ok(())
+        } else {
+            Err(schannel_status_error(
+                "failed to create TLS server credentials",
+                status,
+            ))
+        }
+    }
+
+    #[ported(source = "src/tls/schannel.c", original = "get_or_create_custom_root_store")]
+    fn get_or_create_custom_root_store(
+        ctx: &mut SchannelContext,
+    ) -> io::Result<&mut CertStoreHandle> {
+        if ctx.custom_root_store.is_none() {
+            ctx.custom_root_store = Some(CertStoreHandle::memory()?);
+        }
+        Ok(ctx
+            .custom_root_store
+            .as_mut()
+            .expect("custom root store was just initialized"))
+    }
+
+    #[ported(source = "src/tls/schannel.c", original = "get_or_create_custom_root_chain_engine")]
+    fn get_or_create_custom_root_chain_engine(
+        ctx: &mut SchannelContext,
+    ) -> io::Result<HCERTCHAINENGINE> {
+        if ctx.custom_root_chain_engine.is_none() {
+            let mut chain_engine = 0;
+            let mut chain_config: CERT_CHAIN_ENGINE_CONFIG = unsafe { std::mem::zeroed() };
+            chain_config.cbSize = std::mem::size_of::<CERT_CHAIN_ENGINE_CONFIG>() as u32;
+            chain_config.hExclusiveRoot = ctx
+                .custom_root_store
+                .as_ref()
+                .map(CertStoreHandle::as_ptr)
+                .unwrap_or(std::ptr::null_mut());
+            chain_config.dwExclusiveFlags = CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG;
+            let ok = unsafe { CertCreateCertificateChainEngine(&chain_config, &mut chain_engine) };
+            if ok == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            ctx.custom_root_chain_engine = Some(CertChainEngine(chain_engine));
+        }
+        Ok(ctx
+            .custom_root_chain_engine
+            .as_ref()
+            .expect("custom root chain engine was just initialized")
+            .as_ptr())
+    }
+
+    #[ported(source = "src/tls/schannel.c", original = "moonbitlang_async_schannel_add_root_certificate")]
+    fn schannel_add_root_certificate(ctx: &mut SchannelContext, der: &[u8]) -> io::Result<()> {
+        let cert = CertContextHandle::from_der(der)?;
+        get_or_create_custom_root_store(ctx)?;
+        ctx.custom_root_chain_engine.take();
+        ctx.custom_root_store
+            .as_mut()
+            .expect("custom root store was just initialized")
+            .add_certificate_context(&cert)
+    }
+
+    #[ported(source = "src/tls/schannel.c", original = "moonbitlang_async_schannel_verify_peer_certificate")]
+    fn schannel_verify_peer_certificate(
+        ctx: &mut SchannelContext,
+        host_name: &str,
+    ) -> Result<(), String> {
+        let mut certificate: *mut CERT_CONTEXT = std::ptr::null_mut();
+        let status = unsafe {
+            QueryContextAttributesW(
+                &ctx.context,
+                SECPKG_ATTR_REMOTE_CERT_CONTEXT,
+                &mut certificate as *mut _ as _,
+            )
+        };
+        if status != SEC_E_OK {
+            return Err(schannel_status_error(
+                "failed to get TLS peer certificate",
+                status,
+            ));
+        }
+        let certificate = CertContextHandle(certificate);
+        let chain_engine = get_or_create_custom_root_chain_engine(ctx)
+            .map_err(|error| format!("failed to create TLS custom root chain engine: {error}"))?;
+
+        let mut chain: *mut CERT_CHAIN_CONTEXT = std::ptr::null_mut();
+        let mut chain_para: CERT_CHAIN_PARA = unsafe { std::mem::zeroed() };
+        chain_para.cbSize = std::mem::size_of::<CERT_CHAIN_PARA>() as u32;
+        let ok = unsafe {
+            CertGetCertificateChain(
+                chain_engine,
+                certificate.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                &chain_para,
+                0,
+                std::ptr::null(),
+                &mut chain,
+            )
+        };
+        if ok == 0 {
+            return Err(format!(
+                "failed to build TLS peer certificate chain: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        let chain = CertChain(chain);
+
+        let mut host = host_name.encode_utf16().chain(Some(0)).collect::<Vec<_>>();
+        let mut ssl_policy: HTTPSPolicyCallbackData = unsafe { std::mem::zeroed() };
+        ssl_policy.Anonymous.cbSize = std::mem::size_of::<HTTPSPolicyCallbackData>() as u32;
+        ssl_policy.dwAuthType = AUTHTYPE_SERVER;
+        ssl_policy.fdwChecks = 0;
+        if !host_name.is_empty() {
+            ssl_policy.pwszServerName = host.as_mut_ptr();
+        }
+
+        let mut policy_para: CERT_CHAIN_POLICY_PARA = unsafe { std::mem::zeroed() };
+        policy_para.cbSize = std::mem::size_of::<CERT_CHAIN_POLICY_PARA>() as u32;
+        policy_para.pvExtraPolicyPara = &mut ssl_policy as *mut _ as _;
+        let mut policy_status: CERT_CHAIN_POLICY_STATUS = unsafe { std::mem::zeroed() };
+        policy_status.cbSize = std::mem::size_of::<CERT_CHAIN_POLICY_STATUS>() as u32;
+        let ok = unsafe {
+            CertVerifyCertificateChainPolicy(
+                CERT_CHAIN_POLICY_SSL,
+                chain.0,
+                &policy_para,
+                &mut policy_status,
+            )
+        };
+        if ok == 0 {
+            return Err(format!(
+                "failed to verify TLS peer certificate chain policy: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        if policy_status.dwError != 0 {
+            return Err(format!(
+                "TLS peer certificate verification failed: {}",
+                io::Error::from_raw_os_error(policy_status.dwError as i32)
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+const _: &[crate::async_sys::PortedSymbol] = PORTED_SYMBOLS;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchannelIoKind {
+    WouldBlock,
+    Fatal,
+}
+
+struct SchannelIoError {
+    kind: SchannelIoKind,
+    message: String,
+}
+
+impl SchannelIoError {
+    fn would_block() -> Self {
+        Self {
+            kind: SchannelIoKind::WouldBlock,
+            message: String::new(),
+        }
+    }
+
+    fn fatal(message: impl Into<String>) -> Self {
+        Self {
+            kind: SchannelIoKind::Fatal,
+            message: message.into(),
+        }
+    }
+}
+
+fn zeroed_sec_handle() -> SecHandle {
+    SecHandle {
+        dwLower: 0,
+        dwUpper: 0,
+    }
+}
+
+fn sec_buffer(buffer_type: u32, buffer: &mut [u8]) -> SecBuffer {
+    sec_buffer_with_len(buffer_type, buffer, buffer.len())
+}
+
+fn sec_buffer_with_len(buffer_type: u32, buffer: &mut [u8], len: usize) -> SecBuffer {
+    SecBuffer {
+        cbBuffer: len as u32,
+        BufferType: buffer_type,
+        pvBuffer: buffer.as_mut_ptr().cast(),
+    }
+}
+
+fn empty_sec_buffer() -> SecBuffer {
+    SecBuffer {
+        cbBuffer: 0,
+        BufferType: SECBUFFER_EMPTY,
+        pvBuffer: std::ptr::null_mut(),
+    }
+}
+
+fn sec_buffer_desc(buffers: &mut [SecBuffer]) -> SecBufferDesc {
+    SecBufferDesc {
+        ulVersion: SECBUFFER_VERSION,
+        cBuffers: buffers.len() as u32,
+        pBuffers: buffers.as_mut_ptr(),
+    }
+}
+
+fn consumed_len(input_len: usize, buffers: &[SecBuffer]) -> usize {
+    buffers
+        .iter()
+        .find(|buffer| buffer.BufferType == SECBUFFER_EXTRA)
+        .map(|buffer| input_len.saturating_sub(buffer.cbBuffer as usize))
+        .unwrap_or(input_len)
+}
+
+fn sec_buffer_slice<'a>(
+    buffers: &[SecBuffer],
+    buffer_type: u32,
+    backing: &'a [u8],
+) -> Option<&'a [u8]> {
+    let base = backing.as_ptr() as usize;
+    let end = base.checked_add(backing.len())?;
+    buffers
+        .iter()
+        .find(|buffer| buffer.BufferType == buffer_type && !buffer.pvBuffer.is_null())
+        .and_then(|buffer| {
+            let start = buffer.pvBuffer as usize;
+            let len = buffer.cbBuffer as usize;
+            let slice_end = start.checked_add(len)?;
+            if start >= base && slice_end <= end {
+                let offset = start - base;
+                Some(&backing[offset..offset + len])
+            } else {
+                None
+            }
+        })
+}
+
+fn query_stream_sizes(context: &SecHandle) -> Result<SecPkgContext_StreamSizes, String> {
+    let mut sizes: SecPkgContext_StreamSizes = unsafe { std::mem::zeroed() };
+    let status = unsafe {
+        QueryContextAttributesW(context, SECPKG_ATTR_STREAM_SIZES, &mut sizes as *mut _ as _)
+    };
+    if status == SEC_E_OK {
+        Ok(sizes)
+    } else {
+        Err(schannel_status_error(
+            "failed to query TLS stream sizes",
+            status,
+        ))
+    }
+}
+
+fn schannel_status_error(context: &str, status: i32) -> String {
+    format!(
+        "{context}: SChannel status 0x{:08x}: {}",
+        status as u32,
+        io::Error::from_raw_os_error(status)
+    )
+}
+
+struct CertStoreHandle(HCERTSTORE);
+
+// These are owned Windows CryptoAPI handles with no thread-affine callbacks.
+// Moonrun stores TLS connections behind a mutex, so moving the owner across
+// threads does not introduce concurrent access to the underlying handle.
+unsafe impl Send for CertStoreHandle {}
+
+impl CertStoreHandle {
+    fn memory() -> io::Result<Self> {
+        let store = unsafe {
+            CertOpenStore(
+                CERT_STORE_PROV_MEMORY,
+                0,
+                0,
+                CERT_STORE_CREATE_NEW_FLAG,
+                std::ptr::null(),
+            )
+        };
+        if store.is_null() {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(Self(store))
+        }
+    }
+
+    fn add_certificate_context(&mut self, cert: &CertContextHandle) -> io::Result<()> {
+        let ok = unsafe {
+            CertAddCertificateContextToStore(
+                self.0,
+                cert.as_ptr(),
+                CERT_STORE_ADD_USE_EXISTING,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn as_ptr(&self) -> HCERTSTORE {
+        self.0
+    }
+}
+
+impl Drop for CertStoreHandle {
+    fn drop(&mut self) {
+        unsafe {
+            CertCloseStore(self.0, 0);
+        }
+    }
+}
+
+struct CertContextHandle(*mut CERT_CONTEXT);
+
+impl CertContextHandle {
+    fn from_der(cert: &[u8]) -> io::Result<Self> {
+        let cert_len = u32::try_from(cert.len()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "TLS certificate is too large")
+        })?;
+        let context = unsafe {
+            CertCreateCertificateContext(
+                X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                cert.as_ptr(),
+                cert_len,
+            )
+        };
+        if context.is_null() {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(Self(context))
+        }
+    }
+
+    fn as_ptr(&self) -> *mut CERT_CONTEXT {
+        self.0
+    }
+
+    fn to_der(&self) -> &[u8] {
+        let context = unsafe { &*self.0 };
+        unsafe { std::slice::from_raw_parts(context.pbCertEncoded, context.cbCertEncoded as usize) }
+    }
+}
+
+impl Drop for CertContextHandle {
+    fn drop(&mut self) {
+        unsafe {
+            CertFreeCertificateContext(self.0);
+        }
+    }
+}
+
+struct ChannelBindingsHandle {
+    bindings: *mut SEC_CHANNEL_BINDINGS,
+    len: usize,
+}
+
+impl ChannelBindingsHandle {
+    unsafe fn application_data(&self) -> Result<&[u8], String> {
+        let bindings = unsafe { &*self.bindings };
+        let offset = usize::try_from(bindings.dwApplicationDataOffset)
+            .map_err(|_| "TLS channel binding offset overflow".to_string())?;
+        let len = usize::try_from(bindings.cbApplicationDataLength)
+            .map_err(|_| "TLS channel binding size overflow".to_string())?;
+        let end = offset
+            .checked_add(len)
+            .ok_or_else(|| "TLS channel binding bounds overflow".to_string())?;
+        if end > self.len {
+            return Err("TLS channel binding application data is out of bounds".to_string());
+        }
+        Ok(unsafe { std::slice::from_raw_parts((self.bindings as *const u8).add(offset), len) })
+    }
+}
+
+impl Drop for ChannelBindingsHandle {
+    fn drop(&mut self) {
+        unsafe {
+            FreeContextBuffer(self.bindings.cast());
+        }
+    }
+}
+
+struct CertChainEngine(HCERTCHAINENGINE);
+
+// The chain engine is owned by the SChannel context and only accessed through
+// the locked TLS connection. It is safe to move that owner between threads.
+unsafe impl Send for CertChainEngine {}
+
+impl CertChainEngine {
+    fn as_ptr(&self) -> HCERTCHAINENGINE {
+        self.0
+    }
+}
+
+impl Drop for CertChainEngine {
+    fn drop(&mut self) {
+        unsafe {
+            CertFreeCertificateChainEngine(self.0);
+        }
+    }
+}
+
+struct CertChain(*mut CERT_CHAIN_CONTEXT);
+
+impl Drop for CertChain {
+    fn drop(&mut self) {
+        unsafe {
+            CertFreeCertificateChain(self.0);
+        }
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/io.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/io.rs
@@ -105,16 +105,28 @@ pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
         let mut symbols = PORTED_SYMBOLS.to_vec();
         symbols.extend_from_slice(&[
             ported_windows_symbol(
-                "make_file_io_result",
-                "moonbitlang_async_make_file_io_result",
+                "make_file_read_io_result",
+                "moonbitlang_async_make_file_read_io_result",
             ),
             ported_windows_symbol(
-                "make_socket_io_result",
-                "moonbitlang_async_make_socket_io_result",
+                "make_file_write_io_result",
+                "moonbitlang_async_make_file_write_io_result",
             ),
             ported_windows_symbol(
-                "make_socket_with_addr_io_result",
-                "moonbitlang_async_make_socket_with_addr_io_result",
+                "make_socket_read_io_result",
+                "moonbitlang_async_make_socket_read_io_result",
+            ),
+            ported_windows_symbol(
+                "make_socket_write_io_result",
+                "moonbitlang_async_make_socket_write_io_result",
+            ),
+            ported_windows_symbol(
+                "make_socket_with_addr_read_io_result",
+                "moonbitlang_async_make_socket_with_addr_read_io_result",
+            ),
+            ported_windows_symbol(
+                "make_socket_with_addr_write_io_result",
+                "moonbitlang_async_make_socket_with_addr_write_io_result",
             ),
             ported_windows_symbol(
                 "make_connect_io_result",

--- a/crates/moonrun/src/async_sys/socket.rs
+++ b/crates/moonrun/src/async_sys/socket.rs
@@ -808,7 +808,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/network.mbt",
+        source = "src/internal/event_loop/network.wasm.mbt",
         original = "gai_strerror"
     )]
     #[cfg(unix)]


### PR DESCRIPTION
## Why

Wasm async currently has socket support but cannot run the upstream async HTTP/TLS packages end to end. This PR wires the wasm host imports needed by the MoonBit async TLS and HTTP layers, and updates the async submodule pointer to the matching wasm HTTP/TLS support stack.

Depends on moonbitlang/async#468.

## Correctness

The wasm TLS boundary keeps guest memory ownership explicit: encrypted and plaintext buffers are copied at import boundaries, TLS state stays behind host handles, and BIO state is owned by `moonrun` rather than retaining guest pointers. The host TLS implementation follows the native platform split: OpenSSL on non-Windows targets and SChannel on Windows. The Windows path uses a PFX-specific server constructor, matching the native SChannel shape instead of forcing OpenSSL-style key/certificate files onto SChannel.

## Minimality

The change is scoped to the async host/import registry, TLS host state, the focused upstream async package tests, and the async submodule pointer. The OpenSSL and SChannel engines share only the bounded host-owned encrypted I/O queues; platform-specific TLS behavior stays behind `cfg`-gated connection implementations.