### PR TITLE
Escape Windows solver paths in why3 config

### DIFF
--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -477,9 +477,16 @@ fn try_detect_solver(spec: &SolverSpec) -> Option<DetectedSolver> {
 
     Some(DetectedSolver {
         name: spec.name,
-        path: path_str,
+        path: escape_windows_path(&path_str),
         version: version.to_string(),
     })
+}
+
+fn escape_windows_path(s: &str) -> String {
+    // Why3 configuration strings treat backslashes as escapes. Keep the native
+    // Windows path spelling instead of normalizing to `/`, so the generated
+    // prover path stays the exact executable path returned by PATH/env lookup.
+    s.replace('\\', "\\\\")
 }
 
 fn generate_why3_config(solvers: &[DetectedSolver]) -> String {
@@ -905,6 +912,14 @@ mod tests {
         assert!(config.contains("[partial_prover]\nname = \"Z3\""));
         assert!(config.contains("name = \"MoonBit_Auto\""));
         assert!(!config.contains("Alt-Ergo"));
+    }
+
+    #[test]
+    fn test_generate_config_escapes_windows_solver_path() {
+        let path = escape_windows_path(r"C:\Users\guest\bin\z3.exe");
+        let solvers = vec![make_solver("Z3", &path, "4.16.0")];
+        let config = generate_why3_config(&solvers);
+        assert!(config.contains(r#"path = "C:\\Users\\guest\\bin\\z3.exe""#));
     }
 
     #[test]

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -477,7 +477,7 @@ fn try_detect_solver(spec: &SolverSpec) -> Option<DetectedSolver> {
 
     Some(DetectedSolver {
         name: spec.name,
-        path: escape_windows_path(&path_str),
+        path: path_str,
         version: version.to_string(),
     })
 }
@@ -504,7 +504,9 @@ fn generate_why3_config(solvers: &[DetectedSolver]) -> String {
              name = \"{}\"\n\
              path = \"{}\"\n\
              version = \"{}\"\n",
-            solver.name, solver.path, solver.version,
+            solver.name,
+            escape_windows_path(&solver.path),
+            solver.version,
         ));
     }
 
@@ -916,8 +918,7 @@ mod tests {
 
     #[test]
     fn test_generate_config_escapes_windows_solver_path() {
-        let path = escape_windows_path(r"C:\Users\guest\bin\z3.exe");
-        let solvers = vec![make_solver("Z3", &path, "4.16.0")];
+        let solvers = vec![make_solver("Z3", r"C:\Users\guest\bin\z3.exe", "4.16.0")];
         let config = generate_why3_config(&solvers);
         assert!(config.contains(r#"path = "C:\\Users\\guest\\bin\\z3.exe""#));
     }


### PR DESCRIPTION
## Summary

This PR escapes backslashes in Windows solver executable paths before writing them to the generated why3.conf. Why3 config strings treat backslashes as escape characters, so native Windows paths like C:\Users\...\z3.exe could be parsed incorrectly and cause prover invocation failures. The change preserves the original Windows path spelling, documents the reasoning, and adds a regression test for generated solver paths.