### PR TITLE
fix(moonrun): clear errno for macOS pid fallback

### DIFF
--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -213,9 +213,13 @@ pub(super) fn open_pid_handle(
     context: &mut ImportContext<'_, '_>,
     pid: i32,
 ) -> AsyncHostResult<u64> {
-    context
+    let handle = context
         .host
-        .with_owned_child_pid(pid, || Ok(context.host.invalid_fd()))
+        .with_owned_child_pid(pid, || Ok(context.host.invalid_fd()))?;
+    // The invalid handle selects the kqueue fallback rather than reporting an
+    // error. Match the native C implementation by clearing any stale errno.
+    context.host.set_errno(0);
+    Ok(handle)
 }
 
 #[ported(

--- a/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
@@ -20,6 +20,27 @@
 fn get_platform() -> Int = "moonbitlang/async" "runtime/get_platform"
 
 ///|
+fn get_pid() -> Int = "moonbitlang/async" "env_util/getpid"
+
+///|
+fn get_errno() -> Int = "moonbitlang/async" "os_error/get_errno"
+
+///|
+fn invalid_fd() -> UInt64 = "moonbitlang/async" "fd_util/invalid_fd"
+
+///|
+fn open_pid_handle(pid : Int) -> UInt64 = "moonbitlang/async" "process/open_pid_handle"
+
+///|
+#unsafe_skip_stub_check
+#borrow(out)
+fn get_process_result(
+  handle : UInt64,
+  pid : Int,
+  out : Ref[Int],
+) -> Int = "moonbitlang/async" "process/get_process_result"
+
+///|
 fn ms_since_epoch() -> UInt64 = "moonbitlang/async" "time/get_ms_since_epoch"
 
 ///|
@@ -126,6 +147,22 @@ fn assert_true(cond : Bool, message : String) -> Unit {
 fn main {
   let platform = get_platform()
   assert_true(platform >= 0 && platform <= 2, "invalid platform")
+  if platform == 1 {
+    let out = Ref(0)
+    assert_true(
+      get_process_result(invalid_fd(), get_pid(), out) == -1,
+      "waiting on the current process unexpectedly succeeded",
+    )
+    assert_true(get_errno() != 0, "failed process wait did not set errno")
+    assert_true(
+      open_pid_handle(get_pid()) == invalid_fd(),
+      "macOS PID handle fallback returned a valid handle",
+    )
+    assert_true(
+      get_errno() == 0,
+      "macOS PID handle fallback did not clear stale errno",
+    )
+  }
   let before = ms_since_epoch()
   assert_true(before > 1_600_000_000_000, "time is not Unix epoch milliseconds")
   let after = ms_since_epoch()


### PR DESCRIPTION
## Why

moonbitlang/async#505 enabled process tests that exposed a macOS-only failure in the WASM async host. The macOS PID-handle path intentionally returns the invalid-handle sentinel to select the kqueue fallback, but unlike the native C implementation it left a stale errno behind. `Process::from_pid` then interpreted that stale errno as a new failure.

## What changed

- Clear async-host errno after the macOS PID-handle fallback succeeds.
- Add a WASM integration regression that seeds errno before opening the PID handle and verifies the fallback clears it.

## Why this is correct

The change restores parity with the native implementation, which returns the sentinel with errno set to zero. The sentinel still selects the existing kqueue path; only the stale error state is removed.

## Scope

The runtime change is limited to the non-Linux Unix PID-handle fallback. Other platforms and process paths are unchanged.