### PR TITLE
Remove deprecated --manifest-path option

### DIFF
--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -234,7 +234,7 @@ fn cram_external_args(raw_args: &[OsString]) -> Option<(Option<PathBuf>, Vec<OsS
             }
         } else if matches!(
             arg.to_str(),
-            Some("--manifest-path" | "--target-dir" | "--unstable-feature" | "-Z")
+            Some("--target-dir" | "--unstable-feature" | "-Z")
         ) {
             index += 1;
         } else if is_global_bool_arg(arg) {

--- a/crates/moon/src/cli/mooncake_adapter.rs
+++ b/crates/moon/src/cli/mooncake_adapter.rs
@@ -19,12 +19,9 @@
 use std::process::{Command, Stdio};
 
 use anyhow::bail;
-use moonutil::{
-    cli_support::{
-        LoginSubcommand, MooncakeSubcommands, PackageSubcommand, PublishSubcommand,
-        RegisterSubcommand, UniversalFlags,
-    },
-    constants::{MOON_MOD, MOON_MOD_JSON},
+use moonutil::cli_support::{
+    LoginSubcommand, MooncakeSubcommands, PackageSubcommand, PublishSubcommand, RegisterSubcommand,
+    UniversalFlags,
 };
 use serde::Serialize;
 
@@ -126,126 +123,12 @@ fn single_module_mooncake_cli(
 ) -> anyhow::Result<UniversalFlags> {
     let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
     let project = query.project()?;
-    let module_dir = project
-        .selected_module()
-        .map(|module| module.root.clone())
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "`moon {command}` cannot infer a target module in workspace `{}`. Run it from a workspace member or use `moon -C <member> {command} ...`.",
-                project.root().display(),
-            )
-        })?;
+    if project.selected_module().is_none() {
+        bail!(
+            "`moon {command}` cannot infer a target module in workspace `{}`. Run it from a workspace member or use `moon -C <member> {command} ...`.",
+            project.root().display(),
+        );
+    }
     cli.source_tgt_dir.cwd = None;
-    cli.source_tgt_dir.manifest_path = Some(if module_dir.join(MOON_MOD).exists() {
-        module_dir.join(MOON_MOD)
-    } else {
-        module_dir.join(MOON_MOD_JSON)
-    });
     Ok(cli)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::single_module_mooncake_cli;
-    use moonutil::{
-        cli_support::UniversalFlags,
-        constants::{MOON_MOD, MOON_MOD_JSON},
-        project::{SourceTargetDirs, WorkspaceEnv},
-    };
-    use std::path::Path;
-
-    fn write_file(path: &Path, content: &str) {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).unwrap();
-        }
-        std::fs::write(path, content).unwrap();
-    }
-
-    #[test]
-    fn single_module_mooncake_cli_targets_the_selected_member_manifest() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
-        let member = root.join("app");
-        write_file(&root.join("moon.work"), "members = [\n  \"./app\",\n]\n");
-        write_file(
-            &member.join(MOON_MOD),
-            "name = \"alice/app\"\n\nversion = \"0.1.0\"\n",
-        );
-
-        let cli = UniversalFlags {
-            source_tgt_dir: SourceTargetDirs {
-                cwd: None,
-                manifest_path: Some(member.join(MOON_MOD)),
-                target_dir: None,
-            },
-            quiet: false,
-            verbose: false,
-            trace: false,
-            dry_run: false,
-            build_graph: false,
-            workspace_env: WorkspaceEnv::Auto,
-            unstable_feature: Box::default(),
-        };
-
-        let cli = single_module_mooncake_cli(cli, "package").unwrap();
-        let actual_manifest_path = cli
-            .source_tgt_dir
-            .manifest_path
-            .as_ref()
-            .map(dunce::canonicalize)
-            .unwrap()
-            .unwrap();
-        let expected_manifest_path = member.join(MOON_MOD);
-
-        assert_eq!(cli.source_tgt_dir.cwd, None);
-        assert_eq!(
-            actual_manifest_path,
-            dunce::canonicalize(expected_manifest_path).unwrap()
-        );
-        assert_eq!(cli.source_tgt_dir.target_dir, None);
-    }
-
-    #[test]
-    fn single_module_mooncake_cli_falls_back_to_json_manifest() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
-        let member = root.join("app");
-        write_file(&root.join("moon.work"), "members = [\n  \"./app\",\n]\n");
-        write_file(
-            &member.join(MOON_MOD_JSON),
-            "{\n  \"name\": \"alice/app\",\n  \"version\": \"0.1.0\"\n}\n",
-        );
-
-        let cli = UniversalFlags {
-            source_tgt_dir: SourceTargetDirs {
-                cwd: None,
-                manifest_path: Some(member.join(MOON_MOD_JSON)),
-                target_dir: None,
-            },
-            quiet: false,
-            verbose: false,
-            trace: false,
-            dry_run: false,
-            build_graph: false,
-            workspace_env: WorkspaceEnv::Auto,
-            unstable_feature: Box::default(),
-        };
-
-        let cli = single_module_mooncake_cli(cli, "package").unwrap();
-        let actual_manifest_path = cli
-            .source_tgt_dir
-            .manifest_path
-            .as_ref()
-            .map(dunce::canonicalize)
-            .unwrap()
-            .unwrap();
-        let expected_manifest_path = member.join(MOON_MOD_JSON);
-
-        assert_eq!(cli.source_tgt_dir.cwd, None);
-        assert_eq!(
-            actual_manifest_path,
-            dunce::canonicalize(expected_manifest_path).unwrap()
-        );
-        assert_eq!(cli.source_tgt_dir.target_dir, None);
-    }
 }

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -309,15 +309,6 @@ fn run_source_as_single_file(
     result
 }
 
-fn reject_manifest_path_for_run(cli: &UniversalFlags) -> anyhow::Result<()> {
-    if cli.source_tgt_dir.manifest_path.is_some() {
-        bail!(
-            "`--manifest-path` is no longer supported for `moon run`. Use `moon -C <project-dir> run ...` instead."
-        );
-    }
-    Ok(())
-}
-
 fn resolve_run_start_dir(input: &str) -> anyhow::Result<std::path::PathBuf> {
     let input_path =
         dunce::canonicalize(input).with_context(|| format!("failed to resolve path `{input}`"))?;
@@ -372,8 +363,6 @@ fn build_wasm_file_executable_from_arg(
 
 #[instrument(skip_all)]
 pub(crate) fn run_run(cli: &UniversalFlags, cmd: RunSubcommand) -> anyhow::Result<i32> {
-    reject_manifest_path_for_run(cli)?;
-
     if cmd.profile {
         return super::profile::run_profiled_run(cli, cmd);
     }

--- a/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_bash.stdout
@@ -409,17 +409,13 @@ _moon() {
 
     case "${cmd}" in
         moon)
-            opts="-V -C -q -v -Z -h --version --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --unstable-feature --help new bundle build check prove run runwasm test cram generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help"
+            opts="-V -C -q -v -Z -h --version --target-dir --quiet --verbose --trace --dry-run --build-graph --unstable-feature --help new bundle build check prove run runwasm test cram generate-test-driver clean fmt doc explain info bench add remove install tree fetch work login whoami register publish package update coverage generate-build-matrix upgrade shell-completion version tool ide help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 -C)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --manifest-path)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -443,16 +439,12 @@ _moon() {
             return 0
             ;;
         moon__add)
-            opts="-u -q -v -h --bin --upgrade --no-update --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help <MODULE>"
+            opts="-u -q -v -h --bin --upgrade --no-update --target-dir --quiet --verbose --trace --dry-run --build-graph --help <MODULE>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -465,7 +457,7 @@ _moon() {
             return 0
             ;;
         moon__bench)
-            opts="-g -d -j -p -f -i -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --package --file --index --frozen --build-only --no-parallelize --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
+            opts="-g -d -j -p -f -i -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --package --file --index --frozen --build-only --no-parallelize --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -519,10 +511,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -535,7 +523,7 @@ _moon() {
             return 0
             ;;
         moon__build)
-            opts="-g -d -j -w -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --frozen --watch --package --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
+            opts="-g -d -j -w -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --frozen --watch --package --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -569,10 +557,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -585,7 +569,7 @@ _moon() {
             return 0
             ;;
         moon__bundle)
-            opts="-g -d -j -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --all --frozen --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-g -d -j -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --all --frozen --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -615,10 +599,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -631,7 +611,7 @@ _moon() {
             return 0
             ;;
         moon__check)
-            opts="-g -d -j -w -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --frozen --watch --package-path --patch-file --explain --fmt --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
+            opts="-g -d -j -w -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --frozen --watch --package-path --patch-file --explain --fmt --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -669,10 +649,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -685,16 +661,12 @@ _moon() {
             return 0
             ;;
         moon__clean)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -707,16 +679,12 @@ _moon() {
             return 0
             ;;
         moon__coverage)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help analyze report clean help"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help analyze report clean help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -729,7 +697,7 @@ _moon() {
             return 0
             ;;
         moon__coverage__analyze)
-            opts="-p -t -q -v -h --package --test-flag --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [EXTRA_FLAGS]..."
+            opts="-p -t -q -v -h --package --test-flag --target-dir --quiet --verbose --trace --dry-run --build-graph --help [EXTRA_FLAGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -751,10 +719,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -767,16 +731,12 @@ _moon() {
             return 0
             ;;
         moon__coverage__clean)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -859,16 +819,12 @@ _moon() {
             return 0
             ;;
         moon__coverage__report)
-            opts="-h -q -v --help --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph [args]..."
+            opts="-h -q -v --help --target-dir --quiet --verbose --trace --dry-run --build-graph [args]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -881,16 +837,12 @@ _moon() {
             return 0
             ;;
         moon__cram)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help test"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help test"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -903,7 +855,7 @@ _moon() {
             return 0
             ;;
         moon__cram__test)
-            opts="-q -v -h --release --target --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [SCRUT_ARGS]..."
+            opts="-q -v -h --release --target --target-dir --quiet --verbose --trace --dry-run --build-graph --help [SCRUT_ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -911,10 +863,6 @@ _moon() {
             case "${prev}" in
                 --target)
                     COMPREPLY=($(compgen -W "native" -- "${cur}"))
-                    return 0
-                    ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --target-dir)
@@ -929,7 +877,7 @@ _moon() {
             return 0
             ;;
         moon__doc)
-            opts="-b -p -q -v -h --serve --bind --port --frozen --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [SYMBOL]"
+            opts="-b -p -q -v -h --serve --bind --port --frozen --target-dir --quiet --verbose --trace --dry-run --build-graph --help [SYMBOL]"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -951,10 +899,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -967,7 +911,7 @@ _moon() {
             return 0
             ;;
         moon__explain)
-            opts="-q -v -h --diagnostic --attribute --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --diagnostic --attribute --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -978,10 +922,6 @@ _moon() {
                     return 0
                     ;;
                 --attribute)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --manifest-path)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -997,16 +937,12 @@ _moon() {
             return 0
             ;;
         moon__fetch)
-            opts="-q -v -h --no-update --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help <MODULE[@VERSION]>"
+            opts="-q -v -h --no-update --target-dir --quiet --verbose --trace --dry-run --build-graph --help <MODULE[@VERSION]>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -1019,16 +955,12 @@ _moon() {
             return 0
             ;;
         moon__fmt)
-            opts="-q -v -h --check --sort-input --warn --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]... [ARGS]..."
+            opts="-q -v -h --check --sort-input --warn --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]... [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -1041,7 +973,7 @@ _moon() {
             return 0
             ;;
         moon__generate__build__matrix)
-            opts="-n -o -q -v -h --drow --dcol --mrow --mcol --output-dir --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-n -o -q -v -h --drow --dcol --mrow --mcol --output-dir --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1075,10 +1007,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -1091,7 +1019,7 @@ _moon() {
             return 0
             ;;
         moon__generate__test__driver)
-            opts="-q -v -h --doctest-only --output-driver --output-metadata --target --pkg-name --bench --enable-coverage --coverage-package-override --driver-kind --patch-file --max-concurrent-tests --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [FILES]..."
+            opts="-q -v -h --doctest-only --output-driver --output-metadata --target --pkg-name --bench --enable-coverage --coverage-package-override --driver-kind --patch-file --max-concurrent-tests --target-dir --quiet --verbose --trace --dry-run --build-graph --help [FILES]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1130,10 +1058,6 @@ _moon() {
                     return 0
                     ;;
                 --max-concurrent-tests)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --manifest-path)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -2075,7 +1999,7 @@ _moon() {
             return 0
             ;;
         moon__info)
-            opts="-p -q -v -h --frozen --no-alias --target --package --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
+            opts="-p -q -v -h --frozen --no-alias --target --package --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2093,10 +2017,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2109,7 +2029,7 @@ _moon() {
             return 0
             ;;
         moon__install)
-            opts="-q -v -h --bin --path --rev --branch --tag --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [SOURCE] [PATH_IN_REPO]"
+            opts="-q -v -h --bin --path --rev --branch --tag --target-dir --quiet --verbose --trace --dry-run --build-graph --help [SOURCE] [PATH_IN_REPO]"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2135,10 +2055,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2151,16 +2067,12 @@ _moon() {
             return 0
             ;;
         moon__login)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2173,7 +2085,7 @@ _moon() {
             return 0
             ;;
         moon__new)
-            opts="-q -v -h --user --name --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help <PATH>"
+            opts="-q -v -h --user --name --target-dir --quiet --verbose --trace --dry-run --build-graph --help <PATH>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2184,10 +2096,6 @@ _moon() {
                     return 0
                     ;;
                 --name)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --manifest-path)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -2203,16 +2111,12 @@ _moon() {
             return 0
             ;;
         moon__package)
-            opts="-q -v -h --frozen --list --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --frozen --list --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2225,7 +2129,7 @@ _moon() {
             return 0
             ;;
         moon__prove)
-            opts="-d -j -q -v -h --why3-config --frozen --deny-warn --no-render --output-json --warn-list --jobs --render-no-loc --diagnostic-limit --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]"
+            opts="-d -j -q -v -h --why3-config --frozen --deny-warn --no-render --output-json --warn-list --jobs --render-no-loc --diagnostic-limit --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2255,10 +2159,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2271,16 +2171,12 @@ _moon() {
             return 0
             ;;
         moon__publish)
-            opts="-q -v -h --frozen --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --frozen --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2293,16 +2189,12 @@ _moon() {
             return 0
             ;;
         moon__register)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2315,16 +2207,12 @@ _moon() {
             return 0
             ;;
         moon__remove)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help <MODULE>"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help <MODULE>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2337,7 +2225,7 @@ _moon() {
             return 0
             ;;
         moon__run)
