### PR TITLE
Add level-based user logging for moon info

### DIFF
--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -30,6 +30,7 @@ use moonutil::{
     cli_support::AutoSyncFlags,
     project::PackageDirs,
     target::{SurfaceTarget, TargetBackend, lower_surface_targets},
+    user_log::UserLog,
 };
 
 use crate::{
@@ -170,7 +171,7 @@ struct InfoIntentContext<'a> {
     selection: &'a PackageSelection,
     output_plan: &'a imp::InfoOutputPlan,
     target_kind: imp::TargetKind,
-    output: UserDiagnostics,
+    output: &'a UserLog,
 }
 
 fn calc_user_intent_for_info(
@@ -264,7 +265,7 @@ fn calc_user_intent_for_info(
 }
 
 pub(crate) fn run_info(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32> {
-    let output = UserDiagnostics::from_flags(&cli);
+    let output = UserLog::new(cli.user_log_level());
     if cmd.no_alias {
         output.warn("`--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092");
     }
@@ -363,18 +364,19 @@ fn run_info_rr_internal(
         RunMode::Check,
     );
     preconfig.info_no_alias = cmd.no_alias;
-    let output = UserDiagnostics::from_flags(cli);
+    let user_log = UserLog::new(cli.user_log_level());
+    let user_diagnostics = UserDiagnostics::from_flags(cli);
     let ctx = InfoIntentContext {
         selection,
         output_plan,
         target_kind,
-        output,
+        output: &user_log,
     };
     let planning_context = rr_build::prepare_resolved_build(
         &preconfig,
         &cli.unstable_feature,
         target_dir,
-        output,
+        user_diagnostics,
         &resolve_output,
     )?;
     let intent =
@@ -382,7 +384,7 @@ fn run_info_rr_internal(
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
-        output,
+        user_diagnostics,
         planning_context,
         intent,
         mooncake_bin_dir,
@@ -397,7 +399,7 @@ fn run_info_rr_internal(
         &BuildFlags::default(),
         &cli.unstable_feature,
         cli.verbose,
-        output,
+        user_diagnostics,
     );
     let result = rr_build::execute_build(&cfg, build_graph, target_dir)?;
     let success = result.successful();

--- a/crates/moon/tests/test_cases/moon_info_001/mod.rs
+++ b/crates/moon/tests/test_cases/moon_info_001/mod.rs
@@ -4,3 +4,24 @@ use super::*;
 fn test_moon_info_001() {
     run_moon_cmdtest("moon_info_001.in");
 }
+
+#[test]
+fn test_moon_info_user_log_output() {
+    let dir = TestDir::new("moon_info_001.in");
+    moon_cmd(&dir)
+        .args(["info", "--no-alias"])
+        .assert()
+        .success()
+        .stdout_eq("")
+        .stderr_eq(
+            "Warning: `--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092\nFinished. moon: ran 4 tasks, now up to date\n",
+        );
+
+    let quiet_dir = TestDir::new("moon_info_001.in");
+    moon_cmd(&quiet_dir)
+        .args(["info", "--no-alias", "--quiet", "--verbose"])
+        .assert()
+        .success()
+        .stdout_eq("")
+        .stderr_eq("");
+}

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -351,6 +351,27 @@ fn test_supported_targets_empty_list_is_never_selected() {
 }
 
 #[test]
+fn test_moon_info_verbose_unsupported_path_is_bare_stderr() {
+    let dir = TestDir::new("supported_targets_empty.in");
+    let assert = moon_cmd(&dir)
+        .args(["info", "lib", "never", "--verbose"])
+        .assert()
+        .success()
+        .stdout_eq("");
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    let message = "skipping path `never` because package `supported/empty/never` does not support target backend `wasm-gc`. Supported backends: []";
+
+    assert!(
+        stderr.lines().any(|line| line == message),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains(&format!("Info: {message}")),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn test_module_supported_targets_intersects_package_supported_targets() {
     let dir = TestDir::new("supported_targets_module_intersection.in");
 

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -354,7 +354,7 @@ fn test_supported_targets_empty_list_is_never_selected() {
 fn test_moon_info_verbose_unsupported_path_is_bare_stderr() {
     let dir = TestDir::new("supported_targets_empty.in");
     let assert = moon_cmd(&dir)
-        .args(["info", "lib", "never", "--verbose"])
+        .args(["info", "lib", "never", "--verbose", "--target", "wasm-gc"])
         .assert()
         .success()
         .stdout_eq("");

--- a/crates/moonutil/src/cli.rs
+++ b/crates/moonutil/src/cli.rs
@@ -65,6 +65,16 @@ pub struct UniversalFlags {
 }
 
 impl UniversalFlags {
+    pub fn user_log_level(&self) -> log::LevelFilter {
+        if self.quiet {
+            log::LevelFilter::Error
+        } else if self.verbose {
+            log::LevelFilter::Info
+        } else {
+            log::LevelFilter::Warn
+        }
+    }
+
     /// Collect deprecation warnings for deprecated flags.
     pub fn deprecation_warnings(&self) -> Vec<&'static str> {
         let mut warnings = Vec::new();

--- a/crates/moonutil/src/lib.rs
+++ b/crates/moonutil/src/lib.rs
@@ -57,6 +57,7 @@ pub mod target;
 pub mod test_metadata;
 pub mod text;
 pub mod toolchain;
+pub mod user_log;
 pub mod user_warning;
 pub mod version;
 pub mod workspace;

--- a/crates/moonutil/src/user_log.rs
+++ b/crates/moonutil/src/user_log.rs
@@ -1,0 +1,164 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::{fmt::Display, io::Write};
+
+use colored::Colorize;
+use log::LevelFilter;
+
+#[derive(Debug)]
+pub struct UserLog {
+    level: LevelFilter,
+}
+
+impl UserLog {
+    pub fn new(level: LevelFilter) -> Self {
+        Self { level }
+    }
+
+    pub fn error(&self, message: impl Display) {
+        let mut stderr = std::io::stderr().lock();
+        self.error_to(&mut stderr, message);
+    }
+
+    pub fn warn(&self, message: impl Display) {
+        let mut stderr = std::io::stderr().lock();
+        self.warn_to(&mut stderr, message);
+    }
+
+    pub fn info(&self, message: impl Display) {
+        let mut stderr = std::io::stderr().lock();
+        self.info_to(&mut stderr, message);
+    }
+
+    pub fn debug(&self, message: impl Display) {
+        let mut stderr = std::io::stderr().lock();
+        self.debug_to(&mut stderr, message);
+    }
+
+    fn error_to(&self, writer: &mut impl Write, message: impl Display) {
+        if self.level >= LevelFilter::Error {
+            let _ = writeln!(writer, "{}: {}", "Error".red().bold(), message);
+        }
+    }
+
+    fn warn_to(&self, writer: &mut impl Write, message: impl Display) {
+        if self.level >= LevelFilter::Warn {
+            let _ = writeln!(writer, "{}: {}", "Warning".yellow().bold(), message);
+        }
+    }
+
+    fn info_to(&self, writer: &mut impl Write, message: impl Display) {
+        if self.level >= LevelFilter::Info {
+            let _ = writeln!(writer, "{message}");
+        }
+    }
+
+    fn debug_to(&self, writer: &mut impl Write, message: impl Display) {
+        if self.level >= LevelFilter::Debug {
+            let _ = writeln!(writer, "{}: {}", "Debug".bright_black().bold(), message);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use log::LevelFilter;
+
+    use super::UserLog;
+
+    #[test]
+    fn error_level_renders_error_and_suppresses_other_messages() {
+        let output = UserLog::new(LevelFilter::Error);
+        let mut writer = Vec::new();
+
+        output.error_to(&mut writer, "failed");
+        output.warn_to(&mut writer, "be careful");
+        output.info_to(&mut writer, "more context");
+        output.debug_to(&mut writer, "internal context");
+
+        assert_eq!(writer, b"Error: failed\n");
+    }
+
+    #[test]
+    fn info_level_renders_error_warn_and_bare_info_but_not_debug() {
+        let output = UserLog::new(LevelFilter::Info);
+        let mut writer = Vec::new();
+
+        output.error_to(&mut writer, "failed");
+        output.warn_to(&mut writer, "be careful");
+        output.info_to(&mut writer, "more context");
+        output.debug_to(&mut writer, "internal context");
+
+        assert_eq!(
+            writer,
+            b"Error: failed\nWarning: be careful\nmore context\n"
+        );
+    }
+
+    #[test]
+    fn warn_level_renders_warn_but_not_info() {
+        let output = UserLog::new(LevelFilter::Warn);
+        let mut writer = Vec::new();
+
+        output.warn_to(&mut writer, "be careful");
+        output.info_to(&mut writer, "more context");
+
+        assert_eq!(writer, b"Warning: be careful\n");
+    }
+
+    #[test]
+    fn debug_level_renders_debug() {
+        let output = UserLog::new(LevelFilter::Debug);
+        let mut writer = Vec::new();
+
+        output.debug_to(&mut writer, "internal context");
+
+        assert_eq!(writer, b"Debug: internal context\n");
+    }
+
+    #[test]
+    fn write_errors_are_best_effort() {
+        struct FailingWriter {
+            attempts: usize,
+        }
+
+        impl Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                self.attempts += 1;
+                Err(std::io::Error::other("write failed"))
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let output = UserLog::new(LevelFilter::Debug);
+        let mut writer = FailingWriter { attempts: 0 };
+
+        output.error_to(&mut writer, "failed");
+        output.warn_to(&mut writer, "be careful");
+        output.info_to(&mut writer, "more context");
+        output.debug_to(&mut writer, "internal context");
+
+        assert_eq!(writer.attempts, 4);
+    }
+}


### PR DESCRIPTION
## Why

Moon's human-facing output currently couples message filtering to `quiet` and `verbose` booleans. This makes it difficult to establish a uniform stderr logging policy without also disturbing command results, compiler diagnostics, or shared build-system warnings.

## What changed

- Add a `UserLog` interface based on standard Error, Warn, Info, and Debug levels.
- Map the existing common CLI flags to a log level at the CLI edge.
- Serialize each user-log message through locked stderr and treat write failures as best effort.
- Migrate only command-local `moon info` warning and informational messages.
- Preserve `moon info` command-result stdout and keep shared build diagnostics on the existing path.
- Add regression coverage for warning filtering and bare verbose Info output on stderr.

## Scope

This is intentionally a small tracer slice. It does not change compiler diagnostics, `--deny-warn`, shared `UserWarning`/`UserDiagnostics` handling, tracing, other commands, or n2 progress output. Those concerns can be designed and migrated independently in follow-up work.