### PR TITLE
Fix SIGCHLD inheritance in moon run

### DIFF
--- a/crates/moon/src/cli/process.rs
+++ b/crates/moon/src/cli/process.rs
@@ -30,19 +30,15 @@ pub(crate) fn delegate(cmd: &mut Command) -> anyhow::Result<ExitStatus> {
     Err(cmd.exec().into())
 }
 
-/// Delegate to a command as directly as the platform allows.
-///
-/// On Unix this replaces the current process. On Windows there is no direct
-/// equivalent, so we run the child and wait while letting it handle Ctrl-C.
-/// Use this only for command paths that return directly to process exit.
+/// Keep the parent alive while its Windows console delivers Ctrl-C to children.
 #[cfg(windows)]
-pub(crate) fn delegate(cmd: &mut Command) -> anyhow::Result<ExitStatus> {
+pub(crate) fn install_ctrl_c_passthrough_handler() -> anyhow::Result<()> {
     use anyhow::bail;
     use windows_sys::Win32::Foundation::{BOOL, FALSE, TRUE};
     use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
 
     unsafe extern "system" fn ctrlc_handler(_: u32) -> BOOL {
-        // Do nothing. Let the child process handle it.
+        // The child receives the console event independently.
         TRUE
     }
 
@@ -51,6 +47,16 @@ pub(crate) fn delegate(cmd: &mut Command) -> anyhow::Result<ExitStatus> {
             bail!("could not set Ctrl-C handler")
         }
     }
+    Ok(())
+}
 
+/// Delegate to a command as directly as the platform allows.
+///
+/// On Unix this replaces the current process. On Windows there is no direct
+/// equivalent, so we run the child and wait while letting it handle Ctrl-C.
+/// Use this only for command paths that return directly to process exit.
+#[cfg(windows)]
+pub(crate) fn delegate(cmd: &mut Command) -> anyhow::Result<ExitStatus> {
+    install_ctrl_c_passthrough_handler()?;
     Ok(cmd.status()?)
 }

--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -313,12 +313,9 @@ fn run_artifact(
     );
     run_cmd.args(args);
 
-    user_log.info(rr_build::format_dry_run_command(
-        run_cmd.as_std(),
-        Path::new("."),
-    ));
+    user_log.info(rr_build::format_dry_run_command(&run_cmd, Path::new(".")));
 
-    let status = super::process::delegate(run_cmd.as_std_mut())
+    let status = super::process::delegate(&mut run_cmd)
         .context("failed to delegate to registry executable")?;
     status
         .code()

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -202,6 +202,12 @@ pub(crate) struct RunExecutable {
     lock: Option<FileLock>,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RunExecution {
+    ReplaceProcess,
+    WaitForCleanup,
+}
+
 struct BuildExecutableFromPlanOptions {
     print_dry_run_run_command: bool,
     output: RunOutputVerbosity,
@@ -304,7 +310,10 @@ fn run_source_as_single_file(
         build_only,
         profile,
     };
-    let result = run_single_file_from_arg_with_options(cli, cmd, options, output);
+    let executable = build_single_file_executable_from_arg(cli, &cmd, options, output)?;
+    // The source and build outputs live under `temp_dir`, so this invocation
+    // must return before the directory can be removed.
+    let result = run_executable(cli, &cmd, executable, RunExecution::WaitForCleanup, output);
     drop(temp_dir);
     result
 }
@@ -391,7 +400,7 @@ pub(crate) fn run_run(
     } else {
         build_run_executable(cli, &cmd, BuildRunExecutableOptions::for_run(cli), output)?
     };
-    run_executable(cli, &cmd, executable, output)
+    run_executable(cli, &cmd, executable, RunExecution::ReplaceProcess, output)
 }
 
 /// Resolve the run input, plan it, and build the executable artifact.
@@ -613,17 +622,6 @@ fn resolve_run_selection(
     Ok(ResolvedRunSelection { package })
 }
 
