### PR TITLE
fix(test): omit empty test driver entries

### DIFF
--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -393,12 +393,12 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
     },
     WarningEntry {
         mnemonic: "lexmatch_first_match",
-        description: "Using `lexmatch` with first-match semantics.",
+        description: "Deprecated `lexmatch` with first-match semantics.",
         id: 76,
     },
     WarningEntry {
         mnemonic: "lexmatch_longest_match",
-        description: "Using `lexmatch` with longest-match semantics.",
+        description: "Deprecated `lexmatch` with longest-match semantics.",
         id: 77,
     },
     WarningEntry {

--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -371,6 +371,10 @@ fn generate_driver(
         .replace("{END_MOONTEST}", MOON_TEST_DELIMITER_END)
         .replace("// {COVERAGE_END}", &coverage_end_template);
 
+    adapt_core_references_for_package(template, pkgname)
+}
+
+fn adapt_core_references_for_package(template: String, pkgname: &str) -> String {
     if pkgname == MOONBITLANG_CORE_BUILTIN {
         template.replace(&format!("@{MOONBITLANG_CORE_PRELUDE}."), "")
     } else if pkgname.starts_with(MOONBITLANG_CORE) {
@@ -453,5 +457,24 @@ fn test_driver_template_replacement_depends_only_on_marker() {
     assert_eq!(
         replace_template_initializer(template, "generated_value", "42"),
         "let value : Int = 42\n"
+    );
+}
+
+#[test]
+fn test_driver_default_reference_is_adapted_for_core_packages() {
+    const INITIALIZER: &str =
+        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default())";
+
+    assert_eq!(
+        adapt_core_references_for_package(INITIALIZER.into(), "username/test"),
+        INITIALIZER
+    );
+    assert_eq!(
+        adapt_core_references_for_package(INITIALIZER.into(), MOONBITLANG_CORE_PRELUDE),
+        "MoonBitTestDriverInternalTestMap(@moonbitlang/core/builtin.Default::default())"
+    );
+    assert_eq!(
+        adapt_core_references_for_package(INITIALIZER.into(), MOONBITLANG_CORE_BUILTIN),
+        "MoonBitTestDriverInternalTestMap(Default::default())"
     );
 }

--- a/crates/moon/src/cli/generate_test_driver.rs
+++ b/crates/moon/src/cli/generate_test_driver.rs
@@ -263,16 +263,14 @@ fn replace_template_initializer(template: &str, name: &str, replacement: &str) -
         "test driver template marker `{marker}` appears more than once"
     );
 
-    let line_start = template[..marker_start]
-        .rfind('\n')
-        .map_or(0, |position| position + 1);
-    let initializer_start = template[line_start..marker_start]
-        .rfind(" = ")
-        .map(|position| line_start + position + " = ".len())
+    let initializer_start = template[..marker_start]
+        .rfind('=')
+        .map(|position| position + 1)
         .unwrap_or_else(|| panic!("test driver template marker `{marker}` has no initializer"));
 
     let mut result = String::with_capacity(template.len() + replacement.len());
     result.push_str(&template[..initializer_start]);
+    result.push(' ');
     result.push_str(replacement);
     result.push_str(&template[marker_start + marker.len()..]);
     result
@@ -458,6 +456,36 @@ fn test_driver_template_replacement_depends_only_on_marker() {
         replace_template_initializer(template, "generated_value", "42"),
         "let value : Int = 42\n"
     );
+}
+
+#[test]
+fn formatted_test_driver_templates_have_replaceable_initializers() {
+    for (template, name) in [
+        (
+            TEMPLATE_NO_ARGS,
+            "moonbit_test_driver_internal_no_args_tests",
+        ),
+        (
+            TEMPLATE_WITH_ARGS,
+            "moonbit_test_driver_internal_with_args_tests",
+        ),
+        (
+            TEMPLATE_NO_ARGS_ASYNC,
+            "moonbit_test_driver_internal_async_tests",
+        ),
+        (
+            TEMPLATE_WITH_ARGS_ASYNC,
+            "moonbit_test_driver_internal_async_tests_with_args",
+        ),
+        (
+            TEMPLATE_WITH_BENCH_ARGS,
+            "moonbit_test_driver_internal_with_bench_args_tests",
+        ),
+    ] {
+        let replaced = replace_template_initializer(template, name, "Default::default()");
+        assert!(replaced.contains("] = Default::default()\n"));
+        assert!(!replaced.contains("REPLACE ME:"));
+    }
 }
 
 #[test]

--- a/crates/moon/src/cli/snapshots/explain_warning_index.txt
+++ b/crates/moon/src/cli/snapshots/explain_warning_index.txt
@@ -68,8 +68,8 @@
 0073	unnecessary_annotation	unnecessary type annotation
 0074	missing_doc	Missing documentation for public definition
 0075	unnecessary_view_op	Unnecessary `[:]` view operator
