### PR TITLE
ci: skip async submodule in Ubuntu release build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Checkout
         run: |
           git clone --depth 1 "https://${{ secrets.MOON_CLONE_PAT }}@github.com/moonbitlang/moon.git" "$GITHUB_WORKSPACE"
-          git submodule update --init --recursive
+          git submodule update --init crates/moonutil/resources/error_codes
 
       - name: Install Rustup
         run: |


### PR DESCRIPTION
## Why

The CD `ubuntu-build` job uses a custom shallow clone in an Ubuntu 16.04 container, then initializes every submodule recursively. That makes the release build fail while checking out `third_party/moonbitlang_async`, even though this artifact build does not need the async submodule.

## Correctness

`cargo build --release` still gets the error-code docs submodule needed by `moonutil`'s build script. The async submodule remains available to the normal CI/test jobs that initialize all submodules and run async wasm parity coverage.

## Minimality

This changes only the custom `ubuntu-build` checkout step in CD. Other checkout paths and test workflows keep their existing submodule behavior.