### PR TITLE
fix: support MSVC cwd and environment in n2 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,10 +162,6 @@ jobs:
           "$env:USERPROFILE\.moon\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
           "$env:GITHUB_WORKSPACE\target\debug" | Out-File -FilePath $env:GITHUB_PATH -Append
 
-      - name: Setup MSVC
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
-
       - name: Build
         run: cargo build
 
@@ -249,9 +245,6 @@ jobs:
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; irm https://cli.moonbitlang.com/install/powershell.ps1 | iex
           "$env:USERPROFILE\.moon\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
           "$env:GITHUB_WORKSPACE\target\debug" | Out-File -FilePath $env:GITHUB_PATH -Append
-
-      - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build
         run: cargo build
@@ -396,10 +389,6 @@ jobs:
         run: |
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; irm https://cli.moonbitlang.com/install/powershell.ps1 | iex
           "C:\Users\runneradmin\.moon\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
-
-      - name: Setup MSVC
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build
         run: cargo build

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,12 +52,24 @@ _Avoid_: Using entity names for operations, adding containers only to mirror voc
 
 ## Native Build
 
+**Target Backend**:
+The user-visible backend selection for a build, such as Native, LLVM, Wasm, WasmGC, or JS.
+_Avoid_: Native target
+
+**Generated-C Native Backend**:
+The Native target backend implementation where `moonc link-core` emits C and MoonBuild invokes a C toolchain to compile and link it.
+_Avoid_: Native target, direct object target
+
+**Direct Object Native Target**:
+The concrete architecture/OS/ABI target used by the experimental direct object-code native path, such as `x86_64-pc-windows-msvc`.
+_Avoid_: Generated-C native backend, native backend
+
 **Native Payload Form**:
 The representation produced by MoonBit before the host C compiler or linker is invoked, such as generated C or direct object code.
 _Avoid_: Treating generated C, TCC execution, and direct object linking as the same kind of backend choice
 
 **Native Toolchain**:
-The selected native compiler/linker together with the ABI family and runtime-linkage obligations it imposes on runtime, C stubs, and executable linking.
+The selected native compiler/linker used after MoonBit lowering, together with any ABI family, command environment, and runtime-linkage obligations it imposes on runtime, C stubs, and executable linking.
 _Avoid_: Raw compiler path, native backend mode
 
 **ABI Family**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "n2"
 version = "0.1.5"
