### PR TITLE
fix: discover MSVC toolchain on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,10 +162,6 @@ jobs:
           "$env:USERPROFILE\.moon\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
           "$env:GITHUB_WORKSPACE\target\debug" | Out-File -FilePath $env:GITHUB_PATH -Append
 
-      - name: Setup MSVC
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
-
       - name: Build
         run: cargo build
 
@@ -249,9 +245,6 @@ jobs:
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; irm https://cli.moonbitlang.com/install/powershell.ps1 | iex
           "$env:USERPROFILE\.moon\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
           "$env:GITHUB_WORKSPACE\target\debug" | Out-File -FilePath $env:GITHUB_PATH -Append
-
-      - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build
         run: cargo build

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,12 +52,24 @@ _Avoid_: Using entity names for operations, adding containers only to mirror voc
 
 ## Native Build
 
+**Target Backend**:
+The user-visible backend selection for a build, such as Native, LLVM, Wasm, WasmGC, or JS.
+_Avoid_: Native target
+
+**Generated-C Native Backend**:
+The Native target backend implementation where `moonc link-core` emits C and MoonBuild invokes a C toolchain to compile and link it.
+_Avoid_: Native target, direct object target
+
+**Direct Object Native Target**:
+The concrete architecture/OS/ABI target used by the experimental direct object-code native path, such as `x86_64-pc-windows-msvc`.
+_Avoid_: Generated-C native backend, native backend
+
 **Native Payload Form**:
 The representation produced by MoonBit before the host C compiler or linker is invoked, such as generated C or direct object code.
 _Avoid_: Treating generated C, TCC execution, and direct object linking as the same kind of backend choice
 
 **Native Toolchain**:
