### PR TITLE
refactor(test-driver): use byte literal instead of Byte::default()

### DIFF
--- a/crates/moonbuild/template/test_driver_project/common.mbt
+++ b/crates/moonbuild/template/test_driver_project/common.mbt
@@ -66,7 +66,7 @@ fn fixedarray_to_bytes(arr : FixedArray[Byte]) -> Bytes = "%identity"
 fn moonbit_test_driver_internal_string_from_extern(
   e : MoonbitTestDriverInternalExternString,
 ) -> String {
-  let buf = FixedArray::make(512, Byte::default())
+  let buf = FixedArray::make(512, b'\x00')
   let mut len = 0
   let handle = moonbit_test_driver_internal_begin_read_string(e)
   while true {


### PR DESCRIPTION
## Summary

The generated wasm/wasm-gc test driver (`crates/moonbuild/template/test_driver_project/common.mbt`) allocates a scratch buffer with:

```moonbit
let buf = FixedArray::make(512, Byte::default())
```

This replaces `Byte::default()` with the byte literal `b'\x00'`:

```moonbit
let buf = FixedArray::make(512, b'\x00')
```

## Why

- **Clearer** — an explicit zero byte rather than an inherent-method call.
- **Removes a toolchain dependency on `Byte::default()`.** `Byte::default()` is an inherent-method *promotion* of `Default::default` in `moonbitlang/core`. If that promotion is ever deprecated (part of the ongoing `extend`/`implicit_impl_as_method` cleanup), the generated driver — which lives in a different package — would fail `moon test --build-only --deny-warn` on wasm/wasm-gc with a deprecation error in toolchain-generated code. Using a literal keeps the driver independent of that promotion.

No behavioral change: both produce a zero-filled `FixedArray[Byte]`.

## Scope

Single line in the driver template. It's the only `Byte::default()` (and only bare `::default()`) in the driver templates; no snapshots embed the old text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
