### PR TITLE
Support async stdio in moonrun

### DIFF
--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -794,6 +794,16 @@ fn test_async_wasm_upstream_pipe_package() {
 }
 
 #[test]
+fn test_async_wasm_upstream_stdio_package() {
+    check(
+        run_upstream_async_wasm_package("moonbitlang/async/stdio"),
+        expect![[r#"
+            Total tests: 1, passed: 1, failed: 0.
+        "#]],
+    );
+}
+
+#[test]
 fn test_async_wasm_upstream_socket_package() {
     check(
         run_upstream_async_wasm_package("moonbitlang/async/socket"),

--- a/crates/moonrun/src/async_api/fd_util.rs
+++ b/crates/moonrun/src/async_api/fd_util.rs
@@ -34,6 +34,20 @@ pub(super) fn invalid_fd(context: &mut ImportContext<'_, '_>) -> u64 {
     context.host.invalid_fd()
 }
 
+#[ported(
+    source = "src/internal/event_loop/detect_file_kind.c",
+    original = "moonbitlang_async_kind_of_fd"
+)]
+pub(super) fn kind_of_fd(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
+    match context.host.kind_of_fd(fd) {
+        Ok(kind) => kind,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
 pub(super) fn sizeof_file_time(_context: &mut ImportContext<'_, '_>) -> i32 {
     FILE_TIME_RECORD_LEN
 }

--- a/crates/moonrun/src/async_api/mod.rs
+++ b/crates/moonrun/src/async_api/mod.rs
@@ -39,6 +39,7 @@ mod provenance;
 mod registry;
 mod runtime;
 mod socket;
+mod stdio;
 mod thread_pool;
 mod time;
 mod tls;

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -26,7 +26,7 @@ use super::context::{
 use super::provenance::{PortedImport, SourceLocation, SourceRoot};
 use super::{
     c_buffer, env_util, event_bus, event_loop, fd_util, fs, io, os_error, os_string, runtime,
-    socket, thread_pool, time, tls,
+    socket, stdio, thread_pool, time, tls,
 };
 
 pub(crate) const MOONBIT_ASYNC_MODULE: &str = "moonbitlang/async";
@@ -386,6 +386,10 @@ declare_async_imports! {
     helper fs::close_fd(fd: u64) -> i32 => "fd_util/close_fd";
 
     helper fd_util::invalid_fd() -> u64 => "fd_util/invalid_fd";
+
+    helper stdio::get_stdio_handle(id: i32) -> u64 => "stdio/get_stdio_handle";
+
+    ported fd_util::kind_of_fd(fd: u64) -> i32 => "fd_util/kind_of_fd";
 
     #[cfg(unix)]
     ported fd_util::pipe(

--- a/crates/moonrun/src/async_api/stdio.rs
+++ b/crates/moonrun/src/async_api/stdio.rs
@@ -1,0 +1,29 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use super::context::ImportContext;
+
+pub(super) fn get_stdio_handle(context: &mut ImportContext<'_, '_>, id: i32) -> u64 {
+    match context.host.std_handle(id) {
+        Ok(handle) => handle,
+        Err(error) => {
+            context.host.record_error(error);
+            context.host.invalid_fd()
+        }
+    }
+}

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -214,6 +214,28 @@ struct HostAddrInfo {
     next: Option<HostHandle>,
 }
 
+const STDIN_ID: i32 = 0;
+const STDOUT_ID: i32 = 1;
+const STDERR_ID: i32 = 2;
+
+#[cfg(windows)]
+const WINDOWS_STDIO_IDS: [u32; 3] = [
+    windows_sys::Win32::System::Console::STD_INPUT_HANDLE,
+    windows_sys::Win32::System::Console::STD_OUTPUT_HANDLE,
+    windows_sys::Win32::System::Console::STD_ERROR_HANDLE,
+];
+
+#[cfg(unix)]
+const STDIO_IDS: [i32; 3] = [STDIN_ID, STDOUT_ID, STDERR_ID];
+
+#[repr(usize)]
+#[derive(Clone, Copy)]
+enum Stdio {
+    Stdin,
+    Stdout,
+    Stderr,
+}
+
 fn handle_from_key(key: HandleKey) -> HostHandle {
     key.data().as_ffi()
 }
@@ -256,18 +278,54 @@ struct HandleTable {
     handles: SlotMap<HandleKey, HandleKind>,
     resources: SecondaryMap<HandleKey, ResourceRef>,
     invalid_resource: HandleKey,
+    stdio_resources: [HandleKey; 3],
 }
 
 impl Default for HandleTable {
     fn default() -> Self {
         let mut handles = SlotMap::with_key();
-        let invalid_resource = handles.insert(HandleKind::Resource);
         let mut resources = SecondaryMap::new();
+
+        let invalid_resource = handles.insert(HandleKind::Resource);
         resources.insert(invalid_resource, Arc::new(Resource::invalid()));
+
+        #[cfg(unix)]
+        let stdio_resources = STDIO_IDS.map(|id| {
+            let key = handles.insert(HandleKind::Resource);
+            resources.insert(key, Arc::new(Resource::stdio_file(id)));
+            key
+        });
+
+        #[cfg(windows)]
+        let stdio_resources = {
+            use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+            use windows_sys::Win32::System::Console::GetStdHandle;
+
+            let mut keys = [invalid_resource; 3];
+            let mut raws = [0isize; 3];
+            for (index, id) in WINDOWS_STDIO_IDS.iter().enumerate() {
+                let handle = unsafe { GetStdHandle(*id) };
+                if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+                    continue;
+                }
+                let raw = handle as isize;
+                if let Some(prev) = (0..index).find(|prev| raws[*prev] == raw) {
+                    keys[index] = keys[prev];
+                    continue;
+                }
+                let key = handles.insert(HandleKind::Resource);
+                resources.insert(key, Arc::new(Resource::stdio_file(handle)));
+                keys[index] = key;
+                raws[index] = raw;
+            }
+            keys
+        };
+
         Self {
             handles,
             resources,
             invalid_resource,
+            stdio_resources,
         }
     }
 }
@@ -322,7 +380,7 @@ impl HandleTable {
 
     fn remove_resource(&mut self, handle: HostHandle) -> AsyncHostResult<ResourceRef> {
         let key = self.key(handle, HandleKind::Resource)?;
-        if key == self.invalid_resource {
+        if key == self.invalid_resource || self.stdio_resources.contains(&key) {
             return Err(AsyncHostError::Badf);
         }
         self.handles.remove(key).ok_or(AsyncHostError::Badf)?;
@@ -407,10 +465,32 @@ impl HandleTable {
         self.remove(handle, HandleKind::IoResult)
     }
 
-    fn resource_count_excluding_invalid(&self) -> usize {
+    fn resource_count_excluding_reserved(&self) -> usize {
         self.resources
             .iter()
-            .filter(|(key, resource)| *key != self.invalid_resource && !resource.is_invalid())
+            .filter(|(key, resource)| {
+                *key != self.invalid_resource
+                    && !self.stdio_resources.contains(key)
+                    && !resource.is_invalid()
+            })
+            .count()
+    }
+
+    fn handle_count_excluding_reserved(&self) -> usize {
+        self.handles
+            .iter()
+            .filter(|(key, kind)| {
+                if *key == self.invalid_resource || self.stdio_resources.contains(key) {
+                    return false;
+                }
+                match kind {
+                    HandleKind::Resource => self
+                        .resources
+                        .get(*key)
+                        .is_some_and(|resource| !resource.is_invalid()),
+                    _ => true,
+                }
+            })
             .count()
     }
 
@@ -1080,6 +1160,19 @@ impl AsyncHost {
         self.handles.lock().unwrap().invalid_fd()
     }
 
+    pub(crate) fn std_handle(&self, id: i32) -> AsyncHostResult<HostHandle> {
+        let stdio = match id {
+            STDIN_ID => Stdio::Stdin,
+            STDOUT_ID => Stdio::Stdout,
+            STDERR_ID => Stdio::Stderr,
+            _ => return Err(AsyncHostError::Inval),
+        };
+        let handles = self.handles.lock().unwrap();
+        let handle = handle_from_key(handles.stdio_resources[stdio as usize]);
+        handles.resource(handle)?;
+        Ok(handle)
+    }
+
     pub(crate) fn get_errno(&self) -> i32 {
         *self.errno.lock().unwrap()
     }
@@ -1204,12 +1297,8 @@ impl AsyncHost {
             }
             {
                 let handles = self.handles.lock().unwrap();
-                let leaked_resources = handles.resource_count_excluding_invalid();
-                let leaked_handles = handles
-                    .handles
-                    .iter()
-                    .filter(|(key, _)| *key != handles.invalid_resource)
-                    .count();
+                let leaked_resources = handles.resource_count_excluding_reserved();
+                let leaked_handles = handles.handle_count_excluding_reserved();
                 let invalid_resource_is_valid = handles
                     .handles
                     .get(handles.invalid_resource)
@@ -2007,6 +2096,11 @@ impl AsyncHost {
     pub(crate) fn set_nonblocking(&self, handle: HostHandle) -> AsyncHostResult<()> {
         let file = self.resource(handle)?;
         crate::async_sys::internal::fd_util::stub::set_nonblocking(file.raw_fd())
+    }
+
+    pub(crate) fn kind_of_fd(&self, handle: HostHandle) -> AsyncHostResult<i32> {
+        let file = self.resource(handle)?;
+        crate::async_sys::internal::fd_util::stub::kind_of_fd(file.raw_fd())
     }
 
     pub(crate) fn set_cloexec(&self, handle: HostHandle) -> AsyncHostResult<()> {
@@ -3507,7 +3601,7 @@ mod tests {
         host.handles
             .lock()
             .unwrap()
-            .resource_count_excluding_invalid()
+            .resource_count_excluding_reserved()
     }
 
     fn host_with_policy(path: &std::path::Path) -> AsyncHost {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -543,7 +543,26 @@ struct OpenedFile {
 #[cfg(unix)]
 fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHostResult<usize> {
     let ret = if position < 0 {
-        unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) }
+        loop {
+            let ret = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+            if ret >= 0 {
+                break ret;
+            }
+            let errno = std::io::Error::last_os_error()
+                .raw_os_error()
+                .unwrap_or_else(|| AsyncHostError::Inval.errno());
+            if errno != libc::EAGAIN && errno != libc::EWOULDBLOCK {
+                break ret;
+            }
+            let mut pfd = libc::pollfd {
+                fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            if unsafe { libc::poll(&mut pfd, 1, -1) } < 0 {
+                break -1;
+            }
+        }
     } else {
         unsafe {
             libc::pread(
@@ -560,7 +579,26 @@ fn read_from_native_file(fd: RawFile, buf: &mut [u8], position: i64) -> AsyncHos
 #[cfg(unix)]
 fn write_to_native_file(fd: RawFile, data: &[u8], position: i64) -> AsyncHostResult<usize> {
     let ret = if position < 0 {
-        unsafe { libc::write(fd, data.as_ptr().cast(), data.len()) }
+        loop {
+            let ret = unsafe { libc::write(fd, data.as_ptr().cast(), data.len()) };
+            if ret >= 0 {
+                break ret;
+            }
+            let errno = std::io::Error::last_os_error()
+                .raw_os_error()
+                .unwrap_or_else(|| AsyncHostError::Inval.errno());
+            if errno != libc::EAGAIN && errno != libc::EWOULDBLOCK {
+                break ret;
+            }
+            let mut pfd = libc::pollfd {
+                fd,
+                events: libc::POLLOUT,
+                revents: 0,
+            };
+            if unsafe { libc::poll(&mut pfd, 1, -1) } < 0 {
+                break -1;
+            }
+        }
     } else {
         unsafe {
             libc::pwrite(

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -66,6 +66,8 @@ pub(crate) struct Resource {
 enum RawResource {
     Invalid,
     File(OwnedRawFile),
+    // Reserved process stdio handle. The guest can use it, but does not own it.
+    StdioFile(isize),
     #[cfg(windows)]
     Socket(OwnedSocket),
 }
@@ -95,6 +97,19 @@ impl Resource {
             raw: RawResource::File(owned_raw_file(raw)),
             class: ResourceClass::File,
             policy_path,
+            socket_family: None,
+            directory_cursor: Mutex::new(()),
+        }
+    }
+
+    pub(crate) fn stdio_file(raw: fd_util::stub::RawFd) -> Self {
+        if raw == invalid_raw_file() {
+            return Self::invalid();
+        }
+        Self {
+            raw: RawResource::StdioFile(raw as isize),
+            class: ResourceClass::File,
+            policy_path: None,
             socket_family: None,
             directory_cursor: Mutex::new(()),
         }
@@ -152,6 +167,7 @@ impl Resource {
         match &self.raw {
             RawResource::Invalid => invalid_raw_file(),
             RawResource::File(raw) => raw_file(raw),
+            RawResource::StdioFile(raw) => *raw as fd_util::stub::RawFd,
             #[cfg(windows)]
             RawResource::Socket(raw) => raw_socket(raw),
         }

--- a/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
@@ -32,6 +32,38 @@ pub(crate) type FileTime = windows_sys::Win32::Storage::FileSystem::FILE_BASIC_I
 #[cfg(unix)]
 pub(crate) type FileTime = libc::stat;
 
+#[cfg(unix)]
+const FILE_KIND_UNKNOWN: i32 = 0;
+#[cfg(unix)]
+const FILE_KIND_REGULAR: i32 = 1;
+#[cfg(unix)]
+const FILE_KIND_DIRECTORY: i32 = 2;
+#[cfg(unix)]
+const FILE_KIND_SYMLINK: i32 = 3;
+#[cfg(unix)]
+const FILE_KIND_SOCKET: i32 = 4;
+#[cfg(unix)]
+const FILE_KIND_PIPE: i32 = 5;
+#[cfg(unix)]
+const FILE_KIND_BLOCK_DEVICE: i32 = 6;
+#[cfg(unix)]
+const FILE_KIND_CHAR_DEVICE: i32 = 7;
+
+#[cfg(windows)]
+const FILE_KIND_UNKNOWN: i32 = 0;
+#[cfg(windows)]
+const FILE_KIND_REGULAR: i32 = 1;
+#[cfg(windows)]
+const FILE_KIND_DIRECTORY: i32 = 2;
+#[cfg(windows)]
+const FILE_KIND_SYMLINK: i32 = 3;
+#[cfg(windows)]
+const FILE_KIND_SOCKET: i32 = 4;
+#[cfg(windows)]
+const FILE_KIND_PIPE: i32 = 5;
+#[cfg(windows)]
+const FILE_KIND_CHAR_DEVICE: i32 = 7;
+
 #[cfg(windows)]
 const WINDOWS_TICKS_PER_SECOND: i64 = 10_000_000;
 #[cfg(windows)]
@@ -87,6 +119,26 @@ ported_fns! {
             }
         }
         Ok(())
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/detect_file_kind.c",
+        original = "moonbitlang_async_kind_of_fd"
+    )]
+    pub(crate) fn kind_of_fd(fd: RawFd) -> AsyncHostResult<i32> {
+        #[cfg(unix)]
+        {
+            let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+            if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } < 0 {
+                return Err(last_native_error());
+            }
+            Ok(file_kind_from_stat(&unsafe { stat.assume_init() }))
+        }
+
+        #[cfg(windows)]
+        {
+            kind_of_raw_file(fd)
+        }
     }
 
     #[ported(
@@ -180,6 +232,107 @@ ported_fns! {
         {
             file_time.st_ctime_nsec as i32
         }
+    }
+}
+
+#[cfg(unix)]
+fn file_kind_from_stat(stat: &libc::stat) -> i32 {
+    match stat.st_mode & libc::S_IFMT {
+        libc::S_IFREG => FILE_KIND_REGULAR,
+        libc::S_IFDIR => FILE_KIND_DIRECTORY,
+        libc::S_IFLNK => FILE_KIND_SYMLINK,
+        libc::S_IFSOCK => FILE_KIND_SOCKET,
+        libc::S_IFIFO => FILE_KIND_PIPE,
+        libc::S_IFBLK => FILE_KIND_BLOCK_DEVICE,
+        libc::S_IFCHR => FILE_KIND_CHAR_DEVICE,
+        _ => FILE_KIND_UNKNOWN,
+    }
+}
+
+#[cfg(windows)]
+fn kind_of_raw_file(handle: RawFd) -> AsyncHostResult<i32> {
+    use windows_sys::Win32::Foundation::{GetLastError, SetLastError};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_BASIC_INFO, FILE_TYPE_CHAR, FILE_TYPE_DISK, FILE_TYPE_PIPE, FILE_TYPE_UNKNOWN,
+        FileBasicInfo, GetFileInformationByHandleEx, GetFileType,
+    };
+
+    unsafe {
+        SetLastError(0);
+    }
+    match unsafe { GetFileType(handle) } {
+        FILE_TYPE_DISK => {
+            let mut info = std::mem::MaybeUninit::<FILE_BASIC_INFO>::uninit();
+            if unsafe {
+                GetFileInformationByHandleEx(
+                    handle,
+                    FileBasicInfo,
+                    info.as_mut_ptr().cast(),
+                    std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+                )
+            } == 0
+            {
+                Err(last_native_error())
+            } else {
+                Ok(file_kind_from_attr(unsafe {
+                    info.assume_init().FileAttributes
+                }))
+            }
+        }
+        FILE_TYPE_CHAR => Ok(FILE_KIND_CHAR_DEVICE),
+        FILE_TYPE_PIPE => {
+            if handle_is_socket(handle) {
+                Ok(FILE_KIND_SOCKET)
+            } else {
+                Ok(FILE_KIND_PIPE)
+            }
+        }
+        FILE_TYPE_UNKNOWN => {
+            let get_file_type_error = unsafe { GetLastError() };
+            if handle_is_socket(handle) {
+                Ok(FILE_KIND_SOCKET)
+            } else if get_file_type_error == 0 {
+                Ok(FILE_KIND_UNKNOWN)
+            } else {
+                unsafe {
+                    SetLastError(get_file_type_error);
+                }
+                Err(last_native_error())
+            }
+        }
+        _ => Ok(FILE_KIND_UNKNOWN),
+    }
+}
+
+#[cfg(windows)]
+fn file_kind_from_attr(attrs: u32) -> i32 {
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+    };
+
+    if (attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+        FILE_KIND_SYMLINK
+    } else if (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0 {
+        FILE_KIND_DIRECTORY
+    } else {
+        FILE_KIND_REGULAR
+    }
+}
+
+#[cfg(windows)]
+fn handle_is_socket(handle: RawFd) -> bool {
+    use windows_sys::Win32::Networking::WinSock::{SO_TYPE, SOCKET, SOL_SOCKET, getsockopt};
+
+    let mut opt = 0i32;
+    let mut opt_len = std::mem::size_of::<i32>() as i32;
+    unsafe {
+        getsockopt(
+            handle as SOCKET,
+            SOL_SOCKET,
+            SO_TYPE,
+            (&mut opt as *mut i32).cast(),
+            &mut opt_len,
+        ) == 0
     }
 }
 

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -374,6 +374,28 @@ fn test_moon_run_with_async_host_imports() {
 }
 
 #[test]
+fn test_moon_run_with_async_stdio_imports() {
+    let dir = TestDir::new("test_async_stdio.in");
+
+    moon_cmd()
+        .current_dir(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success();
+
+    let wasm_file = dir.join("_build/wasm/debug/build/main/main.wasm");
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .env(MOONBIT_ASYNC_CHECK_FD_LEAK, "1")
+        .arg(&wasm_file)
+        .stdin("stdio input\n")
+        .assert()
+        .success()
+        .stdout_eq("stdout-ok\n")
+        .stderr_eq("stderr-ok\n");
+}
+
+#[test]
 fn test_moon_run_with_memory_sanitizer_imports() {
     let dir = TestDir::new("test_memory_sanitizer.in");
 

--- a/crates/moonrun/tests/test_cases/test_async_stdio.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_stdio.in/main/main.mbt
@@ -1,0 +1,110 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+///|
+fn get_stdio_handle(id : Int) -> UInt64 = "moonbitlang/async" "stdio/get_stdio_handle"
+
+///|
+fn kind_of_fd(fd : UInt64) -> Int = "moonbitlang/async" "fd_util/kind_of_fd"
+
+///|
+fn make_read_job(
+  fd : UInt64,
+  len : Int,
+  position : Int64,
+) -> UInt64 = "moonbitlang/async" "thread_pool/make_read_job"
+
+///|
+#unsafe_skip_stub_check
+#borrow(buf)
+fn get_read_result(
+  job : UInt64,
+  buf : FixedArray[Byte],
+  offset : Int,
+  len : Int,
+) -> Unit = "moonbitlang/async" "thread_pool/get_read_result"
+
+///|
+#unsafe_skip_stub_check
+#borrow(buf)
+fn make_write_job(
+  fd : UInt64,
+  buf : Bytes,
+  offset : Int,
+  len : Int,
+  position : Int64,
+) -> UInt64 = "moonbitlang/async" "thread_pool/make_write_job"
+
+///|
+fn run_job(job : UInt64) -> Unit = "moonbitlang/async" "thread_pool/run_job"
+
+///|
+fn free_job(job : UInt64) -> Unit = "moonbitlang/async" "thread_pool/free_job"
+
+///|
+fn job_get_ret(job : UInt64) -> Int = "moonbitlang/async" "thread_pool/job_get_ret"
+
+///|
+fn job_get_err(job : UInt64) -> Int = "moonbitlang/async" "thread_pool/job_get_err"
+
+///|
+fn assert_true(cond : Bool, message : String) -> Unit {
+  if !cond {
+    abort(message)
+  }
+}
+
+///|
+fn assert_file_kind(fd : UInt64, label : String) -> Unit {
+  let kind = kind_of_fd(fd)
+  assert_true(kind > 0, "\{label} was not classified as a concrete file kind")
+}
+
+///|
+fn write_all(fd : UInt64, data : Bytes, label : String) -> Unit {
+  let no_position : Int64 = -1
+  let job = make_write_job(fd, data, 0, data.length(), no_position)
+  run_job(job)
+  assert_true(job_get_err(job) == 0, "\{label} write failed")
+  assert_true(job_get_ret(job) == data.length(), "\{label} write was partial")
+  free_job(job)
+}
+
+///|
+fn main {
+  let stdin = get_stdio_handle(0)
+  let stdout = get_stdio_handle(1)
+  let stderr = get_stdio_handle(2)
+  assert_file_kind(stdin, "stdin")
+  assert_file_kind(stdout, "stdout")
+  assert_file_kind(stderr, "stderr")
+
+  let no_position : Int64 = -1
+  let input = FixedArray::make(12, b'\x00')
+  let read = make_read_job(stdin, input.length(), no_position)
+  run_job(read)
+  assert_true(job_get_err(read) == 0, "stdin read failed")
+  assert_true(job_get_ret(read) == input.length(), "stdin read was partial")
+  get_read_result(read, input, 0, input.length())
+  assert_true(input[0] == b's', "stdin content did not start with expected byte")
+  assert_true(input[11] == b'\n', "stdin content did not end with newline")
+  free_job(read)
+
+  write_all(stdout, b"stdout-ok\n", "stdout")
+  write_all(stderr, b"stderr-ok\n", "stderr")
+}

--- a/crates/moonrun/tests/test_cases/test_async_stdio.in/main/moon.pkg.json
+++ b/crates/moonrun/tests/test_cases/test_async_stdio.in/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moonrun/tests/test_cases/test_async_stdio.in/moon.mod.json
+++ b/crates/moonrun/tests/test_cases/test_async_stdio.in/moon.mod.json
@@ -1,0 +1,3 @@
+{
+  "name": "username/async-stdio"
+}


### PR DESCRIPTION
## Why

`moonrun` had runtime support for the async host surface but no standard stream resources for the upstream `moonbitlang/async/stdio` package. The companion async PR enables that package on wasm and expects the host to provide stdio handles that follow upstream stdio and thread-pool behavior.

Companion PR: https://github.com/moonbitlang/async/pull/482

## What

This adds reserved stdin/stdout/stderr resources to the async host handle table, exposes `moonbitlang/async`'s `stdio/get_stdio_handle` import, updates the Unix thread-pool read/write jobs to wait and retry on nonblocking stdio fds like upstream, and adds focused moonrun tests for stdio reads/writes and the upstream async stdio package.

## Why This Is Correct

The runtime keeps stdio handles host-owned, so guest `close_fd` and leak checks do not consume or report process stdio. The import accepts logical stream ids (`0`, `1`, `2`), matching the upstream async stdio setup. Upstream now always routes stdio through the thread pool, and the Rust thread-pool helpers match the native retry-on-`EAGAIN`/`EWOULDBLOCK` behavior for unpositioned Unix reads/writes.

## Scope

The change is limited to moonrun's async host resources/import registry, thread-pool file IO parity for unpositioned Unix reads/writes, and tests. General WASI stdio handling and unrelated async APIs are unchanged.