### PR TITLE
Respect Why3 environment overrides in `moon prove`

### DIFF
--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -296,11 +296,15 @@ fn configure_why3_environment() -> anyhow::Result<ScopedWhy3Env> {
             "failed to locate `why3` required by `moon prove`; install Why3 1.7.2 preferably via opam, and ensure `why3` is available on PATH"
         )
     })?;
-    let why3_data = query_why3_path(&why3, "--print-datadir", "data")?;
-    let why3_lib = query_why3_path(&why3, "--print-libdir", "library")?;
-
     let prev_data = std::env::var_os("WHY3DATA");
     let prev_lib = std::env::var_os("WHY3LIB");
+    let why3_data_env = resolve_why3_env_path("WHY3DATA", prev_data.as_ref(), "data")?;
+    let why3_lib_env = resolve_why3_env_path("WHY3LIB", prev_lib.as_ref(), "library")?;
+    let why3_data =
+        why3_data_env.map_or_else(|| query_why3_path(&why3, "--print-datadir", "data"), Ok)?;
+    let why3_lib =
+        why3_lib_env.map_or_else(|| query_why3_path(&why3, "--print-libdir", "library"), Ok)?;
+
     unsafe {
         std::env::set_var("WHY3DATA", &why3_data);
         std::env::set_var("WHY3LIB", &why3_lib);
@@ -312,10 +316,31 @@ fn configure_why3_environment() -> anyhow::Result<ScopedWhy3Env> {
     })
 }
 
