### PR TITLE
Ziyue/use c in release

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -337,8 +337,8 @@ impl CompilePreConfig {
             "The final selected target backend must either be default or match the explicit one"
         );
 
-        let native_target = match target_backend {
-            TargetBackend::Native => NativeTarget::from_env_for_host(),
+        let native_target = match (target_backend, self.opt_level) {
+            (TargetBackend::Native, BuildProfile::Debug) => NativeTarget::from_env_for_host(),
             _ => None,
         };
         info!("New native target: {:?}", native_target);

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -621,9 +621,10 @@ fn test_moon_run_with_cli_args() {
 fn test_moon_run_single_file_dry_run() {
     let dir = TestDir::new("run_single_mbt_file.in");
 
-    let output = get_stdout(
+    let output = get_stdout_with_envs(
         &dir,
         ["run", "a/b/single.mbt", "--target", "native", "--dry-run"],
+        [("MOONBIT_NEW_NATIVE", "0")],
     )
     // Normalize clang-only warnings to keep snapshots portable across macOS/Linux.
     .replace(" -Wno-unused-value", "");

--- a/crates/moon/tests/test_cases/moon_test/use_cc_for_native_release.rs
+++ b/crates/moon/tests/test_cases/moon_test/use_cc_for_native_release.rs
@@ -1,5 +1,6 @@
-use crate::{TestDir, build_graph::compare_graphs_with_replacements, snap_dry_run_graph};
+use crate::{TestDir, build_graph::compare_graphs_with_replacements, get_stdout_with_envs};
 use expect_test::expect_file;
+use moonbuild_debug::graph::ENV_VAR;
 
 #[track_caller]
 fn assert_dry_run_graph(
@@ -9,7 +10,14 @@ fn assert_dry_run_graph(
     expected: expect_test::ExpectFile,
 ) {
     let graph = dir.join(tmp_name);
-    snap_dry_run_graph(dir, args.iter().copied(), &graph);
+    get_stdout_with_envs(
+        dir,
+        args.iter().copied(),
+        [
+            (ENV_VAR.to_owned(), graph.to_string_lossy().into_owned()),
+            ("MOONBIT_NEW_NATIVE".to_owned(), "0".to_owned()),
+        ],
+    );
     compare_graphs_with_replacements(&graph, expected, |s| {
         // Normalize clang-only warnings to keep snapshots portable across macOS/Linux.
         *s = s.replace(" -Wno-unused-value", "");
@@ -35,7 +43,7 @@ fn test_use_cc_for_native_release() {
             ],
             expect_file!["cc_for_native_release/build_release_graph.jsonl.snap"],
         );
-        // if --release is not specified, it should not use cc
+        // Keep a debug-profile baseline for the generated-C backend.
         assert_dry_run_graph(
             &dir,
             "build_graph.jsonl",
@@ -73,7 +81,7 @@ fn test_use_cc_for_native_release() {
             ],
             expect_file!["cc_for_native_release/run_release_graph.jsonl.snap"],
         );
-        // if --release is not specified, it should not use cc
+        // Keep a debug-profile baseline for the generated-C backend.
         assert_dry_run_graph(
             &dir,
             "run_graph.jsonl",

--- a/crates/moon/tests/test_cases/native_abort_trace/mod.rs
+++ b/crates/moon/tests/test_cases/native_abort_trace/mod.rs
@@ -4,19 +4,34 @@ use super::*;
 fn test_native_abort_trace() {
     let dir = TestDir::new("native_abort_trace/native_abort_trace.in");
     let redactions = moon_test_util::stack_trace::stack_trace_redactions(dir.as_ref());
-    snapbox::cmd::Command::new(moon_bin())
-        .with_assert(snapbox::Assert::new().redact_with(redactions))
-        .current_dir(&dir)
-        .args(["run", "--target", "native", "cmd/main"])
-        .assert()
-        .code(255)
-        .stdout_eq("Hello\n")
-        .stderr_eq(snapbox::str![[r#"
+    let expected_stderr = if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        snapbox::str![[r#"
+PanicError
+    at @moonbitlang/core/option.Option::unwrap[Int] (/option.mbt:[..])
+    at @username/scratch/cmd/main.g (/main.mbt:[..])
+    at @username/scratch/cmd/main.f (/main.mbt:[..])
+    at moonbit_main (/main.mbt:[..])
+    at main (/main.mbt:[..])
+Error: Command exited without a return code
+
+"#]]
+    } else {
+        snapbox::str![[r#"
 RUNTIME ERROR: abort() called
 [CORE_PATH]/builtin/option.mbt[LINE_NUMBER] at @moonbitlang/core/option.Option::unwrap[Int]
 [..]/cmd/main/main.mbt[LINE_NUMBER] by @username/scratch/cmd/main.g
 [..]/cmd/main/main.mbt[LINE_NUMBER] by @username/scratch/cmd/main.f
 [..]/cmd/main/main.mbt[LINE_NUMBER] by main
 
-"#]]);
+"#]]
+    };
+    snapbox::cmd::Command::new(moon_bin())
+        .with_assert(snapbox::Assert::new().redact_with(redactions))
+        .current_dir(&dir)
+        .env_remove("MOONBIT_NEW_NATIVE")
+        .args(["run", "--target", "native", "cmd/main"])
+        .assert()
+        .code(255)
+        .stdout_eq("Hello\n")
+        .stderr_eq(expected_stderr);
 }

--- a/crates/moon/tests/test_cases/native_backend/cc_flags.rs
+++ b/crates/moon/tests/test_cases/native_backend/cc_flags.rs
@@ -107,14 +107,20 @@ fn test_native_backend_cc_flags_with_env_override() {
         &dir,
         "build_native_env_graph.jsonl",
         &["build", "--target", "native", "--dry-run", "--sort-input"],
-        &[("MOON_CC", "x86_64-unknown-fake_os-fake_libc-gcc")],
+        &[
+            ("MOONBIT_NEW_NATIVE", "0"),
+            ("MOON_CC", "x86_64-unknown-fake_os-fake_libc-gcc"),
+        ],
         expect_file!["cc_flags/build_native_env_graph.jsonl.snap"],
     );
     assert_native_backend_graph(
         &dir,
         "test_native_env_graph.jsonl",
         &["test", "--target", "native", "--dry-run", "--sort-input"],
-        &[("MOON_CC", "x86_64-unknown-fake_os-fake_libc-gcc")],
+        &[
+            ("MOONBIT_NEW_NATIVE", "0"),
+            ("MOON_CC", "x86_64-unknown-fake_os-fake_libc-gcc"),
+        ],
         expect_file!["cc_flags/test_native_env_graph.jsonl.snap"],
     );
     assert_native_backend_graph(
@@ -128,7 +134,10 @@ fn test_native_backend_cc_flags_with_env_override() {
             "--dry-run",
             "--sort-input",
         ],
-        &[("MOON_CC", "x86_64-unknown-fake_os-fake_libc-gcc")],
+        &[
+            ("MOONBIT_NEW_NATIVE", "0"),
+            ("MOON_CC", "x86_64-unknown-fake_os-fake_libc-gcc"),
+        ],
         expect_file!["cc_flags/run_native_env_graph.jsonl.snap"],
     );
     assert_native_backend_graph(
@@ -136,6 +145,7 @@ fn test_native_backend_cc_flags_with_env_override() {
         "build_native_env_paths_graph.jsonl",
         &["build", "--target", "native", "--dry-run", "--sort-input"],
         &[
+            ("MOONBIT_NEW_NATIVE", "0"),
             (
                 "MOON_CC",
                 "/some/path/A/x86_64-unknown-fake_os-fake_libc-gcc",
@@ -152,6 +162,7 @@ fn test_native_backend_cc_flags_with_env_override() {
         "test_native_env_paths_graph.jsonl",
         &["test", "--target", "native", "--dry-run", "--sort-input"],
         &[
+            ("MOONBIT_NEW_NATIVE", "0"),
             (
                 "MOON_CC",
                 "/some/path/A/x86_64-unknown-fake_os-fake_libc-gcc",
@@ -175,6 +186,7 @@ fn test_native_backend_cc_flags_with_env_override() {
             "--sort-input",
         ],
         &[
+            ("MOONBIT_NEW_NATIVE", "0"),
             (
                 "MOON_CC",
                 "/some/path/A/x86_64-unknown-fake_os-fake_libc-gcc",

--- a/crates/moon/tests/test_cases/native_backend/new_native_e2e.rs
+++ b/crates/moon/tests/test_cases/native_backend/new_native_e2e.rs
@@ -1,5 +1,56 @@
 use crate::{TestDir, get_stdout_with_envs, moon_process_cmd};
 
+fn command_mentions_c_source(line: &str) -> bool {
+    line.split_whitespace()
+        .any(|arg| arg.trim_matches('\'').ends_with(".c"))
+}
+
+fn assert_debug_uses_direct_object_without_env(dir: &TestDir, args: &[&str]) {
+    let output = moon_process_cmd(dir)
+        .env_remove("MOONBIT_NEW_NATIVE")
+        .env_remove("MOON_CC")
+        .args(args)
+        .output()
+        .expect("failed to get debug dry-run output");
+    assert!(
+        output.status.success(),
+        "debug dry-run failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("__moonbit_link_core__"),
+        "debug dry-run did not use the direct object backend:\n{stdout}"
+    );
+    assert!(
+        !stdout
+            .lines()
+            .any(|line| line.contains("moonc link-core") && command_mentions_c_source(line)),
+        "debug dry-run unexpectedly generated C source:\n{stdout}"
+    );
+}
+
+fn assert_debug_uses_generated_c_when_disabled(dir: &TestDir, args: &[&str]) {
+    let output = get_stdout_with_envs(
+        dir,
+        args.iter().copied(),
+        [("MOONBIT_NEW_NATIVE", "0"), ("MOON_CC", "cc")],
+    );
+
+    assert!(
+        output
+            .lines()
+            .any(|line| line.contains("moonc link-core") && command_mentions_c_source(line)),
+        "disabled new native dry-run did not generate C source:\n{output}"
+    );
+    assert!(
+        !output.contains("__moonbit_link_core__"),
+        "disabled new native dry-run unexpectedly used the direct object backend:\n{output}"
+    );
+}
+
 fn assert_release_uses_generated_c(dir: &TestDir, args: &[&str]) {
     let output = get_stdout_with_envs(
         dir,
@@ -10,13 +61,13 @@ fn assert_release_uses_generated_c(dir: &TestDir, args: &[&str]) {
     assert!(
         output
             .lines()
-            .any(|line| line.contains("moonc link-core") && line.contains(".c")),
+            .any(|line| line.contains("moonc link-core") && command_mentions_c_source(line)),
         "release dry-run did not generate C source:\n{output}"
     );
     assert!(
         output
             .lines()
-            .any(|line| line.contains(" -O2 ") && line.contains(".c")),
+            .any(|line| line.contains(" -O2 ") && command_mentions_c_source(line)),
         "release dry-run did not compile generated C with -O2:\n{output}"
     );
     assert!(
@@ -26,11 +77,11 @@ fn assert_release_uses_generated_c(dir: &TestDir, args: &[&str]) {
 }
 
 #[test]
-fn test_new_native_run_and_test_e2e() {
+fn test_new_native_is_default_for_run_and_test_e2e() {
     let dir = TestDir::new("native_backend/new_native_e2e");
 
     let run_output = moon_process_cmd(&dir)
-        .env("MOONBIT_NEW_NATIVE", "1")
+        .env_remove("MOONBIT_NEW_NATIVE")
         .env_remove("MOON_CC")
         .args(["run", "main", "--target", "native"])
         .output()
@@ -47,7 +98,7 @@ fn test_new_native_run_and_test_e2e() {
     );
 
     let test_output = moon_process_cmd(&dir)
-        .env("MOONBIT_NEW_NATIVE", "1")
+        .env_remove("MOONBIT_NEW_NATIVE")
         .env_remove("MOON_CC")
         .args(["test", "--target", "native", "-v", "--no-parallelize"])
         .output()
@@ -63,6 +114,36 @@ fn test_new_native_run_and_test_e2e() {
         "new native test stdout did not contain expected output\nstdout:\n{}",
         String::from_utf8_lossy(&test_output.stdout)
     );
+}
+
+#[test]
+fn test_new_native_is_default_for_debug_build_run_and_test() {
+    let dir = TestDir::new("native_backend/new_native_e2e");
+
+    assert_debug_uses_direct_object_without_env(
+        &dir,
+        &["build", "--target", "native", "--dry-run"],
+    );
+    assert_debug_uses_direct_object_without_env(
+        &dir,
+        &["run", "main", "--target", "native", "--dry-run"],
+    );
+    assert_debug_uses_direct_object_without_env(&dir, &["test", "--target", "native", "--dry-run"]);
+}
+
+#[test]
+fn test_new_native_zero_uses_generated_c_for_debug_build_run_and_test() {
+    let dir = TestDir::new("native_backend/new_native_e2e");
+
+    assert_debug_uses_generated_c_when_disabled(
+        &dir,
+        &["build", "--target", "native", "--dry-run"],
+    );
+    assert_debug_uses_generated_c_when_disabled(
+        &dir,
+        &["run", "main", "--target", "native", "--dry-run"],
+    );
+    assert_debug_uses_generated_c_when_disabled(&dir, &["test", "--target", "native", "--dry-run"]);
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/native_backend/new_native_e2e.rs
+++ b/crates/moon/tests/test_cases/native_backend/new_native_e2e.rs
@@ -1,4 +1,29 @@
-use crate::{TestDir, moon_process_cmd};
+use crate::{TestDir, get_stdout_with_envs, moon_process_cmd};
+
+fn assert_release_uses_generated_c(dir: &TestDir, args: &[&str]) {
+    let output = get_stdout_with_envs(
+        dir,
+        args.iter().copied(),
+        [("MOONBIT_NEW_NATIVE", "1"), ("MOON_CC", "cc")],
+    );
+
+    assert!(
+        output
+            .lines()
+            .any(|line| line.contains("moonc link-core") && line.contains(".c")),
+        "release dry-run did not generate C source:\n{output}"
+    );
+    assert!(
+        output
+            .lines()
+            .any(|line| line.contains(" -O2 ") && line.contains(".c")),
+        "release dry-run did not compile generated C with -O2:\n{output}"
+    );
+    assert!(
+        !output.contains("__moonbit_link_core__"),
+        "release dry-run unexpectedly used the direct object backend:\n{output}"
+    );
+}
 
 #[test]
 fn test_new_native_run_and_test_e2e() {
@@ -37,5 +62,30 @@ fn test_new_native_run_and_test_e2e() {
         String::from_utf8_lossy(&test_output.stdout).contains("new native test ok\n"),
         "new native test stdout did not contain expected output\nstdout:\n{}",
         String::from_utf8_lossy(&test_output.stdout)
+    );
+}
+
+#[test]
+fn test_new_native_release_uses_generated_c_with_o2() {
+    let dir = TestDir::new("native_backend/new_native_e2e");
+
+    assert_release_uses_generated_c(
+        &dir,
+        &["build", "--target", "native", "--release", "--dry-run"],
+    );
+    assert_release_uses_generated_c(
+        &dir,
+        &[
+            "run",
+            "main",
+            "--target",
+            "native",
+            "--release",
+            "--dry-run",
+        ],
+    );
+    assert_release_uses_generated_c(
+        &dir,
+        &["test", "--target", "native", "--release", "--dry-run"],
     );
 }

--- a/crates/moon/tests/test_cases/native_backend/tcc_run.rs
+++ b/crates/moon/tests/test_cases/native_backend/tcc_run.rs
@@ -2,22 +2,25 @@ use crate::{TestDir, moon_process_cmd};
 use expect_test::expect_file;
 use walkdir::WalkDir;
 
-use super::unix_graph::assert_native_backend_graph_no_env;
+use super::unix_graph::assert_native_backend_graph;
 
 #[test]
 fn test_native_backend_tcc_run() {
     let dir = TestDir::new("native_backend/tcc_run");
-    assert_native_backend_graph_no_env(
+    let envs = &[("MOONBIT_NEW_NATIVE", "0")];
+    assert_native_backend_graph(
         &dir,
         "build_native_graph.jsonl",
         &["build", "--target", "native", "--dry-run", "--sort-input"],
+        envs,
         expect_file!["tcc_run/build_native_graph.jsonl.snap"],
     );
 
-    assert_native_backend_graph_no_env(
+    assert_native_backend_graph(
         &dir,
         "test_native_graph.jsonl",
         &["test", "--target", "native", "--dry-run", "--sort-input"],
+        envs,
         if cfg!(target_os = "macos") {
             expect_file!["tcc_run/test_native_macos_graph.jsonl.snap"]
         } else {
@@ -34,7 +37,7 @@ fn test_native_tcc_run_when_moon_spawned_from_other_dir() {
 
     let output = moon_process_cmd(&spawn_dir)
         .env_remove("MOON_CC")
-        .env_remove("MOONBIT_NEW_NATIVE")
+        .env("MOONBIT_NEW_NATIVE", "0")
         .args([
             "--manifest-path",
             "../moon.work",

--- a/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
@@ -1,8 +1,8 @@
 use std::cell::OnceCell;
 
-use crate::{TestDir, assert_success, get_err_stderr, get_stdout_with_envs};
 #[cfg(unix)]
-use crate::{get_stdout, util};
+use crate::util;
+use crate::{TestDir, assert_success, get_err_stderr, get_stdout_with_envs};
 
 // Notice the two `this-is-added-by-config-script`
 #[test]
@@ -63,9 +63,10 @@ fn test_prebuild_config_common(dir: TestDir) {
 #[cfg(unix)]
 fn test_prebuild_config_tcc_rspfile_snapshot() {
     let dir = TestDir::new("prebuild_config_script/tcc_rspfile");
-    let stdout = get_stdout(
+    let stdout = get_stdout_with_envs(
         &dir,
         ["run", "src/main", "--target", "native", "--build-only"],
+        [("MOONBIT_NEW_NATIVE", "0")],
     );
     println!("{}", &stdout);
 

--- a/crates/moon/tests/test_cases/virtual_pkg_dep/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg_dep/mod.rs
@@ -4,11 +4,15 @@ use super::*;
 fn test_indirect_depend_virtual() {
     let dir = TestDir::new("virtual_pkg_dep/indirect_depend_virtual");
     // need to omit the command generated for cc, because it's platform dependent
-    let dry_run = get_stdout(&dir, ["run", "src/main", "--target", "native", "--dry-run"])
-        .lines()
-        .filter(|x| !(x.contains("cc") || x.contains("cl.exe")))
-        .collect::<Vec<_>>()
-        .join("\n");
+    let dry_run = get_stdout_with_envs(
+        &dir,
+        ["run", "src/main", "--target", "native", "--dry-run"],
+        [("MOONBIT_NEW_NATIVE", "0")],
+    )
+    .lines()
+    .filter(|x| !(x.contains("cc") || x.contains("cl.exe")))
+    .collect::<Vec<_>>()
+    .join("\n");
 
     #[cfg(windows)]
     snapbox::assert_data_eq!(

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -76,10 +76,25 @@ pub enum DirectNativeMode {
 
 impl NativeTarget {
     pub fn from_env_for_host() -> Option<Self> {
-        if std::env::var(ENV_MOONBIT_NEW_NATIVE).as_deref() != Ok("1") {
-            return None;
-        }
-        Self::from_host(std::env::consts::ARCH, std::env::consts::OS)
+        let env_value = std::env::var(ENV_MOONBIT_NEW_NATIVE).ok();
+        Self::from_host_with_new_native_env(
+            std::env::consts::ARCH,
+            std::env::consts::OS,
+            env_value.as_deref(),
+        )
+    }
+
+    fn from_host_with_new_native_env(
+        arch: &str,
+        os: &str,
+        env_value: Option<&str>,
+    ) -> Option<Self> {
+        let target = Self::from_host(arch, os)?;
+        let enabled = match target {
+            Self::Aarch64AppleDarwin => env_value != Some("0"),
+            Self::X86_64UnknownLinuxGnu | Self::X86_64PcWindowsMsvc => env_value == Some("1"),
+        };
+        enabled.then_some(target)
     }
 
     pub fn from_host(arch: &str, os: &str) -> Option<Self> {
@@ -638,6 +653,51 @@ mod tests {
             Some(NativeTarget::X86_64PcWindowsMsvc)
         );
         assert_eq!(NativeTarget::from_host("aarch64", "linux"), None);
+    }
+
+    #[test]
+    fn new_native_defaults_on_only_for_apple_silicon_macos() {
+        assert_eq!(
+            NativeTarget::from_host_with_new_native_env("aarch64", "macos", None),
+            Some(NativeTarget::Aarch64AppleDarwin)
+        );
+        assert_eq!(
+            NativeTarget::from_host_with_new_native_env("aarch64", "macos", Some("1")),
+            Some(NativeTarget::Aarch64AppleDarwin)
+        );
+        assert_eq!(
+            NativeTarget::from_host_with_new_native_env("aarch64", "macos", Some("0")),
+            None
+        );
+        assert_eq!(
+            NativeTarget::from_host_with_new_native_env("aarch64", "macos", Some("other")),
+            Some(NativeTarget::Aarch64AppleDarwin)
+        );
+
+        assert_eq!(
+            NativeTarget::from_host_with_new_native_env("x86_64", "linux", None),
+            None
+        );
+        assert_eq!(
+            NativeTarget::from_host_with_new_native_env("x86_64", "linux", Some("1")),
+            Some(NativeTarget::X86_64UnknownLinuxGnu)
+        );
+        assert_eq!(
+            NativeTarget::from_host_with_new_native_env("x86_64", "linux", Some("0")),
+            None
+        );
+        assert_eq!(
+            NativeTarget::from_host_with_new_native_env("x86_64", "windows", None),
+            None
+        );
+        assert_eq!(
+            NativeTarget::from_host_with_new_native_env("x86_64", "windows", Some("1")),
+            Some(NativeTarget::X86_64PcWindowsMsvc)
+        );
+        assert_eq!(
+            NativeTarget::from_host_with_new_native_env("x86_64", "macos", Some("1")),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
commit 1: 在release模式下，走C后端使用-O2优化。

commit 2: 在MacOS上，moon run/build/test --target native默认走新native后端， 加了--release的时候，使用C后端进行-O2优化。当MOONBIT_NEW_NATIVE=0设置时，全部走C后端，moon run/test --target native用tcc，moon build --target native用c。

其它操作系统环境保持原来MOONBIT_NEW_NATIVE=1的逻辑。