### PR TITLE
Move moonrun pipe nonblocking setup to runtime

### DIFF
--- a/crates/moonrun/docs/adr/0010-preserve-stdio-blocking-mode-for-compat-imports.md
+++ b/crates/moonrun/docs/adr/0010-preserve-stdio-blocking-mode-for-compat-imports.md
@@ -1,0 +1,3 @@
+# Preserve stdio blocking mode for compatibility imports
+
+Moonrun keeps deprecated wasm imports such as `fd_util/set_nonblocking/unix` only so older `moonbitlang/async` wasm guests can instantiate. These compatibility imports must not change a descriptor's blocking mode, because an older guest may call them with stdin, stdout, or stderr handles whose blocking state belongs to the embedding process. Runtime-owned paths that create or register descriptors, such as pipe creation and poll registration, remain responsible for any nonblocking setup they require.

--- a/crates/moonrun/src/async_api/fd_util.rs
+++ b/crates/moonrun/src/async_api/fd_util.rs
@@ -111,18 +111,6 @@ pub(super) fn pipe(
     }
 }
 
-#[ported(source = "src/internal/fd_util/stub.c")]
-#[cfg(unix)]
-pub(super) fn set_nonblocking(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
-    match context.host.set_nonblocking(fd) {
-        Ok(()) => 0,
-        Err(error) => {
-            context.host.record_error(error);
-            -1
-        }
-    }
-}
-
 pub(super) fn set_cloexec(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
     match context.host.set_cloexec(fd) {
         Ok(()) => 0,
@@ -131,6 +119,11 @@ pub(super) fn set_cloexec(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
             -1
         }
     }
+}
+
+// Deprecated. We'll remove it later.
+pub(super) fn set_nonblocking(_context: &mut ImportContext<'_, '_>, _fd: u64) -> i32 {
+    0
 }
 
 #[ported(

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -427,11 +427,7 @@ declare_async_imports! {
         write_end_is_async: i32,
     ) -> i32 => "fd_util/pipe";
 
-    #[cfg(unix)]
-    ported fd_util::set_nonblocking(fd: u64) -> i32 => "fd_util/set_nonblocking/unix";
-
-    #[cfg(windows)]
-    fake fd_util::set_nonblocking(fd: u64) -> i32 => "fd_util/set_nonblocking/unix";
+    helper fd_util::set_nonblocking(fd: u64) -> i32 => "fd_util/set_nonblocking/unix";
 
     helper fd_util::set_cloexec(fd: u64) -> i32 => "fd_util/set_cloexec";
 

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -2139,12 +2139,6 @@ impl AsyncHost {
         )
     }
 
