### PR TITLE
perf(moonrun): read native poll events directly

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -59,6 +59,7 @@ _Avoid_: Host Handle, Guest Handle, raw fd, pointer, id
 **Poll Token**:
 An opaque snapshot of Resource Handle identity attached to a Host Poller registration and returned with its events.
 It preserves the handle generation across Resource closure and platform identifier reuse.
+Supported moonrun hosts are 64-bit, so the complete Handle identity fits platform-sized poll fields without truncation.
 _Avoid_: Resource Handle, raw fd, completion key, pointer
 
 **Acquired Resource**:

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -56,6 +56,11 @@ A Resource Handle is a Handle that names a Resource while it remains reachable t
 Closing a Resource Handle removes future reachability; it does not describe ownership of already-acquired references.
 _Avoid_: Host Handle, Guest Handle, raw fd, pointer, id
 
+**Poll Token**:
+An opaque snapshot of Resource Handle identity attached to a Host Poller registration and returned with its events.
+It preserves the handle generation across Resource closure and platform identifier reuse.
+_Avoid_: Resource Handle, raw fd, completion key, pointer
+
 **Acquired Resource**:
 A host-owned reference to a Resource captured before a Job runs.
 It lets an already-submitted Job finish without duplicating OS handles, even if the Resource Handle is closed later.
@@ -83,7 +88,7 @@ The V8-free native-stub port layer. Implemented files follow the `moonbitlang/as
 _Avoid_: V8 adapter, placeholder unsupported imports
 
 **Host Poller**:
-The `async_sys::internal::event_loop::poll` port of native epoll, kqueue, or IOCP. The wasm event loop owns opaque `Instance` handles and calls `poll/wait`, `poll/event_fd`, and `poll/event_events`; moonrun resolves registered file-like Resource Handles to platform fds or HANDLEs.
+The `async_sys::internal::event_loop::poll` port of native epoll, kqueue, or IOCP. The wasm event loop owns opaque `Instance` handles and calls `poll/wait`, `poll/event_fd`, and `poll/event_events`; the Host Poller returns Poll Tokens that moonrun validates as live Resource Handles.
 _Avoid_: Completion queue, worker wakeup
 
 **Thread-Pool Completion Source**:

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -83,7 +83,7 @@ The V8-free native-stub port layer. Implemented files follow the `moonbitlang/as
 _Avoid_: V8 adapter, placeholder unsupported imports
 
 **Host Poller**:
-The `async_sys::internal::event_loop::poll` port of native epoll, kqueue, or IOCP. The wasm event loop owns opaque `Instance` handles and calls `poll/wait`, `poll/event_fd`, and `poll/event_events`. A Resource Handle is stored directly in the poller's opaque user-data field and returned unchanged as the event's `fd`; later Resource operations—not the event accessor—validate that Handle.
+The `async_sys::internal::event_loop::poll` port of native epoll, kqueue, or IOCP. The wasm event loop owns opaque `Instance` handles and calls `poll/wait`, `poll/event_fd`, and `poll/event_events`. Resource registrations store their Resource Handle directly in the poller's opaque user-data field. The event accessor returns the native field unchanged, including platform-specific non-Resource values; later Resource operations—not the accessor—validate any returned Handle.
 _Avoid_: Completion queue, worker wakeup
 
 **Thread-Pool Completion Source**:

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -89,7 +89,7 @@ The V8-free native-stub port layer. Implemented files follow the `moonbitlang/as
 _Avoid_: V8 adapter, placeholder unsupported imports
 
 **Host Poller**:
-The `async_sys::internal::event_loop::poll` port of native epoll, kqueue, or IOCP. The wasm event loop owns opaque `Instance` handles and calls `poll/wait`, `poll/event_fd`, and `poll/event_events`; the Host Poller returns Poll Tokens that moonrun validates as live Resource Handles.
+The `async_sys::internal::event_loop::poll` port of native epoll, kqueue, or IOCP. The wasm event loop owns opaque `Instance` handles and calls `poll/wait`, `poll/event_fd`, and `poll/event_events`; the Host Poller returns opaque Poll Tokens unchanged. Resource registrations encode their generation-bearing Resource Handle in the token, while later Resource operations—not the event accessor—validate that identity.
 _Avoid_: Completion queue, worker wakeup
 
 **Thread-Pool Completion Source**:

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -56,12 +56,6 @@ A Resource Handle is a Handle that names a Resource while it remains reachable t
 Closing a Resource Handle removes future reachability; it does not describe ownership of already-acquired references.
 _Avoid_: Host Handle, Guest Handle, raw fd, pointer, id
 
-**Poll Token**:
-An opaque snapshot of Resource Handle identity attached to a Host Poller registration and returned with its events.
-It preserves the handle generation across Resource closure and platform identifier reuse.
-Supported moonrun hosts are 64-bit, so the complete Handle identity fits platform-sized poll fields without truncation.
-_Avoid_: Resource Handle, raw fd, completion key, pointer
-
 **Acquired Resource**:
 A host-owned reference to a Resource captured before a Job runs.
 It lets an already-submitted Job finish without duplicating OS handles, even if the Resource Handle is closed later.
@@ -89,7 +83,7 @@ The V8-free native-stub port layer. Implemented files follow the `moonbitlang/as
 _Avoid_: V8 adapter, placeholder unsupported imports
 
 **Host Poller**:
-The `async_sys::internal::event_loop::poll` port of native epoll, kqueue, or IOCP. The wasm event loop owns opaque `Instance` handles and calls `poll/wait`, `poll/event_fd`, and `poll/event_events`; the Host Poller returns opaque Poll Tokens unchanged. Resource registrations encode their generation-bearing Resource Handle in the token, while later Resource operations—not the event accessor—validate that identity.
+The `async_sys::internal::event_loop::poll` port of native epoll, kqueue, or IOCP. The wasm event loop owns opaque `Instance` handles and calls `poll/wait`, `poll/event_fd`, and `poll/event_events`. A Resource Handle is stored directly in the poller's opaque user-data field and returned unchanged as the event's `fd`; later Resource operations—not the event accessor—validate that Handle.
 _Avoid_: Completion queue, worker wakeup
 
 **Thread-Pool Completion Source**:

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -4,6 +4,11 @@
 
 Moonrun is the WebAssembly runtime for MoonBit, utilizing V8 at its core to offer an efficient and flexible environment for executing WASM.
 
+## Platform Support
+
+Moonrun currently supports 64-bit host targets only. 32-bit host targets are
+not supported.
+
 # Building and Running
 
 ## Building

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -697,19 +697,6 @@ struct ThreadPoolCompletions {
     old_signal_mask: Option<libc::sigset_t>,
     #[cfg(windows)]
     target: Option<ThreadPoolCompletionTarget>,
-    #[cfg(windows)]
-    generation_counter: usize,
-}
-
-impl ThreadPoolCompletions {
-    #[cfg(windows)]
-    fn advance_generation(&mut self) -> usize {
-        self.generation_counter = self.generation_counter.wrapping_add(1);
-        if self.generation_counter == 0 {
-            self.generation_counter = 1;
-        }
-        self.generation_counter
-    }
 }
 
 #[cfg(unix)]
