### PR TITLE
fix(moonrun): report memory leaks on exit

### DIFF
--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -22,11 +22,10 @@ To run a WebAssembly file:
 
 ## Memory Leak Reporting
 
-Set `MOONBIT_MEMORY_SANITIZER=1` to make `moonrun` report objects that were
-registered through `moonbit:ffi/memory-sanitizer` but not freed before the
-program returned. A detected leak is written to stderr with its allocation
-stack and makes `moonrun` exit unsuccessfully. Leak reporting is disabled when
-the environment variable is unset.
+When a program uses `moonbit:ffi/memory-sanitizer`, `moonrun` reports objects
+that were registered but not freed before the program returned. A detected leak
+is written to stderr with its allocation stack and makes `moonrun` exit
+unsuccessfully.
 
 ## Experimental Policy
 

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -20,6 +20,14 @@ To run a WebAssembly file:
 ./target/debug/moonrun path/to/your/file.wasm
 ```
 
+## Memory Leak Reporting
+
+Set `MOONBIT_MEMORY_SANITIZER=1` to make `moonrun` report objects that were
+registered through `moonbit:ffi/memory-sanitizer` but not freed before the
+program returned. A detected leak is written to stderr with its allocation
+stack and makes `moonrun` exit unsuccessfully. Leak reporting is disabled when
+the environment variable is unset.
+
 ## Experimental Policy
 
 By default, running `moonrun` without `--policy` preserves existing behavior.

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -361,7 +361,7 @@ fn init_env(
     wasm_file_name: &str,
     args: &[String],
     async_policy: Arc<async_policy::AsyncPolicy>,
-) {
+) -> memory_sanitizer_api::MemorySanitizer {
     let global_proxy = scope.get_current_context().global(scope);
 
     let print_env_box = Box::<PrintEnv>::default();
@@ -396,11 +396,11 @@ fn init_env(
         async_api::init_env(async_runtime, scope, dtors, Arc::clone(&async_policy));
     }
 
-    {
+    let memory_sanitizer = {
         let memory_sanitizer =
             global_proxy.child(scope, memory_sanitizer_api::MEMORY_SANITIZER_MODULE);
-        memory_sanitizer_api::init_env(memory_sanitizer, scope, dtors);
-    }
+        memory_sanitizer_api::init_env(memory_sanitizer, scope)
+    };
 
     {
         let wasi = global_proxy.child(scope, "__moonbit_wasi_unstable");
@@ -445,6 +445,8 @@ fn init_env(
         sys.set_func(scope, "exit", exit);
         sys.set_func(scope, "is_windows", is_windows);
     }
+
+    memory_sanitizer
 }
 
 fn create_script_origin<'s>(scope: &mut v8::HandleScope<'s>, name: &str) -> v8::ScriptOrigin<'s> {
@@ -511,7 +513,7 @@ fn wasm_mode(
         }
     }
     let mut dtors = Vec::new();
-    init_env(&mut dtors, scope, &wasm_file_name, args, async_policy);
+    let memory_sanitizer = init_env(&mut dtors, scope, &wasm_file_name, args, async_policy);
 
     if let Some(ref test_args) = test_args {
         let test_args = serde_json_lenient::from_str::<TestArgs>(test_args).unwrap();
@@ -544,6 +546,7 @@ fn wasm_mode(
 
     script.run(scope);
     drop(dtors);
+    memory_sanitizer.check_for_leaks_if_enabled()?;
     Ok(())
 }
 

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -361,7 +361,7 @@ fn init_env(
     wasm_file_name: &str,
     args: &[String],
     async_policy: Arc<async_policy::AsyncPolicy>,
-) -> memory_sanitizer_api::MemorySanitizer {
+) {
     let global_proxy = scope.get_current_context().global(scope);
 
     let print_env_box = Box::<PrintEnv>::default();
@@ -395,12 +395,6 @@ fn init_env(
         let async_runtime = global_proxy.child(scope, async_api::MOONBIT_ASYNC_MODULE);
         async_api::init_env(async_runtime, scope, dtors, Arc::clone(&async_policy));
     }
-
-    let memory_sanitizer = {
-        let memory_sanitizer =
-            global_proxy.child(scope, memory_sanitizer_api::MEMORY_SANITIZER_MODULE);
-        memory_sanitizer_api::init_env(memory_sanitizer, scope)
-    };
 
     {
         let wasi = global_proxy.child(scope, "__moonbit_wasi_unstable");
@@ -445,8 +439,6 @@ fn init_env(
         sys.set_func(scope, "exit", exit);
         sys.set_func(scope, "is_windows", is_windows);
     }
-
-    memory_sanitizer
 }
 
 fn create_script_origin<'s>(scope: &mut v8::HandleScope<'s>, name: &str) -> v8::ScriptOrigin<'s> {
@@ -512,8 +504,14 @@ fn wasm_mode(
             global_proxy.set(scope, bytes_key, u8arr.cast());
         }
     }
+    let memory_sanitizer = memory_sanitizer_api::MemorySanitizer::default();
+
     let mut dtors = Vec::new();
-    let memory_sanitizer = init_env(&mut dtors, scope, &wasm_file_name, args, async_policy);
+    init_env(&mut dtors, scope, &wasm_file_name, args, async_policy);
+
+    let memory_sanitizer_imports =
+        global_proxy.child(scope, memory_sanitizer_api::MEMORY_SANITIZER_MODULE);
+    memory_sanitizer_api::init_env(memory_sanitizer_imports, scope, &memory_sanitizer);
 
     if let Some(ref test_args) = test_args {
         let test_args = serde_json_lenient::from_str::<TestArgs>(test_args).unwrap();
@@ -546,7 +544,7 @@ fn wasm_mode(
 
     script.run(scope);
     drop(dtors);
-    memory_sanitizer.check_for_leaks_if_enabled()?;
+    memory_sanitizer.check_for_leaks()?;
     Ok(())
 }
 

--- a/crates/moonrun/src/memory_sanitizer_api.rs
+++ b/crates/moonrun/src/memory_sanitizer_api.rs
@@ -18,7 +18,6 @@
 
 //! Host-side `moonbit:ffi/memory-sanitizer` imports.
 
-use std::any::Any;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet};
 use std::rc::Rc;
@@ -26,6 +25,7 @@ use std::rc::Rc;
 use crate::v8_builder::ObjectExt;
 
 pub(crate) const MEMORY_SANITIZER_MODULE: &str = "moonbit:ffi/memory-sanitizer";
+const MEMORY_SANITIZER_ENV: &str = "MOONBIT_MEMORY_SANITIZER";
 
 #[derive(Debug)]
 struct ObjectRecord {
@@ -91,6 +91,70 @@ struct MemorySanitizerContext {
     state: RefCell<MemorySanitizerState>,
 }
 
+pub(crate) struct MemorySanitizer {
+    context: Box<MemorySanitizerContext>,
+}
+
+impl MemorySanitizer {
+    pub(crate) fn check_for_leaks_if_enabled(&self) -> Result<(), MemoryLeakError> {
+        if std::env::var_os(MEMORY_SANITIZER_ENV).is_none() {
+            return Ok(());
+        }
+
+        let state = self.context.state.borrow();
+        if state.live.is_empty() {
+            return Ok(());
+        }
+
+        Err(MemoryLeakError {
+            objects: state
+                .live
+                .iter()
+                .map(|(&ptr, record)| LeakedObject {
+                    ptr,
+                    size: record.size,
+                    alloc_stack: record.alloc_stack.as_ref().clone(),
+                })
+                .collect(),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct LeakedObject {
+    ptr: u32,
+    size: u32,
+    alloc_stack: SanitizerStack,
+}
+
+#[derive(Debug)]
+pub(crate) struct MemoryLeakError {
+    objects: Vec<LeakedObject>,
+}
+
+impl std::fmt::Display for MemoryLeakError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let total_size: u64 = self
+            .objects
+            .iter()
+            .map(|object| u64::from(object.size))
+            .sum();
+        write!(
+            f,
+            "moonrun memory sanitizer detected {} leaked object{} ({total_size} bytes)",
+            self.objects.len(),
+            if self.objects.len() == 1 { "" } else { "s" }
+        )?;
+        for object in &self.objects {
+            write!(f, "\nleaked object {} ({} bytes)", object.ptr, object.size)?;
+            object.alloc_stack.write_to(f, "allocation stack")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for MemoryLeakError {}
+
 #[derive(Debug)]
 enum MemorySanitizerError {
     BadArgument,
@@ -124,11 +188,9 @@ impl std::fmt::Display for MemorySanitizerError {
 pub(crate) fn init_env<'s>(
     obj: v8::Local<'s, v8::Object>,
     scope: &mut v8::HandleScope<'s>,
-    dtors: &mut Vec<Box<dyn Any>>,
-) {
+) -> MemorySanitizer {
     let context = Box::<MemorySanitizerContext>::default();
     let context_ptr = &*context as *const MemorySanitizerContext;
-    dtors.push(context);
 
     register_func(
         obj,
@@ -145,6 +207,8 @@ pub(crate) fn init_env<'s>(
         context_ptr,
     );
     register_func(obj, scope, "object-is-valid", object_is_valid, context_ptr);
+
+    MemorySanitizer { context }
 }
 
 fn register_func<'s>(
@@ -218,7 +282,7 @@ fn callback_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s MemoryS
     unsafe { &*(ptr as *const MemorySanitizerContext) }
 }
 
-#[derive(Debug, Default, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Default, Eq, Hash, PartialEq)]
 struct SanitizerStack {
     frames: Vec<SanitizerStackFrame>,
 }
@@ -257,7 +321,7 @@ impl SanitizerStack {
     }
 }
 
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
 struct SanitizerStackFrame {
     raw_function: String,
     is_wasm: bool,

--- a/crates/moonrun/src/memory_sanitizer_api.rs
+++ b/crates/moonrun/src/memory_sanitizer_api.rs
@@ -20,12 +20,12 @@
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet};
+use std::fmt::Write as _;
 use std::rc::Rc;
 
 use crate::v8_builder::ObjectExt;
 
 pub(crate) const MEMORY_SANITIZER_MODULE: &str = "moonbit:ffi/memory-sanitizer";
-const MEMORY_SANITIZER_ENV: &str = "MOONBIT_MEMORY_SANITIZER";
 
 #[derive(Debug)]
 struct ObjectRecord {
@@ -91,69 +91,38 @@ struct MemorySanitizerContext {
     state: RefCell<MemorySanitizerState>,
 }
 
+#[derive(Default)]
 pub(crate) struct MemorySanitizer {
     context: Box<MemorySanitizerContext>,
 }
 
 impl MemorySanitizer {
-    pub(crate) fn check_for_leaks_if_enabled(&self) -> Result<(), MemoryLeakError> {
-        if std::env::var_os(MEMORY_SANITIZER_ENV).is_none() {
-            return Ok(());
-        }
-
+    pub(crate) fn check_for_leaks(&self) -> anyhow::Result<()> {
         let state = self.context.state.borrow();
         if state.live.is_empty() {
             return Ok(());
         }
 
-        Err(MemoryLeakError {
-            objects: state
-                .live
-                .iter()
-                .map(|(&ptr, record)| LeakedObject {
-                    ptr,
-                    size: record.size,
-                    alloc_stack: record.alloc_stack.as_ref().clone(),
-                })
-                .collect(),
-        })
-    }
-}
-
-#[derive(Debug)]
-struct LeakedObject {
-    ptr: u32,
-    size: u32,
-    alloc_stack: SanitizerStack,
-}
-
-#[derive(Debug)]
-pub(crate) struct MemoryLeakError {
-    objects: Vec<LeakedObject>,
-}
-
-impl std::fmt::Display for MemoryLeakError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let total_size: u64 = self
-            .objects
-            .iter()
+        let total_size: u64 = state
+            .live
+            .values()
             .map(|object| u64::from(object.size))
             .sum();
-        write!(
-            f,
+        let mut report = format!(
             "moonrun memory sanitizer detected {} leaked object{} ({total_size} bytes)",
-            self.objects.len(),
-            if self.objects.len() == 1 { "" } else { "s" }
-        )?;
-        for object in &self.objects {
-            write!(f, "\nleaked object {} ({} bytes)", object.ptr, object.size)?;
-            object.alloc_stack.write_to(f, "allocation stack")?;
+            state.live.len(),
+            if state.live.len() == 1 { "" } else { "s" }
+        );
+        for (&ptr, object) in &state.live {
+            write!(&mut report, "\nleaked object {ptr} ({} bytes)", object.size).unwrap();
+            object
+                .alloc_stack
+                .write_to(&mut report, "allocation stack")
+                .unwrap();
         }
-        Ok(())
+        Err(anyhow::anyhow!(report))
     }
 }
-
-impl std::error::Error for MemoryLeakError {}
 
 #[derive(Debug)]
 enum MemorySanitizerError {
@@ -188,10 +157,9 @@ impl std::fmt::Display for MemorySanitizerError {
 pub(crate) fn init_env<'s>(
     obj: v8::Local<'s, v8::Object>,
     scope: &mut v8::HandleScope<'s>,
-) -> MemorySanitizer {
-    let context = Box::<MemorySanitizerContext>::default();
-    let context_ptr = &*context as *const MemorySanitizerContext;
-
+    memory_sanitizer: &MemorySanitizer,
+) {
+    let context_ptr = &*memory_sanitizer.context as *const MemorySanitizerContext;
     register_func(
         obj,
         scope,
@@ -207,8 +175,6 @@ pub(crate) fn init_env<'s>(
         context_ptr,
     );
     register_func(obj, scope, "object-is-valid", object_is_valid, context_ptr);
-
-    MemorySanitizer { context }
 }
 
 fn register_func<'s>(
@@ -282,7 +248,7 @@ fn callback_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s MemoryS
     unsafe { &*(ptr as *const MemorySanitizerContext) }
 }
 
-#[derive(Debug, Clone, Default, Eq, Hash, PartialEq)]
+#[derive(Debug, Default, Eq, Hash, PartialEq)]
 struct SanitizerStack {
     frames: Vec<SanitizerStackFrame>,
 }
@@ -301,7 +267,7 @@ impl SanitizerStack {
         Self { frames }
     }
 
-    fn write_to(&self, f: &mut std::fmt::Formatter<'_>, title: &str) -> std::fmt::Result {
+    fn write_to(&self, f: &mut impl std::fmt::Write, title: &str) -> std::fmt::Result {
         if self.frames.is_empty() {
             return Ok(());
         }
@@ -321,7 +287,7 @@ impl SanitizerStack {
     }
 }
 
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 struct SanitizerStackFrame {
     raw_function: String,
     is_wasm: bool,

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -19,6 +19,7 @@
 use std::{path::PathBuf, sync::OnceLock};
 
 const MOONBIT_ASYNC_CHECK_FD_LEAK: &str = "MOONBIT_ASYNC_CHECK_FD_LEAK";
+const MOONBIT_MEMORY_SANITIZER: &str = "MOONBIT_MEMORY_SANITIZER";
 
 fn moon_cmd() -> snapbox::cmd::Command {
     snapbox::cmd::Command::new(moon_bin())
@@ -410,6 +411,7 @@ fn test_moon_run_with_memory_sanitizer_imports() {
     let wasm_file = dir.join("_build/wasm/debug/build/main/main.wasm");
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .env(MOONBIT_MEMORY_SANITIZER, "1")
         .arg(&wasm_file)
         .assert()
         .success()
@@ -468,6 +470,58 @@ Error: moonbit:ffi/memory-sanitizer.register-object-free failed: invalid object 
     at @moonbit/ffi-memory-sanitizer-test/memory_sanitizer.register_object_free
     at @moonbit/ffi-memory-sanitizer-test/double_free.free_twice
     at @__moonbit_main
+...
+"#]]);
+}
+
+#[test]
+fn test_moon_run_memory_sanitizer_leak_reporting_is_opt_in() {
+    let dir = TestDir::new("test_memory_sanitizer.in");
+
+    moon_cmd()
+        .current_dir(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success();
+
+    let wasm_file = dir.join("_build/wasm/debug/build/leak/leak.wasm");
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .env_remove(MOONBIT_MEMORY_SANITIZER)
+        .arg(&wasm_file)
+        .assert()
+        .success()
+        .stdout_eq("")
+        .stderr_eq("");
+}
+
+#[test]
+fn test_moon_run_memory_sanitizer_reports_leaked_object() {
+    let dir = TestDir::new("test_memory_sanitizer.in");
+
+    moon_cmd()
+        .current_dir(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success();
+
+    let wasm_file = dir.join("_build/wasm/debug/build/leak/leak.wasm");
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .env(MOONBIT_MEMORY_SANITIZER, "1")
+        .arg(&wasm_file)
+        .assert()
+        .failure()
+        .stdout_eq("")
+        .stderr_eq(snapbox::str![[r#"
+Error: moonrun memory sanitizer detected 1 leaked object (16 bytes)
+leaked object 8192 (16 bytes)
+allocation stack:
+    at @moonbit/ffi-memory-sanitizer-test/memory_sanitizer.host_register_object_alloc
+    at @moonbit/ffi-memory-sanitizer-test/memory_sanitizer.register_object_alloc
+    at @moonbit/ffi-memory-sanitizer-test/leak.leak_object
+    at @__moonbit_main
+    at <anonymous>
 ...
 "#]]);
 }

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -19,7 +19,6 @@
 use std::{path::PathBuf, sync::OnceLock};
 
 const MOONBIT_ASYNC_CHECK_FD_LEAK: &str = "MOONBIT_ASYNC_CHECK_FD_LEAK";
-const MOONBIT_MEMORY_SANITIZER: &str = "MOONBIT_MEMORY_SANITIZER";
 
 fn moon_cmd() -> snapbox::cmd::Command {
     snapbox::cmd::Command::new(moon_bin())
@@ -411,7 +410,6 @@ fn test_moon_run_with_memory_sanitizer_imports() {
     let wasm_file = dir.join("_build/wasm/debug/build/main/main.wasm");
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
-        .env(MOONBIT_MEMORY_SANITIZER, "1")
         .arg(&wasm_file)
         .assert()
         .success()
@@ -475,7 +473,7 @@ Error: moonbit:ffi/memory-sanitizer.register-object-free failed: invalid object 
 }
 
 #[test]
-fn test_moon_run_memory_sanitizer_leak_reporting_is_opt_in() {
+fn test_moon_run_memory_sanitizer_reports_leaks() {
     let dir = TestDir::new("test_memory_sanitizer.in");
 
     moon_cmd()
@@ -487,28 +485,6 @@ fn test_moon_run_memory_sanitizer_leak_reporting_is_opt_in() {
     let wasm_file = dir.join("_build/wasm/debug/build/leak/leak.wasm");
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
-        .env_remove(MOONBIT_MEMORY_SANITIZER)
-        .arg(&wasm_file)
-        .assert()
-        .success()
-        .stdout_eq("")
-        .stderr_eq("");
-}
-
-#[test]
-fn test_moon_run_memory_sanitizer_reports_leaked_object() {
-    let dir = TestDir::new("test_memory_sanitizer.in");
-
-    moon_cmd()
-        .current_dir(&dir)
-        .args(["build", "--target", "wasm"])
-        .assert()
-        .success();
-
-    let wasm_file = dir.join("_build/wasm/debug/build/leak/leak.wasm");
-
-    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
-        .env(MOONBIT_MEMORY_SANITIZER, "1")
         .arg(&wasm_file)
         .assert()
         .failure()

--- a/crates/moonrun/tests/test_cases/test_memory_sanitizer.in/leak/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_memory_sanitizer.in/leak/main.mbt
@@ -1,0 +1,27 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+///|
+fn leak_object(ptr : UInt) -> Unit {
+  @memory_sanitizer.register_object_alloc(16U, ptr)
+}
+
+///|
+fn main {
+  leak_object(8192U)
+}

--- a/crates/moonrun/tests/test_cases/test_memory_sanitizer.in/leak/moon.pkg.json
+++ b/crates/moonrun/tests/test_cases/test_memory_sanitizer.in/leak/moon.pkg.json
@@ -1,0 +1,6 @@
+{
+  "is-main": true,
+  "import": [
+    "moonbit/ffi-memory-sanitizer-test/memory_sanitizer"
+  ]
+}


### PR DESCRIPTION
## Summary

- report objects still live when a program using `moonbit:ffi/memory-sanitizer` returns
- include leaked object counts, total bytes, addresses, sizes, and demangled allocation stacks
- add focused CLI regression coverage and document the behavior

## Why

moonrun already tracked live allocations registered through `moonbit:ffi/memory-sanitizer`, but it discarded that state when a Wasm program returned. As a result, duplicate allocations and invalid frees were diagnosed while actual unfreed allocations exited successfully.

## Why this is correct

The sanitizer context now stays alive through Wasm execution and is checked after the program returns normally. A balanced allocation path still succeeds, while any remaining registered objects produce a diagnostic on stderr and an unsuccessful exit. Duplicate-allocation and invalid-free behavior remains unchanged.

## Scope

The change is limited to moonrun's memory-sanitizer host integration, its focused fixture, and user-facing documentation. It does not add configuration or change the async host leak checks.