### PR TITLE
fix(moonrun): port async runtime fixes

### DIFF
--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -366,14 +366,17 @@ fn open_native_file(
     use windows_sys::Win32::Storage::FileSystem::{
         BY_HANDLE_FILE_INFORMATION, CREATE_ALWAYS, CREATE_NEW, CreateFileW, FILE_APPEND_DATA,
         FILE_ATTRIBUTE_NORMAL, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OVERLAPPED,
-        FILE_LIST_DIRECTORY, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
-        GetFileInformationByHandle, OPEN_ALWAYS, OPEN_EXISTING, TRUNCATE_EXISTING,
+        FILE_FLAG_WRITE_THROUGH, FILE_LIST_DIRECTORY, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, GetFileInformationByHandle, OPEN_ALWAYS, OPEN_EXISTING,
+        TRUNCATE_EXISTING,
     };
     use windows_sys::Win32::System::Pipes::{NMPWAIT_WAIT_FOREVER, WaitNamedPipeW};
 
-    if !(0..=2).contains(&sync) {
-        return Err(AsyncHostError::Inval);
-    }
+    let sync_flag = match sync {
+        0 => 0,
+        1 | 2 => FILE_FLAG_WRITE_THROUGH,
+        _ => return Err(AsyncHostError::Inval),
+    };
     let mut access_flag = match access {
         0 => GENERIC_READ,
         1 => GENERIC_WRITE,
@@ -392,7 +395,7 @@ fn open_native_file(
     if append {
         access_flag = (access_flag ^ GENERIC_WRITE) | FILE_APPEND_DATA;
     }
-    let mut flags = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS;
+    let mut flags = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS | sync_flag;
     if access == 3 {
         flags |= FILE_FLAG_OVERLAPPED;
     }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/signal.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/signal.rs
@@ -37,7 +37,12 @@ ported_fns! {
             check_signal_call(unsafe { libc::sigaddset(&mut set, signal) })?;
         }
         check_signal_call(unsafe { libc::sigaddset(&mut set, libc::SIGUSR2) })?;
-        let _mask_guard = SignalMaskGuard::block(&set)?;
+
+        // The cancellation signal is part of the wait set, so all signals must
+        // remain blocked while sigwait owns delivery on this worker thread.
+        let mut all_signals = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+        check_signal_call(unsafe { libc::sigfillset(&mut all_signals) })?;
+        let _mask_guard = SignalMaskGuard::replace(&all_signals)?;
 
         loop {
             let mut signal = 0;
@@ -60,9 +65,9 @@ struct SignalMaskGuard {
 }
 
 impl SignalMaskGuard {
-    fn block(set: &libc::sigset_t) -> AsyncHostResult<Self> {
+    fn replace(set: &libc::sigset_t) -> AsyncHostResult<Self> {
         let mut old = unsafe { std::mem::zeroed::<libc::sigset_t>() };
-        check_pthread_call(unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, set, &mut old) })?;
+        check_pthread_call(unsafe { libc::pthread_sigmask(libc::SIG_SETMASK, set, &mut old) })?;
         Ok(Self { old })
     }
 }

--- a/crates/moonrun/src/async_sys/process.rs
+++ b/crates/moonrun/src/async_sys/process.rs
@@ -67,7 +67,6 @@ ported_fns! {
     ) -> AsyncHostResult<i32> {
         #[cfg(windows)]
         {
-            use windows_sys::Win32::Foundation::{ERROR_IO_PENDING, STILL_ACTIVE};
             use windows_sys::Win32::System::Threading::GetExitCodeProcess;
 
             let _ = pid;
@@ -75,9 +74,6 @@ ported_fns! {
             let mut code = 0;
             if unsafe { GetExitCodeProcess(handle, &mut code) } == 0 {
                 return Err(last_native_error());
-            }
-            if code == STILL_ACTIVE as u32 {
-                return Err(AsyncHostError::Native(ERROR_IO_PENDING as i32));
             }
             Ok(code as i32)
         }
@@ -95,7 +91,7 @@ ported_fns! {
                         libc::P_PIDFD,
                         handle as libc::id_t,
                         &mut info,
-                        libc::WEXITED | libc::WSTOPPED | libc::WNOHANG,
+                        libc::WEXITED | libc::WNOHANG,
                     )
                 } < 0
                 {

--- a/crates/moonrun/src/async_sys/process.rs
+++ b/crates/moonrun/src/async_sys/process.rs
@@ -67,10 +67,28 @@ ported_fns! {
     ) -> AsyncHostResult<i32> {
         #[cfg(windows)]
         {
-            use windows_sys::Win32::System::Threading::GetExitCodeProcess;
+            use windows_sys::Win32::Foundation::{
+                ERROR_IO_PENDING, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+            };
+            use windows_sys::Win32::System::Threading::{
+                GetExitCodeProcess, WaitForSingleObject,
+            };
 
             let _ = pid;
             let handle = handle.ok_or(AsyncHostError::Badf)?;
+
+            // Native async only calls this after its wait job completes, but a
+            // Wasm guest can call the import directly. Check the waitable handle
+            // because STILL_ACTIVE (259) can also be a real process exit code.
+            match unsafe { WaitForSingleObject(handle, 0) } {
+                WAIT_OBJECT_0 => {}
+                WAIT_TIMEOUT => {
+                    return Err(AsyncHostError::Native(ERROR_IO_PENDING as i32));
+                }
+                WAIT_FAILED => return Err(last_native_error()),
+                _ => return Err(AsyncHostError::Inval),
+            }
+
             let mut code = 0;
             if unsafe { GetExitCodeProcess(handle, &mut code) } == 0 {
                 return Err(last_native_error());
@@ -237,4 +255,45 @@ fn last_native_errno() -> i32 {
 #[cfg(target_os = "macos")]
 fn last_native_errno() -> i32 {
     unsafe { *libc::__error() }
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use std::os::windows::io::AsRawHandle;
+    use std::process::Command;
+
+    use super::*;
+
+    #[test]
+    fn running_process_result_is_pending() {
+        let mut child = Command::new("cmd.exe")
+            .args(["/D", "/C", "ping -n 30 127.0.0.1 >NUL"])
+            .spawn()
+            .unwrap();
+        let result = get_process_result(Some(child.as_raw_handle()), child.id() as i32);
+
+        let _ = child.kill();
+        child.wait().unwrap();
+
+        assert_eq!(
+            result,
+            Err(AsyncHostError::Native(
+                windows_sys::Win32::Foundation::ERROR_IO_PENDING as i32
+            ))
+        );
+    }
+
+    #[test]
+    fn completed_process_can_return_still_active_value() {
+        let mut child = Command::new("cmd.exe")
+            .args(["/D", "/C", "exit /B 259"])
+            .spawn()
+            .unwrap();
+        let handle = child.as_raw_handle();
+        let pid = child.id() as i32;
+
+        child.wait().unwrap();
+
+        assert_eq!(get_process_result(Some(handle), pid), Ok(259));
+    }
 }


### PR DESCRIPTION
## Why

`moonrun` mirrors the host-side behavior of `moonbitlang/async`, but three fixes marked `wasm-runtime-port-required` were still missing. Without them, the Wasm runtime diverges from the native async runtime for Windows synchronous opens, process completion, and Unix signal waiting.

The fourth labeled change, moonbitlang/async#483, is already present on `main` as the async stdio support, so it is intentionally not duplicated here.

## What changed

- Honor data/full sync opens on Windows with `FILE_FLAG_WRITE_THROUGH` (moonbitlang/async#464).
- Return the Windows process exit code verbatim and stop requesting stopped-child notifications from Linux `waitid` (moonbitlang/async#490).
- Replace the `sigwait` worker mask with a fully blocked mask, including its `SIGUSR2` cancellation signal, and restore the previous mask when the worker exits (moonbitlang/async#504).

## Why this is correct

Each change follows the corresponding upstream host implementation while preserving the existing Wasm imports and call signatures. The patch is limited to the three runtime implementations that differ from upstream.