### PR TITLE
Clarify native toolchain policy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,3 +45,21 @@ _Avoid_: Using process names for durable data entities
 **Entity Name**:
 A noun or noun phrase used for stable MoonBuild concepts produced or consumed by build stages. A distinct entity name does not require a distinct data container.
 _Avoid_: Using entity names for operations, adding containers only to mirror vocabulary
+
+## Native Build
+
+**Native Payload Form**:
+The representation produced by MoonBit before the host C compiler or linker is invoked, such as generated C or direct object code.
+_Avoid_: Treating generated C, TCC execution, and direct object linking as the same kind of backend choice
+
+**Native Toolchain**:
+The selected native compiler/linker together with the ABI family and runtime-linkage obligations it imposes on runtime, C stubs, and executable linking.
+_Avoid_: Raw compiler path, native backend mode
+
+**ABI Family**:
+The binary interface family fixed by the native toolchain. On Windows, MSVC and GNU-like toolchains are different ABI families and must not be mixed in one native executable.
+_Avoid_: Compiler flavor, executable style
+
+**CRT Linkage**:
+The C runtime linkage policy required by an ABI family. For MSVC, every native object participating in one executable must use a consistent CRT linkage policy.
+_Avoid_: Per-command compiler flag

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -349,9 +349,7 @@ impl CompilePreConfig {
             TargetBackend::Native => {
                 let native_mode = if let Some(native_target) = native_target {
                     info!("Disabling `tcc -run`: new native backend selected");
-                    NativeBackendMode::DirectObject(
-                        self.direct_native_mode(native_target, input_nodes)?,
-                    )
+                    NativeBackendMode::DirectObject(self.direct_native_mode(native_target))
                 } else if let Some(tcc_run) =
                     self.select_tcc_run_config(resolve_output, input_nodes, output)
                 {
@@ -431,36 +429,9 @@ impl CompilePreConfig {
         Some(TccRunConfig::new(internal_tcc))
     }
 
-    fn direct_native_mode(
-        &self,
-        native_target: NativeTarget,
-        input_nodes: &[BuildPlanNode],
-    ) -> anyhow::Result<DirectNativeMode> {
-        match native_target {
-            NativeTarget::X86_64PcWindowsMsvc if needs_native_c_toolchain(input_nodes) => {
-                let toolchain = compiler_flags::windows_msvc_native_toolchain(None).with_context(
-                    || "failed to resolve Windows MSVC native toolchain for direct native mode",
-                )?;
-                Ok(DirectNativeMode::resolved_windows_msvc(toolchain))
-            }
-            NativeTarget::X86_64PcWindowsMsvc => Ok(DirectNativeMode::pending_windows_msvc()),
-            NativeTarget::Aarch64AppleDarwin | NativeTarget::X86_64UnknownLinuxGnu => {
-                Ok(DirectNativeMode::generic(native_target))
-            }
-        }
+    fn direct_native_mode(&self, native_target: NativeTarget) -> DirectNativeMode {
+        DirectNativeMode::Target(native_target)
     }
-}
-
-fn needs_native_c_toolchain(input_nodes: &[BuildPlanNode]) -> bool {
-    input_nodes.iter().any(|node| {
-        matches!(
-            node,
-            BuildPlanNode::BuildCStub(_, _)
-                | BuildPlanNode::ArchiveOrLinkCStubs(_)
-                | BuildPlanNode::MakeExecutable(_)
-                | BuildPlanNode::BuildRuntimeLib
-        )
-    })
 }
 
 /// Read in the commandline flags and build flags to create a

--- a/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
@@ -22,22 +22,15 @@
 //! backend branch for command shape and runtime/linking behavior. Concrete
 //! product paths are resolved by `target_layout`.
 
-use crate::model::{DirectNativeMode, NativeBackendMode, RunBackend, TccRunConfig};
+use crate::model::{NativeBackendMode, RunBackend};
 
 #[derive(Clone, Debug)]
 pub(crate) enum SelectedBackend {
     Wasm { use_wat: bool },
     WasmGc { use_wat: bool },
     Js,
-    C(CBackend),
+    C(NativeBackendMode),
     Llvm,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) enum CBackend {
-    GeneratedC,
-    TccRun(TccRunConfig),
-    DirectObject(DirectNativeMode),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -82,7 +75,7 @@ impl SelectedBackend {
                 use_wat: output_wat,
             },
             RunBackend::Js => Self::Js,
-            RunBackend::Native => Self::C(CBackend::new(native_mode)),
+            RunBackend::Native => Self::C(native_mode.clone()),
             RunBackend::Llvm => Self::Llvm,
         }
     }
@@ -95,20 +88,6 @@ impl SelectedBackend {
                 unreachable!("C stubs are only realized for C or LLVM backends")
             }
         }
-    }
-
-    pub(crate) fn direct_native_mode(&self) -> Option<&DirectNativeMode> {
-        match self {
-            Self::C(backend) => backend.direct_native_mode(),
-            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js | Self::Llvm => None,
-        }
-    }
-
-    pub(crate) fn is_windows_msvc_direct(&self) -> bool {
-        matches!(
-            self.direct_native_mode(),
-            Some(DirectNativeMode::WindowsMsvc(_))
-        )
     }
 
     pub(crate) fn use_wat(&self) -> bool {
@@ -131,48 +110,30 @@ impl SelectedBackend {
     }
 }
 