-            opts="-e -g -d -j -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --frozen --build-only --profile --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PACKAGE_OR_MBT_FILE] [ARGS]..."
+            opts="-e -g -d -j -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --frozen --build-only --profile --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PACKAGE_OR_MBT_FILE] [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2371,10 +2259,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2387,17 +2271,13 @@ _moon() {
             return 0
             ;;
         moon__runwasm)
-            opts="-q -v -h --experimental-policy --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help <LOCAL_PACKAGE|PACKAGE[@VERSION]> [ARGS]..."
+            opts="-q -v -h --experimental-policy --target-dir --quiet --verbose --trace --dry-run --build-graph --help <LOCAL_PACKAGE|PACKAGE[@VERSION]> [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --experimental-policy)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --manifest-path)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -2413,7 +2293,7 @@ _moon() {
             return 0
             ;;
         moon__shell__completion)
-            opts="-q -v -h --shell --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --shell --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2421,10 +2301,6 @@ _moon() {
             case "${prev}" in
                 --shell)
                     COMPREPLY=($(compgen -W "bash elvish fish powershell zsh" -- "${cur}"))
-                    return 0
-                    ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --target-dir)
@@ -2439,7 +2315,7 @@ _moon() {
             return 0
             ;;
         moon__test)
-            opts="-g -d -j -p -i -u -l -f -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --package --file --index --doc-index --update --limit --frozen --build-only --profile --no-parallelize --outline --test-failure-json --patch-file --doc --include-skipped --filter --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
+            opts="-g -d -j -p -i -u -l -f -q -v -h --std --nostd --debug --release --strip --no-strip --target --serial --enable-coverage --sort-input --output-wat --deny-warn --no-render --output-json --warn-list --enable-value-tracing --jobs --render-no-loc --diagnostic-limit --package --file --index --doc-index --update --limit --frozen --build-only --profile --no-parallelize --outline --test-failure-json --patch-file --doc --include-skipped --filter --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATH]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2513,10 +2389,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2529,16 +2401,12 @@ _moon() {
             return 0
             ;;
         moon__tool)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help format-and-diff format-workspace embed write-tcc-rsp-file build-binary-dep demangle help"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help format-and-diff format-workspace embed write-tcc-rsp-file build-binary-dep demangle help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2551,17 +2419,13 @@ _moon() {
             return 0
             ;;
         moon__tool__build__binary__dep)
-            opts="-q -v -h --all-pkgs --install-path --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PKG_NAMES]..."
+            opts="-q -v -h --all-pkgs --install-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PKG_NAMES]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --install-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --manifest-path)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -2577,16 +2441,12 @@ _moon() {
             return 0
             ;;
         moon__tool__demangle)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help <NAME>..."
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help <NAME>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2599,7 +2459,7 @@ _moon() {
             return 0
             ;;
         moon__tool__embed)
-            opts="-i -o -q -v -h --binary --text --input --output --name --timestamp --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-i -o -q -v -h --binary --text --input --output --name --timestamp --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2625,10 +2485,6 @@ _moon() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2641,7 +2497,7 @@ _moon() {
             return 0
             ;;
         moon__tool__format__and__diff)
-            opts="-q -v -h --old --new --warn --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [ARGS]..."
+            opts="-q -v -h --old --new --warn --target-dir --quiet --verbose --trace --dry-run --build-graph --help [ARGS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2652,10 +2508,6 @@ _moon() {
                     return 0
                     ;;
                 --new)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --manifest-path)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -2671,7 +2523,7 @@ _moon() {
             return 0
             ;;
         moon__tool__format__workspace)
-            opts="-w -q -v -h --old --new --write --check --warn --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-w -q -v -h --old --new --write --check --warn --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2682,10 +2534,6 @@ _moon() {
                     return 0
                     ;;
                 --new)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --manifest-path)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -2813,16 +2661,12 @@ _moon() {
             return 0
             ;;
         moon__tool__write__tcc__rsp__file)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help <OUTPUT> [args]..."
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help <OUTPUT> [args]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2835,16 +2679,12 @@ _moon() {
             return 0
             ;;
         moon__tree)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2857,16 +2697,12 @@ _moon() {
             return 0
             ;;
         moon__update)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2879,17 +2715,13 @@ _moon() {
             return 0
             ;;
         moon__upgrade)
-            opts="-f -q -v -h --force --dev --non-interactive --base-url --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-f -q -v -h --force --dev --non-interactive --base-url --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --base-url)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --manifest-path)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -2905,16 +2737,12 @@ _moon() {
             return 0
             ;;
         moon__version)
