### PR TITLE
test: update warning index snapshot

### DIFF
--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -38,7 +38,7 @@ Warning name: `{mnemonic}`
     }
 }
 
-// Snapshot generated from `moonc check -warn-help` on 2026-07-14.
+// Snapshot generated from `moonc check -warn-help` on 2026-07-26.
 // Update this file manually when the compiler's warning table changes.
 const WARNING_ENTRIES: &[WarningEntry] = &[
     WarningEntry {
@@ -430,6 +430,11 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
         mnemonic: "type_param_method",
         description: "Calling method of type parameter in a deprecated way.",
         id: 83,
+    },
+    WarningEntry {
+        mnemonic: "unqualified_record",
+        description: "Struct literal in a `let` binding without a type prefix.",
+        id: 84,
     },
 ];
 

--- a/crates/moon/src/cli/snapshots/explain_warning_index.txt
+++ b/crates/moon/src/cli/snapshots/explain_warning_index.txt
@@ -76,3 +76,4 @@
 0081	regex_match_missing_after	Missing `after` binding in `regex match`.
 0082	ambiguous_braces	Ambiguous `{}` braces.
 0083	type_param_method	Calling method of type parameter in a deprecated way.
+0084	unqualified_record	Struct literal in a `let` binding without a type prefix.


### PR DESCRIPTION
## Why

The nightly MoonBit compiler now reports warning 0084 (`unqualified_record`) in `moonc check -warn-help`. The checked-in warning index still ended at 0083, causing the warning-index consistency test to fail on every CI platform.

## Correctness

Add the compiler-reported warning entry with the same mnemonic and description, then regenerate the checked-in warning snapshot from that entry table. This keeps the internal warning index and the compiler's `-warn-help` output aligned.

## Scope

This PR only updates the warning entry snapshot date, the new 0084 entry, and its generated text snapshot. It does not change warning behavior or production control flow.