+fn resolve_why3_env_path(
+    var: &str,
+    env_value: Option<&OsString>,
+    kind: &str,
+) -> anyhow::Result<Option<PathBuf>> {
+    // Historically `moon prove` assumed Why3 was built and installed locally on
+    // each user's machine, so `why3 --print-*dir` was a reliable source of
+    // installation paths and user-provided WHY3DATA/WHY3LIB looked like stale
+    // environment pollution. With binary distribution, those compiled-in paths
+    // may point at the packager's layout instead: Why3's normal runtime lookup
+    // respects WHY3DATA/WHY3LIB, but `why3 --print-*dir` reports compile-time
+    // fixed values. In that model WHY3DATA and WHY3LIB are the intended runtime
+    // relocation mechanism, so explicit non-empty environment values must win
+    // and `why3 --print-*dir` is only a fallback for local/source installs.
+    if let Some(value) = env_value.filter(|value| !value.is_empty()) {
+        let path = PathBuf::from(value);
+        validate_why3_path(&path, kind, &format!("`{var}`"))?;
+        return Ok(Some(path));
+    }
+
+    Ok(None)
+}
+
 fn query_why3_path(why3: &Path, flag: &str, kind: &str) -> anyhow::Result<PathBuf> {
     let output = std::process::Command::new(why3)
-        .env_remove("WHY3DATA")
-        .env_remove("WHY3LIB")
         .arg(flag)
         .output()
         .with_context(|| format!("failed to run `why3 {flag}`"))?;
@@ -329,14 +354,20 @@ fn query_why3_path(why3: &Path, flag: &str, kind: &str) -> anyhow::Result<PathBu
     if path.as_os_str().is_empty() {
         bail!("`why3 {flag}` returned an empty {kind} path");
     }
+    validate_why3_path(&path, kind, &format!("`why3 {flag}`"))?;
+
+    Ok(path)
+}
+
+fn validate_why3_path(path: &Path, kind: &str, source: &str) -> anyhow::Result<()> {
     if !path.is_dir() {
         bail!(
-            "`why3 {flag}` returned a non-directory {kind} path `{}`",
+            "{source} resolved to a non-directory {kind} path `{}`",
             path.display()
         );
     }
 
-    Ok(path)
+    Ok(())
 }
 
 unsafe fn restore_env_var(key: &str, value: Option<&OsString>) {
@@ -845,6 +876,26 @@ mod tests {
     #[test]
     fn test_parse_solver_version_no_version() {
         assert_eq!(parse_solver_version("no version here"), None);
+    }
+
+    #[test]
+    fn test_resolve_why3_path_prefers_env_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let env_value = dir.path().as_os_str().to_os_string();
+        let path = resolve_why3_env_path("WHY3DATA", Some(&env_value), "data")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(path, dir.path());
+    }
+
+    #[test]
+    fn test_resolve_why3_path_rejects_invalid_env_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let env_value = dir.path().join("missing").into_os_string();
+        let err = resolve_why3_env_path("WHY3DATA", Some(&env_value), "data").unwrap_err();
+
+        assert!(format!("{err:#}").contains("`WHY3DATA` resolved to a non-directory data path"));
     }
 
     fn make_solver(name: &'static str, path: &str, version: &str) -> DetectedSolver {

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -22,7 +22,10 @@ use std::{
 };
 
 use anyhow::{Context, bail};
-use moonbuild_rupes_recta::{intent::UserIntent, model::BuildPlanNode, user_warning::UserWarning};
+use moonbuild_rupes_recta::{
+    build_plan::Why3Environment, intent::UserIntent, model::BuildPlanNode,
+    user_warning::UserWarning,
+};
 use moonutil::{
     build_options::RunMode, cli_support::AutoSyncFlags, cli_support::UniversalFlags,
     locks::FileLock, project::PackageDirs, resolution::ModuleId, target::TargetBackend,
@@ -132,7 +135,7 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
         .map(canonicalize_why3_config)
         .transpose()?;
     let generated_why3_config_path = verif_dir.join("why3.conf");
-    let _why3_env = (!cli.dry_run)
+    let prove_why3_env = (!cli.dry_run)
         .then(configure_why3_environment)
         .transpose()?;
 
@@ -175,6 +178,7 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
         &resolve_output,
         planning_context.target_backend(),
         prove_why3_config.as_deref(),
+        prove_why3_env,
     )?;
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
@@ -218,9 +222,11 @@ fn calc_user_intent(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     target_backend: TargetBackend,
     prove_why3_config: Option<&Path>,
+    prove_why3_env: Option<Why3Environment>,
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
     let directive = moonbuild_rupes_recta::build_plan::InputDirective {
         prove_why3_config: prove_why3_config.map(Path::to_path_buf),
+        prove_why3_env,
         ..Default::default()
     };
 
@@ -276,21 +282,7 @@ fn canonicalize_why3_config(path: &Path) -> anyhow::Result<PathBuf> {
         .with_context(|| format!("failed to resolve why3 config `{}`", path.display()))
 }
 
-struct ScopedWhy3Env {
-    prev_data: Option<OsString>,
-    prev_lib: Option<OsString>,
-}
-
-impl Drop for ScopedWhy3Env {
-    fn drop(&mut self) {
-        unsafe {
-            restore_env_var("WHY3DATA", self.prev_data.as_ref());
-            restore_env_var("WHY3LIB", self.prev_lib.as_ref());
-        }
-    }
-}
-
-fn configure_why3_environment() -> anyhow::Result<ScopedWhy3Env> {
+fn configure_why3_environment() -> anyhow::Result<Why3Environment> {
     let why3 = which::which("why3").map_err(|_| {
         anyhow::anyhow!(
             "failed to locate `why3` required by `moon prove`; install Why3 1.7.2 preferably via opam, and ensure `why3` is available on PATH"
@@ -305,15 +297,10 @@ fn configure_why3_environment() -> anyhow::Result<ScopedWhy3Env> {
     let why3_lib =
         why3_lib_env.map_or_else(|| query_why3_path(&why3, "--print-libdir", "library"), Ok)?;
 
-    unsafe {
-        std::env::set_var("WHY3DATA", &why3_data);
-        std::env::set_var("WHY3LIB", &why3_lib);
-    }
-
-    Ok(ScopedWhy3Env {
-        prev_data,
-        prev_lib,
-    })
+    Ok(Why3Environment::new(
+        why3_env_path_string("WHY3DATA", why3_data)?,
+        why3_env_path_string("WHY3LIB", why3_lib)?,
+    ))
 }
 
 fn resolve_why3_env_path(
@@ -370,11 +357,18 @@ fn validate_why3_path(path: &Path, kind: &str, source: &str) -> anyhow::Result<(
     Ok(())
 }
 
-unsafe fn restore_env_var(key: &str, value: Option<&OsString>) {
-    if let Some(value) = value {
-        unsafe { std::env::set_var(key, value) };
-    } else {
-        unsafe { std::env::remove_var(key) };
+fn why3_env_path_string(key: &str, value: PathBuf) -> anyhow::Result<String> {
+    // n2's per-command environment representation stores names and values as
+    // `String`, so command-scoped Why3 paths must be valid Unicode. The old
+    // process-wide `set_var` implementation accepted arbitrary `OsString`
+    // paths on Unix; rejecting those paths here is an accepted compatibility
+    // limitation rather than silently changing them with a lossy conversion.
+    match value.into_os_string().into_string() {
+        Ok(value) => Ok(value),
+        Err(value) => bail!(
+            "`{key}` path `{}` is not valid Unicode",
+            PathBuf::from(value).display()
+        ),
     }
 }
 

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -212,6 +212,7 @@ pub fn build_patch_directive_for_package(
         specify_patch_file: patch_directive,
         value_tracing,
         prove_why3_config: None,
+        prove_why3_env: None,
     })
 }
 

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/tests.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/tests.rs
@@ -41,6 +41,7 @@ fn target_info() -> BuildTargetInfo {
         specified_no_mi: false,
         patch_file: None,
         why3_config: None,
+        why3_env: None,
         check_mi_against: None,
         value_tracing: false,
     }

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -493,6 +493,12 @@ impl<'a> LoweringContext<'a> {
             extra_inputs,
             commandline: cmd.build_command(&*BINARIES.moonc).into(),
         }
+        .with_env(
+            info.why3_env
+                .as_ref()
+                .map(|env| env.command_env())
+                .unwrap_or_default(),
+        )
     }
 
     #[instrument(level = Level::DEBUG, skip(self, products, info))]
@@ -573,6 +579,12 @@ impl<'a> LoweringContext<'a> {
             extra_inputs,
             commandline: cmd.build_command(&*BINARIES.moonc).into(),
         }
+        .with_env(
+            info.why3_env
+                .as_ref()
+                .map(|env| env.command_env())
+                .unwrap_or_default(),
+        )
     }
 
     #[instrument(level = Level::DEBUG, skip(self, products, info))]

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -405,7 +405,7 @@ mod tests {
     use crate::{
         build_plan::{
             BuildCStubsInfo, BuildPlan, BuildRuntimeInfo, BuildTargetInfo, FileDependencyKind,
-            LinkCoreInfo, MakeExecutableInfo, PlanArtifactNeed,
+            LinkCoreInfo, MakeExecutableInfo, PlanArtifactNeed, Why3Environment,
         },
         discover::{DiscoverResult, DiscoveredPackage},
         model::{
@@ -559,6 +559,7 @@ mod tests {
             specified_no_mi: false,
             patch_file: None,
             why3_config: None,
+            why3_env: None,
             check_mi_against: None,
             value_tracing: false,
         }
@@ -611,6 +612,85 @@ mod tests {
         command
             .iter()
             .any(|arg| arg.replace('\\', "/").ends_with(suffix))
+    }
+
+    fn lowered_proof_command_environment(
+        node_for_target: fn(BuildTarget) -> BuildPlanNode,
+    ) -> Vec<(String, String)> {
+        let (resolve_output, target) = single_package_resolve_output();
+        let mut info = build_target_info();
+        info.why3_env = Some(Why3Environment::new(
+            "why3/share".to_string(),
+            "why3/lib".to_string(),
+        ));
+
+        let mut plan = BuildPlan::default();
+        plan.test_add_node(node_for_target(target));
+        plan.test_insert_build_target_info(target, info);
+
+        let artifact_paths = ArtifactPathResolver::new(
+            TargetLayout::new(
+                PathBuf::from("_build"),
+                TargetLayoutMode::Workspace,
+                OptLevel::Debug,
+                RunMode::Prove,
+            ),
+            None,
+        );
+        let native_mode = NativeBackendMode::GeneratedC;
+        let target_backend = RunBackend::WasmGC;
+        let options = BuildOptions {
+            artifact_paths,
+            target_backend,
+            native_mode: native_mode.clone(),
+            selected_backend: SelectedBackend::new(target_backend, &native_mode, false),
+            opt_level: OptLevel::Debug,
+            action: RunMode::Prove,
+            debug_symbols: false,
+            enable_coverage: false,
+            output_wat: false,
+            moonc_output_json: false,
+            docs_serve: false,
+            warning_condition: WarningCondition::Default,
+            info_no_alias: false,
+            wasi_link: false,
+            stdlib_path: None,
+            lowering_environment: LoweringEnvironment::default(),
+        };
+
+        let action_plan = plan.build_action_plan();
+        let lowered = lower_build_plan(&resolve_output, &action_plan, &options)
+            .expect("lowering should succeed");
+        let mut builds = lowered.build_graph.builds.iter();
+        let build = builds.next().expect("proof command should be lowered");
+        assert!(
+            builds.next().is_none(),
+            "expected exactly one proof command"
+        );
+        build.env.clone()
+    }
+
+    fn expected_why3_environment() -> Vec<(String, String)> {
+        vec![
+            ("WHY3DATA".to_string(), "why3/share".to_string()),
+            ("WHY3LIB".to_string(), "why3/lib".to_string()),
+        ]
+    }
+
+    #[test]
+    fn lowered_prove_command_carries_complete_why3_environment() {
+        assert_eq!(
+            lowered_proof_command_environment(BuildPlanNode::Prove),
+            expected_why3_environment()
+        );
+    }
+
+    #[test]
+    fn lowered_emit_proof_command_carries_complete_why3_environment() {
+        assert_eq!(
+            lowered_proof_command_environment(BuildPlanNode::EmitProof),
+            expected_why3_environment()
+        );
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -654,6 +654,7 @@ impl<'a> BuildPlanConstructor<'a> {
             .filter(|(specify_target, _)| specify_target == &target)
             .map(|(_, path)| path.clone());
         let why3_config = self.input_directive.prove_why3_config.clone();
+        let why3_env = self.input_directive.prove_why3_env.clone();
 
         let mi_check_target = self.mi_check_target(target, pkg);
 
@@ -666,6 +667,7 @@ impl<'a> BuildPlanConstructor<'a> {
             specified_no_mi,
             patch_file,
             why3_config,
+            why3_env,
             check_mi_against: mi_check_target,
             value_tracing: self
                 .input_directive

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -313,6 +313,26 @@ impl BuildPlan {
     }
 }
 
+/// Why3 runtime directories supplied to proof commands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Why3Environment {
+    data_dir: String,
+    lib_dir: String,
+}
+
+impl Why3Environment {
+    pub fn new(data_dir: String, lib_dir: String) -> Self {
+        Self { data_dir, lib_dir }
+    }
+
+    pub(crate) fn command_env(&self) -> Vec<(String, String)> {
+        vec![
+            ("WHY3DATA".to_string(), self.data_dir.clone()),
+            ("WHY3LIB".to_string(), self.lib_dir.clone()),
+        ]
+    }
+}
+
 /// Common information about a moonbit package being built
 #[derive(Debug)]
 pub struct BuildTargetInfo {
@@ -341,6 +361,9 @@ pub struct BuildTargetInfo {
 
     /// The Why3 configuration file to supply to proof commands.
     pub(crate) why3_config: Option<PathBuf>,
+
+    /// Why3 runtime directories to supply to proof commands.
+    pub(crate) why3_env: Option<Why3Environment>,
 
     /// Check the `.mi` file against the given target. Used in virtual packages.
     /// Also implies that the target must not generate a `.mi` file.
@@ -472,6 +495,9 @@ pub struct InputDirective {
 
     /// Use the given Why3 config file for `moon prove`.
     pub prove_why3_config: Option<PathBuf>,
+
+    /// Why3 runtime directories to use for `moon prove`.
+    pub prove_why3_env: Option<Why3Environment>,
 }
 
 /// Represents errors that may occur during build graph construction.

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -1245,6 +1245,7 @@ mod tests {
             specified_no_mi: false,
             patch_file: None,
             why3_config: None,
+            why3_env: None,
             check_mi_against: None,
             value_tracing: false,
         }


### PR DESCRIPTION
  This PR fixes moon prove handling of Why3 runtime paths.

  Previously, moon prove always queried:

  - `why3 --print-datadir`
  - `why3 --print-libdir`

  and then temporarily set `WHY3DATA` / `WHY3LIB` process-wide. This can break relocated or binary-distributed Why3
  installations, where why3 --print-*dir may report compile-time paths while the correct runtime paths are provided
  through `WHY3DATA` / `WHY3LIB`.

  This PR changes the behavior to:

  - prefer explicit non-empty `WHY3DATA` / `WHY3LIB`;
  - fall back to why3 --print-*dir only when env overrides are absent;
  - validate the resolved directories early;
  - avoid process-global environment mutation;
  - pass Why3 paths as per-command environment variables only to proof commands.

  It also introduces a dedicated Why3Environment type instead of threading a generic env vector through the build
  plan. This keeps the build-plan API clearer and ensures the environment is only attached to Prove / EmitProof
  commands during lowering.