### PR TITLE
Report sandbox policy denials in moonrun

### DIFF
--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -177,8 +177,8 @@ fn test_runwasm_local_package_forwards_experimental_policy() {
         [("MOONRUN_OVERRIDE", moonrun_bin())],
     );
     assert!(
-        stderr.contains("failed to load moonrun policy"),
-        "expected moonrun policy load error, got:\n{stderr}"
+        stderr.contains("failed to load sandbox policy"),
+        "expected sandbox policy load error, got:\n{stderr}"
     );
 }
 
@@ -291,8 +291,8 @@ fn test_runwasm_cached_asset_forwards_experimental_policy() {
         envs,
     );
     assert!(
-        stderr.contains("failed to load moonrun policy"),
-        "expected moonrun policy load error, got:\n{stderr}"
+        stderr.contains("failed to load sandbox policy"),
+        "expected sandbox policy load error, got:\n{stderr}"
     );
 }
 

--- a/crates/moonrun/src/async_policy/fs.rs
+++ b/crates/moonrun/src/async_policy/fs.rs
@@ -69,11 +69,19 @@ impl FsPolicy {
         path: &OsStr,
         intents: FsIntents,
     ) -> AsyncHostResult<()> {
+        let target = sandbox_path_target(base, path);
         let path = Path::new(path);
-        let path = resolve_runtime_path(base, path)?;
-        let path = canonicalize_existing_prefix(&path)?;
+        let path = match resolve_runtime_path(base, path)
+            .and_then(|path| canonicalize_existing_prefix(&path))
+        {
+            Ok(path) => path,
+            Err(AsyncHostError::PermissionDenied) => {
+                return sandbox_denied(intents.sandbox_action(), &target);
+            }
+            Err(error) => return Err(error),
+        };
 
-        self.allows_resolved(&path, intents)
+        self.allows_resolved(&path, intents, &target)
     }
 
     pub(super) fn allows_entry(
@@ -82,19 +90,32 @@ impl FsPolicy {
         path: &OsStr,
         intents: FsIntents,
     ) -> AsyncHostResult<()> {
+        let target = sandbox_path_target(base, path);
         let path = Path::new(path);
-        let path = resolve_runtime_path(base, path)?;
-        let path = canonicalize_entry_path(&path)?;
+        let path = match resolve_runtime_path(base, path)
+            .and_then(|path| canonicalize_entry_path(&path))
+        {
+            Ok(path) => path,
+            Err(AsyncHostError::PermissionDenied) => {
+                return sandbox_denied(intents.sandbox_action(), &target);
+            }
+            Err(error) => return Err(error),
+        };
 
-        self.allows_resolved(&path, intents)
+        self.allows_resolved(&path, intents, &target)
     }
 
-    fn allows_resolved(&self, path: &Path, intents: FsIntents) -> AsyncHostResult<()> {
+    fn allows_resolved(
+        &self,
+        path: &Path,
+        intents: FsIntents,
+        target: &str,
+    ) -> AsyncHostResult<()> {
         if intents.read && !self.allows_read(path) {
-            return Err(AsyncHostError::PermissionDenied);
+            return sandbox_denied("file read", target);
         }
         if intents.write && !self.allows_write(path) {
-            return Err(AsyncHostError::PermissionDenied);
+            return sandbox_denied("file write", target);
         }
         Ok(())
     }
@@ -159,6 +180,14 @@ impl FsIntents {
             Self::read()
         }
     }
+
+    fn sandbox_action(self) -> &'static str {
+        match (self.read, self.write) {
+            (true, false) => "file read",
+            (false, true) => "file write",
+            _ => "file access",
+        }
+    }
 }
 
 fn resolve_roots(roots: Vec<PathBuf>, config_dir: &Path) -> anyhow::Result<Vec<FsRoot>> {
@@ -173,8 +202,12 @@ fn resolve_roots(roots: Vec<PathBuf>, config_dir: &Path) -> anyhow::Result<Vec<F
             } else {
                 config_dir.join(root)
             };
-            let path = std::fs::canonicalize(&path)
-                .with_context(|| format!("failed to resolve async fs root {}", path.display()))?;
+            let path = std::fs::canonicalize(&path).with_context(|| {
+                format!(
+                    "failed to resolve sandbox filesystem root {}",
+                    path.display()
+                )
+            })?;
             Ok(FsRoot::Path(path))
         })
         .collect()
@@ -228,6 +261,27 @@ fn normalize_path(path: PathBuf) -> PathBuf {
         }
     }
     normalized
