### PR TITLE
Fix diagnostics for generated test drivers

### DIFF
--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -1653,6 +1653,7 @@ fn rr_test_from_plan(
                 &built.build_config,
                 build_graph,
                 target_dir,
+                Some(build_meta),
                 Box::new(|work| {
                     trace!("requesting rerun artifacts");
                     for file_path in want_files {
@@ -1759,7 +1760,7 @@ fn execute_test_build_from_plan(
 
     // since n2 build consumes the graph, we back it up for reruns
     let build_graph_backup = cmd.update.then(|| build_graph.clone());
-    let result = rr_build::execute_build(&build_config, build_graph, target_dir)?;
+    let result = rr_build::execute_test_build(&build_config, build_graph, target_dir, build_meta)?;
     debug!(
         success = result.successful(),
         exit_code = result.return_code_for_success(),

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -48,7 +48,7 @@ use moonbuild_rupes_recta::{
         RunBackend, TargetKind, TccRunConfig,
     },
     prebuild::{PrebuildEnvironment, run_prebuild_config},
-    target_layout::{ArtifactPathResolver, TargetLayout},
+    target_layout::{ArtifactPathResolver, GENERATED_TEST_DRIVER_PREFIX, TargetLayout},
     user_warning::UserWarning,
 };
 use moonutil::{
@@ -966,8 +966,36 @@ pub fn execute_build(
         cfg,
         input,
         target_dir,
+        None,
         Box::new(|work| {
             // Want only the leaf output files, not all files including stdlib
+            for file_id in start_nodes {
+                work.want_file(file_id)?;
+            }
+            Ok(())
+        }),
+    )
+}
+
+/// Execute a test build.
+///
+/// Test builds may report diagnostics for generated drivers using their
+/// source-tree paths. The test build metadata lets the diagnostic processing
+/// stage resolve those paths through the target layout.
+pub fn execute_test_build(
+    cfg: &BuildConfig,
+    input: BuildInput,
+    target_dir: &Path,
+    build_meta: &BuildMeta,
+) -> anyhow::Result<N2RunStats> {
+    let start_nodes = input.graph.get_start_nodes();
+
+    execute_build_partial(
+        cfg,
+        input,
+        target_dir,
+        Some(build_meta),
+        Box::new(|work| {
             for file_id in start_nodes {
                 work.want_file(file_id)?;
             }
@@ -990,6 +1018,7 @@ pub fn execute_build_partial(
     cfg: &BuildConfig,
     input: BuildInput,
     target_dir: &Path,
+    build_meta: Option<&BuildMeta>,
     want_files: Box<WantFileFn>,
 ) -> anyhow::Result<N2RunStats> {
     // Ensure target directory exists
@@ -1023,20 +1052,13 @@ pub fn execute_build_partial(
         .unwrap();
 
     let result_catcher = Arc::new(Mutex::new(ResultCatcher::default()));
-    let mut prog_console: Box<dyn n2::progress::Progress> = match cfg.output_style {
-        OutputStyle::Raw => create_progress_console(
-            Some(Box::new(no_render_callback())),
-            cfg.verbose,
-            cfg.suppress_progress,
-        ),
-        OutputStyle::Fancy | OutputStyle::Json => create_progress_console(
-            Some(Box::new(capture_diagnostics_callback(Arc::clone(
-                &result_catcher,
-            )))),
-            cfg.verbose,
-            cfg.suppress_progress,
-        ),
-    };
+    let mut prog_console: Box<dyn n2::progress::Progress> = create_progress_console(
+        Some(Box::new(capture_diagnostics_callback(Arc::clone(
+            &result_catcher,
+        )))),
+        cfg.verbose,
+        cfg.suppress_progress,
+    );
     let mut work = n2::work::Work::new(
         build_graph,
         hashes,
@@ -1061,7 +1083,7 @@ pub fn execute_build_partial(
     let build_succeeded = res.is_some();
 
     let mut result_catcher = result_catcher.lock().unwrap();
-    process_captured_diagnostics(&mut result_catcher, cfg, build_succeeded);
+    process_captured_diagnostics(&mut result_catcher, cfg, build_succeeded, build_meta);
     let stats = N2RunStats {
         n_tasks_executed: res,
         n_errors: result_catcher.n_errors,
@@ -1071,9 +1093,7 @@ pub fn execute_build_partial(
     Ok(stats)
 }
 
-/// The callback function that catches diagnostics output. The output is
-/// expected to have json format. The captured diagnostics will be processed
-/// later.
+/// Capture compiler output from n2 so it can be processed after the build.
 fn capture_diagnostics_callback(catcher: Arc<Mutex<ResultCatcher>>) -> impl Fn(&str) {
     move |output: &str| {
         let mut catcher = catcher.lock().unwrap();
@@ -1086,17 +1106,6 @@ fn capture_diagnostics_callback(catcher: Arc<Mutex<ResultCatcher>>) -> impl Fn(&
     }
 }
 
-fn no_render_callback() -> impl Fn(&str) {
-    move |output: &str| {
-        output
-            .split('\n')
-            .filter(|it| !it.is_empty())
-            .for_each(|content| {
-                println!("{}", content);
-            });
-    }
-}
-
 fn should_render_non_diagnostic_build_output(cfg: &BuildConfig, build_succeeded: bool) -> bool {
     !(cfg.suppress_progress && build_succeeded)
 }
@@ -1105,21 +1114,75 @@ fn process_captured_diagnostics(
     catcher: &mut ResultCatcher,
     cfg: &BuildConfig,
     build_succeeded: bool,
+    build_meta: Option<&BuildMeta>,
 ) {
+    let captured = catcher.content_writer.iter().map(|content| {
+        let Some(meta) = build_meta else {
+            return content.to_owned();
+        };
+        let layout = meta.artifact_paths.target_layout();
+        let packages = &meta.resolve_output.pkg_dirs;
+        let backend = meta.target_backend.into();
+
+        if cfg.output_style.needs_moonc_json() {
+            let Ok(mut value) = serde_json::from_str::<serde_json::Value>(content) else {
+                return content.to_owned();
+            };
+            let mut changed = false;
+            let mut diagnostics = vec![&mut value];
+            while let Some(diagnostic) = diagnostics.pop() {
+                let Some(object) = diagnostic.as_object_mut() else {
+                    continue;
+                };
+                if let Some(serde_json::Value::String(path)) = object.get_mut("path")
+                    && let Some(physical) = layout.generated_test_driver_diagnostic_path(
+                        packages,
+                        Path::new(path),
+                        backend,
+                    )
+                {
+                    *path = physical.to_string_lossy().into_owned();
+                    changed = true;
+                }
+                if let Some(serde_json::Value::Array(children)) = object.get_mut("children") {
+                    diagnostics.extend(children.iter_mut());
+                }
+            }
+            return if changed {
+                serde_json::to_string(&value).expect("diagnostic JSON should serialize")
+            } else {
+                content.to_owned()
+            };
+        }
+
+        let Some(prefix_start) = content.find(GENERATED_TEST_DRIVER_PREFIX) else {
+            return content.to_owned();
+        };
+        let Some(extension_end) = content[prefix_start..].find(".mbt") else {
+            return content.to_owned();
+        };
+        let path_end = prefix_start + extension_end + ".mbt".len();
+        let Some(physical) = layout.generated_test_driver_diagnostic_path(
+            packages,
+            Path::new(&content[..path_end]),
+            backend,
+        ) else {
+            return content.to_owned();
+        };
+        format!("{}{}", physical.display(), &content[path_end..])
+    });
+
     match cfg.output_style {
         OutputStyle::Json => {
             let mut by_file = BTreeMap::<String, BTreeSet<(MooncDiagnostic, String)>>::new();
-            for content in &catcher.content_writer {
-                match serde_json::from_str::<moonutil::render::MooncDiagnostic>(content) {
+            for content in captured {
+                match serde_json::from_str::<moonutil::render::MooncDiagnostic>(&content) {
                     Ok(d) => {
                         if diagnostic_is_generated_test_driver_warning(&d) {
                             continue;
                         }
                         let file_key = d.path.clone();
-                        by_file
-                            .entry(file_key)
-                            .or_default()
-                            .insert((d, content.clone()));
+                        by_file.entry(file_key).or_default().insert((d, content));
                     }
                     Err(_) => {
                         // Non-diagnostics output, just print as-is
@@ -1194,8 +1257,8 @@ fn process_captured_diagnostics(
         }
         OutputStyle::Fancy => {
             let mut by_file = BTreeMap::<String, BTreeSet<MooncDiagnostic>>::new();
-            for content in &catcher.content_writer {
-                match serde_json::from_str::<moonutil::render::MooncDiagnostic>(content) {
+            for content in captured {
+                match serde_json::from_str::<moonutil::render::MooncDiagnostic>(&content) {
                     Ok(d) => {
                         if diagnostic_is_generated_test_driver_warning(&d) {
                             continue;
@@ -1292,7 +1355,11 @@ fn process_captured_diagnostics(
                 }
             }
         }
-        OutputStyle::Raw => {}
+        OutputStyle::Raw => {
+            for content in captured {
+                println!("{content}");
+            }
+        }
     }
 }
 
@@ -1378,7 +1445,7 @@ mod tests {
             output_style: OutputStyle::Json,
             ..Default::default()
         };
-        process_captured_diagnostics(&mut catcher, &cfg, false);
+        process_captured_diagnostics(&mut catcher, &cfg, false, None);
 
         assert_eq!(catcher.n_warnings, 0);
         assert_eq!(catcher.n_errors, 1);

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -115,6 +115,7 @@ mod target_backend;
 mod targets;
 mod test_dot_source;
 mod test_driver_dependencies;
+mod test_driver_diagnostics;
 mod test_driver_map_collision;
 mod test_error_report;
 mod test_exclude_001;

--- a/crates/moon/tests/test_cases/test_driver_diagnostics/collision.mbt
+++ b/crates/moon/tests/test_cases/test_driver_diagnostics/collision.mbt
@@ -1,0 +1,8 @@
+///|
+#warnings("-unused_type_declaration")
+priv struct MoonBitTestDriverInternalTestMap(Int)
+
+///|
+test "generated driver diagnostic" {
+  inspect(1, content="1")
+}

--- a/crates/moon/tests/test_cases/test_driver_diagnostics/mod.rs
+++ b/crates/moon/tests/test_cases/test_driver_diagnostics/mod.rs
@@ -1,0 +1,67 @@
+use crate::{TestDir, moon_cmd};
+
+fn failed_test_output(dir: &TestDir, args: &[&str]) -> String {
+    let assert = moon_cmd(dir).args(args).assert().failure();
+    let output = assert.get_output();
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+    .replace('\\', "/")
+}
+
+fn assert_uses_physical_driver_path(output: &str, target_dir: &str) {
+    let driver_path =
+        format!("{target_dir}/wasm-gc/debug/test/__generated_driver_for_internal_test.mbt");
+    assert!(
+        output.contains(&driver_path),
+        "diagnostic should use the generated driver's physical path:\n{output}"
+    );
+    assert!(
+        !output.contains("failed to read file"),
+        "generated driver should be available to the diagnostic renderer:\n{output}"
+    );
+}
+
+#[test]
+fn generated_driver_diagnostics_use_the_physical_path() {
+    let dir = TestDir::new("test_driver_diagnostics");
+    let fancy = failed_test_output(
+        &dir,
+        &[
+            "test",
+            "--target",
+            "wasm-gc",
+            "--target-dir",
+            "fancy-target",
+        ],
+    );
+    assert_uses_physical_driver_path(&fancy, "fancy-target");
+
+    let raw = failed_test_output(
+        &dir,
+        &[
+            "test",
+            "--target",
+            "wasm-gc",
+            "--target-dir",
+            "raw-target",
+            "--no-render",
+        ],
+    );
+    assert_uses_physical_driver_path(&raw, "raw-target");
+
+    let json = failed_test_output(
+        &dir,
+        &[
+            "test",
+            "--target",
+            "wasm-gc",
+            "--target-dir",
+            "json-target",
+            "--output-json",
+        ],
+    );
+    assert_uses_physical_driver_path(&json, "json-target");
+}

--- a/crates/moon/tests/test_cases/test_driver_diagnostics/mod.rs
+++ b/crates/moon/tests/test_cases/test_driver_diagnostics/mod.rs
@@ -1,67 +1,66 @@
 use crate::{TestDir, moon_cmd};
 
-fn failed_test_output(dir: &TestDir, args: &[&str]) -> String {
-    let assert = moon_cmd(dir).args(args).assert().failure();
-    let output = assert.get_output();
-    format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    )
-    .replace('\\', "/")
-}
-
-fn assert_uses_physical_driver_path(output: &str, target_dir: &str) {
-    let driver_path =
-        format!("{target_dir}/wasm-gc/debug/test/__generated_driver_for_internal_test.mbt");
-    assert!(
-        output.contains(&driver_path),
-        "diagnostic should use the generated driver's physical path:\n{output}"
-    );
-    assert!(
-        !output.contains("failed to read file"),
-        "generated driver should be available to the diagnostic renderer:\n{output}"
-    );
-}
-
 #[test]
-fn generated_driver_diagnostics_use_the_physical_path() {
+fn rendered_generated_driver_diagnostic_uses_the_physical_path() {
     let dir = TestDir::new("test_driver_diagnostics");
-    let fancy = failed_test_output(
-        &dir,
-        &[
+    moon_cmd(&dir)
+        .args([
             "test",
             "--target",
             "wasm-gc",
             "--target-dir",
             "fancy-target",
-        ],
-    );
-    assert_uses_physical_driver_path(&fancy, "fancy-target");
+        ])
+        .assert()
+        .failure()
+        .stdout_eq("")
+        .stderr_eq(snapbox::str![[r#"
+Error: [4051]
+     ╭─[ [..]/fancy-target/wasm-gc/debug/test/__generated_driver_for_internal_test.mbt:123:13 ]
+     │
+ 123 │ priv struct MoonBitTestDriverInternalTestMap[F](
+...
+"#]]);
+}
 
-    let raw = failed_test_output(
-        &dir,
-        &[
+#[test]
+fn raw_generated_driver_diagnostic_uses_the_physical_path() {
+    let dir = TestDir::new("test_driver_diagnostics");
+    moon_cmd(&dir)
+        .args([
             "test",
             "--target",
             "wasm-gc",
             "--target-dir",
             "raw-target",
             "--no-render",
-        ],
-    );
-    assert_uses_physical_driver_path(&raw, "raw-target");
+        ])
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![[r#"
+[..]/raw-target/wasm-gc/debug/test/__generated_driver_for_internal_test.mbt:123:13-123:45 [E4051] The type MoonBitTestDriverInternalTestMap is declared twice: it was previously defined at [..]/collision.mbt:2:1.
+...
+"#]])
+        .stderr_eq("");
+}
 
-    let json = failed_test_output(
-        &dir,
-        &[
+#[test]
+fn json_generated_driver_diagnostic_uses_the_physical_path() {
+    let dir = TestDir::new("test_driver_diagnostics");
+    moon_cmd(&dir)
+        .args([
             "test",
             "--target",
             "wasm-gc",
             "--target-dir",
             "json-target",
             "--output-json",
-        ],
-    );
-    assert_uses_physical_driver_path(&json, "json-target");
+        ])
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![[r#"
+{"$message_type":"diagnostic","level":"error","error_code":4051,"path":"[..]json-target[..]wasm-gc[..]debug[..]test[..]__generated_driver_for_internal_test.mbt","loc":"123:13-123:45","message":"The type MoonBitTestDriverInternalTestMap is declared twice: it was previously defined at [..]collision.mbt:2:1.","context":""}
+...
+"#]])
+        .stderr_eq("");
 }

--- a/crates/moon/tests/test_cases/test_driver_diagnostics/moon.mod
+++ b/crates/moon/tests/test_cases/test_driver_diagnostics/moon.mod
@@ -1,0 +1,3 @@
+name = "username/test_driver_diagnostics"
+
+version = "0.1.0"

--- a/crates/moon/tests/test_cases/test_driver_diagnostics/moon.pkg
+++ b/crates/moon/tests/test_cases/test_driver_diagnostics/moon.pkg
@@ -1,0 +1,1 @@
+pkgtype(kind: "library")

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -50,6 +50,7 @@ const CORE_EXTENSION: &str = ".core";
 const MI_EXTENSION: &str = ".mi";
 /// Implementation packages generate a dummy mi file so they are not rebuilt every time.
 const IMPL_MI_EXTENSION: &str = ".impl.mi";
+pub const GENERATED_TEST_DRIVER_PREFIX: &str = "__generated_driver_for";
 
 #[derive(Clone, Copy, Debug)]
 pub enum ExecutableArtifact {
@@ -358,11 +359,30 @@ impl TargetLayout {
     ) -> PathBuf {
         let pkg_fqn = &pkg_list.get_package(target.package).fqn;
         let mut base_dir = self.package_dir(pkg_fqn, backend);
-        base_dir.push(format!(
-            "__generated_driver_for{}.mbt",
-            build_kind_suffix_filename(target.kind)
-        ));
+        base_dir.push(generated_test_driver_filename(target.kind));
         base_dir
+    }
+
+    /// Maps a compiler-reported generated test driver path into this target
+    /// layout. moonc reports the driver under the package's source directory.
+    pub fn generated_test_driver_diagnostic_path(
+        &self,
+        pkg_list: &DiscoverResult,
+        reported: &Path,
+        backend: TargetBackend,
+    ) -> Option<PathBuf> {
+        let filename = reported.file_name()?;
+        if !filename
+            .to_string_lossy()
+            .starts_with(GENERATED_TEST_DRIVER_PREFIX)
+        {
+            return None;
+        }
+
+        let package = pkg_list.all_packages(false).find_map(|(_, package)| {
+            (reported.parent()? == package.root_path).then_some(package)
+        })?;
+        Some(self.package_dir(&package.fqn, backend).join(filename))
     }
 
     pub fn generated_test_driver_metadata(
@@ -1087,6 +1107,13 @@ fn build_kind_suffix_filename(kind: TargetKind) -> &'static str {
     }
 }
 
+fn generated_test_driver_filename(kind: TargetKind) -> String {
+    format!(
+        "{GENERATED_TEST_DRIVER_PREFIX}{}.mbt",
+        build_kind_suffix_filename(kind)
+    )
+}
+
 /// Returns the file extension for static libraries on the given OS.
 fn static_library_ext(os: OperatingSystem) -> &'static str {
     match os {
@@ -1372,6 +1399,28 @@ mod tests {
         assert_eq!(
             layout.package_dir(&dep_pkg, TargetBackend::WasmGC),
             PathBuf::from("_build/wasm-gc/debug/build/username/world/v2/lib"),
+        );
+    }
+
+    #[test]
+    fn generated_test_driver_diagnostic_path_follows_the_target_layout() {
+        let (packages, modules, _) = package_fixture("ffi");
+        let layout = layout(TargetLayoutMode::Mono {
+            main_module: modules.module_source(modules.input_module_ids()[0]).clone(),
+        });
+        let reported = PathBuf::from("ffi/__generated_driver_for_internal_test.mbt");
+
+        let physical = layout.generated_test_driver_diagnostic_path(
+            &packages,
+            &reported,
+            TargetBackend::WasmGC,
+        );
+
+        assert_eq!(
+            physical,
+            Some(PathBuf::from(
+                "_build/wasm-gc/debug/build/ffi/__generated_driver_for_internal_test.mbt"
+            ))
         );
     }
 

--- a/crates/moonutil/src/render.rs
+++ b/crates/moonutil/src/render.rs
@@ -341,71 +341,6 @@ impl MooncDiagnostic {
         Some(kind)
     }
 
-    pub fn render(
-        content: &str,
-        use_fancy: bool,
-        check_patch_file: Option<PathBuf>,
-        explain: bool,
-        render_no_loc_level: DiagnosticLevel,
-        source_dir: &Path,
-        target_dir: &Path,
-    ) -> Option<ReportKind<'static>> {
-        let bail_print_original = || {
-            eprintln!("{content}");
-            None
-        };
-        let mut diagnostic = match serde_json_lenient::from_str::<MooncDiagnostic>(content) {
-            Ok(d) => d,
-            Err(_) => bail_print_original()?,
-        };
-
-        // a workaround for rendering the diagnostaic and error in generated test driver file correctly
-        'fail_to_get_source: {
-            if diagnostic.path.contains("__generated_driver_for_") {
-                let Ok(file) = crate::manifest::read_module_desc_file_in_dir(source_dir) else {
-                    error!(
-                        "when working around driver file path issue, failed to read module.desc file in source dir: {}",
-                        source_dir.display()
-                    );
-                    break 'fail_to_get_source;
-                };
-                let source = file.source;
-                let source_code_dir = match source {
-                    Some(source) => source_dir.join(source),
-                    None => source_dir.to_owned(),
-                };
-
-                // Normalize source dir. Work around when `source_dir` ends with `.`
-                let Ok(source_code_dir) = dunce::canonicalize(&source_code_dir) else {
-                    warn!(
-                        "when working around driver file path issue, failed to canonicalize source code dir: {}",
-                        source_code_dir.display()
-                    );
-                    break 'fail_to_get_source;
-                };
-                let diag_path: &Path = diagnostic.path.as_ref();
-                let Ok(rel_path) = diag_path.strip_prefix(&source_code_dir) else {
-                    warn!(
-                        "when working around driver file path issue, failed to strip prefix {} from {}",
-                        source_code_dir.display(),
-                        diag_path.display()
-                    );
-                    break 'fail_to_get_source;
-                };
-
-                let mbt_file_path = target_dir.join(rel_path);
-                diagnostic.path = mbt_file_path.display().to_string();
-            }
-        }
-
-        diagnostic.render_diagnostics(
-            use_fancy,
-            check_patch_file.as_ref(),
-            explain,
-            render_no_loc_level,
-        )
-    }
-
     fn get_content_and_filename_from_diagnostic_patch_file(
         patch_file: &Path,
         diagnostic_location_path: &str,
@@ -443,10 +378,9 @@ impl MooncDiagnostic {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
 
     #[test]
-    fn render_accepts_no_location_diagnostic_json() {
+    fn render_diagnostics_accepts_no_location_diagnostic_json() {
         // Stable compiler repro: run `moonc check` on any valid `.mbt` file and
         // pass that same existing non-`.mi` file to `-check-mi`. This emits a
         // no-location diagnostic with `path: ""` and `loc: "0:0-0:0"`.
@@ -455,15 +389,7 @@ mod tests {
         let diagnostic = serde_json_lenient::from_str::<MooncDiagnostic>(diagnostic_json).unwrap();
         assert!(diagnostic.path.is_empty());
 
-        let rendered = MooncDiagnostic::render(
-            diagnostic_json,
-            false,
-            None,
-            false,
-            DiagnosticLevel::Error,
-            Path::new("."),
-            Path::new("."),
-        );
+        let rendered = diagnostic.render_diagnostics(false, None, false, DiagnosticLevel::Error);
 
         assert!(rendered.is_some());
     }


### PR DESCRIPTION
## Summary

- Remap compiler-reported generated test-driver paths to their physical target-layout paths before diagnostic processing.
- Apply the mapping consistently to rendered, JSON, and `--no-render` output.
- Remove the obsolete `module.desc`/substring rendering workaround.
- Add regression coverage for generated-driver errors across all output styles.

## Why

`moonc` reports generated test drivers as if they were located under the package source directory, while Moon writes them under the configured target layout. The final renderer therefore attempted to read a path that did not exist, and raw/JSON diagnostics exposed the same incorrect location.

## Why this is correct

The mapping recognizes the generated-driver filename prefix, locates the owning package from the reported parent directory, and delegates physical placement to `TargetLayout::package_dir` while preserving the filename. This keeps target layout knowledge in one place and works with custom target directories and workspace layouts.

## Scope

This is a Moon-side diagnostic normalization change. It does not change compiler behavior or revive the old source-directory heuristic.