### PR TITLE
fix(moonrun): align socket addr import with async

### DIFF
--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -462,7 +462,7 @@ declare_async_imports! {
 
     ported socket::addr_is_multicast(addr: i32, addr_len: i32) -> i32 => "socket/addr_is_multicast";
 
-    ported socket::addr_copy_ipv6_bytes(addr: i32, out: i32, addr_len: i32, len: i32) -> void => "socket/addr_copy_ipv6_bytes";
+    ported socket::addr_get_ipv6_bytes_offset() -> i32 => "socket/addr_get_ipv6_bytes_offset";
 
     ported socket::addr_get_ipv6_scope_id(addr: i32, addr_len: i32) -> i32 => "socket/addr_get_ipv6_scope_id";
 

--- a/crates/moonrun/src/async_api/socket.rs
+++ b/crates/moonrun/src/async_api/socket.rs
@@ -124,22 +124,9 @@ pub(super) fn addr_is_multicast(
         .map(i32::from)
 }
 
-#[ported(
-    source = "src/socket/socket.c",
-    original = "moonbitlang_async_addr_get_ipv6_bytes"
-)]
-pub(super) fn addr_copy_ipv6_bytes(
-    context: &mut ImportContext<'_, '_>,
-    addr: i32,
-    out: i32,
-    addr_len: i32,
-    len: i32,
-) -> AsyncHostResult<()> {
-    context.with_memory_mut(|memory| {
-        let addr = memory.read_exact(addr, addr_len)?.to_vec();
-        let out = memory.read_exact_mut(out, len)?;
-        sys::addr_copy_ipv6_bytes(&addr, out)
-    })
+#[ported(source = "src/socket/socket.c")]
+pub(super) fn addr_get_ipv6_bytes_offset(_context: &mut ImportContext<'_, '_>) -> i32 {
+    sys::addr_get_ipv6_bytes_offset()
 }
 
 #[ported(source = "src/socket/socket.c")]

--- a/crates/moonrun/src/async_sys/socket.rs
+++ b/crates/moonrun/src/async_sys/socket.rs
@@ -22,6 +22,8 @@ use std::ffi::CStr;
 use std::ffi::CString;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStringExt;
+#[cfg(windows)]
+use windows_sys::Win32::Networking::WinSock as ws;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util::stub::RawFd;
@@ -351,13 +353,6 @@ mod win {
             ws::AF_INET6 => Ok(unsafe { read_sockaddr_in6(addr)?.sin6_addr.u.Byte[0] } == 0xff),
             _ => Ok(false),
         }
-    }
-
-    pub(super) fn addr_copy_ipv6_bytes(addr: &[u8], out: &mut [u8]) -> AsyncHostResult<()> {
-        let addr = read_sockaddr_in6(addr)?;
-        let out = out.get_mut(..16).ok_or(AsyncHostError::Fault)?;
-        out.copy_from_slice(unsafe { &addr.sin6_addr.u.Byte });
-        Ok(())
     }
 
     pub(super) fn addr_get_ipv6_scope_id(addr: &[u8]) -> AsyncHostResult<i32> {
@@ -903,23 +898,20 @@ ported_fns! {
 
     #[ported(
         source = "src/socket/socket.c",
-        original = "moonbitlang_async_addr_get_ipv6_bytes"
+        original = "moonbitlang_async_addr_get_ipv6_bytes_offset"
     )]
     #[cfg(unix)]
-    pub(crate) fn addr_copy_ipv6_bytes(addr: &[u8], out: &mut [u8]) -> AsyncHostResult<()> {
-        let addr = read_sockaddr_in6(addr)?;
-        let out = out.get_mut(..16).ok_or(AsyncHostError::Fault)?;
-        out.copy_from_slice(&addr.sin6_addr.s6_addr);
-        Ok(())
+    pub(crate) fn addr_get_ipv6_bytes_offset() -> i32 {
+        std::mem::offset_of!(libc::sockaddr_in6, sin6_addr) as i32
     }
 
     #[ported(
         source = "src/socket/socket.c",
-        original = "moonbitlang_async_addr_get_ipv6_bytes"
+        original = "moonbitlang_async_addr_get_ipv6_bytes_offset"
     )]
     #[cfg(windows)]
-    pub(crate) fn addr_copy_ipv6_bytes(addr: &[u8], out: &mut [u8]) -> AsyncHostResult<()> {
-        win::addr_copy_ipv6_bytes(addr, out)
+    pub(crate) fn addr_get_ipv6_bytes_offset() -> i32 {
+        std::mem::offset_of!(ws::SOCKADDR_IN6, sin6_addr) as i32
     }
 
     #[ported(
@@ -1804,5 +1796,25 @@ fn set_tcp_int(fd: RawFd, option: libc::c_int, value: i32) -> AsyncHostResult<()
         Err(last_native_error())
     } else {
         Ok(())
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn addr_get_ipv6_bytes_offset_uses_sin6_addr_offset() {
+        let ip = [
+            0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0x00, 0x00, 0x00, 0x00, 0x8a, 0x2e, 0x03, 0x70,
+            0x73, 0x34,
+        ];
+        let mut addr = vec![0; ipv6_addr_size() as usize];
+        init_ipv6_addr(&mut addr, &ip, 443, 0).unwrap();
+
+        let offset = std::mem::offset_of!(libc::sockaddr_in6, sin6_addr);
+        assert_eq!(addr_get_ipv6_bytes_offset(), offset as i32);
+        let len = std::mem::size_of::<libc::in6_addr>();
+        assert_eq!(&addr[offset..offset + len], &ip);
     }
 }


### PR DESCRIPTION
## Summary

- Update moonrun's async socket registry and provider to expose `socket/addr_get_ipv6_bytes_offset`.
- Remove the old `socket/addr_copy_ipv6_bytes` provider path.
- Bump the async submodule to the matching socket address implementation.

## Why

The async socket package now expects the PR 470-style offset import and formats IPv6 addresses directly from the sockaddr bytes. moonrun needs to provide the same import shape for the upstream wasm socket package to run against the host implementation.

## Correctness

The Rust provider computes the offset of the `sin6_addr` field for the platform sockaddr layout. The async submodule consumes that offset from shared MoonBit address code.

Depends on: https://github.com/moonbitlang/async/pull/471