-source = "git+https://github.com/moonbitlang/n2.git?rev=3f3eb821ba064a91076aa42042b2d376a2a11bce#3f3eb821ba064a91076aa42042b2d376a2a11bce"
+source = "git+https://github.com/moonbitlang/n2.git?rev=e070bc9758d39dd37e045be25351e6a256fa98c1#e070bc9758d39dd37e045be25351e6a256fa98c1"
 dependencies = [
  "anyhow",
  "argh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.90"
 edition = "2024"
 
 [workspace.dependencies]
-n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "3f3eb821ba064a91076aa42042b2d376a2a11bce" }
+n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "e070bc9758d39dd37e045be25351e6a256fa98c1" }
 arcstr = { version = "1.2", features = ["serde"] }
 moonbuild = { path = "./crates/moonbuild", version = "*" }
 moonbuild-rupes-recta = { path = "./crates/moonbuild-rupes-recta", version = "*" }

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -139,7 +139,8 @@ fn test_moon_pkg() {
     check(
         get_stdout(&dir, ["check", "--dry-run"]),
         expect![[r#"
-            moon tool exec --cwd . --shell 'cat ./pkg/pkg.mbt > ./pkg/gen.txt'
+            moon tool exec --shell 'cat ./pkg/pkg.mbt > ./pkg/gen.txt'
+              cwd: .
             moonc check ./pkg/pkg.mbt -w -unused_value-todo -o ./_build/wasm-gc/debug/check/pkg/pkg.mi -pkg user/mod/pkg -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources user/mod/pkg:./pkg -target wasm-gc -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
             moonc check ./pkg/pkg_test.mbt -doctest-only ./pkg/pkg.mbt -include-doctests -w -unused_value-todo -o ./_build/wasm-gc/debug/check/pkg/pkg.blackbox_test.mi -pkg user/mod/pkg_blackbox_test -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/pkg/pkg.mi:pkg -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources user/mod/pkg_blackbox_test:./pkg -target wasm-gc -blackbox-test -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
             moonc check ./main/main.mbt -o ./_build/wasm-gc/debug/check/main/main.mi -pkg user/mod/main -is-main -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/pkg/pkg.mi:lib -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources user/mod/main:./main -target wasm-gc -workspace-path . -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
@@ -149,7 +150,8 @@ fn test_moon_pkg() {
     check(
         get_stdout(&dir, ["build", "--dry-run"]),
         expect![[r#"
-            moon tool exec --cwd . --shell 'cat ./pkg/pkg.mbt > ./pkg/gen.txt'
+            moon tool exec --shell 'cat ./pkg/pkg.mbt > ./pkg/gen.txt'
+              cwd: .
             moonc build-package ./pkg/pkg.mbt -w -unused_value-todo -o ./_build/wasm-gc/debug/build/pkg/pkg.core -pkg user/mod/pkg -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources user/mod/pkg:./pkg -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
             moonc link-core '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/core.core' ./_build/wasm-gc/debug/build/pkg/pkg.core -main user/mod/pkg -o ./_build/wasm-gc/debug/build/pkg/pkg.wasm -pkg-config-path ./pkg/moon.pkg -pkg-sources user/mod/pkg:./pkg -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target wasm-gc -g -O0 -source-map
             moonc build-package ./main/main.mbt -o ./_build/wasm-gc/debug/build/main/main.core -pkg user/mod/main -is-main -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/build/pkg/pkg.mi:lib -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources user/mod/main:./main -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/msvc.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/msvc.rs
@@ -22,28 +22,11 @@ use std::path::Path;
 
 use moonutil::compiler_flags::{MsvcCrtPolicy, Toolchain, WINDOWS_MSVC_DEFAULT_LIBS};
 
-pub(crate) fn add_environment_include_paths(toolchain: &Toolchain, command: &mut Vec<String>) {
-    let Some(environment) = toolchain.msvc_environment() else {
-        return;
-    };
-    command.extend(
-        environment
-            .include_paths
-            .iter()
-            .map(|path| format!("/I{}", path.display())),
-    );
-}
-
-fn add_environment_lib_paths(toolchain: &Toolchain, command: &mut Vec<String>) {
-    let Some(environment) = toolchain.msvc_environment() else {
-        return;
-    };
-    command.extend(
-        environment
-            .lib_paths
-            .iter()
-            .map(|path| format!("/LIBPATH:{}", path.display())),
-    );
+pub(crate) fn command_env(toolchain: &Toolchain) -> Vec<(String, String)> {
+    toolchain
+        .msvc_environment()
+        .map(|environment| environment.command_env().to_vec())
+        .unwrap_or_default()
 }
 
 pub(crate) fn compile_runtime_command(
@@ -54,7 +37,7 @@ pub(crate) fn compile_runtime_command(
     crt: MsvcCrtPolicy,
 ) -> Vec<String> {
     let mut command = vec![
-        toolchain.cc().cc_path.clone(),
+        toolchain.cc_command_path(),
         "/nologo".to_string(),
         "/utf-8".to_string(),
         "/wd4819".to_string(),
@@ -65,7 +48,6 @@ pub(crate) fn compile_runtime_command(
         format!("/Fo{}", dest.display()),
         format!("/I{moon_include_path}"),
     ];
-    add_environment_include_paths(toolchain, &mut command);
     command.push(source.display().to_string());
     command
 }
@@ -78,7 +60,7 @@ pub(crate) fn link_executable_command(
     lib_path: &str,
 ) -> Vec<String> {
     let mut command = vec![
-        toolchain.cc().cc_path.clone(),
+        toolchain.cc_command_path(),
         "/nologo".to_string(),
         format!("/Fe{dest}"),
     ];
@@ -89,7 +71,6 @@ pub(crate) fn link_executable_command(
         "/subsystem:console".to_string(),
         format!("/LIBPATH:{lib_path}"),
     ]);
-    add_environment_lib_paths(toolchain, &mut command);
     command.extend(user_link_flags.iter().cloned());
     command.extend(WINDOWS_MSVC_DEFAULT_LIBS.iter().map(|lib| lib.to_string()));
     command
@@ -114,13 +95,15 @@ mod tests {
         })
         .with_msvc_environment(MsvcEnvironment {
             cl_exe: PathBuf::from("cl.exe"),
-            include_paths: vec![PathBuf::from("crt/include"), PathBuf::from("sdk/include")],
-            lib_paths: vec![PathBuf::from("crt/lib"), PathBuf::from("sdk/lib")],
+            command_env: vec![
+                ("INCLUDE".to_string(), "crt/include;sdk/include".to_string()),
+                ("LIB".to_string(), "crt/lib;sdk/lib".to_string()),
+            ],
         })
     }
 
     #[test]
-    fn runtime_compile_command_includes_msvc_environment_paths() {
+    fn runtime_compile_command_uses_command_env_for_msvc_environment() {
         let command = compile_runtime_command(
             &fake_msvc_toolchain(),
             Path::new("runtime.c"),
@@ -129,8 +112,6 @@ mod tests {
             MsvcCrtPolicy::StaticMt,
         );
 
-        assert!(command.iter().any(|arg| arg == "/Icrt/include"));
-        assert!(command.iter().any(|arg| arg == "/Isdk/include"));
         assert!(command.iter().any(|arg| arg == "/Imoon/include"));
         assert!(
             command
@@ -140,7 +121,7 @@ mod tests {
     }
 
     #[test]
-    fn executable_link_command_includes_msvc_environment_paths_and_default_libs() {
+    fn executable_link_command_uses_command_env_for_msvc_environment() {
         let command = link_executable_command(
             &fake_msvc_toolchain(),
             &["main.obj".to_string(), "runtime.obj".to_string()],
@@ -149,8 +130,6 @@ mod tests {
             "moon/lib",
         );
 
-        assert!(command.iter().any(|arg| arg == "/LIBPATH:crt/lib"));
-        assert!(command.iter().any(|arg| arg == "/LIBPATH:sdk/lib"));
         assert!(command.iter().any(|arg| arg == "/LIBPATH:moon/lib"));
         assert!(command.iter().any(|arg| arg == "custom.lib"));
         assert!(command.iter().any(|arg| arg == "libcmt.lib"));

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -36,7 +36,7 @@ use crate::{
 use moonutil::toolchain::BINARIES;
 
 use super::{
-    BuildOptions, CommandArgMap, Commandline, LoweringError,
+    BuildOptions, CommandArgMap, LoweringError,
     utils::{build_ins, build_n2_fileloc, build_outs},
 };
 
@@ -319,7 +319,7 @@ impl<'a> LoweringContext<'a> {
         let ins = build_ins(&mut self.graph, ins);
 
         let output_paths = action_products.output_paths();
-        if let Commandline::Args(args) = &cmd.commandline {
+        if let Some(args) = cmd.commandline.args() {
             for output_path in &output_paths {
                 self.command_args_by_output
                     .insert(output_path.clone(), args.clone());
@@ -338,6 +338,8 @@ impl<'a> LoweringContext<'a> {
             outs,
         );
         build.cmdline = Some(cmd.commandline.to_n2_string());
+        build.cwd = cmd.commandline.cwd().map(|cwd| cwd.display().to_string());
+        build.env = cmd.commandline.env().to_vec();
         build.desc = Some(self.plan.human_desc(id, self.modules, self.packages));
         // n2 can't capture and replay command outputs. this is a workaround to
         // avoid losing warnings from `moonc`. According to legacy code, this

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -170,56 +170,63 @@ impl<'a> super::LoweringContext<'a> {
 
         let runtime_toolchain = &info.effective_native_toolchain;
         let resolved_cc = runtime_toolchain.cc().clone();
-        let cc_cmd = if let Some(crt) = runtime_toolchain.msvc_crt_policy() {
-            compiler::msvc::compile_runtime_command(
-                runtime_toolchain,
-                &runtime_c_path,
-                &artifact_path,
-                &self.opt.compiler_paths().include_path,
-                crt,
+        let (cc_cmd, command_env) = if let Some(crt) = runtime_toolchain.msvc_crt_policy() {
+            (
+                compiler::msvc::compile_runtime_command(
+                    runtime_toolchain,
+                    &runtime_c_path,
+                    &artifact_path,
+                    &self.opt.compiler_paths().include_path,
+                    crt,
+                )
+                .into(),
+                compiler::msvc::command_env(runtime_toolchain),
             )
-            .into()
         } else {
             let use_simdutf = !use_shared_runtime
                 && resolved_cc.can_use_simdutf()
                 && self.opt.compiler_paths().simdutf_object_paths().is_some();
 
-            make_cc_command_resolved(
-                resolved_cc,
-                CCConfigBuilder::default()
-                    .no_sys_header(true)
-                    .output_ty(output_ty)
-                    .opt_level(CCOptLevel::Speed)
-                    .debug_info(true)
-                    .allow_stacktrace(
-                        self.opt.debug_symbols && self.opt.os() != OperatingSystem::Windows,
-                    )
-                    .define_tinyc_macro(use_shared_runtime)
-                    .preserve_frame_pointer(use_shared_runtime)
-                    .link_moonbitrun(link_moonbitrun)
-                    .link_libbacktrace(output_ty == CCOutputType::SharedLib)
-                    .define_use_shared_runtime_macro(false)
-                    .use_simdutf(use_simdutf)
-                    .build()
-                    .expect("Failed to build CC configuration for runtime"),
-                &[] as &[&str],
-                [runtime_c_path.display().to_string()],
-                &self
-                    .artifact_paths
-                    .target_layout()
-                    .runtime_output_dir(self.opt.target_backend)
-                    .display()
-                    .to_string(),
-                Some(&artifact_path.display().to_string()),
-                self.opt.compiler_paths(),
+            (
+                make_cc_command_resolved(
+                    resolved_cc,
+                    CCConfigBuilder::default()
+                        .no_sys_header(true)
+                        .output_ty(output_ty)
+                        .opt_level(CCOptLevel::Speed)
+                        .debug_info(true)
+                        .allow_stacktrace(
+                            self.opt.debug_symbols && self.opt.os() != OperatingSystem::Windows,
+                        )
+                        .define_tinyc_macro(use_shared_runtime)
+                        .preserve_frame_pointer(use_shared_runtime)
+                        .link_moonbitrun(link_moonbitrun)
+                        .link_libbacktrace(output_ty == CCOutputType::SharedLib)
+                        .define_use_shared_runtime_macro(false)
+                        .use_simdutf(use_simdutf)
+                        .build()
+                        .expect("Failed to build CC configuration for runtime"),
+                    &[] as &[&str],
+                    [runtime_c_path.display().to_string()],
+                    &self
+                        .artifact_paths
+                        .target_layout()
+                        .runtime_output_dir(self.opt.target_backend)
+                        .display()
+                        .to_string(),
+                    Some(&artifact_path.display().to_string()),
+                    self.opt.compiler_paths(),
+                )
+                .into(),
+                Vec::new(),
             )
-            .into()
         };
 
         BuildCommand {
             extra_inputs: vec![runtime_c_path],
             commandline: cc_cmd,
         }
+        .with_env(command_env)
     }
 
     #[instrument(level = Level::DEBUG, skip(self, products))]
@@ -306,8 +313,6 @@ impl<'a> super::LoweringContext<'a> {
             BINARIES.moonbuild.display().to_string(),
             "tool".to_string(),
             "exec".to_string(),
-            "--cwd".to_string(),
-            info.cwd.display().to_string(),
             "--shell".to_string(),
             info.command.clone(),
         ];
@@ -316,6 +321,7 @@ impl<'a> super::LoweringContext<'a> {
             commandline: commandline.into(),
             extra_inputs: info.resolved_inputs.clone(),
         }
+        .with_cwd(info.cwd.clone())
     }
 
     pub(super) fn lower_moon_lex_prebuild(&self, pkg: PackageId, idx: u32) -> BuildCommand {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -65,7 +65,7 @@ fn commandline_with_dsymutil(cmd: &[String], dest: &str) -> Commandline {
     let cmd_str = moonutil::shlex::join_unix(cmd.iter().map(|x| x.as_str()));
     let dsymutil_args = ["dsymutil", dest];
     let dsymutil_cmd_str = moonutil::shlex::join_unix(dsymutil_args.iter().copied());
-    Commandline::Verbatim(format!("{cmd_str} && {dsymutil_cmd_str}"))
+    Commandline::verbatim(format!("{cmd_str} && {dsymutil_cmd_str}"))
 }
 
 fn should_run_new_native_dsymutil(
@@ -940,6 +940,7 @@ impl<'a> LoweringContext<'a> {
             commandline: cc_cmd.into(),
             extra_inputs: vec![input_file.clone()],
         }
+        .with_msvc_env(&info.effective_native_toolchain)
     }
 
     #[instrument(level = Level::DEBUG, skip(self, products, info))]
@@ -1008,6 +1009,7 @@ impl<'a> LoweringContext<'a> {
             extra_inputs: vec![],
             commandline: archiver_cmd.into(),
         }
+        .with_msvc_env(&info.effective_native_toolchain)
     }
 
     fn lower_link_c_stubs(
@@ -1064,6 +1066,7 @@ impl<'a> LoweringContext<'a> {
             extra_inputs: vec![],
             commandline: cc_cmd.into(),
         }
+        .with_msvc_env(&info.effective_native_toolchain)
     }
 
     #[instrument(level = Level::DEBUG, skip(self, products, info))]
@@ -1228,6 +1231,7 @@ impl<'a> LoweringContext<'a> {
             extra_inputs: simdutf_objects,
             commandline,
         }
+        .with_msvc_env(&info.effective_native_toolchain)
     }
 
     fn lower_link_new_native_exe(
@@ -1309,6 +1313,7 @@ impl<'a> LoweringContext<'a> {
             extra_inputs: simdutf_objects,
             commandline,
         }
+        .with_msvc_env(&info.effective_native_toolchain)
     }
 
     /// Build the command for `tcc -run` to execute when running, as well as

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -21,7 +21,11 @@
 use std::{collections::BTreeMap, path::PathBuf, str::FromStr, sync::OnceLock};
 
 use log::{debug, info};
-use moonutil::{build_options::RunMode, compiler_flags::CompilerPaths, cond_expr::OptLevel};
+use moonutil::{
+    build_options::RunMode,
+    compiler_flags::{CompilerPaths, Toolchain},
+    cond_expr::OptLevel,
+};
 use n2::graph::Graph as N2Graph;
 use tracing::instrument;
 
@@ -250,7 +254,7 @@ pub struct LoweringResult {
 /// time. Other shell features should be disallowed. The result will then be
 /// handled like `Args` native to the platform.
 #[derive(Debug, Clone)]
-enum Commandline {
+enum CommandlineKind {
     /// This commandline will be joined using the platform's default convention.
     Args(Vec<String>),
 
@@ -262,21 +266,65 @@ enum Commandline {
     Verbatim(String),
 }
 
+#[derive(Debug, Clone)]
+struct Commandline {
+    kind: CommandlineKind,
+    cwd: Option<PathBuf>,
+    env: Vec<(String, String)>,
+}
+
 impl From<Vec<String>> for Commandline {
     fn from(v: Vec<String>) -> Self {
-        Commandline::Args(v)
+        Commandline {
+            kind: CommandlineKind::Args(v),
+            cwd: None,
+            env: Vec::new(),
+        }
     }
 }
 
 impl Commandline {
+    fn verbatim(s: String) -> Self {
+        Self {
+            kind: CommandlineKind::Verbatim(s),
+            cwd: None,
+            env: Vec::new(),
+        }
+    }
+
     /// Convert this to the string representation expected by n2.
     fn to_n2_string(&self) -> String {
-        match self {
-            Commandline::Args(args) => {
+        match &self.kind {
+            CommandlineKind::Args(args) => {
                 moonutil::shlex::join_native(args.iter().map(|x| x.as_str()))
             }
-            Commandline::Verbatim(s) => s.clone(),
+            CommandlineKind::Verbatim(s) => s.clone(),
         }
+    }
+
+    fn args(&self) -> Option<&Vec<String>> {
+        match &self.kind {
+            CommandlineKind::Args(args) => Some(args),
+            CommandlineKind::Verbatim(_) => None,
+        }
+    }
+
+    fn cwd(&self) -> Option<&PathBuf> {
+        self.cwd.as_ref()
+    }
+
+    fn env(&self) -> &[(String, String)] {
+        &self.env
+    }
+
+    fn with_cwd(mut self, cwd: PathBuf) -> Self {
+        self.cwd = Some(cwd);
+        self
+    }
+
+    fn with_env(mut self, env: Vec<(String, String)>) -> Self {
+        self.env.extend(env);
+        self
     }
 }
 
@@ -289,6 +337,22 @@ struct BuildCommand {
 
     /// The command to execute.
     commandline: Commandline,
+}
+
+impl BuildCommand {
+    fn with_cwd(mut self, cwd: PathBuf) -> Self {
+        self.commandline = self.commandline.with_cwd(cwd);
+        self
+    }
+
+    fn with_env(mut self, env: Vec<(String, String)>) -> Self {
+        self.commandline = self.commandline.with_env(env);
+        self
+    }
+
+    fn with_msvc_env(self, toolchain: &Toolchain) -> Self {
+        self.with_env(compiler::msvc::command_env(toolchain))
+    }
 }
 
 /// Lowers a normalized action plan into an n2 [Build Graph](n2::graph::Graph).
@@ -477,9 +541,11 @@ mod tests {
             is_env_override: false,
         })
         .with_msvc_environment(MsvcEnvironment {
-            cl_exe: PathBuf::from("cl.exe"),
-            include_paths: vec![PathBuf::from("crt/include"), PathBuf::from("sdk/include")],
-            lib_paths: vec![PathBuf::from("crt/lib"), PathBuf::from("sdk/lib")],
+            cl_exe: PathBuf::from("msvc/bin/cl.exe"),
+            command_env: vec![
+                ("INCLUDE".to_string(), "crt/include;sdk/include".to_string()),
+                ("LIB".to_string(), "crt/lib;sdk/lib".to_string()),
+            ],
         })
     }
 
@@ -652,10 +718,8 @@ mod tests {
             .get(&exe_path)
             .expect("executable command args should be captured");
 
-        assert!(command.iter().any(|arg| arg == "cl.exe"));
+        assert!(command.iter().any(|arg| arg == "msvc/bin/cl.exe"));
         assert!(command.iter().any(|arg| arg == "/subsystem:console"));
-        assert!(command.iter().any(|arg| arg == "/LIBPATH:crt/lib"));
-        assert!(command.iter().any(|arg| arg == "/LIBPATH:sdk/lib"));
         assert!(command.iter().any(|arg| arg == "/LIBPATH:pkg/lib"));
         assert!(command.iter().any(|arg| arg == "dep.lib"));
         assert!(command.iter().any(|arg| arg == "libcmt.lib"));
@@ -674,6 +738,19 @@ mod tests {
             stub_compile_command
                 .iter()
                 .any(|arg| arg == moonutil::compiler_flags::WINDOWS_MSVC_STATIC_RUNTIME_FLAG)
+        );
+
+        let msvc_env_build = lowered
+            .build_graph
+            .builds
+            .iter()
+            .find(|build| build.env.iter().any(|(key, _)| key == "INCLUDE"))
+            .expect("MSVC build should carry command environment");
+        assert!(
+            msvc_env_build
+                .env
+                .iter()
+                .any(|(key, value)| key == "LIB" && value == "crt/lib;sdk/lib")
         );
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -80,7 +80,7 @@ impl<'a> BuildPlanConstructor<'a> {
     fn new_native_linker_context(&self, err: anyhow::Error) -> anyhow::Error {
         if self.build_env.native_mode.direct_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
             err.context(
-                "Windows MSVC native backend requires an MSVC compiler/linker driver such as cl.exe or clang-cl.exe",
+                "Windows MSVC direct object native target requires an MSVC compiler/linker driver such as cl.exe or clang-cl.exe",
             )
         } else if self.build_env.native_mode.direct_target().is_some() {
             err.context(
@@ -97,7 +97,7 @@ impl<'a> BuildPlanConstructor<'a> {
         }
 
         let warning = UserWarning::warn(
-            "MOON_CC is ignored for Windows MSVC native backend because it is not a cl-compatible driver; set MOON_CC to cl.exe or clang-cl.exe to override MSVC discovery.",
+            "MOON_CC is ignored for Windows MSVC direct object native target because it is not a cl-compatible driver; set MOON_CC to cl.exe or clang-cl.exe to override MSVC discovery.",
         );
         if !self.user_warnings.contains(&warning) {
             self.user_warnings.push(warning);

--- a/crates/moonbuild/src/dry_run.rs
+++ b/crates/moonbuild/src/dry_run.rs
@@ -47,9 +47,19 @@ pub fn print_build_commands(
         let builds: Vec<BuildId> = stable_toposort_graph(graph, &sorted_default);
         for b in builds.iter() {
             let build = &graph.builds[*b];
-            if let Some(cmdline) = &build.cmdline {
-                let res = replacer.normalize_command(cmdline);
-                println!("{}", res);
+            if let Some(cmdline) = build.cmdline.as_ref() {
+                println!("{}", replacer.normalize_command(cmdline));
+            }
+            if let Some(cwd) = build.cwd.as_deref().map(Path::new) {
+                let resolved_cwd = if cwd.is_absolute() {
+                    cwd.to_path_buf()
+                } else {
+                    source_dir.join(cwd)
+                };
+                println!("  cwd: {}", replacer.normalize_context_path(&resolved_cwd));
+            }
+            if !build.env.is_empty() {
+                println!("  env: <set by MSVC discovery for cl.exe>");
             }
         }
     }
@@ -152,6 +162,11 @@ impl PathNormalizer {
         path = self.normalize_binary_file_name(path);
 
         path
+    }
+
+    pub fn normalize_context_path(&self, path: &Path) -> String {
+        let normalized_path = dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        self.normalize_path(&normalized_path.to_string_lossy())
     }
 
     fn normalize_binary_file_name(&self, s: String) -> String {
@@ -440,5 +455,16 @@ mod tests {
             replacer.normalize_path("/tmp/toolchain/bin/moonc"),
             "$MOON_TOOLCHAIN_ROOT/bin/moonc"
         );
+    }
+
+    #[test]
+    fn normalizes_context_path_relative_to_source_dir() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let cwd = source_dir.path().join("pkg");
+        std::fs::create_dir(&cwd).unwrap();
+
+        let replacer = PathNormalizer::new(source_dir.path());
+        assert_eq!(replacer.normalize_context_path(&cwd), "./pkg");
+        assert_eq!(replacer.normalize_context_path(source_dir.path()), ".");
     }
 }

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -20,14 +20,13 @@ use crate::moon_dir::MOON_DIRS;
 use anyhow::Context;
 use colored::Colorize;
 use derive_builder::Builder;
-#[cfg(any(windows, test))]
-use std::ffi::OsString;
+#[cfg(windows)]
+use std::sync::OnceLock;
 use std::{
     env,
     ffi::OsStr,
     path::{Path, PathBuf},
     process::Command,
-    sync::OnceLock,
 };
 
 const ENV_MOON_CC: &str = "MOON_CC";
@@ -35,7 +34,7 @@ const ENV_MOON_AR: &str = "MOON_AR";
 
 #[derive(Copy, Clone, Debug)]
 pub enum CCKind {
-    Msvc,     // cl.exe
+    Msvc,     // cl-compatible driver, such as cl.exe or clang-cl.exe
     SystemCC, // cc
     Gcc,      // gcc
     Clang,    // clang
@@ -77,8 +76,13 @@ pub struct Toolchain {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MsvcEnvironment {
     pub cl_exe: PathBuf,
-    pub include_paths: Vec<PathBuf>,
-    pub lib_paths: Vec<PathBuf>,
+    pub command_env: Vec<(String, String)>,
+}
+
+impl MsvcEnvironment {
+    pub fn command_env(&self) -> &[(String, String)] {
+        &self.command_env
+    }
 }
 
 /// MSVC CRT policy shared by runtime, C stubs, and final linking.
@@ -176,6 +180,16 @@ impl Toolchain {
         self.msvc_environment.as_ref()
     }
 
+    pub fn cc_command_path(&self) -> String {
+        if self.cc.is_msvc()
+            && let Some(environment) = self.msvc_environment()
+        {
+            return environment.cl_exe.display().to_string();
+        }
+
+        self.cc.cc_path.clone()
+    }
+
     pub fn with_package_override(&self, package_cc: Option<&CC>) -> Toolchain {
         match (self.source, package_cc) {
             (ToolchainSource::EnvOverride, Some(_)) => {
@@ -219,69 +233,55 @@ pub const WINDOWS_MSVC_DEFAULT_LIBS: &[&str] = &[
 ];
 pub const WINDOWS_MSVC_STATIC_RUNTIME_FLAG: &str = "/MT";
 
+#[cfg(windows)]
 static WINDOWS_MSVC_ENVIRONMENT: OnceLock<Option<MsvcEnvironment>> = OnceLock::new();
 
-#[cfg(any(windows, test))]
-fn get_env_value<'a>(env: &'a [(OsString, OsString)], name: &str) -> Option<&'a OsStr> {
-    env.iter()
-        .find(|(key, _)| key.to_string_lossy().eq_ignore_ascii_case(name))
-        .map(|(_, value)| value.as_os_str())
-}
-
-#[cfg(any(windows, test))]
-fn msvc_environment_from_env_pairs(
-    cl_exe: PathBuf,
-    env: &[(OsString, OsString)],
-) -> Option<MsvcEnvironment> {
-    let include = get_env_value(env, "INCLUDE")?;
-    let lib = get_env_value(env, "LIB")?;
-    let include_paths = env::split_paths(include)
-        .filter(|path| !path.as_os_str().is_empty())
-        .collect::<Vec<_>>();
-    let lib_paths = env::split_paths(lib)
-        .filter(|path| !path.as_os_str().is_empty())
-        .collect::<Vec<_>>();
-    Some(MsvcEnvironment {
-        cl_exe,
-        include_paths,
-        lib_paths,
-    })
-}
-
-#[cfg(any(windows, test))]
-fn msvc_environment_from_tool_env_or_current_env(
-    cl_exe: PathBuf,
-    tool_env: &[(OsString, OsString)],
-    current_env: &[(OsString, OsString)],
-) -> Option<MsvcEnvironment> {
-    msvc_environment_from_env_pairs(cl_exe.clone(), tool_env)
-        .or_else(|| msvc_environment_from_env_pairs(cl_exe, current_env))
+#[cfg(windows)]
+fn windows_msvc_host_target_triple() -> Option<String> {
+    let arch = env::consts::ARCH;
+    match arch {
+        "x86_64" | "aarch64" => Some(format!("{arch}-pc-windows-msvc")),
+        _ => None,
+    }
 }
 
 #[cfg(windows)]
-fn find_windows_msvc_environment() -> Option<MsvcEnvironment> {
-    let tool = find_msvc_tools::find_tool("x86_64-pc-windows-msvc", "cl.exe")?;
-    let env = tool.env().into_iter().cloned().collect::<Vec<_>>();
-    let current_env = env::vars_os().collect::<Vec<_>>();
-    msvc_environment_from_tool_env_or_current_env(tool.path().to_path_buf(), &env, &current_env)
-}
-
-#[cfg(not(windows))]
-fn find_windows_msvc_environment() -> Option<MsvcEnvironment> {
-    None
+fn find_windows_msvc_environment(target: &str) -> Option<MsvcEnvironment> {
+    let tool = find_msvc_tools::find_tool(target, "cl.exe")
+        .or_else(|| find_msvc_tools::find_tool(target, "clang-cl.exe"))?;
+    Some(MsvcEnvironment {
+        cl_exe: tool.path().to_path_buf(),
+        command_env: tool
+            .env()
+            .into_iter()
+            .map(|(key, value)| {
+                (
+                    key.to_string_lossy().into_owned(),
+                    value.to_string_lossy().into_owned(),
+                )
+            })
+            .collect(),
+    })
 }
 
 pub fn resolve_windows_msvc_environment() -> anyhow::Result<MsvcEnvironment> {
-    if !cfg!(windows) {
-        anyhow::bail!("Windows MSVC environment resolution is only supported on Windows");
+    #[cfg(not(windows))]
+    {
+        anyhow::bail!("Windows MSVC environment resolution is only supported on Windows")
     }
 
-    WINDOWS_MSVC_ENVIRONMENT
-        .get_or_init(find_windows_msvc_environment)
-        .clone()
-        .with_context(
-            || "Windows native backend requires MSVC Build Tools with C++ tools and Windows SDK",
-        )
+    #[cfg(windows)]
+    {
+        let target = windows_msvc_host_target_triple()
+            .context("Windows MSVC discovery currently supports 64-bit x64 and ARM64 hosts")?;
+
+        WINDOWS_MSVC_ENVIRONMENT
+            .get_or_init(|| find_windows_msvc_environment(&target))
+            .clone()
+            .with_context(|| {
+                "Windows native backend requires MSVC Build Tools with C++ tools and Windows SDK"
+            })
+    }
 }
 
 fn attach_msvc_environment_if_available(toolchain: Toolchain) -> Toolchain {
@@ -291,11 +291,10 @@ fn attach_msvc_environment_if_available(toolchain: Toolchain) -> Toolchain {
 
     match resolve_windows_msvc_environment() {
         Ok(environment) => {
-            let cl_exe = PathBuf::from(&toolchain.cc().cc_path);
+            let cl_exe = msvc_driver_path_for_toolchain(toolchain.cc(), &environment);
             toolchain.with_msvc_environment(MsvcEnvironment {
                 cl_exe,
-                include_paths: environment.include_paths,
-                lib_paths: environment.lib_paths,
+                command_env: environment.command_env,
             })
         }
         Err(_) => toolchain,
@@ -350,15 +349,26 @@ fn windows_msvc_toolchain_with_package_override(
     if toolchain.source() == ToolchainSource::PackageOverride
         && let Some(environment) = resolved.msvc_environment()
     {
-        let cl_exe = PathBuf::from(&toolchain.cc().cc_path);
+        let cl_exe = msvc_driver_path_for_toolchain(toolchain.cc(), environment);
         toolchain = toolchain.with_msvc_environment(MsvcEnvironment {
             cl_exe,
-            include_paths: environment.include_paths.clone(),
-            lib_paths: environment.lib_paths.clone(),
+            command_env: environment.command_env.clone(),
         });
     }
 
     Ok(toolchain)
+}
+
+fn msvc_driver_path_for_toolchain(cc: &CC, environment: &MsvcEnvironment) -> PathBuf {
+    let cc_path = Path::new(&cc.cc_path);
+    let has_parent = cc_path
+        .parent()
+        .is_some_and(|parent| !parent.as_os_str().is_empty());
+    if cc_path.is_absolute() || has_parent {
+        cc_path.to_path_buf()
+    } else {
+        environment.cl_exe.clone()
+    }
 }
 
 impl CC {
@@ -758,12 +768,23 @@ pub fn has_cc_env_override() -> bool {
     env::var_os(ENV_MOON_CC).is_some()
 }
 
+fn detected_default_native_toolchain() -> anyhow::Result<Toolchain> {
+    #[cfg(windows)]
+    {
+        if let Ok(toolchain) = resolve_windows_msvc_toolchain() {
+            return Ok(toolchain);
+        }
+    }
+
+    try_system_cc().map(Toolchain::from_path_probe)
+}
+
 pub fn default_native_toolchain(internal_tcc_fallback: Option<&CC>) -> anyhow::Result<Toolchain> {
     if let Some(env_cc) = ENV_CC.as_ref() {
         return Ok(Toolchain::from_env_override(env_cc.clone()));
     }
-    match try_system_cc() {
-        Ok(cc) => Ok(Toolchain::from_path_probe(cc)),
+    match detected_default_native_toolchain() {
+        Ok(toolchain) => Ok(toolchain),
         Err(err) => match internal_tcc_fallback {
             Some(internal_tcc) => Ok(Toolchain::from_path_probe(internal_tcc.clone())),
             None => Err(err),
@@ -1239,18 +1260,6 @@ fn add_cc_include_and_lib_paths(cc: &CC, buf: &mut Vec<String>, ipath: &str, lpa
     }
 }
 
-fn add_cc_msvc_environment_include_paths(toolchain: Option<&Toolchain>, buf: &mut Vec<String>) {
-    let Some(environment) = toolchain.and_then(Toolchain::msvc_environment) else {
-        return;
-    };
-    buf.extend(
-        environment
-            .include_paths
-            .iter()
-            .map(|path| format!("/I{}", path.display())),
-    );
-}
-
 fn add_cc_intermediate_dir_flags(
     cc: &CC,
     buf: &mut Vec<String>,
@@ -1609,7 +1618,11 @@ where
     S: AsRef<str>,
     L: AsRef<str>,
 {
-    let mut buf = vec![cc.cc_path.clone()];
+    let mut buf = vec![
+        toolchain
+            .map(Toolchain::cc_command_path)
+            .unwrap_or_else(|| cc.cc_path.clone()),
+    ];
 
     // If user C flags are set, we only set necessary flags
     // that are tightly coupled with the paths and output types
@@ -1619,7 +1632,6 @@ where
 
     add_cc_output_flags(&cc, &mut buf, &config, dest);
     add_cc_include_and_lib_paths(&cc, &mut buf, &paths.include_path, &paths.lib_path);
-    add_cc_msvc_environment_include_paths(toolchain, &mut buf);
     add_cc_intermediate_dir_flags(&cc, &mut buf, &config, intermediate_dir);
     add_cc_debug_flags(&cc, &mut buf, &config);
     add_cc_shared_lib_flags(&cc, &mut buf, &config);
@@ -1699,6 +1711,23 @@ mod tests {
         assert!(!fake_cc(CCKind::Gcc, None).targets_msvc());
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn windows_msvc_host_target_triple_matches_supported_64_bit_arch() {
+        #[cfg(target_arch = "x86_64")]
+        assert_eq!(
+            windows_msvc_host_target_triple().as_deref(),
+            Some("x86_64-pc-windows-msvc")
+        );
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            windows_msvc_host_target_triple().as_deref(),
+            Some("aarch64-pc-windows-msvc")
+        );
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        assert_eq!(windows_msvc_host_target_triple(), None);
+    }
+
     #[test]
     fn windows_msvc_compatibility_rejects_gnu_toolchains() {
         assert!(ensure_windows_msvc_compatible(&fake_cc(CCKind::Msvc, None)).is_ok());
@@ -1756,8 +1785,7 @@ mod tests {
         let resolved =
             Toolchain::from_env_override(env_cc).with_msvc_environment(MsvcEnvironment {
                 cl_exe: PathBuf::from("env-cl.exe"),
-                include_paths: vec![PathBuf::from("env/include")],
-                lib_paths: vec![PathBuf::from("env/lib")],
+                command_env: vec![("INCLUDE".to_string(), "env/include".to_string())],
             });
         let mut package_cc = fake_cc(CCKind::Clang, Some("x86_64-pc-windows-msvc"));
         package_cc.cc_path = "clang.exe".to_string();
@@ -1771,9 +1799,33 @@ mod tests {
             toolchain
                 .msvc_environment()
                 .expect("env toolchain keeps MSVC environment")
-                .lib_paths,
-            vec![PathBuf::from("env/lib")]
+                .command_env(),
+            &[("INCLUDE".to_string(), "env/include".to_string())]
         );
+    }
+
+    #[test]
+    fn bare_windows_msvc_package_override_uses_discovered_driver_path() {
+        let mut discovered_cc = fake_cc(CCKind::Msvc, None);
+        discovered_cc.cc_path = "msvc/bin/cl.exe".to_string();
+        discovered_cc.ar_kind = ARKind::MsvcLib;
+        discovered_cc.ar_path = "msvc/bin/lib.exe".to_string();
+        let resolved =
+            Toolchain::from_path_probe(discovered_cc).with_msvc_environment(MsvcEnvironment {
+                cl_exe: PathBuf::from("msvc/bin/cl.exe"),
+                command_env: vec![("PATH".to_string(), "msvc/bin".to_string())],
+            });
+        let mut package_cc = fake_cc(CCKind::Msvc, None);
+        package_cc.cc_path = "cl.exe".to_string();
+        package_cc.ar_kind = ARKind::MsvcLib;
+        package_cc.ar_path = "lib.exe".to_string();
+
+        let toolchain = windows_msvc_toolchain_with_package_override(resolved, Some(&package_cc))
+            .expect("bare cl.exe package override should remain MSVC-compatible");
+
+        assert_eq!(toolchain.source(), ToolchainSource::PackageOverride);
+        assert_eq!(toolchain.cc().cc_path, "cl.exe");
+        assert_eq!(toolchain.cc_command_path(), "msvc/bin/cl.exe");
     }
 
     #[test]
@@ -1814,76 +1866,6 @@ mod tests {
             .position(|arg| arg == WINDOWS_MSVC_STATIC_RUNTIME_FLAG)
             .expect("test command should force static runtime flag");
         assert!(mt_position > md_position);
-    }
-
-    #[test]
-    fn msvc_environment_uses_find_msvc_tools_env_pairs_case_insensitively() {
-        let include_paths = vec![PathBuf::from("crt/include"), PathBuf::from("sdk/include")];
-        let lib_paths = vec![PathBuf::from("crt/lib"), PathBuf::from("sdk/lib")];
-        let env = vec![
-            (OsString::from("Path"), OsString::from("C:\\Windows")),
-            (
-                OsString::from("include"),
-                env::join_paths(&include_paths).unwrap(),
-            ),
-            (OsString::from("LIB"), env::join_paths(&lib_paths).unwrap()),
-        ];
-        let environment = msvc_environment_from_env_pairs(PathBuf::from("cl.exe"), &env);
-
-        let environment = environment.expect("find-msvc-tools env pairs should parse");
-        assert_eq!(environment.cl_exe, PathBuf::from("cl.exe"));
-        assert_eq!(environment.include_paths, include_paths);
-        assert_eq!(environment.lib_paths, lib_paths);
-    }
-
-    #[test]
-    fn msvc_environment_ignores_empty_include_and_lib_paths() {
-        #[cfg(windows)]
-        const PATH_LIST_SEPARATOR: &str = ";";
-        #[cfg(not(windows))]
-        const PATH_LIST_SEPARATOR: &str = ":";
-
-        let include_paths = vec![PathBuf::from("crt/include"), PathBuf::from("sdk/include")];
-        let lib_paths = vec![PathBuf::from("crt/lib"), PathBuf::from("sdk/lib")];
-        let mut include = env::join_paths(&include_paths).unwrap();
-        include.push(PATH_LIST_SEPARATOR);
-        let mut lib = env::join_paths(&lib_paths).unwrap();
-        lib.push(PATH_LIST_SEPARATOR);
-        let env = vec![
-            (OsString::from("INCLUDE"), include),
-            (OsString::from("LIB"), lib),
-        ];
-
-        let environment = msvc_environment_from_env_pairs(PathBuf::from("cl.exe"), &env)
-            .expect("MSVC environment with trailing separators should parse");
-
-        assert_eq!(environment.include_paths, include_paths);
-        assert_eq!(environment.lib_paths, lib_paths);
-    }
-
-    #[test]
-    fn msvc_environment_falls_back_to_current_env_when_tool_env_is_empty() {
-        let include_paths = vec![PathBuf::from("current/include")];
-        let lib_paths = vec![PathBuf::from("current/lib")];
-        let tool_env = vec![];
-        let current_env = vec![
-            (
-                OsString::from("INCLUDE"),
-                env::join_paths(&include_paths).unwrap(),
-            ),
-            (OsString::from("LIB"), env::join_paths(&lib_paths).unwrap()),
-        ];
-
-        let environment = msvc_environment_from_tool_env_or_current_env(
-            PathBuf::from("cl.exe"),
-            &tool_env,
-            &current_env,
-        )
-        .expect("current MSVC environment should parse when find-msvc-tools env is empty");
-
-        assert_eq!(environment.cl_exe, PathBuf::from("cl.exe"));
-        assert_eq!(environment.include_paths, include_paths);
-        assert_eq!(environment.lib_paths, lib_paths);
     }
 
     #[test]
@@ -2222,6 +2204,12 @@ mod tests {
     fn try_from_path_recognizes_clang_exe() {
         let cc = CC::try_from_path("C:/llvm/bin/clang.exe").expect("parse clang.exe");
         assert!(matches!(cc.cc_kind, CCKind::Clang));
+    }
+
+    #[test]
+    fn try_from_path_recognizes_clang_cl_exe_as_msvc() {
+        let cc = CC::try_from_path("C:/llvm/bin/clang-cl.exe").expect("parse clang-cl.exe");
+        assert!(matches!(cc.cc_kind, CCKind::Msvc));
     }
 
     fn normalize_path_separators(path: &str) -> String {

--- a/docs/dev/reference/native-c-toolchain-resolution.md
+++ b/docs/dev/reference/native-c-toolchain-resolution.md
@@ -44,8 +44,9 @@ The high-level build flow is documented in `build.md`:
 
 For native backends, `LinkCore` emits:
 
-- a generated C file for the Native backend
+- a generated C file for the generated-C native backend
 - an object file for the LLVM backend
+- an object file for a direct object native target
 
 Package C stubs are handled separately:
 
@@ -104,7 +105,14 @@ other toolchain families.
 ## Default Auto-Detection
 
 When `MOON_CC` is unset and no package-specific override is being applied to that step, Moon probes
-for a default native toolchain in this order:
+for a default native toolchain.
+
+On Windows, Moon first tries to discover an MSVC toolchain environment for the current 64-bit host
+architecture using the Visual Studio/MSVC discovery logic. The discovery target is
+`x86_64-pc-windows-msvc` on x64 Windows hosts and `aarch64-pc-windows-msvc` on ARM64 Windows hosts.
+Moon does not model cross compilation in this path. This discovery is needed so generated-C builds
+can use `cl.exe` outside a Developer Command Prompt. If MSVC discovery fails, or on non-Windows
+hosts, Moon falls back to PATH probing in this order:
 
 1. `cl`
 2. `cc`
@@ -174,6 +182,8 @@ In practice, the important dimensions are:
 - object format
 - ABI and runtime ecosystem
 - command-line style of the selected tool driver
+- required command environment
+- CRT policy on MSVC
 
 Examples:
 
@@ -183,6 +193,29 @@ Examples:
 
 This matters because two tools may both run on Windows while still expect different flags,
 different runtime libraries, or different default link behavior.
+
+Moon keeps MSVC discovery environment values such as `PATH`, `INCLUDE`, `LIB`, and `LIBPATH` as
+command environment. These values are not equivalent to simply appending more `/I` or `/LIBPATH`
+flags: the driver and SDK tools use the full environment contract.
+
+Moon currently uses focused predicates for the compatibility checks it needs, rather than a general
+"native build contract" that validates every C compiler involved in a build. This keeps fake
+toolchains, dry runs, and package-level escape hatches working unless a concrete build step requires
+a stricter tool.
+
+The generated-C native backend does not require MSVC. If a user explicitly sets `MOON_CC` or
+`link.native.cc`, Moon keeps using that compiler for the generated-C path. Package-level
+`link.native.stub_cc` is resolved independently for that package's C stubs. Moon does not preflight
+whether an independently configured stub compiler is link-compatible with the executable compiler;
+incompatible objects or archives fail naturally when the final linker consumes them.
+
+The direct object native target `x86_64-pc-windows-msvc` is stricter: it requires selecting a
+`cl`-compatible compiler driver and preserving the discovered Visual Studio command environment.
+
+The MSVC CRT policy is a separate axis from the ABI family. Moon currently forces the static CRT
+flag `/MT` for `cl`-style compile commands, matching the default MSVC runtime library list that uses
+`libcmt.lib`. `/MD` is not currently modeled as a selectable policy. `/LD` is not a CRT policy; it
+is emitted when the requested output type is a shared library.
 
 ## Flags Depend on Both Tool and Target
 


### PR DESCRIPTION
## Why

Windows MSVC native builds need the full Visual Studio command environment, not only compiler and linker search flags. The newer n2 support for command `cwd` and `env` lets Moon carry that execution context directly in the build graph.

## What

- Bump n2 and lower command `cwd` / `env` into n2 builds.
- Preserve the `find-msvc-tools` command environment and use the discovered `cl.exe` path for MSVC commands.
- Print dry-run `cwd` / `env` as context lines without introducing shell-specific dry-run reconstruction.
- Remove the CI MSVC setup workaround and update the native toolchain reference.

## Correctness

MSVC discovery now preserves the environment contract used by the compiler, linker, SDK tools, and runtime libraries instead of translating it into incomplete `/I` and `/LIBPATH` flags. n2 owns command execution, hashing, cwd, and env, so the build graph records the execution context that affects outputs.

## Minimality

This keeps the dry-run shell redesign out of scope and avoids changing prebuild execution semantics beyond passing cwd through n2. The older partial MSVC discovery PR was closed in favor of this approach.