### PR TITLE
fix(moonrun): transfer spawn buffer ownership to spawn jobs

### DIFF
--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -126,7 +126,7 @@ pub(super) fn write_env_block(
     dst: u64,
     src: u64,
 ) -> AsyncHostResult<()> {
-    context.host.process_env_write_block(dst, src)
+    context.host.transfer_process_env_block(dst, src)
 }
 
 #[ported(source = "src/process/windows.c", original = "moonbitlang_async_write_env_block")]
@@ -136,7 +136,7 @@ pub(super) fn write_env_block(
     dst: u64,
     src: u64,
 ) -> AsyncHostResult<()> {
-    context.host.process_env_write_block(dst, src)
+    context.host.transfer_process_env_block(dst, src)
 }
 
 #[ported(source = "src/process/unix.c", original = "moonbitlang_async_env_block_add_entry")]

--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -108,13 +108,15 @@ pub(super) fn allocate_env_block(
     Ok(context.host.insert_process_env(vec![0; size]))
 }
 
-pub(super) fn free_env(context: &mut ImportContext<'_, '_>, env: u64) -> AsyncHostResult<()> {
-    context.host.free_process_env(env)
+// Deprecated. We'll remove it later.
+pub(super) fn free_env(_context: &mut ImportContext<'_, '_>, _env: u64) -> AsyncHostResult<()> {
+    Ok(())
 }
 
 #[cfg(unix)]
-pub(super) fn free_argv(context: &mut ImportContext<'_, '_>, argv: u64) -> AsyncHostResult<()> {
-    context.host.free_process_argv(argv)
+// Deprecated. We'll remove it later.
+pub(super) fn free_argv(_context: &mut ImportContext<'_, '_>, _argv: u64) -> AsyncHostResult<()> {
+    Ok(())
 }
 
 #[ported(source = "src/process/unix.c", original = "moonbitlang_async_write_env_block")]

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -438,6 +438,7 @@ pub(super) fn make_spawn_job_unix(
     has_cwd: i32,
 ) -> AsyncHostResult<u64> {
     let _ = inherited_env_entry_count;
+    let (args, env) = context.host.take_process_spawn_buffers(args, env)?;
     let path = read_guest_os_string(context, path, path_len)?;
     let cwd = if has_cwd == 0 {
         None
@@ -450,7 +451,6 @@ pub(super) fn make_spawn_job_unix(
     let options = thread_pool::SpawnOptions {
         child_signal_mask: context.host.thread_pool_child_signal_mask()?,
     };
-    let (args, env) = context.host.take_process_spawn_buffers(args, env)?;
     context.host.insert_job(thread_pool::make_spawn_job_unix(
         path,
         args,
@@ -480,6 +480,7 @@ pub(super) fn make_spawn_job_windows(
     no_console_window: i32,
     is_orphan: i32,
 ) -> AsyncHostResult<u64> {
+    let env = context.host.take_process_env(env)?;
     let command_line = read_guest_os_string(context, command_line, command_line_len)?;
     let cwd = if has_cwd == 0 {
         None
@@ -493,7 +494,6 @@ pub(super) fn make_spawn_job_windows(
         no_console_window: no_console_window != 0,
         is_orphan: is_orphan != 0,
     };
-    let env = context.host.take_process_env(env)?;
     context.host.insert_job(thread_pool::make_spawn_job_windows(
         command_line,
         env,

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -438,8 +438,6 @@ pub(super) fn make_spawn_job_unix(
     has_cwd: i32,
 ) -> AsyncHostResult<u64> {
     let _ = inherited_env_entry_count;
-    let args = context.host.clone_process_argv(args)?;
-    let env = context.host.clone_process_env(env)?;
     let path = read_guest_os_string(context, path, path_len)?;
     let cwd = if has_cwd == 0 {
         None
@@ -452,6 +450,7 @@ pub(super) fn make_spawn_job_unix(
     let options = thread_pool::SpawnOptions {
         child_signal_mask: context.host.thread_pool_child_signal_mask()?,
     };
+    let (args, env) = context.host.take_process_spawn_buffers(args, env)?;
     context.host.insert_job(thread_pool::make_spawn_job_unix(
         path,
         args,
@@ -481,7 +480,6 @@ pub(super) fn make_spawn_job_windows(
     no_console_window: i32,
     is_orphan: i32,
 ) -> AsyncHostResult<u64> {
-    let env = context.host.clone_process_env(env)?;
     let command_line = read_guest_os_string(context, command_line, command_line_len)?;
     let cwd = if has_cwd == 0 {
         None
@@ -495,6 +493,7 @@ pub(super) fn make_spawn_job_windows(
         no_console_window: no_console_window != 0,
         is_orphan: is_orphan != 0,
     };
+    let env = context.host.take_process_env(env)?;
     context.host.insert_job(thread_pool::make_spawn_job_windows(
         command_line,
         env,

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -2069,27 +2069,49 @@ impl AsyncHost {
     }
 
     #[cfg(unix)]
-    pub(crate) fn clone_process_argv(&self, handle: u64) -> AsyncHostResult<Vec<OsString>> {
-        let argv = self.process_argv(handle)?;
-        let argv = argv.lock().unwrap();
-        argv.iter()
-            .cloned()
-            .collect::<Option<Vec<_>>>()
-            .ok_or(AsyncHostError::Inval)
-    }
-
-    #[cfg(unix)]
-    pub(crate) fn free_process_argv(&self, handle: u64) -> AsyncHostResult<()> {
-        if handle == INVALID_HOST_HANDLE {
-            return Ok(());
+    pub(crate) fn take_process_spawn_buffers(
+        &self,
+        argv_handle: u64,
+        env_handle: u64,
+    ) -> AsyncHostResult<(Vec<OsString>, Vec<OsString>)> {
+        if argv_handle == INVALID_HOST_HANDLE || env_handle == INVALID_HOST_HANDLE {
+            return Err(AsyncHostError::Badf);
         }
-        let key = self.handles.lock().unwrap().remove_process_argv(handle)?;
-        self.process_argvs
-            .lock()
-            .unwrap()
-            .remove(key)
-            .map(|_| ())
-            .ok_or(AsyncHostError::Badf)
+
+        // Validate both buffers before consuming either handle. A malformed
+        // spawn request must not partially transfer ownership.
+        let mut handles = self.handles.lock().unwrap();
+        let argv_key = handles.process_argv(argv_handle)?;
+        let env_key = handles.process_env(env_handle)?;
+        let mut process_argvs = self.process_argvs.lock().unwrap();
+        let argv = process_argvs
+            .get(argv_key)
+            .cloned()
+            .ok_or(AsyncHostError::Badf)?;
+        let mut process_envs = self.process_envs.lock().unwrap();
+        let env = process_envs
+            .get(env_key)
+            .cloned()
+            .ok_or(AsyncHostError::Badf)?;
+        let mut argv = argv.lock().unwrap();
+        let mut env = env.lock().unwrap();
+        if argv.iter().any(Option::is_none) || env.iter().any(Option::is_none) {
+            return Err(AsyncHostError::Inval);
+        }
+
+        handles.remove_process_argv(argv_handle)?;
+        handles.remove_process_env(env_handle)?;
+        let _ = process_argvs.remove(argv_key);
+        let _ = process_envs.remove(env_key);
+        let argv = std::mem::take(&mut *argv)
+            .into_iter()
+            .map(Option::unwrap)
+            .collect();
+        let env = std::mem::take(&mut *env)
+            .into_iter()
+            .map(Option::unwrap)
+            .collect();
+        Ok((argv, env))
     }
 
     #[cfg(unix)]
@@ -2200,33 +2222,20 @@ impl AsyncHost {
         Ok(())
     }
 
-    #[cfg(unix)]
-    pub(crate) fn clone_process_env(&self, handle: u64) -> AsyncHostResult<Vec<OsString>> {
-        let env = self.process_env(handle)?;
-        let env = env.lock().unwrap();
-        env.iter()
-            .cloned()
-            .collect::<Option<Vec<_>>>()
-            .ok_or(AsyncHostError::Inval)
-    }
-
-    pub(crate) fn free_process_env(&self, handle: u64) -> AsyncHostResult<()> {
-        if handle == INVALID_HOST_HANDLE {
-            return Ok(());
-        }
-        let key = self.handles.lock().unwrap().remove_process_env(handle)?;
-        self.process_envs
-            .lock()
-            .unwrap()
-            .remove(key)
-            .map(|_| ())
-            .ok_or(AsyncHostError::Badf)
-    }
-
     #[cfg(windows)]
-    pub(crate) fn clone_process_env(&self, handle: u64) -> AsyncHostResult<Vec<u16>> {
-        let env = self.process_env(handle)?;
-        Ok(env.lock().unwrap().clone())
+    pub(crate) fn take_process_env(&self, handle: u64) -> AsyncHostResult<Vec<u16>> {
+        if handle == INVALID_HOST_HANDLE {
+            return Err(AsyncHostError::Badf);
+        }
+        let mut handles = self.handles.lock().unwrap();
+        let key = handles.process_env(handle)?;
+        let mut process_envs = self.process_envs.lock().unwrap();
+        let env = process_envs.get(key).cloned().ok_or(AsyncHostError::Badf)?;
+        let mut env = env.lock().unwrap();
+
+        handles.remove_process_env(handle)?;
+        let _ = process_envs.remove(key);
+        Ok(std::mem::take(&mut *env))
     }
 
     #[cfg(unix)]
@@ -4701,8 +4710,56 @@ mod tests {
         let env = host.insert_process_env(vec![b'A' as u16, b'=' as u16, b'B' as u16, 0, 0]);
 
         host.process_env_write_block(env, env).unwrap();
+    }
 
-        host.free_process_env(env).unwrap();
+    #[cfg(unix)]
+    #[test]
+    fn process_spawn_buffers_transfer_ownership_together() {
+        let host = AsyncHost::default();
+        let argv = host.insert_process_argv(2).unwrap();
+        host.process_argv_add_entry(argv, 0, OsString::from("command"))
+            .unwrap();
+        host.process_argv_add_entry(argv, 1, OsString::from("argument"))
+            .unwrap();
+        let env = host.insert_process_env(vec![Some(OsString::from("A=B"))]);
+
+        let (args, entries) = host.take_process_spawn_buffers(argv, env).unwrap();
+
+        assert_eq!(
+            args,
+            vec![OsString::from("command"), OsString::from("argument")]
+        );
+        assert_eq!(entries, vec![OsString::from("A=B")]);
+        assert!(matches!(host.process_argv(argv), Err(AsyncHostError::Badf)));
+        assert!(matches!(host.process_env(env), Err(AsyncHostError::Badf)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invalid_process_spawn_buffers_are_not_partially_consumed() {
+        let host = AsyncHost::default();
+        let argv = host.insert_process_argv(1).unwrap();
+        host.process_argv_add_entry(argv, 0, OsString::from("command"))
+            .unwrap();
+        let env = host.insert_process_env(vec![None]);
+
+        assert_eq!(
+            host.take_process_spawn_buffers(argv, env),
+            Err(AsyncHostError::Inval)
+        );
+        assert!(host.process_argv(argv).is_ok());
+        assert!(host.process_env(env).is_ok());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn process_spawn_environment_transfers_ownership() {
+        let host = AsyncHost::default();
+        let block = vec![b'A' as u16, b'=' as u16, b'B' as u16, 0, 0];
+        let env = host.insert_process_env(block.clone());
+
+        assert_eq!(host.take_process_env(env).unwrap(), block);
+        assert!(matches!(host.process_env(env), Err(AsyncHostError::Badf)));
     }
 
     #[cfg(windows)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -2150,25 +2150,43 @@ impl AsyncHost {
     }
 
     #[cfg(unix)]
-    pub(crate) fn process_env_write_block(&self, dst: u64, src: u64) -> AsyncHostResult<()> {
-        let dst = self.process_env(dst)?;
-        let src = self.process_env(src)?;
-        let src = src.lock().unwrap().clone();
+    pub(crate) fn transfer_process_env_block(
+        &self,
+        dst_handle: u64,
+        src_handle: u64,
+    ) -> AsyncHostResult<()> {
+        if dst_handle == src_handle {
+            return Err(AsyncHostError::Inval);
+        }
+        let dst = self.process_env(dst_handle)?;
+        let src = self.take_process_env_handle(src_handle)?;
+        // The source is the temporary snapshot returned by get_curr_env.
+        // Consume it here so its lifetime does not depend on deprecated free_env.
+        let src = std::mem::take(&mut *src.lock().unwrap());
         let mut dst = dst.lock().unwrap();
         if dst.len() < src.len() {
             return Err(AsyncHostError::Fault);
         }
-        for (index, entry) in src.iter().enumerate() {
-            dst[index] = entry.clone();
+        for (index, entry) in src.into_iter().enumerate() {
+            dst[index] = entry;
         }
         Ok(())
     }
 
     #[cfg(windows)]
-    pub(crate) fn process_env_write_block(&self, dst: u64, src: u64) -> AsyncHostResult<()> {
-        let dst = self.process_env(dst)?;
-        let src = self.process_env(src)?;
-        let src = src.lock().unwrap().clone();
+    pub(crate) fn transfer_process_env_block(
+        &self,
+        dst_handle: u64,
+        src_handle: u64,
+    ) -> AsyncHostResult<()> {
+        if dst_handle == src_handle {
+            return Err(AsyncHostError::Inval);
+        }
+        let dst = self.process_env(dst_handle)?;
+        let src = self.take_process_env_handle(src_handle)?;
+        // The source is the temporary snapshot returned by get_curr_env.
+        // Consume it here so its lifetime does not depend on deprecated free_env.
+        let src = std::mem::take(&mut *src.lock().unwrap());
         let mut dst = dst.lock().unwrap();
         let src_len = src.len().checked_sub(1).ok_or(AsyncHostError::Fault)?;
         if dst.len() <= src_len {
@@ -2224,18 +2242,21 @@ impl AsyncHost {
 
     #[cfg(windows)]
     pub(crate) fn take_process_env(&self, handle: u64) -> AsyncHostResult<Vec<u16>> {
+        let env = self.take_process_env_handle(handle)?;
+        let result = std::mem::take(&mut *env.lock().unwrap());
+        Ok(result)
+    }
+
+    fn take_process_env_handle(&self, handle: u64) -> AsyncHostResult<HostProcessEnv> {
         if handle == INVALID_HOST_HANDLE {
             return Err(AsyncHostError::Badf);
         }
-        let mut handles = self.handles.lock().unwrap();
-        let key = handles.process_env(handle)?;
-        let mut process_envs = self.process_envs.lock().unwrap();
-        let env = process_envs.get(key).cloned().ok_or(AsyncHostError::Badf)?;
-        let mut env = env.lock().unwrap();
-
-        handles.remove_process_env(handle)?;
-        let _ = process_envs.remove(key);
-        Ok(std::mem::take(&mut *env))
+        let key = self.handles.lock().unwrap().remove_process_env(handle)?;
+        self.process_envs
+            .lock()
+            .unwrap()
+            .remove(key)
+            .ok_or(AsyncHostError::Badf)
     }
 
     #[cfg(unix)]
@@ -4702,14 +4723,49 @@ mod tests {
     }
 
     #[test]
-    fn process_env_block_can_copy_to_itself() {
+    fn process_env_block_transfer_consumes_source() {
         let host = AsyncHost::default();
         #[cfg(unix)]
-        let env = host.insert_process_env(vec![Some(OsString::from("A=B"))]);
+        let src = host.insert_process_env(vec![Some(OsString::from("A=B"))]);
         #[cfg(windows)]
-        let env = host.insert_process_env(vec![b'A' as u16, b'=' as u16, b'B' as u16, 0, 0]);
+        let src = host.insert_process_env(vec![b'A' as u16, b'=' as u16, b'B' as u16, 0, 0]);
+        #[cfg(unix)]
+        let dst = host.insert_process_env(vec![None, None]);
+        #[cfg(windows)]
+        let dst = host.insert_process_env(vec![0; 7]);
 
-        host.process_env_write_block(env, env).unwrap();
+        host.transfer_process_env_block(dst, src).unwrap();
+
+        assert!(matches!(host.process_env(src), Err(AsyncHostError::Badf)));
+        #[cfg(unix)]
+        assert_eq!(
+            &*host.process_env(dst).unwrap().lock().unwrap(),
+            &[Some(OsString::from("A=B")), None]
+        );
+        #[cfg(windows)]
+        assert_eq!(
+            &*host.process_env(dst).unwrap().lock().unwrap(),
+            &[b'A' as u16, b'=' as u16, b'B' as u16, 0, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn process_env_block_transfer_consumes_source_on_failure() {
+        let host = AsyncHost::default();
+        #[cfg(unix)]
+        let src = host.insert_process_env(vec![Some(OsString::from("A=B"))]);
+        #[cfg(windows)]
+        let src = host.insert_process_env(vec![b'A' as u16, b'=' as u16, b'B' as u16, 0, 0]);
+        #[cfg(unix)]
+        let dst = host.insert_process_env(vec![]);
+        #[cfg(windows)]
+        let dst = host.insert_process_env(vec![0]);
+
+        assert_eq!(
+            host.transfer_process_env_block(dst, src),
+            Err(AsyncHostError::Fault)
+        );
+        assert!(matches!(host.process_env(src), Err(AsyncHostError::Badf)));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Transfer the temporary current-environment snapshot into the constructed child environment.
- Move Unix argv/environment buffers and the Windows environment buffer into the spawn job instead of cloning them.
- Consume spawn buffers at the import boundary so later validation errors drop their moved Rust values.
- Keep the legacy guest free imports as deprecated no-ops and remove the obsolete host free methods.

## Rationale

MoonBit process bindings are moving away from deferred argv/environment cleanup. Every intermediate buffer therefore needs an explicit ownership destination rather than a later free call.

The current-environment snapshot is consumed when it is copied into the child environment. The completed argv/environment buffers are then consumed when the spawn import begins and ultimately owned by the spawn job. This also ensures a later path, cwd, descriptor, or option validation error drops the already-moved buffers instead of leaving host handles behind.

On Unix, argv and environment inputs are validated together before either handle is consumed, preventing malformed input from causing a partial transfer. The change remains limited to process spawn buffer lifetimes; the old free imports stay only as temporary ABI compatibility shims.