### PR TITLE
Fix local install workspace resolution

### DIFF
--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -18,12 +18,13 @@
 
 use anyhow::bail;
 use mooncake::pkg::{
-    add::AddSubcommand, install::InstallSubcommand, remove::RemoveSubcommand, tree::TreeSubcommand,
+    add::AddSubcommand, install::InstallSubcommand, remove::RemoveSubcommand,
+    sync::SyncOutputOptions, tree::TreeSubcommand,
 };
 use moonutil::{
     dirs::{PackageDirs, ProjectContext},
     moon_dir,
-    mooncakes::{ModuleName, RegistryConfig},
+    mooncakes::{ModuleName, RegistryConfig, sync::AutoSyncFlags},
 };
 use std::path::{Path, PathBuf};
 
@@ -74,18 +75,22 @@ pub(crate) fn install_cli(cli: UniversalFlags, cmd: InstallSubcommand) -> anyhow
         let PackageDirs {
             source_dir,
             mooncakes_dir,
+            project_manifest_path,
             ..
         } = cli
             .source_tgt_dir
             .query(cli.workspace_env.clone())?
             .package_dirs()?;
-        return mooncake::pkg::install::install(
+        mooncake::pkg::sync::auto_sync(
             &source_dir,
             &mooncakes_dir,
-            cli.quiet,
-            cli.verbose,
+            &AutoSyncFlags { frozen: false },
+            SyncOutputOptions::new(cli.quiet, true),
             true,
-        );
+            cli.workspace_env.clone(),
+            project_manifest_path.as_deref(),
+        )?;
+        return Ok(0);
     }
 
     let install_dir = cmd.bin.unwrap_or_else(moon_dir::user_bin);

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -28,7 +28,7 @@ use moonutil::{
     cli::UniversalFlags,
     common::{FileLock, MOON_MOD, MOON_MOD_JSON, RunMode, TargetBackend},
     dirs::PackageDirs,
-    mooncakes::{ModuleName, RegistryConfig},
+    mooncakes::{ModuleName, ModuleSourceKind, RegistryConfig},
 };
 use semver::Version;
 use std::path::{Path, PathBuf};
@@ -298,9 +298,13 @@ pub(super) fn install_from_local(
         )
     })?;
 
-    let module_dirs = cli
+    let mut query = cli
         .source_tgt_dir
-        .source_module_package_dirs(&input_path)?
+        .query_from(&input_path, cli.workspace_env.clone())?;
+    let project = query.project()?;
+    let module_root = project
+        .selected_module()
+        .map(|module| module.root)
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "Path `{}` is not in a MoonBit module (no {} or {} found in ancestors)",
@@ -309,16 +313,17 @@ pub(super) fn install_from_local(
                 MOON_MOD_JSON
             )
         })?;
+    let package_dirs = query.package_dirs()?;
 
-    let module = moonutil::common::read_module_desc_file_in_dir(&module_dirs.module_root)?;
+    let module = moonutil::common::read_module_desc_file_in_dir(&module_root)?;
     let module_name: ModuleName = module.name.parse().map_err(|e| anyhow::anyhow!("{}", e))?;
     let filter = PackageFilter::filesystem(input_path, install_all);
 
     build_and_install_packages(
         cli,
         &module_name,
-        &module_dirs.module_root,
-        module_dirs.package_dirs,
+        &module_root,
+        package_dirs,
         install_dir,
         filter,
     )
