### PR TITLE
perf(moonrun): reuse poll buffers and cache wasm memory

### DIFF
--- a/crates/moonrun/src/async_api/context.rs
+++ b/crates/moonrun/src/async_api/context.rs
@@ -17,12 +17,16 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use std::ptr::NonNull;
+use std::sync::OnceLock;
 
 use crate::async_host::{AsyncHost, AsyncHostError, AsyncHostResult};
 
 pub(super) struct AsyncContext {
     pub(super) host: AsyncHost,
     imports: v8::Global<v8::Object>,
+    // The memory object is stable, but memory.grow may replace its buffer.
+    // Cache the object while reacquiring buffer storage for every import.
+    memory: OnceLock<v8::Global<v8::WasmMemoryObject>>,
 }
 
 impl AsyncContext {
@@ -34,6 +38,7 @@ impl AsyncContext {
         Self {
             host,
             imports: v8::Global::new(scope, imports),
+            memory: OnceLock::new(),
         }
     }
 }
@@ -56,6 +61,7 @@ pub(super) struct ImportContext<'a, 'scope> {
     pub(super) scope: &'a mut v8::HandleScope<'scope>,
     pub(super) host: &'a AsyncHost,
     imports: &'a v8::Global<v8::Object>,
+    memory: &'a OnceLock<v8::Global<v8::WasmMemoryObject>>,
 }
 
 impl<'a, 'scope> ImportContext<'a, 'scope> {
@@ -64,6 +70,7 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
             scope,
             host: &context.host,
             imports: &context.imports,
+            memory: &context.memory,
         }
     }
 
@@ -72,7 +79,7 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
         f: impl FnOnce(&AsyncHost, &mut [u8]) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
         let host = self.host;
-        let memory_object = memory_object(self.scope, self.imports)?;
+        let memory_object = memory_object(self.scope, self.imports, self.memory)?;
         let buffer = memory_object.buffer();
         let len = buffer.byte_length();
 
@@ -156,13 +163,21 @@ impl<'a, 'scope, 'args> ImportArgs<'a, 'scope, 'args> {
 fn memory_object<'s>(
     scope: &mut v8::HandleScope<'s>,
     imports: &v8::Global<v8::Object>,
+    cached: &OnceLock<v8::Global<v8::WasmMemoryObject>>,
 ) -> AsyncHostResult<v8::Local<'s, v8::WasmMemoryObject>> {
+    if let Some(memory) = cached.get() {
+        return Ok(v8::Local::new(scope, memory));
+    }
+
     let imports = v8::Local::new(scope, imports);
     let key = v8::String::new(scope, "memory").ok_or(AsyncHostError::Fault)?;
     let memory = imports
         .get(scope, key.into())
         .ok_or(AsyncHostError::Fault)?;
-    v8::Local::<v8::WasmMemoryObject>::try_from(memory).map_err(|_| AsyncHostError::Fault)
+    let memory =
+        v8::Local::<v8::WasmMemoryObject>::try_from(memory).map_err(|_| AsyncHostError::Fault)?;
+    let _ = cached.set(v8::Global::new(scope, memory));
+    Ok(memory)
 }
 
 pub(super) fn throw_import_error(

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -37,7 +37,11 @@ ported_fns! {
         } else {
             Ok(PollInstance {
                 fd: unsafe { OwnedFd::from_raw_fd(fd) },
-                events: Vec::new(),
+                raw_events: vec![
+                    libc::epoll_event { events: 0, u64: 0 };
+                    EVENT_BUFFER_SIZE
+                ],
+                events: Vec::with_capacity(EVENT_BUFFER_SIZE),
             })
         }
     }