-    #[cfg(unix)]
-    pub(crate) fn set_nonblocking(&self, handle: HostHandle) -> AsyncHostResult<()> {
-        let file = self.resource(handle)?;
-        crate::async_sys::internal::fd_util::stub::set_nonblocking(file.raw_fd())
-    }
-
     pub(crate) fn kind_of_fd(&self, handle: HostHandle) -> AsyncHostResult<i32> {
         let file = self.resource(handle)?;
         crate::async_sys::internal::fd_util::stub::kind_of_fd(file.raw_fd())
@@ -3796,6 +3790,30 @@ mod tests {
 
         host.close_fd(read).unwrap();
         host.close_fd(write).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pipe_applies_async_flags_to_nonblocking_state() {
+        let host = AsyncHost::default();
+
+        for (read_is_async, write_is_async) in
+            [(false, false), (true, false), (false, true), (true, true)]
+        {
+            let [read, write] = host.pipe(read_is_async, write_is_async).unwrap();
+            let read_fd = host.resource(read).unwrap().raw_fd();
+            let write_fd = host.resource(write).unwrap().raw_fd();
+            let read_flags = unsafe { libc::fcntl(read_fd, libc::F_GETFL) };
+            let write_flags = unsafe { libc::fcntl(write_fd, libc::F_GETFL) };
+
+            assert!(read_flags >= 0);
+            assert!(write_flags >= 0);
+            assert_eq!((read_flags & libc::O_NONBLOCK) != 0, read_is_async);
+            assert_eq!((write_flags & libc::O_NONBLOCK) != 0, write_is_async);
+
+            host.close_fd(read).unwrap();
+            host.close_fd(write).unwrap();
+        }
     }
 
     #[test]

--- a/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
@@ -35,12 +35,7 @@ pub(crate) struct ThreadPoolCompletionNotifier {
 #[cfg(unix)]
 impl ThreadPoolCompletionNotifier {
     pub(crate) fn new(poll: &poll::PollInstance) -> AsyncHostResult<(Self, RawFd)> {
-        let fds = fd_util::pipe()?;
-
-        if let Err(error) = fd_util::set_nonblocking(fds[0]) {
-            close_fds(fds);
-            return Err(error);
-        }
+        let fds = fd_util::pipe(true, false)?;
 
         if let Err(error) = poll::poll_register(poll, fds[0], true) {
             close_fds(fds);

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/process.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/process.rs
@@ -620,7 +620,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn wait_for_unknown_process_reports_native_error() {
-        let err = run_wait_for_process_job(None, -1).unwrap_err();
+        let err = run_wait_for_process_job(None, i32::MAX).unwrap_err();
         assert!(matches!(err, AsyncHostError::Native(_)));
     }
 }

--- a/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
@@ -85,12 +85,15 @@ ported_fns! {
         original = "moonbitlang_async_pipe"
     )]
     #[cfg(unix)]
-    pub(crate) fn pipe() -> AsyncHostResult<[RawFd; 2]> {
+    pub(crate) fn pipe(
+        read_end_is_async: bool,
+        write_end_is_async: bool,
+    ) -> AsyncHostResult<[RawFd; 2]> {
         let mut fds = [0, 0];
         if unsafe { libc::pipe(fds.as_mut_ptr()) } < 0 {
             return Err(last_native_error());
         }
-        for fd in fds {
+        for (fd, is_async) in [(fds[0], read_end_is_async), (fds[1], write_end_is_async)] {
             if let Err(error) = set_cloexec(fd) {
                 unsafe {
                     libc::close(fds[0]);
@@ -98,27 +101,28 @@ ported_fns! {
                 }
                 return Err(error);
             }
-        }
-        Ok(fds)
-    }
-
-    #[ported(
-        source = "src/internal/fd_util/stub.c",
-        original = "moonbitlang_async_set_nonblocking"
-    )]
-    #[cfg(unix)]
-    pub(crate) fn set_nonblocking(fd: RawFd) -> AsyncHostResult<()> {
-        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-        if flags < 0 {
-            return Err(last_native_error());
-        }
-        if (flags & libc::O_NONBLOCK) == 0 {
-            let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
-            if ret < 0 {
-                return Err(last_native_error());
+            if is_async {
+                let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+                if flags < 0 {
+                    unsafe {
+                        libc::close(fds[0]);
+                        libc::close(fds[1]);
+                    }
+                    return Err(last_native_error());
+                }
+                if (flags & libc::O_NONBLOCK) == 0 {
+                    let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+                    if ret < 0 {
+                        unsafe {
+                            libc::close(fds[0]);
+                            libc::close(fds[1]);
+                        }
+                        return Err(last_native_error());
+                    }
+                }
             }
         }
-        Ok(())
+        Ok(fds)
     }
 
     #[ported(
@@ -429,8 +433,7 @@ pub(crate) fn pipe_resources(
 ) -> AsyncHostResult<[HostHandle; 2]> {
     #[cfg(unix)]
     {
-        let _ = (read_end_is_async, write_end_is_async);
-        let fds = pipe()?;
+        let fds = pipe(read_end_is_async, write_end_is_async)?;
         let read = resources.insert_file(fds[0])?;
         let write = resources.insert_file(fds[1])?;
         Ok([read, write])

--- a/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
@@ -93,34 +93,32 @@ ported_fns! {
         if unsafe { libc::pipe(fds.as_mut_ptr()) } < 0 {
             return Err(last_native_error());
         }
-        for (fd, is_async) in [(fds[0], read_end_is_async), (fds[1], write_end_is_async)] {
-            if let Err(error) = set_cloexec(fd) {
-                unsafe {
-                    libc::close(fds[0]);
-                    libc::close(fds[1]);
-                }
-                return Err(error);
-            }
-            if is_async {
-                let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-                if flags < 0 {
-                    unsafe {
-                        libc::close(fds[0]);
-                        libc::close(fds[1]);
-                    }
-                    return Err(last_native_error());
-                }
-                if (flags & libc::O_NONBLOCK) == 0 {
-                    let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
-                    if ret < 0 {
-                        unsafe {
-                            libc::close(fds[0]);
-                            libc::close(fds[1]);
-                        }
+
+        let setup_result = (|| {
+            for (fd, is_async) in [(fds[0], read_end_is_async), (fds[1], write_end_is_async)] {
+                set_cloexec(fd)?;
+                if is_async {
+                    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+                    if flags < 0 {
                         return Err(last_native_error());
                     }
+                    if (flags & libc::O_NONBLOCK) == 0 {
+                        let ret =
+                            unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+                        if ret < 0 {
+                            return Err(last_native_error());
+                        }
+                    }
                 }
             }
+            Ok(())
+        })();
+        if let Err(error) = setup_result {
+            unsafe {
+                libc::close(fds[0]);
+                libc::close(fds[1]);
+            }
+            return Err(error);
         }
         Ok(fds)
     }

--- a/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
@@ -94,31 +94,15 @@ ported_fns! {
             return Err(last_native_error());
         }
 
-        let setup_result = (|| {
-            for (fd, is_async) in [(fds[0], read_end_is_async), (fds[1], write_end_is_async)] {
-                set_cloexec(fd)?;
-                if is_async {
-                    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-                    if flags < 0 {
-                        return Err(last_native_error());
-                    }
-                    if (flags & libc::O_NONBLOCK) == 0 {
-                        let ret =
-                            unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
-                        if ret < 0 {
-                            return Err(last_native_error());
-                        }
+        for (fd, is_async) in [(fds[0], read_end_is_async), (fds[1], write_end_is_async)] {
+            if let Err(error) = setup_pipe_fd(fd, is_async) {
+                for fd in fds {
+                    unsafe {
+                        libc::close(fd);
                     }
                 }
+                return Err(error);
             }
-            Ok(())
-        })();
-        if let Err(error) = setup_result {
-            unsafe {
-                libc::close(fds[0]);
-                libc::close(fds[1]);
-            }
-            return Err(error);
         }
         Ok(fds)
     }
@@ -365,6 +349,30 @@ pub(crate) fn set_cloexec(fd: RawFd) -> AsyncHostResult<()> {
     }
     if (flags & libc::FD_CLOEXEC) == 0 {
         let ret = unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) };
+        if ret < 0 {
+            return Err(last_native_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn setup_pipe_fd(fd: RawFd, is_async: bool) -> AsyncHostResult<()> {
+    set_cloexec(fd)?;
+    if is_async {
+        set_nonblocking(fd)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_nonblocking(fd: RawFd) -> AsyncHostResult<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(last_native_error());
+    }
+    if (flags & libc::O_NONBLOCK) == 0 {
+        let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
         if ret < 0 {
             return Err(last_native_error());
         }


### PR DESCRIPTION
## Why

The ultimate goal is that we should not allow Wasm to change file blocking / nonblocking accidentally.

The async fd-util pipe change moves nonblocking setup to the runtime side. Moonrun needs to mirror that ownership for wasm guests while keeping the old import name available for compatibility.

## What

- Let host pipe creation accept read/write async flags and apply nonblocking mode directly.
- Stop routing pipe setup through a standalone host `set_nonblocking` helper.
- Keep `fd_util/set_nonblocking/unix` as a deprecated no-op compatibility import.
- Update the async submodule pointer to moonbitlang/async#486.

## Correctness

The host sets pipe descriptor state before publishing handles, and closes both fds if setup fails. The deprecated import still satisfies older wasm modules, but new pipe and raw-fd paths no longer depend on it.

## Scope

This is stacked on moonbitlang/moon#1870 and moonbitlang/async#486.
