### PR TITLE
refactor(pkg): deprecate implicit postadd hooks

### DIFF
--- a/crates/moon/src/cli/fetch.rs
+++ b/crates/moon/src/cli/fetch.rs
@@ -132,6 +132,7 @@ pub(crate) fn fetch_cli(cli: UniversalFlags, cmd: FetchSubcommand) -> anyhow::Re
     }
 
     registry.install_to(&pkg_name, &version, &pkg_dir, cli.quiet)?;
+    super::registry_runner::warn_ignored_postadd(&pkg_dir, &pkg_name, &version, output)?;
 
     if !cli.quiet {
         println!(

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -274,6 +274,7 @@ pub(super) fn install_binary(
     let module_dir = tmp_dir.path();
 
     registry.install_to(&spec.module_name, &version, module_dir, quiet)?;
+    super::registry_runner::warn_ignored_postadd(module_dir, &spec.module_name, &version, output)?;
 
     let filter =
         PackageFilter::package_path(spec.package_path.clone().unwrap_or_default(), install_all);
@@ -713,6 +714,7 @@ pub(super) fn build_registry_native_executable_to(
     // Moonx needs the sources for its temporary build, but must not run package
     // installation hooks or let acquisition progress precede program stdout.
     OnlineRegistry::mooncakes_io().extract_to(module_name, version, source.path(), true)?;
+    super::registry_runner::warn_ignored_postadd(source.path(), module_name, version, output)?;
 
     let cli = UniversalFlags {
         source_tgt_dir: SourceTargetDirs {

--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -26,6 +26,21 @@ use semver::Version;
 
 use crate::{rr_build, user_diagnostics::UserDiagnostics};
 
+pub(super) fn warn_ignored_postadd(
+    destination: &Path,
+    module_name: &ModuleName,
+    version: &Version,
+    output: UserDiagnostics,
+) -> anyhow::Result<()> {
+    if moonutil::scripts::declared_postadd_script(destination)?.is_some() {
+        output.warn(mooncake::pkg::install::ignored_postadd_warning(
+            module_name,
+            version,
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) enum RegistryRunTarget {
     Wasm {
         experimental_policy: Option<PathBuf>,

--- a/crates/moon/tests/mod.rs
+++ b/crates/moon/tests/mod.rs
@@ -23,7 +23,7 @@ use moonbuild_debug::graph::ENV_VAR;
 use std::path::{Path, PathBuf};
 use util::*;
 
-pub(crate) use support::{build_graph, dry_run_utils, process, util};
+pub(crate) use support::{build_graph, dry_run_utils, process, registry, util};
 
 pub(crate) struct TestDir(moon_test_util::test_dir::TestDir);
 

--- a/crates/moon/tests/support/mod.rs
+++ b/crates/moon/tests/support/mod.rs
@@ -19,4 +19,5 @@
 pub(crate) mod build_graph;
 pub(crate) mod dry_run_utils;
 pub(crate) mod process;
+pub(crate) mod registry;
 pub(crate) mod util;

--- a/crates/moon/tests/support/registry.rs
+++ b/crates/moon/tests/support/registry.rs
@@ -1,0 +1,77 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use sha2::{Digest, Sha256};
+
+pub(crate) fn cache_package<I, P, B>(
+    moon_home: &Path,
+    manifest: serde_json::Value,
+    files: I,
+) -> (PathBuf, PathBuf)
+where
+    I: IntoIterator<Item = (P, B)>,
+    P: AsRef<str>,
+    B: AsRef<[u8]>,
+{
+    let name = manifest["name"].as_str().expect("fixture module name");
+    let version = manifest["version"].as_str().expect("fixture version");
+    let mut archive = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    archive
+        .start_file("moon.mod.json", zip::write::FileOptions::default())
+        .unwrap();
+    archive
+        .write_all(&serde_json::to_vec_pretty(&manifest).unwrap())
+        .unwrap();
+    for (path, contents) in files {
+        archive
+            .start_file(path.as_ref(), zip::write::FileOptions::default())
+            .unwrap();
+        archive.write_all(contents.as_ref()).unwrap();
+    }
+    let archive = archive.finish().unwrap().into_inner();
+
+    let (username, package) = name.split_once('/').unwrap();
+    let cache_path = moon_home
+        .join("registry/cache")
+        .join(username)
+        .join(package)
+        .join(format!("{version}.zip"));
+    std::fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+    std::fs::write(&cache_path, &archive).unwrap();
+
+    let index_path = moon_home
+        .join("registry/index/user")
+        .join(username)
+        .join(format!("{package}.index"));
+    std::fs::create_dir_all(index_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &index_path,
+        format!(
+            "{{\"name\":\"{name}\",\"version\":\"{version}\",\"checksum\":\"{:x}\"}}\n",
+            Sha256::digest(&archive)
+        ),
+    )
+    .unwrap();
+
+    (cache_path, index_path)
+}

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -234,7 +234,8 @@ fn test_moonx_native_skips_postadd_and_reuses_cached_executable() {
         .failure()
         .stdout_eq("")
         .stderr_eq(snapbox::str![[r#"
-[..]Package `testuser/runner` not found or is not a main package (is-main: true required)
+Warning: Package `testuser/runner@1.2.3` declares deprecated `scripts.postadd`; the hook was not executed
+Error: Package `testuser/runner` not found or is not a main package (is-main: true required)
 
 "#]]);
 
@@ -247,7 +248,8 @@ fn test_moonx_native_skips_postadd_and_reuses_cached_executable() {
         .failure()
         .stdout_eq("")
         .stderr_eq(snapbox::str![[r#"
-[..]Package `testuser/runner/lib` not found or is not a main package (is-main: true required)
+Warning: Package `testuser/runner@1.2.3` declares deprecated `scripts.postadd`; the hook was not executed
+Error: Package `testuser/runner/lib` not found or is not a main package (is-main: true required)
 
 "#]]);
 

--- a/crates/moon/tests/test_cases/package_management.rs
+++ b/crates/moon/tests/test_cases/package_management.rs
@@ -321,22 +321,131 @@ fn test_upgrade_refuses_split_toolchain_root() -> anyhow::Result<()> {
 
 #[test]
 fn test_postadd_script() {
-    if std::env::var("CI").is_err() {
-        return;
-    }
     let dir = TestDir::new("test_postadd_script.in");
-    let output = get_stdout(&dir, ["add", "lijunchen/test_postadd"]);
-    assert!(output.contains(".mooncakes/lijunchen/test_postadd"));
+    let moon_home = tempfile::TempDir::new().unwrap();
+    registry::cache_package(
+        moon_home.path(),
+        serde_json::json!({
+            "name": "testuser/postadd",
+            "version": "1.2.3",
+            "scripts": { "postadd": format!("{} version", moon_bin().display()) },
+        }),
+        [] as [(&str, &[u8]); 0],
+    );
 
-    let _ = get_stdout(&dir, ["remove", "lijunchen/test_postadd"]);
-
-    let out = moon_process_cmd(&dir)
-        .env("MOON_IGNORE_POSTADD", "1")
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .args(["add", "lijunchen/test_postadd"])
+    let executed = moon_process_cmd(&dir)
+        .env("MOON_HOME", moon_home.path())
+        .args(["add", "--quiet", "--no-update", "testuser/postadd@1.2.3"])
         .output()
         .unwrap();
-    let out = String::from_utf8(out.stderr).unwrap();
-    assert!(!out.contains(".mooncakes/lijunchen/test_postadd"));
+    assert!(executed.status.success(), "{executed:?}");
+    assert!(!executed.stdout.is_empty(), "postadd should execute once");
+    snapbox::assert_data_eq!(
+        String::from_utf8_lossy(&executed.stderr).as_ref(),
+        snapbox::str![[r#"
+Warning: Package `testuser/postadd@1.2.3` declares deprecated `scripts.postadd`; explicit `moon add` may still execute it temporarily for compatibility (set `MOON_IGNORE_POSTADD` to skip)
+
+"#]],
+    );
+
+    let ignored_dir = TestDir::new("test_postadd_script.in");
+    let ignored = moon_process_cmd(&ignored_dir)
+        .env("MOON_HOME", moon_home.path())
+        .env("MOON_IGNORE_POSTADD", "1")
+        .args(["add", "--quiet", "--no-update", "testuser/postadd@1.2.3"])
+        .output()
+        .unwrap();
+    assert!(ignored.status.success(), "{ignored:?}");
+    assert!(
+        ignored.stdout.is_empty(),
+        "ignored postadd must not execute"
+    );
+    snapbox::assert_data_eq!(
+        String::from_utf8_lossy(&ignored.stderr).as_ref(),
+        snapbox::str![[r#"
+Warning: Package `testuser/postadd@1.2.3` declares deprecated `scripts.postadd`; explicit `moon add` may still execute it temporarily for compatibility (set `MOON_IGNORE_POSTADD` to skip)
+
+"#]],
+    );
+}
+
+#[test]
+fn fetch_warns_and_skips_deprecated_postadd() {
+    let dir = TestDir::new_empty();
+    let moon_home = tempfile::TempDir::new().unwrap();
+    registry::cache_package(
+        moon_home.path(),
+        serde_json::json!({
+            "name": "testuser/postadd",
+            "version": "1.2.3",
+            "scripts": { "postadd": "postadd-must-not-run" },
+        }),
+        [("README.md", b"fetched")],
+    );
+
+    let output = moon_process_cmd(&dir)
+        .env("MOON_HOME", moon_home.path())
+        .args(["fetch", "--quiet", "--no-update", "testuser/postadd@1.2.3"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(output.stdout.is_empty());
+    snapbox::assert_data_eq!(
+        String::from_utf8_lossy(&output.stderr).as_ref(),
+        snapbox::str![[r#"
+Warning: Package `testuser/postadd@1.2.3` declares deprecated `scripts.postadd`; the hook was not executed
+
+"#]],
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join(".repos/testuser/postadd/1.2.3/README.md")).unwrap(),
+        "fetched"
+    );
+}
+
+#[test]
+fn dependency_sync_warns_and_skips_deprecated_postadd() {
+    let dir = TestDir::new_empty();
+    std::fs::write(
+        dir.join("moon.mod.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "name": "testuser/project",
+            "version": "0.1.0",
+            "deps": { "testuser/postadd": "1.2.3" },
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let moon_home = tempfile::TempDir::new().unwrap();
+    registry::cache_package(
+        moon_home.path(),
+        serde_json::json!({
+            "name": "testuser/postadd",
+            "version": "1.2.3",
+            "scripts": { "postadd": "postadd-must-not-run" },
+        }),
+        [] as [(&str, &[u8]); 0],
+    );
+
+    let output = moon_process_cmd(&dir)
+        .env("MOON_HOME", moon_home.path())
+        .args(["install", "--quiet"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(output.stdout.is_empty());
+    snapbox::assert_data_eq!(
+        String::from_utf8_lossy(&output.stderr).as_ref(),
+        snapbox::str![[r#"
+Warning: `moon install` without arguments is deprecated and will be removed in a future version. Use `moon install <package>` to install binaries globally, or use `moon build` to build your project.
+Warning: Package `testuser/postadd@1.2.3` declares deprecated `scripts.postadd`; the hook was not executed
+
+"#]],
+    );
+    assert!(
+        dir.join(".mooncakes/testuser/postadd/moon.mod.json")
+            .is_file()
+    );
 }

--- a/crates/mooncake/src/dep_dir.rs
+++ b/crates/mooncake/src/dep_dir.rs
@@ -201,6 +201,7 @@ pub(crate) fn sync_deps(
     registry: &dyn Registry,
     pkg_list: &ResolvedEnv,
     quiet: bool,
+    on_postadd: &mut dyn FnMut(&Path, &ModuleSource) -> anyhow::Result<()>,
     frozen: bool,
     verbose: bool,
 ) -> anyhow::Result<()> {
@@ -265,6 +266,9 @@ pub(crate) fn sync_deps(
                 unreachable!()
             };
             registry.install_to(version.name(), version.version(), &pkg_path, quiet)?;
+            if moonutil::scripts::declared_postadd_script(&pkg_path)?.is_some() {
+                on_postadd(&pkg_path, version)?;
+            }
             // TODO: parallelize this
         }
     }

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -31,7 +31,9 @@ use semver::Version;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::pkg::{install::install_impl, roots_for_selected_module, sync::SyncOutputOptions};
+use crate::pkg::{
+    install::install_impl_with_postadd, roots_for_selected_module, sync::SyncOutputOptions,
+};
 use crate::registry::{self, Registry};
 
 /// Add a dependency
@@ -192,13 +194,26 @@ pub fn add(
 
     let m = Arc::new(m);
     let roots = roots_for_selected_module(module_dir, Arc::clone(&m), project_manifest)?;
-    install_impl(
+    install_impl_with_postadd(
         mooncakes_dir,
         roots,
         SyncOutputOptions::new(quiet, true),
         false,
         false,
         true,
+        |path, source| {
+            if source.name() == pkg_name && source.version() == version {
+                eprintln!(
+                    "{}: Package `{}@{}` declares deprecated `scripts.postadd`; explicit `moon add` may still execute it temporarily for compatibility (set `MOON_IGNORE_POSTADD` to skip)",
+                    "Warning".yellow().bold(),
+                    source.name(),
+                    source.version()
+                );
+                moonutil::scripts::execute_postadd_script(path)
+            } else {
+                crate::pkg::install::warn_ignored_postadd(path, source)
+            }
+        },
     )?;
 
     if module_dir.join(MOON_MOD).exists() {

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -24,10 +24,14 @@ use crate::{
 
 use super::sync::SyncOutputOptions;
 use anyhow::Context;
+use colored::Colorize;
 use moonutil::{
     constants::MOONBITLANG_CORE,
-    resolution::{DependencyKind, DirSyncResult, ResolvedEnv, ResolvedRootModules},
+    resolution::{
+        DependencyKind, DirSyncResult, ModuleName, ModuleSource, ResolvedEnv, ResolvedRootModules,
+    },
 };
+use semver::Version;
 use std::path::{Path, PathBuf};
 
 /// Install a binary package globally or install project dependencies (deprecated without args)
@@ -85,6 +89,26 @@ pub(crate) fn install_impl(
     dont_sync: bool,
     no_std: bool,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult)> {
+    install_impl_with_postadd(
+        mooncakes_dir,
+        roots,
+        output_options,
+        verbose,
+        dont_sync,
+        no_std,
+        warn_ignored_postadd,
+    )
+}
+
+pub(crate) fn install_impl_with_postadd(
+    mooncakes_dir: &Path,
+    roots: ResolvedRootModules,
+    output_options: SyncOutputOptions,
+    verbose: bool,
+    dont_sync: bool,
+    no_std: bool,
+    mut on_postadd: impl FnMut(&Path, &ModuleSource) -> anyhow::Result<()>,
+) -> anyhow::Result<(ResolvedEnv, DirSyncResult)> {
     let includes_core = roots
         .iter()
         .any(|(_, module)| module.module_info().name == MOONBITLANG_CORE);
@@ -105,6 +129,7 @@ pub(crate) fn install_impl(
         resolve_config.registry.as_ref(),
         &res,
         output_options.quiet(),
+        &mut on_postadd,
         dont_sync,
         output_options.verbose(),
     )
@@ -115,6 +140,21 @@ pub(crate) fn install_impl(
     install_bin_deps(verbose, &res, &dir_sync_result)?;
 
     Ok((res, dir_sync_result))
+}
+
+pub fn ignored_postadd_warning(name: &ModuleName, version: &Version) -> String {
+    format!(
+        "Package `{name}@{version}` declares deprecated `scripts.postadd`; the hook was not executed"
+    )
+}
+
+pub(crate) fn warn_ignored_postadd(_path: &Path, source: &ModuleSource) -> anyhow::Result<()> {
+    eprintln!(
+        "{}: {}",
+        "Warning".yellow().bold(),
+        ignored_postadd_warning(source.name(), source.version())
+    );
+    Ok(())
 }
 
 fn install_bin_deps(

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -28,7 +28,6 @@ use anyhow::bail;
 use indexmap::map::IndexMap;
 use moonutil::{
     dependency::SourceDependencyInfo, registry::RegistryConfig, resolution::ModuleName,
-    scripts::execute_postadd_script,
 };
 use reqwest::header::USER_AGENT;
 use semver::Version;
@@ -129,7 +128,7 @@ impl super::Registry for OnlineRegistry {
         to: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
-        self.install_to_impl(name, version, to, quiet)
+        self.extract_to(name, version, to, quiet)
     }
 }
 
@@ -234,18 +233,6 @@ impl OnlineRegistry {
         std::fs::create_dir_all(cache_file.parent().unwrap())?;
         std::fs::write(cache_file, &data)?;
         Ok(data)
-    }
-
-    pub fn install_to_impl(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        pkg_install_dir: &Path,
-        quiet: bool,
-    ) -> anyhow::Result<()> {
-        self.extract_to(name, version, pkg_install_dir, quiet)?;
-        execute_postadd_script(pkg_install_dir)?;
-        Ok(())
     }
 
     /// Download and extract a registry package without running `scripts.postadd`.

--- a/crates/moonutil/src/scripts.rs
+++ b/crates/moonutil/src/scripts.rs
@@ -61,15 +61,8 @@ pub fn execute_postadd_script(dir: &Path) -> anyhow::Result<()> {
     if is_moon_script_ignored(IgnoredMoonScript::Postadd) {
         return Ok(());
     }
-    let m = read_module_desc_file_in_dir(dir)?;
-    if let Some(scripts) = &m.scripts
-        && scripts.contains_key("postadd")
-    {
-        let postadd = scripts
-            .get("postadd")
-            .unwrap()
-            .split(' ')
-            .collect::<Vec<_>>();
+    if let Some(script) = declared_postadd_script(dir)? {
+        let postadd = script.split(' ').collect::<Vec<_>>();
         if !postadd.is_empty() {
             let command = postadd[0];
             let args = &postadd[1..];
@@ -90,4 +83,13 @@ pub fn execute_postadd_script(dir: &Path) -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+pub fn declared_postadd_script(dir: &Path) -> anyhow::Result<Option<String>> {
+    let module = read_module_desc_file_in_dir(dir)?;
+    Ok(module
+        .scripts
+        .as_ref()
+        .and_then(|scripts| scripts.get("postadd"))
+        .cloned())
 }

--- a/docs/adr/0004-deprecate-implicit-postadd-hooks.md
+++ b/docs/adr/0004-deprecate-implicit-postadd-hooks.md
@@ -1,0 +1,5 @@
+# Deprecate implicit postadd hooks
+
+The `scripts.postadd` package hook is deprecated because package extraction should not implicitly execute arbitrary package commands. During migration, manifests continue to accept it and an explicit `moon add` warns before retaining compatibility execution. Automatic dependency synchronization, `moon fetch`, `moon install`, and delegated execution such as `moonx` warn and skip the hook.
+
+There is no general `--allow-postadd` escape hatch. Once affected packages have an explicit setup or lazy-build path, hook execution and then the schema entry can be removed.

--- a/docs/dev/reference/moonx.md
+++ b/docs/dev/reference/moonx.md
@@ -80,8 +80,9 @@ finished executable into the registry cache instead of the user's binary
 directory.
 
 Source acquisition for `moonx` does not execute the downloaded module's
-`scripts.postadd` hook. Normal registry installation retains its existing
-postadd behavior.
+`scripts.postadd` hook. The hook is deprecated: implicit workflows including
+dependency synchronization, `moon fetch`, `moon install`, and `moonx` warn and
+skip it. Explicit `moon add` retains compatibility execution temporarily.
 
 The Cached Executable Artifact is keyed by the resolved module version, package
 path, and Target Backend. A cache hit executes it directly; Moon toolchain


### PR DESCRIPTION
## Why

Registry package extraction currently executes `scripts.postadd` implicitly. That gives dependency synchronization, fetching, installation, and delegated execution an unrelated ability to run arbitrary package commands, and makes their stdout/stderr impossible to control reliably.

## What changed

- Make registry installation extract packages without executing `scripts.postadd`.
- Warn and skip declared hooks in automatic dependency synchronization, `moon fetch`, `moon install`, and `moonx`.
- Temporarily retain compatibility execution for the package explicitly selected by `moon add`, with a deprecation warning and the existing `MOON_IGNORE_POSTADD` opt-out.
- Add deterministic coverage for explicit add, fetch, dependency sync, and moonx behavior.

## Scope

This PR does not change registry download output, archive acquisition, cache validation, checksum policy, or destination replacement semantics. Those concerns are intentionally left to separate follow-up work.