### PR TITLE
refactor: split native build contract from driver

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,9 +52,25 @@ _Avoid_: Using entity names for operations, adding containers only to mirror voc
 The representation produced by MoonBit before the host C compiler or linker is invoked, such as generated C or direct object code.
 _Avoid_: Treating generated C, TCC execution, and direct object linking as the same kind of backend choice
 
+**Native Command Driver**:
+The concrete compiler/linker executable and archiver used by one native build action, such as `cl.exe`, `clang-cl.exe`, `cc`, or `tcc`.
+_Avoid_: ABI family, process environment, build graph contract
+
+**Native Build Contract**:
+The single ABI family, CRT linkage, and toolchain environment selected for one native build invocation. Every native runtime build, C stub archive, generated-C compile/link, and direct-object link in that invocation must match this contract.
+_Avoid_: Per-package ABI world, implicit compiler preference, duplicate shared native artifacts
+
 **Native Toolchain**:
-The selected native compiler/linker together with the ABI family and runtime-linkage obligations it imposes on runtime, C stubs, and executable linking.
-_Avoid_: Raw compiler path, native backend mode
+A native command driver paired with the native build contract it has been validated against. It is action-scoped; the durable graph-level choice is the native build contract.
+_Avoid_: Raw compiler path, native backend mode, global per-package compiler
+
+**Native Link Unit**:
+The final native artifact together with every object file and archive that participates in one link. A native link unit consumes the invocation's native build contract.
+_Avoid_: Per-package executable world, independent C command
+
+**Native Toolchain Environment**:
+The installation- and target-specific environment required to run a native toolchain, including the tool, header, library, and SDK search context.
+_Avoid_: User shell, PATH lookup result, compiler flags
 
 **ABI Family**:
 The binary interface family fixed by the native toolchain. On Windows, MSVC and GNU-like toolchains are different ABI families and must not be mixed in one native executable.

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -29,6 +29,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ffi::OsString,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -57,7 +58,7 @@ use moonutil::{
         BLACKBOX_TEST_PATCH, DiagnosticLevel, MOONBITLANG_CORE, RunMode, TargetBackend,
         WHITEBOX_TEST_PATCH,
     },
-    compiler_flags::{self, CC},
+    compiler_flags::{self, CC, NativeBuildContract},
     cond_expr::OptLevel as BuildProfile,
     dirs::WorkspaceEnv,
     features::FeatureGate,
