### PR TITLE
Reduce moonrun memory sanitizer overhead

### DIFF
--- a/crates/moonrun/src/memory_sanitizer_api.rs
+++ b/crates/moonrun/src/memory_sanitizer_api.rs
@@ -19,8 +19,9 @@
 //! Host-side `moonbit:ffi/memory-sanitizer` imports.
 
 use std::any::Any;
-use std::collections::BTreeMap;
-use std::sync::Mutex;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashSet};
+use std::rc::Rc;
 
 use crate::v8_builder::ObjectExt;
 
@@ -29,12 +30,15 @@ pub(crate) const MEMORY_SANITIZER_MODULE: &str = "moonbit:ffi/memory-sanitizer";
 #[derive(Debug)]
 struct ObjectRecord {
     size: u32,
-    alloc_stack: SanitizerStack,
+    alloc_stack: Rc<SanitizerStack>,
 }
 
 #[derive(Debug, Default)]
 struct MemorySanitizerState {
     live: BTreeMap<u32, ObjectRecord>,
+    // Allocations usually come from a small number of call stacks. Share their
+    // frame data so each live object only needs to retain an Rc.
+    alloc_stacks: HashSet<Rc<SanitizerStack>>,
 }
 
 impl MemorySanitizerState {
@@ -42,28 +46,37 @@ impl MemorySanitizerState {
         &mut self,
         size: u32,
         ptr: u32,
-        alloc_stack: SanitizerStack,
+        capture_alloc_stack: impl FnOnce() -> SanitizerStack,
     ) -> Result<(), MemorySanitizerError> {
         if let Some(record) = self.live.get(&ptr) {
             return Err(MemorySanitizerError::DuplicateObject {
                 ptr,
                 size: record.size,
-                alloc_stack: record.alloc_stack.clone(),
+                alloc_stack: Rc::clone(&record.alloc_stack),
             });
         }
+
+        let alloc_stack = capture_alloc_stack();
+        let alloc_stack = if let Some(interned) = self.alloc_stacks.get(&alloc_stack) {
+            Rc::clone(interned)
+        } else {
+            let alloc_stack = Rc::new(alloc_stack);
+            self.alloc_stacks.insert(Rc::clone(&alloc_stack));
+            alloc_stack
+        };
         self.live.insert(ptr, ObjectRecord { size, alloc_stack });
         Ok(())
     }
 
-    fn register_object_free(
-        &mut self,
-        ptr: u32,
-        free_stack: SanitizerStack,
-    ) -> Result<(), MemorySanitizerError> {
-        self.live
+    fn register_object_free(&mut self, ptr: u32) -> Result<(), MemorySanitizerError> {
+        let record = self
+            .live
             .remove(&ptr)
-            .map(|_| ())
-            .ok_or(MemorySanitizerError::InvalidObject { ptr, free_stack })
+            .ok_or(MemorySanitizerError::InvalidObject { ptr })?;
+        if Rc::strong_count(&record.alloc_stack) == 2 {
+            self.alloc_stacks.remove(record.alloc_stack.as_ref());
+        }
+        Ok(())
     }
 
     fn object_is_valid(&self, ptr: u32) -> bool {
@@ -73,7 +86,9 @@ impl MemorySanitizerState {
 
 #[derive(Default)]
 struct MemorySanitizerContext {
-    state: Mutex<MemorySanitizerState>,
+    // V8 invokes these callbacks on the isolate thread; RefCell only provides
+    // the interior mutability needed through callback data.
+    state: RefCell<MemorySanitizerState>,
 }
 
 #[derive(Debug)]
@@ -82,11 +97,10 @@ enum MemorySanitizerError {
     DuplicateObject {
         ptr: u32,
         size: u32,
-        alloc_stack: SanitizerStack,
+        alloc_stack: Rc<SanitizerStack>,
     },
     InvalidObject {
         ptr: u32,
-        free_stack: SanitizerStack,
     },
 }
 
@@ -102,10 +116,7 @@ impl std::fmt::Display for MemorySanitizerError {
                 write!(f, "object {ptr} is already live with size {size}")?;
                 alloc_stack.write_to(f, "previous allocation stack")
             }
-            Self::InvalidObject { ptr, free_stack } => {
-                write!(f, "invalid object {ptr}")?;
-                free_stack.write_to(f, "free stack")
-            }
+            Self::InvalidObject { ptr } => write!(f, "invalid object {ptr}"),
         }
     }
 }
@@ -160,12 +171,10 @@ fn register_object_alloc(
     let result = (|| {
         let size = read_u32_arg(scope, &args, 0)?;
         let ptr = read_u32_arg(scope, &args, 1)?;
-        let alloc_stack = SanitizerStack::capture(scope);
         context
             .state
-            .lock()
-            .unwrap()
-            .register_object_alloc(size, ptr, alloc_stack)
+            .borrow_mut()
+            .register_object_alloc(size, ptr, || SanitizerStack::capture(scope))
     })();
     match result {
         Ok(()) => ret.set_undefined(),
@@ -179,14 +188,8 @@ fn register_object_free(
     mut ret: v8::ReturnValue,
 ) {
     let context = callback_context(&args);
-    let result = read_u32_arg(scope, &args, 0).and_then(|ptr| {
-        let free_stack = SanitizerStack::capture(scope);
-        context
-            .state
-            .lock()
-            .unwrap()
-            .register_object_free(ptr, free_stack)
-    });
+    let result = read_u32_arg(scope, &args, 0)
+        .and_then(|ptr| context.state.borrow_mut().register_object_free(ptr));
     match result {
         Ok(()) => ret.set_undefined(),
         Err(error) => throw_import_error(scope, "register-object-free", error),
@@ -200,7 +203,7 @@ fn object_is_valid(
 ) {
     let context = callback_context(&args);
     let result =
-        read_u32_arg(scope, &args, 0).map(|ptr| context.state.lock().unwrap().object_is_valid(ptr));
+        read_u32_arg(scope, &args, 0).map(|ptr| context.state.borrow().object_is_valid(ptr));
     match result {
         Ok(is_valid) => ret.set_bool(is_valid),
         Err(error) => throw_import_error(scope, "object-is-valid", error),
@@ -215,7 +218,7 @@ fn callback_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s MemoryS
     unsafe { &*(ptr as *const MemorySanitizerContext) }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default, Eq, Hash, PartialEq)]
 struct SanitizerStack {
     frames: Vec<SanitizerStackFrame>,
 }
@@ -240,30 +243,37 @@ impl SanitizerStack {
         }
         write!(f, "\n{title}:")?;
         for frame in &self.frames {
-            write!(f, "\n    at {}", frame.function)?;
+            if frame.is_wasm {
+                write!(
+                    f,
+                    "\n    at {}",
+                    moonutil::demangle::demangle_mangled_function_name(&frame.raw_function)
+                )?;
+            } else {
+                write!(f, "\n    at {}", frame.raw_function)?;
+            }
         }
         Ok(())
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 struct SanitizerStackFrame {
-    function: String,
+    raw_function: String,
+    is_wasm: bool,
 }
 
 impl SanitizerStackFrame {
     fn from_v8(scope: &mut v8::HandleScope, frame: v8::Local<v8::StackFrame>) -> Self {
-        let function = frame
+        let raw_function = frame
             .get_function_name(scope)
             .map(|name| name.to_rust_string_lossy(scope))
             .filter(|name| !name.is_empty())
             .unwrap_or_else(|| "<anonymous>".to_string());
-        let function = if frame.is_wasm() {
-            moonutil::demangle::demangle_mangled_function_name(&function)
-        } else {
-            function
-        };
-        Self { function }
+        Self {
+            raw_function,
+            is_wasm: frame.is_wasm(),
+        }
     }
 }
 
@@ -282,4 +292,61 @@ fn throw_import_error(scope: &mut v8::HandleScope, import_name: &str, error: Mem
     let message = v8::String::new(scope, &message).unwrap_or_else(|| v8::String::empty(scope));
     let exception = v8::Exception::error(scope, message);
     scope.throw_exception(exception);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stack(function: &str) -> SanitizerStack {
+        SanitizerStack {
+            frames: vec![SanitizerStackFrame {
+                raw_function: function.to_string(),
+                is_wasm: true,
+            }],
+        }
+    }
+
+    #[test]
+    fn duplicate_allocation_does_not_capture_an_unused_stack() {
+        let mut state = MemorySanitizerState::default();
+        state
+            .register_object_alloc(16, 1024, || stack("first"))
+            .unwrap();
+
+        let error = state.register_object_alloc(32, 1024, || {
+            panic!("duplicate allocation should reuse the previous stack")
+        });
+
+        assert!(matches!(
+            error,
+            Err(MemorySanitizerError::DuplicateObject {
+                ptr: 1024,
+                size: 16,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn allocation_stacks_are_shared_while_live() {
+        let mut state = MemorySanitizerState::default();
+        state
+            .register_object_alloc(16, 1024, || stack("shared"))
+            .unwrap();
+        state
+            .register_object_alloc(16, 2048, || stack("shared"))
+            .unwrap();
+
+        assert_eq!(state.alloc_stacks.len(), 1);
+        assert!(Rc::ptr_eq(
+            &state.live[&1024].alloc_stack,
+            &state.live[&2048].alloc_stack
+        ));
+
+        state.register_object_free(1024).unwrap();
+        assert_eq!(state.alloc_stacks.len(), 1);
+        state.register_object_free(2048).unwrap();
+        assert!(state.alloc_stacks.is_empty());
+    }
 }

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -428,41 +428,25 @@ fn test_moon_run_memory_sanitizer_reports_demangled_alloc_stack() {
 
     let wasm_file = dir.join("_build/wasm/debug/build/duplicate_alloc/duplicate_alloc.wasm");
 
-    let assert = snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .arg(&wasm_file)
         .assert()
         .failure()
-        .stdout_eq("");
-    let stderr = std::str::from_utf8(&assert.get_output().stderr).unwrap();
-    let diagnostic = stderr.lines().next().expect("missing sanitizer diagnostic");
-    snapbox::assert_data_eq!(
-        diagnostic,
-        snapbox::str![[r#"
+        .stdout_eq("")
+        .stderr_eq(snapbox::str![[r#"
 Error: moonbit:ffi/memory-sanitizer.register-object-alloc failed: object 2048 is already live with size 16
-"#]]
-    );
-
-    let stack_section = stderr
-        .lines()
-        .skip_while(|line| *line != "previous allocation stack:")
-        .take(6)
-        .collect::<Vec<_>>()
-        .join("\n");
-    snapbox::assert_data_eq!(
-        stack_section,
-        snapbox::str![[r#"
 previous allocation stack:
     at @moonbit/ffi-memory-sanitizer-test/memory_sanitizer.host_register_object_alloc
     at @moonbit/ffi-memory-sanitizer-test/memory_sanitizer.register_object_alloc
     at @moonbit/ffi-memory-sanitizer-test/duplicate_alloc.allocate_once
     at @__moonbit_main
     at <anonymous>
-"#]]
-    );
+...
+"#]]);
 }
 
 #[test]
-fn test_moon_run_memory_sanitizer_reports_double_free_stack() {
+fn test_moon_run_memory_sanitizer_reports_double_free() {
     let dir = TestDir::new("test_memory_sanitizer.in");
 
     moon_cmd()
@@ -473,37 +457,19 @@ fn test_moon_run_memory_sanitizer_reports_double_free_stack() {
 
     let wasm_file = dir.join("_build/wasm/debug/build/double_free/double_free.wasm");
 
-    let assert = snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .arg(&wasm_file)
         .assert()
         .failure()
-        .stdout_eq("");
-    let stderr = std::str::from_utf8(&assert.get_output().stderr).unwrap();
-    let diagnostic = stderr.lines().next().expect("missing sanitizer diagnostic");
-    snapbox::assert_data_eq!(
-        diagnostic,
-        snapbox::str![[r#"
+        .stdout_eq("")
+        .stderr_eq(snapbox::str![[r#"
 Error: moonbit:ffi/memory-sanitizer.register-object-free failed: invalid object 4096
-"#]]
-    );
-
-    let stack_section = stderr
-        .lines()
-        .skip_while(|line| *line != "free stack:")
-        .take(6)
-        .collect::<Vec<_>>()
-        .join("\n");
-    snapbox::assert_data_eq!(
-        stack_section,
-        snapbox::str![[r#"
-free stack:
     at @moonbit/ffi-memory-sanitizer-test/memory_sanitizer.host_register_object_free
     at @moonbit/ffi-memory-sanitizer-test/memory_sanitizer.register_object_free
     at @moonbit/ffi-memory-sanitizer-test/double_free.free_twice
     at @__moonbit_main
-    at <anonymous>
-"#]]
-    );
+...
+"#]]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- stop capturing free stacks and demangle allocation symbols only when reporting an error
- share identical live allocation stacks with `Rc` and avoid capturing an unused stack for duplicate allocations
- replace the sanitizer state's mutex with `RefCell`, matching V8 isolate callback execution
- update the sanitizer diagnostic regression tests

## Why

The sanitizer eagerly captured and processed a full V8 stack for every allocation and free. Successful frees discarded that stack immediately, while allocation symbols were demangled even when no error was reported. This added substantial overhead to allocation-heavy programs.

## Correctness

Duplicate allocations still report the original allocation stack, with symbols demangled when the diagnostic is rendered. Invalid frees continue to surface the current V8 exception stack without retaining a redundant explicit free stack. Interned allocation stacks remain alive while referenced by live objects and are removed after the final object is freed.

## Scope

This change is limited to the host-side sanitizer state and diagnostics. More invasive compact or fully lazy stack representations can be considered separately.