-The selected native compiler/linker together with the ABI family and runtime-linkage obligations it imposes on runtime, C stubs, and executable linking.
+The selected native compiler/linker used after MoonBit lowering, together with any ABI family and runtime-linkage obligations it imposes on runtime, C stubs, and executable linking.
 _Avoid_: Raw compiler path, native backend mode
 
 **ABI Family**:

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -80,7 +80,7 @@ impl<'a> BuildPlanConstructor<'a> {
     fn new_native_linker_context(&self, err: anyhow::Error) -> anyhow::Error {
         if self.build_env.native_mode.direct_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
             err.context(
-                "Windows MSVC native backend requires an MSVC compiler/linker driver such as cl.exe or clang-cl.exe",
+                "Windows MSVC direct object native target requires an MSVC compiler/linker driver such as cl.exe or clang-cl.exe",
             )
         } else if self.build_env.native_mode.direct_target().is_some() {
             err.context(
@@ -97,7 +97,7 @@ impl<'a> BuildPlanConstructor<'a> {
         }
 
         let warning = UserWarning::warn(
-            "MOON_CC is ignored for Windows MSVC native backend because it is not a cl-compatible driver; set MOON_CC to cl.exe or clang-cl.exe to override MSVC discovery.",
+            "MOON_CC is ignored for Windows MSVC direct object native target because it is not a cl-compatible driver; set MOON_CC to cl.exe or clang-cl.exe to override MSVC discovery.",
         );
         if !self.user_warnings.contains(&warning) {
             self.user_warnings.push(warning);

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -95,13 +95,6 @@ impl MsvcCrtPolicy {
     }
 }
 
-/// ABI family carried by a native compiler/linker selection.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum NativeAbiFamily {
-    Msvc,
-    Other,
-}
-
 impl Toolchain {
     pub fn from_env_override(cc: CC) -> Self {
         Self {
@@ -143,16 +136,8 @@ impl Toolchain {
         self.source
     }
 
-    pub fn abi_family(&self) -> NativeAbiFamily {
-        if self.cc.is_msvc() || self.cc.targets_msvc() {
-            NativeAbiFamily::Msvc
-        } else {
-            NativeAbiFamily::Other
-        }
-    }
-
     pub fn uses_msvc_abi(&self) -> bool {
-        self.abi_family() == NativeAbiFamily::Msvc
+        self.cc.is_msvc() || self.cc.targets_msvc()
     }
 
     pub fn uses_msvc_driver(&self) -> bool {
@@ -221,6 +206,14 @@ pub const WINDOWS_MSVC_STATIC_RUNTIME_FLAG: &str = "/MT";
 
 static WINDOWS_MSVC_ENVIRONMENT: OnceLock<Option<MsvcEnvironment>> = OnceLock::new();
 
+fn windows_msvc_host_target_triple() -> Option<String> {
+    let arch = env::consts::ARCH;
+    match arch {
+        "x86_64" | "aarch64" => Some(format!("{arch}-pc-windows-msvc")),
+        _ => None,
+    }
+}
+
 #[cfg(any(windows, test))]
 fn get_env_value<'a>(env: &'a [(OsString, OsString)], name: &str) -> Option<&'a OsStr> {
     env.iter()
@@ -259,15 +252,15 @@ fn msvc_environment_from_tool_env_or_current_env(
 }
 
 #[cfg(windows)]
-fn find_windows_msvc_environment() -> Option<MsvcEnvironment> {
-    let tool = find_msvc_tools::find_tool("x86_64-pc-windows-msvc", "cl.exe")?;
+fn find_windows_msvc_environment(target: &str) -> Option<MsvcEnvironment> {
+    let tool = find_msvc_tools::find_tool(target, "cl.exe")?;
     let env = tool.env().into_iter().cloned().collect::<Vec<_>>();
     let current_env = env::vars_os().collect::<Vec<_>>();
     msvc_environment_from_tool_env_or_current_env(tool.path().to_path_buf(), &env, &current_env)
 }
 
 #[cfg(not(windows))]
-fn find_windows_msvc_environment() -> Option<MsvcEnvironment> {
+fn find_windows_msvc_environment(_target: &str) -> Option<MsvcEnvironment> {
     None
 }
 
@@ -275,9 +268,11 @@ pub fn resolve_windows_msvc_environment() -> anyhow::Result<MsvcEnvironment> {
     if !cfg!(windows) {
         anyhow::bail!("Windows MSVC environment resolution is only supported on Windows");
     }
+    let target = windows_msvc_host_target_triple()
+        .context("Windows MSVC discovery currently supports 64-bit x64 and ARM64 hosts")?;
 
     WINDOWS_MSVC_ENVIRONMENT
-        .get_or_init(find_windows_msvc_environment)
+        .get_or_init(|| find_windows_msvc_environment(&target))
         .clone()
         .with_context(
             || "Windows native backend requires MSVC Build Tools with C++ tools and Windows SDK",
@@ -758,12 +753,23 @@ pub fn has_cc_env_override() -> bool {
     env::var_os(ENV_MOON_CC).is_some()
 }
 
+fn detected_default_native_toolchain() -> anyhow::Result<Toolchain> {
+    #[cfg(windows)]
+    {
+        if let Ok(toolchain) = resolve_windows_msvc_toolchain() {
+            return Ok(toolchain);
+        }
+    }
+
+    try_system_cc().map(Toolchain::from_path_probe)
+}
+
 pub fn default_native_toolchain(internal_tcc_fallback: Option<&CC>) -> anyhow::Result<Toolchain> {
     if let Some(env_cc) = ENV_CC.as_ref() {
         return Ok(Toolchain::from_env_override(env_cc.clone()));
     }
-    match try_system_cc() {
-        Ok(cc) => Ok(Toolchain::from_path_probe(cc)),
+    match detected_default_native_toolchain() {
+        Ok(toolchain) => Ok(toolchain),
         Err(err) => match internal_tcc_fallback {
             Some(internal_tcc) => Ok(Toolchain::from_path_probe(internal_tcc.clone())),
             None => Err(err),
@@ -1466,10 +1472,24 @@ fn add_cc_common_libraries(cc: &CC, buf: &mut Vec<String>, config: &CCConfig) {
     }
 }
 
-fn add_cc_msvc_linker_flags(cc: &CC, buf: &mut Vec<String>, config: &CCConfig, lpath: &str) {
+fn add_cc_msvc_linker_flags(
+    cc: &CC,
+    toolchain: Option<&Toolchain>,
+    buf: &mut Vec<String>,
+    config: &CCConfig,
+    lpath: &str,
+) {
     if cc.is_msvc() && config.output_ty != OutputType::Object {
         buf.push("/link".to_string());
         buf.push(format!("/LIBPATH:{lpath}"));
+        if let Some(environment) = toolchain.and_then(Toolchain::msvc_environment) {
+            buf.extend(
+                environment
+                    .lib_paths
+                    .iter()
+                    .map(|path| format!("/LIBPATH:{}", path.display())),
+            );
+        }
     }
 }
 
@@ -1648,7 +1668,7 @@ where
             buf.push(libbacktrace_path.display().to_string());
         }
     }
-    add_cc_msvc_linker_flags(&cc, &mut buf, &config, &paths.lib_path);
+    add_cc_msvc_linker_flags(&cc, toolchain, &mut buf, &config, &paths.lib_path);
 
     buf
 }
@@ -1721,7 +1741,6 @@ mod tests {
 
         let toolchain = Toolchain::from_path_probe(cc);
 
-        assert_eq!(toolchain.abi_family(), NativeAbiFamily::Msvc);
         assert!(toolchain.uses_msvc_abi());
         assert!(toolchain.uses_msvc_driver());
         assert_eq!(toolchain.msvc_crt_policy(), Some(MsvcCrtPolicy::StaticMt));
@@ -1739,10 +1758,19 @@ mod tests {
         let toolchain =
             Toolchain::from_path_probe(fake_cc(CCKind::Clang, Some("x86_64-pc-windows-msvc")));
 
-        assert_eq!(toolchain.abi_family(), NativeAbiFamily::Msvc);
         assert!(toolchain.uses_msvc_abi());
         assert!(!toolchain.uses_msvc_driver());
         assert!(toolchain.uses_msvc_link_library_names());
+        assert_eq!(toolchain.msvc_crt_policy(), None);
+    }
+
+    #[test]
+    fn toolchain_does_not_treat_windows_gnu_as_msvc_abi() {
+        let toolchain =
+            Toolchain::from_path_probe(fake_cc(CCKind::Gcc, Some("x86_64-w64-windows-gnu")));
+
+        assert!(!toolchain.uses_msvc_abi());
+        assert!(!toolchain.uses_msvc_link_library_names());
         assert_eq!(toolchain.msvc_crt_policy(), None);
     }
 
@@ -1814,6 +1842,54 @@ mod tests {
             .position(|arg| arg == WINDOWS_MSVC_STATIC_RUNTIME_FLAG)
             .expect("test command should force static runtime flag");
         assert!(mt_position > md_position);
+    }
+
+    #[test]
+    fn msvc_toolchain_adds_environment_lib_paths_to_link_command() {
+        let mut cc = fake_cc(CCKind::Msvc, None);
+        cc.cc_path = "cl.exe".to_string();
+        cc.ar_kind = ARKind::MsvcLib;
+        cc.ar_path = "lib.exe".to_string();
+        let toolchain = Toolchain::from_path_probe(cc).with_msvc_environment(MsvcEnvironment {
+            cl_exe: PathBuf::from("cl.exe"),
+            include_paths: vec![PathBuf::from("crt/include")],
+            lib_paths: vec![PathBuf::from("crt/lib"), PathBuf::from("sdk/lib")],
+        });
+        let paths = CompilerPaths {
+            include_path: "moon/include".to_string(),
+            lib_path: "moon/lib".to_string(),
+        };
+
+        let command = make_cc_command_resolved_for_toolchain(
+            &toolchain,
+            executable_cc_config(),
+            &[] as &[&str],
+            &[] as &[&str],
+            ["main.c".to_string(), "runtime.obj".to_string()],
+            "pkg",
+            Some("main.exe"),
+            &paths,
+        );
+
+        assert!(command.iter().any(|arg| arg == "/LIBPATH:moon/lib"));
+        assert!(command.iter().any(|arg| arg == "/LIBPATH:crt/lib"));
+        assert!(command.iter().any(|arg| arg == "/LIBPATH:sdk/lib"));
+    }
+
+    #[test]
+    fn windows_msvc_host_target_triple_matches_supported_64_bit_arch() {
+        #[cfg(target_arch = "x86_64")]
+        assert_eq!(
+            windows_msvc_host_target_triple().as_deref(),
+            Some("x86_64-pc-windows-msvc")
+        );
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            windows_msvc_host_target_triple().as_deref(),
+            Some("aarch64-pc-windows-msvc")
+        );
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        assert_eq!(windows_msvc_host_target_triple(), None);
     }
 
     #[test]

--- a/docs/dev/reference/native-c-toolchain-resolution.md
+++ b/docs/dev/reference/native-c-toolchain-resolution.md
@@ -11,6 +11,19 @@ The resolved toolchain has three roles:
 Moon does not resolve a standalone linker executable such as `ld` or `lld-link` in this path.
 Linking is performed through the selected compiler driver.
 
+## Terminology
+
+This document uses these terms distinctly:
+
+- **Target backend**: the user-visible backend selection, such as Native, LLVM, Wasm, WasmGC, or
+  JS.
+- **Generated-C native backend**: the Native target backend implementation where `moonc link-core`
+  emits C and Moon invokes a C toolchain to compile and link it.
+- **Direct object native target**: the experimental direct object-code native path under the Native
+  backend, such as `x86_64-pc-windows-msvc`.
+- **Native toolchain**: the selected C compiler/linker driver and archiver used after MoonBit
+  lowering.
+
 ## Standard C Pipeline
 
 The ordinary C pipeline is:
@@ -44,8 +57,9 @@ The high-level build flow is documented in `build.md`:
 
 For native backends, `LinkCore` emits:
 
-- a generated C file for the Native backend
+- a generated C file for the generated-C native backend
 - an object file for the LLVM backend
+- an object file for a direct object native target
 
 Package C stubs are handled separately:
 
@@ -104,7 +118,14 @@ other toolchain families.
 ## Default Auto-Detection
 
 When `MOON_CC` is unset and no package-specific override is being applied to that step, Moon probes
-for a default native toolchain in this order:
+for a default native toolchain.
+
+On Windows, Moon first tries to discover an MSVC toolchain environment for the current 64-bit host
+architecture using the Visual Studio/MSVC discovery logic. The discovery target is
+`x86_64-pc-windows-msvc` on x64 Windows hosts and `aarch64-pc-windows-msvc` on ARM64 Windows hosts.
+Moon does not model cross compilation in this path. This discovery is needed so generated-C builds
+can use `cl.exe` outside a Developer Command Prompt. If MSVC discovery fails, or on non-Windows
+hosts, Moon falls back to PATH probing in this order:
 
 1. `cl`
 2. `cc`
@@ -174,6 +195,7 @@ In practice, the important dimensions are:
 - object format
 - ABI and runtime ecosystem
 - command-line style of the selected tool driver
+- CRT policy on MSVC
 
 Examples:
 
@@ -183,6 +205,26 @@ Examples:
 
 This matters because two tools may both run on Windows while still expect different flags,
 different runtime libraries, or different default link behavior.
+
+Moon currently uses focused predicates for the compatibility checks it needs, rather than a general
+"native build contract" that validates every C compiler involved in a build. This keeps fake
+toolchains, dry runs, and package-level escape hatches working unless a concrete build step requires
+a stricter tool.
+
+The generated-C native backend does not require MSVC. If a user explicitly sets `MOON_CC` or
+`link.native.cc`, Moon keeps using that compiler for the generated-C path. Package-level
+`link.native.stub_cc` is resolved independently for that package's C stubs. Moon does not preflight
+whether an independently configured stub compiler is link-compatible with the executable compiler;
+incompatible objects or archives fail naturally when the final linker consumes them.
+
+The direct object native target `x86_64-pc-windows-msvc` is stricter: it requires selecting a
+`cl`-compatible compiler driver and attaching the discovered Visual Studio include and library
+paths.
+
+The MSVC CRT policy is a separate axis from the ABI family. Moon currently forces the static CRT
+flag `/MT` for `cl`-style compile commands, matching the default MSVC runtime library list that uses
+`libcmt.lib`. `/MD` is not currently modeled as a selectable policy. `/LD` is not a CRT policy; it
+is emitted when the requested output type is a shared library.
 
 ## Flags Depend on Both Tool and Target
 


### PR DESCRIPTION
## Why

Windows generated-C native builds currently depend on `cl.exe` being available from the caller's environment. That means users often need to launch from a Visual Studio Developer Command Prompt even when the installed MSVC tools can be discovered programmatically.

## What Changed

- Discover the default Windows MSVC toolchain with `find-msvc-tools` when no explicit native C compiler is configured.
- Attach the discovered MSVC include and library paths to generated-C compile and link commands.
- Keep explicit `MOON_CC`, package `link.native.cc`, and independently resolved `stub_cc` behavior intact.
- Remove active CI setup of the MSVC developer command environment so Windows CI exercises automatic discovery.
- Clarify the generated-C native backend, direct object native target, native toolchain, ABI, and CRT terminology in developer docs.

## Why This Is Correct

The generated-C native backend only needs a usable C compiler/linker driver. On Windows, MSVC discovery now supplies the compiler path plus the include and library paths that were previously inherited from the developer environment. Explicit user compiler choices still take precedence, and incompatible stub/executable compiler combinations are left to fail naturally at link time.

## Scope

This does not introduce cross compilation or full `vcvarsall` environment emulation. The discovery target follows the current 64-bit Windows host architecture only.