-#[instrument(level = Level::DEBUG, skip_all)]
-fn run_single_file_from_arg_with_options(
-    cli: &UniversalFlags,
-    cmd: RunSubcommand,
-    options: BuildRunExecutableOptions,
-    output: &CommandOutput,
-) -> anyhow::Result<i32> {
-    let executable = build_single_file_executable_from_arg(cli, &cmd, options, output)?;
-    run_executable(cli, &cmd, executable, output)
-}
-
 /// Build a standalone `.mbt`/`.mbtx` input through the synthesized single-file
 /// package machinery.
 fn build_single_file_executable_from_arg(
@@ -818,6 +816,7 @@ fn run_executable(
     cli: &UniversalFlags,
     cmd: &RunSubcommand,
     mut executable: RunExecutable,
+    execution: RunExecution,
     output: &CommandOutput,
 ) -> Result<i32, anyhow::Error> {
     if cli.dry_run {
@@ -857,27 +856,38 @@ fn run_executable(
     }
 
     #[cfg(unix)]
-    {
+    if execution == RunExecution::ReplaceProcess {
         let error = run_cmd.exec();
-        Err(error).context("failed to execute command")
+        return Err(error).context("failed to execute command");
     }
 
+    #[cfg(unix)]
+    // Keep the parent alive until a temp-backed child exits so its build tree
+    // can be removed. The child receives terminal signals independently.
+    ctrlc::set_handler(|| {}).context("failed to install signal handler")?;
     #[cfg(not(unix))]
+    let _ = execution;
+    #[cfg(windows)]
+    super::process::install_ctrl_c_passthrough_handler()?;
+
+    let mut child = run_cmd
+        .spawn()
+        .with_context(|| format!("Failed to spawn command {:?}", run_cmd))?;
+    #[cfg(windows)]
+    if let Err(err) = crate::run::assign_process_to_job(child.as_raw_handle()) {
+        tracing::warn!(?err, "Failed to assign child process to job object");
+    }
+    let status = child.wait().context("failed to wait for command")?;
+    if let Some(code) = status.code() {
+        return Ok(code);
+    }
+    #[cfg(unix)]
     {
-        #[cfg(windows)]
-        super::process::install_ctrl_c_passthrough_handler()?;
-        let mut child = run_cmd
-            .spawn()
-            .with_context(|| format!("Failed to spawn command {:?}", run_cmd))?;
-        #[cfg(windows)]
-        if let Err(err) = crate::run::assign_process_to_job(child.as_raw_handle()) {
-            tracing::warn!(?err, "Failed to assign child process to job object");
-        }
-        let status = child.wait().context("failed to wait for command")?;
-        if let Some(code) = status.code() {
-            Ok(code)
-        } else {
-            bail!("Command exited without a return code")
+        use std::os::unix::process::ExitStatusExt;
+
+        if let Some(signal) = status.signal() {
+            return Ok(128 + signal);
         }
     }
+    bail!("Command exited without a return code")
 }

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -391,11 +391,7 @@ pub(crate) fn run_run(
     } else {
         build_run_executable(cli, &cmd, BuildRunExecutableOptions::for_run(cli), output)?
     };
-    let result = run_executable(cli, &cmd, executable, output);
-    if crate::run::shutdown_requested() {
-        return Ok(130);
-    }
-    result
+    run_executable(cli, &cmd, executable, output)
 }
 
 /// Resolve the run input, plan it, and build the executable artifact.
@@ -868,6 +864,8 @@ fn run_executable(
 
     #[cfg(not(unix))]
     {
+        #[cfg(windows)]
+        super::process::install_ctrl_c_passthrough_handler()?;
         let mut child = run_cmd
             .spawn()
             .with_context(|| format!("Failed to spawn command {:?}", run_cmd))?;

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -848,7 +848,8 @@ fn run_executable(
     // on Unix: although it preserves raw signal status, it skips RAII cleanup
     // in `main` and callers, including the Chrome trace guard and temporary
     // source/build directories. Standard spawning also avoids the Tokio runner
-    // that temporarily masks SIGCHLD on macOS.
+    // that temporarily masks SIGCHLD on macOS. See
+    // `docs/dev/design/moon-run-process-lifecycle.md`.
     #[cfg(unix)]
     ctrlc::set_handler(|| {}).context("failed to install signal handler")?;
     #[cfg(windows)]

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -16,6 +16,10 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
 use std::{io::Read, path::Path, path::PathBuf};
 
 use anyhow::{Context, bail};
@@ -39,7 +43,6 @@ use crate::filter::ensure_package_supports_backend;
 use crate::rr_build;
 use crate::rr_build::preconfig_compile;
 use crate::rr_build::{BuildConfig, CalcUserIntentOutput};
-use crate::run::default_rt;
 
 use super::{BuildFlags, UniversalFlags};
 
@@ -344,7 +347,7 @@ fn build_wasm_file_executable_from_arg(
             cmd.moonrun_policy.as_deref(),
         );
         run_cmd.args(&cmd.args);
-        let command = rr_build::format_dry_run_command(run_cmd.as_std(), &print_dir);
+        let command = rr_build::format_dry_run_command(&run_cmd, &print_dir);
         output.write_result(|writer| writeln!(writer, "{command}"))?;
     }
 
@@ -579,7 +582,7 @@ fn get_run_cmd(
     build_meta: &rr_build::BuildMeta,
     argv: &[String],
     moonrun_policy: Option<&Path>,
-) -> tokio::process::Command {
+) -> std::process::Command {
     let executable = get_run_executable(build_meta);
     let mut cmd = crate::run::command_for_with_moonrun_policy(
         build_meta.target_backend,
@@ -772,7 +775,7 @@ fn build_executable_from_plan(
                 writeln!(
                     writer,
                     "{}",
-                    rr_build::format_dry_run_command(run_cmd.as_std(), source_dir)
+                    rr_build::format_dry_run_command(&run_cmd, source_dir)
                 )?;
             }
             Ok::<_, std::io::Error>(())
@@ -841,11 +844,11 @@ fn run_executable(
     );
     run_cmd.args(&cmd.args);
     output.user_log().info(rr_build::format_dry_run_command(
-        run_cmd.as_std(),
+        &run_cmd,
         &executable.source_dir,
     ));
 
-    // Release the lock before spawning the subprocess
+    // Release the lock before handing control to the executable.
     executable.release_lock();
 
     if cmd.build_only {
@@ -857,14 +860,26 @@ fn run_executable(
         return Ok(0);
     }
 
-    let res = default_rt()
-        .context("Failed to create runtime")?
-        .block_on(crate::run::run(&mut [], false, run_cmd))
-        .context("failed to run command")?;
+    #[cfg(unix)]
+    {
+        let error = run_cmd.exec();
+        Err(error).context("failed to execute command")
+    }
 
-    if let Some(code) = res.code() {
-        Ok(code)
-    } else {
-        bail!("Command exited without a return code")
+    #[cfg(not(unix))]
+    {
+        let mut child = run_cmd
+            .spawn()
+            .with_context(|| format!("Failed to spawn command {:?}", run_cmd))?;
+        #[cfg(windows)]
+        if let Err(err) = crate::run::assign_process_to_job(child.as_raw_handle()) {
+            tracing::warn!(?err, "Failed to assign child process to job object");
+        }
+        let status = child.wait().context("failed to wait for command")?;
+        if let Some(code) = status.code() {
+            Ok(code)
+        } else {
+            bail!("Command exited without a return code")
+        }
     }
 }

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -16,8 +16,6 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-#[cfg(unix)]
-use std::os::unix::process::CommandExt;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 use std::{io::Read, path::Path, path::PathBuf};
@@ -202,12 +200,6 @@ pub(crate) struct RunExecutable {
     lock: Option<FileLock>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum RunExecution {
-    ReplaceProcess,
-    WaitForCleanup,
-}
-
 struct BuildExecutableFromPlanOptions {
     print_dry_run_run_command: bool,
     output: RunOutputVerbosity,
@@ -311,9 +303,7 @@ fn run_source_as_single_file(
         profile,
     };
     let executable = build_single_file_executable_from_arg(cli, &cmd, options, output)?;
-    // The source and build outputs live under `temp_dir`, so this invocation
-    // must return before the directory can be removed.
-    let result = run_executable(cli, &cmd, executable, RunExecution::WaitForCleanup, output);
+    let result = run_executable(cli, &cmd, executable, output);
     drop(temp_dir);
     result
 }
@@ -400,7 +390,7 @@ pub(crate) fn run_run(
     } else {
         build_run_executable(cli, &cmd, BuildRunExecutableOptions::for_run(cli), output)?
     };
-    run_executable(cli, &cmd, executable, RunExecution::ReplaceProcess, output)
+    run_executable(cli, &cmd, executable, output)
 }
 
 /// Resolve the run input, plan it, and build the executable artifact.
@@ -816,7 +806,6 @@ fn run_executable(
     cli: &UniversalFlags,
     cmd: &RunSubcommand,
     mut executable: RunExecutable,
-    execution: RunExecution,
     output: &CommandOutput,
 ) -> Result<i32, anyhow::Error> {
     if cli.dry_run {
@@ -855,18 +844,13 @@ fn run_executable(
         return Ok(0);
     }
 
+    // Keep Moon as the parent on every platform. We deliberately avoid `exec`
+    // on Unix: although it preserves raw signal status, it skips RAII cleanup
+    // in `main` and callers, including the Chrome trace guard and temporary
+    // source/build directories. Standard spawning also avoids the Tokio runner
+    // that temporarily masks SIGCHLD on macOS.
     #[cfg(unix)]
-    if execution == RunExecution::ReplaceProcess {
-        let error = run_cmd.exec();
-        return Err(error).context("failed to execute command");
-    }
-
-    #[cfg(unix)]
-    // Keep the parent alive until a temp-backed child exits so its build tree
-    // can be removed. The child receives terminal signals independently.
     ctrlc::set_handler(|| {}).context("failed to install signal handler")?;
-    #[cfg(not(unix))]
-    let _ = execution;
     #[cfg(windows)]
     super::process::install_ctrl_c_passthrough_handler()?;
 

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -277,8 +277,8 @@ fn install_build_rr(
         &installed_artifact,
         None,
     );
-    let parts = std::iter::once(guard.as_std().get_program())
-        .chain(guard.as_std().get_args())
+    let parts = std::iter::once(guard.get_program())
+        .chain(guard.get_args())
         .map(|x| x.to_string_lossy().to_string())
         .collect::<Vec<_>>();
     let line = shlex::try_join(parts.iter().map(|s| &**s))

--- a/crates/moon/src/run/child.rs
+++ b/crates/moon/src/run/child.rs
@@ -18,13 +18,12 @@
 
 //! Handles spawning of a child process under the govern of `moon run`
 
-use std::process::{ExitStatus, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
 use std::time::Instant;
 
 use anyhow::Context;
 use moonbuild::section_capture::{SectionCapture, handle_stdout_async};
 use moonutil::platform::macos_with_sigchild_blocked;
-use tokio::process::Command;
 use tracing::debug;
 #[cfg(windows)]
 use tracing::warn;
@@ -45,8 +44,9 @@ use tracing::warn;
 pub(crate) async fn run<'a>(
     captures: &mut [&mut SectionCapture<'a>],
     capture: bool,
-    mut cmd: Command,
+    cmd: Command,
 ) -> anyhow::Result<ExitStatus> {
+    let mut cmd = tokio::process::Command::from(cmd);
     let shutdown = super::shutdown_token();
     if capture {
         // If we want to capture some/all of the output, we want to set piped
@@ -81,7 +81,11 @@ pub(crate) async fn run<'a>(
         "spawn_child_process_finished"
     );
     #[cfg(windows)]
-    if let Err(err) = assign_child_to_job(&child) {
+    if let Err(err) = child
+        .raw_handle()
+        .ok_or_else(|| anyhow::anyhow!("Missing child process handle"))
+        .and_then(assign_process_to_job)
+    {
         warn!(?err, "Failed to assign child process to job object");
     }
 
@@ -148,7 +152,9 @@ pub(crate) async fn run<'a>(
 }
 
 #[cfg(windows)]
-fn assign_child_to_job(child: &tokio::process::Child) -> anyhow::Result<()> {
+pub(crate) fn assign_process_to_job(
+    proc_handle: std::os::windows::io::RawHandle,
+) -> anyhow::Result<()> {
     use std::sync::OnceLock;
     use windows_sys::Win32::Foundation::{ERROR_ACCESS_DENIED, HANDLE};
     use windows_sys::Win32::System::JobObjects::{
@@ -191,9 +197,6 @@ fn assign_child_to_job(child: &tokio::process::Child) -> anyhow::Result<()> {
         }
     };
 
-    let Some(proc_handle) = child.raw_handle() else {
-        return Err(anyhow::anyhow!("Missing child process handle"));
-    };
     let job_handle = job.0;
     let ok = unsafe { AssignProcessToJobObject(job_handle, proc_handle) };
     if ok == 0 {

--- a/crates/moon/src/run/mod.rs
+++ b/crates/moon/src/run/mod.rs
@@ -22,6 +22,8 @@ mod child;
 mod runtest;
 mod runtime;
 
+#[cfg(windows)]
+pub(crate) use child::assign_process_to_job;
 pub(crate) use child::run;
 pub(crate) use runtest::{
     PackageFilter, TestFilter, TestIndex, TestOutlineEntry, collect_test_invocations,

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -769,7 +769,7 @@ fn run_one_test_executable(
     let mut cov_cap = mk_coverage_capture();
     let mut test_cap = make_test_capture();
     ctx.user_log.info(crate::rr_build::format_dry_run_command(
-        cmd.as_std(),
+        &cmd,
         ctx.source_dir,
     ));
     info!(package = %test.args.package, executable = %test.executable.display(), "launching test executable");

--- a/crates/moon/src/run/runtime.rs
+++ b/crates/moon/src/run/runtime.rs
@@ -19,10 +19,10 @@
 //! Handles which runtime to use to run a specific output.
 
 use std::path::Path;
+use std::process::Command;
 
 use moonbuild::entry::TestArgs;
 use moonbuild_rupes_recta::model::{RunBackend, TccRunConfig};
-use tokio::process::Command;
 
 /// Returns a command to run the given MoonBit executable of a specific
 /// `backend`. The returning command is suitable for adding more commandline

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -1367,6 +1367,30 @@ fn test_moon_run_command_string_reads_inline_script() {
         .stderr_eq("");
 }
 
+#[cfg(unix)]
+#[test]
+fn test_moon_run_command_string_removes_temporary_project() {
+    let dir = TestDir::new_empty();
+    let temp_root = dir.join("tmp");
+    std::fs::create_dir(&temp_root).unwrap();
+
+    moon_cmd(&dir)
+        .env("TMPDIR", &temp_root)
+        .args([
+            "run",
+            "-e",
+            r#"fn main {
+  println("hello")
+}
+"#,
+        ])
+        .assert()
+        .success()
+        .stdout_eq("hello\n");
+
+    assert_eq!(std::fs::read_dir(temp_root).unwrap().count(), 0);
+}
+
 #[test]
 fn test_moon_run_command_string_short_alias_c_reads_inline_script() {
     let dir = TestDir::new_empty();

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -1391,6 +1391,21 @@ fn test_moon_run_command_string_removes_temporary_project() {
     assert_eq!(std::fs::read_dir(temp_root).unwrap().count(), 0);
 }
 
+#[cfg(unix)]
+#[test]
+fn test_moon_run_flushes_trace() {
+    let dir = TestDir::new("moon_commands");
+
+    moon_cmd(&dir)
+        .args(["run", "--trace", "main1"])
+        .assert()
+        .success();
+
+    let trace = std::fs::read_to_string(dir.join("trace.json")).unwrap();
+    let events: serde_json::Value = serde_json::from_str(&trace).unwrap();
+    assert!(events.as_array().is_some_and(|events| !events.is_empty()));
+}
+
 #[test]
 fn test_moon_run_command_string_short_alias_c_reads_inline_script() {
     let dir = TestDir::new_empty();

--- a/crates/moon/tests/test_cases/native_abort_trace/mod.rs
+++ b/crates/moon/tests/test_cases/native_abort_trace/mod.rs
@@ -37,10 +37,13 @@ RUNTIME ERROR: abort() called
         .env_remove("MOONBIT_NEW_NATIVE")
         .args(["run", "--target", "native", "cmd/main"])
         .assert();
-    let assert = if exits_via_signal {
-        assert.interrupted()
+    let expected_code = if exits_via_signal {
+        128 + libc::SIGABRT
     } else {
-        assert.code(255)
+        255
     };
-    assert.stdout_eq("Hello\n").stderr_eq(expected_stderr);
+    assert
+        .code(expected_code)
+        .stdout_eq("Hello\n")
+        .stderr_eq(expected_stderr);
 }

--- a/crates/moon/tests/test_cases/native_abort_trace/mod.rs
+++ b/crates/moon/tests/test_cases/native_abort_trace/mod.rs
@@ -4,10 +4,13 @@ use super::*;
 fn test_native_abort_trace() {
     let dir = TestDir::new("native_abort_trace/native_abort_trace.in");
     let redactions = moon_test_util::stack_trace::stack_trace_redactions(dir.as_ref());
-    let expected_stderr = if cfg!(any(
+    // The new native runtime aborts after reporting the panic, while the legacy
+    // runtime reports a runtime error and exits 255.
+    let exits_via_signal = cfg!(any(
         all(target_os = "macos", target_arch = "aarch64"),
         all(target_os = "linux", target_arch = "x86_64")
-    )) {
+    ));
+    let expected_stderr = if exits_via_signal {
         snapbox::str![[r#"
 PanicError
     at @moonbitlang/core/option.Option::unwrap[Int] (/option.mbt:[..])
@@ -16,7 +19,6 @@ PanicError
     at moonbit_main (/main.mbt:[..])
     at main (/main.mbt:[..])
 ...
-Error: Command exited without a return code
 
 "#]]
     } else {
@@ -29,13 +31,16 @@ RUNTIME ERROR: abort() called
 
 "#]]
     };
-    snapbox::cmd::Command::new(moon_bin())
+    let assert = snapbox::cmd::Command::new(moon_bin())
         .with_assert(snapbox::Assert::new().redact_with(redactions))
         .current_dir(&dir)
         .env_remove("MOONBIT_NEW_NATIVE")
         .args(["run", "--target", "native", "cmd/main"])
-        .assert()
-        .code(255)
-        .stdout_eq("Hello\n")
-        .stderr_eq(expected_stderr);
+        .assert();
+    let assert = if exits_via_signal {
+        assert.interrupted()
+    } else {
+        assert.code(255)
+    };
+    assert.stdout_eq("Hello\n").stderr_eq(expected_stderr);
 }

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -72,6 +72,7 @@ cargo install --path ./crates/moon --debug --offline
 ### Design
 
 - [Global build state and cache design](design/global-build-cache.md)
+- [`moon run` process lifecycle](design/moon-run-process-lifecycle.md)
 - [`docs/dev/reference`](reference/readme.md): implemented MoonBuild behavior.
 
 - `crates/moon`

--- a/docs/dev/design/moon-run-process-lifecycle.md
+++ b/docs/dev/design/moon-run-process-lifecycle.md
@@ -1,0 +1,198 @@
+# `moon run` process lifecycle
+
+## Status
+
+Accepted and implemented.
+
+This decision applies to the process that executes a program for `moon run`.
+It does not require `moon test` to stop using its asynchronous runner, because
+tests have different requirements for output capture, cancellation, and
+parallel execution.
+
+## Context
+
+`moon run` used to pass the requested program through the shared Tokio child
+runner. On macOS, that runner wraps process creation in
+`macos_with_sigchild_blocked`, which temporarily blocks `SIGCHLD` to work
+around a suspected Tokio child-wait race.
+
+Signal masks are inherited at process creation. Blocking `SIGCHLD` around
+spawn therefore also started the requested user program with `SIGCHLD`
+blocked. A program that later spawned and waited for its own children could
+hang with zombie processes. Build tools exposed this particularly clearly:
+queries that did not create children completed, while compiler detection and
+other subprocess-heavy operations could hang.
+
+The upstream report involved Tokio 1.39.2, which is also the version originally
+used by Moon. The proposed Tokio change to block `SIGCHLD` during spawn was not
+merged. Tokio maintainers noted that changing a thread's signal mask around
+spawn is unsafe in the presence of concurrent spawns and other signal users,
+and the underlying race was never confirmed.
+
+Unlike the test runner, `moon run` does not need asynchronous output capture or
+parallel child management. It is a synchronous operation: build one artifact,
+launch it with inherited standard streams, and wait for it to finish.
+
+## Decision
+
+`moon run` uses `std::process::Command` and a blocking `spawn`/`wait` lifecycle
+on every platform.
+
+The execution flow is:
+
+1. Build the selected artifact while holding the target-directory lock.
+2. Construct its runtime command as `std::process::Command`.
+3. Release the build lock.
+4. Install the platform's parent-side terminal-signal handling.
+5. Spawn the child without the Tokio process runner or the macOS `SIGCHLD`
+   masking wrapper.
+6. On Windows, assign the child to the existing kill-on-close Job Object.
+7. Wait for the child and return its exit result to `main`.
+8. Let normal Rust destruction finalize process-scoped and caller-owned state.
+
+On Unix, termination by signal is reported as the conventional shell-visible
+`128 + signal` exit status. This preserves the result users normally observe
+from a shell, although an outer `waitpid` observes a normal exit with that code
+rather than `WIFSIGNALED`.
+
+On Windows, Moon's console handler keeps the parent alive while the console
+delivers Ctrl-C independently to the child. The Job Object has a separate
+responsibility: it cleans up the child process tree if the parent exits.
+
+Command construction remains shared between run and test paths. The test
+runner converts the standard command into a Tokio command only at its own
+execution seam.
+
+## Why Unix `exec` was rejected
+
+An earlier implementation used `exec` on Unix. It appeared attractive because
+it removed the intermediate Moon process, could not pass Moon's later signal
+mask changes to another spawn, and preserved raw Unix signal status.
+
+However, a successful `exec` never returns. It bypasses every Rust destructor
+owned by Moon, including state outside the run module:
+
+- `moon run -e` and `moon run -` own a `tempfile::TempDir` containing their
+  synthesized source project and build outputs. Without a return path, those
+  directories are leaked.
+- `main` owns the `tracing_chrome` guard. Its destructor flushes and finalizes
+  Chrome trace output. Without it, queued events can be lost and `trace.json`
+  can be incomplete or invalid.
+- Future process-scoped RAII state would fail in the same way even if today's
+  two known resources were special-cased.
+
+Explicitly flushing the trace guard before `exec` is the wrong seam. The run
+module does not own that guard, and teaching it about selected resources would
+split cleanup knowledge between `main`, callers, and process execution.
+Likewise, deleting the inline-source directory before `exec` is impossible
+because the executable being launched lives inside that directory.
+
+Using `exec` only for invocations that currently appear not to own temporary
+state was also rejected. Whether `exec` is safe would then depend on invisible
+ownership in every caller and on future RAII additions. The short-lived
+`ReplaceProcess` versus `WaitForCleanup` distinction demonstrated this
+problem: it exposed a lifecycle implementation detail through the run
+interface without making the classification future-proof.
+
+## Other rejected alternatives
+
+### Retain the Tokio runner for `moon run`
+
+This would preserve normal destruction, but would reintroduce the original
+`SIGCHLD` inheritance through Moon's macOS workaround. Removing that
+workaround alone would rely on an upstream child-wait race that was reported
+against the same Tokio version and was not conclusively fixed.
+
+Tokio remains appropriate for `moon test`, where asynchronous capture and
+parallel child execution provide real value. Those requirements do not apply
+to `moon run`.
+
+### Add defensive child-side signal-mask changes
+
+Unconditionally unblocking `SIGCHLD` in the child can conceal a bug in the
+parent runner and silently changes the signal-mask contract inherited from the
+caller. `moon run` has no need to manipulate the mask at all once it avoids the
+masking runner. Defensive normalization in a general process library would be
+a separate decision with separate compatibility requirements.
+
+### Use a cleanup helper process
+
+A helper could retain `exec` for the target while another process monitored
+its lifetime and removed temporary state. It would also need a reliable
+protocol for trace finalization, signal forwarding, process groups, abnormal
+termination, and Windows Job Object behavior. That is substantially more
+lifecycle machinery than a synchronous parent waiting for one child.
+
+### Periodically poll the child
+
+No periodic status probe is needed. Blocking `wait` is event-driven by the
+operating system and lets the parent perform cleanup when the child exits.
+
+## Required invariants
+
+Changes to `moon run` process execution must preserve all of the following:
+
+- The user program is not spawned through `tokio::process::Command`.
+- The user program is not spawned while Moon has temporarily blocked
+  `SIGCHLD`.
+- Moon remains alive until the child exits so control returns through `main`
+  and caller scopes.
+- The build lock is released before the user program starts.
+- Standard input, output, and error retain interactive command behavior.
+- Ctrl-C reaches the child while the parent remains alive long enough to
+  finish cleanup.
+- Windows descendants remain covered by the kill-on-close Job Object.
+- Inline and stdin source projects are removed after normal execution.
+- Chrome trace output is flushed into valid JSON.
+- Waiting does not depend on periodic polling.
+
+An uncatchable termination such as `SIGKILL` can still bypass cleanup. That is
+an operating-system limitation and not a reason to weaken cleanup on normal
+exit or handled terminal interruption.
+
+## Regression coverage
+
+The process-lifecycle behavior is anchored by integration tests:
+
+- `test_moon_run_command_string_removes_temporary_project` verifies that a
+  successful inline run leaves its isolated temporary root empty.
+- `test_moon_run_flushes_trace` parses `trace.json`, catching an unflushed or
+  incomplete Chrome trace.
+- `test_native_abort_trace` verifies the shell-visible signal exit status and
+  ensures Moon does not add a wrapper error to the child's panic output.
+- The run-command suite covers normal Wasm, JavaScript, native error, argument,
+  and backtrace behavior.
+
+Prefer end-to-end child behavior over signal-mask probes when adding
+regressions. A representative program that spawns and waits for its own child
+tests the user-visible contract without coupling the test to mask inspection.
+
+## Reconsidering this decision
+
+Do not replace the standard spawn/wait path with `exec` solely to remove one
+parent process or recover raw `WIFSIGNALED` status.
+
+Reconsideration requires a concrete requirement that cannot be met by the
+current lifecycle and a design that:
+
+- identifies one owner for all process-scoped finalization;
+- preserves temporary-project and tracing cleanup without enumerating
+  resources in the run module;
+- specifies Ctrl-C, direct termination, descendant, and Windows Job Object
+  behavior;
+- avoids periodic polling and unsafe signal-mask changes around concurrent
+  spawn;
+- includes end-to-end regressions for nested child creation, trace validity,
+  temporary cleanup, and signal exit behavior; and
+- updates this decision record with the new trade-off.
+
+If a future Tokio release conclusively fixes the macOS child-wait problem, that
+may justify simplifying the asynchronous test runner. It does not by itself
+justify moving the synchronous `moon run` path back to Tokio or `exec`.
+
+## References
+
+- [Tokio issue #6770: `Command.wait` hanging on macOS](https://github.com/tokio-rs/tokio/issues/6770)
+- [Unmerged Tokio PR #6953: block `SIGCHLD` while spawning](https://github.com/tokio-rs/tokio/pull/6953)
+- [Microsoft `SetConsoleCtrlHandler` documentation](https://learn.microsoft.com/en-us/windows/console/setconsolectrlhandler)
+- [Microsoft Job Objects documentation](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects)


### PR DESCRIPTION
## Why

moon run launched user programs through the shared Tokio child runner. On macOS, that runner temporarily blocks SIGCHLD while spawning to work around a Tokio wait race. Signal masks are inherited across process creation, so a program launched by moon run could start with SIGCHLD blocked. Programs that spawn and wait for their own children, such as CMake during compiler detection, could then hang with zombie processes.

## What changed

- Construct runnable commands as std::process::Command, keeping Tokio conversion local to the test runner.
- Run moon run children with standard-library spawn and blocking wait on every platform.
- Keep the parent alive for terminal-signal handling and map Unix signal termination to the conventional 128 + signal exit status.
- On Windows, preserve Ctrl-C delegation and the existing Job Object cleanup behavior.
- Add regressions for temporary inline-source cleanup and complete Chrome trace output.

## Why this is correct

moon run is a synchronous operation and does not need the asynchronous child runner. Standard-library spawning keeps it outside both Tokio process handling and the macOS SIGCHLD masking workaround, so user programs start without inheriting that temporary mask. The asynchronous test runner remains intact and converts the standard command to a Tokio command only at its execution seam.

Keeping Moon as the waiting parent also lets normal command unwinding run. Temporary inline and stdin source projects are removed after their child exits, and the process-level Chrome trace guard is dropped so trace output is finalized. Terminal Ctrl-C is still delivered independently to the child while Moon stays alive long enough to perform this cleanup.

## Why this does not use exec on Unix

An earlier version replaced Moon with the target program using exec. That avoided an intermediate process and preserved raw Unix signal status, but it also bypassed every Rust destructor owned by Moon. This leaked temporary inline-source projects and prevented the Chrome trace guard from flushing; future process-scoped RAII state would have the same problem. Special-casing each resource before exec would spread cleanup ownership into the run path, while a helper process would add substantially more lifecycle and signal complexity.

The final implementation therefore uses one standard spawn-and-wait path. When a Unix child is terminated by a signal, Moon returns the conventional shell-visible 128 + signal status. This is a deliberate trade-off: callers observe the same shell exit code, while Moon retains reliable cleanup and tracing finalization.

## Design record

The accepted process-lifecycle decision is recorded in docs/dev/design/moon-run-process-lifecycle.md. It documents the required invariants, rejected alternatives, regression anchors, known trade-offs, and the evidence required before revisiting exec or the Tokio runner.