@@ -662,6 +663,7 @@ pub(crate) fn plan_resolved_build_from_intent(
     let input = BuildInput {
         graph: compile_output.build_graph,
         command_args_by_output: compile_output.command_args_by_output,
+        native_contract: compile_output.native_contract,
         db_path,
     };
 
@@ -695,6 +697,7 @@ pub fn plan_fmt(
     let input = BuildInput {
         graph,
         command_args_by_output: Default::default(),
+        native_contract: None,
         db_path,
     };
     Ok((input, user_warnings))
@@ -937,10 +940,56 @@ pub struct BuildInput {
     /// Structured command argv keyed by generated output path.
     command_args_by_output: moonbuild_rupes_recta::build_lower::CommandArgMap,
 
+    /// Native ABI/CRT/toolchain-environment contract selected for this build graph.
+    native_contract: Option<NativeBuildContract>,
+
     /// The build cache database path for n2
     ///
     /// This path is passed here because it changes between different execution configurations.
     db_path: PathBuf,
+}
+
+struct ScopedEnv {
+    saved: Vec<(OsString, Option<OsString>)>,
+}
+
+impl ScopedEnv {
+    fn apply(pairs: &[(OsString, OsString)]) -> Self {
+        // n2 only accepts command strings. MSVC environment discovered during
+        // planning is therefore applied to the Moon process before n2 starts
+        // worker jobs, then restored after n2 exits.
+        let saved = pairs
+            .iter()
+            .map(|(key, value)| {
+                let old_value = std::env::var_os(key);
+                // SAFETY: this is scoped to graph execution and Moon does not
+                // concurrently mutate environment variables while n2 is
+                // running. If n2 grows per-command environments, this global
+                // mutation should be removed.
+                unsafe {
+                    std::env::set_var(key, value);
+                }
+                (key.clone(), old_value)
+            })
+            .collect();
+        Self { saved }
+    }
+}
+
+impl Drop for ScopedEnv {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.iter().rev() {
+            // SAFETY: see ScopedEnv::apply. Restore happens after n2 has
+            // returned and before this build invocation continues.
+            unsafe {
+                if let Some(value) = value {
+                    std::env::set_var(key, value);
+                } else {
+                    std::env::remove_var(key);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1001,6 +1050,7 @@ pub fn execute_build_partial(
     ))?;
 
     let mut build_graph = input.graph;
+    let native_contract = input.native_contract;
     let db_path = input.db_path;
     db_path
         .parent()
@@ -1056,8 +1106,13 @@ pub fn execute_build_partial(
     want_files(&mut work).context("Failed to determine the files to be built")?;
 
     // The actual execution done by the n2 executor
+    let msvc_env = native_contract
+        .as_ref()
+        .and_then(NativeBuildContract::msvc_environment)
+        .map(|environment| ScopedEnv::apply(&environment.env_pairs));
     let res = work.run().context("Failed to run n2 graph");
     drop(work);
+    drop(msvc_env);
     drop(prog_console); // Ensure the progress bar won't mess with diagnostic output
     let res = res?;
     let build_succeeded = res.is_some();

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/msvc.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/msvc.rs
@@ -20,9 +20,12 @@
 
 use std::path::Path;
 
-use moonutil::compiler_flags::{MsvcCrtPolicy, Toolchain, WINDOWS_MSVC_DEFAULT_LIBS};
+use moonutil::compiler_flags::{MsvcCrtPolicy, NativeToolchain, WINDOWS_MSVC_DEFAULT_LIBS};
 
-pub(crate) fn add_environment_include_paths(toolchain: &Toolchain, command: &mut Vec<String>) {
+pub(crate) fn add_environment_include_paths(
+    toolchain: &NativeToolchain,
+    command: &mut Vec<String>,
+) {
     let Some(environment) = toolchain.msvc_environment() else {
         return;
     };
@@ -34,7 +37,7 @@ pub(crate) fn add_environment_include_paths(toolchain: &Toolchain, command: &mut
     );
 }
 
-fn add_environment_lib_paths(toolchain: &Toolchain, command: &mut Vec<String>) {
+fn add_environment_lib_paths(toolchain: &NativeToolchain, command: &mut Vec<String>) {
     let Some(environment) = toolchain.msvc_environment() else {
         return;
     };
@@ -47,7 +50,7 @@ fn add_environment_lib_paths(toolchain: &Toolchain, command: &mut Vec<String>) {
 }
 
 pub(crate) fn compile_runtime_command(
-    toolchain: &Toolchain,
+    toolchain: &NativeToolchain,
     source: &Path,
     dest: &Path,
     moon_include_path: &str,
@@ -71,7 +74,7 @@ pub(crate) fn compile_runtime_command(
 }
 
 pub(crate) fn link_executable_command(
-    toolchain: &Toolchain,
+    toolchain: &NativeToolchain,
     sources: &[String],
     user_link_flags: &[String],
     dest: &str,
@@ -99,12 +102,12 @@ pub(crate) fn link_executable_command(
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use moonutil::compiler_flags::{ARKind, CC, CCKind, MsvcEnvironment, Toolchain};
+    use moonutil::compiler_flags::{ARKind, CC, CCKind, MsvcEnvironment, NativeToolchain};
 
     use super::*;
 
-    fn fake_msvc_toolchain() -> Toolchain {
-        Toolchain::from_path_probe(CC {
+    fn fake_msvc_toolchain() -> NativeToolchain {
+        NativeToolchain::from_path_probe(CC {
             cc_kind: CCKind::Msvc,
             cc_path: "cl.exe".to_string(),
             ar_kind: ARKind::MsvcLib,
@@ -114,6 +117,10 @@ mod tests {
         })
         .with_msvc_environment(MsvcEnvironment {
             cl_exe: PathBuf::from("cl.exe"),
+            env_pairs: vec![(
+                std::ffi::OsString::from("PATH"),
+                std::ffi::OsString::from("msvc/bin"),
+            )],
             include_paths: vec![PathBuf::from("crt/include"), PathBuf::from("sdk/include")],
             lib_paths: vec![PathBuf::from("crt/lib"), PathBuf::from("sdk/lib")],
         })

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -332,7 +332,7 @@ mod tests {
     use indexmap::IndexSet;
     use moonutil::{
         common::TargetBackend,
-        compiler_flags::{ARKind, CC, CCKind, MsvcEnvironment, Toolchain},
+        compiler_flags::{ARKind, CC, CCKind, MsvcEnvironment, NativeToolchain},
         module::MoonMod,
         mooncakes::{
             DEFAULT_VERSION, DirSyncResult, ModuleName, ModuleSource, result::ResolvedEnv,
@@ -469,8 +469,8 @@ mod tests {
         }
     }
 
-    fn msvc_toolchain() -> Toolchain {
-        Toolchain::from_path_probe(CC {
+    fn msvc_toolchain() -> NativeToolchain {
+        NativeToolchain::from_path_probe(CC {
             cc_kind: CCKind::Msvc,
             cc_path: "cl.exe".to_string(),
             ar_kind: ARKind::MsvcLib,
@@ -480,6 +480,10 @@ mod tests {
         })
         .with_msvc_environment(MsvcEnvironment {
             cl_exe: PathBuf::from("cl.exe"),
+            env_pairs: vec![(
+                std::ffi::OsString::from("PATH"),
+                std::ffi::OsString::from("msvc/bin"),
+            )],
             include_paths: vec![PathBuf::from("crt/include"), PathBuf::from("sdk/include")],
             lib_paths: vec![PathBuf::from("crt/lib"), PathBuf::from("sdk/lib")],
         })

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -32,7 +32,7 @@ use moonutil::{
         DOT_MBT_DOT_MD, IgnoredMoonScript, MOD_DIR, MOONCAKE_BIN, PKG_DIR, TargetBackend,
         is_moon_mod, is_moon_pkg, is_moon_script_ignored,
     },
-    compiler_flags::{self, CC, Toolchain},
+    compiler_flags::{self, CC, NativeAbiFamily, NativeToolchain},
     module::{MoonMod, MoonModRule},
     mooncakes::ModuleId,
     package::{MoonPkgGenerate, SupportedTargetsDeclKind},
@@ -78,6 +78,14 @@ impl DependencyInterfaceMode {
 }
 
 impl<'a> BuildPlanConstructor<'a> {
+    fn expected_direct_target_abi(&self) -> Option<NativeAbiFamily> {
+        match self.build_env.native_mode.direct_target()? {
+            NativeTarget::Aarch64AppleDarwin => Some(NativeAbiFamily::AppleDarwin),
+            NativeTarget::X86_64UnknownLinuxGnu => Some(NativeAbiFamily::UnixLike),
+            NativeTarget::X86_64PcWindowsMsvc => Some(NativeAbiFamily::Msvc),
+        }
+    }
+
     fn new_native_linker_context(&self, err: anyhow::Error) -> anyhow::Error {
         if self.build_env.native_mode.direct_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
             err.context(
@@ -90,6 +98,28 @@ impl<'a> BuildPlanConstructor<'a> {
         } else {
             err
         }
+    }
+
+    fn validate_direct_target_toolchain(&self, toolchain: &NativeToolchain) -> anyhow::Result<()> {
+        let Some(expected) = self.expected_direct_target_abi() else {
+            return Ok(());
+        };
+
+        if toolchain.abi_family() != expected {
+            anyhow::bail!(
+                "native target {} requires {} ABI, but selected compiler {} uses {} ABI",
+                self.build_env
+                    .native_mode
+                    .direct_target()
+                    .expect("expected direct native target")
+                    .moonc_target_flag(),
+                expected,
+                toolchain.cc().cc_path,
+                toolchain.abi_family()
+            );
+        }
+
+        Ok(())
     }
 
     fn warn_incompatible_windows_msvc_env_override(&mut self) {
@@ -105,20 +135,34 @@ impl<'a> BuildPlanConstructor<'a> {
         }
     }
 
-    fn effective_native_toolchain(&mut self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
+    fn native_toolchain_for_action(
+        &mut self,
+        package_cc: Option<&CC>,
+    ) -> anyhow::Result<NativeToolchain> {
         debug_assert!(self.build_env.target_backend.is_native());
-        if self.build_env.native_mode.direct_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
-            self.warn_incompatible_windows_msvc_env_override();
-            return compiler_flags::windows_msvc_native_toolchain(package_cc);
+        if let Some(selected) = self.native_default_toolchain.as_ref() {
+            return compiler_flags::native_toolchain_with_package_override(selected, package_cc);
         }
 
-        compiler_flags::effective_native_toolchain(
-            package_cc,
-            self.build_env
-                .native_mode
-                .tcc_run()
-                .map(|config| config.internal_tcc()),
-        )
+        let selected = if self.build_env.native_mode.direct_target()
+            == Some(NativeTarget::X86_64PcWindowsMsvc)
+        {
+            self.warn_incompatible_windows_msvc_env_override();
+            compiler_flags::windows_msvc_native_toolchain()?
+        } else {
+            compiler_flags::default_native_toolchain(
+                self.build_env
+                    .native_mode
+                    .tcc_run()
+                    .map(|config| config.internal_tcc()),
+            )?
+        };
+
+        compiler_flags::ensure_supported_native_toolchain_contract(selected.contract())?;
+        self.validate_direct_target_toolchain(&selected)?;
+        self.res.native_contract = Some(selected.contract().clone());
+        self.native_default_toolchain = Some(selected.clone());
+        compiler_flags::native_toolchain_with_package_override(&selected, package_cc)
     }
 
     fn module_prebuild_vars(&self, module: ModuleId) -> Option<&HashMap<String, String>> {
@@ -815,7 +859,7 @@ impl<'a> BuildPlanConstructor<'a> {
             .unwrap_or_default();
 
         let effective_native_toolchain = self
-            .effective_native_toolchain(stub_cc.as_ref())
+            .native_toolchain_for_action(stub_cc.as_ref())
             .map_err(|e| {
                 BuildPlanConstructError::FailedToSetStubCC(
                     self.new_native_linker_context(e),
@@ -957,7 +1001,7 @@ impl<'a> BuildPlanConstructor<'a> {
         }
 
         let effective_native_toolchain =
-            self.effective_native_toolchain(cc.as_ref()).map_err(|e| {
+            self.native_toolchain_for_action(cc.as_ref()).map_err(|e| {
                 BuildPlanConstructError::FailedToSetCC(
                     self.new_native_linker_context(e),
                     pkg.fqn.clone().into(),
@@ -1147,7 +1191,7 @@ impl<'a> BuildPlanConstructor<'a> {
     /// Propagate the link configuration of the packages in dependency to the output list
     fn propagate_link_config(
         &self,
-        toolchain: &Toolchain,
+        toolchain: &NativeToolchain,
         pkgs: impl Iterator<Item = PackageId>,
         out: &mut Vec<String>,
     ) {
@@ -1323,7 +1367,7 @@ impl<'a> BuildPlanConstructor<'a> {
         &mut self,
         node: BuildPlanNode,
     ) -> Result<(), BuildPlanConstructError> {
-        let effective_native_toolchain = self.effective_native_toolchain(None).map_err(|e| {
+        let effective_native_toolchain = self.native_toolchain_for_action(None).map_err(|e| {
             BuildPlanConstructError::FailedToSetRuntimeCC(self.new_native_linker_context(e))
         })?;
         self.res.runtime_info = Some(BuildRuntimeInfo {

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -31,6 +31,7 @@ use crate::{
     user_warning::UserWarning,
 };
 use indexmap::IndexMap;
+use moonutil::compiler_flags::NativeToolchain;
 use tracing::{Level, debug, instrument};
 
 use super::{BuildEnvironment, BuildPlan, BuildPlanConstructError};
@@ -48,6 +49,11 @@ pub(super) struct BuildPlanConstructor<'a> {
 
     /// The resulting build plan
     pub(super) res: BuildPlan,
+
+    /// Default native command driver selected for this planning invocation.
+    /// The build plan stores only the native compatibility contract; this
+    /// driver is planner-local state for later compatible package overrides.
+    pub(super) native_default_toolchain: Option<NativeToolchain>,
 
     /// Currently pending nodes that need to be processed.
     pub(super) pending: Vec<BuildPlanNode>,
@@ -146,6 +152,7 @@ impl<'a> BuildPlanConstructor<'a> {
             user_warnings: Vec::new(),
 
             res: BuildPlan::default(),
+            native_default_toolchain: None,
             pending: Vec::new(),
             resolved: HashSet::new(),
             warned_missing_supported_targets: HashSet::new(),

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -52,7 +52,7 @@ use std::{
 use log::{debug, info};
 use moonutil::{
     common::{RunMode, TargetBackend},
-    compiler_flags::Toolchain,
+    compiler_flags::{NativeBuildContract, NativeToolchain},
     cond_expr::OptLevel,
     mooncakes::ModuleId,
 };
@@ -107,6 +107,9 @@ pub struct BuildPlan {
 
     /// The information needed to build the native runtime library.
     runtime_info: Option<BuildRuntimeInfo>,
+
+    /// The native ABI/CRT/toolchain-environment contract selected for this build graph.
+    native_contract: Option<NativeBuildContract>,
 
     /// The map of package to its prebuild information, if any.
     prebuild_info: HashMap<PackageId, Vec<Option<PrebuildInfo>>>,
@@ -235,6 +238,10 @@ impl BuildPlan {
     /// Get runtime library build information.
     pub fn get_runtime_info(&self) -> Option<&BuildRuntimeInfo> {
         self.runtime_info.as_ref()
+    }
+
+    pub fn native_contract(&self) -> Option<&NativeBuildContract> {
+        self.native_contract.as_ref()
     }
 
     /// Get prebuild information for the given package.
@@ -399,7 +406,7 @@ pub struct LinkCoreInfo {
 #[derive(Debug)]
 pub struct BuildCStubsInfo {
     /// The effective native toolchain for compiling the C stubs
-    pub(crate) effective_native_toolchain: Toolchain,
+    pub(crate) effective_native_toolchain: NativeToolchain,
     /// Additional flags to pass to the C compiler when compiling the C stubs
     pub(crate) cc_flags: Vec<String>,
     /// Additional flags to pass to the linker (TCC only)
@@ -410,7 +417,7 @@ pub struct BuildCStubsInfo {
 #[derive(Debug)]
 pub struct MakeExecutableInfo {
     /// The effective native toolchain for this executable step
-    pub(crate) effective_native_toolchain: Toolchain,
+    pub(crate) effective_native_toolchain: NativeToolchain,
     /// The flags to pass to the C compiler when compiling the package itself
     pub(crate) c_flags: Vec<String>,
     /// The flags to pass to the C compiler driver when linking the executable
@@ -422,7 +429,7 @@ pub struct MakeExecutableInfo {
 #[derive(Debug)]
 pub struct BuildRuntimeInfo {
     /// The effective native toolchain for compiling the runtime library.
-    pub(crate) effective_native_toolchain: Toolchain,
+    pub(crate) effective_native_toolchain: NativeToolchain,
 }
 
 /// Resolved information about a prebuild command.

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -18,7 +18,7 @@
 
 use indexmap::IndexMap;
 use log::{debug, info};
-use moonutil::{common::RunMode, cond_expr::OptLevel};
+use moonutil::{common::RunMode, compiler_flags::NativeBuildContract, cond_expr::OptLevel};
 use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
 
@@ -91,6 +91,9 @@ pub struct CompileOutput {
 
     /// User-facing warnings discovered during planning.
     pub user_warnings: Vec<UserWarning>,
+
+    /// Native ABI/CRT/toolchain-environment contract selected for this build graph.
+    pub native_contract: Option<NativeBuildContract>,
 
     /// The build plan, but only if we decided to export it.
     pub build_plan: Option<Box<build_plan::BuildPlan>>,
@@ -187,6 +190,7 @@ pub fn compile(
         command_args_by_output,
         artifacts,
         user_warnings,
+        native_contract: plan.native_contract().cloned(),
         build_plan: if cx.debug_export_build_plan {
             Some(Box::new(plan))
         } else {

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -1131,7 +1131,7 @@ mod tests {
     use indexmap::IndexSet;
     use moonutil::mooncakes::{DEFAULT_VERSION, ModuleName, ModuleSource};
     use moonutil::{
-        compiler_flags::{ARKind, CC, CCKind, Toolchain},
+        compiler_flags::{ARKind, CC, CCKind, NativeToolchain},
         module::MoonMod,
         package::{MoonPkg, MoonPkgFormatter, SupportedTargetsDeclKind},
     };
@@ -1257,8 +1257,8 @@ mod tests {
         }
     }
 
-    fn system_cc_toolchain() -> Toolchain {
-        Toolchain::from_path_probe(CC {
+    fn system_cc_toolchain() -> NativeToolchain {
+        NativeToolchain::from_path_probe(CC {
             cc_kind: CCKind::SystemCC,
             cc_path: "cc".to_string(),
             ar_kind: ARKind::GnuAr,

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -20,11 +20,10 @@ use crate::moon_dir::MOON_DIRS;
 use anyhow::Context;
 use colored::Colorize;
 use derive_builder::Builder;
-#[cfg(any(windows, test))]
-use std::ffi::OsString;
 use std::{
     env,
-    ffi::OsStr,
+    ffi::{OsStr, OsString},
+    fmt,
     path::{Path, PathBuf},
     process::Command,
     sync::OnceLock,
@@ -61,22 +60,23 @@ pub struct CC {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ToolchainSource {
+enum NativeDriverSource {
     EnvOverride,
     PathProbe,
     PackageOverride,
 }
 
+/// Compiler/linker executable and archiver chosen for one native action.
 #[derive(Clone, Debug)]
-pub struct Toolchain {
+struct NativeCommandDriver {
     cc: CC,
-    source: ToolchainSource,
-    msvc_environment: Option<MsvcEnvironment>,
+    source: NativeDriverSource,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MsvcEnvironment {
     pub cl_exe: PathBuf,
+    pub env_pairs: Vec<(OsString, OsString)>,
     pub include_paths: Vec<PathBuf>,
     pub lib_paths: Vec<PathBuf>,
 }
@@ -99,86 +99,100 @@ impl MsvcCrtPolicy {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NativeAbiFamily {
     Msvc,
+    WindowsGnu,
+    AppleDarwin,
+    UnixLike,
     Other,
 }
 
-impl Toolchain {
-    pub fn from_env_override(cc: CC) -> Self {
+impl fmt::Display for NativeAbiFamily {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Msvc => f.write_str("msvc"),
+            Self::WindowsGnu => f.write_str("windows-gnu"),
+            Self::AppleDarwin => f.write_str("apple-darwin"),
+            Self::UnixLike => f.write_str("unix-like"),
+            Self::Other => f.write_str("other"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeBuildContract {
+    abi_family: NativeAbiFamily,
+    msvc_crt_policy: Option<MsvcCrtPolicy>,
+    msvc_environment: Option<MsvcEnvironment>,
+}
+
+/// Action-scoped driver paired with the native build contract it satisfies.
+#[derive(Clone, Debug)]
+pub struct NativeToolchain {
+    driver: NativeCommandDriver,
+    contract: NativeBuildContract,
+}
+
+impl NativeCommandDriver {
+    fn from_env_override(cc: CC) -> Self {
         Self {
             cc,
-            source: ToolchainSource::EnvOverride,
-            msvc_environment: None,
+            source: NativeDriverSource::EnvOverride,
         }
     }
 
-    pub fn from_path_probe(cc: CC) -> Self {
+    fn from_path_probe(cc: CC) -> Self {
         Self {
             cc,
-            source: ToolchainSource::PathProbe,
-            msvc_environment: None,
+            source: NativeDriverSource::PathProbe,
         }
     }
 
-    pub fn from_package_override(cc: CC) -> Self {
+    fn from_package_override(cc: CC) -> Self {
         Self {
             cc,
-            source: ToolchainSource::PackageOverride,
-            msvc_environment: None,
+            source: NativeDriverSource::PackageOverride,
         }
     }
 
-    pub fn from_cc(cc: CC) -> Self {
-        if cc.is_env_override {
-            Toolchain::from_env_override(cc)
-        } else {
-            Toolchain::from_path_probe(cc)
-        }
-    }
-
-    pub fn cc(&self) -> &CC {
+    fn cc(&self) -> &CC {
         &self.cc
     }
 
-    pub fn source(&self) -> ToolchainSource {
-        self.source
-    }
+    fn abi_family(&self) -> NativeAbiFamily {
+        if self.cc.is_msvc() {
+            return NativeAbiFamily::Msvc;
+        }
 
-    pub fn abi_family(&self) -> NativeAbiFamily {
-        if self.cc.is_msvc() || self.cc.targets_msvc() {
+        let Some(target) = self.cc.target_triple.as_deref() else {
+            return NativeAbiFamily::Other;
+        };
+
+        if target.contains("msvc") {
             NativeAbiFamily::Msvc
+        } else if target.contains("windows-gnu")
+            || target.contains("windows-gnullvm")
+            || target.contains("w64")
+        {
+            NativeAbiFamily::WindowsGnu
+        } else if target.contains("apple-darwin") {
+            NativeAbiFamily::AppleDarwin
+        } else if target.contains("linux") || target.contains("freebsd") {
+            NativeAbiFamily::UnixLike
         } else {
             NativeAbiFamily::Other
         }
     }
 
-    pub fn uses_msvc_abi(&self) -> bool {
-        self.abi_family() == NativeAbiFamily::Msvc
-    }
-
-    pub fn uses_msvc_driver(&self) -> bool {
+    fn uses_msvc_driver(&self) -> bool {
         self.cc.is_msvc()
     }
 
-    pub fn uses_msvc_link_library_names(&self) -> bool {
-        self.uses_msvc_abi()
-    }
-
-    pub fn msvc_crt_policy(&self) -> Option<MsvcCrtPolicy> {
+    fn msvc_crt_policy(&self) -> Option<MsvcCrtPolicy> {
         self.uses_msvc_driver().then_some(MsvcCrtPolicy::StaticMt)
     }
 
-    pub fn with_msvc_environment(mut self, environment: MsvcEnvironment) -> Self {
-        self.msvc_environment = Some(environment);
-        self
-    }
-
-    pub fn msvc_environment(&self) -> Option<&MsvcEnvironment> {
-        self.msvc_environment.as_ref()
-    }
-
-    pub fn with_package_override(&self, package_cc: Option<&CC>) -> Toolchain {
+    fn with_package_override(&self, package_cc: Option<&CC>) -> Self {
         match (self.source, package_cc) {
-            (ToolchainSource::EnvOverride, Some(_)) => {
+            (NativeDriverSource::EnvOverride, Some(_)) => {
                 static WARN_ONCE: std::sync::Once = std::sync::Once::new();
                 WARN_ONCE.call_once(|| {
                     eprintln!(
@@ -189,8 +203,107 @@ impl Toolchain {
                 });
                 self.clone()
             }
-            (ToolchainSource::EnvOverride, None) | (_, None) => self.clone(),
-            (_, Some(package_cc)) => Toolchain::from_package_override(package_cc.clone()),
+            (NativeDriverSource::EnvOverride, None) | (_, None) => self.clone(),
+            (_, Some(package_cc)) => Self::from_package_override(package_cc.clone()),
+        }
+    }
+}
+
+impl NativeBuildContract {
+    fn from_driver(driver: &NativeCommandDriver) -> Self {
+        Self {
+            abi_family: driver.abi_family(),
+            msvc_crt_policy: driver.msvc_crt_policy(),
+            msvc_environment: None,
+        }
+    }
+
+    pub fn abi_family(&self) -> NativeAbiFamily {
+        self.abi_family
+    }
+
+    pub fn uses_msvc_abi(&self) -> bool {
+        self.abi_family == NativeAbiFamily::Msvc
+    }
+
+    pub fn uses_msvc_link_library_names(&self) -> bool {
+        self.uses_msvc_abi()
+    }
+
+    pub fn msvc_crt_policy(&self) -> Option<MsvcCrtPolicy> {
+        self.msvc_crt_policy
+    }
+
+    pub fn msvc_environment(&self) -> Option<&MsvcEnvironment> {
+        self.msvc_environment.as_ref()
+    }
+
+    pub fn with_msvc_environment(mut self, environment: MsvcEnvironment) -> Self {
+        self.msvc_environment = Some(environment);
+        self
+    }
+}
+
+impl NativeToolchain {
+    fn from_driver(driver: NativeCommandDriver) -> Self {
+        let contract = NativeBuildContract::from_driver(&driver);
+        Self { driver, contract }
+    }
+
+    pub fn from_env_override(cc: CC) -> Self {
+        Self::from_driver(NativeCommandDriver::from_env_override(cc))
+    }
+
+    pub fn from_path_probe(cc: CC) -> Self {
+        Self::from_driver(NativeCommandDriver::from_path_probe(cc))
+    }
+
+    pub fn contract(&self) -> &NativeBuildContract {
+        &self.contract
+    }
+
+    fn driver(&self) -> &NativeCommandDriver {
+        &self.driver
+    }
+
+    pub fn cc(&self) -> &CC {
+        self.driver.cc()
+    }
+
+    pub fn abi_family(&self) -> NativeAbiFamily {
+        self.contract.abi_family()
+    }
+
+    pub fn uses_msvc_abi(&self) -> bool {
+        self.contract.uses_msvc_abi()
+    }
+
+    pub fn uses_msvc_driver(&self) -> bool {
+        self.driver.uses_msvc_driver()
+    }
+
+    pub fn uses_msvc_link_library_names(&self) -> bool {
+        self.contract.uses_msvc_link_library_names()
+    }
+
+    pub fn msvc_crt_policy(&self) -> Option<MsvcCrtPolicy> {
+        self.contract.msvc_crt_policy()
+    }
+
+    pub fn msvc_environment(&self) -> Option<&MsvcEnvironment> {
+        self.contract.msvc_environment()
+    }
+
+    pub fn with_msvc_environment(mut self, environment: MsvcEnvironment) -> Self {
+        self.contract = self.contract.with_msvc_environment(environment);
+        self
+    }
+
+    pub fn with_package_override(&self, package_cc: Option<&CC>) -> Self {
+        let driver = self.driver.with_package_override(package_cc);
+        Self {
+            driver,
+            contract: self.contract.clone(),
         }
     }
 }
@@ -243,6 +356,7 @@ fn msvc_environment_from_env_pairs(
         .collect::<Vec<_>>();
     Some(MsvcEnvironment {
         cl_exe,
+        env_pairs: env.to_vec(),
         include_paths,
         lib_paths,
     })
@@ -284,16 +398,31 @@ pub fn resolve_windows_msvc_environment() -> anyhow::Result<MsvcEnvironment> {
         )
 }
 
-fn attach_msvc_environment_if_available(toolchain: Toolchain) -> Toolchain {
+fn attach_msvc_environment(toolchain: NativeToolchain) -> anyhow::Result<NativeToolchain> {
+    if !toolchain.cc().is_msvc() {
+        return Ok(toolchain);
+    }
+
+    let environment = resolve_windows_msvc_environment()?;
+    let cl_exe = PathBuf::from(&toolchain.cc().cc_path);
+    Ok(toolchain.with_msvc_environment(MsvcEnvironment {
+        cl_exe,
+        env_pairs: environment.env_pairs,
+        include_paths: environment.include_paths,
+        lib_paths: environment.lib_paths,
+    }))
+}
+
+fn attach_msvc_environment_if_available(toolchain: NativeToolchain) -> NativeToolchain {
     if !toolchain.cc().is_msvc() {
         return toolchain;
     }
-
     match resolve_windows_msvc_environment() {
         Ok(environment) => {
             let cl_exe = PathBuf::from(&toolchain.cc().cc_path);
             toolchain.with_msvc_environment(MsvcEnvironment {
                 cl_exe,
+                env_pairs: environment.env_pairs,
                 include_paths: environment.include_paths,
                 lib_paths: environment.lib_paths,
             })
@@ -302,12 +431,12 @@ fn attach_msvc_environment_if_available(toolchain: Toolchain) -> Toolchain {
     }
 }
 
-pub fn resolve_windows_msvc_toolchain() -> anyhow::Result<Toolchain> {
+pub fn resolve_windows_msvc_toolchain() -> anyhow::Result<NativeToolchain> {
     let environment = resolve_windows_msvc_environment()?;
     let cl_exe = environment.cl_exe.display().to_string();
     let cc = CC::try_from_path(&cl_exe)
         .with_context(|| format!("failed to resolve MSVC compiler at {cl_exe}"))?;
-    Ok(Toolchain::from_path_probe(cc).with_msvc_environment(environment))
+    Ok(NativeToolchain::from_path_probe(cc).with_msvc_environment(environment))
 }
 
 fn ensure_windows_msvc_compatible(cc: &CC) -> anyhow::Result<()> {
@@ -315,50 +444,75 @@ fn ensure_windows_msvc_compatible(cc: &CC) -> anyhow::Result<()> {
         Ok(())
     } else {
         anyhow::bail!(
-            "Windows native backend requires an MSVC cl-compatible compiler driver such as cl.exe or clang-cl.exe; found {}",
+            "MSVC ABI native builds require a cl-compatible compiler driver such as cl.exe or clang-cl.exe; found {}",
             cc.cc_path
         )
     }
 }
 
-pub fn windows_msvc_native_toolchain(package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
+pub fn ensure_supported_native_toolchain_contract(
+    contract: &NativeBuildContract,
+) -> anyhow::Result<()> {
+    if contract.uses_msvc_abi() {
+        if contract.msvc_crt_policy().is_none() {
+            anyhow::bail!("MSVC ABI native builds require a known CRT policy")
+        }
+        if contract.msvc_environment().is_none() {
+            anyhow::bail!("MSVC ABI native builds require a resolved MSVC toolchain environment")
+        }
+    }
+    Ok(())
+}
+
+fn validate_native_driver_for_contract(
+    contract: &NativeBuildContract,
+    driver: &NativeCommandDriver,
+) -> anyhow::Result<()> {
+    if driver.abi_family() != contract.abi_family() {
+        anyhow::bail!(
+            "native toolchain ABI mismatch: selected build uses {} ABI, but package override uses {} ABI via {}",
+            contract.abi_family(),
+            driver.abi_family(),
+            driver.cc().cc_path
+        );
+    }
+
+    if driver.msvc_crt_policy() != contract.msvc_crt_policy() {
+        anyhow::bail!(
+            "native toolchain CRT mismatch: selected build uses {:?}, but package override uses {:?} via {}",
+            contract.msvc_crt_policy(),
+            driver.msvc_crt_policy(),
+            driver.cc().cc_path
+        );
+    }
+
+    if contract.uses_msvc_abi() {
+        ensure_windows_msvc_compatible(driver.cc())?;
+    }
+
+    Ok(())
+}
+
+pub fn native_toolchain_with_package_override(
+    selected: &NativeToolchain,
+    package_cc: Option<&CC>,
+) -> anyhow::Result<NativeToolchain> {
+    let toolchain = selected.with_package_override(package_cc);
+    validate_native_driver_for_contract(toolchain.contract(), toolchain.driver())?;
+    ensure_supported_native_toolchain_contract(toolchain.contract())?;
+    Ok(toolchain)
+}
+
+pub fn windows_msvc_native_toolchain() -> anyhow::Result<NativeToolchain> {
     if let Some(env_cc) = ENV_CC.as_ref().filter(|cc| cc.is_msvc()) {
-        let resolved =
-            attach_msvc_environment_if_available(Toolchain::from_env_override(env_cc.clone()));
-        return windows_msvc_toolchain_with_package_override(resolved, package_cc);
+        return attach_msvc_environment(NativeToolchain::from_env_override(env_cc.clone()));
     }
 
-    if let Some(package_cc) = package_cc {
-        ensure_windows_msvc_compatible(package_cc)?;
-    }
-
-    let resolved = resolve_windows_msvc_toolchain()?;
-    windows_msvc_toolchain_with_package_override(resolved, package_cc)
+    resolve_windows_msvc_toolchain()
 }
 
 pub fn has_incompatible_windows_msvc_env_override() -> bool {
     ENV_CC.as_ref().is_some_and(|cc| !cc.is_msvc())
-}
-
-fn windows_msvc_toolchain_with_package_override(
-    resolved: Toolchain,
-    package_cc: Option<&CC>,
-) -> anyhow::Result<Toolchain> {
-    let mut toolchain = resolved.with_package_override(package_cc);
-    ensure_windows_msvc_compatible(toolchain.cc())?;
-
-    if toolchain.source() == ToolchainSource::PackageOverride
-        && let Some(environment) = resolved.msvc_environment()
-    {
-        let cl_exe = PathBuf::from(&toolchain.cc().cc_path);
-        toolchain = toolchain.with_msvc_environment(MsvcEnvironment {
-            cl_exe,
-            include_paths: environment.include_paths.clone(),
-            lib_paths: environment.lib_paths.clone(),
-        });
-    }
-
-    Ok(toolchain)
 }
 
 impl CC {
@@ -758,30 +912,30 @@ pub fn has_cc_env_override() -> bool {
     env::var_os(ENV_MOON_CC).is_some()
 }
 
-pub fn default_native_toolchain(internal_tcc_fallback: Option<&CC>) -> anyhow::Result<Toolchain> {
+pub fn default_native_toolchain(
+    internal_tcc_fallback: Option<&CC>,
+) -> anyhow::Result<NativeToolchain> {
     if let Some(env_cc) = ENV_CC.as_ref() {
-        return Ok(Toolchain::from_env_override(env_cc.clone()));
+        return Ok(attach_msvc_environment_if_available(
+            NativeToolchain::from_env_override(env_cc.clone()),
+        ));
     }
+
+    if cfg!(windows)
+        && let Ok(toolchain) = resolve_windows_msvc_toolchain()
+    {
+        return Ok(toolchain);
+    }
+
     match try_system_cc() {
-        Ok(cc) => Ok(Toolchain::from_path_probe(cc)),
+        Ok(cc) => Ok(attach_msvc_environment_if_available(
+            NativeToolchain::from_path_probe(cc),
+        )),
         Err(err) => match internal_tcc_fallback {
-            Some(internal_tcc) => Ok(Toolchain::from_path_probe(internal_tcc.clone())),
+            Some(internal_tcc) => Ok(NativeToolchain::from_path_probe(internal_tcc.clone())),
             None => Err(err),
         },
     }
-}
-
-pub fn effective_native_toolchain(
-    package_cc: Option<&CC>,
-    internal_tcc_fallback: Option<&CC>,
-) -> anyhow::Result<Toolchain> {
-    if let Some(env_cc) = ENV_CC.as_ref() {
-        return Ok(Toolchain::from_env_override(env_cc.clone()).with_package_override(package_cc));
-    }
-    if let Some(package_cc) = package_cc {
-        return Ok(Toolchain::from_package_override(package_cc.clone()));
-    }
-    default_native_toolchain(internal_tcc_fallback)
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -1239,8 +1393,11 @@ fn add_cc_include_and_lib_paths(cc: &CC, buf: &mut Vec<String>, ipath: &str, lpa
     }
 }
 
-fn add_cc_msvc_environment_include_paths(toolchain: Option<&Toolchain>, buf: &mut Vec<String>) {
-    let Some(environment) = toolchain.and_then(Toolchain::msvc_environment) else {
+fn add_cc_msvc_environment_include_paths(
+    toolchain: Option<&NativeToolchain>,
+    buf: &mut Vec<String>,
+) {
+    let Some(environment) = toolchain.and_then(NativeToolchain::msvc_environment) else {
         return;
     };
     buf.extend(
@@ -1309,9 +1466,9 @@ fn add_cc_msvc_specific_flags(cc: &CC, buf: &mut Vec<String>, has_user_flags: bo
     buf.push("/nologo".to_string());
 }
 
-fn add_cc_msvc_runtime_flags(cc: &CC, toolchain: Option<&Toolchain>, buf: &mut Vec<String>) {
+fn add_cc_msvc_runtime_flags(cc: &CC, toolchain: Option<&NativeToolchain>, buf: &mut Vec<String>) {
     if cc.is_msvc()
-        && let Some(crt) = toolchain.and_then(Toolchain::msvc_crt_policy)
+        && let Some(crt) = toolchain.and_then(NativeToolchain::msvc_crt_policy)
     {
         buf.push(crt.compiler_flag().to_string());
     }
@@ -1567,7 +1724,7 @@ where
 
 #[allow(clippy::too_many_arguments)]
 pub fn make_cc_command_resolved_for_toolchain<S, L>(
-    toolchain: &Toolchain,
+    toolchain: &NativeToolchain,
     config: CCConfig,
     cc_flags: &[S],
     user_link_flags: &[L],
@@ -1595,7 +1752,7 @@ where
 
 #[allow(clippy::too_many_arguments)]
 fn make_cc_command_resolved_with_link_flags_and_toolchain<S, L>(
-    toolchain: Option<&Toolchain>,
+    toolchain: Option<&NativeToolchain>,
     cc: CC,
     config: CCConfig,
     cc_flags: &[S],
@@ -1700,6 +1857,43 @@ mod tests {
     }
 
     #[test]
+    fn classifies_native_abi_family_from_target_triple() {
+        assert_eq!(
+            NativeToolchain::from_path_probe(fake_cc(CCKind::Msvc, None)).abi_family(),
+            NativeAbiFamily::Msvc
+        );
+        assert_eq!(
+            NativeToolchain::from_path_probe(fake_cc(
+                CCKind::Clang,
+                Some("x86_64-pc-windows-msvc")
+            ))
+            .abi_family(),
+            NativeAbiFamily::Msvc
+        );
+        assert_eq!(
+            NativeToolchain::from_path_probe(fake_cc(CCKind::Gcc, Some("x86_64-w64-windows-gnu")))
+                .abi_family(),
+            NativeAbiFamily::WindowsGnu
+        );
+        assert_eq!(
+            NativeToolchain::from_path_probe(fake_cc(
+                CCKind::Clang,
+                Some("arm64-apple-darwin25.5.0")
+            ))
+            .abi_family(),
+            NativeAbiFamily::AppleDarwin
+        );
+        assert_eq!(
+            NativeToolchain::from_path_probe(fake_cc(
+                CCKind::Gcc,
+                Some("x86_64-unknown-linux-gnu")
+            ))
+            .abi_family(),
+            NativeAbiFamily::UnixLike
+        );
+    }
+
+    #[test]
     fn windows_msvc_compatibility_rejects_gnu_toolchains() {
         assert!(ensure_windows_msvc_compatible(&fake_cc(CCKind::Msvc, None)).is_ok());
         assert!(
@@ -1719,7 +1913,7 @@ mod tests {
         cc.ar_kind = ARKind::MsvcLib;
         cc.ar_path = "lib.exe".to_string();
 
-        let toolchain = Toolchain::from_path_probe(cc);
+        let toolchain = NativeToolchain::from_path_probe(cc);
 
         assert_eq!(toolchain.abi_family(), NativeAbiFamily::Msvc);
         assert!(toolchain.uses_msvc_abi());
@@ -1736,14 +1930,30 @@ mod tests {
 
     #[test]
     fn toolchain_tracks_msvc_abi_without_cl_driver_crt_policy() {
-        let toolchain =
-            Toolchain::from_path_probe(fake_cc(CCKind::Clang, Some("x86_64-pc-windows-msvc")));
+        let toolchain = NativeToolchain::from_path_probe(fake_cc(
+            CCKind::Clang,
+            Some("x86_64-pc-windows-msvc"),
+        ));
 
         assert_eq!(toolchain.abi_family(), NativeAbiFamily::Msvc);
         assert!(toolchain.uses_msvc_abi());
         assert!(!toolchain.uses_msvc_driver());
         assert!(toolchain.uses_msvc_link_library_names());
         assert_eq!(toolchain.msvc_crt_policy(), None);
+    }
+
+    #[test]
+    fn msvc_contract_requires_resolved_toolchain_environment() {
+        let mut cc = fake_cc(CCKind::Msvc, None);
+        cc.cc_path = "cl.exe".to_string();
+        cc.ar_kind = ARKind::MsvcLib;
+        cc.ar_path = "lib.exe".to_string();
+        let toolchain = NativeToolchain::from_path_probe(cc);
+
+        let err = ensure_supported_native_toolchain_contract(toolchain.contract())
+            .expect_err("MSVC ABI contract without environment should be rejected");
+
+        assert!(err.to_string().contains("MSVC toolchain environment"));
     }
 
     #[test]
@@ -1754,18 +1964,18 @@ mod tests {
         env_cc.ar_path = "env-lib.exe".to_string();
         env_cc.is_env_override = true;
         let resolved =
-            Toolchain::from_env_override(env_cc).with_msvc_environment(MsvcEnvironment {
+            NativeToolchain::from_env_override(env_cc).with_msvc_environment(MsvcEnvironment {
                 cl_exe: PathBuf::from("env-cl.exe"),
+                env_pairs: vec![(OsString::from("PATH"), OsString::from("env/bin"))],
                 include_paths: vec![PathBuf::from("env/include")],
                 lib_paths: vec![PathBuf::from("env/lib")],
             });
         let mut package_cc = fake_cc(CCKind::Clang, Some("x86_64-pc-windows-msvc"));
         package_cc.cc_path = "clang.exe".to_string();
 
-        let toolchain = windows_msvc_toolchain_with_package_override(resolved, Some(&package_cc))
+        let toolchain = native_toolchain_with_package_override(&resolved, Some(&package_cc))
             .expect("MOON_CC-style source should ignore package cc");
 
-        assert_eq!(toolchain.source(), ToolchainSource::EnvOverride);
         assert_eq!(toolchain.cc().cc_path, "env-cl.exe");
         assert_eq!(
             toolchain
@@ -1773,6 +1983,89 @@ mod tests {
                 .expect("env toolchain keeps MSVC environment")
                 .lib_paths,
             vec![PathBuf::from("env/lib")]
+        );
+        assert_eq!(
+            toolchain
+                .msvc_environment()
+                .expect("env toolchain keeps MSVC environment")
+                .env_pairs,
+            vec![(OsString::from("PATH"), OsString::from("env/bin"))]
+        );
+    }
+
+    #[test]
+    fn native_toolchain_contract_rejects_mixed_msvc_and_windows_gnu_abi() {
+        let mut selected_cc = fake_cc(CCKind::Msvc, None);
+        selected_cc.cc_path = "cl.exe".to_string();
+        selected_cc.ar_kind = ARKind::MsvcLib;
+        selected_cc.ar_path = "lib.exe".to_string();
+        let selected =
+            NativeToolchain::from_path_probe(selected_cc).with_msvc_environment(MsvcEnvironment {
+                cl_exe: PathBuf::from("cl.exe"),
+                env_pairs: vec![(OsString::from("PATH"), OsString::from("msvc/bin"))],
+                include_paths: vec![PathBuf::from("msvc/include")],
+                lib_paths: vec![PathBuf::from("msvc/lib")],
+            });
+        let mut package_cc = fake_cc(CCKind::Gcc, Some("x86_64-w64-windows-gnu"));
+        package_cc.cc_path = "x86_64-w64-mingw32-gcc".to_string();
+
+        let err = native_toolchain_with_package_override(&selected, Some(&package_cc))
+            .expect_err("Windows-GNU package override must not enter an MSVC link contract");
+
+        assert!(err.to_string().contains("ABI mismatch"));
+    }
+
+    #[test]
+    fn native_toolchain_contract_rejects_plain_clang_msvc_driver_for_now() {
+        let mut selected_cc = fake_cc(CCKind::Msvc, None);
+        selected_cc.cc_path = "cl.exe".to_string();
+        selected_cc.ar_kind = ARKind::MsvcLib;
+        selected_cc.ar_path = "lib.exe".to_string();
+        let selected = NativeToolchain::from_path_probe(selected_cc);
+        let mut package_cc = fake_cc(CCKind::Clang, Some("x86_64-pc-windows-msvc"));
+        package_cc.cc_path = "clang.exe".to_string();
+
+        let err = native_toolchain_with_package_override(&selected, Some(&package_cc))
+            .expect_err("plain clang MSVC target has a different CRT driver contract today");
+
+        assert!(err.to_string().contains("CRT mismatch"));
+    }
+
+    #[test]
+    fn native_toolchain_contract_reuses_msvc_environment_for_clang_cl_override() {
+        let mut selected_cc = fake_cc(CCKind::Msvc, None);
+        selected_cc.cc_path = "cl.exe".to_string();
+        selected_cc.ar_kind = ARKind::MsvcLib;
+        selected_cc.ar_path = "lib.exe".to_string();
+        let selected =
+            NativeToolchain::from_path_probe(selected_cc).with_msvc_environment(MsvcEnvironment {
+                cl_exe: PathBuf::from("cl.exe"),
+                env_pairs: vec![(OsString::from("PATH"), OsString::from("msvc/bin"))],
+                include_paths: vec![PathBuf::from("msvc/include")],
+                lib_paths: vec![PathBuf::from("msvc/lib")],
+            });
+        let mut package_cc = fake_cc(CCKind::Msvc, None);
+        package_cc.cc_path = "clang-cl.exe".to_string();
+        package_cc.ar_kind = ARKind::MsvcLib;
+        package_cc.ar_path = "lib.exe".to_string();
+
+        let toolchain = native_toolchain_with_package_override(&selected, Some(&package_cc))
+            .expect("clang-cl should be compatible with the selected MSVC contract");
+
+        assert_eq!(toolchain.cc().cc_path, "clang-cl.exe");
+        assert_eq!(
+            toolchain
+                .msvc_environment()
+                .expect("compatible package override reuses MSVC env")
+                .env_pairs,
+            vec![(OsString::from("PATH"), OsString::from("msvc/bin"))]
+        );
+        assert_eq!(
+            toolchain
+                .msvc_environment()
+                .expect("compatible package override reuses MSVC env")
+                .cl_exe,
+            PathBuf::from("cl.exe")
         );
     }
 
@@ -1782,7 +2075,7 @@ mod tests {
         cc.cc_path = "cl.exe".to_string();
         cc.ar_kind = ARKind::MsvcLib;
         cc.ar_path = "lib.exe".to_string();
-        let toolchain = Toolchain::from_path_probe(cc);
+        let toolchain = NativeToolchain::from_path_probe(cc);
         let paths = CompilerPaths {
             include_path: "moon/include".to_string(),
             lib_path: "moon/lib".to_string(),

--- a/docs/adr/0002-native-abi-policy-belongs-to-toolchains.md
+++ b/docs/adr/0002-native-abi-policy-belongs-to-toolchains.md
@@ -12,4 +12,4 @@ Native builds have separate choices that are easy to conflate: the native payloa
 
 ## Consequences
 
-The interface between build planning and lowering carries more domain meaning than a raw compiler path, which improves locality for ABI and CRT changes. Future GNU-like Windows support should refine toolchain policy and resolution instead of adding another backend mode. Follow-up work may split payload form and executable realization further if more native backends make the current enum shallow.
+The interface between build planning and lowering carries more domain meaning than a raw compiler path, which improves locality for ABI and CRT changes. Future GNU-like Windows support should refine toolchain policy and resolution instead of adding another backend mode. Follow-up work may split payload form and executable realization further if more native backends make the current enum shallow. Invocation-scoped native contract selection follows the same toolchain-owned boundary and is recorded separately in [ADR 0003](0003-one-native-build-contract-per-invocation.md).

--- a/docs/adr/0003-one-native-build-contract-per-invocation.md
+++ b/docs/adr/0003-one-native-build-contract-per-invocation.md
@@ -1,0 +1,35 @@
+# One Native Build Contract Per Invocation
+
+Moon resolves one native build contract for each native build invocation. The contract contains the ABI family, CRT linkage policy where applicable, and toolchain environment. Runtime compilation, generated-C compilation and linking, package C stub archives, and direct-object executable linking must all match that contract.
+
+When Moon targets the MSVC ABI on Windows, the native toolchain is not just a `cl.exe`-compatible executable path: the compiler, linker, headers, libraries, Windows SDK, and CRT library set are tied to one Visual Studio/MSVC environment. Moon resolves one MSVC-family toolchain environment per native build invocation and reuses it for runtime compilation, package C stub compilation, and final executable linking, regardless of whether MoonBit produced generated C or direct object code.
+
+The implementation separates the durable compatibility choice from the executable used for an individual command:
+
+- `NativeBuildContract` is the invocation-level ABI/CRT/environment contract and is the only native toolchain state stored on the build plan as a whole.
+- `NativeCommandDriver` is the concrete compiler/linker/archiver selected for one native action.
+- `NativeToolchain` pairs a command driver with the contract it has been validated against before lowering emits command lines.
+
+Package-level `link.native.cc` and `link.native.stub_cc` therefore produce action-scoped command drivers. They may choose a compatible executable, but they do not choose an independent ABI family, CRT linkage, or MSVC environment.
+
+## Considered Options
+
+- Resolve tools independently for each package or native build step. Rejected because a single final executable could silently mix different Visual Studio installations, Windows SDK views, ABI families, or CRT policies.
+- Scan every package configuration first and let package-level overrides choose the global toolchain. Rejected because package overrides are escape hatches for specific build steps; they should be validated against the invocation contract, not decide the executable's ABI world.
+- Build shared packages multiple times when roots require different native contracts. Rejected for now because it requires action keys, artifact paths, and cache keys to include the native contract for runtime objects, C stub archives, generated C outputs, and final executable links.
+- Keep MSVC discovery only in the direct-object backend path. Rejected because generated-C builds that use `cl.exe` or `clang-cl.exe` have the same MSVC environment and CRT constraints.
+
+## Consequences
+
+- `MOON_CC` remains the highest-precedence user override, but when a build path requires the MSVC ABI it must name a cl-compatible driver such as `cl.exe` or `clang-cl.exe`.
+- Package-level `link.native.cc` and `link.native.stub_cc` may choose a compatible driver, but must not switch the invocation to a different ABI family, CRT policy, or independent MSVC environment.
+- A native build invocation rejects conflicting package overrides instead of building shared packages twice under different native contracts.
+- Windows default resolution should use MSVC environment discovery when the MSVC ABI is required or selected, and generic `cc`/`gcc`/`clang` fallback should only apply outside that MSVC-required path.
+- `clang-cl.exe` is treated as MSVC-family for ABI and environment purposes even though it is a Clang driver.
+
+## References
+
+- [Use the Microsoft C++ Build Tools from the command line](https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170)
+- [CL environment variables](https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables?view=msvc-170)
+- [/MD, /MT, /LD runtime library options](https://learn.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170)
+- [clang-cl user manual](https://clang.llvm.org/docs/UsersManual.html#clang-cl)

--- a/docs/dev/reference/native-c-toolchain-resolution.md
+++ b/docs/dev/reference/native-c-toolchain-resolution.md
@@ -11,6 +11,17 @@ The resolved toolchain has three roles:
 Moon does not resolve a standalone linker executable such as `ld` or `lld-link` in this path.
 Linking is performed through the selected compiler driver.
 
+For MSVC-family toolchains, the resolved toolchain also needs the Visual Studio/MSVC environment
+that supplies tool, header, library, Windows SDK, and CRT search context. That environment is part
+of the toolchain decision, not a separate backend choice.
+
+Implementation vocabulary:
+
+- `NativeCommandDriver`: the compiler/linker executable and archiver used by one native action
+- `NativeBuildContract`: the invocation-level ABI family, CRT policy, and MSVC environment
+- `NativeToolchain`: an action-level command driver paired with the contract it has been checked
+  against
+
 ## Standard C Pipeline
 
 The ordinary C pipeline is:
@@ -68,11 +79,19 @@ There are three sources of C toolchain selection:
 2. package-level override
 3. default auto-detection
 
-When a native build step chooses its compiler, the current precedence is:
+When a native build invocation chooses its contract, the package-level overrides are not scanned
+first and do not decide the graph's ABI world. The contract selection is:
 
-1. `MOON_CC` / `MOON_AR`
-2. package-level override (`link.native.cc` or `link.native.stub_cc`)
-3. detected default toolchain
+1. Windows direct-object MSVC target: resolve an MSVC-family toolchain environment and require a
+   cl-compatible driver. A cl-compatible `MOON_CC` may choose the driver; incompatible `MOON_CC`
+   is ignored for this target with a warning.
+2. Other native paths: use `MOON_CC` / `MOON_AR` if present.
+3. Otherwise use default auto-detection.
+
+Moon then treats the result as the native build contract for the invocation: one ABI family, one CRT
+linkage policy where applicable, and one toolchain environment. Runtime compilation, generated-C
+compilation and linking, C stub archives, and direct-object executable linking are all validated
+against that contract.
 
 ## Global Environment Override
 
@@ -101,16 +120,61 @@ They are useful as escape hatches, but they are toolchain-specific, not portable
 For example, `cc = "cl"` is MSVC-specific, while `cc = "gcc"` or GNU-style flags are specific to
 other toolchain families.
 
+Package-level overrides must not be treated as independent ABI decisions for a final executable.
+If the executable has selected an MSVC-family toolchain, package-level C compiler overrides must stay
+within that family and use the same toolchain environment. If they do not, Moon should reject the
+combination instead of producing a mixed-ABI link.
+
+Moon currently does not build the same dependency package multiple times for different native
+contracts in one `moon build --target native` invocation. Supporting that would require the build
+plan, artifact paths, and cache keys for runtime objects, C stub archives, generated C outputs, and
+final executable links to include the native contract. Until that model exists, conflicting package
+overrides are rejected.
+
 ## Default Auto-Detection
 
-When `MOON_CC` is unset and no package-specific override is being applied to that step, Moon probes
-for a default native toolchain in this order:
+When `MOON_CC` is unset, Moon probes for a default native toolchain. On Windows, Moon first tries
+MSVC environment discovery so generated-C builds can also work outside a Developer Command Prompt.
+If that fails, or on non-Windows hosts, Moon falls back to generic compiler probing:
 
 1. `cl`
 2. `cc`
 3. `gcc`
 4. `clang`
 5. internal `tcc`
+
+Moon should not scan every package configuration first to decide the default native toolchain. The
+default belongs to the build invocation: use the explicit global/direct-target choice when present,
+otherwise use host default resolution. Package C and C-stub overrides are then compatibility checks
+against that selected contract.
+
+On Windows, host default resolution for an MSVC-family build should prefer MSVC discovery through
+the Visual Studio tool environment before falling back to generic C compiler probes. Generic GNU-like
+fallbacks remain valid only for build paths that have not selected or required the MSVC ABI.
+
+## MSVC Toolchain Environment
+
+The decision record for this model is [ADR 0003](../../adr/0003-one-native-build-contract-per-invocation.md).
+
+Microsoft's command-line C++ tools require more than a compiler executable on `PATH`. The environment
+sets the locations of the compiler tools, include files, libraries, and SDKs, and is specific to the
+installed Visual Studio/MSVC version, host architecture, target architecture, Windows SDK, and platform
+toolset.
+
+`cl.exe` consumes this environment directly, including `INCLUDE`, `LIB`, and `LIBPATH`. `clang-cl.exe`
+is also a cl-compatible Windows driver: it uses MSVC-style options, links with the Microsoft runtime
+ecosystem, and needs a Visual Studio/MSVC environment to find system headers, libraries, and the
+linker when used from the command line.
+
+Because of that, a Moon build that targets the MSVC ABI resolves one MSVC toolchain environment for
+the build invocation. It may use a different compatible driver within that environment, such as
+`clang-cl.exe`, but it must not mix a runtime built under one Visual Studio environment with C stubs
+or final linking under another.
+
+The `n2` graph currently stores command lines, not per-command environment maps. Moon therefore
+applies the resolved MSVC environment to the Moon process while the native graph executes and restores
+the previous environment afterward. That operational constraint is another reason the current model
+has one MSVC environment per native build invocation.
 
 ## Compiler Kind Detection
 


### PR DESCRIPTION
## Why

Native builds currently conflate the compiler command used for an action with the ABI, CRT, and MSVC environment obligations that apply to the whole native build invocation. That makes the MSVC path easy to extend incorrectly, especially when package-level `cc` overrides are involved.

## What changed

This separates the native build contract from the action command driver. The build plan records one invocation-level contract, while individual native actions use a compatible driver checked against that contract. MSVC ABI contracts now require a known CRT policy and a resolved MSVC toolchain environment, and the resolved environment is applied while n2 executes native jobs.

The PR also records the model in the native toolchain reference docs and a new ADR.

## Why this is correct

MSVC ABI, CRT linkage, and Visual Studio environment selection are link-unit constraints, not independent per-package choices. Package-level compiler overrides remain available, but they are treated as per-action driver overrides and rejected if they would switch ABI family, CRT policy, or MSVC environment.

## Scope

The change keeps the current one-contract-per-invocation model. Supporting multiple native contracts in one build graph remains future work because artifact paths, action keys, and shared native products would need to be contract-keyed first.