### PR TITLE
Accept object or array moon.mod.json rules

### DIFF
--- a/crates/moonbuild/template/mod.schema.json
+++ b/crates/moonbuild/template/mod.schema.json
@@ -103,6 +103,17 @@
         "null"
       ]
     },
+    "rule": {
+      "description": "Rules that can be referenced by package-level `dev_build` entries.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/MoonModJSONRules"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "scripts": {
       "description": "Scripts related to the current module.",
       "type": [
@@ -193,6 +204,34 @@
           ]
         }
       ]
+    },
+    "MoonModJSONRules": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/MoonModRule"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MoonModRule"
+          }
+        }
+      ]
+    },
+    "MoonModRule": {
+      "type": "object",
+      "required": [
+        "command",
+        "name"
+      ],
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "SourceDependencyInfo": {
       "description": "Information about a specific dependency. This supports both simple string syntax and detailed object syntax in `moon.mod.json`.",

--- a/crates/moonutil/src/common.rs
+++ b/crates/moonutil/src/common.rs
@@ -260,10 +260,14 @@ impl Serialize for MoonfmtModJsonInput<'_> {
         for (key, value) in map.iter() {
             output.serialize_entry(key, value)?;
         }
-        if let Some(serde_json_lenient::Value::Array(rules)) = rules {
-            for rule in rules {
-                output.serialize_entry("rule", &rule)?;
+        match rules {
+            Some(serde_json_lenient::Value::Array(rules)) => {
+                for rule in rules {
+                    output.serialize_entry("rule", &rule)?;
+                }
             }
+            Some(rule) => output.serialize_entry("rule", &rule)?,
+            None => {}
         }
         output.end()
     }

--- a/crates/moonutil/src/module.rs
+++ b/crates/moonutil/src/module.rs
@@ -76,7 +76,31 @@ pub struct MoonModRule {
     pub command: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum MoonModJSONRules {
+    Single(MoonModRule),
+    Multiple(Vec<MoonModRule>),
+}
+
+impl MoonModJSONRules {
+    fn into_vec(self) -> Vec<MoonModRule> {
+        match self {
+            Self::Single(rule) => vec![rule],
+            Self::Multiple(rules) => rules,
+        }
+    }
+
+    fn from_vec(mut rules: Vec<MoonModRule>) -> Option<Self> {
+        match rules.len() {
+            0 => None,
+            1 => rules.pop().map(Self::Single),
+            _ => Some(Self::Multiple(rules)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 #[schemars(
     title = "JSON schema for MoonBit moon.mod.json files",
@@ -141,8 +165,7 @@ pub struct MoonModJSON {
 
     /// Rules that can be referenced by package-level `dev_build` entries.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(skip)]
-    pub rule: Option<Vec<MoonModRule>>,
+    pub rule: Option<MoonModJSONRules>,
 
     /// Fields not covered by the info above, which should be left as-is.
     #[serde(flatten)]
@@ -239,7 +262,7 @@ impl TryFrom<MoonModJSON> for MoonMod {
             link_flags: j.link_flags,
             checksum: j.checksum,
             source,
-            rule: j.rule,
+            rule: j.rule.map(MoonModJSONRules::into_vec),
             ext: j.ext,
 
             warn_list: j.warn_list,
@@ -274,7 +297,7 @@ pub fn convert_module_to_mod_json(m: MoonMod) -> MoonModJSON {
         link_flags: m.link_flags,
         checksum: m.checksum,
         source: m.source,
-        rule: m.rule,
+        rule: m.rule.and_then(MoonModJSONRules::from_vec),
         ext: m.ext,
 
         warn_list: m.warn_list,

--- a/crates/moonutil/tests/expect_moon_mod.rs
+++ b/crates/moonutil/tests/expect_moon_mod.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use moonutil::common::{
     TargetBackend, read_module_desc_file_in_dir, read_module_from_dsl, write_module_dsl_to_file,
 };
-use moonutil::module::{MoonModJSON, convert_module_to_mod_json};
+use moonutil::module::{MoonMod, MoonModJSON, MoonModRule, convert_module_to_mod_json};
 use moonutil::package::SupportedTargetsConfig;
 use semver::Version;
 
@@ -321,8 +321,6 @@ rule(name: "rule2", command: "exe2 $input -o $output")
     let module = read_module_from_dsl(&path).unwrap();
     let module_json = convert_module_to_mod_json(module);
     assert!(module_json.rule.is_some());
-    let json = serde_json_lenient::to_string(&module_json).unwrap();
-    assert!(json.contains("\"rule\""));
     write_module_dsl_to_file(&module_json, &dir).unwrap();
 
     let module = read_module_from_dsl(&path).unwrap();
@@ -332,6 +330,111 @@ rule(name: "rule2", command: "exe2 $input -o $output")
     assert_eq!(rule[0].command, "exe1 $input -o $output");
     assert_eq!(rule[1].name, "rule2");
     assert_eq!(rule[1].command, "exe2 $input -o $output");
+}
+
+#[test]
+fn read_module_json_accepts_object_rule() {
+    let dir = temp_dir("object-rule-module-read");
+    std::fs::write(
+        dir.join("moon.mod.json"),
+        r#"{
+  "name": "example/mod",
+  "rule": {
+    "name": "rule1",
+    "command": "exe1 $input -o $output"
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let module = read_module_desc_file_in_dir(&dir).unwrap();
+    let rule = module.rule.unwrap();
+    assert_eq!(rule.len(), 1);
+    assert_eq!(rule[0].name, "rule1");
+    assert_eq!(rule[0].command, "exe1 $input -o $output");
+}
+
+#[test]
+fn moon_mod_json_conversion_serializes_single_rule_as_object() {
+    let module_json = convert_module_to_mod_json(MoonMod {
+        name: "example/mod".to_string(),
+        rule: Some(vec![MoonModRule {
+            name: "rule1".to_string(),
+            command: "exe1".to_string(),
+        }]),
+        ..Default::default()
+    });
+    let actual = serde_json_lenient::to_string_pretty(&module_json).unwrap();
+
+    expect_test::expect![[r#"
+        {
+          "name": "example/mod",
+          "deps": {},
+          "rule": {
+            "name": "rule1",
+            "command": "exe1"
+          }
+        }"#]]
+    .assert_eq(&actual);
+}
+
+#[test]
+fn moon_mod_json_conversion_serializes_multiple_rules_as_array() {
+    let module_json = convert_module_to_mod_json(MoonMod {
+        name: "example/mod".to_string(),
+        rule: Some(vec![
+            MoonModRule {
+                name: "rule1".to_string(),
+                command: "exe1".to_string(),
+            },
+            MoonModRule {
+                name: "rule2".to_string(),
+                command: "exe2".to_string(),
+            },
+        ]),
+        ..Default::default()
+    });
+    let actual = serde_json_lenient::to_string_pretty(&module_json).unwrap();
+
+    expect_test::expect![[r#"
+        {
+          "name": "example/mod",
+          "deps": {},
+          "rule": [
+            {
+              "name": "rule1",
+              "command": "exe1"
+            },
+            {
+              "name": "rule2",
+              "command": "exe2"
+            }
+          ]
+        }"#]]
+    .assert_eq(&actual);
+}
+
+#[test]
+fn moon_mod_json_accepts_array_rule() {
+    let module_json = serde_json_lenient::from_str::<MoonModJSON>(
+        r#"{
+  "name": "example/mod",
+  "rule": [
+    {
+      "name": "rule1",
+      "command": "exe1"
+    }
+  ]
+}
+"#,
+    )
+    .unwrap();
+    let module: MoonMod = module_json.try_into().unwrap();
+    let rule = module.rule.unwrap();
+    assert_eq!(rule.len(), 1);
+    assert_eq!(rule[0].name, "rule1");
+    assert_eq!(rule[0].command, "exe1");
 }
 
 #[test]

--- a/docs/manual-zh/src/source/mod_json_schema.html
+++ b/docs/manual-zh/src/source/mod_json_schema.html
@@ -141,6 +141,17 @@
         "null"
       ]
     },
+    "rule": {
+      "description": "Rules that can be referenced by package-level `dev_build` entries.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/MoonModJSONRules"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "scripts": {
       "description": "Scripts related to the current module.",
       "type": [
@@ -231,6 +242,34 @@
           ]
         }
       ]
+    },
+    "MoonModJSONRules": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/MoonModRule"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MoonModRule"
+          }
+        }
+      ]
+    },
+    "MoonModRule": {
+      "type": "object",
+      "required": [
+        "command",
+        "name"
+      ],
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "SourceDependencyInfo": {
       "description": "Information about a specific dependency. This supports both simple string syntax and detailed object syntax in `moon.mod.json`.",

--- a/docs/manual/src/source/mod_json_schema.html
+++ b/docs/manual/src/source/mod_json_schema.html
@@ -141,6 +141,17 @@
         "null"
       ]
     },
+    "rule": {
+      "description": "Rules that can be referenced by package-level `dev_build` entries.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/MoonModJSONRules"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "scripts": {
       "description": "Scripts related to the current module.",
       "type": [
@@ -231,6 +242,34 @@
           ]
         }
       ]
+    },
+    "MoonModJSONRules": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/MoonModRule"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MoonModRule"
+          }
+        }
+      ]
+    },
+    "MoonModRule": {
+      "type": "object",
+      "required": [
+        "command",
+        "name"
+      ],
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "SourceDependencyInfo": {
       "description": "Information about a specific dependency. This supports both simple string syntax and detailed object syntax in `moon.mod.json`.",


### PR DESCRIPTION
## Why

`MoonMod` keeps module rules as a vector because the legacy `moon.mod` DSL can contain repeated top-level `rule(...)` definitions. Published/indexed JSON data uses the compact object form when there is one rule, and the JSON shape also needs to support arrays when multiple rules are present.

## What

This introduces a JSON-specific `MoonModJSONRules` wrapper for `rule`, accepting either a single rule object or an array of rule objects. Parsing either shape normalizes into the internal `MoonMod.rule` vector. Serializing from `MoonMod` emits the single object form for exactly one rule and an array for multiple rules.

The generated schema and manual schema pages are updated to document both JSON shapes. The `moon.mod` DSL writer keeps its existing API and now preserves both serialized JSON forms when converting back to repeated `rule(...)` entries.

## Why This Is Minimal

The internal `MoonMod` shape and package-manager call sites are unchanged. The compatibility behavior is isolated to the JSON-specific `MoonModJSONRules` boundary, plus schema and focused regression coverage.