### PR TITLE
Normalize UserLog levels and build result ownership

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -204,7 +204,6 @@ fn run_build_rr(
             if result.successful() {
                 crate::resources::reconcile_resource_mappings(&build_meta)?;
             }
-            result.print_info(cli.quiet, "building")?;
             ok &= result.successful();
         }
         ok

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -204,6 +204,7 @@ fn run_build_rr(
             if result.successful() {
                 crate::resources::reconcile_resource_mappings(&build_meta)?;
             }
+            rr_build::report_build_result(&result, rr_build::BuildOperation::Build, &cfg, output)?;
             ok &= result.successful();
         }
         ok

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -135,7 +135,6 @@ pub(crate) fn run_bundle_internal_rr(
             target_dir,
             user_log,
         )?;
-        result.print_info(cli.quiet, "bundling")?;
         Ok(result.return_code_for_success())
     }
 }

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -129,12 +129,9 @@ pub(crate) fn run_bundle_internal_rr(
         // Generate metadata for IDE & bundler
         rr_build::generate_metadata(source_dir, target_dir, &build_meta, &build_graph, None)?;
 
-        let result = rr_build::execute_build(
-            &BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose),
-            build_graph,
-            target_dir,
-            user_log,
-        )?;
+        let cfg = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose);
+        let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
+        rr_build::report_build_result(&result, rr_build::BuildOperation::Bundle, &cfg, output)?;
         Ok(result.return_code_for_success())
     }
 }

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -137,7 +137,7 @@ pub(crate) fn run_check(
     if cmd.fmt {
         let mut cli_for_fmt = cli.clone();
         cli_for_fmt.quiet = true;
-        let fmt_output = CommandOutput::new(LevelFilter::Error);
+        let fmt_output = CommandOutput::new(LevelFilter::Error, true);
         let fmt_exit_code = crate::cli::fmt::run_fmt(
             &cli_for_fmt,
             crate::cli::FmtSubcommand {

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -48,9 +48,8 @@ use tracing::{Level, instrument};
 
 use crate::filter::{
     TargetPackageGroup, canonicalize_with_filename, ensure_package_supports_backend,
-    ensure_packages_support_backend, filter_pkg_by_dir, format_supported_backends,
-    group_packages_by_preferred_backend, package_supports_backend, select_packages,
-    select_supported_packages,
+    ensure_packages_support_backend, filter_pkg_by_dir, group_packages_by_preferred_backend,
+    package_supports_backend, select_packages, select_supported_packages,
 };
 use crate::rr_build::{self, BuildConfig, CalcUserIntentOutput, preconfig_compile};
 use crate::watch::prebuild_output::{PrebuildWatchPaths, rr_get_prebuild_watch_paths};
@@ -698,7 +697,6 @@ pub(crate) fn resolve_check_target_selections(
             resolve_output,
             selection.packages,
             selection.target_backend,
-            user_log,
         )?;
         if !packages.is_empty() {
             filtered.push(TargetPackageGroup {
@@ -751,7 +749,6 @@ fn filter_packages_for_backend(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     packages: Vec<PackageId>,
     target_backend: TargetBackend,
-    user_log: &UserLog,
 ) -> anyhow::Result<Vec<PackageId>> {
     let mut supported = Vec::new();
     let mut unsupported = Vec::new();
@@ -774,17 +771,6 @@ fn filter_packages_for_backend(
                 target_backend,
             )?;
         }
-    }
-
-    for pkg in unsupported {
-        let pkg_id = pkg;
-        let pkg = resolve_output.pkg_dirs.get_package(pkg_id);
-        user_log.info(format!(
-            "skipping package `{}` because it does not support the selected target backend `{}`. Supported backends: {}",
-            pkg.fqn,
-            target_backend,
-            format_supported_backends(resolve_output, pkg_id),
-        ));
     }
 
     Ok(supported)

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -351,6 +351,7 @@ fn run_check_for_single_file_rr(
     cfg.explain_errors |= cmd.explain;
 
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
+    rr_build::report_build_result(&result, rr_build::BuildOperation::Check, &cfg, output)?;
 
     Ok(if result.successful() { 0 } else { 1 })
 }
@@ -479,6 +480,7 @@ fn run_check_normal_internal_rr(
             rr_build::generate_metadata(source_dir, target_dir, &build_meta, &build_graph, None)?;
 
             let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
+            rr_build::report_build_result(&result, rr_build::BuildOperation::Check, &cfg, output)?;
             ok &= result.successful();
         }
         ok

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -352,7 +352,6 @@ fn run_check_for_single_file_rr(
     cfg.explain_errors |= cmd.explain;
 
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
-    result.print_info(cli.quiet, "checking")?;
 
     Ok(if result.successful() { 0 } else { 1 })
 }
@@ -481,7 +480,6 @@ fn run_check_normal_internal_rr(
             rr_build::generate_metadata(source_dir, target_dir, &build_meta, &build_graph, None)?;
 
             let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
-            result.print_info(cli.quiet, "checking")?;
             ok &= result.successful();
         }
         ok

--- a/crates/moon/src/cli/coverage.rs
+++ b/crates/moon/src/cli/coverage.rs
@@ -103,7 +103,7 @@ fn run_coverage_analyze(
         quiet: true, // Disable output for `moon test` on success
         ..cli.clone()
     };
-    let test_output = CommandOutput::new(test_cli.user_log_level());
+    let test_output = CommandOutput::new(test_cli.user_log_level(), test_cli.quiet);
     run_test(test_cli, test_flags, &test_output)?;
 
     let mut report_flags = CoverageReportSubcommand::default();

--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -186,6 +186,7 @@ fn run_cram_test(
     for (build_meta, build_graph) in planned_runs {
         rr_build::generate_all_pkgs_json(&build_meta)?;
         let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
+        rr_build::report_build_result(&result, rr_build::BuildOperation::Build, &cfg, output)?;
         if !result.successful() {
             return Ok(result.return_code_for_success());
         }

--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -186,7 +186,6 @@ fn run_cram_test(
     for (build_meta, build_graph) in planned_runs {
         rr_build::generate_all_pkgs_json(&build_meta)?;
         let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
-        result.print_info(cli.quiet, "building")?;
         if !result.successful() {
             return Ok(result.return_code_for_success());
         }

--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -23,6 +23,7 @@ use mooncake::pkg::{
 };
 use moonutil::{
     cli_support::AutoSyncFlags,
+    command_output::CommandOutput,
     project::{PackageDirs, ProjectContext},
     registry::RegistryConfig,
     resolution::ModuleName,
@@ -69,8 +70,9 @@ fn local_wildcard_path(source: &str) -> Option<PathBuf> {
 pub(crate) fn install_cli(
     cli: UniversalFlags,
     cmd: InstallSubcommand,
-    user_log: &UserLog,
+    output: &CommandOutput,
 ) -> anyhow::Result<i32> {
+    let user_log = output.user_log();
     // If no package path and no local path, use legacy behavior
     if cmd.source.is_none() && cmd.path.is_none() {
         user_log.warn(
@@ -108,7 +110,7 @@ pub(crate) fn install_cli(
                 local_path_str
             );
         }
-        return install_from_local(&cli, &local_path, &install_dir, false, user_log);
+        return install_from_local(&cli, &local_path, &install_dir, false, output);
     }
 
     let source = cmd.source.ok_or_else(|| {
@@ -132,7 +134,7 @@ pub(crate) fn install_cli(
             Path::new(&local_path),
             &install_dir,
             install_all,
-            user_log,
+            output,
         );
     }
 
@@ -158,7 +160,7 @@ pub(crate) fn install_cli(
             cmd.path_in_repo.as_deref(),
             &install_dir,
             install_all,
-            user_log,
+            output,
         );
     }
 
@@ -171,7 +173,7 @@ pub(crate) fn install_cli(
     }
     let spec = parse_package_spec(&source)?;
     let install_all = spec.is_wildcard;
-    install_binary(&cli, &spec, &install_dir, install_all, user_log)
+    install_binary(&cli, &spec, &install_dir, install_all, output)
 }
 
 pub(crate) fn remove_cli(

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -181,7 +181,6 @@ pub(crate) fn run_doc_rr(
     // Execute the build
     let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature, cli.verbose);
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
-    result.print_info(cli.quiet, "checking")?;
 
     if !result.successful() {
         return Ok(result.return_code_for_success());

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -181,6 +181,7 @@ pub(crate) fn run_doc_rr(
     // Execute the build
     let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature, cli.verbose);
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
+    rr_build::report_build_result(&result, rr_build::BuildOperation::Check, &cfg, output)?;
 
     if !result.successful() {
         return Ok(result.return_code_for_success());

--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -113,7 +113,6 @@ fn run_fmt_rr(
         Ok(0)
     } else {
         let res = rr_build::execute_build(&BuildConfig::default(), graph, &target_dir, user_log)?;
-        res.print_info(cli.quiet, "formatting")?;
         Ok(res.return_code_for_success())
     }
 }

--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -112,7 +112,9 @@ fn run_fmt_rr(
         })?;
         Ok(0)
     } else {
-        let res = rr_build::execute_build(&BuildConfig::default(), graph, &target_dir, user_log)?;
+        let cfg = BuildConfig::default();
+        let res = rr_build::execute_build(&cfg, graph, &target_dir, user_log)?;
+        rr_build::report_build_result(&res, rr_build::BuildOperation::Format, &cfg, output)?;
         Ok(res.return_code_for_success())
     }
 }

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -217,7 +217,7 @@ fn calc_user_intent_for_info(
 
             for (path, pkg_id) in &unsupported {
                 let pkg = resolve_output.pkg_dirs.get_package(*pkg_id);
-                ctx.user_log.info(format!(
+                ctx.user_log.warn(format!(
                     "skipping path `{}` because package `{}` does not support target backend `{}`. Supported backends: {}",
                     path.display(),
                     pkg.fqn,

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -321,7 +321,7 @@ pub(crate) fn run_info(
             resolve_output.clone(),
             &selection,
             &output_plan,
-            output.user_log(),
+            output,
         )?;
         if !success {
             ok = false;
@@ -355,8 +355,9 @@ fn run_info_rr_internal(
     resolve_output: ResolveOutput,
     selection: &PackageSelection,
     output_plan: &imp::InfoOutputPlan,
-    user_log: &UserLog,
+    output: &CommandOutput,
 ) -> anyhow::Result<(bool, BuildMeta)> {
+    let user_log = output.user_log();
     let mut preconfig = rr_build::preconfig_compile(
         &cmd.auto_sync_flags,
         cli,
@@ -397,6 +398,12 @@ fn run_info_rr_internal(
     // TODO: UX: Consider mirroring flags from `moon check`?
     let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature, cli.verbose);
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
+    rr_build::report_build_result(
+        &result,
+        rr_build::BuildOperation::GenerateMbti,
+        &cfg,
+        output,
+    )?;
     let success = result.successful();
 
     Ok((success, build_meta))

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -398,10 +398,6 @@ fn run_info_rr_internal(
     let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature, cli.verbose);
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
     let success = result.successful();
-    let print_result = result.print_info(cli.quiet, "generating mbti files");
-    if success {
-        print_result?;
-    }
 
     Ok((success, build_meta))
 }

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -576,7 +576,6 @@ fn build_selected_package(
     pkg: &SelectedPackage,
     user_log: &UserLog,
 ) -> anyhow::Result<Option<PathBuf>> {
-    let quiet = cli.quiet;
     std::fs::create_dir_all(&prepared.target_dir).context("Failed to create build directory")?;
 
     user_log.info(format!("Building `{}`...", pkg.full_pkg_name));
@@ -623,11 +622,8 @@ fn build_selected_package(
         user_log,
     )?;
     if !result.successful() {
-        result.print_info(quiet, "building").ok();
-        user_log.error(format!("Failed to build `{}`", pkg.full_pkg_name));
         return Ok(None);
     }
-    result.print_info(quiet, "building").ok();
 
     let target = BuildTarget {
         package: pkg.pkg_id,

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -30,6 +30,7 @@ use mooncake::{
 use moonutil::{
     build_options::RunMode,
     cli_support::UniversalFlags,
+    command_output::CommandOutput,
     constants::{MOON_MOD, MOON_MOD_JSON},
     locks::FileLock,
     project::{PackageDirs, SourceTargetDirs, WorkspaceEnv},
@@ -238,8 +239,9 @@ pub(super) fn install_binary(
     spec: &PackageSpec,
     install_dir: &Path,
     install_all: bool,
-    user_log: &UserLog,
+    output: &CommandOutput,
 ) -> anyhow::Result<i32> {
+    let user_log = output.user_log();
     let quiet = cli.quiet;
 
     let index_dir = moonutil::registry::index();
@@ -289,7 +291,7 @@ pub(super) fn install_binary(
         package_dirs,
         install_dir,
         filter,
-        user_log,
+        output,
     )
 }
 
@@ -299,7 +301,7 @@ pub(super) fn install_from_local(
     local_path: &Path,
     install_dir: &Path,
     install_all: bool,
-    user_log: &UserLog,
+    output: &CommandOutput,
 ) -> anyhow::Result<i32> {
     let input_path = dunce::canonicalize(local_path).with_context(|| {
         format!(
@@ -311,7 +313,7 @@ pub(super) fn install_from_local(
     let mut query = cli
         .source_tgt_dir
         .query_from(&input_path, cli.workspace_env.clone())?;
-    let project = query.project(user_log)?;
+    let project = query.project(output.user_log())?;
     let module_root = project
         .selected_module()
         .map(|module| module.root)
@@ -323,7 +325,7 @@ pub(super) fn install_from_local(
                 MOON_MOD_JSON
             )
         })?;
-    let package_dirs = query.package_dirs(user_log)?;
+    let package_dirs = query.package_dirs(output.user_log())?;
 
     let module = moonutil::manifest::read_module_desc_file_in_dir(&module_root)?;
     let module_name: ModuleName = module.name.parse().map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -336,7 +338,7 @@ pub(super) fn install_from_local(
         package_dirs,
         install_dir,
         filter,
-        user_log,
+        output,
     )
 }
 
@@ -360,8 +362,9 @@ pub(super) fn install_from_git(
     path_in_repo: Option<&str>,
     install_dir: &Path,
     install_all: bool,
-    user_log: &UserLog,
+    output: &CommandOutput,
 ) -> anyhow::Result<i32> {
+    let user_log = output.user_log();
     user_log.info(format!("Cloning `{}`...", git_url));
 
     let tmp_dir = tempfile::TempDir::new().context("Failed to create temporary directory")?;
@@ -461,7 +464,7 @@ pub(super) fn install_from_git(
         module_dirs.package_dirs,
         install_dir,
         filter,
-        user_log,
+        output,
     )
 }
 
@@ -469,6 +472,11 @@ struct SelectedPackage {
     pkg_id: PackageId,
     full_pkg_name: String,
     binary_name: String,
+}
+
+enum BuildResultDestination<'a> {
+    Command(&'a CommandOutput),
+    Internal,
 }
 
 struct PreparedNativeBuild {
@@ -575,6 +583,7 @@ fn build_selected_package(
     prepared: &PreparedNativeBuild,
     pkg: &SelectedPackage,
     user_log: &UserLog,
+    result_destination: BuildResultDestination<'_>,
 ) -> anyhow::Result<Option<PathBuf>> {
     std::fs::create_dir_all(&prepared.target_dir).context("Failed to create build directory")?;
 
@@ -615,12 +624,11 @@ fn build_selected_package(
     let _lock = FileLock::lock(&prepared.target_dir)?;
     rr_build::generate_all_pkgs_json(&build_meta)?;
 
-    let result = rr_build::execute_build(
-        &BuildConfig::from_flags(&build_flags, &cli.unstable_feature, cli.verbose),
-        build_graph,
-        &prepared.target_dir,
-        user_log,
-    )?;
+    let cfg = BuildConfig::from_flags(&build_flags, &cli.unstable_feature, cli.verbose);
+    let result = rr_build::execute_build(&cfg, build_graph, &prepared.target_dir, user_log)?;
+    if let BuildResultDestination::Command(output) = result_destination {
+        rr_build::report_build_result(&result, rr_build::BuildOperation::Build, &cfg, output)?;
+    }
     if !result.successful() {
         return Ok(None);
     }
@@ -656,8 +664,14 @@ fn build_native_executable_to(
         .selected_packages
         .first()
         .context("exact package selection returned no package")?;
-    let binary_src = build_selected_package(cli, &prepared, pkg, user_log)?
-        .ok_or_else(|| anyhow::anyhow!("Failed to build `{}`", pkg.full_pkg_name))?;
+    let binary_src = build_selected_package(
+        cli,
+        &prepared,
+        pkg,
+        user_log,
+        BuildResultDestination::Internal,
+    )?
+    .ok_or_else(|| anyhow::anyhow!("Failed to build `{}`", pkg.full_pkg_name))?;
     std::fs::copy(&binary_src, destination).with_context(|| {
         format!(
             "Failed to copy binary from `{}` to `{}`",
@@ -764,8 +778,9 @@ fn build_and_install_packages(
     package_dirs: PackageDirs,
     install_dir: &Path,
     filter: PackageFilter,
-    user_log: &UserLog,
+    output: &CommandOutput,
 ) -> anyhow::Result<i32> {
+    let user_log = output.user_log();
     let quiet = cli.quiet;
     let prepared = prepare_native_build(
         cli,
@@ -827,7 +842,14 @@ fn build_and_install_packages(
             continue;
         }
 
-        let Some(binary_src) = build_selected_package(cli, &prepared, pkg, user_log)? else {
+        let Some(binary_src) = build_selected_package(
+            cli,
+            &prepared,
+            pkg,
+            user_log,
+            BuildResultDestination::Command(output),
+        )?
+        else {
             continue;
         };
         let dst_name = if cfg!(windows) {

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -197,7 +197,7 @@ pub(crate) fn run_prove(
     let _lock = FileLock::lock(target_dir)?;
     rr_build::generate_all_pkgs_json(&build_meta)?;
     let cfg = BuildConfig::from_flags(&build_flags, &cli.unstable_feature, cli.verbose);
-    let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
+    let result = rr_build::execute_build_silently(&cfg, build_graph, target_dir, user_log)?;
     if !cli.quiet && !build_flags.output_json {
         let _ = print_prove_summary(project_root, &proof_reports);
     }

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -197,7 +197,7 @@ pub(crate) fn run_prove(
     let _lock = FileLock::lock(target_dir)?;
     rr_build::generate_all_pkgs_json(&build_meta)?;
     let cfg = BuildConfig::from_flags(&build_flags, &cli.unstable_feature, cli.verbose);
-    let result = rr_build::execute_build_silently(&cfg, build_graph, target_dir, user_log)?;
+    let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
     if !cli.quiet && !build_flags.output_json {
         let _ = print_prove_summary(project_root, &proof_reports);
     }

--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -250,7 +250,7 @@ pub(super) fn ensure_cached_file(
     produce: impl FnOnce(&Path) -> anyhow::Result<()>,
 ) -> anyhow::Result<PathBuf> {
     if cache_path.exists() {
-        user_log.info(format!("Using cached {}", cache_path.to_string_lossy()));
+        user_log.debug(format!("Using cached {}", cache_path.to_string_lossy()));
         return Ok(cache_path.to_path_buf());
     }
 
@@ -267,7 +267,7 @@ pub(super) fn ensure_cached_file(
         .with_context(|| format!("failed to lock cache directory {}", parent.display()))?;
 
     if cache_path.exists() {
-        user_log.info(format!("Using cached {}", cache_path.to_string_lossy()));
+        user_log.debug(format!("Using cached {}", cache_path.to_string_lossy()));
         return Ok(cache_path.to_path_buf());
     }
 
@@ -354,7 +354,7 @@ fn run_artifact(
         crate::run::command_for_with_moonrun_policy(mode, artifact, None, experimental_policy);
     run_cmd.args(args);
 
-    user_log.info(rr_build::format_dry_run_command(&run_cmd, Path::new(".")));
+    user_log.debug(rr_build::format_dry_run_command(&run_cmd, Path::new(".")));
 
     let status = super::process::delegate(&mut run_cmd)
         .context("failed to delegate to registry executable")?;

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -797,14 +797,11 @@ fn build_executable_from_plan(
             .with_suppressed_progress(options.output.suppress_build_progress());
     let build_result = match build_graph {
         RunBuildInput::Ordinary(build_graph) => {
-            rr_build::execute_build_silently(&build_config, build_graph, target_dir, user_log)?
+            rr_build::execute_build(&build_config, build_graph, target_dir, user_log)?
         }
-        RunBuildInput::Standalone(build_graph) => rr_build::execute_standalone_build_silently(
-            &build_config,
-            build_graph,
-            target_dir,
-            user_log,
-        )?,
+        RunBuildInput::Standalone(build_graph) => {
+            rr_build::execute_standalone_build(&build_config, build_graph, target_dir, user_log)?
+        }
     };
     if build_result.successful() {
         crate::resources::reconcile_resource_mappings(build_meta)?;

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -797,11 +797,14 @@ fn build_executable_from_plan(
             .with_suppressed_progress(options.output.suppress_build_progress());
     let build_result = match build_graph {
         RunBuildInput::Ordinary(build_graph) => {
-            rr_build::execute_build(&build_config, build_graph, target_dir, user_log)?
+            rr_build::execute_build_silently(&build_config, build_graph, target_dir, user_log)?
         }
-        RunBuildInput::Standalone(build_graph) => {
-            rr_build::execute_standalone_build(&build_config, build_graph, target_dir, user_log)?
-        }
+        RunBuildInput::Standalone(build_graph) => rr_build::execute_standalone_build_silently(
+            &build_config,
+            build_graph,
+            target_dir,
+            user_log,
+        )?,
     };
     if build_result.successful() {
         crate::resources::reconcile_resource_mappings(build_meta)?;
@@ -847,7 +850,7 @@ fn run_executable(
         cmd.moonrun_policy.as_deref(),
     );
     run_cmd.args(&cmd.args);
-    output.user_log().info(rr_build::format_dry_run_command(
+    output.user_log().debug(rr_build::format_dry_run_command(
         &run_cmd,
         &executable.source_dir,
     ));

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -1208,7 +1208,7 @@ fn calc_user_intent_from_packages(
                 debug!(dir = %dir.display(), filename = ?filename, "resolved explicit path filter");
 
                 let Ok(pkg) = filter_pkg_by_dir(resolve_output, &dir) else {
-                    user_log.info(format!(
+                    user_log.warn(format!(
                         "skipping path `{}` because it is not a package in the current work context.",
                         path.display()
                     ));
@@ -1240,7 +1240,7 @@ fn calc_user_intent_from_packages(
 
             for (path, pkg_id) in unsupported_paths {
                 let pkg = resolve_output.pkg_dirs.get_package(pkg_id);
-                user_log.info(format!(
+                user_log.warn(format!(
                     "skipping path `{}` because package `{}` does not support target backend `{}`. Supported backends: {}",
                     path.display(),
                     pkg.fqn,

--- a/crates/moon/src/cli/tool.rs
+++ b/crates/moon/src/cli/tool.rs
@@ -28,7 +28,7 @@ use demangle::*;
 use embed::*;
 use format_and_diff::*;
 use format_workspace::*;
-use moonutil::{cli_support::UniversalFlags, user_log::UserLog};
+use moonutil::{cli_support::UniversalFlags, command_output::CommandOutput};
 use write_rsp_file::*;
 
 #[derive(Debug, clap::Parser)]
@@ -50,7 +50,7 @@ pub(crate) enum ToolSubcommands {
 pub(crate) fn run_tool(
     cli: &UniversalFlags,
     cmd: ToolSubcommand,
-    user_log: &UserLog,
+    output: &CommandOutput,
 ) -> anyhow::Result<i32> {
     match cmd.subcommand {
         ToolSubcommands::FormatAndDiff(subcmd) => run_format_and_diff(subcmd),
@@ -58,7 +58,7 @@ pub(crate) fn run_tool(
         ToolSubcommands::Embed(subcmd) => run_embed(subcmd),
         ToolSubcommands::WriteTccRspFile(subcmd) => write_tcc_rsp_file(subcmd),
         ToolSubcommands::BuildBinaryDep(subcmd) => {
-            build_binary_dep::run_build_binary_dep(cli, &subcmd, user_log)
+            build_binary_dep::run_build_binary_dep(cli, &subcmd, output)
         }
         ToolSubcommands::Demangle(subcmd) => Ok(run_demangle(subcmd)),
     }

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -186,7 +186,9 @@ pub(crate) fn run_build_binary_dep(
             target_dir,
             user_log,
         )?;
-        result.print_info(cli.quiet, "building")?;
+        if !result.successful() {
+            return Ok(result.return_code_for_success());
+        }
 
         install_build_rr(&build_meta, &cmd.install_path, bin_name)?;
     }

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -37,7 +37,8 @@ use moonbuild_rupes_recta::{
 };
 use moonutil::{
     build_options::RunMode, cli_support::AutoSyncFlags, cli_support::UniversalFlags,
-    locks::FileLock, project::PackageDirs, target::TargetBackend, user_log::UserLog,
+    command_output::CommandOutput, locks::FileLock, project::PackageDirs, target::TargetBackend,
+    user_log::UserLog,
 };
 
 use crate::{
@@ -66,8 +67,9 @@ pub(crate) struct BuildBinaryDepArgs {
 pub(crate) fn run_build_binary_dep(
     cli: &UniversalFlags,
     cmd: &BuildBinaryDepArgs,
-    user_log: &UserLog,
+    output: &CommandOutput,
 ) -> anyhow::Result<i32> {
+    let user_log = output.user_log();
     let dirs = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
@@ -180,12 +182,9 @@ pub(crate) fn run_build_binary_dep(
         // Generate all_pkgs.json for indirect dependency resolution
         rr_build::generate_all_pkgs_json(&build_meta)?;
 
-        let result = rr_build::execute_build(
-            &BuildConfig::from_flags(&build_flags, &cli.unstable_feature, cli.verbose),
-            build_graph,
-            target_dir,
-            user_log,
-        )?;
+        let cfg = BuildConfig::from_flags(&build_flags, &cli.unstable_feature, cli.verbose);
+        let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
+        rr_build::report_build_result(&result, rr_build::BuildOperation::Build, &cfg, output)?;
         if !result.successful() {
             return Ok(result.return_code_for_success());
         }

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -87,7 +87,7 @@ where
         let path = path.as_ref();
         let (dir, _) = canonicalize_with_filename(path)?;
         let Ok(pkg_id) = filter_pkg_by_dir(&dir) else {
-            user_log.info(format!(
+            user_log.warn(format!(
                 "skipping path `{}` because it is not a package in the current work context.",
                 path.display()
             ));
@@ -449,7 +449,7 @@ where
 
     for (path, pkg_id) in &unsupported {
         let pkg = resolve_output.pkg_dirs.get_package(*pkg_id);
-        user_log.info(format!(
+        user_log.warn(format!(
             "skipping path `{}` because package `{}` does not support target backend `{}`. Supported backends: {}",
             path.display(),
             pkg.fqn,

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -200,7 +200,7 @@ pub fn main() {
         GenerateTestDriver(g) => cli::generate_test_driver(flags, g),
         Info(i) => cli::run_info(flags, i, &output),
         Explain(e) => cli::run_explain(&flags, e),
-        Install(i) => cli::install_cli(flags, i, output.user_log()),
+        Install(i) => cli::install_cli(flags, i, &output),
         Login(l) => cli::mooncake_adapter::login_cli(flags, l),
         Whoami(w) => cli::run_whoami(&flags, w),
         New(n) => cli::run_new(&flags, n, output.user_log()),
@@ -216,7 +216,7 @@ pub fn main() {
         Upgrade(u) => cli::run_upgrade(flags, u),
         ShellCompletion(gs) => cli::gen_shellcomp(&flags, gs),
         Version(v) => cli::run_version(&flags, v),
-        Tool(v) => cli::run_tool(&flags, v, output.user_log()),
+        Tool(v) => cli::run_tool(&flags, v, &output),
         External(args) => cli::run_external(args),
     };
 

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -171,7 +171,7 @@ pub fn main() {
             }
         };
     flags.workspace_env = workspace_env;
-    let output = CommandOutput::new(flags.user_log_level());
+    let output = CommandOutput::new(flags.user_log_level(), flags.quiet);
 
     // Check for deprecated flags and emit warnings (after tracing is initialized)
     for warning in flags.deprecation_warnings() {

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -1147,15 +1147,21 @@ pub fn report_build_result(
     } else {
         String::new()
     };
-    if n_tasks == 0 {
-        output.user_log().info(format_args!(
-            "{FINISHED_STYLE}Finished.{FINISHED_STYLE:#} moon: no work to do{warnings_errors}"
-        ));
-    } else {
-        let task_plural = if n_tasks == 1 { "" } else { "s" };
-        output.user_log().info(format_args!(
-            "{FINISHED_STYLE}Finished.{FINISHED_STYLE:#} moon: ran {n_tasks} task{task_plural}, now up to date{warnings_errors}"
-        ));
+    if cfg.output_style != OutputStyle::Json {
+        output.write_status(|writer| {
+            if n_tasks == 0 {
+                writeln!(
+                    writer,
+                    "{FINISHED_STYLE}Finished.{FINISHED_STYLE:#} moon: no work to do{warnings_errors}"
+                )
+            } else {
+                let task_plural = if n_tasks == 1 { "" } else { "s" };
+                writeln!(
+                    writer,
+                    "{FINISHED_STYLE}Finished.{FINISHED_STYLE:#} moon: ran {n_tasks} task{task_plural}, now up to date{warnings_errors}"
+                )
+            }
+        })?;
     }
     Ok(())
 }

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -1013,22 +1013,37 @@ pub fn execute_build(
     target_dir: &Path,
     user_log: &UserLog,
 ) -> anyhow::Result<N2RunStats> {
-    let execution = execute_build_capturing(cfg, input, target_dir)?;
-    let result = finish_captured_build(cfg, &execution, None, user_log);
+    let result = execute_build_silently(cfg, input, target_dir, user_log)?;
     report_build_success(&result, user_log);
     Ok(result)
 }
 
-/// Execute standalone dependency-package work before script-package work.
+/// Execute a build plan without a durable completion summary.
+///
+/// This is for commands such as `run` and `prove` whose own result follows the
+/// build. Diagnostics and progress still use `user_log` during execution.
 #[instrument(skip_all)]
-pub fn execute_standalone_build(
+pub fn execute_build_silently(
+    cfg: &BuildConfig,
+    input: BuildInput,
+    target_dir: &Path,
+    user_log: &UserLog,
+) -> anyhow::Result<N2RunStats> {
+    let execution = execute_build_capturing(cfg, input, target_dir)?;
+    Ok(finish_captured_build(cfg, &execution, None, user_log))
+}
+
+/// Execute standalone dependency-package work before script-package work
+/// without a durable completion summary.
+#[instrument(skip_all)]
+pub fn execute_standalone_build_silently(
     cfg: &BuildConfig,
     input: StandaloneBuildInput,
     target_dir: &Path,
     user_log: &UserLog,
 ) -> anyhow::Result<N2RunStats> {
     let Some(dependencies) = input.dependencies else {
-        return execute_build(cfg, input.script, target_dir, user_log);
+        return execute_build_silently(cfg, input.script, target_dir, user_log);
     };
 
     let dependency_execution = execute_build_capturing(cfg, dependencies, target_dir)?;
@@ -1083,7 +1098,7 @@ pub fn execute_test_build(
 ) -> anyhow::Result<N2RunStats> {
     let start_nodes = input.graph.get_start_nodes();
 
-    let result = execute_build_partial(
+    execute_build_partial(
         cfg,
         input,
         target_dir,
@@ -1095,9 +1110,7 @@ pub fn execute_test_build(
             }
             Ok(())
         }),
-    )?;
-    report_build_success(&result, user_log);
-    Ok(result)
+    )
 }
 
 fn report_build_success(result: &N2RunStats, user_log: &UserLog) {

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -54,6 +54,7 @@ use moonutil::{
     build_options::RunMode,
     cli_support::AutoSyncFlags,
     cli_support::UniversalFlags,
+    command_output::CommandOutput,
     compiler_flags::{self, CC},
     cond_expr::OptLevel as BuildProfile,
     constants::{BLACKBOX_TEST_PATCH, MOONBITLANG_CORE, WHITEBOX_TEST_PATCH},
@@ -1013,37 +1014,20 @@ pub fn execute_build(
     target_dir: &Path,
     user_log: &UserLog,
 ) -> anyhow::Result<N2RunStats> {
-    let result = execute_build_silently(cfg, input, target_dir, user_log)?;
-    report_build_success(&result, user_log);
-    Ok(result)
-}
-
-/// Execute a build plan without a durable completion summary.
-///
-/// This is for commands such as `run` and `prove` whose own result follows the
-/// build. Diagnostics and progress still use `user_log` during execution.
-#[instrument(skip_all)]
-pub fn execute_build_silently(
-    cfg: &BuildConfig,
-    input: BuildInput,
-    target_dir: &Path,
-    user_log: &UserLog,
-) -> anyhow::Result<N2RunStats> {
     let execution = execute_build_capturing(cfg, input, target_dir)?;
     Ok(finish_captured_build(cfg, &execution, None, user_log))
 }
 
-/// Execute standalone dependency-package work before script-package work
-/// without a durable completion summary.
+/// Execute standalone dependency-package work before script-package work.
 #[instrument(skip_all)]
-pub fn execute_standalone_build_silently(
+pub fn execute_standalone_build(
     cfg: &BuildConfig,
     input: StandaloneBuildInput,
     target_dir: &Path,
     user_log: &UserLog,
 ) -> anyhow::Result<N2RunStats> {
     let Some(dependencies) = input.dependencies else {
-        return execute_build_silently(cfg, input.script, target_dir, user_log);
+        return execute_build(cfg, input.script, target_dir, user_log);
     };
 
     let dependency_execution = execute_build_capturing(cfg, dependencies, target_dir)?;
@@ -1113,11 +1097,46 @@ pub fn execute_test_build(
     )
 }
 
-fn report_build_success(result: &N2RunStats, user_log: &UserLog) {
+#[derive(Debug, Clone, Copy)]
+pub enum BuildOperation {
+    Build,
+    Bundle,
+    Check,
+    Format,
+    GenerateMbti,
+}
+
+/// Report the user-facing result of a complete command build.
+///
+/// Compiler diagnostics are emitted independently during execution. This
+/// function owns only Moon's durable command result and status messages.
+pub fn report_build_result(
+    result: &N2RunStats,
+    operation: BuildOperation,
+    cfg: &BuildConfig,
+    output: &CommandOutput,
+) -> anyhow::Result<()> {
     let Some(n_tasks) = result.n_tasks_executed else {
-        // Failed tasks already emitted their diagnostics. Reporting another error here
-        // would duplicate that output, and diagnostic counts vary by output renderer.
-        return;
+        if cfg.output_style != OutputStyle::Json {
+            output.write_result(|writer| {
+                writeln!(
+                    writer,
+                    "Failed with {} warnings, {} errors.",
+                    result.n_warnings, result.n_errors
+                )
+            })?;
+        }
+        let operation = match operation {
+            BuildOperation::Build => "building",
+            BuildOperation::Bundle => "bundling",
+            BuildOperation::Check => "checking",
+            BuildOperation::Format => "formatting",
+            BuildOperation::GenerateMbti => "generating mbti files",
+        };
+        output
+            .user_log()
+            .error(format!("failed when {operation} project"));
+        return Ok(());
     };
 
     let warnings_errors = if result.n_warnings > 0 || result.n_errors > 0 {
@@ -1129,15 +1148,16 @@ fn report_build_success(result: &N2RunStats, user_log: &UserLog) {
         String::new()
     };
     if n_tasks == 0 {
-        user_log.info(format_args!(
+        output.user_log().info(format_args!(
             "{FINISHED_STYLE}Finished.{FINISHED_STYLE:#} moon: no work to do{warnings_errors}"
         ));
     } else {
         let task_plural = if n_tasks == 1 { "" } else { "s" };
-        user_log.info(format_args!(
+        output.user_log().info(format_args!(
             "{FINISHED_STYLE}Finished.{FINISHED_STYLE:#} moon: ran {n_tasks} task{task_plural}, now up to date{warnings_errors}"
         ));
     }
+    Ok(())
 }
 
 /// Callback on the [`n2::work::Work`] to be done for target artifacts.

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -75,6 +75,8 @@ pub use dry_run::{
     format_dry_run_command, write_dry_run, write_dry_run_all, write_standalone_dry_run,
 };
 
+const FINISHED_STYLE: anstyle::Style = anstyle::AnsiColor::Green.on_default().bold();
+
 /// The output of a calculate user intent operation.
 pub struct CalcUserIntentOutput {
     /// The list of user intents; will be expanded to concrete BuildPlanNode(s) later.
@@ -218,40 +220,6 @@ impl BuildMeta {
         self.backend.target_backend()
     }
 }
-
-/// Represents the result of the build process
-#[derive(Debug, Clone)]
-pub enum BuildResult {
-    /// The build succeeded with the given number of tasks executed.
-    Succeeded(usize),
-    /// The build failed.
-    Failed,
-}
-
-impl BuildResult {
-    /// Whether the build was successful.
-    pub fn successful(&self) -> bool {
-        matches!(self, BuildResult::Succeeded(_))
-    }
-
-    /// Get the return code that should be returned to the shell.
-    pub fn return_code_for_success(&self) -> i32 {
-        if self.successful() { 0 } else { 1 }
-    }
-
-    /// Print information about the build result.
-    pub fn print_info(&self) {
-        match self {
-            BuildResult::Succeeded(n) => {
-                println!("{} task(s) executed.", n);
-            }
-            BuildResult::Failed => {
-                println!("Build failed.");
-            }
-        }
-    }
-}
-
 /// A preliminary configuration that does not require run-time information to
 /// populate. Will be transformed into [`CompileConfig`] later in the pipeline.
 ///
@@ -1046,7 +1014,9 @@ pub fn execute_build(
     user_log: &UserLog,
 ) -> anyhow::Result<N2RunStats> {
     let execution = execute_build_capturing(cfg, input, target_dir)?;
-    Ok(finish_captured_build(cfg, &execution, None, user_log))
+    let result = finish_captured_build(cfg, &execution, None, user_log);
+    report_build_success(&result, user_log);
+    Ok(result)
 }
 
 /// Execute standalone dependency-package work before script-package work.
@@ -1113,7 +1083,7 @@ pub fn execute_test_build(
 ) -> anyhow::Result<N2RunStats> {
     let start_nodes = input.graph.get_start_nodes();
 
-    execute_build_partial(
+    let result = execute_build_partial(
         cfg,
         input,
         target_dir,
@@ -1125,7 +1095,36 @@ pub fn execute_test_build(
             }
             Ok(())
         }),
-    )
+    )?;
+    report_build_success(&result, user_log);
+    Ok(result)
+}
+
+fn report_build_success(result: &N2RunStats, user_log: &UserLog) {
+    let Some(n_tasks) = result.n_tasks_executed else {
+        // Failed tasks already emitted their diagnostics. Reporting another error here
+        // would duplicate that output, and diagnostic counts vary by output renderer.
+        return;
+    };
+
+    let warnings_errors = if result.n_warnings > 0 || result.n_errors > 0 {
+        format!(
+            " ({} warnings, {} errors)",
+            result.n_warnings, result.n_errors
+        )
+    } else {
+        String::new()
+    };
+    if n_tasks == 0 {
+        user_log.info(format_args!(
+            "{FINISHED_STYLE}Finished.{FINISHED_STYLE:#} moon: no work to do{warnings_errors}"
+        ));
+    } else {
+        let task_plural = if n_tasks == 1 { "" } else { "s" };
+        user_log.info(format_args!(
+            "{FINISHED_STYLE}Finished.{FINISHED_STYLE:#} moon: ran {n_tasks} task{task_plural}, now up to date{warnings_errors}"
+        ));
+    }
 }
 
 /// Callback on the [`n2::work::Work`] to be done for target artifacts.

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -29,6 +29,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    io,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -1106,6 +1107,13 @@ pub enum BuildOperation {
     GenerateMbti,
 }
 
+fn ignore_broken_pipe(result: io::Result<()>) -> io::Result<()> {
+    match result {
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        result => result,
+    }
+}
+
 /// Report the user-facing result of a complete command build.
 ///
 /// Compiler diagnostics are emitted independently during execution. This
@@ -1118,13 +1126,13 @@ pub fn report_build_result(
 ) -> anyhow::Result<()> {
     let Some(n_tasks) = result.n_tasks_executed else {
         if cfg.output_style != OutputStyle::Json {
-            output.write_result(|writer| {
+            ignore_broken_pipe(output.write_result(|writer| {
                 writeln!(
                     writer,
                     "Failed with {} warnings, {} errors.",
                     result.n_warnings, result.n_errors
                 )
-            })?;
+            }))?;
         }
         let operation = match operation {
             BuildOperation::Build => "building",
@@ -1148,7 +1156,7 @@ pub fn report_build_result(
         String::new()
     };
     if cfg.output_style != OutputStyle::Json {
-        output.write_status(|writer| {
+        ignore_broken_pipe(output.write_status(|writer| {
             if n_tasks == 0 {
                 writeln!(
                     writer,
@@ -1161,7 +1169,7 @@ pub fn report_build_result(
                     "{FINISHED_STYLE}Finished.{FINISHED_STYLE:#} moon: ran {n_tasks} task{task_plural}, now up to date{warnings_errors}"
                 )
             }
-        })?;
+        }))?;
     }
     Ok(())
 }

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -767,7 +767,7 @@ fn run_one_test_executable(
     cmd.current_dir(module_root);
     let mut cov_cap = mk_coverage_capture();
     let mut test_cap = make_test_capture();
-    ctx.user_log.info(crate::rr_build::format_dry_run_command(
+    ctx.user_log.debug(crate::rr_build::format_dry_run_command(
         &cmd,
         ctx.source_dir,
     ));

--- a/crates/moon/tests/test_cases/build_binary_dep_failure.in/main/main.mbt
+++ b/crates/moon/tests/test_cases/build_binary_dep_failure.in/main/main.mbt
@@ -1,0 +1,4 @@
+fn main {
+  let value : Int = "not an integer"
+  println(value)
+}

--- a/crates/moon/tests/test_cases/build_binary_dep_failure.in/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/build_binary_dep_failure.in/main/moon.pkg.json
@@ -1,0 +1,5 @@
+{
+  "is-main": true,
+  "bin-target": "native",
+  "bin-name": "broken-bin"
+}

--- a/crates/moon/tests/test_cases/build_binary_dep_failure.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/build_binary_dep_failure.in/moon.mod.json
@@ -1,0 +1,3 @@
+{
+  "name": "test/build_binary_dep_failure"
+}

--- a/crates/moon/tests/test_cases/build_package_dep_core/mod.rs
+++ b/crates/moon/tests/test_cases/build_package_dep_core/mod.rs
@@ -6,7 +6,7 @@ use super::*;
 fn test_build_package_tracks_dependency_core_artifact() {
     let dir = TestDir::new("build_package_dep_core/build_package_dep_core.in");
 
-    let first_build = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
+    let first_build = get_stderr(&dir, ["build", "--target", "wasm-gc", "--verbose"]);
     assert!(
         first_build.contains("Finished. moon: ran 3 tasks, now up to date"),
         "initial build should compile lib, main, and linked core; got:\n{first_build}"
@@ -27,11 +27,9 @@ fn test_build_package_tracks_dependency_core_artifact() {
         .expect("lib core edit should succeed");
     drop(lib_core_file);
 
-    let second_build = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
-    check(
-        second_build,
-        expect![[r#"
-            Finished. moon: ran 3 tasks, now up to date
-        "#]],
+    let second_build = get_stderr(&dir, ["build", "--target", "wasm-gc", "--verbose"]);
+    assert!(
+        second_build.contains("Finished. moon: ran 3 tasks, now up to date"),
+        "editing the dependency core should rebuild lib, main, and the link; got:\n{second_build}"
     );
 }

--- a/crates/moon/tests/test_cases/build_package_dep_core/mod.rs
+++ b/crates/moon/tests/test_cases/build_package_dep_core/mod.rs
@@ -6,7 +6,7 @@ use super::*;
 fn test_build_package_tracks_dependency_core_artifact() {
     let dir = TestDir::new("build_package_dep_core/build_package_dep_core.in");
 
-    let first_build = get_stderr(&dir, ["build", "--target", "wasm-gc", "--verbose"]);
+    let first_build = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
     assert!(
         first_build.contains("Finished. moon: ran 3 tasks, now up to date"),
         "initial build should compile lib, main, and linked core; got:\n{first_build}"
@@ -27,9 +27,11 @@ fn test_build_package_tracks_dependency_core_artifact() {
         .expect("lib core edit should succeed");
     drop(lib_core_file);
 
-    let second_build = get_stderr(&dir, ["build", "--target", "wasm-gc", "--verbose"]);
-    assert!(
-        second_build.contains("Finished. moon: ran 3 tasks, now up to date"),
-        "editing the dependency core should rebuild lib, main, and the link; got:\n{second_build}"
+    let second_build = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
+    check(
+        second_build,
+        expect![[r#"
+            Finished. moon: ran 3 tasks, now up to date
+        "#]],
     );
 }

--- a/crates/moon/tests/test_cases/build_package_dep_core/mod.rs
+++ b/crates/moon/tests/test_cases/build_package_dep_core/mod.rs
@@ -6,7 +6,7 @@ use super::*;
 fn test_build_package_tracks_dependency_core_artifact() {
     let dir = TestDir::new("build_package_dep_core/build_package_dep_core.in");
 
-    let first_build = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
+    let first_build = get_stdout(&dir, ["build", "--target", "wasm-gc"]);
     assert!(
         first_build.contains("Finished. moon: ran 3 tasks, now up to date"),
         "initial build should compile lib, main, and linked core; got:\n{first_build}"
@@ -27,7 +27,7 @@ fn test_build_package_tracks_dependency_core_artifact() {
         .expect("lib core edit should succeed");
     drop(lib_core_file);
 
-    let second_build = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
+    let second_build = get_stdout(&dir, ["build", "--target", "wasm-gc"]);
     check(
         second_build,
         expect![[r#"

--- a/crates/moon/tests/test_cases/build_workflow.rs
+++ b/crates/moon/tests/test_cases/build_workflow.rs
@@ -70,18 +70,45 @@ fn test_need_link() {
 }
 
 #[test]
-fn test_no_work_to_do() {
+fn test_build_summary_follows_user_log_level() {
     let dir = TestDir::new("moon_new/plain");
-    let out = get_stderr(&dir, ["check"]);
-    assert!(out.contains("now up to date"));
+    assert_eq!(get_stderr(&dir, ["check"]), "");
 
-    let out = get_stderr(&dir, ["check"]);
+    let out = get_stderr(&dir, ["check", "--verbose"]);
     assert!(out.contains("moon: no work to do"));
 
-    let out = get_stderr(&dir, ["build"]);
-    assert!(out.contains("now up to date"));
-    let out = get_stderr(&dir, ["build"]);
+    assert_eq!(get_stderr(&dir, ["build"]), "");
+    let out = get_stderr(&dir, ["build", "--verbose"]);
     assert!(out.contains("moon: no work to do"));
+}
+
+#[test]
+fn failed_binary_dependency_build_is_not_installed() {
+    let dir = TestDir::new("build_binary_dep_failure.in");
+    let assert = moon_cmd(&dir)
+        .args([
+            "tool",
+            "build-binary-dep",
+            "main",
+            "--install-path",
+            "installed",
+        ])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+
+    assert!(
+        stderr.contains("Expr Type Mismatch"),
+        "expected the compiler diagnostic, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Failed to build"),
+        "build failure should not add a synthetic summary, stderr: {stderr}"
+    );
+    assert!(
+        !dir.join("installed").exists(),
+        "a failed binary dependency build must not install any artifact"
+    );
 }
 
 #[test]
@@ -140,9 +167,7 @@ fn test_failed_to_fill_whole_buffer() {
     let dir = TestDir::new("hello");
     check(
         get_stderr(&dir, ["check", "--target", "wasm-gc"]),
-        expect![[r#"
-            Finished. moon: ran 2 tasks, now up to date
-        "#]],
+        expect![""],
     );
 
     // corrupt the DB intentionally
@@ -368,8 +393,6 @@ fn test_diag_source_map_remaps_generated_sources() {
                     has type : String
                     wanted   : Int
             ─────╯
-            Failed with 0 warnings, 1 errors.
-            Error: failed when checking project
         "#]],
     );
 
@@ -388,8 +411,6 @@ fn test_diag_source_map_remaps_generated_sources() {
                     has type : String
                     wanted   : Int
             ───╯
-            Failed with 0 warnings, 1 errors.
-            Error: failed when checking project
         "#]],
     );
 }
@@ -415,22 +436,7 @@ fn test_no_warn_deps() {
     let dir = TestDir::new("no_warn_deps.in");
     let dir = dir.join("user.in");
 
-    check(
-        get_stderr(&dir, ["check"]),
-        expect![[r#"
-            Finished. moon: ran 5 tasks, now up to date
-        "#]],
-    );
-    check(
-        get_stderr(&dir, ["check", "--deny-warn"]),
-        expect![[r#"
-            Finished. moon: ran 5 tasks, now up to date
-        "#]],
-    );
-    check(
-        get_stderr(&dir, ["build"]),
-        expect![[r#"
-            Finished. moon: ran 3 tasks, now up to date
-        "#]],
-    );
+    check(get_stderr(&dir, ["check"]), expect![""]);
+    check(get_stderr(&dir, ["check", "--deny-warn"]), expect![""]);
+    check(get_stderr(&dir, ["build"]), expect![""]);
 }

--- a/crates/moon/tests/test_cases/build_workflow.rs
+++ b/crates/moon/tests/test_cases/build_workflow.rs
@@ -16,6 +16,8 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use std::process::Stdio;
+
 use super::*;
 
 #[test]
@@ -90,6 +92,48 @@ fn test_build_summary_uses_stdout_and_respects_quiet() {
 
     let out = get_stdout(&dir, ["build"]);
     assert!(out.contains("moon: no work to do"));
+}
+
+#[test]
+fn test_closed_summary_pipe_does_not_change_build_status() {
+    let dir = TestDir::new("moon_new/plain");
+    let mut child = moon_process_cmd(&dir)
+        .args(["check"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    drop(child.stdout.take());
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "a closed summary pipe changed a successful build to {output:?}"
+    );
+    assert_eq!(output.stderr, b"");
+
+    let dir = TestDir::new("build_binary_dep_failure.in");
+    let mut child = moon_process_cmd(&dir)
+        .args([
+            "tool",
+            "build-binary-dep",
+            "main",
+            "--install-path",
+            "installed",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    drop(child.stdout.take());
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a closed summary pipe changed the failed build status: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Error: failed when building project"));
+    assert!(!stderr.contains("Broken pipe"));
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/build_workflow.rs
+++ b/crates/moon/tests/test_cases/build_workflow.rs
@@ -103,15 +103,17 @@ fn failed_binary_dependency_build_is_not_installed() {
         ])
         .assert()
         .failure();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
 
+    assert_eq!(stdout, "Failed with 0 warnings, 1 errors.\n");
     assert!(
         stderr.contains("Expr Type Mismatch"),
         "expected the compiler diagnostic, stderr: {stderr}"
     );
     assert!(
-        !stderr.contains("Failed to build"),
-        "build failure should not add a synthetic summary, stderr: {stderr}"
+        stderr.contains("Error: failed when building project"),
+        "expected the command failure context, stderr: {stderr}"
     );
     assert!(
         !dir.join("installed").exists(),
@@ -403,6 +405,7 @@ fn test_diag_source_map_remaps_generated_sources() {
                     has type : String
                     wanted   : Int
             ─────╯
+            Error: failed when checking project
         "#]],
     );
 
@@ -421,6 +424,7 @@ fn test_diag_source_map_remaps_generated_sources() {
                     has type : String
                     wanted   : Int
             ───╯
+            Error: failed when checking project
         "#]],
     );
 }

--- a/crates/moon/tests/test_cases/build_workflow.rs
+++ b/crates/moon/tests/test_cases/build_workflow.rs
@@ -72,13 +72,21 @@ fn test_need_link() {
 #[test]
 fn test_build_summary_follows_user_log_level() {
     let dir = TestDir::new("moon_new/plain");
-    assert_eq!(get_stderr(&dir, ["check"]), "");
+    let out = get_stderr(&dir, ["check"]);
+    assert!(out.contains("now up to date"));
 
-    let out = get_stderr(&dir, ["check", "--verbose"]);
+    assert_eq!(get_stderr(&dir, ["check", "--quiet"]), "");
+
+    let out = get_stderr(&dir, ["check"]);
     assert!(out.contains("moon: no work to do"));
 
-    assert_eq!(get_stderr(&dir, ["build"]), "");
-    let out = get_stderr(&dir, ["build", "--verbose"]);
+    let dir = TestDir::new("moon_new/plain");
+    let out = get_stderr(&dir, ["build"]);
+    assert!(out.contains("now up to date"));
+
+    assert_eq!(get_stderr(&dir, ["build", "--quiet"]), "");
+
+    let out = get_stderr(&dir, ["build"]);
     assert!(out.contains("moon: no work to do"));
 }
 
@@ -167,7 +175,9 @@ fn test_failed_to_fill_whole_buffer() {
     let dir = TestDir::new("hello");
     check(
         get_stderr(&dir, ["check", "--target", "wasm-gc"]),
-        expect![""],
+        expect![[r#"
+            Finished. moon: ran 2 tasks, now up to date
+        "#]],
     );
 
     // corrupt the DB intentionally
@@ -436,7 +446,22 @@ fn test_no_warn_deps() {
     let dir = TestDir::new("no_warn_deps.in");
     let dir = dir.join("user.in");
 
-    check(get_stderr(&dir, ["check"]), expect![""]);
-    check(get_stderr(&dir, ["check", "--deny-warn"]), expect![""]);
-    check(get_stderr(&dir, ["build"]), expect![""]);
+    check(
+        get_stderr(&dir, ["check"]),
+        expect![[r#"
+            Finished. moon: ran 5 tasks, now up to date
+        "#]],
+    );
+    check(
+        get_stderr(&dir, ["check", "--deny-warn"]),
+        expect![[r#"
+            Finished. moon: ran 5 tasks, now up to date
+        "#]],
+    );
+    check(
+        get_stderr(&dir, ["build"]),
+        expect![[r#"
+            Finished. moon: ran 3 tasks, now up to date
+        "#]],
+    );
 }

--- a/crates/moon/tests/test_cases/build_workflow.rs
+++ b/crates/moon/tests/test_cases/build_workflow.rs
@@ -70,23 +70,25 @@ fn test_need_link() {
 }
 
 #[test]
-fn test_build_summary_follows_user_log_level() {
+fn test_build_summary_uses_stdout_and_respects_quiet() {
     let dir = TestDir::new("moon_new/plain");
-    let out = get_stderr(&dir, ["check"]);
+    let out = get_stdout(&dir, ["check"]);
     assert!(out.contains("now up to date"));
+    assert_eq!(get_stderr(&dir, ["check"]), "");
 
-    assert_eq!(get_stderr(&dir, ["check", "--quiet"]), "");
+    assert_eq!(get_stdout(&dir, ["check", "--quiet"]), "");
 
-    let out = get_stderr(&dir, ["check"]);
+    let out = get_stdout(&dir, ["check"]);
     assert!(out.contains("moon: no work to do"));
 
     let dir = TestDir::new("moon_new/plain");
-    let out = get_stderr(&dir, ["build"]);
+    let out = get_stdout(&dir, ["build"]);
     assert!(out.contains("now up to date"));
+    assert_eq!(get_stderr(&dir, ["build"]), "");
 
-    assert_eq!(get_stderr(&dir, ["build", "--quiet"]), "");
+    assert_eq!(get_stdout(&dir, ["build", "--quiet"]), "");
 
-    let out = get_stderr(&dir, ["build"]);
+    let out = get_stdout(&dir, ["build"]);
     assert!(out.contains("moon: no work to do"));
 }
 
@@ -176,7 +178,7 @@ fn test_failed_to_fill_whole_buffer() {
 
     let dir = TestDir::new("hello");
     check(
-        get_stderr(&dir, ["check", "--target", "wasm-gc"]),
+        get_stdout(&dir, ["check", "--target", "wasm-gc"]),
         expect![[r#"
             Finished. moon: ran 2 tasks, now up to date
         "#]],
@@ -451,19 +453,19 @@ fn test_no_warn_deps() {
     let dir = dir.join("user.in");
 
     check(
-        get_stderr(&dir, ["check"]),
+        get_stdout(&dir, ["check"]),
         expect![[r#"
             Finished. moon: ran 5 tasks, now up to date
         "#]],
     );
     check(
-        get_stderr(&dir, ["check", "--deny-warn"]),
+        get_stdout(&dir, ["check", "--deny-warn"]),
         expect![[r#"
             Finished. moon: ran 5 tasks, now up to date
         "#]],
     );
     check(
-        get_stderr(&dir, ["build"]),
+        get_stdout(&dir, ["build"]),
         expect![[r#"
             Finished. moon: ran 3 tasks, now up to date
         "#]],

--- a/crates/moon/tests/test_cases/cond_comp.in/moon.test
+++ b/crates/moon/tests/test_cases/cond_comp.in/moon.test
@@ -76,6 +76,7 @@
      │     ──────────┬─────────  
      │               ╰─────────── Warning (unused_package): Unused package 'username/hello/lib'
   ───╯
+  Finished. moon: ran 4 tasks, now up to date (2 warnings, 0 errors)
   
   $ xcat _build/packages.json
   {

--- a/crates/moon/tests/test_cases/cond_comp.in/moon.test
+++ b/crates/moon/tests/test_cases/cond_comp.in/moon.test
@@ -61,6 +61,7 @@
   moonc bundle-core ./_build/js/release/bundle/lib/lib.core ./_build/js/release/bundle/main/main.core -o ./_build/js/release/bundle/hello.core
   
   $ moon check --target wasm-gc --sort-input
+  Finished. moon: ran 4 tasks, now up to date (2 warnings, 0 errors)
   
   Warning: [0002]
      ╭─[ [WORK_DIR]/src/lib/only_debug.mbt:2:7 ]
@@ -76,7 +77,6 @@
      │     ──────────┬─────────  
      │               ╰─────────── Warning (unused_package): Unused package 'username/hello/lib'
   ───╯
-  Finished. moon: ran 4 tasks, now up to date (2 warnings, 0 errors)
   
   $ xcat _build/packages.json
   {

--- a/crates/moon/tests/test_cases/cond_comp.in/moon.test
+++ b/crates/moon/tests/test_cases/cond_comp.in/moon.test
@@ -76,7 +76,6 @@
      │     ──────────┬─────────  
      │               ╰─────────── Warning (unused_package): Unused package 'username/hello/lib'
   ───╯
-  Finished. moon: ran 4 tasks, now up to date (2 warnings, 0 errors)
   
   $ xcat _build/packages.json
   {

--- a/crates/moon/tests/test_cases/dedup_diag/mod.rs
+++ b/crates/moon/tests/test_cases/dedup_diag/mod.rs
@@ -82,8 +82,6 @@ fn test_diagnostic_limit_prioritizes_errors() {
                │            ╰────────── The value identifier missing_identifier is unbound.
             ───╯
             Warning: diagnostic output limited by --diagnostic-limit: 0 errors and 3 warnings were not displayed.
-            Failed with 3 warnings, 1 errors.
-            Error: failed when checking project
         "#]],
     )
 }

--- a/crates/moon/tests/test_cases/dedup_diag/mod.rs
+++ b/crates/moon/tests/test_cases/dedup_diag/mod.rs
@@ -69,6 +69,13 @@ fn test_diagnostic_limit_rendered_output() {
 #[test]
 fn test_diagnostic_limit_prioritizes_errors() {
     let dir = TestDir::new("dedup_diag_error_limit.in");
+    check(
+        get_err_stdout(&dir, ["check", "--diagnostic-limit", "1"]),
+        expect![[r#"
+            Failed with 3 warnings, 1 errors.
+        "#]],
+    );
+
     let err = trim_trailing_spaces(get_err_stderr(&dir, ["check", "--diagnostic-limit", "1"]));
 
     check(
@@ -82,6 +89,30 @@ fn test_diagnostic_limit_prioritizes_errors() {
                │            ╰────────── The value identifier missing_identifier is unbound.
             ───╯
             Warning: diagnostic output limited by --diagnostic-limit: 0 errors and 3 warnings were not displayed.
+            Error: failed when checking project
         "#]],
     )
+}
+
+#[test]
+fn test_json_diagnostics_do_not_include_human_failure_summary() {
+    let dir = TestDir::new("dedup_diag_error_limit.in");
+    let stdout = get_err_stdout(
+        &dir,
+        [
+            "check",
+            "--output-json",
+            "--diagnostic-limit",
+            "1",
+            "--sort-input",
+        ],
+    );
+
+    assert!(!stdout.contains("Failed with"), "stdout: {stdout}");
+    assert!(
+        stdout
+            .lines()
+            .all(|line| serde_json::from_str::<serde_json::Value>(line).is_ok()),
+        "stdout must remain JSONL diagnostics: {stdout}"
+    );
 }

--- a/crates/moon/tests/test_cases/executable_resources/mod.rs
+++ b/crates/moon/tests/test_cases/executable_resources/mod.rs
@@ -128,8 +128,8 @@ fn changing_data_directory_contents_does_not_rebuild_the_executable() {
         .args(["build", "--target", "wasm"])
         .assert()
         .success()
-        .stdout_eq("")
-        .stderr_eq("Finished. moon: no work to do\n");
+        .stdout_eq("Finished. moon: no work to do\n")
+        .stderr_eq("");
     assert_eq!(
         std::fs::read_to_string(dir.join("_build/wasm/debug/build/app/assets/template.mbt"))
             .unwrap(),

--- a/crates/moon/tests/test_cases/filter_by_path/mod.rs
+++ b/crates/moon/tests/test_cases/filter_by_path/mod.rs
@@ -515,7 +515,14 @@ fn test_moon_build_filter_by_multiple_paths_skips_outside_current_root() {
             OsString::from("--sort-input"),
         ],
     );
-    assert!(!stderr.contains("skipping path"), "stderr: {stderr}");
+    assert!(
+        stderr.contains(&format!("Warning: skipping path `{outside_display}`")),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("Warning: skipping path `{other_pkg_display}`")),
+        "stderr: {stderr}"
+    );
 }
 
 #[test]
@@ -704,7 +711,14 @@ fn test_moon_check_filter_by_multiple_paths_skips_outside_current_root() {
             OsString::from("--sort-input"),
         ],
     );
-    assert!(!stderr.contains("skipping path"), "stderr: {stderr}");
+    assert!(
+        stderr.contains(&format!("Warning: skipping path `{outside_display}`")),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("Warning: skipping path `{other_pkg_display}`")),
+        "stderr: {stderr}"
+    );
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/filter_by_path/mod.rs
+++ b/crates/moon/tests/test_cases/filter_by_path/mod.rs
@@ -136,7 +136,8 @@ fn test_moon_info_compile_failure_exits_with_status_1() {
         .current_dir(&dir)
         .args(["info"])
         .assert()
-        .failure();
+        .failure()
+        .stdout_eq("Failed with 0 warnings, 1 errors.\n");
 
     assert_eq!(assert.get_output().status.code(), Some(1));
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
@@ -145,7 +146,7 @@ fn test_moon_info_compile_failure_exits_with_status_1() {
         "stderr: {stderr}"
     );
     assert!(
-        !stderr.contains("Error: failed when generating mbti files project"),
+        stderr.contains("Error: failed when generating mbti files project"),
         "stderr: {stderr}"
     );
 }

--- a/crates/moon/tests/test_cases/filter_by_path/mod.rs
+++ b/crates/moon/tests/test_cases/filter_by_path/mod.rs
@@ -47,9 +47,10 @@ fn run_info_and_clear(
         std::fs::remove_file(&generated).unwrap();
     }
 
-    check(
-        get_stdout(working_dir, args.iter().copied()),
-        expect![[r#""#]],
+    let stdout = get_stdout(working_dir, args.iter().copied());
+    assert!(
+        stdout.contains("now up to date") || stdout.contains("no work to do"),
+        "stdout: {stdout}"
     );
 
     assert!(
@@ -162,7 +163,12 @@ fn test_moon_info_filter_by_multiple_paths_success() {
         }
     }
 
-    check(get_stdout(&dir, ["info", "A", "lib"]), expect![[r#""#]]);
+    check(
+        get_stdout(&dir, ["info", "A", "lib"]),
+        expect![[r#"
+            Finished. moon: ran 4 tasks, now up to date
+        "#]],
+    );
 
     for pkg in ["A", "lib"] {
         let generated = dir.join(pkg).join(MBTI_GENERATED);
@@ -203,7 +209,9 @@ fn test_moon_info_filter_by_multiple_paths_skips_outside_current_root() {
                 other_pkg.as_os_str().to_os_string(),
             ],
         ),
-        expect![[r#""#]],
+        expect![[r#"
+            Finished. moon: ran 2 tasks, now up to date
+        "#]],
     );
 
     let generated = dir.join("A").join(MBTI_GENERATED);
@@ -243,7 +251,12 @@ fn test_moon_info_filter_by_multiple_paths_skips_same_root_non_packages() {
         }
     }
 
-    check(get_stdout(&dir, ["info", "A", "notes"]), expect![[r#""#]]);
+    check(
+        get_stdout(&dir, ["info", "A", "notes"]),
+        expect![[r#"
+            Finished. moon: ran 2 tasks, now up to date
+        "#]],
+    );
 
     let generated = dir.join("A").join(MBTI_GENERATED);
     assert!(generated.exists(), "missing {}", generated.display());
@@ -266,7 +279,9 @@ fn test_moon_info_filter_by_multiple_paths_skips_pkg_like_dirs_outside_source() 
 
     check(
         get_stdout(&dir, ["info", "src/main", "generated/ghost"]),
-        expect![[r#""#]],
+        expect![[r#"
+            Finished. moon: ran 2 tasks, now up to date
+        "#]],
     );
 
     assert!(generated.exists(), "missing {}", generated.display());

--- a/crates/moon/tests/test_cases/import_stdlib/mod.rs
+++ b/crates/moon/tests/test_cases/import_stdlib/mod.rs
@@ -4,13 +4,13 @@ use super::*;
 fn test_import_stdlib() {
     let dir = TestDir::new("import_stdlib/import_stdlib.in");
 
-    let check = get_stderr(&dir, ["check"]);
+    let check = get_stdout(&dir, ["check"]);
     expect![[r#"
         Finished. moon: ran 4 tasks, now up to date
     "#]]
     .assert_eq(&check);
 
-    let build = get_stderr(&dir, ["build"]);
+    let build = get_stdout(&dir, ["build"]);
     expect![[r#"
         Finished. moon: ran 2 tasks, now up to date
     "#]]

--- a/crates/moon/tests/test_cases/import_stdlib/mod.rs
+++ b/crates/moon/tests/test_cases/import_stdlib/mod.rs
@@ -5,15 +5,11 @@ fn test_import_stdlib() {
     let dir = TestDir::new("import_stdlib/import_stdlib.in");
 
     let check = get_stderr(&dir, ["check"]);
-    expect![[r#"
-        Finished. moon: ran 4 tasks, now up to date
-    "#]]
+    expect![""]
     .assert_eq(&check);
 
     let build = get_stderr(&dir, ["build"]);
-    expect![[r#"
-        Finished. moon: ran 2 tasks, now up to date
-    "#]]
+    expect![""]
     .assert_eq(&build);
 
     let test = get_stderr(&dir, ["test"]);

--- a/crates/moon/tests/test_cases/import_stdlib/mod.rs
+++ b/crates/moon/tests/test_cases/import_stdlib/mod.rs
@@ -5,11 +5,15 @@ fn test_import_stdlib() {
     let dir = TestDir::new("import_stdlib/import_stdlib.in");
 
     let check = get_stderr(&dir, ["check"]);
-    expect![""]
+    expect![[r#"
+        Finished. moon: ran 4 tasks, now up to date
+    "#]]
     .assert_eq(&check);
 
     let build = get_stderr(&dir, ["build"]);
-    expect![""]
+    expect![[r#"
+        Finished. moon: ran 2 tasks, now up to date
+    "#]]
     .assert_eq(&build);
 
     let test = get_stderr(&dir, ["test"]);

--- a/crates/moon/tests/test_cases/indirect_dep/mod.rs
+++ b/crates/moon/tests/test_cases/indirect_dep/mod.rs
@@ -59,9 +59,7 @@ fn test_all_pkgs() {
     let _ = get_stdout(&dir, ["clean"]);
     check(
         get_stderr(&dir, ["check", "--target", "wasm-gc"]),
-        expect![[r#"
-        Finished. moon: ran 10 tasks, now up to date
-    "#]],
+        expect![""],
     );
     let all_pkgs_path = dir.join("_build/wasm-gc/debug/check/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);
@@ -71,9 +69,7 @@ fn test_all_pkgs() {
     let _ = get_stdout(&dir, ["clean"]);
     check(
         get_stderr(&dir, ["build", "--target", "wasm-gc"]),
-        expect![[r#"
-            Finished. moon: ran 7 tasks, now up to date
-        "#]],
+        expect![""],
     );
     let all_pkgs_path = dir.join("_build/wasm-gc/debug/build/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);
@@ -108,9 +104,7 @@ fn test_all_pkgs() {
     let _ = get_stdout(&dir, ["clean"]);
     check(
         get_stderr(&dir, ["info", "--target", "wasm-gc"]),
-        expect![[r#"
-            Finished. moon: ran 10 tasks, now up to date
-        "#]],
+        expect![""],
     );
     let all_pkgs_path = dir.join("_build/wasm-gc/debug/check/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);
@@ -124,9 +118,7 @@ fn test_indirect_dep_bundle() {
     let _ = get_stdout(&dir, ["clean"]);
     check(
         get_stderr(&dir, ["bundle", "--target", "wasm-gc"]),
-        expect![[r#"
-            Finished. moon: ran 7 tasks, now up to date
-        "#]],
+        expect![""],
     );
     let all_pkgs_path = dir.join("_build/wasm-gc/release/bundle/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);

--- a/crates/moon/tests/test_cases/indirect_dep/mod.rs
+++ b/crates/moon/tests/test_cases/indirect_dep/mod.rs
@@ -60,8 +60,8 @@ fn test_all_pkgs() {
     check(
         get_stderr(&dir, ["check", "--target", "wasm-gc"]),
         expect![[r#"
-            Finished. moon: ran 10 tasks, now up to date
-        "#]],
+        Finished. moon: ran 10 tasks, now up to date
+    "#]],
     );
     let all_pkgs_path = dir.join("_build/wasm-gc/debug/check/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);

--- a/crates/moon/tests/test_cases/indirect_dep/mod.rs
+++ b/crates/moon/tests/test_cases/indirect_dep/mod.rs
@@ -59,7 +59,9 @@ fn test_all_pkgs() {
     let _ = get_stdout(&dir, ["clean"]);
     check(
         get_stderr(&dir, ["check", "--target", "wasm-gc"]),
-        expect![""],
+        expect![[r#"
+            Finished. moon: ran 10 tasks, now up to date
+        "#]],
     );
     let all_pkgs_path = dir.join("_build/wasm-gc/debug/check/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);
@@ -69,7 +71,9 @@ fn test_all_pkgs() {
     let _ = get_stdout(&dir, ["clean"]);
     check(
         get_stderr(&dir, ["build", "--target", "wasm-gc"]),
-        expect![""],
+        expect![[r#"
+            Finished. moon: ran 7 tasks, now up to date
+        "#]],
     );
     let all_pkgs_path = dir.join("_build/wasm-gc/debug/build/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);
@@ -104,7 +108,9 @@ fn test_all_pkgs() {
     let _ = get_stdout(&dir, ["clean"]);
     check(
         get_stderr(&dir, ["info", "--target", "wasm-gc"]),
-        expect![""],
+        expect![[r#"
+            Finished. moon: ran 10 tasks, now up to date
+        "#]],
     );
     let all_pkgs_path = dir.join("_build/wasm-gc/debug/check/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);
@@ -118,7 +124,9 @@ fn test_indirect_dep_bundle() {
     let _ = get_stdout(&dir, ["clean"]);
     check(
         get_stderr(&dir, ["bundle", "--target", "wasm-gc"]),
-        expect![""],
+        expect![[r#"
+            Finished. moon: ran 7 tasks, now up to date
+        "#]],
     );
     let all_pkgs_path = dir.join("_build/wasm-gc/release/bundle/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);

--- a/crates/moon/tests/test_cases/indirect_dep/mod.rs
+++ b/crates/moon/tests/test_cases/indirect_dep/mod.rs
@@ -58,7 +58,7 @@ fn test_all_pkgs() {
     // check
     let _ = get_stdout(&dir, ["clean"]);
     check(
-        get_stderr(&dir, ["check", "--target", "wasm-gc"]),
+        get_stdout(&dir, ["check", "--target", "wasm-gc"]),
         expect![[r#"
         Finished. moon: ran 10 tasks, now up to date
     "#]],
@@ -70,7 +70,7 @@ fn test_all_pkgs() {
     // build
     let _ = get_stdout(&dir, ["clean"]);
     check(
-        get_stderr(&dir, ["build", "--target", "wasm-gc"]),
+        get_stdout(&dir, ["build", "--target", "wasm-gc"]),
         expect![[r#"
             Finished. moon: ran 7 tasks, now up to date
         "#]],
@@ -107,7 +107,7 @@ fn test_all_pkgs() {
     // info
     let _ = get_stdout(&dir, ["clean"]);
     check(
-        get_stderr(&dir, ["info", "--target", "wasm-gc"]),
+        get_stdout(&dir, ["info", "--target", "wasm-gc"]),
         expect![[r#"
             Finished. moon: ran 10 tasks, now up to date
         "#]],
@@ -123,7 +123,7 @@ fn test_indirect_dep_bundle() {
     // bundle
     let _ = get_stdout(&dir, ["clean"]);
     check(
-        get_stderr(&dir, ["bundle", "--target", "wasm-gc"]),
+        get_stdout(&dir, ["bundle", "--target", "wasm-gc"]),
         expect![[r#"
             Finished. moon: ran 7 tasks, now up to date
         "#]],

--- a/crates/moon/tests/test_cases/moon_build_package.in/moon.test
+++ b/crates/moon/tests/test_cases/moon_build_package.in/moon.test
@@ -3,7 +3,7 @@
   moonc build-package ./src/top.mbt -o ./_build/wasm-gc/debug/build/hello.core -pkg username/hello -pkg-type library -std-path '[MOON_HOME]/lib/core/_build/wasm-gc/release/bundle' -i ./_build/wasm-gc/debug/build/lib/lib.mi:lib -i '[MOON_HOME]/lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/hello:./src -target wasm-gc -g -O0 -source-map -workspace-path . -all-pkgs ./_build/wasm-gc/debug/build/all_pkgs.json
   
   $ moon build --target wasm-gc --build-graph --sort-input
+  Finished. moon: ran 2 tasks, now up to date
   
   Warning: `--build-graph` is deprecated. Use -Z rr_export_module_graph, -Z rr_export_package_graph, or -Z rr_export_build_plan instead
-  Finished. moon: ran 2 tasks, now up to date
   

--- a/crates/moon/tests/test_cases/moon_build_package.in/moon.test
+++ b/crates/moon/tests/test_cases/moon_build_package.in/moon.test
@@ -5,4 +5,5 @@
   $ moon build --target wasm-gc --build-graph --sort-input
   
   Warning: `--build-graph` is deprecated. Use -Z rr_export_module_graph, -Z rr_export_package_graph, or -Z rr_export_build_plan instead
+  Finished. moon: ran 2 tasks, now up to date
   

--- a/crates/moon/tests/test_cases/moon_build_package.in/moon.test
+++ b/crates/moon/tests/test_cases/moon_build_package.in/moon.test
@@ -5,5 +5,4 @@
   $ moon build --target wasm-gc --build-graph --sort-input
   
   Warning: `--build-graph` is deprecated. Use -Z rr_export_module_graph, -Z rr_export_package_graph, or -Z rr_export_build_plan instead
-  Finished. moon: ran 2 tasks, now up to date
   

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -307,7 +307,6 @@ Using cached testuser/runner@1.2.3
 Using cached testuser/dependency@1.0.0
 Building `testuser/runner/tool`...
 ...
-Finished. moon: ran 9 tasks, now up to date
 '$MOON_HOME/registry/cache/assets/testuser/runner/1.2.3/tool/tool[..]' --child-arg
 
 "#]]);

--- a/crates/moon/tests/test_cases/moon_info_001.in/moon.test
+++ b/crates/moon/tests/test_cases/moon_info_001.in/moon.test
@@ -1,7 +1,5 @@
   $ moon info
   
-  Finished. moon: ran 4 tasks, now up to date
-  
   $ xcat src/lib/pkg.generated.mbti
   // Generated using `moon info`, DON'T EDIT IT
   package "username/hello/lib"

--- a/crates/moon/tests/test_cases/moon_info_001.in/moon.test
+++ b/crates/moon/tests/test_cases/moon_info_001.in/moon.test
@@ -1,5 +1,4 @@
   $ moon info
-  
   Finished. moon: ran 4 tasks, now up to date
   
   $ xcat src/lib/pkg.generated.mbti

--- a/crates/moon/tests/test_cases/moon_info_001.in/moon.test
+++ b/crates/moon/tests/test_cases/moon_info_001.in/moon.test
@@ -1,5 +1,7 @@
   $ moon info
   
+  Finished. moon: ran 4 tasks, now up to date
+  
   $ xcat src/lib/pkg.generated.mbti
   // Generated using `moon info`, DON'T EDIT IT
   package "username/hello/lib"

--- a/crates/moon/tests/test_cases/moon_info_001/mod.rs
+++ b/crates/moon/tests/test_cases/moon_info_001/mod.rs
@@ -14,7 +14,7 @@ fn test_moon_info_user_log_output() {
         .success()
         .stdout_eq("")
         .stderr_eq(
-            "Warning: `--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092\n",
+            "Warning: `--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092\nFinished. moon: ran 4 tasks, now up to date\n",
         );
 
     let verbose_dir = TestDir::new("moon_info_001.in");

--- a/crates/moon/tests/test_cases/moon_info_001/mod.rs
+++ b/crates/moon/tests/test_cases/moon_info_001/mod.rs
@@ -14,8 +14,21 @@ fn test_moon_info_user_log_output() {
         .success()
         .stdout_eq("")
         .stderr_eq(
-            "Warning: `--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092\nFinished. moon: ran 4 tasks, now up to date\n",
+            "Warning: `--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092\n",
         );
+
+    let verbose_dir = TestDir::new("moon_info_001.in");
+    moon_cmd(&verbose_dir)
+        .args(["info", "--no-alias", "--verbose"])
+        .assert()
+        .success()
+        .stdout_eq("")
+        .stderr_eq(snapbox::str![[r#"
+Warning: `--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092
+...
+Finished. moon: ran 4 tasks, now up to date
+
+"#]]);
 
     let quiet_dir = TestDir::new("moon_info_001.in");
     moon_cmd(&quiet_dir)

--- a/crates/moon/tests/test_cases/moon_info_001/mod.rs
+++ b/crates/moon/tests/test_cases/moon_info_001/mod.rs
@@ -12,21 +12,18 @@ fn test_moon_info_user_log_output() {
         .args(["info", "--no-alias"])
         .assert()
         .success()
-        .stdout_eq("")
-        .stderr_eq(
-            "Warning: `--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092\nFinished. moon: ran 4 tasks, now up to date\n",
-        );
+        .stdout_eq("Finished. moon: ran 4 tasks, now up to date\n")
+        .stderr_eq("Warning: `--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092\n");
 
     let verbose_dir = TestDir::new("moon_info_001.in");
     moon_cmd(&verbose_dir)
         .args(["info", "--no-alias", "--verbose"])
         .assert()
         .success()
-        .stdout_eq("")
+        .stdout_eq("Finished. moon: ran 4 tasks, now up to date\n")
         .stderr_eq(snapbox::str![[r#"
 Warning: `--no-alias` will be removed soon. See: https://github.com/moonbitlang/moon/issues/1092
 ...
-Finished. moon: ran 4 tasks, now up to date
 
 "#]]);
 

--- a/crates/moon/tests/test_cases/moon_info_002.in/moon.test
+++ b/crates/moon/tests/test_cases/moon_info_002.in/moon.test
@@ -1,5 +1,7 @@
   $ moon info
   
+  Finished. moon: ran 2 tasks, now up to date
+  
   $ xcat lib/pkg.generated.mbti
   // Generated using `moon info`, DON'T EDIT IT
   package "username/hello/lib"

--- a/crates/moon/tests/test_cases/moon_info_002.in/moon.test
+++ b/crates/moon/tests/test_cases/moon_info_002.in/moon.test
@@ -1,5 +1,4 @@
   $ moon info
-  
   Finished. moon: ran 2 tasks, now up to date
   
   $ xcat lib/pkg.generated.mbti

--- a/crates/moon/tests/test_cases/moon_info_002.in/moon.test
+++ b/crates/moon/tests/test_cases/moon_info_002.in/moon.test
@@ -1,7 +1,5 @@
   $ moon info
   
-  Finished. moon: ran 2 tasks, now up to date
-  
   $ xcat lib/pkg.generated.mbti
   // Generated using `moon info`, DON'T EDIT IT
   package "username/hello/lib"

--- a/crates/moon/tests/test_cases/moon_info_compare_backends/moon_info_compare_backends.out
+++ b/crates/moon/tests/test_cases/moon_info_compare_backends/moon_info_compare_backends.out
@@ -1,3 +1,7 @@
+Finished. moon: ran 2 tasks, now up to date
+Finished. moon: ran 2 tasks, now up to date
+Finished. moon: ran 2 tasks, now up to date
+Finished. moon: ran 2 tasks, now up to date
 #
 # Package username/hello/lib has diverging interfaces across backends:
 #

--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -898,6 +898,7 @@ fn test_async_wasm_upstream_signal_package() {
     check(
         run_upstream_async_wasm_package("moonbitlang/async/signal"),
         expect![[r#"
+            Finished. moon: no work to do
             Total tests: 3, passed: 3, failed: 0.
         "#]],
     );

--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -895,10 +895,16 @@ fn test_async_wasm_upstream_process_package() {
 
 #[test]
 fn test_async_wasm_upstream_signal_package() {
+    // The upstream signal tests invoke `moon build` for a helper program and
+    // inherit its stdout. Its build status depends on whether that target
+    // directory is already warm, so it is not part of this test's result.
+    let output = run_upstream_async_wasm_package("moonbitlang/async/signal")
+        .split_inclusive('\n')
+        .filter(|line| !line.starts_with("Finished. moon: "))
+        .collect::<String>();
     check(
-        run_upstream_async_wasm_package("moonbitlang/async/signal"),
+        output,
         expect![[r#"
-            Finished. moon: no work to do
             Total tests: 3, passed: 3, failed: 0.
         "#]],
     );

--- a/crates/moon/tests/test_cases/package_management.rs
+++ b/crates/moon/tests/test_cases/package_management.rs
@@ -176,7 +176,6 @@ fn test_moon_package_list() {
         get_stderr(&dir, ["package", "--list"]),
         expect![[r#"
             Running moon check ...
-            Finished. moon: ran 4 tasks, now up to date
             Check passed
             README.md
             moon.mod.json

--- a/crates/moon/tests/test_cases/package_management.rs
+++ b/crates/moon/tests/test_cases/package_management.rs
@@ -176,6 +176,7 @@ fn test_moon_package_list() {
         get_stderr(&dir, ["package", "--list"]),
         expect![[r#"
             Running moon check ...
+            Finished. moon: ran 4 tasks, now up to date
             Check passed
             README.md
             moon.mod.json

--- a/crates/moon/tests/test_cases/package_testing.rs
+++ b/crates/moon/tests/test_cases/package_testing.rs
@@ -111,7 +111,7 @@ fn test_multi_process() {
 
                 if output.status.success() {
                     success.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    let out = String::from_utf8(output.stderr).unwrap();
+                    let out = String::from_utf8(output.stdout).unwrap();
                     assert!(out.contains("no work to do") || out.contains("now up to date"));
                 } else {
                     println!("moon output: {:?}", String::from_utf8(output.stdout));
@@ -422,7 +422,6 @@ fn test_render_diagnostic_in_patch_file() {
                │      ────────────┬────────────  
                │                  ╰────────────── Warning (unused_value): Unused variable 'unused_in_patch_test_json'
             ───╯
-            Finished. moon: ran 3 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
     check(
@@ -446,7 +445,6 @@ fn test_render_diagnostic_in_patch_file() {
                │      ─────────────┬─────────────  
                │                   ╰─────────────── Warning (unused_value): Unused variable 'unused_in_patch_wbtest_json'
             ───╯
-            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
     check(
@@ -470,7 +468,6 @@ fn test_render_diagnostic_in_patch_file() {
                │      ──────────┬─────────  
                │                ╰─────────── Warning (unused_value): Unused variable 'unused_in_patch_json'
             ───╯
-            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 
@@ -581,7 +578,6 @@ fn test_render_diagnostic_in_patch_file() {
                │       }
                │       ```
             ───╯
-            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 }
@@ -607,10 +603,15 @@ fn test_add_mi_if_self_not_set_in_test_imports() {
         "#]],
     );
 
-    check(get_stdout(&dir, ["check"]), expect![""]);
+    check(
+        get_stdout(&dir, ["check"]),
+        expect![[r#"
+            Finished. moon: ran 8 tasks, now up to date
+        "#]],
+    );
     get_stdout(&dir, ["clean"]);
     check(
-        get_stderr(&dir, ["check"]),
+        get_stdout(&dir, ["check"]),
         expect![[r#"
             Finished. moon: ran 8 tasks, now up to date
         "#]],
@@ -795,7 +796,6 @@ fn test_in_main_pkg() {
                │       ┬  
                │       ╰── Warning (unused_value): Unused variable 'a'
             ───╯
-            Finished. moon: ran 6 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 

--- a/crates/moon/tests/test_cases/package_testing.rs
+++ b/crates/moon/tests/test_cases/package_testing.rs
@@ -111,6 +111,8 @@ fn test_multi_process() {
 
                 if output.status.success() {
                     success.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let out = String::from_utf8(output.stderr).unwrap();
+                    assert!(out.contains("no work to do") || out.contains("now up to date"));
                 } else {
                     println!("moon output: {:?}", String::from_utf8(output.stdout));
                     let error_message = String::from_utf8_lossy(&output.stderr);
@@ -610,8 +612,8 @@ fn test_add_mi_if_self_not_set_in_test_imports() {
     check(
         get_stderr(&dir, ["check"]),
         expect![[r#"
-        Finished. moon: ran 8 tasks, now up to date
-    "#]],
+            Finished. moon: ran 8 tasks, now up to date
+        "#]],
     );
 
     check(

--- a/crates/moon/tests/test_cases/package_testing.rs
+++ b/crates/moon/tests/test_cases/package_testing.rs
@@ -420,6 +420,7 @@ fn test_render_diagnostic_in_patch_file() {
                │      ────────────┬────────────  
                │                  ╰────────────── Warning (unused_value): Unused variable 'unused_in_patch_test_json'
             ───╯
+            Finished. moon: ran 3 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
     check(
@@ -443,6 +444,7 @@ fn test_render_diagnostic_in_patch_file() {
                │      ─────────────┬─────────────  
                │                   ╰─────────────── Warning (unused_value): Unused variable 'unused_in_patch_wbtest_json'
             ───╯
+            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
     check(
@@ -466,6 +468,7 @@ fn test_render_diagnostic_in_patch_file() {
                │      ──────────┬─────────  
                │                ╰─────────── Warning (unused_value): Unused variable 'unused_in_patch_json'
             ───╯
+            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 
@@ -576,6 +579,7 @@ fn test_render_diagnostic_in_patch_file() {
                │       }
                │       ```
             ───╯
+            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 }
@@ -603,7 +607,12 @@ fn test_add_mi_if_self_not_set_in_test_imports() {
 
     check(get_stdout(&dir, ["check"]), expect![""]);
     get_stdout(&dir, ["clean"]);
-    check(get_stderr(&dir, ["check"]), expect![""]);
+    check(
+        get_stderr(&dir, ["check"]),
+        expect![[r#"
+        Finished. moon: ran 8 tasks, now up to date
+    "#]],
+    );
 
     check(
         get_stdout(&dir, ["test", "--no-parallelize", "--sort-input"]),
@@ -784,6 +793,7 @@ fn test_in_main_pkg() {
                │       ┬  
                │       ╰── Warning (unused_value): Unused variable 'a'
             ───╯
+            Finished. moon: ran 6 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 

--- a/crates/moon/tests/test_cases/package_testing.rs
+++ b/crates/moon/tests/test_cases/package_testing.rs
@@ -111,8 +111,6 @@ fn test_multi_process() {
 
                 if output.status.success() {
                     success.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    let out = String::from_utf8(output.stderr).unwrap();
-                    assert!(out.contains("no work to do") || out.contains("now up to date"));
                 } else {
                     println!("moon output: {:?}", String::from_utf8(output.stdout));
                     let error_message = String::from_utf8_lossy(&output.stderr);
@@ -422,7 +420,6 @@ fn test_render_diagnostic_in_patch_file() {
                │      ────────────┬────────────  
                │                  ╰────────────── Warning (unused_value): Unused variable 'unused_in_patch_test_json'
             ───╯
-            Finished. moon: ran 3 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
     check(
@@ -446,7 +443,6 @@ fn test_render_diagnostic_in_patch_file() {
                │      ─────────────┬─────────────  
                │                   ╰─────────────── Warning (unused_value): Unused variable 'unused_in_patch_wbtest_json'
             ───╯
-            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
     check(
@@ -470,7 +466,6 @@ fn test_render_diagnostic_in_patch_file() {
                │      ──────────┬─────────  
                │                ╰─────────── Warning (unused_value): Unused variable 'unused_in_patch_json'
             ───╯
-            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 
@@ -581,7 +576,6 @@ fn test_render_diagnostic_in_patch_file() {
                │       }
                │       ```
             ───╯
-            Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 }
@@ -609,12 +603,7 @@ fn test_add_mi_if_self_not_set_in_test_imports() {
 
     check(get_stdout(&dir, ["check"]), expect![""]);
     get_stdout(&dir, ["clean"]);
-    check(
-        get_stderr(&dir, ["check"]),
-        expect![[r#"
-            Finished. moon: ran 8 tasks, now up to date
-        "#]],
-    );
+    check(get_stderr(&dir, ["check"]), expect![""]);
 
     check(
         get_stdout(&dir, ["test", "--no-parallelize", "--sort-input"]),
@@ -795,7 +784,6 @@ fn test_in_main_pkg() {
                │       ┬  
                │       ╰── Warning (unused_value): Unused variable 'a'
             ───╯
-            Finished. moon: ran 6 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 

--- a/crates/moon/tests/test_cases/prebuild/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild/mod.rs
@@ -413,13 +413,13 @@ fn test_pre_build_dirty() {
     let mtime = file.metadata().unwrap().modified().unwrap();
 
     check(
-        get_stderr(&dir, ["check"]),
+        get_stdout(&dir, ["check"]),
         expect![[r#"
             Finished. moon: no work to do
         "#]],
     );
     check(
-        get_stderr(&dir, ["check"]),
+        get_stdout(&dir, ["check"]),
         expect![[r#"
             Finished. moon: no work to do
         "#]],

--- a/crates/moon/tests/test_cases/prebuild/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild/mod.rs
@@ -412,18 +412,8 @@ fn test_pre_build_dirty() {
     assert!(file.exists(), "prebuild.txt should exist after prebuild");
     let mtime = file.metadata().unwrap().modified().unwrap();
 
-    check(
-        get_stderr(&dir, ["check"]),
-        expect![[r#"
-            Finished. moon: no work to do
-        "#]],
-    );
-    check(
-        get_stderr(&dir, ["check"]),
-        expect![[r#"
-            Finished. moon: no work to do
-        "#]],
-    );
+    check(get_stderr(&dir, ["check"]), expect![""]);
+    check(get_stderr(&dir, ["check"]), expect![""]);
 
     let mtime_end = file.metadata().unwrap().modified().unwrap();
     assert_eq!(mtime, mtime_end, "file should not be modified");

--- a/crates/moon/tests/test_cases/prebuild/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild/mod.rs
@@ -415,14 +415,14 @@ fn test_pre_build_dirty() {
     check(
         get_stderr(&dir, ["check"]),
         expect![[r#"
-        Finished. moon: no work to do
-    "#]],
+            Finished. moon: no work to do
+        "#]],
     );
     check(
         get_stderr(&dir, ["check"]),
         expect![[r#"
-        Finished. moon: no work to do
-    "#]],
+            Finished. moon: no work to do
+        "#]],
     );
 
     let mtime_end = file.metadata().unwrap().modified().unwrap();

--- a/crates/moon/tests/test_cases/prebuild/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild/mod.rs
@@ -412,8 +412,18 @@ fn test_pre_build_dirty() {
     assert!(file.exists(), "prebuild.txt should exist after prebuild");
     let mtime = file.metadata().unwrap().modified().unwrap();
 
-    check(get_stderr(&dir, ["check"]), expect![""]);
-    check(get_stderr(&dir, ["check"]), expect![""]);
+    check(
+        get_stderr(&dir, ["check"]),
+        expect![[r#"
+        Finished. moon: no work to do
+    "#]],
+    );
+    check(
+        get_stderr(&dir, ["check"]),
+        expect![[r#"
+        Finished. moon: no work to do
+    "#]],
+    );
 
     let mtime_end = file.metadata().unwrap().modified().unwrap();
     assert_eq!(mtime, mtime_end, "file should not be modified");

--- a/crates/moon/tests/test_cases/run_md_test/mod.rs
+++ b/crates/moon/tests/test_cases/run_md_test/mod.rs
@@ -14,7 +14,6 @@ fn test_run_md_test() {
                 │         ┬  
                 │         ╰── Warning (unused_value): Unused variable 'a'
             ────╯
-            Finished. moon: ran 4 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 

--- a/crates/moon/tests/test_cases/run_md_test/mod.rs
+++ b/crates/moon/tests/test_cases/run_md_test/mod.rs
@@ -14,6 +14,7 @@ fn test_run_md_test() {
                 │         ┬  
                 │         ╰── Warning (unused_value): Unused variable 'a'
             ────╯
+            Finished. moon: ran 4 tasks, now up to date (1 warnings, 0 errors)
         "#]],
     );
 

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -539,6 +539,7 @@ fn test_single_file_commands_work_with_workspace_disabled() {
         String::from_utf8(check_result).unwrap(),
         expect![[r#"
             Warning: `MOON_NO_WORKSPACE` is deprecated. Use `MOON_WORK=off` to disable workspace mode.
+            Finished. moon: ran 2 tasks, now up to date
         "#]],
     );
 

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -319,7 +319,6 @@ Total tests: 1, passed: 1, failed: 0.
                    │       ─────┬────  
                    │            ╰────── Warning (unused_value): Unused variable 'single_mbt'
                 ───╯
-                Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
             "#]],
         );
         // abs path
@@ -333,7 +332,6 @@ Total tests: 1, passed: 1, failed: 0.
                    │       ─────┬────  
                    │            ╰────── Warning (unused_value): Unused variable 'single_mbt'
                 ───╯
-                Finished. moon: ran 1 task, now up to date (1 warnings, 0 errors)
             "#]],
         );
     }
@@ -414,7 +412,6 @@ Warning: [0002]
                     │         ──────┬──────  
                     │               ╰──────── Warning (unused_value): Unused variable 'single_mbt_md'
                 ────╯
-                Finished. moon: ran 1 task, now up to date (1 warnings, 0 errors)
             "#]],
         );
     }
@@ -542,7 +539,6 @@ fn test_single_file_commands_work_with_workspace_disabled() {
         String::from_utf8(check_result).unwrap(),
         expect![[r#"
             Warning: `MOON_NO_WORKSPACE` is deprecated. Use `MOON_WORK=off` to disable workspace mode.
-            Finished. moon: ran 2 tasks, now up to date
         "#]],
     );
 

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -319,6 +319,7 @@ Total tests: 1, passed: 1, failed: 0.
                    │       ─────┬────  
                    │            ╰────── Warning (unused_value): Unused variable 'single_mbt'
                 ───╯
+                Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
             "#]],
         );
         // abs path
@@ -332,6 +333,7 @@ Total tests: 1, passed: 1, failed: 0.
                    │       ─────┬────  
                    │            ╰────── Warning (unused_value): Unused variable 'single_mbt'
                 ───╯
+                Finished. moon: ran 1 task, now up to date (1 warnings, 0 errors)
             "#]],
         );
     }
@@ -412,6 +414,7 @@ Warning: [0002]
                     │         ──────┬──────  
                     │               ╰──────── Warning (unused_value): Unused variable 'single_mbt_md'
                 ────╯
+                Finished. moon: ran 1 task, now up to date (1 warnings, 0 errors)
             "#]],
         );
     }

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -319,7 +319,6 @@ Total tests: 1, passed: 1, failed: 0.
                    │       ─────┬────  
                    │            ╰────── Warning (unused_value): Unused variable 'single_mbt'
                 ───╯
-                Finished. moon: ran 2 tasks, now up to date (1 warnings, 0 errors)
             "#]],
         );
         // abs path
@@ -333,7 +332,6 @@ Total tests: 1, passed: 1, failed: 0.
                    │       ─────┬────  
                    │            ╰────── Warning (unused_value): Unused variable 'single_mbt'
                 ───╯
-                Finished. moon: ran 1 task, now up to date (1 warnings, 0 errors)
             "#]],
         );
     }
@@ -414,7 +412,6 @@ Warning: [0002]
                     │         ──────┬──────  
                     │               ╰──────── Warning (unused_value): Unused variable 'single_mbt_md'
                 ────╯
-                Finished. moon: ran 1 task, now up to date (1 warnings, 0 errors)
             "#]],
         );
     }
@@ -536,12 +533,16 @@ fn test_single_file_commands_work_with_workspace_disabled() {
         .assert()
         .success()
         .get_output()
-        .stderr
         .clone();
     check(
-        String::from_utf8(check_result).unwrap(),
+        String::from_utf8(check_result.stderr).unwrap(),
         expect![[r#"
             Warning: `MOON_NO_WORKSPACE` is deprecated. Use `MOON_WORK=off` to disable workspace mode.
+        "#]],
+    );
+    check(
+        String::from_utf8(check_result.stdout).unwrap(),
+        expect![[r#"
             Finished. moon: ran 2 tasks, now up to date
         "#]],
     );

--- a/crates/moon/tests/test_cases/source_directory.rs
+++ b/crates/moon/tests/test_cases/source_directory.rs
@@ -21,23 +21,13 @@ use super::*;
 #[test]
 fn test_specify_source_dir_003() {
     let dir = TestDir::new("specify_source_dir_003_empty_string.in");
-    check(
-        get_stderr(&dir, ["check"]),
-        expect![[r#"
-            Finished. moon: ran 2 tasks, now up to date
-        "#]],
-    );
+    check(get_stderr(&dir, ["check"]), expect![""]);
 }
 
 #[test]
 fn test_specify_source_dir_004() {
     let dir = TestDir::new("specify_source_dir_004.in");
-    check(
-        get_stderr(&dir, ["check"]),
-        expect![[r#"
-            Finished. moon: ran 4 tasks, now up to date
-        "#]],
-    );
+    check(get_stderr(&dir, ["check"]), expect![""]);
 
     get_stdout(&dir, ["clean"]);
     check(
@@ -80,18 +70,8 @@ fn test_specify_source_dir_with_deps() {
         expect_file!["./specify_source_dir_with_deps_001.in/test_graph.jsonl.snap"],
     );
 
-    check(
-        get_stderr(&dir, ["check"]),
-        expect![[r#"
-            Finished. moon: ran 6 tasks, now up to date
-        "#]],
-    );
-    check(
-        get_stderr(&dir, ["build"]),
-        expect![[r#"
-            Finished. moon: ran 5 tasks, now up to date
-        "#]],
-    );
+    check(get_stderr(&dir, ["check"]), expect![""]);
+    check(get_stderr(&dir, ["build"]), expect![""]);
     check(
         get_stdout(&dir, ["test"]),
         expect![[r#"
@@ -117,7 +97,6 @@ fn test_specify_source_dir_with_deps_002() {
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello004/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello003/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello003/source003/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello002/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello002/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello001/lib`
-            Finished. moon: ran 10 tasks, now up to date
         "#]],
     );
     check(
@@ -126,7 +105,6 @@ fn test_specify_source_dir_with_deps_002() {
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello004/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello003/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello003/source003/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello002/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello002/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello001/lib`
-            Finished. moon: ran 10 tasks, now up to date
         "#]],
     );
     check(

--- a/crates/moon/tests/test_cases/source_directory.rs
+++ b/crates/moon/tests/test_cases/source_directory.rs
@@ -24,8 +24,8 @@ fn test_specify_source_dir_003() {
     check(
         get_stderr(&dir, ["check"]),
         expect![[r#"
-        Finished. moon: ran 2 tasks, now up to date
-    "#]],
+            Finished. moon: ran 2 tasks, now up to date
+        "#]],
     );
 }
 
@@ -35,8 +35,8 @@ fn test_specify_source_dir_004() {
     check(
         get_stderr(&dir, ["check"]),
         expect![[r#"
-        Finished. moon: ran 4 tasks, now up to date
-    "#]],
+            Finished. moon: ran 4 tasks, now up to date
+        "#]],
     );
 
     get_stdout(&dir, ["clean"]);
@@ -83,14 +83,14 @@ fn test_specify_source_dir_with_deps() {
     check(
         get_stderr(&dir, ["check"]),
         expect![[r#"
-        Finished. moon: ran 6 tasks, now up to date
-    "#]],
+            Finished. moon: ran 6 tasks, now up to date
+        "#]],
     );
     check(
         get_stderr(&dir, ["build"]),
         expect![[r#"
-        Finished. moon: ran 5 tasks, now up to date
-    "#]],
+            Finished. moon: ran 5 tasks, now up to date
+        "#]],
     );
     check(
         get_stdout(&dir, ["test"]),

--- a/crates/moon/tests/test_cases/source_directory.rs
+++ b/crates/moon/tests/test_cases/source_directory.rs
@@ -22,7 +22,7 @@ use super::*;
 fn test_specify_source_dir_003() {
     let dir = TestDir::new("specify_source_dir_003_empty_string.in");
     check(
-        get_stderr(&dir, ["check"]),
+        get_stdout(&dir, ["check"]),
         expect![[r#"
             Finished. moon: ran 2 tasks, now up to date
         "#]],
@@ -33,7 +33,7 @@ fn test_specify_source_dir_003() {
 fn test_specify_source_dir_004() {
     let dir = TestDir::new("specify_source_dir_004.in");
     check(
-        get_stderr(&dir, ["check"]),
+        get_stdout(&dir, ["check"]),
         expect![[r#"
             Finished. moon: ran 4 tasks, now up to date
         "#]],
@@ -81,13 +81,13 @@ fn test_specify_source_dir_with_deps() {
     );
 
     check(
-        get_stderr(&dir, ["check"]),
+        get_stdout(&dir, ["check"]),
         expect![[r#"
             Finished. moon: ran 6 tasks, now up to date
         "#]],
     );
     check(
-        get_stderr(&dir, ["build"]),
+        get_stdout(&dir, ["build"]),
         expect![[r#"
             Finished. moon: ran 5 tasks, now up to date
         "#]],
@@ -117,7 +117,6 @@ fn test_specify_source_dir_with_deps_002() {
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello004/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello003/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello003/source003/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello002/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello002/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello001/lib`
-            Finished. moon: ran 10 tasks, now up to date
         "#]],
     );
     check(
@@ -126,7 +125,6 @@ fn test_specify_source_dir_with_deps_002() {
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello004/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello003/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello003/source003/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello002/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello002/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello001/lib`
-            Finished. moon: ran 10 tasks, now up to date
         "#]],
     );
     check(

--- a/crates/moon/tests/test_cases/source_directory.rs
+++ b/crates/moon/tests/test_cases/source_directory.rs
@@ -21,13 +21,23 @@ use super::*;
 #[test]
 fn test_specify_source_dir_003() {
     let dir = TestDir::new("specify_source_dir_003_empty_string.in");
-    check(get_stderr(&dir, ["check"]), expect![""]);
+    check(
+        get_stderr(&dir, ["check"]),
+        expect![[r#"
+        Finished. moon: ran 2 tasks, now up to date
+    "#]],
+    );
 }
 
 #[test]
 fn test_specify_source_dir_004() {
     let dir = TestDir::new("specify_source_dir_004.in");
-    check(get_stderr(&dir, ["check"]), expect![""]);
+    check(
+        get_stderr(&dir, ["check"]),
+        expect![[r#"
+        Finished. moon: ran 4 tasks, now up to date
+    "#]],
+    );
 
     get_stdout(&dir, ["clean"]);
     check(
@@ -70,8 +80,18 @@ fn test_specify_source_dir_with_deps() {
         expect_file!["./specify_source_dir_with_deps_001.in/test_graph.jsonl.snap"],
     );
 
-    check(get_stderr(&dir, ["check"]), expect![""]);
-    check(get_stderr(&dir, ["build"]), expect![""]);
+    check(
+        get_stderr(&dir, ["check"]),
+        expect![[r#"
+        Finished. moon: ran 6 tasks, now up to date
+    "#]],
+    );
+    check(
+        get_stderr(&dir, ["build"]),
+        expect![[r#"
+        Finished. moon: ran 5 tasks, now up to date
+    "#]],
+    );
     check(
         get_stdout(&dir, ["test"]),
         expect![[r#"
@@ -97,6 +117,7 @@ fn test_specify_source_dir_with_deps_002() {
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello004/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello003/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello003/source003/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello002/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello002/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello001/lib`
+            Finished. moon: ran 10 tasks, now up to date
         "#]],
     );
     check(
@@ -105,6 +126,7 @@ fn test_specify_source_dir_with_deps_002() {
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello004/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello003/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello003/source003/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello002/lib`
             Warning: Duplicate alias `lib` at "$ROOT/deps/hello002/lib/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `just/hello001/lib`
+            Finished. moon: ran 10 tasks, now up to date
         "#]],
     );
     check(

--- a/crates/moon/tests/test_cases/specify_source_dir_001.in/moon.test
+++ b/crates/moon/tests/test_cases/specify_source_dir_001.in/moon.test
@@ -27,7 +27,6 @@
   
   $ moon check --sort-input
   
-  Finished. moon: ran 4 tasks, now up to date
   
   $ xcat _build/packages.json
   {
@@ -120,7 +119,6 @@
   }
   $ moon build
   
-  Finished. moon: ran 3 tasks, now up to date
   
   $ moon test
   Total tests: 1, passed: 1, failed: 0.

--- a/crates/moon/tests/test_cases/specify_source_dir_001.in/moon.test
+++ b/crates/moon/tests/test_cases/specify_source_dir_001.in/moon.test
@@ -27,6 +27,7 @@
   
   $ moon check --sort-input
   
+  Finished. moon: ran 4 tasks, now up to date
   
   $ xcat _build/packages.json
   {
@@ -119,6 +120,7 @@
   }
   $ moon build
   
+  Finished. moon: ran 3 tasks, now up to date
   
   $ moon test
   Total tests: 1, passed: 1, failed: 0.

--- a/crates/moon/tests/test_cases/specify_source_dir_001.in/moon.test
+++ b/crates/moon/tests/test_cases/specify_source_dir_001.in/moon.test
@@ -26,7 +26,6 @@
   moonc link-core [MOON_HOME]/lib/core/_build/wasm-gc/release/bundle/abort/abort.core [MOON_HOME]/lib/core/_build/wasm-gc/release/bundle/core.core ./_build/wasm-gc/debug/test/lib/lib.core ./_build/wasm-gc/debug/test/lib/lib.blackbox_test.core -main username/hello/lib_blackbox_test -o ./_build/wasm-gc/debug/test/lib/lib.blackbox_test.wasm -test-mode -pkg-config-path ./src/lib/moon.pkg.json -pkg-sources username/hello/lib:./src/lib -pkg-sources username/hello/lib_blackbox_test:./src/lib -pkg-sources moonbitlang/core:[MOON_HOME]/lib/core -exported_functions moonbit_test_driver_internal_execute,moonbit_test_driver_finish -target wasm-gc -g -O0 -source-map
   
   $ moon check --sort-input
-  
   Finished. moon: ran 4 tasks, now up to date
   
   $ xcat _build/packages.json
@@ -119,7 +118,6 @@
     "source": "src"
   }
   $ moon build
-  
   Finished. moon: ran 3 tasks, now up to date
   
   $ moon test

--- a/crates/moon/tests/test_cases/specify_source_dir_001/mod.rs
+++ b/crates/moon/tests/test_cases/specify_source_dir_001/mod.rs
@@ -19,7 +19,7 @@ fn test_specify_source_dir_001() {
         expect_file!["test_graph.jsonl.snap"],
     );
     check(
-        get_stderr(&dir, ["check", "--target", "wasm-gc", "--sort-input"]),
+        get_stdout(&dir, ["check", "--target", "wasm-gc", "--sort-input"]),
         expect![[r#"
             Finished. moon: ran 4 tasks, now up to date
         "#]],
@@ -283,7 +283,7 @@ fn test_specify_source_dir_001() {
         )
     }
     check(
-        get_stderr(&dir, ["build", "--target", "wasm-gc"]),
+        get_stdout(&dir, ["build", "--target", "wasm-gc"]),
         expect![[r#"
             Finished. moon: ran 3 tasks, now up to date
         "#]],

--- a/crates/moon/tests/test_cases/specify_source_dir_001/mod.rs
+++ b/crates/moon/tests/test_cases/specify_source_dir_001/mod.rs
@@ -20,7 +20,9 @@ fn test_specify_source_dir_001() {
     );
     check(
         get_stderr(&dir, ["check", "--target", "wasm-gc", "--sort-input"]),
-        expect![""],
+        expect![[r#"
+            Finished. moon: ran 4 tasks, now up to date
+        "#]],
     );
     #[cfg(unix)]
     {
@@ -282,7 +284,9 @@ fn test_specify_source_dir_001() {
     }
     check(
         get_stderr(&dir, ["build", "--target", "wasm-gc"]),
-        expect![""],
+        expect![[r#"
+            Finished. moon: ran 3 tasks, now up to date
+        "#]],
     );
     check(
         get_stdout(&dir, ["test", "--target", "wasm-gc"]),

--- a/crates/moon/tests/test_cases/specify_source_dir_001/mod.rs
+++ b/crates/moon/tests/test_cases/specify_source_dir_001/mod.rs
@@ -20,9 +20,7 @@ fn test_specify_source_dir_001() {
     );
     check(
         get_stderr(&dir, ["check", "--target", "wasm-gc", "--sort-input"]),
-        expect![[r#"
-            Finished. moon: ran 4 tasks, now up to date
-        "#]],
+        expect![""],
     );
     #[cfg(unix)]
     {
@@ -284,9 +282,7 @@ fn test_specify_source_dir_001() {
     }
     check(
         get_stderr(&dir, ["build", "--target", "wasm-gc"]),
-        expect![[r#"
-            Finished. moon: ran 3 tasks, now up to date
-        "#]],
+        expect![""],
     );
     check(
         get_stdout(&dir, ["test", "--target", "wasm-gc"]),

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -158,8 +158,18 @@ fn test_mixed_backend_explicit_multi_path_selection_filters_unsupported_packages
 }
 
 #[test]
-fn test_mixed_backend_explicit_multi_path_selection_warns_only_in_verbose_mode() {
+fn test_mixed_backend_explicit_multi_path_selection_warns_by_default() {
     let dir = TestDir::new("mixed_backend_local_dep.in");
+
+    let stderr = get_stderr(
+        &dir,
+        ["check", "web", "server", "--target", "js", "--dry-run"],
+    );
+    assert!(
+        stderr.contains("skipping path `server`"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("mixed/localdep/server"), "stderr: {stderr}");
 
     let stderr = get_stderr(
         &dir,
@@ -170,18 +180,8 @@ fn test_mixed_backend_explicit_multi_path_selection_warns_only_in_verbose_mode()
             "--target",
             "js",
             "--dry-run",
-            "--verbose",
+            "--quiet",
         ],
-    );
-    assert!(
-        stderr.contains("skipping path `server`"),
-        "stderr: {stderr}"
-    );
-    assert!(stderr.contains("mixed/localdep/server"), "stderr: {stderr}");
-
-    let stderr = get_stderr(
-        &dir,
-        ["check", "web", "server", "--target", "js", "--dry-run"],
     );
     assert!(
         !stderr.contains("skipping path `server`"),
@@ -206,19 +206,30 @@ fn test_moon_build_package_selection_uses_user_log_policy() {
         .success();
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     let message = "skipping path `never` because package `supported/empty/never` does not support target backend `wasm-gc`. Supported backends: []";
+    let warning = format!("Warning: {message}");
 
     assert!(
-        stderr.lines().any(|line| line == message),
-        "stderr: {stderr}"
-    );
-    assert!(
-        !stderr.contains(&format!("Info: {message}")),
+        stderr.lines().any(|line| line == warning),
         "stderr: {stderr}"
     );
 
     let stderr = get_stderr(
         &dir,
         ["build", "lib", "never", "--target", "wasm-gc", "--dry-run"],
+    );
+    assert!(stderr.contains(&warning), "stderr: {stderr}");
+
+    let stderr = get_stderr(
+        &dir,
+        [
+            "build",
+            "lib",
+            "never",
+            "--target",
+            "wasm-gc",
+            "--dry-run",
+            "--quiet",
+        ],
     );
     assert!(!stderr.contains(message), "stderr: {stderr}");
 }
@@ -403,7 +414,7 @@ fn test_supported_targets_empty_list_is_never_selected() {
 }
 
 #[test]
-fn test_moon_info_verbose_unsupported_path_is_bare_stderr() {
+fn test_moon_info_unsupported_path_is_warning() {
     let dir = TestDir::new("supported_targets_empty.in");
     let assert = moon_cmd(&dir)
         .args(["info", "lib", "never", "--verbose", "--target", "wasm-gc"])
@@ -414,11 +425,9 @@ fn test_moon_info_verbose_unsupported_path_is_bare_stderr() {
     let message = "skipping path `never` because package `supported/empty/never` does not support target backend `wasm-gc`. Supported backends: []";
 
     assert!(
-        stderr.lines().any(|line| line == message),
-        "stderr: {stderr}"
-    );
-    assert!(
-        !stderr.contains(&format!("Info: {message}")),
+        stderr
+            .lines()
+            .any(|line| line == format!("Warning: {message}")),
         "stderr: {stderr}"
     );
 }
@@ -673,7 +682,7 @@ fn test_test_warns_when_test_target_is_never_realizable() {
 }
 
 #[test]
-fn test_check_skips_backend_mismatched_tests_as_info() {
+fn test_check_reports_backend_mismatched_tests_only_in_debug() {
     let dir = TestDir::new("supported_targets_test_target_mismatch.in");
 
     let stderr = get_stderr(&dir, ["check", "--target", "js", "--dry-run"]);

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -420,7 +420,9 @@ fn test_moon_info_unsupported_path_is_warning() {
         .args(["info", "lib", "never", "--verbose", "--target", "wasm-gc"])
         .assert()
         .success()
-        .stdout_eq("");
+        .stdout_eq(
+            "Finished. moon: ran 2 tasks, now up to date\nFinished. moon: ran 2 tasks, now up to date\n",
+        );
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     let message = "skipping path `never` because package `supported/empty/never` does not support target backend `wasm-gc`. Supported backends: []";
 

--- a/crates/moon/tests/test_cases/test_exclude_001.in/moon.test
+++ b/crates/moon/tests/test_cases/test_exclude_001.in/moon.test
@@ -1,7 +1,6 @@
   $ moon package --list
   
   Running moon check ...
-  Finished. moon: ran 4 tasks, now up to date
   Check passed
   README.md
   moon.mod.json

--- a/crates/moon/tests/test_cases/test_exclude_001.in/moon.test
+++ b/crates/moon/tests/test_cases/test_exclude_001.in/moon.test
@@ -1,6 +1,7 @@
   $ moon package --list
   
   Running moon check ...
+  Finished. moon: ran 4 tasks, now up to date
   Check passed
   README.md
   moon.mod.json

--- a/crates/moon/tests/test_cases/test_exclude_002.in/moon.test
+++ b/crates/moon/tests/test_cases/test_exclude_002.in/moon.test
@@ -1,7 +1,6 @@
   $ moon package --list
   
   Running moon check ...
-  Finished. moon: ran 4 tasks, now up to date
   Check passed
   README.md
   moon.mod.json

--- a/crates/moon/tests/test_cases/test_exclude_002.in/moon.test
+++ b/crates/moon/tests/test_cases/test_exclude_002.in/moon.test
@@ -1,6 +1,7 @@
   $ moon package --list
   
   Running moon check ...
+  Finished. moon: ran 4 tasks, now up to date
   Check passed
   README.md
   moon.mod.json

--- a/crates/moon/tests/test_cases/test_include_001.in/moon.test
+++ b/crates/moon/tests/test_cases/test_include_001.in/moon.test
@@ -1,7 +1,6 @@
   $ moon package --list
   
   Running moon check ...
-  Finished. moon: ran 4 tasks, now up to date
   Check passed
   moon.mod.json
   src/lib/hello.mbt

--- a/crates/moon/tests/test_cases/test_include_001.in/moon.test
+++ b/crates/moon/tests/test_cases/test_include_001.in/moon.test
@@ -1,6 +1,7 @@
   $ moon package --list
   
   Running moon check ...
+  Finished. moon: ran 4 tasks, now up to date
   Check passed
   moon.mod.json
   src/lib/hello.mbt

--- a/crates/moon/tests/test_cases/test_include_002.in/moon.test
+++ b/crates/moon/tests/test_cases/test_include_002.in/moon.test
@@ -1,7 +1,6 @@
   $ moon package --list
   
   Running moon check ...
-  Finished. moon: ran 4 tasks, now up to date
   Check passed
   moon.mod.json
   src/lib/hello.mbt

--- a/crates/moon/tests/test_cases/test_include_002.in/moon.test
+++ b/crates/moon/tests/test_cases/test_include_002.in/moon.test
@@ -1,6 +1,7 @@
   $ moon package --list
   
   Running moon check ...
+  Finished. moon: ran 4 tasks, now up to date
   Check passed
   moon.mod.json
   src/lib/hello.mbt

--- a/crates/moon/tests/test_cases/test_include_003.in/moon.test
+++ b/crates/moon/tests/test_cases/test_include_003.in/moon.test
@@ -1,7 +1,6 @@
   $ moon package --list
   
   Running moon check ...
-  Finished. moon: ran 4 tasks, now up to date
   Check passed
   moon.mod.json
   src/lib/hello.mbt

--- a/crates/moon/tests/test_cases/test_include_003.in/moon.test
+++ b/crates/moon/tests/test_cases/test_include_003.in/moon.test
@@ -1,6 +1,7 @@
   $ moon package --list
   
   Running moon check ...
+  Finished. moon: ran 4 tasks, now up to date
   Check passed
   moon.mod.json
   src/lib/hello.mbt

--- a/crates/moon/tests/test_cases/test_moon_info.in/moon.test
+++ b/crates/moon/tests/test_cases/test_moon_info.in/moon.test
@@ -1,7 +1,6 @@
   $ xls lib
   lib.mbt moon.pkg.json
   $ moon info
-  
   Finished. moon: ran 2 tasks, now up to date
   
   $ xls lib

--- a/crates/moon/tests/test_cases/test_moon_info.in/moon.test
+++ b/crates/moon/tests/test_cases/test_moon_info.in/moon.test
@@ -2,5 +2,7 @@
   lib.mbt moon.pkg.json
   $ moon info
   
+  Finished. moon: ran 2 tasks, now up to date
+  
   $ xls lib
   lib.mbt moon.pkg.json pkg.generated.mbti

--- a/crates/moon/tests/test_cases/test_moon_info.in/moon.test
+++ b/crates/moon/tests/test_cases/test_moon_info.in/moon.test
@@ -2,7 +2,5 @@
   lib.mbt moon.pkg.json
   $ moon info
   
-  Finished. moon: ran 2 tasks, now up to date
-  
   $ xls lib
   lib.mbt moon.pkg.json pkg.generated.mbti

--- a/crates/moon/tests/test_cases/third_party/mod.rs
+++ b/crates/moon/tests/test_cases/third_party/mod.rs
@@ -1,8 +1,6 @@
 use expect_test::{expect, expect_file};
 
-use crate::{
-    TestDir, build_graph::compare_graphs, get_stderr, get_stdout, snap_dry_run_graph, util::check,
-};
+use crate::{TestDir, build_graph::compare_graphs, get_stdout, snap_dry_run_graph, util::check};
 
 #[test]
 fn test_third_party() {
@@ -12,7 +10,7 @@ fn test_third_party() {
     get_stdout(&dir, ["build", "--target", "wasm-gc"]);
     get_stdout(&dir, ["clean"]);
 
-    let actual = get_stderr(&dir, ["check", "--target", "wasm-gc"]);
+    let actual = get_stdout(&dir, ["check", "--target", "wasm-gc"]);
     expect![[r#"
         Finished. moon: ran 5 tasks, now up to date
     "#]]
@@ -35,7 +33,7 @@ fn test_third_party() {
         "#]],
     );
 
-    let actual = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
+    let actual = get_stdout(&dir, ["build", "--target", "wasm-gc"]);
     expect![[r#"
         Finished. moon: ran 3 tasks, now up to date
     "#]]

--- a/crates/moon/tests/test_cases/third_party/mod.rs
+++ b/crates/moon/tests/test_cases/third_party/mod.rs
@@ -13,7 +13,10 @@ fn test_third_party() {
     get_stdout(&dir, ["clean"]);
 
     let actual = get_stderr(&dir, ["check", "--target", "wasm-gc"]);
-    expect![""].assert_eq(&actual);
+    expect![[r#"
+        Finished. moon: ran 5 tasks, now up to date
+    "#]]
+    .assert_eq(&actual);
 
     let file = dir.join("test_dry_run.jsonl");
     snap_dry_run_graph(
@@ -33,7 +36,10 @@ fn test_third_party() {
     );
 
     let actual = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
-    expect![""].assert_eq(&actual);
+    expect![[r#"
+        Finished. moon: ran 3 tasks, now up to date
+    "#]]
+    .assert_eq(&actual);
 
     let actual = get_stdout(&dir, ["run", "--target", "wasm-gc", "main"]);
     assert!(actual.contains("Hello, world!"));

--- a/crates/moon/tests/test_cases/third_party/mod.rs
+++ b/crates/moon/tests/test_cases/third_party/mod.rs
@@ -13,10 +13,7 @@ fn test_third_party() {
     get_stdout(&dir, ["clean"]);
 
     let actual = get_stderr(&dir, ["check", "--target", "wasm-gc"]);
-    expect![[r#"
-        Finished. moon: ran 5 tasks, now up to date
-    "#]]
-    .assert_eq(&actual);
+    expect![""].assert_eq(&actual);
 
     let file = dir.join("test_dry_run.jsonl");
     snap_dry_run_graph(
@@ -36,10 +33,7 @@ fn test_third_party() {
     );
 
     let actual = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
-    expect![[r#"
-        Finished. moon: ran 3 tasks, now up to date
-    "#]]
-    .assert_eq(&actual);
+    expect![""].assert_eq(&actual);
 
     let actual = get_stdout(&dir, ["run", "--target", "wasm-gc", "main"]);
     assert!(actual.contains("Hello, world!"));

--- a/crates/moon/tests/test_cases/virtual_pkg/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg/mod.rs
@@ -102,8 +102,6 @@ fn test_virtual_pkg_err() {
                │ ──────────┬──────────  
                │           ╰──────────── Missing implementation for function f2.
             ───╯
-            Failed with 0 warnings, 1 errors.
-            Error: failed when building project
         "#]],
     );
 }

--- a/crates/moon/tests/test_cases/virtual_pkg/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg/mod.rs
@@ -102,6 +102,7 @@ fn test_virtual_pkg_err() {
                │ ──────────┬──────────  
                │           ╰──────────── Missing implementation for function f2.
             ───╯
+            Error: failed when building project
         "#]],
     );
 }

--- a/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
@@ -14,12 +14,7 @@ fn implement_third_party1() {
     );
 
     let s = get_stderr(&dir, ["check", "--target", "wasm-gc", "."]);
-    check(
-        s,
-        expect![[r#"
-            Finished. moon: ran 2 tasks, now up to date
-        "#]],
-    );
+    check(s, expect![""]);
 
     let packages_json: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("_build/packages.json")).unwrap())
@@ -83,10 +78,5 @@ fn implement_third_party2() {
     );
 
     let s = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
-    check(
-        s,
-        expect![[r#"
-        Finished. moon: ran 2 tasks, now up to date
-    "#]],
-    );
+    check(s, expect![""]);
 }

--- a/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
@@ -14,7 +14,12 @@ fn implement_third_party1() {
     );
 
     let s = get_stderr(&dir, ["check", "--target", "wasm-gc", "."]);
-    check(s, expect![""]);
+    check(
+        s,
+        expect![[r#"
+        Finished. moon: ran 2 tasks, now up to date
+    "#]],
+    );
 
     let packages_json: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("_build/packages.json")).unwrap())
@@ -78,5 +83,10 @@ fn implement_third_party2() {
     );
 
     let s = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
-    check(s, expect![""]);
+    check(
+        s,
+        expect![[r#"
+        Finished. moon: ran 2 tasks, now up to date
+    "#]],
+    );
 }

--- a/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
@@ -13,7 +13,7 @@ fn implement_third_party1() {
         expect_file!["./check_graph.jsonl"],
     );
 
-    let s = get_stderr(&dir, ["check", "--target", "wasm-gc", "."]);
+    let s = get_stdout(&dir, ["check", "--target", "wasm-gc", "."]);
     check(
         s,
         expect![[r#"
@@ -82,7 +82,7 @@ fn implement_third_party2() {
         expect_file!["./build_graph.jsonl"],
     );
 
-    let s = get_stderr(&dir, ["build", "--target", "wasm-gc"]);
+    let s = get_stdout(&dir, ["build", "--target", "wasm-gc"]);
     check(
         s,
         expect![[r#"

--- a/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
@@ -17,8 +17,8 @@ fn implement_third_party1() {
     check(
         s,
         expect![[r#"
-        Finished. moon: ran 2 tasks, now up to date
-    "#]],
+            Finished. moon: ran 2 tasks, now up to date
+        "#]],
     );
 
     let packages_json: serde_json::Value =

--- a/crates/moon/tests/test_cases/warns/mod.rs
+++ b/crates/moon/tests/test_cases/warns/mod.rs
@@ -186,7 +186,7 @@ fn test_warn_list_real_run() {
     let dir = TestDir::new("warns/warn_list");
 
     check(
-        get_stderr(&dir, ["build", "--sort-input", "--no-render"]),
+        get_stdout(&dir, ["build", "--sort-input", "--no-render"]),
         expect![[r#"
             Finished. moon: ran 4 tasks, now up to date
         "#]],
@@ -207,7 +207,7 @@ fn test_warn_list_real_run() {
     );
 
     check(
-        get_stderr(&dir, ["bundle", "--sort-input", "--no-render"]),
+        get_stdout(&dir, ["bundle", "--sort-input", "--no-render"]),
         expect![[r#"
             Finished. moon: ran 4 tasks, now up to date
         "#]],
@@ -217,7 +217,7 @@ fn test_warn_list_real_run() {
     get_stdout(&dir, ["bundle", "--sort-input"]);
 
     check(
-        get_stderr(&dir, ["check", "--sort-input", "--no-render"]),
+        get_stdout(&dir, ["check", "--sort-input", "--no-render"]),
         expect![[r#"
             Finished. moon: ran 6 tasks, now up to date
         "#]],
@@ -333,7 +333,6 @@ fn test_warn_list_alerts() {
                │   ───────┬───────  
                │          ╰───────── Warning (alert_two): two
             ───╯
-            Finished. moon: ran 4 tasks, now up to date (2 warnings, 0 errors)
         "#]],
     );
 
@@ -411,7 +410,6 @@ fn test_deny_warn() {
                │       ┬  
                │       ╰── Warning (unused_value): Unused variable 'a'
             ───╯
-            Finished. moon: ran 4 tasks, now up to date (4 warnings, 0 errors)
         "#]],
     );
 
@@ -453,7 +451,6 @@ fn test_deny_warn() {
                │       ┬  
                │       ╰── Warning (unused_value): Unused variable 'a'
             ───╯
-            Finished. moon: ran 3 tasks, now up to date (4 warnings, 0 errors)
         "#]],
     );
 

--- a/crates/moon/tests/test_cases/warns/mod.rs
+++ b/crates/moon/tests/test_cases/warns/mod.rs
@@ -187,9 +187,7 @@ fn test_warn_list_real_run() {
 
     check(
         get_stderr(&dir, ["build", "--sort-input", "--no-render"]),
-        expect![[r#"
-            Finished. moon: ran 4 tasks, now up to date
-        "#]],
+        expect![""],
     );
 
     check(
@@ -208,9 +206,7 @@ fn test_warn_list_real_run() {
 
     check(
         get_stderr(&dir, ["bundle", "--sort-input", "--no-render"]),
-        expect![[r#"
-            Finished. moon: ran 4 tasks, now up to date
-        "#]],
+        expect![""],
     );
 
     // to cover `moon bundle` no work to do
@@ -218,9 +214,7 @@ fn test_warn_list_real_run() {
 
     check(
         get_stderr(&dir, ["check", "--sort-input", "--no-render"]),
-        expect![[r#"
-            Finished. moon: ran 6 tasks, now up to date
-        "#]],
+        expect![""],
     );
 }
 
@@ -333,7 +327,6 @@ fn test_warn_list_alerts() {
                │   ───────┬───────  
                │          ╰───────── Warning (alert_two): two
             ───╯
-            Finished. moon: ran 4 tasks, now up to date (2 warnings, 0 errors)
         "#]],
     );
 
@@ -411,7 +404,6 @@ fn test_deny_warn() {
                │       ┬  
                │       ╰── Warning (unused_value): Unused variable 'a'
             ───╯
-            Finished. moon: ran 4 tasks, now up to date (4 warnings, 0 errors)
         "#]],
     );
 
@@ -451,7 +443,6 @@ fn test_deny_warn() {
                │       ┬  
                │       ╰── Warning (unused_value): Unused variable 'a'
             ───╯
-            Finished. moon: ran 3 tasks, now up to date (4 warnings, 0 errors)
         "#]],
     );
 

--- a/crates/moon/tests/test_cases/warns/mod.rs
+++ b/crates/moon/tests/test_cases/warns/mod.rs
@@ -417,7 +417,9 @@ fn test_deny_warn() {
 
     check(
         get_err_stdout(&dir, ["check", "--deny-warn", "--sort-input"]),
-        expect![""],
+        expect![[r#"
+            Failed with 0 warnings, 3 errors.
+        "#]],
     );
 
     check(
@@ -457,6 +459,8 @@ fn test_deny_warn() {
 
     check(
         get_err_stdout(&dir, ["build", "--deny-warn", "--sort-input"]),
-        expect![""],
+        expect![[r#"
+            Failed with 0 warnings, 3 errors.
+        "#]],
     );
 }

--- a/crates/moon/tests/test_cases/warns/mod.rs
+++ b/crates/moon/tests/test_cases/warns/mod.rs
@@ -187,7 +187,9 @@ fn test_warn_list_real_run() {
 
     check(
         get_stderr(&dir, ["build", "--sort-input", "--no-render"]),
-        expect![""],
+        expect![[r#"
+            Finished. moon: ran 4 tasks, now up to date
+        "#]],
     );
 
     check(
@@ -206,7 +208,9 @@ fn test_warn_list_real_run() {
 
     check(
         get_stderr(&dir, ["bundle", "--sort-input", "--no-render"]),
-        expect![""],
+        expect![[r#"
+            Finished. moon: ran 4 tasks, now up to date
+        "#]],
     );
 
     // to cover `moon bundle` no work to do
@@ -214,7 +218,9 @@ fn test_warn_list_real_run() {
 
     check(
         get_stderr(&dir, ["check", "--sort-input", "--no-render"]),
-        expect![""],
+        expect![[r#"
+            Finished. moon: ran 6 tasks, now up to date
+        "#]],
     );
 }
 
@@ -327,6 +333,7 @@ fn test_warn_list_alerts() {
                │   ───────┬───────  
                │          ╰───────── Warning (alert_two): two
             ───╯
+            Finished. moon: ran 4 tasks, now up to date (2 warnings, 0 errors)
         "#]],
     );
 
@@ -404,6 +411,7 @@ fn test_deny_warn() {
                │       ┬  
                │       ╰── Warning (unused_value): Unused variable 'a'
             ───╯
+            Finished. moon: ran 4 tasks, now up to date (4 warnings, 0 errors)
         "#]],
     );
 
@@ -443,6 +451,7 @@ fn test_deny_warn() {
                │       ┬  
                │       ╰── Warning (unused_value): Unused variable 'a'
             ───╯
+            Finished. moon: ran 3 tasks, now up to date (4 warnings, 0 errors)
         "#]],
     );
 

--- a/crates/moon/tests/test_cases/whitespace_test/mod.rs
+++ b/crates/moon/tests/test_cases/whitespace_test/mod.rs
@@ -92,8 +92,8 @@ fn test_whitespace_parent_space() -> anyhow::Result<()> {
     check(
         &out,
         expect![[r#"
-        Finished. moon: ran 3 tasks, now up to date
-    "#]],
+            Finished. moon: ran 3 tasks, now up to date
+        "#]],
     );
     Ok(())
 }

--- a/crates/moon/tests/test_cases/whitespace_test/mod.rs
+++ b/crates/moon/tests/test_cases/whitespace_test/mod.rs
@@ -37,7 +37,7 @@ fn whitespace_test() {
         "#]],
     );
 
-    let out = get_stderr(&dir, ["check", "--target", "wasm-gc"]);
+    let out = get_stdout(&dir, ["check", "--target", "wasm-gc"]);
     expect![[r#"
         Finished. moon: ran 5 tasks, now up to date
     "#]]
@@ -75,7 +75,7 @@ fn test_whitespace_parent_space() -> anyhow::Result<()> {
         expect_file!["../whitespace_test.in/parent_space_build_graph.jsonl.snap"],
     );
 
-    let out = get_stderr(
+    let out = get_stdout(
         &path_with_space,
         ["build", "--target", "wasm-gc", "--no-render"],
     );

--- a/crates/moon/tests/test_cases/whitespace_test/mod.rs
+++ b/crates/moon/tests/test_cases/whitespace_test/mod.rs
@@ -38,10 +38,7 @@ fn whitespace_test() {
     );
 
     let out = get_stderr(&dir, ["check", "--target", "wasm-gc"]);
-    expect![[r#"
-        Finished. moon: ran 5 tasks, now up to date
-    "#]]
-    .assert_eq(&out);
+    expect![""].assert_eq(&out);
 }
 
 #[test]
@@ -89,11 +86,6 @@ fn test_whitespace_parent_space() -> anyhow::Result<()> {
     );
 
     copy(&dir, &path_with_space)?;
-    check(
-        &out,
-        expect![[r#"
-            Finished. moon: ran 3 tasks, now up to date
-        "#]],
-    );
+    check(&out, expect![""]);
     Ok(())
 }

--- a/crates/moon/tests/test_cases/whitespace_test/mod.rs
+++ b/crates/moon/tests/test_cases/whitespace_test/mod.rs
@@ -38,7 +38,10 @@ fn whitespace_test() {
     );
 
     let out = get_stderr(&dir, ["check", "--target", "wasm-gc"]);
-    expect![""].assert_eq(&out);
+    expect![[r#"
+        Finished. moon: ran 5 tasks, now up to date
+    "#]]
+    .assert_eq(&out);
 }
 
 #[test]
@@ -86,6 +89,11 @@ fn test_whitespace_parent_space() -> anyhow::Result<()> {
     );
 
     copy(&dir, &path_with_space)?;
-    check(&out, expect![""]);
+    check(
+        &out,
+        expect![[r#"
+        Finished. moon: ran 3 tasks, now up to date
+    "#]],
+    );
     Ok(())
 }

--- a/crates/moon/tests/test_cases/windows_long_paths/mod.rs
+++ b/crates/moon/tests/test_cases/windows_long_paths/mod.rs
@@ -193,8 +193,11 @@ fn fmt_reports_its_long_format_directory() {
         .stdout_eq(snapbox::str![[r#"
 Fatal error: exception Sys_error("[..]_build[..]wasm-gc[..]release[..]format[..]: No such file or directory")
 ...
+Failed with 0 warnings, 0 errors.
 "#]])
         .stderr_eq(snapbox::str![[r#"
+Error: failed when formatting project
+
 "#]]);
 }
 

--- a/crates/moon/tests/test_cases/windows_long_paths/mod.rs
+++ b/crates/moon/tests/test_cases/windows_long_paths/mod.rs
@@ -195,9 +195,6 @@ Fatal error: exception Sys_error("[..]_build[..]wasm-gc[..]release[..]format[..]
 ...
 "#]])
         .stderr_eq(snapbox::str![[r#"
-Failed with 0 warnings, 0 errors.
-Error: failed when formatting project
-
 "#]]);
 }
 

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -266,12 +266,15 @@ fn test_workspace_commands() {
         );
     }
 
-    let stderr = get_stderr(&dir, ["check", "--target", "wasm-gc", "--sort-input"]);
-    assert!(stderr.contains("Finished. moon: ran "));
+    let stdout = get_stdout(&dir, ["check", "--target", "wasm-gc", "--sort-input"]);
+    assert!(stdout.contains("Finished. moon: ran "));
 
     check(
         get_stdout(&dir, ["info", "--target", "wasm-gc"]),
-        expect![[r#""#]],
+        expect![[r#"
+            Finished. moon: ran 2 tasks, now up to date
+            Finished. moon: ran 4 tasks, now up to date
+        "#]],
     );
 
     let lib_mi_out =
@@ -349,13 +352,13 @@ fn test_empty_workspace_commands_do_not_panic() {
     let dir = empty_workspace_dir();
 
     check(
-        get_stderr(&dir, ["build"]),
+        get_stdout(&dir, ["build"]),
         expect![[r#"
             Finished. moon: no work to do
         "#]],
     );
     check(
-        get_stderr(&dir, ["check"]),
+        get_stdout(&dir, ["check"]),
         expect![[r#"
             Finished. moon: no work to do
         "#]],
@@ -757,7 +760,12 @@ fn test_workspace_commands_find_ancestor_workspace_from_nested_non_module_dir() 
     let dir = TestDir::new("workspace_basic.in");
     std::fs::create_dir_all(dir.join("tools")).unwrap();
 
-    check(get_stdout(&dir, ["-C", "tools", "info"]), expect![[r#""#]]);
+    check(
+        get_stdout(&dir, ["-C", "tools", "info"]),
+        expect![[r#"
+            Finished. moon: ran 4 tasks, now up to date
+        "#]],
+    );
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -266,13 +266,8 @@ fn test_workspace_commands() {
         );
     }
 
-    check(
-        get_stderr(&dir, ["check", "--target", "wasm-gc", "--sort-input"]),
-        expect![[r#"
-            Warning: Main package `alice/app/main` uses blackbox-only test inputs (`_test.mbt` files) in package directory "$ROOT/app/src/main". Main packages will stop generating blackbox tests in a future release. Move public behavior into a non-main package and keep the main package as an entrypoint.
-            Finished. moon: ran 4 tasks, now up to date
-        "#]],
-    );
+    let stderr = get_stderr(&dir, ["check", "--target", "wasm-gc", "--sort-input"]);
+    assert!(stderr.contains("Finished. moon: ran "));
 
     check(
         get_stdout(&dir, ["info", "--target", "wasm-gc"]),
@@ -356,14 +351,14 @@ fn test_empty_workspace_commands_do_not_panic() {
     check(
         get_stderr(&dir, ["build"]),
         expect![[r#"
-        Finished. moon: no work to do
-    "#]],
+            Finished. moon: no work to do
+        "#]],
     );
     check(
         get_stderr(&dir, ["check"]),
         expect![[r#"
-        Finished. moon: no work to do
-    "#]],
+            Finished. moon: no work to do
+        "#]],
     );
     check(
         get_stderr(&dir, ["test"]),

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -270,6 +270,7 @@ fn test_workspace_commands() {
         get_stderr(&dir, ["check", "--target", "wasm-gc", "--sort-input"]),
         expect![[r#"
             Warning: Main package `alice/app/main` uses blackbox-only test inputs (`_test.mbt` files) in package directory "$ROOT/app/src/main". Main packages will stop generating blackbox tests in a future release. Move public behavior into a non-main package and keep the main package as an entrypoint.
+            Finished. moon: ran 4 tasks, now up to date
         "#]],
     );
 
@@ -352,8 +353,18 @@ fn test_workspace_commands() {
 fn test_empty_workspace_commands_do_not_panic() {
     let dir = empty_workspace_dir();
 
-    check(get_stderr(&dir, ["build"]), expect![""]);
-    check(get_stderr(&dir, ["check"]), expect![""]);
+    check(
+        get_stderr(&dir, ["build"]),
+        expect![[r#"
+        Finished. moon: no work to do
+    "#]],
+    );
+    check(
+        get_stderr(&dir, ["check"]),
+        expect![[r#"
+        Finished. moon: no work to do
+    "#]],
+    );
     check(
         get_stderr(&dir, ["test"]),
         expect![[r#"
@@ -498,13 +509,17 @@ fn test_workspace_root_path_selector_is_skipped() {
 
     let build_stderr = get_stderr(&dir, ["build", ".", "--dry-run"]);
     assert!(
-        !build_stderr.contains("skipping path"),
+        build_stderr.contains(
+            "Warning: skipping path `.` because it is not a package in the current work context."
+        ),
         "stderr: {build_stderr}"
     );
 
     let check_stderr = get_stderr(&dir, ["check", ".", "--dry-run"]);
     assert!(
-        !check_stderr.contains("skipping path"),
+        check_stderr.contains(
+            "Warning: skipping path `.` because it is not a package in the current work context."
+        ),
         "stderr: {check_stderr}"
     );
 

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -266,8 +266,12 @@ fn test_workspace_commands() {
         );
     }
 
-    let stderr = get_stderr(&dir, ["check", "--target", "wasm-gc", "--sort-input"]);
-    assert!(stderr.contains("Finished. moon: ran "));
+    check(
+        get_stderr(&dir, ["check", "--target", "wasm-gc", "--sort-input"]),
+        expect![[r#"
+            Warning: Main package `alice/app/main` uses blackbox-only test inputs (`_test.mbt` files) in package directory "$ROOT/app/src/main". Main packages will stop generating blackbox tests in a future release. Move public behavior into a non-main package and keep the main package as an entrypoint.
+        "#]],
+    );
 
     check(
         get_stdout(&dir, ["info", "--target", "wasm-gc"]),
@@ -348,18 +352,8 @@ fn test_workspace_commands() {
 fn test_empty_workspace_commands_do_not_panic() {
     let dir = empty_workspace_dir();
 
-    check(
-        get_stderr(&dir, ["build"]),
-        expect![[r#"
-            Finished. moon: no work to do
-        "#]],
-    );
-    check(
-        get_stderr(&dir, ["check"]),
-        expect![[r#"
-            Finished. moon: no work to do
-        "#]],
-    );
+    check(get_stderr(&dir, ["build"]), expect![""]);
+    check(get_stderr(&dir, ["check"]), expect![""]);
     check(
         get_stderr(&dir, ["test"]),
         expect![[r#"

--- a/crates/moonbuild-rupes-recta/src/intent.rs
+++ b/crates/moonbuild-rupes-recta/src/intent.rs
@@ -244,7 +244,7 @@ fn should_skip_test_target(
         return false;
     }
 
-    warn_or_info_test_target_skip(resolved, target, target_backend, user_log);
+    report_test_target_skip(resolved, target, target_backend, user_log);
     true
 }
 
@@ -274,7 +274,7 @@ fn realizable_supported_backends(
         )
 }
 
-fn warn_or_info_test_target_skip(
+fn report_test_target_skip(
     resolved: &ResolveOutput,
     target: BuildTarget,
     target_backend: TargetBackend,
@@ -302,7 +302,7 @@ fn warn_or_info_test_target_skip(
         .map(ToString::to_string)
         .collect::<Vec<_>>();
     supported_backends.sort();
-    user_log.info(format!(
+    user_log.debug(format!(
         "Skipping {test_kind} tests for package `{}` on backend `{}`: target is not realizable for this backend. Realizable backends: [{}]",
         pkg.fqn,
         target_backend,

--- a/crates/moonbuild/src/entry.rs
+++ b/crates/moonbuild/src/entry.rs
@@ -38,45 +38,6 @@ pub fn create_progress_console(
     }
 }
 
-fn render_result(result: &N2RunStats, quiet: bool, mode: &str) -> anyhow::Result<i32> {
-    match result.n_tasks_executed {
-        None => {
-            eprintln!(
-                "Failed with {} warnings, {} errors.",
-                result.n_warnings, result.n_errors
-            );
-            anyhow::bail!("failed when {mode} project");
-        }
-        Some(n_tasks) => {
-            if !quiet {
-                let finished = "Finished.".green().bold();
-                let warnings_errors = format_warnings_errors(result.n_warnings, result.n_errors);
-
-                match n_tasks {
-                    0 => {
-                        eprintln!("{finished} moon: no work to do{warnings_errors}");
-                    }
-                    n => {
-                        let task_plural = if n == 1 { "" } else { "s" };
-                        eprintln!(
-                            "{finished} moon: ran {n} task{task_plural}, now up to date{warnings_errors}"
-                        );
-                    }
-                }
-            }
-        }
-    }
-    Ok(0)
-}
-
-fn format_warnings_errors(n_warnings: usize, n_errors: usize) -> String {
-    if n_warnings > 0 || n_errors > 0 {
-        format!(" ({n_warnings} warnings, {n_errors} errors)")
-    } else {
-        String::new()
-    }
-}
-
 #[derive(Default)]
 pub struct ResultCatcher {
     pub content_writer: Vec<String>, // todo: might be better to directly write to string
@@ -129,11 +90,6 @@ impl N2RunStats {
     /// Get the return code that should be returned to the shell.
     pub fn return_code_for_success(&self) -> i32 {
         if self.successful() { 0 } else { 1 }
-    }
-
-    pub fn print_info(&self, quiet: bool, mode: &str) -> anyhow::Result<()> {
-        render_result(self, quiet, mode)?;
-        Ok(())
     }
 }
 

--- a/crates/moonutil/src/command_output.rs
+++ b/crates/moonutil/src/command_output.rs
@@ -31,12 +31,14 @@ use crate::user_log::UserLog;
 #[derive(Debug)]
 pub struct CommandOutput {
     user_log: UserLog,
+    quiet: bool,
 }
 
 impl CommandOutput {
-    pub fn new(user_log_level: LevelFilter) -> Self {
+    pub fn new(user_log_level: LevelFilter, quiet: bool) -> Self {
         Self {
             user_log: UserLog::new(user_log_level),
+            quiet,
         }
     }
 
@@ -51,5 +53,16 @@ impl CommandOutput {
     ) -> Result<T, E> {
         let mut stdout = anstream::stdout().lock();
         render(&mut stdout)
+    }
+
+    /// Render an informational command status unless quiet output was requested.
+    pub fn write_status<E>(
+        &self,
+        render: impl FnOnce(&mut dyn Write) -> Result<(), E>,
+    ) -> Result<(), E> {
+        if self.quiet {
+            return Ok(());
+        }
+        self.write_result(render)
     }
 }

--- a/crates/moonutil/src/user_log.rs
+++ b/crates/moonutil/src/user_log.rs
@@ -23,7 +23,6 @@ use log::LevelFilter;
 
 const ERROR_STYLE: Style = AnsiColor::Red.on_default().bold();
 const WARNING_STYLE: Style = AnsiColor::Yellow.on_default().bold();
-const DEBUG_STYLE: Style = AnsiColor::BrightBlack.on_default().bold();
 
 #[derive(Debug, Clone, Copy)]
 pub struct UserLog {
@@ -37,9 +36,9 @@ pub fn user_log_level(verbose: bool, quiet: bool) -> LevelFilter {
     if quiet {
         LevelFilter::Error
     } else if verbose {
-        LevelFilter::Info
+        LevelFilter::Debug
     } else {
-        LevelFilter::Warn
+        LevelFilter::Info
     }
 }
 
@@ -88,7 +87,7 @@ impl UserLog {
 
     fn debug_to(&self, writer: &mut impl Write, message: impl Display) {
         if self.level >= LevelFilter::Debug {
-            let _ = writeln!(writer, "{DEBUG_STYLE}Debug{DEBUG_STYLE:#}: {message}");
+            let _ = writeln!(writer, "{message}");
         }
     }
 }
@@ -100,7 +99,7 @@ mod tests {
     use anstream::{AutoStream, ColorChoice};
     use log::LevelFilter;
 
-    use super::UserLog;
+    use super::{UserLog, user_log_level};
 
     #[test]
     fn error_level_renders_error_and_suppresses_other_messages() {
@@ -143,13 +142,21 @@ mod tests {
     }
 
     #[test]
-    fn debug_level_renders_debug() {
+    fn debug_level_renders_bare_debug() {
         let output = UserLog::new(LevelFilter::Debug);
         let mut writer = AutoStream::new(Vec::new(), ColorChoice::Never);
 
         output.debug_to(&mut writer, "internal context");
 
-        assert_eq!(writer.into_inner(), b"Debug: internal context\n");
+        assert_eq!(writer.into_inner(), b"internal context\n");
+    }
+
+    #[test]
+    fn cli_verbosity_maps_to_user_log_detail() {
+        assert_eq!(user_log_level(false, true), LevelFilter::Error);
+        assert_eq!(user_log_level(false, false), LevelFilter::Info);
+        assert_eq!(user_log_level(true, false), LevelFilter::Debug);
+        assert_eq!(user_log_level(true, true), LevelFilter::Error);
     }
 
     #[test]

--- a/docs/dev/command-output-migration.md
+++ b/docs/dev/command-output-migration.md
@@ -8,7 +8,7 @@ Every MoonBuild-authored Command Result and User Log has one explicit owner and 
 
 The migration must preserve observable command behavior unless a slice names and tests an intentional change. Each slice should be independently reviewable and leave the tree ready for the next slice.
 
-Splitting stdout from stderr is independent from normalizing default verbosity. The quiet user-log level is error-only, whether selected explicitly or by a command default, but commands such as `moonx` may retain a quieter default until a later slice deliberately changes it.
+Splitting stdout from stderr is independent from normalizing default verbosity. The shared CLI mapping is error-only under `--quiet`, informational by default, and debug under `--verbose`. Commands such as `moonx` may retain an explicitly quieter default when transparency is part of their contract.
 
 ## Interface Shape
 
@@ -35,9 +35,9 @@ The facade does not own Process Passthrough, Progress Displays, compiler diagnos
 | Progress Display | terminal stderr | quiet-aware | renderer-specific lifecycle | progress renderer |
 | tracing | configured tracing sink | `RUST_LOG`/trace configuration | tracing subscriber policy | tracing setup |
 
-`UserLog` is the sole owner of filtered user-facing stderr. Informational messages are rendered as bare lines, while warnings and errors retain their canonical labels.
+`UserLog` is the sole owner of filtered user-facing stderr. Informational and debug messages are rendered as bare lines, while warnings and errors retain their canonical labels.
 
-The quiet user-log level follows `UserLog` and suppresses warnings. Default levels and informational formatting remain command-specific until affected command snapshots make any intended behavior change visible.
+The quiet user-log level follows `UserLog` and suppresses warnings. Explicit inputs that are skipped while other work continues are warnings. Automatic workspace filtering is silent; the existing behavior when all explicit inputs are skipped remains a separate command-semantics concern.
 
 ## Slices and Blocking Edges
 
@@ -134,6 +134,10 @@ Blocks: CO-8
 - Let full build executors emit successful completion summaries through
   `UserLog`; failed executions rely on diagnostics plus their nonzero status,
   and partial execution remains summary-free.
+- Keep execution silent when a command owns a subsequent primary result, such
+  as running a program, reporting proof results, or running tests.
+- Normalize the shared CLI user-log mapping after reclassifying command echoes
+  and cache details as debug-only messages.
 - Migrate build reports to writer-based Command Results.
 - Keep child stdout/stderr forwarding byte-preserving and keep concurrent progress behind its own renderer seam.
 - Cover both Rupes Recta and the legacy engine in each applicable behavior test.

--- a/docs/dev/command-output-migration.md
+++ b/docs/dev/command-output-migration.md
@@ -12,10 +12,12 @@ Splitting stdout from stderr is independent from normalizing default verbosity. 
 
 ## Interface Shape
 
-`moonutil` should expose a `CommandOutput` facade constructed from the command's user-log level. Its intentionally small interface is:
+`moonutil` should expose a `CommandOutput` facade constructed from the command's
+user-log level and quiet policy. Its intentionally small interface is:
 
 - borrow its `UserLog` for filtered stderr messages;
-- run one closure against locked stdout to render a fallible Command Result.
+- run a closure against locked stdout to render a fallible Command Result;
+- render an informational stdout status unless quiet output was requested.
 
 The stdout operation should preserve the renderer's result type, propagate its `std::io::Write` failures, and hold the lock for the entire logical result. It should not grow methods for every output format.
 
@@ -30,6 +32,7 @@ The facade does not own Process Passthrough, Progress Displays, compiler diagnos
 | Communication | Channel | Filtered | Write policy | Initial owner |
 | --- | --- | --- | --- | --- |
 | Command Result | stdout | never | return failures | `CommandOutput` |
+| Command Status | stdout | `--quiet` | return failures | `CommandOutput` |
 | User Log | stderr | by user-log level | best effort, matching `UserLog` | `UserLog` |
 | Compiler diagnostics | renderer-selected | diagnostic policy | renderer-specific | diagnostic renderer |
 | Process Passthrough | original child channel | never | preserve bytes and ordering as far as the executor permits | run/build executor |
@@ -135,9 +138,10 @@ Blocks: CO-8
 - Keep build execution independent from durable result presentation: it emits
   diagnostics and progress through their existing seams and returns build
   statistics to its caller.
-- Report successful completion through `UserLog`. For human failure output,
-  write the `Failed with ...` command result to stdout and the command context
-  through `UserLog::error`; compiler diagnostics remain independently owned.
+- Write human `Finished ...` and `Failed with ...` build results to stdout.
+  Quiet output suppresses successful status, while failed results remain
+  visible. Write failure context through `UserLog::error`; compiler
+  diagnostics remain independently owned.
 - Omit the build result when a command owns a subsequent primary result, such
   as running a program, reporting proof results, or running tests.
 - Normalize the shared CLI user-log mapping after reclassifying command echoes

--- a/docs/dev/command-output-migration.md
+++ b/docs/dev/command-output-migration.md
@@ -31,6 +31,7 @@ The facade does not own Process Passthrough, Progress Displays, compiler diagnos
 | --- | --- | --- | --- | --- |
 | Command Result | stdout | never | return failures | `CommandOutput` |
 | User Log | stderr | by user-log level | best effort, matching `UserLog` | `UserLog` |
+| Compiler diagnostics | renderer-selected | diagnostic policy | renderer-specific | diagnostic renderer |
 | Process Passthrough | original child channel | never | preserve bytes and ordering as far as the executor permits | run/build executor |
 | Progress Display | terminal stderr | quiet-aware | renderer-specific lifecycle | progress renderer |
 | tracing | configured tracing sink | `RUST_LOG`/trace configuration | tracing subscriber policy | tracing setup |
@@ -131,10 +132,13 @@ Blocked by: CO-4, CO-5
 Blocks: CO-8
 
 - Separate durable build summaries from Progress Displays and Process Passthrough.
-- Let full build executors emit successful completion summaries through
-  `UserLog`; failed executions rely on diagnostics plus their nonzero status,
-  and partial execution remains summary-free.
-- Keep execution silent when a command owns a subsequent primary result, such
+- Keep build execution independent from durable result presentation: it emits
+  diagnostics and progress through their existing seams and returns build
+  statistics to its caller.
+- Report successful completion through `UserLog`. For human failure output,
+  write the `Failed with ...` command result to stdout and the command context
+  through `UserLog::error`; compiler diagnostics remain independently owned.
+- Omit the build result when a command owns a subsequent primary result, such
   as running a program, reporting proof results, or running tests.
 - Normalize the shared CLI user-log mapping after reclassifying command echoes
   and cache details as debug-only messages.

--- a/docs/dev/command-output-migration.md
+++ b/docs/dev/command-output-migration.md
@@ -142,6 +142,8 @@ Blocks: CO-8
   Quiet output suppresses successful status, while failed results remain
   visible. Write failure context through `UserLog::error`; compiler
   diagnostics remain independently owned.
+- Treat a closed stdout pipe as the consumer finishing early, without changing
+  the semantic build exit status. Propagate other stdout write failures.
 - Omit the build result when a command owns a subsequent primary result, such
   as running a program, reporting proof results, or running tests.
 - Normalize the shared CLI user-log mapping after reclassifying command echoes

--- a/docs/dev/command-output-migration.md
+++ b/docs/dev/command-output-migration.md
@@ -1,6 +1,6 @@
 # Command Output Migration
 
-Status: accepted; CO-1, CO-2, CO-4, and CO-5 complete
+Status: accepted; CO-1, CO-2, CO-4, and CO-5 complete; CO-7 in progress
 
 ## Goal
 
@@ -124,12 +124,17 @@ Blocked by: CO-3, CO-4
 
 ### CO-7: Classify build execution output
 
+Status: in progress
+
 Blocked by: CO-4, CO-5
 
 Blocks: CO-8
 
 - Separate durable build summaries from Progress Displays and Process Passthrough.
-- Migrate durable summaries to `UserLog` and build reports to writer-based Command Results.
+- Let full build executors emit successful completion summaries through
+  `UserLog`; failed executions rely on diagnostics plus their nonzero status,
+  and partial execution remains summary-free.
+- Migrate build reports to writer-based Command Results.
 - Keep child stdout/stderr forwarding byte-preserving and keep concurrent progress behind its own renderer seam.
 - Cover both Rupes Recta and the legacy engine in each applicable behavior test.
 - Done when every executor print site is either migrated or documented as passthrough/progress.


### PR DESCRIPTION
## Why

Build output had two coupled problems: the default `UserLog` level hid normal lifecycle messages, and Rupes Recta execution mixed compilation with durable command-result presentation. That made build results inconsistent, treated explicit skipped inputs like internal detail, and allowed build summaries to compete with compiler diagnostics on stderr.

## What

- Normalize shared user-log filtering to `Error` for `--quiet`, `Info` by default, and `Debug` for `--verbose`; `Info` and `Debug` both remain bare text.
- Keep normal lifecycle messages such as installs, downloads, clones, and registry updates at `Info`.
- Reclassify cache hits, concrete command echoes, and optional backend-selection detail as `Debug`.
- Report explicitly requested paths that are skipped as `Warn`, while keeping automatic workspace filtering silent by default.
- Make RR build execution return statistics without owning the durable build result. Full command callers decide whether and how to report it.
- Write human `Finished ...` and `Failed with ...` build results to stdout through `CommandOutput`.
- Apply `--quiet` only to successful status output; failed build results remain visible.
- Preserve the semantic build exit status when a pipe consumer closes stdout early; other stdout write failures still propagate.
- Keep failure context in `UserLog::error` and compiler diagnostics in their existing independent renderer and channel policy.
- Omit intermediate build results for commands that own a later primary result, including `run`, `prove`, tests, benchmarks, and internal moonx builds.
- Keep JSON diagnostic stdout free of human summary text.
- Preserve the current successful exit behavior when all explicit inputs are skipped.

## Why this is correct

Each output now has an explicit owner: `CommandOutput` owns command-result and command-status stdout, `UserLog` owns filtered Moon-authored stderr messages, and the diagnostic renderer continues to own compiler diagnostics. Success and failure summaries follow the same channel rule, while quiet filtering remains a presentation policy rather than a log-level side effect. Build execution still emits diagnostics and progress as before, but callers decide whether a durable build result belongs to the command. A regression test closes the stdout pipe before both successful and failed summaries are written, proving that output delivery cannot replace exit codes 0 and 1 with a BrokenPipe error.

## Scope

This PR is limited to build-result ownership and persistent user-log filtering. New command-level `--json` and `--jsonl` formats remain isolated in the separate structured-output work, and changing the all-explicit-inputs-skipped exit behavior remains follow-up work.