### PR TITLE
fix(moonx): forward arguments after package

### DIFF
--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -18,7 +18,7 @@
 
 use std::{ffi::OsString, path::PathBuf};
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, ValueEnum};
 
 use crate::user_diagnostics::UserDiagnostics;
 
@@ -36,7 +36,6 @@ pub(crate) enum MoonxTarget {
     name = "moonx",
     about = "Run a package from the Mooncakes registry without installing it",
     override_usage = "moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...",
-    help_template = "{about-with-newline}\n{usage-heading} {usage}\n\nArguments:\n  <PACKAGE>          Registry package coordinate\n  [PROGRAM_ARGS]...  Arguments passed to the program\n\n{all-args}",
     version
 )]
 pub(crate) struct MoonxCli {
@@ -51,14 +50,14 @@ pub(crate) struct MoonxCli {
     #[arg(short = 'v', long)]
     pub verbose: bool,
 
-    #[command(subcommand)]
-    package: MoonxPackage,
-}
-
-#[derive(Debug, Subcommand)]
-enum MoonxPackage {
-    #[command(external_subcommand)]
-    External(Vec<String>),
+    /// Registry package coordinate followed by arguments passed to the program
+    #[arg(
+        value_names = ["PACKAGE", "PROGRAM_ARGS"],
+        required = true,
+        num_args = 1..,
+        trailing_var_arg = true
+    )]
+    pub package_and_args: Vec<String>,
 }
 
 pub(crate) fn is_moonx_invocation(raw_args: &[OsString]) -> bool {
@@ -76,14 +75,13 @@ pub(crate) fn is_moonx_invocation(raw_args: &[OsString]) -> bool {
 
 pub(crate) fn run_from_args(raw_args: &[OsString]) -> i32 {
     let cli = MoonxCli::try_parse_from(raw_args).unwrap_or_else(|err| err.exit());
-    let MoonxPackage::External(package_and_args) = cli.package;
-    let mut package_and_args = package_and_args.into_iter();
-    let package = package_and_args
-        .next()
-        .expect("external subcommand always contains its name");
-    let args = package_and_args.collect::<Vec<_>>();
-    let args = match args.as_slice() {
-        [separator, args @ ..] if separator == "--" => args.to_vec(),
+    let (package, args) = cli
+        .package_and_args
+        .split_first()
+        .expect("package_and_args requires at least one value");
+    // A trailing positional preserves `--`; moonx treats one leading occurrence as a separator.
+    let args = match args {
+        [separator, args @ ..] if separator == "--" => args,
         _ => args,
     };
     // moonx is a transparent runner unless the user explicitly requests details.
@@ -99,7 +97,7 @@ pub(crate) fn run_from_args(raw_args: &[OsString]) -> i32 {
         }
         MoonxTarget::Native => RegistryRunTarget::Native,
     };
-    match registry_runner::run(package, target, args, quiet, cli.verbose) {
+    match registry_runner::run(package.clone(), target, args.to_vec(), quiet, cli.verbose) {
         Ok(code) => code,
         Err(err) => {
             output.error(format!("{:?}", err));
@@ -146,8 +144,7 @@ mod tests {
     fn forwards_help_and_version_flags_after_package() {
         for flag in ["-h", "--help", "-V", "--version"] {
             let cli = MoonxCli::try_parse_from(["moonx", "user/module", flag]).unwrap();
-            let MoonxPackage::External(package_and_args) = cli.package;
-            assert_eq!(package_and_args, ["user/module", flag]);
+            assert_eq!(cli.package_and_args, ["user/module", flag]);
         }
     }
 }

--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -24,17 +24,6 @@ use crate::user_diagnostics::UserDiagnostics;
 
 use super::registry_runner::{self, RegistryRunTarget};
 
-const MOONX_HELP_TEMPLATE: &str = "\
-{about-with-newline}
-{usage-heading} {usage}
-
-Arguments:
-  <PACKAGE>          Registry package coordinate
-  [PROGRAM_ARGS]...  Arguments passed to the program
-
-Options:
-{options}";
-
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
 pub(crate) enum MoonxTarget {
     #[default]
@@ -47,7 +36,6 @@ pub(crate) enum MoonxTarget {
     name = "moonx",
     about = "Run a package from the Mooncakes registry without installing it",
     override_usage = "moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...",
-    help_template = MOONX_HELP_TEMPLATE,
     version
 )]
 pub(crate) struct MoonxCli {

--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -18,7 +18,7 @@
 
 use std::{ffi::OsString, path::PathBuf};
 
-use clap::{Parser, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::user_diagnostics::UserDiagnostics;
 
@@ -62,14 +62,14 @@ pub(crate) struct MoonxCli {
     #[arg(short = 'v', long)]
     pub verbose: bool,
 
-    /// Registry package coordinate followed by arguments passed to the program
-    #[arg(
-        value_names = ["PACKAGE", "PROGRAM_ARGS"],
-        required = true,
-        num_args = 1..,
-        trailing_var_arg = true
-    )]
-    pub package_and_args: Vec<String>,
+    #[command(subcommand)]
+    package: MoonxPackage,
+}
+
+#[derive(Debug, Subcommand)]
+enum MoonxPackage {
+    #[command(external_subcommand)]
+    External(Vec<String>),
 }
 
 pub(crate) fn is_moonx_invocation(raw_args: &[OsString]) -> bool {
@@ -87,11 +87,11 @@ pub(crate) fn is_moonx_invocation(raw_args: &[OsString]) -> bool {
 
 pub(crate) fn run_from_args(raw_args: &[OsString]) -> i32 {
     let cli = MoonxCli::try_parse_from(raw_args).unwrap_or_else(|err| err.exit());
-    let (package, args) = cli
-        .package_and_args
+    let MoonxPackage::External(package_and_args) = cli.package;
+    let (package, args) = package_and_args
         .split_first()
-        .expect("package_and_args requires at least one value");
-    // A trailing positional preserves `--`; moonx treats one leading occurrence as a separator.
+        .expect("external subcommand always contains its name");
+    // External subcommands preserve `--`; moonx treats one leading occurrence as a separator.
     let args = match args {
         [separator, args @ ..] if separator == "--" => args,
         _ => args,
@@ -155,14 +155,18 @@ mod tests {
     #[test]
     fn requires_package() {
         let error = MoonxCli::try_parse_from(["moonx"]).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+        assert_eq!(
+            error.kind(),
+            ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+        );
     }
 
     #[test]
     fn forwards_help_and_version_flags_after_package() {
         for flag in ["-h", "--help", "-V", "--version"] {
             let cli = MoonxCli::try_parse_from(["moonx", "user/module", flag]).unwrap();
-            assert_eq!(cli.package_and_args, ["user/module", flag]);
+            let MoonxPackage::External(package_and_args) = cli.package;
+            assert_eq!(package_and_args, ["user/module", flag]);
         }
     }
 }

--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -24,6 +24,17 @@ use crate::user_diagnostics::UserDiagnostics;
 
 use super::registry_runner::{self, RegistryRunTarget};
 
+const MOONX_HELP_TEMPLATE: &str = "\
+{about-with-newline}
+{usage-heading} {usage}
+
+Arguments:
+  <PACKAGE>          Registry package coordinate
+  [PROGRAM_ARGS]...  Arguments passed to the program
+
+Options:
+{options}";
+
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
 pub(crate) enum MoonxTarget {
     #[default]
@@ -36,6 +47,7 @@ pub(crate) enum MoonxTarget {
     name = "moonx",
     about = "Run a package from the Mooncakes registry without installing it",
     override_usage = "moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...",
+    help_template = MOONX_HELP_TEMPLATE,
     version
 )]
 pub(crate) struct MoonxCli {
@@ -138,6 +150,12 @@ mod tests {
     fn rejects_removed_quiet_option() {
         let error = MoonxCli::try_parse_from(["moonx", "--quiet", "user/module"]).unwrap_err();
         assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn requires_package() {
+        let error = MoonxCli::try_parse_from(["moonx"]).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
     }
 
     #[test]

--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -18,7 +18,7 @@
 
 use std::{ffi::OsString, path::PathBuf};
 
-use clap::{Parser, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::user_diagnostics::UserDiagnostics;
 
@@ -36,13 +36,10 @@ pub(crate) enum MoonxTarget {
     name = "moonx",
     about = "Run a package from the Mooncakes registry without installing it",
     override_usage = "moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...",
+    help_template = "{about-with-newline}\n{usage-heading} {usage}\n\nArguments:\n  <PACKAGE>          Registry package coordinate\n  [PROGRAM_ARGS]...  Arguments passed to the program\n\n{all-args}",
     version
 )]
 pub(crate) struct MoonxCli {
-    /// Registry package coordinate
-    #[arg(value_name = "PACKAGE")]
-    pub package: String,
-
     #[arg(long, value_enum, default_value_t)]
     pub target: MoonxTarget,
 
@@ -54,13 +51,14 @@ pub(crate) struct MoonxCli {
     #[arg(short = 'v', long)]
     pub verbose: bool,
 
-    /// Arguments passed to the program
-    #[arg(
-        value_name = "PROGRAM_ARGS",
-        trailing_var_arg = true,
-        allow_hyphen_values = true
-    )]
-    pub args: Vec<String>,
+    #[command(subcommand)]
+    package: MoonxPackage,
+}
+
+#[derive(Debug, Subcommand)]
+enum MoonxPackage {
+    #[command(external_subcommand)]
+    External(Vec<String>),
 }
 
 pub(crate) fn is_moonx_invocation(raw_args: &[OsString]) -> bool {
@@ -78,6 +76,16 @@ pub(crate) fn is_moonx_invocation(raw_args: &[OsString]) -> bool {
 
 pub(crate) fn run_from_args(raw_args: &[OsString]) -> i32 {
     let cli = MoonxCli::try_parse_from(raw_args).unwrap_or_else(|err| err.exit());
+    let MoonxPackage::External(package_and_args) = cli.package;
+    let mut package_and_args = package_and_args.into_iter();
+    let package = package_and_args
+        .next()
+        .expect("external subcommand always contains its name");
+    let args = package_and_args.collect::<Vec<_>>();
+    let args = match args.as_slice() {
+        [separator, args @ ..] if separator == "--" => args.to_vec(),
+        _ => args,
+    };
     // moonx is a transparent runner unless the user explicitly requests details.
     let quiet = !cli.verbose;
     let output = UserDiagnostics::new(cli.verbose, quiet);
@@ -91,7 +99,7 @@ pub(crate) fn run_from_args(raw_args: &[OsString]) -> i32 {
         }
         MoonxTarget::Native => RegistryRunTarget::Native,
     };
-    match registry_runner::run(cli.package, target, cli.args, quiet, cli.verbose) {
+    match registry_runner::run(package, target, args, quiet, cli.verbose) {
         Ok(code) => code,
         Err(err) => {
             output.error(format!("{:?}", err));
@@ -132,5 +140,14 @@ mod tests {
     fn rejects_removed_quiet_option() {
         let error = MoonxCli::try_parse_from(["moonx", "--quiet", "user/module"]).unwrap_err();
         assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn forwards_help_and_version_flags_after_package() {
+        for flag in ["-h", "--help", "-V", "--version"] {
+            let cli = MoonxCli::try_parse_from(["moonx", "user/module", flag]).unwrap();
+            let MoonxPackage::External(package_and_args) = cli.package;
+            assert_eq!(package_and_args, ["user/module", flag]);
+        }
     }
 }

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -206,17 +206,25 @@ fn test_moonx_runs_cached_wasm_and_forwards_everything_after_the_coordinate() {
         .env("MOONRUN_OVERRIDE", moonrun_bin())
         .args([
             "moonbitlang/parser/cmd/moonfmt@0.3.3",
+            "--help",
             "--arg1",
             "--target",
             "native",
+            "-h",
+            "-V",
+            "--version",
         ])
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
 [..]/registry/cache/assets/moonbitlang/parser/0.3.3/cmd/moonfmt/moonfmt.wasm
+--help
 --arg1
 --target
 native
+-h
+-V
+--version
 
 "#]])
         .stderr_eq("");

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -164,7 +164,8 @@ Run a package from the Mooncakes registry without installing it
 Usage: moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...
 
 Arguments:
-  <PACKAGE> <PROGRAM_ARGS>...  Registry package coordinate followed by arguments passed to the program
+  <PACKAGE>          Registry package coordinate
+  [PROGRAM_ARGS]...  Arguments passed to the program
 
 Options:
       --target <TARGET>             [default: wasm] [possible values: wasm, native]

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -164,8 +164,7 @@ Run a package from the Mooncakes registry without installing it
 Usage: moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...
 
 Arguments:
-  <PACKAGE>          Registry package coordinate
-  [PROGRAM_ARGS]...  Arguments passed to the program
+  <PACKAGE> <PROGRAM_ARGS>...  Registry package coordinate followed by arguments passed to the program
 
 Options:
       --target <TARGET>             [default: wasm] [possible values: wasm, native]

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -163,10 +163,6 @@ Run a package from the Mooncakes registry without installing it
 
 Usage: moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...
 
-Arguments:
-  <PACKAGE>          Registry package coordinate
-  [PROGRAM_ARGS]...  Arguments passed to the program
-
 Options:
       --target <TARGET>             [default: wasm] [possible values: wasm, native]
       --experimental-policy <PATH>  Experimental moonrun policy file; only valid for wasm


### PR DESCRIPTION
## Summary

`moonx` promises that every argument after the package coordinate is forwarded to the delegated program. Clap could still interpret a recognized `moonx` flag when it was the program's first argument, so invocations such as `moonx package --help` displayed the runner's help instead.

Model the package coordinate as an external subcommand. Options before it remain `moonx` options, while the external subcommand name and all following values are captured as the package and opaque program arguments. A leading explicit `--` is still accepted and removed before delegation.

## Why this is correct

Clap's external-subcommand boundary directly represents the point after which `moonx` must stop interpreting arguments. Child help, version, and runner-shaped flags are therefore forwarded even when they are the first delegated argument, while runner options before the package continue to parse normally.

External subcommands are dynamically named and do not produce positional help entries. The generated help therefore uses the accurate `moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...` usage line and Clap's generated option list without adding a misleading argument section. Regression coverage verifies first-position child flags, explicit separators, help output, and that the package remains required.

## Scope

This changes only `moonx` argument parsing and its regression coverage. Registry resolution and execution behavior are unchanged.