### PR TITLE
Fix test driver template warnings

### DIFF
--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -251,6 +251,33 @@ const TEMPLATE_WITH_BENCH_ARGS: &str = include_str!(concat!(
     "/../moonbuild/template/test_driver_project/template_with_bench_args.mbt"
 ));
 
+fn replace_template_initializer(template: &str, name: &str, replacement: &str) -> String {
+    let marker = format!("// REPLACE ME: {name}");
+    let mut markers = template.match_indices(&marker);
+    let marker_start = markers
+        .next()
+        .unwrap_or_else(|| panic!("missing test driver template marker `{marker}`"))
+        .0;
+    assert!(
+        markers.next().is_none(),
+        "test driver template marker `{marker}` appears more than once"
+    );
+
+    let line_start = template[..marker_start]
+        .rfind('\n')
+        .map_or(0, |position| position + 1);
+    let initializer_start = template[line_start..marker_start]
+        .rfind(" = ")
+        .map(|position| line_start + position + " = ".len())
+        .unwrap_or_else(|| panic!("test driver template marker `{marker}` has no initializer"));
+
+    let mut result = String::with_capacity(template.len() + replacement.len());
+    result.push_str(&template[..initializer_start]);
+    result.push_str(replacement);
+    result.push_str(&template[marker_start + marker.len()..]);
+    result
+}
+
 fn generate_driver(
     data: &MooncGenTestInfo,
     pkgname: &str,
@@ -274,65 +301,47 @@ fn generate_driver(
 
     if enable_bench {
         if has_bench_args {
-            template.push_str(
-                TEMPLATE_WITH_BENCH_ARGS
-                    .replace(
-                        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_with_bench_args_tests",
-                        &MooncGenTestInfo::section_to_mbt(&data.with_bench_args_tests),
-                    )
-                    .as_str(),
-            );
+            template.push_str(&replace_template_initializer(
+                TEMPLATE_WITH_BENCH_ARGS,
+                "moonbit_test_driver_internal_with_bench_args_tests",
+                &MooncGenTestInfo::section_to_mbt(&data.with_bench_args_tests),
+            ));
         }
     } else {
         if has_no_args {
-            template.push_str(
-                TEMPLATE_NO_ARGS
-                    .replace(
-                        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_no_args_tests",
-                        &MooncGenTestInfo::section_to_mbt(&data.no_args_tests),
-                    )
-                    .as_str(),
-            );
+            template.push_str(&replace_template_initializer(
+                TEMPLATE_NO_ARGS,
+                "moonbit_test_driver_internal_no_args_tests",
+                &MooncGenTestInfo::section_to_mbt(&data.no_args_tests),
+            ));
         }
         if has_with_args {
-            template.push_str(
-                TEMPLATE_WITH_ARGS
-                    .replace(
-                        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_with_args_tests",
-                        &MooncGenTestInfo::section_to_mbt(&data.with_args_tests),
-                    )
-                    .as_str(),
-            );
+            template.push_str(&replace_template_initializer(
+                TEMPLATE_WITH_ARGS,
+                "moonbit_test_driver_internal_with_args_tests",
+                &MooncGenTestInfo::section_to_mbt(&data.with_args_tests),
+            ));
         }
         if has_any_async {
-            template.push_str(
-                TEMPLATE_ASYNC_RUNTIME
-                    .replace(
-                        "0 // REPLACE ME: moonbit_test_driver_internal_max_concurrent_tests",
-                        &format!("{}", max_concurrent_tests.unwrap_or(10)),
-                    )
-                    .as_str(),
-            );
+            template.push_str(&replace_template_initializer(
+                TEMPLATE_ASYNC_RUNTIME,
+                "moonbit_test_driver_internal_max_concurrent_tests",
+                &max_concurrent_tests.unwrap_or(10).to_string(),
+            ));
         }
         if has_no_args_async {
-            template.push_str(
-                TEMPLATE_NO_ARGS_ASYNC
-                    .replace(
-                        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests",
-                        &MooncGenTestInfo::section_to_mbt(&data.async_tests),
-                    )
-                    .as_str(),
-            );
+            template.push_str(&replace_template_initializer(
+                TEMPLATE_NO_ARGS_ASYNC,
+                "moonbit_test_driver_internal_async_tests",
+                &MooncGenTestInfo::section_to_mbt(&data.async_tests),
+            ));
         }
         if has_with_args_async {
-            template.push_str(
-                TEMPLATE_WITH_ARGS_ASYNC
-                    .replace(
-                        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests_with_args",
-                        &MooncGenTestInfo::section_to_mbt(&data.async_tests_with_args),
-                    )
-                    .as_str(),
-            );
+            template.push_str(&replace_template_initializer(
+                TEMPLATE_WITH_ARGS_ASYNC,
+                "moonbit_test_driver_internal_async_tests_with_args",
+                &MooncGenTestInfo::section_to_mbt(&data.async_tests_with_args),
+            ));
         }
     }
 
@@ -435,4 +444,14 @@ fn empty_test_sections_are_not_rendered() {
 
     let generated = generate_driver(&data, "username/test", false, false, None, None);
     assert!(!generated.contains("REPLACE ME:"));
+}
+
+#[test]
+fn test_driver_template_replacement_depends_only_on_marker() {
+    let template = "let value : Int = any_valid_placeholder() // REPLACE ME: generated_value\n";
+
+    assert_eq!(
+        replace_template_initializer(template, "generated_value", "42"),
+        "let value : Int = 42\n"
+    );
 }

--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -277,7 +277,7 @@ fn generate_driver(
             template.push_str(
                 TEMPLATE_WITH_BENCH_ARGS
                     .replace(
-                        "{} // REPLACE ME: moonbit_test_driver_internal_with_bench_args_tests",
+                        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_with_bench_args_tests",
                         &MooncGenTestInfo::section_to_mbt(&data.with_bench_args_tests),
                     )
                     .as_str(),
@@ -288,7 +288,7 @@ fn generate_driver(
             template.push_str(
                 TEMPLATE_NO_ARGS
                     .replace(
-                        "{} // REPLACE ME: moonbit_test_driver_internal_no_args_tests",
+                        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_no_args_tests",
                         &MooncGenTestInfo::section_to_mbt(&data.no_args_tests),
                     )
                     .as_str(),
@@ -298,7 +298,7 @@ fn generate_driver(
             template.push_str(
                 TEMPLATE_WITH_ARGS
                     .replace(
-                        "{} // REPLACE ME: moonbit_test_driver_internal_with_args_tests",
+                        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_with_args_tests",
                         &MooncGenTestInfo::section_to_mbt(&data.with_args_tests),
                     )
                     .as_str(),
@@ -318,7 +318,7 @@ fn generate_driver(
             template.push_str(
                 TEMPLATE_NO_ARGS_ASYNC
                     .replace(
-                        "{} // REPLACE ME: moonbit_test_driver_internal_async_tests",
+                        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests",
                         &MooncGenTestInfo::section_to_mbt(&data.async_tests),
                     )
                     .as_str(),
@@ -328,7 +328,7 @@ fn generate_driver(
             template.push_str(
                 TEMPLATE_WITH_ARGS_ASYNC
                     .replace(
-                        "{} // REPLACE ME: moonbit_test_driver_internal_async_tests_with_args",
+                        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests_with_args",
                         &MooncGenTestInfo::section_to_mbt(&data.async_tests_with_args),
                     )
                     .as_str(),
@@ -418,4 +418,21 @@ fn test_base16() {
         expect!["28297b7d5b5d2e2b2d2a2f3d27225c7c7e5f3a"],
     );
     check("filename.mbt", expect!["66696c656e616d652e6d6274"]);
+}
+
+#[test]
+fn empty_test_sections_are_not_rendered() {
+    use indexmap::IndexMap;
+
+    let empty = IndexMap::new();
+    let data = MooncGenTestInfo {
+        no_args_tests: empty.clone(),
+        with_args_tests: empty.clone(),
+        with_bench_args_tests: empty.clone(),
+        async_tests: empty.clone(),
+        async_tests_with_args: empty,
+    };
+
+    let generated = generate_driver(&data, "username/test", false, false, None, None);
+    assert!(!generated.contains("REPLACE ME:"));
 }

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -108,6 +108,7 @@ mod target_backend;
 mod targets;
 mod test_dot_source;
 mod test_driver_dependencies;
+mod test_driver_map_collision;
 mod test_error_report;
 mod test_exclude_001;
 mod test_exclude_002;

--- a/crates/moon/tests/test_cases/test_driver_map_collision/map.mbt
+++ b/crates/moon/tests/test_cases/test_driver_map_collision/map.mbt
@@ -1,0 +1,1 @@
+struct Map(Int)

--- a/crates/moon/tests/test_cases/test_driver_map_collision/map_test.mbt
+++ b/crates/moon/tests/test_cases/test_driver_map_collision/map_test.mbt
@@ -1,0 +1,3 @@
+test "local Map does not shadow the test driver map" {
+  inspect(1, content="1")
+}

--- a/crates/moon/tests/test_cases/test_driver_map_collision/mod.rs
+++ b/crates/moon/tests/test_cases/test_driver_map_collision/mod.rs
@@ -1,0 +1,8 @@
+use crate::{TestDir, get_stdout};
+
+#[test]
+fn test_driver_allows_local_map_type() {
+    let dir = TestDir::new("test_driver_map_collision");
+    let stdout = get_stdout(&dir, ["test"]);
+    assert!(stdout.contains("Total tests: 1, passed: 1, failed: 0."));
+}

--- a/crates/moon/tests/test_cases/test_driver_map_collision/moon.mod
+++ b/crates/moon/tests/test_cases/test_driver_map_collision/moon.mod
@@ -1,0 +1,3 @@
+name = "username/test_driver_map_collision"
+
+version = "0.1.0"

--- a/crates/moon/tests/test_cases/test_driver_map_collision/moon.pkg
+++ b/crates/moon/tests/test_cases/test_driver_map_collision/moon.pkg
@@ -1,0 +1,1 @@
+pkgtype(kind: "library")

--- a/crates/moonbuild/template/test_driver_project/moon.mod
+++ b/crates/moonbuild/template/test_driver_project/moon.mod
@@ -3,7 +3,7 @@ name = "moonbuild/test_driver_project"
 version = "0.1.0"
 
 import {
-  "moonbitlang/async@0.16.2",
+  "moonbitlang/async@0.20.0",
 }
 
 readme = "README.mbt.md"

--- a/crates/moonbuild/template/test_driver_project/moon.pkg
+++ b/crates/moonbuild/template/test_driver_project/moon.pkg
@@ -6,6 +6,4 @@ import {
 
 warnings = "-unused_package"
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")

--- a/crates/moonbuild/template/test_driver_project/template_no_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_no_args.mbt
@@ -3,7 +3,7 @@
 ///|
 let moonbit_test_driver_internal_no_args_tests : MoonBitTestDriverInternalTestMap[
   () -> Unit raise,
-] = {} // REPLACE ME: moonbit_test_driver_internal_no_args_tests
+] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_no_args_tests
 
 ///|
 impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_No_Args with fn run_test(

--- a/crates/moonbuild/template/test_driver_project/template_no_args_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_no_args_async.mbt
@@ -4,7 +4,7 @@
 ///|
 let moonbit_test_driver_internal_async_tests : MoonBitTestDriverInternalTestMap[
   async () -> Unit,
-] = {} // REPLACE ME: moonbit_test_driver_internal_async_tests
+] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests
 
 ///|
 impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_Async_No_Args with fn run_test(

--- a/crates/moonbuild/template/test_driver_project/template_with_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_args.mbt
@@ -4,7 +4,7 @@
 ///|
 let moonbit_test_driver_internal_with_args_tests : MoonBitTestDriverInternalTestMap[
   (@moonbitlang/core/test.Test) -> Unit raise,
-] = {} // REPLACE ME: moonbit_test_driver_internal_with_args_tests
+] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_with_args_tests
 
 ///|
 #warnings("-unnecessary_annotation")

--- a/crates/moonbuild/template/test_driver_project/template_with_args_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_args_async.mbt
@@ -4,7 +4,7 @@
 ///|
 let moonbit_test_driver_internal_async_tests_with_args : MoonBitTestDriverInternalTestMap[
   async (@moonbitlang/core/test.Test) -> Unit,
-] = {} // REPLACE ME: moonbit_test_driver_internal_async_tests_with_args
+] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests_with_args
 
 ///|
 #warnings("-unnecessary_annotation")

--- a/crates/moonbuild/template/test_driver_project/template_with_bench_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_bench_args.mbt
@@ -4,7 +4,7 @@
 ///|
 let moonbit_test_driver_internal_with_bench_args_tests : MoonBitTestDriverInternalTestMap[
   (@moonbitlang/core/bench.T) -> Unit raise,
-] = {} // REPLACE ME: moonbit_test_driver_internal_with_bench_args_tests
+] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_with_bench_args_tests
 
 ///|
 impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_With_Bench_Args with fn run_test(

--- a/crates/moonutil/src/package.rs
+++ b/crates/moonutil/src/package.rs
@@ -1113,10 +1113,12 @@ fn convert_pkgtype_derives_is_main_and_force_link() {
     for (kind, want_is_main, want_force_link) in cases {
         let src = format!(r#"pkgtype(kind: "{kind}")"#);
         let json = crate::moon_pkg::parse(&src).unwrap();
-        let (pkg, _) =
-            convert_pkg_dsl_to_package_with_supported_targets_decl(json, false).unwrap();
+        let (pkg, _) = convert_pkg_dsl_to_package_with_supported_targets_decl(json, false).unwrap();
         assert_eq!(pkg.is_main, want_is_main, "is_main for kind {kind}");
-        assert_eq!(pkg.force_link, want_force_link, "force_link for kind {kind}");
+        assert_eq!(
+            pkg.force_link, want_force_link,
+            "force_link for kind {kind}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace ambiguous `{}` placeholders in test-driver templates with an explicit empty test-map value.
- Keep the generator's replacement markers synchronized and avoid rendering unused sections.
- Add regression coverage for a package defining a local `Map(Int)` type.
- Update the test-driver template project manifests needed by the current toolchain.

## Why

The raw test-driver templates emitted warning 0082 for ambiguous `{}`. The new placeholder is an explicitly constructed `MoonBitTestDriverInternalTestMap`, and it is replaced only when the corresponding test section is present. The local `Map(Int)` regression ensures generated test drivers do not accidentally resolve an unqualified map constructor from the package under test.

## Scope

The change is limited to test-driver templates, their generator replacement markers, related template-project compatibility updates, and regression coverage.