### PR TITLE
fix: use package type in new project template

### DIFF
--- a/crates/moon/tests/test_cases/moon_new/new_snapshot.expect
+++ b/crates/moon/tests/test_cases/moon_new/new_snapshot.expect
@@ -142,9 +142,7 @@ fn main {
 //   "testuser/asdf" @lib,
 // }
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")
 
 === ./moon.mod ===
 // Learn more about moon.mod configuration:

--- a/crates/moon/tests/test_cases/moon_new/new_snapshot_with_user_name.expect
+++ b/crates/moon/tests/test_cases/moon_new/new_snapshot_with_user_name.expect
@@ -127,9 +127,7 @@ fn main {
 //   "moonbitlang/hello" @lib,
 // }
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")
 
 === ./hello.mbt ===
 // Main package file for your library code.

--- a/crates/moon/tests/test_cases/moon_new/new_snapshot_with_user_name_different.expect
+++ b/crates/moon/tests/test_cases/moon_new/new_snapshot_with_user_name_different.expect
@@ -127,9 +127,7 @@ fn main {
 //   "moonbitlang/wow" @lib,
 // }
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")
 
 === ./moon.mod ===
 // Learn more about moon.mod configuration:

--- a/crates/moonbuild/template/moon_new_template.toml
+++ b/crates/moonbuild/template/moon_new_template.toml
@@ -9,9 +9,7 @@ content = """
 //   "{{username}}/{{module}}" @lib,
 // }
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")
 """
 
 [[files]]

--- a/crates/moonbuild/template/moon_new_template/cmd/main/moon.pkg
+++ b/crates/moonbuild/template/moon_new_template/cmd/main/moon.pkg
@@ -2,6 +2,4 @@
 //   "{{username}}/{{module}}" @lib,
 // }
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")


### PR DESCRIPTION
## Why

`moon new` still generates the deprecated `is-main` option for its executable package. New projects should use the current package-type declaration instead of starting with legacy configuration.

## Correctness

The template now emits `pkgtype(kind: "executable")`, which preserves the generated package's executable behavior while using the supported manifest form. The embedded template bundle and generated-project snapshots are updated together.

## Scope

The change is limited to the executable package manifest in the new-project template, its bundled representation, and the corresponding snapshot expectations.