@@ -86,11 +90,10 @@ ported_fns! {
         original = "moonbitlang_async_event_bus_wait"
     )]
     pub(crate) fn poll_wait(instance: &mut PollInstance, timeout: i32) -> AsyncHostResult<i32> {
-        let mut events = vec![libc::epoll_event { events: 0, u64: 0 }; EVENT_BUFFER_SIZE];
         let count = unsafe {
             libc::epoll_wait(
                 instance.raw_fd(),
-                events.as_mut_ptr(),
+                instance.raw_events.as_mut_ptr(),
                 EVENT_BUFFER_SIZE as i32,
                 timeout,
             )
@@ -98,14 +101,17 @@ ported_fns! {
         if count < 0 {
             return Err(last_native_error());
         }
-        instance.events = events
-            .into_iter()
+        instance.events.clear();
+        instance.events.extend(
+            instance
+            .raw_events
+            .iter()
             .take(count as usize)
             .map(|event| PollEvent {
                 fd: event.u64 as RawFd,
                 events: epoll_result_events(event.events),
-            })
-            .collect();
+            }),
+        );
         Ok(count)
     }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -40,7 +40,8 @@ ported_fns! {
                 raw_events: vec![
                     libc::epoll_event { events: 0, u64: 0 };
                     EVENT_BUFFER_SIZE
-                ],
+                ]
+                .into_boxed_slice(),
                 events: Vec::with_capacity(EVENT_BUFFER_SIZE),
             })
         }

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
@@ -22,8 +22,8 @@ use crate::async_sys::ported_fns;
 use std::os::fd::{FromRawFd, OwnedFd};
 
 use super::{
-    EVENT_BUFFER_SIZE, PROCESS_EVENT, PollEvent, PollInstance, READ_EVENT, WRITE_EVENT, last_errno,
-    last_native_error,
+    EVENT_BUFFER_SIZE, KeventBuffer, PROCESS_EVENT, PollEvent, PollInstance, READ_EVENT,
+    WRITE_EVENT, last_errno, last_native_error,
 };
 
 ported_fns! {
@@ -38,7 +38,8 @@ ported_fns! {
         } else {
             Ok(PollInstance {
                 fd: unsafe { OwnedFd::from_raw_fd(fd) },
-                events: Vec::new(),
+                raw_events: KeventBuffer(vec![empty_kevent(); EVENT_BUFFER_SIZE]),
+                events: Vec::with_capacity(EVENT_BUFFER_SIZE),
             })
         }
     }
@@ -132,13 +133,12 @@ ported_fns! {
             tv_sec: (timeout / 1000) as libc::time_t,
             tv_nsec: ((timeout % 1000) * 1_000_000) as libc::c_long,
         };