-0076	lexmatch_first_match	Using `lexmatch` with first-match semantics.
-0077	lexmatch_longest_match	Using `lexmatch` with longest-match semantics.
+0076	lexmatch_first_match	Deprecated `lexmatch` with first-match semantics.
+0077	lexmatch_longest_match	Deprecated `lexmatch` with longest-match semantics.
 0078	result_error_return	Using `Result[T, E]` where `E` is an error type.
 0079	implicit_impl_as_method	`impl` implicitly promoted as method
 0080	regex_match_missing_before	Missing `before` binding in `regex match`.

--- a/crates/moonbuild/template/test_driver_project/template_no_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_no_args.mbt
@@ -3,7 +3,7 @@
 ///|
 let moonbit_test_driver_internal_no_args_tests : MoonBitTestDriverInternalTestMap[
   () -> Unit raise,
-] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_no_args_tests
+] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default()) // REPLACE ME: moonbit_test_driver_internal_no_args_tests
 
 ///|
 impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_No_Args with fn run_test(

--- a/crates/moonbuild/template/test_driver_project/template_no_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_no_args.mbt
@@ -3,7 +3,9 @@
 ///|
 let moonbit_test_driver_internal_no_args_tests : MoonBitTestDriverInternalTestMap[
   () -> Unit raise,
-] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default()) // REPLACE ME: moonbit_test_driver_internal_no_args_tests
+] = MoonBitTestDriverInternalTestMap(
+  @moonbitlang/core/prelude.Default::default(),
+) // REPLACE ME: moonbit_test_driver_internal_no_args_tests
 
 ///|
 impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_No_Args with fn run_test(

--- a/crates/moonbuild/template/test_driver_project/template_no_args_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_no_args_async.mbt
@@ -4,7 +4,9 @@
 ///|
 let moonbit_test_driver_internal_async_tests : MoonBitTestDriverInternalTestMap[
   async () -> Unit,
-] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests
+] = MoonBitTestDriverInternalTestMap(
+  @moonbitlang/core/prelude.Default::default(),
+) // REPLACE ME: moonbit_test_driver_internal_async_tests
 
 ///|
 impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_Async_No_Args with fn run_test(

--- a/crates/moonbuild/template/test_driver_project/template_no_args_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_no_args_async.mbt
@@ -4,7 +4,7 @@
 ///|
 let moonbit_test_driver_internal_async_tests : MoonBitTestDriverInternalTestMap[
   async () -> Unit,
-] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests
+] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests
 
 ///|
 impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_Async_No_Args with fn run_test(

--- a/crates/moonbuild/template/test_driver_project/template_with_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_args.mbt
@@ -4,7 +4,7 @@
 ///|
 let moonbit_test_driver_internal_with_args_tests : MoonBitTestDriverInternalTestMap[
   (@moonbitlang/core/test.Test) -> Unit raise,
-] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_with_args_tests
+] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default()) // REPLACE ME: moonbit_test_driver_internal_with_args_tests
 
 ///|
 #warnings("-unnecessary_annotation")

--- a/crates/moonbuild/template/test_driver_project/template_with_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_args.mbt
@@ -4,7 +4,9 @@
 ///|
 let moonbit_test_driver_internal_with_args_tests : MoonBitTestDriverInternalTestMap[
   (@moonbitlang/core/test.Test) -> Unit raise,
-] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default()) // REPLACE ME: moonbit_test_driver_internal_with_args_tests
+] = MoonBitTestDriverInternalTestMap(
+  @moonbitlang/core/prelude.Default::default(),
+) // REPLACE ME: moonbit_test_driver_internal_with_args_tests
 
 ///|
 #warnings("-unnecessary_annotation")

--- a/crates/moonbuild/template/test_driver_project/template_with_args_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_args_async.mbt
@@ -4,7 +4,7 @@
 ///|
 let moonbit_test_driver_internal_async_tests_with_args : MoonBitTestDriverInternalTestMap[
   async (@moonbitlang/core/test.Test) -> Unit,
-] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests_with_args
+] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests_with_args
 
 ///|
 #warnings("-unnecessary_annotation")

--- a/crates/moonbuild/template/test_driver_project/template_with_args_async.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_args_async.mbt
@@ -4,7 +4,9 @@
 ///|
 let moonbit_test_driver_internal_async_tests_with_args : MoonBitTestDriverInternalTestMap[
   async (@moonbitlang/core/test.Test) -> Unit,
-] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default()) // REPLACE ME: moonbit_test_driver_internal_async_tests_with_args
+] = MoonBitTestDriverInternalTestMap(
+  @moonbitlang/core/prelude.Default::default(),
+) // REPLACE ME: moonbit_test_driver_internal_async_tests_with_args
 
 ///|
 #warnings("-unnecessary_annotation")

