### PR TITLE
perf(moonrun): minimize shared async host state

### DIFF
--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -277,18 +277,21 @@ pub(super) fn get_process_result(
         } else {
             Some(handle)
         };
-        let resource = handle_id
-            .map(|handle| context.host.resource(handle))
-            .transpose()?;
         #[cfg(unix)]
-        let raw_handle = resource
-            .as_ref()
-            .map(|resource| resource.as_fd().map(|fd| fd.as_raw_fd()))
+        let raw_handle = handle_id
+            .map(|handle| {
+                context
+                    .host
+                    .with_resource(handle, |resource| Ok(resource.as_fd()?.as_raw_fd()))
+            })
             .transpose()?;
         #[cfg(windows)]
-        let raw_handle = resource
-            .as_ref()
-            .map(|resource| resource.as_handle().map(|handle| handle.as_raw_handle()))
+        let raw_handle = handle_id
+            .map(|handle| {
+                context.host.with_resource(handle, |resource| {
+                    Ok(resource.as_handle()?.as_raw_handle())
+                })
+            })
             .transpose()?;
         #[cfg(unix)]
         let code = context.host.finish_owned_child(pid, handle_id, || {

--- a/crates/moonrun/src/async_api/socket.rs
+++ b/crates/moonrun/src/async_api/socket.rs
@@ -23,7 +23,7 @@ use std::os::windows::io::AsRawSocket;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory, read_u16};
 use crate::async_policy::AsyncPolicy;
-use crate::async_sys::internal::event_loop::thread_pool::{ResourceClass, ResourceRef};
+use crate::async_sys::internal::event_loop::thread_pool::{Resource, ResourceClass};
 use crate::async_sys::socket as sys;
 
 use super::context::ImportContext;
@@ -383,12 +383,10 @@ pub(super) fn set_ipv6_only(context: &mut ImportContext<'_, '_>, fd: u64, ipv6_o
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn listen(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
     let host = context.host;
-    let result = host
-        .resource_of_class(fd, ResourceClass::TcpSocket)
-        .and_then(|file| {
-            check_listen_bind_policy(host.policy(), &file)?;
-            sys::listen(raw_socket(&file)?)
-        });
+    let result = host.with_resource_of_class(fd, ResourceClass::TcpSocket, |file| {
+        check_listen_bind_policy(host.policy(), file)?;
+        sys::listen(raw_socket(file)?)
+    });
     zero_or_minus_one(context, result)
 }
 
@@ -585,10 +583,11 @@ pub(super) fn accept(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, ad
     let host = context.host;
     let result = context.with_memory_mut(|memory| {
         let addr = memory.read_exact_mut(addr, addr_len)?;
-        let file = host.resource_of_class(fd, ResourceClass::TcpSocket)?;
-        let family = file.socket_family().ok_or(AsyncHostError::Inval)?;
-        let fd = sys::accept(raw_socket(&file)?, addr)?;
-        Ok((fd, family))
+        host.with_resource_of_class(fd, ResourceClass::TcpSocket, |file| {
+            let family = file.socket_family().ok_or(AsyncHostError::Inval)?;
+            let fd = sys::accept(raw_socket(file)?, addr)?;
+            Ok((fd, family))
+        })
     });
     match result {
         Ok((fd, family)) => context
@@ -671,7 +670,7 @@ fn zero_or_minus_one(context: &mut ImportContext<'_, '_>, result: AsyncHostResul
     }
 }
 
-fn check_listen_bind_policy(policy: &AsyncPolicy, file: &ResourceRef) -> AsyncHostResult<()> {
+fn check_listen_bind_policy(policy: &AsyncPolicy, file: &Resource) -> AsyncHostResult<()> {
     let mut local_addr = vec![0; socket_addr_buffer_len()];
     let implicit_addr = match sys::getsockname(raw_socket(file)?, &mut local_addr) {
         Ok(()) if socket_addr_port(&local_addr)? == 0 => Some(local_addr),
@@ -685,18 +684,18 @@ fn check_listen_bind_policy(policy: &AsyncPolicy, file: &ResourceRef) -> AsyncHo
 }
 
 #[cfg(unix)]
-fn raw_socket(file: &ResourceRef) -> AsyncHostResult<sys::RawSocket> {
+fn raw_socket(file: &Resource) -> AsyncHostResult<sys::RawSocket> {
     Ok(file.as_fd()?.as_raw_fd())
 }
 
 #[cfg(windows)]
-fn raw_socket(file: &ResourceRef) -> AsyncHostResult<sys::RawSocket> {
+fn raw_socket(file: &Resource) -> AsyncHostResult<sys::RawSocket> {
     Ok(file.as_socket()?.as_raw_socket())
 }
 
 #[cfg(unix)]
 fn listen_bind_addr_after_getsockname_error(
-    _file: &ResourceRef,
+    _file: &Resource,
     error: AsyncHostError,
 ) -> AsyncHostResult<Vec<u8>> {
     Err(error)
@@ -704,7 +703,7 @@ fn listen_bind_addr_after_getsockname_error(
 
 #[cfg(windows)]
 fn listen_bind_addr_after_getsockname_error(
-    file: &ResourceRef,
+    file: &Resource,
     _error: AsyncHostError,
 ) -> AsyncHostResult<Vec<u8>> {
     let family = file.socket_family().ok_or(AsyncHostError::Inval)?;
@@ -827,7 +826,9 @@ mod tests {
         );
 
         {
-            let file = host.resource_of_class(fd, ResourceClass::TcpSocket).unwrap();
+            let file = host
+                .acquire_resource_of_class(fd, ResourceClass::TcpSocket)
+                .unwrap();
             assert_eq!(
                 check_listen_bind_policy(host.policy(), &file),
                 Err(AsyncHostError::PermissionDenied)

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -145,7 +145,9 @@ pub(super) fn make_read_job(
     len: i32,
     position: i64,
 ) -> AsyncHostResult<u64> {
-    let file = context.host.resource_of_class(fd, ResourceClass::File)?;
+    let file = context
+        .host
+        .acquire_resource_of_class(fd, ResourceClass::File)?;
     context.host
         .insert_job(thread_pool::make_read_job(file, len, position))
 }
@@ -159,7 +161,9 @@ pub(super) fn make_write_job(
     len: i32,
     position: i64,
 ) -> AsyncHostResult<u64> {
-    let file = context.host.resource_of_class(fd, ResourceClass::File)?;
+    let file = context
+        .host
+        .acquire_resource_of_class(fd, ResourceClass::File)?;
     let offset_ptr = ptr.checked_add(offset).ok_or(AsyncHostError::Fault)?;
     let data =
         context.with_memory_mut(|memory| Ok(memory.read_exact(offset_ptr, len)?.to_vec()))?;
@@ -194,7 +198,7 @@ pub(super) fn make_file_kind_by_path_job(
         Some(
             context
                 .host
-                .resource_of_class(parent, ResourceClass::File)?,
+                .acquire_resource_of_class(parent, ResourceClass::File)?,
         )
     };
     let path = read_guest_os_string(context, path_ptr, path_len)?;
@@ -209,7 +213,9 @@ pub(super) fn make_file_kind_by_path_job(
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_file_size_job(context: &mut ImportContext<'_, '_>, fd: u64) -> AsyncHostResult<u64> {
-    let file = context.host.resource_of_class(fd, ResourceClass::File)?;
+    let file = context
+        .host
+        .acquire_resource_of_class(fd, ResourceClass::File)?;
     context.host.insert_job(thread_pool::make_file_size_job(file))
 }
 
@@ -223,7 +229,9 @@ pub(super) fn make_file_time_job(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
 ) -> AsyncHostResult<u64> {
-    let file = context.host.resource_of_class(fd, ResourceClass::File)?;
+    let file = context
+        .host
+        .acquire_resource_of_class(fd, ResourceClass::File)?;
     context.host
         .insert_job(thread_pool::make_file_time_job(file))
 }
@@ -286,7 +294,9 @@ pub(super) fn make_fsync_job(
     fd: u64,
     only_data: i32,
 ) -> AsyncHostResult<u64> {
-    let file = context.host.resource_of_class(fd, ResourceClass::File)?;
+    let file = context
+        .host
+        .acquire_resource_of_class(fd, ResourceClass::File)?;
     context.host
         .insert_job(thread_pool::make_fsync_job(file, only_data != 0))
 }
@@ -297,7 +307,9 @@ pub(super) fn make_flock_job(
     fd: u64,
     exclusive: i32,
 ) -> AsyncHostResult<u64> {
-    let file = context.host.resource_of_class(fd, ResourceClass::File)?;
+    let file = context
+        .host
+        .acquire_resource_of_class(fd, ResourceClass::File)?;
     context.host
         .insert_job(thread_pool::make_flock_job(file, exclusive != 0))
 }
@@ -381,7 +393,9 @@ pub(super) fn make_readdir_job(
     len: i32,
     restart: i32,
 ) -> AsyncHostResult<u64> {
-    let dir = context.host.resource_of_class(dir, ResourceClass::File)?;
+    let dir = context
+        .host
+        .acquire_resource_of_class(dir, ResourceClass::File)?;
     let buffer = context.host.share_c_buffer(buf)?;
     context.host
         .insert_job(thread_pool::make_readdir_job(
@@ -399,7 +413,7 @@ pub(super) fn make_bind_job(
     addr: i32,
     addr_len: i32,
 ) -> AsyncHostResult<u64> {
-    let socket = context.host.socket_resource(socket)?;
+    let socket = context.host.acquire_socket_resource(socket)?;
     let addr = context.with_memory_mut(|memory| Ok(memory.read_exact(addr, addr_len)?.to_vec()))?;
     match context.host.policy().bind_socket(&addr) {
         Ok(()) => context.host.insert_job(thread_pool::make_bind_job(socket, addr)),
@@ -556,7 +570,7 @@ fn optional_resource(
     if handle == crate::async_host::INVALID_HOST_HANDLE || handle == context.host.invalid_fd() {
         Ok(None)
     } else {
-        context.host.resource(handle).map(Some)
+        context.host.acquire_resource(handle).map(Some)
     }
 }
 

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -382,7 +382,7 @@ pub(super) fn make_readdir_job(
     restart: i32,
 ) -> AsyncHostResult<u64> {
     let dir = context.host.resource_of_class(dir, ResourceClass::File)?;
-    let buffer = context.host.c_buffer(buf)?;
+    let buffer = context.host.share_c_buffer(buf)?;
     context.host
         .insert_job(thread_pool::make_readdir_job(
             dir,

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -3644,9 +3644,12 @@ impl AsyncHost {
     fn cancel_host_worker(&self, worker: &HostWorkerHandle) -> AsyncHostResult<i32> {
         #[cfg(windows)]
         {
-            if let Some(cancel) = thread_pool::worker_cancellation_resource(worker) {
-                thread_pool::cancel_job_resource(&cancel)?;
-                return Ok(1);
+            match thread_pool::worker_cancellation_target(worker) {
+                thread_pool::WorkerCancellationTarget::Resource(cancel) => {
+                    thread_pool::cancel_job_resource(&cancel)?;
+                    return Ok(1);
+                }
+                thread_pool::WorkerCancellationTarget::Thread => {}
             }
         }
         thread_pool::cancel_worker(worker)

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -2358,7 +2358,7 @@ impl AsyncHost {
             #[cfg(windows)]
             {
                 let file = handles.resource(handle)?;
-                if self.io_results.borrow().has_pending_io_for_resource(&file) {
+                if self.io_results.borrow().has_pending_io_for_resource(file) {
                     return Err(AsyncHostError::Inval);
                 }
             }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -34,7 +34,7 @@ use std::ffi::OsString;
 use std::os::fd::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, AsRawSocket, RawHandle};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
 
 use slotmap::{Key, KeyData, SecondaryMap, SlotMap, new_key_type};
 
@@ -72,7 +72,14 @@ pub(crate) enum AsyncHostError {
 pub(crate) type AsyncHostResult<T> = Result<T, AsyncHostError>;
 pub(crate) const INVALID_HOST_HANDLE: u64 = 0;
 pub(crate) const CHECK_FD_LEAK_ENV: &str = "MOONBIT_ASYNC_CHECK_FD_LEAK";
-pub(crate) type HostCBuffer = Arc<Mutex<Box<[u8]>>>;
+pub(crate) type SharedCBuffer = Arc<Mutex<Box<[u8]>>>;
+
+enum HostCBuffer {
+    // Most buffers never cross the V8/worker boundary and need no synchronization.
+    Local(Box<[u8]>),
+    // readdir writes into a guest-visible buffer from a worker thread.
+    Shared(SharedCBuffer),
+}
 #[cfg(unix)]
 type HostProcessArgv = Vec<Option<OsString>>;
 #[cfg(unix)]
@@ -566,12 +573,11 @@ impl ResourceTable for HandleTable {
     }
 }
 
-// Jobs are one-shot work items with result handles. Queued jobs stay cancellable
-// by handle, running jobs keep only a reservation slot, and finished jobs become
-// result-readable but cannot be submitted again.
+// Jobs are one-shot work items with result handles. A worker owns the Job while
+// it is running; this table keeps only a reservation so a malicious guest cannot
+// reuse that handle until the completed Job returns to the V8 thread.
 enum HostJobState {
     Ready(Job),
-    Queued(Job),
     Running,
     ResultReady(Job),
 }
@@ -618,57 +624,20 @@ impl JobTable {
         }
     }
 
-    fn queue_job(&mut self, key: HandleKey) -> AsyncHostResult<()> {
-        let slot = self.jobs.get_mut(key).ok_or(AsyncHostError::Badf)?;
-        match std::mem::replace(slot, HostJobState::Running) {
-            HostJobState::Ready(job) => {
-                *slot = HostJobState::Queued(job);
-                Ok(())
-            }
-            other => {
-                *slot = other;
-                Err(AsyncHostError::Badf)
-            }
-        }
-    }
-
-    #[cfg(windows)]
-    fn queued_job_cancel_resource(&self, key: HandleKey) -> Option<ResourceRef> {
-        match self.jobs.get(key) {
-            Some(HostJobState::Queued(job)) => thread_pool::job_cancel_resource(job),
-            _ => None,
-        }
-    }
-
-    fn take_queued_job(&mut self, key: HandleKey) -> AsyncHostResult<Job> {
-        let slot = self.jobs.get_mut(key).ok_or(AsyncHostError::Badf)?;
-        match std::mem::replace(slot, HostJobState::Running) {
-            HostJobState::Queued(job) => Ok(job),
-            other => {
-                *slot = other;
-                Err(AsyncHostError::Badf)
-            }
-        }
-    }
-
-    fn unqueue_job(&mut self, key: HandleKey) -> AsyncHostResult<()> {
-        let slot = self.jobs.get_mut(key).ok_or(AsyncHostError::Badf)?;
-        match std::mem::replace(slot, HostJobState::Running) {
-            HostJobState::Queued(job) => {
-                *slot = HostJobState::Ready(job);
-                Ok(())
-            }
-            other => {
-                *slot = other;
-                Err(AsyncHostError::Badf)
-            }
-        }
-    }
-
     fn restore_job(&mut self, key: HandleKey, job: Job) -> Option<Job> {
         match self.jobs.get_mut(key) {
             Some(slot @ HostJobState::Running) => {
                 *slot = HostJobState::ResultReady(job);
+                None
+            }
+            _ => Some(job),
+        }
+    }
+
+    fn restore_unrun_job(&mut self, key: HandleKey, job: Job) -> Option<Job> {
+        match self.jobs.get_mut(key) {
+            Some(slot @ HostJobState::Running) => {
+                *slot = HostJobState::Ready(job);
                 None
             }
             _ => Some(job),
@@ -785,15 +754,9 @@ impl OverlappedAddr {
 }
 
 #[derive(Debug)]
-struct RegisteredFd {
-    handle: HostHandle,
-    resource: ResourceRef,
-}
-
-#[derive(Debug)]
 struct HostPoll {
     instance: PollInstance,
-    registered_fds: HashMap<isize, RegisteredFd>,
+    registered_fds: HashMap<isize, HostHandle>,
     #[cfg(unix)]
     completion_notifier: Option<Arc<ThreadPoolCompletionNotifier>>,
     event_fd_handles: Vec<Option<HostHandle>>,
@@ -1199,8 +1162,8 @@ impl Drop for HostIoResult {
 
 pub(crate) struct AsyncHost {
     // V8 enters this host synchronously on one thread. Cell and RefCell encode
-    // that ownership; worker threads receive only the explicitly shared state
-    // below (jobs, cancellation state, policy state, and individual payloads).
+    // that ownership; worker threads own their Jobs and return them through the
+    // completion channel instead of sharing the host's tables.
     policy: Arc<AsyncPolicy>,
     errno: Cell<i32>,
     addr_infos: RefCell<SecondaryMap<HandleKey, HostAddrInfo>>,
@@ -1212,9 +1175,9 @@ pub(crate) struct AsyncHost {
     process_policy_state: Option<Arc<ProcessPolicyState>>,
     #[cfg(windows)]
     io_results: RefCell<IoResultTable>,
-    jobs: Arc<Mutex<JobTable>>,
-    #[cfg(windows)]
-    running_job_cancellations: Arc<Mutex<HashMap<HandleKey, ResourceRef>>>,
+    jobs: RefCell<JobTable>,
+    completed_job_sender: mpsc::Sender<thread_pool::HostWorkerJobResult>,
+    completed_job_receiver: mpsc::Receiver<thread_pool::HostWorkerJobResult>,
     polls: RefCell<PollTable>,
     thread_pool_completions: RefCell<ThreadPoolCompletions>,
     handles: RefCell<HandleTable>,
@@ -1234,6 +1197,7 @@ impl AsyncHost {
         let process_policy_state = policy
             .has_process_policy()
             .then(|| Arc::new(ProcessPolicyState::default()));
+        let (completed_job_sender, completed_job_receiver) = mpsc::channel();
         Self {
             policy,
             errno: Cell::new(0),
@@ -1245,9 +1209,9 @@ impl AsyncHost {
             process_policy_state,
             #[cfg(windows)]
             io_results: RefCell::new(IoResultTable::default()),
-            jobs: Arc::new(Mutex::new(JobTable::default())),
-            #[cfg(windows)]
-            running_job_cancellations: Arc::new(Mutex::new(HashMap::new())),
+            jobs: RefCell::new(JobTable::default()),
+            completed_job_sender,
+            completed_job_receiver,
             polls: RefCell::new(PollTable::default()),
             thread_pool_completions: RefCell::new(ThreadPoolCompletions::default()),
             handles: RefCell::new(HandleTable::default()),
@@ -1289,7 +1253,7 @@ impl AsyncHost {
     }
 
     fn restore_job(&self, key: HandleKey, job: Job) -> AsyncHostResult<()> {
-        let result = { self.jobs.lock().unwrap().restore_job(key, job) };
+        let result = self.jobs.borrow_mut().restore_job(key, job);
         if let Some(job) = result {
             Self::revoke_unclaimed_spawn(self.process_policy_state.as_deref(), &job);
             Err(AsyncHostError::Badf)
@@ -1298,25 +1262,32 @@ impl AsyncHost {
         }
     }
 
-    fn queue_worker_job(&self, key: HandleKey) -> AsyncHostResult<()> {
-        let mut jobs = self.jobs.lock().unwrap();
-        jobs.queue_job(key)?;
-        #[cfg(windows)]
-        let cancel = jobs.queued_job_cancel_resource(key);
-        drop(jobs);
-        #[cfg(windows)]
-        if let Some(cancel) = cancel {
-            self.running_job_cancellations
-                .lock()
-                .unwrap()
-                .insert(key, cancel);
-        }
-        Ok(())
+    fn take_worker_job(
+        &self,
+        completion_id: WorkerCompletionId,
+        key: HandleKey,
+    ) -> AsyncHostResult<HostWorkerJob> {
+        let job = self.jobs.borrow_mut().take_ready_job(key)?;
+        Ok(HostWorkerJob::new(completion_id, key, job))
     }
 
-    #[cfg(windows)]
-    fn unregister_worker_job_cancel(&self, key: HandleKey) {
-        self.running_job_cancellations.lock().unwrap().remove(&key);
+    fn restore_unrun_worker_job(&self, worker_job: HostWorkerJob) {
+        let _ = self
+            .jobs
+            .borrow_mut()
+            .restore_unrun_job(worker_job.job_key, worker_job.job);
+    }
+
+    fn restore_completed_worker_jobs(&self) {
+        while let Ok(worker_job) = self.completed_job_receiver.try_recv() {
+            let discarded = self
+                .jobs
+                .borrow_mut()
+                .restore_job(worker_job.job_key, worker_job.job);
+            if let Some(job) = discarded {
+                Self::revoke_unclaimed_spawn(self.process_policy_state.as_deref(), &job);
+            }
+        }
     }
 
     fn revoke_unclaimed_spawn(process_policy_state: Option<&ProcessPolicyState>, job: &Job) {
@@ -1351,7 +1322,7 @@ impl AsyncHost {
     }
 
     fn publish_open_job_result(&self, key: HandleKey) -> AsyncHostResult<HostHandle> {
-        let mut jobs = self.jobs.lock().unwrap();
+        let mut jobs = self.jobs.borrow_mut();
         let placeholder = OpenJobResource::Published(self.invalid_fd());
         let file = {
             let job = jobs.visible_job_mut(key)?;
@@ -1405,7 +1376,7 @@ impl AsyncHost {
                 }
             }
             {
-                let jobs = self.jobs.lock().unwrap();
+                let jobs = self.jobs.borrow();
                 if !jobs.jobs.is_empty() {
                     leaks.push(format!("jobs={}", jobs.jobs.len()));
                 }
@@ -1582,13 +1553,7 @@ impl AsyncHost {
             poll::poll_unregister(&poll.instance, raw_fd)?;
             return Err(AsyncHostError::Badf);
         }
-        poll.registered_fds.insert(
-            resource_identity,
-            RegisteredFd {
-                handle: fd_handle,
-                resource,
-            },
-        );
+        poll.registered_fds.insert(resource_identity, fd_handle);
         Ok(())
     }
 
@@ -1654,7 +1619,7 @@ impl AsyncHost {
                 let fd_handle = poll
                     .registered_fds
                     .get(&raw_fd_key(raw_fd))
-                    .map(|registered| registered.handle)
+                    .copied()
                     .or_else(|| completion_event_fd(raw_fd));
                 #[cfg(windows)]
                 let fd_handle = fd_handle.or(Some(invalid_fd));
@@ -1663,6 +1628,8 @@ impl AsyncHost {
             result
         };
         polls.current_event_poll = Some(poll_key);
+        drop(polls);
+        self.restore_completed_worker_jobs();
         Ok(result)
     }
 
@@ -1692,24 +1659,16 @@ impl AsyncHost {
 
     pub(crate) fn poll_event_fd(&self, event_handle: u64) -> AsyncHostResult<HostHandle> {
         let index = event_index(event_handle)?;
-        let (fd, registered_resource) = {
+        let fd = {
             let polls = self.polls.borrow();
             let poll_key = polls.current_event_poll.ok_or(AsyncHostError::Badf)?;
             let poll = polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?;
-            let event = poll::event_list_get(&poll.instance, index)?;
-            let raw_fd = poll::event_get_fd(event);
-            let registered_resource = poll
-                .registered_fds
-                .get(&raw_fd_key(raw_fd))
-                .map(|registered| Arc::clone(&registered.resource));
             let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
-            let fd = poll
-                .event_fd_handles
+            poll.event_fd_handles
                 .get(index)
                 .copied()
                 .flatten()
-                .ok_or(AsyncHostError::Badf)?;
-            (fd, registered_resource)
+                .ok_or(AsyncHostError::Badf)?
         };
         #[cfg(windows)]
         let is_thread_pool_completion =
@@ -1719,12 +1678,6 @@ impl AsyncHost {
         let handles = self.handles.borrow();
         if fd == handles.invalid_fd() || is_thread_pool_completion {
             Ok(fd)
-        } else if let Some(registered_resource) = registered_resource {
-            if handles.resource_is(fd, &registered_resource) {
-                Ok(fd)
-            } else {
-                Err(AsyncHostError::Badf)
-            }
         } else {
             handles
                 .contains_resource(fd)
@@ -1802,17 +1755,10 @@ impl AsyncHost {
                 }
                 let mut handles = self.handles.borrow_mut();
                 let source = handles.insert_resource(Resource::new(event_fd));
-                let source_resource = handles.resource(source)?;
                 drop(handles);
                 // Publish the poll-side mapping before exposing the notifier:
                 // workers can notify as soon as completions.notifier is visible.
-                poll.registered_fds.insert(
-                    raw_fd_key(event_fd),
-                    RegisteredFd {
-                        handle: source,
-                        resource: source_resource,
-                    },
-                );
+                poll.registered_fds.insert(raw_fd_key(event_fd), source);
                 poll.completion_notifier = Some(Arc::clone(&completion_notifier));
                 completions.notifier = Some(completion_notifier);
                 completions.source = Some(source);
@@ -1859,11 +1805,10 @@ impl AsyncHost {
         }
         for worker in workers {
             if let Some(replaced_job) = thread_pool::free_worker(worker) {
-                #[cfg(windows)]
-                self.unregister_worker_job_cancel(replaced_job.job_key);
-                let _ = self.jobs.lock().unwrap().unqueue_job(replaced_job.job_key);
+                self.restore_unrun_worker_job(replaced_job);
             }
         }
+        self.restore_completed_worker_jobs();
         #[cfg(unix)]
         {
             let (completion_source, old_signal_mask) = {
@@ -1903,7 +1848,7 @@ impl AsyncHost {
         let key = self.handles.borrow_mut().insert(HandleKind::CBuffer);
         self.c_buffers
             .borrow_mut()
-            .insert(key, Arc::new(Mutex::new(buffer)));
+            .insert(key, HostCBuffer::Local(buffer));
         handle_from_key(key)
     }
 
@@ -1927,9 +1872,17 @@ impl AsyncHost {
         // A c_buffer handle always names a whole host-owned buffer entry.
         // Callers that need a subrange must pass explicit offset/length
         // arguments; never reinterpret raw or interior pointers as handles.
-        let buffer = self.c_buffer(handle)?;
-        let buffer = buffer.lock().unwrap();
-        f(buffer.as_ref())
+        let key = self.handles.borrow().c_buffer(handle)?;
+        let buffers = self.c_buffers.borrow();
+        match buffers.get(key).ok_or(AsyncHostError::Badf)? {
+            HostCBuffer::Local(buffer) => f(buffer),
+            HostCBuffer::Shared(buffer) => {
+                let buffer = Arc::clone(buffer);
+                drop(buffers);
+                let buffer = buffer.lock().unwrap();
+                f(&buffer)
+            }
+        }
     }
 
     pub(crate) fn with_c_buffer_mut<T>(
@@ -1937,21 +1890,34 @@ impl AsyncHost {
         handle: u64,
         f: impl FnOnce(&mut [u8]) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
-        let buffer = self.c_buffer(handle)?;
-        let mut buffer = buffer.lock().unwrap();
-        f(buffer.as_mut())
+        let key = self.handles.borrow().c_buffer(handle)?;
+        let mut buffers = self.c_buffers.borrow_mut();
+        match buffers.get_mut(key).ok_or(AsyncHostError::Badf)? {
+            HostCBuffer::Local(buffer) => f(buffer),
+            HostCBuffer::Shared(buffer) => {
+                let buffer = Arc::clone(buffer);
+                drop(buffers);
+                let mut buffer = buffer.lock().unwrap();
+                f(&mut buffer)
+            }
+        }
     }
 
-    pub(crate) fn c_buffer(&self, handle: u64) -> AsyncHostResult<HostCBuffer> {
+    pub(crate) fn share_c_buffer(&self, handle: u64) -> AsyncHostResult<SharedCBuffer> {
         if handle == INVALID_HOST_HANDLE {
             return Err(AsyncHostError::Badf);
         }
         let key = self.handles.borrow().c_buffer(handle)?;
-        self.c_buffers
-            .borrow()
-            .get(key)
-            .cloned()
-            .ok_or(AsyncHostError::Badf)
+        let mut buffers = self.c_buffers.borrow_mut();
+        let entry = buffers.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        match entry {
+            HostCBuffer::Local(buffer) => {
+                let buffer = Arc::new(Mutex::new(std::mem::take(buffer)));
+                *entry = HostCBuffer::Shared(Arc::clone(&buffer));
+                Ok(buffer)
+            }
+            HostCBuffer::Shared(buffer) => Ok(Arc::clone(buffer)),
+        }
     }
 
     #[cfg(unix)]
@@ -2181,23 +2147,29 @@ impl AsyncHost {
 
     pub(crate) fn insert_job(&self, job: Job) -> AsyncHostResult<u64> {
         let key = self.handles.borrow_mut().insert(HandleKind::Job);
-        self.jobs.lock().unwrap().insert_job(key, job);
+        self.jobs.borrow_mut().insert_job(key, job);
         Ok(handle_from_key(key))
     }
 
     pub(crate) fn free_job(&self, handle: u64) -> AsyncHostResult<()> {
-        let key = self.handles.borrow_mut().remove_job(handle)?;
+        let key = self.handles.borrow().job(handle)?;
+        // Native freeing an in-flight job would be a use-after-free. Reject the
+        // invalid guest operation while keeping the worker-owned Job alive.
+        if matches!(
+            self.jobs.borrow().jobs.get(key),
+            Some(HostJobState::Running)
+        ) {
+            return Err(AsyncHostError::Inval);
+        }
+        self.handles.borrow_mut().remove_job(handle)?;
         let state = self
             .jobs
-            .lock()
-            .unwrap()
+            .borrow_mut()
             .jobs
             .remove(key)
             .ok_or(AsyncHostError::Badf)?;
         match state {
-            HostJobState::Ready(job)
-            | HostJobState::Queued(job)
-            | HostJobState::ResultReady(job) => {
+            HostJobState::Ready(job) | HostJobState::ResultReady(job) => {
                 Self::revoke_unclaimed_spawn(self.process_policy_state.as_deref(), &job);
 
                 // Native realpath frees its resolved path from the job finalizer.
@@ -2211,21 +2183,21 @@ impl AsyncHost {
                     let _ = self.free_c_buffer(*buffer_handle);
                 }
             }
-            HostJobState::Running => {}
+            HostJobState::Running => unreachable!("running jobs are rejected before removal"),
         }
         Ok(())
     }
 
     pub(crate) fn job_get_ret(&self, handle: u64) -> AsyncHostResult<i64> {
         let key = self.handles.borrow().job(handle)?;
-        let jobs = self.jobs.lock().unwrap();
+        let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         Ok(crate::async_sys::internal::event_loop::thread_pool::job_get_ret(job))
     }
 
     pub(crate) fn job_get_err(&self, handle: u64) -> AsyncHostResult<i32> {
         let key = self.handles.borrow().job(handle)?;
-        let jobs = self.jobs.lock().unwrap();
+        let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         Ok(crate::async_sys::internal::event_loop::thread_pool::job_get_err(job))
     }
@@ -2237,7 +2209,7 @@ impl AsyncHost {
 
     pub(crate) fn open_job_get_kind(&self, handle: u64) -> AsyncHostResult<i32> {
         let key = self.handles.borrow().job(handle)?;
-        let jobs = self.jobs.lock().unwrap();
+        let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         let result = thread_pool::open_job_result(job)?;
         Ok(thread_pool::open_job_get_kind(result))
@@ -2245,7 +2217,7 @@ impl AsyncHost {
 
     pub(crate) fn open_job_get_dev_id(&self, handle: u64) -> AsyncHostResult<u64> {
         let key = self.handles.borrow().job(handle)?;
-        let jobs = self.jobs.lock().unwrap();
+        let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         let result = thread_pool::open_job_result(job)?;
         Ok(thread_pool::open_job_get_dev_id(result))
@@ -2253,7 +2225,7 @@ impl AsyncHost {
 
     pub(crate) fn open_job_get_file_id(&self, handle: u64) -> AsyncHostResult<u64> {
         let key = self.handles.borrow().job(handle)?;
-        let jobs = self.jobs.lock().unwrap();
+        let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         let result = thread_pool::open_job_result(job)?;
         Ok(thread_pool::open_job_get_file_id(result))
@@ -2261,7 +2233,7 @@ impl AsyncHost {
 
     pub(crate) fn get_file_size_result(&self, handle: u64) -> AsyncHostResult<i64> {
         let key = self.handles.borrow().job(handle)?;
-        let jobs = self.jobs.lock().unwrap();
+        let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         crate::async_sys::internal::event_loop::thread_pool::get_file_size_result(job)
     }
@@ -2269,7 +2241,7 @@ impl AsyncHost {
     pub(crate) fn get_getaddrinfo_result(&self, handle: u64) -> AsyncHostResult<u64> {
         let (host, addrs) = {
             let key = self.handles.borrow().job(handle)?;
-            let jobs = self.jobs.lock().unwrap();
+            let jobs = self.jobs.borrow();
             let job = jobs.visible_job(key)?;
             let (host, addrs) = thread_pool::getaddrinfo_job_result(job)?;
             (host.to_os_string(), addrs.to_vec())
@@ -2296,7 +2268,7 @@ impl AsyncHost {
 
     pub(crate) fn get_spawn_job_result_handle(&self, handle: u64) -> AsyncHostResult<HostHandle> {
         let key = self.handles.borrow().job(handle)?;
-        let mut jobs = self.jobs.lock().unwrap();
+        let mut jobs = self.jobs.borrow_mut();
         let job = jobs.visible_job_mut(key)?;
         let Some(result) = thread_pool::take_spawn_job_result(job)? else {
             let fd = self.invalid_fd();
@@ -3300,7 +3272,7 @@ impl AsyncHost {
 
     pub(crate) fn run_job(&self, handle: u64) -> AsyncHostResult<()> {
         let key = self.handles.borrow().job(handle)?;
-        let mut job = self.jobs.lock().unwrap().take_ready_job(key)?;
+        let mut job = self.jobs.borrow_mut().take_ready_job(key)?;
         Self::run_policy_checked_job(&self.policy, self.process_policy_state.as_deref(), &mut job);
         self.restore_job(key, job)
     }
@@ -3539,16 +3511,10 @@ impl AsyncHost {
                 .notifier
                 .clone()
                 .ok_or(AsyncHostError::Badf)?;
-            self.queue_worker_job(job_key)?;
-            self.spawn_worker_thread(
-                HostWorkerJob {
-                    completion_id,
-                    job_key,
-                },
-                move |completion_id| {
-                    let _ = completion_notifier.notify(completion_id.as_i32());
-                },
-            )
+            let init_job = self.take_worker_job(completion_id, job_key)?;
+            self.spawn_worker_thread(init_job, move |completion_id| {
+                let _ = completion_notifier.notify(completion_id.as_i32());
+            })
         };
         #[cfg(windows)]
         let worker = {
@@ -3558,20 +3524,14 @@ impl AsyncHost {
                 .target
                 .clone()
                 .ok_or(AsyncHostError::Badf)?;
-            self.queue_worker_job(job_key)?;
-            self.spawn_worker_thread(
-                HostWorkerJob {
-                    completion_id,
-                    job_key,
-                },
-                move |completion_id| {
-                    let _ = poll::post_thread_pool_completion(
-                        &completion_target.port,
-                        completion_id.as_i32(),
-                        completion_target.generation,
-                    );
-                },
-            )
+            let init_job = self.take_worker_job(completion_id, job_key)?;
+            self.spawn_worker_thread(init_job, move |completion_id| {
+                let _ = poll::post_thread_pool_completion(
+                    &completion_target.port,
+                    completion_id.as_i32(),
+                    completion_target.generation,
+                );
+            })
         };
         let key = self.handles.borrow_mut().insert(HandleKind::Worker);
         self.workers.borrow_mut().insert(key, worker);
@@ -3594,19 +3554,11 @@ impl AsyncHost {
             let Some(worker) = workers.get(worker_key) else {
                 return Err(AsyncHostError::Badf);
             };
-            self.queue_worker_job(job_key)?;
-            thread_pool::wake_worker(
-                worker,
-                HostWorkerJob {
-                    completion_id,
-                    job_key,
-                },
-            )
+            let job = self.take_worker_job(completion_id, job_key)?;
+            thread_pool::wake_worker(worker, job)
         };
         if let Some(replaced_job) = replaced_job {
-            #[cfg(windows)]
-            self.unregister_worker_job_cancel(replaced_job.job_key);
-            let _ = self.jobs.lock().unwrap().unqueue_job(replaced_job.job_key);
+            self.restore_unrun_worker_job(replaced_job);
         }
         Ok(())
     }
@@ -3619,9 +3571,7 @@ impl AsyncHost {
             thread_pool::worker_enter_idle(worker)
         };
         if let Some(replaced_job) = replaced_job {
-            #[cfg(windows)]
-            self.unregister_worker_job_cancel(replaced_job.job_key);
-            let _ = self.jobs.lock().unwrap().unqueue_job(replaced_job.job_key);
+            self.restore_unrun_worker_job(replaced_job);
         }
         Ok(())
     }
@@ -3636,10 +3586,9 @@ impl AsyncHost {
         self.handles.borrow_mut().remove_worker(worker_handle)?;
         let _ = self.cancel_host_worker(&worker);
         if let Some(replaced_job) = thread_pool::free_worker(worker) {
-            #[cfg(windows)]
-            self.unregister_worker_job_cancel(replaced_job.job_key);
-            let _ = self.jobs.lock().unwrap().unqueue_job(replaced_job.job_key);
+            self.restore_unrun_worker_job(replaced_job);
         }
+        self.restore_completed_worker_jobs();
         Ok(())
     }
 
@@ -3653,17 +3602,9 @@ impl AsyncHost {
     fn cancel_host_worker(&self, worker: &HostWorkerHandle) -> AsyncHostResult<i32> {
         #[cfg(windows)]
         {
-            if let Some(running_job) = thread_pool::worker_cancellable_job(worker) {
-                let cancel = self
-                    .running_job_cancellations
-                    .lock()
-                    .unwrap()
-                    .get(&running_job.job_key)
-                    .cloned();
-                if let Some(cancel) = cancel {
-                    thread_pool::cancel_job_resource(&cancel)?;
-                    return Ok(1);
-                }
+            if let Some(cancel) = thread_pool::worker_cancellation_resource(worker) {
+                thread_pool::cancel_job_resource(&cancel)?;
+                return Ok(1);
             }
         }
         thread_pool::cancel_worker(worker)
@@ -3698,7 +3639,7 @@ impl AsyncHost {
         len: i32,
     ) -> AsyncHostResult<()> {
         let key = self.handles.borrow().job(handle)?;
-        let jobs = self.jobs.lock().unwrap();
+        let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         thread_pool::get_read_result(job, memory, dst, offset, len)
     }
@@ -3710,22 +3651,22 @@ impl AsyncHost {
         dst: i32,
     ) -> AsyncHostResult<()> {
         let key = self.handles.borrow().job(handle)?;
-        let jobs = self.jobs.lock().unwrap();
+        let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         thread_pool::get_file_time_result(job, memory, dst)
     }
 
     pub(crate) fn get_realpath_result(&self, handle: u64) -> AsyncHostResult<u64> {
         let key = self.handles.borrow().job(handle)?;
-        let mut jobs = self.jobs.lock().unwrap();
+        let mut jobs = self.jobs.borrow_mut();
         let job = jobs.visible_job_mut(key)?;
-        // Keep the job locked through publication so free_job either observes
-        // and cleans up the c_buffer or removes the job before publication.
+        // Keep the mutable job borrow through publication so its ownership of
+        // the resulting c_buffer changes atomically on the V8 thread.
         thread_pool::publish_realpath_result(job, |buffer| {
             let buffer_key = self.handles.borrow_mut().insert(HandleKind::CBuffer);
             self.c_buffers
                 .borrow_mut()
-                .insert(buffer_key, Arc::new(Mutex::new(buffer)));
+                .insert(buffer_key, HostCBuffer::Local(buffer));
             handle_from_key(buffer_key)
         })
     }
@@ -3768,13 +3709,11 @@ impl AsyncHost {
             .checked_mul(std::mem::size_of::<i32>())
             .ok_or(AsyncHostError::Fault)?;
         let max_bytes_i32 = i32::try_from(max_bytes).map_err(|_| AsyncHostError::Fault)?;
-        memory.read_exact(dst, max_bytes_i32)?;
-
-        let mut completions = vec![0; max_bytes];
-        let bytes = completion_notifier.fetch(&mut completions)?;
+        let completions = memory.read_exact_mut(dst, max_bytes_i32)?;
+        let bytes = completion_notifier.fetch(completions)?;
+        self.restore_completed_worker_jobs();
         debug_assert_eq!(bytes % std::mem::size_of::<i32>(), 0);
         let bytes_i32 = i32::try_from(bytes).map_err(|_| AsyncHostError::Fault)?;
-        memory.write_exact(dst, &completions[..bytes])?;
         Ok(bytes_i32)
     }
 
@@ -4064,59 +4003,23 @@ impl AsyncHost {
         init_job: HostWorkerJob,
         mut complete_job: impl FnMut(WorkerCompletionId) + Send + 'static,
     ) -> HostWorkerHandle {
-        let jobs_for_runner = Arc::clone(&self.jobs);
-        let jobs_for_completion = Arc::clone(&self.jobs);
-        #[cfg(windows)]
-        let running_job_cancellations = Arc::clone(&self.running_job_cancellations);
+        let completed_job_sender = self.completed_job_sender.clone();
         let policy = Arc::clone(&self.policy);
         let process_policy_state_for_runner = self.process_policy_state.clone();
-        let process_policy_state_for_completion = self.process_policy_state.clone();
         thread_pool::spawn_worker(
             init_job,
             move |worker_job| {
-                let Ok(mut job) = jobs_for_runner
-                    .lock()
-                    .unwrap()
-                    .take_queued_job(worker_job.job_key)
-                else {
-                    #[cfg(windows)]
-                    running_job_cancellations
-                        .lock()
-                        .unwrap()
-                        .remove(&worker_job.job_key);
-                    return None;
-                };
                 Self::run_policy_checked_job(
                     &policy,
                     process_policy_state_for_runner.as_deref(),
-                    &mut job,
+                    &mut worker_job.job,
                 );
-                #[cfg(windows)]
-                {
-                    running_job_cancellations
-                        .lock()
-                        .unwrap()
-                        .remove(&worker_job.job_key);
-                }
-                Some(job)
             },
             move |worker_job| {
                 let completion_id = worker_job.completion_id;
-                if let Some(job) = worker_job.job {
-                    let discarded = jobs_for_completion
-                        .lock()
-                        .unwrap()
-                        .restore_job(worker_job.job_key, job);
-                    if let Some(job) = discarded {
-                        Self::revoke_unclaimed_spawn(
-                            process_policy_state_for_completion.as_deref(),
-                            &job,
-                        );
-                    }
+                if completed_job_sender.send(worker_job).is_ok() {
+                    complete_job(completion_id);
                 }
-                // Even if cancellation discarded the job handle, the event loop
-                // still needs the completion to move the worker out of running.
-                complete_job(completion_id);
             },
         )
     }
@@ -4889,7 +4792,7 @@ mod tests {
             assert_eq!(
                 poll.registered_fds
                     .get(&raw_fd_key(raw_completion_fd))
-                    .map(|registered| registered.handle),
+                    .copied(),
                 Some(completion_source)
             );
         }
@@ -4920,7 +4823,7 @@ mod tests {
         let job = thread_pool::make_read_job(Arc::new(Resource::invalid()), 3, -1);
         let job_handle = host.insert_job(job).unwrap();
         {
-            let mut jobs = host.jobs.lock().unwrap();
+            let mut jobs = host.jobs.borrow_mut();
             let job = jobs.visible_job_mut(job_key(&host, job_handle)).unwrap();
             let thread_pool::JobPayload::Read { result, .. } = job.payload_mut() else {
                 panic!("expected read job");
@@ -4973,6 +4876,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn c_buffer_becomes_shared_only_when_requested_by_a_worker_job() {
+        let host = AsyncHost::default();
+        let handle = host.insert_c_buffer(b"abcd".to_vec().into_boxed_slice());
+        let key = host.handles.borrow().c_buffer(handle).unwrap();
+        assert!(matches!(
+            host.c_buffers.borrow().get(key),
+            Some(HostCBuffer::Local(_))
+        ));
+
+        let first = host.share_c_buffer(handle).unwrap();
+        let second = host.share_c_buffer(handle).unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(matches!(
+            host.c_buffers.borrow().get(key),
+            Some(HostCBuffer::Shared(_))
+        ));
+
+        host.with_c_buffer_mut(handle, |buffer| {
+            buffer[0] = b'z';
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(&**first.lock().unwrap(), b"zbcd");
+    }
+
     #[cfg(unix)]
     #[test]
     fn realpath_result_is_registered_c_buffer_cleaned_up_with_job() {
@@ -4983,7 +4912,7 @@ mod tests {
             )))
             .unwrap();
         {
-            let mut jobs = host.jobs.lock().unwrap();
+            let mut jobs = host.jobs.borrow_mut();
             let job = jobs.visible_job_mut(job_key(&host, job_handle)).unwrap();
             let thread_pool::JobPayload::Realpath { result, .. } = job.payload_mut() else {
                 panic!("expected realpath job");
@@ -5585,7 +5514,7 @@ mod tests {
             ))
             .unwrap();
         let key = job_key(&host, job_handle);
-        let mut job = host.jobs.lock().unwrap().take_ready_job(key).unwrap();
+        let mut job = host.jobs.borrow_mut().take_ready_job(key).unwrap();
 
         thread_pool::run_host_job(&mut job);
 
@@ -5595,7 +5524,7 @@ mod tests {
             OpenJobResource::Unpublished(_)
         ));
         assert_eq!(resource_count(&host), 0);
-        host.jobs.lock().unwrap().jobs.remove(key);
+        host.jobs.borrow_mut().jobs.remove(key);
 
         {
             assert_eq!(host.restore_job(key, job), Err(AsyncHostError::Badf));
@@ -5607,8 +5536,9 @@ mod tests {
 
     #[test]
     fn drop_destroys_pool_even_when_worker_holds_state() {
-        let host = AsyncHost::default();
-        let jobs = Arc::downgrade(&host.jobs);
+        let policy = Arc::new(AsyncPolicy::allow_all());
+        let policy_weak = Arc::downgrade(&policy);
+        let host = AsyncHost::new(policy);
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
@@ -5630,7 +5560,7 @@ mod tests {
 
         drop(host);
 
-        assert!(jobs.upgrade().is_none());
+        assert!(policy_weak.upgrade().is_none());
     }
 
     #[test]
@@ -5667,7 +5597,7 @@ mod tests {
     }
 
     #[test]
-    fn freed_running_worker_job_is_not_restored_after_completion() {
+    fn free_running_worker_job_is_rejected_until_completion() {
         let host = AsyncHost::default();
         let first_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
         let first_key = job_key(&host, first_job);
@@ -5675,35 +5605,19 @@ mod tests {
         let (release_sender, release_receiver) = std::sync::mpsc::channel();
         let (completion_sender, completion_receiver) = std::sync::mpsc::channel();
         let worker = {
-            let jobs_for_runner = Arc::clone(&host.jobs);
-            let jobs_for_completion = Arc::clone(&host.jobs);
-            host.jobs.lock().unwrap().queue_job(first_key).unwrap();
+            let completed_job_sender = host.completed_job_sender.clone();
             thread_pool::spawn_worker(
-                HostWorkerJob {
-                    completion_id: WorkerCompletionId::from_abi(1),
-                    job_key: first_key,
-                },
+                host.take_worker_job(WorkerCompletionId::from_abi(1), first_key)
+                    .unwrap(),
                 move |worker_job| {
-                    let Ok(mut job) = jobs_for_runner
-                        .lock()
-                        .unwrap()
-                        .take_queued_job(worker_job.job_key)
-                    else {
-                        return None;
-                    };
                     started_sender.send(worker_job.completion_id).unwrap();
                     release_receiver.recv().unwrap();
-                    thread_pool::run_host_job(&mut job);
-                    Some(job)
+                    thread_pool::run_host_job(&mut worker_job.job);
                 },
                 move |worker_job| {
-                    if let Some(job) = worker_job.job {
-                        let _ = jobs_for_completion
-                            .lock()
-                            .unwrap()
-                            .restore_job(worker_job.job_key, job);
-                    }
-                    completion_sender.send(worker_job.completion_id).unwrap();
+                    let completion_id = worker_job.completion_id;
+                    completed_job_sender.send(worker_job).unwrap();
+                    completion_sender.send(completion_id).unwrap();
                 },
             )
         };
@@ -5715,22 +5629,23 @@ mod tests {
             started_receiver.recv().unwrap(),
             WorkerCompletionId::from_abi(1)
         );
-        host.free_job(first_job).unwrap();
+        assert_eq!(host.free_job(first_job), Err(AsyncHostError::Inval));
 
         release_sender.send(()).unwrap();
         assert_eq!(
             completion_receiver.recv().unwrap(),
             WorkerCompletionId::from_abi(1)
         );
-        assert_eq!(host.job_get_ret(first_job), Err(AsyncHostError::Badf));
-        assert_eq!(host.run_job(first_job), Err(AsyncHostError::Badf));
+        host.restore_completed_worker_jobs();
+        assert_eq!(host.job_get_ret(first_job), Ok(0));
+        host.free_job(first_job).unwrap();
 
         host.free_worker(worker).unwrap();
         host.destroy_thread_pool();
     }
 
     #[test]
-    fn queued_worker_job_can_be_freed_before_worker_runs_it() {
+    fn free_queued_worker_job_is_rejected_until_completion() {
         let host = AsyncHost::default();
         let first_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
         let first_key = job_key(&host, first_job);
@@ -5738,40 +5653,21 @@ mod tests {
         let (release_sender, release_receiver) = std::sync::mpsc::channel();
         let (completion_sender, completion_receiver) = std::sync::mpsc::channel();
         let worker = {
-            let jobs_for_runner = Arc::clone(&host.jobs);
-            let jobs_for_completion = Arc::clone(&host.jobs);
-            host.jobs.lock().unwrap().queue_job(first_key).unwrap();
+            let completed_job_sender = host.completed_job_sender.clone();
             thread_pool::spawn_worker(
-                HostWorkerJob {
-                    completion_id: WorkerCompletionId::from_abi(1),
-                    job_key: first_key,
-                },
+                host.take_worker_job(WorkerCompletionId::from_abi(1), first_key)
+                    .unwrap(),
                 move |worker_job| {
-                    let Ok(mut job) = jobs_for_runner
-                        .lock()
-                        .unwrap()
-                        .take_queued_job(worker_job.job_key)
-                    else {
-                        return None;
-                    };
                     started_sender.send(worker_job.completion_id).unwrap();
                     if worker_job.job_key == first_key {
                         release_receiver.recv().unwrap();
                     }
-                    thread_pool::run_host_job(&mut job);
-                    Some(job)
+                    thread_pool::run_host_job(&mut worker_job.job);
                 },
                 move |worker_job| {
-                    let completed = worker_job.job.is_some();
-                    if let Some(job) = worker_job.job {
-                        let _ = jobs_for_completion
-                            .lock()
-                            .unwrap()
-                            .restore_job(worker_job.job_key, job);
-                    }
-                    completion_sender
-                        .send((worker_job.completion_id, completed))
-                        .unwrap();
+                    let completion_id = worker_job.completion_id;
+                    completed_job_sender.send(worker_job).unwrap();
+                    completion_sender.send(completion_id).unwrap();
                 },
             )
         };
@@ -5813,21 +5709,23 @@ mod tests {
         assert_eq!(host.job_get_ret(queued_job), Err(AsyncHostError::Badf));
         assert_eq!(host.run_job(queued_job), Err(AsyncHostError::Badf));
         assert_eq!(host.spawn_worker(4, queued_job), Err(AsyncHostError::Badf));
-        host.free_job(queued_job).unwrap();
+        assert_eq!(host.free_job(queued_job), Err(AsyncHostError::Inval));
 
         release_sender.send(()).unwrap();
         assert_eq!(
             completion_receiver.recv().unwrap(),
-            (WorkerCompletionId::from_abi(1), true)
+            WorkerCompletionId::from_abi(1)
         );
-        host.free_job(first_job).unwrap();
         assert_eq!(
             completion_receiver
                 .recv_timeout(std::time::Duration::from_secs(1))
                 .unwrap(),
-            (WorkerCompletionId::from_abi(3), false)
+            WorkerCompletionId::from_abi(3)
         );
-        assert!(queued_path.exists());
+        host.restore_completed_worker_jobs();
+        host.free_job(first_job).unwrap();
+        assert!(!queued_path.exists());
+        host.free_job(queued_job).unwrap();
 
         host.free_worker(worker).unwrap();
         let _ = std::fs::remove_file(displaced_path);

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -462,8 +462,11 @@ impl HandleTable {
         self.key(handle, HandleKind::Job)
     }
 
-    fn remove_job(&mut self, handle: HostHandle) -> AsyncHostResult<HandleKey> {
-        self.remove(handle, HandleKind::Job)
+    fn remove_job_key(&mut self, key: HandleKey) {
+        assert!(
+            matches!(self.handles.remove(key), Some(HandleKind::Job)),
+            "validated Job Handle must remain reserved until removal"
+        );
     }
 
     fn poll(&self, handle: HostHandle) -> AsyncHostResult<HandleKey> {
@@ -594,12 +597,12 @@ impl ResourceTable for HandleTable {
     }
 }
 
-// Jobs are one-shot work items with result handles. A worker owns the Job while
-// it is running; this table keeps only a reservation so a malicious guest cannot
-// reuse that handle until the completed Job returns to the V8 thread.
+// Jobs are one-shot work items with result handles. Once a Job leaves this
+// table for synchronous execution or worker submission, its slot stays reserved
+// so a malicious guest cannot reuse the Handle before the Job returns.
 enum HostJobState {
     Ready(Job),
-    Running,
+    Reserved,
     ResultReady(Job),
 }
 
@@ -636,7 +639,7 @@ impl JobTable {
 
     fn take_ready_job(&mut self, key: HandleKey) -> AsyncHostResult<Job> {
         let slot = self.jobs.get_mut(key).ok_or(AsyncHostError::Badf)?;
-        match std::mem::replace(slot, HostJobState::Running) {
+        match std::mem::replace(slot, HostJobState::Reserved) {
             HostJobState::Ready(job) => Ok(job),
             other => {
                 *slot = other;
@@ -647,7 +650,7 @@ impl JobTable {
 
     fn restore_job(&mut self, key: HandleKey, job: Job) -> Option<Job> {
         match self.jobs.get_mut(key) {
-            Some(slot @ HostJobState::Running) => {
+            Some(slot @ HostJobState::Reserved) => {
                 *slot = HostJobState::ResultReady(job);
                 None
             }
@@ -657,11 +660,22 @@ impl JobTable {
 
     fn restore_unrun_job(&mut self, key: HandleKey, job: Job) -> Option<Job> {
         match self.jobs.get_mut(key) {
-            Some(slot @ HostJobState::Running) => {
+            Some(slot @ HostJobState::Reserved) => {
                 *slot = HostJobState::Ready(job);
                 None
             }
             _ => Some(job),
+        }
+    }
+
+    fn take_for_free(&mut self, key: HandleKey) -> AsyncHostResult<Job> {
+        match self.jobs.remove(key) {
+            Some(HostJobState::Ready(job) | HostJobState::ResultReady(job)) => Ok(job),
+            Some(HostJobState::Reserved) => {
+                self.jobs.insert(key, HostJobState::Reserved);
+                Err(AsyncHostError::Inval)
+            }
+            None => Err(AsyncHostError::Badf),
         }
     }
 }
@@ -801,27 +815,18 @@ enum HostIoKind {
 
 #[cfg(windows)]
 impl HostIoKind {
-    fn resource(self, handles: &HandleTable, handle: HostHandle) -> AsyncHostResult<&Resource> {
-        match self {
-            Self::File => handles.resource_of_class(handle, ResourceClass::File),
-            Self::Socket => handles.socket(handle),
-            Self::SocketWithAddr => handles.resource_of_class(handle, ResourceClass::UdpSocket),
-            Self::Connect | Self::Accept => Err(AsyncHostError::Inval),
-        }
-    }
-
-    fn acquire_resource(
+    fn resource_ref(
         self,
         handles: &HandleTable,
         handle: HostHandle,
-    ) -> AsyncHostResult<ResourceRef> {
+    ) -> AsyncHostResult<&ResourceRef> {
+        let resource = handles.resource_ref(handle)?;
+        let class = resource.resource_class();
         match self {
-            Self::File => handles.acquire_resource_of_class(handle, ResourceClass::File),
-            Self::Socket => handles.acquire_socket(handle),
-            Self::SocketWithAddr => {
-                handles.acquire_resource_of_class(handle, ResourceClass::UdpSocket)
-            }
-            Self::Connect | Self::Accept => Err(AsyncHostError::Inval),
+            Self::File if class == ResourceClass::File => Ok(resource),
+            Self::Socket if class.is_socket() => Ok(resource),
+            Self::SocketWithAddr if class == ResourceClass::UdpSocket => Ok(resource),
+            _ => Err(AsyncHostError::Inval),
         }
     }
 }
@@ -2182,38 +2187,24 @@ impl AsyncHost {
     }
 
     pub(crate) fn free_job(&self, handle: u64) -> AsyncHostResult<()> {
-        let key = self.handles.borrow().job(handle)?;
+        let mut handles = self.handles.borrow_mut();
+        let key = handles.job(handle)?;
         // Native freeing an in-flight job would be a use-after-free. Reject the
         // invalid guest operation while keeping the worker-owned Job alive.
-        if matches!(
-            self.jobs.borrow().jobs.get(key),
-            Some(HostJobState::Running)
-        ) {
-            return Err(AsyncHostError::Inval);
-        }
-        self.handles.borrow_mut().remove_job(handle)?;
-        let state = self
-            .jobs
-            .borrow_mut()
-            .jobs
-            .remove(key)
-            .ok_or(AsyncHostError::Badf)?;
-        match state {
-            HostJobState::Ready(job) | HostJobState::ResultReady(job) => {
-                Self::revoke_unclaimed_spawn(self.process_policy_state.as_deref(), &job);
+        let job = self.jobs.borrow_mut().take_for_free(key)?;
+        handles.remove_job_key(key);
+        drop(handles);
+        Self::revoke_unclaimed_spawn(self.process_policy_state.as_deref(), &job);
 
-                // Native realpath frees its resolved path from the job finalizer.
-                // After get_realpath_result exposes that path as a host c_buffer,
-                // freeing the job must also release the c_buffer slot.
-                if let thread_pool::JobPayload::Realpath {
-                    result: Some(thread_pool::RealpathJobResult::Published(buffer_handle)),
-                    ..
-                } = job.payload()
-                {
-                    let _ = self.free_c_buffer(*buffer_handle);
-                }
-            }
-            HostJobState::Running => unreachable!("running jobs are rejected before removal"),
+        // Native realpath frees its resolved path from the job finalizer.
+        // After get_realpath_result exposes that path as a host c_buffer,
+        // freeing the job must also release the c_buffer slot.
+        if let thread_pool::JobPayload::Realpath {
+            result: Some(thread_pool::RealpathJobResult::Published(buffer_handle)),
+            ..
+        } = job.payload()
+        {
+            let _ = self.free_c_buffer(*buffer_handle);
         }
         Ok(())
     }
@@ -2963,7 +2954,7 @@ impl AsyncHost {
         if result.is_pending() || result.event != IO_RESULT_READ_EVENT {
             return Err(AsyncHostError::Inval);
         }
-        let file = result.kind.resource(&handles, fd_handle)?;
+        let file = result.kind.resource_ref(&handles, fd_handle)?;
         let mut bytes_transferred = 0;
         let success = match result.kind {
             HostIoKind::File => {
@@ -3030,7 +3021,7 @@ impl AsyncHost {
         if errno == ERROR_HANDLE_EOF as i32 {
             Ok(0)
         } else if errno == ERROR_IO_PENDING as i32 {
-            result.mark_pending(result.kind.acquire_resource(&handles, fd_handle)?)?;
+            result.mark_pending(Arc::clone(file))?;
             Err(AsyncHostError::Native(errno))
         } else {
             Err(AsyncHostError::Native(errno))
@@ -3059,7 +3050,7 @@ impl AsyncHost {
         if result.is_pending() || result.event != IO_RESULT_WRITE_EVENT {
             return Err(AsyncHostError::Inval);
         }
-        let file = result.kind.resource(&handles, fd_handle)?;
+        let file = result.kind.resource_ref(&handles, fd_handle)?;
         if result.kind == HostIoKind::SocketWithAddr {
             self.policy.connect_socket(&result.addr_buffer)?;
         }
@@ -3122,7 +3113,7 @@ impl AsyncHost {
             };
             let error = AsyncHostError::Native(errno);
             if matches!(error, AsyncHostError::Native(errno) if errno == ERROR_IO_PENDING as i32) {
-                result.mark_pending(result.kind.acquire_resource(&handles, fd_handle)?)?;
+                result.mark_pending(Arc::clone(file))?;
             }
             Err(error)
         }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -463,8 +463,9 @@ impl HandleTable {
     }
 
     fn remove_job_key(&mut self, key: HandleKey) {
-        assert!(
-            matches!(self.handles.remove(key), Some(HandleKind::Job)),
+        let removed = self.handles.remove(key);
+        debug_assert!(
+            matches!(removed, Some(HandleKind::Job)),
             "validated Job Handle must remain reserved until removal"
         );
     }
@@ -599,7 +600,7 @@ impl ResourceTable for HandleTable {
 
 // Jobs are one-shot work items with result handles. Once a Job leaves this
 // table for synchronous execution or worker submission, its slot stays reserved
-// so a malicious guest cannot reuse the Handle before the Job returns.
+// until the Job returns or the guest detaches it with free_job.
 enum HostJobState {
     Ready(Job),
     Reserved,
@@ -668,13 +669,12 @@ impl JobTable {
         }
     }
 
-    fn take_for_free(&mut self, key: HandleKey) -> AsyncHostResult<Job> {
+    fn take_for_free(&mut self, key: HandleKey) -> AsyncHostResult<Option<Job>> {
         match self.jobs.remove(key) {
-            Some(HostJobState::Ready(job) | HostJobState::ResultReady(job)) => Ok(job),
-            Some(HostJobState::Reserved) => {
-                self.jobs.insert(key, HostJobState::Reserved);
-                Err(AsyncHostError::Inval)
-            }
+            Some(HostJobState::Ready(job) | HostJobState::ResultReady(job)) => Ok(Some(job)),
+            // The worker owns an in-flight Job. Removing its reservation
+            // detaches the guest handle; completion will discard the result.
+            Some(HostJobState::Reserved) => Ok(None),
             None => Err(AsyncHostError::Badf),
         }
     }
@@ -854,14 +854,6 @@ struct HostIoResult {
     // close protection must cover the accepted socket as well until completion.
     extra_pending_close_resource: Option<ResourceRef>,
 }
-
-#[cfg(windows)]
-// SAFETY: IoResultTable stores each value in a Box before its OVERLAPPED
-// address can be submitted to Windows, never removes a pending result, and
-// serializes all access through its mutex. Moving the Box between threads does
-// not move the HostIoResult allocation; its buffers and ResourceRefs are owned
-// and remain alive until the operation reaches a terminal state.
-unsafe impl Send for HostIoResult {}
 
 #[cfg(windows)]
 impl HostIoResult {
@@ -2189,11 +2181,12 @@ impl AsyncHost {
     pub(crate) fn free_job(&self, handle: u64) -> AsyncHostResult<()> {
         let mut handles = self.handles.borrow_mut();
         let key = handles.job(handle)?;
-        // Native freeing an in-flight job would be a use-after-free. Reject the
-        // invalid guest operation while keeping the worker-owned Job alive.
         let job = self.jobs.borrow_mut().take_for_free(key)?;
         handles.remove_job_key(key);
         drop(handles);
+        let Some(job) = job else {
+            return Ok(());
+        };
         Self::revoke_unclaimed_spawn(self.process_policy_state.as_deref(), &job);
 
         // Native realpath frees its resolved path from the job finalizer.
@@ -5655,7 +5648,7 @@ mod tests {
     }
 
     #[test]
-    fn free_running_worker_job_is_rejected_until_completion() {
+    fn free_running_worker_job_detaches_its_result() {
         let host = AsyncHost::default();
         let first_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
         let first_key = job_key(&host, first_job);
@@ -5687,7 +5680,8 @@ mod tests {
             started_receiver.recv().unwrap(),
             WorkerCompletionId::from_abi(1)
         );
-        assert_eq!(host.free_job(first_job), Err(AsyncHostError::Inval));
+        host.free_job(first_job).unwrap();
+        let replacement_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
 
         release_sender.send(()).unwrap();
         assert_eq!(
@@ -5695,15 +5689,17 @@ mod tests {
             WorkerCompletionId::from_abi(1)
         );
         host.restore_completed_worker_jobs();
-        assert_eq!(host.job_get_ret(first_job), Ok(0));
-        host.free_job(first_job).unwrap();
+        assert_eq!(host.job_get_ret(first_job), Err(AsyncHostError::Badf));
+        host.run_job(replacement_job).unwrap();
+        assert_eq!(host.job_get_ret(replacement_job), Ok(0));
+        host.free_job(replacement_job).unwrap();
 
         host.free_worker(worker).unwrap();
         host.destroy_thread_pool();
     }
 
     #[test]
-    fn free_queued_worker_job_is_rejected_until_completion() {
+    fn free_queued_worker_job_detaches_without_cancelling_it() {
         let host = AsyncHost::default();
         let first_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
         let first_key = job_key(&host, first_job);
@@ -5767,7 +5763,7 @@ mod tests {
         assert_eq!(host.job_get_ret(queued_job), Err(AsyncHostError::Badf));
         assert_eq!(host.run_job(queued_job), Err(AsyncHostError::Badf));
         assert_eq!(host.spawn_worker(4, queued_job), Err(AsyncHostError::Badf));
-        assert_eq!(host.free_job(queued_job), Err(AsyncHostError::Inval));
+        host.free_job(queued_job).unwrap();
 
         release_sender.send(()).unwrap();
         assert_eq!(
@@ -5783,7 +5779,7 @@ mod tests {
         host.restore_completed_worker_jobs();
         host.free_job(first_job).unwrap();
         assert!(!queued_path.exists());
-        host.free_job(queued_job).unwrap();
+        assert_eq!(host.job_get_ret(queued_job), Err(AsyncHostError::Badf));
 
         host.free_worker(worker).unwrap();
         let _ = std::fs::remove_file(displaced_path);

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -26,7 +26,7 @@
 //! source. The wasm ABI exposes that same shape: MoonBit owns event-loop
 //! scheduling and Rust owns the OS poller behind opaque poll handles.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 #[cfg(unix)]
 use std::ffi::OsString;
@@ -74,11 +74,11 @@ pub(crate) const INVALID_HOST_HANDLE: u64 = 0;
 pub(crate) const CHECK_FD_LEAK_ENV: &str = "MOONBIT_ASYNC_CHECK_FD_LEAK";
 pub(crate) type HostCBuffer = Arc<Mutex<Box<[u8]>>>;
 #[cfg(unix)]
-pub(crate) type HostProcessArgv = Arc<Mutex<Vec<Option<OsString>>>>;
+type HostProcessArgv = Vec<Option<OsString>>;
 #[cfg(unix)]
-pub(crate) type HostProcessEnv = Arc<Mutex<Vec<Option<OsString>>>>;
+type HostProcessEnv = Vec<Option<OsString>>;
 #[cfg(windows)]
-pub(crate) type HostProcessEnv = Arc<Mutex<Vec<u16>>>;
+type HostProcessEnv = Vec<u16>;
 
 #[derive(Default)]
 struct ProcessPolicyState {
@@ -1198,34 +1198,29 @@ impl Drop for HostIoResult {
 }
 
 pub(crate) struct AsyncHost {
-    // V8 enters this host synchronously on one thread. Handles and pollers stay
-    // thread-local; worker threads receive only the explicitly shared state
+    // V8 enters this host synchronously on one thread. Cell and RefCell encode
+    // that ownership; worker threads receive only the explicitly shared state
     // below (jobs, cancellation state, policy state, and individual payloads).
-    // RefCell encodes that ownership and avoids synchronization in the poll hot
-    // path.
-    //
-    // State captured by worker threads remains behind Arc<Mutex<_>>. The other
-    // payload tables keep their existing representation in this refactor.
     policy: Arc<AsyncPolicy>,
-    errno: Mutex<i32>,
-    addr_infos: Mutex<SecondaryMap<HandleKey, HostAddrInfo>>,
-    c_buffers: Mutex<SecondaryMap<HandleKey, HostCBuffer>>,
+    errno: Cell<i32>,
+    addr_infos: RefCell<SecondaryMap<HandleKey, HostAddrInfo>>,
+    c_buffers: RefCell<SecondaryMap<HandleKey, HostCBuffer>>,
     #[cfg(unix)]
-    process_argvs: Mutex<SecondaryMap<HandleKey, HostProcessArgv>>,
-    process_envs: Mutex<SecondaryMap<HandleKey, HostProcessEnv>>,
+    process_argvs: RefCell<SecondaryMap<HandleKey, HostProcessArgv>>,
+    process_envs: RefCell<SecondaryMap<HandleKey, HostProcessEnv>>,
     // The unrestricted path leaves this absent, avoiding registry allocation and locking.
     process_policy_state: Option<Arc<ProcessPolicyState>>,
     #[cfg(windows)]
-    io_results: Mutex<IoResultTable>,
+    io_results: RefCell<IoResultTable>,
     jobs: Arc<Mutex<JobTable>>,
     #[cfg(windows)]
     running_job_cancellations: Arc<Mutex<HashMap<HandleKey, ResourceRef>>>,
     polls: RefCell<PollTable>,
-    thread_pool_completions: Mutex<ThreadPoolCompletions>,
+    thread_pool_completions: RefCell<ThreadPoolCompletions>,
     handles: RefCell<HandleTable>,
-    tls_connections: Mutex<SecondaryMap<HandleKey, tls::TlsHandleRef>>,
-    tls_error: Mutex<Option<String>>,
-    workers: Mutex<SecondaryMap<HandleKey, HostWorkerHandle>>,
+    tls_connections: RefCell<SecondaryMap<HandleKey, tls::TlsHandle>>,
+    tls_error: RefCell<Option<String>>,
+    workers: RefCell<SecondaryMap<HandleKey, HostWorkerHandle>>,
 }
 
 impl Default for AsyncHost {
@@ -1241,24 +1236,24 @@ impl AsyncHost {
             .then(|| Arc::new(ProcessPolicyState::default()));
         Self {
             policy,
-            errno: Mutex::new(0),
-            addr_infos: Mutex::new(SecondaryMap::new()),
-            c_buffers: Mutex::new(SecondaryMap::new()),
+            errno: Cell::new(0),
+            addr_infos: RefCell::new(SecondaryMap::new()),
+            c_buffers: RefCell::new(SecondaryMap::new()),
             #[cfg(unix)]
-            process_argvs: Mutex::new(SecondaryMap::new()),
-            process_envs: Mutex::new(SecondaryMap::new()),
+            process_argvs: RefCell::new(SecondaryMap::new()),
+            process_envs: RefCell::new(SecondaryMap::new()),
             process_policy_state,
             #[cfg(windows)]
-            io_results: Mutex::new(IoResultTable::default()),
+            io_results: RefCell::new(IoResultTable::default()),
             jobs: Arc::new(Mutex::new(JobTable::default())),
             #[cfg(windows)]
             running_job_cancellations: Arc::new(Mutex::new(HashMap::new())),
             polls: RefCell::new(PollTable::default()),
-            thread_pool_completions: Mutex::new(ThreadPoolCompletions::default()),
+            thread_pool_completions: RefCell::new(ThreadPoolCompletions::default()),
             handles: RefCell::new(HandleTable::default()),
-            tls_connections: Mutex::new(SecondaryMap::new()),
-            tls_error: Mutex::new(None),
-            workers: Mutex::new(SecondaryMap::new()),
+            tls_connections: RefCell::new(SecondaryMap::new()),
+            tls_error: RefCell::new(None),
+            workers: RefCell::new(SecondaryMap::new()),
         }
     }
 
@@ -1280,11 +1275,11 @@ impl AsyncHost {
     }
 
     pub(crate) fn get_errno(&self) -> i32 {
-        *self.errno.lock().unwrap()
+        self.errno.get()
     }
 
     pub(crate) fn set_errno(&self, errno: i32) {
-        *self.errno.lock().unwrap() = errno;
+        self.errno.set(errno);
     }
 
     pub(crate) fn record_error(&self, error: AsyncHostError) -> i32 {
@@ -1385,20 +1380,20 @@ impl AsyncHost {
             let mut leaks = Vec::new();
 
             {
-                let c_buffers = self.c_buffers.lock().unwrap();
+                let c_buffers = self.c_buffers.borrow();
                 if !c_buffers.is_empty() {
                     leaks.push(format!("c_buffers={}", c_buffers.len()));
                 }
             }
             {
-                let addr_infos = self.addr_infos.lock().unwrap();
+                let addr_infos = self.addr_infos.borrow();
                 if !addr_infos.is_empty() {
                     leaks.push(format!("addr_infos={}", addr_infos.len()));
                 }
             }
             #[cfg(windows)]
             {
-                let io_results = self.io_results.lock().unwrap();
+                let io_results = self.io_results.borrow();
                 if !io_results.io_results.is_empty() {
                     leaks.push(format!("io_results={}", io_results.io_results.len()));
                 }
@@ -1422,7 +1417,7 @@ impl AsyncHost {
                 }
             }
             {
-                let completions = self.thread_pool_completions.lock().unwrap();
+                let completions = self.thread_pool_completions.borrow();
                 #[cfg(unix)]
                 {
                     if completions.notifier.is_some() {
@@ -1440,7 +1435,7 @@ impl AsyncHost {
                 }
             }
             {
-                let tls_connections = self.tls_connections.lock().unwrap();
+                let tls_connections = self.tls_connections.borrow();
                 if !tls_connections.is_empty() {
                     leaks.push(format!("tls_connections={}", tls_connections.len()));
                 }
@@ -1468,7 +1463,7 @@ impl AsyncHost {
                 }
             }
             {
-                let workers = self.workers.lock().unwrap();
+                let workers = self.workers.borrow();
                 if !workers.is_empty() {
                     leaks.push(format!("workers={}", workers.len()));
                 }
@@ -1514,7 +1509,7 @@ impl AsyncHost {
 
         #[cfg(unix)]
         let (completion_source, old_signal_mask) = {
-            let mut completions = self.thread_pool_completions.lock().unwrap();
+            let mut completions = self.thread_pool_completions.borrow_mut();
             if let Some(notifier) = &poll.completion_notifier
                 && completions
                     .notifier
@@ -1541,7 +1536,7 @@ impl AsyncHost {
         }
         #[cfg(windows)]
         {
-            let mut completions = self.thread_pool_completions.lock().unwrap();
+            let mut completions = self.thread_pool_completions.borrow_mut();
             if completions
                 .target
                 .as_ref()
@@ -1613,8 +1608,7 @@ impl AsyncHost {
         let (thread_pool_generation, invalid_fd) = {
             let thread_pool_generation = self
                 .thread_pool_completions
-                .lock()
-                .unwrap()
+                .borrow()
                 .target
                 .as_ref()
                 .filter(|target| target.poll == poll_key)
@@ -1755,7 +1749,7 @@ impl AsyncHost {
             Ok(OverlappedAddr::from_ptr(poll::event_get_io_result(event)))
         })?;
         let handle = {
-            let io_results = self.io_results.lock().unwrap();
+            let io_results = self.io_results.borrow();
             io_results
                 .io_results_by_overlapped
                 .get(&overlapped)
@@ -1763,7 +1757,7 @@ impl AsyncHost {
                 .ok_or(AsyncHostError::Badf)?
         };
         let key = self.handles.borrow().io_result(handle)?;
-        let mut io_results = self.io_results.lock().unwrap();
+        let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
             .get_mut(key)
@@ -1782,23 +1776,11 @@ impl AsyncHost {
     pub(crate) fn init_thread_pool(&self, poll_handle: u64) -> AsyncHostResult<HostHandle> {
         let poll_key = self.handles.borrow().poll(poll_handle)?;
         #[cfg(unix)]
-        if self
-            .thread_pool_completions
-            .lock()
-            .unwrap()
-            .source
-            .is_some()
-        {
+        if self.thread_pool_completions.borrow().source.is_some() {
             return Err(AsyncHostError::Inval);
         }
         #[cfg(windows)]
-        if self
-            .thread_pool_completions
-            .lock()
-            .unwrap()
-            .target
-            .is_some()
-        {
+        if self.thread_pool_completions.borrow().target.is_some() {
             return Err(AsyncHostError::Inval);
         }
         #[cfg(unix)]
@@ -1811,7 +1793,7 @@ impl AsyncHost {
                 ThreadPoolCompletionNotifier::new(&poll.instance)?;
             let completion_notifier = Arc::new(completion_notifier);
             let source = {
-                let mut completions = self.thread_pool_completions.lock().unwrap();
+                let mut completions = self.thread_pool_completions.borrow_mut();
                 if completions.source.is_some() {
                     drop(completions);
                     let _ = poll::poll_unregister(&poll.instance, event_fd);
@@ -1844,7 +1826,7 @@ impl AsyncHost {
             let polls = self.polls.borrow();
             let poll = polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?;
             let completion_port = poll::CompletionPort::from_poll(&poll.instance);
-            let mut completions = self.thread_pool_completions.lock().unwrap();
+            let mut completions = self.thread_pool_completions.borrow_mut();
             if completions.target.is_some() {
                 return Err(AsyncHostError::Inval);
             }
@@ -1861,8 +1843,7 @@ impl AsyncHost {
     pub(crate) fn destroy_thread_pool(&self) {
         let worker_keys = self
             .workers
-            .lock()
-            .unwrap()
+            .borrow()
             .iter()
             .map(|(key, _)| key)
             .collect::<Vec<_>>();
@@ -1870,7 +1851,7 @@ impl AsyncHost {
             .into_iter()
             .filter_map(|key| {
                 self.handles.borrow_mut().remove_worker_key(key);
-                self.workers.lock().unwrap().remove(key)
+                self.workers.borrow_mut().remove(key)
             })
             .collect::<Vec<_>>();
         for worker in &workers {
@@ -1886,7 +1867,7 @@ impl AsyncHost {
         #[cfg(unix)]
         {
             let (completion_source, old_signal_mask) = {
-                let mut completions = self.thread_pool_completions.lock().unwrap();
+                let mut completions = self.thread_pool_completions.borrow_mut();
                 let completion_source = completions.source.take();
                 completions.notifier = None;
                 (completion_source, completions.old_signal_mask.take())
@@ -1914,15 +1895,14 @@ impl AsyncHost {
         #[cfg(windows)]
         {
             let _ = crate::async_sys::signal::set_console_control_handler(false, None);
-            self.thread_pool_completions.lock().unwrap().target = None;
+            self.thread_pool_completions.borrow_mut().target = None;
         }
     }
 
     pub(crate) fn insert_c_buffer(&self, buffer: Box<[u8]>) -> u64 {
         let key = self.handles.borrow_mut().insert(HandleKind::CBuffer);
         self.c_buffers
-            .lock()
-            .unwrap()
+            .borrow_mut()
             .insert(key, Arc::new(Mutex::new(buffer)));
         handle_from_key(key)
     }
@@ -1933,8 +1913,7 @@ impl AsyncHost {
         }
         let key = self.handles.borrow_mut().remove_c_buffer(handle)?;
         self.c_buffers
-            .lock()
-            .unwrap()
+            .borrow_mut()
             .remove(key)
             .map(|_| ())
             .ok_or(AsyncHostError::Badf)
@@ -1969,8 +1948,7 @@ impl AsyncHost {
         }
         let key = self.handles.borrow().c_buffer(handle)?;
         self.c_buffers
-            .lock()
-            .unwrap()
+            .borrow()
             .get(key)
             .cloned()
             .ok_or(AsyncHostError::Badf)
@@ -1980,10 +1958,7 @@ impl AsyncHost {
     pub(crate) fn insert_process_argv(&self, len: i32) -> AsyncHostResult<u64> {
         let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
         let key = self.handles.borrow_mut().insert(HandleKind::ProcessArgv);
-        self.process_argvs
-            .lock()
-            .unwrap()
-            .insert(key, Arc::new(Mutex::new(vec![None; len])));
+        self.process_argvs.borrow_mut().insert(key, vec![None; len]);
         Ok(handle_from_key(key))
     }
 
@@ -1995,8 +1970,9 @@ impl AsyncHost {
         value: OsString,
     ) -> AsyncHostResult<()> {
         let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
-        let argv = self.process_argv(handle)?;
-        let mut argv = argv.lock().unwrap();
+        let key = self.process_argv(handle)?;
+        let mut process_argvs = self.process_argvs.borrow_mut();
+        let argv = process_argvs.get_mut(key).ok_or(AsyncHostError::Badf)?;
         let slot = argv.get_mut(index).ok_or(AsyncHostError::Fault)?;
         *slot = Some(value);
         Ok(())
@@ -2017,31 +1993,25 @@ impl AsyncHost {
         let mut handles = self.handles.borrow_mut();
         let argv_key = handles.process_argv(argv_handle)?;
         let env_key = handles.process_env(env_handle)?;
-        let mut process_argvs = self.process_argvs.lock().unwrap();
-        let argv = process_argvs
-            .get(argv_key)
-            .cloned()
-            .ok_or(AsyncHostError::Badf)?;
-        let mut process_envs = self.process_envs.lock().unwrap();
-        let env = process_envs
-            .get(env_key)
-            .cloned()
-            .ok_or(AsyncHostError::Badf)?;
-        let mut argv = argv.lock().unwrap();
-        let mut env = env.lock().unwrap();
+        let mut process_argvs = self.process_argvs.borrow_mut();
+        let argv = process_argvs.get(argv_key).ok_or(AsyncHostError::Badf)?;
+        let mut process_envs = self.process_envs.borrow_mut();
+        let env = process_envs.get(env_key).ok_or(AsyncHostError::Badf)?;
         if argv.iter().any(Option::is_none) || env.iter().any(Option::is_none) {
             return Err(AsyncHostError::Inval);
         }
 
         handles.remove_process_argv(argv_handle)?;
         handles.remove_process_env(env_handle)?;
-        let _ = process_argvs.remove(argv_key);
-        let _ = process_envs.remove(env_key);
-        let argv = std::mem::take(&mut *argv)
+        let argv = process_argvs
+            .remove(argv_key)
+            .ok_or(AsyncHostError::Badf)?
             .into_iter()
             .map(Option::unwrap)
             .collect();
-        let env = std::mem::take(&mut *env)
+        let env = process_envs
+            .remove(env_key)
+            .ok_or(AsyncHostError::Badf)?
             .into_iter()
             .map(Option::unwrap)
             .collect();
@@ -2051,34 +2021,30 @@ impl AsyncHost {
     #[cfg(unix)]
     pub(crate) fn insert_process_env(&self, entries: Vec<Option<OsString>>) -> u64 {
         let key = self.handles.borrow_mut().insert(HandleKind::ProcessEnv);
-        self.process_envs
-            .lock()
-            .unwrap()
-            .insert(key, Arc::new(Mutex::new(entries)));
+        self.process_envs.borrow_mut().insert(key, entries);
         handle_from_key(key)
     }
 
     #[cfg(windows)]
     pub(crate) fn insert_process_env(&self, env: Vec<u16>) -> u64 {
         let key = self.handles.borrow_mut().insert(HandleKind::ProcessEnv);
-        self.process_envs
-            .lock()
-            .unwrap()
-            .insert(key, Arc::new(Mutex::new(env)));
+        self.process_envs.borrow_mut().insert(key, env);
         handle_from_key(key)
     }
 
     #[cfg(unix)]
     pub(crate) fn process_env_length(&self, handle: u64) -> AsyncHostResult<i32> {
-        let env = self.process_env(handle)?;
-        let env = env.lock().unwrap();
+        let key = self.process_env(handle)?;
+        let process_envs = self.process_envs.borrow();
+        let env = process_envs.get(key).ok_or(AsyncHostError::Badf)?;
         i32::try_from(env.len()).map_err(|_| AsyncHostError::Fault)
     }
 
     #[cfg(windows)]
     pub(crate) fn process_env_length(&self, handle: u64) -> AsyncHostResult<i32> {
-        let env = self.process_env(handle)?;
-        let env = env.lock().unwrap();
+        let key = self.process_env(handle)?;
+        let process_envs = self.process_envs.borrow();
+        let env = process_envs.get(key).ok_or(AsyncHostError::Badf)?;
         let len = env.len().checked_sub(1).ok_or(AsyncHostError::Fault)?;
         i32::try_from(len).map_err(|_| AsyncHostError::Fault)
     }
@@ -2092,12 +2058,15 @@ impl AsyncHost {
         if dst_handle == src_handle {
             return Err(AsyncHostError::Inval);
         }
-        let dst = self.process_env(dst_handle)?;
-        let src = self.take_process_env_handle(src_handle)?;
+        let dst_key = self.process_env(dst_handle)?;
+        if self.process_envs.borrow().get(dst_key).is_none() {
+            return Err(AsyncHostError::Badf);
+        }
+        let src = self.take_process_env_buffer(src_handle)?;
         // The source is the temporary snapshot returned by get_curr_env.
         // Consume it here so its lifetime does not depend on deprecated free_env.
-        let src = std::mem::take(&mut *src.lock().unwrap());
-        let mut dst = dst.lock().unwrap();
+        let mut process_envs = self.process_envs.borrow_mut();
+        let dst = process_envs.get_mut(dst_key).ok_or(AsyncHostError::Badf)?;
         if dst.len() < src.len() {
             return Err(AsyncHostError::Fault);
         }
@@ -2116,12 +2085,15 @@ impl AsyncHost {
         if dst_handle == src_handle {
             return Err(AsyncHostError::Inval);
         }
-        let dst = self.process_env(dst_handle)?;
-        let src = self.take_process_env_handle(src_handle)?;
+        let dst_key = self.process_env(dst_handle)?;
+        if self.process_envs.borrow().get(dst_key).is_none() {
+            return Err(AsyncHostError::Badf);
+        }
+        let src = self.take_process_env_buffer(src_handle)?;
         // The source is the temporary snapshot returned by get_curr_env.
         // Consume it here so its lifetime does not depend on deprecated free_env.
-        let src = std::mem::take(&mut *src.lock().unwrap());
-        let mut dst = dst.lock().unwrap();
+        let mut process_envs = self.process_envs.borrow_mut();
+        let dst = process_envs.get_mut(dst_key).ok_or(AsyncHostError::Badf)?;
         let src_len = src.len().checked_sub(1).ok_or(AsyncHostError::Fault)?;
         if dst.len() <= src_len {
             return Err(AsyncHostError::Fault);
@@ -2138,8 +2110,9 @@ impl AsyncHost {
         entry: OsString,
     ) -> AsyncHostResult<()> {
         let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
-        let env = self.process_env(handle)?;
-        let mut env = env.lock().unwrap();
+        let key = self.process_env(handle)?;
+        let mut process_envs = self.process_envs.borrow_mut();
+        let env = process_envs.get_mut(key).ok_or(AsyncHostError::Badf)?;
         let slot = env.get_mut(index).ok_or(AsyncHostError::Fault)?;
         *slot = Some(entry);
         Ok(())
@@ -2154,8 +2127,9 @@ impl AsyncHost {
         value: &[u16],
     ) -> AsyncHostResult<()> {
         let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
-        let env = self.process_env(handle)?;
-        let mut env = env.lock().unwrap();
+        let handle = self.process_env(handle)?;
+        let mut process_envs = self.process_envs.borrow_mut();
+        let env = process_envs.get_mut(handle).ok_or(AsyncHostError::Badf)?;
         let value_start = offset
             .checked_add(key.len())
             .and_then(|index| index.checked_add(1))
@@ -2176,48 +2150,33 @@ impl AsyncHost {
 
     #[cfg(windows)]
     pub(crate) fn take_process_env(&self, handle: u64) -> AsyncHostResult<Vec<u16>> {
-        let env = self.take_process_env_handle(handle)?;
-        let result = std::mem::take(&mut *env.lock().unwrap());
-        Ok(result)
+        self.take_process_env_buffer(handle)
     }
 
-    fn take_process_env_handle(&self, handle: u64) -> AsyncHostResult<HostProcessEnv> {
+    fn take_process_env_buffer(&self, handle: u64) -> AsyncHostResult<HostProcessEnv> {
         if handle == INVALID_HOST_HANDLE {
             return Err(AsyncHostError::Badf);
         }
         let key = self.handles.borrow_mut().remove_process_env(handle)?;
         self.process_envs
-            .lock()
-            .unwrap()
+            .borrow_mut()
             .remove(key)
             .ok_or(AsyncHostError::Badf)
     }
 
     #[cfg(unix)]
-    fn process_argv(&self, handle: u64) -> AsyncHostResult<HostProcessArgv> {
+    fn process_argv(&self, handle: u64) -> AsyncHostResult<HandleKey> {
         if handle == INVALID_HOST_HANDLE {
             return Err(AsyncHostError::Badf);
         }
-        let key = self.handles.borrow().process_argv(handle)?;
-        self.process_argvs
-            .lock()
-            .unwrap()
-            .get(key)
-            .cloned()
-            .ok_or(AsyncHostError::Badf)
+        self.handles.borrow().process_argv(handle)
     }
 
-    fn process_env(&self, handle: u64) -> AsyncHostResult<HostProcessEnv> {
+    fn process_env(&self, handle: u64) -> AsyncHostResult<HandleKey> {
         if handle == INVALID_HOST_HANDLE {
             return Err(AsyncHostError::Badf);
         }
-        let key = self.handles.borrow().process_env(handle)?;
-        self.process_envs
-            .lock()
-            .unwrap()
-            .get(key)
-            .cloned()
-            .ok_or(AsyncHostError::Badf)
+        self.handles.borrow().process_env(handle)
     }
 
     pub(crate) fn insert_job(&self, job: Job) -> AsyncHostResult<u64> {
@@ -2328,7 +2287,7 @@ impl AsyncHost {
             }
             (entries, next)
         };
-        let mut addr_infos = self.addr_infos.lock().unwrap();
+        let mut addr_infos = self.addr_infos.borrow_mut();
         for (key, addrinfo) in entries {
             addr_infos.insert(key, addrinfo);
         }
@@ -2365,14 +2324,14 @@ impl AsyncHost {
             return Ok(INVALID_HOST_HANDLE);
         }
         let key = self.handles.borrow().addrinfo(handle)?;
-        let addr_infos = self.addr_infos.lock().unwrap();
+        let addr_infos = self.addr_infos.borrow();
         let addrinfo = addr_infos.get(key).ok_or(AsyncHostError::Badf)?;
         Ok(addrinfo.next.unwrap_or(INVALID_HOST_HANDLE))
     }
 
     pub(crate) fn addrinfo_addr(&self, handle: u64) -> AsyncHostResult<Box<[u8]>> {
         let key = self.handles.borrow().addrinfo(handle)?;
-        let addr_infos = self.addr_infos.lock().unwrap();
+        let addr_infos = self.addr_infos.borrow();
         let addrinfo = addr_infos.get(key).ok_or(AsyncHostError::Badf)?;
         Ok(addrinfo.addr.clone())
     }
@@ -2384,7 +2343,7 @@ impl AsyncHost {
         let mut current = Some(handle);
         while let Some(handle) = current {
             let key = self.handles.borrow_mut().remove_addrinfo(handle)?;
-            let mut addr_infos = self.addr_infos.lock().unwrap();
+            let mut addr_infos = self.addr_infos.borrow_mut();
             let addrinfo = addr_infos.remove(key).ok_or(AsyncHostError::Badf)?;
             current = addrinfo.next;
         }
@@ -2397,12 +2356,7 @@ impl AsyncHost {
             #[cfg(windows)]
             {
                 let file = handles.resource(handle)?;
-                if self
-                    .io_results
-                    .lock()
-                    .unwrap()
-                    .has_pending_io_for_resource(&file)
-                {
+                if self.io_results.borrow().has_pending_io_for_resource(&file) {
                     return Err(AsyncHostError::Inval);
                 }
             }
@@ -2423,7 +2377,7 @@ impl AsyncHost {
         #[cfg(unix)]
         {
             let (completion_source_closed, old_signal_mask) = {
-                let mut completions = self.thread_pool_completions.lock().unwrap();
+                let mut completions = self.thread_pool_completions.borrow_mut();
                 if completions.source == Some(handle) {
                     completions.source = None;
                     completions.notifier = None;
@@ -2816,7 +2770,7 @@ impl AsyncHost {
         let key = self.handles.borrow_mut().insert(HandleKind::IoResult);
         let handle = handle_from_key(key);
         let overlapped = {
-            let mut io_results = self.io_results.lock().unwrap();
+            let mut io_results = self.io_results.borrow_mut();
             io_results.io_results.insert(key, Box::new(result));
             io_results
                 .io_results
@@ -2825,8 +2779,7 @@ impl AsyncHost {
                 .overlapped_addr()
         };
         self.io_results
-            .lock()
-            .unwrap()
+            .borrow_mut()
             .io_results_by_overlapped
             .insert(overlapped, handle);
         Ok(handle)
@@ -2836,7 +2789,7 @@ impl AsyncHost {
     pub(crate) fn free_io_result(&self, handle: u64) -> AsyncHostResult<()> {
         let mut handles = self.handles.borrow_mut();
         let key = handles.io_result(handle)?;
-        let mut io_results = self.io_results.lock().unwrap();
+        let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
             .get_mut(key)
@@ -2857,7 +2810,7 @@ impl AsyncHost {
     #[cfg(windows)]
     pub(crate) fn io_result_get_event(&self, handle: u64) -> AsyncHostResult<i32> {
         let key = self.handles.borrow().io_result(handle)?;
-        let io_results = self.io_results.lock().unwrap();
+        let io_results = self.io_results.borrow();
         let result = io_results.io_results.get(key).ok_or(AsyncHostError::Badf)?;
         Ok(result.event)
     }
@@ -2870,7 +2823,7 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         let file = self.resource(fd_handle)?;
         let result_key = self.handles.borrow().io_result(result_handle)?;
-        let mut io_results = self.io_results.lock().unwrap();
+        let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
             .get_mut(result_key)
@@ -2890,7 +2843,7 @@ impl AsyncHost {
         let file = self.resource(fd_handle)?;
         let raw_handle = raw_overlapped_handle(&file)?;
         let result_key = self.handles.borrow().io_result(result_handle)?;
-        let mut io_results = self.io_results.lock().unwrap();
+        let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
             .get_mut(result_key)
@@ -2931,7 +2884,7 @@ impl AsyncHost {
         len: i32,
     ) -> AsyncHostResult<()> {
         let key = self.handles.borrow().io_result(result_handle)?;
-        let io_results = self.io_results.lock().unwrap();
+        let io_results = self.io_results.borrow();
         let result = io_results.io_results.get(key).ok_or(AsyncHostError::Badf)?;
         result.copy_read_result(memory, dst, offset, len)
     }
@@ -2949,7 +2902,7 @@ impl AsyncHost {
         addr_len: i32,
     ) -> AsyncHostResult<()> {
         let key = self.handles.borrow().io_result(result_handle)?;
-        let io_results = self.io_results.lock().unwrap();
+        let io_results = self.io_results.borrow();
         let result = io_results.io_results.get(key).ok_or(AsyncHostError::Badf)?;
         result.copy_read_result_with_addr(memory, dst, offset, len, addr, addr_len)
     }
@@ -2968,7 +2921,7 @@ impl AsyncHost {
         // both while their tables are borrowed.
         let handles = self.handles.borrow();
         let result_key = handles.io_result(result_handle)?;
-        let mut io_results = self.io_results.lock().unwrap();
+        let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
             .get_mut(result_key)
@@ -3065,7 +3018,7 @@ impl AsyncHost {
         // both while their tables are borrowed.
         let handles = self.handles.borrow();
         let result_key = handles.io_result(result_handle)?;
-        let mut io_results = self.io_results.lock().unwrap();
+        let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
             .get_mut(result_key)
@@ -3158,7 +3111,7 @@ impl AsyncHost {
             let result_key = handles.io_result(result_handle)?;
             (file, raw_socket, result_key)
         };
-        let mut io_results = self.io_results.lock().unwrap();
+        let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
             .get_mut(result_key)
@@ -3241,7 +3194,7 @@ impl AsyncHost {
                 result_key,
             )
         };
-        let mut io_results = self.io_results.lock().unwrap();
+        let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
             .get_mut(result_key)
@@ -3286,7 +3239,7 @@ impl AsyncHost {
         dst_len: i32,
     ) -> AsyncHostResult<()> {
         let key = self.handles.borrow().io_result(result_handle)?;
-        let io_results = self.io_results.lock().unwrap();
+        let io_results = self.io_results.borrow();
         let result = io_results.io_results.get(key).ok_or(AsyncHostError::Badf)?;
         if result.kind != HostIoKind::Accept || result.is_pending() {
             return Err(AsyncHostError::Inval);
@@ -3582,8 +3535,7 @@ impl AsyncHost {
         let worker = {
             let completion_notifier = self
                 .thread_pool_completions
-                .lock()
-                .unwrap()
+                .borrow()
                 .notifier
                 .clone()
                 .ok_or(AsyncHostError::Badf)?;
@@ -3602,8 +3554,7 @@ impl AsyncHost {
         let worker = {
             let completion_target = self
                 .thread_pool_completions
-                .lock()
-                .unwrap()
+                .borrow()
                 .target
                 .clone()
                 .ok_or(AsyncHostError::Badf)?;
@@ -3623,7 +3574,7 @@ impl AsyncHost {
             )
         };
         let key = self.handles.borrow_mut().insert(HandleKind::Worker);
-        self.workers.lock().unwrap().insert(key, worker);
+        self.workers.borrow_mut().insert(key, worker);
         Ok(handle_from_key(key))
     }
 
@@ -3639,7 +3590,7 @@ impl AsyncHost {
             (handles.worker(worker_handle)?, handles.job(job_handle)?)
         };
         let replaced_job = {
-            let workers = self.workers.lock().unwrap();
+            let workers = self.workers.borrow();
             let Some(worker) = workers.get(worker_key) else {
                 return Err(AsyncHostError::Badf);
             };
@@ -3663,7 +3614,7 @@ impl AsyncHost {
     pub(crate) fn worker_enter_idle(&self, worker_handle: u64) -> AsyncHostResult<()> {
         let worker_key = self.handles.borrow().worker(worker_handle)?;
         let replaced_job = {
-            let workers = self.workers.lock().unwrap();
+            let workers = self.workers.borrow();
             let worker = workers.get(worker_key).ok_or(AsyncHostError::Badf)?;
             thread_pool::worker_enter_idle(worker)
         };
@@ -3679,8 +3630,7 @@ impl AsyncHost {
         let worker_key = self.handles.borrow().worker(worker_handle)?;
         let worker = self
             .workers
-            .lock()
-            .unwrap()
+            .borrow_mut()
             .remove(worker_key)
             .ok_or(AsyncHostError::Badf)?;
         self.handles.borrow_mut().remove_worker(worker_handle)?;
@@ -3695,7 +3645,7 @@ impl AsyncHost {
 
     pub(crate) fn cancel_worker(&self, worker_handle: u64) -> AsyncHostResult<i32> {
         let worker_key = self.handles.borrow().worker(worker_handle)?;
-        let workers = self.workers.lock().unwrap();
+        let workers = self.workers.borrow();
         let worker = workers.get(worker_key).ok_or(AsyncHostError::Badf)?;
         self.cancel_host_worker(worker)
     }
@@ -3722,8 +3672,7 @@ impl AsyncHost {
     #[cfg(unix)]
     pub(crate) fn thread_pool_child_signal_mask(&self) -> AsyncHostResult<libc::sigset_t> {
         self.thread_pool_completions
-            .lock()
-            .unwrap()
+            .borrow()
             .old_signal_mask
             .ok_or(AsyncHostError::Badf)
     }
@@ -3733,8 +3682,7 @@ impl AsyncHost {
         &self,
     ) -> AsyncHostResult<(poll::CompletionPort, usize)> {
         self.thread_pool_completions
-            .lock()
-            .unwrap()
+            .borrow()
             .target
             .as_ref()
             .map(|target| (target.port.clone(), target.generation))
@@ -3776,8 +3724,7 @@ impl AsyncHost {
         thread_pool::publish_realpath_result(job, |buffer| {
             let buffer_key = self.handles.borrow_mut().insert(HandleKind::CBuffer);
             self.c_buffers
-                .lock()
-                .unwrap()
+                .borrow_mut()
                 .insert(buffer_key, Arc::new(Mutex::new(buffer)));
             handle_from_key(buffer_key)
         })
@@ -3788,8 +3735,7 @@ impl AsyncHost {
         &self,
     ) -> AsyncHostResult<Arc<ThreadPoolCompletionNotifier>> {
         self.thread_pool_completions
-            .lock()
-            .unwrap()
+            .borrow()
             .notifier
             .clone()
             .ok_or(AsyncHostError::Badf)
@@ -3804,7 +3750,7 @@ impl AsyncHost {
         max_jobs: i32,
     ) -> AsyncHostResult<i32> {
         let (completion_notifier, completion_source) = {
-            let completions = self.thread_pool_completions.lock().unwrap();
+            let completions = self.thread_pool_completions.borrow();
             (
                 completions.notifier.clone().ok_or(AsyncHostError::Badf)?,
                 completions.source.ok_or(AsyncHostError::Badf)?,
@@ -3833,23 +3779,23 @@ impl AsyncHost {
     }
 
     pub(crate) fn tls_take_error(&self, handle: HostHandle) -> AsyncHostResult<HostHandle> {
-        let tls = self.tls_connection(handle)?;
-        let message = match &mut *tls.lock().unwrap() {
-            tls::TlsHandle::Connection(tls) => tls
-                .take_error()
-                .unwrap_or_else(|| "unknown TLS error".to_string()),
-            tls::TlsHandle::Empty(pending) => pending
-                .take_error()
-                .unwrap_or_else(|| "unknown TLS error".to_string()),
-        };
+        let message = self.with_tls_handle_mut(handle, |handle| {
+            Ok(match handle {
+                tls::TlsHandle::Connection(tls) => tls
+                    .take_error()
+                    .unwrap_or_else(|| "unknown TLS error".to_string()),
+                tls::TlsHandle::Empty(pending) => pending
+                    .take_error()
+                    .unwrap_or_else(|| "unknown TLS error".to_string()),
+            })
+        })?;
         Ok(self.insert_c_buffer(error_message_buffer(message)))
     }
 
     pub(crate) fn tls_take_global_error(&self) -> HostHandle {
         let message = self
             .tls_error
-            .lock()
-            .unwrap()
+            .borrow_mut()
             .take()
             .unwrap_or_else(|| "unknown TLS error".to_string());
         self.insert_c_buffer(error_message_buffer(message))
@@ -3866,9 +3812,7 @@ impl AsyncHost {
         sni: bool,
         trust: tls::TlsTrust,
     ) -> AsyncHostResult<i32> {
-        let tls = self.tls_connection(handle)?;
-        let mut handle = tls.lock().unwrap();
-        match &mut *handle {
+        self.with_tls_handle_mut(handle, |handle| match handle {
             tls::TlsHandle::Empty(pending) => {
                 match tls::TlsConnection::client(&host, sni, pending.client_config(trust)) {
                     Ok(connection) => {
@@ -3879,7 +3823,7 @@ impl AsyncHost {
                 }
             }
             tls::TlsHandle::Connection(_) => Err(AsyncHostError::Inval),
-        }
+        })
     }
 
     pub(crate) fn tls_add_root_certificate(
@@ -3914,9 +3858,7 @@ impl AsyncHost {
                 });
             }
         }
-        let tls = self.tls_connection(handle)?;
-        let mut handle = tls.lock().unwrap();
-        match &mut *handle {
+        self.with_tls_handle_mut(handle, |handle| match handle {
             tls::TlsHandle::Empty(pending) => {
                 if pending.has_root_certificates() {
                     return Ok(pending.set_error(
@@ -3937,7 +3879,7 @@ impl AsyncHost {
                 }
             }
             tls::TlsHandle::Connection(_) => Err(AsyncHostError::Inval),
-        }
+        })
     }
 
     pub(crate) fn tls_set_server_pfx(
@@ -3945,9 +3887,7 @@ impl AsyncHost {
         handle: HostHandle,
         pfx_content: Vec<u8>,
     ) -> AsyncHostResult<i32> {
-        let tls = self.tls_connection(handle)?;
-        let mut handle = tls.lock().unwrap();
-        match &mut *handle {
+        self.with_tls_handle_mut(handle, |handle| match handle {
             tls::TlsHandle::Empty(pending) => {
                 if pending.has_root_certificates() {
                     return Ok(pending.set_error(
@@ -3963,13 +3903,12 @@ impl AsyncHost {
                 }
             }
             tls::TlsHandle::Connection(_) => Err(AsyncHostError::Inval),
-        }
+        })
     }
 
     fn insert_tls_handle(&self, handle: tls::TlsHandle) -> HostHandle {
-        let handle = Arc::new(Mutex::new(handle));
         let key = self.handles.borrow_mut().insert(HandleKind::TlsConnection);
-        self.tls_connections.lock().unwrap().insert(key, handle);
+        self.tls_connections.borrow_mut().insert(key, handle);
         handle_from_key(key)
     }
 
@@ -3979,8 +3918,7 @@ impl AsyncHost {
         }
         let key = self.handles.borrow_mut().remove_tls_connection(handle)?;
         self.tls_connections
-            .lock()
-            .unwrap()
+            .borrow_mut()
             .remove(key)
             .map(|_| ())
             .ok_or(AsyncHostError::Badf)
@@ -4090,15 +4028,13 @@ impl AsyncHost {
         unconfigured_value: T,
         f: impl FnOnce(&mut tls::TlsConnection) -> T,
     ) -> AsyncHostResult<T> {
-        let connection = self.tls_connection(handle)?;
-        let mut handle = connection.lock().unwrap();
-        match &mut *handle {
+        self.with_tls_handle_mut(handle, |handle| match handle {
             tls::TlsHandle::Connection(connection) => Ok(f(connection)),
             tls::TlsHandle::Empty(pending) => {
                 pending.set_error("TLS handle is not configured".to_string());
                 Ok(unconfigured_value)
             }
-        }
+        })
     }
 
     fn with_tls_pending_mut<T>(
@@ -4106,22 +4042,21 @@ impl AsyncHost {
         handle: HostHandle,
         f: impl FnOnce(&mut tls::TlsPending) -> T,
     ) -> AsyncHostResult<T> {
-        let tls = self.tls_connection(handle)?;
-        let mut handle = tls.lock().unwrap();
-        match &mut *handle {
+        self.with_tls_handle_mut(handle, |handle| match handle {
             tls::TlsHandle::Empty(pending) => Ok(f(pending)),
             tls::TlsHandle::Connection(_) => Err(AsyncHostError::Inval),
-        }
+        })
     }
 
-    fn tls_connection(&self, handle: HostHandle) -> AsyncHostResult<tls::TlsHandleRef> {
+    fn with_tls_handle_mut<T>(
+        &self,
+        handle: HostHandle,
+        f: impl FnOnce(&mut tls::TlsHandle) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
         let key = self.handles.borrow().tls_connection(handle)?;
-        self.tls_connections
-            .lock()
-            .unwrap()
-            .get(key)
-            .map(Arc::clone)
-            .ok_or(AsyncHostError::Badf)
+        let mut tls_connections = self.tls_connections.borrow_mut();
+        let handle = tls_connections.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        f(handle)
     }
 
     fn spawn_worker_thread(
@@ -4651,12 +4586,20 @@ mod tests {
         assert!(matches!(host.process_env(src), Err(AsyncHostError::Badf)));
         #[cfg(unix)]
         assert_eq!(
-            &*host.process_env(dst).unwrap().lock().unwrap(),
+            host.process_envs
+                .borrow()
+                .get(host.process_env(dst).unwrap())
+                .unwrap()
+                .as_slice(),
             &[Some(OsString::from("A=B")), None]
         );
         #[cfg(windows)]
         assert_eq!(
-            &*host.process_env(dst).unwrap().lock().unwrap(),
+            host.process_envs
+                .borrow()
+                .get(host.process_env(dst).unwrap())
+                .unwrap()
+                .as_slice(),
             &[b'A' as u16, b'=' as u16, b'B' as u16, 0, 0, 0, 0]
         );
     }
@@ -4952,7 +4895,7 @@ mod tests {
         }
 
         {
-            let completions = host.thread_pool_completions.lock().unwrap();
+            let completions = host.thread_pool_completions.borrow();
             completions.notifier.as_ref().unwrap().notify(17).unwrap();
         }
         assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
@@ -4984,8 +4927,7 @@ mod tests {
             };
             *result = Some(b"abc".to_vec());
             host.thread_pool_completions
-                .lock()
-                .unwrap()
+                .borrow()
                 .notifier
                 .as_ref()
                 .unwrap()
@@ -5074,7 +5016,7 @@ mod tests {
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         {
-            let completions = host.thread_pool_completions.lock().unwrap();
+            let completions = host.thread_pool_completions.borrow();
             let notifier = completions.notifier.as_ref().unwrap();
             notifier.notify(41).unwrap();
             notifier.notify(42).unwrap();
@@ -5766,7 +5708,7 @@ mod tests {
             )
         };
         let worker_key = host.handles.borrow_mut().insert(HandleKind::Worker);
-        host.workers.lock().unwrap().insert(worker_key, worker);
+        host.workers.borrow_mut().insert(worker_key, worker);
         let worker = handle_from_key(worker_key);
 
         assert_eq!(
@@ -5834,7 +5776,7 @@ mod tests {
             )
         };
         let worker_key = host.handles.borrow_mut().insert(HandleKind::Worker);
-        host.workers.lock().unwrap().insert(worker_key, worker);
+        host.workers.borrow_mut().insert(worker_key, worker);
         let worker = handle_from_key(worker_key);
 
         assert_eq!(
@@ -5990,8 +5932,7 @@ mod tests {
         host.init_thread_pool(poll).unwrap();
         let stale_completion = host
             .thread_pool_completions
-            .lock()
-            .unwrap()
+            .borrow()
             .target
             .clone()
             .unwrap();
@@ -6010,8 +5951,7 @@ mod tests {
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let current_completion = host
             .thread_pool_completions
-            .lock()
-            .unwrap()
+            .borrow()
             .target
             .clone()
             .unwrap();
@@ -6195,7 +6135,7 @@ mod tests {
             .unwrap();
         memory[3..6].copy_from_slice(b"xxx");
 
-        let io_results = host.io_results.lock().unwrap();
+        let io_results = host.io_results.borrow();
         let result = io_results
             .io_results
             .get(io_result_key(&host, result))
@@ -6214,8 +6154,7 @@ mod tests {
             let read_file = host.resource(read).unwrap();
             let raw_read = read_file.raw_identity();
             host.io_results
-                .lock()
-                .unwrap()
+                .borrow_mut()
                 .io_results
                 .get_mut(io_result_key(&host, result))
                 .unwrap()
@@ -6229,7 +6168,7 @@ mod tests {
             Err(AsyncHostError::Badf)
         );
         {
-            let mut io_results = host.io_results.lock().unwrap();
+            let mut io_results = host.io_results.borrow_mut();
             let result = io_results
                 .io_results
                 .get_mut(io_result_key(&host, result))
@@ -6252,8 +6191,7 @@ mod tests {
         {
             let read_file = host.resource(read).unwrap();
             host.io_results
-                .lock()
-                .unwrap()
+                .borrow_mut()
                 .io_results
                 .get_mut(io_result_key(&host, result))
                 .unwrap()
@@ -6263,7 +6201,7 @@ mod tests {
 
         assert_eq!(host.cancel_io_result(result, read), Ok(0));
         {
-            let io_results = host.io_results.lock().unwrap();
+            let io_results = host.io_results.borrow();
             let result = io_results
                 .io_results
                 .get(io_result_key(&host, result))
@@ -6285,7 +6223,7 @@ mod tests {
         let raw_read = {
             let read_file = host.resource(read).unwrap();
             let raw_read = read_file.raw_identity();
-            let mut io_results = host.io_results.lock().unwrap();
+            let mut io_results = host.io_results.borrow_mut();
             let result = io_results
                 .io_results
                 .get_mut(io_result_key(&host, result))
@@ -6299,7 +6237,7 @@ mod tests {
         assert_eq!(host.free_io_result(result), Err(AsyncHostError::Inval));
         assert_eq!(host.close_fd(read), Err(AsyncHostError::Inval));
         {
-            let mut io_results = host.io_results.lock().unwrap();
+            let mut io_results = host.io_results.borrow_mut();
             let result = io_results
                 .io_results
                 .get_mut(io_result_key(&host, result))
@@ -6323,8 +6261,7 @@ mod tests {
             let read_file = host.resource(read).unwrap();
             let raw_read = read_file.raw_identity();
             host.io_results
-                .lock()
-                .unwrap()
+                .borrow_mut()
                 .io_results
                 .get_mut(io_result_key(&host, result))
                 .unwrap()
@@ -6336,7 +6273,7 @@ mod tests {
         assert_eq!(host.close_fd(read), Err(AsyncHostError::Inval));
         {
             assert!(host.resource(read).is_ok());
-            let mut io_results = host.io_results.lock().unwrap();
+            let mut io_results = host.io_results.borrow_mut();
             let result = io_results
                 .io_results
                 .get_mut(io_result_key(&host, result))
@@ -6362,8 +6299,7 @@ mod tests {
             let raw_read = read_file.raw_identity();
             let raw_write = write_file.raw_identity();
             host.io_results
-                .lock()
-                .unwrap()
+                .borrow_mut()
                 .io_results
                 .get_mut(io_result_key(&host, result))
                 .unwrap()
@@ -6381,7 +6317,7 @@ mod tests {
         {
             assert!(host.resource(read).is_ok());
             assert!(host.resource(write).is_ok());
-            let mut io_results = host.io_results.lock().unwrap();
+            let mut io_results = host.io_results.borrow_mut();
             let result = io_results
                 .io_results
                 .get_mut(io_result_key(&host, result))
@@ -6412,8 +6348,7 @@ mod tests {
         {
             let read_file = host.resource(read).unwrap();
             host.io_results
-                .lock()
-                .unwrap()
+                .borrow_mut()
                 .io_results
                 .get_mut(io_result_key(&host, result))
                 .unwrap()
@@ -6424,14 +6359,12 @@ mod tests {
         assert_eq!(host.free_io_result(result), Err(AsyncHostError::Inval));
         assert!(
             host.io_results
-                .lock()
-                .unwrap()
+                .borrow()
                 .io_results
                 .contains_key(io_result_key(&host, result))
         );
         host.io_results
-            .lock()
-            .unwrap()
+            .borrow_mut()
             .io_results
             .get_mut(io_result_key(&host, result))
             .unwrap()
@@ -6458,7 +6391,7 @@ mod tests {
         let read_file = host.resource(read).unwrap();
         let raw_fd = read_file.raw_identity();
         let overlapped = {
-            let mut io_results = host.io_results.lock().unwrap();
+            let mut io_results = host.io_results.borrow_mut();
             let result = io_results
                 .io_results
                 .get_mut(io_result_key(&host, result))
@@ -6476,8 +6409,7 @@ mod tests {
         assert_eq!(host.poll_event_io_result(event).unwrap(), result);
         assert_eq!(
             host.io_results
-                .lock()
-                .unwrap()
+                .borrow()
                 .io_results
                 .get(io_result_key(&host, result))
                 .unwrap()

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -375,20 +375,24 @@ impl HandleTable {
         handle_from_key(self.invalid_resource)
     }
 
-    fn resource(&self, handle: HostHandle) -> AsyncHostResult<ResourceRef> {
+    fn resource_ref(&self, handle: HostHandle) -> AsyncHostResult<&ResourceRef> {
         let key = self.key(handle, HandleKind::Resource)?;
         let resource = self.resources.get(key).ok_or(AsyncHostError::Badf)?;
         if resource.is_invalid() {
             return Err(AsyncHostError::Badf);
         }
-        Ok(Arc::clone(resource))
+        Ok(resource)
+    }
+
+    fn resource(&self, handle: HostHandle) -> AsyncHostResult<&Resource> {
+        self.resource_ref(handle).map(ResourceRef::as_ref)
     }
 
     fn resource_of_class(
         &self,
         handle: HostHandle,
         class: ResourceClass,
-    ) -> AsyncHostResult<ResourceRef> {
+    ) -> AsyncHostResult<&Resource> {
         let resource = self.resource(handle)?;
         if resource.resource_class() != class {
             return Err(AsyncHostError::Inval);
@@ -396,7 +400,7 @@ impl HandleTable {
         Ok(resource)
     }
 
-    fn socket(&self, handle: HostHandle) -> AsyncHostResult<ResourceRef> {
+    fn socket(&self, handle: HostHandle) -> AsyncHostResult<&Resource> {
         let resource = self.resource(handle)?;
         if !resource.resource_class().is_socket() {
             return Err(AsyncHostError::Inval);
@@ -404,11 +408,28 @@ impl HandleTable {
         Ok(resource)
     }
 
-    fn resource_is(&self, handle: HostHandle, resource: &ResourceRef) -> bool {
-        self.key(handle, HandleKind::Resource)
-            .ok()
-            .and_then(|key| self.resources.get(key))
-            .is_some_and(|current| Arc::ptr_eq(current, resource))
+    fn acquire_resource(&self, handle: HostHandle) -> AsyncHostResult<ResourceRef> {
+        self.resource_ref(handle).map(Arc::clone)
+    }
+
+    fn acquire_resource_of_class(
+        &self,
+        handle: HostHandle,
+        class: ResourceClass,
+    ) -> AsyncHostResult<ResourceRef> {
+        let resource = self.resource_ref(handle)?;
+        if resource.resource_class() != class {
+            return Err(AsyncHostError::Inval);
+        }
+        Ok(Arc::clone(resource))
+    }
+
+    fn acquire_socket(&self, handle: HostHandle) -> AsyncHostResult<ResourceRef> {
+        let resource = self.resource_ref(handle)?;
+        if !resource.resource_class().is_socket() {
+            return Err(AsyncHostError::Inval);
+        }
+        Ok(Arc::clone(resource))
     }
 
     fn contains_resource(&self, handle: HostHandle) -> bool {
@@ -727,7 +748,7 @@ impl Default for IoResultTable {
 
 #[cfg(windows)]
 impl IoResultTable {
-    fn has_pending_io_for_resource(&self, file: &ResourceRef) -> bool {
+    fn has_pending_io_for_resource(&self, file: &Resource) -> bool {
         self.io_results
             .values()
             .any(|result| result.protects_pending_resource(file))
@@ -780,11 +801,26 @@ enum HostIoKind {
 
 #[cfg(windows)]
 impl HostIoKind {
-    fn resource(self, handles: &HandleTable, handle: HostHandle) -> AsyncHostResult<ResourceRef> {
+    fn resource(self, handles: &HandleTable, handle: HostHandle) -> AsyncHostResult<&Resource> {
         match self {
             Self::File => handles.resource_of_class(handle, ResourceClass::File),
             Self::Socket => handles.socket(handle),
             Self::SocketWithAddr => handles.resource_of_class(handle, ResourceClass::UdpSocket),
+            Self::Connect | Self::Accept => Err(AsyncHostError::Inval),
+        }
+    }
+
+    fn acquire_resource(
+        self,
+        handles: &HandleTable,
+        handle: HostHandle,
+    ) -> AsyncHostResult<ResourceRef> {
+        match self {
+            Self::File => handles.acquire_resource_of_class(handle, ResourceClass::File),
+            Self::Socket => handles.acquire_socket(handle),
+            Self::SocketWithAddr => {
+                handles.acquire_resource_of_class(handle, ResourceClass::UdpSocket)
+            }
             Self::Connect | Self::Accept => Err(AsyncHostError::Inval),
         }
     }
@@ -1043,14 +1079,14 @@ impl HostIoResult {
         self.pending_resource.is_some() || self.extra_pending_close_resource.is_some()
     }
 
-    fn protects_pending_resource(&self, file: &ResourceRef) -> bool {
+    fn protects_pending_resource(&self, file: &Resource) -> bool {
         self.pending_resource
             .as_ref()
-            .is_some_and(|pending| Arc::ptr_eq(pending, file))
+            .is_some_and(|pending| std::ptr::eq(pending.as_ref(), file))
             || self
                 .extra_pending_close_resource
                 .as_ref()
-                .is_some_and(|pending| Arc::ptr_eq(pending, file))
+                .is_some_and(|pending| std::ptr::eq(pending.as_ref(), file))
     }
 
     fn mark_pending(&mut self, file: ResourceRef) -> AsyncHostResult<()> {
@@ -1076,18 +1112,18 @@ impl HostIoResult {
         self.extra_pending_close_resource = None;
     }
 
-    fn validate_pending_resource(&self, file: &ResourceRef) -> AsyncHostResult<()> {
+    fn validate_pending_resource(&self, file: &Resource) -> AsyncHostResult<()> {
         // The import boundary may receive malformed/stale fd handles. Validate
         // before asserting the internal "pending operation uses submitter fd"
         // invariant so debug builds do not panic on bad guest input.
         if let Some(pending_resource) = &self.pending_resource
-            && !Arc::ptr_eq(pending_resource, file)
+            && !std::ptr::eq(pending_resource.as_ref(), file)
         {
             return Err(AsyncHostError::Badf);
         }
         debug_assert!(
             match &self.pending_resource {
-                Some(pending_resource) => Arc::ptr_eq(pending_resource, file),
+                Some(pending_resource) => std::ptr::eq(pending_resource.as_ref(), file),
                 None => true,
             },
             "pending IO operation must use the submitting handle"
@@ -1527,11 +1563,12 @@ impl AsyncHost {
         fd_handle: HostHandle,
         read_only: bool,
     ) -> AsyncHostResult<()> {
-        let resource = self.resource(fd_handle)?;
+        let handles = self.handles.borrow();
+        let resource = handles.resource(fd_handle)?;
         let resource_identity = resource.raw_identity();
         #[cfg(unix)]
         let raw_fd = resource.as_file()?.as_raw_fd();
-        let poll_key = self.handles.borrow().poll(poll_handle)?;
+        let poll_key = handles.poll(poll_handle)?;
         let mut polls = self.polls.borrow_mut();
         let poll = polls.polls.get_mut(poll_key).ok_or(AsyncHostError::Badf)?;
         #[cfg(unix)]
@@ -1545,13 +1582,6 @@ impl AsyncHost {
                 resource.as_file()?.as_raw_handle(),
                 read_only,
             )?;
-        }
-        let handles = self.handles.borrow();
-        if !handles.resource_is(fd_handle, &resource) {
-            drop(handles);
-            #[cfg(unix)]
-            poll::poll_unregister(&poll.instance, raw_fd)?;
-            return Err(AsyncHostError::Badf);
         }
         poll.registered_fds.insert(resource_identity, fd_handle);
         Ok(())
@@ -2515,12 +2545,13 @@ impl AsyncHost {
         f: impl FnOnce(RawSocket) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
         debug_assert!(class.is_socket());
-        let file = self.resource_of_class(handle, class)?;
-        #[cfg(unix)]
-        let socket = file.as_fd()?.as_raw_fd();
-        #[cfg(windows)]
-        let socket = file.as_socket()?.as_raw_socket();
-        f(socket)
+        self.with_resource_of_class(handle, class, |file| {
+            #[cfg(unix)]
+            let socket = file.as_fd()?.as_raw_fd();
+            #[cfg(windows)]
+            let socket = file.as_socket()?.as_raw_socket();
+            f(socket)
+        })
     }
 
     pub(crate) fn with_raw_socket<T>(
@@ -2528,7 +2559,8 @@ impl AsyncHost {
         handle: HostHandle,
         f: impl FnOnce(RawSocket) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
-        let file = self.socket_resource(handle)?;
+        let handles = self.handles.borrow();
+        let file = handles.socket(handle)?;
         #[cfg(unix)]
         let socket = file.as_fd()?.as_raw_fd();
         #[cfg(windows)]
@@ -2546,20 +2578,44 @@ impl AsyncHost {
         handle
     }
 
-    pub(crate) fn resource(&self, handle: HostHandle) -> AsyncHostResult<ResourceRef> {
-        self.handles.borrow().resource(handle)
+    pub(crate) fn with_resource<T>(
+        &self,
+        handle: HostHandle,
+        f: impl FnOnce(&Resource) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
+        let handles = self.handles.borrow();
+        f(handles.resource(handle)?)
     }
 
-    pub(crate) fn resource_of_class(
+    pub(crate) fn with_resource_of_class<T>(
+        &self,
+        handle: HostHandle,
+        class: ResourceClass,
+        f: impl FnOnce(&Resource) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
+        let handles = self.handles.borrow();
+        f(handles.resource_of_class(handle, class)?)
+    }
+
+    pub(crate) fn acquire_resource(&self, handle: HostHandle) -> AsyncHostResult<ResourceRef> {
+        self.handles.borrow().acquire_resource(handle)
+    }
+
+    pub(crate) fn acquire_resource_of_class(
         &self,
         handle: HostHandle,
         class: ResourceClass,
     ) -> AsyncHostResult<ResourceRef> {
-        self.handles.borrow().resource_of_class(handle, class)
+        self.handles
+            .borrow()
+            .acquire_resource_of_class(handle, class)
     }
 
-    pub(crate) fn socket_resource(&self, handle: HostHandle) -> AsyncHostResult<ResourceRef> {
-        self.handles.borrow().socket(handle)
+    pub(crate) fn acquire_socket_resource(
+        &self,
+        handle: HostHandle,
+    ) -> AsyncHostResult<ResourceRef> {
+        self.handles.borrow().acquire_socket(handle)
     }
 
     pub(crate) fn pipe(
@@ -2576,32 +2632,34 @@ impl AsyncHost {
     }
 
     pub(crate) fn kind_of_fd(&self, handle: HostHandle) -> AsyncHostResult<i32> {
-        let file = self.resource(handle)?;
-        #[cfg(unix)]
-        {
-            crate::async_sys::internal::fd_util::stub::kind_of_file(file.as_file()?)
-        }
-        #[cfg(windows)]
-        {
-            if file.resource_class().is_socket() {
-                crate::async_sys::internal::fd_util::stub::kind_of_socket(file.as_socket()?)
-            } else {
+        self.with_resource(handle, |file| {
+            #[cfg(unix)]
+            {
                 crate::async_sys::internal::fd_util::stub::kind_of_file(file.as_file()?)
             }
-        }
+            #[cfg(windows)]
+            {
+                if file.resource_class().is_socket() {
+                    crate::async_sys::internal::fd_util::stub::kind_of_socket(file.as_socket()?)
+                } else {
+                    crate::async_sys::internal::fd_util::stub::kind_of_file(file.as_file()?)
+                }
+            }
+        })
     }
 
     pub(crate) fn set_cloexec(&self, handle: HostHandle) -> AsyncHostResult<()> {
-        let file = self.resource(handle)?;
-        #[cfg(unix)]
-        {
-            crate::async_sys::internal::fd_util::stub::set_cloexec(file.as_file()?.as_raw_fd())
-        }
-        #[cfg(windows)]
-        {
-            let _ = file;
-            Ok(())
-        }
+        self.with_resource(handle, |file| {
+            #[cfg(unix)]
+            {
+                crate::async_sys::internal::fd_util::stub::set_cloexec(file.as_file()?.as_raw_fd())
+            }
+            #[cfg(windows)]
+            {
+                let _ = file;
+                Ok(())
+            }
+        })
     }
 
     #[cfg(unix)]
@@ -2615,9 +2673,10 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         let offset_dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
         let dst = memory.read_exact_mut(offset_dst, len)?;
-        let file = self.resource(handle)?;
-        crate::async_sys::internal::event_loop::io::read(file.as_file()?.as_raw_fd(), dst)
-            .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
+        self.with_resource(handle, |file| {
+            crate::async_sys::internal::event_loop::io::read(file.as_file()?.as_raw_fd(), dst)
+                .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
+        })
     }
 
     #[cfg(unix)]
@@ -2631,9 +2690,10 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         let offset_src = src.checked_add(offset).ok_or(AsyncHostError::Fault)?;
         let src = memory.read_exact(offset_src, len)?;
-        let file = self.resource(handle)?;
-        crate::async_sys::internal::event_loop::io::write(file.as_file()?.as_raw_fd(), src)
-            .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
+        self.with_resource(handle, |file| {
+            crate::async_sys::internal::event_loop::io::write(file.as_file()?.as_raw_fd(), src)
+                .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
+        })
     }
 
     #[cfg(windows)]
@@ -2793,14 +2853,15 @@ impl AsyncHost {
         result_handle: u64,
         fd_handle: HostHandle,
     ) -> AsyncHostResult<i32> {
-        let file = self.resource(fd_handle)?;
-        let result_key = self.handles.borrow().io_result(result_handle)?;
+        let handles = self.handles.borrow();
+        let file = handles.resource(fd_handle)?;
+        let result_key = handles.io_result(result_handle)?;
         let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
             .get_mut(result_key)
             .ok_or(AsyncHostError::Badf)?;
-        result.validate_pending_resource(&file)?;
+        result.validate_pending_resource(file)?;
         result.cancel_pending()
     }
 
@@ -2812,15 +2873,16 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::System::IO::GetOverlappedResult;
 
-        let file = self.resource(fd_handle)?;
-        let raw_handle = raw_overlapped_handle(&file)?;
-        let result_key = self.handles.borrow().io_result(result_handle)?;
+        let handles = self.handles.borrow();
+        let file = handles.resource(fd_handle)?;
+        let raw_handle = raw_overlapped_handle(file)?;
+        let result_key = handles.io_result(result_handle)?;
         let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
             .get_mut(result_key)
             .ok_or(AsyncHostError::Badf)?;
-        result.validate_pending_resource(&file)?;
+        result.validate_pending_resource(file)?;
         let mut bytes_transferred = 0;
         if unsafe {
             GetOverlappedResult(
@@ -2902,7 +2964,6 @@ impl AsyncHost {
             return Err(AsyncHostError::Inval);
         }
         let file = result.kind.resource(&handles, fd_handle)?;
-        drop(handles);
         let mut bytes_transferred = 0;
         let success = match result.kind {
             HostIoKind::File => {
@@ -2969,7 +3030,7 @@ impl AsyncHost {
         if errno == ERROR_HANDLE_EOF as i32 {
             Ok(0)
         } else if errno == ERROR_IO_PENDING as i32 {
-            result.mark_pending(file)?;
+            result.mark_pending(result.kind.acquire_resource(&handles, fd_handle)?)?;
             Err(AsyncHostError::Native(errno))
         } else {
             Err(AsyncHostError::Native(errno))
@@ -2999,7 +3060,6 @@ impl AsyncHost {
             return Err(AsyncHostError::Inval);
         }
         let file = result.kind.resource(&handles, fd_handle)?;
-        drop(handles);
         if result.kind == HostIoKind::SocketWithAddr {
             self.policy.connect_socket(&result.addr_buffer)?;
         }
@@ -3062,7 +3122,7 @@ impl AsyncHost {
             };
             let error = AsyncHostError::Native(errno);
             if matches!(error, AsyncHostError::Native(errno) if errno == ERROR_IO_PENDING as i32) {
-                result.mark_pending(file)?;
+                result.mark_pending(result.kind.acquire_resource(&handles, fd_handle)?)?;
             }
             Err(error)
         }
@@ -3076,13 +3136,10 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let (file, raw_socket, result_key) = {
-            let handles = self.handles.borrow();
-            let file = handles.resource_of_class(fd_handle, ResourceClass::TcpSocket)?;
-            let raw_socket = file.as_socket()?.as_raw_socket();
-            let result_key = handles.io_result(result_handle)?;
-            (file, raw_socket, result_key)
-        };
+        let handles = self.handles.borrow();
+        let file = handles.resource_of_class(fd_handle, ResourceClass::TcpSocket)?;
+        let raw_socket = file.as_socket()?.as_raw_socket();
+        let result_key = handles.io_result(result_handle)?;
         let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
@@ -3113,7 +3170,9 @@ impl AsyncHost {
         } else {
             let errno = last_wsa_errno();
             if errno == windows_sys::Win32::Foundation::ERROR_IO_PENDING as i32 {
-                result.mark_pending(file)?;
+                result.mark_pending(
+                    handles.acquire_resource_of_class(fd_handle, ResourceClass::TcpSocket)?,
+                )?;
             }
             Err(AsyncHostError::Native(errno))
         }
@@ -3123,22 +3182,23 @@ impl AsyncHost {
     pub(crate) fn setup_connected_socket(&self, fd_handle: HostHandle) -> AsyncHostResult<()> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let file = self.resource_of_class(fd_handle, ResourceClass::TcpSocket)?;
-        let yes: u32 = 1;
-        if unsafe {
-            ws::setsockopt(
-                file.as_socket()?.as_raw_socket() as usize,
-                ws::SOL_SOCKET,
-                ws::SO_UPDATE_CONNECT_CONTEXT,
-                (&yes as *const u32).cast(),
-                std::mem::size_of_val(&yes) as i32,
-            )
-        } == ws::SOCKET_ERROR
-        {
-            Err(AsyncHostError::Native(last_wsa_errno()))
-        } else {
-            Ok(())
-        }
+        self.with_resource_of_class(fd_handle, ResourceClass::TcpSocket, |file| {
+            let yes: u32 = 1;
+            if unsafe {
+                ws::setsockopt(
+                    file.as_socket()?.as_raw_socket() as usize,
+                    ws::SOL_SOCKET,
+                    ws::SO_UPDATE_CONNECT_CONTEXT,
+                    (&yes as *const u32).cast(),
+                    std::mem::size_of_val(&yes) as i32,
+                )
+            } == ws::SOCKET_ERROR
+            {
+                Err(AsyncHostError::Native(last_wsa_errno()))
+            } else {
+                Ok(())
+            }
+        })
     }
 
     #[cfg(windows)]
@@ -3150,22 +3210,12 @@ impl AsyncHost {
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let (server_file, conn_file, server_socket, conn_socket, result_key) = {
-            let handles = self.handles.borrow();
-            let server_file =
-                handles.resource_of_class(server_fd_handle, ResourceClass::TcpSocket)?;
-            let conn_file = handles.resource_of_class(conn_fd_handle, ResourceClass::TcpSocket)?;
-            let server_socket = server_file.as_socket()?.as_raw_socket();
-            let conn_socket = conn_file.as_socket()?.as_raw_socket();
-            let result_key = handles.io_result(result_handle)?;
-            (
-                server_file,
-                conn_file,
-                server_socket,
-                conn_socket,
-                result_key,
-            )
-        };
+        let handles = self.handles.borrow();
+        let server_file = handles.resource_of_class(server_fd_handle, ResourceClass::TcpSocket)?;
+        let conn_file = handles.resource_of_class(conn_fd_handle, ResourceClass::TcpSocket)?;
+        let server_socket = server_file.as_socket()?.as_raw_socket();
+        let conn_socket = conn_file.as_socket()?.as_raw_socket();
+        let result_key = handles.io_result(result_handle)?;
         let mut io_results = self.io_results.borrow_mut();
         let result = io_results
             .io_results
@@ -3196,7 +3246,11 @@ impl AsyncHost {
         } else {
             let errno = last_wsa_errno();
             if errno == windows_sys::Win32::Foundation::ERROR_IO_PENDING as i32 {
-                result.mark_pending_with_close_guard(server_file, conn_file)?;
+                result.mark_pending_with_close_guard(
+                    handles
+                        .acquire_resource_of_class(server_fd_handle, ResourceClass::TcpSocket)?,
+                    handles.acquire_resource_of_class(conn_fd_handle, ResourceClass::TcpSocket)?,
+                )?;
             }
             Err(AsyncHostError::Native(errno))
         }
@@ -3234,8 +3288,9 @@ impl AsyncHost {
     ) -> AsyncHostResult<()> {
         use windows_sys::Win32::Networking::WinSock as ws;
 
-        let listen_file = self.resource_of_class(listen_fd_handle, ResourceClass::TcpSocket)?;
-        let accept_file = self.resource_of_class(accept_fd_handle, ResourceClass::TcpSocket)?;
+        let handles = self.handles.borrow();
+        let listen_file = handles.resource_of_class(listen_fd_handle, ResourceClass::TcpSocket)?;
+        let accept_file = handles.resource_of_class(accept_fd_handle, ResourceClass::TcpSocket)?;
         let listen_socket = listen_file.as_socket()?.as_raw_socket() as usize;
         if unsafe {
             ws::setsockopt(
@@ -3254,20 +3309,16 @@ impl AsyncHost {
     }
 
     pub(crate) fn try_lock_file(&self, handle: HostHandle, exclusive: bool) -> AsyncHostResult<()> {
-        let file = self
-            .handles
-            .borrow()
-            .resource_of_class(handle, ResourceClass::File)?;
-        Self::check_file_lock_policy(&self.policy, Some(&file), exclusive)?;
-        crate::async_sys::fs::stub::try_lock_acquired_file(&file, exclusive)
+        self.with_resource_of_class(handle, ResourceClass::File, |file| {
+            Self::check_file_lock_policy(&self.policy, Some(file), exclusive)?;
+            crate::async_sys::fs::stub::try_lock_acquired_file(file, exclusive)
+        })
     }
 
     pub(crate) fn unlock_file(&self, handle: HostHandle) -> AsyncHostResult<()> {
-        let file = self
-            .handles
-            .borrow()
-            .resource_of_class(handle, ResourceClass::File)?;
-        crate::async_sys::fs::stub::unlock_acquired_file(&file)
+        self.with_resource_of_class(handle, ResourceClass::File, |file| {
+            crate::async_sys::fs::stub::unlock_acquired_file(file)
+        })
     }
 
     pub(crate) fn run_job(&self, handle: u64) -> AsyncHostResult<()> {
@@ -3317,12 +3368,12 @@ impl AsyncHost {
                 follow_symlink,
             } => Self::check_path_metadata_policy(
                 policy,
-                Self::resource_path_base(parent.as_ref()),
+                Self::resource_path_base(parent.as_deref()),
                 path,
                 *follow_symlink,
             ),
             JobPayload::FileSize { file, .. } | JobPayload::FileTime { file, .. } => {
-                Self::check_file_metadata_policy(policy, file.as_ref())
+                Self::check_file_metadata_policy(policy, file.as_deref())
             }
             JobPayload::FileTimeByPath {
                 path,
@@ -3340,7 +3391,7 @@ impl AsyncHost {
             JobPayload::Access { path, access } => policy.access_path(path, *access),
             JobPayload::Chmod { path, .. } => policy.chmod_path(path),
             JobPayload::Flock { file, exclusive } => {
-                Self::check_file_lock_policy(policy, file.as_ref(), *exclusive)
+                Self::check_file_lock_policy(policy, file.as_deref(), *exclusive)
             }
             JobPayload::Remove { path } => policy.remove_path(path),
             JobPayload::Rename {
@@ -3448,7 +3499,7 @@ impl AsyncHost {
 
     fn check_file_metadata_policy(
         policy: &AsyncPolicy,
-        file: Option<&ResourceRef>,
+        file: Option<&Resource>,
     ) -> AsyncHostResult<()> {
         let file = file.ok_or(AsyncHostError::Badf)?;
         match file.policy_path() {
@@ -3472,7 +3523,7 @@ impl AsyncHost {
 
     fn check_file_lock_policy(
         policy: &AsyncPolicy,
-        file: Option<&ResourceRef>,
+        file: Option<&Resource>,
         exclusive: bool,
     ) -> AsyncHostResult<()> {
         let file = file.ok_or(AsyncHostError::Badf)?;
@@ -3490,7 +3541,7 @@ impl AsyncHost {
         }
     }
 
-    fn resource_path_base(parent: Option<&ResourceRef>) -> RuntimePathBase<'_> {
+    fn resource_path_base(parent: Option<&Resource>) -> RuntimePathBase<'_> {
         match parent {
             None => RuntimePathBase::CurrentDirectory,
             Some(parent) => parent
@@ -4312,7 +4363,7 @@ mod tests {
         let process_resource = if process_handle == host.invalid_fd() {
             None
         } else {
-            Some(host.resource(process_handle).unwrap())
+            Some(host.acquire_resource(process_handle).unwrap())
         };
         let process_handle_pid = host.process_handle_pid(process_handle).unwrap();
         if process_resource.is_some() {
@@ -4372,7 +4423,7 @@ mod tests {
             .extend([checked_pid, tracked_pid]);
         let [process_handle, other] = host.pipe(false, false).unwrap();
         host.track_process_handle(process_handle, tracked_pid);
-        let process_resource = host.resource(process_handle).unwrap();
+        let process_resource = host.acquire_resource(process_handle).unwrap();
 
         assert_eq!(
             host.check_process_handle_pid(process_handle, checked_pid),
@@ -4699,10 +4750,13 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
 
         assert_eq!(
-            host.socket_resource(read).unwrap_err(),
+            host.acquire_socket_resource(read).unwrap_err(),
             AsyncHostError::Inval
         );
-        assert!(host.resource_of_class(read, ResourceClass::File).is_ok());
+        assert!(
+            host.acquire_resource_of_class(read, ResourceClass::File)
+                .is_ok()
+        );
 
         host.close_fd(read).unwrap();
         host.close_fd(write).unwrap();
@@ -4717,8 +4771,18 @@ mod tests {
             [(false, false), (true, false), (false, true), (true, true)]
         {
             let [read, write] = host.pipe(read_is_async, write_is_async).unwrap();
-            let read_fd = host.resource(read).unwrap().as_fd().unwrap().as_raw_fd();
-            let write_fd = host.resource(write).unwrap().as_fd().unwrap().as_raw_fd();
+            let read_fd = host
+                .acquire_resource(read)
+                .unwrap()
+                .as_fd()
+                .unwrap()
+                .as_raw_fd();
+            let write_fd = host
+                .acquire_resource(write)
+                .unwrap()
+                .as_fd()
+                .unwrap()
+                .as_raw_fd();
             let read_flags = unsafe { libc::fcntl(read_fd, libc::F_GETFL) };
             let write_flags = unsafe { libc::fcntl(write_fd, libc::F_GETFL) };
 
@@ -4753,7 +4817,7 @@ mod tests {
             host.with_raw_resource_class(tcp, ResourceClass::TcpSocket, |_| Ok(()))
                 .is_ok()
         );
-        assert_eq!(host.resource(tcp).unwrap().socket_family(), Some(4));
+        assert_eq!(host.acquire_resource(tcp).unwrap().socket_family(), Some(4));
         assert_eq!(
             host.with_raw_resource_class(tcp, ResourceClass::UdpSocket, |_| Ok(())),
             Err(AsyncHostError::Inval)
@@ -4781,7 +4845,7 @@ mod tests {
         let poll = host.poll_create().unwrap();
         let completion_source = host.init_thread_pool(poll).unwrap();
         let raw_completion_fd = host
-            .resource(completion_source)
+            .acquire_resource(completion_source)
             .unwrap()
             .as_fd()
             .unwrap()
@@ -5004,7 +5068,7 @@ mod tests {
         assert_eq!(host.open_job_get_fd(job).unwrap(), opened);
         assert_eq!(host.run_job(job), Err(AsyncHostError::Badf));
         assert_eq!(resource_count(&host), 1);
-        assert!(host.resource(opened).is_ok());
+        assert!(host.acquire_resource(opened).is_ok());
 
         host.close_fd(opened).unwrap();
         host.free_job(job).unwrap();
@@ -5304,7 +5368,7 @@ mod tests {
 
         host.run_job(parent_open_job).unwrap();
         let parent_fd = host.open_job_get_fd(parent_open_job).unwrap();
-        let parent = host.resource(parent_fd).unwrap();
+        let parent = host.acquire_resource(parent_fd).unwrap();
         let allowed_link_job = host
             .insert_job(thread_pool::make_file_kind_by_path_job(
                 Some(Arc::clone(&parent)),
@@ -5358,7 +5422,7 @@ mod tests {
 
         host.run_job(open_job).unwrap();
         let fd = host.open_job_get_fd(open_job).unwrap();
-        let resource = host.resource(fd).unwrap();
+        let resource = host.acquire_resource(fd).unwrap();
         let size_job = host
             .insert_job(thread_pool::make_file_size_job(Arc::clone(&resource)))
             .unwrap();
@@ -5441,7 +5505,7 @@ mod tests {
 
         host.run_job(open_job).unwrap();
         let fd = host.open_job_get_fd(open_job).unwrap();
-        let resource = host.resource(fd).unwrap();
+        let resource = host.acquire_resource(fd).unwrap();
         let flock_job = host
             .insert_job(thread_pool::make_flock_job(Arc::clone(&resource), true))
             .unwrap();
@@ -5904,7 +5968,7 @@ mod tests {
     fn acquired_resource_survives_guest_close() {
         let host = AsyncHost::default();
         let [read, write] = host.pipe(false, false).unwrap();
-        let file = host.resource(read).unwrap();
+        let file = host.acquire_resource(read).unwrap();
 
         host.close_fd(read).unwrap();
         let mut input = *b"x";
@@ -5933,14 +5997,19 @@ mod tests {
         host.poll_register(poll, read, true).unwrap();
         let job = host
             .insert_job(thread_pool::make_read_job(
-                host.resource(read).unwrap(),
+                host.acquire_resource(read).unwrap(),
                 1,
                 -1,
             ))
             .unwrap();
 
         host.close_fd(read).unwrap();
-        let fd = host.resource(write).unwrap().as_fd().unwrap().as_raw_fd();
+        let fd = host
+            .acquire_resource(write)
+            .unwrap()
+            .as_fd()
+            .unwrap()
+            .as_raw_fd();
         let byte = b"x";
         let ret = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
         assert_eq!(ret, 1);
@@ -6049,7 +6118,7 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let raw_read = {
-            let read_file = host.resource(read).unwrap();
+            let read_file = host.acquire_resource(read).unwrap();
             let raw_read = read_file.raw_identity();
             host.io_results
                 .borrow_mut()
@@ -6087,7 +6156,7 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         {
-            let read_file = host.resource(read).unwrap();
+            let read_file = host.acquire_resource(read).unwrap();
             host.io_results
                 .borrow_mut()
                 .io_results
@@ -6119,7 +6188,7 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let raw_read = {
-            let read_file = host.resource(read).unwrap();
+            let read_file = host.acquire_resource(read).unwrap();
             let raw_read = read_file.raw_identity();
             let mut io_results = host.io_results.borrow_mut();
             let result = io_results
@@ -6156,7 +6225,7 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let raw_read = {
-            let read_file = host.resource(read).unwrap();
+            let read_file = host.acquire_resource(read).unwrap();
             let raw_read = read_file.raw_identity();
             host.io_results
                 .borrow_mut()
@@ -6170,7 +6239,7 @@ mod tests {
 
         assert_eq!(host.close_fd(read), Err(AsyncHostError::Inval));
         {
-            assert!(host.resource(read).is_ok());
+            assert!(host.acquire_resource(read).is_ok());
             let mut io_results = host.io_results.borrow_mut();
             let result = io_results
                 .io_results
@@ -6192,8 +6261,8 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let (raw_read, raw_write) = {
-            let read_file = host.resource(read).unwrap();
-            let write_file = host.resource(write).unwrap();
+            let read_file = host.acquire_resource(read).unwrap();
+            let write_file = host.acquire_resource(write).unwrap();
             let raw_read = read_file.raw_identity();
             let raw_write = write_file.raw_identity();
             host.io_results
@@ -6213,15 +6282,15 @@ mod tests {
         );
         assert_eq!(host.close_fd(read), Err(AsyncHostError::Inval));
         {
-            assert!(host.resource(read).is_ok());
-            assert!(host.resource(write).is_ok());
+            assert!(host.acquire_resource(read).is_ok());
+            assert!(host.acquire_resource(write).is_ok());
             let mut io_results = host.io_results.borrow_mut();
             let result = io_results
                 .io_results
                 .get_mut(io_result_key(&host, result))
                 .unwrap();
             assert_eq!(result.pending_resource_identity(), Some(raw_read));
-            assert!(result.protects_pending_resource(&host.resource(write).unwrap()));
+            assert!(result.protects_pending_resource(&host.acquire_resource(write).unwrap()));
             assert_eq!(
                 result
                     .extra_pending_close_resource
@@ -6244,7 +6313,7 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         {
-            let read_file = host.resource(read).unwrap();
+            let read_file = host.acquire_resource(read).unwrap();
             host.io_results
                 .borrow_mut()
                 .io_results
@@ -6286,7 +6355,7 @@ mod tests {
         };
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let [read, write] = host.pipe(true, true).unwrap();
-        let read_file = host.resource(read).unwrap();
+        let read_file = host.acquire_resource(read).unwrap();
         let raw_fd = read_file.raw_identity();
         let overlapped = {
             let mut io_results = host.io_results.borrow_mut();
@@ -6351,7 +6420,12 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         host.poll_register(poll, read, true).unwrap();
 
-        let fd = host.resource(write).unwrap().as_fd().unwrap().as_raw_fd();
+        let fd = host
+            .acquire_resource(write)
+            .unwrap()
+            .as_fd()
+            .unwrap()
+            .as_raw_fd();
         let byte = b"x";
         let ret = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
         assert_eq!(ret, 1);
@@ -6377,7 +6451,12 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         host.poll_register(poll, read, true).unwrap();
 
-        let fd = host.resource(write).unwrap().as_fd().unwrap().as_raw_fd();
+        let fd = host
+            .acquire_resource(write)
+            .unwrap()
+            .as_fd()
+            .unwrap()
+            .as_raw_fd();
         let byte = b"x";
         let ret = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
         assert_eq!(ret, 1);

--- a/crates/moonrun/src/async_host/tls/mod.rs
+++ b/crates/moonrun/src/async_host/tls/mod.rs
@@ -17,7 +17,6 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
 
 use super::{AsyncHostError, AsyncHostResult};
 
@@ -133,8 +132,6 @@ pub(crate) enum TlsConfig {
         pfx_content: Vec<u8>,
     },
 }
-
-pub(crate) type TlsHandleRef = Arc<Mutex<TlsHandle>>;
 
 // The wasm ABI exposes one TLS handle. New handles start empty and become a
 // live connection as soon as a client/server setter has enough data.

--- a/crates/moonrun/src/async_host/tls/openssl.rs
+++ b/crates/moonrun/src/async_host/tls/openssl.rs
@@ -16,9 +16,10 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use std::cell::RefCell;
 use std::io::{self, Read, Write};
 use std::net::IpAddr;
-use std::sync::{Arc, Mutex};
+use std::rc::Rc;
 
 use openssl::hash::MessageDigest;
 use openssl::nid::Nid;
@@ -36,7 +37,9 @@ use super::{
 pub(crate) struct TlsConnection {
     stream: Option<SslStream<QueueStream>>,
     pending_ssl: Option<Ssl>,
-    state: Arc<Mutex<BioState>>,
+    // OpenSSL calls QueueStream synchronously on the V8 thread. Share the
+    // scoped buffers with that adapter without implying cross-thread access.
+    state: Rc<RefCell<BioState>>,
     mode: TlsMode,
     shutdown_started: bool,
     shutdown_complete: bool,
@@ -141,7 +144,7 @@ impl TlsConnection {
     }
 
     fn new(ssl: Ssl, mode: TlsMode) -> Result<Self, String> {
-        let state = Arc::new(Mutex::new(BioState::new()));
+        let state = Rc::new(RefCell::new(BioState::new()));
         Ok(Self {
             stream: None,
             pending_ssl: Some(ssl),
@@ -277,22 +280,14 @@ impl TlsConnection {
     ) -> i32 {
         self.last_bytes_read = 0;
         self.last_bytes_to_write = 0;
-        let scoped = self
-            .state
-            .lock()
-            .map_err(|_| "TLS BIO state lock poisoned".to_string())
-            .and_then(|mut state| state.begin_scoped(input, output));
+        let scoped = self.state.borrow_mut().begin_scoped(input, output);
         if let Err(error) = scoped {
             return self.error(error);
         }
 
         let status = f(self);
 
-        let counters = self
-            .state
-            .lock()
-            .map_err(|_| "TLS BIO state lock poisoned".to_string())
-            .and_then(|mut state| state.end_scoped());
+        let counters = self.state.borrow_mut().end_scoped();
         match counters {
             Ok((bytes_read, bytes_to_write)) => {
                 self.last_bytes_read = bytes_read;
@@ -504,7 +499,7 @@ impl TlsConnection {
                 .take()
                 .ok_or_else(|| "TLS stream is not initialized".to_string())?;
             let stream = QueueStream {
-                state: Arc::clone(&self.state),
+                state: Rc::clone(&self.state),
             };
             self.stream = Some(
                 SslStream::new(ssl, stream)
@@ -526,10 +521,7 @@ impl TlsConnection {
     }
 
     fn last_bio_blocked(&self) -> Option<BioBlocked> {
-        self.state
-            .lock()
-            .ok()
-            .and_then(|state| state.last_blocked())
+        self.state.borrow().last_blocked()
     }
 }
 
@@ -627,8 +619,7 @@ struct ScopedBio {
 
 // The raw pointers are borrowed guest-memory slices registered only while a
 // single synchronous OpenSSL call is active. `QueueStream` reaches them through
-// the same mutex and `advance_state` always clears them before returning.
-unsafe impl Send for ScopedBio {}
+// the same RefCell and `advance_state` always clears them before returning.
 
 impl ScopedBio {
     fn new(input: &mut [u8], output: &mut [u8]) -> Self {
@@ -679,7 +670,7 @@ impl ScopedBio {
 
 #[derive(Debug, Clone)]
 struct QueueStream {
-    state: Arc<Mutex<BioState>>,
+    state: Rc<RefCell<BioState>>,
 }
 
 impl Read for QueueStream {
@@ -687,10 +678,7 @@ impl Read for QueueStream {
         if dst.is_empty() {
             return Ok(0);
         }
-        let mut state = self
-            .state
-            .lock()
-            .map_err(|_| io::Error::other("TLS BIO state lock poisoned"))?;
+        let mut state = self.state.borrow_mut();
         if !state.input_pending() {
             state.block_on_read();
             Err(io::Error::from(io::ErrorKind::WouldBlock))
@@ -702,10 +690,7 @@ impl Read for QueueStream {
 
 impl Write for QueueStream {
     fn write(&mut self, src: &[u8]) -> io::Result<usize> {
-        let mut state = self
-            .state
-            .lock()
-            .map_err(|_| io::Error::other("TLS BIO state lock poisoned"))?;
+        let mut state = self.state.borrow_mut();
         let written = state.write_output(src);
         if written == 0 && !src.is_empty() {
             state.block_on_write();

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
@@ -55,7 +55,8 @@ ported_fns! {
         } else {
             Ok(PollInstance {
                 fd: Arc::new(unsafe { OwnedHandle::from_raw_handle(fd) }),
-                events: Vec::new(),
+                raw_events: vec![empty_overlapped_entry(); EVENT_BUFFER_SIZE].into_boxed_slice(),
+                events: Vec::with_capacity(EVENT_BUFFER_SIZE),
             })
         }
     }
@@ -103,12 +104,11 @@ ported_fns! {
         use windows_sys::Win32::System::IO::GetQueuedCompletionStatusEx;
         use windows_sys::Win32::System::Threading::INFINITE;
 
-        let mut entries = vec![empty_overlapped_entry(); EVENT_BUFFER_SIZE];
         let mut count = 0;
         let ok = unsafe {
             GetQueuedCompletionStatusEx(
                 instance.raw_fd(),
-                entries.as_mut_ptr(),
+                instance.raw_events.as_mut_ptr(),
                 EVENT_BUFFER_SIZE as u32,
                 &mut count,
                 if timeout < 0 { INFINITE } else { timeout as u32 },
@@ -122,10 +122,13 @@ ported_fns! {
             }
             return Err(last_native_error());
         }
-        instance.events = entries
-            .into_iter()
-            .take(count as usize)
-            .map(|entry| {
+        instance.events.clear();
+        instance.events.extend(
+            instance
+                .raw_events
+                .iter()
+                .take(count as usize)
+                .map(|entry| {
                 let fd = entry.lpCompletionKey as RawFd;
                 let worker_generation = if is_thread_pool_completion(fd) {
                     worker_generation_from_overlapped(entry.lpOverlapped)
@@ -146,8 +149,8 @@ ported_fns! {
                     bytes_transferred: entry.dwNumberOfBytesTransferred as i32,
                     worker_generation,
                 }
-            })
-            .collect();
+            }),
+        );
         i32::try_from(count).map_err(|_| AsyncHostError::Fault)
     }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
@@ -61,7 +61,6 @@ struct KeventBuffer(Box<[libc::kevent]>);
 // values returned in that field. The buffer owns every event value.
 unsafe impl Send for KeventBuffer {}
 
-#[derive(Debug)]
 pub(crate) struct PollInstance {
     #[cfg(unix)]
     fd: OwnedFd,
@@ -73,7 +72,19 @@ pub(crate) struct PollInstance {
     raw_events: Box<[libc::epoll_event]>,
     #[cfg(target_os = "macos")]
     raw_events: KeventBuffer,
+    #[cfg(windows)]
+    raw_events: Box<[windows_sys::Win32::System::IO::OVERLAPPED_ENTRY]>,
     events: Vec<PollEvent>,
+}
+
+impl std::fmt::Debug for PollInstance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PollInstance")
+            .field("fd", &self.fd)
+            .field("raw_event_capacity", &EVENT_BUFFER_SIZE)
+            .field("events", &self.events)
+            .finish()
+    }
 }
 
 impl PollInstance {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -25,7 +25,7 @@ use std::os::fd::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 
-use crate::async_host::{AsyncHostError, AsyncHostResult, HostCBuffer};
+use crate::async_host::{AsyncHostError, AsyncHostResult, SharedCBuffer};
 use crate::async_sys::internal::fd_util;
 use crate::async_sys::ported_fns;
 
@@ -261,7 +261,7 @@ ported_fns! {
     )]
     pub(super) fn run_readdir_job(
         dir: &Resource,
-        buffer: &HostCBuffer,
+        buffer: &SharedCBuffer,
         len: i32,
         restart: bool,
     ) -> AsyncHostResult<i64> {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -326,7 +326,7 @@ ported_fns! {
     )]
     pub(crate) fn make_readdir_job(
         dir: ResourceRef,
-        buffer: crate::async_host::HostCBuffer,
+        buffer: crate::async_host::SharedCBuffer,
         len: i32,
         restart: bool,
     ) -> Job {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -51,12 +51,12 @@ pub(crate) use types::{
     FileRef, FileTimeResult, HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult,
     RealpathJobResult, Resource, ResourceClass, ResourceRef, ResourceTable, SpawnOptions,
 };
-#[cfg(windows)]
-pub(crate) use worker::worker_cancellation_resource;
 pub(crate) use worker::{
     HostWorkerHandle, HostWorkerJob, HostWorkerJobResult, WorkerCompletionId, cancel_worker,
     free_worker, spawn_worker, wake_worker, worker_enter_idle,
 };
+#[cfg(windows)]
+pub(crate) use worker::{WorkerCancellationTarget, worker_cancellation_target};
 
 #[cfg(test)]
 pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -52,10 +52,10 @@ pub(crate) use types::{
     RealpathJobResult, Resource, ResourceClass, ResourceRef, ResourceTable, SpawnOptions,
 };
 #[cfg(windows)]
-pub(crate) use worker::worker_cancellable_job;
+pub(crate) use worker::worker_cancellation_resource;
 pub(crate) use worker::{
-    HostWorkerHandle, HostWorkerJob, WorkerCompletionId, cancel_worker, free_worker, spawn_worker,
-    wake_worker, worker_enter_idle,
+    HostWorkerHandle, HostWorkerJob, HostWorkerJobResult, WorkerCompletionId, cancel_worker,
+    free_worker, spawn_worker, wake_worker, worker_enter_idle,
 };
 
 #[cfg(test)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -55,7 +55,7 @@ pub(crate) fn run_host_job(job: &mut Job) {
             result,
         } => run_open_job(
             result,
-            filename.clone(),
+            std::mem::take(filename),
             *access,
             *create_mode,
             *append,
@@ -85,7 +85,7 @@ pub(crate) fn run_host_job(job: &mut Job) {
             follow_symlink,
         } => {
             let parent = parent.take();
-            run_file_kind_by_path_job(parent.as_deref(), path.clone(), *follow_symlink)
+            run_file_kind_by_path_job(parent.as_deref(), std::mem::take(path), *follow_symlink)
         }
         JobPayload::FileSize { file, result } => match file.take() {
             Some(file) => run_file_size_job(&file, result),
@@ -100,9 +100,9 @@ pub(crate) fn run_host_job(job: &mut Job) {
             follow_symlink,
             result,
             ..
-        } => run_file_time_by_path_job(path.clone(), *follow_symlink, result),
-        JobPayload::Access { path, access } => run_access_job(path.clone(), *access),
-        JobPayload::Chmod { path, mode } => run_chmod_job(path.clone(), *mode),
+        } => run_file_time_by_path_job(std::mem::take(path), *follow_symlink, result),
+        JobPayload::Access { path, access } => run_access_job(std::mem::take(path), *access),
+        JobPayload::Chmod { path, mode } => run_chmod_job(std::mem::take(path), *mode),
         JobPayload::Fsync { file, only_data } => match file.take() {
             Some(file) => run_fsync_job(&file, *only_data),
             None => Err(AsyncHostError::Badf),
@@ -111,19 +111,19 @@ pub(crate) fn run_host_job(job: &mut Job) {
             Some(file) => run_flock_job(&file, *exclusive),
             None => Err(AsyncHostError::Badf),
         },
-        JobPayload::Remove { path } => run_remove_job(path.clone()),
+        JobPayload::Remove { path } => run_remove_job(std::mem::take(path)),
         JobPayload::Rename {
             old_path,
             new_path,
             replace,
-        } => run_rename_job(old_path.clone(), new_path.clone(), *replace),
+        } => run_rename_job(std::mem::take(old_path), std::mem::take(new_path), *replace),
         JobPayload::Symlink {
             target,
             path,
             force_symlink,
-        } => run_symlink_job(target.clone(), path.clone(), *force_symlink),
-        JobPayload::Mkdir { path, mode } => run_mkdir_job(path.clone(), *mode),
-        JobPayload::Rmdir { path } => run_rmdir_job(path.clone()),
+        } => run_symlink_job(std::mem::take(target), std::mem::take(path), *force_symlink),
+        JobPayload::Mkdir { path, mode } => run_mkdir_job(std::mem::take(path), *mode),
+        JobPayload::Rmdir { path } => run_rmdir_job(std::mem::take(path)),
         JobPayload::Readdir {
             dir,
             buffer,
@@ -138,7 +138,7 @@ pub(crate) fn run_host_job(job: &mut Job) {
             None => Err(AsyncHostError::Badf),
         },
         JobPayload::GetAddrInfo { host, result } => run_getaddrinfo_job(host.clone(), result),
-        JobPayload::Realpath { path, result, .. } => run_realpath_job(path.clone(), result),
+        JobPayload::Realpath { path, result, .. } => run_realpath_job(std::mem::take(path), result),
         #[cfg(unix)]
         JobPayload::SpawnUnix {
             path,
@@ -149,11 +149,11 @@ pub(crate) fn run_host_job(job: &mut Job) {
             cwd,
             result,
         } => run_spawn_job_unix(
-            path.clone(),
-            args.clone(),
-            env.clone(),
-            stdio.clone(),
-            cwd.clone(),
+            std::mem::take(path),
+            std::mem::take(args),
+            std::mem::take(env),
+            std::mem::take(stdio),
+            cwd.take(),
             *options,
             result,
         ),
@@ -166,10 +166,10 @@ pub(crate) fn run_host_job(job: &mut Job) {
             cwd,
             result,
         } => run_spawn_job_windows(
-            command_line.clone(),
-            env.clone(),
-            stdio.clone(),
-            cwd.clone(),
+            std::mem::take(command_line),
+            std::mem::take(env),
+            std::mem::take(stdio),
+            cwd.take(),
             *options,
             result,
         ),

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -20,7 +20,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use crate::async_host::{AsyncHostResult, HostCBuffer};
+use crate::async_host::{AsyncHostResult, SharedCBuffer};
 #[cfg(unix)]
 use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 use crate::async_sys::internal::fd_util;
@@ -488,7 +488,7 @@ pub(crate) enum JobPayload {
     },
     Readdir {
         dir: Option<ResourceRef>,
-        buffer: HostCBuffer,
+        buffer: SharedCBuffer,
         len: i32,
         restart: bool,
     },

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -247,9 +247,12 @@ impl HostWorkerHandle {
             RunningCancellation::Active(Some(cancel)) => {
                 WorkerCancellationTarget::Resource(Arc::clone(cancel))
             }
-            RunningCancellation::Active(None) | RunningCancellation::Idle => {
-                WorkerCancellationTarget::Thread
-            }
+            RunningCancellation::Active(None) => WorkerCancellationTarget::Thread,
+            // A queued Job is not yet the worker thread's current operation.
+            // Match native by targeting the thread; if cancellation races job
+            // startup, CancelSynchronousIo returns RetryLater and MoonBit
+            // retries after the worker publishes the Active target.
+            RunningCancellation::Idle => WorkerCancellationTarget::Thread,
         }
     }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -71,11 +71,24 @@ pub(crate) struct HostWorkerJobResult {
     pub(crate) job: Job,
 }
 
+#[cfg(windows)]
+#[derive(Debug)]
+enum RunningCancellation {
+    Idle,
+    Active(Option<super::ResourceRef>),
+}
+
+#[cfg(windows)]
+pub(crate) enum WorkerCancellationTarget {
+    Thread,
+    Resource(super::ResourceRef),
+}
+
 #[derive(Debug)]
 struct HostWorkerState {
     job: Option<HostWorkerJob>,
     #[cfg(windows)]
-    running_cancel: Option<super::ResourceRef>,
+    running_cancel: RunningCancellation,
     waiting: bool,
     terminating: bool,
 }
@@ -138,7 +151,7 @@ impl HostWorkerHandle {
             state: Mutex::new(HostWorkerState {
                 job: Some(init_job),
                 #[cfg(windows)]
-                running_cancel: None,
+                running_cancel: RunningCancellation::Idle,
                 waiting: false,
                 terminating: false,
             }),
@@ -163,7 +176,10 @@ impl HostWorkerHandle {
                     let job = (!state.terminating).then(|| state.job.take()).flatten();
                     #[cfg(windows)]
                     {
-                        state.running_cancel = job.as_ref().and_then(|job| job.cancel.clone());
+                        state.running_cancel = match job.as_ref() {
+                            Some(job) => RunningCancellation::Active(job.cancel.clone()),
+                            None => RunningCancellation::Idle,
+                        };
                     }
                     job
                 };
@@ -176,7 +192,7 @@ impl HostWorkerHandle {
                     let mut state = worker_shared.state.lock().unwrap();
                     #[cfg(windows)]
                     {
-                        state.running_cancel = None;
+                        state.running_cancel = RunningCancellation::Idle;
                     }
                     if !state.terminating && state.job.is_none() {
                         state.waiting = true;
@@ -225,13 +241,20 @@ impl HostWorkerHandle {
     }
 
     #[cfg(windows)]
-    pub(crate) fn cancellation_resource(&self) -> Option<super::ResourceRef> {
+    pub(crate) fn cancellation_target(&self) -> WorkerCancellationTarget {
         let state = self.shared.state.lock().unwrap();
-        state
-            .running_cancel
-            .as_ref()
-            .cloned()
-            .or_else(|| state.job.as_ref().and_then(|job| job.cancel.clone()))
+        match &state.running_cancel {
+            RunningCancellation::Active(Some(cancel)) => {
+                WorkerCancellationTarget::Resource(Arc::clone(cancel))
+            }
+            RunningCancellation::Active(None) => WorkerCancellationTarget::Thread,
+            RunningCancellation::Idle => state
+                .job
+                .as_ref()
+                .and_then(|job| job.cancel.as_ref())
+                .map(|cancel| WorkerCancellationTarget::Resource(Arc::clone(cancel)))
+                .unwrap_or(WorkerCancellationTarget::Thread),
+        }
     }
 
     pub(crate) fn cancel(&self) -> AsyncHostResult<i32> {
@@ -338,16 +361,16 @@ ported_fns! {
 }
 
 #[cfg(windows)]
-pub(crate) fn worker_cancellation_resource(
-    worker: &HostWorkerHandle,
-) -> Option<super::ResourceRef> {
-    worker.cancellation_resource()
+pub(crate) fn worker_cancellation_target(worker: &HostWorkerHandle) -> WorkerCancellationTarget {
+    worker.cancellation_target()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::async_sys::internal::event_loop::thread_pool::make_sleep_job;
+    #[cfg(windows)]
+    use crate::async_sys::internal::event_loop::thread_pool::make_wait_for_process_job;
     use slotmap::KeyData;
     use std::sync::mpsc;
 
@@ -470,6 +493,63 @@ mod tests {
         );
         assert_eq!(
             completion_receiver.recv().unwrap().0,
+            WorkerCompletionId::from_abi(3)
+        );
+        assert!(free_worker(worker).is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn running_job_cancellation_does_not_target_queued_job() {
+        let (started_sender, started_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let (completion_sender, completion_receiver) = mpsc::channel();
+        let worker = spawn_worker(
+            make_worker_job(1, 2),
+            move |job| {
+                started_sender.send(job.completion_id).unwrap();
+                if job.completion_id == WorkerCompletionId::from_abi(1) {
+                    release_receiver.recv().unwrap();
+                }
+            },
+            move |job| completion_sender.send(job.completion_id).unwrap(),
+        );
+
+        assert_eq!(
+            started_receiver
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .unwrap(),
+            WorkerCompletionId::from_abi(1)
+        );
+        let queued_job = HostWorkerJob::new(
+            WorkerCompletionId::from_abi(3),
+            make_job_key(4),
+            make_wait_for_process_job(None, None, 0).unwrap(),
+        );
+        assert!(queued_job.cancel.is_some());
+        assert!(wake_worker(&worker, queued_job).is_none());
+        assert!(matches!(
+            worker.cancellation_target(),
+            WorkerCancellationTarget::Thread
+        ));
+
+        release_sender.send(()).unwrap();
+        assert_eq!(
+            completion_receiver
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .unwrap(),
+            WorkerCompletionId::from_abi(1)
+        );
+        assert_eq!(
+            started_receiver
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .unwrap(),
+            WorkerCompletionId::from_abi(3)
+        );
+        assert_eq!(
+            completion_receiver
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .unwrap(),
             WorkerCompletionId::from_abi(3)
         );
         assert!(free_worker(worker).is_none());

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -247,13 +247,9 @@ impl HostWorkerHandle {
             RunningCancellation::Active(Some(cancel)) => {
                 WorkerCancellationTarget::Resource(Arc::clone(cancel))
             }
-            RunningCancellation::Active(None) => WorkerCancellationTarget::Thread,
-            RunningCancellation::Idle => state
-                .job
-                .as_ref()
-                .and_then(|job| job.cancel.as_ref())
-                .map(|cancel| WorkerCancellationTarget::Resource(Arc::clone(cancel)))
-                .unwrap_or(WorkerCancellationTarget::Thread),
+            RunningCancellation::Active(None) | RunningCancellation::Idle => {
+                WorkerCancellationTarget::Thread
+            }
         }
     }
 
@@ -687,5 +683,33 @@ mod tests {
                 .is_some_and(|thread| thread.is_finished())
         );
         assert!(free_worker(worker).is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn queued_job_cancellation_targets_the_worker_thread() {
+        let queued_job = HostWorkerJob::new(
+            WorkerCompletionId::from_abi(3),
+            make_job_key(4),
+            make_wait_for_process_job(None, None, 0).unwrap(),
+        );
+        assert!(queued_job.cancel.is_some());
+        let worker = HostWorkerHandle {
+            shared: Arc::new(HostWorkerShared {
+                state: Mutex::new(HostWorkerState {
+                    job: Some(queued_job),
+                    running_cancel: RunningCancellation::Idle,
+                    waiting: false,
+                    terminating: false,
+                }),
+                wakeup: Condvar::new(),
+            }),
+            thread: None,
+        };
+
+        assert!(matches!(
+            worker.cancellation_target(),
+            WorkerCancellationTarget::Thread
+        ));
     }
 }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -41,23 +41,41 @@ impl WorkerCompletionId {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub(crate) struct HostWorkerJob {
     pub(crate) completion_id: WorkerCompletionId,
     pub(crate) job_key: HandleKey,
+    pub(crate) job: Job,
+    #[cfg(windows)]
+    cancel: Option<super::ResourceRef>,
+}
+
+impl HostWorkerJob {
+    pub(crate) fn new(completion_id: WorkerCompletionId, job_key: HandleKey, job: Job) -> Self {
+        #[cfg(windows)]
+        let cancel = super::job_cancel_resource(&job);
+        Self {
+            completion_id,
+            job_key,
+            job,
+            #[cfg(windows)]
+            cancel,
+        }
+    }
 }
 
 #[derive(Debug)]
 pub(crate) struct HostWorkerJobResult {
     pub(crate) completion_id: WorkerCompletionId,
     pub(crate) job_key: HandleKey,
-    pub(crate) job: Option<Job>,
+    pub(crate) job: Job,
 }
 
 #[derive(Debug)]
 struct HostWorkerState {
     job: Option<HostWorkerJob>,
-    running: Option<HostWorkerJob>,
+    #[cfg(windows)]
+    running_cancel: Option<super::ResourceRef>,
     waiting: bool,
     terminating: bool,
 }
@@ -74,8 +92,6 @@ struct HostWorkerShared {
 pub(crate) struct HostWorkerHandle {
     shared: Arc<HostWorkerShared>,
     thread: Option<JoinHandle<()>>,
-    #[cfg(unix)]
-    thread_id: Arc<Mutex<Option<libc::pthread_t>>>,
 }
 
 impl std::fmt::Debug for HostWorkerHandle {
@@ -112,7 +128,7 @@ fn init_worker_signal_handler() {
 impl HostWorkerHandle {
     pub(crate) fn spawn(
         init_job: HostWorkerJob,
-        mut run_job: impl FnMut(HostWorkerJob) -> Option<Job> + Send + 'static,
+        mut run_job: impl FnMut(&mut HostWorkerJob) + Send + 'static,
         mut complete_job: impl FnMut(HostWorkerJobResult) + Send + 'static,
     ) -> Self {
         #[cfg(unix)]
@@ -121,7 +137,8 @@ impl HostWorkerHandle {
         let shared = Arc::new(HostWorkerShared {
             state: Mutex::new(HostWorkerState {
                 job: Some(init_job),
-                running: None,
+                #[cfg(windows)]
+                running_cancel: None,
                 waiting: false,
                 terminating: false,
             }),
@@ -129,16 +146,11 @@ impl HostWorkerHandle {
         });
         let worker_shared = Arc::clone(&shared);
         #[cfg(unix)]
-        let thread_id = Arc::new(Mutex::new(None));
-        #[cfg(unix)]
-        let worker_thread_id = Arc::clone(&thread_id);
-        #[cfg(unix)]
         let parent_signal_mask = crate::async_sys::signal::set_worker_thread_signal_mask().ok();
         let thread = std::thread::spawn(move || {
             #[cfg(unix)]
             {
                 let _ = crate::async_sys::signal::set_worker_thread_signal_mask();
-                *worker_thread_id.lock().unwrap() = Some(unsafe { libc::pthread_self() });
             }
 
             loop {
@@ -148,20 +160,24 @@ impl HostWorkerHandle {
                         state.waiting = true;
                         state = worker_shared.wakeup.wait(state).unwrap();
                     }
-                    (!state.terminating).then(|| state.job.take()).flatten()
+                    let job = (!state.terminating).then(|| state.job.take()).flatten();
+                    #[cfg(windows)]
+                    {
+                        state.running_cancel = job.as_ref().and_then(|job| job.cancel.clone());
+                    }
+                    job
                 };
-                let Some(job) = job else {
+                let Some(mut job) = job else {
                     break;
                 };
-                {
-                    let mut state = worker_shared.state.lock().unwrap();
-                    state.running = Some(job);
-                }
-                let result = run_job(job);
+                run_job(&mut job);
 
                 let terminating = {
                     let mut state = worker_shared.state.lock().unwrap();
-                    state.running = None;
+                    #[cfg(windows)]
+                    {
+                        state.running_cancel = None;
+                    }
                     if !state.terminating && state.job.is_none() {
                         state.waiting = true;
                     }
@@ -170,21 +186,15 @@ impl HostWorkerHandle {
                 complete_job(HostWorkerJobResult {
                     completion_id: job.completion_id,
                     job_key: job.job_key,
-                    job: result,
+                    job: job.job,
                 });
                 if terminating {
                     break;
                 }
             }
-
-            #[cfg(unix)]
-            {
-                *worker_thread_id.lock().unwrap() = None;
-            }
         });
         #[cfg(unix)]
         {
-            *thread_id.lock().unwrap() = Some(thread.as_pthread_t());
             if let Some(parent_signal_mask) = parent_signal_mask {
                 let _ =
                     crate::async_sys::signal::restore_thread_pool_signal_mask(&parent_signal_mask);
@@ -193,8 +203,6 @@ impl HostWorkerHandle {
         Self {
             shared,
             thread: Some(thread),
-            #[cfg(unix)]
-            thread_id,
         }
     }
 
@@ -217,22 +225,27 @@ impl HostWorkerHandle {
     }
 
     #[cfg(windows)]
-    pub(crate) fn cancellable_job(&self) -> Option<HostWorkerJob> {
+    pub(crate) fn cancellation_resource(&self) -> Option<super::ResourceRef> {
         let state = self.shared.state.lock().unwrap();
-        state.running.or(state.job)
+        state
+            .running_cancel
+            .as_ref()
+            .cloned()
+            .or_else(|| state.job.as_ref().and_then(|job| job.cancel.clone()))
     }
 
     pub(crate) fn cancel(&self) -> AsyncHostResult<i32> {
-        if self.shared.state.lock().unwrap().waiting {
-            return Ok(1);
-        }
-
         #[cfg(unix)]
         {
-            if let Some(thread_id) = *self.thread_id.lock().unwrap() {
-                unsafe {
-                    libc::pthread_kill(thread_id, libc::SIGUSR2);
-                }
+            let state = self.shared.state.lock().unwrap();
+            if state.waiting {
+                return Ok(1);
+            }
+            let Some(thread) = &self.thread else {
+                return Err(crate::async_host::AsyncHostError::Badf);
+            };
+            unsafe {
+                libc::pthread_kill(thread.as_pthread_t(), libc::SIGUSR2);
             }
             Ok(0)
         }
@@ -243,6 +256,9 @@ impl HostWorkerHandle {
             use windows_sys::Win32::Foundation::{ERROR_NOT_FOUND, GetLastError};
             use windows_sys::Win32::System::IO::CancelSynchronousIo;
 
+            if self.shared.state.lock().unwrap().waiting {
+                return Ok(1);
+            }
             let Some(thread) = &self.thread else {
                 return Err(AsyncHostError::Badf);
             };
@@ -279,7 +295,7 @@ ported_fns! {
     )]
     pub(crate) fn spawn_worker(
         init_job: HostWorkerJob,
-        run_job: impl FnMut(HostWorkerJob) -> Option<Job> + Send + 'static,
+        run_job: impl FnMut(&mut HostWorkerJob) + Send + 'static,
         complete_job: impl FnMut(HostWorkerJobResult) + Send + 'static,
     ) -> HostWorkerHandle {
         HostWorkerHandle::spawn(init_job, run_job, complete_job)
@@ -322,8 +338,10 @@ ported_fns! {
 }
 
 #[cfg(windows)]
-pub(crate) fn worker_cancellable_job(worker: &HostWorkerHandle) -> Option<HostWorkerJob> {
-    worker.cancellable_job()
+pub(crate) fn worker_cancellation_resource(
+    worker: &HostWorkerHandle,
+) -> Option<super::ResourceRef> {
+    worker.cancellation_resource()
 }
 
 #[cfg(test)]
@@ -346,10 +364,11 @@ mod tests {
     }
 
     fn make_worker_job(completion_id: i32, job_key: u64) -> HostWorkerJob {
-        HostWorkerJob {
-            completion_id: WorkerCompletionId::from_abi(completion_id),
-            job_key: make_job_key(job_key),
-        }
+        HostWorkerJob::new(
+            WorkerCompletionId::from_abi(completion_id),
+            make_job_key(job_key),
+            make_sleep_job(0),
+        )
     }
 
     #[test]
@@ -359,8 +378,7 @@ mod tests {
         let worker = spawn_worker(
             make_worker_job(7, 11),
             move |job| {
-                sender.send(worker_job_summary(&job)).unwrap();
-                Some(make_sleep_job(0))
+                sender.send(worker_job_summary(job)).unwrap();
             },
             move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
         );
@@ -394,8 +412,7 @@ mod tests {
         let worker = spawn_worker(
             make_worker_job(1, 2),
             move |job| {
-                sender.send(worker_job_summary(&job)).unwrap();
-                Some(make_sleep_job(0))
+                sender.send(worker_job_summary(job)).unwrap();
             },
             move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
         );
@@ -425,11 +442,10 @@ mod tests {
         let worker = spawn_worker(
             make_worker_job(1, 2),
             move |job| {
-                started_sender.send(worker_job_summary(&job)).unwrap();
+                started_sender.send(worker_job_summary(job)).unwrap();
                 if job.completion_id == WorkerCompletionId::from_abi(1) {
                     release_receiver.recv().unwrap();
                 }
-                Some(make_sleep_job(0))
             },
             move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
         );
@@ -464,12 +480,8 @@ mod tests {
         let (completion_sender, completion_receiver) = mpsc::channel();
         let worker = spawn_worker(
             make_worker_job(1, 2),
-            move |_| {
-                let mut job = make_sleep_job(0);
-                job.set_ret(123);
-                Some(job)
-            },
-            move |job| completion_sender.send(job.job.unwrap().ret()).unwrap(),
+            move |job| job.job.set_ret(123),
+            move |job| completion_sender.send(job.job.ret()).unwrap(),
         );
 
         assert_eq!(completion_receiver.recv().unwrap(), 123);
@@ -477,20 +489,15 @@ mod tests {
     }
 
     #[test]
-    fn completion_reports_missing_job_and_worker_continues() {
+    fn worker_continues_after_completion() {
         let (started_sender, started_receiver) = mpsc::channel();
         let (completion_sender, completion_receiver) = mpsc::channel();
         let worker = spawn_worker(
             make_worker_job(1, 2),
             move |job| {
-                started_sender.send(worker_job_summary(&job)).unwrap();
-                None
+                started_sender.send(worker_job_summary(job)).unwrap();
             },
-            move |job| {
-                completion_sender
-                    .send((worker_result_summary(&job), job.job.is_some()))
-                    .unwrap()
-            },
+            move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
         );
 
         assert_eq!(
@@ -499,7 +506,7 @@ mod tests {
         );
         assert_eq!(
             completion_receiver.recv().unwrap(),
-            ((WorkerCompletionId::from_abi(1), make_job_key(2)), false)
+            (WorkerCompletionId::from_abi(1), make_job_key(2))
         );
 
         assert!(wake_worker(&worker, make_worker_job(3, 4)).is_none());
@@ -509,7 +516,7 @@ mod tests {
         );
         assert_eq!(
             completion_receiver.recv().unwrap(),
-            ((WorkerCompletionId::from_abi(3), make_job_key(4)), false)
+            (WorkerCompletionId::from_abi(3), make_job_key(4))
         );
         assert!(free_worker(worker).is_none());
     }
@@ -522,9 +529,8 @@ mod tests {
         let worker = spawn_worker(
             make_worker_job(1, 2),
             move |job| {
-                started_sender.send(worker_job_summary(&job)).unwrap();
+                started_sender.send(worker_job_summary(job)).unwrap();
                 release_receiver.recv().unwrap();
-                Some(make_sleep_job(0))
             },
             move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
         );
@@ -568,9 +574,8 @@ mod tests {
         let worker = spawn_worker(
             make_worker_job(21, 34),
             move |job| {
-                started_sender.send(worker_job_summary(&job)).unwrap();
+                started_sender.send(worker_job_summary(job)).unwrap();
                 release_receiver.recv().unwrap();
-                Some(make_sleep_job(0))
             },
             move |job| completion_sender.send(worker_result_summary(&job)).unwrap(),
         );


### PR DESCRIPTION
## Why

Moonrun's async host is owned by the V8 thread, but several host-local tables and short-lived resources were represented as if they were generally shared. That added unnecessary locking, atomic reference-count traffic, and cloning around async imports.

## What changed

- Keep handle, job, poll, buffer, TLS, and other host-local state on the V8 thread without synchronization.
- Transfer complete jobs to workers and return completed jobs through the completion channel instead of sharing the job table.
- Detach in-flight jobs safely when their guest handle is freed; workers retain ownership and discarded completions release their results.
- Move one-shot job payloads into workers and upgrade C buffers to shared storage only for jobs that retain them.
- Reuse the Windows IOCP event buffer.
- Distinguish borrowed Resources used synchronously from acquired Resources retained by jobs or pending Windows I/O.
- Keep Windows worker cancellation targeted at the active operation rather than a queued job.

## Correctness

Generation-checked Resource Handles remain the guest-visible identity. Synchronous borrows cannot escape an import, while acquired Resources keep the underlying OS object alive when work outlives the Resource Handle. Freeing an in-flight job removes only the guest-visible handle; the worker-owned Job remains valid, and its eventual result is discarded without contaminating a reused handle slot. Pending Windows I/O continues to protect retained resources until completion.

The MoonBit-facing async ABI and valid native behavior are unchanged. Invalid or stale handles continue to be rejected safely.

## Scope

This PR is limited to ownership and synchronization inside the async host. Poll event identity remains unchanged and is handled separately so its cross-platform stale-event invariant can be reviewed independently.