@@ -767,7 +754,6 @@ impl IoResultTable {
 struct ThreadPoolCompletionTarget {
     poll: HandleKey,
     port: poll::CompletionPort,
-    generation: usize,
 }
 
 #[cfg(windows)]
@@ -1560,18 +1546,22 @@ impl AsyncHost {
         let poll_key = handles.poll(poll_handle)?;
         let mut polls = self.polls.borrow_mut();
         let poll = polls.polls.get_mut(poll_key).ok_or(AsyncHostError::Badf)?;
-        let token = poll::PollToken::new(fd_handle);
         #[cfg(unix)]
-        poll::poll_register(&poll.instance, raw_fd, read_only, token)?;
+        poll::poll_register(&poll.instance, raw_fd, read_only, fd_handle)?;
         #[cfg(windows)]
         if resource.resource_class().is_socket() {
-            poll::poll_register_socket(&poll.instance, resource.as_socket()?, read_only, token)?;
+            poll::poll_register_socket(
+                &poll.instance,
+                resource.as_socket()?,
+                read_only,
+                fd_handle,
+            )?;
         } else {
             poll::poll_register_file(
                 &poll.instance,
                 resource.as_file()?.as_raw_handle(),
                 read_only,
-                token,
+                fd_handle,
             )?;
         }
         #[cfg(unix)]
@@ -1591,47 +1581,10 @@ impl AsyncHost {
 
     pub(crate) fn poll_wait(&self, poll_handle: u64, timeout_ms: i32) -> AsyncHostResult<i32> {
         let poll_key = self.handles.borrow().poll(poll_handle)?;
-        #[cfg(windows)]
-        let thread_pool_generation = self
-            .thread_pool_completions
-            .borrow()
-            .target
-            .as_ref()
-            .filter(|target| target.poll == poll_key)
-            .map(|target| target.generation);
         let mut polls = self.polls.borrow_mut();
         let result = {
             let poll = polls.polls.get_mut(poll_key).ok_or(AsyncHostError::Badf)?;
-            #[cfg(not(windows))]
-            let result = poll::poll_wait(&mut poll.instance, timeout_ms)?;
-            #[cfg(windows)]
-            let result = {
-                let deadline = (timeout_ms >= 0).then(|| {
-                    std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms as u64)
-                });
-                let mut next_timeout = timeout_ms;
-                loop {
-                    poll::poll_wait(&mut poll.instance, next_timeout)?;
-                    let result = poll::retain_current_thread_pool_completions(
-                        &mut poll.instance,
-                        thread_pool_generation,
-                    )?;
-                    if result != 0 || timeout_ms == 0 {
-                        break result;
-                    }
-                    let Some(deadline) = deadline else {
-                        continue;
-                    };
-                    let now = std::time::Instant::now();
-                    if now >= deadline {
-                        break 0;
-                    }
-                    next_timeout = i32::try_from(deadline.duration_since(now).as_millis())
-                        .unwrap_or(i32::MAX)
-                        .max(1);
-                }
-            };
-            result
+            poll::poll_wait(&mut poll.instance, timeout_ms)?
         };
         polls.current_event_poll = Some(poll_key);
         drop(polls);
@@ -1664,14 +1617,7 @@ impl AsyncHost {
     }
 
     pub(crate) fn poll_event_fd(&self, event_handle: u64) -> AsyncHostResult<HostHandle> {
-        let token = self.with_event(event_handle, |event| Ok(poll::event_get_token(event)))?;
-        #[cfg(windows)]
-        let Some(token) = token else {
-            return raw_fd_to_guest(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE);
-        };
-        #[cfg(unix)]
-        let token = token.ok_or(AsyncHostError::Badf)?;
-        Ok(token.get())
+        self.with_event(event_handle, |event| Ok(poll::event_get_fd(event)))
     }
 
     #[cfg(target_os = "macos")]
@@ -1736,9 +1682,7 @@ impl AsyncHost {
                 .handles
                 .borrow_mut()
                 .insert_resource(Resource::new(event_fd));
-            if let Err(error) =
-                poll::poll_register(&poll.instance, event_fd, true, poll::PollToken::new(source))
-            {
+            if let Err(error) = poll::poll_register(&poll.instance, event_fd, true, source) {
                 let _ = self.handles.borrow_mut().remove_resource(source);
                 return Err(error);
             }
@@ -1770,11 +1714,9 @@ impl AsyncHost {
             if completions.target.is_some() {
                 return Err(AsyncHostError::Inval);
             }
-            let generation = completions.advance_generation();
             completions.target = Some(ThreadPoolCompletionTarget {
                 poll: poll_key,
                 port: completion_port,
-                generation,
             });
             raw_fd_to_guest(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE)
         }
@@ -3529,7 +3471,6 @@ impl AsyncHost {
                 let _ = poll::post_thread_pool_completion(
                     &completion_target.port,
                     completion_id.as_i32(),
-                    completion_target.generation,
                 );
             })
         };
@@ -3622,14 +3563,12 @@ impl AsyncHost {
     }
 
     #[cfg(windows)]
-    pub(crate) fn thread_pool_completion_target(
-        &self,
-    ) -> AsyncHostResult<(poll::CompletionPort, usize)> {
+    pub(crate) fn thread_pool_completion_target(&self) -> AsyncHostResult<poll::CompletionPort> {
         self.thread_pool_completions
             .borrow()
             .target
             .as_ref()
-            .map(|target| (target.port.clone(), target.generation))
+            .map(|target| target.port.clone())
             .ok_or(AsyncHostError::Badf)
     }
 
@@ -5782,7 +5721,7 @@ mod tests {
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let completion = host.thread_pool_completion_target().unwrap();
 
-        poll::post_thread_pool_completion(&completion.0, 42, completion.1).unwrap();
+        poll::post_thread_pool_completion(&completion, 42).unwrap();
 
         assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
         let event = host.poll_get_event(poll, 0).unwrap();
@@ -5808,53 +5747,7 @@ mod tests {
 
         host.poll_destroy(poll).unwrap();
 
-        poll::post_thread_pool_completion(&completion.0, 42, completion.1).unwrap();
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn stale_thread_pool_completions_are_ignored_after_reinit() {
-        let host = AsyncHost::default();
-        let poll = host.poll_create().unwrap();
-
-        host.init_thread_pool(poll).unwrap();
-        let stale_completion = host
-            .thread_pool_completions
-            .borrow()
-            .target
-            .clone()
-            .unwrap();
-        // Fill the current IOCP batch so a valid completion can sit behind
-        // stale completions from the destroyed pool generation.
-        for completion_id in 0..1024 {
-            poll::post_thread_pool_completion(
-                &stale_completion.port,
-                completion_id,
-                stale_completion.generation,
-            )
-            .unwrap();
-        }
-        host.destroy_thread_pool();
-
-        let completion_notifier = host.init_thread_pool(poll).unwrap();
-        let current_completion = host
-            .thread_pool_completions
-            .borrow()
-            .target
-            .clone()
-            .unwrap();
-        assert_ne!(stale_completion.generation, current_completion.generation);
-
-        poll::post_thread_pool_completion(
-            &current_completion.port,
-            43,
-            current_completion.generation,
-        )
-        .unwrap();
-        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
-        let event = host.poll_get_event(poll, 0).unwrap();
-        assert_eq!(host.poll_event_fd(event).unwrap(), completion_notifier);
-        assert_eq!(host.poll_event_bytes_transferred(event).unwrap(), 43);
+        poll::post_thread_pool_completion(&completion, 42).unwrap();
     }
 
     #[test]
@@ -6316,7 +6209,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn unregistered_iocp_completion_token_is_returned() {
+    fn unregistered_iocp_completion_key_is_returned() {
         use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
         let host = AsyncHost::default();
@@ -6340,7 +6233,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn zero_iocp_completion_token_is_returned() {
+    fn zero_iocp_completion_key_is_returned() {
         use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
         let host = AsyncHost::default();
@@ -6362,7 +6255,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn close_fd_preserves_polled_iocp_resource_token() {
+    fn close_fd_preserves_polled_iocp_resource_handle() {
         use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
         let host = AsyncHost::default();
@@ -6426,7 +6319,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn close_fd_preserves_polled_resource_token() {
+    fn close_fd_preserves_polled_resource_handle() {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let [read, write] = host.pipe(true, true).unwrap();

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -432,13 +432,6 @@ impl HandleTable {
         Ok(Arc::clone(resource))
     }
 
-    fn contains_resource(&self, handle: HostHandle) -> bool {
-        self.key(handle, HandleKind::Resource)
-            .ok()
-            .and_then(|key| self.resources.get(key))
-            .is_some_and(|resource| !resource.is_invalid())
-    }
-
     fn remove_resource(&mut self, handle: HostHandle) -> AsyncHostResult<ResourceRef> {
         let key = self.key(handle, HandleKind::Resource)?;
         if key == self.invalid_resource || self.stdio_resources.contains(&key) {
@@ -791,7 +784,8 @@ impl OverlappedAddr {
 #[derive(Debug)]
 struct HostPoll {
     instance: PollInstance,
-    registered_fds: HashMap<isize, HostHandle>,
+    #[cfg(unix)]
+    registered_fds: HashSet<RawFd>,
     #[cfg(unix)]
     completion_notifier: Option<Arc<ThreadPoolCompletionNotifier>>,
 }
@@ -1487,7 +1481,8 @@ impl AsyncHost {
             key,
             HostPoll {
                 instance,
-                registered_fds: HashMap::new(),
+                #[cfg(unix)]
+                registered_fds: HashSet::new(),
                 #[cfg(unix)]
                 completion_notifier: None,
             },
@@ -1560,7 +1555,6 @@ impl AsyncHost {
     ) -> AsyncHostResult<()> {
         let handles = self.handles.borrow();
         let resource = handles.resource(fd_handle)?;
-        let resource_identity = resource.raw_identity();
         #[cfg(unix)]
         let raw_fd = resource.as_file()?.as_raw_fd();
         let poll_key = handles.poll(poll_handle)?;
@@ -1580,7 +1574,8 @@ impl AsyncHost {
                 token,
             )?;
         }
-        poll.registered_fds.insert(resource_identity, fd_handle);
+        #[cfg(unix)]
+        poll.registered_fds.insert(raw_fd);
         Ok(())
     }
 
@@ -1676,12 +1671,7 @@ impl AsyncHost {
         };
         #[cfg(unix)]
         let token = token.ok_or(AsyncHostError::Badf)?;
-        let handle = token.get();
-        self.handles
-            .borrow()
-            .contains_resource(handle)
-            .then_some(handle)
-            .ok_or(AsyncHostError::Badf)
+        Ok(token.get())
     }
 
     #[cfg(target_os = "macos")]
@@ -1762,7 +1752,7 @@ impl AsyncHost {
                 }
                 // Publish the poll-side mapping before exposing the notifier:
                 // workers can notify as soon as completions.notifier is visible.
-                poll.registered_fds.insert(raw_fd_key(event_fd), source);
+                poll.registered_fds.insert(event_fd);
                 poll.completion_notifier = Some(Arc::clone(&completion_notifier));
                 completions.notifier = Some(completion_notifier);
                 completions.source = Some(source);
@@ -1828,10 +1818,10 @@ impl AsyncHost {
             {
                 let raw_fd = file.as_raw_fd();
                 for poll in polls.polls.values_mut() {
-                    if poll.registered_fds.contains_key(&raw_fd_key(raw_fd)) {
+                    if poll.registered_fds.contains(&raw_fd) {
                         let _ = poll::poll_unregister(&poll.instance, raw_fd);
                     }
-                    poll.registered_fds.remove(&raw_fd_key(raw_fd));
+                    poll.registered_fds.remove(&raw_fd);
                 }
             }
             for poll in polls.polls.values_mut() {
@@ -2326,19 +2316,17 @@ impl AsyncHost {
             handles.remove_resource(handle)?
         };
         self.untrack_process_handle(handle);
-        let resource_identity = file.raw_identity();
-        #[cfg(unix)]
-        let raw_fd = file.as_fd()?.as_raw_fd();
-        let mut polls = self.polls.borrow_mut();
-        for poll in polls.polls.values_mut() {
-            if poll.registered_fds.contains_key(&resource_identity) {
-                #[cfg(unix)]
-                let _ = poll::poll_unregister(&poll.instance, raw_fd);
-            }
-            poll.registered_fds.remove(&resource_identity);
-        }
+        #[cfg(windows)]
+        drop(file);
         #[cfg(unix)]
         {
+            let raw_fd = file.as_fd()?.as_raw_fd();
+            let mut polls = self.polls.borrow_mut();
+            for poll in polls.polls.values_mut() {
+                if poll.registered_fds.remove(&raw_fd) {
+                    let _ = poll::poll_unregister(&poll.instance, raw_fd);
+                }
+            }
             let (completion_source_closed, old_signal_mask) = {
                 let mut completions = self.thread_pool_completions.borrow_mut();
                 if completions.source == Some(handle) {
@@ -4199,11 +4187,6 @@ fn event_index(event: u64) -> AsyncHostResult<i32> {
     i32::try_from(event).map_err(|_| AsyncHostError::Fault)
 }
 
-#[cfg(unix)]
-fn raw_fd_key(fd: RawFd) -> isize {
-    fd as isize
-}
-
 #[cfg(test)]
 mod tests {
     use std::ffi::OsString;
@@ -4798,12 +4781,7 @@ mod tests {
         {
             let polls = host.polls.borrow();
             let poll = polls.polls.get(poll_key(&host, poll)).unwrap();
-            assert_eq!(
-                poll.registered_fds
-                    .get(&raw_fd_key(raw_completion_fd))
-                    .copied(),
-                Some(completion_source)
-            );
+            assert!(poll.registered_fds.contains(&raw_completion_fd));
         }
 
         {
@@ -6338,7 +6316,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn unregistered_iocp_completion_token_is_rejected() {
+    fn unregistered_iocp_completion_token_is_returned() {
         use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
         let host = AsyncHost::default();
@@ -6348,21 +6326,43 @@ mod tests {
             let poll = polls.polls.get(poll_key(&host, poll)).unwrap();
             poll.instance.raw_fd()
         };
-        let raw_fd = 0x1234usize as RawFd;
+        let completion_key = 0x1234usize;
         let posted = unsafe {
-            PostQueuedCompletionStatus(completion_port, 0, raw_fd as usize, std::ptr::null_mut())
+            PostQueuedCompletionStatus(completion_port, 0, completion_key, std::ptr::null_mut())
         };
         assert_ne!(posted, 0);
 
         assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
         let event = host.poll_get_event(poll, 0).unwrap();
 
-        assert_eq!(host.poll_event_fd(event), Err(AsyncHostError::Badf));
+        assert_eq!(host.poll_event_fd(event).unwrap(), completion_key as u64);
     }
 
     #[cfg(windows)]
     #[test]
-    fn close_fd_invalidates_polled_iocp_resource_token() {
+    fn zero_iocp_completion_token_is_returned() {
+        use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
+
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let completion_port = {
+            let polls = host.polls.borrow();
+            let poll = polls.polls.get(poll_key(&host, poll)).unwrap();
+            poll.instance.raw_fd()
+        };
+        let posted =
+            unsafe { PostQueuedCompletionStatus(completion_port, 0, 0, std::ptr::null_mut()) };
+        assert_ne!(posted, 0);
+
+        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+        let event = host.poll_get_event(poll, 0).unwrap();
+
+        assert_eq!(host.poll_event_fd(event).unwrap(), 0);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn close_fd_preserves_polled_iocp_resource_token() {
         use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
         let host = AsyncHost::default();
@@ -6388,7 +6388,8 @@ mod tests {
 
         host.close_fd(read).unwrap();
 
-        assert_eq!(host.poll_event_fd(event), Err(AsyncHostError::Badf));
+        assert_eq!(host.poll_event_fd(event).unwrap(), read);
+        assert_eq!(host.close_fd(read), Err(AsyncHostError::Badf));
         host.close_fd(write).unwrap();
     }
 
@@ -6425,7 +6426,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn close_fd_invalidates_polled_resource_token() {
+    fn close_fd_preserves_polled_resource_token() {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let [read, write] = host.pipe(true, true).unwrap();
@@ -6445,7 +6446,8 @@ mod tests {
 
         host.close_fd(read).unwrap();
 
-        assert_eq!(host.poll_event_fd(event), Err(AsyncHostError::Badf));
+        assert_eq!(host.poll_event_fd(event).unwrap(), read);
+        assert_eq!(host.close_fd(read), Err(AsyncHostError::Badf));
         host.close_fd(write).unwrap();
     }
 

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -794,7 +794,6 @@ struct HostPoll {
     registered_fds: HashMap<isize, HostHandle>,
     #[cfg(unix)]
     completion_notifier: Option<Arc<ThreadPoolCompletionNotifier>>,
-    event_fd_handles: Vec<Option<HostHandle>>,
 }
 
 #[cfg(windows)]
@@ -1491,7 +1490,6 @@ impl AsyncHost {
                 registered_fds: HashMap::new(),
                 #[cfg(unix)]
                 completion_notifier: None,
-                event_fd_handles: Vec::new(),
             },
         );
         Ok(handle_from_key(key))
@@ -1568,16 +1566,18 @@ impl AsyncHost {
         let poll_key = handles.poll(poll_handle)?;
         let mut polls = self.polls.borrow_mut();
         let poll = polls.polls.get_mut(poll_key).ok_or(AsyncHostError::Badf)?;
+        let token = poll::PollToken::new(fd_handle);
         #[cfg(unix)]
-        poll::poll_register(&poll.instance, raw_fd, read_only)?;
+        poll::poll_register(&poll.instance, raw_fd, read_only, token)?;
         #[cfg(windows)]
         if resource.resource_class().is_socket() {
-            poll::poll_register_socket(&poll.instance, resource.as_socket()?, read_only)?;
+            poll::poll_register_socket(&poll.instance, resource.as_socket()?, read_only, token)?;
         } else {
             poll::poll_register_file(
                 &poll.instance,
                 resource.as_file()?.as_raw_handle(),
                 read_only,
+                token,
             )?;
         }
         poll.registered_fds.insert(resource_identity, fd_handle);
@@ -1597,16 +1597,13 @@ impl AsyncHost {
     pub(crate) fn poll_wait(&self, poll_handle: u64, timeout_ms: i32) -> AsyncHostResult<i32> {
         let poll_key = self.handles.borrow().poll(poll_handle)?;
         #[cfg(windows)]
-        let (thread_pool_generation, invalid_fd) = {
-            let thread_pool_generation = self
-                .thread_pool_completions
-                .borrow()
-                .target
-                .as_ref()
-                .filter(|target| target.poll == poll_key)
-                .map(|target| target.generation);
-            (thread_pool_generation, self.invalid_fd())
-        };
+        let thread_pool_generation = self
+            .thread_pool_completions
+            .borrow()
+            .target
+            .as_ref()
+            .filter(|target| target.poll == poll_key)
+            .map(|target| target.generation);
         let mut polls = self.polls.borrow_mut();
         let result = {
             let poll = polls.polls.get_mut(poll_key).ok_or(AsyncHostError::Badf)?;
@@ -1639,19 +1636,6 @@ impl AsyncHost {
                         .max(1);
                 }
             };
-            poll.event_fd_handles.clear();
-            for index in 0..result {
-                let event = poll::event_list_get(&poll.instance, index)?;
-                let raw_fd = poll::event_get_fd(event);
-                let fd_handle = poll
-                    .registered_fds
-                    .get(&raw_fd_key(raw_fd))
-                    .copied()
-                    .or_else(|| completion_event_fd(raw_fd));
-                #[cfg(windows)]
-                let fd_handle = fd_handle.or(Some(invalid_fd));
-                poll.event_fd_handles.push(fd_handle);
-            }
             result
         };
         polls.current_event_poll = Some(poll_key);
@@ -1674,58 +1658,45 @@ impl AsyncHost {
     fn with_event<T>(
         &self,
         event_handle: u64,
-        f: impl FnOnce(&HostPoll, &poll::PollEvent) -> AsyncHostResult<T>,
+        f: impl FnOnce(&poll::PollEvent) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
         let index = event_index(event_handle)?;
         let polls = self.polls.borrow();
         let poll_key = polls.current_event_poll.ok_or(AsyncHostError::Badf)?;
         let poll = polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?;
         let poll_event = poll::event_list_get(&poll.instance, index)?;
-        f(poll, poll_event)
+        f(poll_event)
     }
 
     pub(crate) fn poll_event_fd(&self, event_handle: u64) -> AsyncHostResult<HostHandle> {
-        let index = event_index(event_handle)?;
-        let fd = {
-            let polls = self.polls.borrow();
-            let poll_key = polls.current_event_poll.ok_or(AsyncHostError::Badf)?;
-            let poll = polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?;
-            let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
-            poll.event_fd_handles
-                .get(index)
-                .copied()
-                .flatten()
-                .ok_or(AsyncHostError::Badf)?
-        };
+        let token = self.with_event(event_handle, |event| Ok(poll::event_get_token(event)))?;
         #[cfg(windows)]
-        let is_thread_pool_completion =
-            fd == raw_fd_to_guest(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE)?;
-        #[cfg(not(windows))]
-        let is_thread_pool_completion = false;
-        let handles = self.handles.borrow();
-        if fd == handles.invalid_fd() || is_thread_pool_completion {
-            Ok(fd)
-        } else {
-            handles
-                .contains_resource(fd)
-                .then_some(fd)
-                .ok_or(AsyncHostError::Badf)
-        }
+        let Some(token) = token else {
+            return raw_fd_to_guest(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE);
+        };
+        #[cfg(unix)]
+        let token = token.ok_or(AsyncHostError::Badf)?;
+        let handle = token.get();
+        self.handles
+            .borrow()
+            .contains_resource(handle)
+            .then_some(handle)
+            .ok_or(AsyncHostError::Badf)
     }
 
     #[cfg(target_os = "macos")]
     pub(crate) fn poll_event_pid(&self, event_handle: u64) -> AsyncHostResult<i32> {
-        self.with_event(event_handle, |_, event| Ok(poll::event_get_fd(event)))
+        self.with_event(event_handle, |event| Ok(poll::event_get_pid(event)))
     }
 
     #[cfg(unix)]
     pub(crate) fn poll_event_events(&self, event_handle: u64) -> AsyncHostResult<i32> {
-        self.with_event(event_handle, |_, event| Ok(poll::event_get_events(event)))
+        self.with_event(event_handle, |event| Ok(poll::event_get_events(event)))
     }
 
     #[cfg(windows)]
     pub(crate) fn poll_event_io_result(&self, event_handle: u64) -> AsyncHostResult<u64> {
-        let overlapped = self.with_event(event_handle, |_, event| {
+        let overlapped = self.with_event(event_handle, |event| {
             Ok(OverlappedAddr::from_ptr(poll::event_get_io_result(event)))
         })?;
         let handle = {
@@ -1748,7 +1719,7 @@ impl AsyncHost {
 
     #[cfg(windows)]
     pub(crate) fn poll_event_bytes_transferred(&self, event_handle: u64) -> AsyncHostResult<i32> {
-        self.with_event(event_handle, |_, event| {
+        self.with_event(event_handle, |event| {
             Ok(poll::event_get_bytes_transferred(event))
         })
     }
@@ -1769,20 +1740,26 @@ impl AsyncHost {
             let signal_mask_guard = ThreadPoolSignalMaskGuard::new(old_signal_mask);
             let mut polls = self.polls.borrow_mut();
             let poll = polls.polls.get_mut(poll_key).ok_or(AsyncHostError::Badf)?;
-            let (completion_notifier, event_fd) =
-                ThreadPoolCompletionNotifier::new(&poll.instance)?;
+            let (completion_notifier, event_fd) = ThreadPoolCompletionNotifier::new()?;
             let completion_notifier = Arc::new(completion_notifier);
+            let source = self
+                .handles
+                .borrow_mut()
+                .insert_resource(Resource::new(event_fd));
+            if let Err(error) =
+                poll::poll_register(&poll.instance, event_fd, true, poll::PollToken::new(source))
+            {
+                let _ = self.handles.borrow_mut().remove_resource(source);
+                return Err(error);
+            }
             let source = {
                 let mut completions = self.thread_pool_completions.borrow_mut();
                 if completions.source.is_some() {
                     drop(completions);
                     let _ = poll::poll_unregister(&poll.instance, event_fd);
-                    drop(Resource::new(event_fd));
+                    let _ = self.handles.borrow_mut().remove_resource(source);
                     return Err(AsyncHostError::Inval);
                 }
-                let mut handles = self.handles.borrow_mut();
-                let source = handles.insert_resource(Resource::new(event_fd));
-                drop(handles);
                 // Publish the poll-side mapping before exposing the notifier:
                 // workers can notify as soon as completions.notifier is visible.
                 poll.registered_fds.insert(raw_fd_key(event_fd), source);
@@ -4218,30 +4195,11 @@ fn raw_fd_to_guest(fd: RawFd) -> AsyncHostResult<HostHandle> {
     Ok(fd as usize as u64)
 }
 
-#[cfg(unix)]
-fn completion_event_fd(_fd: RawFd) -> Option<HostHandle> {
-    None
-}
-
-#[cfg(windows)]
-fn completion_event_fd(fd: RawFd) -> Option<HostHandle> {
-    if fd == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
-        raw_fd_to_guest(fd).ok()
-    } else {
-        None
-    }
-}
-
 fn event_index(event: u64) -> AsyncHostResult<i32> {
     i32::try_from(event).map_err(|_| AsyncHostError::Fault)
 }
 
 #[cfg(unix)]
-fn raw_fd_key(fd: RawFd) -> isize {
-    fd as isize
-}
-
-#[cfg(windows)]
 fn raw_fd_key(fd: RawFd) -> isize {
     fd as isize
 }
@@ -6380,7 +6338,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn unregistered_iocp_completion_reports_invalid_fd() {
+    fn unregistered_iocp_completion_token_is_rejected() {
         use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
         let host = AsyncHost::default();
@@ -6399,7 +6357,39 @@ mod tests {
         assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
         let event = host.poll_get_event(poll, 0).unwrap();
 
-        assert_eq!(host.poll_event_fd(event).unwrap(), host.invalid_fd());
+        assert_eq!(host.poll_event_fd(event), Err(AsyncHostError::Badf));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn close_fd_invalidates_polled_iocp_resource_token() {
+        use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
+
+        let host = AsyncHost::default();
+        let poll = host.poll_create().unwrap();
+        let [read, write] = host.pipe(true, true).unwrap();
+        host.poll_register(poll, read, true).unwrap();
+        let completion_port = {
+            let polls = host.polls.borrow();
+            let poll = polls.polls.get(poll_key(&host, poll)).unwrap();
+            poll.instance.raw_fd()
+        };
+        let posted = unsafe {
+            PostQueuedCompletionStatus(
+                completion_port,
+                0,
+                usize::try_from(read).unwrap(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_ne!(posted, 0);
+        assert_eq!(host.poll_wait(poll, 1000).unwrap(), 1);
+        let event = host.poll_get_event(poll, 0).unwrap();
+
+        host.close_fd(read).unwrap();
+
+        assert_eq!(host.poll_event_fd(event), Err(AsyncHostError::Badf));
+        host.close_fd(write).unwrap();
     }
 
     #[cfg(unix)]
@@ -6435,7 +6425,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn close_fd_invalidates_cached_poll_event_fd() {
+    fn close_fd_invalidates_polled_resource_token() {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let [read, write] = host.pipe(true, true).unwrap();

--- a/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/completion.rs
@@ -19,8 +19,6 @@
 #[cfg(unix)]
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 #[cfg(unix)]
-use crate::async_sys::internal::event_loop::poll;
-#[cfg(unix)]
 use crate::async_sys::internal::fd_util::stub as fd_util;
 #[cfg(unix)]
 use crate::async_sys::internal::fd_util::stub::RawFd;
@@ -34,13 +32,8 @@ pub(crate) struct ThreadPoolCompletionNotifier {
 
 #[cfg(unix)]
 impl ThreadPoolCompletionNotifier {
-    pub(crate) fn new(poll: &poll::PollInstance) -> AsyncHostResult<(Self, RawFd)> {
+    pub(crate) fn new() -> AsyncHostResult<(Self, RawFd)> {
         let fds = fd_util::pipe(true, false)?;
-
-        if let Err(error) = poll::poll_register(poll, fds[0], true) {
-            close_fds(fds);
-            return Err(error);
-        }
 
         // The read end is transferred to AsyncHost's file table so poll
         // events report the same handle space as ordinary pipe/file fds.
@@ -116,14 +109,6 @@ impl Drop for ThreadPoolCompletionNotifier {
 }
 
 #[cfg(unix)]
-fn close_fds(fds: [RawFd; 2]) {
-    unsafe {
-        libc::close(fds[0]);
-        libc::close(fds[1]);
-    }
-}
-
-#[cfg(unix)]
 fn last_errno() -> i32 {
     std::io::Error::last_os_error()
         .raw_os_error()
@@ -141,8 +126,7 @@ mod tests {
 
     #[test]
     fn completion_pipe_is_close_on_exec() {
-        let poll = poll::poll_create().unwrap();
-        let (notifier, notify_recv) = ThreadPoolCompletionNotifier::new(&poll).unwrap();
+        let (notifier, notify_recv) = ThreadPoolCompletionNotifier::new().unwrap();
 
         for fd in [notify_recv, notifier.notify_send] {
             let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -22,7 +22,8 @@ use crate::async_sys::ported_fns;
 use std::os::fd::{FromRawFd, OwnedFd};
 
 use super::{
-    EVENT_BUFFER_SIZE, PollEvent, PollInstance, READ_EVENT, WRITE_EVENT, last_native_error,
+    EVENT_BUFFER_SIZE, PollEvent, PollInstance, PollToken, READ_EVENT, WRITE_EVENT,
+    last_native_error,
 };
 
 ported_fns! {
@@ -63,6 +64,7 @@ ported_fns! {
         instance: &PollInstance,
         fd: RawFd,
         read_only: bool,
+        token: PollToken,
     ) -> AsyncHostResult<()> {
         let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
         if flags >= 0 && (flags & libc::O_NONBLOCK) == 0 {
@@ -77,7 +79,7 @@ ported_fns! {
         };
         let mut event = libc::epoll_event {
             events: epoll_event_mask(events)?,
-            u64: fd as u64,
+            u64: token.get(),
         };
         if unsafe { libc::epoll_ctl(instance.raw_fd(), libc::EPOLL_CTL_ADD, fd, &mut event) } < 0 {
             Err(last_native_error())
@@ -109,7 +111,7 @@ ported_fns! {
             .iter()
             .take(count as usize)
             .map(|event| PollEvent {
-                fd: event.u64 as RawFd,
+                token: Some(PollToken::new(event.u64)),
                 events: epoll_result_events(event.events),
             }),
         );
@@ -129,8 +131,8 @@ ported_fns! {
         source = "src/internal/event_loop/epoll.c",
         original = "moonbitlang_async_event_get_fd"
     )]
-    pub(crate) fn event_get_fd(event: &PollEvent) -> RawFd {
-        event.fd
+    pub(crate) fn event_get_token(event: &PollEvent) -> Option<PollToken> {
+        event.token
     }
 
     #[ported(

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -22,8 +22,7 @@ use crate::async_sys::ported_fns;
 use std::os::fd::{FromRawFd, OwnedFd};
 
 use super::{
-    EVENT_BUFFER_SIZE, PollEvent, PollInstance, PollToken, READ_EVENT, WRITE_EVENT,
-    last_native_error,
+    EVENT_BUFFER_SIZE, PollEvent, PollInstance, READ_EVENT, WRITE_EVENT, last_native_error,
 };
 
 ported_fns! {
@@ -43,7 +42,7 @@ ported_fns! {
                     EVENT_BUFFER_SIZE
                 ]
                 .into_boxed_slice(),
-                events: Vec::with_capacity(EVENT_BUFFER_SIZE),
+                event_count: 0,
             })
         }
     }
@@ -64,7 +63,7 @@ ported_fns! {
         instance: &PollInstance,
         fd: RawFd,
         read_only: bool,
-        token: PollToken,
+        fd_handle: u64,
     ) -> AsyncHostResult<()> {
         let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
         if flags >= 0 && (flags & libc::O_NONBLOCK) == 0 {
@@ -79,7 +78,7 @@ ported_fns! {
         };
         let mut event = libc::epoll_event {
             events: epoll_event_mask(events)?,
-            u64: token.get(),
+            u64: fd_handle,
         };
         if unsafe { libc::epoll_ctl(instance.raw_fd(), libc::EPOLL_CTL_ADD, fd, &mut event) } < 0 {
             Err(last_native_error())
@@ -104,17 +103,7 @@ ported_fns! {
         if count < 0 {
             return Err(last_native_error());
         }
-        instance.events.clear();
-        instance.events.extend(
-            instance
-            .raw_events
-            .iter()
-            .take(count as usize)
-            .map(|event| PollEvent {
-                token: Some(PollToken::new(event.u64)),
-                events: epoll_result_events(event.events),
-            }),
-        );
+        instance.event_count = count as usize;
         Ok(count)
     }
 
@@ -124,15 +113,21 @@ ported_fns! {
     )]
     pub(crate) fn event_list_get(instance: &PollInstance, index: i32) -> AsyncHostResult<&PollEvent> {
         let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
-        instance.events.get(index).ok_or(AsyncHostError::Fault)
+        if index >= instance.event_count {
+            return Err(AsyncHostError::Fault);
+        }
+        instance
+            .raw_events
+            .get(index)
+            .ok_or(AsyncHostError::Fault)
     }
 
     #[ported(
         source = "src/internal/event_loop/epoll.c",
         original = "moonbitlang_async_event_get_fd"
     )]
-    pub(crate) fn event_get_token(event: &PollEvent) -> Option<PollToken> {
-        event.token
+    pub(crate) fn event_get_fd(event: &PollEvent) -> u64 {
+        event.u64
     }
 
     #[ported(
@@ -140,7 +135,7 @@ ported_fns! {
         original = "moonbitlang_async_event_get_events"
     )]
     pub(crate) fn event_get_events(event: &PollEvent) -> i32 {
-        event.events
+        epoll_result_events(event.events)
     }
 }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
@@ -25,7 +25,7 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::ported_fns;
 
-use super::{EVENT_BUFFER_SIZE, PollEvent, PollInstance, PollToken, last_errno, last_native_error};
+use super::{EVENT_BUFFER_SIZE, PollEvent, PollInstance, last_errno, last_native_error};
 
 #[derive(Debug, Clone)]
 pub(crate) struct CompletionPort(Arc<OwnedHandle>);
@@ -56,7 +56,7 @@ ported_fns! {
             Ok(PollInstance {
                 fd: Arc::new(unsafe { OwnedHandle::from_raw_handle(fd) }),
                 raw_events: vec![empty_overlapped_entry(); EVENT_BUFFER_SIZE].into_boxed_slice(),
-                events: Vec::with_capacity(EVENT_BUFFER_SIZE),
+                event_count: 0,
             })
         }
     }
@@ -77,7 +77,7 @@ ported_fns! {
         instance: &PollInstance,
         fd: RawFd,
         read_only: bool,
-        token: PollToken,
+        fd_handle: u64,
     ) -> AsyncHostResult<()> {
         use windows_sys::Win32::Storage::FileSystem::SetFileCompletionNotificationModes;
         use windows_sys::Win32::System::IO::CreateIoCompletionPort;
@@ -87,9 +87,9 @@ ported_fns! {
         if unsafe { SetFileCompletionNotificationModes(fd, FILE_SKIP_COMPLETION_PORT_ON_SUCCESS as u8) } == 0 {
             return Err(last_native_error());
         }
-        let registered = unsafe {
-            CreateIoCompletionPort(fd, instance.raw_fd(), token.as_usize()?, 0)
-        };
+        let completion_key = usize::try_from(fd_handle).map_err(|_| AsyncHostError::Fault)?;
+        let registered =
+            unsafe { CreateIoCompletionPort(fd, instance.raw_fd(), completion_key, 0) };
         if registered.is_null() {
             Err(last_native_error())
         } else {
@@ -119,44 +119,12 @@ ported_fns! {
         };
         if ok == 0 {
             if last_errno() == WAIT_TIMEOUT as i32 {
-                instance.events.clear();
+                instance.event_count = 0;
                 return Ok(0);
             }
             return Err(last_native_error());
         }
-        instance.events.clear();
-        instance.events.extend(
-            instance
-                .raw_events
-                .iter()
-                .take(count as usize)
-                .map(|entry| {
-                let fd = entry.lpCompletionKey as RawFd;
-                let worker_generation = if is_thread_pool_completion(fd) {
-                    worker_generation_from_overlapped(entry.lpOverlapped)
-                } else {
-                    None
-                };
-                PollEvent {
-                    token: if worker_generation.is_some() {
-                        None
-                    } else {
-                        Some(PollToken::from_completion_key(entry.lpCompletionKey))
-                    },
-                    events: 0,
-                    // Worker completion packets use lpOverlapped only as a
-                    // host generation token; guest-visible worker events match
-                    // native and expose no IO result.
-                    io_result: if worker_generation.is_some() {
-                        0
-                    } else {
-                        entry.lpOverlapped as usize
-                    },
-                    bytes_transferred: entry.dwNumberOfBytesTransferred as i32,
-                    worker_generation,
-                }
-            }),
-        );
+        instance.event_count = count as usize;
         i32::try_from(count).map_err(|_| AsyncHostError::Fault)
     }
 
@@ -166,15 +134,21 @@ ported_fns! {
     )]
     pub(crate) fn event_list_get(instance: &PollInstance, index: i32) -> AsyncHostResult<&PollEvent> {
         let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
-        instance.events.get(index).ok_or(AsyncHostError::Fault)
+        if index >= instance.event_count {
+            return Err(AsyncHostError::Fault);
+        }
+        instance
+            .raw_events
+            .get(index)
+            .ok_or(AsyncHostError::Fault)
     }
 
     #[ported(
         source = "src/internal/event_loop/iocp.c",
         original = "moonbitlang_async_event_get_fd"
     )]
-    pub(crate) fn event_get_token(event: &PollEvent) -> Option<PollToken> {
-        event.token
+    pub(crate) fn event_get_fd(event: &PollEvent) -> u64 {
+        event.lpCompletionKey as u64
     }
 
     #[ported(
@@ -184,7 +158,7 @@ ported_fns! {
     pub(crate) fn event_get_io_result(
         event: &PollEvent,
     ) -> *mut windows_sys::Win32::System::IO::OVERLAPPED {
-        event.io_result as *mut windows_sys::Win32::System::IO::OVERLAPPED
+        event.lpOverlapped
     }
 
     #[ported(
@@ -192,7 +166,7 @@ ported_fns! {
         original = "moonbitlang_async_event_get_bytes_transferred"
     )]
     pub(crate) fn event_get_bytes_transferred(event: &PollEvent) -> i32 {
-        event.bytes_transferred
+        event.dwNumberOfBytesTransferred as i32
     }
 }
 
@@ -200,75 +174,49 @@ pub(crate) fn poll_register_file(
     instance: &PollInstance,
     handle: RawHandle,
     read_only: bool,
-    token: PollToken,
+    fd_handle: u64,
 ) -> AsyncHostResult<()> {
-    poll_register(instance, handle, read_only, token)
+    poll_register(instance, handle, read_only, fd_handle)
 }
 
 pub(crate) fn poll_register_socket(
     instance: &PollInstance,
     socket: BorrowedSocket<'_>,
     read_only: bool,
-    token: PollToken,
+    fd_handle: u64,
 ) -> AsyncHostResult<()> {
     // IOCP accepts a socket value in the HANDLE parameter. Keep that Windows
     // ABI conversion inside the IOCP adapter rather than the resource model.
-    poll_register(instance, socket.as_raw_socket() as RawFd, read_only, token)
+    poll_register(
+        instance,
+        socket.as_raw_socket() as RawFd,
+        read_only,
+        fd_handle,
+    )
 }
 
 pub(crate) fn post_thread_pool_completion(
     completion_port: &CompletionPort,
     completion_id: i32,
-    generation: usize,
 ) -> AsyncHostResult<()> {
     use windows_sys::Win32::Foundation::{GetLastError, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
-    debug_assert_ne!(generation, 0);
     // Native thread_pool.c posts worker completions to the event bus IOCP with
     // INVALID_HANDLE_VALUE as the completion key and the native job id as
-    // transferred bytes. Rust treats that value as an opaque completion id.
+    // transferred bytes.
     if unsafe {
         PostQueuedCompletionStatus(
             completion_port.0.as_raw_handle(),
             completion_id as u32,
             INVALID_HANDLE_VALUE as usize,
-            worker_generation_to_overlapped(generation),
+            std::ptr::null_mut(),
         )
     } == 0
     {
         return Err(AsyncHostError::Native(unsafe { GetLastError() } as i32));
     }
     Ok(())
-}
-
-pub(crate) fn retain_current_thread_pool_completions(
-    instance: &mut PollInstance,
-    generation: Option<usize>,
-) -> AsyncHostResult<i32> {
-    instance.events.retain(|event| {
-        event
-            .worker_generation
-            .is_none_or(|event_generation| Some(event_generation) == generation)
-    });
-    i32::try_from(instance.events.len()).map_err(|_| AsyncHostError::Fault)
-}
-
-fn is_thread_pool_completion(fd: RawFd) -> bool {
-    fd == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE
-}
-
-fn worker_generation_to_overlapped(
-    generation: usize,
-) -> *mut windows_sys::Win32::System::IO::OVERLAPPED {
-    generation as *mut windows_sys::Win32::System::IO::OVERLAPPED
-}
-
-fn worker_generation_from_overlapped(
-    overlapped: *mut windows_sys::Win32::System::IO::OVERLAPPED,
-) -> Option<usize> {
-    let generation = overlapped as usize;
-    (generation != 0).then_some(generation)
 }
 
 fn empty_overlapped_entry() -> windows_sys::Win32::System::IO::OVERLAPPED_ENTRY {

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
@@ -25,7 +25,7 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::ported_fns;
 
-use super::{EVENT_BUFFER_SIZE, PollEvent, PollInstance, last_errno, last_native_error};
+use super::{EVENT_BUFFER_SIZE, PollEvent, PollInstance, PollToken, last_errno, last_native_error};
 
 #[derive(Debug, Clone)]
 pub(crate) struct CompletionPort(Arc<OwnedHandle>);
@@ -77,6 +77,7 @@ ported_fns! {
         instance: &PollInstance,
         fd: RawFd,
         read_only: bool,
+        token: PollToken,
     ) -> AsyncHostResult<()> {
         use windows_sys::Win32::Storage::FileSystem::SetFileCompletionNotificationModes;
         use windows_sys::Win32::System::IO::CreateIoCompletionPort;
@@ -86,8 +87,9 @@ ported_fns! {
         if unsafe { SetFileCompletionNotificationModes(fd, FILE_SKIP_COMPLETION_PORT_ON_SUCCESS as u8) } == 0 {
             return Err(last_native_error());
         }
-        let registered =
-            unsafe { CreateIoCompletionPort(fd, instance.raw_fd(), fd as usize, 0) };
+        let registered = unsafe {
+            CreateIoCompletionPort(fd, instance.raw_fd(), token.as_usize()?, 0)
+        };
         if registered.is_null() {
             Err(last_native_error())
         } else {
@@ -136,7 +138,11 @@ ported_fns! {
                     None
                 };
                 PollEvent {
-                    fd: entry.lpCompletionKey,
+                    token: if worker_generation.is_some() {
+                        None
+                    } else {
+                        PollToken::from_usize(entry.lpCompletionKey)
+                    },
                     events: 0,
                     // Worker completion packets use lpOverlapped only as a
                     // host generation token; guest-visible worker events match
@@ -167,8 +173,8 @@ ported_fns! {
         source = "src/internal/event_loop/iocp.c",
         original = "moonbitlang_async_event_get_fd"
     )]
-    pub(crate) fn event_get_fd(event: &PollEvent) -> RawFd {
-        event.fd as RawFd
+    pub(crate) fn event_get_token(event: &PollEvent) -> Option<PollToken> {
+        event.token
     }
 
     #[ported(
@@ -194,18 +200,20 @@ pub(crate) fn poll_register_file(
     instance: &PollInstance,
     handle: RawHandle,
     read_only: bool,
+    token: PollToken,
 ) -> AsyncHostResult<()> {
-    poll_register(instance, handle, read_only)
+    poll_register(instance, handle, read_only, token)
 }
 
 pub(crate) fn poll_register_socket(
     instance: &PollInstance,
     socket: BorrowedSocket<'_>,
     read_only: bool,
+    token: PollToken,
 ) -> AsyncHostResult<()> {
     // IOCP accepts a socket value in the HANDLE parameter. Keep that Windows
     // ABI conversion inside the IOCP adapter rather than the resource model.
-    poll_register(instance, socket.as_raw_socket() as RawFd, read_only)
+    poll_register(instance, socket.as_raw_socket() as RawFd, read_only, token)
 }
 
 pub(crate) fn post_thread_pool_completion(

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
@@ -141,7 +141,7 @@ ported_fns! {
                     token: if worker_generation.is_some() {
                         None
                     } else {
-                        PollToken::from_usize(entry.lpCompletionKey)
+                        Some(PollToken::from_completion_key(entry.lpCompletionKey))
                     },
                     events: 0,
                     // Worker completion packets use lpOverlapped only as a

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
@@ -22,7 +22,7 @@ use crate::async_sys::ported_fns;
 use std::os::fd::{FromRawFd, OwnedFd};
 
 use super::{
-    EVENT_BUFFER_SIZE, KeventBuffer, PROCESS_EVENT, PollEvent, PollInstance, PollToken, READ_EVENT,
+    EVENT_BUFFER_SIZE, KeventBuffer, PROCESS_EVENT, PollEvent, PollInstance, READ_EVENT,
     WRITE_EVENT, last_errno, last_native_error,
 };
 
@@ -41,7 +41,7 @@ ported_fns! {
                 raw_events: KeventBuffer(
                     vec![empty_kevent(); EVENT_BUFFER_SIZE].into_boxed_slice(),
                 ),
-                events: Vec::with_capacity(EVENT_BUFFER_SIZE),
+                event_count: 0,
             })
         }
     }
@@ -62,7 +62,7 @@ ported_fns! {
         instance: &PollInstance,
         fd: RawFd,
         read_only: bool,
-        token: PollToken,
+        fd_handle: u64,
     ) -> AsyncHostResult<()> {
         let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
         if flags >= 0 && (flags & libc::O_NONBLOCK) == 0 {
@@ -79,7 +79,7 @@ ported_fns! {
                 flags,
                 0,
                 0,
-                Some(token),
+                Some(fd_handle),
             )?,
             new_kevent(
                 fd as libc::uintptr_t,
@@ -87,7 +87,7 @@ ported_fns! {
                 flags,
                 0,
                 0,
-                Some(token),
+                Some(fd_handle),
             )?,
         ];
         if unsafe {
@@ -174,19 +174,7 @@ ported_fns! {
         if count < 0 {
             return Err(last_native_error());
         }
-        instance.events.clear();
-        instance.events.extend(
-            instance
-                .raw_events
-                .0
-                .iter()
-            .take(count as usize)
-            .map(|event| PollEvent {
-                token: PollToken::from_usize(event.udata as usize),
-                ident: event.ident as RawFd,
-                events: kqueue_result_events(event),
-            }),
-        );
+        instance.event_count = count as usize;
         Ok(count)
     }
 
@@ -196,15 +184,29 @@ ported_fns! {
     )]
     pub(crate) fn event_list_get(instance: &PollInstance, index: i32) -> AsyncHostResult<&PollEvent> {
         let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
-        instance.events.get(index).ok_or(AsyncHostError::Fault)
+        if index >= instance.event_count {
+            return Err(AsyncHostError::Fault);
+        }
+        instance
+            .raw_events
+            .0
+            .get(index)
+            .ok_or(AsyncHostError::Fault)
     }
 
     #[ported(
         source = "src/internal/event_loop/kqueue.c",
         original = "moonbitlang_async_event_get_fd"
     )]
-    pub(crate) fn event_get_token(event: &PollEvent) -> Option<PollToken> {
-        event.token
+    pub(crate) fn event_get_fd(event: &PollEvent) -> u64 {
+        let fd_handle = event.udata as usize;
+        // Resource filters carry the guest Resource Handle in udata. Process
+        // filters have no Resource Handle and preserve native's ident result.
+        if fd_handle == 0 {
+            event.ident as u64
+        } else {
+            fd_handle as u64
+        }
     }
 
     #[ported(
@@ -212,12 +214,12 @@ ported_fns! {
         original = "moonbitlang_async_event_get_events"
     )]
     pub(crate) fn event_get_events(event: &PollEvent) -> i32 {
-        event.events
+        kqueue_result_events(event)
     }
 }
 
 pub(crate) fn event_get_pid(event: &PollEvent) -> RawFd {
-    event.ident
+    event.ident as RawFd
 }
 
 pub(crate) fn poll_unregister(instance: &PollInstance, fd: RawFd) -> AsyncHostResult<()> {
@@ -265,7 +267,7 @@ fn new_kevent(
     flags: u16,
     fflags: u32,
     data: libc::intptr_t,
-    token: Option<PollToken>,
+    fd_handle: Option<u64>,
 ) -> AsyncHostResult<libc::kevent> {
     let mut event = empty_kevent();
     event.ident = ident;
@@ -273,10 +275,10 @@ fn new_kevent(
     event.flags = flags;
     event.fflags = fflags;
     event.data = data;
-    event.udata = token
-        .map(PollToken::as_usize)
+    event.udata = fd_handle
+        .map(|handle| usize::try_from(handle).map_err(|_| AsyncHostError::Fault))
         .transpose()?
-        .map_or(std::ptr::null_mut(), |token| token as *mut libc::c_void);
+        .map_or(std::ptr::null_mut(), |handle| handle as *mut libc::c_void);
     Ok(event)
 }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
@@ -22,7 +22,7 @@ use crate::async_sys::ported_fns;
 use std::os::fd::{FromRawFd, OwnedFd};
 
 use super::{
-    EVENT_BUFFER_SIZE, KeventBuffer, PROCESS_EVENT, PollEvent, PollInstance, READ_EVENT,
+    EVENT_BUFFER_SIZE, KeventBuffer, PROCESS_EVENT, PollEvent, PollInstance, PollToken, READ_EVENT,
     WRITE_EVENT, last_errno, last_native_error,
 };
 
@@ -62,6 +62,7 @@ ported_fns! {
         instance: &PollInstance,
         fd: RawFd,
         read_only: bool,
+        token: PollToken,
     ) -> AsyncHostResult<()> {
         let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
         if flags >= 0 && (flags & libc::O_NONBLOCK) == 0 {
@@ -72,8 +73,22 @@ ported_fns! {
 
         let flags = libc::EV_ADD | libc::EV_CLEAR;
         let events = [
-            new_kevent(fd as libc::uintptr_t, libc::EVFILT_READ, flags, 0, 0),
-            new_kevent(fd as libc::uintptr_t, libc::EVFILT_WRITE, flags, 0, 0),
+            new_kevent(
+                fd as libc::uintptr_t,
+                libc::EVFILT_READ,
+                flags,
+                0,
+                0,
+                Some(token),
+            )?,
+            new_kevent(
+                fd as libc::uintptr_t,
+                libc::EVFILT_WRITE,
+                flags,
+                0,
+                0,
+                Some(token),
+            )?,
         ];
         if unsafe {
             libc::kevent(
@@ -102,7 +117,14 @@ ported_fns! {
         let fflags = libc::NOTE_EXITSTATUS;
         #[cfg(not(target_os = "macos"))]
         let fflags = libc::NOTE_EXIT;
-        let event = new_kevent(pid as libc::uintptr_t, libc::EVFILT_PROC, flags, fflags, 0);
+        let event = new_kevent(
+            pid as libc::uintptr_t,
+            libc::EVFILT_PROC,
+            flags,
+            fflags,
+            0,
+            None,
+        )?;
         let ret = unsafe {
             libc::kevent(
                 instance.raw_fd(),
@@ -160,7 +182,8 @@ ported_fns! {
                 .iter()
             .take(count as usize)
             .map(|event| PollEvent {
-                fd: event.ident as RawFd,
+                token: PollToken::from_usize(event.udata as usize),
+                ident: event.ident as RawFd,
                 events: kqueue_result_events(event),
             }),
         );
@@ -180,8 +203,8 @@ ported_fns! {
         source = "src/internal/event_loop/kqueue.c",
         original = "moonbitlang_async_event_get_fd"
     )]
-    pub(crate) fn event_get_fd(event: &PollEvent) -> RawFd {
-        event.fd
+    pub(crate) fn event_get_token(event: &PollEvent) -> Option<PollToken> {
+        event.token
     }
 
     #[ported(
@@ -193,9 +216,13 @@ ported_fns! {
     }
 }
 
+pub(crate) fn event_get_pid(event: &PollEvent) -> RawFd {
+    event.ident
+}
+
 pub(crate) fn poll_unregister(instance: &PollInstance, fd: RawFd) -> AsyncHostResult<()> {
     for filter in [libc::EVFILT_READ, libc::EVFILT_WRITE] {
-        let event = new_kevent(fd as libc::uintptr_t, filter, libc::EV_DELETE, 0, 0);
+        let event = new_kevent(fd as libc::uintptr_t, filter, libc::EV_DELETE, 0, 0, None)?;
         if unsafe {
             libc::kevent(
                 instance.raw_fd(),
@@ -238,15 +265,19 @@ fn new_kevent(
     flags: u16,
     fflags: u32,
     data: libc::intptr_t,
-) -> libc::kevent {
+    token: Option<PollToken>,
+) -> AsyncHostResult<libc::kevent> {
     let mut event = empty_kevent();
     event.ident = ident;
     event.filter = filter;
     event.flags = flags;
     event.fflags = fflags;
     event.data = data;
-    event.udata = std::ptr::null_mut();
-    event
+    event.udata = token
+        .map(PollToken::as_usize)
+        .transpose()?
+        .map_or(std::ptr::null_mut(), |token| token as *mut libc::c_void);
+    Ok(event)
 }
 
 fn empty_kevent() -> libc::kevent {

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
@@ -57,8 +57,9 @@ struct KeventBuffer(Box<[libc::kevent]>);
 
 #[cfg(target_os = "macos")]
 // SAFETY: libc::kevent is plain kernel event storage. Its udata field prevents
-// automatic Send, but moonrun always registers null udata and never dereferences
-// values returned in that field. The buffer owns every event value.
+// automatic Send, but moonrun stores only opaque integer PollTokens in udata
+// and never dereferences values returned in that field. The buffer owns every
+// event value.
 unsafe impl Send for KeventBuffer {}
 
 pub(crate) struct PollInstance {
@@ -101,13 +102,34 @@ impl PollInstance {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PollToken(u64);
+
+impl PollToken {
+    pub(crate) fn new(value: u64) -> Self {
+        debug_assert_ne!(value, 0);
+        Self(value)
+    }
+
+    pub(crate) fn get(self) -> u64 {
+        self.0
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    fn as_usize(self) -> crate::async_host::AsyncHostResult<usize> {
+        usize::try_from(self.0).map_err(|_| AsyncHostError::Fault)
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    fn from_usize(value: usize) -> Option<Self> {
+        (value != 0).then_some(Self(value as u64))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PollEvent {
-    #[cfg(unix)]
-    fd: RawFd,
-    #[cfg(windows)]
-    // IOCP completion keys are opaque values. Store the address bits rather
-    // than a pointer so cached events carry no false pointer provenance.
-    fd: usize,
+    token: Option<PollToken>,
+    #[cfg(target_os = "macos")]
+    ident: RawFd,
     events: i32,
     #[cfg(windows)]
     io_result: usize,
@@ -177,7 +199,8 @@ mod tests {
         let write_fd = fds[1];
 
         let mut poll = poll_create().unwrap();
-        poll_register(&poll, read_fd, true).unwrap();
+        let token = PollToken::new(0x1234);
+        poll_register(&poll, read_fd, true, token).unwrap();
         let byte = b"x";
         assert_eq!(
             unsafe { libc::write(write_fd, byte.as_ptr().cast(), byte.len()) },
@@ -187,7 +210,7 @@ mod tests {
         let count = poll_wait(&mut poll, 100).unwrap();
         assert_eq!(count, 1);
         let event = *event_list_get(&poll, 0).unwrap();
-        assert_eq!(event_get_fd(&event), read_fd);
+        assert_eq!(event_get_token(&event), Some(token));
         assert_eq!(event_get_events(&event) & READ_EVENT, READ_EVENT);
 
         unsafe {
@@ -204,7 +227,7 @@ mod tests {
         let write_fd = fds[1];
 
         let mut poll = poll_create().unwrap();
-        poll_register(&poll, read_fd, true).unwrap();
+        poll_register(&poll, read_fd, true, PollToken::new(0x1234)).unwrap();
         poll_unregister(&poll, read_fd).unwrap();
         let byte = b"x";
         assert_eq!(

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
@@ -57,25 +57,32 @@ struct KeventBuffer(Box<[libc::kevent]>);
 
 #[cfg(target_os = "macos")]
 // SAFETY: libc::kevent is plain kernel event storage. Its udata field prevents
-// automatic Send, but moonrun stores only opaque integer PollTokens in udata
-// and never dereferences values returned in that field. The buffer owns every
-// event value.
+// automatic Send, but moonrun stores only Resource Handle integer bits in
+// udata and never dereferences values returned in that field. The buffer owns
+// every event value.
 unsafe impl Send for KeventBuffer {}
+
+#[cfg(target_os = "linux")]
+pub(crate) type PollEvent = libc::epoll_event;
+#[cfg(target_os = "macos")]
+pub(crate) type PollEvent = libc::kevent;
+#[cfg(windows)]
+pub(crate) type PollEvent = windows_sys::Win32::System::IO::OVERLAPPED_ENTRY;
 
 pub(crate) struct PollInstance {
     #[cfg(unix)]
     fd: OwnedFd,
     #[cfg(windows)]
     fd: Arc<OwnedHandle>,
-    // Unix pollers retain both buffers so waits do not allocate or initialize
-    // 1024 native events before copying the ready subset on every call.
+    // poll/wait returns only a count. Later event accessor imports read the
+    // ready prefix of this reusable native buffer directly.
     #[cfg(target_os = "linux")]
     raw_events: Box<[libc::epoll_event]>,
     #[cfg(target_os = "macos")]
     raw_events: KeventBuffer,
     #[cfg(windows)]
     raw_events: Box<[windows_sys::Win32::System::IO::OVERLAPPED_ENTRY]>,
-    events: Vec<PollEvent>,
+    event_count: usize,
 }
 
 impl std::fmt::Debug for PollInstance {
@@ -83,7 +90,7 @@ impl std::fmt::Debug for PollInstance {
         f.debug_struct("PollInstance")
             .field("fd", &self.fd)
             .field("raw_event_capacity", &EVENT_BUFFER_SIZE)
-            .field("events", &self.events)
+            .field("event_count", &self.event_count)
             .finish()
     }
 }
@@ -99,49 +106,6 @@ impl PollInstance {
             self.fd.as_raw_handle()
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct PollToken(u64);
-
-impl PollToken {
-    pub(crate) fn new(value: u64) -> Self {
-        debug_assert_ne!(value, 0);
-        Self(value)
-    }
-
-    pub(crate) fn get(self) -> u64 {
-        self.0
-    }
-
-    #[cfg(any(target_os = "macos", windows))]
-    fn as_usize(self) -> crate::async_host::AsyncHostResult<usize> {
-        usize::try_from(self.0).map_err(|_| AsyncHostError::Fault)
-    }
-
-    #[cfg(target_os = "macos")]
-    fn from_usize(value: usize) -> Option<Self> {
-        (value != 0).then_some(Self(value as u64))
-    }
-
-    #[cfg(windows)]
-    fn from_completion_key(value: usize) -> Self {
-        Self(value as u64)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct PollEvent {
-    token: Option<PollToken>,
-    #[cfg(target_os = "macos")]
-    ident: RawFd,
-    events: i32,
-    #[cfg(windows)]
-    io_result: usize,
-    #[cfg(windows)]
-    bytes_transferred: i32,
-    #[cfg(windows)]
-    worker_generation: Option<usize>,
 }
 
 pub(super) fn last_errno() -> i32 {
@@ -204,8 +168,8 @@ mod tests {
         let write_fd = fds[1];
 
         let mut poll = poll_create().unwrap();
-        let token = PollToken::new(0x1234);
-        poll_register(&poll, read_fd, true, token).unwrap();
+        let fd_handle = 0x1234;
+        poll_register(&poll, read_fd, true, fd_handle).unwrap();
         let byte = b"x";
         assert_eq!(
             unsafe { libc::write(write_fd, byte.as_ptr().cast(), byte.len()) },
@@ -215,7 +179,7 @@ mod tests {
         let count = poll_wait(&mut poll, 100).unwrap();
         assert_eq!(count, 1);
         let event = *event_list_get(&poll, 0).unwrap();
-        assert_eq!(event_get_token(&event), Some(token));
+        assert_eq!(event_get_fd(&event), fd_handle);
         assert_eq!(event_get_events(&event) & READ_EVENT, READ_EVENT);
 
         unsafe {
@@ -232,7 +196,7 @@ mod tests {
         let write_fd = fds[1];
 
         let mut poll = poll_create().unwrap();
-        poll_register(&poll, read_fd, true, PollToken::new(0x1234)).unwrap();
+        poll_register(&poll, read_fd, true, 0x1234).unwrap();
         poll_unregister(&poll, read_fd).unwrap();
         let byte = b"x";
         assert_eq!(

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
@@ -119,9 +119,14 @@ impl PollToken {
         usize::try_from(self.0).map_err(|_| AsyncHostError::Fault)
     }
 
-    #[cfg(any(target_os = "macos", windows))]
+    #[cfg(target_os = "macos")]
     fn from_usize(value: usize) -> Option<Self> {
         (value != 0).then_some(Self(value as u64))
+    }
+
+    #[cfg(windows)]
+    fn from_completion_key(value: usize) -> Self {
+        Self(value as u64)
     }
 }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -27,10 +27,12 @@ use crate::async_sys::internal::fd_util;
 
 #[cfg(unix)]
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+#[cfg(all(test, windows))]
+use std::os::windows::io::AsRawSocket;
 #[cfg(windows)]
 use std::os::windows::io::{
-    AsHandle, AsRawHandle, AsRawSocket, AsSocket, BorrowedHandle, BorrowedSocket, FromRawHandle,
-    FromRawSocket, OwnedHandle, OwnedSocket, RawHandle, RawSocket,
+    AsHandle, AsRawHandle, AsSocket, BorrowedHandle, BorrowedSocket, FromRawHandle, FromRawSocket,
+    OwnedHandle, OwnedSocket, RawHandle, RawSocket,
 };
 
 pub(crate) type ResourceHandle = u64;
@@ -210,6 +212,7 @@ impl Resource {
         self.class
     }
 
+    #[cfg(all(test, windows))]
     pub(crate) fn raw_identity(&self) -> isize {
         match &self.raw {
             RawResource::Invalid => -1,

--- a/crates/moonrun/src/async_sys/signal.rs
+++ b/crates/moonrun/src/async_sys/signal.rs
@@ -69,7 +69,7 @@ ported_fns! {
     #[cfg(windows)]
     pub(crate) fn set_console_control_handler(
         add: bool,
-        completion_target: Option<(CompletionPort, usize)>,
+        completion_target: Option<CompletionPort>,
     ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
 
@@ -179,7 +179,7 @@ static INTERESTED_CONSOLE_CTRL_EVENT: std::sync::atomic::AtomicI32 =
     std::sync::atomic::AtomicI32::new(0);
 
 #[cfg(windows)]
-static CONSOLE_COMPLETION_TARGET: std::sync::Mutex<Option<(CompletionPort, usize)>> =
+static CONSOLE_COMPLETION_TARGET: std::sync::Mutex<Option<CompletionPort>> =
     std::sync::Mutex::new(None);
 
 #[cfg(windows)]
@@ -187,12 +187,9 @@ unsafe extern "system" fn console_control_handler(ctrl_type: u32) -> i32 {
     let interested = INTERESTED_CONSOLE_CTRL_EVENT.load(std::sync::atomic::Ordering::Relaxed);
     if ctrl_type < i32::BITS && (interested & (1_i32 << ctrl_type)) != 0 {
         let target = CONSOLE_COMPLETION_TARGET.lock().unwrap().clone();
-        if let Some((completion_port, generation)) = target {
-            let _ = poll::post_thread_pool_completion(
-                &completion_port,
-                (ctrl_type | (1 << 31)) as i32,
-                generation,
-            );
+        if let Some(completion_port) = target {
+            let _ =
+                poll::post_thread_pool_completion(&completion_port, (ctrl_type | (1 << 31)) as i32);
             return 1;
         }
     }


### PR DESCRIPTION
## Why

MoonBit owns event dispatch and only needs each native event's source handle and result fields. The poll adapters already receive those values in epoll `data.u64`, kqueue `udata`, and the IOCP completion key, so copying every ready entry into a second normalized `PollEvent` buffer adds hot-path work and suggests host-side routing state that does not exist.

Windows thread-pool generations also protected a same-IOCP destroy/reinitialize sequence outside the native event-loop lifecycle. Native posts these synthetic completions with a null `OVERLAPPED`, and host safety does not require stronger guest semantics for that sequence.

## What changed

- Store the Resource Handle directly in each platform's native opaque event field.
- Retain one reusable native event buffer plus the valid event count required by the existing multi-call ABI.
- Read `event_fd`, readiness flags, IO result, and transferred bytes directly from the native event entry.
- Remove the `PollToken` and normalized `PollEvent` representations and their per-wait copy.
- Remove Windows thread-pool generation state, stale-completion filtering, and timeout retry logic; synthetic completions again match native with a null `OVERLAPPED`.
- Keep only the independent state required for resource ownership, Unix unregistration, pending Windows IO, and completion-port lifetime safety.

## Correctness

The MoonBit-facing ABI and routing values are unchanged: `event_fd` returns the Resource Handle stored at registration, Unix readiness flags are derived from the same native event bits, and Windows returns the same completion key, `OVERLAPPED`, and byte count produced by IOCP. Event access remains bounds-checked against the ready prefix of the retained native buffer.

macOS process events continue to use `ident`, Unix thread-pool notifications continue through their registered Resource Handle, and Windows synthetic completions continue to use `INVALID_HANDLE_VALUE` plus the job id, matching native behavior.

## Scope

This is an internal poll-adapter simplification. It does not change the Wasm ABI, OS registration mode, readiness/completion semantics, Resource lifetime, or event batch size.