--- a/crates/moonbuild/template/test_driver_project/template_with_bench_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_bench_args.mbt
@@ -4,7 +4,9 @@
 ///|
 let moonbit_test_driver_internal_with_bench_args_tests : MoonBitTestDriverInternalTestMap[
   (@moonbitlang/core/bench.T) -> Unit raise,
-] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default()) // REPLACE ME: moonbit_test_driver_internal_with_bench_args_tests
+] = MoonBitTestDriverInternalTestMap(
+  @moonbitlang/core/prelude.Default::default(),
+) // REPLACE ME: moonbit_test_driver_internal_with_bench_args_tests
 
 ///|
 impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_With_Bench_Args with fn run_test(

--- a/crates/moonbuild/template/test_driver_project/template_with_bench_args.mbt
+++ b/crates/moonbuild/template/test_driver_project/template_with_bench_args.mbt
@@ -4,7 +4,7 @@
 ///|
 let moonbit_test_driver_internal_with_bench_args_tests : MoonBitTestDriverInternalTestMap[
   (@moonbitlang/core/bench.T) -> Unit raise,
-] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Map::default()) // REPLACE ME: moonbit_test_driver_internal_with_bench_args_tests
+] = MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default()) // REPLACE ME: moonbit_test_driver_internal_with_bench_args_tests
 
 ///|
 impl MoonBit_Test_Driver for MoonBit_Test_Driver_Internal_With_Bench_Args with fn run_test(

--- a/crates/moonutil/src/test_metadata.rs
+++ b/crates/moonutil/src/test_metadata.rs
@@ -107,17 +107,23 @@ impl MbtTestInfo {
 }
 
 impl MooncGenTestInfo {
-    /// Convert part of the driver metadata into MoonBit declaraction code for
-    /// the test driver to use.
+    /// Convert part of the driver metadata into MoonBit declaration code for
+    /// the test driver to use. Files without tests are omitted to avoid
+    /// generating ambiguous empty map literals.
     pub fn section_to_mbt(section: &IndexMap<FileName, Vec<MbtTestInfo>>) -> String {
         use std::fmt::Write;
+
+        if section.values().all(Vec::is_empty) {
+            return "MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default())"
+                .into();
+        }
 
         let mut result = String::new();
         let default_name = "";
 
         // Writing to string cannot fail, so unwrap() is safe here.
         writeln!(result, "{{").unwrap();
-        for (file, tests) in section {
+        for (file, tests) in section.iter().filter(|(_, tests)| !tests.is_empty()) {
             writeln!(result, "  \"{file}\": {{").unwrap();
             for test in tests {
                 // tests with #skip attribute are also included in the driver, they will
@@ -136,5 +142,47 @@ impl MooncGenTestInfo {
         writeln!(result, "}}").unwrap();
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+
+    use super::*;
+
+    #[test]
+    fn section_to_mbt_omits_files_without_tests() {
+        let section = IndexMap::from([
+            ("empty.mbt".into(), vec![]),
+            (
+                "tests.mbt".into(),
+                vec![MbtTestInfo {
+                    index: 2,
+                    func: "__test_tests_2".into(),
+                    name: Some("works".into()),
+                    line_number: Some(3),
+                    attrs: vec![],
+                }],
+            ),
+        ]);
+
+        expect![[r#"
+            {
+              "tests.mbt": {
+                2: (__test_tests_2, ["works"]),
+              },
+            }
+        "#]]
+        .assert_eq(&MooncGenTestInfo::section_to_mbt(&section));
+    }
+
+    #[test]
+    fn section_to_mbt_uses_default_when_all_files_are_omitted() {
+        expect!["MoonBitTestDriverInternalTestMap(@moonbitlang/core/prelude.Default::default())"]
+            .assert_eq(&MooncGenTestInfo::section_to_mbt(&IndexMap::from([(
+                "empty.mbt".into(),
+                vec![],
+            )])));
     }
 }


### PR DESCRIPTION
## Summary

Generated test-driver maps currently retain filenames whose test lists are empty, producing ambiguous `{}` literals and compiler warnings.

This change omits empty filename entries during serialization. If every entry is omitted, it initializes the test-map wrapper with `@moonbitlang/core/prelude.Default::default()`. The test-driver templates use the same initializer form.

It also synchronizes warning descriptions 0076 and 0077, plus their checked-in snapshot, with the current toolchain wording so the warning-index consistency checks remain aligned.

## Why this is correct

- Non-empty test entries retain their existing order and generated contents.
- The qualified `Default` reference is warning-free for ordinary packages.
- The existing core-package rewrite converts it to `@moonbitlang/core/builtin.Default::default()` for core packages and `Default::default()` for `moonbitlang/core/builtin`.
- The behavior is centralized in test metadata serialization and applies consistently to synchronous, asynchronous, argument-taking, and benchmark drivers.
- The warning-index changes reproduce the current `moonc -warn-help` output exactly.

## Scope

The functional change is limited to test-driver serialization and its template placeholders. The separate warning-index commit only updates the two toolchain-owned descriptions and their snapshot.