### PR TITLE
fix(moonx): keep dependency progress off stdout

### DIFF
--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -23,7 +23,10 @@ use moonbuild_rupes_recta::{
     intent::UserIntent,
     model::{BuildPlanNode, BuildTarget, PackageId, TargetKind},
 };
-use mooncake::registry::{OnlineRegistry, Registry, path as registry_path};
+use mooncake::{
+    pkg::sync::SyncOutputOptions,
+    registry::{OnlineRegistry, Registry, path as registry_path},
+};
 use moonutil::{
     build_options::RunMode,
     cli_support::UniversalFlags,
@@ -477,6 +480,7 @@ fn prepare_native_build(
     module_name: &ModuleName,
     module_dir: &Path,
     package_dirs: PackageDirs,
+    sync_output: SyncOutputOptions,
     filter: PackageFilter,
 ) -> anyhow::Result<PreparedNativeBuild> {
     let module_dir = dunce::canonicalize(module_dir).with_context(|| {
@@ -491,7 +495,8 @@ fn prepare_native_build(
     let project_manifest = package_dirs.project_manifest;
 
     let resolve_cfg =
-        ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone());
+        ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone())
+            .with_sync_output(sync_output);
     let mooncake_bin_dir = mooncakes_dir.join(moonutil::constants::MOON_BIN_DIR);
     let synced_env = moonbuild_rupes_recta::sync_dependencies(
         &resolve_cfg,
@@ -654,6 +659,7 @@ fn build_native_executable_to(
         module_name,
         module_dir,
         package_dirs,
+        SyncOutputOptions::new(!cli.verbose, cli.verbose),
         PackageFilter::package_path(package_path.to_string(), false),
     )?;
     let pkg = prepared
@@ -712,7 +718,7 @@ pub(super) fn build_registry_native_executable_to(
     let source = tempfile::TempDir::new().context("Failed to create temporary directory")?;
     // Moonx needs the sources for its temporary build, but must not run package
     // installation hooks or let acquisition progress precede program stdout.
-    OnlineRegistry::mooncakes_io().extract_to(module_name, version, source.path(), true)?;
+    OnlineRegistry::mooncakes_io().extract_to(module_name, version, source.path(), !verbose)?;
 
     let cli = UniversalFlags {
         source_tgt_dir: SourceTargetDirs {
@@ -770,7 +776,14 @@ fn build_and_install_packages(
 ) -> anyhow::Result<i32> {
     let quiet = cli.quiet;
     let output = UserDiagnostics::from_flags(cli);
-    let prepared = prepare_native_build(cli, module_name, module_dir, package_dirs, filter)?;
+    let prepared = prepare_native_build(
+        cli,
+        module_name,
+        module_dir,
+        package_dirs,
+        SyncOutputOptions::new(cli.quiet, cli.verbose),
+        filter,
+    )?;
 
     if cli.dry_run {
         let mut dry_run_count = 0;

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -279,6 +279,131 @@ fn test_moonx_native_skips_postadd_and_reuses_cached_executable() {
     run();
 }
 
+#[test]
+fn test_moonx_native_dependency_download_stays_off_stdout() {
+    use sha2::{Digest, Sha256};
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+    };
+
+    fn package_archive(manifest: &serde_json::Value, files: &[(&str, Vec<u8>)]) -> Vec<u8> {
+        let mut archive = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        archive
+            .start_file("moon.mod.json", zip::write::FileOptions::default())
+            .unwrap();
+        archive
+            .write_all(&serde_json::to_vec_pretty(manifest).unwrap())
+            .unwrap();
+        for (path, contents) in files {
+            archive
+                .start_file(*path, zip::write::FileOptions::default())
+                .unwrap();
+            archive.write_all(contents).unwrap();
+        }
+        archive.finish().unwrap().into_inner()
+    }
+
+    fn write_index(moon_home: &std::path::Path, name: &str, version: &str, archive: &[u8]) {
+        let (username, package) = name.split_once('/').unwrap();
+        let index = moon_home
+            .join("registry/index/user")
+            .join(username)
+            .join(format!("{package}.index"));
+        std::fs::create_dir_all(index.parent().unwrap()).unwrap();
+        std::fs::write(
+            index,
+            format!(
+                "{{\"name\":\"{name}\",\"version\":\"{version}\",\"checksum\":\"{:x}\"}}\n",
+                Sha256::digest(archive)
+            ),
+        )
+        .unwrap();
+    }
+
+    let fixture = TestDir::new("moonx_registry_native.in");
+    let moon_home = tempfile::TempDir::new().expect("failed to create temp MOON_HOME");
+    let mut runner_manifest: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(fixture.join("moon.mod.json")).unwrap()).unwrap();
+    runner_manifest.as_object_mut().unwrap().remove("scripts");
+    runner_manifest["deps"] = serde_json::json!({ "testuser/dependency": "1.0.0" });
+    let runner_files = [
+        "src/lib/moon.pkg.json",
+        "src/lib/lib.mbt",
+        "src/tool/moon.pkg.json",
+        "src/tool/main.mbt",
+    ]
+    .map(|path| (path, std::fs::read(fixture.join(path)).unwrap()));
+    let runner_archive = package_archive(&runner_manifest, &runner_files);
+    let runner_cache = moon_home
+        .path()
+        .join("registry/cache/testuser/runner/1.2.3.zip");
+    std::fs::create_dir_all(runner_cache.parent().unwrap()).unwrap();
+    std::fs::write(runner_cache, &runner_archive).unwrap();
+    write_index(
+        moon_home.path(),
+        "testuser/runner",
+        "1.2.3",
+        &runner_archive,
+    );
+
+    let dependency_archive = package_archive(
+        &serde_json::json!({
+            "name": "testuser/dependency",
+            "version": "1.0.0",
+        }),
+        &[],
+    );
+    write_index(
+        moon_home.path(),
+        "testuser/dependency",
+        "1.0.0",
+        &dependency_archive,
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let registry_url = format!("http://{}", listener.local_addr().unwrap());
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0; 4096];
+        let _ = stream.read(&mut request).unwrap();
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            dependency_archive.len()
+        )
+        .unwrap();
+        stream.write_all(&dependency_archive).unwrap();
+    });
+
+    let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");
+    snapbox::cmd::Command::new(moonx_bin(&bin_dir))
+        .current_dir(&fixture)
+        .env("MOON_HOME", moon_home.path())
+        .env("MOONCAKES_REGISTRY", registry_url)
+        .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
+        .args([
+            "--verbose",
+            "--target",
+            "native",
+            "testuser/runner/tool@1.2.3",
+            "--child-arg",
+        ])
+        .assert()
+        .success()
+        .stdout_eq("native runner\n--child-arg\n")
+        .stderr_eq(snapbox::str![[r#"
+Using cached testuser/runner@1.2.3
+Downloading testuser/dependency@1.0.0
+Info: Building `testuser/runner/tool`...
+Finished. moon: ran 4 tasks, now up to date
+'$MOON_HOME/registry/cache/assets/testuser/runner/1.2.3/tool/tool.exe' --child-arg
+
+"#]]);
+
+    server.join().unwrap();
+}
+
 #[cfg(any(unix, windows))]
 #[test]
 fn test_moonx_delegates_interrupt_to_cached_native_executable() {

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -209,13 +209,13 @@ impl OnlineRegistry {
         }
         if checksum_ok {
             if !quiet {
-                println!("Using cached {name}@{version}");
+                eprintln!("Using cached {name}@{version}");
             }
             let data = std::fs::read(cache_file)?;
             return Ok(bytes::Bytes::from(data));
         }
         if !quiet {
-            println!("Downloading {name}@{version}");
+            eprintln!("Downloading {name}@{version}");
         }
         let filepath = form_urlencoded::Serializer::new(String::new())
             .append_key_only(&format!("{}/{}/{}", name.username, name.unqual, version))

--- a/docs/dev/reference/moonx.md
+++ b/docs/dev/reference/moonx.md
@@ -83,6 +83,10 @@ Source acquisition for `moonx` does not execute the downloaded module's
 `scripts.postadd` hook. Normal registry installation retains its existing
 postadd behavior.
 
+Normal `moonx` execution suppresses registry acquisition progress. With
+`--verbose`, progress is written to stderr; stdout remains reserved for the
+delegated program.
+
 The Cached Executable Artifact is keyed by the resolved module version, package
 path, and Target Backend. A cache hit executes it directly; Moon toolchain
 upgrades do not invalidate an existing cached executable. Source trees and


### PR DESCRIPTION
## Why

Native `moonx` cache misses prepare registry dependencies after source extraction. The default dependency-sync output can print `Downloading` or `Using cached` to stdout before the delegated program starts, corrupting pipelines and command substitution.

## What changed

- Pass explicit dependency-sync output options into native build preparation.
- Keep normal `moonx` dependency acquisition quiet; allow verbose acquisition status on stderr.
- Move registry acquisition status from stdout to stderr.
- Add a local-registry dependency cache-miss regression test proving that `Downloading` is on stderr and delegated stdout remains exact.

## Relationship to #1916

PR #1916 independently deprecates implicit `postadd` hooks and keeps hook output out of automatic and delegated workflows. This PR handles acquisition status only; the branches are intentionally independent so each diff is reviewable against `main`.

## Scope

No archive type, cache/checksum policy, atomic publication, destination replacement, `postadd` policy, or install-flow refactor.