### PR TITLE
feat(moonrun): support secure random imports

### DIFF
--- a/crates/moonrun/src/async_api/mod.rs
+++ b/crates/moonrun/src/async_api/mod.rs
@@ -37,6 +37,7 @@ mod os_error;
 mod os_string;
 mod process;
 mod provenance;
+mod random;
 mod registry;
 mod runtime;
 mod signal;

--- a/crates/moonrun/src/async_api/random.rs
+++ b/crates/moonrun/src/async_api/random.rs
@@ -1,0 +1,41 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use rand::{RngCore, rngs::OsRng};
+
+use crate::async_host::{AsyncHostError, GuestMemory};
+
+use super::context::ImportContext;
+
+pub(super) fn fill(context: &mut ImportContext<'_, '_>, buffer: i32, length: i32) -> i32 {
+    let result = context.with_memory_mut(|memory| {
+        let destination = memory.read_exact_mut(buffer, length)?;
+        OsRng.try_fill_bytes(destination).map_err(|error| {
+            error
+                .raw_os_error()
+                .map_or(AsyncHostError::Io, AsyncHostError::Native)
+        })
+    });
+    match result {
+        Ok(()) => 0,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -26,7 +26,7 @@ use super::context::{
 use super::provenance::{PortedImport, SourceLocation, SourceRoot};
 use super::{
     c_buffer, env_util, event_bus, event_loop, fd_util, fs, io, os_error, os_string, process,
-    runtime, signal, socket, stdio, thread_pool, time, tls,
+    random, runtime, signal, socket, stdio, thread_pool, time, tls,
 };
 
 pub(crate) const MOONBIT_ASYNC_MODULE: &str = "moonbitlang/async";
@@ -366,6 +366,10 @@ declare_async_imports! {
 
     // Time helpers.
     helper time::get_ms_since_epoch() -> u64 => "time/get_ms_since_epoch";
+
+    // Cryptographically secure random bytes. Like the other native-style
+    // helpers, this returns 0 on success and -1 after recording errno.
+    helper random::fill(buffer: i32, length: i32) -> i32 => "random/fill";
 
     // os_error/stub.c predicates, errno accessors, and string formatting.
     ported os_error::get_errno() -> i32 => "os_error/get_errno";

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -62,6 +62,7 @@ pub(crate) mod tls;
 pub(crate) enum AsyncHostError {
     Fault,
     Inval,
+    Io,
     Badf,
     PermissionDenied,
     Native(i32),
@@ -96,18 +97,21 @@ mod native_errno {
     pub(crate) const ACCESS: i32 = libc::EACCES;
     pub(crate) const FAULT: i32 = libc::EFAULT;
     pub(crate) const INVAL: i32 = libc::EINVAL;
+    pub(crate) const IO: i32 = libc::EIO;
 }
 
 #[cfg(windows)]
 mod native_errno {
     use windows_sys::Win32::Foundation::{
-        ERROR_ACCESS_DENIED, ERROR_INVALID_ADDRESS, ERROR_INVALID_HANDLE, ERROR_INVALID_PARAMETER,
+        ERROR_ACCESS_DENIED, ERROR_GEN_FAILURE, ERROR_INVALID_ADDRESS, ERROR_INVALID_HANDLE,
+        ERROR_INVALID_PARAMETER,
     };
 
     pub(crate) const ACCESS: i32 = ERROR_ACCESS_DENIED as i32;
     pub(crate) const BADF: i32 = ERROR_INVALID_HANDLE as i32;
     pub(crate) const FAULT: i32 = ERROR_INVALID_ADDRESS as i32;
     pub(crate) const INVAL: i32 = ERROR_INVALID_PARAMETER as i32;
+    pub(crate) const IO: i32 = ERROR_GEN_FAILURE as i32;
 }
 
 impl AsyncHostError {
@@ -115,6 +119,7 @@ impl AsyncHostError {
         match self {
             Self::Fault => native_errno::FAULT,
             Self::Inval => native_errno::INVAL,
+            Self::Io => native_errno::IO,
             Self::Badf => native_errno::BADF,
             Self::PermissionDenied => native_errno::ACCESS,
             Self::Native(errno) => errno,

--- a/crates/moonrun/src/wasi_api.rs
+++ b/crates/moonrun/src/wasi_api.rs
@@ -17,6 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::v8_builder::ScopeExt;
+use rand::{RngCore, rngs::OsRng};
 use std::any::Any;
 use std::collections::BTreeMap;
 use std::fs;
@@ -755,6 +756,25 @@ fn set_memory(
             .map_err(|_| WASI_ERRNO_INVAL)?;
         let _ = context.memory.set(v8::Global::new(scope, memory));
         Ok(())
+    })();
+    finish_with_result(&mut ret, result);
+}
+
+fn random_get(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut ret: v8::ReturnValue,
+) {
+    let result = (|| -> WasiResult<()> {
+        let buffer = read_i32_arg(scope, &args, 0)?;
+        let length = read_i32_arg(scope, &args, 1)?;
+        let context = callback_context(&args);
+        with_wasi_memory_mut(scope, context, |memory| {
+            let offset = ptr_to_offset(buffer)?;
+            let length = usize::try_from(length).map_err(|_| WASI_ERRNO_FAULT)?;
+            let destination = checked_mut_range(memory, offset, length)?;
+            OsRng.try_fill_bytes(destination).map_err(|_| WASI_ERRNO_IO)
+        })
     })();
     finish_with_result(&mut ret, result);
 }
@@ -1821,6 +1841,7 @@ pub(crate) fn init_env<'s>(
     set_wasi_func!(obj, scope, context_ptr, args_sizes_get);
     set_wasi_func!(obj, scope, context_ptr, environ_get);
     set_wasi_func!(obj, scope, context_ptr, environ_sizes_get);
+    set_wasi_func!(obj, scope, context_ptr, random_get);
     set_wasi_func!(obj, scope, context_ptr, fd_read);
     set_wasi_func!(obj, scope, context_ptr, fd_write);
     set_wasi_func!(obj, scope, context_ptr, fd_close);

--- a/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
@@ -44,6 +44,22 @@ fn get_process_result(
 fn ms_since_epoch() -> UInt64 = "moonbitlang/async" "time/get_ms_since_epoch"
 
 ///|
+#unsafe_skip_stub_check
+#borrow(buffer)
+fn random_fill(
+  buffer : FixedArray[Byte],
+  length : Int,
+) -> Int = "moonbitlang/async" "random/fill"
+
+///|
+#unsafe_skip_stub_check
+#borrow(buffer)
+fn wasi_random_get(
+  buffer : FixedArray[Byte],
+  length : Int,
+) -> Int = "wasi_snapshot_preview1" "random_get"
+
+///|
 fn event_bus_create() -> UInt64 = "moonbitlang/async" "event_bus/create"
 
 ///|
@@ -167,6 +183,41 @@ fn main {
   assert_true(before > 1_600_000_000_000, "time is not Unix epoch milliseconds")
   let after = ms_since_epoch()
   assert_true(after >= before, "time moved backwards")
+  let random_bytes = FixedArray::make(32, b'\x00')
+  assert_true(
+    random_fill(random_bytes, random_bytes.length()) == 0,
+    "secure random fill failed",
+  )
+  let mut random_byte_changed = false
+  for byte in random_bytes {
+    if byte != b'\x00' {
+      random_byte_changed = true
+      break
+    }
+  }
+  assert_true(random_byte_changed, "secure random fill wrote only zeroes")
+  assert_true(
+    random_fill(random_bytes, 2_147_483_647) == -1,
+    "invalid async random range did not use the native error convention",
+  )
+  assert_true(get_errno() != 0, "async random failure did not record errno")
+  let wasi_random_bytes = FixedArray::make(32, b'\x00')
+  assert_true(
+    wasi_random_get(wasi_random_bytes, wasi_random_bytes.length()) == 0,
+    "WASI random_get failed",
+  )
+  let mut wasi_random_byte_changed = false
+  for byte in wasi_random_bytes {
+    if byte != b'\x00' {
+      wasi_random_byte_changed = true
+      break
+    }
+  }
+  assert_true(wasi_random_byte_changed, "WASI random_get wrote only zeroes")
+  assert_true(
+    wasi_random_get(wasi_random_bytes, 2_147_483_647) == 21,
+    "invalid WASI random range did not return WASI errno.fault",
+  )
   let message_buf = errno_to_string(2)
   let message_len = os_string_decode_len(message_buf, 0, -1)
   assert_true(message_len > 0, "errno string size query failed")


### PR DESCRIPTION
## Why

The Wasm backend of `moonbitlang/async` needs cryptographically secure random bytes for WebSocket client masking and handshake keys. `moonrun` did not expose the async-native random primitive, and its WASI Preview 1 surface also lacked `random_get`.

The two imports cannot share an error ABI: async-native helpers return `0` or `-1` and record native errno, while WASI returns Preview 1 errno values directly.

## What changed

- Add `moonbitlang/async` `random/fill`, backed by `OsRng`.
- Add a separate `wasi_snapshot_preview1` `random_get` implementation.
- Preserve native async and WASI error conventions independently.
- Extend the async host integration fixture to cover successful fills and invalid guest ranges for both imports.

## Why this is correct

Both paths validate the guest memory range before filling it. Entropy comes directly from the operating system through `OsRng`; failures are translated according to the importing module's existing ABI instead of conflating native errno with WASI errno.

## Companion PR

moonbitlang/async#510 enables WebSocket on Wasm using this primitive.