### PR TITLE
make x86_64-linux use new native backend on debug build in default

### DIFF
--- a/crates/moon/tests/test_cases/native_abort_trace/mod.rs
+++ b/crates/moon/tests/test_cases/native_abort_trace/mod.rs
@@ -4,7 +4,10 @@ use super::*;
 fn test_native_abort_trace() {
     let dir = TestDir::new("native_abort_trace/native_abort_trace.in");
     let redactions = moon_test_util::stack_trace::stack_trace_redactions(dir.as_ref());
-    let expected_stderr = if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+    let expected_stderr = if cfg!(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )) {
         snapbox::str![[r#"
 PanicError
     at @moonbitlang/core/option.Option::unwrap[Int] (/option.mbt:[..])
@@ -12,6 +15,7 @@ PanicError
     at @username/scratch/cmd/main.f (/main.mbt:[..])
     at moonbit_main (/main.mbt:[..])
     at main (/main.mbt:[..])
+...
 Error: Command exited without a return code
 
 "#]]

--- a/crates/moon/tests/test_cases/native_backend/mod.rs
+++ b/crates/moon/tests/test_cases/native_backend/mod.rs
@@ -1,5 +1,8 @@
 mod cc_flags;
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "linux", target_arch = "x86_64")
+))]
 mod new_native_e2e;
 #[cfg(windows)]
 mod parallel_msvc;

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -91,8 +91,8 @@ impl NativeTarget {
     ) -> Option<Self> {
         let target = Self::from_host(arch, os)?;
         let enabled = match target {
-            Self::Aarch64AppleDarwin => env_value != Some("0"),
-            Self::X86_64UnknownLinuxGnu | Self::X86_64PcWindowsMsvc => env_value == Some("1"),
+            Self::Aarch64AppleDarwin | Self::X86_64UnknownLinuxGnu => env_value != Some("0"),
+            Self::X86_64PcWindowsMsvc => env_value == Some("1"),
         };
         enabled.then_some(target)
     }
@@ -656,7 +656,7 @@ mod tests {
     }
 
     #[test]
-    fn new_native_defaults_on_only_for_apple_silicon_macos() {
+    fn new_native_defaults_on_for_apple_silicon_macos_and_x86_64_linux() {
         assert_eq!(
             NativeTarget::from_host_with_new_native_env("aarch64", "macos", None),
             Some(NativeTarget::Aarch64AppleDarwin)
@@ -676,7 +676,7 @@ mod tests {
 
         assert_eq!(
             NativeTarget::from_host_with_new_native_env("x86_64", "linux", None),
-            None
+            Some(NativeTarget::X86_64UnknownLinuxGnu)
         );
         assert_eq!(
             NativeTarget::from_host_with_new_native_env("x86_64", "linux", Some("1")),
@@ -687,12 +687,20 @@ mod tests {
             None
         );
         assert_eq!(
+            NativeTarget::from_host_with_new_native_env("x86_64", "linux", Some("other")),
+            Some(NativeTarget::X86_64UnknownLinuxGnu)
+        );
+        assert_eq!(
             NativeTarget::from_host_with_new_native_env("x86_64", "windows", None),
             None
         );
         assert_eq!(
             NativeTarget::from_host_with_new_native_env("x86_64", "windows", Some("1")),
             Some(NativeTarget::X86_64PcWindowsMsvc)
+        );
+        assert_eq!(
+            NativeTarget::from_host_with_new_native_env("x86_64", "windows", Some("other")),
+            None
         );
         assert_eq!(
             NativeTarget::from_host_with_new_native_env("x86_64", "macos", Some("1")),


### PR DESCRIPTION
x86_64 linux 在moon build/run/test 的debug构建下，默认使用原生native后端，除非开启MOONBIT_NEW_NATIVE=0才回退到C后端使用tcc，同MacOS。