### PR TITLE
Model selected project manifest

### DIFF
--- a/crates/moon/src/cli/bench.rs
+++ b/crates/moon/src/cli/bench.rs
@@ -19,7 +19,7 @@
 use anyhow::Context;
 use moonutil::{
     common::{TargetBackend, TestIndexRange, lower_surface_targets},
-    dirs::PackageDirs,
+    dirs::{PackageDirs, ProjectManifest},
     mooncakes::sync::AutoSyncFlags,
 };
 use std::path::{Path, PathBuf};
@@ -69,7 +69,7 @@ pub(crate) fn run_bench(cli: UniversalFlags, cmd: BenchSubcommand) -> anyhow::Re
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     } = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
@@ -82,7 +82,7 @@ pub(crate) fn run_bench(cli: UniversalFlags, cmd: BenchSubcommand) -> anyhow::Re
             &source_dir,
             &target_dir,
             &mooncakes_dir,
-            project_manifest_path.as_deref(),
+            &project_manifest,
             None,
             None,
         );
@@ -99,7 +99,7 @@ pub(crate) fn run_bench(cli: UniversalFlags, cmd: BenchSubcommand) -> anyhow::Re
             &source_dir,
             &target_dir,
             &mooncakes_dir,
-            project_manifest_path.as_deref(),
+            &project_manifest,
             display_backend_hint,
             Some(t),
         )
@@ -117,7 +117,7 @@ fn run_bench_internal(
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     display_backend_hint: Option<()>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
@@ -127,7 +127,7 @@ fn run_bench_internal(
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
         display_backend_hint,
         selected_target_backend,
     )

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -23,7 +23,7 @@ use moonutil::common::FileLock;
 use moonutil::common::RunMode;
 use moonutil::common::TargetBackend;
 use moonutil::common::lower_surface_targets;
-use moonutil::dirs::PackageDirs;
+use moonutil::dirs::{PackageDirs, ProjectManifest};
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
@@ -87,7 +87,7 @@ pub(crate) fn run_build(cli: &UniversalFlags, cmd: BuildSubcommand) -> anyhow::R
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     } = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
@@ -100,7 +100,7 @@ pub(crate) fn run_build(cli: &UniversalFlags, cmd: BuildSubcommand) -> anyhow::R
             &source_dir,
             &target_dir,
             &mooncakes_dir,
-            project_manifest_path.as_deref(),
+            &project_manifest,
             None,
         );
     }
@@ -115,7 +115,7 @@ pub(crate) fn run_build(cli: &UniversalFlags, cmd: BuildSubcommand) -> anyhow::R
             &source_dir,
             &target_dir,
             &mooncakes_dir,
-            project_manifest_path.as_deref(),
+            &project_manifest,
             Some(t),
         )
         .context(format!("failed to run build for target {t:?}"))?;
