### PR TITLE
Remove unused moonrun tracing subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,8 +1764,6 @@ dependencies = [
  "snapbox",
  "tempfile",
  "toml",
- "tracing",
- "tracing-subscriber",
  "v8",
  "vergen",
  "windows-sys 0.59.0",

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -32,8 +32,6 @@ slotmap.workspace = true
 toml = { workspace = true, features = ["parse", "serde", "std"] }
 moonutil.workspace = true
 rand = "0.8.5"
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 v8 = "0.106.0"
 
 [target."cfg(not(windows))".dependencies]

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -654,11 +654,6 @@ fn initialize_v8() {
 }
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::FmtSubscriber::builder()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .compact()
-        .init();
-
     let matches = Commandline::parse();
     let async_policy = Arc::new(match matches.policy.as_ref() {
         Some(path) => async_policy::AsyncPolicy::from_file(path).context(


### PR DESCRIPTION
## Why

`moonrun` initialized a tracing subscriber at startup, but it does not emit tracing events directly. Keeping `tracing-subscriber` in `moonrun` pulls in extra runtime dependencies without providing useful behavior today.

## What

- Remove direct `tracing` and `tracing-subscriber` dependencies from `moonrun`.
- Remove the unused subscriber initialization from `moonrun` startup.
- Leave `moonutil` unchanged instead of introducing a feature split.

## Regex follow-up notes

`regex` and `globset` still reach `moonrun` through `moonutil`. The current uses are:

- `regex::Regex` in frontmatter parsing.
- `globset` in test-name glob filtering.
- `logos` regex attributes in the `moon_pkg` lexer.
- `RegexBackend` package config names, which do not by themselves pull in the regex crate.

This PR intentionally keeps those as follow-up analysis rather than mixing dependency restructuring into the tracing cleanup.