### PR TITLE
Unify command results and user logs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,24 @@ _Avoid_: Always-full package model, eager package facts
 A MoonBuild command whose information demand stops before full dependency resolution and build target projection.
 _Avoid_: Partial resolve, incomplete build command
 
+## Command Communication
+
+**Command Result**:
+The stdout representation a MoonBuild command intentionally produces for a user or another program. It is not filtered by `--quiet` or `--verbose`.
+_Avoid_: User log, progress message, child output
+
+**User Log**:
+A MoonBuild-authored stderr message that explains an error, warning, informational event, or debugging detail. Its visibility is controlled by the command's user-log level.
+_Avoid_: Command result, tracing log, child output
+
+**Process Passthrough**:
+The stdout or stderr bytes of a child tool or executed program forwarded without MoonBuild changing their channel, content, or visibility.
+_Avoid_: Command result, user log
+
+**Progress Display**:
+Transient terminal status for concurrent or long-running work, rendered independently from durable user-log lines.
+_Avoid_: User log, command result
+
 ## Package Execution
 
 **Executable Package Coordinate**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,7 @@ dependencies = [
 name = "moon"
 version = "0.1.0"
 dependencies = [
+ "anstyle",
  "anyhow",
  "chrono",
  "clap",
@@ -1616,6 +1617,8 @@ dependencies = [
 name = "moonbuild"
 version = "0.1.0"
 dependencies = [
+ "anstream",
+ "anstyle",
  "anyhow",
  "arcstr",
  "ariadne",
@@ -1756,6 +1759,8 @@ dependencies = [
 name = "moonutil"
 version = "0.1.0"
 dependencies = [
+ "anstream",
+ "anstyle",
  "anyhow",
  "arcstr",
  "ariadne",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ moonbuild-debug = { path = "./crates/moonbuild-debug", version = "*" }
 mooncake = { path = "./crates/mooncake", version = "*" }
 moonutil = { path = "./crates/moonutil", version = "*" }
 anyhow = { version = "1.0.86" }
+anstream = "0.6.21"
+anstyle = "1.0.13"
 clap = { version = "4.5.4", features = ["derive", "string", "env"] }
 colored = "2.1.0"
 ctrlc = { version = "3.4.4", features = ["termination"] }

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -27,6 +27,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anstyle.workspace = true
 moonbuild.workspace = true
 mooncake.workspace = true
 moonutil.workspace = true

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -99,7 +99,7 @@ impl PackageSelection {
     fn new(
         cmd: &InfoSubcommand,
         resolve_output: &ResolveOutput,
-        output: UserDiagnostics,
+        user_log: &UserLog,
     ) -> anyhow::Result<Self> {
         let package_ids: Vec<_> = resolve_output
             .local_modules()
@@ -124,9 +124,10 @@ impl PackageSelection {
         }
 
         if !cmd.path.is_empty() {
-            let path_packages = select_packages(&cmd.path, output, |dir| {
-                filter_pkg_by_dir(resolve_output, dir)
-            })?;
+            let path_packages =
+                select_packages(&cmd.path, UserDiagnostics::from_user_log(user_log), |dir| {
+                    filter_pkg_by_dir(resolve_output, dir)
+                })?;
             let package_ids = path_packages.iter().map(|(_, pkg_id)| *pkg_id).collect();
             return Ok(Self {
                 mode: SelectionMode::Paths,
@@ -150,7 +151,7 @@ impl PackageSelection {
             }
 
             for missing in matches.missing {
-                output.warn(format!("Input `{}` did not match any package", missing));
+                user_log.warn(format!("Input `{}` did not match any package", missing));
             }
 
             return Ok(Self {
@@ -172,7 +173,7 @@ struct InfoIntentContext<'a> {
     selection: &'a PackageSelection,
     output_plan: &'a imp::InfoOutputPlan,
     target_kind: imp::TargetKind,
-    output: &'a UserLog,
+    user_log: &'a UserLog,
 }
 
 fn calc_user_intent_for_info(
@@ -191,7 +192,7 @@ fn calc_user_intent_for_info(
             if (canonical || !is_canonical_run) && supported {
                 vec![UserIntent::Info(package)]
             } else {
-                ctx.output.warn(format!(
+                ctx.user_log.warn(format!(
                     "Skipping package `{}` for `moon info`: it does not support target backend `{}`",
                     resolve_output.pkg_dirs.get_package(package).fqn,
                     target_backend
@@ -218,7 +219,7 @@ fn calc_user_intent_for_info(
 
             for (path, pkg_id) in &unsupported {
                 let pkg = resolve_output.pkg_dirs.get_package(*pkg_id);
-                ctx.output.info(format!(
+                ctx.user_log.info(format!(
                     "skipping path `{}` because package `{}` does not support target backend `{}`. Supported backends: {}",
                     path.display(),
                     pkg.fqn,
@@ -228,7 +229,7 @@ fn calc_user_intent_for_info(
             }
 
             if filtered.is_empty() && !unsupported.is_empty() {
-                ctx.output.warn(format!(
+                ctx.user_log.warn(format!(
                     "No selected package supports target backend `{}` for `moon info`",
                     target_backend
                 ));
@@ -252,7 +253,7 @@ fn calc_user_intent_for_info(
                 .collect();
 
             if filtered.is_empty() {
-                ctx.output.warn(format!(
+                ctx.user_log.warn(format!(
                     "No selected package supports target backend `{}` for `moon info`",
                     target_backend
                 ));
@@ -276,14 +277,6 @@ pub(crate) fn run_info(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Resu
         bail!("dry-run is not supported for info")
     }
 
-    run_info_rr(cli, cmd, &output)
-}
-
-fn run_info_rr(
-    cli: UniversalFlags,
-    cmd: InfoSubcommand,
-    output: &CommandOutput,
-) -> anyhow::Result<i32> {
     let PackageDirs {
         source_dir,
         target_dir,
@@ -305,8 +298,7 @@ fn run_info_rr(
     let synced_env =
         sync_dependencies(&resolve_cfg, &source_dir, &mooncakes_dir, &project_manifest)?;
     let resolve_output = resolve_synced_project(&resolve_cfg, synced_env)?;
-    let user_diagnostics = UserDiagnostics::from_flags(&cli);
-    let selection = PackageSelection::new(&cmd, &resolve_output, user_diagnostics)?;
+    let selection = PackageSelection::new(&cmd, &resolve_output, output.user_log())?;
 
     let requested_targets = cmd
         .target
@@ -330,7 +322,7 @@ fn run_info_rr(
             resolve_output.clone(),
             &selection,
             &output_plan,
-            output,
+            output.user_log(),
         )?;
         if !success {
             ok = false;
@@ -364,7 +356,7 @@ fn run_info_rr_internal(
     resolve_output: ResolveOutput,
     selection: &PackageSelection,
     output_plan: &imp::InfoOutputPlan,
-    output: &CommandOutput,
+    user_log: &UserLog,
 ) -> anyhow::Result<(bool, BuildMeta)> {
     let mut preconfig = rr_build::preconfig_compile(
         &cmd.auto_sync_flags,
@@ -375,12 +367,12 @@ fn run_info_rr_internal(
         RunMode::Check,
     );
     preconfig.info_no_alias = cmd.no_alias;
-    let user_diagnostics = UserDiagnostics::from_flags(cli);
+    let user_diagnostics = UserDiagnostics::from_user_log(user_log);
     let ctx = InfoIntentContext {
         selection,
         output_plan,
         target_kind,
-        output: output.user_log(),
+        user_log,
     };
     let planning_context = rr_build::prepare_resolved_build(
         &preconfig,

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -28,6 +28,7 @@ use moonbuild_rupes_recta::{
 use moonutil::{
     build_options::RunMode,
     cli_support::AutoSyncFlags,
+    command_output::CommandOutput,
     project::PackageDirs,
     target::{SurfaceTarget, TargetBackend, lower_surface_targets},
     user_log::UserLog,
@@ -265,18 +266,24 @@ fn calc_user_intent_for_info(
 }
 
 pub(crate) fn run_info(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32> {
-    let output = UserLog::new(cli.user_log_level());
+    let output = CommandOutput::new(cli.user_log_level());
     if cmd.no_alias {
-        output.warn("`--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092");
+        output.user_log().warn(
+            "`--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092",
+        );
     }
     if cli.dry_run {
         bail!("dry-run is not supported for info")
     }
 
-    run_info_rr(cli, cmd)
+    run_info_rr(cli, cmd, &output)
 }
 
-pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::Result<i32> {
+fn run_info_rr(
+    cli: UniversalFlags,
+    cmd: InfoSubcommand,
+    output: &CommandOutput,
+) -> anyhow::Result<i32> {
     let PackageDirs {
         source_dir,
         target_dir,
@@ -298,8 +305,8 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
     let synced_env =
         sync_dependencies(&resolve_cfg, &source_dir, &mooncakes_dir, &project_manifest)?;
     let resolve_output = resolve_synced_project(&resolve_cfg, synced_env)?;
-    let output = UserDiagnostics::from_flags(&cli);
-    let selection = PackageSelection::new(&cmd, &resolve_output, output)?;
+    let user_diagnostics = UserDiagnostics::from_flags(&cli);
+    let selection = PackageSelection::new(&cmd, &resolve_output, user_diagnostics)?;
 
     let requested_targets = cmd
         .target
@@ -323,6 +330,7 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
             resolve_output.clone(),
             &selection,
             &output_plan,
+            output,
         )?;
         if !success {
             ok = false;
@@ -336,7 +344,9 @@ pub(crate) fn run_info_rr(cli: UniversalFlags, cmd: InfoSubcommand) -> anyhow::R
     }
 
     imp::promote_info_results(&output_plan, all_meta.iter());
-    imp::report_info_outputs(&output_plan, all_meta.iter(), &requested_targets)?;
+    output.write_result(|writer| {
+        imp::report_info_outputs(&output_plan, all_meta.iter(), &requested_targets, writer)
+    })?;
     Ok(0)
 }
 
@@ -354,6 +364,7 @@ fn run_info_rr_internal(
     resolve_output: ResolveOutput,
     selection: &PackageSelection,
     output_plan: &imp::InfoOutputPlan,
+    output: &CommandOutput,
 ) -> anyhow::Result<(bool, BuildMeta)> {
     let mut preconfig = rr_build::preconfig_compile(
         &cmd.auto_sync_flags,
@@ -364,13 +375,12 @@ fn run_info_rr_internal(
         RunMode::Check,
     );
     preconfig.info_no_alias = cmd.no_alias;
-    let user_log = UserLog::new(cli.user_log_level());
     let user_diagnostics = UserDiagnostics::from_flags(cli);
     let ctx = InfoIntentContext {
         selection,
         output_plan,
         target_kind,
-        output: &user_log,
+        output: output.user_log(),
     };
     let planning_context = rr_build::prepare_resolved_build(
         &preconfig,

--- a/crates/moon/src/cli/info/imp.rs
+++ b/crates/moon/src/cli/info/imp.rs
@@ -20,6 +20,7 @@
 
 use std::{
     collections::BTreeSet,
+    io::Write,
     path::{Path, PathBuf},
 };
 
@@ -189,6 +190,7 @@ pub(super) fn report_info_outputs<'a>(
     plan: &'a InfoOutputPlan,
     it: impl Iterator<Item = &'a (TargetBackend, BuildMeta)>,
     requested_backends: &[TargetBackend],
+    writer: &mut dyn Write,
 ) -> anyhow::Result<()> {
     if requested_backends.is_empty() {
         return Ok(());
@@ -197,7 +199,7 @@ pub(super) fn report_info_outputs<'a>(
     let requested_backends = requested_backends.iter().copied().collect::<BTreeSet<_>>();
 
     for (_package, group) in collect_package_output_groups(plan, it) {
-        report_info_output_for_package(&requested_backends, &group)?;
+        report_info_output_for_package(&requested_backends, &group, writer)?;
     }
 
     Ok(())
@@ -274,6 +276,7 @@ fn read_backend_contents<'a>(
 fn report_info_output_for_package(
     requested_backends: &BTreeSet<TargetBackend>,
     group: &PackageOutputGroup,
+    writer: &mut dyn Write,
 ) -> anyhow::Result<()> {
     let backend_contents = read_backend_contents(group)?;
     let requested_outputs = requested_backends
@@ -305,15 +308,17 @@ fn report_info_output_for_package(
     }
 
     if canonical.is_some() {
-        println!(
+        writeln!(
+            writer,
             "#\n# Package {} has diverging interfaces across backends:",
             group.plan.pkg_name
-        );
+        )?;
     } else {
-        println!(
+        writeln!(
+            writer,
             "#\n# Package {} has requested interfaces different from canonical backend {:?}:",
             group.plan.pkg_name, canonical_backend
-        );
+        )?;
     }
 
     for (hash, backends) in hash_groups {
@@ -325,31 +330,33 @@ fn report_info_output_for_package(
             .get(&backends[0])
             .context("Backend output not found")?;
 
-        println!("#\n# ---");
-        println!(
+        writeln!(writer, "#\n# ---")?;
+        writeln!(
+            writer,
             "{} {} {:?} {}",
             "---".bright_red(),
             group.plan.pkg_name,
             canonical_backend,
             baseline_file_label.bright_black(),
-        );
+        )?;
         for backend in &backends {
             let actual = backend_contents
                 .get(backend)
                 .context("Backend output not found")?;
-            println!(
+            writeln!(
+                writer,
                 "{} {} {:?} {}",
                 "+++".bright_green(),
                 group.plan.pkg_name,
                 backend,
                 format!("({})", actual.filename.display()).bright_black(),
-            );
+            )?;
         }
 
-        write_diff(baseline_content, &actual.content, 1, 2, std::io::stdout())?;
+        write_diff(baseline_content, &actual.content, 1, 2, &mut *writer)?;
     }
 
-    println!("# ------");
+    writeln!(writer, "# ------")?;
     Ok(())
 }
 

--- a/crates/moon/src/cli/info/imp.rs
+++ b/crates/moon/src/cli/info/imp.rs
@@ -24,8 +24,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use anstyle::{AnsiColor, Style};
 use anyhow::Context;
-use colored::Colorize;
 use indexmap::IndexMap;
 use moonbuild::expect::write_diff;
 use moonbuild_rupes_recta::{
@@ -38,6 +38,10 @@ use sha2::Digest;
 use tracing::error;
 
 use crate::{filter::preferred_target_backend_for_package, rr_build::BuildMeta};
+
+const REMOVED_STYLE: Style = AnsiColor::BrightRed.on_default();
+const ADDED_STYLE: Style = AnsiColor::BrightGreen.on_default();
+const PATH_STYLE: Style = AnsiColor::BrightBlack.on_default();
 
 pub(super) struct InfoOutputPlan {
     packages: IndexMap<PackageId, PackageOutputPlan>,
@@ -333,11 +337,8 @@ fn report_info_output_for_package(
         writeln!(writer, "#\n# ---")?;
         writeln!(
             writer,
-            "{} {} {:?} {}",
-            "---".bright_red(),
-            group.plan.pkg_name,
-            canonical_backend,
-            baseline_file_label.bright_black(),
+            "{REMOVED_STYLE}---{REMOVED_STYLE:#} {} {:?} {PATH_STYLE}{}{PATH_STYLE:#}",
+            group.plan.pkg_name, canonical_backend, baseline_file_label,
         )?;
         for backend in &backends {
             let actual = backend_contents
@@ -345,11 +346,10 @@ fn report_info_output_for_package(
                 .context("Backend output not found")?;
             writeln!(
                 writer,
-                "{} {} {:?} {}",
-                "+++".bright_green(),
+                "{ADDED_STYLE}+++{ADDED_STYLE:#} {} {:?} {PATH_STYLE}({}){PATH_STYLE:#}",
                 group.plan.pkg_name,
                 backend,
-                format!("({})", actual.filename.display()).bright_black(),
+                actual.filename.display(),
             )?;
         }
 

--- a/crates/moon/src/user_diagnostics.rs
+++ b/crates/moon/src/user_diagnostics.rs
@@ -18,57 +18,55 @@
 
 use std::fmt::Display;
 
-use colored::{ColoredString, Colorize};
-use moonutil::cli_support::UniversalFlags;
-use moonutil::user_warning::{UserMessageLevel, UserWarning};
+use anstyle::{AnsiColor, Style};
+use moonutil::{
+    cli_support::UniversalFlags,
+    user_log::{UserLog, user_log_level},
+    user_warning::{UserMessageLevel, UserWarning},
+};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum UserThreshold {
-    Warn,
-    Info,
-}
+const INFO_STYLE: Style = AnsiColor::Cyan.on_default().bold();
+const HINT_STYLE: Style = AnsiColor::Green.on_default().bold();
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum UserMessageKind {
-    Error,
-    Warn,
-    Info,
-    #[allow(dead_code)]
-    Hint,
-}
-
+/// Compatibility adapter for call sites that still use diagnostic-style labels.
+///
+/// Filtering and stderr ownership belong to `UserLog`; this type only preserves
+/// the legacy `Info:` and `Hint:` presentation until those callers migrate.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct UserDiagnostics {
-    threshold: UserThreshold,
-    quiet: bool,
+    user_log: UserLog,
 }
 
 impl UserDiagnostics {
     pub(crate) fn from_flags(flags: &UniversalFlags) -> Self {
-        Self::new(flags.verbose, flags.quiet)
+        Self {
+            user_log: UserLog::new(flags.user_log_level()),
+        }
+    }
+
+    pub(crate) fn from_user_log(user_log: &UserLog) -> Self {
+        Self {
+            user_log: *user_log,
+        }
     }
 
     pub(crate) fn new(verbose: bool, quiet: bool) -> Self {
         Self {
-            threshold: if verbose {
-                UserThreshold::Info
-            } else {
-                UserThreshold::Warn
-            },
-            quiet,
+            user_log: UserLog::new(user_log_level(verbose, quiet)),
         }
     }
 
     pub(crate) fn error(self, message: impl Display) {
-        self.emit(UserMessageKind::Error, message);
+        self.user_log.error(message);
     }
 
     pub(crate) fn warn(self, message: impl Display) {
-        self.emit(UserMessageKind::Warn, message);
+        self.user_log.warn(message);
     }
 
     pub(crate) fn info(self, message: impl Display) {
-        self.emit(UserMessageKind::Info, message);
+        self.user_log
+            .info(format_args!("{INFO_STYLE}Info{INFO_STYLE:#}: {message}"));
     }
 
     pub(crate) fn user_message(self, message: &UserWarning) {
@@ -80,69 +78,13 @@ impl UserDiagnostics {
 
     #[allow(dead_code)]
     pub(crate) fn hint(self, message: impl Display) {
-        self.emit(UserMessageKind::Hint, message);
-    }
-
-    fn emit(self, kind: UserMessageKind, message: impl Display) {
-        if self.enabled(kind) {
-            eprintln!("{}: {}", kind.label(), message);
-        }
-    }
-
-    fn enabled(self, kind: UserMessageKind) -> bool {
-        match kind {
-            UserMessageKind::Error => true,
-            UserMessageKind::Warn => !self.quiet,
-            UserMessageKind::Info | UserMessageKind::Hint => {
-                !self.quiet && self.threshold >= UserThreshold::Info
-            }
-        }
+        self.user_log
+            .info(format_args!("{HINT_STYLE}Hint{HINT_STYLE:#}: {message}"));
     }
 }
 
 impl Default for UserDiagnostics {
     fn default() -> Self {
         Self::new(false, false)
-    }
-}
-
-impl UserMessageKind {
-    fn label(self) -> ColoredString {
-        match self {
-            UserMessageKind::Error => "Error".red().bold(),
-            UserMessageKind::Warn => "Warning".yellow().bold(),
-            UserMessageKind::Info => "Info".cyan().bold(),
-            UserMessageKind::Hint => "Hint".green().bold(),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{UserDiagnostics, UserMessageKind};
-
-    #[test]
-    fn default_output_shows_warn_but_not_info() {
-        let output = UserDiagnostics::new(false, false);
-        assert!(output.enabled(UserMessageKind::Warn));
-        assert!(output.enabled(UserMessageKind::Error));
-        assert!(!output.enabled(UserMessageKind::Info));
-        assert!(!output.enabled(UserMessageKind::Hint));
-    }
-
-    #[test]
-    fn verbose_output_enables_info() {
-        let output = UserDiagnostics::new(true, false);
-        assert!(output.enabled(UserMessageKind::Info));
-        assert!(output.enabled(UserMessageKind::Hint));
-    }
-
-    #[test]
-    fn quiet_output_only_shows_errors() {
-        let output = UserDiagnostics::new(true, true);
-        assert!(output.enabled(UserMessageKind::Error));
-        assert!(!output.enabled(UserMessageKind::Warn));
-        assert!(!output.enabled(UserMessageKind::Info));
-        assert!(!output.enabled(UserMessageKind::Hint));
     }
 }

--- a/crates/moon/src/user_diagnostics.rs
+++ b/crates/moon/src/user_diagnostics.rs
@@ -91,7 +91,8 @@ impl UserDiagnostics {
 
     fn enabled(self, kind: UserMessageKind) -> bool {
         match kind {
-            UserMessageKind::Error | UserMessageKind::Warn => true,
+            UserMessageKind::Error => true,
+            UserMessageKind::Warn => !self.quiet,
             UserMessageKind::Info | UserMessageKind::Hint => {
                 !self.quiet && self.threshold >= UserThreshold::Info
             }
@@ -137,10 +138,10 @@ mod tests {
     }
 
     #[test]
-    fn quiet_output_still_shows_warn() {
+    fn quiet_output_only_shows_errors() {
         let output = UserDiagnostics::new(true, true);
-        assert!(output.enabled(UserMessageKind::Warn));
         assert!(output.enabled(UserMessageKind::Error));
+        assert!(!output.enabled(UserMessageKind::Warn));
         assert!(!output.enabled(UserMessageKind::Info));
         assert!(!output.enabled(UserMessageKind::Hint));
     }

--- a/crates/moon/tests/test_cases/diagnostics_format/test.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/test.rs
@@ -52,7 +52,6 @@ fn test_moon_test_rendered_output() {
                │       ┬  
                │       ╰── Warning (unused_value): Unused variable 'a'
             ───╯
-            Warning: no test entry found.
         "#]],
     );
 }

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -372,6 +372,28 @@ fn test_moon_info_verbose_unsupported_path_is_bare_stderr() {
 }
 
 #[test]
+fn test_moon_info_quiet_keeps_command_result_and_suppresses_user_log() {
+    let dir = TestDir::new("mixed_backend_local_dep.in");
+    let assert = moon_cmd(&dir)
+        .args(["info", "--target", "js", "--no-alias", "--quiet"])
+        .assert()
+        .success()
+        .stderr_eq("");
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+
+    assert!(
+        stdout.contains(
+            "Package mixed/localdep/shared has requested interfaces different from canonical backend"
+        ),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("pub fn shared_banner() -> String"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
 fn test_module_supported_targets_intersects_package_supported_targets() {
     let dir = TestDir::new("supported_targets_module_intersection.in");
 

--- a/crates/moon/tests/test_cases/test_filter/mod.rs
+++ b/crates/moon/tests/test_cases/test_filter/mod.rs
@@ -99,12 +99,7 @@ fn test_moon_test_filter_outline_wiring() {
             "-q",
         ],
     ));
-    check(
-        output,
-        expect![[r#"
-Warning: no test entry found.
-"#]],
-    );
+    check(output, expect!["\n\n"]);
 
     let output = normalize_outline(get_stdout(
         &dir,

--- a/crates/moonbuild/Cargo.toml
+++ b/crates/moonbuild/Cargo.toml
@@ -25,6 +25,8 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anstream.workspace = true
+anstyle.workspace = true
 arcstr.workspace = true
 moonutil.workspace = true
 mooncake.workspace = true

--- a/crates/moonbuild/src/expect.rs
+++ b/crates/moonbuild/src/expect.rs
@@ -17,6 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::runtest::TestStatistics;
+use anstyle::{AnsiColor, Style};
 use anyhow::Context;
 use base64::Engine;
 use colored::Colorize;
@@ -818,12 +819,21 @@ const DIFF_MIN_CTX: usize = 5;
 /// without chunking.
 const MIN_LINES_FOR_CHUNKING: usize = 20;
 
+const DIFF_CONTEXT_STYLE: Style = AnsiColor::BrightBlack.on_default();
+const DIFF_REMOVED_STYLE: Style = AnsiColor::BrightRed.on_default();
+const DIFF_REMOVED_EMPHASIS_STYLE: Style = AnsiColor::BrightRed.on_default().underline();
+const DIFF_ADDED_STYLE: Style = AnsiColor::BrightGreen.on_default();
+const DIFF_ADDED_EMPHASIS_STYLE: Style = AnsiColor::BrightGreen.on_default().underline();
+const DIFF_MISSING_NEWLINE_STYLE: Style = Style::new().dimmed();
+
 /// Write the difference between strings `expected` and `actual` to the provided
 /// writer `to`, in unified diff format.
 ///
 /// The function uses a number of heuristics to determine the best format for
 /// the diff output. Inline diffs will not show newline differences, short diffs
 /// will be displayed in full, and long diffs will be chunked.
+/// ANSI styles are always rendered; the destination writer decides whether to
+/// retain or strip them.
 pub fn write_diff(
     expected: &str,
     actual: &str,
@@ -855,6 +865,28 @@ pub fn write_diff(
     Ok(())
 }
 
+#[test]
+fn diff_color_follows_destination_writer() {
+    let render = |choice| {
+        let mut writer = anstream::AutoStream::new(Vec::new(), choice);
+        write_diff("old\n", "new\n", 1, 2, &mut writer).unwrap();
+        writer.into_inner()
+    };
+
+    let colored = render(anstream::ColorChoice::AlwaysAnsi);
+    assert!(
+        colored.contains(&b'\x1b'),
+        "output was not colored: {colored:?}"
+    );
+
+    let plain = render(anstream::ColorChoice::Never);
+    assert!(!plain.contains(&b'\x1b'));
+    assert!(
+        plain.starts_with(b"-old\n+new\n"),
+        "unexpected diff: {plain:?}"
+    );
+}
+
 /// Write a hunk of diff
 fn write_hunk<'a>(
     orig_diff: &'a TextDiff<'a, 'a, 'a, str>,
@@ -865,7 +897,7 @@ fn write_hunk<'a>(
 ) -> std::io::Result<()> {
     if header {
         let header = similar::udiff::UnifiedHunkHeader::new(hunk);
-        writeln!(to, "{}", header.to_string().bright_black())?;
+        writeln!(to, "{DIFF_CONTEXT_STYLE}{header}{DIFF_CONTEXT_STYLE:#}")?;
     }
 
     for op in hunk {
@@ -882,22 +914,28 @@ fn write_hunk<'a>(
                         unreachable!("Equal should have been handled earlier")
                     }
                     similar::ChangeTag::Delete => {
-                        write!(to, "{}", "-".bright_red())?;
+                        write!(to, "{DIFF_REMOVED_STYLE}-{DIFF_REMOVED_STYLE:#}")?;
                         for &(emph, slice) in change.values() {
                             if emph {
-                                write!(to, "{}", slice.underline().bright_red())?;
+                                write!(
+                                    to,
+                                    "{DIFF_REMOVED_EMPHASIS_STYLE}{slice}{DIFF_REMOVED_EMPHASIS_STYLE:#}"
+                                )?;
                             } else {
-                                write!(to, "{}", slice.bright_red())?;
+                                write!(to, "{DIFF_REMOVED_STYLE}{slice}{DIFF_REMOVED_STYLE:#}")?;
                             }
                         }
                     }
                     similar::ChangeTag::Insert => {
-                        write!(to, "{}", "+".bright_green())?;
+                        write!(to, "{DIFF_ADDED_STYLE}+{DIFF_ADDED_STYLE:#}")?;
                         for &(emph, slice) in change.values() {
                             if emph {
-                                write!(to, "{}", slice.underline().bright_green())?;
+                                write!(
+                                    to,
+                                    "{DIFF_ADDED_EMPHASIS_STYLE}{slice}{DIFF_ADDED_EMPHASIS_STYLE:#}"
+                                )?;
                             } else {
-                                write!(to, "{}", slice.bright_green())?;
+                                write!(to, "{DIFF_ADDED_STYLE}{slice}{DIFF_ADDED_STYLE:#}")?;
                             }
                         }
                     }
@@ -918,19 +956,23 @@ fn report_missing_nl_f(
     if missing {
         writeln!(to)?;
         if report_missing_newlines {
-            writeln!(to, "{}", "\\ No newline at end of file".dimmed())?;
+            writeln!(
+                to,
+                "{DIFF_MISSING_NEWLINE_STYLE}\\ No newline at end of file{DIFF_MISSING_NEWLINE_STYLE:#}"
+            )?;
         }
     }
     Ok(())
 }
 
 fn write_diff_header(mut to: impl Write) -> std::io::Result<()> {
+    const LABEL_STYLE: Style = Style::new().bold();
+    const EXPECTED_STYLE: Style = AnsiColor::Red.on_default();
+    const ACTUAL_STYLE: Style = AnsiColor::Green.on_default();
+
     writeln!(
         to,
-        "{} ({}, {})",
-        "Diff:".bold(),
-        "- expected".red(),
-        "+ actual".green()
+        "{LABEL_STYLE}Diff:{LABEL_STYLE:#} ({EXPECTED_STYLE}- expected{EXPECTED_STYLE:#}, {ACTUAL_STYLE}+ actual{ACTUAL_STYLE:#})"
     )
 }
 
@@ -954,18 +996,19 @@ pub fn render_expect_fail(
         return Ok(());
     }
 
-    println!("expect test failed at {}", rep.loc);
-    write_diff_header(std::io::stdout())?;
-    println!("----");
+    let mut stdout = anstream::stdout().lock();
+    writeln!(stdout, "expect test failed at {}", rep.loc)?;
+    write_diff_header(&mut stdout)?;
+    writeln!(stdout, "----")?;
     write_diff(
         &rep.expect,
         &rep.actual,
         MIN_LINES_FOR_CHUNKING,
         DIFF_MIN_CTX,
-        std::io::stdout(),
+        &mut stdout,
     )?;
-    println!("----");
-    println!();
+    writeln!(stdout, "----")?;
+    writeln!(stdout)?;
 
     Ok(())
 }
@@ -1022,23 +1065,25 @@ pub fn render_snapshot_fail(
     };
     let eq = actual == expect;
     if !eq {
-        println!(
+        let mut stdout = anstream::stdout().lock();
+        writeln!(
+            stdout,
             "expect test failed at {}:{}:{}",
             loc.filename,
             loc.line_start + 1,
             loc.col_start + 1
-        );
-        write_diff_header(std::io::stdout())?;
-        println!("----");
+        )?;
+        write_diff_header(&mut stdout)?;
+        writeln!(stdout, "----")?;
         write_diff(
             &expect,
             &actual,
             MIN_LINES_FOR_CHUNKING,
             DIFF_MIN_CTX,
-            std::io::stdout(),
+            &mut stdout,
         )?;
-        println!("----");
-        println!();
+        writeln!(stdout, "----")?;
+        writeln!(stdout)?;
     }
     Ok((eq, expect, actual))
 }

--- a/crates/moonutil/Cargo.toml
+++ b/crates/moonutil/Cargo.toml
@@ -25,6 +25,8 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anstream.workspace = true
+anstyle.workspace = true
 arcstr.workspace = true
 home.workspace = true
 anyhow.workspace = true

--- a/crates/moonutil/src/cli.rs
+++ b/crates/moonutil/src/cli.rs
@@ -66,13 +66,7 @@ pub struct UniversalFlags {
 
 impl UniversalFlags {
     pub fn user_log_level(&self) -> log::LevelFilter {
-        if self.quiet {
-            log::LevelFilter::Error
-        } else if self.verbose {
-            log::LevelFilter::Info
-        } else {
-            log::LevelFilter::Warn
-        }
+        crate::user_log::user_log_level(self.verbose, self.quiet)
     }
 
     /// Collect deprecation warnings for deprecated flags.

--- a/crates/moonutil/src/command_output.rs
+++ b/crates/moonutil/src/command_output.rs
@@ -1,0 +1,55 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::io::{self, Write};
+
+use log::LevelFilter;
+
+use crate::user_log::UserLog;
+
+/// Owns the two MoonBuild-authored communication channels for one command.
+///
+/// Command results are fallible writes to stdout. Filtered user logs are
+/// emitted through [`UserLog`] on stderr. Child-process passthrough, progress
+/// displays, and tracing have separate output policies and do not use this
+/// interface.
+#[derive(Debug)]
+pub struct CommandOutput {
+    user_log: UserLog,
+}
+
+impl CommandOutput {
+    pub fn new(user_log_level: LevelFilter) -> Self {
+        Self {
+            user_log: UserLog::new(user_log_level),
+        }
+    }
+
+    pub fn user_log(&self) -> &UserLog {
+        &self.user_log
+    }
+
+    /// Render one logical command result while holding the stdout lock.
+    pub fn write_result<T, E>(
+        &self,
+        render: impl FnOnce(&mut dyn Write) -> Result<T, E>,
+    ) -> Result<T, E> {
+        let mut stdout = io::stdout().lock();
+        render(&mut stdout)
+    }
+}

--- a/crates/moonutil/src/command_output.rs
+++ b/crates/moonutil/src/command_output.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::io::{self, Write};
+use std::io::Write;
 
 use log::LevelFilter;
 
@@ -49,7 +49,7 @@ impl CommandOutput {
         &self,
         render: impl FnOnce(&mut dyn Write) -> Result<T, E>,
     ) -> Result<T, E> {
-        let mut stdout = io::stdout().lock();
+        let mut stdout = anstream::stdout().lock();
         render(&mut stdout)
     }
 }

--- a/crates/moonutil/src/lib.rs
+++ b/crates/moonutil/src/lib.rs
@@ -24,6 +24,7 @@ pub mod build_script;
 pub mod cache;
 mod cli;
 pub mod cli_support;
+pub mod command_output;
 pub mod compiler_flags;
 pub mod cond_expr;
 pub mod constants;

--- a/crates/moonutil/src/user_log.rs
+++ b/crates/moonutil/src/user_log.rs
@@ -30,6 +30,9 @@ pub struct UserLog {
     level: LevelFilter,
 }
 
+/// Maps legacy CLI verbosity flags to the shared user-log level.
+// FIXME: Remove this compatibility bridge once callers no longer receive raw
+// `verbose` and `quiet` booleans.
 pub fn user_log_level(verbose: bool, quiet: bool) -> LevelFilter {
     if quiet {
         LevelFilter::Error

--- a/crates/moonutil/src/user_log.rs
+++ b/crates/moonutil/src/user_log.rs
@@ -18,12 +18,26 @@
 
 use std::{fmt::Display, io::Write};
 
-use colored::Colorize;
+use anstyle::{AnsiColor, Style};
 use log::LevelFilter;
 
-#[derive(Debug)]
+const ERROR_STYLE: Style = AnsiColor::Red.on_default().bold();
+const WARNING_STYLE: Style = AnsiColor::Yellow.on_default().bold();
+const DEBUG_STYLE: Style = AnsiColor::BrightBlack.on_default().bold();
+
+#[derive(Debug, Clone, Copy)]
 pub struct UserLog {
     level: LevelFilter,
+}
+
+pub fn user_log_level(verbose: bool, quiet: bool) -> LevelFilter {
+    if quiet {
+        LevelFilter::Error
+    } else if verbose {
+        LevelFilter::Info
+    } else {
+        LevelFilter::Warn
+    }
 }
 
 impl UserLog {
@@ -32,34 +46,34 @@ impl UserLog {
     }
 
     pub fn error(&self, message: impl Display) {
-        let mut stderr = std::io::stderr().lock();
+        let mut stderr = anstream::stderr().lock();
         self.error_to(&mut stderr, message);
     }
 
     pub fn warn(&self, message: impl Display) {
-        let mut stderr = std::io::stderr().lock();
+        let mut stderr = anstream::stderr().lock();
         self.warn_to(&mut stderr, message);
     }
 
     pub fn info(&self, message: impl Display) {
-        let mut stderr = std::io::stderr().lock();
+        let mut stderr = anstream::stderr().lock();
         self.info_to(&mut stderr, message);
     }
 
     pub fn debug(&self, message: impl Display) {
-        let mut stderr = std::io::stderr().lock();
+        let mut stderr = anstream::stderr().lock();
         self.debug_to(&mut stderr, message);
     }
 
     fn error_to(&self, writer: &mut impl Write, message: impl Display) {
         if self.level >= LevelFilter::Error {
-            let _ = writeln!(writer, "{}: {}", "Error".red().bold(), message);
+            let _ = writeln!(writer, "{ERROR_STYLE}Error{ERROR_STYLE:#}: {message}");
         }
     }
 
     fn warn_to(&self, writer: &mut impl Write, message: impl Display) {
         if self.level >= LevelFilter::Warn {
-            let _ = writeln!(writer, "{}: {}", "Warning".yellow().bold(), message);
+            let _ = writeln!(writer, "{WARNING_STYLE}Warning{WARNING_STYLE:#}: {message}");
         }
     }
 
@@ -71,7 +85,7 @@ impl UserLog {
 
     fn debug_to(&self, writer: &mut impl Write, message: impl Display) {
         if self.level >= LevelFilter::Debug {
-            let _ = writeln!(writer, "{}: {}", "Debug".bright_black().bold(), message);
+            let _ = writeln!(writer, "{DEBUG_STYLE}Debug{DEBUG_STYLE:#}: {message}");
         }
     }
 }
@@ -80,6 +94,7 @@ impl UserLog {
 mod tests {
     use std::io::Write;
 
+    use anstream::{AutoStream, ColorChoice};
     use log::LevelFilter;
 
     use super::UserLog;
@@ -87,20 +102,20 @@ mod tests {
     #[test]
     fn error_level_renders_error_and_suppresses_other_messages() {
         let output = UserLog::new(LevelFilter::Error);
-        let mut writer = Vec::new();
+        let mut writer = AutoStream::new(Vec::new(), ColorChoice::Never);
 
         output.error_to(&mut writer, "failed");
         output.warn_to(&mut writer, "be careful");
         output.info_to(&mut writer, "more context");
         output.debug_to(&mut writer, "internal context");
 
-        assert_eq!(writer, b"Error: failed\n");
+        assert_eq!(writer.into_inner(), b"Error: failed\n");
     }
 
     #[test]
     fn info_level_renders_error_warn_and_bare_info_but_not_debug() {
         let output = UserLog::new(LevelFilter::Info);
-        let mut writer = Vec::new();
+        let mut writer = AutoStream::new(Vec::new(), ColorChoice::Never);
 
         output.error_to(&mut writer, "failed");
         output.warn_to(&mut writer, "be careful");
@@ -108,7 +123,7 @@ mod tests {
         output.debug_to(&mut writer, "internal context");
 
         assert_eq!(
-            writer,
+            writer.into_inner(),
             b"Error: failed\nWarning: be careful\nmore context\n"
         );
     }
@@ -116,22 +131,41 @@ mod tests {
     #[test]
     fn warn_level_renders_warn_but_not_info() {
         let output = UserLog::new(LevelFilter::Warn);
-        let mut writer = Vec::new();
+        let mut writer = AutoStream::new(Vec::new(), ColorChoice::Never);
 
         output.warn_to(&mut writer, "be careful");
         output.info_to(&mut writer, "more context");
 
-        assert_eq!(writer, b"Warning: be careful\n");
+        assert_eq!(writer.into_inner(), b"Warning: be careful\n");
     }
 
     #[test]
     fn debug_level_renders_debug() {
         let output = UserLog::new(LevelFilter::Debug);
-        let mut writer = Vec::new();
+        let mut writer = AutoStream::new(Vec::new(), ColorChoice::Never);
 
         output.debug_to(&mut writer, "internal context");
 
-        assert_eq!(writer, b"Debug: internal context\n");
+        assert_eq!(writer.into_inner(), b"Debug: internal context\n");
+    }
+
+    #[test]
+    fn destination_writer_controls_color_output() {
+        let output = UserLog::new(LevelFilter::Error);
+        let mut colored = AutoStream::new(Vec::new(), ColorChoice::AlwaysAnsi);
+
+        output.error_to(&mut colored, "failed");
+
+        let colored = colored.into_inner();
+        assert!(
+            colored.starts_with(b"\x1b["),
+            "output was not colored: {colored:?}"
+        );
+
+        let mut plain = AutoStream::new(Vec::new(), ColorChoice::Never);
+        output.error_to(&mut plain, "failed");
+
+        assert_eq!(plain.into_inner(), b"Error: failed\n");
     }
 
     #[test]

--- a/docs/adr/0004-separate-command-results-from-user-logs.md
+++ b/docs/adr/0004-separate-command-results-from-user-logs.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+---
+
+# Separate Command Results from User Logs
+
+MoonBuild will place a small `CommandOutput` interface at the CLI orchestration seam. It will own the command's `UserLog` and provide fallible, locked writes for Command Results on stdout, while renderers below that seam accept a writer and library code prefers returning values. Process Passthrough, Progress Displays, and tracing remain separate because combining their different filtering, ordering, and byte-preservation requirements would create a mode-switched interface and make incremental migration unsafe.
+
+## Consequences
+
+- `--quiet` and `--verbose` affect User Logs but never suppress a Command Result.
+- The quiet user-log level is error-only, whether selected explicitly or by a command default. Commands may retain different default user-log levels while they migrate.
+- Command Result write failures are returned to the command instead of being discarded.
+- One logical result can hold the stdout lock for its complete render, preventing MoonBuild-authored fragments from interleaving.
+- The build engines do not receive the whole `CommandOutput` merely to print; they return data or accept the narrower `UserLog` or writer their operation requires.
+- Existing direct output migrates command by command. Explicitly classified passthrough, progress, and tracing sites are not mechanical conversion targets.
+
+## Considered Options
+
+- A generic output trait spanning stdout, stderr, progress, child processes, and tracing was rejected because callers would need to understand unrelated modes and ordering rules.
+- Generic or boxed writers stored throughout the build graph were rejected because they would spread lifetime, synchronization, and object-safety concerns through planning code that does not own CLI output policy.
+- Replacing every print site in one rewrite was rejected because output compatibility could not be reviewed or bisected one command family at a time.

--- a/docs/adr/0004-separate-command-results-from-user-logs.md
+++ b/docs/adr/0004-separate-command-results-from-user-logs.md
@@ -4,7 +4,7 @@ status: accepted
 
 # Separate Command Results from User Logs
 
-MoonBuild will place a small `CommandOutput` interface at the CLI orchestration seam. It will own the command's `UserLog` and provide fallible, locked writes for Command Results on stdout, while renderers below that seam accept a writer and library code prefers returning values. Process Passthrough, Progress Displays, and tracing remain separate because combining their different filtering, ordering, and byte-preservation requirements would create a mode-switched interface and make incremental migration unsafe.
+MoonBuild will place a small `CommandOutput` interface at the CLI orchestration seam. It will own the command's `UserLog` and provide fallible, locked writes for Command Results on stdout, while renderers below that seam accept a writer and library code prefers returning values. The stdout and stderr boundaries use adaptive streams, so each destination independently decides whether to retain ANSI styling. Process Passthrough, Progress Displays, and tracing remain separate because combining their different filtering, ordering, and byte-preservation requirements would create a mode-switched interface and make incremental migration unsafe.
 
 ## Consequences
 
@@ -12,6 +12,7 @@ MoonBuild will place a small `CommandOutput` interface at the CLI orchestration 
 - The quiet user-log level is error-only, whether selected explicitly or by a command default. Commands may retain different default user-log levels while they migrate.
 - Command Result write failures are returned to the command instead of being discarded.
 - One logical result can hold the stdout lock for its complete render, preventing MoonBuild-authored fragments from interleaving.
+- Color follows the actual destination channel. Redirecting stdout does not disable color on an interactive stderr, and redirecting stderr does not affect stdout.
 - The build engines do not receive the whole `CommandOutput` merely to print; they return data or accept the narrower `UserLog` or writer their operation requires.
 - Existing direct output migrates command by command. Explicitly classified passthrough, progress, and tracing sites are not mechanical conversion targets.
 

--- a/docs/dev/command-output-migration.md
+++ b/docs/dev/command-output-migration.md
@@ -1,6 +1,6 @@
 # Command Output Migration
 
-Status: accepted; CO-1 complete
+Status: accepted; CO-1 complete, including review follow-up
 
 ## Goal
 
@@ -19,6 +19,8 @@ Splitting stdout from stderr is independent from normalizing default verbosity. 
 
 The stdout operation should preserve the renderer's result type, propagate its `std::io::Write` failures, and hold the lock for the entire logical result. It should not grow methods for every output format.
 
+Both standard-stream boundaries are adaptive. Renderers emit ANSI styles, and the stdout or stderr writer retains or strips them according to that destination's terminal and environment policy. Color detection must not consult a different global stream: stdout and stderr may be redirected independently.
+
 Renderers below the CLI seam should accept a writer. Library operations should return data when the CLI owns presentation. A lower-level operation may accept `UserLog` when emitting a user-facing event is inherently part of that operation, but pure build planning should not depend on `CommandOutput`.
 
 The facade does not own Process Passthrough, Progress Displays, compiler diagnostics, or tracing. Those paths have different byte-preservation, concurrency, terminal, and configuration contracts and should be migrated only within their own seams.
@@ -33,9 +35,7 @@ The facade does not own Process Passthrough, Progress Displays, compiler diagnos
 | Progress Display | terminal stderr | quiet-aware | renderer-specific lifecycle | progress renderer |
 | tracing | configured tracing sink | `RUST_LOG`/trace configuration | tracing subscriber policy | tracing setup |
 
-One current behavior requires an explicit compatibility decision in its migration slice:
-
-- `UserDiagnostics` prefixes informational messages with `Info:`, while `UserLog` renders informational messages without a label.
+`UserDiagnostics` is a transitional presentation adapter over `UserLog`. It preserves the legacy `Info:` and `Hint:` labels, but filtering and stderr ownership come only from its underlying `UserLog`. New code should use `UserLog` directly.
 
 The quiet user-log level follows `UserLog` and suppresses warnings. Default levels and informational formatting remain command-specific until affected command snapshots make any intended behavior change visible.
 
@@ -49,10 +49,11 @@ Blocks: CO-2, CO-3
 
 - Add `moonutil::CommandOutput` composed with `UserLog`.
 - Route the existing `moon info` backend-difference report through one locked stdout writer closure.
-- Apply the resolved error-only quiet invariant to the transitional `UserDiagnostics`, without changing which commands default to quiet.
+- Make `UserDiagnostics` a compatibility adapter over `UserLog`, without changing which commands default to quiet.
+- Make ANSI styling follow the actual stdout or stderr destination instead of global stdout detection.
 - Keep build execution output on its current paths.
 - Test the public `moon` process seam: backend differences remain on stdout under `--quiet`, while a known warning is filtered on stderr.
-- Unit-test the transitional `UserDiagnostics` quiet invariant because it is shared by commands not yet migrated to `UserLog`.
+- Unit-test `UserLog` filtering and destination-controlled ANSI rendering.
 - Done when `moon info` contains no direct stdout macro or handle access and its existing output remains compatible.
 
 ### CO-2: Establish command-level construction

--- a/docs/dev/command-output-migration.md
+++ b/docs/dev/command-output-migration.md
@@ -1,0 +1,134 @@
+# Command Output Migration
+
+Status: accepted; CO-1 complete
+
+## Goal
+
+Every MoonBuild-authored Command Result and User Log has one explicit owner and follows the same channel, filtering, formatting, and error policy, while Process Passthrough, Progress Displays, and tracing remain explicit separate mechanisms.
+
+The migration must preserve observable command behavior unless a slice names and tests an intentional change. Each slice should be independently reviewable and leave the tree ready for the next slice.
+
+Splitting stdout from stderr is independent from normalizing default verbosity. The quiet user-log level is error-only, whether selected explicitly or by a command default, but commands such as `moonx` may retain a quieter default until a later slice deliberately changes it.
+
+## Interface Shape
+
+`moonutil` should expose a `CommandOutput` facade constructed from the command's user-log level. Its intentionally small interface is:
+
+- borrow its `UserLog` for filtered stderr messages;
+- run one closure against locked stdout to render a fallible Command Result.
+
+The stdout operation should preserve the renderer's result type, propagate its `std::io::Write` failures, and hold the lock for the entire logical result. It should not grow methods for every output format.
+
+Renderers below the CLI seam should accept a writer. Library operations should return data when the CLI owns presentation. A lower-level operation may accept `UserLog` when emitting a user-facing event is inherently part of that operation, but pure build planning should not depend on `CommandOutput`.
+
+The facade does not own Process Passthrough, Progress Displays, compiler diagnostics, or tracing. Those paths have different byte-preservation, concurrency, terminal, and configuration contracts and should be migrated only within their own seams.
+
+## Behavioral Policy
+
+| Communication | Channel | Filtered | Write policy | Initial owner |
+| --- | --- | --- | --- | --- |
+| Command Result | stdout | never | return failures | `CommandOutput` |
+| User Log | stderr | by user-log level | best effort, matching `UserLog` | `UserLog` |
+| Process Passthrough | original child channel | never | preserve bytes and ordering as far as the executor permits | run/build executor |
+| Progress Display | terminal stderr | quiet-aware | renderer-specific lifecycle | progress renderer |
+| tracing | configured tracing sink | `RUST_LOG`/trace configuration | tracing subscriber policy | tracing setup |
+
+One current behavior requires an explicit compatibility decision in its migration slice:
+
+- `UserDiagnostics` prefixes informational messages with `Info:`, while `UserLog` renders informational messages without a label.
+
+The quiet user-log level follows `UserLog` and suppresses warnings. Default levels and informational formatting remain command-specific until affected command snapshots make any intended behavior change visible.
+
+## Slices and Blocking Edges
+
+### CO-1: Prove the seam with `moon info`
+
+Status: complete
+
+Blocks: CO-2, CO-3
+
+- Add `moonutil::CommandOutput` composed with `UserLog`.
+- Route the existing `moon info` backend-difference report through one locked stdout writer closure.
+- Apply the resolved error-only quiet invariant to the transitional `UserDiagnostics`, without changing which commands default to quiet.
+- Keep build execution output on its current paths.
+- Test the public `moon` process seam: backend differences remain on stdout under `--quiet`, while a known warning is filtered on stderr.
+- Unit-test the transitional `UserDiagnostics` quiet invariant because it is shared by commands not yet migrated to `UserLog`.
+- Done when `moon info` contains no direct stdout macro or handle access and its existing output remains compatible.
+
+### CO-2: Establish command-level construction
+
+Blocked by: CO-1
+
+Blocks: CO-4, CO-5
+
+- Construct one `CommandOutput` after universal flags and workspace setup are known.
+- Pass references through command dispatch without migrating all commands in the same change.
+- Keep early argument/help and pre-dispatch failures on explicit bootstrap output paths.
+- Done when a command can receive one output context without reconstructing log policy in nested functions.
+
+### CO-3: Migrate self-contained result commands
+
+Blocked by: CO-1
+
+Blocks: CO-6
+
+- Migrate one command family per change: `version`, `whoami`, `explain`, shell completion, and other leaf commands.
+- Keep machine-readable output byte-for-byte stable and add channel assertions where missing.
+- Prefer a renderer taking a writer when a command emits more than one fragment.
+- Done when the selected command family has no unclassified direct stdout writes.
+
+### CO-4: Replace `UserDiagnostics` incrementally
+
+Blocked by: CO-2
+
+Blocks: CO-6, CO-7
+
+- Move one build-facing command family at a time to `UserLog`.
+- Preserve each command's current default log level unless the slice explicitly changes it; pin error-only `--quiet` and any informational-label decision for the affected family.
+- Delete `UserDiagnostics` only after its last caller moves; do not keep it as a permanent wrapper over `UserLog`.
+- Done when `UserDiagnostics` is removed and all user-authored log sites use the shared level policy.
+
+### CO-5: Migrate dry-run and graph Command Results
+
+Blocked by: CO-2
+
+Blocks: CO-7
+
+- Route dry-run commands, graph exports, and other build reports through writer-based renderers.
+- Preserve which reports intentionally use stdout versus stderr.
+- Keep planning data independent from CLI output types.
+- Done when Rupes Recta and legacy dry-run output share the Command Result policy without sharing renderer implementation unnecessarily.
+
+### CO-6: Move package-manager presentation to the CLI seam
+
+Blocked by: CO-3, CO-4
+
+- Replace `mooncake` direct result printing with returned report data or writer-based rendering.
+- Pass `UserLog` only to operations whose user-facing events occur during long-running work such as downloads.
+- Migrate add, fetch, tree, work, update, install, and registry notifications in small command-family changes.
+- Done when `mooncake` has no unclassified direct stdout or stderr writes.
+
+### CO-7: Classify build execution output
+
+Blocked by: CO-4, CO-5
+
+Blocks: CO-8
+
+- Separate durable build summaries from Progress Displays and Process Passthrough.
+- Migrate durable summaries to `UserLog` and build reports to writer-based Command Results.
+- Keep child stdout/stderr forwarding byte-preserving and keep concurrent progress behind its own renderer seam.
+- Cover both Rupes Recta and the legacy engine in each applicable behavior test.
+- Done when every executor print site is either migrated or documented as passthrough/progress.
+
+### CO-8: Close the inventory
+
+Blocked by: CO-6, CO-7
+
+- Classify remaining production print macros and direct standard-stream handles.
+- Add a lightweight repository check or documented allowlist only after the categories are stable.
+- Update developer reference documentation with the final ownership rules and remove this migration roadmap.
+- Done when new unclassified MoonBuild-authored output is difficult to introduce accidentally.
+
+## Review and Verification Per Slice
+
+Use the public `moon` process as the primary test seam and assert stdout and stderr separately. Add renderer tests only when formatting logic has meaningful branches that are cheaper to exercise through an injected writer. Every slice should run its focused integration tests, formatting, and the affected crate checks before review; broader workspace verification belongs at milestone boundaries.


### PR DESCRIPTION
## Why

MoonBuild currently mixes command results with user-facing logs, making it difficult to guarantee that durable results stay on stdout while warnings and informational messages stay on stderr. The previous `UserLog` change established log filtering, but commands still need an explicit owner for fallible stdout rendering.

## What changed

- Add a small `CommandOutput` facade that owns a command's `UserLog` and provides locked, fallible stdout rendering.
- Migrate the `moon info` backend-difference report as the first command-result slice.
- Make ANSI styling follow the actual stdout or stderr destination instead of global stdout detection.
- Turn `UserDiagnostics` into a temporary presentation adapter over `UserLog`, with one shared verbosity policy.
- Document the communication vocabulary, accepted design, and incremental migration roadmap.

## Why this is correct and minimal

Command results remain unfiltered on stdout, while user logs are filtered by level on stderr. Lower layers receive only the narrow writer or `UserLog` capability they need. Process passthrough, progress displays, tracing, and unrelated command families remain unchanged; the roadmap splits those migrations into independently reviewable follow-ups.