### PR TITLE
test: update warning list snapshot

### DIFF
--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -38,7 +38,7 @@ Warning name: `{mnemonic}`
     }
 }
 
-// Snapshot generated from `moonc check -warn-help` on 2026-07-09.
+// Snapshot generated from `moonc check -warn-help` on 2026-07-10.
 // Update this file manually when the compiler's warning table changes.
 const WARNING_ENTRIES: &[WarningEntry] = &[
     WarningEntry {
@@ -420,6 +420,11 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
         mnemonic: "regex_match_missing_after",
         description: "Missing `after` binding in `regex match`.",
         id: 81,
+    },
+    WarningEntry {
+        mnemonic: "ambiguous_braces",
+        description: "Ambiguous `{}` braces.",
+        id: 82,
     },
 ];
 

--- a/crates/moon/src/cli/snapshots/explain_warning_index.txt
+++ b/crates/moon/src/cli/snapshots/explain_warning_index.txt
@@ -74,3 +74,4 @@
 0079	implicit_impl_as_method	`impl` implicitly promoted as method
 0080	regex_match_missing_before	Missing `before` binding in `regex match`.
 0081	regex_match_missing_after	Missing `after` binding in `regex match`.
+0082	ambiguous_braces	Ambiguous `{}` braces.


### PR DESCRIPTION
## Summary

Update the warning index and checked-in snapshot for warning `0082` (`ambiguous_braces`) reported by the current `moonc check -warn-help` output, and refresh the generated-on date.

## Why

The warning-index snapshot had fallen behind the compiler warning table, causing the warning-list consistency test to fail. This keeps the documented warning index aligned with the compiler.