@@ -131,7 +131,7 @@ fn run_build_internal(
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     let f = |watch: bool| {
@@ -141,7 +141,7 @@ fn run_build_internal(
             source_dir,
             target_dir,
             mooncakes_dir,
-            project_manifest_path,
+            project_manifest,
             watch,
             selected_target_backend,
         )
@@ -165,7 +165,7 @@ fn run_build_rr(
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     watch: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<WatchOutput> {
@@ -180,7 +180,7 @@ fn run_build_rr(
         &resolve_cfg,
         source_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     )?;
     let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
     let prebuild_list = if watch {

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -21,7 +21,7 @@ use moonbuild_rupes_recta::{build_lower::WarningCondition, intent::UserIntent};
 use moonutil::{
     cli::UniversalFlags,
     common::{FileLock, RunMode, SurfaceTarget, TargetBackend, lower_surface_targets},
-    dirs::PackageDirs,
+    dirs::{PackageDirs, ProjectManifest},
     mooncakes::sync::AutoSyncFlags,
 };
 use std::path::Path;
@@ -53,7 +53,7 @@ pub(crate) fn run_bundle(cli: UniversalFlags, cmd: BundleSubcommand) -> anyhow::
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     } = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
@@ -71,7 +71,7 @@ pub(crate) fn run_bundle(cli: UniversalFlags, cmd: BundleSubcommand) -> anyhow::
             &source_dir,
             &target_dir,
             &mooncakes_dir,
-            project_manifest_path.as_deref(),
+            &project_manifest,
             None,
         );
     }
@@ -86,7 +86,7 @@ pub(crate) fn run_bundle(cli: UniversalFlags, cmd: BundleSubcommand) -> anyhow::
             &source_dir,
             &target_dir,
             &mooncakes_dir,
-            project_manifest_path.as_deref(),
+            &project_manifest,
             Some(t),
         )
         .context(format!("failed to run bundle for target {t:?}"))?;
@@ -102,7 +102,7 @@ pub(crate) fn run_bundle_internal(
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     run_bundle_internal_rr(
@@ -111,7 +111,7 @@ pub(crate) fn run_bundle_internal(
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
         selected_target_backend,
     )
 }
@@ -123,7 +123,7 @@ pub(crate) fn run_bundle_internal_rr(
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     let (build_meta, build_graph) = plan_bundle_rr(
@@ -132,7 +132,7 @@ pub(crate) fn run_bundle_internal_rr(
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
         selected_target_backend,
     )?;
 
@@ -172,7 +172,7 @@ pub(crate) fn plan_bundle_rr(
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<(rr_build::BuildMeta, rr_build::BuildInput)> {
     let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
@@ -186,7 +186,7 @@ pub(crate) fn plan_bundle_rr(
         &resolve_cfg,
         source_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     )?;
     let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
     plan_bundle_rr_from_resolved(

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -37,7 +37,7 @@ use moonutil::common::RunMode;
 use moonutil::common::WATCH_MODE_DIR;
 use moonutil::common::lower_surface_targets;
 use moonutil::common::{FileLock, TargetBackend};
-use moonutil::dirs::ProjectProbe;
+use moonutil::dirs::{ProjectManifest, ProjectProbe};
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
@@ -148,7 +148,7 @@ pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::
 
     // Check if we're running within a project
     let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
-    let (source_dir, target_dir, mooncakes_dir, single_file, project_manifest_path) = match query
+    let (source_dir, target_dir, mooncakes_dir, single_file, project_manifest) = match query
         .probe_project()?
     {
         ProjectProbe::Found(_) => {
@@ -158,7 +158,7 @@ pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::
                 dirs.target_dir,
                 dirs.mooncakes_dir,
                 false,
-                dirs.project_manifest_path,
+                dirs.project_manifest,
             )
         }
         ProjectProbe::NotFound(not_found) => {
@@ -173,7 +173,7 @@ pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::
                         target_dir,
                         mooncakes_dir,
                         true,
-                        None,
+                        ProjectManifest::None,
                     )
                 }
                 [] => return Err(not_found.into_error().into()),
@@ -192,7 +192,7 @@ pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::
             &target_dir,
             &mooncakes_dir,
             single_file,
-            project_manifest_path.as_deref(),
+            &project_manifest,
             None,
         );
     }
@@ -208,7 +208,7 @@ pub(crate) fn run_check(cli: &UniversalFlags, cmd: &CheckSubcommand) -> anyhow::
             &target_dir,
             &mooncakes_dir,
             single_file,
-            project_manifest_path.as_deref(),
+            &project_manifest,
             Some(t),
         )
         .context(format!("failed to run check for target {t:?}"))?;
@@ -226,7 +226,7 @@ fn run_check_internal(
     target_dir: &Path,
     mooncakes_dir: &Path,
     single_file: bool,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     if single_file {
@@ -245,7 +245,7 @@ fn run_check_internal(
             source_dir,
             target_dir,
             mooncakes_dir,
-            project_manifest_path,
+            project_manifest,
             selected_target_backend,
         )
     }
@@ -407,7 +407,7 @@ fn run_check_normal_internal(
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
     let run_once = |watch: bool, target_dir: &Path| -> anyhow::Result<WatchOutput> {
@@ -417,7 +417,7 @@ fn run_check_normal_internal(
             source_dir,
             target_dir,
             mooncakes_dir,
-            project_manifest_path,
+            project_manifest,
             watch,
             selected_target_backend,
         )
@@ -450,7 +450,7 @@ fn run_check_normal_internal_rr(
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     watch: bool,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<WatchOutput> {
@@ -465,7 +465,7 @@ fn run_check_normal_internal_rr(
         &resolve_cfg,
         source_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     )
     .context("Failed to calculate build plan")?;
     let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)

--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -111,7 +111,7 @@ fn run_cram_test(cli: &UniversalFlags, cmd: CramTestSubcommand) -> anyhow::Resul
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     } = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
@@ -136,7 +136,7 @@ fn run_cram_test(cli: &UniversalFlags, cmd: CramTestSubcommand) -> anyhow::Resul
         &resolve_cfg,
         &source_dir,
         &mooncakes_dir,
-        project_manifest_path.as_deref(),
+        &project_manifest,
     )?;
     let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
 

--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -75,7 +75,7 @@ pub(crate) fn install_cli(cli: UniversalFlags, cmd: InstallSubcommand) -> anyhow
         let PackageDirs {
             source_dir,
             mooncakes_dir,
-            project_manifest_path,
+            project_manifest,
             ..
         } = cli
             .source_tgt_dir
@@ -88,7 +88,7 @@ pub(crate) fn install_cli(cli: UniversalFlags, cmd: InstallSubcommand) -> anyhow
             SyncOutputOptions::new(cli.quiet, true),
             true,
             cli.workspace_env.clone(),
-            project_manifest_path.as_deref(),
+            &project_manifest,
         )?;
         return Ok(0);
     }
@@ -173,9 +173,7 @@ pub(crate) fn remove_cli(cli: UniversalFlags, cmd: RemoveSubcommand) -> anyhow::
     let project = query.project()?;
     let module_dir = require_selected_module(&project, "remove")?;
     let PackageDirs {
-        source_dir: project_root,
-        project_manifest_path,
-        ..
+        project_manifest, ..
     } = query.package_dirs()?;
     let package_path = cmd.package_path;
     let parts: Vec<&str> = package_path.splitn(2, '/').collect();
@@ -184,13 +182,7 @@ pub(crate) fn remove_cli(cli: UniversalFlags, cmd: RemoveSubcommand) -> anyhow::
     }
     let username = parts[0];
     let pkgname = parts[1];
-    mooncake::pkg::remove::remove(
-        &project_root,
-        &module_dir,
-        project_manifest_path.as_deref(),
-        username,
-        pkgname,
-    )
+    mooncake::pkg::remove::remove(&module_dir, &project_manifest, username, pkgname)
 }
 
 pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result<i32> {
@@ -199,9 +191,8 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
     let project = query.project()?;
     let module_dir = require_selected_module(&project, "add")?;
     let PackageDirs {
-        source_dir: project_root,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
         ..
     } = query.package_dirs()?;
 
@@ -251,9 +242,8 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
         let version: &str = parts[1];
         let version = version.parse()?;
         mooncake::pkg::add::add(
-            &project_root,
             &module_dir,
-            project_manifest_path.as_deref(),
+            &project_manifest,
             &mooncakes_dir,
             &pkg_name,
             cmd.bin,
@@ -263,9 +253,8 @@ pub(crate) fn add_cli(cli: UniversalFlags, cmd: AddSubcommand) -> anyhow::Result
         )
     } else {
         mooncake::pkg::add::add_latest(
-            &project_root,
             &module_dir,
-            project_manifest_path.as_deref(),
+            &project_manifest,
             &mooncakes_dir,
             &pkg_name,
             cmd.bin,
@@ -281,11 +270,9 @@ pub(crate) fn tree_cli(cli: UniversalFlags, _cmd: TreeSubcommand) -> anyhow::Res
     let project = query.project()?;
     let module_dir = require_selected_module(&project, "tree")?;
     let PackageDirs {
-        source_dir: project_root,
-        project_manifest_path,
-        ..
+        project_manifest, ..
     } = query.package_dirs()?;
-    mooncake::pkg::tree::tree(&project_root, &module_dir, project_manifest_path.as_deref())
+    mooncake::pkg::tree::tree(&module_dir, &project_manifest)
 }
 
 #[cfg(test)]

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -104,7 +104,7 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     } = query.package_dirs()?;
 
     // FIXME: This is copied from `moon check`'s code. Share code if possible.
@@ -124,7 +124,7 @@ pub(crate) fn run_doc_rr(cli: UniversalFlags, cmd: DocSubcommand) -> anyhow::Res
         &resolve_cfg,
         &source_dir,
         &mooncakes_dir,
-        project_manifest_path.as_deref(),
+        &project_manifest,
     )?;
     let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
 