+}
+
+fn sandbox_denied(action: &str, target: &str) -> AsyncHostResult<()> {
+    eprintln!("Sandbox policy blocked {action}: {target}");
+    Err(AsyncHostError::PermissionDenied)
+}
+
+fn sandbox_path_target(base: RuntimePathBase<'_>, path: &OsStr) -> String {
+    if matches!(base, RuntimePathBase::Untracked) {
+        quote_str("<untracked resource>")
+    } else {
+        quote_os_str(path)
+    }
+}
+
+fn quote_os_str(value: &OsStr) -> String {
+    quote_str(&value.to_string_lossy())
+}
+
+fn quote_str(value: &str) -> String {
+    format!("{value:?}")
 }
 
 #[cfg(test)]

--- a/crates/moonrun/src/async_policy/net.rs
+++ b/crates/moonrun/src/async_policy/net.rs
@@ -104,6 +104,7 @@ impl NetPolicy {
     }
 
     pub(super) fn resolve_dns(&self, host: &OsStr) -> AsyncHostResult<()> {
+        let target = quote_os_str(host);
         let host = host.to_string_lossy();
         let host = normalize_dns_name(&host);
         if self.dns.iter().any(|pattern| pattern.matches(&host))
@@ -111,7 +112,7 @@ impl NetPolicy {
         {
             Ok(())
         } else {
-            Err(AsyncHostError::PermissionDenied)
+            sandbox_denied("DNS lookup", &target)
         }
     }
 
@@ -150,6 +151,7 @@ impl NetPolicy {
         addr: &[u8],
     ) -> AsyncHostResult<()> {
         let addr = parse_socket_addr(addr)?;
+        let target = quote_str(&addr.describe());
         let rules = match operation {
             NetOperation::Connect => &self.connect,
             NetOperation::Bind => &self.bind,
@@ -161,7 +163,16 @@ impl NetPolicy {
         {
             Ok(())
         } else {
-            Err(AsyncHostError::PermissionDenied)
+            sandbox_denied(operation.sandbox_action(), &target)
+        }
+    }
+}
+
+impl NetOperation {
+    fn sandbox_action(self) -> &'static str {
+        match self {
+            Self::Connect => "network connect",
+            Self::Bind => "network bind",
         }
     }
 }
@@ -250,6 +261,15 @@ impl SocketRule {
     }
 }
 
