### PR TITLE
fix(moonx): keep dependency progress off stdout

### DIFF
--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -23,7 +23,10 @@ use moonbuild_rupes_recta::{
     intent::UserIntent,
     model::{BuildPlanNode, BuildTarget, PackageId, TargetKind},
 };
-use mooncake::registry::{OnlineRegistry, Registry, path as registry_path};
+use mooncake::{
+    pkg::sync::SyncOutputOptions,
+    registry::{OnlineRegistry, Registry, path as registry_path},
+};
 use moonutil::{
     build_options::RunMode,
     cli_support::UniversalFlags,
@@ -477,6 +480,7 @@ fn prepare_native_build(
     module_name: &ModuleName,
     module_dir: &Path,
     package_dirs: PackageDirs,
+    sync_output: SyncOutputOptions,
     filter: PackageFilter,
 ) -> anyhow::Result<PreparedNativeBuild> {
     let module_dir = dunce::canonicalize(module_dir).with_context(|| {
@@ -491,7 +495,8 @@ fn prepare_native_build(
     let project_manifest = package_dirs.project_manifest;
 
     let resolve_cfg =
-        ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone());
+        ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone())
+            .with_sync_output(sync_output);
     let mooncake_bin_dir = mooncakes_dir.join(moonutil::constants::MOON_BIN_DIR);
     let synced_env = moonbuild_rupes_recta::sync_dependencies(
         &resolve_cfg,
@@ -654,6 +659,7 @@ fn build_native_executable_to(
         module_name,
         module_dir,
         package_dirs,
+        SyncOutputOptions::new(!cli.verbose, cli.verbose),
         PackageFilter::package_path(package_path.to_string(), false),
     )?;
     let pkg = prepared
@@ -712,7 +718,7 @@ pub(super) fn build_registry_native_executable_to(
     let source = tempfile::TempDir::new().context("Failed to create temporary directory")?;
     // Moonx needs the sources for its temporary build, but must not run package
     // installation hooks or let acquisition progress precede program stdout.
-    OnlineRegistry::mooncakes_io().extract_to(module_name, version, source.path(), true)?;
+    OnlineRegistry::mooncakes_io().extract_to(module_name, version, source.path(), !verbose)?;
 
     let cli = UniversalFlags {
         source_tgt_dir: SourceTargetDirs {
@@ -770,7 +776,14 @@ fn build_and_install_packages(
 ) -> anyhow::Result<i32> {
     let quiet = cli.quiet;
     let output = UserDiagnostics::from_flags(cli);
-    let prepared = prepare_native_build(cli, module_name, module_dir, package_dirs, filter)?;
+    let prepared = prepare_native_build(
+        cli,
+        module_name,
+        module_dir,
+        package_dirs,
+        SyncOutputOptions::new(cli.quiet, cli.verbose),
+        filter,
+    )?;
 
     if cli.dry_run {
         let mut dry_run_count = 0;

--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -50,11 +50,7 @@ pub(crate) struct MoonxCli {
     #[arg(long = "experimental-policy", value_name = "PATH")]
     pub experimental_policy: Option<PathBuf>,
 
-    /// Suppress output
-    #[arg(short = 'q', long)]
-    pub quiet: bool,
-
-    /// Increase verbosity
+    /// Show progress and execution details
     #[arg(short = 'v', long)]
     pub verbose: bool,
 
@@ -82,7 +78,9 @@ pub(crate) fn is_moonx_invocation(raw_args: &[OsString]) -> bool {
 
 pub(crate) fn run_from_args(raw_args: &[OsString]) -> i32 {
     let cli = MoonxCli::try_parse_from(raw_args).unwrap_or_else(|err| err.exit());
-    let output = UserDiagnostics::new(cli.verbose, cli.quiet);
+    // moonx is a transparent runner unless the user explicitly requests details.
+    let quiet = !cli.verbose;
+    let output = UserDiagnostics::new(cli.verbose, quiet);
     let target = match cli.target {
         MoonxTarget::Wasm => RegistryRunTarget::Wasm {
             experimental_policy: cli.experimental_policy,
@@ -93,7 +91,7 @@ pub(crate) fn run_from_args(raw_args: &[OsString]) -> i32 {
         }
         MoonxTarget::Native => RegistryRunTarget::Native,
     };
-    match registry_runner::run(cli.package, target, cli.args, cli.quiet, cli.verbose) {
+    match registry_runner::run(cli.package, target, cli.args, quiet, cli.verbose) {
         Ok(code) => code,
         Err(err) => {
             output.error(format!("{:?}", err));
@@ -104,6 +102,8 @@ pub(crate) fn run_from_args(raw_args: &[OsString]) -> i32 {
 
 #[cfg(test)]
 mod tests {
+    use clap::error::ErrorKind;
+
     use super::*;
 
     fn invoked_as(name: &str) -> bool {
@@ -126,5 +126,11 @@ mod tests {
     fn rejects_moon_executable_names() {
         assert!(!invoked_as("moon"));
         assert!(!invoked_as("moon.exe"));
+    }
+
+    #[test]
+    fn rejects_removed_quiet_option() {
+        let error = MoonxCli::try_parse_from(["moonx", "--quiet", "user/module"]).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
     }
 }

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -279,6 +279,131 @@ fn test_moonx_native_skips_postadd_and_reuses_cached_executable() {
     run();
 }
 
+#[test]
+fn test_moonx_native_dependency_download_stays_off_stdout() {
+    use sha2::{Digest, Sha256};
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+    };
+
+    fn package_archive(manifest: &serde_json::Value, files: &[(&str, Vec<u8>)]) -> Vec<u8> {
+        let mut archive = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        archive
+            .start_file("moon.mod.json", zip::write::FileOptions::default())
+            .unwrap();
+        archive
+            .write_all(&serde_json::to_vec_pretty(manifest).unwrap())
+            .unwrap();
+        for (path, contents) in files {
+            archive
+                .start_file(*path, zip::write::FileOptions::default())
+                .unwrap();
+            archive.write_all(contents).unwrap();
+        }
+        archive.finish().unwrap().into_inner()
+    }
+
+    fn write_index(moon_home: &std::path::Path, name: &str, version: &str, archive: &[u8]) {
+        let (username, package) = name.split_once('/').unwrap();
+        let index = moon_home
+            .join("registry/index/user")
+            .join(username)
+            .join(format!("{package}.index"));
+        std::fs::create_dir_all(index.parent().unwrap()).unwrap();
+        std::fs::write(
+            index,
+            format!(
+                "{{\"name\":\"{name}\",\"version\":\"{version}\",\"checksum\":\"{:x}\"}}\n",
+                Sha256::digest(archive)
+            ),
+        )
+        .unwrap();
+    }
+
+    let fixture = TestDir::new("moonx_registry_native.in");
+    let moon_home = tempfile::TempDir::new().expect("failed to create temp MOON_HOME");
+    let mut runner_manifest: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(fixture.join("moon.mod.json")).unwrap()).unwrap();
+    runner_manifest.as_object_mut().unwrap().remove("scripts");
+    runner_manifest["deps"] = serde_json::json!({ "testuser/dependency": "1.0.0" });
+    let runner_files = [
+        "src/lib/moon.pkg.json",
+        "src/lib/lib.mbt",
+        "src/tool/moon.pkg.json",
+        "src/tool/main.mbt",
+    ]
+    .map(|path| (path, std::fs::read(fixture.join(path)).unwrap()));
+    let runner_archive = package_archive(&runner_manifest, &runner_files);
+    let runner_cache = moon_home
+        .path()
+        .join("registry/cache/testuser/runner/1.2.3.zip");
+    std::fs::create_dir_all(runner_cache.parent().unwrap()).unwrap();
+    std::fs::write(runner_cache, &runner_archive).unwrap();
+    write_index(
+        moon_home.path(),
+        "testuser/runner",
+        "1.2.3",
+        &runner_archive,
+    );
+
+    let dependency_archive = package_archive(
+        &serde_json::json!({
+            "name": "testuser/dependency",
+            "version": "1.0.0",
+        }),
+        &[],
+    );
+    write_index(
+        moon_home.path(),
+        "testuser/dependency",
+        "1.0.0",
+        &dependency_archive,
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let registry_url = format!("http://{}", listener.local_addr().unwrap());
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0; 4096];
+        let _ = stream.read(&mut request).unwrap();
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            dependency_archive.len()
+        )
+        .unwrap();
+        stream.write_all(&dependency_archive).unwrap();
+    });
+
+    let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");
+    snapbox::cmd::Command::new(moonx_bin(&bin_dir))
+        .current_dir(&fixture)
+        .env("MOON_HOME", moon_home.path())
+        .env("MOONCAKES_REGISTRY", registry_url)
+        .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
+        .args([
+            "--verbose",
+            "--target",
+            "native",
+            "testuser/runner/tool@1.2.3",
+            "--child-arg",
+        ])
+        .assert()
+        .success()
+        .stdout_eq("native runner\n--child-arg\n")
+        .stderr_eq(snapbox::str![[r#"
+Using cached testuser/runner@1.2.3
+Downloading testuser/dependency@1.0.0
+Info: Building `testuser/runner/tool`...
+Finished. moon: ran 4 tasks, now up to date
+'$MOON_HOME/registry/cache/assets/testuser/runner/1.2.3/tool/tool.exe' --child-arg
+
+"#]]);
+
+    server.join().unwrap();
+}
+
 #[cfg(any(unix, windows))]
 #[test]
 fn test_moonx_delegates_interrupt_to_cached_native_executable() {

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -314,8 +314,9 @@ fn test_moonx_native_output_and_cache_contract() {
 Using cached testuser/runner@1.2.3
 Using cached testuser/dependency@1.0.0
 Info: Building `testuser/runner/tool`...
+...
 Finished. moon: ran 4 tasks, now up to date
-'$MOON_HOME/registry/cache/assets/testuser/runner/1.2.3/tool/tool.exe' --child-arg
+'$MOON_HOME/registry/cache/assets/testuser/runner/1.2.3/tool/tool[..]' --child-arg
 
 "#]]);
 

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -11,6 +11,50 @@ fn moonx_bin(bin_dir: &tempfile::TempDir) -> std::path::PathBuf {
     moonx
 }
 
+fn cache_registry_package(
+    moon_home: &std::path::Path,
+    name: &str,
+    version: &str,
+    files: &[(&str, Vec<u8>)],
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    use sha2::{Digest, Sha256};
+    use std::io::Write;
+
+    let mut archive = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    for (path, contents) in files {
+        archive
+            .start_file(*path, zip::write::FileOptions::default())
+            .unwrap();
+        archive.write_all(contents).unwrap();
+    }
+    let zip = archive.finish().unwrap().into_inner();
+
+    let (username, package) = name.split_once('/').unwrap();
+    let zip_path = moon_home
+        .join("registry/cache")
+        .join(username)
+        .join(package)
+        .join(format!("{version}.zip"));
+    std::fs::create_dir_all(zip_path.parent().unwrap()).unwrap();
+    std::fs::write(&zip_path, &zip).unwrap();
+
+    let index_path = moon_home
+        .join("registry/index/user")
+        .join(username)
+        .join(format!("{package}.index"));
+    std::fs::create_dir_all(index_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &index_path,
+        format!(
+            "{{\"name\":\"{name}\",\"version\":\"{version}\",\"checksum\":\"{:x}\"}}\n",
+            Sha256::digest(&zip)
+        ),
+    )
+    .unwrap();
+
+    (zip_path, index_path)
+}
+
 #[test]
 fn test_moon_cmd() {
     let dir = TestDir::new("moon_commands");
@@ -180,46 +224,28 @@ native
 }
 
 #[test]
-fn test_moonx_native_skips_postadd_and_reuses_cached_executable() {
-    use sha2::{Digest, Sha256};
-    use std::io::Write;
-
+fn test_moonx_native_output_and_cache_contract() {
     let fixture = TestDir::new("moonx_registry_native.in");
     let moon_home = tempfile::TempDir::new().expect("failed to create temp MOON_HOME");
-    let zip_path = moon_home
-        .path()
-        .join("registry/cache/testuser/runner/1.2.3.zip");
-    std::fs::create_dir_all(zip_path.parent().unwrap()).unwrap();
-
-    let mut archive = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
-    let options = zip::write::FileOptions::default();
-    for relative in [
+    let runner_files = [
         "moon.mod.json",
         "src/lib/moon.pkg.json",
         "src/lib/lib.mbt",
         "src/tool/moon.pkg.json",
         "src/tool/main.mbt",
-    ] {
-        archive.start_file(relative, options).unwrap();
-        archive
-            .write_all(&std::fs::read(fixture.join(relative)).unwrap())
-            .unwrap();
-    }
-    let zip = archive.finish().unwrap().into_inner();
-    std::fs::write(&zip_path, &zip).unwrap();
-
-    let index_path = moon_home
-        .path()
-        .join("registry/index/user/testuser/runner.index");
-    std::fs::create_dir_all(index_path.parent().unwrap()).unwrap();
-    std::fs::write(
-        &index_path,
-        format!(
-            "{{\"name\":\"testuser/runner\",\"version\":\"1.2.3\",\"checksum\":\"{:x}\"}}\n",
-            Sha256::digest(&zip)
-        ),
-    )
-    .unwrap();
+    ]
+    .map(|path| (path, std::fs::read(fixture.join(path)).unwrap()));
+    let (zip_path, index_path) =
+        cache_registry_package(moon_home.path(), "testuser/runner", "1.2.3", &runner_files);
+    cache_registry_package(
+        moon_home.path(),
+        "testuser/dependency",
+        "1.0.0",
+        &[(
+            "moon.mod.json",
+            br#"{"name":"testuser/dependency","version":"1.0.0"}"#.to_vec(),
+        )],
+    );
 
     let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");
     let moonx = moonx_bin(&bin_dir);
@@ -267,137 +293,12 @@ fn test_moonx_native_skips_postadd_and_reuses_cached_executable() {
             .stderr_eq("");
     };
 
-    run();
-    assert!(
-        moon_home
-            .path()
-            .join("registry/cache/assets/testuser/runner/1.2.3/tool/tool.exe")
-            .is_file()
-    );
-    std::fs::remove_file(&zip_path).unwrap();
-    std::fs::remove_file(&index_path).unwrap();
-    run();
-}
-
-#[test]
-fn test_moonx_native_dependency_download_stays_off_stdout() {
-    use sha2::{Digest, Sha256};
-    use std::{
-        io::{ErrorKind, Read, Write},
-        net::TcpListener,
-        time::{Duration, Instant},
-    };
-
-    fn package_archive(manifest: &serde_json::Value, files: &[(&str, Vec<u8>)]) -> Vec<u8> {
-        let mut archive = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
-        archive
-            .start_file("moon.mod.json", zip::write::FileOptions::default())
-            .unwrap();
-        archive
-            .write_all(&serde_json::to_vec_pretty(manifest).unwrap())
-            .unwrap();
-        for (path, contents) in files {
-            archive
-                .start_file(*path, zip::write::FileOptions::default())
-                .unwrap();
-            archive.write_all(contents).unwrap();
-        }
-        archive.finish().unwrap().into_inner()
-    }
-
-    fn write_index(moon_home: &std::path::Path, name: &str, version: &str, archive: &[u8]) {
-        let (username, package) = name.split_once('/').unwrap();
-        let index = moon_home
-            .join("registry/index/user")
-            .join(username)
-            .join(format!("{package}.index"));
-        std::fs::create_dir_all(index.parent().unwrap()).unwrap();
-        std::fs::write(
-            index,
-            format!(
-                "{{\"name\":\"{name}\",\"version\":\"{version}\",\"checksum\":\"{:x}\"}}\n",
-                Sha256::digest(archive)
-            ),
-        )
-        .unwrap();
-    }
-
-    let fixture = TestDir::new("moonx_registry_native.in");
-    let moon_home = tempfile::TempDir::new().expect("failed to create temp MOON_HOME");
-    let mut runner_manifest: serde_json::Value =
-        serde_json::from_slice(&std::fs::read(fixture.join("moon.mod.json")).unwrap()).unwrap();
-    runner_manifest.as_object_mut().unwrap().remove("scripts");
-    runner_manifest["deps"] = serde_json::json!({ "testuser/dependency": "1.0.0" });
-    let runner_files = [
-        "src/lib/moon.pkg.json",
-        "src/lib/lib.mbt",
-        "src/tool/moon.pkg.json",
-        "src/tool/main.mbt",
-    ]
-    .map(|path| (path, std::fs::read(fixture.join(path)).unwrap()));
-    let runner_archive = package_archive(&runner_manifest, &runner_files);
-    let runner_cache = moon_home
+    let executable = moon_home
         .path()
-        .join("registry/cache/testuser/runner/1.2.3.zip");
-    std::fs::create_dir_all(runner_cache.parent().unwrap()).unwrap();
-    std::fs::write(runner_cache, &runner_archive).unwrap();
-    write_index(
-        moon_home.path(),
-        "testuser/runner",
-        "1.2.3",
-        &runner_archive,
-    );
-
-    let dependency_archive = package_archive(
-        &serde_json::json!({
-            "name": "testuser/dependency",
-            "version": "1.0.0",
-        }),
-        &[],
-    );
-    write_index(
-        moon_home.path(),
-        "testuser/dependency",
-        "1.0.0",
-        &dependency_archive,
-    );
-
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    listener.set_nonblocking(true).unwrap();
-    let registry_url = format!("http://{}", listener.local_addr().unwrap());
-    let server = std::thread::spawn(move || {
-        let deadline = Instant::now() + Duration::from_secs(10);
-        let (mut stream, _) = loop {
-            match listener.accept() {
-                Ok(connection) => break connection,
-                Err(err) if err.kind() == ErrorKind::WouldBlock && Instant::now() < deadline => {
-                    std::thread::sleep(Duration::from_millis(10));
-                }
-                Err(err) if err.kind() == ErrorKind::WouldBlock => {
-                    panic!("timed out waiting for dependency download request");
-                }
-                Err(err) => panic!("failed to accept dependency download request: {err}"),
-            }
-        };
-        stream
-            .set_read_timeout(Some(Duration::from_secs(10)))
-            .unwrap();
-        let mut request = [0; 4096];
-        let _ = stream.read(&mut request).unwrap();
-        write!(
-            stream,
-            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-            dependency_archive.len()
-        )
-        .unwrap();
-        stream.write_all(&dependency_archive).unwrap();
-    });
-
-    let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");
-    snapbox::cmd::Command::new(moonx_bin(&bin_dir))
+        .join("registry/cache/assets/testuser/runner/1.2.3/tool/tool.exe");
+    snapbox::cmd::Command::new(&moonx)
         .current_dir(&fixture)
         .env("MOON_HOME", moon_home.path())
-        .env("MOONCAKES_REGISTRY", registry_url)
         .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
         .args([
             "--verbose",
@@ -411,14 +312,19 @@ fn test_moonx_native_dependency_download_stays_off_stdout() {
         .stdout_eq("native runner\n--child-arg\n")
         .stderr_eq(snapbox::str![[r#"
 Using cached testuser/runner@1.2.3
-Downloading testuser/dependency@1.0.0
+Using cached testuser/dependency@1.0.0
 Info: Building `testuser/runner/tool`...
 Finished. moon: ran 4 tasks, now up to date
 '$MOON_HOME/registry/cache/assets/testuser/runner/1.2.3/tool/tool.exe' --child-arg
 
 "#]]);
 
-    server.join().unwrap();
+    std::fs::remove_file(&executable).unwrap();
+    run();
+    assert!(executable.is_file());
+    std::fs::remove_file(&zip_path).unwrap();
+    std::fs::remove_file(&index_path).unwrap();
+    run();
 }
 
 #[cfg(any(unix, windows))]

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -290,16 +290,10 @@ fn test_moonx_native_output_and_cache_contract() {
             .assert()
             .success()
             .stdout_eq("native runner\n--child-arg\n")
-            .stderr_eq(if cfg!(windows) {
-                snapbox::str![[r#"
-runtime.c
-tool.c
-[..]Creating library [..]tool.lib and object [..]tool.exp
+            .stderr_eq(snapbox::str![[r#"
+...
 
-"#]]
-            } else {
-                snapbox::str![""]
-            });
+"#]]);
     };
 
     let executable = moon_home

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -290,7 +290,16 @@ fn test_moonx_native_output_and_cache_contract() {
             .assert()
             .success()
             .stdout_eq("native runner\n--child-arg\n")
-            .stderr_eq("");
+            .stderr_eq(if cfg!(windows) {
+                snapbox::str![[r#"
+runtime.c
+tool.c
+[..]Creating library [..]tool.lib and object [..]tool.exp
+
+"#]]
+            } else {
+                snapbox::str![""]
+            });
     };
 
     let executable = moon_home

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -116,8 +116,7 @@ Arguments:
 Options:
       --target <TARGET>             [default: wasm] [possible values: wasm, native]
       --experimental-policy <PATH>  Experimental moonrun policy file; only valid for wasm
-  -q, --quiet                       Suppress output
-  -v, --verbose                     Increase verbosity
+  -v, --verbose                     Show progress and execution details
   -h, --help                        Print help
   -V, --version                     Print version
 
@@ -229,7 +228,7 @@ fn test_moonx_native_skips_postadd_and_reuses_cached_executable() {
         .current_dir(&fixture)
         .env("MOON_HOME", moon_home.path())
         .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
-        .args(["--quiet", "--target", "native", "testuser/runner@1.2.3"])
+        .args(["--target", "native", "testuser/runner@1.2.3"])
         .assert()
         .failure()
         .stdout_eq("")
@@ -242,7 +241,7 @@ fn test_moonx_native_skips_postadd_and_reuses_cached_executable() {
         .current_dir(&fixture)
         .env("MOON_HOME", moon_home.path())
         .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
-        .args(["--quiet", "--target", "native", "testuser/runner/lib@1.2.3"])
+        .args(["--target", "native", "testuser/runner/lib@1.2.3"])
         .assert()
         .failure()
         .stdout_eq("")
@@ -264,7 +263,8 @@ fn test_moonx_native_skips_postadd_and_reuses_cached_executable() {
             ])
             .assert()
             .success()
-            .stdout_eq("native runner\n--child-arg\n");
+            .stdout_eq("native runner\n--child-arg\n")
+            .stderr_eq("");
     };
 
     run();
@@ -283,8 +283,9 @@ fn test_moonx_native_skips_postadd_and_reuses_cached_executable() {
 fn test_moonx_native_dependency_download_stays_off_stdout() {
     use sha2::{Digest, Sha256};
     use std::{
-        io::{Read, Write},
+        io::{ErrorKind, Read, Write},
         net::TcpListener,
+        time::{Duration, Instant},
     };
 
     fn package_archive(manifest: &serde_json::Value, files: &[(&str, Vec<u8>)]) -> Vec<u8> {
@@ -362,9 +363,25 @@ fn test_moonx_native_dependency_download_stays_off_stdout() {
     );
 
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
     let registry_url = format!("http://{}", listener.local_addr().unwrap());
     let server = std::thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(connection) => break connection,
+                Err(err) if err.kind() == ErrorKind::WouldBlock && Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                    panic!("timed out waiting for dependency download request");
+                }
+                Err(err) => panic!("failed to accept dependency download request: {err}"),
+            }
+        };
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
         let mut request = [0; 4096];
         let _ = stream.read(&mut request).unwrap();
         write!(

--- a/crates/moon/tests/test_cases/moonx_registry_native.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/moonx_registry_native.in/moon.mod.json
@@ -2,6 +2,9 @@
   "name": "testuser/runner",
   "version": "1.2.3",
   "source": "src",
+  "deps": {
+    "testuser/dependency": "1.0.0"
+  },
   "scripts": {
     "postadd": "moonx-postadd-must-not-run"
   }

--- a/crates/moon/tests/test_cases/package_management.rs
+++ b/crates/moon/tests/test_cases/package_management.rs
@@ -66,8 +66,14 @@ fn mooncakes_io_smoke_test() {
     );
 
     std::fs::remove_dir_all(&mooncakes_dir).unwrap();
-    let out = get_stdout(&dir, ["install"]);
-    let mut lines = out.lines().collect::<Vec<_>>();
+    let assert = moon_cmd(&dir).arg("install").assert().success();
+    let output = assert.get_output();
+    assert!(output.stdout.is_empty());
+    let mut lines = std::str::from_utf8(&output.stderr)
+        .unwrap()
+        .lines()
+        .filter(|line| line.starts_with("Using cached "))
+        .collect::<Vec<_>>();
     lines.sort();
     check(
         lines.join("\n"),

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -209,13 +209,13 @@ impl OnlineRegistry {
         }
         if checksum_ok {
             if !quiet {
-                println!("Using cached {name}@{version}");
+                eprintln!("Using cached {name}@{version}");
             }
             let data = std::fs::read(cache_file)?;
             return Ok(bytes::Bytes::from(data));
         }
         if !quiet {
-            println!("Downloading {name}@{version}");
+            eprintln!("Downloading {name}@{version}");
         }
         let filepath = form_urlencoded::Serializer::new(String::new())
             .append_key_only(&format!("{}/{}/{}", name.username, name.unqual, version))

--- a/docs/dev/reference/moonx.md
+++ b/docs/dev/reference/moonx.md
@@ -83,6 +83,10 @@ Source acquisition for `moonx` does not execute the downloaded module's
 `scripts.postadd` hook. Normal registry installation retains its existing
 postadd behavior.
 
+Normal `moonx` execution suppresses registry acquisition progress. With
+`--verbose`, progress is written to stderr; stdout remains reserved for the
+delegated program.
+
 The Cached Executable Artifact is keyed by the resolved module version, package
 path, and Target Backend. A cache hit executes it directly; Moon toolchain
 upgrades do not invalidate an existing cached executable. Source trees and

--- a/docs/dev/reference/moonx.md
+++ b/docs/dev/reference/moonx.md
@@ -24,7 +24,6 @@ The supported options are:
 ```text
 --target <wasm|native>        # defaults to wasm
 --experimental-policy <PATH> # wasm only
--q, --quiet
 -v, --verbose
 -h, --help
 -V, --version
@@ -83,9 +82,10 @@ Source acquisition for `moonx` does not execute the downloaded module's
 `scripts.postadd` hook. Normal registry installation retains its existing
 postadd behavior.
 
-Normal `moonx` execution suppresses registry acquisition progress. With
-`--verbose`, progress is written to stderr; stdout remains reserved for the
-delegated program.
+By default, `moonx` emits no informational output of its own. With `--verbose`,
+registry acquisition, build progress, and execution details are written to
+stderr. Stdout remains reserved for the delegated program, whose standard
+streams are inherited unchanged.
 
 The Cached Executable Artifact is keyed by the resolved module version, package
 path, and Target Backend. A cache hit executes it directly; Moon toolchain


### PR DESCRIPTION
Supersedes #1910 with a clean, focused review history.

## Why

Native `moonx` cache misses prepare registry dependencies after source extraction. Dependency-sync output could print `Downloading` or `Using cached` to stdout before the delegated program starts, corrupting pipelines and command substitution. The existing `--quiet` flag also made the interface imply a normal progress mode that `moonx` does not need.

## Behavior contract

- Stdout is reserved for the delegated program and is inherited unchanged.
- By default, `moonx` emits no informational progress of its own.
- `--verbose` opts into registry acquisition, build progress, and execution details on stderr.
- Errors and warnings remain visible on stderr.

## What changed

- Remove `moonx --quiet`; the default behavior is already silent.
- Pass the existing dependency-sync output options into native build preparation.
- Move registry acquisition status from stdout to stderr, including normal installs.
- Add regression coverage for both default-silent execution and verbose dependency acquisition while preserving delegated stdout.

## Relationship to #1916

PR #1916 independently deprecates implicit `postadd` hooks and keeps hook output out of automatic and delegated workflows. This PR handles acquisition status only; the branches are intentionally independent so each diff is reviewable against `main`.

## Scope

This reuses the existing output flags and sync options. It does not introduce a callback, channel, or library-wide progress reporter, and it does not change archive types, cache/checksum policy, atomic publication, destination replacement, or `postadd` policy.