### PR TITLE
Speed up nightly core tests with shared build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,49 @@ jobs:
           mdbook build docs/manual
           mdbook build docs/manual-zh
 
+  # Build once per OS so the core shards can share the exact same tools.
+  build-core-test-tools:
+    needs: [typo-check, license-header-check]
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Configure git
+        run: git config --global core.autocrlf false
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@1.90.0
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build moon and moonrun
+        run: cargo build --bin moon --bin moonrun
+
+      - name: Package tools (Unix)
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: tar -C target/debug -cf moon-tools.tar moon moonrun
+
+      - name: Package tools (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: tar -C target/debug -cf moon-tools.tar moon.exe moonrun.exe
+
+      - name: Upload tools
+        uses: actions/upload-artifact@v4
+        with:
+          name: moon-core-test-tools-${{ matrix.os }}
+          path: moon-tools.tar
+          if-no-files-found: error
+          retention-days: 1
+
   nightly-test:
     needs: [typo-check, license-header-check]
     strategy:
@@ -193,14 +236,19 @@ jobs:
         run: cargo build -p xtask
 
       - name: Run tests
+        env:
+          MOON_TEST_MOON_BIN: ${{ github.workspace }}/target/debug/moon${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+          MOON_TEST_MOONRUN_BIN: ${{ github.workspace }}/target/debug/moonrun${{ matrix.os == 'windows-latest' && '.exe' || '' }}
         run: cargo test
 
       - name: Auxiliary checks
         if: matrix.os == 'ubuntu-latest'
         run: cargo xtask ci
 
-      - name: Test core (Unix)
-        if: ${{ matrix.os != 'windows-latest' }}
+      # Keep core testing in the existing macOS job because hosted macOS
+      # runners are scarce. Linux and Windows use the sharded jobs below.
+      - name: Test core (macOS)
+        if: ${{ matrix.os == 'macos-latest' }}
         env:
           MOONRUN_OVERRIDE: ${{ github.workspace }}/target/debug/moonrun
         run: |
@@ -221,55 +269,124 @@ jobs:
       #     cargo run --bin moon -- -C ~/.moon/lib/core test --target llvm
       #     cargo run --bin moon -- -C ~/.moon/lib/core test --target llvm --release
 
-  nightly-test-core-windows:
-    needs: [typo-check, license-header-check]
-    runs-on: windows-latest
+  nightly-test-core:
+    needs: build-core-test-tools
+    name: core test (${{ matrix.os }}, ${{ matrix.shard }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        # Native release compilation dominates the core suite, so keep it in
+        # its own shard and group the shorter non-native release targets.
+        shard:
+          - debug-all
+          - release-nonnative
+          - release-native
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - uses: dtolnay/rust-toolchain@1.90.0
-        with:
-          components: rustfmt, clippy
-
-      - name: Cargo cache
-        uses: Swatinem/rust-cache@v2
-
       - name: install MoonBit(Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
         run: |
           $env:MOONBIT_INSTALL_VERSION="nightly"
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; irm https://cli.moonbitlang.com/install/powershell.ps1 | iex
           "$env:USERPROFILE\.moon\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
-          "$env:GITHUB_WORKSPACE\target\debug" | Out-File -FilePath $env:GITHUB_PATH -Append
 
-      - name: Build
-        run: cargo build
+      - name: install MoonBit(Unix)
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s nightly
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
-      - name: Set built binary to PATH (Windows)
-        run: Add-Content $env:GITHUB_PATH "$env:GITHUB_WORKSPACE\target\debug"
+      - name: Download tools
+        uses: actions/download-artifact@v4
+        with:
+          name: moon-core-test-tools-${{ matrix.os }}
 
-      - name: Versions
-        run: cargo run --bin moon -- version --all
+      - name: Extract tools (Unix)
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          mkdir tools
+          tar -C tools -xf moon-tools.tar
+
+      - name: Extract tools (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path tools
+          tar -C tools -xf moon-tools.tar
+
+      - name: Versions (Unix)
+        if: ${{ matrix.os != 'windows-latest' }}
+        env:
+          MOONRUN_OVERRIDE: ${{ github.workspace }}/tools/moonrun
+        run: ./tools/moon version --all
+
+      - name: Versions (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        env:
+          MOONRUN_OVERRIDE: ${{ github.workspace }}\tools\moonrun.exe
+        run: '& "$env:GITHUB_WORKSPACE\tools\moon.exe" version --all'
+
+      - name: Bundle core (Unix)
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: ./tools/moon -C ~/.moon/lib/core bundle --all
 
       - name: Bundle core (Windows)
-        run: cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" bundle --all
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: '& "$env:GITHUB_WORKSPACE\tools\moon.exe" -C "$env:USERPROFILE\.moon\lib\core" bundle --all'
 
-      - name: Test core (Windows)
+      - name: Test core debug targets (Unix)
+        if: ${{ matrix.os != 'windows-latest' && matrix.shard == 'debug-all' }}
         env:
-          MOONRUN_OVERRIDE: ${{ github.workspace }}\target\debug\moonrun.exe
+          MOONRUN_OVERRIDE: ${{ github.workspace }}/tools/moonrun
+        run: ./tools/moon -C ~/.moon/lib/core test --target all
+
+      - name: Test core release non-native targets (Unix)
+        if: ${{ matrix.os != 'windows-latest' && matrix.shard == 'release-nonnative' }}
+        env:
+          MOONRUN_OVERRIDE: ${{ github.workspace }}/tools/moonrun
         run: |
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target wasm-gc
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target js
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target wasm
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target native
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm-gc
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target js
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target native
+          ./tools/moon -C ~/.moon/lib/core test --release --target wasm-gc
+          ./tools/moon -C ~/.moon/lib/core test --release --target js
+          ./tools/moon -C ~/.moon/lib/core test --release --target wasm
+
+      - name: Test core release native target (Unix)
+        if: ${{ matrix.os != 'windows-latest' && matrix.shard == 'release-native' }}
+        env:
+          MOONRUN_OVERRIDE: ${{ github.workspace }}/tools/moonrun
+        run: ./tools/moon -C ~/.moon/lib/core test --release --target native
+
+      - name: Test core debug targets (Windows)
+        if: ${{ matrix.os == 'windows-latest' && matrix.shard == 'debug-all' }}
+        shell: pwsh
+        env:
+          MOONRUN_OVERRIDE: ${{ github.workspace }}\tools\moonrun.exe
+        run: '& "$env:GITHUB_WORKSPACE\tools\moon.exe" -C "$env:USERPROFILE\.moon\lib\core" test --target all'
+
+      - name: Test core release non-native targets (Windows)
+        if: ${{ matrix.os == 'windows-latest' && matrix.shard == 'release-nonnative' }}
+        shell: pwsh
+        env:
+          MOONRUN_OVERRIDE: ${{ github.workspace }}\tools\moonrun.exe
+        run: |
+          & "$env:GITHUB_WORKSPACE\tools\moon.exe" -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm-gc
+          & "$env:GITHUB_WORKSPACE\tools\moon.exe" -C "$env:USERPROFILE\.moon\lib\core" test --release --target js
+          & "$env:GITHUB_WORKSPACE\tools\moon.exe" -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm
+
+      - name: Test core release native target (Windows)
+        if: ${{ matrix.os == 'windows-latest' && matrix.shard == 'release-native' }}
+        shell: pwsh
+        env:
+          MOONRUN_OVERRIDE: ${{ github.workspace }}\tools\moonrun.exe
+        run: '& "$env:GITHUB_WORKSPACE\tools\moon.exe" -C "$env:USERPROFILE\.moon\lib\core" test --release --target native'
 
       # LLVM is currently disabled because it doesn't exist on non-bleeding channels.
       # TODO: Add this back when we add LLVM to nightly

--- a/crates/moon/tests/support/util.rs
+++ b/crates/moon/tests/support/util.rs
@@ -37,6 +37,10 @@ pub(crate) fn moon_bin() -> PathBuf {
 pub(crate) fn moonrun_bin() -> PathBuf {
     MOONRUN_BIN
         .get_or_init(|| {
+            if let Some(path) = std::env::var_os("MOON_TEST_MOONRUN_BIN") {
+                return PathBuf::from(path);
+            }
+
             escargot::CargoBuild::new()
                 .manifest_path(
                     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../moonrun/Cargo.toml"),

--- a/crates/moon/tests/test_cases/check_watch/mod.rs
+++ b/crates/moon/tests/test_cases/check_watch/mod.rs
@@ -59,10 +59,7 @@ fn check_watch_recovers_when_nested_watch_target_is_deleted() {
 
     let _watch_process = WatchProcess { child };
 
-    wait_for_watch_success(&rx, "initial check");
-    wait_for_watch_message(&rx, "watcher startup", |line| {
-        line.contains("Watcher loop started")
-    });
+    wait_for_initial_watch_ready(&rx);
     assert!(watch_target.exists());
 
     std::fs::remove_dir_all(&watch_target).expect("delete nested watch target");
@@ -83,6 +80,16 @@ test {
     assert!(watch_target.exists());
 }
 
+fn wait_for_initial_watch_ready(rx: &mpsc::Receiver<String>) {
+    let mut initial_check_succeeded = false;
+    let mut watcher_started = false;
+    wait_for_watch_message(rx, "initial watcher readiness", |line| {
+        initial_check_succeeded |= line.contains("Success, waiting for filesystem changes...");
+        watcher_started |= line.contains("Watcher loop started");
+        initial_check_succeeded && watcher_started
+    });
+}
+
 fn wait_for_watch_success(rx: &mpsc::Receiver<String>, phase: &str) {
     wait_for_watch_message(rx, phase, |line| {
         line.contains("Success, waiting for filesystem changes...")
@@ -92,7 +99,7 @@ fn wait_for_watch_success(rx: &mpsc::Receiver<String>, phase: &str) {
 fn wait_for_watch_message(
     rx: &mpsc::Receiver<String>,
     phase: &str,
-    matches: impl Fn(&str) -> bool,
+    mut matches: impl FnMut(&str) -> bool,
 ) {
     let deadline = Instant::now() + Duration::from_secs(30);
     let mut output = Vec::new();
@@ -127,4 +134,16 @@ fn wait_for_watch_message(
             }
         }
     }
+}
+
+#[test]
+fn initial_watch_readiness_accepts_startup_before_check_success() {
+    let (tx, rx) = mpsc::channel();
+    tx.send("stderr: Watcher loop started (debounce = 100ms)".to_owned())
+        .unwrap();
+    tx.send("Success, waiting for filesystem changes...".to_owned())
+        .unwrap();
+    drop(tx);
+
+    wait_for_initial_watch_ready(&rx);
 }

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -28,6 +28,10 @@ fn moon_cmd() -> snapbox::cmd::Command {
 fn moon_bin() -> &'static PathBuf {
     static MOON_BIN: OnceLock<PathBuf> = OnceLock::new();
     MOON_BIN.get_or_init(|| {
+        if let Some(path) = std::env::var_os("MOON_TEST_MOON_BIN") {
+            return PathBuf::from(path);
+        }
+
         let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../moon/Cargo.toml");
         escargot::CargoBuild::new()
             .manifest_path(manifest_path)


### PR DESCRIPTION
## Why

The nightly workflow currently puts the full core suite on the same critical path as the Rust workspace tests. The core matrix is also executed serially, while two integration-test helpers can start nested Cargo builds even after the workspace binaries have already been built.

## What changed

- Build `moon` and `moonrun` once per Linux/Windows platform and publish short-lived tar artifacts.
- Reuse those artifacts across three balanced core shards: all debug targets, non-native release targets, and native release.
- Keep the existing single macOS job and its serial core run, since hosted macOS runners are scarce.
- Let the `moon` and `moonrun` integration tests reuse prebuilt binaries through test-only binary selectors instead of invoking nested Cargo builds.
- Make watcher readiness independent of whether the startup log or initial-success message arrives first.

## Why this is correct

All existing debug/release and wasm-gc/js/wasm/native combinations remain covered. Every shard still installs the rolling nightly toolchain and bundles its own core checkout, so nightly drift continues to exercise the rest of the toolchain. Local fallback behavior is unchanged when no test binary is supplied.

The watcher test now consumes messages until both readiness conditions have been observed, instead of discarding an early startup message while waiting for initial success. A deterministic regression covers the startup-before-success ordering.

## Initial CI signal

All six Linux/Windows core shards passed in both the cold- and warm-cache runs. Producer-to-slowest-shard latency was 9:10 cold and 8:10 warm.

Compared with the previous sampled run, the regular `Run tests` step changed as follows:

| OS | Before | This PR |
| --- | ---: | ---: |
| Ubuntu | 3:07 | 2:15 |
| macOS | 7:07 | 3:49 |
| Windows | 5:24 | 4:53 |

The verification canary still fails when the rolling nightly changes expected snapshots or command-line behavior, which is intentionally left visible rather than pinned or masked.

This remains a draft so the runner-cost/latency tradeoff can be evaluated before the workflow shape is finalized.