### PR TITLE
Print dry-run command env

### DIFF
--- a/crates/moon/tests/test_cases/virtual_pkg_dep/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/mod.rs
@@ -4,19 +4,41 @@ use super::*;
 fn test_indirect_depend_virtual() {
     let dir = TestDir::new("virtual_pkg_dep/indirect_depend_virtual");
     // need to omit the command generated for cc, because it's platform dependent
-    check(
-        get_stdout(&dir, ["run", "src/main", "--target", "native", "--dry-run"])
-            .lines()
-            .filter(|x| !(x.contains("cc") || x.contains("cl.exe")))
-            .collect::<Vec<_>>()
-            .join("\n"),
-        expect![[r#"
-            moonc build-interface ./src/virtual/pkg.mbti -o ./_build/native/debug/build/virtual/virtual.mi -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -pkg indirect_depend_virtual/virtual -pkg-sources indirect_depend_virtual/virtual:./src/virtual -virtual -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -error-format json
-            moonc build-package ./src/middle/p.mbt -o ./_build/native/debug/build/middle/middle.core -pkg indirect_depend_virtual/middle -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -i ./_build/native/debug/build/virtual/virtual.mi:virtual -pkg-sources indirect_depend_virtual/middle:./src/middle -target native -g -O0 -workspace-path . -all-pkgs ./_build/native/debug/build/all_pkgs.json
-            moonc build-package ./src/main/main.mbt -o ./_build/native/debug/build/main/main.core -pkg indirect_depend_virtual/main -is-main -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i ./_build/native/debug/build/middle/middle.mi:middle -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -i ./_build/native/debug/build/virtual/virtual.mi:virtual -pkg-sources indirect_depend_virtual/main:./src/main -target native -g -O0 -workspace-path . -all-pkgs ./_build/native/debug/build/all_pkgs.json
-            moonc build-package ./src/impl/p.mbt -o ./_build/native/debug/build/impl/impl.core -pkg indirect_depend_virtual/impl -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -pkg-sources indirect_depend_virtual/impl:./src/impl -target native -g -O0 -check-mi ./_build/native/debug/build/virtual/virtual.mi -impl-virtual -pkg-sources indirect_depend_virtual/virtual:./src/virtual -workspace-path . -all-pkgs ./_build/native/debug/build/all_pkgs.json
-            moonc link-core '$MOON_HOME/lib/core/_build/native/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/native/release/bundle/core.core' ./_build/native/debug/build/impl/impl.core ./_build/native/debug/build/middle/middle.core ./_build/native/debug/build/main/main.core -main indirect_depend_virtual/main -o ./_build/native/debug/build/main/main.c -pkg-config-path ./src/main/moon.pkg.json -pkg-sources indirect_depend_virtual/impl:./src/impl -pkg-sources indirect_depend_virtual/middle:./src/middle -pkg-sources indirect_depend_virtual/main:./src/main -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target native -g -O0
-            ./_build/native/debug/build/main/main.exe"#]],
+    let dry_run = get_stdout(&dir, ["run", "src/main", "--target", "native", "--dry-run"])
+        .lines()
+        .filter(|x| !(x.contains("cc") || x.contains("cl.exe")))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    #[cfg(windows)]
+    snapbox::assert_data_eq!(
+        dry_run,
+        snapbox::str![[r#"
+  env:
+    LIB=[..]
+    PATH=[..]
+    INCLUDE=[..]
+moonc build-interface ./src/virtual/pkg.mbti -o ./_build/native/debug/build/virtual/virtual.mi -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -pkg indirect_depend_virtual/virtual -pkg-sources indirect_depend_virtual/virtual:./src/virtual -virtual -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -error-format json
+moonc build-package ./src/middle/p.mbt -o ./_build/native/debug/build/middle/middle.core -pkg indirect_depend_virtual/middle -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -i ./_build/native/debug/build/virtual/virtual.mi:virtual -pkg-sources indirect_depend_virtual/middle:./src/middle -target native -g -O0 -workspace-path . -all-pkgs ./_build/native/debug/build/all_pkgs.json
+moonc build-package ./src/main/main.mbt -o ./_build/native/debug/build/main/main.core -pkg indirect_depend_virtual/main -is-main -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i ./_build/native/debug/build/middle/middle.mi:middle -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -i ./_build/native/debug/build/virtual/virtual.mi:virtual -pkg-sources indirect_depend_virtual/main:./src/main -target native -g -O0 -workspace-path . -all-pkgs ./_build/native/debug/build/all_pkgs.json
+moonc build-package ./src/impl/p.mbt -o ./_build/native/debug/build/impl/impl.core -pkg indirect_depend_virtual/impl -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -pkg-sources indirect_depend_virtual/impl:./src/impl -target native -g -O0 -check-mi ./_build/native/debug/build/virtual/virtual.mi -impl-virtual -pkg-sources indirect_depend_virtual/virtual:./src/virtual -workspace-path . -all-pkgs ./_build/native/debug/build/all_pkgs.json
+moonc link-core '$MOON_HOME/lib/core/_build/native/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/native/release/bundle/core.core' ./_build/native/debug/build/impl/impl.core ./_build/native/debug/build/middle/middle.core ./_build/native/debug/build/main/main.core -main indirect_depend_virtual/main -o ./_build/native/debug/build/main/main.c -pkg-config-path ./src/main/moon.pkg.json -pkg-sources indirect_depend_virtual/impl:./src/impl -pkg-sources indirect_depend_virtual/middle:./src/middle -pkg-sources indirect_depend_virtual/main:./src/main -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target native -g -O0
+  env:
+    LIB=[..]
+    PATH=[..]
+    INCLUDE=[..]
+./_build/native/debug/build/main/main[..]"#]],
+    );
+    #[cfg(not(windows))]
+    snapbox::assert_data_eq!(
+        dry_run,
+        snapbox::str![[r#"
+moonc build-interface ./src/virtual/pkg.mbti -o ./_build/native/debug/build/virtual/virtual.mi -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -pkg indirect_depend_virtual/virtual -pkg-sources indirect_depend_virtual/virtual:./src/virtual -virtual -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -error-format json
+moonc build-package ./src/middle/p.mbt -o ./_build/native/debug/build/middle/middle.core -pkg indirect_depend_virtual/middle -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -i ./_build/native/debug/build/virtual/virtual.mi:virtual -pkg-sources indirect_depend_virtual/middle:./src/middle -target native -g -O0 -workspace-path . -all-pkgs ./_build/native/debug/build/all_pkgs.json
+moonc build-package ./src/main/main.mbt -o ./_build/native/debug/build/main/main.core -pkg indirect_depend_virtual/main -is-main -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i ./_build/native/debug/build/middle/middle.mi:middle -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -i ./_build/native/debug/build/virtual/virtual.mi:virtual -pkg-sources indirect_depend_virtual/main:./src/main -target native -g -O0 -workspace-path . -all-pkgs ./_build/native/debug/build/all_pkgs.json
+moonc build-package ./src/impl/p.mbt -o ./_build/native/debug/build/impl/impl.core -pkg indirect_depend_virtual/impl -std-path '$MOON_HOME/lib/core/_build/native/release/bundle' -i '$MOON_HOME/lib/core/_build/native/release/bundle/prelude/prelude.mi:prelude' -pkg-sources indirect_depend_virtual/impl:./src/impl -target native -g -O0 -check-mi ./_build/native/debug/build/virtual/virtual.mi -impl-virtual -pkg-sources indirect_depend_virtual/virtual:./src/virtual -workspace-path . -all-pkgs ./_build/native/debug/build/all_pkgs.json
+moonc link-core '$MOON_HOME/lib/core/_build/native/release/bundle/abort/abort.core' '$MOON_HOME/lib/core/_build/native/release/bundle/core.core' ./_build/native/debug/build/impl/impl.core ./_build/native/debug/build/middle/middle.core ./_build/native/debug/build/main/main.core -main indirect_depend_virtual/main -o ./_build/native/debug/build/main/main.c -pkg-config-path ./src/main/moon.pkg.json -pkg-sources indirect_depend_virtual/impl:./src/impl -pkg-sources indirect_depend_virtual/middle:./src/middle -pkg-sources indirect_depend_virtual/main:./src/main -pkg-sources 'moonbitlang/core:$MOON_HOME/lib/core' -target native -g -O0
+./_build/native/debug/build/main/main[..]"#]],
     );
     check(
         get_stdout(&dir, ["run", "src/main", "--target", "native"]),

--- a/crates/moonbuild/src/dry_run.rs
+++ b/crates/moonbuild/src/dry_run.rs
@@ -59,12 +59,21 @@ pub fn print_build_commands(
                 println!("  cwd: {}", replacer.normalize_context_path(&resolved_cwd));
             }
             if !build.env.is_empty() {
-                println!("  env: <set by MSVC discovery for cl.exe>");
+                println!("  env:");
+                for line in normalized_env_lines(&build.env, &replacer) {
+                    println!("    {line}");
+                }
             }
         }
     }
 
     try_debug_dump_build_graph_to_file(graph, default, source_dir);
+}
+
+fn normalized_env_lines(env: &[(String, String)], replacer: &PathNormalizer) -> Vec<String> {
+    env.iter()
+        .map(|(key, value)| format!("{key}={}", replacer.normalize_command_arg(value)))
+        .collect()
 }
 
 // FIXME: `PathNormalizer` is production-facing dry-run output formatting, not
@@ -391,7 +400,7 @@ fn stable_toposort_graph(graph: &Graph, inputs: &[FileId]) -> Vec<BuildId> {
 
 #[cfg(test)]
 mod tests {
-    use super::PathNormalizer;
+    use super::{PathNormalizer, normalized_env_lines};
 
     #[test]
     fn normalizes_known_tool_exe_suffix_without_touching_native_outputs() {
@@ -466,5 +475,27 @@ mod tests {
         let replacer = PathNormalizer::new(source_dir.path());
         assert_eq!(replacer.normalize_context_path(&cwd), "./pkg");
         assert_eq!(replacer.normalize_context_path(source_dir.path()), ".");
+    }
+
+    #[test]
+    fn renders_build_env_with_normalized_values() {
+        let replacer = PathNormalizer {
+            canonical: Some("/workspace".into()),
+            replace_table: vec![],
+            binary_file_name_table: vec![],
+            show_toolchain_root: false,
+            toolchain_root: "/toolchain".to_owned(),
+            moon_home: "/home".to_owned(),
+        };
+
+        let lines = normalized_env_lines(
+            &[
+                ("LIB".to_owned(), "C:\\SDK\\Lib".to_owned()),
+                ("INCLUDE".to_owned(), "/workspace/crt/include".to_owned()),
+            ],
+            &replacer,
+        );
+
+        assert_eq!(lines, ["LIB=C:/SDK/Lib", "INCLUDE=./crt/include"]);
     }
 }


### PR DESCRIPTION
## Why

Dry-run output currently hides command environment details behind a placeholder when a build step carries environment overrides, such as MSVC discovery for `cl.exe`. That makes the printed plan less useful when diagnosing native toolchain setup.

## What changed

This replaces the placeholder with an `env:` block that prints the actual key/value pairs carried by the build graph. Values use the existing dry-run path normalizer, and the display preserves the order passed to n2.

## Why this is correct

n2 treats `Build.env` as additive command environment overrides and includes those entries in the build manifest hash. Printing the same entries makes dry-run output reflect the execution model instead of summarizing it.

## Scope

The change is limited to dry-run rendering and a focused unit test for environment value normalization.