### PR TITLE
Build Linux releases with Zig

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,12 @@ name: CD
 
 on:
   workflow_dispatch:
+    inputs:
+      glibc-version:
+        description: Minimum glibc version for Linux x86_64 binaries
+        required: true
+        default: "2.23"
+        type: string
   push:
     branches:
       - main
@@ -71,49 +77,30 @@ jobs:
 
   ubuntu-build:
     runs-on: ubuntu-latest
-    container:
-      image: ubuntu:16.04
+    env:
+      LINUX_GLIBC_VERSION: ${{ inputs.glibc-version || '2.23' }}
+      LINUX_TARGET: x86_64-unknown-linux-gnu
     steps:
-      - name: Install dependencies
-        run: |
-          apt update && apt install -y software-properties-common curl unzip build-essential git sudo coreutils pkg-config libssl-dev
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
-      - name: Configure git
-        run: git config --global core.autocrlf false
+      - uses: dtolnay/rust-toolchain@1.90.0
+        with:
+          targets: ${{ env.LINUX_TARGET }}
 
-      - name: Checkout
-        run: |
-          git clone --depth 1 "https://${{ secrets.MOON_CLONE_PAT }}@github.com/moonbitlang/moon.git" "$GITHUB_WORKSPACE"
-          git submodule update --init crates/moonutil/resources/error_codes
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
 
-      - name: Install Rustup
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - name: Install cargo-zigbuild
+        run: cargo install --locked --version 0.22.1 cargo-zigbuild
 
-      - name: Install Rust
-        run: |
-          rustup toolchain install ${{ env.toolchain }} --profile minimal --no-self-update
-        env:
-          toolchain: 1.90.0
-
-      - name: Rust Version
-        run: |
-          cargo version
-          rustc --version
-
-      - run: |
-          git config --global --add safe.directory "$(pwd)"
-          git status
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --release
-
-      - name: Setup AWS
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          bash ./aws/install
+        run: cargo zigbuild --release --target "${LINUX_TARGET}.${LINUX_GLIBC_VERSION}"
 
       - name: Upload
         env:
@@ -122,5 +109,5 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         run: |
           version=$(echo "$GITHUB_SHA" | cut -c 1-9)
-          aws s3 cp target/release/moon "s3://${{ secrets.AWS_BUCKET_NAME }}/bleeding-moon/$version/$(uname -s)-$(uname -m)/"
-          aws s3 cp target/release/moonrun "s3://${{ secrets.AWS_BUCKET_NAME }}/bleeding-moonrun/$version/$(uname -s)-$(uname -m)/"
+          aws s3 cp "target/$LINUX_TARGET/release/moon" "s3://${{ secrets.AWS_BUCKET_NAME }}/bleeding-moon/$version/$(uname -s)-$(uname -m)/"
+          aws s3 cp "target/$LINUX_TARGET/release/moonrun" "s3://${{ secrets.AWS_BUCKET_NAME }}/bleeding-moonrun/$version/$(uname -s)-$(uname -m)/"


### PR DESCRIPTION
## Why

The Linux x86_64 release job currently builds inside an end-of-life Ubuntu 16.04 container to preserve its glibc compatibility floor. That forces the workflow to maintain manual checkout, Rust installation, Git safety, and AWS CLI setup steps, including a secret-backed clone instead of the standard checkout action.

## What changed

- Build Linux x86_64 releases on the maintained GitHub runner with pinned Zig 0.15.2 and cargo-zigbuild 0.22.1.
- Make the minimum glibc version configurable for manual runs, defaulting to 2.23 for Ubuntu 16.04 compatibility.
- Use the explicit cross-target artifact paths during upload.
- Remove setup steps that are already provided by the hosted runner.

## Why this is correct

The versioned cargo-zigbuild target makes the glibc ABI ceiling explicit while allowing the build itself to run on a maintained host. The pinned tool versions keep release output stable across Zig upgrades, and the upstream process-spawn fallback avoids a hard link-time dependency on newer glibc spawn APIs. Standard checkout also ensures the release is built from the workflow's triggering commit.

## Scope

This only changes the Linux x86_64 release job. The macOS, Linux ARM64, and Windows release paths remain unchanged.