### PR TITLE
Share dependency sources for standalone .mbtx runs

### DIFF
--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -633,11 +633,18 @@ fn build_single_file_executable_from_arg(
     options: BuildRunExecutableOptions,
     output: &CommandOutput,
 ) -> anyhow::Result<RunExecutable> {
-    let single_file_dirs = cli.source_tgt_dir.single_file_package_dirs(
-        cmd.package_or_mbt_file
-            .as_deref()
-            .expect("single-file run from arg requires a positional input path"),
-    )?;
+    let input = cmd
+        .package_or_mbt_file
+        .as_deref()
+        .expect("single-file run from arg requires a positional input path");
+    let single_file_dirs = if Path::new(input)
+        .extension()
+        .is_some_and(|extension| extension == "mbtx")
+    {
+        cli.source_tgt_dir.cached_single_file_package_dirs(input)?
+    } else {
+        cli.source_tgt_dir.single_file_package_dirs(input)?
+    };
     build_single_file_executable(
         cli,
         cmd,

--- a/crates/moon/tests/dependency_source_cache.rs
+++ b/crates/moon/tests/dependency_source_cache.rs
@@ -78,12 +78,34 @@ fn cache_registry_package_with_manifest(
     manifest: &str,
     padding_files: usize,
 ) -> PathBuf {
+    cache_registry_package_with_manifest_and_files(
+        moon_home,
+        published_name,
+        manifest,
+        padding_files,
+        &[],
+    )
+}
+
+fn cache_registry_package_with_manifest_and_files(
+    moon_home: &Path,
+    published_name: &str,
+    manifest: &str,
+    padding_files: usize,
+    extra_files: &[(&str, &str)],
+) -> PathBuf {
     let mut archive = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
     for (path, contents) in [
         ("moon.mod.json", manifest.to_string()),
         ("src/moon.pkg.json", "{}".to_string()),
         ("src/lib.mbt", "pub fn answer() -> Int { 42 }\n".to_string()),
     ] {
+        archive
+            .start_file(path, zip::write::FileOptions::default())
+            .unwrap();
+        archive.write_all(contents.as_bytes()).unwrap();
+    }
+    for &(path, contents) in extra_files {
         archive
             .start_file(path, zip::write::FileOptions::default())
             .unwrap();
@@ -377,60 +399,70 @@ fn changed_checksum_for_published_version_is_rejected() {
     )
     .unwrap();
 
-    let output = run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
         .args(["run", script.to_str().unwrap()])
         .assert()
         .failure()
-        .get_output()
-        .stderr
-        .clone();
-    let stderr = String::from_utf8_lossy(&output);
-    assert!(
-        stderr.contains(
-            "registry checksum for `cachetest/shared@1.0.0` changed; published versions are immutable"
-        ),
-        "unexpected stderr:\n{stderr}"
-    );
+        .stderr_eq(snapbox::str![[r#"
+Error: Failed to resolve the module dependency graph
+
+Caused by:
+    0: When preparing cached packages
+    1: registry checksum for `cachetest/shared@1.0.0` changed; published versions are immutable
+
+"#]]);
 }
 
 #[test]
-fn source_mutating_module_hooks_are_rejected() {
-    for (manifest_field, expected) in [
-        (
-            r#""scripts":{"postadd":"command-that-must-not-run"}"#,
-            "declares `scripts.postadd`",
+fn postadd_is_rejected() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package_with_manifest(
+        moon_home.path(),
+        MODULE_NAME,
+        &format!(
+            r#"{{"name":"{MODULE_NAME}","version":"{MODULE_VERSION}","source":"src","scripts":{{"postadd":"command-that-must-not-run"}}}}"#
         ),
-        (
-            r#""--moonbit-unstable-prebuild":"build.js""#,
-            "declares a prebuild configuration script",
-        ),
-    ] {
-        let moon_home = tempfile::tempdir().unwrap();
-        let dependency_cache = tempfile::tempdir().unwrap();
-        let source_dir = tempfile::tempdir().unwrap();
-        cache_registry_package_with_manifest(
-            moon_home.path(),
-            MODULE_NAME,
-            &format!(
-                r#"{{"name":"{MODULE_NAME}","version":"{MODULE_VERSION}","source":"src",{manifest_field}}}"#
-            ),
-            0,
-        );
-        let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+        0,
+    );
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
 
-        let output = run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
-            .args(["run", script.to_str().unwrap()])
-            .assert()
-            .failure()
-            .get_output()
-            .stderr
-            .clone();
-        let stderr = String::from_utf8_lossy(&output);
-        assert!(
-            stderr.contains(expected),
-            "expected {expected:?} in stderr:\n{stderr}"
-        );
-    }
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Failed to resolve the module dependency graph
+
+Caused by:
+    0: When preparing cached packages
+    1: dependency `cachetest/shared@1.0.0` declares `scripts.postadd`, which is not supported by the shared dependency cache
+
+"#]]);
+}
+
+#[test]
+fn module_prebuild_config_runs_with_shared_dependency_source() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package_with_manifest_and_files(
+        moon_home.path(),
+        MODULE_NAME,
+        &format!(
+            r#"{{"name":"{MODULE_NAME}","version":"{MODULE_VERSION}","source":"src","--moonbit-unstable-prebuild":"build.js"}}"#
+        ),
+        0,
+        &[("build.js", "console.log(\"{}\")\n")],
+    );
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout_eq("42\n");
 }
 
 #[test]
@@ -446,10 +478,22 @@ fn published_dependency_source_is_read_only_and_cleanable() {
         .assert()
         .success();
 
-    let source_file = dependency_cache
+    let entry = dependency_cache
         .path()
-        .join("registry/cachetest/shared/1.0.0/source/src/lib.mbt");
-    assert!(source_file.metadata().unwrap().permissions().readonly());
+        .join("registry/cachetest/shared/1.0.0");
+    for path in [
+        entry.clone(),
+        entry.join("checksum"),
+        entry.join("source"),
+        entry.join("source/src/lib.mbt"),
+    ] {
+        assert!(
+            path.metadata().unwrap().permissions().readonly(),
+            "{} is writable",
+            path.display()
+        );
+    }
+    assert!(std::fs::write(entry.join("checksum"), "replacement\n").is_err());
 
     run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
         .args(["clean", "--dep-cache"])
@@ -484,6 +528,50 @@ fn disabled_dependency_cache_uses_file_local_mooncakes() {
             .next()
             .is_none()
     );
+}
+
+#[test]
+#[cfg(unix)]
+fn cached_dependency_source_must_not_be_a_symlink() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package(moon_home.path());
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let entry = dependency_cache
+        .path()
+        .join("registry/cachetest/shared/1.0.0");
+    moonutil::cache::make_cache_tree_writable(&entry).unwrap();
+    let source = entry.join("source");
+    let moved_source = entry.join("moved-source");
+    std::fs::rename(&source, &moved_source).unwrap();
+    std::os::unix::fs::symlink(&moved_source, &source).unwrap();
+    let checksum = entry.join("checksum");
+    let mut checksum_permissions = std::fs::metadata(&checksum).unwrap().permissions();
+    checksum_permissions.set_readonly(true);
+    std::fs::set_permissions(checksum, checksum_permissions).unwrap();
+    let mut entry_permissions = std::fs::metadata(&entry).unwrap().permissions();
+    entry_permissions.set_readonly(true);
+    std::fs::set_permissions(&entry, entry_permissions).unwrap();
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Failed to resolve the module dependency graph
+
+Caused by:
+    0: When preparing cached packages
+    1: prepared dependency source `cachetest/shared@1.0.0` has an invalid source directory
+
+"#]]);
 }
 
 #[test]
@@ -523,16 +611,8 @@ fn concurrent_first_use_publishes_one_complete_source() {
     let first_output = first.wait_with_output().unwrap();
     let second_output = second.wait_with_output().unwrap();
 
-    assert!(
-        first_output.status.success(),
-        "first command failed:\n{}",
-        String::from_utf8_lossy(&first_output.stderr)
-    );
-    assert!(
-        second_output.status.success(),
-        "second command failed:\n{}",
-        String::from_utf8_lossy(&second_output.stderr)
-    );
+    snapbox::cmd::OutputAssert::new(first_output).success();
+    snapbox::cmd::OutputAssert::new(second_output).success();
     assert!(
         dependency_cache
             .path()
@@ -554,20 +634,18 @@ fn archive_manifest_must_match_requested_module() {
     );
     let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
 
-    let output = run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
         .args(["run", script.to_str().unwrap()])
         .assert()
         .failure()
-        .get_output()
-        .stderr
-        .clone();
-    let stderr = String::from_utf8_lossy(&output);
-    assert!(
-        stderr.contains(
-            "registry archive for `cachetest/shared@1.0.0` contains manifest for `cachetest/different@1.0.0`"
-        ),
-        "unexpected stderr:\n{stderr}"
-    );
+        .stderr_eq(snapbox::str![[r#"
+Error: Failed to resolve the module dependency graph
+
+Caused by:
+    0: When preparing cached packages
+    1: registry archive for `cachetest/shared@1.0.0` contains manifest for `cachetest/different@1.0.0`
+
+"#]]);
 
     cache_registry_package(moon_home.path());
     run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())

--- a/crates/moon/tests/dependency_source_cache.rs
+++ b/crates/moon/tests/dependency_source_cache.rs
@@ -294,46 +294,6 @@ fn multi_segment_registry_module_uses_nested_cache_path() {
 }
 
 #[test]
-fn path_safe_registry_module_characters_are_preserved_in_cache() {
-    let moon_home = tempfile::tempdir().unwrap();
-    let dependency_cache = tempfile::tempdir().unwrap();
-    let source_dir = tempfile::tempdir().unwrap();
-    cache_registry_package_with_manifest(
-        moon_home.path(),
-        "user/foo.bar",
-        r#"{"name":"user/foo.bar","version":"1.0.0","source":"src"}"#,
-        0,
-    );
-    cache_registry_package_with_manifest(
-        moon_home.path(),
-        MODULE_NAME,
-        r#"{
-  "name": "cachetest/shared",
-  "version": "1.0.0",
-  "source": "src",
-  "deps": {
-    "user/foo.bar": "1.0.0"
-  }
-}"#,
-        0,
-    );
-    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
-
-    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
-        .args(["run", script.to_str().unwrap()])
-        .assert()
-        .success()
-        .stdout_eq("42\n");
-
-    assert!(
-        dependency_cache
-            .path()
-            .join("registry/user/foo.bar/1.0.0/source/src/lib.mbt")
-            .is_file()
-    );
-}
-
-#[test]
 fn major_version_module_suffixes_coexist_in_nested_cache() {
     let moon_home = tempfile::tempdir().unwrap();
     let dependency_cache = tempfile::tempdir().unwrap();

--- a/crates/moon/tests/dependency_source_cache.rs
+++ b/crates/moon/tests/dependency_source_cache.rs
@@ -447,6 +447,7 @@ fn module_prebuild_config_runs_with_shared_dependency_source() {
     let moon_home = tempfile::tempdir().unwrap();
     let dependency_cache = tempfile::tempdir().unwrap();
     let source_dir = tempfile::tempdir().unwrap();
+    let prebuild_runs = source_dir.path().join("prebuild-runs");
     cache_registry_package_with_manifest_and_files(
         moon_home.path(),
         MODULE_NAME,
@@ -454,15 +455,31 @@ fn module_prebuild_config_runs_with_shared_dependency_source() {
             r#"{{"name":"{MODULE_NAME}","version":"{MODULE_VERSION}","source":"src","--moonbit-unstable-prebuild":"build.js"}}"#
         ),
         0,
-        &[("build.js", "console.log(\"{}\")\n")],
+        &[(
+            "build.js",
+            "require('node:fs').appendFileSync(process.env.MOON_CACHE_TEST_PREBUILD_RUNS, 'run\\n')\nconsole.log('{}')\n",
+        )],
     );
     let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
 
     run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .env("MOON_CACHE_TEST_PREBUILD_RUNS", &prebuild_runs)
         .args(["run", script.to_str().unwrap()])
         .assert()
         .success()
         .stdout_eq("42\n");
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .env("MOON_CACHE_TEST_PREBUILD_RUNS", &prebuild_runs)
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout_eq("42\n");
+
+    assert_eq!(
+        std::fs::read_to_string(prebuild_runs).unwrap(),
+        "run\nrun\n"
+    );
 }
 
 #[test]

--- a/crates/moon/tests/dependency_source_cache.rs
+++ b/crates/moon/tests/dependency_source_cache.rs
@@ -1,0 +1,515 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use sha2::{Digest, Sha256};
+
+const MODULE_NAME: &str = "cachetest/shared";
+const MODULE_VERSION: &str = "1.0.0";
+
+fn moon_bin() -> PathBuf {
+    snapbox::cargo_bin!("moon").to_owned()
+}
+
+fn run_moon(
+    current_dir: &Path,
+    moon_home: &Path,
+    dependency_cache: &Path,
+) -> snapbox::cmd::Command {
+    snapbox::cmd::Command::new(moon_bin())
+        .current_dir(current_dir)
+        .env("MOON_HOME", moon_home)
+        .env("MOON_DEP_CACHE", dependency_cache)
+        .env("MOON_TOOLCHAIN_ROOT", moonutil::toolchain::toolchain_root())
+        .env("MOONCAKES_REGISTRY", "http://127.0.0.1:9")
+        .arg("--quiet")
+}
+
+fn mbtx_source(module: &str) -> String {
+    format!(
+        r#"import {{
+  "{module}@{MODULE_VERSION}",
+}}
+
+fn main {{
+  println(@shared.answer())
+}}
+"#
+    )
+}
+
+fn write_mbtx(directory: &Path, name: &str, module: &str) -> PathBuf {
+    let path = directory.join(name);
+    std::fs::write(&path, mbtx_source(module)).unwrap();
+    path
+}
+
+fn cache_registry_package(moon_home: &Path) -> PathBuf {
+    cache_registry_package_with_manifest(
+        moon_home,
+        MODULE_NAME,
+        &format!(r#"{{"name":"{MODULE_NAME}","version":"{MODULE_VERSION}","source":"src"}}"#),
+        0,
+    )
+}
+
+fn cache_registry_package_with_manifest(
+    moon_home: &Path,
+    published_name: &str,
+    manifest: &str,
+    padding_files: usize,
+) -> PathBuf {
+    let mut archive = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    for (path, contents) in [
+        ("moon.mod.json", manifest.to_string()),
+        ("src/moon.pkg.json", "{}".to_string()),
+        ("src/lib.mbt", "pub fn answer() -> Int { 42 }\n".to_string()),
+    ] {
+        archive
+            .start_file(path, zip::write::FileOptions::default())
+            .unwrap();
+        archive.write_all(contents.as_bytes()).unwrap();
+    }
+    for index in 0..padding_files {
+        archive
+            .start_file(
+                format!("padding/{index}.txt"),
+                zip::write::FileOptions::default(),
+            )
+            .unwrap();
+        archive.write_all(b"padding").unwrap();
+    }
+    let archive = archive.finish().unwrap().into_inner();
+
+    let manifest_json = serde_json::from_str::<serde_json::Value>(manifest).unwrap();
+    let module_version = manifest_json["version"].as_str().unwrap();
+    let (username, unqualified_name) = published_name.split_once('/').unwrap();
+    let archive_path = moon_home
+        .join("registry/cache")
+        .join(username)
+        .join(unqualified_name)
+        .join(format!("{module_version}.zip"));
+    std::fs::create_dir_all(archive_path.parent().unwrap()).unwrap();
+    std::fs::write(&archive_path, &archive).unwrap();
+
+    let mut index_entry = serde_json::json!({
+        "name": published_name,
+        "version": module_version,
+        "checksum": format!("{:x}", Sha256::digest(&archive)),
+    });
+    if let Some(deps) = manifest_json.get("deps") {
+        index_entry["deps"] = deps.clone();
+    }
+    let index_path = moon_home
+        .join("registry/index/user")
+        .join(username)
+        .join(format!("{unqualified_name}.index"));
+    std::fs::create_dir_all(index_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        index_path,
+        format!("{}\n", serde_json::to_string(&index_entry).unwrap()),
+    )
+    .unwrap();
+
+    archive_path
+}
+
+fn registry_index(moon_home: &Path) -> PathBuf {
+    moon_home.join("registry/index/user/cachetest/shared.index")
+}
+
+fn write_project(project: &Path) {
+    std::fs::write(
+        project.join("moon.mod.json"),
+        format!(
+            r#"{{
+  "name": "cachetest/project",
+  "version": "0.0.1",
+  "deps": {{
+    "{MODULE_NAME}": "{MODULE_VERSION}"
+  }},
+  "source": "src"
+}}
+"#
+        ),
+    )
+    .unwrap();
+    let package = project.join("src/main");
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::write(
+        package.join("moon.pkg.json"),
+        format!(r#"{{"import":["{MODULE_NAME}"]}}"#),
+    )
+    .unwrap();
+    std::fs::write(
+        package.join("main.mbt"),
+        "fn use_dependency() -> Int { @shared.answer() }\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn run_mbtx_forms_reuse_prepared_dependency_source() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    let archive = cache_registry_package(moon_home.path());
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+    let source = mbtx_source(MODULE_NAME);
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout_eq("42\n");
+
+    std::fs::remove_file(archive).unwrap();
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", "-e", &source])
+        .assert()
+        .success()
+        .stdout_eq("42\n");
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", "-"])
+        .stdin(source)
+        .assert()
+        .success()
+        .stdout_eq("42\n");
+
+    assert!(!source_dir.path().join(".mooncakes").exists());
+}
+
+#[test]
+fn ordinary_project_commands_keep_project_local_mooncakes() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    cache_registry_package(moon_home.path());
+    write_project(project.path());
+
+    run_moon(project.path(), moon_home.path(), dependency_cache.path())
+        .arg("check")
+        .assert()
+        .success();
+
+    assert!(
+        project
+            .path()
+            .join(".mooncakes/cachetest/shared/moon.mod.json")
+            .is_file()
+    );
+    assert!(
+        std::fs::read_dir(dependency_cache.path())
+            .unwrap()
+            .next()
+            .is_none()
+    );
+}
+
+#[test]
+fn non_run_single_file_commands_keep_file_local_mooncakes() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package(moon_home.path());
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["check", script.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(
+        source_dir
+            .path()
+            .join(".mooncakes/cachetest/shared/moon.mod.json")
+            .is_file()
+    );
+    assert!(
+        std::fs::read_dir(dependency_cache.path())
+            .unwrap()
+            .next()
+            .is_none()
+    );
+}
+
+#[test]
+fn multi_segment_registry_module_uses_nested_cache_path() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package_with_manifest(
+        moon_home.path(),
+        "h/e/l/l/o",
+        r#"{"name":"h/e/l/l/o","version":"1.0.0","source":"src"}"#,
+        0,
+    );
+    cache_registry_package_with_manifest(
+        moon_home.path(),
+        MODULE_NAME,
+        r#"{
+  "name": "cachetest/shared",
+  "version": "1.0.0",
+  "source": "src",
+  "deps": {
+    "h/e/l/l/o": "1.0.0"
+  }
+}"#,
+        0,
+    );
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(
+        dependency_cache
+            .path()
+            .join("registry/h/e/l/l/o/1.0.0/source/src/lib.mbt")
+            .is_file()
+    );
+}
+
+#[test]
+fn changed_checksum_for_published_version_is_rejected() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package(moon_home.path());
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success();
+
+    std::fs::write(
+        registry_index(moon_home.path()),
+        format!(
+            "{{\"name\":\"{MODULE_NAME}\",\"version\":\"{MODULE_VERSION}\",\"checksum\":\"{}\"}}\n",
+            "0".repeat(64)
+        ),
+    )
+    .unwrap();
+
+    let output = run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8_lossy(&output);
+    assert!(
+        stderr.contains(
+            "registry checksum for `cachetest/shared@1.0.0` changed; published versions are immutable"
+        ),
+        "unexpected stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn source_mutating_module_hooks_are_rejected() {
+    for (manifest_field, expected) in [
+        (
+            r#""scripts":{"postadd":"command-that-must-not-run"}"#,
+            "declares `scripts.postadd`",
+        ),
+        (
+            r#""--moonbit-unstable-prebuild":"build.js""#,
+            "declares a prebuild configuration script",
+        ),
+    ] {
+        let moon_home = tempfile::tempdir().unwrap();
+        let dependency_cache = tempfile::tempdir().unwrap();
+        let source_dir = tempfile::tempdir().unwrap();
+        cache_registry_package_with_manifest(
+            moon_home.path(),
+            MODULE_NAME,
+            &format!(
+                r#"{{"name":"{MODULE_NAME}","version":"{MODULE_VERSION}","source":"src",{manifest_field}}}"#
+            ),
+            0,
+        );
+        let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+        let output = run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+            .args(["run", script.to_str().unwrap()])
+            .assert()
+            .failure()
+            .get_output()
+            .stderr
+            .clone();
+        let stderr = String::from_utf8_lossy(&output);
+        assert!(
+            stderr.contains(expected),
+            "expected {expected:?} in stderr:\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn published_dependency_source_is_read_only_and_cleanable() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package(moon_home.path());
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let source_file = dependency_cache
+        .path()
+        .join("registry/cachetest/shared/1.0.0/source/src/lib.mbt");
+    assert!(source_file.metadata().unwrap().permissions().readonly());
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["clean", "--dep-cache"])
+        .assert()
+        .success();
+    assert!(!dependency_cache.path().exists());
+}
+
+#[test]
+fn disabled_dependency_cache_uses_file_local_mooncakes() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package(moon_home.path());
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .env("MOON_DEP_CACHE", "off")
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(
+        source_dir
+            .path()
+            .join(".mooncakes/cachetest/shared/moon.mod.json")
+            .is_file()
+    );
+    assert!(
+        std::fs::read_dir(dependency_cache.path())
+            .unwrap()
+            .next()
+            .is_none()
+    );
+}
+
+#[test]
+fn concurrent_first_use_publishes_one_complete_source() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let first_source = tempfile::tempdir().unwrap();
+    let second_source = tempfile::tempdir().unwrap();
+    cache_registry_package_with_manifest(
+        moon_home.path(),
+        MODULE_NAME,
+        &format!(r#"{{"name":"{MODULE_NAME}","version":"{MODULE_VERSION}","source":"src"}}"#),
+        512,
+    );
+    let first_script = write_mbtx(first_source.path(), "main.mbtx", MODULE_NAME);
+    let second_script = write_mbtx(second_source.path(), "main.mbtx", MODULE_NAME);
+
+    let command = |source_dir: &Path, script: &Path| {
+        let mut command = std::process::Command::new(moon_bin());
+        command
+            .current_dir(source_dir)
+            .env("MOON_HOME", moon_home.path())
+            .env("MOON_DEP_CACHE", dependency_cache.path())
+            .env("MOON_TOOLCHAIN_ROOT", moonutil::toolchain::toolchain_root())
+            .env("MOONCAKES_REGISTRY", "http://127.0.0.1:9")
+            .args(["--quiet", "run"])
+            .arg(script)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        command
+    };
+
+    let first = command(first_source.path(), &first_script).spawn().unwrap();
+    let second = command(second_source.path(), &second_script)
+        .spawn()
+        .unwrap();
+    let first_output = first.wait_with_output().unwrap();
+    let second_output = second.wait_with_output().unwrap();
+
+    assert!(
+        first_output.status.success(),
+        "first command failed:\n{}",
+        String::from_utf8_lossy(&first_output.stderr)
+    );
+    assert!(
+        second_output.status.success(),
+        "second command failed:\n{}",
+        String::from_utf8_lossy(&second_output.stderr)
+    );
+    assert!(
+        dependency_cache
+            .path()
+            .join("registry/cachetest/shared/1.0.0/source/src/lib.mbt")
+            .is_file()
+    );
+}
+
+#[test]
+fn archive_manifest_must_match_requested_module() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package_with_manifest(
+        moon_home.path(),
+        MODULE_NAME,
+        &format!(r#"{{"name":"cachetest/different","version":"{MODULE_VERSION}","source":"src"}}"#),
+        0,
+    );
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+    let output = run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8_lossy(&output);
+    assert!(
+        stderr.contains(
+            "registry archive for `cachetest/shared@1.0.0` contains manifest for `cachetest/different@1.0.0`"
+        ),
+        "unexpected stderr:\n{stderr}"
+    );
+
+    cache_registry_package(moon_home.path());
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success();
+}

--- a/crates/moon/tests/dependency_source_cache.rs
+++ b/crates/moon/tests/dependency_source_cache.rs
@@ -223,6 +223,60 @@ fn run_mbtx_forms_reuse_prepared_dependency_source() {
 }
 
 #[test]
+fn frozen_cache_miss_does_not_initialize_dependency_cache() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let cache_parent = tempfile::tempdir().unwrap();
+    let dependency_cache = cache_parent.path().join("missing");
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package(moon_home.path());
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+    run_moon(source_dir.path(), moon_home.path(), &dependency_cache)
+        .args(["run", script.to_str().unwrap(), "--frozen"])
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Failed to resolve the module dependency graph
+
+Caused by:
+    0: When preparing cached packages
+    1: Failed to sync dependencies: `frozen` is set, so the build system cannot prepare `cachetest/shared@1.0.0` in the dependency cache
+
+"#]]);
+
+    assert!(!dependency_cache.exists());
+}
+
+#[test]
+fn frozen_cache_hit_does_not_touch_dependency_lock() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package(moon_home.path());
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout_eq("42\n");
+
+    let lock = dependency_cache
+        .path()
+        .join("registry/cachetest/shared")
+        .join(moonutil::constants::MOON_LOCK);
+    std::fs::write(&lock, "unchanged").unwrap();
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap(), "--frozen"])
+        .assert()
+        .success()
+        .stdout_eq("42\n");
+
+    assert_eq!(std::fs::read_to_string(lock).unwrap(), "unchanged");
+}
+
+#[test]
 fn ordinary_project_commands_keep_project_local_mooncakes() {
     let moon_home = tempfile::tempdir().unwrap();
     let dependency_cache = tempfile::tempdir().unwrap();

--- a/crates/moon/tests/dependency_source_cache.rs
+++ b/crates/moon/tests/dependency_source_cache.rs
@@ -294,6 +294,108 @@ fn multi_segment_registry_module_uses_nested_cache_path() {
 }
 
 #[test]
+fn path_safe_registry_module_characters_are_preserved_in_cache() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    cache_registry_package_with_manifest(
+        moon_home.path(),
+        "user/foo.bar",
+        r#"{"name":"user/foo.bar","version":"1.0.0","source":"src"}"#,
+        0,
+    );
+    cache_registry_package_with_manifest(
+        moon_home.path(),
+        MODULE_NAME,
+        r#"{
+  "name": "cachetest/shared",
+  "version": "1.0.0",
+  "source": "src",
+  "deps": {
+    "user/foo.bar": "1.0.0"
+  }
+}"#,
+        0,
+    );
+    let script = write_mbtx(source_dir.path(), "main.mbtx", MODULE_NAME);
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout_eq("42\n");
+
+    assert!(
+        dependency_cache
+            .path()
+            .join("registry/user/foo.bar/1.0.0/source/src/lib.mbt")
+            .is_file()
+    );
+}
+
+#[test]
+fn major_version_module_suffixes_coexist_in_nested_cache() {
+    let moon_home = tempfile::tempdir().unwrap();
+    let dependency_cache = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    let modules = [("a/b", "1.0.0"), ("a/b/v2", "2.0.0"), ("a/b/v3", "3.0.0")];
+    for &(name, version) in &modules[1..] {
+        cache_registry_package_with_manifest(
+            moon_home.path(),
+            name,
+            &format!(r#"{{"name":"{name}","version":"{version}","source":"src"}}"#),
+            0,
+        );
+    }
+    cache_registry_package_with_manifest(
+        moon_home.path(),
+        "a/b",
+        r#"{
+  "name": "a/b",
+  "version": "1.0.0",
+  "source": "src",
+  "deps": {
+    "a/b/v2": "2.0.0",
+    "a/b/v3": "3.0.0"
+  }
+}"#,
+        0,
+    );
+    let script = source_dir.path().join("main.mbtx");
+    std::fs::write(
+        &script,
+        r#"import {
+  "a/b@1.0.0",
+}
+
+fn main {
+  println(@b.answer())
+}
+"#,
+    )
+    .unwrap();
+
+    run_moon(source_dir.path(), moon_home.path(), dependency_cache.path())
+        .args(["run", script.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout_eq("42\n");
+
+    for (name, version) in modules {
+        assert!(
+            dependency_cache
+                .path()
+                .join("registry")
+                .join(name)
+                .join(version)
+                .join("source/src/lib.mbt")
+                .is_file(),
+            "missing cached source for {name}@{version}"
+        );
+    }
+}
+
+#[test]
 fn changed_checksum_for_published_version_is_rejected() {
     let moon_home = tempfile::tempdir().unwrap();
     let dependency_cache = tempfile::tempdir().unwrap();

--- a/crates/moon/tests/test_cases/clean/mod.rs
+++ b/crates/moon/tests/test_cases/clean/mod.rs
@@ -201,3 +201,29 @@ fn test_clean_refuses_symlinked_cache_root() {
         "must survive"
     );
 }
+
+#[test]
+#[cfg(unix)]
+fn test_clean_removes_descendant_symlink_without_following_it() {
+    let dir = TestDir::new_empty();
+    let cache = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+    let outside_file = outside.path().join("must-survive");
+    std::fs::write(cache.path().join(".moon-cache"), "dependency-sources\n").unwrap();
+    std::fs::write(&outside_file, "outside cache").unwrap();
+    std::os::unix::fs::symlink(outside.path(), cache.path().join("outside-link")).unwrap();
+
+    moon_cmd(&dir)
+        .env("MOON_DEP_CACHE", cache.path())
+        .args(["clean", "--dep-cache"])
+        .assert()
+        .success()
+        .stdout_eq("")
+        .stderr_eq("");
+
+    assert!(!cache.path().exists());
+    assert_eq!(
+        std::fs::read_to_string(outside_file).unwrap(),
+        "outside cache"
+    );
+}

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -58,15 +58,25 @@ fn test_single_file_front_matter_import_module_root() {
 #[test]
 fn test_single_file_mbtx_run() {
     let dir = TestDir::new("moon_test_single_file.in");
-    let stdout = get_stdout(&dir, ["run", "import_ok.mbtx"]);
-    assert!(stdout.contains("hello"));
+    let dependency_cache = tempfile::tempdir().unwrap();
+    moon_cmd(&dir)
+        .env("MOON_DEP_CACHE", dependency_cache.path())
+        .args(["run", "import_ok.mbtx"])
+        .assert()
+        .success()
+        .stdout_eq("hello\n");
 }
 
 #[test]
 fn test_single_file_mbtx_run_block_import() {
     let dir = TestDir::new("moon_test_single_file.in");
-    let stdout = get_stdout(&dir, ["run", "import_block_ok.mbtx"]);
-    assert!(stdout.contains("hello"));
+    let dependency_cache = tempfile::tempdir().unwrap();
+    moon_cmd(&dir)
+        .env("MOON_DEP_CACHE", dependency_cache.path())
+        .args(["run", "import_block_ok.mbtx"])
+        .assert()
+        .success()
+        .stdout_eq("hello\n");
 }
 
 #[test]

--- a/crates/mooncake/src/dep_dir.rs
+++ b/crates/mooncake/src/dep_dir.rs
@@ -26,7 +26,7 @@ use std::{
 use anyhow::Context;
 use arcstr::ArcStr;
 use moonutil::{
-    cache::{CacheKind, initialize_cache_root},
+    cache::{CacheKind, initialize_cache_root, validate_cache_root},
     constants::MOONBITLANG_CORE,
     locks::FileLock,
     resolution::{DirSyncResult, ModuleSource, ModuleSourceKind, ResolvedEnv},
@@ -329,7 +329,11 @@ pub(crate) fn prepare_cached_deps(
         .all_modules()
         .any(|module| matches!(module.source(), ModuleSourceKind::Registry));
     if has_registry_module {
-        initialize_cache_root(CacheKind::DependencySources, cache_root)?;
+        if frozen {
+            validate_cache_root(CacheKind::DependencySources, cache_root)?;
+        } else {
+            initialize_cache_root(CacheKind::DependencySources, cache_root)?;
+        }
     }
 
     let mut result = DirSyncResult::default();
@@ -359,8 +363,12 @@ fn prepare_cached_dep(
         .join("registry")
         .join(name.username.as_str())
         .join(name.unqual.as_str());
-    std::fs::create_dir_all(&module_root)?;
-    let _lock = FileLock::lock_with_verbosity(&module_root, verbose)?;
+    let _lock = if frozen {
+        None
+    } else {
+        std::fs::create_dir_all(&module_root)?;
+        Some(FileLock::lock_with_verbosity(&module_root, verbose)?)
+    };
 
     let entry = module_root.join(version.to_string());
     let source = entry.join(PREPARED_SOURCE_DIR);

--- a/crates/mooncake/src/dep_dir.rs
+++ b/crates/mooncake/src/dep_dir.rs
@@ -26,6 +26,7 @@ use std::{
 use anyhow::Context;
 use arcstr::ArcStr;
 use moonutil::{
+    cache::{CacheKind, initialize_cache_root},
     constants::MOONBITLANG_CORE,
     locks::FileLock,
     resolution::{DirSyncResult, ModuleSource, ModuleSourceKind, ResolvedEnv},
@@ -34,6 +35,9 @@ use moonutil::{
 use semver::Version;
 
 use crate::registry::Registry;
+
+const PREPARED_SOURCE_CHECKSUM: &str = "checksum";
+const PREPARED_SOURCE_DIR: &str = "source";
 
 type DepDirState = HashMap<ArcStr, HashMap<ArcStr, Option<Version>>>;
 type NewDepDirState<'a> = HashMap<ArcStr, HashMap<ArcStr, &'a ModuleSource>>;
@@ -274,7 +278,7 @@ pub(crate) fn sync_deps(
     Ok(())
 }
 
-fn pkg_to_dir(dep_dir: &DepDir, username: &str, pkgname: &str) -> PathBuf {
+pub(crate) fn pkg_to_dir(dep_dir: &DepDir, username: &str, pkgname: &str) -> PathBuf {
     // Special case: core library locates in ~/.moon
     if format!("{username}/{pkgname}") == MOONBITLANG_CORE {
         return toolchain::core();
@@ -308,6 +312,127 @@ pub(crate) fn resolve_dep_dirs(dep_dir: &DepDir, pkg_list: &ResolvedEnv) -> DirS
         res.insert(id, map_source_to_dir(dep_dir, module));
     }
     res
+}
+
+pub(crate) fn prepare_cached_deps(
+    cache_root: &Path,
+    registry: &dyn Registry,
+    pkg_list: &ResolvedEnv,
+    quiet: bool,
+    frozen: bool,
+    verbose: bool,
+) -> anyhow::Result<DirSyncResult> {
+    let has_registry_module = pkg_list
+        .all_modules()
+        .any(|module| matches!(module.source(), ModuleSourceKind::Registry));
+    if has_registry_module {
+        initialize_cache_root(CacheKind::DependencySources, cache_root)?;
+    }
+
+    let mut result = DirSyncResult::default();
+    for (id, module) in pkg_list.all_modules_and_id() {
+        let path = match module.source() {
+            ModuleSourceKind::Registry => {
+                prepare_cached_dep(cache_root, registry, module, quiet, frozen, verbose)?
+            }
+            ModuleSourceKind::Local(path) => path.clone(),
+            ModuleSourceKind::Git(url) => {
+                todo!("Git dependency is not yet supported. Got git url: {}", url)
+            }
+            ModuleSourceKind::Stdlib(path) => path.clone(),
+            ModuleSourceKind::SingleFile(path) => path.clone(),
+        };
+        result.insert(id, path);
+    }
+    Ok(result)
+}
+
+fn prepare_cached_dep(
+    cache_root: &Path,
+    registry: &dyn Registry,
+    module: &ModuleSource,
+    quiet: bool,
+    frozen: bool,
+    verbose: bool,
+) -> anyhow::Result<PathBuf> {
+    let name = module.name();
+    let version = module.version();
+    crate::registry::path::validate_module_name(name)?;
+    let expected_checksum = registry.checksum_of(name, version)?;
+    let module_root = cache_root
+        .join("registry")
+        .join(name.username.as_str())
+        .join(name.unqual.as_str());
+    std::fs::create_dir_all(&module_root)?;
+    let _lock = FileLock::lock_with_verbosity(&module_root, verbose)?;
+
+    let entry = module_root.join(version.to_string());
+    let source = entry.join(PREPARED_SOURCE_DIR);
+    if entry.exists() {
+        let published_checksum = std::fs::read_to_string(entry.join(PREPARED_SOURCE_CHECKSUM))
+            .with_context(|| {
+                format!(
+                    "prepared dependency source `{name}@{version}` is missing checksum metadata"
+                )
+            })?;
+        // A registry version is one immutable identity. A changed checksum is
+        // registry corruption, not a new cache variant to publish.
+        if published_checksum.trim() != expected_checksum {
+            anyhow::bail!(
+                "registry checksum for `{name}@{version}` changed; published versions are immutable"
+            );
+        }
+        return Ok(source);
+    }
+
+    if frozen {
+        anyhow::bail!(
+            "Failed to sync dependencies: `frozen` is set, so the build system cannot prepare `{name}@{version}` in the dependency cache"
+        );
+    }
+
+    let staging = tempfile::TempDir::new_in(&module_root)?;
+    let staging_source = staging.path().join(PREPARED_SOURCE_DIR);
+    registry.extract_to_verified(name, version, &expected_checksum, &staging_source, quiet)?;
+    let manifest = moonutil::manifest::read_module_desc_file_in_dir(&staging_source)?;
+    if manifest.name != name.to_string() || manifest.version.as_ref() != Some(version) {
+        anyhow::bail!(
+            "registry archive for `{name}@{version}` contains manifest for `{}@{}`",
+            manifest.name,
+            manifest
+                .version
+                .as_ref()
+                .map_or_else(|| "<missing>".to_string(), ToString::to_string)
+        );
+    }
+    if manifest
+        .scripts
+        .as_ref()
+        .is_some_and(|scripts| scripts.contains_key("postadd"))
+    {
+        anyhow::bail!(
+            "dependency `{name}@{version}` declares `scripts.postadd`, which is not supported by the shared dependency cache"
+        );
+    }
+    if manifest.__moonbit_unstable_prebuild.is_some() {
+        anyhow::bail!(
+            "dependency `{name}@{version}` declares a prebuild configuration script, which is not supported by the shared dependency cache"
+        );
+    }
+    std::fs::write(
+        staging.path().join(PREPARED_SOURCE_CHECKSUM),
+        format!("{expected_checksum}\n"),
+    )?;
+    moonutil::cache::make_cache_tree_readonly(&staging_source)?;
+    // The lock makes the version path single-writer; renaming makes it
+    // impossible for readers to observe a partially extracted source.
+    if let Err(error) = std::fs::rename(staging.path(), &entry) {
+        // TempDir cleanup needs write permission if publication fails.
+        moonutil::cache::make_cache_tree_writable(&staging_source)?;
+        return Err(error.into());
+    }
+
+    Ok(source)
 }
 
 #[cfg(test)]

--- a/crates/mooncake/src/dep_dir.rs
+++ b/crates/mooncake/src/dep_dir.rs
@@ -278,7 +278,7 @@ pub(crate) fn sync_deps(
     Ok(())
 }
 
-pub(crate) fn pkg_to_dir(dep_dir: &DepDir, username: &str, pkgname: &str) -> PathBuf {
+fn pkg_to_dir(dep_dir: &DepDir, username: &str, pkgname: &str) -> PathBuf {
     // Special case: core library locates in ~/.moon
     if format!("{username}/{pkgname}") == MOONBITLANG_CORE {
         return toolchain::core();
@@ -289,16 +289,19 @@ pub(crate) fn pkg_to_dir(dep_dir: &DepDir, username: &str, pkgname: &str) -> Pat
 
 /// The result of a directory sync.
 fn map_source_to_dir(dep_dir: &DepDir, module: &ModuleSource) -> PathBuf {
+    non_registry_source_dir(module)
+        .unwrap_or_else(|| pkg_to_dir(dep_dir, &module.name().username, &module.name().unqual))
+}
+
+fn non_registry_source_dir(module: &ModuleSource) -> Option<PathBuf> {
     match module.source() {
-        ModuleSourceKind::Registry => {
-            pkg_to_dir(dep_dir, &module.name().username, &module.name().unqual)
-        }
-        ModuleSourceKind::Local(path) => path.clone(),
+        ModuleSourceKind::Registry => None,
+        ModuleSourceKind::Local(path) => Some(path.clone()),
         ModuleSourceKind::Git(url) => {
             todo!("Git dependency is not yet supported. Got git url: {}", url)
         }
-        ModuleSourceKind::Stdlib(path) => path.clone(),
-        ModuleSourceKind::SingleFile(path) => path.clone(),
+        ModuleSourceKind::Stdlib(path) => Some(path.clone()),
+        ModuleSourceKind::SingleFile(path) => Some(path.clone()),
     }
 }
 
@@ -331,16 +334,9 @@ pub(crate) fn prepare_cached_deps(
 
     let mut result = DirSyncResult::default();
     for (id, module) in pkg_list.all_modules_and_id() {
-        let path = match module.source() {
-            ModuleSourceKind::Registry => {
-                prepare_cached_dep(cache_root, registry, module, quiet, frozen, verbose)?
-            }
-            ModuleSourceKind::Local(path) => path.clone(),
-            ModuleSourceKind::Git(url) => {
-                todo!("Git dependency is not yet supported. Got git url: {}", url)
-            }
-            ModuleSourceKind::Stdlib(path) => path.clone(),
-            ModuleSourceKind::SingleFile(path) => path.clone(),
+        let path = match non_registry_source_dir(module) {
+            Some(path) => path,
+            None => prepare_cached_dep(cache_root, registry, module, quiet, frozen, verbose)?,
         };
         result.insert(id, path);
     }

--- a/crates/mooncake/src/dep_dir.rs
+++ b/crates/mooncake/src/dep_dir.rs
@@ -368,21 +368,51 @@ fn prepare_cached_dep(
 
     let entry = module_root.join(version.to_string());
     let source = entry.join(PREPARED_SOURCE_DIR);
-    if entry.exists() {
-        let published_checksum = std::fs::read_to_string(entry.join(PREPARED_SOURCE_CHECKSUM))
-            .with_context(|| {
-                format!(
-                    "prepared dependency source `{name}@{version}` is missing checksum metadata"
-                )
-            })?;
-        // A registry version is one immutable identity. A changed checksum is
-        // registry corruption, not a new cache variant to publish.
-        if published_checksum.trim() != expected_checksum {
-            anyhow::bail!(
-                "registry checksum for `{name}@{version}` changed; published versions are immutable"
-            );
+    match std::fs::symlink_metadata(&entry) {
+        Ok(entry_metadata) => {
+            if !entry_metadata.is_dir() || !entry_metadata.permissions().readonly() {
+                anyhow::bail!(
+                    "prepared dependency source `{name}@{version}` has an invalid entry directory"
+                );
+            }
+            let checksum_path = entry.join(PREPARED_SOURCE_CHECKSUM);
+            let Ok(checksum_metadata) = std::fs::symlink_metadata(&checksum_path) else {
+                anyhow::bail!(
+                    "prepared dependency source `{name}@{version}` has invalid checksum metadata"
+                );
+            };
+            if !checksum_metadata.is_file() || !checksum_metadata.permissions().readonly() {
+                anyhow::bail!(
+                    "prepared dependency source `{name}@{version}` has invalid checksum metadata"
+                );
+            }
+            let Ok(source_metadata) = std::fs::symlink_metadata(&source) else {
+                anyhow::bail!(
+                    "prepared dependency source `{name}@{version}` has an invalid source directory"
+                );
+            };
+            if !source_metadata.is_dir() || !source_metadata.permissions().readonly() {
+                anyhow::bail!(
+                    "prepared dependency source `{name}@{version}` has an invalid source directory"
+                );
+            }
+            let published_checksum =
+                std::fs::read_to_string(&checksum_path).with_context(|| {
+                    format!(
+                        "prepared dependency source `{name}@{version}` is missing checksum metadata"
+                    )
+                })?;
+            // A registry version is one immutable identity. A changed checksum is
+            // registry corruption, not a new cache variant to publish.
+            if published_checksum.trim() != expected_checksum {
+                anyhow::bail!(
+                    "registry checksum for `{name}@{version}` changed; published versions are immutable"
+                );
+            }
+            return Ok(source);
         }
-        return Ok(source);
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
     }
 
     if frozen {
@@ -414,22 +444,19 @@ fn prepare_cached_dep(
             "dependency `{name}@{version}` declares `scripts.postadd`, which is not supported by the shared dependency cache"
         );
     }
-    if manifest.__moonbit_unstable_prebuild.is_some() {
-        anyhow::bail!(
-            "dependency `{name}@{version}` declares a prebuild configuration script, which is not supported by the shared dependency cache"
-        );
-    }
     std::fs::write(
         staging.path().join(PREPARED_SOURCE_CHECKSUM),
         format!("{expected_checksum}\n"),
     )?;
-    moonutil::cache::make_cache_tree_readonly(&staging_source)?;
-    // The lock makes the version path single-writer; renaming makes it
-    // impossible for readers to observe a partially extracted source.
-    if let Err(error) = std::fs::rename(staging.path(), &entry) {
-        // TempDir cleanup needs write permission if publication fails.
-        moonutil::cache::make_cache_tree_writable(&staging_source)?;
-        return Err(error.into());
+    // The lock keeps readers out until the atomically renamed entry is fully
+    // read-only. Some platforms do not allow renaming a read-only directory.
+    std::fs::rename(staging.path(), &entry)?;
+    if let Err(error) = moonutil::cache::make_cache_tree_readonly(&entry) {
+        // Do not leave a visible entry that a later cache hit could accept as
+        // a complete publication.
+        let _ = moonutil::cache::make_cache_tree_writable(&entry);
+        let _ = std::fs::remove_dir_all(&entry);
+        return Err(error);
     }
 
     Ok(source)

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -17,7 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::{
-    dep_dir::resolve_dep_dirs,
+    dep_dir::{prepare_cached_deps, resolve_dep_dirs},
     registry,
     resolver::{ResolveConfig, resolve_with_default_env_and_resolver},
 };
@@ -26,7 +26,7 @@ use super::sync::SyncOutputOptions;
 use anyhow::Context;
 use moonutil::{
     constants::MOONBITLANG_CORE,
-    project::PackageDirs,
+    project::{DependencySource, PackageDirs},
     resolution::{
         DependencyKind, DirSyncResult, ModuleSourceKind, ResolvedEnv, ResolvedRootModules,
     },
@@ -108,19 +108,30 @@ pub(crate) fn install_impl(
     };
 
     let res = resolve_with_default_env_and_resolver(&resolve_config, roots)?;
-    let dep_dir = crate::dep_dir::DepDir::new(dirs.mooncakes_dir.clone());
-
-    crate::dep_dir::sync_deps(
-        &dep_dir,
-        resolve_config.registry.as_ref(),
-        &res,
-        output_options.quiet(),
-        dont_sync,
-        output_options.verbose(),
-    )
-    .context("When installing packages")?;
-
-    let dir_sync_result = resolve_dep_dirs(&dep_dir, &res);
+    let dir_sync_result = match &dirs.dependency_source {
+        DependencySource::ProjectLocal => {
+            let dep_dir = crate::dep_dir::DepDir::new(dirs.mooncakes_dir.clone());
+            crate::dep_dir::sync_deps(
+                &dep_dir,
+                resolve_config.registry.as_ref(),
+                &res,
+                output_options.quiet(),
+                dont_sync,
+                output_options.verbose(),
+            )
+            .context("When installing packages")?;
+            resolve_dep_dirs(&dep_dir, &res)
+        }
+        DependencySource::SharedCache(cache_root) => prepare_cached_deps(
+            cache_root,
+            resolve_config.registry.as_ref(),
+            &res,
+            output_options.quiet(),
+            dont_sync,
+            output_options.verbose(),
+        )
+        .context("When preparing cached packages")?,
+    };
 
     install_bin_deps(
         verbose,

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -28,8 +28,8 @@ use moonutil::{
     front_matter::MbtMdHeader,
     manifest::{MoonMod, read_module_desc_file_in_dir},
     project::{
-        MoonWork, PackageDirs, ProjectManifest, WorkspaceEnv, canonical_workspace_module_dirs,
-        read_workspace_file,
+        DependencySource, MoonWork, PackageDirs, ProjectManifest, WorkspaceEnv,
+        canonical_workspace_module_dirs, read_workspace_file,
     },
     resolution::{DirSyncResult, ModuleSource, ResolvedEnv, ResolvedModule, ResolvedRootModules},
 };
@@ -169,6 +169,7 @@ pub fn auto_sync_for_single_mbt_md(
         target_dir: moonbuild_opt.target_dir.clone(),
         mooncake_bin_dir: mooncake_bin_dir.to_path_buf(),
         mooncakes_dir: mooncakes_dir.to_path_buf(),
+        dependency_source: DependencySource::ProjectLocal,
         project_manifest: ProjectManifest::None,
     };
 

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -32,6 +32,7 @@ use semver::Version;
 #[derive(Debug, Clone, Default)]
 pub struct RegistryVersionInfo {
     pub deps: IndexMap<String, SourceDependencyInfo>,
+    pub checksum: Option<String>,
 }
 
 pub trait Registry {
@@ -77,6 +78,22 @@ pub trait Registry {
         to: &Path,
         quiet: bool,
     ) -> anyhow::Result<()>;
+
+    fn extract_to_verified(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        checksum: &str,
+        to: &Path,
+        quiet: bool,
+    ) -> anyhow::Result<()>;
+
+    fn checksum_of(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {
+        self.all_versions_of(name)?
+            .get(version)
+            .and_then(|info| info.checksum.clone())
+            .ok_or_else(|| anyhow::anyhow!("No checksum found for {name}@{version}"))
+    }
 }
 
 impl<R> Registry for &mut R
@@ -98,6 +115,21 @@ where
         quiet: bool,
     ) -> anyhow::Result<()> {
         (**self).install_to(name, version, to, quiet)
+    }
+
+    fn extract_to_verified(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        checksum: &str,
+        to: &Path,
+        quiet: bool,
+    ) -> anyhow::Result<()> {
+        (**self).extract_to_verified(name, version, checksum, to, quiet)
+    }
+
+    fn checksum_of(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {
+        (**self).checksum_of(name, version)
     }
 
     fn get_latest_version(&self, name: &ModuleName) -> Option<Version> {
@@ -128,6 +160,21 @@ where
         quiet: bool,
     ) -> anyhow::Result<()> {
         (**self).install_to(name, version, to, quiet)
+    }
+
+    fn extract_to_verified(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        checksum: &str,
+        to: &Path,
+        quiet: bool,
+    ) -> anyhow::Result<()> {
+        (**self).extract_to_verified(name, version, checksum, to, quiet)
+    }
+
+    fn checksum_of(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {
+        (**self).checksum_of(name, version)
     }
 
     fn get_latest_version(&self, name: &ModuleName) -> Option<Version> {

--- a/crates/mooncake/src/registry/mock.rs
+++ b/crates/mooncake/src/registry/mock.rs
@@ -161,6 +161,7 @@ impl Registry for MockRegistry {
                             version.clone(),
                             RegistryVersionInfo {
                                 deps: module.deps.clone(),
+                                checksum: None,
                             },
                         )
                     })
@@ -178,6 +179,17 @@ impl Registry for MockRegistry {
         _quiet: bool,
     ) -> anyhow::Result<()> {
         panic!("Mock registry does not support installing")
+    }
+
+    fn extract_to_verified(
+        &self,
+        _name: &ModuleName,
+        _version: &Version,
+        _checksum: &str,
+        _to: &std::path::Path,
+        _quiet: bool,
+    ) -> anyhow::Result<()> {
+        panic!("Mock registry does not support extracting")
     }
 }
 

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -108,6 +108,7 @@ impl super::Registry for OnlineRegistry {
                     Version::parse(v)?,
                     RegistryVersionInfo {
                         deps: entry.deps.unwrap_or_default(),
+                        checksum: entry.checksum,
                     },
                 );
             }
@@ -131,6 +132,17 @@ impl super::Registry for OnlineRegistry {
     ) -> anyhow::Result<()> {
         self.install_to_impl(name, version, to, quiet)
     }
+
+    fn extract_to_verified(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        checksum: &str,
+        to: &Path,
+        quiet: bool,
+    ) -> anyhow::Result<()> {
+        self.extract_to_with_checksum(name, version, checksum, to, true, quiet)
+    }
 }
 
 fn calc_sha2(p: &Path) -> anyhow::Result<String> {
@@ -153,6 +165,21 @@ fn calc_sha2(p: &Path) -> anyhow::Result<String> {
     // read hash digest and consume hasher
     let result = hasher.finalize();
     Ok(format!("{result:x}"))
+}
+
+fn verify_archive_checksum(
+    name: &ModuleName,
+    version: &Version,
+    expected: &str,
+    data: &[u8],
+) -> anyhow::Result<()> {
+    use sha2::{Digest, Sha256};
+
+    let actual = format!("{:x}", Sha256::digest(data));
+    if actual != expected {
+        bail!("checksum mismatch for {name}@{version}: expected {expected}, downloaded {actual}");
+    }
+    Ok(())
 }
 
 impl OnlineRegistry {
@@ -192,6 +219,8 @@ impl OnlineRegistry {
         &self,
         name: &ModuleName,
         version: &Version,
+        checksum: &str,
+        verify_download: bool,
         quiet: bool,
     ) -> anyhow::Result<bytes::Bytes> {
         let pkg_index = self.index_file_of(name);
@@ -201,7 +230,6 @@ impl OnlineRegistry {
         let cache_file = cache_of(name, version);
         let mut checksum_ok = false;
         if cache_file.exists() {
-            let checksum = self.read_checksum_from_index_file(name, version)?;
             let current_checksum = calc_sha2(&cache_file);
             if current_checksum.is_ok() && current_checksum.unwrap() == checksum {
                 checksum_ok = true;
@@ -231,6 +259,9 @@ impl OnlineRegistry {
             .send()?
             .error_for_status()?
             .bytes()?;
+        if verify_download {
+            verify_archive_checksum(name, version, checksum, &data)?;
+        }
         std::fs::create_dir_all(cache_file.parent().unwrap())?;
         std::fs::write(cache_file, &data)?;
         Ok(data)
@@ -256,6 +287,19 @@ impl OnlineRegistry {
         pkg_install_dir: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
+        let checksum = self.read_checksum_from_index_file(name, version)?;
+        self.extract_to_with_checksum(name, version, &checksum, pkg_install_dir, false, quiet)
+    }
+
+    fn extract_to_with_checksum(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        checksum: &str,
+        pkg_install_dir: &Path,
+        verify_download: bool,
+        quiet: bool,
+    ) -> anyhow::Result<()> {
         // ensure dir exists and is empty
         if !pkg_install_dir.exists() {
             std::fs::create_dir_all(pkg_install_dir).unwrap();
@@ -264,7 +308,7 @@ impl OnlineRegistry {
             std::fs::create_dir_all(pkg_install_dir).unwrap();
         }
 
-        let data = self.download_or_using_cache(name, version, quiet)?;
+        let data = self.download_or_using_cache(name, version, checksum, verify_download, quiet)?;
         extract_zip_to_dir(pkg_install_dir, data)?;
         Ok(())
     }
@@ -361,5 +405,20 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(index);
+    }
+
+    #[test]
+    fn downloaded_archive_must_match_registry_checksum() {
+        let name = ModuleName {
+            username: "example".into(),
+            unqual: "package".into(),
+        };
+        let version = Version::parse("1.2.3").unwrap();
+        let error = verify_archive_checksum(&name, &version, &"0".repeat(64), b"archive")
+            .expect_err("mismatched archive should be rejected");
+
+        assert!(error.to_string().starts_with(
+            "checksum mismatch for example/package@1.2.3: expected 0000000000000000000000000000000000000000000000000000000000000000, downloaded "
+        ));
     }
 }

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -141,7 +141,10 @@ impl super::Registry for OnlineRegistry {
         to: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
-        self.extract_to_with_checksum(name, version, checksum, to, true, quiet)
+        self.prepare_install_dir(to)?;
+        let data = self.download_or_using_cache_verified(name, version, checksum, quiet)?;
+        extract_zip_to_dir(to, data)?;
+        Ok(())
     }
 }
 
@@ -183,64 +186,68 @@ fn verify_archive_checksum(
 }
 
 impl OnlineRegistry {
-    fn read_checksum_from_index_file(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-    ) -> anyhow::Result<String> {
-        let p = self.index_file_of(name);
-        let file = std::fs::File::open(&p)?;
-        let reader = std::io::BufReader::new(file);
-
-        let lines = reader.lines().collect::<std::io::Result<Vec<String>>>()?;
-        let version_str = version.to_string();
-        for line in lines.iter().rev() {
-            let entry = serde_json_lenient::from_str::<RegistryIndexEntry>(line)?;
-            if entry.version.as_deref() == Some(version_str.as_str()) {
-                if let Some(checksum) = entry.checksum {
-                    return Ok(checksum);
-                } else {
-                    bail!(
-                        "No checksum found for version {} in index file {:?}",
-                        version,
-                        p
-                    );
-                }
-            }
-        }
-        bail!(
-            "No description found for version {} in index file {:?}",
-            version,
-            p,
-        );
-    }
-
     fn download_or_using_cache(
         &self,
         name: &ModuleName,
         version: &Version,
-        checksum: &str,
-        verify_download: bool,
         quiet: bool,
     ) -> anyhow::Result<bytes::Bytes> {
-        let pkg_index = self.index_file_of(name);
-        if !pkg_index.exists() {
-            anyhow::bail!("Module {}@{} not found", name, version);
-        }
         let cache_file = cache_of(name, version);
-        let mut checksum_ok = false;
         if cache_file.exists() {
-            let current_checksum = calc_sha2(&cache_file);
-            if current_checksum.is_ok() && current_checksum.unwrap() == checksum {
-                checksum_ok = true;
+            let checksum = super::Registry::checksum_of(self, name, version)?;
+            if let Some(data) = self.cached_archive_matching(name, version, &checksum, quiet)? {
+                return Ok(data);
             }
         }
-        if checksum_ok {
-            if !quiet {
-                eprintln!("Using cached {name}@{version}");
-            }
-            let data = std::fs::read(cache_file)?;
-            return Ok(bytes::Bytes::from(data));
+        let data = self.download_archive(name, version, quiet)?;
+        std::fs::create_dir_all(cache_file.parent().unwrap())?;
+        std::fs::write(cache_file, &data)?;
+        Ok(data)
+    }
+
+    fn download_or_using_cache_verified(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        checksum: &str,
+        quiet: bool,
+    ) -> anyhow::Result<bytes::Bytes> {
+        if let Some(data) = self.cached_archive_matching(name, version, checksum, quiet)? {
+            return Ok(data);
+        }
+        let data = self.download_archive(name, version, quiet)?;
+        verify_archive_checksum(name, version, checksum, &data)?;
+        let cache_file = cache_of(name, version);
+        std::fs::create_dir_all(cache_file.parent().unwrap())?;
+        std::fs::write(cache_file, &data)?;
+        Ok(data)
+    }
+
+    fn cached_archive_matching(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        checksum: &str,
+        quiet: bool,
+    ) -> anyhow::Result<Option<bytes::Bytes>> {
+        let cache_file = cache_of(name, version);
+        if !cache_file.exists() || !calc_sha2(&cache_file).is_ok_and(|actual| actual == checksum) {
+            return Ok(None);
+        }
+        if !quiet {
+            eprintln!("Using cached {name}@{version}");
+        }
+        Ok(Some(bytes::Bytes::from(std::fs::read(cache_file)?)))
+    }
+
+    fn download_archive(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        quiet: bool,
+    ) -> anyhow::Result<bytes::Bytes> {
+        if !self.index_file_of(name).exists() {
+            anyhow::bail!("Module {}@{} not found", name, version);
         }
         if !quiet {
             eprintln!("Downloading {name}@{version}");
@@ -259,11 +266,6 @@ impl OnlineRegistry {
             .send()?
             .error_for_status()?
             .bytes()?;
-        if verify_download {
-            verify_archive_checksum(name, version, checksum, &data)?;
-        }
-        std::fs::create_dir_all(cache_file.parent().unwrap())?;
-        std::fs::write(cache_file, &data)?;
         Ok(data)
     }
 
@@ -287,29 +289,17 @@ impl OnlineRegistry {
         pkg_install_dir: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
-        let checksum = self.read_checksum_from_index_file(name, version)?;
-        self.extract_to_with_checksum(name, version, &checksum, pkg_install_dir, false, quiet)
+        self.prepare_install_dir(pkg_install_dir)?;
+        let data = self.download_or_using_cache(name, version, quiet)?;
+        extract_zip_to_dir(pkg_install_dir, data)?;
+        Ok(())
     }
 
-    fn extract_to_with_checksum(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        checksum: &str,
-        pkg_install_dir: &Path,
-        verify_download: bool,
-        quiet: bool,
-    ) -> anyhow::Result<()> {
-        // ensure dir exists and is empty
-        if !pkg_install_dir.exists() {
-            std::fs::create_dir_all(pkg_install_dir).unwrap();
-        } else {
-            std::fs::remove_dir_all(pkg_install_dir).unwrap();
-            std::fs::create_dir_all(pkg_install_dir).unwrap();
+    fn prepare_install_dir(&self, pkg_install_dir: &Path) -> anyhow::Result<()> {
+        if pkg_install_dir.exists() {
+            std::fs::remove_dir_all(pkg_install_dir)?;
         }
-
-        let data = self.download_or_using_cache(name, version, checksum, verify_download, quiet)?;
-        extract_zip_to_dir(pkg_install_dir, data)?;
+        std::fs::create_dir_all(pkg_install_dir)?;
         Ok(())
     }
 }
@@ -392,16 +382,10 @@ mod tests {
         let version = Version::parse("0.2.1").unwrap();
         assert!(versions.contains_key(&version));
         assert_eq!(
-            registry
-                .read_checksum_from_index_file(
-                    &ModuleName {
-                        username: "bobzhang".into(),
-                        unqual: "openseek".into(),
-                    },
-                    &version,
-                )
-                .unwrap(),
-            "abc123"
+            versions
+                .get(&version)
+                .and_then(|info| info.checksum.as_deref()),
+            Some("abc123")
         );
 
         let _ = std::fs::remove_dir_all(index);

--- a/crates/mooncake/src/registry/path.rs
+++ b/crates/mooncake/src/registry/path.rs
@@ -68,6 +68,29 @@ fn parse_path_components(path: &str) -> anyhow::Result<Vec<&str>> {
     Ok(components)
 }
 
+pub(crate) fn validate_module_name(module: &ModuleName) -> anyhow::Result<()> {
+    let username_components = parse_path_components(&module.username)?;
+    if username_components.len() != 1
+        || !username_components.iter().all(|component| {
+            component
+                .chars()
+                .all(|character| character.is_alphanumeric() || matches!(character, '_' | '-'))
+        })
+    {
+        anyhow::bail!("registry module `{module}` has an invalid username");
+    }
+    let name_components = parse_path_components(&module.unqual)
+        .map_err(|_| anyhow::anyhow!("registry module `{module}` has an invalid name"))?;
+    if !name_components.iter().all(|component| {
+        component
+            .chars()
+            .all(|character| character.is_alphanumeric() || matches!(character, '_' | '-'))
+    }) {
+        anyhow::bail!("registry module `{module}` has an invalid name");
+    }
+    Ok(())
+}
+
 /// Parse `user/module[/package]` using the install/runwasm interpretation.
 ///
 /// The first two segments are always the module, and later segments are the
@@ -225,8 +248,9 @@ pub fn resolve_unversioned_registry_path(
 mod tests {
     use super::{
         parse_install_style_path, parse_module_at_version_path, parse_package_at_version_path,
-        resolve_unversioned_registry_path,
+        resolve_unversioned_registry_path, validate_module_name,
     };
+    use moonutil::resolution::ModuleName;
 
     #[test]
     fn parse_module_at_version_path_supports_package_suffix() {
@@ -267,6 +291,43 @@ mod tests {
         }
         assert!(parse_module_at_version_path(r"user/module@1.2.3/a\..\..\evil").is_err());
         assert!(parse_package_at_version_path(r"user/module/a\..\..\evil@1.2.3").is_err());
+    }
+
+    #[test]
+    fn cache_module_names_reject_unsafe_path_components() {
+        for module in [
+            ModuleName {
+                username: "..".into(),
+                unqual: "module".into(),
+            },
+            ModuleName {
+                username: "user".into(),
+                unqual: "../module".into(),
+            },
+            ModuleName {
+                username: "user".into(),
+                unqual: "module//package".into(),
+            },
+            ModuleName {
+                username: "user".into(),
+                unqual: "module.name".into(),
+            },
+            ModuleName {
+                username: r"C:\cache".into(),
+                unqual: "module".into(),
+            },
+        ] {
+            assert!(validate_module_name(&module).is_err(), "accepted {module}");
+        }
+    }
+
+    #[test]
+    fn cache_module_names_allow_multiple_name_components() {
+        let module = ModuleName {
+            username: "h".into(),
+            unqual: "e/l/l/o".into(),
+        };
+        validate_module_name(&module).unwrap();
     }
 
     #[test]

--- a/crates/mooncake/src/registry/path.rs
+++ b/crates/mooncake/src/registry/path.rs
@@ -70,24 +70,13 @@ fn parse_path_components(path: &str) -> anyhow::Result<Vec<&str>> {
 
 pub(crate) fn validate_module_name(module: &ModuleName) -> anyhow::Result<()> {
     let username_components = parse_path_components(&module.username)?;
-    if username_components.len() != 1
-        || !username_components.iter().all(|component| {
-            component
-                .chars()
-                .all(|character| character.is_alphanumeric() || matches!(character, '_' | '-'))
-        })
-    {
+    if username_components.len() != 1 {
         anyhow::bail!("registry module `{module}` has an invalid username");
     }
-    let name_components = parse_path_components(&module.unqual)
+    // Cache paths must preserve the registry's existing module-name grammar.
+    // Validate path safety here without imposing an additional character set.
+    parse_path_components(&module.unqual)
         .map_err(|_| anyhow::anyhow!("registry module `{module}` has an invalid name"))?;
-    if !name_components.iter().all(|component| {
-        component
-            .chars()
-            .all(|character| character.is_alphanumeric() || matches!(character, '_' | '-'))
-    }) {
-        anyhow::bail!("registry module `{module}` has an invalid name");
-    }
     Ok(())
 }
 
@@ -309,10 +298,6 @@ mod tests {
                 unqual: "module//package".into(),
             },
             ModuleName {
-                username: "user".into(),
-                unqual: "module.name".into(),
-            },
-            ModuleName {
                 username: r"C:\cache".into(),
                 unqual: "module".into(),
             },
@@ -322,12 +307,14 @@ mod tests {
     }
 
     #[test]
-    fn cache_module_names_allow_multiple_name_components() {
-        let module = ModuleName {
-            username: "h".into(),
-            unqual: "e/l/l/o".into(),
-        };
-        validate_module_name(&module).unwrap();
+    fn cache_module_names_allow_path_safe_name_components() {
+        for name in ["e/l/l/o", "foo.bar"] {
+            let module = ModuleName {
+                username: "h".into(),
+                unqual: name.into(),
+            };
+            validate_module_name(&module).unwrap();
+        }
     }
 
     #[test]

--- a/crates/mooncake/src/registry/path.rs
+++ b/crates/mooncake/src/registry/path.rs
@@ -71,21 +71,18 @@ fn parse_path_components(path: &str) -> anyhow::Result<Vec<&str>> {
 pub(crate) fn validate_module_name(module: &ModuleName) -> anyhow::Result<()> {
     let username_components = parse_path_components(&module.username)?;
     if username_components.len() != 1
-        || !username_components.iter().all(|component| {
-            component
-                .chars()
-                .all(|character| character.is_alphanumeric() || matches!(character, '_' | '-'))
-        })
+        || username_components
+            .iter()
+            .any(|component| component.contains('.'))
     {
         anyhow::bail!("registry module `{module}` has an invalid username");
     }
     let name_components = parse_path_components(&module.unqual)
         .map_err(|_| anyhow::anyhow!("registry module `{module}` has an invalid name"))?;
-    if !name_components.iter().all(|component| {
-        component
-            .chars()
-            .all(|character| character.is_alphanumeric() || matches!(character, '_' | '-'))
-    }) {
+    if name_components
+        .iter()
+        .any(|component| component.contains('.'))
+    {
         anyhow::bail!("registry module `{module}` has an invalid name");
     }
     Ok(())

--- a/crates/mooncake/src/registry/path.rs
+++ b/crates/mooncake/src/registry/path.rs
@@ -70,13 +70,24 @@ fn parse_path_components(path: &str) -> anyhow::Result<Vec<&str>> {
 
 pub(crate) fn validate_module_name(module: &ModuleName) -> anyhow::Result<()> {
     let username_components = parse_path_components(&module.username)?;
-    if username_components.len() != 1 {
+    if username_components.len() != 1
+        || !username_components.iter().all(|component| {
+            component
+                .chars()
+                .all(|character| character.is_alphanumeric() || matches!(character, '_' | '-'))
+        })
+    {
         anyhow::bail!("registry module `{module}` has an invalid username");
     }
-    // Cache paths must preserve the registry's existing module-name grammar.
-    // Validate path safety here without imposing an additional character set.
-    parse_path_components(&module.unqual)
+    let name_components = parse_path_components(&module.unqual)
         .map_err(|_| anyhow::anyhow!("registry module `{module}` has an invalid name"))?;
+    if !name_components.iter().all(|component| {
+        component
+            .chars()
+            .all(|character| character.is_alphanumeric() || matches!(character, '_' | '-'))
+    }) {
+        anyhow::bail!("registry module `{module}` has an invalid name");
+    }
     Ok(())
 }
 
@@ -298,6 +309,10 @@ mod tests {
                 unqual: "module//package".into(),
             },
             ModuleName {
+                username: "user".into(),
+                unqual: "module.name".into(),
+            },
+            ModuleName {
                 username: r"C:\cache".into(),
                 unqual: "module".into(),
             },
@@ -307,14 +322,12 @@ mod tests {
     }
 
     #[test]
-    fn cache_module_names_allow_path_safe_name_components() {
-        for name in ["e/l/l/o", "foo.bar"] {
-            let module = ModuleName {
-                username: "h".into(),
-                unqual: name.into(),
-            };
-            validate_module_name(&module).unwrap();
-        }
+    fn cache_module_names_allow_multiple_name_components() {
+        let module = ModuleName {
+            username: "h".into(),
+            unqual: "e/l/l/o".into(),
+        };
+        validate_module_name(&module).unwrap();
     }
 
     #[test]

--- a/crates/moonutil/Cargo.toml
+++ b/crates/moonutil/Cargo.toml
@@ -54,6 +54,7 @@ slotmap.workspace = true
 shlex.workspace = true
 logos = "0.15.1"
 globset = "0.4"
+tempfile.workspace = true
 
 [target."cfg(unix)".dependencies]
 libc.workspace = true
@@ -63,7 +64,6 @@ find-msvc-tools.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true
-tempfile.workspace = true
 
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }

--- a/crates/moonutil/src/cache.rs
+++ b/crates/moonutil/src/cache.rs
@@ -81,7 +81,14 @@ pub fn resolve_cache_root(kind: CacheKind) -> anyhow::Result<CacheRoot> {
     }
 }
 
-pub fn initialize_cache_root(kind: CacheKind, root: &Path) -> anyhow::Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CacheRootState {
+    Missing,
+    Empty,
+    Initialized,
+}
+
+fn cache_root_state(kind: CacheKind, root: &Path) -> anyhow::Result<CacheRootState> {
     match std::fs::symlink_metadata(root) {
         Ok(metadata) if metadata.file_type().is_symlink() => {
             bail!(
@@ -94,69 +101,98 @@ pub fn initialize_cache_root(kind: CacheKind, root: &Path) -> anyhow::Result<()>
         }
         Ok(_) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            std::fs::create_dir_all(root).with_context(|| {
-                format!("failed to create Moon cache root `{}`", root.display())
-            })?;
+            return Ok(CacheRootState::Missing);
         }
         Err(error) => return Err(error.into()),
     }
 
     let marker = root.join(OWNERSHIP_MARKER);
     match std::fs::read(&marker) {
-        Ok(contents) if contents == kind.ownership() => Ok(()),
+        Ok(contents) if contents == kind.ownership() => Ok(CacheRootState::Initialized),
         Ok(_) => bail!(
             "Moon cache root `{}` has the wrong ownership",
             root.display()
         ),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            if std::fs::read_dir(root)?.next().transpose()?.is_some() {
-                // Another initializer may have published the marker after our
-                // first read. Accept that completed initialization.
-                return match std::fs::read(&marker) {
-                    Ok(contents) if contents == kind.ownership() => Ok(()),
-                    Ok(_) => bail!(
-                        "Moon cache root `{}` has the wrong ownership",
-                        root.display()
-                    ),
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                        bail!(
-                            "refusing to use unrecognized Moon cache root `{}`",
-                            root.display()
-                        )
-                    }
-                    Err(error) => Err(error.into()),
-                };
+            if std::fs::read_dir(root)?.next().transpose()?.is_none() {
+                return Ok(CacheRootState::Empty);
             }
-            let parent = root.parent().with_context(|| {
-                format!(
-                    "Moon cache root `{}` has no parent directory",
+
+            // Another initializer may have published the marker after our
+            // first read. Accept that completed initialization.
+            match std::fs::read(&marker) {
+                Ok(contents) if contents == kind.ownership() => Ok(CacheRootState::Initialized),
+                Ok(_) => bail!(
+                    "Moon cache root `{}` has the wrong ownership",
                     root.display()
-                )
-            })?;
-            // Stage outside the root so another initializer never mistakes our
-            // temporary marker for user-owned contents.
-            let mut staged = tempfile::NamedTempFile::new_in(parent)?;
-            {
-                use std::io::Write;
-                staged.write_all(kind.ownership())?;
-                staged.as_file().sync_all()?;
-            }
-            match staged.persist_noclobber(&marker) {
-                Ok(_) => Ok(()),
-                Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
-                    if std::fs::read(marker)? == kind.ownership() {
-                        Ok(())
-                    } else {
-                        bail!(
-                            "Moon cache root `{}` has the wrong ownership",
-                            root.display()
-                        )
-                    }
+                ),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    bail!(
+                        "refusing to use unrecognized Moon cache root `{}`",
+                        root.display()
+                    )
                 }
-                Err(error) => Err(error.error.into()),
+                Err(error) => Err(error.into()),
             }
         }
         Err(error) => Err(error.into()),
+    }
+}
+
+/// Validate an existing cache root without creating it or its ownership marker.
+pub fn validate_cache_root(kind: CacheKind, root: &Path) -> anyhow::Result<()> {
+    cache_root_state(kind, root).map(|_| ())
+}
+
+pub fn initialize_cache_root(kind: CacheKind, root: &Path) -> anyhow::Result<()> {
+    let state = match cache_root_state(kind, root)? {
+        CacheRootState::Missing => {
+            std::fs::create_dir_all(root).with_context(|| {
+                format!("failed to create Moon cache root `{}`", root.display())
+            })?;
+            cache_root_state(kind, root)?
+        }
+        state => state,
+    };
+    match state {
+        CacheRootState::Initialized => return Ok(()),
+        CacheRootState::Empty => {}
+        CacheRootState::Missing => {
+            bail!(
+                "Moon cache root `{}` disappeared during initialization",
+                root.display()
+            )
+        }
+    }
+
+    let marker = root.join(OWNERSHIP_MARKER);
+    let parent = root.parent().with_context(|| {
+        format!(
+            "Moon cache root `{}` has no parent directory",
+            root.display()
+        )
+    })?;
+    // Stage outside the root so another initializer never mistakes our
+    // temporary marker for user-owned contents.
+    let mut staged = tempfile::NamedTempFile::new_in(parent)?;
+    {
+        use std::io::Write;
+        staged.write_all(kind.ownership())?;
+        staged.as_file().sync_all()?;
+    }
+    match staged.persist_noclobber(&marker) {
+        Ok(_) => Ok(()),
+        Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+            if std::fs::read(marker)? == kind.ownership() {
+                Ok(())
+            } else {
+                bail!(
+                    "Moon cache root `{}` has the wrong ownership",
+                    root.display()
+                )
+            }
+        }
+        Err(error) => Err(error.error.into()),
     }
 }
 

--- a/crates/moonutil/src/cache.rs
+++ b/crates/moonutil/src/cache.rs
@@ -159,10 +159,14 @@ pub fn make_cache_tree_writable(root: &Path) -> anyhow::Result<()> {
 fn set_cache_tree_readonly(root: &Path, readonly: bool) -> anyhow::Result<()> {
     let metadata = std::fs::symlink_metadata(root)?;
     if metadata.file_type().is_symlink() {
-        bail!(
-            "refusing to change permissions through cache symlink `{}`",
-            root.display()
-        );
+        if readonly {
+            bail!(
+                "refusing to change permissions through cache symlink `{}`",
+                root.display()
+            );
+        }
+        // A cache clean removes this directory entry without following it.
+        return Ok(());
     }
     if metadata.is_dir() {
         for entry in std::fs::read_dir(root)? {

--- a/crates/moonutil/src/cache.rs
+++ b/crates/moonutil/src/cache.rs
@@ -110,10 +110,22 @@ pub fn initialize_cache_root(kind: CacheKind, root: &Path) -> anyhow::Result<()>
         ),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             if std::fs::read_dir(root)?.next().transpose()?.is_some() {
-                bail!(
-                    "refusing to use unrecognized Moon cache root `{}`",
-                    root.display()
-                );
+                // Another initializer may have published the marker after our
+                // first read. Accept that completed initialization.
+                return match std::fs::read(&marker) {
+                    Ok(contents) if contents == kind.ownership() => Ok(()),
+                    Ok(_) => bail!(
+                        "Moon cache root `{}` has the wrong ownership",
+                        root.display()
+                    ),
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        bail!(
+                            "refusing to use unrecognized Moon cache root `{}`",
+                            root.display()
+                        )
+                    }
+                    Err(error) => Err(error.into()),
+                };
             }
             let parent = root.parent().with_context(|| {
                 format!(

--- a/crates/moonutil/src/cache.rs
+++ b/crates/moonutil/src/cache.rs
@@ -21,9 +21,9 @@
 //! Cache contents are intentionally opaque here. Source and artifact stores
 //! may choose their own representations without changing the CLI contract.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use anyhow::bail;
+use anyhow::{Context, bail};
 
 const OWNERSHIP_MARKER: &str = ".moon-cache";
 
@@ -81,6 +81,115 @@ pub fn resolve_cache_root(kind: CacheKind) -> anyhow::Result<CacheRoot> {
     }
 }
 
+pub fn initialize_cache_root(kind: CacheKind, root: &Path) -> anyhow::Result<()> {
+    match std::fs::symlink_metadata(root) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            bail!(
+                "refusing to use symlinked Moon cache root `{}`",
+                root.display()
+            );
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            bail!("Moon cache root `{}` is not a directory", root.display());
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(root).with_context(|| {
+                format!("failed to create Moon cache root `{}`", root.display())
+            })?;
+        }
+        Err(error) => return Err(error.into()),
+    }
+
+    let marker = root.join(OWNERSHIP_MARKER);
+    match std::fs::read(&marker) {
+        Ok(contents) if contents == kind.ownership() => Ok(()),
+        Ok(_) => bail!(
+            "Moon cache root `{}` has the wrong ownership",
+            root.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if std::fs::read_dir(root)?.next().transpose()?.is_some() {
+                bail!(
+                    "refusing to use unrecognized Moon cache root `{}`",
+                    root.display()
+                );
+            }
+            let parent = root.parent().with_context(|| {
+                format!(
+                    "Moon cache root `{}` has no parent directory",
+                    root.display()
+                )
+            })?;
+            // Stage outside the root so another initializer never mistakes our
+            // temporary marker for user-owned contents.
+            let mut staged = tempfile::NamedTempFile::new_in(parent)?;
+            {
+                use std::io::Write;
+                staged.write_all(kind.ownership())?;
+                staged.as_file().sync_all()?;
+            }
+            match staged.persist_noclobber(&marker) {
+                Ok(_) => Ok(()),
+                Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    if std::fs::read(marker)? == kind.ownership() {
+                        Ok(())
+                    } else {
+                        bail!(
+                            "Moon cache root `{}` has the wrong ownership",
+                            root.display()
+                        )
+                    }
+                }
+                Err(error) => Err(error.error.into()),
+            }
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub fn make_cache_tree_readonly(root: &Path) -> anyhow::Result<()> {
+    set_cache_tree_readonly(root, true)
+}
+
+pub fn make_cache_tree_writable(root: &Path) -> anyhow::Result<()> {
+    set_cache_tree_readonly(root, false)
+}
+
+fn set_cache_tree_readonly(root: &Path, readonly: bool) -> anyhow::Result<()> {
+    let metadata = std::fs::symlink_metadata(root)?;
+    if metadata.file_type().is_symlink() {
+        bail!(
+            "refusing to change permissions through cache symlink `{}`",
+            root.display()
+        );
+    }
+    if metadata.is_dir() {
+        for entry in std::fs::read_dir(root)? {
+            set_cache_tree_readonly(&entry?.path(), readonly)?;
+        }
+    }
+
+    let mut permissions = metadata.permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = permissions.mode();
+        let mode = if readonly {
+            mode & !0o222
+        } else if metadata.is_dir() {
+            mode | 0o700
+        } else {
+            mode | 0o200
+        };
+        permissions.set_mode(mode);
+    }
+    #[cfg(not(unix))]
+    permissions.set_readonly(readonly);
+    std::fs::set_permissions(root, permissions)?;
+    Ok(())
+}
+
 pub fn clean_cache(kind: CacheKind) -> anyhow::Result<()> {
     let CacheRoot::Path(root) = resolve_cache_root(kind)? else {
         return Ok(());
@@ -106,6 +215,7 @@ pub fn clean_cache(kind: CacheKind) -> anyhow::Result<()> {
             Ok(contents) if contents == kind.ownership()
         )
     {
+        set_cache_tree_readonly(&root, false)?;
         std::fs::remove_dir_all(root)?;
         return Ok(());
     }

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -114,6 +114,7 @@ impl SourceTargetDirs {
             target_dir,
             mooncake_bin_dir,
             mooncakes_dir,
+            dependency_source: DependencySource::ProjectLocal,
             project_manifest: ProjectManifest::None,
         })
     }
@@ -156,6 +157,24 @@ impl SourceTargetDirs {
             file_path,
             package_dirs,
         })
+    }
+
+    /// Resolve a standalone file with registry sources prepared in the shared
+    /// dependency cache. `MOON_DEP_CACHE=off` preserves the project-local
+    /// `.mooncakes` layout.
+    pub fn cached_single_file_package_dirs(
+        &self,
+        file_path: impl AsRef<Path>,
+    ) -> Result<SingleFilePackageDirs, PackageDirsError> {
+        let mut dirs = self.single_file_package_dirs(file_path)?;
+        dirs.package_dirs.dependency_source =
+            match crate::cache::resolve_cache_root(crate::cache::CacheKind::DependencySources)
+                .map_err(PackageDirsError::from)?
+            {
+                crate::cache::CacheRoot::Disabled => DependencySource::ProjectLocal,
+                crate::cache::CacheRoot::Path(root) => DependencySource::SharedCache(root),
+            };
+        Ok(dirs)
     }
 
     pub fn work_root(
@@ -208,6 +227,16 @@ pub enum ProjectManifest {
     Workspace(PathBuf),
 }
 
+/// Where registry dependency sources are prepared for this operation.
+///
+/// This is resolved together with the other package directories so dependency
+/// sync does not rediscover cache policy from process state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DependencySource {
+    ProjectLocal,
+    SharedCache(PathBuf),
+}
+
 /// Authoritative directories resolved at the start of a project operation.
 ///
 /// Command setup and nested project handoffs construct this once. Downstream
@@ -217,6 +246,7 @@ pub struct PackageDirs {
     pub target_dir: PathBuf,
     pub mooncake_bin_dir: PathBuf,
     pub mooncakes_dir: PathBuf,
+    pub dependency_source: DependencySource,
     pub project_manifest: ProjectManifest,
 }
 
@@ -461,6 +491,7 @@ impl ProjectQuery {
             target_dir,
             mooncake_bin_dir,
             mooncakes_dir,
+            dependency_source: DependencySource::ProjectLocal,
             project_manifest: ProjectManifest::from(&project),
         })
     }
@@ -807,8 +838,9 @@ fn manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::{
-        PackageDirsError, ProjectContext, ProjectProbe, SourceTargetDirs, WorkspaceEnv,
-        parse_workspace_env, project_query_from_start_dir, resolve_project_context_from_start_dir,
+        DependencySource, PackageDirsError, ProjectContext, ProjectProbe, SourceTargetDirs,
+        WorkspaceEnv, parse_workspace_env, project_query_from_start_dir,
+        resolve_project_context_from_start_dir,
     };
     use crate::constants::{DEP_PATH, MOON_BIN_DIR, MOON_MOD, MOON_MOD_JSON};
     use std::{
@@ -863,6 +895,7 @@ mod tests {
         .source_root_package_dirs(project.path())
         .unwrap();
         assert_eq!(dirs.mooncakes_dir, canonical(project.path()).join(DEP_PATH));
+        assert_eq!(dirs.dependency_source, DependencySource::ProjectLocal);
         assert_eq!(
             dirs.mooncake_bin_dir,
             canonical(project.path().join("tmp-target")).join(MOON_BIN_DIR)

--- a/crates/moonutil/src/project.rs
+++ b/crates/moonutil/src/project.rs
@@ -22,9 +22,9 @@
 //! module or workspace before building, resolving dependencies, or packaging.
 
 pub use crate::dirs::{
-    ModuleRef, PackageDirs, PackageDirsError, ProjectContext, ProjectManifest, ProjectNotFound,
-    ProjectProbe, ProjectQuery, SingleFilePackageDirs, SourceModulePackageDirs, SourceTargetDirs,
-    WorkRootSelection, WorkspaceEnv, WorkspaceRef, current_workspace_env,
+    DependencySource, ModuleRef, PackageDirs, PackageDirsError, ProjectContext, ProjectManifest,
+    ProjectNotFound, ProjectProbe, ProjectQuery, SingleFilePackageDirs, SourceModulePackageDirs,
+    SourceTargetDirs, WorkRootSelection, WorkspaceEnv, WorkspaceRef, current_workspace_env,
 };
 pub use crate::workspace::{
     MoonWork, canonical_workspace_module_dirs, format_workspace_file, read_workspace,

--- a/docs/dev/design/global-build-cache.md
+++ b/docs/dev/design/global-build-cache.md
@@ -47,13 +47,15 @@ A prepared registry source is identified by its resolved `module@version`.
 The registry checksum is immutable metadata for that identity, not another
 component that permits multiple source variants. On first use, Moon verifies
 the downloaded archive against the registry checksum, extracts into staging,
-marks the prepared source tree read-only, and publishes it atomically.
-Concurrent publishers of the same identity must be harmless.
+renames the complete entry while holding the module lock, and marks the entry,
+including its checksum metadata and source tree, read-only before releasing
+the lock. Concurrent publishers of the same identity must be harmless.
 
 On a cache hit, Moon compares the current registry checksum with the checksum
-recorded at publication. A mismatch is an error: published registry versions
-are immutable, so Moon must not replace the source or create a second
-checksum-keyed variant for the same `module@version`.
+recorded at publication after validating the entry's expected shape and
+read-only state. A mismatch is an error: published registry versions are
+immutable, so Moon must not replace the source or create a second checksum-keyed
+variant for the same `module@version`.
 
 The first rollout is limited to standalone `.mbtx` execution: `moon run -e`,
 `moon run -`, and `moon run <file>.mbtx` resolve registry dependencies from
@@ -197,10 +199,12 @@ rather than execute the hook, silently skip it, or fall back to a mutable local
 installation. A sandboxed, explicitly keyed hook model would require a
 separate design.
 
-Top-level module prebuild configuration is also rejected because it executes
-during build preparation and can write relative to the dependency source.
-Package-level prebuild commands and source generators are skipped for registry
-dependencies; published archives must already contain their generated outputs.
+Top-level module prebuild configuration remains a build-time operation. It runs
+for each invocation against the prepared read-only source, and its structured
+output affects that invocation's build plan rather than the dependency-source
+cache. Package-level prebuild commands and source generators are skipped for
+registry dependencies; published archives must already contain their generated
+outputs.
 
 `__moonbin__` belongs in the invocation's mutable work directory, initially
 under `_build`. If its producer later becomes cacheable, its outputs may be

--- a/docs/dev/design/global-build-cache.md
+++ b/docs/dev/design/global-build-cache.md
@@ -3,13 +3,11 @@
 ## Status
 
 This document records the intended direction for global dependency and build
-caches. Only the cache-root configuration and cleaning contract described
-below is implemented today. Builds do not yet read from or write to either
-global cache.
-
-The first implementation step is intentionally small. It gives later work a
-stable public configuration and lifecycle seam without committing Moon to an
-internal cache layout too early.
+caches. The cache-root contract, explicit cleaning, and globally prepared
+registry dependency sources for `moon run -e`, `moon run -`, and
+`moon run <file>.mbtx` are implemented today. Other commands retain
+project-local `.mooncakes`, and compiler artifacts do not yet use the global
+build cache.
 
 ## Problem
 
@@ -43,6 +41,27 @@ and cleanup rules, so they use separate caches. An artifact is reusable only
 when all compiler-observable inputs have the same identity. Directory names
 are for storage organization, not correctness.
 
+### Prepared dependency source identity
+
+A prepared registry source is identified by its resolved `module@version`.
+The registry checksum is immutable metadata for that identity, not another
+component that permits multiple source variants. On first use, Moon verifies
+the downloaded archive against the registry checksum, extracts into staging,
+marks the prepared source tree read-only, and publishes it atomically.
+Concurrent publishers of the same identity must be harmless.
+
+On a cache hit, Moon compares the current registry checksum with the checksum
+recorded at publication. A mismatch is an error: published registry versions
+are immutable, so Moon must not replace the source or create a second
+checksum-keyed variant for the same `module@version`.
+
+The first rollout is limited to standalone `.mbtx` execution: `moon run -e`,
+`moon run -`, and `moon run <file>.mbtx` resolve registry dependencies from
+the shared cache. Other project and single-file commands retain the existing
+project-local `.mooncakes` installation behavior. This keeps the initial
+migration narrow while preserving the cache format and correctness rules
+needed by later command migrations.
+
 ## Implemented public seam
 
 Two environment variables select the cache roots:
@@ -52,14 +71,12 @@ Two environment variables select the cache roots:
 | `MOON_DEP_CACHE` | `$MOON_HOME/cache/deps` | Disable dependency caching | Use that dependency-cache root |
 | `MOON_BUILD_CACHE` | `$MOON_HOME/cache/build` | Disable build caching | Use that build-cache root |
 
-A relative path is rejected. `off` means that a future build must use
-invocation-private temporary state instead of the corresponding global cache.
-For a disabled dependency cache, dependencies still have to be downloaded and
-prepared somewhere private; disabling the cache must not disable dependency
-resolution.
-
-The environment variables currently configure and clean roots only. Their
-presence does not yet change build execution.
+A relative path is rejected when a command selects the corresponding cache.
+`off` makes the three standalone `.mbtx` run forms use their file-local
+`.mooncakes` flow instead; disabling the cache does not disable dependency
+resolution. Commands that have not migrated do not consult `MOON_DEP_CACHE`
+during dependency sync. `MOON_BUILD_CACHE` currently configures and cleans its
+root only.
 
 ### Cleaning
 
@@ -175,14 +192,25 @@ startup.
 
 `post-add` hooks will not run in globally shared prepared sources. They make
 source state mutable and can have effects that are not captured by an artifact
-key. The initial shared-source flow should reject a dependency that requires
-`post-add`, rather than execute the hook or silently skip it. A sandboxed,
-explicitly keyed hook model would require a separate design.
+key. The shared-source flow rejects a dependency that requires `post-add`,
+rather than execute the hook, silently skip it, or fall back to a mutable local
+installation. A sandboxed, explicitly keyed hook model would require a
+separate design.
+
+Top-level module prebuild configuration is also rejected because it executes
+during build preparation and can write relative to the dependency source.
+Package-level prebuild commands and source generators are skipped for registry
+dependencies; published archives must already contain their generated outputs.
 
 `__moonbin__` belongs in the invocation's mutable work directory, initially
 under `_build`. If its producer later becomes cacheable, its outputs may be
 published like other action results, but a cache location must not become the
 command-visible executable path.
+
+Binary-dependency build isolation is independent of this first shared-source
+rollout. Registry bin-deps are copied to target-owned temporary work before
+building, as described in the architecture reference; local bin-deps retain
+their existing behavior.
 
 Moving `.mooncakes` wholesale into `_build` is not a prerequisite. Acquisition,
 prepared immutable sources, mutable work, and final outputs have different
@@ -194,10 +222,13 @@ Each stage should be useful and reviewable without requiring the next:
 
 1. **Root contract and lifecycle (implemented):** environment selection,
    disabled semantics, safe explicit cleaning, and no internal data layout.
-2. **Prepared dependency sources:** immutable publication in the dependency
-   cache, no shared `post-add`, and private fallback when caching is off.
-3. **Private standalone work:** stop sharing mutable `_build` trees between
-   standalone invocations; place `__moonbin__` there.
+2. **Prepared dependency sources (partially implemented):** immutable
+   publication for the three standalone `.mbtx` run forms, no shared
+   `post-add`, and file-local fallback when caching is off. Other commands can
+   migrate separately after this path is established.
+3. **Private binary-dependency work (implemented):** stop sharing mutable
+   `_build` trees between binary-dependency invocations; place `__moonbin__`
+   there.
 4. **Action model:** define and test canonical action inputs at the Rupes Recta
    compiler boundary, including resolved interfaces and target facts.
 5. **Artifact cache:** publish and restore complete `.mi`/`.core` result sets
@@ -207,9 +238,8 @@ Each stage should be useful and reviewable without requiring the next:
 7. **Operations:** add recency tracking, pruning, diagnostics, and format
    migration only after real cache data exists.
 
-The next implementation should choose one stage, write a failing end-to-end
-test first, and avoid introducing speculative directory structure for later
-stages.
+Each implementation should choose one stage, write a failing end-to-end test
+first, and avoid introducing speculative directory structure for later stages.
 
 ## References
 

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -129,8 +129,11 @@ project paths, the command layer captures user input and passes the result
 forward instead of letting later phases infer it again. In particular:
 
 - project and workspace selection are captured before package discovery;
-- the `.mooncakes` directory is computed during project discovery and passed
-  into dependency sync;
+- the `.mooncakes` directory and dependency-source mode are computed during
+  project discovery and passed into dependency sync; currently only
+  `moon run -e`, `moon run -`, and `moon run <file>.mbtx` select the shared
+  dependency cache, while other operations select project-local
+  `.mooncakes`;
 - `$mooncake_bin` is resolved by the command adapter to a `mooncake_bin_dir`
   path before build planning, so RR planning substitutes an already-computed
   launcher directory instead of deriving it from project layout;
@@ -139,10 +142,11 @@ forward instead of letting later phases infer it again. In particular:
 - package and module directories come from discovery results, not from later
   path guessing.
 
-Source directory, `.mooncakes` directory, target directory, and optional project
-manifest path are user/config facts from project discovery. The synced
-dependency result is derived data: it contains the resolved module
-relationships and module source directories produced by dependency sync.
+Source directory, `.mooncakes` directory, dependency-source mode, target
+directory, and optional project manifest path are user/config facts from
+project discovery. The synced dependency result is derived data: it contains
+the resolved module relationships and module source directories produced by
+dependency sync.
 `ResolveOutput` should contain resolved
 build-model data derived from those inputs, not repeat the captured discovery
 paths.


### PR DESCRIPTION
## Why

Standalone `.mbtx` execution currently unpacks the same registry dependency once per temporary or file-local `.mooncakes` directory. This is especially wasteful for short-lived commands such as `moon run -e` and `moon run -`.

The cache-root and cleaning contract already exists, so this PR adds the first deliberately narrow consumer of the dependency-source cache without changing ordinary project dependency behavior.

## What changed

- Use globally prepared registry sources only for `moon run -e`, `moon run -`, and `moon run <file>.mbtx`.
- Keep project commands, non-`run` single-file commands, and `moon run <file>.mbt` on their existing project/file-local `.mooncakes` flow.
- Resolve the dependency-source mode together with `PackageDirs` before dependency sync, so later phases do not reread process state or recompute directory policy.
- Verify the registry checksum and embedded manifest, extract into staging, make prepared sources read-only, and publish them atomically under a per-module lock.
- Treat `module@version` as the cache identity and reject a changed registry checksum for an already-published version.
- Preserve legacy multi-segment module names as nested cache paths while rejecting unsafe path components.
- Reject source-mutating `postadd` and module prebuild hooks in shared sources.
- Integrate prepared-source removal with `moon clean --dep-cache`.

## Why this is correct

The selected dependency-source mode is an explicit project-resolution fact. Only the three standalone `.mbtx` run entry points select the shared cache; all other callers construct `PackageDirs` with project-local dependency sources.

Readers can observe only a fully verified, immutable source tree. Concurrent first use is serialized, publication is atomic, and a registry checksum change is reported as version immutability corruption rather than creating a hidden second identity. `MOON_DEP_CACHE=off` preserves the file-local fallback.

This branch is based on merged #1928. Its target-owned registry bin-dependency build isolation remains unchanged and is separate from this first shared-source rollout.

## Scope

This is intentionally the first command slice. Migrating additional project or single-file commands can be reviewed independently after the standalone `.mbtx` path has settled.