### PR TITLE
Add deterministic JSON diagnostic output to moon check

### DIFF
--- a/crates/moon/src/build_flags.rs
+++ b/crates/moon/src/build_flags.rs
@@ -83,7 +83,7 @@ pub struct BuildFlags {
     #[clap(long)]
     pub no_render: bool,
 
-    /// Output diagnostics in JSON format
+    /// Output one JSON diagnostic per line
     #[clap(long, conflicts_with = "no_render")]
     pub output_json: bool,
 
@@ -161,19 +161,27 @@ pub enum OutputStyle {
     Raw,
     /// Source code snippets with colors and formatting, rendered from JSON
     Fancy,
-    /// Machine-readable output in JSON
+    /// One machine-readable JSON document
     Json,
+    /// One machine-readable JSON value per line
+    JsonLines,
 }
 
 impl OutputStyle {
     /// Whether the output style requires `moonc` to emit JSON diagnostics.
     pub fn needs_moonc_json(&self) -> bool {
-        matches!(self, OutputStyle::Fancy | OutputStyle::Json)
+        matches!(
+            self,
+            OutputStyle::Fancy | OutputStyle::Json | OutputStyle::JsonLines
+        )
     }
 
     /// Whether the output style requires no rendering (i.e., raw diagnostics).
     pub fn needs_no_render(&self) -> bool {
-        matches!(self, OutputStyle::Raw | OutputStyle::Json)
+        matches!(
+            self,
+            OutputStyle::Raw | OutputStyle::Json | OutputStyle::JsonLines
+        )
     }
 }
 
@@ -243,7 +251,7 @@ impl BuildFlags {
     pub fn output_style(&self) -> OutputStyle {
         match (self.no_render, self.output_json) {
             (true, false) => OutputStyle::Raw,
-            (false, true) => OutputStyle::Json,
+            (false, true) => OutputStyle::JsonLines,
             (false, false) => OutputStyle::Fancy,
             (true, true) => unreachable!(
                 "unreachable: both no_render and output_json flags are set (should be prevented by conflicts_with)"

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -90,6 +90,20 @@ pub(crate) struct CheckSubcommand {
     #[clap(flatten)]
     pub build_flags: BuildFlags,
 
+    /// Output diagnostics as one JSON array
+    #[clap(
+        long,
+        conflicts_with_all = ["jsonl", "output_json", "no_render", "watch", "dry_run", "fmt"]
+    )]
+    pub json: bool,
+
+    /// Output one JSON diagnostic per line
+    #[clap(
+        long,
+        conflicts_with_all = ["json", "output_json", "no_render", "watch", "dry_run", "fmt"]
+    )]
+    pub jsonl: bool,
+
     #[clap(flatten)]
     pub auto_sync_flags: AutoSyncFlags,
 
@@ -134,6 +148,13 @@ pub(crate) fn run_check(
     cmd: &CheckSubcommand,
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
+    let mut cmd = cmd.clone();
+    if cmd.json || cmd.jsonl {
+        // Both machine formats require moonc's structured diagnostics. The
+        // framing difference is handled after the diagnostics are collected.
+        cmd.build_flags.output_json = true;
+    }
+    let cmd = &cmd;
     let user_log = output.user_log();
     if cmd.fmt {
         let mut cli_for_fmt = cli.clone();
@@ -182,8 +203,9 @@ pub(crate) fn run_check(
         dirs.mooncake_bin_dir = dirs.target_dir.join(moonutil::constants::MOON_BIN_DIR);
     }
 
-    if cmd.build_flags.target.is_empty() {
-        return run_check_internal(
+    let mut json_diagnostics = Vec::new();
+    let ret_value = if cmd.build_flags.target.is_empty() {
+        let (ret_value, diagnostics) = run_check_internal(
             cli,
             cmd,
             &dirs,
@@ -191,25 +213,51 @@ pub(crate) fn run_check(
             single_file.as_deref(),
             None,
             output,
-        );
+        )?;
+        json_diagnostics.extend(diagnostics);
+        ret_value
+    } else {
+        let surface_targets = cmd.build_flags.target.clone();
+        let targets = lower_surface_targets(&surface_targets);
+        let mut ret_value = 0;
+        for t in targets {
+            let (x, diagnostics) = run_check_internal(
+                cli,
+                cmd,
+                &dirs,
+                &watch_ignored_subtree,
+                single_file.as_deref(),
+                Some(t),
+                output,
+            )
+            .context(format!("failed to run check for target {t:?}"))?;
+            json_diagnostics.extend(diagnostics);
+            ret_value = ret_value.max(x);
+        }
+        ret_value
+    };
+
+    if cmd.json {
+        output.write_result(|writer| -> anyhow::Result<()> {
+            write!(writer, "[")?;
+            for (index, diagnostic) in json_diagnostics.iter().enumerate() {
+                if index != 0 {
+                    write!(writer, ",")?;
+                }
+                write!(writer, "{diagnostic}")?;
+            }
+            writeln!(writer, "]")?;
+            Ok(())
+        })?;
+    } else if cmd.jsonl {
+        output.write_result(|writer| -> anyhow::Result<()> {
+            for diagnostic in &json_diagnostics {
+                writeln!(writer, "{diagnostic}")?;
+            }
+            Ok(())
+        })?;
     }
 
-    let surface_targets = cmd.build_flags.target.clone();
-    let targets = lower_surface_targets(&surface_targets);
-    let mut ret_value = 0;
-    for t in targets {
-        let x = run_check_internal(
-            cli,
-            cmd,
-            &dirs,
-            &watch_ignored_subtree,
-            single_file.as_deref(),
-            Some(t),
-            output,
-        )
-        .context(format!("failed to run check for target {t:?}"))?;
-        ret_value = ret_value.max(x);
-    }
     Ok(ret_value)
 }
 
@@ -223,7 +271,7 @@ fn run_check_internal(
     single_file: Option<&Path>,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
-) -> anyhow::Result<i32> {
+) -> anyhow::Result<(i32, Vec<String>)> {
     if let Some(single_file_path) = single_file {
         run_check_for_single_file_rr(
             cli,
@@ -253,7 +301,7 @@ fn run_check_for_single_file_rr(
     dirs: &PackageDirs,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
-) -> anyhow::Result<i32> {
+) -> anyhow::Result<(i32, Vec<String>)> {
     let user_log = output.user_log();
     let PackageDirs {
         source_dir,
@@ -323,7 +371,7 @@ fn run_check_for_single_file_rr(
                 target_dir,
             )
         })?;
-        return Ok(0);
+        return Ok((0, Vec::new()));
     }
 
     let _lock = FileLock::lock(target_dir).with_context(|| {
@@ -347,14 +395,25 @@ fn run_check_for_single_file_rr(
         filename.as_deref(),
     )?;
 
-    let mut cfg = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose);
+    let mut cfg = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose)
+        .with_output_style(if cmd.json || cmd.jsonl {
+            crate::build_flags::OutputStyle::Json
+        } else {
+            cmd.build_flags.output_style()
+        });
     cfg.patch_file = cmd.patch_file.clone();
     cfg.explain_errors |= cmd.explain;
 
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
-    result.print_info(cli.quiet, "checking")?;
+    if !cmd.json && !cmd.jsonl {
+        result.print_info(cli.quiet, "checking")?;
+    }
+    let successful = result.successful();
 
-    Ok(if result.successful() { 0 } else { 1 })
+    Ok((
+        if successful { 0 } else { 1 },
+        result.into_json_diagnostics(),
+    ))
 }
 
 fn get_user_intents_single_file(
@@ -383,14 +442,20 @@ fn run_check_normal_internal(
     watch_ignored_subtree: &Path,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
-) -> anyhow::Result<i32> {
-    let run_once = || -> anyhow::Result<WatchOutput> {
+) -> anyhow::Result<(i32, Vec<String>)> {
+    let run_once = || -> anyhow::Result<(WatchOutput, Vec<String>)> {
         run_check_normal_internal_rr(cli, cmd, dirs, cmd.watch, selected_target_backend, output)
     };
     if cmd.watch {
-        watching(run_once, &dirs.source_dir, watch_ignored_subtree)
+        watching(
+            || run_once().map(|(output, _)| output),
+            &dirs.source_dir,
+            watch_ignored_subtree,
+        )
+        .map(|status| (status, Vec::new()))
     } else {
-        run_once().map(|output| if output.ok { 0 } else { 1 })
+        let (output, diagnostics) = run_once()?;
+        Ok((if output.ok { 0 } else { 1 }, diagnostics))
     }
 }
 
@@ -403,7 +468,7 @@ fn run_check_normal_internal_rr(
     watch: bool,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
-) -> anyhow::Result<WatchOutput> {
+) -> anyhow::Result<(WatchOutput, Vec<String>)> {
     let user_log = output.user_log();
     let PackageDirs {
         source_dir,
@@ -449,6 +514,7 @@ fn run_check_normal_internal_rr(
     )
     .context("Failed to calculate build plan")?;
 
+    let mut json_diagnostics = Vec::new();
     let ok = if cli.dry_run {
         output.write_result(|writer| {
             for (build_meta, build_graph) in planned_runs {
@@ -470,7 +536,12 @@ fn run_check_normal_internal_rr(
                 target_dir.display()
             )
         })?;
-        let mut cfg = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose);
+        let mut cfg = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose)
+            .with_output_style(if cmd.json || cmd.jsonl {
+                crate::build_flags::OutputStyle::Json
+            } else {
+                cmd.build_flags.output_style()
+            });
         cfg.patch_file = cmd.patch_file.clone();
         cfg.explain_errors |= cmd.explain;
         let mut ok = true;
@@ -481,17 +552,24 @@ fn run_check_normal_internal_rr(
             rr_build::generate_metadata(source_dir, target_dir, &build_meta, &build_graph, None)?;
 
             let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
-            result.print_info(cli.quiet, "checking")?;
-            ok &= result.successful();
+            if !cmd.json && !cmd.jsonl {
+                result.print_info(cli.quiet, "checking")?;
+            }
+            let successful = result.successful();
+            json_diagnostics.extend(result.into_json_diagnostics());
+            ok &= successful;
         }
         ok
     };
 
-    Ok(WatchOutput {
-        ok,
-        additional_ignored_paths: prebuild_list.ignored_paths,
-        additional_watched_paths: prebuild_list.watched_paths,
-    })
+    Ok((
+        WatchOutput {
+            ok,
+            additional_ignored_paths: prebuild_list.ignored_paths,
+            additional_watched_paths: prebuild_list.watched_paths,
+        },
+        json_diagnostics,
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -214,36 +214,27 @@ pub struct BuildMeta {
     pub artifact_paths: ArtifactPathResolver,
 }
 
-/// Represents the result of the build process
-#[derive(Debug, Clone)]
-pub enum BuildResult {
-    /// The build succeeded with the given number of tasks executed.
-    Succeeded(usize),
-    /// The build failed.
-    Failed,
+/// The result of executing one build graph.
+pub struct BuildResult {
+    stats: N2RunStats,
+    json_diagnostics: Vec<String>,
 }
 
 impl BuildResult {
-    /// Whether the build was successful.
     pub fn successful(&self) -> bool {
-        matches!(self, BuildResult::Succeeded(_))
+        self.stats.successful()
     }
 
-    /// Get the return code that should be returned to the shell.
     pub fn return_code_for_success(&self) -> i32 {
-        if self.successful() { 0 } else { 1 }
+        self.stats.return_code_for_success()
     }
 
-    /// Print information about the build result.
-    pub fn print_info(&self) {
-        match self {
-            BuildResult::Succeeded(n) => {
-                println!("{} task(s) executed.", n);
-            }
-            BuildResult::Failed => {
-                println!("Build failed.");
-            }
-        }
+    pub fn print_info(&self, quiet: bool, mode: &str) -> anyhow::Result<()> {
+        self.stats.print_info(quiet, mode)
+    }
+
+    pub fn into_json_diagnostics(self) -> Vec<String> {
+        self.json_diagnostics
     }
 }
 
@@ -867,6 +858,11 @@ impl BuildConfig {
         self.suppress_progress = suppress_progress;
         self
     }
+
+    pub(crate) fn with_output_style(mut self, output_style: OutputStyle) -> Self {
+        self.output_style = output_style;
+        self
+    }
 }
 
 impl Default for BuildConfig {
@@ -925,7 +921,7 @@ pub fn execute_build(
     input: BuildInput,
     target_dir: &Path,
     user_log: &UserLog,
-) -> anyhow::Result<N2RunStats> {
+) -> anyhow::Result<BuildResult> {
     // Get start nodes (leaf outputs) before moving the graph
     let start_nodes = input.graph.get_start_nodes();
 
@@ -956,7 +952,7 @@ pub fn execute_test_build(
     target_dir: &Path,
     build_meta: &BuildMeta,
     user_log: &UserLog,
-) -> anyhow::Result<N2RunStats> {
+) -> anyhow::Result<BuildResult> {
     let start_nodes = input.graph.get_start_nodes();
 
     execute_build_partial(
@@ -991,7 +987,7 @@ pub fn execute_build_partial(
     build_meta: Option<&BuildMeta>,
     user_log: &UserLog,
     want_files: Box<WantFileFn>,
-) -> anyhow::Result<N2RunStats> {
+) -> anyhow::Result<BuildResult> {
     // Ensure target directory exists
     std::fs::create_dir_all(target_dir).context(format!(
         "Failed to create target directory: '{}'",
@@ -1054,7 +1050,7 @@ pub fn execute_build_partial(
     let build_succeeded = res.is_some();
 
     let mut result_catcher = result_catcher.lock().unwrap();
-    process_captured_diagnostics(
+    let json_diagnostics = process_captured_diagnostics(
         &mut result_catcher,
         cfg,
         build_succeeded,
@@ -1067,7 +1063,10 @@ pub fn execute_build_partial(
         n_warnings: result_catcher.n_warnings,
     };
 
-    Ok(stats)
+    Ok(BuildResult {
+        stats,
+        json_diagnostics,
+    })
 }
 
 /// Capture compiler output from n2 so it can be processed after the build.
@@ -1093,7 +1092,7 @@ fn process_captured_diagnostics(
     build_succeeded: bool,
     build_meta: Option<&BuildMeta>,
     user_log: &UserLog,
-) {
+) -> Vec<String> {
     let captured = catcher.content_writer.iter().map(|content| {
         let Some(meta) = build_meta else {
             return content.to_owned();
@@ -1151,7 +1150,7 @@ fn process_captured_diagnostics(
     });
 
     match cfg.output_style {
-        OutputStyle::Json => {
+        OutputStyle::Json | OutputStyle::JsonLines => {
             let mut by_file = BTreeMap::<String, BTreeSet<(MooncDiagnostic, String)>>::new();
             for content in captured {
                 match serde_json::from_str::<moonutil::render::MooncDiagnostic>(&content) {
@@ -1172,51 +1171,42 @@ fn process_captured_diagnostics(
                 };
             }
 
-            // In JSON mode, just print raw content after dedup.
-            match cfg.diagnostic_limit {
-                None => {
-                    for file_diagnostics in by_file.values() {
-                        for (diag, content) in file_diagnostics {
-                            println!("{content}");
-                            catcher.append_diag(diag);
-                        }
-                    }
-                }
+            let diagnostics = by_file.into_values().flatten().collect::<Vec<_>>();
+            let selected = match cfg.diagnostic_limit {
+                None => diagnostics,
                 Some(limit) => {
                     let mut displayed = 0;
                     let mut hidden_errors = 0;
                     let mut total_warnings = 0;
                     let mut displayed_warnings = 0;
                     let mut non_errors = Vec::new();
+                    let mut selected = Vec::new();
 
-                    for file_diagnostics in by_file.values() {
-                        for (diag, content) in file_diagnostics {
-                            if diagnostic_is_error(diag) {
-                                if displayed < limit {
-                                    println!("{content}");
-                                    catcher.append_diag(diag);
-                                    displayed += 1;
-                                } else {
-                                    hidden_errors += 1;
-                                }
-                                continue;
-                            }
-
-                            if diagnostic_is_warning(diag) {
-                                total_warnings += 1;
-                            }
+                    for (diag, content) in diagnostics {
+                        if diagnostic_is_error(&diag) {
                             if displayed < limit {
-                                non_errors.push((diag, content));
+                                selected.push((diag, content));
+                                displayed += 1;
+                            } else {
+                                hidden_errors += 1;
                             }
+                            continue;
+                        }
+
+                        if diagnostic_is_warning(&diag) {
+                            total_warnings += 1;
+                        }
+                        if displayed < limit {
+                            non_errors.push((diag, content));
                         }
                     }
 
                     if displayed < limit {
                         for (diag, content) in non_errors {
-                            println!("{content}");
-                            catcher.append_diag(diag);
+                            let is_warning = diagnostic_is_warning(&diag);
+                            selected.push((diag, content));
                             displayed += 1;
-                            if diagnostic_is_warning(diag) {
+                            if is_warning {
                                 displayed_warnings += 1;
                             }
                             if displayed == limit {
@@ -1229,7 +1219,21 @@ fn process_captured_diagnostics(
                     warn_limited_diagnostics(hidden_errors, hidden_warnings, user_log);
                     catcher.n_errors += hidden_errors;
                     catcher.n_warnings += hidden_warnings;
+                    selected
                 }
+            };
+
+            for (diag, _) in &selected {
+                catcher.append_diag(diag);
+            }
+
+            if cfg.output_style == OutputStyle::JsonLines {
+                for (_, content) in selected {
+                    println!("{content}");
+                }
+                Vec::new()
+            } else {
+                selected.into_iter().map(|(_, content)| content).collect()
             }
         }
         OutputStyle::Fancy => {
@@ -1331,11 +1335,13 @@ fn process_captured_diagnostics(
                     catcher.n_warnings += hidden_warnings;
                 }
             }
+            Vec::new()
         }
         OutputStyle::Raw => {
             for content in captured {
                 println!("{content}");
             }
+            Vec::new()
         }
     }
 }

--- a/crates/moon/tests/test_cases/diagnostics_format/check.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/check.rs
@@ -1,9 +1,9 @@
 use expect_test::expect;
 
-use crate::{TestDir, get_stderr, get_stdout, util::check};
+use crate::{TestDir, get_stderr, get_stdout, moon_cmd, util::check};
 
 #[test]
-fn test_moon_check_json_output() {
+fn test_moon_check_legacy_json_lines_output() {
     let dir = TestDir::new("warns/deny_warn");
 
     check(
@@ -18,6 +18,85 @@ fn test_moon_check_json_output() {
             {"$message_type":"diagnostic","level":"warning","error_code":2,"path":"$ROOT/main/main.mbt","loc":"2:7-2:8","message":"Warning (unused_value): Unused variable 'a'","context":"1 |fn main {/n2 |  let a = 0/n3 |  @lib.hello()/n"}
         "#]],
     );
+}
+
+#[test]
+fn test_moon_check_json_output() {
+    let dir = TestDir::new("warns/deny_warn");
+
+    moon_cmd(&dir)
+        .args(["check", "--json", "--sort-input", "-j1", "-q"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+[{"$message_type":"diagnostic","level":"warning","error_code":2,"path":"[..]/lib/hello.mbt","loc":"4:7-4:8","message":"Warning (unused_value): Unused variable 'a'","context":"3 |fn _a() -> Unit {/n4 |  let a = 1;/n5 |  // 中文中文中文中文中文中文/n"},{"$message_type":"diagnostic","level":"warning","error_code":2,"path":"[..]/lib/hello.mbt","loc":"11:7-11:9","message":"Warning (unused_value): Unused variable '中文'","context":"10 |  // 🤣😭🤣😭🤣😭🤣😭🤣😭/n11 |  let 中文 = 2/n12 |  let 🤣😭🤣😭🤣 = 2/n"},{"$message_type":"diagnostic","level":"warning","error_code":2,"path":"[..]/lib/hello.mbt","loc":"12:7-12:12","message":"Warning (unused_value): Unused variable '🤣😭🤣😭🤣'","context":"11 |  let 中文 = 2/n12 |  let 🤣😭🤣😭🤣 = 2/n13 |  alert_1();/n"},{"$message_type":"diagnostic","level":"warning","error_code":2,"path":"[..]/main/main.mbt","loc":"2:7-2:8","message":"Warning (unused_value): Unused variable 'a'","context":"1 |fn main {/n2 |  let a = 0/n3 |  @lib.hello()/n"}]
+
+"#]])
+        .stderr_eq("");
+}
+
+#[test]
+fn test_moon_check_json_output_is_an_empty_array_without_diagnostics() {
+    let dir = TestDir::new("moon_new/plain");
+
+    moon_cmd(&dir)
+        .args(["check", "--json", "-q"])
+        .assert()
+        .success()
+        .stdout_eq("[]\n")
+        .stderr_eq("");
+}
+
+#[test]
+fn test_moon_check_json_output_preserves_diagnostics_on_failure() {
+    let dir = TestDir::new("check_failed_should_write_pkg_json.in");
+
+    moon_cmd(&dir)
+        .args(["check", "--json", "--sort-input", "-j1", "-q"])
+        .assert()
+        .code(1)
+        .stdout_eq(snapbox::str![[r#"
+[{"$message_type":"diagnostic","level":"error","error_code":4014,"path":"[..]/lib/hello.mbt","loc":"2:3-2:4","message":"Expr Type Mismatch/n        has type : Int/n        wanted   : String","context":"1 |pub fn hello() -> String {/n2 |  1/n3 |}/n"}]
+
+"#]])
+        .stderr_eq("");
+}
+
+#[test]
+fn test_moon_check_json_lines_output() {
+    let dir = TestDir::new("warns/deny_warn");
+
+    moon_cmd(&dir)
+        .args(["check", "--jsonl", "--sort-input", "-j1", "-q"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+{"$message_type":"diagnostic","level":"warning","error_code":2,"path":"[..]/lib/hello.mbt","loc":"4:7-4:8","message":"Warning (unused_value): Unused variable 'a'","context":"3 |fn _a() -> Unit {/n4 |  let a = 1;/n5 |  // 中文中文中文中文中文中文/n"}
+{"$message_type":"diagnostic","level":"warning","error_code":2,"path":"[..]/lib/hello.mbt","loc":"11:7-11:9","message":"Warning (unused_value): Unused variable '中文'","context":"10 |  // 🤣😭🤣😭🤣😭🤣😭🤣😭/n11 |  let 中文 = 2/n12 |  let 🤣😭🤣😭🤣 = 2/n"}
+{"$message_type":"diagnostic","level":"warning","error_code":2,"path":"[..]/lib/hello.mbt","loc":"12:7-12:12","message":"Warning (unused_value): Unused variable '🤣😭🤣😭🤣'","context":"11 |  let 中文 = 2/n12 |  let 🤣😭🤣😭🤣 = 2/n13 |  alert_1();/n"}
+{"$message_type":"diagnostic","level":"warning","error_code":2,"path":"[..]/main/main.mbt","loc":"2:7-2:8","message":"Warning (unused_value): Unused variable 'a'","context":"1 |fn main {/n2 |  let a = 0/n3 |  @lib.hello()/n"}
+
+"#]])
+        .stderr_eq("");
+}
+
+#[test]
+fn test_moon_check_json_formats_are_mutually_exclusive() {
+    let dir = TestDir::new("warns/deny_warn");
+
+    moon_cmd(&dir)
+        .args(["check", "--json", "--jsonl"])
+        .assert()
+        .code(2)
+        .stdout_eq("")
+        .stderr_eq(snapbox::str![[r#"
+error: the argument '--json' cannot be used with '--jsonl'
+
+Usage: moon check --json [PATH]...
+
+For more information, try '--help'.
+
+"#]]);
 }
 
 #[test]

--- a/docs/dev/command-output-migration.md
+++ b/docs/dev/command-output-migration.md
@@ -1,6 +1,6 @@
 # Command Output Migration
 
-Status: accepted; CO-1, CO-2, CO-4, and CO-5 complete
+Status: accepted; CO-1, CO-2, CO-4, and CO-5 complete; CO-7 in progress
 
 ## Goal
 
@@ -24,6 +24,13 @@ Both standard-stream boundaries are adaptive. Renderers emit ANSI styles, and th
 Renderers below the CLI seam should accept a writer. Library operations should return data when the CLI owns presentation. A lower-level operation may accept `UserLog` when emitting a user-facing event is inherently part of that operation, but pure build planning should not depend on `CommandOutput`.
 
 The facade does not own Process Passthrough, Progress Displays, compiler diagnostics, or tracing. Those paths have different byte-preservation, concurrency, terminal, and configuration contracts and should be migrated only within their own seams.
+
+Machine-readable formats apply to Command Results on stdout, not to `UserLog`
+on stderr. Each command owns its result schema: `--json` writes one complete
+JSON document, while `--jsonl` may stream the same result items one per line.
+The two flags are mutually exclusive. Commands should expose them only after
+their complete stdout contract is defined; unrelated human output must not be
+mixed into either format.
 
 ## Behavioral Policy
 
@@ -124,12 +131,17 @@ Blocked by: CO-3, CO-4
 
 ### CO-7: Classify build execution output
 
+Status: in progress
+
 Blocked by: CO-4, CO-5
 
 Blocks: CO-8
 
 - Separate durable build summaries from Progress Displays and Process Passthrough.
 - Migrate durable summaries to `UserLog` and build reports to writer-based Command Results.
+- Migrate structured diagnostics and other stdout results through
+  `CommandOutput`. `moon check` is the first command to define both JSON-array
+  and JSON-lines contracts.
 - Keep child stdout/stderr forwarding byte-preserving and keep concurrent progress behind its own renderer seam.
 - Cover both Rupes Recta and the legacy engine in each applicable behavior test.
 - Done when every executor print site is either migrated or documented as passthrough/progress.

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -123,7 +123,7 @@ Build the current package
 * `--output-wat` — Output WAT instead of WASM
 * `-d`, `--deny-warn` — Treat all warnings as errors
 * `--no-render` — Don't render diagnostics (in raw human-readable format)
-* `--output-json` — Output diagnostics in JSON format
+* `--output-json` — Output one JSON diagnostic per line
 * `--warn-list <WARN_LIST>` — Warn list config
 * `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `--render-no-loc <MIN_LEVEL>` — Render no-location diagnostics starting from a certain level
@@ -164,6 +164,8 @@ Check the current package, but don't build object files
 * `-d`, `--deny-warn` — Treat all warnings as errors
 * `--no-render` — Don't render diagnostics (in raw human-readable format)
 * `--output-json` — Output diagnostics in JSON format
+* `--json` — Output diagnostics as one JSON array
+* `--jsonl` — Output one JSON diagnostic per line
 * `--warn-list <WARN_LIST>` — Warn list config
 * `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `--render-no-loc <MIN_LEVEL>` — Render no-location diagnostics starting from a certain level

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -123,7 +123,7 @@ Build the current package
 * `--output-wat` — Output WAT instead of WASM
 * `-d`, `--deny-warn` — Treat all warnings as errors
 * `--no-render` — Don't render diagnostics (in raw human-readable format)
-* `--output-json` — Output diagnostics in JSON format
+* `--output-json` — Output one JSON diagnostic per line
 * `--warn-list <WARN_LIST>` — Warn list config
 * `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `--render-no-loc <MIN_LEVEL>` — Render no-location diagnostics starting from a certain level
@@ -164,6 +164,8 @@ Check the current package, but don't build object files
 * `-d`, `--deny-warn` — Treat all warnings as errors
 * `--no-render` — Don't render diagnostics (in raw human-readable format)
 * `--output-json` — Output diagnostics in JSON format
+* `--json` — Output diagnostics as one JSON array
+* `--jsonl` — Output one JSON diagnostic per line
 * `--warn-list <WARN_LIST>` — Warn list config
 * `-j`, `--jobs <JOBS>` — Set the max number of jobs to run in parallel
 * `--render-no-loc <MIN_LEVEL>` — Render no-location diagnostics starting from a certain level


### PR DESCRIPTION
## Why

`moon check --output-json` emits JSON values line by line, so consumers cannot parse the complete stdout as one JSON document. We need explicit, deterministic stdout formats without changing the independent user-log behavior on stderr.

## What changed

- Add mutually exclusive `moon check --json` and `moon check --jsonl` flags.
- Make `--json` write one diagnostics array and `--jsonl` write the same diagnostics one value per line.
- Aggregate diagnostics across all planned target/backend runs before writing the command result.
- Preserve diagnostics and exit status when checking fails.
- Keep the existing `--output-json` behavior as the legacy JSON-lines interface.

## Why this is correct

Both new formats reuse the existing diagnostic parsing, deterministic ordering, deduplication, generated-path remapping, and diagnostic-limit logic; only the final stdout framing differs. Validated diagnostic JSON is retained as raw strings and moved to the command layer, avoiding another JSON parse and deep copies before framing.

`UserLog` remains independent on stderr, so logs cannot corrupt the selected stdout format. This PR intentionally does not change build-summary behavior; that refactoring is being handled separately.