--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -60,7 +60,7 @@ fn run_fmt_rr(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> {
     let PackageDirs {
         source_dir,
         target_dir,
-        project_manifest_path,
+        project_manifest,
         ..
     } = cli
         .source_tgt_dir
@@ -68,9 +68,8 @@ fn run_fmt_rr(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> {
         .package_dirs()?;
 
     let output = UserDiagnostics::from_flags(cli);
-    let resolved =
-        moonbuild_rupes_recta::fmt::resolve_for_fmt(&source_dir, project_manifest_path.as_deref())
-            .context("Failed to resolve environment")?;
+    let resolved = moonbuild_rupes_recta::fmt::resolve_for_fmt(&source_dir, &project_manifest)
+        .context("Failed to resolve environment")?;
 
     let mut selected_packages = Vec::new();
 
@@ -94,10 +93,9 @@ fn run_fmt_rr(cli: &UniversalFlags, cmd: FmtSubcommand) -> anyhow::Result<i32> {
     let (graph, user_warnings) = plan_fmt(
         &resolved,
         &fmt_config,
-        &source_dir,
         &target_dir,
         &selected_packages,
-        project_manifest_path.as_deref(),
+        &project_manifest,
     )?;
     for message in &user_warnings {
         output.user_message(message);

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -279,7 +279,7 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     } = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
@@ -293,12 +293,8 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
         cli.workspace_env.clone(),
     );
     let mooncake_bin_dir = mooncakes_dir.join(moonutil::common::MOON_BIN_DIR);
-    let synced_env = sync_dependencies(
-        &resolve_cfg,
-        &source_dir,
-        &mooncakes_dir,
-        project_manifest_path.as_deref(),
-    )?;
+    let synced_env =
+        sync_dependencies(&resolve_cfg, &source_dir, &mooncakes_dir, &project_manifest)?;
     let resolve_output = resolve_synced_project(&resolve_cfg, synced_env)?;
     let output = UserDiagnostics::from_flags(&cli);
     let selection = PackageSelection::new(&cmd, &resolve_output, output)?;

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -475,7 +475,7 @@ fn build_and_install_packages(
     let source_dir = package_dirs.source_dir;
     let target_dir = package_dirs.target_dir;
     let mooncakes_dir = package_dirs.mooncakes_dir;
-    let project_manifest_path = package_dirs.project_manifest_path;
+    let project_manifest = package_dirs.project_manifest;
 
     let resolve_cfg =
         ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone());
@@ -484,7 +484,7 @@ fn build_and_install_packages(
         &resolve_cfg,
         &source_dir,
         &mooncakes_dir,
-        project_manifest_path.as_deref(),
+        &project_manifest,
     )?;
     let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
 

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -123,7 +123,7 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
         source_dir: project_root,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     } = query.package_dirs()?;
     let build_flags = cmd.to_build_flags();
     let verif_dir = target_dir.join("verif");
@@ -158,7 +158,7 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
         &resolve_cfg,
         &project_root,
         &mooncakes_dir,
-        project_manifest_path.as_deref(),
+        &project_manifest,
     )?;
     let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
 

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -469,7 +469,7 @@ fn build_package_executable(
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     } = cli
         .source_tgt_dir
         .query_from(&run_start_dir, cli.workspace_env.clone())?
@@ -487,7 +487,7 @@ fn build_package_executable(
         &resolve_cfg,
         &source_dir,
         &mooncakes_dir,
-        project_manifest_path.as_deref(),
+        &project_manifest,
     )?;
     let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
     let (build_meta, build_graph) = plan_run_rr_from_resolved(

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -46,7 +46,7 @@ use moonutil::common::{
     FileLock, RunMode, SurfaceTarget, TargetBackend, TestArtifacts, TestIndexRange,
     lower_surface_targets,
 };
-use moonutil::dirs::ProjectProbe;
+use moonutil::dirs::{ProjectManifest, ProjectProbe};
 use moonutil::mooncakes::sync::AutoSyncFlags;
 use std::path::{Path, PathBuf};
 use tracing::{Level, debug, info, instrument, trace};
@@ -389,7 +389,7 @@ fn run_test_impl(cli: &UniversalFlags, cmd: &TestSubcommand) -> anyhow::Result<i
             &dirs.source_dir,
             &dirs.target_dir,
             &dirs.mooncakes_dir,
-            dirs.project_manifest_path.as_deref(),
+            &dirs.project_manifest,
             None,
             selected_target_backend,
         );
@@ -410,7 +410,7 @@ fn run_test_impl(cli: &UniversalFlags, cmd: &TestSubcommand) -> anyhow::Result<i
             &dirs.source_dir,
             &dirs.target_dir,
             &dirs.mooncakes_dir,
-            dirs.project_manifest_path.as_deref(),
+            &dirs.project_manifest,
             display_backend_hint,
             Some(t),
         )
@@ -462,7 +462,7 @@ fn run_test_internal(
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     display_backend_hint: Option<()>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
@@ -477,7 +477,7 @@ fn run_test_internal(
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
         display_backend_hint,
         selected_target_backend,
     )?;
@@ -898,7 +898,7 @@ pub(crate) fn run_test_or_bench_internal(
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     display_backend_hint: Option<()>,
     selected_target_backend: Option<TargetBackend>,
 ) -> anyhow::Result<i32> {
@@ -952,7 +952,7 @@ pub(crate) fn run_test_or_bench_internal(
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
         display_backend_hint,
         selected_target_backend,
     )
@@ -966,7 +966,7 @@ fn run_test_rr(
     source_dir: &Path,
     target_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     display_backend_hint: Option<()>, // FIXME: unsure why it's option but as-is for now
     selected_target_backend: Option<TargetBackend>,
 ) -> Result<i32, anyhow::Error> {
@@ -982,7 +982,7 @@ fn run_test_rr(
         &resolve_cfg,
         source_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     )?;
     let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
     let planned_runs = plan_test_or_bench_rr_from_resolved_all(

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -75,7 +75,7 @@ pub(crate) fn run_build_binary_dep(
         source_dir,
         target_dir,
         mooncakes_dir,
-        project_manifest_path,
+        project_manifest,
     } = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
@@ -94,7 +94,7 @@ pub(crate) fn run_build_binary_dep(
         &resolve_cfg,
         &source_dir,
         &mooncakes_dir,
-        project_manifest_path.as_deref(),
+        &project_manifest,
     )?;
     let resolve_output = moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;
 

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -595,7 +595,7 @@ mod tests {
             &cfg,
             &dirs.source_dir,
             &dirs.mooncakes_dir,
-            dirs.project_manifest_path.as_deref(),
+            &dirs.project_manifest,
         )
         .unwrap();
         moonbuild_rupes_recta::resolve_synced_project(&cfg, synced_env).unwrap()

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -59,7 +59,7 @@ use moonutil::{
     },
     compiler_flags::{self, CC},
     cond_expr::OptLevel as BuildProfile,
-    dirs::WorkspaceEnv,
+    dirs::{ProjectManifest, WorkspaceEnv},
     features::FeatureGate,
     mooncakes::sync::AutoSyncFlags,
     package::SupportedTargetsDeclKind,
@@ -673,18 +673,16 @@ pub(crate) fn plan_resolved_build_from_intent(
 pub fn plan_fmt(
     resolved: &FmtResolveOutput,
     cfg: &FmtConfig,
-    source_dir: &Path,
     target_dir: &Path,
     selected_packages: &[PackageId],
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
 ) -> anyhow::Result<(BuildInput, Vec<UserWarning>)> {
     let (graph, user_warnings) = moonbuild_rupes_recta::fmt::build_graph_for_fmt(
         resolved,
         cfg,
-        source_dir,
         target_dir,
         selected_packages,
-        project_manifest_path,
+        project_manifest,
     )?;
     let layout = TargetLayout::from_fmt_resolve_output(
         target_dir.to_path_buf(),

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -25,7 +25,7 @@ use moonutil::{
     cli::UniversalFlags,
     common::{BUILD_DIR, TargetBackend},
     cond_expr::OptLevel,
-    dirs::WorkspaceEnv,
+    dirs::{ProjectManifest, WorkspaceEnv},
 };
 
 use crate::cli::{
@@ -89,7 +89,7 @@ impl PlanningFixture {
             &resolve_cfg,
             &source_dir,
             &mooncakes_dir,
-            None,
+            &ProjectManifest::None,
         )?;
         let resolve_output =
             moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -25,7 +25,7 @@ use moonutil::{
     cli::UniversalFlags,
     common::{BUILD_DIR, TargetBackend},
     cond_expr::OptLevel,
-    dirs::{ProjectManifest, WorkspaceEnv},
+    dirs::{ProjectManifest, SourceTargetDirs, WorkspaceEnv},
 };
 
 use crate::cli::{
@@ -75,7 +75,16 @@ impl PlanningFixture {
         let case_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/test_cases");
         // These planner tests only inspect graph construction, so they can use
         // the checked-in fixture directly without copying it to a temp directory.
-        let source_dir = dunce::canonicalize(case_root.join(case))?;
+        let fixture_dir = dunce::canonicalize(case_root.join(case))?;
+        let project = SourceTargetDirs {
+            cwd: None,
+            manifest_path: None,
+            target_dir: None,
+        }
+        .query_from(&fixture_dir, WorkspaceEnv::Auto)?
+        .project()?;
+        let source_dir = project.root().to_path_buf();
+        let project_manifest = ProjectManifest::from(&project);
         let target_dir = source_dir.join(BUILD_DIR);
         let mooncakes_dir = source_dir.join(".mooncakes");
         let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
@@ -89,7 +98,7 @@ impl PlanningFixture {
             &resolve_cfg,
             &source_dir,
             &mooncakes_dir,
-            &ProjectManifest::None,
+            &project_manifest,
         )?;
         let resolve_output =
             moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env)?;

--- a/crates/moon/src/watch/prebuild_output.rs
+++ b/crates/moon/src/watch/prebuild_output.rs
@@ -91,7 +91,7 @@ mod tests {
     use moonbuild_rupes_recta::resolve::{
         ResolveConfig, resolve_synced_project, sync_dependencies,
     };
-    use moonutil::dirs::WorkspaceEnv;
+    use moonutil::dirs::{ProjectManifest, WorkspaceEnv};
 
     #[test]
     fn rr_get_prebuild_watch_paths_skips_empty_modules() {
@@ -107,8 +107,13 @@ mod tests {
         let resolve_cfg =
             ResolveConfig::new_with_load_defaults(false, false, false, WorkspaceEnv::Auto);
         let mooncakes_dir = temp_dir.path().join(".mooncakes");
-        let synced_env =
-            sync_dependencies(&resolve_cfg, temp_dir.path(), &mooncakes_dir, None).unwrap();
+        let synced_env = sync_dependencies(
+            &resolve_cfg,
+            temp_dir.path(),
+            &mooncakes_dir,
+            &ProjectManifest::None,
+        )
+        .unwrap();
         let resolved = resolve_synced_project(&resolve_cfg, synced_env).unwrap();
 
         let watch_paths = rr_get_prebuild_watch_paths(&resolved);
@@ -143,8 +148,13 @@ mod tests {
         let resolve_cfg =
             ResolveConfig::new_with_load_defaults(false, false, false, WorkspaceEnv::Auto);
         let mooncakes_dir = temp_dir.path().join(".mooncakes");
-        let synced_env =
-            sync_dependencies(&resolve_cfg, temp_dir.path(), &mooncakes_dir, None).unwrap();
+        let synced_env = sync_dependencies(
+            &resolve_cfg,
+            temp_dir.path(),
+            &mooncakes_dir,
+            &ProjectManifest::None,
+        )
+        .unwrap();
         let resolved = resolve_synced_project(&resolve_cfg, synced_env).unwrap();
 
         let watch_paths = rr_get_prebuild_watch_paths(&resolved);

--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -31,7 +31,8 @@ pub mod special_case;
 pub mod synth;
 
 pub use model::{DiscoverError, DiscoverResult, DiscoveredLocalProject, DiscoveredPackage};
-use moonutil::common::{PackageSourceFileKind, is_moon_mod, package_source_file_kind};
+use moonutil::common::{PackageSourceFileKind, package_source_file_kind};
+use moonutil::dirs::ProjectManifest;
 
 use std::{
     path::{Path, PathBuf},
@@ -55,7 +56,7 @@ use moonutil::{
     },
     mooncakes::ModuleSourceKind,
     package::resolve_supported_targets,
-    workspace::{canonical_workspace_module_dirs, read_workspace, read_workspace_file},
+    workspace::{canonical_workspace_module_dirs, read_workspace_file},
 };
 use relative_path::{PathExt, RelativePath};
 use tracing::{Level, instrument};
@@ -116,20 +117,14 @@ pub fn discover_packages(
 #[instrument(skip_all)]
 pub fn discover_local_project(
     source_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
 ) -> Result<DiscoveredLocalProject, DiscoverError> {
     info!(
         "Starting local project discovery for {}",
         source_dir.display()
     );
 
-    let selected_workspace_manifest_path = project_manifest_path.filter(|path| {
-        !matches!(
-            path.file_name().and_then(|name| name.to_str()),
-            Some(name) if is_moon_mod(name)
-        )
-    });
-    let workspace = if let Some(workspace_manifest_path) = selected_workspace_manifest_path {
+    let workspace = if let ProjectManifest::Workspace(workspace_manifest_path) = project_manifest {
         read_workspace_file(workspace_manifest_path)
             .map(Some)
             .map_err(|inner| DiscoverError::CantReadLocalWorkspace {
@@ -137,14 +132,17 @@ pub fn discover_local_project(
                 inner,
             })?
     } else {
-        read_workspace(source_dir).map_err(|inner| DiscoverError::CantReadLocalWorkspace {
-            path: source_dir.to_owned(),
-            inner,
-        })?
+        None
     };
-    let workspace_root = selected_workspace_manifest_path
-        .and_then(Path::parent)
-        .unwrap_or(source_dir);
+    let workspace_root = match project_manifest {
+        ProjectManifest::Workspace(workspace_manifest_path) => workspace_manifest_path
+            .parent()
+            .ok_or_else(|| DiscoverError::CantReadLocalWorkspace {
+                path: workspace_manifest_path.to_owned(),
+                inner: anyhow::anyhow!("workspace manifest path has no parent directory"),
+            })?,
+        ProjectManifest::None | ProjectManifest::Module(_) => source_dir,
+    };
     let module_dirs = if let Some(workspace) = workspace.as_ref() {
         canonical_workspace_module_dirs(workspace_root, workspace).map_err(|inner| {
             DiscoverError::CantReadLocalWorkspace {

--- a/crates/moonbuild-rupes-recta/src/fmt.rs
+++ b/crates/moonbuild-rupes-recta/src/fmt.rs
@@ -34,9 +34,9 @@ use log::*;
 use std::{collections::HashSet, ffi::OsStr, path::Path};
 
 use anyhow::Context;
+use moonutil::dirs::ProjectManifest;
 use moonutil::mooncakes::{ModuleSourceKind, result::ResolvedModule};
 use moonutil::toolchain::BINARIES;
-use moonutil::workspace::workspace_manifest_path;
 use moonutil::{
     common::{
         MOON_MOD, MOON_MOD_JSON, MOON_PKG, MOON_PKG_JSON, MOON_WORK, validate_module_dsl_deps,
@@ -63,13 +63,13 @@ pub type FmtResolveOutput = DiscoveredLocalProject;
 /// rooted there via `moon.work`.
 pub fn resolve_for_fmt(
     source_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
 ) -> Result<FmtResolveOutput, ResolveError> {
     info!(
         "Resolving formatter environment for {}",
         source_dir.display()
     );
-    discover_local_project(source_dir, project_manifest_path).map_err(ResolveError::from)
+    discover_local_project(source_dir, project_manifest).map_err(ResolveError::from)
 }
 
 pub struct FmtConfig {
@@ -96,10 +96,9 @@ pub struct FmtConfig {
 pub fn build_graph_for_fmt(
     resolved: &FmtResolveOutput,
     cfg: &FmtConfig,
-    source_dir: &Path,
     target_dir: &Path,
     selected_packages: &[PackageId],
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
 ) -> anyhow::Result<(n2::graph::Graph, Vec<UserWarning>)> {
     info!(
         "Building format graph for {} root modules",
@@ -117,7 +116,7 @@ pub fn build_graph_for_fmt(
     let selected_packages = (!selected_packages.is_empty())
         .then(|| selected_packages.iter().copied().collect::<HashSet<_>>());
     let has_workspace_manifest = selected_packages.is_none()
-        && format_workspace_node(&mut graph, cfg, &layout, source_dir, project_manifest_path)?;
+        && format_workspace_node(&mut graph, cfg, &layout, project_manifest)?;
     let mut has_module_manifest = false;
 
     // If no path filter is provided, find and format `moon.mod`/`moon.mod.json`.
@@ -392,33 +391,18 @@ fn format_workspace_node(
     graph: &mut n2::graph::Graph,
     cfg: &FmtConfig,
     layout: &TargetLayout,
-    source_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
 ) -> anyhow::Result<bool> {
-    let workspace_manifest_path = project_manifest_path
-        .map(Path::to_path_buf)
-        .or_else(|| workspace_manifest_path(source_dir));
-    let Some(workspace_manifest_path) = workspace_manifest_path else {
+    let ProjectManifest::Workspace(workspace_manifest_path) = project_manifest else {
         return Ok(false);
     };
-    let file_name = workspace_manifest_path
-        .file_name()
-        .and_then(|name| name.to_str());
-    if file_name == Some(MOON_MOD_JSON) {
-        return Ok(false);
-    }
     workspace_manifest_path
         .parent()
         .context("workspace manifest path has no parent directory")?;
 
     let target_moon_work = layout.format_root_artifact_path(std::ffi::OsStr::new(MOON_WORK));
-    match file_name {
-        Some(MOON_WORK) => {
-            format_moon_work_dsl(graph, cfg, &workspace_manifest_path, &target_moon_work)?;
-            Ok(true)
-        }
-        _ => Ok(false),
-    }
+    format_moon_work_dsl(graph, cfg, workspace_manifest_path, &target_moon_work)?;
+    Ok(true)
 }
 
 fn build_for_package(

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -39,7 +39,7 @@ use moonutil::{
         MBTI_USER_WRITTEN, MOONBITLANG_CORE, MbtMdHeader, TargetBackend, parse_front_matter_config,
     },
     dependency::SourceDependencyInfo,
-    dirs::WorkspaceEnv,
+    dirs::{ProjectManifest, WorkspaceEnv},
     module::MoonMod,
     mooncakes::{DirSyncResult, ModuleId, result::ResolvedEnv, sync::AutoSyncFlags},
     package::{Import, PkgJSONImport, pkg_json_imports_to_imports},
@@ -333,7 +333,7 @@ pub fn sync_dependencies(
     cfg: &ResolveConfig,
     source_dir: &Path,
     mooncakes_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
 ) -> Result<(ResolvedEnv, DirSyncResult), ResolveError> {
     info!(
         "Starting dependency sync for source directory: {}",
@@ -348,7 +348,7 @@ pub fn sync_dependencies(
         cfg.sync_output,
         cfg.no_std,
         cfg.workspace_env.clone(),
-        project_manifest_path,
+        project_manifest,
     )
     .map_err(ResolveError::SyncModulesError)?;
     info!("Module dependency resolution completed successfully");

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -23,6 +23,7 @@ use moonutil::common::{
     MOON_MOD, MOONBITLANG_CORE, read_module_desc_file_in_dir, write_module_json_to_file,
 };
 use moonutil::dependency::{BinaryDependencyInfo, SourceDependencyInfo};
+use moonutil::dirs::ProjectManifest;
 use moonutil::module::convert_module_to_mod_json;
 use moonutil::moon_mod_patch::{MoonModPatch, patch_module_dsl_to_file};
 use moonutil::mooncakes::ModuleName;
@@ -55,9 +56,8 @@ pub struct AddSubcommand {
 
 #[allow(clippy::too_many_arguments)]
 pub fn add_latest(
-    project_root: &Path,
     module_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     mooncakes_dir: &Path,
     pkg_name: &ModuleName,
     bin: bool,
@@ -92,9 +92,8 @@ pub fn add_latest(
             }
         })?;
     add(
-        project_root,
         module_dir,
-        project_manifest_path,
+        project_manifest,
         mooncakes_dir,
         pkg_name,
         bin,
@@ -112,9 +111,8 @@ fn test_module_name() {
 
 #[allow(clippy::too_many_arguments)]
 pub fn add(
-    project_root: &Path,
     module_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     mooncakes_dir: &Path,
     pkg_name: &ModuleName,
     bin: bool,
@@ -193,12 +191,7 @@ pub fn add(
     }
 
     let m = Arc::new(m);
-    let roots = roots_for_selected_module(
-        project_root,
-        module_dir,
-        Arc::clone(&m),
-        project_manifest_path,
-    )?;
+    let roots = roots_for_selected_module(module_dir, Arc::clone(&m), project_manifest)?;
     install_impl(
         mooncakes_dir,
         roots,

--- a/crates/mooncake/src/pkg/mod.rs
+++ b/crates/mooncake/src/pkg/mod.rs
@@ -20,13 +20,14 @@ use std::{path::Path, sync::Arc};
 
 use anyhow::Context;
 use moonutil::{
-    common::{MOON_WORK, read_module_desc_file_in_dir},
+    common::read_module_desc_file_in_dir,
+    dirs::ProjectManifest,
     module::MoonMod,
     mooncakes::{
         ModuleSource,
         result::{ResolvedModule, ResolvedRootModules},
     },
-    workspace::{canonical_workspace_module_dirs, read_workspace, read_workspace_file},
+    workspace::{canonical_workspace_module_dirs, read_workspace_file},
 };
 
 pub mod add;
@@ -39,36 +40,17 @@ mod work;
 pub use work::{init_workspace, sync_workspace, use_workspace};
 
 pub(crate) fn roots_for_selected_module(
-    project_root: &Path,
     module_dir: &Path,
     module: Arc<MoonMod>,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
 ) -> anyhow::Result<ResolvedRootModules> {
-    if let Some(project_manifest_path) = project_manifest_path {
-        if project_manifest_path
-            .file_name()
-            .and_then(|name| name.to_str())
-            == Some(MOON_WORK)
-        {
-            let workspace_root = project_manifest_path
-                .parent()
-                .context("workspace manifest path has no parent directory")?;
-            let workspace = read_workspace_file(project_manifest_path)?;
-            let mut roots = ResolvedRootModules::with_key();
-            for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {
-                let member = if member_dir == module_dir {
-                    Arc::clone(&module)
-                } else {
-                    Arc::new(read_module_desc_file_in_dir(&member_dir)?)
-                };
-                let source = ModuleSource::from_local_module(&member, &member_dir);
-                roots.insert(ResolvedModule::new(source, member));
-            }
-            return Ok(roots);
-        }
-    } else if let Some(workspace) = read_workspace(project_root)? {
+    if let ProjectManifest::Workspace(project_manifest) = project_manifest {
+        let workspace_root = project_manifest
+            .parent()
+            .context("workspace manifest path has no parent directory")?;
+        let workspace = read_workspace_file(project_manifest)?;
         let mut roots = ResolvedRootModules::with_key();
-        for member_dir in canonical_workspace_module_dirs(project_root, &workspace)? {
+        for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {
             let member = if member_dir == module_dir {
                 Arc::clone(&module)
             } else {

--- a/crates/mooncake/src/pkg/remove.rs
+++ b/crates/mooncake/src/pkg/remove.rs
@@ -21,6 +21,7 @@ use std::{path::Path, sync::Arc};
 
 use moonutil::{
     common::{MOON_MOD, read_module_desc_file_in_dir, write_module_json_to_file},
+    dirs::ProjectManifest,
     module::convert_module_to_mod_json,
     moon_mod_patch::{MoonModPatch, patch_module_dsl_to_file},
 };
@@ -40,9 +41,8 @@ pub struct RemoveSubcommand {
 }
 
 pub fn remove(
-    project_root: &Path,
     module_dir: &Path,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
     username: &str,
     pkgname: &str,
 ) -> anyhow::Result<i32> {
@@ -57,12 +57,7 @@ pub fn remove(
         )
     }
     let m = Arc::new(m);
-    let roots = roots_for_selected_module(
-        project_root,
-        module_dir,
-        Arc::clone(&m),
-        project_manifest_path,
-    )?;
+    let roots = roots_for_selected_module(module_dir, Arc::clone(&m), project_manifest)?;
 
     let resolve_cfg = ResolveConfig {
         registry: registry::default_registry(),

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -23,15 +23,15 @@ use std::{path::Path, sync::Arc};
 use anyhow::Context;
 use indexmap::IndexMap;
 use moonutil::{
-    common::{MOON_WORK, MbtMdHeader, MoonbuildOpt, MooncOpt, read_module_desc_file_in_dir},
-    dirs::{SourceTargetDirs, WorkspaceEnv},
+    common::{MbtMdHeader, MoonbuildOpt, MooncOpt, read_module_desc_file_in_dir},
+    dirs::{ProjectManifest, WorkspaceEnv},
     module::MoonMod,
     mooncakes::{
         DirSyncResult, ModuleSource,
         result::{ResolvedEnv, ResolvedModule, ResolvedRootModules},
         sync::AutoSyncFlags,
     },
-    workspace::{MoonWork, canonical_workspace_module_dirs, read_workspace, read_workspace_file},
+    workspace::{MoonWork, canonical_workspace_module_dirs, read_workspace_file},
 };
 use semver::Version;
 
@@ -77,70 +77,21 @@ pub fn auto_sync(
     output_options: SyncOutputOptions,
     no_std: bool,
     workspace_env: WorkspaceEnv,
-    project_manifest_path: Option<&Path>,
+    project_manifest: &ProjectManifest,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult, Option<MoonWork>)> {
-    if let Some(project_manifest_path) = project_manifest_path {
-        let manifest_dir = project_manifest_path
-            .parent()
-            .context("manifest path has no parent directory")?;
-        let manifest_dir = if manifest_dir.as_os_str().is_empty() {
-            Path::new(".")
-        } else {
-            manifest_dir
-        };
-        let manifest_dir = dunce::canonicalize(manifest_dir).with_context(|| {
-            format!(
-                "failed to resolve manifest directory `{}`",
-                manifest_dir.display()
-            )
-        })?;
-        if project_manifest_path
-            .file_name()
-            .and_then(|name| name.to_str())
-            == Some(MOON_WORK)
-            && !matches!(workspace_env, WorkspaceEnv::Off)
-        {
-            return resolve_workspace_sync(
-                mooncakes_dir,
-                cli,
-                output_options,
-                no_std,
-                manifest_dir.as_path(),
-                read_workspace_file(project_manifest_path)?,
-            );
-        } else if !matches!(workspace_env, WorkspaceEnv::Off)
-            && let Some(workspace_root) = (SourceTargetDirs {
-                cwd: None,
-                manifest_path: None,
-                target_dir: None,
-            })
-            .query_from(&manifest_dir, workspace_env.clone())?
-            .workspace_ref()?
-            .map(|workspace| workspace.root)
-        {
-            let workspace = read_workspace(&workspace_root)?.context(format!(
-                "failed to parse workspace file under `{}`",
-                workspace_root.display()
-            ))?;
-            return resolve_workspace_sync(
-                mooncakes_dir,
-                cli,
-                output_options,
-                no_std,
-                &workspace_root,
-                workspace,
-            );
-        }
-    } else if !matches!(workspace_env, WorkspaceEnv::Off)
-        && let Some(workspace) = read_workspace(source_dir)?
+    if let ProjectManifest::Workspace(project_manifest) = project_manifest
+        && !matches!(workspace_env, WorkspaceEnv::Off)
     {
+        let workspace_root = project_manifest
+            .parent()
+            .context("workspace manifest path has no parent directory")?;
         return resolve_workspace_sync(
             mooncakes_dir,
             cli,
             output_options,
             no_std,
-            source_dir,
-            workspace,
+            workspace_root,
+            read_workspace_file(project_manifest)?,
         );
     }
 

--- a/crates/mooncake/src/pkg/tree.rs
+++ b/crates/mooncake/src/pkg/tree.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use moonutil::common::read_module_desc_file_in_dir;
+use moonutil::dirs::ProjectManifest;
 use moonutil::mooncakes::result::ResolvedEnv;
 use moonutil::mooncakes::{ModuleId, ModuleName};
 
@@ -124,18 +125,9 @@ fn format_module_label(
     label
 }
 
-pub fn tree(
-    project_root: &Path,
-    module_dir: &Path,
-    project_manifest_path: Option<&Path>,
-) -> anyhow::Result<i32> {
+pub fn tree(module_dir: &Path, project_manifest: &ProjectManifest) -> anyhow::Result<i32> {
     let module = Arc::new(read_module_desc_file_in_dir(module_dir)?);
-    let roots = roots_for_selected_module(
-        project_root,
-        module_dir,
-        Arc::clone(&module),
-        project_manifest_path,
-    )?;
+    let roots = roots_for_selected_module(module_dir, Arc::clone(&module), project_manifest)?;
     let resolve_cfg = ResolveConfig {
         registry: registry::default_registry(),
         inject_std: false,

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -125,7 +125,7 @@ impl SourceTargetDirs {
             source_dir,
             target_dir,
             mooncakes_dir,
-            project_manifest_path: None,
+            project_manifest: ProjectManifest::None,
         })
     }
 
@@ -219,11 +219,22 @@ impl SourceTargetDirs {
     }
 }
 
+/// The project manifest selected during project query.
+///
+/// Downstream stages should treat this as authoritative instead of rediscovering
+/// whether a directory belongs to a module or workspace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectManifest {
+    None,
+    Module(PathBuf),
+    Workspace(PathBuf),
+}
+
 pub struct PackageDirs {
     pub source_dir: PathBuf,
     pub target_dir: PathBuf,
     pub mooncakes_dir: PathBuf,
-    pub project_manifest_path: Option<PathBuf>,
+    pub project_manifest: ProjectManifest,
 }
 
 pub struct SingleFilePackageDirs {
@@ -331,6 +342,17 @@ impl ProjectContext {
                 manifest_path: manifest_path.clone(),
             }),
             Self::Module { .. } => None,
+        }
+    }
+}
+
+impl From<&ProjectContext> for ProjectManifest {
+    fn from(project: &ProjectContext) -> Self {
+        match project {
+            ProjectContext::Workspace { manifest_path, .. } => {
+                Self::Workspace(manifest_path.clone())
+            }
+            ProjectContext::Module { manifest_path, .. } => Self::Module(manifest_path.clone()),
         }
     }
 }
@@ -481,7 +503,7 @@ impl ProjectQuery {
             source_dir,
             target_dir,
             mooncakes_dir,
-            project_manifest_path: Some(project.manifest_path().to_path_buf()),
+            project_manifest: ProjectManifest::from(&project),
         })
     }
 


### PR DESCRIPTION
## Why

Project selection already determines whether a command is operating without a project, inside a module, or inside a workspace. Several downstream paths still received an optional manifest path or a source directory and then reinterpreted that information by checking filenames or probing for `moon.work` again.

That made workspace behavior depend on rediscovery in sync, dependency-root construction, discovery, and formatting code, which is the same class of ambiguity that caused the local install workspace issue.

## What changed

This PR introduces `ProjectManifest` as the selected project manifest identity carried by `PackageDirs`:

- `None`
- `Module(PathBuf)`
- `Workspace(PathBuf)`

Downstream stages now match the semantic variant instead of inferring workspace/module identity from a raw path. Interfaces that only carried `source_dir` or `project_root` for rediscovery were narrowed.

## Why this is correct and minimal

The project query stage remains the only place that selects project identity. Later stages consume that selected identity and only perform workspace behavior for `ProjectManifest::Workspace`.

The change is intentionally limited to replacing the ambiguous optional manifest path plumbing and removing rediscovery from the affected projections. It does not introduce a broader project model or change unrelated command behavior.