@@ -458,6 +463,12 @@ fn build_and_install_packages(
     install_dir: &Path,
     filter: PackageFilter,
 ) -> anyhow::Result<i32> {
+    let module_dir = dunce::canonicalize(module_dir).with_context(|| {
+        format!(
+            "Failed to resolve module directory `{}`",
+            module_dir.display()
+        )
+    })?;
     let quiet = cli.quiet;
     let output = UserDiagnostics::from_flags(cli);
     let source_dir = package_dirs.source_dir;
@@ -476,7 +487,23 @@ fn build_and_install_packages(
     )?;
     let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
 
-    let main_module_id = resolve_output.local_modules()[0];
+    let main_module_id = resolve_output
+        .local_modules()
+        .iter()
+        .copied()
+        .find(|&module_id| {
+            matches!(
+                resolve_output.module_rel.module_source(module_id).source(),
+                ModuleSourceKind::Local(path) if path == &module_dir
+            )
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Module `{}` at path `{}` was not resolved as a local project module",
+                module_name,
+                module_dir.display()
+            )
+        })?;
     let Some(all_pkgs) = resolve_output.pkg_dirs.packages_for_module(main_module_id) else {
         bail!(
             "No packages found in module at path `{}`",
@@ -523,7 +550,7 @@ fn build_and_install_packages(
     }
 
     if selected_packages.is_empty() {
-        return Err(filter.no_match_error(module_name, module_dir));
+        return Err(filter.no_match_error(module_name, &module_dir));
     }
 
     if cli.dry_run {

--- a/crates/moon/tests/test_cases/moon_install_global.rs
+++ b/crates/moon/tests/test_cases/moon_install_global.rs
@@ -33,6 +33,18 @@ fn test_moon_install_global_deprecated_warning() {
 }
 
 #[test]
+fn test_moon_install_global_deprecated_uses_workspace_context() {
+    let dir = TestDir::new("workspace_basic.in");
+
+    let stderr = get_stderr(&dir, ["-C", "app", "install"]);
+    assert!(
+        stderr.contains("deprecated"),
+        "Expected deprecation warning in stderr, got: {}",
+        stderr
+    );
+}
+
+#[test]
 fn test_moon_install_global_local_path() {
     // Test installing from local path using --path
     let dir = TestDir::new("moon_install_global.in");
@@ -54,6 +66,37 @@ fn test_moon_install_global_local_path() {
     );
 
     // Check that the binary was created
+    #[cfg(unix)]
+    let binary_path = install_dir.join("main");
+    #[cfg(target_os = "windows")]
+    let binary_path = install_dir.join("main.exe");
+
+    assert!(
+        binary_path.exists(),
+        "Expected binary at {:?} to exist",
+        binary_path
+    );
+}
+
+#[test]
+fn test_moon_install_global_local_path_uses_workspace_context() {
+    let dir = TestDir::new("workspace_basic.in");
+    let install_dir = dir.join("test_bin_install_workspace");
+    std::fs::create_dir_all(&install_dir).unwrap();
+
+    let _output = get_stdout(
+        &dir,
+        [
+            "-C",
+            "app",
+            "install",
+            "--path",
+            "src/main",
+            "--bin",
+            install_dir.to_str().unwrap(),
+        ],
+    );
+
     #[cfg(unix)]
     let binary_path = install_dir.join("main");
     #[cfg(target_os = "windows")]

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -25,16 +25,13 @@ use crate::{
 use super::sync::SyncOutputOptions;
 use anyhow::Context;
 use moonutil::{
-    common::{MOONBITLANG_CORE, read_module_desc_file_in_dir},
+    common::MOONBITLANG_CORE,
     mooncakes::{
-        DirSyncResult, ModuleSource,
-        result::{DependencyKind, ResolvedEnv, ResolvedModule, ResolvedRootModules},
+        DirSyncResult,
+        result::{DependencyKind, ResolvedEnv, ResolvedRootModules},
     },
 };
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::path::{Path, PathBuf};
 
 /// Install a binary package globally or install project dependencies (deprecated without args)
 #[derive(Debug, clap::Parser)]
@@ -81,28 +78,6 @@ pub struct InstallSubcommand {
     /// Git tag to checkout (requires git URL)
     #[clap(long, group = "git_ref", requires = "source")]
     pub tag: Option<String>,
-}
-
-pub fn install(
-    source_dir: &Path,
-    mooncakes_dir: &Path,
-    quiet: bool,
-    verbose: bool,
-    no_std: bool,
-) -> anyhow::Result<i32> {
-    let m = read_module_desc_file_in_dir(source_dir)?;
-    let m = Arc::new(m);
-    let ms = ModuleSource::from_local_module(&m, source_dir);
-    let (roots, _) = ResolvedModule::only_one_module(ms, m);
-    install_impl(
-        mooncakes_dir,
-        roots,
-        SyncOutputOptions::new(quiet, true),
-        verbose,
-        false,
-        no_std,
-    )
-    .map(|_| 0)
 }
 
 pub(crate) fn install_impl(


### PR DESCRIPTION
## Summary

- Make deprecated no-argument `moon install` use workspace-aware dependency sync.
- Make local binary install resolve project context from the selected local path so `moon.work` is honored.
- Add regressions for workspace-local install behavior.

## Why

Local install paths bypassed the normal project selection pipeline. As a result, a package inside a workspace member could be resolved as a standalone module, and sibling workspace dependencies were not available as local workspace modules.

## Correctness

The change routes local install through the same workspace-aware query and sync plumbing used by other project commands. Binary install then selects the intended resolved module by its local source path instead of depending on the order of resolved local modules.

## Scope

This keeps registry and git install source materialization unchanged. The fix is limited to local install behavior and regression coverage for that path.