-impl CBackend {
-    fn new(native_mode: &NativeBackendMode) -> Self {
-        match native_mode {
-            NativeBackendMode::GeneratedC => Self::GeneratedC,
-            NativeBackendMode::TccRun(config) => Self::TccRun(config.clone()),
-            NativeBackendMode::DirectObject(mode) => Self::DirectObject(mode.clone()),
-        }
-    }
-
+impl NativeBackendMode {
     pub(crate) fn executable_realization(&self) -> CExecutableRealization {
         match self {
-            Self::GeneratedC => CExecutableRealization::CompileAndLinkGeneratedC,
-            Self::TccRun(_) => CExecutableRealization::WriteTccRunResponseFile,
-            Self::DirectObject(_) => CExecutableRealization::LinkDirectObject,
+            NativeBackendMode::GeneratedC => CExecutableRealization::CompileAndLinkGeneratedC,
+            NativeBackendMode::TccRun(_) => CExecutableRealization::WriteTccRunResponseFile,
+            NativeBackendMode::DirectObject(_) => CExecutableRealization::LinkDirectObject,
         }
     }
 
     fn runtime_realization(&self) -> CRuntimeRealization {
         match self {
-            Self::TccRun(_) => CRuntimeRealization::SharedLibraryForTccRun,
-            Self::GeneratedC | Self::DirectObject(_) => CRuntimeRealization::StaticObject,
+            NativeBackendMode::TccRun(_) => CRuntimeRealization::SharedLibraryForTccRun,
+            NativeBackendMode::GeneratedC | NativeBackendMode::DirectObject(_) => {
+                CRuntimeRealization::StaticObject
+            }
         }
     }
 
     pub(crate) fn c_stub_library_realization(&self) -> CStubLibraryRealization {
         match self {
-            Self::TccRun(_) => CStubLibraryRealization::SharedLibraryForTccRun,
-            Self::GeneratedC | Self::DirectObject(_) => CStubLibraryRealization::StaticArchive,
-        }
-    }
-
-    pub(crate) fn tcc_run(&self) -> Option<&TccRunConfig> {
-        match self {
-            Self::TccRun(config) => Some(config),
-            Self::GeneratedC | Self::DirectObject(_) => None,
-        }
-    }
-
-    pub(crate) fn direct_native_mode(&self) -> Option<&DirectNativeMode> {
-        match self {
-            Self::DirectObject(mode) => Some(mode),
-            Self::GeneratedC | Self::TccRun(_) => None,
+            NativeBackendMode::TccRun(_) => CStubLibraryRealization::SharedLibraryForTccRun,
+            NativeBackendMode::GeneratedC | NativeBackendMode::DirectObject(_) => {
+                CStubLibraryRealization::StaticArchive
+            }
         }
     }
 }
@@ -180,6 +141,8 @@ impl CBackend {
 #[cfg(test)]
 mod tests {
     use moonutil::compiler_flags::{ARKind, CC, CCKind};
+
+    use crate::model::{DirectNativeMode, TccRunConfig};
 
     use super::*;
 
@@ -206,11 +169,11 @@ mod tests {
         let native_mode = NativeBackendMode::TccRun(fake_tcc_run());
         let backend = SelectedBackend::new(RunBackend::Native, &native_mode, false);
 
-        let SelectedBackend::C(ref c_backend) = backend else {
+        let SelectedBackend::C(ref native_mode) = backend else {
             panic!("native backend should select C lowering")
         };
         assert_eq!(
-            c_backend.executable_realization(),
+            native_mode.executable_realization(),
             CExecutableRealization::WriteTccRunResponseFile
         );
         assert_eq!(
@@ -222,16 +185,16 @@ mod tests {
 
     #[test]
     fn c_direct_object_realizes_linker_executable() {
-        let native_mode = NativeBackendMode::DirectObject(DirectNativeMode::generic(
+        let native_mode = NativeBackendMode::DirectObject(DirectNativeMode::Target(
             crate::model::NativeTarget::Aarch64AppleDarwin,
         ));
         let backend = SelectedBackend::new(RunBackend::Native, &native_mode, false);
 
-        let SelectedBackend::C(ref c_backend) = backend else {
+        let SelectedBackend::C(ref native_mode) = backend else {
             panic!("native backend should select C lowering")
         };
         assert_eq!(
-            c_backend.executable_realization(),
+            native_mode.executable_realization(),
             CExecutableRealization::LinkDirectObject
         );
         assert_eq!(

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/msvc.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/msvc.rs
@@ -20,9 +20,7 @@
 
 use std::path::Path;
 
-use moonutil::compiler_flags::{Toolchain, WINDOWS_MSVC_DEFAULT_LIBS};
-
-use crate::model::MsvcCrtPolicy;
+use moonutil::compiler_flags::{MsvcCrtPolicy, Toolchain, WINDOWS_MSVC_DEFAULT_LIBS};
 
 pub(crate) fn add_environment_include_paths(toolchain: &Toolchain, command: &mut Vec<String>) {
     let Some(environment) = toolchain.msvc_environment() else {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -166,19 +166,15 @@ impl<'a> super::LoweringContext<'a> {
             (CCOutputType::Object, true)
         };
 
-        let runtime_toolchain = info.effective_native_toolchain.clone();
+        let runtime_toolchain = &info.effective_native_toolchain;
         let resolved_cc = runtime_toolchain.cc().clone();
-        let cc_cmd = if self.opt.selected_backend.is_windows_msvc_direct() && resolved_cc.is_msvc()
-        {
+        let cc_cmd = if let Some(crt) = runtime_toolchain.msvc_crt_policy() {
             compiler::msvc::compile_runtime_command(
-                &runtime_toolchain,
+                runtime_toolchain,
                 &runtime_c_path,
                 &artifact_path,
                 &self.opt.compiler_paths().include_path,
-                self.opt
-                    .native_mode
-                    .msvc_crt_policy()
-                    .expect("Windows MSVC mode should carry a CRT policy"),
+                crt,
             )
             .into()
         } else {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -761,7 +761,7 @@ impl<'a> LoweringContext<'a> {
             extra_link_opts: module.link_flags.as_deref().unwrap_or_default(),
             #[cfg(target_os = "windows")]
             native_toolchain_is_msvc: make_executable_info
-                .is_some_and(|info| info.effective_native_toolchain.cc().is_msvc()),
+                .is_some_and(|info| info.effective_native_toolchain.uses_msvc_abi()),
         };
 
         // Ensure n2 sees stdlib core bundle changes as inputs
@@ -915,7 +915,6 @@ impl<'a> LoweringContext<'a> {
             .debug_info(self.opt.debug_symbols)
             .link_moonbitrun(!use_shared_runtime)
             .define_use_shared_runtime_macro(use_shared_runtime)
-            .msvc_static_runtime(self.opt.selected_backend.is_windows_msvc_direct())
             .build()
             .expect("Failed to build CC configuration for C stub");
 
@@ -1203,8 +1202,8 @@ impl<'a> LoweringContext<'a> {
             .display()
             .to_string();
 
-        let cc_cmd = make_cc_command_resolved_with_link_flags(
-            cc,
+        let cc_cmd = make_cc_command_resolved_for_toolchain(
+            &info.effective_native_toolchain,
             config,
             &info.c_flags,
             &info.link_flags,
@@ -1280,12 +1279,7 @@ impl<'a> LoweringContext<'a> {
             &cc,
         );
 
-        let commandline = if self.opt.selected_backend.is_windows_msvc_direct() {
-            assert!(
-                cc.is_msvc(),
-                "Windows MSVC native backend requires an MSVC cl-compatible compiler driver; found {}",
-                cc.cc_path
-            );
+        let commandline = if info.effective_native_toolchain.uses_msvc_driver() {
             compiler::msvc::link_executable_command(
                 &info.effective_native_toolchain,
                 &source_args,

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -346,7 +346,10 @@ mod tests {
             LinkCoreInfo, MakeExecutableInfo, PlanArtifactNeed,
         },
         discover::{DiscoverResult, DiscoveredPackage},
-        model::{BuildPlanNode, BuildTarget, DirectNativeMode, NativeBackendMode, TargetKind},
+        model::{
+            BuildPlanNode, BuildTarget, DirectNativeMode, NativeBackendMode, NativeTarget,
+            TargetKind,
+        },
         pkg_name::{PackageFQN, PackagePath},
         pkg_solve::DepRelationship,
         resolve::ResolveOutput,
@@ -616,8 +619,8 @@ mod tests {
             ),
             None,
         );
-        let native_mode = NativeBackendMode::DirectObject(DirectNativeMode::resolved_windows_msvc(
-            toolchain.clone(),
+        let native_mode = NativeBackendMode::DirectObject(DirectNativeMode::Target(
+            NativeTarget::X86_64PcWindowsMsvc,
         ));
         let options = BuildOptions {
             artifact_paths: artifact_paths.clone(),

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -32,7 +32,7 @@ use moonutil::{
         DOT_MBT_DOT_MD, IgnoredMoonScript, MOD_DIR, MOONCAKE_BIN, PKG_DIR, TargetBackend,
         is_moon_mod, is_moon_pkg, is_moon_script_ignored,
     },
-    compiler_flags::{CC, Toolchain},
+    compiler_flags::{self, CC, Toolchain},
     module::{MoonMod, MoonModRule},
     mooncakes::ModuleId,
     package::{MoonPkgGenerate, SupportedTargetsDeclKind},
@@ -46,7 +46,7 @@ use crate::{
     build_plan::{BuildBundleInfo, FileDependencyKind, PlanArtifactNeed, PrebuildInfo},
     cond_comp,
     discover::DiscoveredPackage,
-    model::{BuildPlanNode, BuildTarget, DirectNativeMode, PackageId, TargetKind, WindowsMsvcMode},
+    model::{BuildPlanNode, BuildTarget, NativeTarget, PackageId, TargetKind},
     pkg_name::PackageFQNWithSource,
     user_warning::UserWarning,
 };
@@ -79,7 +79,11 @@ impl DependencyInterfaceMode {
 
 impl<'a> BuildPlanConstructor<'a> {
     fn new_native_linker_context(&self, err: anyhow::Error) -> anyhow::Error {
-        if self.build_env.native_mode.direct_target().is_some() {
+        if self.build_env.native_mode.direct_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
+            err.context(
+                "Windows MSVC native backend requires an MSVC compiler/linker driver such as cl.exe or clang-cl.exe",
+            )
+        } else if self.build_env.native_mode.direct_target().is_some() {
             err.context(
                 "new native backend requires a C compiler/linker driver; install clang/cc or set MOON_CC",
             )
@@ -88,21 +92,27 @@ impl<'a> BuildPlanConstructor<'a> {
         }
     }
 
-    fn effective_native_toolchain(&self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
-        debug_assert!(self.build_env.target_backend.is_native());
-        if let Some(DirectNativeMode::WindowsMsvc(msvc_mode)) =
-            self.build_env.native_mode.direct_native_mode()
-        {
-            return match msvc_mode {
-                WindowsMsvcMode::Resolved(mode) => mode.effective_toolchain(package_cc),
-                WindowsMsvcMode::Pending => {
-                    anyhow::bail!(
-                        "Windows MSVC native backend requires a resolved MSVC toolchain for this action"
-                    )
-                }
-            };
+    fn warn_incompatible_windows_msvc_env_override(&mut self) {
+        if !compiler_flags::has_incompatible_windows_msvc_env_override() {
+            return;
         }
-        moonutil::compiler_flags::effective_native_toolchain(
+
+        let warning = UserWarning::warn(
+            "MOON_CC is ignored for Windows MSVC native backend because it is not a cl-compatible driver; set MOON_CC to cl.exe or clang-cl.exe to override MSVC discovery.",
+        );
+        if !self.user_warnings.contains(&warning) {
+            self.user_warnings.push(warning);
+        }
+    }
+
+    fn effective_native_toolchain(&mut self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
+        debug_assert!(self.build_env.target_backend.is_native());
+        if self.build_env.native_mode.direct_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
+            self.warn_incompatible_windows_msvc_env_override();
+            return compiler_flags::windows_msvc_native_toolchain(package_cc);
+        }
+
+        compiler_flags::effective_native_toolchain(
             package_cc,
             self.build_env
                 .native_mode
@@ -1144,7 +1154,7 @@ impl<'a> BuildPlanConstructor<'a> {
         let Some(prebuild) = self.prebuild_config else {
             return;
         };
-        let is_msvc_like = toolchain.cc().is_msvc() || toolchain.cc().targets_msvc();
+        let is_msvc_like = toolchain.uses_msvc_link_library_names();
         for pkg in pkgs {
             let Some(link_config) = prebuild.package_configs.get(&pkg) else {
                 continue;

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 
 use moonutil::{
     common::TargetBackend,
-    compiler_flags::{CC, Toolchain},
+    compiler_flags::CC,
     mooncakes::{ModuleId, result::ResolvedEnv},
 };
 
@@ -71,32 +71,7 @@ pub enum NativeBackendMode {
 /// Concrete direct object-code native implementation.
 #[derive(Clone, Debug)]
 pub enum DirectNativeMode {
-    Generic { target: NativeTarget },
-    WindowsMsvc(WindowsMsvcMode),
-}
-
-/// MSVC CRT policy shared by runtime, C stubs, and final linking.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum MsvcCrtPolicy {
-    StaticMt,
-}
-
-/// Windows MSVC direct-native mode.
-///
-/// `Pending` is used for native check-style operations that need the direct
-/// native target shape but do not need a C compiler/linker. Any runtime, C stub,
-/// or executable action must use `Resolved`.
-#[derive(Clone, Debug)]
-pub enum WindowsMsvcMode {
-    Pending,
-    Resolved(ResolvedWindowsMsvcMode),
-}
-
-/// Resolved Windows MSVC direct-native mode.
-#[derive(Clone, Debug)]
-pub struct ResolvedWindowsMsvcMode {
-    toolchain: Toolchain,
-    crt: MsvcCrtPolicy,
+    Target(NativeTarget),
 }
 
 impl NativeTarget {
@@ -147,77 +122,12 @@ impl NativeBackendMode {
     pub fn is_tcc_run(&self) -> bool {
         self.tcc_run().is_some()
     }
-
-    pub fn is_windows_msvc_direct(&self) -> bool {
-        matches!(
-            self.direct_native_mode(),
-            Some(DirectNativeMode::WindowsMsvc(_))
-        )
-    }
-
-    pub fn resolved_windows_msvc(&self) -> Option<&ResolvedWindowsMsvcMode> {
-        match self.direct_native_mode() {
-            Some(DirectNativeMode::WindowsMsvc(WindowsMsvcMode::Resolved(mode))) => Some(mode),
-            _ => None,
-        }
-    }
-
-    pub fn msvc_crt_policy(&self) -> Option<MsvcCrtPolicy> {
-        self.is_windows_msvc_direct()
-            .then_some(MsvcCrtPolicy::StaticMt)
-    }
 }
 
 impl DirectNativeMode {
-    pub fn generic(target: NativeTarget) -> Self {
-        Self::Generic { target }
-    }
-
-    pub fn pending_windows_msvc() -> Self {
-        Self::WindowsMsvc(WindowsMsvcMode::Pending)
-    }
-
-    pub fn resolved_windows_msvc(toolchain: Toolchain) -> Self {
-        Self::WindowsMsvc(WindowsMsvcMode::Resolved(ResolvedWindowsMsvcMode::new(
-            toolchain,
-            MsvcCrtPolicy::StaticMt,
-        )))
-    }
-
     pub fn target(&self) -> NativeTarget {
         match self {
-            Self::Generic { target } => *target,
-            Self::WindowsMsvc(_) => NativeTarget::X86_64PcWindowsMsvc,
-        }
-    }
-}
-
-impl ResolvedWindowsMsvcMode {
-    pub fn new(toolchain: Toolchain, crt: MsvcCrtPolicy) -> Self {
-        debug_assert!(
-            toolchain.cc().is_msvc(),
-            "Windows MSVC mode requires a cl-compatible compiler"
-        );
-        Self { toolchain, crt }
-    }
-
-    pub fn toolchain(&self) -> &Toolchain {
-        &self.toolchain
-    }
-
-    pub fn crt(&self) -> MsvcCrtPolicy {
-        self.crt
-    }
-
-    pub fn effective_toolchain(&self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
-        moonutil::compiler_flags::windows_msvc_toolchain_from_resolved(&self.toolchain, package_cc)
-    }
-}
-
-impl MsvcCrtPolicy {
-    pub fn compiler_flag(self) -> &'static str {
-        match self {
-            Self::StaticMt => moonutil::compiler_flags::WINDOWS_MSVC_STATIC_RUNTIME_FLAG,
+            Self::Target(target) => *target,
         }
     }
 }
@@ -710,7 +620,7 @@ impl std::str::FromStr for OperatingSystem {
 
 #[cfg(test)]
 mod tests {
-    use super::NativeTarget;
+    use super::{DirectNativeMode, NativeTarget};
 
     #[test]
     fn native_target_selection_is_host_specific() {
@@ -728,5 +638,12 @@ mod tests {
             Some(NativeTarget::X86_64PcWindowsMsvc)
         );
         assert_eq!(NativeTarget::from_host("aarch64", "linux"), None);
+    }
+
+    #[test]
+    fn direct_native_mode_carries_only_target_choice() {
+        let mode = DirectNativeMode::Target(NativeTarget::X86_64PcWindowsMsvc);
+
+        assert_eq!(mode.target(), NativeTarget::X86_64PcWindowsMsvc);
     }
 }

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -81,6 +81,27 @@ pub struct MsvcEnvironment {
     pub lib_paths: Vec<PathBuf>,
 }
 
+/// MSVC CRT policy shared by runtime, C stubs, and final linking.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MsvcCrtPolicy {
+    StaticMt,
+}
+
+impl MsvcCrtPolicy {
+    pub fn compiler_flag(self) -> &'static str {
+        match self {
+            Self::StaticMt => WINDOWS_MSVC_STATIC_RUNTIME_FLAG,
+        }
+    }
+}
+
+/// ABI family carried by a native compiler/linker selection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NativeAbiFamily {
+    Msvc,
+    Other,
+}
+
 impl Toolchain {
     pub fn from_env_override(cc: CC) -> Self {
         Self {
@@ -120,6 +141,30 @@ impl Toolchain {
 
     pub fn source(&self) -> ToolchainSource {
         self.source
+    }
+
+    pub fn abi_family(&self) -> NativeAbiFamily {
+        if self.cc.is_msvc() || self.cc.targets_msvc() {
+            NativeAbiFamily::Msvc
+        } else {
+            NativeAbiFamily::Other
+        }
+    }
+
+    pub fn uses_msvc_abi(&self) -> bool {
+        self.abi_family() == NativeAbiFamily::Msvc
+    }
+
+    pub fn uses_msvc_driver(&self) -> bool {
+        self.cc.is_msvc()
+    }
+
+    pub fn uses_msvc_link_library_names(&self) -> bool {
+        self.uses_msvc_abi()
+    }
+
+    pub fn msvc_crt_policy(&self) -> Option<MsvcCrtPolicy> {
+        self.uses_msvc_driver().then_some(MsvcCrtPolicy::StaticMt)
     }
 
     pub fn with_msvc_environment(mut self, environment: MsvcEnvironment) -> Self {
@@ -277,8 +322,7 @@ fn ensure_windows_msvc_compatible(cc: &CC) -> anyhow::Result<()> {
 }
 
 pub fn windows_msvc_native_toolchain(package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
-    if let Some(env_cc) = ENV_CC.as_ref() {
-        ensure_windows_msvc_compatible(env_cc)?;
+    if let Some(env_cc) = ENV_CC.as_ref().filter(|cc| cc.is_msvc()) {
         let resolved =
             attach_msvc_environment_if_available(Toolchain::from_env_override(env_cc.clone()));
         return windows_msvc_toolchain_with_package_override(resolved, package_cc);
@@ -290,6 +334,10 @@ pub fn windows_msvc_native_toolchain(package_cc: Option<&CC>) -> anyhow::Result<
 
     let resolved = resolve_windows_msvc_toolchain()?;
     windows_msvc_toolchain_with_package_override(resolved, package_cc)
+}
+
+pub fn has_incompatible_windows_msvc_env_override() -> bool {
+    ENV_CC.as_ref().is_some_and(|cc| !cc.is_msvc())
 }
 
 fn windows_msvc_toolchain_with_package_override(
@@ -311,17 +359,6 @@ fn windows_msvc_toolchain_with_package_override(
     }
 
     Ok(toolchain)
-}
-
-/// Apply package-level native CC override to a pre-resolved Windows MSVC toolchain.
-///
-/// This function does not probe the host. It preserves `MOON_CC` precedence and
-/// reuses the MSVC environment already attached to `resolved`.
-pub fn windows_msvc_toolchain_from_resolved(
-    resolved: &Toolchain,
-    package_cc: Option<&CC>,
-) -> anyhow::Result<Toolchain> {
-    windows_msvc_toolchain_with_package_override(resolved.clone(), package_cc)
 }
 
 impl CC {
@@ -801,9 +838,6 @@ pub struct CCConfig {
     #[builder(default = false)]
     // Define MOONBIT_USE_SIMDUTF.
     pub use_simdutf: bool,
-    #[builder(default = false)]
-    // Use the static MSVC runtime library (/MT).
-    pub msvc_static_runtime: bool,
 }
 
 #[derive(Clone, Builder)]
@@ -1275,9 +1309,11 @@ fn add_cc_msvc_specific_flags(cc: &CC, buf: &mut Vec<String>, has_user_flags: bo
     buf.push("/nologo".to_string());
 }
 
-fn add_cc_msvc_runtime_flags(cc: &CC, buf: &mut Vec<String>, config: &CCConfig) {
-    if cc.is_msvc() && config.msvc_static_runtime {
-        buf.push(WINDOWS_MSVC_STATIC_RUNTIME_FLAG.to_string());
+fn add_cc_msvc_runtime_flags(cc: &CC, toolchain: Option<&Toolchain>, buf: &mut Vec<String>) {
+    if cc.is_msvc()
+        && let Some(crt) = toolchain.and_then(Toolchain::msvc_crt_policy)
+    {
+        buf.push(crt.compiler_flag().to_string());
     }
 }
 
@@ -1604,7 +1640,7 @@ where
 
     add_cc_common_libraries(&cc, &mut buf, &config);
     buf.extend(cc_flags.iter().map(|s| s.as_ref().to_string()));
-    add_cc_msvc_runtime_flags(&cc, &mut buf, &config);
+    add_cc_msvc_runtime_flags(&cc, toolchain, &mut buf);
     buf.extend(user_link_flags.iter().map(|s| s.as_ref().to_string()));
     if config.link_libbacktrace && config.output_ty != OutputType::Object {
         let libbacktrace_path = Path::new(&paths.lib_path).join("libbacktrace.a");
@@ -1644,7 +1680,6 @@ mod tests {
             preserve_frame_pointer: false,
             define_use_shared_runtime_macro: false,
             use_simdutf: false,
-            msvc_static_runtime: false,
         }
     }
 
@@ -1678,6 +1713,40 @@ mod tests {
     }
 
     #[test]
+    fn toolchain_detects_msvc_abi_and_crt_policy() {
+        let mut cc = fake_cc(CCKind::Msvc, None);
+        cc.cc_path = "cl.exe".to_string();
+        cc.ar_kind = ARKind::MsvcLib;
+        cc.ar_path = "lib.exe".to_string();
+
+        let toolchain = Toolchain::from_path_probe(cc);
+
+        assert_eq!(toolchain.abi_family(), NativeAbiFamily::Msvc);
+        assert!(toolchain.uses_msvc_abi());
+        assert!(toolchain.uses_msvc_driver());
+        assert_eq!(toolchain.msvc_crt_policy(), Some(MsvcCrtPolicy::StaticMt));
+        assert_eq!(
+            toolchain
+                .msvc_crt_policy()
+                .expect("MSVC toolchain has CRT policy")
+                .compiler_flag(),
+            WINDOWS_MSVC_STATIC_RUNTIME_FLAG
+        );
+    }
+
+    #[test]
+    fn toolchain_tracks_msvc_abi_without_cl_driver_crt_policy() {
+        let toolchain =
+            Toolchain::from_path_probe(fake_cc(CCKind::Clang, Some("x86_64-pc-windows-msvc")));
+
+        assert_eq!(toolchain.abi_family(), NativeAbiFamily::Msvc);
+        assert!(toolchain.uses_msvc_abi());
+        assert!(!toolchain.uses_msvc_driver());
+        assert!(toolchain.uses_msvc_link_library_names());
+        assert_eq!(toolchain.msvc_crt_policy(), None);
+    }
+
+    #[test]
     fn windows_msvc_package_override_preserves_env_override_precedence() {
         let mut env_cc = fake_cc(CCKind::Msvc, None);
         env_cc.cc_path = "env-cl.exe".to_string();
@@ -1708,27 +1777,28 @@ mod tests {
     }
 
     #[test]
-    fn msvc_static_runtime_config_adds_mt_to_cc_command() {
+    fn msvc_toolchain_adds_mt_to_cc_command() {
         let mut cc = fake_cc(CCKind::Msvc, None);
         cc.cc_path = "cl.exe".to_string();
         cc.ar_kind = ARKind::MsvcLib;
         cc.ar_path = "lib.exe".to_string();
+        let toolchain = Toolchain::from_path_probe(cc);
         let paths = CompilerPaths {
             include_path: "moon/include".to_string(),
             lib_path: "moon/lib".to_string(),
         };
 
-        let command = make_cc_command_resolved(
-            cc,
+        let command = make_cc_command_resolved_for_toolchain(
+            &toolchain,
             CCConfigBuilder::default()
                 .no_sys_header(true)
                 .link_moonbitrun(false)
                 .output_ty(OutputType::Object)
                 .define_use_shared_runtime_macro(false)
-                .msvc_static_runtime(true)
                 .build()
-                .expect("MSVC static runtime config should build"),
+                .expect("MSVC command config should build"),
             &["/MD"],
+            &[] as &[&str],
             ["stub.c".to_string()],
             "pkg",
             Some("stub.obj"),

--- a/docs/adr/0002-native-abi-policy-belongs-to-toolchains.md
+++ b/docs/adr/0002-native-abi-policy-belongs-to-toolchains.md
@@ -1,0 +1,15 @@
+# Native ABI Policy Belongs to Toolchains
+
+Native builds have separate choices that are easy to conflate: the native payload form produced by MoonBit, the executable realization used by lowering, and the native toolchain used by the host compiler/linker. We will keep backend mode focused on payload and realization choices, while the toolchain owns ABI family and CRT linkage policy. This keeps MSVC invariants local: once an MSVC toolchain is selected, runtime compilation, C stub compilation, and final executable linking all consume the same ABI and CRT contract.
+
+## Decisions
+
+- Direct object mode records the native target triple, not an MSVC-specific backend mode.
+- Build planning resolves native compiler/linker selections into toolchains before lowering.
+- Windows direct object mode for `x86_64-pc-windows-msvc` requires a cl-compatible MSVC toolchain.
+- Generated-C native builds also consume toolchains, so MSVC CRT policy is not limited to the direct object path.
+- Lowering must branch on the toolchain for MSVC-specific runtime, C stub, and executable-link behavior, not on backend mode.
+
+## Consequences
+
+The interface between build planning and lowering carries more domain meaning than a raw compiler path, which improves locality for ABI and CRT changes. Future GNU-like Windows support should refine toolchain policy and resolution instead of adding another backend mode. Follow-up work may split payload form and executable realization further if more native backends make the current enum shallow.


### PR DESCRIPTION
## Why

PR #1822 introduced the Windows MSVC direct native path, but backend mode started carrying decisions that belong to the selected native toolchain. That made MSVC ABI and CRT invariants harder to keep consistent across runtime compilation, C stubs, generated-C executable compilation, and direct-object executable linking.

## What changed

- Keep direct native mode focused on the native target choice.
- Resolve the effective native toolchain in build planning for runtime, C stubs, and executable actions.
- Move ABI family and MSVC CRT policy onto `Toolchain`, and derive `/MT` from the selected MSVC toolchain instead of a per-command config bit.
- Warn and ignore incompatible `MOON_CC` for the Windows MSVC native backend, while still rejecting package-level non-MSVC overrides that would break the ABI contract.
- Document the native build terminology and toolchain-policy decision.

## Why this is correct

The native backend decides the payload form, while the selected toolchain decides ABI and runtime-linkage obligations. Once an MSVC toolchain is selected, all native artifacts participating in the executable use the same ABI family and CRT policy. This keeps generated-C and direct-object paths aligned instead of treating MSVC policy as a special backend mode.

## Scope

This is intentionally a narrow cleanup around the native toolchain boundary. It does not split the larger compiler flag renderer yet; command dialect rendering such as `/D` versus `-D` remains in the existing command rendering layer.