-            opts="-q -v -h --all --json --no-path --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --all --json --no-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2927,16 +2755,12 @@ _moon() {
             return 0
             ;;
         moon__whoami)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -2949,16 +2773,12 @@ _moon() {
             return 0
             ;;
         moon__work)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help init use sync help"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help init use sync help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -3041,16 +2861,12 @@ _moon() {
             return 0
             ;;
         moon__work__init)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATHS]..."
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help [PATHS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -3063,16 +2879,12 @@ _moon() {
             return 0
             ;;
         moon__work__sync)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -3085,16 +2897,12 @@ _moon() {
             return 0
             ;;
         moon__work__use)
-            opts="-q -v -h --manifest-path --target-dir --quiet --verbose --trace --dry-run --build-graph --help <PATHS>..."
+            opts="-q -v -h --target-dir --quiet --verbose --trace --dry-run --build-graph --help <PATHS>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --manifest-path)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --target-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0

--- a/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_elvish.stdout
@@ -19,7 +19,6 @@ set edit:completion:arg-completer[moon] = {|@words|
     var completions = [
         &'moon'= {
             cand -C 'Change to DIR before doing anything else (must appear before the subcommand). Relative paths in other options and arguments are interpreted relative to DIR. Example: `moon -C a run .` runs the same as invoking `moon run .` from within `a`'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -Z 'Unstable flags to MoonBuild'
             cand --unstable-feature 'Unstable flags to MoonBuild'
@@ -74,7 +73,6 @@ set edit:completion:arg-completer[moon] = {|@words|
         &'moon;new'= {
             cand --user 'The username of the module. Default to the logged-in username'
             cand --name 'The name of the module. Default to the last part of the path'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -93,7 +91,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --jobs 'Set the max number of jobs to run in parallel'
             cand --render-no-loc 'Render no-location diagnostics starting from a certain level'
             cand --diagnostic-limit 'Limit the number of rendered diagnostics'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --std 'Enable the standard library (default)'
             cand --nostd 'Disable the standard library'
@@ -131,7 +128,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --render-no-loc 'Render no-location diagnostics starting from a certain level'
             cand --diagnostic-limit 'Limit the number of rendered diagnostics'
             cand --package 'package'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --std 'Enable the standard library (default)'
             cand --nostd 'Disable the standard library'
@@ -171,7 +167,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --diagnostic-limit 'Limit the number of rendered diagnostics'
             cand --package-path 'Legacy package directory path relative to the module source root (`source` in `moon.mod.json`)'
             cand --patch-file 'The patch file to check. Only valid when the selector resolves to a single package'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --std 'Enable the standard library (default)'
             cand --nostd 'Disable the standard library'
@@ -211,7 +206,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --jobs 'Set the max number of jobs to run in parallel'
             cand --render-no-loc 'Render no-location diagnostics starting from a certain level'
             cand --diagnostic-limit 'Limit the number of rendered diagnostics'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --frozen 'Do not sync dependencies, assuming local dependencies are up-to-date'
             cand -d 'Treat all warnings as errors'
@@ -236,7 +230,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --jobs 'Set the max number of jobs to run in parallel'
             cand --render-no-loc 'Render no-location diagnostics starting from a certain level'
             cand --diagnostic-limit 'Limit the number of rendered diagnostics'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --std 'Enable the standard library (default)'
             cand --nostd 'Disable the standard library'
@@ -269,7 +262,6 @@ set edit:completion:arg-completer[moon] = {|@words|
         }
         &'moon;runwasm'= {
             cand --experimental-policy 'Experimental: pass a moonrun TOML policy file for moonbitlang/async runtime access'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -299,7 +291,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --patch-file 'Path to the patch file'
             cand -f 'Run only tests whose name matches the given glob pattern. Supports ''*'' (matches any sequence) and ''?'' (matches any single character)'
             cand --filter 'Run only tests whose name matches the given glob pattern. Supports ''*'' (matches any sequence) and ''?'' (matches any single character)'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --std 'Enable the standard library (default)'
             cand --nostd 'Disable the standard library'
@@ -338,7 +329,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;cram'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -353,7 +343,6 @@ set edit:completion:arg-completer[moon] = {|@words|
         }
         &'moon;cram;test'= {
             cand --target 'Native is the only target supported by cram test'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --release 'Build native release executables'
             cand -q 'Suppress output'
@@ -376,7 +365,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --driver-kind 'The test driver kind'
             cand --patch-file 'Path to the patch file'
             cand --max-concurrent-tests 'Max concurrent tests for `async test`'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --bench 'Whether to generate the test driver in bench mode. Not providing this option will result in test mode'
             cand --enable-coverage 'Whether coverage is enabled in this build. Enabling it will insert coverage-custom code at the end of the test..'
@@ -391,7 +379,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;clean'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -404,7 +391,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;fmt'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --check 'Check only and don''t change the source code'
             cand --sort-input 'Sort input files'
@@ -424,7 +410,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --bind 'The address of the server'
             cand -p 'The port of the server'
             cand --port 'The port of the server'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --serve 'Start a web server to serve the documentation'
             cand --frozen 'Do not sync dependencies, assuming local dependencies are up-to-date'
@@ -441,7 +426,6 @@ set edit:completion:arg-completer[moon] = {|@words|
         &'moon;explain'= {
             cand --diagnostic 'Explain diagnostics. Without a query, list diagnostic codes and names'
             cand --attribute 'Explain attributes. Without a query, list attribute names'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -457,7 +441,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --target 'Inspect one or more target backends without changing the canonical `pkg.generated.mbti` output'
             cand -p 'The full or subset of name of the package to emit `mbti` files for'
             cand --package 'The full or subset of name of the package to emit `mbti` files for'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --frozen 'Do not sync dependencies, assuming local dependencies are up-to-date'
             cand --no-alias 'Do not use alias to shorten package names in the output'
@@ -484,7 +467,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --file 'Run benchmarks in the specified file. Only valid when `--package` is also specified'
             cand -i 'Run only the index-th benchmark in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when a single file is selected'
             cand --index 'Run only the index-th benchmark in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when a single file is selected'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --std 'Enable the standard library (default)'
             cand --nostd 'Disable the standard library'
@@ -516,7 +498,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;add'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --bin 'Whether to add the dependency as a binary'
             cand -u 'Upgrade an existing dependency'
@@ -533,7 +514,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;remove'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -551,7 +531,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --rev 'Git revision to checkout (commit hash, requires git URL)'
             cand --branch 'Git branch to checkout (requires git URL)'
             cand --tag 'Git tag to checkout (requires git URL)'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -564,7 +543,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help (see more with ''--help'')'
         }
         &'moon;tree'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -577,7 +555,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;fetch'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --no-update 'Do not update the registry index before fetching'
             cand -q 'Suppress output'
@@ -591,7 +568,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;work'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -608,7 +584,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand help 'Print this message or the help of the given subcommand(s)'
         }
         &'moon;work;init'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -621,7 +596,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;work;use'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -634,7 +608,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;work;sync'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -661,7 +634,6 @@ set edit:completion:arg-completer[moon] = {|@words|
         &'moon;work;help;help'= {
         }
         &'moon;login'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -674,7 +646,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;whoami'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -687,7 +658,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;register'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -700,7 +670,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;publish'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --frozen 'Do not sync dependencies, assuming local dependencies are up-to-date'
             cand -q 'Suppress output'
@@ -714,7 +683,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;package'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --frozen 'Do not sync dependencies, assuming local dependencies are up-to-date'
             cand --list 'list'
@@ -729,7 +697,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;update'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -742,7 +709,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;coverage'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -763,7 +729,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --package 'Analyze coverage for a specific package'
             cand -t 'Extra flags passed directly to `moon test`'
             cand --test-flag 'Extra flags passed directly to `moon test`'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -776,7 +741,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;coverage;report'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -h 'Show help for the coverage utility'
             cand --help 'Show help for the coverage utility'
@@ -789,7 +753,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --build-graph 'build-graph'
         }
         &'moon;coverage;clean'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -823,7 +786,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --mcol 'Number of module columns'
             cand -o 'The output directory'
             cand --output-dir 'The output directory'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -837,7 +799,6 @@ set edit:completion:arg-completer[moon] = {|@words|
         }
         &'moon;upgrade'= {
             cand --base-url 'base-url'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -f 'Force upgrade'
             cand --force 'Force upgrade'
@@ -855,7 +816,6 @@ set edit:completion:arg-completer[moon] = {|@words|
         }
         &'moon;shell-completion'= {
             cand --shell 'The shell to generate completion for'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -868,7 +828,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;version'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --all 'Print all version information'
             cand --json 'Print version information in JSON format'
@@ -884,7 +843,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;tool'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -906,7 +864,6 @@ set edit:completion:arg-completer[moon] = {|@words|
         &'moon;tool;format-and-diff'= {
             cand --old 'The source path of the code which needs to be formatted'
             cand --new 'The target path of the formatted code'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --warn 'Warn instead of showing differences'
             cand -q 'Suppress output'
@@ -922,7 +879,6 @@ set edit:completion:arg-completer[moon] = {|@words|
         &'moon;tool;format-workspace'= {
             cand --old 'The source path of the workspace file to format'
             cand --new 'The target path of the formatted workspace file'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -w 'Write the formatted output back to the source file'
             cand --write 'Write the formatted output back to the source file'
@@ -944,7 +900,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand -o 'o'
             cand --output 'output'
             cand --name 'name'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --binary 'binary'
             cand --text 'text'
@@ -960,7 +915,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;tool;write-tcc-rsp-file'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'
@@ -974,7 +928,6 @@ set edit:completion:arg-completer[moon] = {|@words|
         }
         &'moon;tool;build-binary-dep'= {
             cand --install-path 'The parent directory where the binary module is installed to'
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand --all-pkgs 'Whether to build and install all binary packages in the module'
             cand -q 'Suppress output'
@@ -988,7 +941,6 @@ set edit:completion:arg-completer[moon] = {|@words|
             cand --help 'Print help'
         }
         &'moon;tool;demangle'= {
-            cand --manifest-path 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)'
             cand --target-dir 'The target directory. Defaults to `<project-root>/_build`'
             cand -q 'Suppress output'
             cand --quiet 'Suppress output'

--- a/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_fish.stdout
@@ -1,6 +1,6 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_moon_global_optspecs
-	string join \n V/version C= manifest-path= target-dir= q/quiet v/verbose trace dry-run build-graph Z/unstable-feature= h/help
+	string join \n V/version C= target-dir= q/quiet v/verbose trace dry-run build-graph Z/unstable-feature= h/help
 end
 
 function __fish_moon_needs_command
@@ -25,7 +25,6 @@ function __fish_moon_using_subcommand
 end
 
 complete -c moon -n "__fish_moon_needs_command" -s C -d 'Change to DIR before doing anything else (must appear before the subcommand). Relative paths in other options and arguments are interpreted relative to DIR. Example: `moon -C a run .` runs the same as invoking `moon run .` from within `a`' -r -F
-complete -c moon -n "__fish_moon_needs_command" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_needs_command" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_needs_command" -s Z -l unstable-feature -d 'Unstable flags to MoonBuild' -r
 complete -c moon -n "__fish_moon_needs_command" -s V -l version -d 'Print all version information and exit'
@@ -73,7 +72,6 @@ complete -c moon -n "__fish_moon_needs_command" -f -a "ide" -d 'IDE utilities'
 complete -c moon -n "__fish_moon_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c moon -n "__fish_moon_using_subcommand new" -l user -d 'The username of the module. Default to the logged-in username' -r
 complete -c moon -n "__fish_moon_using_subcommand new" -l name -d 'The name of the module. Default to the last part of the path' -r
-complete -c moon -n "__fish_moon_using_subcommand new" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand new" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand new" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand new" -s v -l verbose -d 'Increase verbosity'
@@ -86,7 +84,6 @@ complete -c moon -n "__fish_moon_using_subcommand bundle" -l warn-list -d 'Warn 
 complete -c moon -n "__fish_moon_using_subcommand bundle" -s j -l jobs -d 'Set the max number of jobs to run in parallel' -r
 complete -c moon -n "__fish_moon_using_subcommand bundle" -l render-no-loc -d 'Render no-location diagnostics starting from a certain level' -r -f -a "{info\t'',warn\t'',error\t''}"
 complete -c moon -n "__fish_moon_using_subcommand bundle" -l diagnostic-limit -d 'Limit the number of rendered diagnostics' -r
-complete -c moon -n "__fish_moon_using_subcommand bundle" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand bundle" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand bundle" -l std -d 'Enable the standard library (default)'
 complete -c moon -n "__fish_moon_using_subcommand bundle" -l nostd -d 'Disable the standard library'
@@ -116,7 +113,6 @@ complete -c moon -n "__fish_moon_using_subcommand build" -s j -l jobs -d 'Set th
 complete -c moon -n "__fish_moon_using_subcommand build" -l render-no-loc -d 'Render no-location diagnostics starting from a certain level' -r -f -a "{info\t'',warn\t'',error\t''}"
 complete -c moon -n "__fish_moon_using_subcommand build" -l diagnostic-limit -d 'Limit the number of rendered diagnostics' -r
 complete -c moon -n "__fish_moon_using_subcommand build" -l package -r
-complete -c moon -n "__fish_moon_using_subcommand build" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand build" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand build" -l std -d 'Enable the standard library (default)'
 complete -c moon -n "__fish_moon_using_subcommand build" -l nostd -d 'Disable the standard library'
@@ -147,7 +143,6 @@ complete -c moon -n "__fish_moon_using_subcommand check" -l render-no-loc -d 'Re
 complete -c moon -n "__fish_moon_using_subcommand check" -l diagnostic-limit -d 'Limit the number of rendered diagnostics' -r
 complete -c moon -n "__fish_moon_using_subcommand check" -l package-path -d 'Legacy package directory path relative to the module source root (`source` in `moon.mod.json`)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand check" -l patch-file -d 'The patch file to check. Only valid when the selector resolves to a single package' -r -F
-complete -c moon -n "__fish_moon_using_subcommand check" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand check" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand check" -l std -d 'Enable the standard library (default)'
 complete -c moon -n "__fish_moon_using_subcommand check" -l nostd -d 'Disable the standard library'
@@ -178,7 +173,6 @@ complete -c moon -n "__fish_moon_using_subcommand prove" -l warn-list -d 'Warn l
 complete -c moon -n "__fish_moon_using_subcommand prove" -s j -l jobs -d 'Set the max number of jobs to run in parallel' -r
 complete -c moon -n "__fish_moon_using_subcommand prove" -l render-no-loc -d 'Render no-location diagnostics starting from a certain level' -r -f -a "{info\t'',warn\t'',error\t''}"
 complete -c moon -n "__fish_moon_using_subcommand prove" -l diagnostic-limit -d 'Limit the number of rendered diagnostics' -r
-complete -c moon -n "__fish_moon_using_subcommand prove" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand prove" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand prove" -l frozen -d 'Do not sync dependencies, assuming local dependencies are up-to-date'
 complete -c moon -n "__fish_moon_using_subcommand prove" -s d -l deny-warn -d 'Treat all warnings as errors'
@@ -196,7 +190,6 @@ complete -c moon -n "__fish_moon_using_subcommand run" -l warn-list -d 'Warn lis
 complete -c moon -n "__fish_moon_using_subcommand run" -s j -l jobs -d 'Set the max number of jobs to run in parallel' -r
 complete -c moon -n "__fish_moon_using_subcommand run" -l render-no-loc -d 'Render no-location diagnostics starting from a certain level' -r -f -a "{info\t'',warn\t'',error\t''}"
 complete -c moon -n "__fish_moon_using_subcommand run" -l diagnostic-limit -d 'Limit the number of rendered diagnostics' -r
-complete -c moon -n "__fish_moon_using_subcommand run" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand run" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand run" -l std -d 'Enable the standard library (default)'
 complete -c moon -n "__fish_moon_using_subcommand run" -l nostd -d 'Disable the standard library'
@@ -222,7 +215,6 @@ complete -c moon -n "__fish_moon_using_subcommand run" -l dry-run -d 'Do not act
 complete -c moon -n "__fish_moon_using_subcommand run" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand run" -s h -l help -d 'Print help'
 complete -c moon -n "__fish_moon_using_subcommand runwasm" -l experimental-policy -d 'Experimental: pass a moonrun TOML policy file for moonbitlang/async runtime access' -r -F
-complete -c moon -n "__fish_moon_using_subcommand runwasm" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand runwasm" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand runwasm" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand runwasm" -s v -l verbose -d 'Increase verbosity'
@@ -242,7 +234,6 @@ complete -c moon -n "__fish_moon_using_subcommand test" -l doc-index -d 'Run onl
 complete -c moon -n "__fish_moon_using_subcommand test" -s l -l limit -d 'Limit of expect test update passes to run, in order to avoid infinite loops' -r
 complete -c moon -n "__fish_moon_using_subcommand test" -l patch-file -d 'Path to the patch file' -r -F
 complete -c moon -n "__fish_moon_using_subcommand test" -s f -l filter -d 'Run only tests whose name matches the given glob pattern. Supports \'*\' (matches any sequence) and \'?\' (matches any single character)' -r
-complete -c moon -n "__fish_moon_using_subcommand test" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand test" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand test" -l std -d 'Enable the standard library (default)'
 complete -c moon -n "__fish_moon_using_subcommand test" -l nostd -d 'Disable the standard library'
@@ -273,7 +264,6 @@ complete -c moon -n "__fish_moon_using_subcommand test" -l trace -d 'Trace the e
 complete -c moon -n "__fish_moon_using_subcommand test" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand test" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand test" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand cram; and not __fish_seen_subcommand_from test" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand cram; and not __fish_seen_subcommand_from test" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand cram; and not __fish_seen_subcommand_from test" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand cram; and not __fish_seen_subcommand_from test" -s v -l verbose -d 'Increase verbosity'
@@ -283,7 +273,6 @@ complete -c moon -n "__fish_moon_using_subcommand cram; and not __fish_seen_subc
 complete -c moon -n "__fish_moon_using_subcommand cram; and not __fish_seen_subcommand_from test" -s h -l help -d 'Print help'
 complete -c moon -n "__fish_moon_using_subcommand cram; and not __fish_seen_subcommand_from test" -f -a "test" -d 'Build native executables, then run cram tests with their directories on PATH'
 complete -c moon -n "__fish_moon_using_subcommand cram; and __fish_seen_subcommand_from test" -l target -d 'Native is the only target supported by cram test' -r -f -a "{native\t''}"
-complete -c moon -n "__fish_moon_using_subcommand cram; and __fish_seen_subcommand_from test" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand cram; and __fish_seen_subcommand_from test" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand cram; and __fish_seen_subcommand_from test" -l release -d 'Build native release executables'
 complete -c moon -n "__fish_moon_using_subcommand cram; and __fish_seen_subcommand_from test" -s q -l quiet -d 'Suppress output'
@@ -301,7 +290,6 @@ complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -l cover
 complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -l driver-kind -d 'The test driver kind' -r -f -a "{internal\t'',whitebox\t'',blackbox\t''}"
 complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -l patch-file -d 'Path to the patch file' -r -F
 complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -l max-concurrent-tests -d 'Max concurrent tests for `async test`' -r
-complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -l bench -d 'Whether to generate the test driver in bench mode. Not providing this option will result in test mode'
 complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -l enable-coverage -d 'Whether coverage is enabled in this build. Enabling it will insert coverage-custom code at the end of the test..'
@@ -311,7 +299,6 @@ complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -l trace
 complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand generate-test-driver" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand clean" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand clean" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand clean" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand clean" -s v -l verbose -d 'Increase verbosity'
@@ -319,7 +306,6 @@ complete -c moon -n "__fish_moon_using_subcommand clean" -l trace -d 'Trace the 
 complete -c moon -n "__fish_moon_using_subcommand clean" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand clean" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand clean" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand fmt" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand fmt" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand fmt" -l check -d 'Check only and don\'t change the source code'
 complete -c moon -n "__fish_moon_using_subcommand fmt" -l sort-input -d 'Sort input files'
@@ -332,7 +318,6 @@ complete -c moon -n "__fish_moon_using_subcommand fmt" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand fmt" -s h -l help -d 'Print help'
 complete -c moon -n "__fish_moon_using_subcommand doc" -s b -l bind -d 'The address of the server' -r
 complete -c moon -n "__fish_moon_using_subcommand doc" -s p -l port -d 'The port of the server' -r
-complete -c moon -n "__fish_moon_using_subcommand doc" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand doc" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand doc" -l serve -d 'Start a web server to serve the documentation'
 complete -c moon -n "__fish_moon_using_subcommand doc" -l frozen -d 'Do not sync dependencies, assuming local dependencies are up-to-date'
@@ -344,7 +329,6 @@ complete -c moon -n "__fish_moon_using_subcommand doc" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand doc" -s h -l help -d 'Print help'
 complete -c moon -n "__fish_moon_using_subcommand explain" -l diagnostic -d 'Explain diagnostics. Without a query, list diagnostic codes and names' -r
 complete -c moon -n "__fish_moon_using_subcommand explain" -l attribute -d 'Explain attributes. Without a query, list attribute names' -r
-complete -c moon -n "__fish_moon_using_subcommand explain" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand explain" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand explain" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand explain" -s v -l verbose -d 'Increase verbosity'
@@ -354,7 +338,6 @@ complete -c moon -n "__fish_moon_using_subcommand explain" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand explain" -s h -l help -d 'Print help'
 complete -c moon -n "__fish_moon_using_subcommand info" -l target -d 'Inspect one or more target backends without changing the canonical `pkg.generated.mbti` output' -r -f -a "{wasm\t'',wasm-gc\t'',js\t'',native\t'',llvm\t'',all\t''}"
 complete -c moon -n "__fish_moon_using_subcommand info" -s p -l package -d 'The full or subset of name of the package to emit `mbti` files for' -r
-complete -c moon -n "__fish_moon_using_subcommand info" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand info" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand info" -l frozen -d 'Do not sync dependencies, assuming local dependencies are up-to-date'
 complete -c moon -n "__fish_moon_using_subcommand info" -l no-alias -d 'Do not use alias to shorten package names in the output'
@@ -372,7 +355,6 @@ complete -c moon -n "__fish_moon_using_subcommand bench" -l diagnostic-limit -d 
 complete -c moon -n "__fish_moon_using_subcommand bench" -s p -l package -d 'Run benchmarks in the specified package' -r
 complete -c moon -n "__fish_moon_using_subcommand bench" -s f -l file -d 'Run benchmarks in the specified file. Only valid when `--package` is also specified' -r
 complete -c moon -n "__fish_moon_using_subcommand bench" -s i -l index -d 'Run only the index-th benchmark in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when a single file is selected' -r
-complete -c moon -n "__fish_moon_using_subcommand bench" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand bench" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand bench" -l std -d 'Enable the standard library (default)'
 complete -c moon -n "__fish_moon_using_subcommand bench" -l nostd -d 'Disable the standard library'
@@ -397,7 +379,6 @@ complete -c moon -n "__fish_moon_using_subcommand bench" -l trace -d 'Trace the 
 complete -c moon -n "__fish_moon_using_subcommand bench" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand bench" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand bench" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand add" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand add" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand add" -l bin -d 'Whether to add the dependency as a binary'
 complete -c moon -n "__fish_moon_using_subcommand add" -s u -l upgrade -d 'Upgrade an existing dependency'
@@ -408,7 +389,6 @@ complete -c moon -n "__fish_moon_using_subcommand add" -l trace -d 'Trace the ex
 complete -c moon -n "__fish_moon_using_subcommand add" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand add" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand add" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand remove" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand remove" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand remove" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand remove" -s v -l verbose -d 'Increase verbosity'
@@ -421,7 +401,6 @@ complete -c moon -n "__fish_moon_using_subcommand install" -l path -d 'Install f
 complete -c moon -n "__fish_moon_using_subcommand install" -l rev -d 'Git revision to checkout (commit hash, requires git URL)' -r
 complete -c moon -n "__fish_moon_using_subcommand install" -l branch -d 'Git branch to checkout (requires git URL)' -r
 complete -c moon -n "__fish_moon_using_subcommand install" -l tag -d 'Git tag to checkout (requires git URL)' -r
-complete -c moon -n "__fish_moon_using_subcommand install" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand install" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand install" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand install" -s v -l verbose -d 'Increase verbosity'
@@ -429,7 +408,6 @@ complete -c moon -n "__fish_moon_using_subcommand install" -l trace -d 'Trace th
 complete -c moon -n "__fish_moon_using_subcommand install" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand install" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand install" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c moon -n "__fish_moon_using_subcommand tree" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tree" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tree" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand tree" -s v -l verbose -d 'Increase verbosity'
@@ -437,7 +415,6 @@ complete -c moon -n "__fish_moon_using_subcommand tree" -l trace -d 'Trace the e
 complete -c moon -n "__fish_moon_using_subcommand tree" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand tree" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand tree" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand fetch" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand fetch" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand fetch" -l no-update -d 'Do not update the registry index before fetching'
 complete -c moon -n "__fish_moon_using_subcommand fetch" -s q -l quiet -d 'Suppress output'
@@ -446,7 +423,6 @@ complete -c moon -n "__fish_moon_using_subcommand fetch" -l trace -d 'Trace the 
 complete -c moon -n "__fish_moon_using_subcommand fetch" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand fetch" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand fetch" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand work; and not __fish_seen_subcommand_from init use sync help" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand work; and not __fish_seen_subcommand_from init use sync help" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand work; and not __fish_seen_subcommand_from init use sync help" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand work; and not __fish_seen_subcommand_from init use sync help" -s v -l verbose -d 'Increase verbosity'
@@ -458,7 +434,6 @@ complete -c moon -n "__fish_moon_using_subcommand work; and not __fish_seen_subc
 complete -c moon -n "__fish_moon_using_subcommand work; and not __fish_seen_subcommand_from init use sync help" -f -a "use" -d 'Add modules to the workspace manifest'
 complete -c moon -n "__fish_moon_using_subcommand work; and not __fish_seen_subcommand_from init use sync help" -f -a "sync" -d 'Sync workspace dependency versions into member manifests'
 complete -c moon -n "__fish_moon_using_subcommand work; and not __fish_seen_subcommand_from init use sync help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from init" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from init" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from init" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from init" -s v -l verbose -d 'Increase verbosity'
@@ -466,7 +441,6 @@ complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcomma
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from init" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from init" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from init" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from use" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from use" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from use" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from use" -s v -l verbose -d 'Increase verbosity'
@@ -474,7 +448,6 @@ complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcomma
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from use" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from use" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from use" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from sync" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from sync" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from sync" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from sync" -s v -l verbose -d 'Increase verbosity'
@@ -486,7 +459,6 @@ complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcomma
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from help" -f -a "use" -d 'Add modules to the workspace manifest'
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from help" -f -a "sync" -d 'Sync workspace dependency versions into member manifests'
 complete -c moon -n "__fish_moon_using_subcommand work; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c moon -n "__fish_moon_using_subcommand login" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand login" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand login" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand login" -s v -l verbose -d 'Increase verbosity'
@@ -494,7 +466,6 @@ complete -c moon -n "__fish_moon_using_subcommand login" -l trace -d 'Trace the 
 complete -c moon -n "__fish_moon_using_subcommand login" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand login" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand login" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand whoami" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand whoami" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand whoami" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand whoami" -s v -l verbose -d 'Increase verbosity'
@@ -502,7 +473,6 @@ complete -c moon -n "__fish_moon_using_subcommand whoami" -l trace -d 'Trace the
 complete -c moon -n "__fish_moon_using_subcommand whoami" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand whoami" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand whoami" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand register" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand register" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand register" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand register" -s v -l verbose -d 'Increase verbosity'
@@ -510,7 +480,6 @@ complete -c moon -n "__fish_moon_using_subcommand register" -l trace -d 'Trace t
 complete -c moon -n "__fish_moon_using_subcommand register" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand register" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand register" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand publish" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand publish" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand publish" -l frozen -d 'Do not sync dependencies, assuming local dependencies are up-to-date'
 complete -c moon -n "__fish_moon_using_subcommand publish" -s q -l quiet -d 'Suppress output'
@@ -519,7 +488,6 @@ complete -c moon -n "__fish_moon_using_subcommand publish" -l trace -d 'Trace th
 complete -c moon -n "__fish_moon_using_subcommand publish" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand publish" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand publish" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand package" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand package" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand package" -l frozen -d 'Do not sync dependencies, assuming local dependencies are up-to-date'
 complete -c moon -n "__fish_moon_using_subcommand package" -l list
@@ -529,7 +497,6 @@ complete -c moon -n "__fish_moon_using_subcommand package" -l trace -d 'Trace th
 complete -c moon -n "__fish_moon_using_subcommand package" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand package" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand package" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand update" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand update" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand update" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand update" -s v -l verbose -d 'Increase verbosity'
@@ -537,7 +504,6 @@ complete -c moon -n "__fish_moon_using_subcommand update" -l trace -d 'Trace the
 complete -c moon -n "__fish_moon_using_subcommand update" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand update" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand update" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand coverage; and not __fish_seen_subcommand_from analyze report clean help" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand coverage; and not __fish_seen_subcommand_from analyze report clean help" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand coverage; and not __fish_seen_subcommand_from analyze report clean help" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand coverage; and not __fish_seen_subcommand_from analyze report clean help" -s v -l verbose -d 'Increase verbosity'
@@ -551,7 +517,6 @@ complete -c moon -n "__fish_moon_using_subcommand coverage; and not __fish_seen_
 complete -c moon -n "__fish_moon_using_subcommand coverage; and not __fish_seen_subcommand_from analyze report clean help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from analyze" -s p -l package -d 'Analyze coverage for a specific package' -r
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from analyze" -s t -l test-flag -d 'Extra flags passed directly to `moon test`' -r
-complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from analyze" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from analyze" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from analyze" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from analyze" -s v -l verbose -d 'Increase verbosity'
@@ -559,7 +524,6 @@ complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subc
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from analyze" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from analyze" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from analyze" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from report" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from report" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from report" -s h -l help -d 'Show help for the coverage utility'
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from report" -s q -l quiet -d 'Suppress output'
@@ -567,7 +531,6 @@ complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subc
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from report" -l trace -d 'Trace the execution of the program'
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from report" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from report" -l build-graph
-complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from clean" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from clean" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from clean" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand coverage; and __fish_seen_subcommand_from clean" -s v -l verbose -d 'Increase verbosity'
@@ -585,7 +548,6 @@ complete -c moon -n "__fish_moon_using_subcommand generate-build-matrix" -l dcol
 complete -c moon -n "__fish_moon_using_subcommand generate-build-matrix" -l mrow -d 'Number of module rows' -r
 complete -c moon -n "__fish_moon_using_subcommand generate-build-matrix" -l mcol -d 'Number of module columns' -r
 complete -c moon -n "__fish_moon_using_subcommand generate-build-matrix" -s o -l output-dir -d 'The output directory' -r -F
-complete -c moon -n "__fish_moon_using_subcommand generate-build-matrix" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand generate-build-matrix" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand generate-build-matrix" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand generate-build-matrix" -s v -l verbose -d 'Increase verbosity'
@@ -594,7 +556,6 @@ complete -c moon -n "__fish_moon_using_subcommand generate-build-matrix" -l dry-
 complete -c moon -n "__fish_moon_using_subcommand generate-build-matrix" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand generate-build-matrix" -s h -l help -d 'Print help'
 complete -c moon -n "__fish_moon_using_subcommand upgrade" -l base-url -r
-complete -c moon -n "__fish_moon_using_subcommand upgrade" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand upgrade" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand upgrade" -s f -l force -d 'Force upgrade'
 complete -c moon -n "__fish_moon_using_subcommand upgrade" -l dev -d 'Install the latest development version'
@@ -606,7 +567,6 @@ complete -c moon -n "__fish_moon_using_subcommand upgrade" -l dry-run -d 'Do not
 complete -c moon -n "__fish_moon_using_subcommand upgrade" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand upgrade" -s h -l help -d 'Print help'
 complete -c moon -n "__fish_moon_using_subcommand shell-completion" -l shell -d 'The shell to generate completion for' -r -f -a "{bash\t'',elvish\t'',fish\t'',powershell\t'',zsh\t''}"
-complete -c moon -n "__fish_moon_using_subcommand shell-completion" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand shell-completion" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand shell-completion" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand shell-completion" -s v -l verbose -d 'Increase verbosity'
@@ -614,7 +574,6 @@ complete -c moon -n "__fish_moon_using_subcommand shell-completion" -l trace -d 
 complete -c moon -n "__fish_moon_using_subcommand shell-completion" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand shell-completion" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand shell-completion" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand version" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand version" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand version" -l all -d 'Print all version information'
 complete -c moon -n "__fish_moon_using_subcommand version" -l json -d 'Print version information in JSON format'
@@ -625,7 +584,6 @@ complete -c moon -n "__fish_moon_using_subcommand version" -l trace -d 'Trace th
 complete -c moon -n "__fish_moon_using_subcommand version" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand version" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand version" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand tool; and not __fish_seen_subcommand_from format-and-diff format-workspace embed write-tcc-rsp-file build-binary-dep demangle help" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and not __fish_seen_subcommand_from format-and-diff format-workspace embed write-tcc-rsp-file build-binary-dep demangle help" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and not __fish_seen_subcommand_from format-and-diff format-workspace embed write-tcc-rsp-file build-binary-dep demangle help" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand tool; and not __fish_seen_subcommand_from format-and-diff format-workspace embed write-tcc-rsp-file build-binary-dep demangle help" -s v -l verbose -d 'Increase verbosity'
@@ -642,7 +600,6 @@ complete -c moon -n "__fish_moon_using_subcommand tool; and not __fish_seen_subc
 complete -c moon -n "__fish_moon_using_subcommand tool; and not __fish_seen_subcommand_from format-and-diff format-workspace embed write-tcc-rsp-file build-binary-dep demangle help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-and-diff" -l old -d 'The source path of the code which needs to be formatted' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-and-diff" -l new -d 'The target path of the formatted code' -r -F
-complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-and-diff" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-and-diff" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-and-diff" -l warn -d 'Warn instead of showing differences'
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-and-diff" -s q -l quiet -d 'Suppress output'
@@ -653,7 +610,6 @@ complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcomma
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-and-diff" -s h -l help -d 'Print help'
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-workspace" -l old -d 'The source path of the workspace file to format' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-workspace" -l new -d 'The target path of the formatted workspace file' -r -F
-complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-workspace" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-workspace" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-workspace" -s w -l write -d 'Write the formatted output back to the source file'
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from format-workspace" -l check -d 'Check formatting and print the difference'
@@ -667,7 +623,6 @@ complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcomma
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from embed" -s i -l input -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from embed" -s o -l output -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from embed" -l name -r
-complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from embed" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from embed" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from embed" -l binary
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from embed" -l text
@@ -678,7 +633,6 @@ complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcomma
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from embed" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from embed" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from embed" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from write-tcc-rsp-file" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from write-tcc-rsp-file" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from write-tcc-rsp-file" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from write-tcc-rsp-file" -s v -l verbose -d 'Increase verbosity'
@@ -687,7 +641,6 @@ complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcomma
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from write-tcc-rsp-file" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from write-tcc-rsp-file" -s h -l help -d 'Print help'
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from build-binary-dep" -l install-path -d 'The parent directory where the binary module is installed to' -r -F
-complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from build-binary-dep" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from build-binary-dep" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from build-binary-dep" -l all-pkgs -d 'Whether to build and install all binary packages in the module'
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from build-binary-dep" -s q -l quiet -d 'Suppress output'
@@ -696,7 +649,6 @@ complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcomma
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from build-binary-dep" -l dry-run -d 'Do not actually run the command'
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from build-binary-dep" -l build-graph
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from build-binary-dep" -s h -l help -d 'Print help'
-complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from demangle" -l manifest-path -d 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from demangle" -l target-dir -d 'The target directory. Defaults to `<project-root>/_build`' -r -F
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from demangle" -s q -l quiet -d 'Suppress output'
 complete -c moon -n "__fish_moon_using_subcommand tool; and __fish_seen_subcommand_from demangle" -s v -l verbose -d 'Increase verbosity'

--- a/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_powershell.stdout
@@ -22,7 +22,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
     $completions = @(switch ($command) {
         'moon' {
             [CompletionResult]::new('-C', 'C ', [CompletionResultType]::ParameterName, 'Change to DIR before doing anything else (must appear before the subcommand). Relative paths in other options and arguments are interpreted relative to DIR. Example: `moon -C a run .` runs the same as invoking `moon run .` from within `a`')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-Z', 'Z ', [CompletionResultType]::ParameterName, 'Unstable flags to MoonBuild')
             [CompletionResult]::new('--unstable-feature', 'unstable-feature', [CompletionResultType]::ParameterName, 'Unstable flags to MoonBuild')
@@ -78,7 +77,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
         'moon;new' {
             [CompletionResult]::new('--user', 'user', [CompletionResultType]::ParameterName, 'The username of the module. Default to the logged-in username')
             [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'The name of the module. Default to the last part of the path')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -98,7 +96,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--jobs', 'jobs', [CompletionResultType]::ParameterName, 'Set the max number of jobs to run in parallel')
             [CompletionResult]::new('--render-no-loc', 'render-no-loc', [CompletionResultType]::ParameterName, 'Render no-location diagnostics starting from a certain level')
             [CompletionResult]::new('--diagnostic-limit', 'diagnostic-limit', [CompletionResultType]::ParameterName, 'Limit the number of rendered diagnostics')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--std', 'std', [CompletionResultType]::ParameterName, 'Enable the standard library (default)')
             [CompletionResult]::new('--nostd', 'nostd', [CompletionResultType]::ParameterName, 'Disable the standard library')
@@ -137,7 +134,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--render-no-loc', 'render-no-loc', [CompletionResultType]::ParameterName, 'Render no-location diagnostics starting from a certain level')
             [CompletionResult]::new('--diagnostic-limit', 'diagnostic-limit', [CompletionResultType]::ParameterName, 'Limit the number of rendered diagnostics')
             [CompletionResult]::new('--package', 'package', [CompletionResultType]::ParameterName, 'package')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--std', 'std', [CompletionResultType]::ParameterName, 'Enable the standard library (default)')
             [CompletionResult]::new('--nostd', 'nostd', [CompletionResultType]::ParameterName, 'Disable the standard library')
@@ -178,7 +174,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--diagnostic-limit', 'diagnostic-limit', [CompletionResultType]::ParameterName, 'Limit the number of rendered diagnostics')
             [CompletionResult]::new('--package-path', 'package-path', [CompletionResultType]::ParameterName, 'Legacy package directory path relative to the module source root (`source` in `moon.mod.json`)')
             [CompletionResult]::new('--patch-file', 'patch-file', [CompletionResultType]::ParameterName, 'The patch file to check. Only valid when the selector resolves to a single package')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--std', 'std', [CompletionResultType]::ParameterName, 'Enable the standard library (default)')
             [CompletionResult]::new('--nostd', 'nostd', [CompletionResultType]::ParameterName, 'Disable the standard library')
@@ -219,7 +214,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--jobs', 'jobs', [CompletionResultType]::ParameterName, 'Set the max number of jobs to run in parallel')
             [CompletionResult]::new('--render-no-loc', 'render-no-loc', [CompletionResultType]::ParameterName, 'Render no-location diagnostics starting from a certain level')
             [CompletionResult]::new('--diagnostic-limit', 'diagnostic-limit', [CompletionResultType]::ParameterName, 'Limit the number of rendered diagnostics')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--frozen', 'frozen', [CompletionResultType]::ParameterName, 'Do not sync dependencies, assuming local dependencies are up-to-date')
             [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Treat all warnings as errors')
@@ -245,7 +239,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--jobs', 'jobs', [CompletionResultType]::ParameterName, 'Set the max number of jobs to run in parallel')
             [CompletionResult]::new('--render-no-loc', 'render-no-loc', [CompletionResultType]::ParameterName, 'Render no-location diagnostics starting from a certain level')
             [CompletionResult]::new('--diagnostic-limit', 'diagnostic-limit', [CompletionResultType]::ParameterName, 'Limit the number of rendered diagnostics')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--std', 'std', [CompletionResultType]::ParameterName, 'Enable the standard library (default)')
             [CompletionResult]::new('--nostd', 'nostd', [CompletionResultType]::ParameterName, 'Disable the standard library')
@@ -279,7 +272,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
         }
         'moon;runwasm' {
             [CompletionResult]::new('--experimental-policy', 'experimental-policy', [CompletionResultType]::ParameterName, 'Experimental: pass a moonrun TOML policy file for moonbitlang/async runtime access')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -310,7 +302,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--patch-file', 'patch-file', [CompletionResultType]::ParameterName, 'Path to the patch file')
             [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'Run only tests whose name matches the given glob pattern. Supports ''*'' (matches any sequence) and ''?'' (matches any single character)')
             [CompletionResult]::new('--filter', 'filter', [CompletionResultType]::ParameterName, 'Run only tests whose name matches the given glob pattern. Supports ''*'' (matches any sequence) and ''?'' (matches any single character)')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--std', 'std', [CompletionResultType]::ParameterName, 'Enable the standard library (default)')
             [CompletionResult]::new('--nostd', 'nostd', [CompletionResultType]::ParameterName, 'Disable the standard library')
@@ -350,7 +341,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;cram' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -366,7 +356,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
         }
         'moon;cram;test' {
             [CompletionResult]::new('--target', 'target', [CompletionResultType]::ParameterName, 'Native is the only target supported by cram test')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--release', 'release', [CompletionResultType]::ParameterName, 'Build native release executables')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -390,7 +379,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--driver-kind', 'driver-kind', [CompletionResultType]::ParameterName, 'The test driver kind')
             [CompletionResult]::new('--patch-file', 'patch-file', [CompletionResultType]::ParameterName, 'Path to the patch file')
             [CompletionResult]::new('--max-concurrent-tests', 'max-concurrent-tests', [CompletionResultType]::ParameterName, 'Max concurrent tests for `async test`')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--bench', 'bench', [CompletionResultType]::ParameterName, 'Whether to generate the test driver in bench mode. Not providing this option will result in test mode')
             [CompletionResult]::new('--enable-coverage', 'enable-coverage', [CompletionResultType]::ParameterName, 'Whether coverage is enabled in this build. Enabling it will insert coverage-custom code at the end of the test..')
@@ -406,7 +394,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;clean' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -420,7 +407,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;fmt' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--check', 'check', [CompletionResultType]::ParameterName, 'Check only and don''t change the source code')
             [CompletionResult]::new('--sort-input', 'sort-input', [CompletionResultType]::ParameterName, 'Sort input files')
@@ -441,7 +427,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--bind', 'bind', [CompletionResultType]::ParameterName, 'The address of the server')
             [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'The port of the server')
             [CompletionResult]::new('--port', 'port', [CompletionResultType]::ParameterName, 'The port of the server')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--serve', 'serve', [CompletionResultType]::ParameterName, 'Start a web server to serve the documentation')
             [CompletionResult]::new('--frozen', 'frozen', [CompletionResultType]::ParameterName, 'Do not sync dependencies, assuming local dependencies are up-to-date')
@@ -459,7 +444,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
         'moon;explain' {
             [CompletionResult]::new('--diagnostic', 'diagnostic', [CompletionResultType]::ParameterName, 'Explain diagnostics. Without a query, list diagnostic codes and names')
             [CompletionResult]::new('--attribute', 'attribute', [CompletionResultType]::ParameterName, 'Explain attributes. Without a query, list attribute names')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -476,7 +460,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--target', 'target', [CompletionResultType]::ParameterName, 'Inspect one or more target backends without changing the canonical `pkg.generated.mbti` output')
             [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'The full or subset of name of the package to emit `mbti` files for')
             [CompletionResult]::new('--package', 'package', [CompletionResultType]::ParameterName, 'The full or subset of name of the package to emit `mbti` files for')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--frozen', 'frozen', [CompletionResultType]::ParameterName, 'Do not sync dependencies, assuming local dependencies are up-to-date')
             [CompletionResult]::new('--no-alias', 'no-alias', [CompletionResultType]::ParameterName, 'Do not use alias to shorten package names in the output')
@@ -504,7 +487,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--file', 'file', [CompletionResultType]::ParameterName, 'Run benchmarks in the specified file. Only valid when `--package` is also specified')
             [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'Run only the index-th benchmark in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when a single file is selected')
             [CompletionResult]::new('--index', 'index', [CompletionResultType]::ParameterName, 'Run only the index-th benchmark in the file. Accepts a single index or a left-inclusive right-exclusive range like `0-2`. Only valid when a single file is selected')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--std', 'std', [CompletionResultType]::ParameterName, 'Enable the standard library (default)')
             [CompletionResult]::new('--nostd', 'nostd', [CompletionResultType]::ParameterName, 'Disable the standard library')
@@ -537,7 +519,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;add' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--bin', 'bin', [CompletionResultType]::ParameterName, 'Whether to add the dependency as a binary')
             [CompletionResult]::new('-u', 'u', [CompletionResultType]::ParameterName, 'Upgrade an existing dependency')
@@ -555,7 +536,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;remove' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -574,7 +554,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--rev', 'rev', [CompletionResultType]::ParameterName, 'Git revision to checkout (commit hash, requires git URL)')
             [CompletionResult]::new('--branch', 'branch', [CompletionResultType]::ParameterName, 'Git branch to checkout (requires git URL)')
             [CompletionResult]::new('--tag', 'tag', [CompletionResultType]::ParameterName, 'Git tag to checkout (requires git URL)')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -588,7 +567,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;tree' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -602,7 +580,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;fetch' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--no-update', 'no-update', [CompletionResultType]::ParameterName, 'Do not update the registry index before fetching')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -617,7 +594,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;work' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -635,7 +611,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;work;init' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -649,7 +624,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;work;use' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -663,7 +637,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;work;sync' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -696,7 +669,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;login' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -710,7 +682,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;whoami' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -724,7 +695,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;register' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -738,7 +708,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;publish' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--frozen', 'frozen', [CompletionResultType]::ParameterName, 'Do not sync dependencies, assuming local dependencies are up-to-date')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -753,7 +722,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;package' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--frozen', 'frozen', [CompletionResultType]::ParameterName, 'Do not sync dependencies, assuming local dependencies are up-to-date')
             [CompletionResult]::new('--list', 'list', [CompletionResultType]::ParameterName, 'list')
@@ -769,7 +737,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;update' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -783,7 +750,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;coverage' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -805,7 +771,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--package', 'package', [CompletionResultType]::ParameterName, 'Analyze coverage for a specific package')
             [CompletionResult]::new('-t', 't', [CompletionResultType]::ParameterName, 'Extra flags passed directly to `moon test`')
             [CompletionResult]::new('--test-flag', 'test-flag', [CompletionResultType]::ParameterName, 'Extra flags passed directly to `moon test`')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -819,7 +784,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;coverage;report' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Show help for the coverage utility')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Show help for the coverage utility')
@@ -833,7 +797,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;coverage;clean' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -873,7 +836,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('--mcol', 'mcol', [CompletionResultType]::ParameterName, 'Number of module columns')
             [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'The output directory')
             [CompletionResult]::new('--output-dir', 'output-dir', [CompletionResultType]::ParameterName, 'The output directory')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -888,7 +850,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
         }
         'moon;upgrade' {
             [CompletionResult]::new('--base-url', 'base-url', [CompletionResultType]::ParameterName, 'base-url')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'Force upgrade')
             [CompletionResult]::new('--force', 'force', [CompletionResultType]::ParameterName, 'Force upgrade')
@@ -907,7 +868,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
         }
         'moon;shell-completion' {
             [CompletionResult]::new('--shell', 'shell', [CompletionResultType]::ParameterName, 'The shell to generate completion for')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -921,7 +881,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;version' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--all', 'all', [CompletionResultType]::ParameterName, 'Print all version information')
             [CompletionResult]::new('--json', 'json', [CompletionResultType]::ParameterName, 'Print version information in JSON format')
@@ -938,7 +897,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;tool' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -961,7 +919,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
         'moon;tool;format-and-diff' {
             [CompletionResult]::new('--old', 'old', [CompletionResultType]::ParameterName, 'The source path of the code which needs to be formatted')
             [CompletionResult]::new('--new', 'new', [CompletionResultType]::ParameterName, 'The target path of the formatted code')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--warn', 'warn', [CompletionResultType]::ParameterName, 'Warn instead of showing differences')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -978,7 +935,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
         'moon;tool;format-workspace' {
             [CompletionResult]::new('--old', 'old', [CompletionResultType]::ParameterName, 'The source path of the workspace file to format')
             [CompletionResult]::new('--new', 'new', [CompletionResultType]::ParameterName, 'The target path of the formatted workspace file')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-w', 'w', [CompletionResultType]::ParameterName, 'Write the formatted output back to the source file')
             [CompletionResult]::new('--write', 'write', [CompletionResultType]::ParameterName, 'Write the formatted output back to the source file')
@@ -1001,7 +957,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'o')
             [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'output')
             [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'name')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--binary', 'binary', [CompletionResultType]::ParameterName, 'binary')
             [CompletionResult]::new('--text', 'text', [CompletionResultType]::ParameterName, 'text')
@@ -1018,7 +973,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;tool;write-tcc-rsp-file' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -1033,7 +987,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
         }
         'moon;tool;build-binary-dep' {
             [CompletionResult]::new('--install-path', 'install-path', [CompletionResultType]::ParameterName, 'The parent directory where the binary module is installed to')
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('--all-pkgs', 'all-pkgs', [CompletionResultType]::ParameterName, 'Whether to build and install all binary packages in the module')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
@@ -1048,7 +1001,6 @@ Register-ArgumentCompleter -Native -CommandName 'moon' -ScriptBlock {
             break
         }
         'moon;tool;demangle' {
-            [CompletionResult]::new('--manifest-path', 'manifest-path', [CompletionResultType]::ParameterName, 'Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory)')
             [CompletionResult]::new('--target-dir', 'target-dir', [CompletionResultType]::ParameterName, 'The target directory. Defaults to `<project-root>/_build`')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Suppress output')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Suppress output')

--- a/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
+++ b/crates/moon/src/cli/snapshots/shell_completion_zsh.stdout
@@ -16,7 +16,6 @@ _moon() {
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" : \
 '-C+[Change to DIR before doing anything else (must appear before the subcommand). Relative paths in other options and arguments are interpreted relative to DIR. Example\: \`moon -C a run .\` runs the same as invoking \`moon run .\` from within \`a\`]:DIR:_files' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-Z+[Unstable flags to MoonBuild]:UNSTABLE_FEATURE: ' \
 '--unstable-feature=[Unstable flags to MoonBuild]:UNSTABLE_FEATURE: ' \
@@ -44,7 +43,6 @@ _moon() {
 _arguments "${_arguments_options[@]}" : \
 '--user=[The username of the module. Default to the logged-in username]:USER: ' \
 '--name=[The name of the module. Default to the last part of the path]:NAME: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -66,7 +64,6 @@ _arguments "${_arguments_options[@]}" : \
 '--jobs=[Set the max number of jobs to run in parallel]:JOBS: ' \
 '--render-no-loc=[Render no-location diagnostics starting from a certain level]:MIN_LEVEL:(info warn error)' \
 '--diagnostic-limit=[Limit the number of rendered diagnostics]:N: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '(--nostd)--std[Enable the standard library (default)]' \
 '(--std)--nostd[Disable the standard library]' \
@@ -106,7 +103,6 @@ _arguments "${_arguments_options[@]}" : \
 '--render-no-loc=[Render no-location diagnostics starting from a certain level]:MIN_LEVEL:(info warn error)' \
 '--diagnostic-limit=[Limit the number of rendered diagnostics]:N: ' \
 '--package=[]:PACKAGE: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '(--nostd)--std[Enable the standard library (default)]' \
 '(--std)--nostd[Disable the standard library]' \
@@ -149,7 +145,6 @@ _arguments "${_arguments_options[@]}" : \
 '--diagnostic-limit=[Limit the number of rendered diagnostics]:N: ' \
 '--package-path=[Legacy package directory path relative to the module source root (\`source\` in \`moon.mod.json\`)]:PACKAGE_DIR:_files' \
 '--patch-file=[The patch file to check. Only valid when the selector resolves to a single package]:PATCH_FILE:_files' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '(--nostd)--std[Enable the standard library (default)]' \
 '(--std)--nostd[Disable the standard library]' \
@@ -192,7 +187,6 @@ _arguments "${_arguments_options[@]}" : \
 '--jobs=[Set the max number of jobs to run in parallel]:JOBS: ' \
 '--render-no-loc=[Render no-location diagnostics starting from a certain level]:MIN_LEVEL:(info warn error)' \
 '--diagnostic-limit=[Limit the number of rendered diagnostics]:N: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--frozen[Do not sync dependencies, assuming local dependencies are up-to-date]' \
 '-d[Treat all warnings as errors]' \
@@ -220,7 +214,6 @@ _arguments "${_arguments_options[@]}" : \
 '--jobs=[Set the max number of jobs to run in parallel]:JOBS: ' \
 '--render-no-loc=[Render no-location diagnostics starting from a certain level]:MIN_LEVEL:(info warn error)' \
 '--diagnostic-limit=[Limit the number of rendered diagnostics]:N: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '(--nostd)--std[Enable the standard library (default)]' \
 '(--std)--nostd[Disable the standard library]' \
@@ -257,7 +250,6 @@ _arguments "${_arguments_options[@]}" : \
 (runwasm)
 _arguments "${_arguments_options[@]}" : \
 '--experimental-policy=[Experimental\: pass a moonrun TOML policy file for moonbitlang/async runtime access]:PATH:_files' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -291,7 +283,6 @@ _arguments "${_arguments_options[@]}" : \
 '(-u --update)--patch-file=[Path to the patch file]:PATCH_FILE:_files' \
 '-f+[Run only tests whose name matches the given glob pattern. Supports '\''*'\'' (matches any sequence) and '\''?'\'' (matches any single character)]:FILTER: ' \
 '--filter=[Run only tests whose name matches the given glob pattern. Supports '\''*'\'' (matches any sequence) and '\''?'\'' (matches any single character)]:FILTER: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '(--nostd)--std[Enable the standard library (default)]' \
 '(--std)--nostd[Disable the standard library]' \
@@ -333,7 +324,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (cram)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -357,7 +347,6 @@ _arguments "${_arguments_options[@]}" : \
             (test)
 _arguments "${_arguments_options[@]}" : \
 '--target=[Native is the only target supported by cram test]:TARGET:(native)' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--release[Build native release executables]' \
 '-q[Suppress output]' \
@@ -387,7 +376,6 @@ _arguments "${_arguments_options[@]}" : \
 '--driver-kind=[The test driver kind]:DRIVER_KIND:(internal whitebox blackbox)' \
 '--patch-file=[Path to the patch file]:PATCH_FILE:_files' \
 '--max-concurrent-tests=[Max concurrent tests for \`async test\`]:MAX_CONCURRENT_TESTS: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--bench[Whether to generate the test driver in bench mode. Not providing this option will result in test mode]' \
 '--enable-coverage[Whether coverage is enabled in this build. Enabling it will insert coverage-custom code at the end of the test..]' \
@@ -405,7 +393,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (clean)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -420,7 +407,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (fmt)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--check[Check only and don'\''t change the source code]' \
 '--sort-input[Sort input files]' \
@@ -443,7 +429,6 @@ _arguments "${_arguments_options[@]}" : \
 '--bind=[The address of the server]:BIND: ' \
 '-p+[The port of the server]:PORT: ' \
 '--port=[The port of the server]:PORT: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--serve[Start a web server to serve the documentation]' \
 '--frozen[Do not sync dependencies, assuming local dependencies are up-to-date]' \
@@ -463,7 +448,6 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '--diagnostic=[Explain diagnostics. Without a query, list diagnostic codes and names]' \
 '--attribute=[Explain attributes. Without a query, list attribute names]' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -481,7 +465,6 @@ _arguments "${_arguments_options[@]}" : \
 '*--target=[Inspect one or more target backends without changing the canonical \`pkg.generated.mbti\` output]:TARGET:(wasm wasm-gc js native llvm all)' \
 '-p+[The full or subset of name of the package to emit \`mbti\` files for]:PACKAGE: ' \
 '--package=[The full or subset of name of the package to emit \`mbti\` files for]:PACKAGE: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--frozen[Do not sync dependencies, assuming local dependencies are up-to-date]' \
 '--no-alias[Do not use alias to shorten package names in the output]' \
@@ -511,7 +494,6 @@ _arguments "${_arguments_options[@]}" : \
 '--file=[Run benchmarks in the specified file. Only valid when \`--package\` is also specified]:FILE: ' \
 '-i+[Run only the index-th benchmark in the file. Accepts a single index or a left-inclusive right-exclusive range like \`0-2\`. Only valid when a single file is selected]:INDEX: ' \
 '--index=[Run only the index-th benchmark in the file. Accepts a single index or a left-inclusive right-exclusive range like \`0-2\`. Only valid when a single file is selected]:INDEX: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '(--nostd)--std[Enable the standard library (default)]' \
 '(--std)--nostd[Disable the standard library]' \
@@ -546,7 +528,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (add)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--bin[Whether to add the dependency as a binary]' \
 '-u[Upgrade an existing dependency]' \
@@ -566,7 +547,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (remove)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -587,7 +567,6 @@ _arguments "${_arguments_options[@]}" : \
 '--rev=[Git revision to checkout (commit hash, requires git URL)]:REV: ' \
 '--branch=[Git branch to checkout (requires git URL)]:BRANCH: ' \
 '--tag=[Git tag to checkout (requires git URL)]:TAG: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -604,7 +583,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (tree)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -619,7 +597,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (fetch)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--no-update[Do not update the registry index before fetching]' \
 '-q[Suppress output]' \
@@ -636,7 +613,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (work)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -659,7 +635,6 @@ _arguments "${_arguments_options[@]}" : \
         case $line[1] in
             (init)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -675,7 +650,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (use)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -691,7 +665,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (sync)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -742,7 +715,6 @@ esac
 ;;
 (login)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -757,7 +729,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (whoami)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -772,7 +743,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (register)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -787,7 +757,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (publish)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--frozen[Do not sync dependencies, assuming local dependencies are up-to-date]' \
 '-q[Suppress output]' \
@@ -803,7 +772,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (package)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--frozen[Do not sync dependencies, assuming local dependencies are up-to-date]' \
 '--list[]' \
@@ -820,7 +788,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (update)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -835,7 +802,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (coverage)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -862,7 +828,6 @@ _arguments "${_arguments_options[@]}" : \
 '--package=[Analyze coverage for a specific package]:PACKAGE: ' \
 '*-t+[Extra flags passed directly to \`moon test\`]:TEST_FLAG: ' \
 '*--test-flag=[Extra flags passed directly to \`moon test\`]:TEST_FLAG: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -878,7 +843,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (report)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-h[Show help for the coverage utility]' \
 '--help[Show help for the coverage utility]' \
@@ -894,7 +858,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (clean)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -952,7 +915,6 @@ _arguments "${_arguments_options[@]}" : \
 '--mcol=[Number of module columns]:MOD_COLS: ' \
 '-o+[The output directory]:OUT_DIR:_files' \
 '--output-dir=[The output directory]:OUT_DIR:_files' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -968,7 +930,6 @@ _arguments "${_arguments_options[@]}" : \
 (upgrade)
 _arguments "${_arguments_options[@]}" : \
 '--base-url=[]:BASE_URL: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-f[Force upgrade]' \
 '--force[Force upgrade]' \
@@ -988,7 +949,6 @@ _arguments "${_arguments_options[@]}" : \
 (shell-completion)
 _arguments "${_arguments_options[@]}" : \
 '--shell=[The shell to generate completion for]:SHELL:(bash elvish fish powershell zsh)' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -1003,7 +963,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (version)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--all[Print all version information]' \
 '--json[Print version information in JSON format]' \
@@ -1021,7 +980,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (tool)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -1046,7 +1004,6 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '--old=[The source path of the code which needs to be formatted]:OLD:_files' \
 '--new=[The target path of the formatted code]:NEW:_files' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--warn[Warn instead of showing differences]' \
 '-q[Suppress output]' \
@@ -1065,7 +1022,6 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '--old=[The source path of the workspace file to format]:OLD:_files' \
 '--new=[The target path of the formatted workspace file]:NEW:_files' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-w[Write the formatted output back to the source file]' \
 '--write[Write the formatted output back to the source file]' \
@@ -1089,7 +1045,6 @@ _arguments "${_arguments_options[@]}" : \
 '-o+[]:OUTPUT:_files' \
 '--output=[]:OUTPUT:_files' \
 '--name=[]:NAME: ' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--binary[]' \
 '--text[]' \
@@ -1107,7 +1062,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (write-tcc-rsp-file)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \
@@ -1125,7 +1079,6 @@ _arguments "${_arguments_options[@]}" : \
 (build-binary-dep)
 _arguments "${_arguments_options[@]}" : \
 '--install-path=[The parent directory where the binary module is installed to]:INSTALL_PATH:_files' \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '--all-pkgs[Whether to build and install all binary packages in the module]' \
 '-q[Suppress output]' \
@@ -1142,7 +1095,6 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (demangle)
 _arguments "${_arguments_options[@]}" : \
-'--manifest-path=[Path to \`moon.mod.json\` or \`moon.work\` to use as the project manifest (does not change the working directory)]:PATH:_files' \
 '--target-dir=[The target directory. Defaults to \`<project-root>/_build\`]:TARGET_DIR:_files' \
 '-q[Suppress output]' \
 '--quiet[Suppress output]' \

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -581,17 +581,11 @@ mod tests {
 
     fn resolve_output(source_dir: &Path) -> moonbuild_rupes_recta::ResolveOutput {
         let cfg = ResolveConfig::new_with_load_defaults(false, false, false, WorkspaceEnv::Auto);
-        let manifest_path = if source_dir.join(MOON_WORK).exists() {
-            source_dir.join(MOON_WORK)
-        } else {
-            source_dir.join(MOON_MOD_JSON)
-        };
         let dirs = SourceTargetDirs {
             cwd: None,
-            manifest_path: Some(manifest_path),
             target_dir: None,
         }
-        .query(WorkspaceEnv::Auto)
+        .query_from(source_dir, WorkspaceEnv::Auto)
         .unwrap()
         .package_dirs()
         .unwrap();

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -188,11 +188,6 @@ pub fn main() {
     for warning in flags.deprecation_warnings() {
         output.warn(warning);
     }
-    if flags.source_tgt_dir.manifest_path.is_some() && !matches!(subcommand, Run(_)) {
-        output.warn(
-            "`--manifest-path` is deprecated. Prefer `-C <project-dir>` to select a different project.",
-        );
-    }
     if let Some(warning) = workspace_env_deprecation_warning {
         output.warn(warning);
     }

--- a/crates/moon/src/tests/planner/cli_to_planner.rs
+++ b/crates/moon/src/tests/planner/cli_to_planner.rs
@@ -31,7 +31,6 @@ fn command_string_run_parses_as_expected() {
             UniversalFlags {
                 source_tgt_dir: SourceTargetDirs {
                     cwd: None,
-                    manifest_path: None,
                     target_dir: None,
                 },
                 workspace_env: Auto,
@@ -123,7 +122,6 @@ fn native_target_dry_run_test_command_parses_as_expected() {
             UniversalFlags {
                 source_tgt_dir: SourceTargetDirs {
                     cwd: None,
-                    manifest_path: None,
                     target_dir: None,
                 },
                 workspace_env: Auto,

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -79,7 +79,6 @@ impl PlanningFixture {
         let fixture_dir = dunce::canonicalize(case_root.join(case))?;
         let project = SourceTargetDirs {
             cwd: None,
-            manifest_path: None,
             target_dir: None,
         }
         .query_from(&fixture_dir, WorkspaceEnv::Auto)?

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -1399,7 +1399,7 @@ error: unexpected argument '--manifest-path' found
 
   tip: to pass '--manifest-path' as a value, use '-- --manifest-path'
 
-Usage: moon check [OPTIONS] [PATH]...
+Usage: moon[EXE] check [OPTIONS] [PATH]...
 
 For more information, try '--help'.
 

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -1388,30 +1388,22 @@ fn test_moon_add_help_includes_no_update() {
 }
 
 #[test]
-fn test_manifest_path_deprecation_warning_for_non_run_commands() {
+fn test_manifest_path_is_not_supported() {
     let dir = TestDir::new("moon_commands");
-    let stderr = get_stderr(
-        &dir,
-        ["check", "--manifest-path", "moon.mod.json", "--dry-run"],
-    );
-    assert!(
-        stderr.contains("`--manifest-path` is deprecated"),
-        "expected deprecation warning, got:\n{stderr}"
-    );
-}
+    moon_cmd(&dir)
+        .args(["check", "--manifest-path", "moon.mod.json", "--dry-run"])
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+error: unexpected argument '--manifest-path' found
 
-#[test]
-fn test_run_rejects_manifest_path() {
-    let dir = TestDir::new("moon_commands");
-    let stderr = get_err_stderr(&dir, ["run", "--manifest-path", "moon.mod.json", "main1"]);
-    assert!(
-        stderr.contains("`--manifest-path` is no longer supported for `moon run`"),
-        "expected moon run manifest-path rejection, got:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("Use `moon -C <project-dir> run ...` instead"),
-        "expected moon run manifest-path guidance, got:\n{stderr}"
-    );
+  tip: to pass '--manifest-path' as a value, use '-- --manifest-path'
+
+Usage: moon check [OPTIONS] [PATH]...
+
+For more information, try '--help'.
+
+"#]]);
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -247,8 +247,8 @@ fn test_moon_test_runs_from_module_root() {
         get_stdout(
             &lib_dir,
             [
-                "--manifest-path",
-                "../moon.mod.json",
+                "-C",
+                "..",
                 "test",
                 "--target",
                 "js",
@@ -272,8 +272,8 @@ fn test_moon_test_workspace_members_run_from_module_root() {
         get_stdout(
             &spawn_dir,
             [
-                "--manifest-path",
-                "../moon.work",
+                "-C",
+                "..",
                 "test",
                 "--target",
                 "js",

--- a/crates/moon/tests/test_cases/native_backend/tcc_run.rs
+++ b/crates/moon/tests/test_cases/native_backend/tcc_run.rs
@@ -39,8 +39,8 @@ fn test_native_tcc_run_when_moon_spawned_from_other_dir() {
         .env_remove("MOON_CC")
         .env("MOONBIT_NEW_NATIVE", "0")
         .args([
-            "--manifest-path",
-            "../moon.work",
+            "-C",
+            "..",
             "test",
             "--target",
             "native",

--- a/crates/moon/tests/test_cases/prebuild/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild/mod.rs
@@ -108,12 +108,7 @@ fn test_pre_build_runs_from_module_root() {
 
     moon_cmd(&src_dir)
         .env("MOON_OVERRIDE", moon_bin())
-        .args([
-            "--manifest-path",
-            "../moon.mod.json",
-            "check",
-            "--sort-input",
-        ])
+        .args(["-C", "..", "check", "--sort-input"])
         .assert()
         .success();
 
@@ -152,17 +147,11 @@ fn test_pre_build_dry_run_uses_cwd_relative_placeholders() {
 }
 
 #[test]
-fn test_pre_build_dry_run_uses_prebuild_cwd_with_manifest_path() {
+fn test_pre_build_dry_run_uses_prebuild_cwd_after_chdir() {
     let dir = TestDir::new("pre_build.in");
     let src_dir = dir.join("src");
     let assert = moon_cmd(&src_dir)
-        .args([
-            "--manifest-path",
-            "../moon.mod.json",
-            "check",
-            "--dry-run",
-            "--sort-input",
-        ])
+        .args(["-C", "..", "check", "--dry-run", "--sort-input"])
         .assert()
         .success();
     let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();

--- a/crates/moon/tests/test_cases/run_profile/mod.rs
+++ b/crates/moon/tests/test_cases/run_profile/mod.rs
@@ -281,7 +281,7 @@ fn test_moon_test_profile_runs_profiler_from_module_root() {
     let output = moon_process_cmd(&spawn_dir)
         .env("PATH", path)
         .env("MOON_PROFILE_CWD_MARKER", &marker)
-        .args(["--manifest-path", "../moon.mod.json", "test", "--profile"])
+        .args(["-C", "..", "test", "--profile"])
         .output()
         .expect("failed to run profiled tests");
     assert!(

--- a/crates/moon/tests/test_cases/warns/mod.rs
+++ b/crates/moon/tests/test_cases/warns/mod.rs
@@ -255,16 +255,7 @@ fn test_warn_list_alerts() {
 
     // don't set -w if it's empty string
     check(
-        get_stdout(
-            &dir,
-            [
-                "check",
-                "--manifest-path",
-                "a/moon.mod.json",
-                "--sort-input",
-                "--dry-run",
-            ],
-        ),
+        get_stdout(&dir, ["-C", "a", "check", "--sort-input", "--dry-run"]),
         expect![[r#"
             moonc check ./b/hello.mbt -o ./_build/wasm-gc/debug/check/username/b/b.mi -pkg username/b -pkg-type library -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/b:./b -target wasm-gc -workspace-path ./b -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
             moonc check -doctest-only ./b/hello.mbt -include-doctests -o ./_build/wasm-gc/debug/check/username/b/b.blackbox_test.mi -pkg username/b_blackbox_test -pkg-type library -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/b_blackbox_test:./b -target wasm-gc -blackbox-test -workspace-path ./b -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
@@ -274,17 +265,8 @@ fn test_warn_list_alerts() {
     );
 
     check(
-        get_stderr(
-            &dir,
-            [
-                "check",
-                "--manifest-path",
-                "a/moon.mod.json",
-                "--sort-input",
-            ],
-        ),
+        get_stderr(&dir, ["-C", "a", "check", "--sort-input"]),
         expect![[r#"
-            Warning: `--manifest-path` is deprecated. Prefer `-C <project-dir>` to select a different project.
             Warning: [0014]
                ╭─[ $ROOT/a/main.mbt:2:3 ]
                │
@@ -304,10 +286,7 @@ fn test_warn_list_alerts() {
     );
 
     check(
-        get_stdout(
-            &dir,
-            ["test", "--manifest-path", "a/moon.mod.json", "--sort-input"],
-        ),
+        get_stdout(&dir, ["-C", "a", "test", "--sort-input"]),
         expect![[r#"
             Total tests: 1, passed: 1, failed: 0.
         "#]],
@@ -319,16 +298,7 @@ fn test_mod_level_warn_list_alerts() {
     let dir = TestDir::new("warns/mod_level");
 
     check(
-        get_stdout(
-            &dir,
-            [
-                "check",
-                "--manifest-path",
-                "a/moon.mod.json",
-                "--dry-run",
-                "--sort-input",
-            ],
-        ),
+        get_stdout(&dir, ["-C", "a", "check", "--dry-run", "--sort-input"]),
         expect![[r#"
             moonc check ./b/hello.mbt -o ./_build/wasm-gc/debug/check/username/b/b.mi -pkg username/b -pkg-type library -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/b:./b -target wasm-gc -workspace-path ./b -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json
             moonc check -doctest-only ./b/hello.mbt -include-doctests -o ./_build/wasm-gc/debug/check/username/b/b.blackbox_test.mi -pkg username/b_blackbox_test -pkg-type library -std-path '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/check/username/b/b.mi:b -i '$MOON_HOME/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/b_blackbox_test:./b -target wasm-gc -blackbox-test -workspace-path ./b -all-pkgs ./_build/wasm-gc/debug/check/all_pkgs.json

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -922,83 +922,7 @@ fn test_member_dir_can_disable_implicit_workspace_mode() {
 }
 
 #[test]
-fn test_manifest_path_targets_workspace_member_for_single_module_commands() {
-    let dir = TestDir::new("workspace_basic.in");
-
-    let stderr = get_stderr(
-        &dir,
-        [
-            "--manifest-path",
-            "app/moon.mod.json",
-            "add",
-            "moonbitlang/core",
-            "--no-update",
-        ],
-    );
-    assert!(
-        stderr.contains("no need to add `moonbitlang/core` as dependency"),
-        "expected add command to target app module, got:\n{stderr}"
-    );
-
-    let stderr = get_stderr(
-        &dir,
-        ["--manifest-path", "app/moon.mod.json", "package", "--list"],
-    );
-    assert!(
-        stderr.contains("src/main/main.mbt"),
-        "expected package command to list the app member contents, got:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("Package to $ROOT/_build/publish/alice-app-0.1.0.zip"),
-        "expected package command to write the app member archive, got:\n{stderr}"
-    );
-    assert!(
-        !stderr.contains("liba/src/lib/lib.mbt"),
-        "expected package command to target only the app member, got:\n{stderr}"
-    );
-
-    check(
-        std::fs::read_to_string(dir.join("app/moon.mod.json")).unwrap(),
-        expect![[r#"
-            {
-              "name": "alice/app",
-              "version": "0.1.0",
-              "source": "src",
-              "deps": {
-                "alice/liba": "0.1.0"
-              }
-            }
-        "#]],
-    );
-
-    check(
-        get_stdout(
-            &dir,
-            [
-                "--manifest-path",
-                "app/moon.mod.json",
-                "remove",
-                "alice/liba",
-            ],
-        ),
-        expect![[r#""#]],
-    );
-
-    let app_manifest = std::fs::read_to_string(dir.join("app/moon.mod.json")).unwrap();
-    check(
-        app_manifest.trim_end_matches('\n'),
-        expect![[r#"
-            {
-              "name": "alice/app",
-              "version": "0.1.0",
-              "deps": {},
-              "source": "src"
-            }"#]],
-    );
-}
-
-#[test]
-fn test_manifest_path_targets_dsl_member_for_tree() {
+fn test_member_dir_targets_dsl_member_for_tree() {
     let dir = TestDir::new("workspace_basic.in");
     std::fs::remove_file(dir.join("app/moon.mod.json")).unwrap();
     std::fs::write(
@@ -1018,7 +942,7 @@ options(
     )
     .unwrap();
 
-    let tree = get_stdout(&dir, ["--manifest-path", "app/moon.mod", "tree"]);
+    let tree = get_stdout(&dir, ["-C", "app", "tree"]);
     assert!(
         tree.contains("alice/app@0.1.0"),
         "expected app module in tree output, got:\n{tree}"
@@ -1034,7 +958,7 @@ options(
 }
 
 #[test]
-fn test_manifest_path_targets_dsl_member_for_remove() {
+fn test_member_dir_targets_dsl_member_for_remove() {
     let dir = TestDir::new("workspace_basic.in");
     std::fs::remove_file(dir.join("app/moon.mod.json")).unwrap();
     std::fs::write(
@@ -1057,10 +981,7 @@ options(
     .unwrap();
 
     check(
-        get_stdout(
-            &dir,
-            ["--manifest-path", "app/moon.mod", "remove", "alice/liba"],
-        ),
+        get_stdout(&dir, ["-C", "app", "remove", "alice/liba"]),
         expect![[r#""#]],
     );
 
@@ -1087,18 +1008,6 @@ options(
 }
 
 #[test]
-fn test_manifest_path_can_disable_implicit_workspace_mode() {
-    let dir = TestDir::new("workspace_basic.in");
-
-    let stderr = get_err_stderr_with_envs(
-        &dir,
-        ["--manifest-path", "app/moon.mod.json", "build", "--dry-run"],
-        [(MOON_WORK_ENV, "off")],
-    );
-    assert_registry_resolution_failure(&stderr);
-}
-
-#[test]
 fn test_workspace_root_cannot_use_workspace_with_env_override() {
     let dir = TestDir::new("workspace_basic.in");
 
@@ -1116,54 +1025,6 @@ fn test_same_root_module_can_disable_implicit_workspace_mode() {
 
     let stderr = get_err_stderr_with_envs(&dir, ["build", "--dry-run"], [(MOON_WORK_ENV, "off")]);
     assert_registry_resolution_failure(&stderr);
-}
-
-#[test]
-fn test_same_root_manifest_path_can_disable_implicit_workspace_mode() {
-    let dir = same_root_workspace_dir();
-
-    let stderr = get_err_stderr_with_envs(
-        &dir,
-        ["--manifest-path", "moon.mod.json", "build", "--dry-run"],
-        [(MOON_WORK_ENV, "off")],
-    );
-    assert_registry_resolution_failure(&stderr);
-}
-
-#[test]
-fn test_same_root_workspace_manifest_can_disable_workspace_mode_with_env_override() {
-    let dir = same_root_workspace_dir();
-
-    let stderr = get_err_stderr_with_envs(
-        &dir,
-        [
-            "--manifest-path",
-            "moon.work",
-            "build",
-            "--dry-run",
-            "--sort-input",
-        ],
-        [(MOON_WORK_ENV, "off")],
-    );
-    assert_registry_resolution_failure(&stderr);
-}
-
-#[test]
-fn test_workspace_manifest_path_cannot_use_workspace_with_env_override() {
-    let dir = TestDir::new("workspace_basic.in");
-
-    let stderr = get_err_stderr_with_envs(
-        &dir,
-        [
-            "--manifest-path",
-            "moon.work",
-            "build",
-            "--dry-run",
-            "--sort-input",
-        ],
-        [(MOON_WORK_ENV, "off")],
-    );
-    assert_workspace_disabled_without_module(&stderr);
 }
 
 #[test]
@@ -1342,29 +1203,6 @@ fn test_pinned_workspace_path_selects_outer_module_when_listed() {
 }
 
 #[test]
-fn test_pinned_workspace_path_rejects_unlisted_manifest_path_module() {
-    let dir = nested_workspace_under_unrelated_module_dir();
-
-    let stderr = get_err_stderr_with_envs(
-        &dir,
-        ["--manifest-path", "outer/moon.mod.json", "tree"],
-        [(
-            MOON_WORK_ENV,
-            dir.join("outer/ws/moon.work")
-                .to_string_lossy()
-                .into_owned(),
-        )],
-    );
-
-    assert!(
-        stderr.contains(
-            "pinned workspace `$ROOT/outer/ws/moon.work` from MOON_WORK does not apply to module `$ROOT/outer`"
-        ),
-        "expected pinned workspace membership error, got:\n{stderr}"
-    );
-}
-
-#[test]
 fn test_legacy_workspace_disable_env_warns_and_still_works() {
     let dir = TestDir::new("workspace_basic.in");
 
@@ -1472,32 +1310,7 @@ fn test_prove_targets_member_module_with_workspace_resolution() {
         "expected app prove dry-run to keep workspace-local dependency resolution, got:\n{stdout}"
     );
 
-    let stdout = get_stdout(
-        &dir,
-        ["--manifest-path", "app/moon.mod.json", "prove", "--dry-run"],
-    );
-    assert!(
-        stdout.contains("moonc prove ./app/src/main/main.mbt"),
-        "expected manifest-path prove dry-run to target the app member, got:\n{stdout}"
-    );
-    assert!(
-        stdout.contains("-workspace-path ./app"),
-        "expected manifest-path prove dry-run to keep workspace-local context, got:\n{stdout}"
-    );
-    assert!(
-        stdout.contains("alice/liba/lib"),
-        "expected manifest-path prove dry-run to keep workspace-local dependency resolution, got:\n{stdout}"
-    );
-
-    let stdout = get_stdout(
-        &dir,
-        [
-            "--manifest-path",
-            "liba/moon.mod.json",
-            "prove",
-            "--dry-run",
-        ],
-    );
+    let stdout = get_stdout(&dir, ["-C", "liba", "prove", "--dry-run"]);
     assert!(
         stdout.contains("alice/liba/lib"),
         "expected prove dry-run to target the liba module, got:\n{stdout}"
@@ -1537,15 +1350,6 @@ fn test_doc_targets_member_module_with_workspace_resolution() {
     assert!(
         stdout.contains("-serve-mode"),
         "expected doc --serve dry-run to enable serve mode for moondoc, got:\n{stdout}"
-    );
-
-    let stdout = get_stdout(
-        &dir,
-        ["--manifest-path", "app/moon.mod.json", "doc", "--dry-run"],
-    );
-    assert!(
-        stdout.contains("moondoc ./app -o ./_build/doc"),
-        "expected manifest-path doc dry-run to target the app member, got:\n{stdout}"
     );
 
     let stdout = get_stdout(&dir, ["-C", "app/src/main", "doc", "--dry-run"]);

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -72,23 +72,9 @@ impl PackageDirsError {
 
 #[derive(Debug, clap::Parser, Serialize, Deserialize, Clone)]
 pub struct SourceTargetDirs {
-    // NOTE: This separates "working directory" vs "project root".
-    //
-    // - `-C` changes the process working directory early (like `cd DIR && moon ...`).
-    // - `--manifest-path` pins the project root to a specific project manifest
-    //   (`moon.mod.json` or `moon.work`) without changing the working directory.
     /// Change to DIR before doing anything else (must appear before the subcommand). Relative paths in other options and arguments are interpreted relative to DIR. Example: `moon -C a run .` runs the same as invoking `moon run .` from within `a`.
     #[arg(short = 'C', value_name = "DIR")]
     pub cwd: Option<PathBuf>,
-
-    /// Path to `moon.mod.json` or `moon.work` to use as the project manifest (does not change the working directory).
-    #[arg(
-        long = "manifest-path",
-        global = true,
-        value_name = "PATH",
-        hide = true
-    )]
-    pub manifest_path: Option<PathBuf>,
 
     /// The target directory. Defaults to `<project-root>/_build`.
     #[clap(long, global = true)]
@@ -181,17 +167,6 @@ impl SourceTargetDirs {
             self.query_from(&start_dir, WorkspaceEnv::Off)?
         };
         query.work_root(selection)
-    }
-
-    fn deprecated_manifest_override(
-        &self,
-    ) -> Result<Option<ExplicitManifestOverride>, PackageDirsError> {
-        // TODO: Remove this compatibility path when deprecated `--manifest-path` is removed.
-        self.manifest_path
-            .as_deref()
-            .map(deprecated_manifest_override_from_path)
-            .transpose()
-            .map_err(PackageDirsError::from)
     }
 
     fn current_dir() -> Result<PathBuf, PackageDirsError> {
@@ -368,19 +343,6 @@ fn find_enclosing_module_root(source_dir: &Path) -> Option<PathBuf> {
         .map(|p| p.to_path_buf())
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum ManifestKind {
-    Module,
-    Workspace,
-}
-
-#[derive(Clone)]
-struct ExplicitManifestOverride {
-    path: PathBuf,
-    root: PathBuf,
-    kind: ManifestKind,
-}
-
 struct WorkspaceFacts {
     // Keep this as cheap path-level discovery. Parsed `moon.work` content and
     // member canonicalization are projections, because many commands only need
@@ -395,7 +357,6 @@ pub struct ProjectQuery {
     target_dir: Option<PathBuf>,
     start_dir: PathBuf,
     workspace_env: WorkspaceEnv,
-    deprecated_manifest_override: Option<ExplicitManifestOverride>,
     module_dir: Option<PathBuf>,
     module_manifest_path: Option<PathBuf>,
     workspace: Option<WorkspaceFacts>,
@@ -434,16 +395,8 @@ impl ProjectQuery {
                 )
             })
             .map_err(PackageDirsError::from)?;
-        let deprecated_manifest_override = source_target_dirs.deprecated_manifest_override()?;
-        let module_dir = match &deprecated_manifest_override {
-            Some(manifest) if manifest.kind == ManifestKind::Module => Some(manifest.root.clone()),
-            Some(manifest) => find_enclosing_module_root(&manifest.root),
-            None => find_enclosing_module_root(&start_dir),
-        };
-        let module_manifest_path = match &deprecated_manifest_override {
-            Some(manifest) if manifest.kind == ManifestKind::Module => Some(manifest.path.clone()),
-            _ => module_dir.as_deref().map(module_manifest_path),
-        };
+        let module_dir = find_enclosing_module_root(&start_dir);
+        let module_manifest_path = module_dir.as_deref().map(module_manifest_path);
         let workspace = match &workspace_env {
             WorkspaceEnv::Off => None,
             WorkspaceEnv::Pinned(workspace_path) => {
@@ -463,7 +416,6 @@ impl ProjectQuery {
             target_dir: source_target_dirs.target_dir.clone(),
             start_dir,
             workspace_env,
-            deprecated_manifest_override,
             module_dir,
             module_manifest_path,
             workspace,
@@ -472,11 +424,7 @@ impl ProjectQuery {
     }
 
     pub fn probe_project(&mut self) -> Result<ProjectProbe, PackageDirsError> {
-        let project_context = if let Some(manifest) = self.deprecated_manifest_override.clone() {
-            self.project_context_from_deprecated_manifest_override(&manifest)
-        } else {
-            self.project_context_from_start_dir()
-        };
+        let project_context = self.project_context_from_start_dir();
 
         match project_context {
             Ok(project) => Ok(ProjectProbe::Found(project)),
@@ -523,60 +471,6 @@ impl ProjectQuery {
             Ok(module_dir)
         } else {
             Ok(start_dir)
-        }
-    }
-
-    fn project_context_from_deprecated_manifest_override(
-        &mut self,
-        manifest: &ExplicitManifestOverride,
-    ) -> Result<ProjectContext, PackageDirsError> {
-        match &self.workspace_env {
-            WorkspaceEnv::Off => match manifest.kind {
-                ManifestKind::Module => Ok(ProjectContext::Module {
-                    root: manifest.root.clone(),
-                    manifest_path: manifest.path.clone(),
-                }),
-                ManifestKind::Workspace => {
-                    self.module_context_with_workspace_disabled(manifest.root.clone())
-                }
-            },
-            WorkspaceEnv::Auto => match manifest.kind {
-                ManifestKind::Module => {
-                    if let Some(workspace) = self.find_applicable_workspace_from(&manifest.root)? {
-                        Ok(ProjectContext::Workspace {
-                            root: workspace.root.clone(),
-                            manifest_path: workspace.manifest_path.clone(),
-                            selected_module: Some(ModuleRef {
-                                root: manifest.root.clone(),
-                                manifest_path: manifest.path.clone(),
-                            }),
-                        })
-                    } else {
-                        Ok(ProjectContext::Module {
-                            root: manifest.root.clone(),
-                            manifest_path: manifest.path.clone(),
-                        })
-                    }
-                }
-                ManifestKind::Workspace => Ok(ProjectContext::Workspace {
-                    root: manifest.root.clone(),
-                    manifest_path: manifest.path.clone(),
-                    selected_module: None,
-                }),
-            },
-            WorkspaceEnv::Pinned(_) => match manifest.kind {
-                ManifestKind::Module => {
-                    self.project_context_from_pinned_workspace(Some(ModuleRef {
-                        root: manifest.root.clone(),
-                        manifest_path: manifest.path.clone(),
-                    }))
-                }
-                ManifestKind::Workspace => Ok(ProjectContext::Workspace {
-                    root: manifest.root.clone(),
-                    manifest_path: manifest.path.clone(),
-                    selected_module: None,
-                }),
-            },
         }
     }
 
@@ -665,27 +559,6 @@ impl ProjectQuery {
                 .module_manifest_path
                 .clone()
                 .unwrap_or_else(|| module_manifest_path(module_dir)),
-        })
-    }
-
-    fn project_context_from_pinned_workspace(
-        &mut self,
-        selected_module: Option<ModuleRef>,
-    ) -> Result<ProjectContext, PackageDirsError> {
-        let workspace = self.pinned_workspace_ref();
-        if let Some(module) = &selected_module
-            && !self.workspace_contains_member(&module.root)?
-        {
-            return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
-                workspace: workspace.manifest_path.clone(),
-                module: module.root.clone(),
-            });
-        }
-
-        Ok(ProjectContext::Workspace {
-            root: workspace.root.clone(),
-            manifest_path: workspace.manifest_path.clone(),
-            selected_module,
         })
     }
 
@@ -781,10 +654,7 @@ impl ProjectQuery {
     }
 
     fn work_start_dir(&self) -> PathBuf {
-        self.deprecated_manifest_override
-            .as_ref()
-            .map(|manifest| manifest.root.clone())
-            .unwrap_or_else(|| self.start_dir.clone())
+        self.start_dir.clone()
     }
 
     fn pinned_workspace_ref(&self) -> WorkspaceRef {
@@ -806,7 +676,6 @@ fn project_query_from_start_dir(
 ) -> Result<ProjectQuery, PackageDirsError> {
     SourceTargetDirs {
         cwd: None,
-        manifest_path: None,
         target_dir: None,
     }
     .query_from(start_dir, workspace_env.clone())
@@ -818,24 +687,6 @@ fn resolve_project_context_from_start_dir(
     workspace_env: &WorkspaceEnv,
 ) -> Result<ProjectContext, PackageDirsError> {
     project_query_from_start_dir(start_dir, workspace_env)?.project()
-}
-
-#[cfg(test)]
-fn resolve_project_context_from_manifest_path(
-    manifest_path: &Path,
-    workspace_env: &WorkspaceEnv,
-) -> Result<ProjectContext, PackageDirsError> {
-    let source_target_dirs = SourceTargetDirs {
-        cwd: None,
-        manifest_path: Some(manifest_path.to_path_buf()),
-        target_dir: None,
-    };
-    let start_dir = manifest_path
-        .parent()
-        .context("manifest path has no parent directory")
-        .map_err(PackageDirsError::from)?;
-    let mut query = source_target_dirs.query_from(start_dir, workspace_env.clone())?;
-    query.project()
 }
 
 pub fn current_workspace_env() -> anyhow::Result<(WorkspaceEnv, Option<&'static str>)> {
@@ -943,64 +794,11 @@ fn manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {
         .map(Path::to_path_buf)
 }
 
-fn deprecated_manifest_override_from_path(
-    manifest_path: &Path,
-) -> anyhow::Result<ExplicitManifestOverride> {
-    let manifest_path = dunce::canonicalize(manifest_path).with_context(|| {
-        format!(
-            "failed to resolve manifest path `{}`",
-            manifest_path.display()
-        )
-    })?;
-
-    if manifest_path.is_dir() {
-        anyhow::bail!(
-            "`--manifest-path` must point to `{}`, `{}`, or `{}` (got directory `{}`)",
-            MOON_MOD,
-            MOON_MOD_JSON,
-            MOON_WORK,
-            manifest_path.display()
-        );
-    }
-
-    let file_name = manifest_path.file_name().and_then(|s| s.to_str());
-    if file_name != Some(MOON_MOD)
-        && file_name != Some(MOON_MOD_JSON)
-        && file_name != Some(MOON_WORK)
-    {
-        anyhow::bail!(
-            "`--manifest-path` must point to `{}`, `{}`, or `{}` (got `{}`)",
-            MOON_MOD,
-            MOON_MOD_JSON,
-            MOON_WORK,
-            manifest_path.display()
-        );
-    }
-
-    let kind = match file_name {
-        Some(MOON_MOD | MOON_MOD_JSON) => ManifestKind::Module,
-        Some(MOON_WORK) => ManifestKind::Workspace,
-        _ => unreachable!("manifest file name was validated above"),
-    };
-
-    let root = manifest_path
-        .parent()
-        .context("manifest path has no parent directory")
-        .map(Path::to_path_buf)?;
-
-    Ok(ExplicitManifestOverride {
-        path: manifest_path,
-        root,
-        kind,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
         PackageDirsError, ProjectContext, ProjectProbe, SourceTargetDirs, WorkspaceEnv,
-        parse_workspace_env, project_query_from_start_dir,
-        resolve_project_context_from_manifest_path, resolve_project_context_from_start_dir,
+        parse_workspace_env, project_query_from_start_dir, resolve_project_context_from_start_dir,
     };
     use crate::constants::{DEP_PATH, MOON_MOD, MOON_MOD_JSON};
     use std::{
@@ -1083,7 +881,6 @@ mod tests {
         let target = project.join("tmp-target");
         let dirs = SourceTargetDirs {
             cwd: None,
-            manifest_path: None,
             target_dir: Some(target),
         }
         .source_root_package_dirs(project.path())
@@ -1188,36 +985,6 @@ version = "0.1.0"
             PackageDirsError::PinnedWorkspaceDoesNotApply { workspace, module }
                 if workspace == workspace_path && module == canonical(project.join("outer"))
         ));
-    }
-
-    #[test]
-    fn pinned_workspace_rejects_unlisted_manifest_path_module() {
-        let project = nested_workspace_under_unrelated_module();
-        let workspace_path = canonical(project.join("outer/ws/moon.work"));
-        let json_module = project.join("outer/ws/json-tool");
-        let dsl_module = project.join("outer/ws/dsl-tool");
-        write_json_module(&json_module, "alice/json-tool");
-        write_file(
-            &dsl_module.join(MOON_MOD),
-            r#"name = "alice/dsl-tool"
-
-version = "0.1.0"
-"#,
-        );
-
-        for manifest_path in [json_module.join(MOON_MOD_JSON), dsl_module.join(MOON_MOD)] {
-            let err = resolve_project_context_from_manifest_path(
-                &manifest_path,
-                &WorkspaceEnv::Pinned(workspace_path.clone()),
-            )
-            .unwrap_err();
-
-            assert!(matches!(
-                err,
-                PackageDirsError::PinnedWorkspaceDoesNotApply { workspace, module }
-                    if workspace == workspace_path && module == canonical(manifest_path.parent().unwrap())
-            ));
-        }
     }
 
     #[test]

--- a/docs/dev/reference/workspace.md
+++ b/docs/dev/reference/workspace.md
@@ -205,12 +205,8 @@ Those commands need a selected member and will fail at workspace root with the
 Project selection depends on:
 
 - the working directory after `-C`
-- `--manifest-path`
 - `MOON_WORK`
 - `MOON_NO_WORKSPACE` (deprecated fallback)
-
-`--manifest-path` pins manifest resolution, but does not change the process
-working directory.
 
 ## `MOON_WORK`
 
@@ -234,8 +230,8 @@ With `MOON_WORK=off`:
 With `MOON_WORK=<path-to-moon.work>`:
 
 - project-scoped commands use that workspace even outside the workspace tree
-- if the current or explicitly selected `moon.mod.json` is not a workspace
-  member, Moon fails instead of silently falling back
+- if the module selected from the current directory is not a workspace member,
+  Moon fails instead of silently falling back
 
 ## `MOON_NO_WORKSPACE`
 
@@ -258,63 +254,19 @@ The algorithm is:
 
 1. Canonicalize the current directory.
 2. If `MOON_WORK=off` is enabled:
-   - find the nearest ancestor containing `moon.mod.json`
+   - find the nearest ancestor containing `moon.mod` or `moon.mod.json`
    - if found, select that module manifest
    - otherwise, fail because workspace mode is disabled and no module exists
 3. If `MOON_WORK` points to a `moon.work` file:
    - select that workspace manifest
-   - if the nearest ancestor `moon.mod.json` exists and is not a workspace
-     member, fail
+   - if the nearest ancestor module exists and is not a workspace member, fail
 4. Otherwise, walk ancestors from nearest to farthest and look for applicable
    workspace manifests.
 5. If an applicable workspace manifest is found, select that workspace
    manifest.
 6. If no applicable workspace is found, fall back to the nearest ancestor
-   `moon.mod.json`.
+   module manifest.
 7. If neither exists, fail with "not in a Moon project".
-
-`--manifest-path` still exists as a deprecated compatibility flag for
-non-`run` commands, but the public recommendation is to use `-C` instead.
-
-## Selection With `--manifest-path`
-
-`--manifest-path` accepts exactly:
-
-- `moon.mod.json`
-- `moon.work`
-
-The selected manifest path is canonicalized first.
-
-### `--manifest-path <...>/moon.mod.json`
-
-This means "start from this module".
-
-- if `MOON_WORK=off` is enabled, the command stays in single-module mode
-- otherwise, Moon may still promote to an enclosing applicable workspace
-
-This is important: `--manifest-path moon.mod.json` does not mean "force
-single-module mode". It means "select this module as the starting point".
-
-If an enclosing workspace applies, the command keeps:
-
-- `project_manifest_path = workspace manifest`
-- `project_root = workspace root`
-- `module_dir = selected module`
-
-That is how member-scoped commands can act on one member while still using the
-workspace's local dependency graph.
-
-### `--manifest-path <...>/moon.work`
-
-This means "start from this workspace root", but only when workspace mode is
-enabled.
-
-If `MOON_WORK=off` is enabled:
-
-- Moon ignores the workspace manifest
-- Moon falls back to the nearest ancestor `moon.mod.json`, if any
-- otherwise the command fails because workspace mode is disabled and no module
-  is available
 
 ## How Moon Decides Whether A Workspace Applies
 
@@ -369,9 +321,6 @@ selection.
 | `-C app` | start from `app`, then allow workspace promotion |
 | `-C app` + member-scoped command | act on `app`, but keep workspace-local deps/layout if a workspace applies |
 | `moon run path/to/app` from outside the project | discover the project from `path/to/app` |
-| `--manifest-path app/moon.mod.json` | start from `app`, then allow workspace promotion |
-| `--manifest-path app/moon.mod.json` + member-scoped command | act on `app`, but keep workspace-local deps/layout if a workspace applies |
-| `--manifest-path moon.work` | select the workspace manifest |
 | inside workspace member + `MOON_WORK=off` | ignore the workspace and use the nearest ancestor `moon.mod.json` |
 | workspace root with no module + `MOON_WORK=off` | error: workspace mode is disabled and no module is available |
 | anywhere + `MOON_WORK=/abs/path/to/moon.work` | pin selection to that workspace |


### PR DESCRIPTION
## Summary

- remove the deprecated hidden `--manifest-path` CLI option
- delete the explicit-manifest override field and project-selection branches
- remove the manifest-path handoff to `mooncake`
- update completions, workspace documentation, and affected tests to use `-C`
- retain a regression test that verifies the removed option is rejected

## Why

`-C <project-dir>` is the supported way to select another project. Keeping `--manifest-path` required a second project-selection path, special workspace behavior, and a private serialized field even after the option had been deprecated and hidden.

## Correctness and scope

Project discovery now consistently starts from the working directory after `-C` (or a command-specific selector such as `moon run`). Member-scoped package and publish commands still validate that a workspace member is selected before delegating.

The change removes only the deprecated option and its directly dependent plumbing. Existing project manifest models used by build discovery remain unchanged.