### PR TITLE
Retain Moonrun completion port ownership

### DIFF
--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -760,7 +760,7 @@ impl IoResultTable {
 }
 
 #[cfg(windows)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 struct ThreadPoolCompletionTarget {
     poll: HandleKey,
     port: poll::CompletionPort,
@@ -846,6 +846,11 @@ struct HostIoResult {
 }
 
 #[cfg(windows)]
+// SAFETY: IoResultTable stores each value in a Box before its OVERLAPPED
+// address can be submitted to Windows, never removes a pending result, and
+// serializes all access through its mutex. Moving the Box between threads does
+// not move the HostIoResult allocation; its buffers and ResourceRefs are owned
+// and remain alive until the operation reaches a terminal state.
 unsafe impl Send for HostIoResult {}
 
 #[cfg(windows)]
@@ -1538,6 +1543,7 @@ impl AsyncHost {
             let mut completions = self.thread_pool_completions.lock().unwrap();
             if completions
                 .target
+                .as_ref()
                 .is_some_and(|target| target.poll == poll_key)
             {
                 let _ = crate::async_sys::signal::set_console_control_handler(false, None);
@@ -1637,6 +1643,7 @@ impl AsyncHost {
                 .lock()
                 .unwrap()
                 .target
+                .as_ref()
                 .filter(|target| target.poll == poll_key)
                 .map(|target| target.generation);
             (poll, thread_pool_generation, self.invalid_fd())
@@ -3630,6 +3637,7 @@ impl AsyncHost {
                 .lock()
                 .unwrap()
                 .target
+                .clone()
                 .ok_or(AsyncHostError::Badf)?;
             self.queue_worker_job(job_key)?;
             self.spawn_worker_thread(
@@ -3639,7 +3647,7 @@ impl AsyncHost {
                 },
                 move |completion_id| {
                     let _ = poll::post_thread_pool_completion(
-                        completion_target.port,
+                        &completion_target.port,
                         completion_id.as_i32(),
                         completion_target.generation,
                     );
@@ -3760,7 +3768,8 @@ impl AsyncHost {
             .lock()
             .unwrap()
             .target
-            .map(|target| (target.port, target.generation))
+            .as_ref()
+            .map(|target| (target.port.clone(), target.generation))
             .ok_or(AsyncHostError::Badf)
     }
 
@@ -5818,17 +5827,60 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn native_order_completion_before_poll_destroy_remains_supported() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let completion_notifier = host.init_thread_pool(poll).unwrap();
+        let completion = host.thread_pool_completion_target().unwrap();
+
+        poll::post_thread_pool_completion(&completion.0, 42, completion.1).unwrap();
+
+        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+        let event = host.poll_get_event(poll, 0).unwrap();
+        assert_eq!(host.poll_event_fd(event).unwrap(), completion_notifier);
+        assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 42);
+
+        drop(completion);
+        host.poll_destroy(poll).unwrap();
+        host.destroy_thread_pool();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn alternate_order_poll_destroy_before_completion_remains_safe() {
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+
+        host.init_thread_pool(poll).unwrap();
+        // A worker captures this target when it is spawned. Destroying the
+        // guest poll handle must not invalidate the target while that worker
+        // can still publish its terminal completion.
+        let completion = host.thread_pool_completion_target().unwrap();
+
+        host.poll_destroy(poll).unwrap();
+
+        poll::post_thread_pool_completion(&completion.0, 42, completion.1).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn stale_thread_pool_completions_are_ignored_after_reinit() {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
 
         host.init_thread_pool(poll).unwrap();
-        let stale_completion = host.thread_pool_completions.lock().unwrap().target.unwrap();
+        let stale_completion = host
+            .thread_pool_completions
+            .lock()
+            .unwrap()
+            .target
+            .clone()
+            .unwrap();
         // Fill the current IOCP batch so a valid completion can sit behind
         // stale completions from the destroyed pool generation.
         for completion_id in 0..1024 {
             poll::post_thread_pool_completion(
-                stale_completion.port,
+                &stale_completion.port,
                 completion_id,
                 stale_completion.generation,
             )
@@ -5837,11 +5889,17 @@ mod tests {
         host.destroy_thread_pool();
 
         let completion_notifier = host.init_thread_pool(poll).unwrap();
-        let current_completion = host.thread_pool_completions.lock().unwrap().target.unwrap();
+        let current_completion = host
+            .thread_pool_completions
+            .lock()
+            .unwrap()
+            .target
+            .clone()
+            .unwrap();
         assert_ne!(stale_completion.generation, current_completion.generation);
 
         poll::post_thread_pool_completion(
-            current_completion.port,
+            &current_completion.port,
             43,
             current_completion.generation,
         )
@@ -5850,22 +5908,6 @@ mod tests {
         let event = host.poll_get_event(poll, 0).unwrap();
         assert_eq!(host.poll_event_fd(event).unwrap(), completion_notifier);
         assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 43);
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn thread_pool_completion_reports_native_sentinel() {
-        let host = AsyncHost::default();
-        let poll = host.poll_create().unwrap();
-        let completion_notifier = host.init_thread_pool(poll).unwrap();
-        let completion = host.thread_pool_completions.lock().unwrap().target.unwrap();
-
-        poll::post_thread_pool_completion(completion.port, 42, completion.generation).unwrap();
-
-        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
-        let event = host.poll_get_event(poll, 0).unwrap();
-        assert_eq!(host.poll_event_fd(event).unwrap(), completion_notifier);
-        assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 42);
     }
 
     #[test]

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -19,6 +19,7 @@
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::ported_fns;
+use std::os::fd::{FromRawFd, OwnedFd};
 
 use super::{
     EVENT_BUFFER_SIZE, PollEvent, PollInstance, READ_EVENT, WRITE_EVENT, last_native_error,
@@ -35,7 +36,7 @@ ported_fns! {
             Err(last_native_error())
         } else {
             Ok(PollInstance {
-                fd,
+                fd: unsafe { OwnedFd::from_raw_fd(fd) },
                 events: Vec::new(),
             })
         }
@@ -73,7 +74,7 @@ ported_fns! {
             events: epoll_event_mask(events)?,
             u64: fd as u64,
         };
-        if unsafe { libc::epoll_ctl(instance.fd, libc::EPOLL_CTL_ADD, fd, &mut event) } < 0 {
+        if unsafe { libc::epoll_ctl(instance.raw_fd(), libc::EPOLL_CTL_ADD, fd, &mut event) } < 0 {
             Err(last_native_error())
         } else {
             Ok(())
@@ -88,7 +89,7 @@ ported_fns! {
         let mut events = vec![libc::epoll_event { events: 0, u64: 0 }; EVENT_BUFFER_SIZE];
         let count = unsafe {
             libc::epoll_wait(
-                instance.fd,
+                instance.raw_fd(),
                 events.as_mut_ptr(),
                 EVENT_BUFFER_SIZE as i32,
                 timeout,
@@ -135,7 +136,15 @@ ported_fns! {
 }
 
 pub(crate) fn poll_unregister(instance: &PollInstance, fd: RawFd) -> AsyncHostResult<()> {
-    if unsafe { libc::epoll_ctl(instance.fd, libc::EPOLL_CTL_DEL, fd, std::ptr::null_mut()) } < 0 {
+    if unsafe {
+        libc::epoll_ctl(
+            instance.raw_fd(),
+            libc::EPOLL_CTL_DEL,
+            fd,
+            std::ptr::null_mut(),
+        )
+    } < 0
+    {
         let errno = super::last_errno();
         if errno == libc::ENOENT {
             Ok(())

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
@@ -16,7 +16,10 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::os::windows::io::{AsRawSocket, BorrowedSocket, RawHandle};
+use std::os::windows::io::{
+    AsRawHandle, AsRawSocket, BorrowedSocket, FromRawHandle, OwnedHandle, RawHandle,
+};
+use std::sync::Arc;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util::stub::RawFd;
@@ -24,17 +27,16 @@ use crate::async_sys::ported_fns;
 
 use super::{EVENT_BUFFER_SIZE, PollEvent, PollInstance, last_errno, last_native_error};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct CompletionPort(RawFd);
+#[derive(Debug, Clone)]
+pub(crate) struct CompletionPort(Arc<OwnedHandle>);
 
 // A completion port handle may be used from worker threads to post completion
-// packets. PollInstance owns the actual handle lifetime; this value is only a
-// typed copy used while the owning poll instance remains registered in AsyncHost.
-unsafe impl Send for CompletionPort {}
+// packets. Share ownership with PollInstance so a worker cannot post through a
+// stale handle if the guest destroys the poll instance before the worker exits.
 
 impl CompletionPort {
     pub(crate) fn from_poll(poll: &PollInstance) -> Self {
-        Self(poll.raw_fd())
+        Self(Arc::clone(&poll.fd))
     }
 }
 
@@ -52,7 +54,7 @@ ported_fns! {
             Err(last_native_error())
         } else {
             Ok(PollInstance {
-                fd,
+                fd: Arc::new(unsafe { OwnedHandle::from_raw_handle(fd) }),
                 events: Vec::new(),
             })
         }
@@ -83,7 +85,8 @@ ported_fns! {
         if unsafe { SetFileCompletionNotificationModes(fd, FILE_SKIP_COMPLETION_PORT_ON_SUCCESS as u8) } == 0 {
             return Err(last_native_error());
         }
-        let registered = unsafe { CreateIoCompletionPort(fd, instance.fd, fd as usize, 0) };
+        let registered =
+            unsafe { CreateIoCompletionPort(fd, instance.raw_fd(), fd as usize, 0) };
         if registered.is_null() {
             Err(last_native_error())
         } else {
@@ -104,7 +107,7 @@ ported_fns! {
         let mut count = 0;
         let ok = unsafe {
             GetQueuedCompletionStatusEx(
-                instance.fd,
+                instance.raw_fd(),
                 entries.as_mut_ptr(),
                 EVENT_BUFFER_SIZE as u32,
                 &mut count,
@@ -130,15 +133,15 @@ ported_fns! {
                     None
                 };
                 PollEvent {
-                    fd,
+                    fd: entry.lpCompletionKey,
                     events: 0,
                     // Worker completion packets use lpOverlapped only as a
                     // host generation token; guest-visible worker events match
                     // native and expose no IO result.
                     io_result: if worker_generation.is_some() {
-                        std::ptr::null_mut()
+                        0
                     } else {
-                        entry.lpOverlapped
+                        entry.lpOverlapped as usize
                     },
                     bytes_transferred: entry.dwNumberOfBytesTransferred as i32,
                     worker_generation,
@@ -162,7 +165,7 @@ ported_fns! {
         original = "moonbitlang_async_event_get_fd"
     )]
     pub(crate) fn event_get_fd(event: &PollEvent) -> RawFd {
-        event.fd
+        event.fd as RawFd
     }
 
     #[ported(
@@ -172,7 +175,7 @@ ported_fns! {
     pub(crate) fn event_get_io_result(
         event: &PollEvent,
     ) -> *mut windows_sys::Win32::System::IO::OVERLAPPED {
-        event.io_result
+        event.io_result as *mut windows_sys::Win32::System::IO::OVERLAPPED
     }
 
     #[ported(
@@ -203,7 +206,7 @@ pub(crate) fn poll_register_socket(
 }
 
 pub(crate) fn post_thread_pool_completion(
-    completion_port: CompletionPort,
+    completion_port: &CompletionPort,
     completion_id: i32,
     generation: usize,
 ) -> AsyncHostResult<()> {
@@ -216,7 +219,7 @@ pub(crate) fn post_thread_pool_completion(
     // transferred bytes. Rust treats that value as an opaque completion id.
     if unsafe {
         PostQueuedCompletionStatus(
-            completion_port.0,
+            completion_port.0.as_raw_handle(),
             completion_id as u32,
             INVALID_HANDLE_VALUE as usize,
             worker_generation_to_overlapped(generation),

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
@@ -19,6 +19,7 @@
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::ported_fns;
+use std::os::fd::{FromRawFd, OwnedFd};
 
 use super::{
     EVENT_BUFFER_SIZE, PROCESS_EVENT, PollEvent, PollInstance, READ_EVENT, WRITE_EVENT, last_errno,
@@ -36,7 +37,7 @@ ported_fns! {
             Err(last_native_error())
         } else {
             Ok(PollInstance {
-                fd,
+                fd: unsafe { OwnedFd::from_raw_fd(fd) },
                 events: Vec::new(),
             })
         }
@@ -73,7 +74,7 @@ ported_fns! {
         ];
         if unsafe {
             libc::kevent(
-                instance.fd,
+                instance.raw_fd(),
                 events.as_ptr(),
                 if read_only { 1 } else { 2 },
                 std::ptr::null_mut(),
@@ -101,7 +102,7 @@ ported_fns! {
         let event = new_kevent(pid as libc::uintptr_t, libc::EVFILT_PROC, flags, fflags, 0);
         let ret = unsafe {
             libc::kevent(
-                instance.fd,
+                instance.raw_fd(),
                 &event,
                 1,
                 std::ptr::null_mut(),
@@ -134,7 +135,7 @@ ported_fns! {
         let mut events = vec![empty_kevent(); EVENT_BUFFER_SIZE];
         let count = unsafe {
             libc::kevent(
-                instance.fd,
+                instance.raw_fd(),
                 std::ptr::null(),
                 0,
                 events.as_mut_ptr(),
@@ -191,7 +192,7 @@ pub(crate) fn poll_unregister(instance: &PollInstance, fd: RawFd) -> AsyncHostRe
         let event = new_kevent(fd as libc::uintptr_t, filter, libc::EV_DELETE, 0, 0);
         if unsafe {
             libc::kevent(
-                instance.fd,
+                instance.raw_fd(),
                 &event,
                 1,
                 std::ptr::null_mut(),

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
@@ -22,6 +22,13 @@
 use crate::async_host::AsyncHostError;
 use crate::async_sys::internal::fd_util::stub::RawFd;
 
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, OwnedFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, OwnedHandle};
+#[cfg(windows)]
+use std::sync::Arc;
+
 #[cfg(target_os = "linux")]
 mod epoll;
 #[cfg(windows)]
@@ -46,46 +53,41 @@ pub(crate) const PROCESS_EVENT: i32 = 4;
 
 #[derive(Debug)]
 pub(crate) struct PollInstance {
-    fd: RawFd,
+    #[cfg(unix)]
+    fd: OwnedFd,
+    #[cfg(windows)]
+    fd: Arc<OwnedHandle>,
     events: Vec<PollEvent>,
 }
 
-#[cfg(windows)]
-unsafe impl Send for PollInstance {}
-
-#[cfg(windows)]
-unsafe impl Sync for PollInstance {}
-
 impl PollInstance {
-    #[cfg(windows)]
     pub(crate) fn raw_fd(&self) -> RawFd {
-        self.fd
+        #[cfg(unix)]
+        {
+            self.fd.as_raw_fd()
+        }
+        #[cfg(windows)]
+        {
+            self.fd.as_raw_handle()
+        }
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PollEvent {
+    #[cfg(unix)]
     fd: RawFd,
+    #[cfg(windows)]
+    // IOCP completion keys are opaque values. Store the address bits rather
+    // than a pointer so cached events carry no false pointer provenance.
+    fd: usize,
     events: i32,
     #[cfg(windows)]
-    io_result: *mut windows_sys::Win32::System::IO::OVERLAPPED,
+    io_result: usize,
     #[cfg(windows)]
     bytes_transferred: i32,
     #[cfg(windows)]
     worker_generation: Option<usize>,
-}
-
-impl Drop for PollInstance {
-    fn drop(&mut self) {
-        #[cfg(unix)]
-        unsafe {
-            libc::close(self.fd);
-        }
-        #[cfg(windows)]
-        unsafe {
-            windows_sys::Win32::Foundation::CloseHandle(self.fd);
-        }
-    }
 }
 
 pub(super) fn last_errno() -> i32 {

--- a/crates/moonrun/src/async_sys/signal.rs
+++ b/crates/moonrun/src/async_sys/signal.rs
@@ -186,10 +186,10 @@ static CONSOLE_COMPLETION_TARGET: std::sync::Mutex<Option<(CompletionPort, usize
 unsafe extern "system" fn console_control_handler(ctrl_type: u32) -> i32 {
     let interested = INTERESTED_CONSOLE_CTRL_EVENT.load(std::sync::atomic::Ordering::Relaxed);
     if ctrl_type < i32::BITS && (interested & (1_i32 << ctrl_type)) != 0 {
-        let target = *CONSOLE_COMPLETION_TARGET.lock().unwrap();
+        let target = CONSOLE_COMPLETION_TARGET.lock().unwrap().clone();
         if let Some((completion_port, generation)) = target {
             let _ = poll::post_thread_pool_completion(
-                completion_port,
+                &completion_port,
                 (ctrl_type | (1 << 31)) as i32,
                 generation,
             );


### PR DESCRIPTION
## Why

Moonrun exposes the async-host imports directly to an untrusted guest, so the guest can destroy the host poller while a worker still has a completion to post. The worker previously retained only a copied raw IOCP handle, allowing that valid alternate ordering to target a closed completion port. The poller layer also carried raw platform handles and unnecessary unsafe trait implementations.

The pinned `moonbitlang/async` submodule was also behind its current `origin/main`.

## What changed

- Share ownership of the Windows completion port between the poller and workers, keeping the OS object alive until the last completion producer is gone.
- Make poll instances own their Unix descriptors and Windows handle, and keep raw values confined to the native-call boundary.
- Represent IOCP completion keys and `OVERLAPPED` addresses as integer tokens while they cross the event abstraction.
- Add paired trace-contract coverage for both the native destruction order and the safe alternate order available through the guest ABI.
- Update `third_party/moonbitlang_async` to `7afeffd`, the latest `origin/main` at publication time.

## Why this is correct and minimal

Guest handle invalidation remains immediate, but physical completion-port lifetime now follows outstanding worker ownership. The native ordering remains supported, while alternate guest-controlled ordering can no longer post through a stale handle. The change is confined to the poll/completion ownership seam, does not change the guest ABI or event semantics, and adds no dependency. The submodule update is kept in a separate commit.