-        let mut events = vec![empty_kevent(); EVENT_BUFFER_SIZE];
         let count = unsafe {
             libc::kevent(
                 instance.raw_fd(),
                 std::ptr::null(),
                 0,
-                events.as_mut_ptr(),
+                instance.raw_events.0.as_mut_ptr(),
                 EVENT_BUFFER_SIZE as i32,
                 if timeout < 0 {
                     std::ptr::null()
@@ -150,14 +150,18 @@ ported_fns! {
         if count < 0 {
             return Err(last_native_error());
         }
-        instance.events = events
-            .into_iter()
+        instance.events.clear();
+        instance.events.extend(
+            instance
+                .raw_events
+                .0
+                .iter()
             .take(count as usize)
             .map(|event| PollEvent {
                 fd: event.ident as RawFd,
-                events: kqueue_result_events(&event),
-            })
-            .collect();
+                events: kqueue_result_events(event),
+            }),
+        );
         Ok(count)
     }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
@@ -38,7 +38,9 @@ ported_fns! {
         } else {
             Ok(PollInstance {
                 fd: unsafe { OwnedFd::from_raw_fd(fd) },
-                raw_events: KeventBuffer(vec![empty_kevent(); EVENT_BUFFER_SIZE]),
+                raw_events: KeventBuffer(
+                    vec![empty_kevent(); EVENT_BUFFER_SIZE].into_boxed_slice(),
+                ),
                 events: Vec::with_capacity(EVENT_BUFFER_SIZE),
             })
         }

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
@@ -53,7 +53,7 @@ pub(crate) const PROCESS_EVENT: i32 = 4;
 
 #[cfg(target_os = "macos")]
 #[derive(Debug)]
-struct KeventBuffer(Vec<libc::kevent>);
+struct KeventBuffer(Box<[libc::kevent]>);
 
 #[cfg(target_os = "macos")]
 // SAFETY: libc::kevent is plain kernel event storage. Its udata field prevents
@@ -70,7 +70,7 @@ pub(crate) struct PollInstance {
     // Unix pollers retain both buffers so waits do not allocate or initialize
     // 1024 native events before copying the ready subset on every call.
     #[cfg(target_os = "linux")]
-    raw_events: Vec<libc::epoll_event>,
+    raw_events: Box<[libc::epoll_event]>,
     #[cfg(target_os = "macos")]
     raw_events: KeventBuffer,
     events: Vec<PollEvent>,

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
@@ -51,12 +51,28 @@ pub(crate) const WRITE_EVENT: i32 = 2;
 #[cfg(target_os = "macos")]
 pub(crate) const PROCESS_EVENT: i32 = 4;
 
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+struct KeventBuffer(Vec<libc::kevent>);
+
+#[cfg(target_os = "macos")]
+// SAFETY: libc::kevent is plain kernel event storage. Its udata field prevents
+// automatic Send, but moonrun always registers null udata and never dereferences
+// values returned in that field. The buffer owns every event value.
+unsafe impl Send for KeventBuffer {}
+
 #[derive(Debug)]
 pub(crate) struct PollInstance {
     #[cfg(unix)]
     fd: OwnedFd,
     #[cfg(windows)]
     fd: Arc<OwnedHandle>,
+    // Unix pollers retain both buffers so waits do not allocate or initialize
+    // 1024 native events before copying the ready subset on every call.
+    #[cfg(target_os = "linux")]
+    raw_events: Vec<libc::epoll_event>,
+    #[cfg(target_os = "macos")]
+    raw_events: KeventBuffer,
     events: Vec<PollEvent>,
 }
 

--- a/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_host.in/main/main.mbt
@@ -150,6 +150,12 @@ extern "wasm" fn string_to_ptr(str : String) -> Int =
   #|(func (param i32) (result i32) local.get 0)
 
 ///|
+extern "wasm" fn grow_memory_for_test(pages : Int) -> Int =
+  #|(func (param i32) (result i32)
+  #|  local.get 0
+  #|  memory.grow)
+
+///|
 fn errno_is_lock_violation(errno : Int) -> Bool = "moonbitlang/async" "fs/errno_is_lock_violation"
 
 ///|
@@ -196,6 +202,11 @@ fn main {
     }
   }
   assert_true(random_byte_changed, "secure random fill wrote only zeroes")
+  assert_true(grow_memory_for_test(1) >= 0, "failed to grow wasm memory")
+  assert_true(
+    random_fill(random_bytes, random_bytes.length()) == 0,
+    "secure random fill failed after memory.grow",
+  )
   assert_true(
     random_fill(random_bytes, 2_147_483_647) == -1,
     "invalid async random range did not use the native error convention",


### PR DESCRIPTION
## Why

The async host currently allocates and initializes a 1024-entry native event buffer on every epoll/kqueue wait, then allocates another logical event vector. The native implementation retains its event buffer across waits. V8 async imports also repeatedly look up the same `WebAssembly.Memory` object before each guest-memory access.

## What changed

- Retain raw epoll/kqueue storage and logical `PollEvent` capacity in each `PollInstance`, clearing and refilling only the ready prefix after a wait.
- Cache a `Global<WasmMemoryObject>` in `AsyncContext` while reacquiring its current backing buffer on every access.
- Add regression coverage for host memory access after `memory.grow`.

## Why this is correct

The poll implementations keep the existing 1024-event limit, event ordering, event conversion, error behavior, and public host interface. Only events reported by the latest wait are copied into the logical buffer.

`WebAssembly.Memory` identity remains stable across `memory.grow`, while its backing buffer may change. Caching the object and reacquiring the buffer therefore removes the property lookup without retaining a stale memory pointer.

## Scope

This is confined to buffer lifetime and V8 memory lookup. It does not change the async host ABI, handler representation, or readiness-event delivery model; event batching can be evaluated separately.