### PR TITLE
Remove unused runtime dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,15 +188,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,15 +918,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1764,8 +1746,6 @@ dependencies = [
  "snapbox",
  "tempfile",
  "toml",
- "tracing",
- "tracing-subscriber",
  "v8",
  "vergen",
  "windows-sys 0.59.0",
@@ -1778,7 +1758,6 @@ dependencies = [
  "anyhow",
  "arcstr",
  "ariadne",
- "bincode",
  "chrono",
  "clap",
  "colored",
@@ -1791,14 +1770,12 @@ dependencies = [
  "globset",
  "home",
  "indexmap",
- "junction",
  "libc",
  "line-index",
  "log",
  "logos",
  "nucleo-matcher",
  "petgraph",
- "pulldown-cmark",
  "regex",
  "schemars",
  "semver",
@@ -1808,9 +1785,7 @@ dependencies = [
  "shlex",
  "slotmap",
  "thiserror 1.0.63",
- "tracing",
  "vergen",
- "walkdir",
  "which 6.0.2",
 ]
 
@@ -2130,25 +2105,6 @@ checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
-dependencies = [
- "bitflags 2.6.0",
- "getopts",
- "memchr",
- "pulldown-cmark-escape",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-escape"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quinn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ moonbuild-debug = { path = "./crates/moonbuild-debug", version = "*" }
 mooncake = { path = "./crates/mooncake", version = "*" }
 moonutil = { path = "./crates/moonutil", version = "*" }
 anyhow = { version = "1.0.86" }
-bincode = "1.3.3"
 clap = { version = "4.5.4", features = ["derive", "string", "env"] }
 colored = "2.1.0"
 ctrlc = { version = "3.4.4", features = ["termination"] }
@@ -112,7 +111,6 @@ regex = { version = "1.11.0", default-features = false, features = ["std"] }
 rand = "0.8.5"
 base64 = "0.22.1"
 derive_builder = "0.20.2"
-pulldown-cmark = "0.13.0"
 shlex = "1.3.0"
 relative-path = "2.0.1"
 slotmap = "1.0.7"

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -32,8 +32,6 @@ slotmap.workspace = true
 toml = { workspace = true, features = ["parse", "serde", "std"] }
 moonutil.workspace = true
 rand = "0.8.5"
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 v8 = "0.106.0"
 
 [target."cfg(not(windows))".dependencies]

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -654,11 +654,6 @@ fn initialize_v8() {
 }
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::FmtSubscriber::builder()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .compact()
-        .init();
-
     let matches = Commandline::parse();
     let async_policy = Arc::new(match matches.policy.as_ref() {
         Some(path) => async_policy::AsyncPolicy::from_file(path).context(

--- a/crates/moonutil/Cargo.toml
+++ b/crates/moonutil/Cargo.toml
@@ -32,11 +32,9 @@ colored.workspace = true
 indexmap.workspace = true
 serde = { workspace = true, features = ["rc"] }
 serde_json_lenient.workspace = true
-walkdir.workspace = true
 clap.workspace = true
 dialoguer.workspace = true
 dunce.workspace = true
-bincode.workspace = true
 semver.workspace = true
 fs4.workspace = true
 petgraph.workspace = true
@@ -49,10 +47,8 @@ nucleo-matcher.workspace = true
 which.workspace = true
 regex.workspace = true
 derive_builder.workspace = true
-pulldown-cmark.workspace = true
 serde_yaml.workspace = true
 slotmap.workspace = true
-tracing.workspace = true
 shlex.workspace = true
 logos = "0.15.1"
 globset = "0.4"
@@ -62,7 +58,6 @@ libc.workspace = true
 
 [target."cfg(windows)".dependencies]
 find-msvc-tools.workspace = true
-junction = "1"
 
 [dev-dependencies]
 expect-test.workspace = true


### PR DESCRIPTION
## Why

`moonutil` carried several direct dependencies that are no longer referenced, and `moonrun` initialized a tracing subscriber even though it does not currently emit tracing events. Keeping these around makes the runtime dependency graph larger than the code needs.

## Correctness

The removed dependencies have no remaining source references in the affected crates. Removing the `moonrun` subscriber initialization does not change runtime behavior today because there are no tracing events to consume there. If shared runtime tracing becomes useful again, it can be added back intentionally through the common tracing setup.

## Scope

This is limited to removing unused runtime dependencies, the unused subscriber initialization, and the corresponding lockfile entries. It avoids feature gating or moving demangling code so the change stays focused.