+impl SocketAddr {
+    fn describe(self) -> String {
+        match self.ip {
+            IpAddr::V4(ip) => format!("{ip}:{}", self.port),
+            IpAddr::V6(ip) => format!("[{ip}]:{}", self.port),
+        }
+    }
+}
+
 fn split_host_port(value: &str) -> anyhow::Result<(&str, &str)> {
     if let Some(rest) = value.strip_prefix('[') {
         let Some((host, port)) = rest.split_once("]:") else {
@@ -272,6 +292,19 @@ fn split_host_port(value: &str) -> anyhow::Result<(&str, &str)> {
 
 fn normalize_dns_name(name: &str) -> String {
     name.trim().trim_end_matches('.').to_ascii_lowercase()
+}
+
+fn sandbox_denied(action: &str, target: &str) -> AsyncHostResult<()> {
+    eprintln!("Sandbox policy blocked {action}: {target}");
+    Err(AsyncHostError::PermissionDenied)
+}
+
+fn quote_os_str(value: &OsStr) -> String {
+    quote_str(&value.to_string_lossy())
+}
+
+fn quote_str(value: &str) -> String {
+    format!("{value:?}")
 }
 
 #[cfg(unix)]

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -584,11 +584,11 @@ struct Commandline {
     #[clap(long)]
     stack_size: Option<String>,
 
-    /// Experimental: sandbox moonbitlang/async runtime access using a TOML policy file.
+    /// Experimental: sandbox wasm runtime host access using a TOML policy file.
     #[clap(
         long,
         value_name = "PATH",
-        long_help = r#"Experimental: Sandbox moonbitlang/async and moonrun-owned __moonbit_*_unstable FFI access using a TOML policy file. WASI is not covered.
+        long_help = r#"Experimental: Sandbox wasm runtime host access using a TOML policy file. WASI is not covered.
 
 Supplying --policy enables deny-by-default mode: omitted or empty [fs], [net], and [env] sections deny that surface, and process spawning is disabled unless explicitly enabled.
 
@@ -610,7 +610,7 @@ Common allow-all policy:
 
 Filesystem roots are host paths. Relative roots are resolved relative to the policy file. "*" allows every host path on every platform.
 
-Environment values default to empty in policy mode. Use from_host for optional host variables, required_from_host for required host variables and secrets, and [env.set] for non-secret literals. [env.set] overrides copied host values.
+Environment values default to empty in sandbox policy mode. Use from_host for optional host variables, required_from_host for required host variables and secrets, and [env.set] for non-secret literals. [env.set] overrides copied host values.
 
 Network connect controls outbound sockets; bind controls local bind/listen addresses. Hostname connect rules also permit DNS lookup for those hostnames, so connect = ["api.deepseek.com:443"] does not require a separate dns entry. Bind rules must use IP addresses or *.
 
@@ -663,7 +663,7 @@ fn main() -> anyhow::Result<()> {
     let matches = Commandline::parse();
     let async_policy = Arc::new(match matches.policy.as_ref() {
         Some(path) => async_policy::AsyncPolicy::from_file(path).context(
-            "failed to load moonrun policy (experimental); run `moonrun --help` for policy format notes",
+            "failed to load sandbox policy (experimental); run `moonrun --help` for policy format notes",
         )?,
         None => async_policy::AsyncPolicy::allow_all(),
     });

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -185,7 +185,7 @@ fn test_moonrun_help_describes_policy_shape() {
         .success();
     let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();
 
-    assert!(stdout.contains("Experimental: Sandbox moonbitlang/async"));
+    assert!(stdout.contains("Experimental: Sandbox wasm runtime host access"));
     assert!(stdout.contains("deny-by-default mode"));
     assert!(stdout.contains("from_host = [\"*\"]"));
     assert!(stdout.contains("read = [\"*\"]"));

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -541,7 +541,7 @@ fn test_moon_run_async_policy_with_workspace_async_fs() {
         .arg(&fs_allow_wasm)
         .assert()
         .success()
-        .stdout_eq("workspace input\n|workspace async policy\n");
+        .stdout_eq("workspace input\n|workspace sandbox policy\n");
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .current_dir(dir.path())
@@ -593,7 +593,11 @@ fn test_moon_run_async_policy_with_workspace_async_fs() {
         .arg(&listen_implicit_bind_wasm)
         .assert()
         .success()
-        .stdout_eq("listen denied\n");
+        .stdout_eq("listen denied\n")
+        .stderr_eq(snapbox::str![[r#"
+Sandbox policy blocked network bind: "0.0.0.0:0"
+
+"#]]);
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .current_dir(dir.path())
@@ -604,7 +608,7 @@ fn test_moon_run_async_policy_with_workspace_async_fs() {
         .success()
         .stdout_eq("spawn denied\n");
 
-    let assert = snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .current_dir(dir.path())
         .env(MOONBIT_ASYNC_CHECK_FD_LEAK, "1")
         .arg("--policy")
@@ -612,16 +616,14 @@ fn test_moon_run_async_policy_with_workspace_async_fs() {
         .arg(&fs_deny_read_wasm)
         .assert()
         .failure()
-        .stderr_eq("");
-    let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();
-    assert!(
-        stdout.contains("@fs.open()"),
-        "expected async fs open failure in stdout, got:\n{stdout}"
-    );
-    assert!(
-        stdout.contains("denied/secret.txt"),
-        "expected denied path in stdout, got:\n{stdout}"
-    );
+        .stdout_eq(snapbox::str![[r#"
+OSError("[..]@fs.open()[..]denied/secret.txt[..]Permission denied")
+
+"#]])
+        .stderr_eq(snapbox::str![[r#"
+Sandbox policy blocked file read: "denied/secret.txt"
+
+"#]]);
 }
 
 #[test]

--- a/crates/moonrun/tests/test_cases/test_async_policy_workspace.in/fs_allow/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_policy_workspace.in/fs_allow/main.mbt
@@ -21,7 +21,7 @@ async fn main {
   let input = @fs.read_file("allowed/input.txt").text()
   @fs.write_file(
     "allowed/out.txt",
-    b"workspace async policy",
+    b"workspace sandbox policy",
     create_mode=CreateOrTruncate,
   )
   let output = @fs.read_file("allowed/out.txt").text()


### PR DESCRIPTION
## Summary

This PR makes wasm runtime sandbox policy denials visible to users by printing concise stderr diagnostics such as `Sandbox policy blocked file read: "..."` and `Sandbox policy blocked network bind: "..."`.

It also updates the related CLI/help wording from async-policy terminology to sandbox-policy terminology.

## Why

When the sandbox policy rejects an action, the program currently fails through the normal error path without explaining that the sandbox blocked the operation. That can make policy denials look like ordinary file, DNS, or OS failures.

## Why This Is Correct

The diagnostic is emitted only when the sandbox policy check returns `PermissionDenied`. Guest-visible errno behavior stays unchanged, and native OS errors or malformed guest inputs are not relabeled as sandbox blocks.

## Scope

The change is limited to the moonrun sandbox policy reporting path, user-facing policy wording, and the existing moonrun policy fixture/tests.