### PR TITLE
Use bundled Why3 runtime in `moon prove`

### DIFF
--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -132,9 +132,7 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
         .map(canonicalize_why3_config)
         .transpose()?;
     let generated_why3_config_path = verif_dir.join("why3.conf");
-    let _why3_env = (!cli.dry_run)
-        .then(configure_why3_environment)
-        .transpose()?;
+    let _why3_env = (!cli.dry_run).then(configure_bundled_why3_environment);
 
     if !cli.dry_run && why3_config_path.is_none() {
         ensure_why3_config(&generated_why3_config_path)?;
@@ -290,14 +288,12 @@ impl Drop for ScopedWhy3Env {
     }
 }
 
-fn configure_why3_environment() -> anyhow::Result<ScopedWhy3Env> {
-    let why3 = which::which("why3").map_err(|_| {
-        anyhow::anyhow!(
-            "failed to locate `why3` required by `moon prove`; install Why3 1.7.2 preferably via opam, and ensure `why3` is available on PATH"
-        )
-    })?;
-    let why3_data = query_why3_path(&why3, "--print-datadir", "data")?;
-    let why3_lib = query_why3_path(&why3, "--print-libdir", "library")?;
+fn configure_bundled_why3_environment() -> ScopedWhy3Env {
+    // Why3 is embedded in `moonc`, so there is no standalone executable to
+    // discover or query. Point it at the Why3 data shipped with the toolchain.
+    let why3_root = moonutil::toolchain::lib().join("why3");
+    let why3_data = why3_root.join("share").join("why3");
+    let why3_lib = why3_root.join("lib").join("why3");
 
     let prev_data = std::env::var_os("WHY3DATA");
     let prev_lib = std::env::var_os("WHY3LIB");
@@ -306,37 +302,10 @@ fn configure_why3_environment() -> anyhow::Result<ScopedWhy3Env> {
         std::env::set_var("WHY3LIB", &why3_lib);
     }
 
-    Ok(ScopedWhy3Env {
+    ScopedWhy3Env {
         prev_data,
         prev_lib,
-    })
-}
-
-fn query_why3_path(why3: &Path, flag: &str, kind: &str) -> anyhow::Result<PathBuf> {
-    let output = std::process::Command::new(why3)
-        .env_remove("WHY3DATA")
-        .env_remove("WHY3LIB")
-        .arg(flag)
-        .output()
-        .with_context(|| format!("failed to run `why3 {flag}`"))?;
-    if !output.status.success() {
-        bail!("`why3 {flag}` exited with status {}", output.status);
     }
-
-    let stdout = String::from_utf8(output.stdout)
-        .with_context(|| format!("`why3 {flag}` returned non-utf8 output"))?;
-    let path = PathBuf::from(stdout.trim());
-    if path.as_os_str().is_empty() {
-        bail!("`why3 {flag}` returned an empty {kind} path");
-    }
-    if !path.is_dir() {
-        bail!(
-            "`why3 {flag}` returned a non-directory {kind} path `{}`",
-            path.display()
-        );
-    }
-
-    Ok(path)
 }
 
 unsafe fn restore_env_var(key: &str, value: Option<&OsString>) {

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -16,10 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::{
-    ffi::OsString,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
 use moonbuild_rupes_recta::{intent::UserIntent, model::BuildPlanNode, user_warning::UserWarning};
@@ -132,7 +129,6 @@ pub(crate) fn run_prove(cli: &UniversalFlags, cmd: &ProveSubcommand) -> anyhow::
         .map(canonicalize_why3_config)
         .transpose()?;
     let generated_why3_config_path = verif_dir.join("why3.conf");
-    let _why3_env = (!cli.dry_run).then(configure_bundled_why3_environment);
 
     if !cli.dry_run && why3_config_path.is_none() {
         ensure_why3_config(&generated_why3_config_path)?;
@@ -274,48 +270,6 @@ fn canonicalize_why3_config(path: &Path) -> anyhow::Result<PathBuf> {
         .with_context(|| format!("failed to resolve why3 config `{}`", path.display()))
 }
 
-struct ScopedWhy3Env {
-    prev_data: Option<OsString>,
-    prev_lib: Option<OsString>,
-}
-
-impl Drop for ScopedWhy3Env {
-    fn drop(&mut self) {
-        unsafe {
-            restore_env_var("WHY3DATA", self.prev_data.as_ref());
-            restore_env_var("WHY3LIB", self.prev_lib.as_ref());
-        }
-    }
-}
-
-fn configure_bundled_why3_environment() -> ScopedWhy3Env {
-    // Why3 is embedded in `moonc`, so there is no standalone executable to
-    // discover or query. Point it at the Why3 data shipped with the toolchain.
-    let why3_root = moonutil::toolchain::lib().join("why3");
-    let why3_data = why3_root.join("share").join("why3");
-    let why3_lib = why3_root.join("lib").join("why3");
-
-    let prev_data = std::env::var_os("WHY3DATA");
-    let prev_lib = std::env::var_os("WHY3LIB");
-    unsafe {
-        std::env::set_var("WHY3DATA", &why3_data);
-        std::env::set_var("WHY3LIB", &why3_lib);
-    }
-
-    ScopedWhy3Env {
-        prev_data,
-        prev_lib,
-    }
-}
-
-unsafe fn restore_env_var(key: &str, value: Option<&OsString>) {
-    if let Some(value) = value {
-        unsafe { std::env::set_var(key, value) };
-    } else {
-        unsafe { std::env::remove_var(key) };
-    }
-}
-
 fn selected_main_module_id(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     selected_module_dir: Option<&Path>,
@@ -381,7 +335,14 @@ struct DetectedSolver {
 }
 
 fn ensure_why3_config(path: &Path) -> anyhow::Result<()> {
-    if path.exists() {
+    // Why3 is embedded in `moonc`, while its data files are shipped separately
+    // in the toolchain. Record their locations in the generated config instead
+    // of relying on process-wide WHY3DATA and WHY3LIB environment variables.
+    let why3_data = moonutil::toolchain::why3_datadir();
+    let why3_lib = moonutil::toolchain::why3_libdir();
+    let main_config = generate_why3_main_config(&why3_data, &why3_lib);
+
+    if std::fs::read_to_string(path).is_ok_and(|config| config.starts_with(&main_config)) {
         return Ok(());
     }
 
@@ -397,7 +358,7 @@ fn ensure_why3_config(path: &Path) -> anyhow::Result<()> {
         )
     })?;
 
-    let config = generate_why3_config(&solvers);
+    let config = generate_why3_config(&solvers, &why3_data, &why3_lib);
 
     std::fs::write(path, config)
         .with_context(|| format!("failed to write why3 config to `{}`", path.display()))?;
@@ -457,14 +418,22 @@ fn normalize_why3_config_path(s: &str) -> String {
     s.replace('\\', "/")
 }
 
-fn generate_why3_config(solvers: &[DetectedSolver]) -> String {
-    let mut config = String::from(
+fn generate_why3_main_config(datadir: &Path, libdir: &Path) -> String {
+    format!(
         "[main]\n\
          magic = 14\n\
+         datadir = \"{}\"\n\
+         libdir = \"{}\"\n\
          memlimit = 1000\n\
          running_provers_max = 16\n\
          timelimit = 5.000000\n",
-    );
+        normalize_why3_config_path(&datadir.to_string_lossy()),
+        normalize_why3_config_path(&libdir.to_string_lossy()),
+    )
+}
+
+fn generate_why3_config(solvers: &[DetectedSolver], datadir: &Path, libdir: &Path) -> String {
+    let mut config = generate_why3_main_config(datadir, libdir);
 
     for solver in solvers {
         config.push_str(&format!(
@@ -823,6 +792,14 @@ mod tests {
         }
     }
 
+    fn generate_config(solvers: &[DetectedSolver]) -> String {
+        generate_why3_config(
+            solvers,
+            Path::new("/moon/lib/why3/share/why3"),
+            Path::new("/moon/lib/why3/lib/why3"),
+        )
+    }
+
     #[test]
     fn test_generate_strategy_single_solver() {
         let solvers = vec![make_solver("Z3", "/usr/bin/z3", "4.15.3")];
@@ -878,16 +855,24 @@ mod tests {
     #[test]
     fn test_generate_config_single_solver() {
         let solvers = vec![make_solver("Z3", "/usr/bin/z3", "4.15.3")];
-        let config = generate_why3_config(&solvers);
+        let config = generate_config(&solvers);
+        assert!(config.contains("datadir = \"/moon/lib/why3/share/why3\""));
+        assert!(config.contains("libdir = \"/moon/lib/why3/lib/why3\""));
         assert!(config.contains("[partial_prover]\nname = \"Z3\""));
         assert!(config.contains("name = \"MoonBit_Auto\""));
         assert!(!config.contains("Alt-Ergo"));
     }
 
     #[test]
-    fn test_generate_config_normalizes_windows_solver_path() {
+    fn test_generate_config_normalizes_windows_paths() {
         let solvers = vec![make_solver("Z3", r"C:\Users\guest\bin\z3.exe", "4.16.0")];
-        let config = generate_why3_config(&solvers);
+        let config = generate_why3_config(
+            &solvers,
+            Path::new(r"C:\Users\guest\.moon\lib\why3\share\why3"),
+            Path::new(r"C:\Users\guest\.moon\lib\why3\lib\why3"),
+        );
+        assert!(config.contains(r#"datadir = "C:/Users/guest/.moon/lib/why3/share/why3""#));
+        assert!(config.contains(r#"libdir = "C:/Users/guest/.moon/lib/why3/lib/why3""#));
         assert!(config.contains(r#"path = "C:/Users/guest/bin/z3.exe""#));
     }
 
@@ -898,7 +883,7 @@ mod tests {
             make_solver("CVC5", "/usr/bin/cvc5", "1.3.1"),
             make_solver("Z3", "/usr/bin/z3", "4.15.3"),
         ];
-        let config = generate_why3_config(&solvers);
+        let config = generate_config(&solvers);
         // All partial_prover sections present in alphabetical order
         let alt_ergo_pos = config.find("name = \"Alt-Ergo\"").unwrap();
         let cvc5_pos = config.find("name = \"CVC5\"").unwrap();

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -482,11 +482,10 @@ fn try_detect_solver(spec: &SolverSpec) -> Option<DetectedSolver> {
     })
 }
 
-fn escape_windows_path(s: &str) -> String {
-    // Why3 configuration strings treat backslashes as escapes. Keep the native
-    // Windows path spelling instead of normalizing to `/`, so the generated
-    // prover path stays the exact executable path returned by PATH/env lookup.
-    s.replace('\\', "\\\\")
+fn normalize_why3_config_path(s: &str) -> String {
+    // Why3 configuration strings treat backslashes as escapes. Emit paths with
+    // `/` separators consistently so Windows paths do not need double escaping.
+    s.replace('\\', "/")
 }
 
 fn generate_why3_config(solvers: &[DetectedSolver]) -> String {
@@ -505,7 +504,7 @@ fn generate_why3_config(solvers: &[DetectedSolver]) -> String {
              path = \"{}\"\n\
              version = \"{}\"\n",
             solver.name,
-            escape_windows_path(&solver.path),
+            normalize_why3_config_path(&solver.path),
             solver.version,
         ));
     }
@@ -917,10 +916,10 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_config_escapes_windows_solver_path() {
+    fn test_generate_config_normalizes_windows_solver_path() {
         let solvers = vec![make_solver("Z3", r"C:\Users\guest\bin\z3.exe", "4.16.0")];
         let config = generate_why3_config(&solvers);
-        assert!(config.contains(r#"path = "C:\\Users\\guest\\bin\\z3.exe""#));
+        assert!(config.contains(r#"path = "C:/Users/guest/bin/z3.exe""#));
     }
 
     #[test]

--- a/crates/moonutil/src/moon_dir.rs
+++ b/crates/moonutil/src/moon_dir.rs
@@ -121,6 +121,14 @@ pub fn lib() -> PathBuf {
     toolchain_root().join("lib")
 }
 
+pub fn why3_datadir() -> PathBuf {
+    lib().join("why3").join("share").join("why3")
+}
+
+pub fn why3_libdir() -> PathBuf {
+    lib().join("why3").join("lib").join("why3")
+}
+
 pub fn core() -> PathBuf {
     let env_var = std::env::var_os("MOON_CORE_OVERRIDE");
     if let Some(path) = env_var {
@@ -256,6 +264,8 @@ fn test_moon_dir() {
         bin(),
         include(),
         lib(),
+        why3_datadir(),
+        why3_libdir(),
         core_bundle(TargetBackend::default()),
     ];
     dbg!(&toolchain_dirs);
@@ -274,6 +284,8 @@ fn test_moon_dir() {
             "bin",
             "include",
             "lib",
+            "lib|why3|share|why3",
+            "lib|why3|lib|why3",
             "lib|core|_build|wasm-gc|release|bundle",
         ]
     "#]]

--- a/crates/moonutil/src/toolchain.rs
+++ b/crates/moonutil/src/toolchain.rs
@@ -27,5 +27,5 @@ pub use crate::binaries::{BINARIES, CachedBinaries};
 pub use crate::moon_dir::{
     MOON_DIRS, MoonDirs, RESERVED_BIN_NAMES, abort_core_in, abort_mi_in, bin, core, core_bundle,
     core_bundle_in, core_core, core_core_in, core_package_mi_in, home, include, is_toolchain_root,
-    lib, toolchain_root, user_bin,
+    lib, toolchain_root, user_bin, why3_datadir, why3_libdir,
 };


### PR DESCRIPTION
Why3 is now embedded in `moonc`, with its data and library files shipped in the MoonBit toolchain.

```
.moon/lib/why3/share/why3
.moon/lib/why3/lib/why3
```

This change removes the external why3 executable lookup and directory queries from moon prove. It sets
`WHY3DATA` and `WHY3LIB` directly to the bundled toolchain paths instead. 

External SMT solver detection remains unchanged.