### PR TITLE
Distinguish native resource handle types in moonrun

### DIFF
--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -18,6 +18,10 @@
 
 #[cfg(unix)]
 use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
 
 use crate::async_host::{
     AsyncHostError, AsyncHostResult, GuestMemory, INVALID_HOST_HANDLE, read_u16,
@@ -270,7 +274,16 @@ pub(super) fn get_process_result(
         let resource = handle_id
             .map(|handle| context.host.resource(handle))
             .transpose()?;
-        let raw_handle = resource.as_ref().map(|resource| resource.raw_fd());
+        #[cfg(unix)]
+        let raw_handle = resource
+            .as_ref()
+            .map(|resource| resource.as_fd().map(|fd| fd.as_raw_fd()))
+            .transpose()?;
+        #[cfg(windows)]
+        let raw_handle = resource
+            .as_ref()
+            .map(|resource| resource.as_handle().map(|handle| handle.as_raw_handle()))
+            .transpose()?;
         #[cfg(unix)]
         let code = context.host.finish_owned_child(pid, handle_id, || {
             process::get_process_result(raw_handle, pid)

--- a/crates/moonrun/src/async_api/socket.rs
+++ b/crates/moonrun/src/async_api/socket.rs
@@ -16,6 +16,11 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawSocket;
+
 use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory, read_u16};
 use crate::async_policy::AsyncPolicy;
 use crate::async_sys::internal::event_loop::thread_pool::{ResourceClass, ResourceRef};
@@ -382,7 +387,7 @@ pub(super) fn listen(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
         .resource_of_class(fd, ResourceClass::TcpSocket)
         .and_then(|file| {
             check_listen_bind_policy(host.policy(), &file)?;
-            sys::listen(file.raw_fd())
+            sys::listen(raw_socket(&file)?)
         });
     zero_or_minus_one(context, result)
 }
@@ -582,7 +587,7 @@ pub(super) fn accept(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, ad
         let addr = memory.read_exact_mut(addr, addr_len)?;
         let file = host.resource_of_class(fd, ResourceClass::TcpSocket)?;
         let family = file.socket_family().ok_or(AsyncHostError::Inval)?;
-        let fd = sys::accept(file.raw_fd(), addr)?;
+        let fd = sys::accept(raw_socket(&file)?, addr)?;
         Ok((fd, family))
     });
     match result {
@@ -668,7 +673,7 @@ fn zero_or_minus_one(context: &mut ImportContext<'_, '_>, result: AsyncHostResul
 
 fn check_listen_bind_policy(policy: &AsyncPolicy, file: &ResourceRef) -> AsyncHostResult<()> {
     let mut local_addr = vec![0; socket_addr_buffer_len()];
-    let implicit_addr = match sys::getsockname(file.raw_fd(), &mut local_addr) {
+    let implicit_addr = match sys::getsockname(raw_socket(file)?, &mut local_addr) {
         Ok(()) if socket_addr_port(&local_addr)? == 0 => Some(local_addr),
         Ok(()) => None,
         Err(error) => Some(listen_bind_addr_after_getsockname_error(file, error)?),
@@ -677,6 +682,16 @@ fn check_listen_bind_policy(policy: &AsyncPolicy, file: &ResourceRef) -> AsyncHo
         policy.bind_socket(&addr)?;
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn raw_socket(file: &ResourceRef) -> AsyncHostResult<sys::RawSocket> {
+    Ok(file.as_fd()?.as_raw_fd())
+}
+
+#[cfg(windows)]
+fn raw_socket(file: &ResourceRef) -> AsyncHostResult<sys::RawSocket> {
+    Ok(file.as_socket()?.as_raw_socket())
 }
 
 #[cfg(unix)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -29,6 +29,10 @@
 use std::collections::{HashMap, HashSet};
 #[cfg(unix)]
 use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, AsRawSocket, RawHandle};
 use std::sync::{Arc, Mutex};
 
 use slotmap::{Key, KeyData, SecondaryMap, SlotMap, new_key_type};
@@ -1055,8 +1059,10 @@ impl HostIoResult {
     }
 
     #[cfg(test)]
-    fn pending_raw_fd(&self) -> Option<RawFd> {
-        self.pending_resource.as_ref().map(|file| file.raw_fd())
+    fn pending_resource_identity(&self) -> Option<isize> {
+        self.pending_resource
+            .as_ref()
+            .map(|file| file.raw_identity())
     }
 
     fn is_pending(&self) -> bool {
@@ -1122,9 +1128,9 @@ impl HostIoResult {
         let Some(file) = &self.pending_resource else {
             return Ok(0);
         };
-        let raw_fd = file.raw_fd();
+        let raw_handle = raw_overlapped_handle(file)?;
         let overlapped = self.overlapped_ptr();
-        if unsafe { CancelIoEx(raw_fd, overlapped) } == 0 {
+        if unsafe { CancelIoEx(raw_handle, overlapped) } == 0 {
             let errno = last_errno();
             if errno != ERROR_NOT_FOUND as i32 {
                 return Err(AsyncHostError::Native(errno));
@@ -1132,7 +1138,7 @@ impl HostIoResult {
         }
 
         let mut bytes_transferred = 0;
-        if unsafe { GetOverlappedResult(raw_fd, overlapped, &mut bytes_transferred, 0) } != 0 {
+        if unsafe { GetOverlappedResult(raw_handle, overlapped, &mut bytes_transferred, 0) } != 0 {
             self.clear_pending();
             return Ok(0);
         }
@@ -1154,9 +1160,9 @@ impl HostIoResult {
         let Some(file) = &self.pending_resource else {
             return Ok(());
         };
-        let raw_fd = file.raw_fd();
+        let raw_handle = raw_overlapped_handle(file)?;
         let overlapped = self.overlapped_ptr();
-        if unsafe { CancelIoEx(raw_fd, overlapped) } == 0 {
+        if unsafe { CancelIoEx(raw_handle, overlapped) } == 0 {
             let errno = last_errno();
             if errno != ERROR_NOT_FOUND as i32 {
                 return Err(AsyncHostError::Native(errno));
@@ -1167,7 +1173,7 @@ impl HostIoResult {
         // With bWait=TRUE the operation has reached a final status when this
         // returns, even if the final status is an error such as EOF or broken
         // pipe. At that point the host no longer treats the result as pending.
-        let _ = unsafe { GetOverlappedResult(raw_fd, overlapped, &mut bytes_transferred, 1) };
+        let _ = unsafe { GetOverlappedResult(raw_handle, overlapped, &mut bytes_transferred, 1) };
         self.clear_pending();
         Ok(())
     }
@@ -1549,7 +1555,9 @@ impl AsyncHost {
         read_only: bool,
     ) -> AsyncHostResult<()> {
         let resource = self.resource(fd_handle)?;
-        let raw_fd = resource.raw_fd();
+        let resource_identity = resource.raw_identity();
+        #[cfg(unix)]
+        let raw_fd = resource.as_file()?.as_raw_fd();
         let poll_key = self.handles.lock().unwrap().poll(poll_handle)?;
         let poll = Arc::clone(
             self.polls
@@ -1561,7 +1569,18 @@ impl AsyncHost {
         );
         {
             let poll = poll.lock().unwrap();
+            #[cfg(unix)]
             poll::poll_register(&poll.instance, raw_fd, read_only)?;
+            #[cfg(windows)]
+            if resource.resource_class().is_socket() {
+                poll::poll_register_socket(&poll.instance, resource.as_socket()?, read_only)?;
+            } else {
+                poll::poll_register_file(
+                    &poll.instance,
+                    resource.as_file()?.as_raw_handle(),
+                    read_only,
+                )?;
+            }
         }
         let handles = self.handles.lock().unwrap();
         if !handles.resource_is(fd_handle, &resource) {
@@ -1575,7 +1594,7 @@ impl AsyncHost {
         }
         let mut poll = poll.lock().unwrap();
         poll.registered_fds.insert(
-            raw_fd_key(raw_fd),
+            resource_identity,
             RegisteredFd {
                 handle: fd_handle,
                 resource,
@@ -1928,8 +1947,9 @@ impl AsyncHost {
                 .collect::<Vec<_>>();
             if let Some(source) = completion_source
                 && let Ok(file) = self.handles.lock().unwrap().remove_resource(source)
+                && let Ok(file) = file.as_fd()
             {
-                let raw_fd = file.raw_fd();
+                let raw_fd = file.as_raw_fd();
                 for poll in &polls {
                     let mut poll = poll.lock().unwrap();
                     if poll.registered_fds.contains_key(&raw_fd_key(raw_fd)) {
@@ -2402,7 +2422,9 @@ impl AsyncHost {
             handles.remove_resource(handle)?
         };
         self.untrack_process_handle(handle);
-        let raw_fd = file.raw_fd();
+        let resource_identity = file.raw_identity();
+        #[cfg(unix)]
+        let raw_fd = file.as_fd()?.as_raw_fd();
         let polls = self
             .polls
             .lock()
@@ -2413,11 +2435,11 @@ impl AsyncHost {
             .collect::<Vec<_>>();
         for poll in polls {
             let mut poll = poll.lock().unwrap();
-            if poll.registered_fds.contains_key(&raw_fd_key(raw_fd)) {
+            if poll.registered_fds.contains_key(&resource_identity) {
                 #[cfg(unix)]
                 let _ = poll::poll_unregister(&poll.instance, raw_fd);
             }
-            poll.registered_fds.remove(&raw_fd_key(raw_fd));
+            poll.registered_fds.remove(&resource_identity);
         }
         #[cfg(unix)]
         {
@@ -2593,19 +2615,28 @@ impl AsyncHost {
         &self,
         handle: HostHandle,
         class: ResourceClass,
-        f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
+        f: impl FnOnce(RawSocket) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
+        debug_assert!(class.is_socket());
         let file = self.resource_of_class(handle, class)?;
-        f(file.raw_fd())
+        #[cfg(unix)]
+        let socket = file.as_fd()?.as_raw_fd();
+        #[cfg(windows)]
+        let socket = file.as_socket()?.as_raw_socket();
+        f(socket)
     }
 
     pub(crate) fn with_raw_socket<T>(
         &self,
         handle: HostHandle,
-        f: impl FnOnce(RawFd) -> AsyncHostResult<T>,
+        f: impl FnOnce(RawSocket) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
         let file = self.socket_resource(handle)?;
-        f(file.raw_fd())
+        #[cfg(unix)]
+        let socket = file.as_fd()?.as_raw_fd();
+        #[cfg(windows)]
+        let socket = file.as_socket()?.as_raw_socket();
+        f(socket)
     }
 
     #[cfg(any(windows, target_os = "linux"))]
@@ -2653,19 +2684,29 @@ impl AsyncHost {
 
     pub(crate) fn kind_of_fd(&self, handle: HostHandle) -> AsyncHostResult<i32> {
         let file = self.resource(handle)?;
-        crate::async_sys::internal::fd_util::stub::kind_of_fd(file.raw_fd())
+        #[cfg(unix)]
+        {
+            crate::async_sys::internal::fd_util::stub::kind_of_file(file.as_file()?)
+        }
+        #[cfg(windows)]
+        {
+            if file.resource_class().is_socket() {
+                crate::async_sys::internal::fd_util::stub::kind_of_socket(file.as_socket()?)
+            } else {
+                crate::async_sys::internal::fd_util::stub::kind_of_file(file.as_file()?)
+            }
+        }
     }
 
     pub(crate) fn set_cloexec(&self, handle: HostHandle) -> AsyncHostResult<()> {
         let file = self.resource(handle)?;
-        let raw_fd = file.raw_fd();
         #[cfg(unix)]
         {
-            crate::async_sys::internal::fd_util::stub::set_cloexec(raw_fd)
+            crate::async_sys::internal::fd_util::stub::set_cloexec(file.as_file()?.as_raw_fd())
         }
         #[cfg(windows)]
         {
-            let _ = raw_fd;
+            let _ = file;
             Ok(())
         }
     }
@@ -2682,7 +2723,7 @@ impl AsyncHost {
         let offset_dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
         let dst = memory.read_exact_mut(offset_dst, len)?;
         let file = self.resource(handle)?;
-        crate::async_sys::internal::event_loop::io::read(file.raw_fd(), dst)
+        crate::async_sys::internal::event_loop::io::read(file.as_file()?.as_raw_fd(), dst)
             .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
     }
 
@@ -2698,7 +2739,7 @@ impl AsyncHost {
         let offset_src = src.checked_add(offset).ok_or(AsyncHostError::Fault)?;
         let src = memory.read_exact(offset_src, len)?;
         let file = self.resource(handle)?;
-        crate::async_sys::internal::event_loop::io::write(file.raw_fd(), src)
+        crate::async_sys::internal::event_loop::io::write(file.as_file()?.as_raw_fd(), src)
             .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
     }
 
@@ -2880,7 +2921,7 @@ impl AsyncHost {
         use windows_sys::Win32::System::IO::GetOverlappedResult;
 
         let file = self.resource(fd_handle)?;
-        let raw_fd = file.raw_fd();
+        let raw_handle = raw_overlapped_handle(&file)?;
         let result_key = self.handles.lock().unwrap().io_result(result_handle)?;
         let mut io_results = self.io_results.lock().unwrap();
         let result = io_results
@@ -2890,7 +2931,12 @@ impl AsyncHost {
         result.validate_pending_resource(&file)?;
         let mut bytes_transferred = 0;
         if unsafe {
-            GetOverlappedResult(raw_fd, result.overlapped_ptr(), &mut bytes_transferred, 0)
+            GetOverlappedResult(
+                raw_handle,
+                result.overlapped_ptr(),
+                &mut bytes_transferred,
+                0,
+            )
         } == 0
         {
             let error = last_native_error();
@@ -2964,7 +3010,6 @@ impl AsyncHost {
             return Err(AsyncHostError::Inval);
         }
         let file = result.kind.resource(&handles, fd_handle)?;
-        let raw_fd = file.raw_fd();
         drop(handles);
         let mut bytes_transferred = 0;
         let success = match result.kind {
@@ -2972,7 +3017,7 @@ impl AsyncHost {
                 let len = u32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
                 unsafe {
                     ReadFile(
-                        raw_fd,
+                        file.as_file()?.as_raw_handle(),
                         result.buffer.as_mut_ptr().cast(),
                         len,
                         &mut bytes_transferred,
@@ -2985,7 +3030,7 @@ impl AsyncHost {
                 unsafe {
                     i32::from(
                         ws::WSARecv(
-                            raw_fd as usize,
+                            file.as_socket()?.as_raw_socket() as usize,
                             &buffer,
                             1,
                             &mut bytes_transferred,
@@ -3007,7 +3052,7 @@ impl AsyncHost {
                 unsafe {
                     i32::from(
                         ws::WSARecvFrom(
-                            raw_fd as usize,
+                            file.as_socket()?.as_raw_socket() as usize,
                             &buffer,
                             1,
                             &mut bytes_transferred,
@@ -3062,7 +3107,6 @@ impl AsyncHost {
             return Err(AsyncHostError::Inval);
         }
         let file = result.kind.resource(&handles, fd_handle)?;
-        let raw_fd = file.raw_fd();
         drop(handles);
         if result.kind == HostIoKind::SocketWithAddr {
             self.policy.connect_socket(&result.addr_buffer)?;
@@ -3073,7 +3117,7 @@ impl AsyncHost {
                 let len = u32::try_from(result.buffer.len()).map_err(|_| AsyncHostError::Fault)?;
                 unsafe {
                     WriteFile(
-                        raw_fd,
+                        file.as_file()?.as_raw_handle(),
                         result.buffer.as_ptr().cast(),
                         len,
                         &mut bytes_transferred,
@@ -3086,7 +3130,7 @@ impl AsyncHost {
                 unsafe {
                     i32::from(
                         ws::WSASend(
-                            raw_fd as usize,
+                            file.as_socket()?.as_raw_socket() as usize,
                             &buffer,
                             1,
                             &mut bytes_transferred,
@@ -3102,7 +3146,7 @@ impl AsyncHost {
                 unsafe {
                     i32::from(
                         ws::WSASendTo(
-                            raw_fd as usize,
+                            file.as_socket()?.as_raw_socket() as usize,
                             &buffer,
                             1,
                             &mut bytes_transferred,
@@ -3144,7 +3188,7 @@ impl AsyncHost {
         // the same order before removing the handle from the namespace.
         let handles = self.handles.lock().unwrap();
         let file = handles.resource_of_class(fd_handle, ResourceClass::TcpSocket)?;
-        let raw_fd = file.raw_fd();
+        let raw_socket = file.as_socket()?.as_raw_socket();
         let result_key = handles.io_result(result_handle)?;
         let mut io_results = self.io_results.lock().unwrap();
         drop(handles);
@@ -3157,13 +3201,13 @@ impl AsyncHost {
         }
         self.policy.connect_socket(&result.addr_buffer)?;
 
-        bind_any_for_connect(raw_fd, &result.addr_buffer)?;
-        let connect_ex = get_wsa_extension::<ws::LPFN_CONNECTEX>(raw_fd, &ws::WSAID_CONNECTEX)?
+        bind_any_for_connect(raw_socket, &result.addr_buffer)?;
+        let connect_ex = get_wsa_extension::<ws::LPFN_CONNECTEX>(raw_socket, &ws::WSAID_CONNECTEX)?
             .ok_or(AsyncHostError::Inval)?;
         let addr_len = socket_addr_len(&result.addr_buffer)?;
         let success = unsafe {
             connect_ex(
-                raw_fd as usize,
+                raw_socket as usize,
                 result.addr_buffer.as_ptr().cast::<ws::SOCKADDR>(),
                 addr_len,
                 std::ptr::null(),
@@ -3191,7 +3235,7 @@ impl AsyncHost {
         let yes: u32 = 1;
         if unsafe {
             ws::setsockopt(
-                file.raw_fd() as usize,
+                file.as_socket()?.as_raw_socket() as usize,
                 ws::SOL_SOCKET,
                 ws::SO_UPDATE_CONNECT_CONTEXT,
                 (&yes as *const u32).cast(),
@@ -3219,8 +3263,8 @@ impl AsyncHost {
         let handles = self.handles.lock().unwrap();
         let server_file = handles.resource_of_class(server_fd_handle, ResourceClass::TcpSocket)?;
         let conn_file = handles.resource_of_class(conn_fd_handle, ResourceClass::TcpSocket)?;
-        let server_fd = server_file.raw_fd();
-        let conn_fd = conn_file.raw_fd();
+        let server_socket = server_file.as_socket()?.as_raw_socket();
+        let conn_socket = conn_file.as_socket()?.as_raw_socket();
         let result_key = handles.io_result(result_handle)?;
         let mut io_results = self.io_results.lock().unwrap();
         drop(handles);
@@ -3232,14 +3276,14 @@ impl AsyncHost {
             return Err(AsyncHostError::Inval);
         }
 
-        let accept_ex = get_wsa_extension::<ws::LPFN_ACCEPTEX>(server_fd, &ws::WSAID_ACCEPTEX)?
+        let accept_ex = get_wsa_extension::<ws::LPFN_ACCEPTEX>(server_socket, &ws::WSAID_ACCEPTEX)?
             .ok_or(AsyncHostError::Inval)?;
         let addr_len = u32::try_from(result.addr_len).map_err(|_| AsyncHostError::Fault)?;
         let accept_addr_len = addr_len.checked_add(16).ok_or(AsyncHostError::Fault)?;
         let success = unsafe {
             accept_ex(
-                server_fd as usize,
-                conn_fd as usize,
+                server_socket as usize,
+                conn_socket as usize,
                 result.accept_buffer.as_mut_ptr().cast(),
                 0,
                 accept_addr_len,
@@ -3293,10 +3337,10 @@ impl AsyncHost {
 
         let listen_file = self.resource_of_class(listen_fd_handle, ResourceClass::TcpSocket)?;
         let accept_file = self.resource_of_class(accept_fd_handle, ResourceClass::TcpSocket)?;
-        let listen_socket = listen_file.raw_fd() as usize;
+        let listen_socket = listen_file.as_socket()?.as_raw_socket() as usize;
         if unsafe {
             ws::setsockopt(
-                accept_file.raw_fd() as usize,
+                accept_file.as_socket()?.as_raw_socket() as usize,
                 ws::SOL_SOCKET,
                 ws::SO_UPDATE_ACCEPT_CONTEXT,
                 (&listen_socket as *const usize).cast(),
@@ -4218,7 +4262,7 @@ fn socket_addr_len(addr: &[u8]) -> AsyncHostResult<i32> {
 }
 
 #[cfg(windows)]
-fn bind_any_for_connect(raw_fd: RawFd, remote_addr: &[u8]) -> AsyncHostResult<()> {
+fn bind_any_for_connect(raw_socket: RawSocket, remote_addr: &[u8]) -> AsyncHostResult<()> {
     use windows_sys::Win32::Networking::WinSock;
 
     let result = match socket_addr_family(remote_addr)? {
@@ -4227,7 +4271,7 @@ fn bind_any_for_connect(raw_fd: RawFd, remote_addr: &[u8]) -> AsyncHostResult<()
             addr.sin_family = WinSock::AF_INET;
             unsafe {
                 WinSock::bind(
-                    raw_fd as usize,
+                    raw_socket as usize,
                     (&addr as *const WinSock::SOCKADDR_IN).cast::<WinSock::SOCKADDR>(),
                     std::mem::size_of_val(&addr) as i32,
                 )
@@ -4238,7 +4282,7 @@ fn bind_any_for_connect(raw_fd: RawFd, remote_addr: &[u8]) -> AsyncHostResult<()
             addr.sin6_family = WinSock::AF_INET6;
             unsafe {
                 WinSock::bind(
-                    raw_fd as usize,
+                    raw_socket as usize,
                     (&addr as *const WinSock::SOCKADDR_IN6).cast::<WinSock::SOCKADDR>(),
                     std::mem::size_of_val(&addr) as i32,
                 )
@@ -4260,7 +4304,10 @@ fn bind_any_for_connect(raw_fd: RawFd, remote_addr: &[u8]) -> AsyncHostResult<()
 }
 
 #[cfg(windows)]
-fn get_wsa_extension<T: Copy>(raw_fd: RawFd, guid: &windows_sys::core::GUID) -> AsyncHostResult<T> {
+fn get_wsa_extension<T: Copy>(
+    raw_socket: RawSocket,
+    guid: &windows_sys::core::GUID,
+) -> AsyncHostResult<T> {
     use windows_sys::Win32::Networking::WinSock;
 
     debug_assert_eq!(
@@ -4271,7 +4318,7 @@ fn get_wsa_extension<T: Copy>(raw_fd: RawFd, guid: &windows_sys::core::GUID) -> 
     let mut bytes_returned = 0;
     let ret = unsafe {
         WinSock::WSAIoctl(
-            raw_fd as usize,
+            raw_socket as usize,
             WinSock::SIO_GET_EXTENSION_FUNCTION_POINTER,
             (guid as *const windows_sys::core::GUID).cast(),
             std::mem::size_of_val(guid) as u32,
@@ -4286,6 +4333,18 @@ fn get_wsa_extension<T: Copy>(raw_fd: RawFd, guid: &windows_sys::core::GUID) -> 
         Err(AsyncHostError::Native(last_wsa_errno()))
     } else {
         Ok(unsafe { std::mem::transmute_copy(&extension) })
+    }
+}
+
+#[cfg(windows)]
+fn raw_overlapped_handle(file: &Resource) -> AsyncHostResult<RawHandle> {
+    if file.resource_class().is_socket() {
+        // The Windows overlapped-I/O functions used by the native async host
+        // accept sockets through their HANDLE parameter. Keep that ABI cast at
+        // this adapter seam rather than representing sockets as file handles.
+        Ok(file.as_socket()?.as_raw_socket() as RawHandle)
+    } else {
+        Ok(file.as_file()?.as_raw_handle())
     }
 }
 
@@ -4438,7 +4497,12 @@ mod tests {
         #[cfg(windows)]
         assert_eq!(
             crate::async_sys::process::process_id_from_handle(
-                process_resource.as_ref().unwrap().raw_fd()
+                process_resource
+                    .as_ref()
+                    .unwrap()
+                    .as_handle()
+                    .unwrap()
+                    .as_raw_handle()
             )
             .unwrap(),
             pid
@@ -4738,8 +4802,8 @@ mod tests {
             [(false, false), (true, false), (false, true), (true, true)]
         {
             let [read, write] = host.pipe(read_is_async, write_is_async).unwrap();
-            let read_fd = host.resource(read).unwrap().raw_fd();
-            let write_fd = host.resource(write).unwrap().raw_fd();
+            let read_fd = host.resource(read).unwrap().as_fd().unwrap().as_raw_fd();
+            let write_fd = host.resource(write).unwrap().as_fd().unwrap().as_raw_fd();
             let read_flags = unsafe { libc::fcntl(read_fd, libc::F_GETFL) };
             let write_flags = unsafe { libc::fcntl(write_fd, libc::F_GETFL) };
 
@@ -4801,7 +4865,12 @@ mod tests {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let completion_source = host.init_thread_pool(poll).unwrap();
-        let raw_completion_fd = host.resource(completion_source).unwrap().raw_fd();
+        let raw_completion_fd = host
+            .resource(completion_source)
+            .unwrap()
+            .as_fd()
+            .unwrap()
+            .as_raw_fd();
         {
             let polls = host.polls.lock().unwrap();
             let poll = polls
@@ -5843,7 +5912,13 @@ mod tests {
         host.write_fd(&mut input, write, 0, 0, 1).unwrap();
 
         let mut output = [0];
-        let ret = unsafe { libc::read(file.raw_fd(), output.as_mut_ptr().cast(), output.len()) };
+        let ret = unsafe {
+            libc::read(
+                file.as_fd().unwrap().as_raw_fd(),
+                output.as_mut_ptr().cast(),
+                output.len(),
+            )
+        };
         assert_eq!(ret, 1);
 
         assert_eq!(output[0], b'x');
@@ -5866,7 +5941,7 @@ mod tests {
             .unwrap();
 
         host.close_fd(read).unwrap();
-        let fd = host.resource(write).unwrap().raw_fd();
+        let fd = host.resource(write).unwrap().as_fd().unwrap().as_raw_fd();
         let byte = b"x";
         let ret = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
         assert_eq!(ret, 1);
@@ -5883,7 +5958,7 @@ mod tests {
         let mut result = HostIoResult::for_file_read(0, 0).unwrap();
         let pending_resource = Arc::new(Resource::invalid());
         let other_file = Arc::new(Resource::invalid());
-        let pending_fd = pending_resource.raw_fd();
+        let pending_fd = pending_resource.raw_identity();
 
         result.mark_pending(pending_resource).unwrap();
 
@@ -5891,7 +5966,7 @@ mod tests {
             result.validate_pending_resource(&other_file),
             Err(AsyncHostError::Badf)
         );
-        assert_eq!(result.pending_raw_fd(), Some(pending_fd));
+        assert_eq!(result.pending_resource_identity(), Some(pending_fd));
     }
 
     #[cfg(windows)]
@@ -5901,7 +5976,7 @@ mod tests {
 
         assert_eq!(result.buffer, vec![0; 3]);
         assert_eq!(result.event, IO_RESULT_READ_EVENT);
-        assert_eq!(result.pending_raw_fd(), None);
+        assert_eq!(result.pending_resource_identity(), None);
     }
 
     #[cfg(windows)]
@@ -5976,7 +6051,7 @@ mod tests {
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let raw_read = {
             let read_file = host.resource(read).unwrap();
-            let raw_read = read_file.raw_fd();
+            let raw_read = read_file.raw_identity();
             host.io_results
                 .lock()
                 .unwrap()
@@ -5998,7 +6073,7 @@ mod tests {
                 .io_results
                 .get_mut(io_result_key(&host, result))
                 .unwrap();
-            assert_eq!(result.pending_raw_fd(), Some(raw_read));
+            assert_eq!(result.pending_resource_identity(), Some(raw_read));
             result.clear_pending();
         }
 
@@ -6032,7 +6107,7 @@ mod tests {
                 .io_results
                 .get(io_result_key(&host, result))
                 .unwrap();
-            assert_eq!(result.pending_raw_fd(), None);
+            assert_eq!(result.pending_resource_identity(), None);
         }
 
         host.free_io_result(result).unwrap();
@@ -6048,7 +6123,7 @@ mod tests {
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let raw_read = {
             let read_file = host.resource(read).unwrap();
-            let raw_read = read_file.raw_fd();
+            let raw_read = read_file.raw_identity();
             let mut io_results = host.io_results.lock().unwrap();
             let result = io_results
                 .io_results
@@ -6068,7 +6143,7 @@ mod tests {
                 .io_results
                 .get_mut(io_result_key(&host, result))
                 .unwrap();
-            assert_eq!(result.pending_raw_fd(), Some(raw_read));
+            assert_eq!(result.pending_resource_identity(), Some(raw_read));
             result.clear_pending();
         }
 
@@ -6085,7 +6160,7 @@ mod tests {
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let raw_read = {
             let read_file = host.resource(read).unwrap();
-            let raw_read = read_file.raw_fd();
+            let raw_read = read_file.raw_identity();
             host.io_results
                 .lock()
                 .unwrap()
@@ -6105,7 +6180,7 @@ mod tests {
                 .io_results
                 .get_mut(io_result_key(&host, result))
                 .unwrap();
-            assert_eq!(result.pending_raw_fd(), Some(raw_read));
+            assert_eq!(result.pending_resource_identity(), Some(raw_read));
             result.clear_pending();
         }
 
@@ -6123,8 +6198,8 @@ mod tests {
         let (raw_read, raw_write) = {
             let read_file = host.resource(read).unwrap();
             let write_file = host.resource(write).unwrap();
-            let raw_read = read_file.raw_fd();
-            let raw_write = write_file.raw_fd();
+            let raw_read = read_file.raw_identity();
+            let raw_write = write_file.raw_identity();
             host.io_results
                 .lock()
                 .unwrap()
@@ -6150,13 +6225,13 @@ mod tests {
                 .io_results
                 .get_mut(io_result_key(&host, result))
                 .unwrap();
-            assert_eq!(result.pending_raw_fd(), Some(raw_read));
+            assert_eq!(result.pending_resource_identity(), Some(raw_read));
             assert!(result.protects_pending_resource(&host.resource(write).unwrap()));
             assert_eq!(
                 result
                     .extra_pending_close_resource
                     .as_ref()
-                    .map(|file| file.raw_fd()),
+                    .map(|file| file.raw_identity()),
                 Some(raw_write)
             );
             result.clear_pending();
@@ -6225,7 +6300,7 @@ mod tests {
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let [read, write] = host.pipe(true, true).unwrap();
         let read_file = host.resource(read).unwrap();
-        let raw_fd = read_file.raw_fd();
+        let raw_fd = read_file.raw_identity();
         let overlapped = {
             let mut io_results = host.io_results.lock().unwrap();
             let result = io_results
@@ -6250,7 +6325,7 @@ mod tests {
                 .io_results
                 .get(io_result_key(&host, result))
                 .unwrap()
-                .pending_raw_fd(),
+                .pending_resource_identity(),
             None
         );
         host.free_io_result(result).unwrap();
@@ -6295,7 +6370,7 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         host.poll_register(poll, read, true).unwrap();
 
-        let fd = host.resource(write).unwrap().raw_fd();
+        let fd = host.resource(write).unwrap().as_fd().unwrap().as_raw_fd();
         let byte = b"x";
         let ret = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
         assert_eq!(ret, 1);
@@ -6321,7 +6396,7 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         host.poll_register(poll, read, true).unwrap();
 
-        let fd = host.resource(write).unwrap().raw_fd();
+        let fd = host.resource(write).unwrap().as_fd().unwrap().as_raw_fd();
         let byte = b"x";
         let ret = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
         assert_eq!(ret, 1);

--- a/crates/moonrun/src/async_sys/fs/stub.rs
+++ b/crates/moonrun/src/async_sys/fs/stub.rs
@@ -17,6 +17,10 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use std::ffi::{OsStr, OsString};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::event_loop::thread_pool::Resource;
@@ -140,11 +144,19 @@ fn unlock_file_from_native_stub(handle: RawFileHandle) -> AsyncHostResult<()> {
 }
 
 pub(crate) fn try_lock_acquired_file(file: &Resource, exclusive: bool) -> AsyncHostResult<()> {
-    try_lock_file(file.raw_fd(), exclusive)
+    #[cfg(unix)]
+    let handle = file.as_file()?.as_raw_fd();
+    #[cfg(windows)]
+    let handle = file.as_file()?.as_raw_handle();
+    try_lock_file(handle, exclusive)
 }
 
 pub(crate) fn unlock_acquired_file(file: &Resource) -> AsyncHostResult<()> {
-    unlock_file(file.raw_fd())
+    #[cfg(unix)]
+    let handle = file.as_file()?.as_raw_fd();
+    #[cfg(windows)]
+    let handle = file.as_file()?.as_raw_handle();
+    unlock_file(handle)
 }
 
 #[cfg(unix)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
@@ -16,6 +16,8 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use std::os::windows::io::{AsRawSocket, BorrowedSocket, RawHandle};
+
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::ported_fns;
@@ -68,7 +70,7 @@ ported_fns! {
         source = "src/internal/event_loop/iocp.c",
         original = "moonbitlang_async_event_bus_register"
     )]
-    pub(crate) fn poll_register(
+    fn poll_register(
         instance: &PollInstance,
         fd: RawFd,
         read_only: bool,
@@ -180,6 +182,24 @@ ported_fns! {
     pub(crate) fn event_get_bytes_transferred(event: &PollEvent) -> i32 {
         event.bytes_transferred
     }
+}
+
+pub(crate) fn poll_register_file(
+    instance: &PollInstance,
+    handle: RawHandle,
+    read_only: bool,
+) -> AsyncHostResult<()> {
+    poll_register(instance, handle, read_only)
+}
+
+pub(crate) fn poll_register_socket(
+    instance: &PollInstance,
+    socket: BorrowedSocket<'_>,
+    read_only: bool,
+) -> AsyncHostResult<()> {
+    // IOCP accepts a socket value in the HANDLE parameter. Keep that Windows
+    // ABI conversion inside the IOCP adapter rather than the resource model.
+    poll_register(instance, socket.as_raw_socket() as RawFd, read_only)
 }
 
 pub(crate) fn post_thread_pool_completion(

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -20,6 +20,10 @@
 //! `moonbitlang/async/src/internal/event_loop/thread_pool.c`.
 
 use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult, HostCBuffer};
 use crate::async_sys::internal::fd_util;
@@ -28,6 +32,16 @@ use crate::async_sys::ported_fns;
 use super::{FileTimeResult, OpenJobResource, OpenJobResult, Resource};
 
 type RawFile = fd_util::stub::RawFd;
+
+#[cfg(unix)]
+fn raw_file_handle(file: &Resource) -> AsyncHostResult<RawFile> {
+    Ok(file.as_file()?.as_raw_fd())
+}
+
+#[cfg(windows)]
+fn raw_file_handle(file: &Resource) -> AsyncHostResult<RawFile> {
+    Ok(file.as_file()?.as_raw_handle())
+}
 
 ported_fns! {
     #[ported(
@@ -75,7 +89,7 @@ ported_fns! {
         result: &mut Option<Vec<u8>>,
     ) -> AsyncHostResult<i64> {
         let mut buf = vec![0; usize::try_from(len).map_err(|_| AsyncHostError::Fault)?];
-        let n = read_from_native_file(file.raw_fd(), &mut buf, position)?;
+        let n = read_from_native_file(raw_file_handle(file)?, &mut buf, position)?;
         buf.truncate(n);
         *result = Some(buf);
         Ok(n as i64)
@@ -90,7 +104,7 @@ ported_fns! {
         data: &[u8],
         position: i64,
     ) -> AsyncHostResult<i64> {
-        let n = write_to_native_file(file.raw_fd(), data, position)?;
+        let n = write_to_native_file(raw_file_handle(file)?, data, position)?;
         Ok(n as i64)
     }
 
@@ -114,7 +128,7 @@ ported_fns! {
         file: &Resource,
         result: &mut i64,
     ) -> AsyncHostResult<i64> {
-        *result = file_size(file.raw_fd())?;
+        *result = file_size(raw_file_handle(file)?)?;
         Ok(0)
     }
 
@@ -126,7 +140,7 @@ ported_fns! {
         file: &Resource,
         result: &mut Option<FileTimeResult>,
     ) -> AsyncHostResult<i64> {
-        *result = Some(FileTimeResult::new(file_time(file.raw_fd())?));
+        *result = Some(FileTimeResult::new(file_time(raw_file_handle(file)?)?));
         Ok(0)
     }
 
@@ -172,7 +186,7 @@ ported_fns! {
         file: &Resource,
         only_data: bool,
     ) -> AsyncHostResult<i64> {
-        sync_native_file(file.raw_fd(), only_data)?;
+        sync_native_file(raw_file_handle(file)?, only_data)?;
         Ok(0)
     }
 
@@ -184,7 +198,7 @@ ported_fns! {
         file: &Resource,
         exclusive: bool,
     ) -> AsyncHostResult<i64> {
-        lock_native_file(file.raw_fd(), exclusive)?;
+        lock_native_file(raw_file_handle(file)?, exclusive)?;
         Ok(0)
     }
 
@@ -625,7 +639,10 @@ fn file_kind_by_path(
         libc::AT_SYMLINK_NOFOLLOW
     };
     let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-    let parent = parent.map(Resource::raw_fd).unwrap_or(libc::AT_FDCWD);
+    let parent = match parent {
+        Some(parent) => raw_file_handle(parent)?,
+        None => libc::AT_FDCWD,
+    };
     let ret = unsafe { libc::fstatat(parent, path.as_ptr(), stat.as_mut_ptr(), flags) };
     if ret < 0 {
         Err(last_native_error())
@@ -783,7 +800,7 @@ fn rmdir_native_path(path: OsString) -> AsyncHostResult<()> {
 
 #[cfg(all(unix, target_os = "linux"))]
 fn read_native_dir(file: &Resource, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
-    let fd = file.raw_fd();
+    let fd = raw_file_handle(file)?;
     if restart && unsafe { libc::lseek(fd, 0, libc::SEEK_SET) } < 0 {
         return Err(last_native_error());
     }
@@ -799,7 +816,7 @@ fn read_native_dir(file: &Resource, out: &mut [u8], restart: bool) -> AsyncHostR
 
 #[cfg(all(unix, target_os = "macos"))]
 fn read_native_dir(file: &Resource, out: &mut [u8], restart: bool) -> AsyncHostResult<i64> {
-    let fd = file.raw_fd();
+    let fd = raw_file_handle(file)?;
     if restart && unsafe { libc::lseek(fd, 0, libc::SEEK_SET) } < 0 {
         return Err(last_native_error());
     }
@@ -1096,7 +1113,8 @@ fn resolve_windows_path_for_parent(
         return Ok(path);
     }
 
-    let mut parent_path = std::path::PathBuf::from(final_path_from_handle(parent.raw_fd())?);
+    let mut parent_path =
+        std::path::PathBuf::from(final_path_from_handle(raw_file_handle(parent)?)?);
     parent_path.push(path);
     Ok(parent_path.into_os_string())
 }
@@ -1547,7 +1565,7 @@ fn read_native_dir(file: &Resource, out: &mut [u8], restart: bool) -> AsyncHostR
     };
     let ok = unsafe {
         GetFileInformationByHandleEx(
-            file.raw_fd() as HANDLE,
+            raw_file_handle(file)? as HANDLE,
             info_class,
             out.as_mut_ptr().cast(),
             u32::try_from(out.len()).map_err(|_| AsyncHostError::Fault)?,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -48,7 +48,7 @@ pub(crate) use jobs::{
 };
 pub(crate) use runner::{get_file_time_result, get_read_result, run_host_job};
 pub(crate) use types::{
-    FileTimeResult, HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult, Resource,
+    FileRef, FileTimeResult, HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult, Resource,
     ResourceClass, ResourceRef, ResourceTable, SpawnOptions,
 };
 #[cfg(windows)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/process.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/process.rs
@@ -21,6 +21,10 @@
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::ffi::{CStr, CString};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, AsRawSocket};
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util;
@@ -254,7 +258,7 @@ fn duplicate_stdio_fds(stdio: &[Option<ResourceRef>; 3]) -> AsyncHostResult<[Opt
         let Some(resource) = resource else {
             continue;
         };
-        let fd = unsafe { libc::fcntl(resource.raw_fd(), libc::F_DUPFD_CLOEXEC, 3) };
+        let fd = unsafe { libc::fcntl(resource.as_file()?.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 3) };
         if fd < 0 {
             let error = last_native_error();
             close_stdio_fds(&fds);
@@ -383,7 +387,7 @@ fn spawn_process_windows(
     let mut inherited_handles = Vec::with_capacity(std_handles.len());
     for (resource, std_handle) in stdio.iter().zip(std_handles) {
         let raw_result = if let Some(resource) = resource {
-            Ok(resource.raw_fd())
+            spawn_stdio_handle(resource)
         } else {
             let raw = unsafe { GetStdHandle(std_handle) };
             if raw.is_null() || raw == INVALID_HANDLE_VALUE {
@@ -546,6 +550,18 @@ fn spawn_process_windows(
 }
 
 #[cfg(windows)]
+fn spawn_stdio_handle(resource: &Resource) -> AsyncHostResult<RawFile> {
+    if resource.resource_class().is_socket() {
+        // Windows permits sockets in STARTUPINFO standard-handle fields and
+        // supports inheriting them as handles. Keep that ABI conversion at the
+        // process-spawn seam without representing sockets as file handles.
+        Ok(resource.as_socket()?.as_raw_socket() as RawFile)
+    } else {
+        Ok(resource.as_file()?.as_raw_handle())
+    }
+}
+
+#[cfg(windows)]
 fn global_job_object() -> AsyncHostResult<Option<RawFile>> {
     static GLOBAL_JOB_OBJECT: std::sync::OnceLock<Option<usize>> = std::sync::OnceLock::new();
     static GLOBAL_JOB_OBJECT_INIT: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -628,7 +644,7 @@ fn wait_for_process(
 
     #[cfg(target_os = "linux")]
     if let Some(handle) = handle {
-        return wait_for_process_pidfd(handle.raw_fd(), defer_reap);
+        return wait_for_process_pidfd(handle.as_fd()?.as_raw_fd(), defer_reap);
     }
     wait_for_process_pid(pid, defer_reap)
 }
@@ -698,7 +714,7 @@ pub(super) fn make_wait_for_process_cancel() -> AsyncHostResult<Resource> {
 pub(super) fn cancel_wait_for_process(cancel: &ResourceRef) -> AsyncHostResult<()> {
     use windows_sys::Win32::System::Threading::SetEvent;
 
-    if unsafe { SetEvent(cancel.raw_fd()) } == 0 {
+    if unsafe { SetEvent(cancel.as_handle()?.as_raw_handle()) } == 0 {
         Err(last_native_error())
     } else {
         Ok(())
@@ -713,7 +729,7 @@ fn wait_for_process(
 ) -> AsyncHostResult<i64> {
     let cancel = cancel.ok_or(AsyncHostError::Badf)?;
     if let Some(handle) = handle {
-        return wait_for_process_handle(handle.raw_fd(), &cancel);
+        return wait_for_process_handle(handle.as_handle()?.as_raw_handle(), &cancel);
     }
 
     use windows_sys::Win32::Foundation::CloseHandle;
@@ -746,7 +762,7 @@ fn wait_for_process_handle(handle: RawFile, cancel: &ResourceRef) -> AsyncHostRe
         GetExitCodeProcess, INFINITE, WaitForMultipleObjects, WaitForSingleObject,
     };
 
-    let handles = [handle, cancel.raw_fd()];
+    let handles = [handle, cancel.as_handle()?.as_raw_handle()];
     let wait = unsafe { WaitForMultipleObjects(2, handles.as_ptr(), 0, INFINITE) };
     if wait == WAIT_OBJECT_0 + 1 {
         match unsafe { WaitForSingleObject(handle, 0) } {
@@ -839,5 +855,26 @@ mod tests {
     fn wait_for_unknown_process_reports_native_error() {
         let err = run_wait_for_process_job(None, -1, false).unwrap_err();
         assert!(matches!(err, AsyncHostError::Native(_)));
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::super::ResourceClass;
+    use super::*;
+
+    #[test]
+    fn spawn_stdio_accepts_socket_resource() {
+        assert_eq!(crate::async_sys::internal::event_loop::io::init_wsa(), 0);
+        let raw_socket = crate::async_sys::socket::make_tcp_socket(4).unwrap();
+        let resource = Resource::new_socket(raw_socket, ResourceClass::TcpSocket, 4);
+
+        assert_eq!(
+            spawn_stdio_handle(&resource).unwrap() as usize,
+            raw_socket as usize
+        );
+
+        drop(resource);
+        assert_eq!(crate::async_sys::internal::event_loop::io::cleanup_wsa(), 0);
     }
 }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/socket.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/socket.rs
@@ -17,6 +17,10 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawSocket;
 
 use crate::async_host::AsyncHostResult;
 use crate::async_sys::ported_fns;
@@ -32,7 +36,11 @@ ported_fns! {
         socket: &Resource,
         addr: &[u8],
     ) -> AsyncHostResult<i64> {
-        crate::async_sys::socket::bind(socket.raw_fd(), addr)?;
+        #[cfg(unix)]
+        let socket = socket.as_fd()?.as_raw_fd();
+        #[cfg(windows)]
+        let socket = socket.as_socket()?.as_raw_socket();
+        crate::async_sys::socket::bind(socket, addr)?;
         Ok(0)
     }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -26,10 +26,11 @@ use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 use crate::async_sys::internal::fd_util;
 
 #[cfg(unix)]
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{
-    AsRawHandle, AsRawSocket, FromRawHandle, FromRawSocket, OwnedHandle, OwnedSocket, RawSocket,
+    AsHandle, AsRawHandle, AsRawSocket, AsSocket, BorrowedHandle, BorrowedSocket, FromRawHandle,
+    FromRawSocket, OwnedHandle, OwnedSocket, RawHandle, RawSocket,
 };
 
 pub(crate) type ResourceHandle = u64;
@@ -50,6 +51,40 @@ pub(crate) struct SpawnOptions {
 type OwnedRawFile = OwnedFd;
 #[cfg(windows)]
 type OwnedRawFile = OwnedHandle;
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum FileRef<'a> {
+    Borrowed(BorrowedFd<'a>),
+    Stdio(RawFd),
+}
+
+#[cfg(unix)]
+impl AsRawFd for FileRef<'_> {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            Self::Borrowed(fd) => fd.as_raw_fd(),
+            Self::Stdio(fd) => *fd,
+        }
+    }
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum FileRef<'a> {
+    Borrowed(BorrowedHandle<'a>),
+    Stdio(RawHandle),
+}
+
+#[cfg(windows)]
+impl AsRawHandle for FileRef<'_> {
+    fn as_raw_handle(&self) -> RawHandle {
+        match self {
+            Self::Borrowed(handle) => handle.as_raw_handle(),
+            Self::Stdio(handle) => *handle,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ResourceClass {
@@ -175,13 +210,67 @@ impl Resource {
         self.class
     }
 
-    pub(crate) fn raw_fd(&self) -> fd_util::stub::RawFd {
+    pub(crate) fn raw_identity(&self) -> isize {
         match &self.raw {
-            RawResource::Invalid => invalid_raw_file(),
-            RawResource::File(raw) => raw_file(raw),
-            RawResource::StdioFile(raw) => *raw as fd_util::stub::RawFd,
+            RawResource::Invalid => -1,
+            #[cfg(unix)]
+            RawResource::File(raw) => raw.as_fd().as_raw_fd() as isize,
             #[cfg(windows)]
-            RawResource::Socket(raw) => raw_socket(raw),
+            RawResource::File(raw) => raw.as_handle().as_raw_handle() as isize,
+            RawResource::StdioFile(raw) => *raw,
+            #[cfg(windows)]
+            RawResource::Socket(raw) => raw.as_socket().as_raw_socket() as isize,
+        }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn as_fd(&self) -> AsyncHostResult<BorrowedFd<'_>> {
+        match &self.raw {
+            RawResource::Invalid => Err(crate::async_host::AsyncHostError::Badf),
+            RawResource::File(raw) => Ok(raw.as_fd()),
+            RawResource::StdioFile(_) => Err(crate::async_host::AsyncHostError::Inval),
+        }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn as_file(&self) -> AsyncHostResult<FileRef<'_>> {
+        match &self.raw {
+            RawResource::Invalid => Err(crate::async_host::AsyncHostError::Badf),
+            RawResource::File(raw) => Ok(FileRef::Borrowed(raw.as_fd())),
+            RawResource::StdioFile(raw) => i32::try_from(*raw)
+                .map(FileRef::Stdio)
+                .map_err(|_| crate::async_host::AsyncHostError::Badf),
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn as_handle(&self) -> AsyncHostResult<BorrowedHandle<'_>> {
+        match &self.raw {
+            RawResource::Invalid => Err(crate::async_host::AsyncHostError::Badf),
+            RawResource::File(raw) => Ok(raw.as_handle()),
+            RawResource::StdioFile(_) => Err(crate::async_host::AsyncHostError::Inval),
+            RawResource::Socket(_) => Err(crate::async_host::AsyncHostError::Inval),
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn as_file(&self) -> AsyncHostResult<FileRef<'_>> {
+        match &self.raw {
+            RawResource::Invalid => Err(crate::async_host::AsyncHostError::Badf),
+            RawResource::File(raw) => Ok(FileRef::Borrowed(raw.as_handle())),
+            RawResource::StdioFile(raw) => Ok(FileRef::Stdio(*raw as RawHandle)),
+            RawResource::Socket(_) => Err(crate::async_host::AsyncHostError::Inval),
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn as_socket(&self) -> AsyncHostResult<BorrowedSocket<'_>> {
+        match &self.raw {
+            RawResource::Invalid => Err(crate::async_host::AsyncHostError::Badf),
+            RawResource::Socket(raw) => Ok(raw.as_socket()),
+            RawResource::File(_) | RawResource::StdioFile(_) => {
+                Err(crate::async_host::AsyncHostError::Inval)
+            }
         }
     }
 
@@ -229,21 +318,6 @@ fn owned_raw_file(raw: fd_util::stub::RawFd) -> OwnedRawFile {
 fn owned_raw_socket(raw: RawSocket) -> OwnedSocket {
     // Resource takes ownership of sockets returned by platform APIs.
     unsafe { OwnedSocket::from_raw_socket(raw) }
-}
-
-#[cfg(unix)]
-fn raw_file(raw: &OwnedRawFile) -> fd_util::stub::RawFd {
-    raw.as_raw_fd()
-}
-
-#[cfg(windows)]
-fn raw_file(raw: &OwnedRawFile) -> fd_util::stub::RawFd {
-    raw.as_raw_handle()
-}
-
-#[cfg(windows)]
-fn raw_socket(raw: &OwnedSocket) -> fd_util::stub::RawFd {
-    raw.as_raw_socket() as fd_util::stub::RawFd
 }
 
 #[derive(Debug)]
@@ -470,5 +544,30 @@ pub(crate) fn platform() -> i32 {
     #[cfg(target_os = "linux")]
     {
         0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stdio_resource_remains_explicitly_unowned() {
+        #[cfg(unix)]
+        let resource = Resource::stdio_file(0);
+        #[cfg(windows)]
+        let resource = Resource::stdio_file(1usize as RawHandle);
+
+        assert!(matches!(resource.as_file(), Ok(FileRef::Stdio(_))));
+        #[cfg(unix)]
+        assert!(matches!(
+            resource.as_fd(),
+            Err(crate::async_host::AsyncHostError::Inval)
+        ));
+        #[cfg(windows)]
+        assert!(matches!(
+            resource.as_handle(),
+            Err(crate::async_host::AsyncHostError::Inval)
+        ));
     }
 }

--- a/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
@@ -17,8 +17,13 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
-use crate::async_sys::internal::event_loop::thread_pool::{HostHandle, ResourceTable};
+use crate::async_sys::internal::event_loop::thread_pool::{FileRef, HostHandle, ResourceTable};
 use crate::async_sys::ported_fns;
+
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, BorrowedSocket};
 
 #[cfg(unix)]
 pub(crate) type RawFd = std::os::fd::RawFd;
@@ -72,6 +77,21 @@ const WINDOWS_TO_UNIX_EPOCH_SECONDS: i64 = 11_644_473_600;
 #[cfg(windows)]
 fn windows_filetime_to_unix_seconds(ticks: i64) -> i64 {
     ticks / WINDOWS_TICKS_PER_SECOND - WINDOWS_TO_UNIX_EPOCH_SECONDS
+}
+
+#[cfg(unix)]
+pub(crate) fn kind_of_file(file: FileRef<'_>) -> AsyncHostResult<i32> {
+    kind_of_fd(file.as_raw_fd())
+}
+
+#[cfg(windows)]
+pub(crate) fn kind_of_file(file: FileRef<'_>) -> AsyncHostResult<i32> {
+    kind_of_fd(file.as_raw_handle())
+}
+
+#[cfg(windows)]
+pub(crate) fn kind_of_socket(_socket: BorrowedSocket<'_>) -> AsyncHostResult<i32> {
+    Ok(FILE_KIND_SOCKET)
 }
 
 #[cfg(windows)]

--- a/crates/moonrun/src/async_sys/socket.rs
+++ b/crates/moonrun/src/async_sys/socket.rs
@@ -26,6 +26,7 @@ use std::os::unix::ffi::OsStringExt;
 use windows_sys::Win32::Networking::WinSock as ws;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
+#[cfg(unix)]
 use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::ported_fns;
 
@@ -151,9 +152,9 @@ mod win {
     use windows_sys::Win32::NetworkManagement::Ndis::{IfOperStatusUp, NET_LUID_LH};
     use windows_sys::Win32::Networking::WinSock as ws;
 
-    use super::{AsyncHostError, AsyncHostResult, RawFd, RawSocket};
+    use super::{AsyncHostError, AsyncHostResult, RawSocket};
 
-    fn socket(fd: RawFd) -> ws::SOCKET {
+    fn socket(fd: RawSocket) -> ws::SOCKET {
         fd as usize
     }
 
@@ -236,7 +237,7 @@ mod win {
         Ok(())
     }
 
-    fn set_socket_int(fd: RawFd, level: i32, option: i32, value: i32) -> AsyncHostResult<()> {
+    fn set_socket_int(fd: RawSocket, level: i32, option: i32, value: i32) -> AsyncHostResult<()> {
         socket_error(unsafe {
             ws::setsockopt(
                 socket(fd),
@@ -377,9 +378,12 @@ mod win {
         if socket == ws::INVALID_SOCKET {
             return Err(last_wsa_error());
         }
-        if let Err(error) =
-            set_socket_int(socket as RawFd, ws::SOL_SOCKET, ws::SO_EXCLUSIVEADDRUSE, 0)
-        {
+        if let Err(error) = set_socket_int(
+            socket as RawSocket,
+            ws::SOL_SOCKET,
+            ws::SO_EXCLUSIVEADDRUSE,
+            0,
+        ) {
             unsafe {
                 ws::closesocket(socket);
             }
@@ -404,13 +408,18 @@ mod win {
         }
         let result = if multicast {
             set_socket_int(
-                socket as RawFd,
+                socket as RawSocket,
                 ws::SOL_SOCKET,
                 ws::SO_REUSE_MULTICASTPORT,
                 1,
             )
         } else {
-            set_socket_int(socket as RawFd, ws::SOL_SOCKET, ws::SO_EXCLUSIVEADDRUSE, 0)
+            set_socket_int(
+                socket as RawSocket,
+                ws::SOL_SOCKET,
+                ws::SO_EXCLUSIVEADDRUSE,
+                0,
+            )
         };
         if let Err(error) = result {
             unsafe {
@@ -422,7 +431,7 @@ mod win {
     }
 
     pub(super) fn join_multicast_group(
-        fd: RawFd,
+        fd: RawSocket,
         multi_addr: &[u8],
         local_addr: &[u8],
     ) -> AsyncHostResult<()> {
@@ -444,7 +453,7 @@ mod win {
     }
 
     pub(super) fn join_multicast_group_v6(
-        fd: RawFd,
+        fd: RawSocket,
         multi_addr: &[u8],
         interface_index: i32,
     ) -> AsyncHostResult<()> {
@@ -464,7 +473,7 @@ mod win {
         })
     }
 
-    pub(super) fn set_multicast_interface(fd: RawFd, local_addr: &[u8]) -> AsyncHostResult<()> {
+    pub(super) fn set_multicast_interface(fd: RawSocket, local_addr: &[u8]) -> AsyncHostResult<()> {
         let local_addr = read_sockaddr_in(local_addr)?;
         socket_error(unsafe {
             ws::setsockopt(
@@ -478,7 +487,7 @@ mod win {
     }
 
     pub(super) fn set_multicast_interface_v6(
-        fd: RawFd,
+        fd: RawSocket,
         interface_index: i32,
     ) -> AsyncHostResult<()> {
         let interface_index = interface_index as u32;
@@ -493,7 +502,7 @@ mod win {
         })
     }
 
-    pub(super) fn set_multicast_ttl(fd: RawFd, ttl: i32, family: i32) -> AsyncHostResult<()> {
+    pub(super) fn set_multicast_ttl(fd: RawSocket, ttl: i32, family: i32) -> AsyncHostResult<()> {
         let (level, option) = match family {
             4 => (ws::IPPROTO_IP, ws::IP_MULTICAST_TTL),
             6 => (ws::IPPROTO_IPV6, ws::IPV6_MULTICAST_HOPS),
@@ -503,7 +512,7 @@ mod win {
     }
 
     pub(super) fn set_multicast_loopback(
-        fd: RawFd,
+        fd: RawSocket,
         enable: bool,
         family: i32,
     ) -> AsyncHostResult<()> {
@@ -515,24 +524,24 @@ mod win {
         set_socket_int(fd, level, option, i32::from(enable))
     }
 
-    pub(super) fn disable_nagle(fd: RawFd) -> AsyncHostResult<()> {
+    pub(super) fn disable_nagle(fd: RawSocket) -> AsyncHostResult<()> {
         set_socket_int(fd, ws::IPPROTO_TCP, ws::TCP_NODELAY, 1)
     }
 
-    pub(super) fn allow_reuse_addr(fd: RawFd) -> AsyncHostResult<()> {
+    pub(super) fn allow_reuse_addr(fd: RawSocket) -> AsyncHostResult<()> {
         set_socket_int(fd, ws::SOL_SOCKET, ws::SO_REUSEADDR, 1)
     }
 
-    pub(super) fn set_ipv6_only(fd: RawFd, ipv6_only: bool) -> AsyncHostResult<()> {
+    pub(super) fn set_ipv6_only(fd: RawSocket, ipv6_only: bool) -> AsyncHostResult<()> {
         set_socket_int(fd, ws::IPPROTO_IPV6, ws::IPV6_V6ONLY, i32::from(ipv6_only))
     }
 
-    pub(super) fn listen(fd: RawFd) -> AsyncHostResult<()> {
+    pub(super) fn listen(fd: RawSocket) -> AsyncHostResult<()> {
         socket_error(unsafe { ws::listen(socket(fd), ws::SOMAXCONN as i32) })
     }
 
     pub(super) fn enable_keepalive(
-        fd: RawFd,
+        fd: RawSocket,
         keep_idle: i32,
         keep_count: i32,
         keep_intvl: i32,
@@ -550,7 +559,7 @@ mod win {
         Ok(())
     }
 
-    pub(super) fn getsockname(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
+    pub(super) fn getsockname(fd: RawSocket, addr_out: &mut [u8]) -> AsyncHostResult<()> {
         let mut len = i32::try_from(addr_out.len()).map_err(|_| AsyncHostError::Fault)?;
         socket_error(unsafe {
             ws::getsockname(
@@ -654,16 +663,16 @@ mod win {
         0
     }
 
-    pub(super) fn udp_client_connect(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+    pub(super) fn udp_client_connect(fd: RawSocket, addr: &[u8]) -> AsyncHostResult<()> {
         connect(fd, addr)
     }
 
-    pub(super) fn bind(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+    pub(super) fn bind(fd: RawSocket, addr: &[u8]) -> AsyncHostResult<()> {
         let len = sockaddr_len(addr)?;
         socket_error(unsafe { ws::bind(socket(fd), addr.as_ptr().cast::<ws::SOCKADDR>(), len) })
     }
 
-    pub(super) fn connect(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+    pub(super) fn connect(fd: RawSocket, addr: &[u8]) -> AsyncHostResult<()> {
         let len = sockaddr_len(addr)?;
         socket_error(unsafe { ws::connect(socket(fd), addr.as_ptr().cast::<ws::SOCKADDR>(), len) })
     }
@@ -1033,7 +1042,7 @@ ported_fns! {
     )]
     #[cfg(unix)]
     pub(crate) fn join_multicast_group(
-        fd: RawFd,
+        fd: RawSocket,
         multi_addr: &[u8],
         local_addr: &[u8],
     ) -> AsyncHostResult<()> {
@@ -1065,7 +1074,7 @@ ported_fns! {
     )]
     #[cfg(windows)]
     pub(crate) fn join_multicast_group(
-        fd: RawFd,
+        fd: RawSocket,
         multi_addr: &[u8],
         local_addr: &[u8],
     ) -> AsyncHostResult<()> {
@@ -1078,7 +1087,7 @@ ported_fns! {
     )]
     #[cfg(unix)]
     pub(crate) fn join_multicast_group_v6(
-        fd: RawFd,
+        fd: RawSocket,
         multi_addr: &[u8],
         interface_index: i32,
     ) -> AsyncHostResult<()> {
@@ -1113,7 +1122,7 @@ ported_fns! {
     )]
     #[cfg(windows)]
     pub(crate) fn join_multicast_group_v6(
-        fd: RawFd,
+        fd: RawSocket,
         multi_addr: &[u8],
         interface_index: i32,
     ) -> AsyncHostResult<()> {
@@ -1125,7 +1134,7 @@ ported_fns! {
         original = "moonbitlang_async_set_multicast_interface"
     )]
     #[cfg(unix)]
-    pub(crate) fn set_multicast_interface(fd: RawFd, local_addr: &[u8]) -> AsyncHostResult<()> {
+    pub(crate) fn set_multicast_interface(fd: RawSocket, local_addr: &[u8]) -> AsyncHostResult<()> {
         let local_addr = read_sockaddr_in(local_addr)?;
         if unsafe {
             libc::setsockopt(
@@ -1148,7 +1157,7 @@ ported_fns! {
         original = "moonbitlang_async_set_multicast_interface"
     )]
     #[cfg(windows)]
-    pub(crate) fn set_multicast_interface(fd: RawFd, local_addr: &[u8]) -> AsyncHostResult<()> {
+    pub(crate) fn set_multicast_interface(fd: RawSocket, local_addr: &[u8]) -> AsyncHostResult<()> {
         win::set_multicast_interface(fd, local_addr)
     }
 
@@ -1158,7 +1167,7 @@ ported_fns! {
     )]
     #[cfg(unix)]
     pub(crate) fn set_multicast_interface_v6(
-        fd: RawFd,
+        fd: RawSocket,
         interface_index: i32,
     ) -> AsyncHostResult<()> {
         let interface_index = interface_index as libc::c_uint;
@@ -1184,7 +1193,7 @@ ported_fns! {
     )]
     #[cfg(windows)]
     pub(crate) fn set_multicast_interface_v6(
-        fd: RawFd,
+        fd: RawSocket,
         interface_index: i32,
     ) -> AsyncHostResult<()> {
         win::set_multicast_interface_v6(fd, interface_index)
@@ -1195,7 +1204,7 @@ ported_fns! {
         original = "moonbitlang_async_set_multicast_ttl"
     )]
     #[cfg(unix)]
-    pub(crate) fn set_multicast_ttl(fd: RawFd, ttl: i32, family: i32) -> AsyncHostResult<()> {
+    pub(crate) fn set_multicast_ttl(fd: RawSocket, ttl: i32, family: i32) -> AsyncHostResult<()> {
         let (level, option) = match family {
             4 => (libc::IPPROTO_IP, libc::IP_MULTICAST_TTL),
             6 => (libc::IPPROTO_IPV6, libc::IPV6_MULTICAST_HOPS),
@@ -1223,7 +1232,7 @@ ported_fns! {
         original = "moonbitlang_async_set_multicast_ttl"
     )]
     #[cfg(windows)]
-    pub(crate) fn set_multicast_ttl(fd: RawFd, ttl: i32, family: i32) -> AsyncHostResult<()> {
+    pub(crate) fn set_multicast_ttl(fd: RawSocket, ttl: i32, family: i32) -> AsyncHostResult<()> {
         win::set_multicast_ttl(fd, ttl, family)
     }
 
@@ -1233,7 +1242,7 @@ ported_fns! {
     )]
     #[cfg(unix)]
     pub(crate) fn set_multicast_loopback(
-        fd: RawFd,
+        fd: RawSocket,
         enable: bool,
         family: i32,
     ) -> AsyncHostResult<()> {
@@ -1265,7 +1274,7 @@ ported_fns! {
     )]
     #[cfg(windows)]
     pub(crate) fn set_multicast_loopback(
-        fd: RawFd,
+        fd: RawSocket,
         enable: bool,
         family: i32,
     ) -> AsyncHostResult<()> {
@@ -1277,7 +1286,7 @@ ported_fns! {
         original = "moonbitlang_async_disable_nagle"
     )]
     #[cfg(unix)]
-    pub(crate) fn disable_nagle(fd: RawFd) -> AsyncHostResult<()> {
+    pub(crate) fn disable_nagle(fd: RawSocket) -> AsyncHostResult<()> {
         let enable: libc::c_int = 1;
         if unsafe {
             libc::setsockopt(
@@ -1299,7 +1308,7 @@ ported_fns! {
         original = "moonbitlang_async_disable_nagle"
     )]
     #[cfg(windows)]
-    pub(crate) fn disable_nagle(fd: RawFd) -> AsyncHostResult<()> {
+    pub(crate) fn disable_nagle(fd: RawSocket) -> AsyncHostResult<()> {
         win::disable_nagle(fd)
     }
 
@@ -1308,7 +1317,7 @@ ported_fns! {
         original = "moonbitlang_async_allow_reuse_addr"
     )]
     #[cfg(unix)]
-    pub(crate) fn allow_reuse_addr(fd: RawFd) -> AsyncHostResult<()> {
+    pub(crate) fn allow_reuse_addr(fd: RawSocket) -> AsyncHostResult<()> {
         let enable: libc::c_int = 1;
         if unsafe {
             libc::setsockopt(
@@ -1330,7 +1339,7 @@ ported_fns! {
         original = "moonbitlang_async_allow_reuse_addr"
     )]
     #[cfg(windows)]
-    pub(crate) fn allow_reuse_addr(fd: RawFd) -> AsyncHostResult<()> {
+    pub(crate) fn allow_reuse_addr(fd: RawSocket) -> AsyncHostResult<()> {
         win::allow_reuse_addr(fd)
     }
 
@@ -1339,7 +1348,7 @@ ported_fns! {
         original = "moonbitlang_async_set_ipv6_only"
     )]
     #[cfg(unix)]
-    pub(crate) fn set_ipv6_only(fd: RawFd, ipv6_only: bool) -> AsyncHostResult<()> {
+    pub(crate) fn set_ipv6_only(fd: RawSocket, ipv6_only: bool) -> AsyncHostResult<()> {
         let value: libc::c_int = i32::from(ipv6_only);
         if unsafe {
             libc::setsockopt(
@@ -1361,7 +1370,7 @@ ported_fns! {
         original = "moonbitlang_async_set_ipv6_only"
     )]
     #[cfg(windows)]
-    pub(crate) fn set_ipv6_only(fd: RawFd, ipv6_only: bool) -> AsyncHostResult<()> {
+    pub(crate) fn set_ipv6_only(fd: RawSocket, ipv6_only: bool) -> AsyncHostResult<()> {
         win::set_ipv6_only(fd, ipv6_only)
     }
 
@@ -1370,7 +1379,7 @@ ported_fns! {
         original = "moonbitlang_async_listen"
     )]
     #[cfg(unix)]
-    pub(crate) fn listen(fd: RawFd) -> AsyncHostResult<()> {
+    pub(crate) fn listen(fd: RawSocket) -> AsyncHostResult<()> {
         if unsafe { libc::listen(fd, libc::SOMAXCONN) } < 0 {
             Err(last_native_error())
         } else {
@@ -1383,7 +1392,7 @@ ported_fns! {
         original = "moonbitlang_async_listen"
     )]
     #[cfg(windows)]
-    pub(crate) fn listen(fd: RawFd) -> AsyncHostResult<()> {
+    pub(crate) fn listen(fd: RawSocket) -> AsyncHostResult<()> {
         win::listen(fd)
     }
 
@@ -1393,7 +1402,7 @@ ported_fns! {
     )]
     #[cfg(unix)]
     pub(crate) fn enable_keepalive(
-        fd: RawFd,
+        fd: RawSocket,
         keep_idle: i32,
         keep_count: i32,
         keep_intvl: i32,
@@ -1446,7 +1455,7 @@ ported_fns! {
     )]
     #[cfg(windows)]
     pub(crate) fn enable_keepalive(
-        fd: RawFd,
+        fd: RawSocket,
         keep_idle: i32,
         keep_count: i32,
         keep_intvl: i32,
@@ -1459,7 +1468,7 @@ ported_fns! {
         original = "moonbitlang_async_getsockname"
     )]
     #[cfg(unix)]
-    pub(crate) fn getsockname(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
+    pub(crate) fn getsockname(fd: RawSocket, addr_out: &mut [u8]) -> AsyncHostResult<()> {
         let mut len = libc::socklen_t::try_from(addr_out.len()).map_err(|_| AsyncHostError::Fault)?;
         if unsafe {
             libc::getsockname(fd, addr_out.as_mut_ptr().cast::<libc::sockaddr>(), &mut len)
@@ -1475,7 +1484,7 @@ ported_fns! {
         original = "moonbitlang_async_getsockname"
     )]
     #[cfg(windows)]
-    pub(crate) fn getsockname(fd: RawFd, addr_out: &mut [u8]) -> AsyncHostResult<()> {
+    pub(crate) fn getsockname(fd: RawSocket, addr_out: &mut [u8]) -> AsyncHostResult<()> {
         win::getsockname(fd, addr_out)
     }
 
@@ -1593,7 +1602,7 @@ ported_fns! {
         original = "moonbitlang_async_udp_client_connect"
     )]
     #[cfg(unix)]
-    pub(crate) fn udp_client_connect(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+    pub(crate) fn udp_client_connect(fd: RawSocket, addr: &[u8]) -> AsyncHostResult<()> {
         connect(fd, addr)
     }
 
@@ -1602,12 +1611,12 @@ ported_fns! {
         original = "moonbitlang_async_udp_client_connect"
     )]
     #[cfg(windows)]
-    pub(crate) fn udp_client_connect(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+    pub(crate) fn udp_client_connect(fd: RawSocket, addr: &[u8]) -> AsyncHostResult<()> {
         win::udp_client_connect(fd, addr)
     }
 
     #[cfg(unix)]
-    pub(crate) fn bind(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+    pub(crate) fn bind(fd: RawSocket, addr: &[u8]) -> AsyncHostResult<()> {
         let len = sockaddr_len(addr)?;
         if unsafe { libc::bind(fd, addr.as_ptr().cast::<libc::sockaddr>(), len) } < 0 {
             Err(last_native_error())
@@ -1617,7 +1626,7 @@ ported_fns! {
     }
 
     #[cfg(windows)]
-    pub(crate) fn bind(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+    pub(crate) fn bind(fd: RawSocket, addr: &[u8]) -> AsyncHostResult<()> {
         win::bind(fd, addr)
     }
 
@@ -1626,7 +1635,7 @@ ported_fns! {
         original = "moonbitlang_async_connect"
     )]
     #[cfg(unix)]
-    pub(crate) fn connect(fd: RawFd, addr: &[u8]) -> AsyncHostResult<()> {
+    pub(crate) fn connect(fd: RawSocket, addr: &[u8]) -> AsyncHostResult<()> {
         let len = sockaddr_len(addr)?;
         if unsafe { libc::connect(fd, addr.as_ptr().cast::<libc::sockaddr>(), len) } < 0 {
             Err(last_native_error())
@@ -1640,7 +1649,7 @@ ported_fns! {
         original = "moonbitlang_async_getsockerr"
     )]
     #[cfg(unix)]
-    pub(crate) fn getsockerr(fd: RawFd) -> AsyncHostResult<i32> {
+    pub(crate) fn getsockerr(fd: RawSocket) -> AsyncHostResult<i32> {
         let mut err = 0;
         let mut len = std::mem::size_of_val(&err) as libc::socklen_t;
         if unsafe {
@@ -1663,7 +1672,7 @@ ported_fns! {
         original = "moonbitlang_async_accept"
     )]
     #[cfg(unix)]
-    pub(crate) fn accept(fd: RawFd, addr: &mut [u8]) -> AsyncHostResult<RawSocket> {
+    pub(crate) fn accept(fd: RawSocket, addr: &mut [u8]) -> AsyncHostResult<RawSocket> {
         let mut len = sockaddr_len(addr)?;
         let conn = unsafe { libc::accept(fd, addr.as_mut_ptr().cast::<libc::sockaddr>(), &mut len) };
         if conn < 0 {
@@ -1678,7 +1687,7 @@ ported_fns! {
     )]
     #[cfg(unix)]
     pub(crate) fn recvfrom(
-        fd: RawFd,
+        fd: RawSocket,
         buf: &mut [u8],
         addr: &mut [u8],
     ) -> AsyncHostResult<usize> {
@@ -1705,7 +1714,7 @@ ported_fns! {
         original = "moonbitlang_async_sendto"
     )]
     #[cfg(unix)]
-    pub(crate) fn sendto(fd: RawFd, buf: &[u8], addr: &[u8]) -> AsyncHostResult<usize> {
+    pub(crate) fn sendto(fd: RawSocket, buf: &[u8], addr: &[u8]) -> AsyncHostResult<usize> {
         let len = sockaddr_len(addr)?;
         let ret = unsafe {
             libc::sendto(
@@ -1781,7 +1790,7 @@ ported_fns! {
     unix,
     any(target_os = "linux", target_os = "android", target_os = "macos")
 ))]
-fn set_tcp_int(fd: RawFd, option: libc::c_int, value: i32) -> AsyncHostResult<()> {
+fn set_tcp_int(fd: RawSocket, option: libc::c_int, value: i32) -> AsyncHostResult<()> {
     let value: libc::c_int = value;
     if unsafe {
         libc::setsockopt(


### PR DESCRIPTION
## Summary

- replace the universal moonrun async-host raw descriptor accessor with typed borrowed file, handle, and socket accessors
- use the standard platform `RawFd`, `RawHandle`, and `RawSocket` types at their corresponding native call sites
- keep reserved stdio explicitly unowned and localize the few required Windows SOCKET-to-HANDLE conversions to their ABI seams

## Why

The resource table already stored owned descriptors with `OwnedFd`, `OwnedHandle`, and `OwnedSocket`, but most callers immediately erased those distinctions through a single raw descriptor interface. On Windows in particular, that made file handles and Winsock sockets unnecessarily interchangeable and made native calls harder to audit.

This change preserves the existing ownership model while making the resource kind explicit at each use site. It also preserves the native Windows behavior that permits sockets as inherited child stdio handles.

## Correctness

The handle table continues to manage guest-visible handle identity, while `Arc<Resource>` and the existing owned standard-library types manage the physical OS resource lifetime. Reserved process stdio remains raw and unowned, so it is never closed by `Resource`.

Windows socket-to-handle conversions remain only where the Windows ABI explicitly permits them: IOCP registration, overlapped cancellation/status, and process stdio inheritance. A Windows regression test covers the socket-stdio adapter.

## Scope

This is a type and interface refactor only. It adds no dependency, does not change the Unix spawning strategy, and does not introduce new resource-closing behavior.