### PR TITLE
refactor(build): separate action lowering from n2 graph construction

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_action_plan/view.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/view.rs
@@ -16,14 +16,14 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use moonutil::resolution::ResolvedEnv;
 
 use crate::{
     build_plan::{BuildPlan, FileDependencyKind, PlanArtifactKind},
     discover::DiscoverResult,
-    model::{BuildPlanNode, BuildTarget},
+    model::{BuildPlanNode, BuildTarget, PackageId},
 };
 
 use super::{BuildAction, BuildActionId, BuildProduct};
@@ -70,6 +70,77 @@ impl<'a> BuildActionPlan<'a> {
 
     pub fn input_action_ids(&self) -> &[BuildActionId] {
         &self.input_actions
+    }
+
+    /// Separate reusable package preparation from work owned by the
+    /// synthesized script package while preserving the original action edges.
+    pub(crate) fn partition_standalone_actions(
+        &self,
+        script_package: PackageId,
+    ) -> (Vec<BuildActionId>, Vec<BuildActionId>) {
+        let action_package = |action| match action {
+            BuildAction::Check { target, .. }
+            | BuildAction::EmitProof { target, .. }
+            | BuildAction::Prove { target, .. }
+            | BuildAction::BuildCore { target, .. }
+            | BuildAction::LinkCore { target, .. }
+            | BuildAction::MakeExecutable { target, .. }
+            | BuildAction::GenerateTestInfo { target, .. }
+            | BuildAction::GenerateMbti { target } => Some(target.package),
+            BuildAction::BuildCStub { package, .. }
+            | BuildAction::ArchiveOrLinkCStubs { package, .. }
+            | BuildAction::BuildVirtual { package }
+            | BuildAction::RunPrebuild { package, .. }
+            | BuildAction::RunMoonLexPrebuild { package, .. }
+            | BuildAction::RunMoonYaccPrebuild { package, .. } => Some(package),
+            BuildAction::Bundle { .. }
+            | BuildAction::BuildRuntimeLib { .. }
+            | BuildAction::BuildDocs { .. } => None,
+        };
+        let script_owned_actions = self
+            .action_ids()
+            .filter(|&action| action_package(self.action(action)) == Some(script_package))
+            .collect::<HashSet<_>>();
+        assert!(
+            !script_owned_actions.is_empty(),
+            "standalone action plan should contain work for the synthesized script package"
+        );
+
+        let mut dependency_actions = self
+            .action_ids()
+            .filter(|&action| {
+                action_package(self.action(action)).is_some_and(|package| package != script_package)
+            })
+            .collect::<HashSet<_>>();
+        let mut pending = dependency_actions.iter().copied().collect::<Vec<_>>();
+        while let Some(action) = pending.pop() {
+            for dependency in self.dependency_action_ids(action) {
+                assert!(
+                    !script_owned_actions.contains(&dependency),
+                    "standalone dependency preparation action {action:?} depends on \
+                     script action {dependency:?}"
+                );
+                if dependency_actions.insert(dependency) {
+                    pending.push(dependency);
+                }
+            }
+        }
+        assert!(
+            self.input_action_ids()
+                .iter()
+                .all(|action| !dependency_actions.contains(action)),
+            "standalone root action should remain in the script execution phase"
+        );
+
+        let dependencies = self
+            .action_ids()
+            .filter(|action| dependency_actions.contains(action))
+            .collect();
+        let script = self
+            .action_ids()
+            .filter(|action| !dependency_actions.contains(action))
+            .collect();
+        (dependencies, script)
     }
 
     pub fn action(&self, id: BuildActionId) -> BuildAction<'a> {

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -20,9 +20,7 @@
 
 use std::path::PathBuf;
 
-use log::debug;
 use moonutil::resolution::{DirSyncResult, ResolvedEnv};
-use n2::graph::{Build, Graph as N2Graph};
 use tracing::{Level, instrument};
 
 use crate::{
@@ -35,17 +33,9 @@ use crate::{
 };
 use moonutil::toolchain::BINARIES;
 
-use super::{
-    BuildOptions, CommandArgMap, LoweringError,
-    utils::{build_ins, build_n2_fileloc, build_outs},
-};
+use super::{BuildOptions, LoweredAction, LoweredProduct, LoweringError};
 
 pub(crate) struct LoweringContext<'a> {
-    // What we're building
-    pub(crate) graph: N2Graph,
-
-    pub(crate) command_args_by_output: CommandArgMap,
-
     // Physical paths for logical build products.
     pub(crate) artifact_paths: ArtifactPathResolver,
 
@@ -59,13 +49,8 @@ pub(crate) struct LoweringContext<'a> {
 }
 
 pub(super) struct ActionProducts {
-    outputs: Vec<RealizedProduct>,
-    dependencies: Vec<RealizedProduct>,
-}
-
-struct RealizedProduct {
-    product: BuildProduct,
-    paths: Vec<PathBuf>,
+    outputs: Vec<LoweredProduct>,
+    dependencies: Vec<LoweredProduct>,
 }
 
 impl ActionProducts {
@@ -92,7 +77,7 @@ impl ActionProducts {
         ctx: &LoweringContext<'_>,
         product_action: BuildActionId,
         product: BuildProduct,
-    ) -> RealizedProduct {
+    ) -> LoweredProduct {
         let paths = ctx.artifact_paths.paths_for_product(
             &product,
             ctx.plan.action(product_action),
@@ -100,15 +85,11 @@ impl ActionProducts {
             ctx.modules,
             ctx.opt.artifact_path_options(),
         );
-        RealizedProduct { product, paths }
-    }
-
-    pub(super) fn dependency_paths(&self) -> Vec<PathBuf> {
-        Self::paths(&self.dependencies)
-    }
-
-    pub(super) fn output_paths(&self) -> Vec<PathBuf> {
-        Self::paths(&self.outputs)
+        LoweredProduct {
+            producer: product_action,
+            product,
+            paths,
+        }
     }
 
     pub(super) fn single_output_path(&self) -> PathBuf {
@@ -160,15 +141,8 @@ impl ActionProducts {
             .collect()
     }
 
-    fn paths(realized: &[RealizedProduct]) -> Vec<PathBuf> {
-        realized
-            .iter()
-            .flat_map(|product| product.paths.iter().cloned())
-            .collect()
-    }
-
     fn single_matching_path(
-        realized: &[RealizedProduct],
+        realized: &[LoweredProduct],
         matches: impl Fn(&BuildProduct) -> bool,
     ) -> Option<PathBuf> {
         let matched = realized
@@ -182,7 +156,7 @@ impl ActionProducts {
         }
     }
 
-    fn optional_single_realized_path(product: &RealizedProduct) -> Option<PathBuf> {
+    fn optional_single_realized_path(product: &LoweredProduct) -> Option<PathBuf> {
         match product.paths.as_slice() {
             [path] => Some(path.clone()),
             [] => None,
@@ -202,8 +176,6 @@ impl<'a> LoweringContext<'a> {
         opt: &'a BuildOptions,
     ) -> Self {
         Self {
-            graph: N2Graph::default(),
-            command_args_by_output: CommandArgMap::new(),
             artifact_paths,
             rel: &resolve_output.pkg_rel,
             modules: &resolve_output.module_rel,
@@ -241,10 +213,13 @@ impl<'a> LoweringContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self))]
-    pub(super) fn lower_action(&mut self, id: BuildActionId) -> Result<(), LoweringError> {
+    pub(super) fn lower_action(
+        &mut self,
+        id: BuildActionId,
+    ) -> Result<Option<LoweredAction>, LoweringError> {
         let action = self.plan.action(id);
         if self.is_action_noop(action) {
-            return Ok(());
+            return Ok(None);
         }
         let action_products = ActionProducts::new(self, id);
 
@@ -305,107 +280,26 @@ impl<'a> LoweringContext<'a> {
             }
         };
 
-        // Collect n2 inputs and outputs.
-        //
-        // MAINTAINERS: some of the inputs and outputs might be calculated
-        // twice, once for the commandline and another here. This is currently
-        // not a performance concern, but if you have found a way to optimize
-        // this, or if you are duplicating a lot of code for it, please refactor.
-        let mut ins = action_products.dependency_paths();
-        ins.extend(cmd.extra_inputs);
-        // Track tool binary dependencies so that n2 detects when compilers
-        // or other toolchain binaries change (e.g. after a toolchain update)
-        // and triggers a rebuild.
+        let mut external_inputs = cmd.extra_inputs;
         if self.plan.needs_moonc_tool_dep(id) {
-            ins.push(BINARIES.moonc.clone());
+            external_inputs.push(BINARIES.moonc.clone());
         }
-        ins.sort(); // make sure the order is deterministic
-        let ins = build_ins(&mut self.graph, ins);
 
-        let output_paths = action_products.output_paths();
-        if let Some(args) = cmd.commandline.args() {
-            for output_path in &output_paths {
-                self.command_args_by_output
-                    .insert(output_path.clone(), args.clone());
-            }
-        }
-        let mut commandline = cmd.commandline;
-        let cwd = commandline.cwd.take();
-        let env = std::mem::take(&mut commandline.env);
-        let (n2_command, rspfile) = commandline.into_n2();
-        let outs = build_outs(&mut self.graph, output_paths);
-
-        // Construct n2 build node
-        let mut build = Build::new(
-            build_n2_fileloc(self.plan.fileloc(id, self.modules, self.packages)),
-            ins,
-            outs,
-        );
-        build.cmdline = Some(n2_command);
-        build.rspfile = rspfile;
-        build.cwd = cwd.map(|cwd| cwd.display().to_string());
-        build.env = env;
-        build.desc = Some(self.plan.human_desc(id, self.modules, self.packages));
-        // n2 can't capture and replay command outputs. this is a workaround to
-        // avoid losing warnings from `moonc`. According to legacy code, this
-        // only triggers for `Check` nodes.
-        //
-        // FIXME: Revisit for other `moonc` invocations, e.g. `BuildCore`.
-        build.can_dirty_on_output = self.plan.can_dirty_on_output(id);
-
-        self.debug_print_command_and_files(id, &build);
-        let fqn = self
+        let error_package = self
             .plan
             .package_for_error(id)
-            .map(|x| self.get_package(x).fqn.clone());
-        self.graph
-            .add_build(build)
-            .map(|_| ())
-            .map_err(|e| LoweringError::N2 {
-                package: fqn.into(),
-                action: id,
-                source: e,
-            })
-    }
-
-    /// **For debug use only.** Prints debug information about a lowered action,
-    /// the n2 build it's mapped into, and its input and output files.
-    #[doc(hidden)]
-    fn debug_print_command_and_files(&mut self, action: BuildActionId, build: &Build) {
-        if log::log_enabled!(log::Level::Debug) {
-            let in_files = build
-                .ins
-                .ids
-                .iter()
-                .map(|id| {
-                    &self
-                        .graph
-                        .files
-                        .by_id
-                        .lookup(*id)
-                        .expect("Input file should exist")
-                        .name
-                })
-                .collect::<Vec<_>>();
-            let out_files = build
-                .outs
-                .ids
-                .iter()
-                .map(|id| {
-                    &self
-                        .graph
-                        .files
-                        .by_id
-                        .lookup(*id)
-                        .expect("Output file should exist")
-                        .name
-                })
-                .collect::<Vec<_>>();
-
-            debug!(
-                "lowered: {:?}\n into {:?};\n ins: {:?};\n outs: {:?}",
-                action, build.cmdline, in_files, out_files
-            );
-        }
+            .map(|target| self.get_package(target).fqn.clone())
+            .into();
+        Ok(Some(LoweredAction {
+            id,
+            dependencies: action_products.dependencies,
+            external_inputs,
+            outputs: action_products.outputs,
+            command: cmd.commandline,
+            fileloc: self.plan.fileloc(id, self.modules, self.packages),
+            description: self.plan.human_desc(id, self.modules, self.packages),
+            can_dirty_on_output: self.plan.can_dirty_on_output(id),
+            error_package,
+        }))
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -57,16 +57,16 @@ use crate::{
 };
 
 use super::{
-    BuildCommand, Commandline, LoweringError, compiler,
+    BuildCommand, LoweredCommand, LoweringError, compiler,
     context::{ActionProducts, LoweringContext},
     moonc_command,
 };
 
-fn commandline_with_dsymutil(cmd: &[String], dest: &str) -> Commandline {
+fn commandline_with_dsymutil(cmd: &[String], dest: &str) -> LoweredCommand {
     let cmd_str = moonutil::shlex::join_unix(cmd.iter().map(|x| x.as_str()));
     let dsymutil_args = ["dsymutil", dest];
     let dsymutil_cmd_str = moonutil::shlex::join_unix(dsymutil_args.iter().copied());
-    Commandline::verbatim(format!("{cmd_str} && {dsymutil_cmd_str}"))
+    LoweredCommand::verbatim(format!("{cmd_str} && {dsymutil_cmd_str}"))
 }
 
 fn should_run_new_native_dsymutil(

--- a/crates/moonbuild-rupes-recta/src/build_lower/lowered_action.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lowered_action.rs
@@ -1,0 +1,226 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Concrete action data produced before n2 file registration.
+
+use std::path::PathBuf;
+
+use moonutil::compiler_flags::Toolchain;
+
+use crate::{
+    build_action_plan::{BuildActionId, BuildProduct},
+    pkg_name::OptionalPackageFQNWithSource,
+};
+
+/// One logical product after its concrete artifact paths have been selected.
+#[derive(Debug)]
+pub struct LoweredProduct {
+    pub(crate) producer: BuildActionId,
+    pub(crate) product: BuildProduct,
+    pub(crate) paths: Vec<PathBuf>,
+}
+
+impl LoweredProduct {
+    pub fn producer(&self) -> BuildActionId {
+        self.producer
+    }
+
+    pub fn product(&self) -> &BuildProduct {
+        &self.product
+    }
+
+    pub fn paths(&self) -> &[PathBuf] {
+        &self.paths
+    }
+}
+
+/// A response file selected while lowering a command.
+#[derive(Debug, Clone)]
+pub struct LoweredResponseFile {
+    pub path: PathBuf,
+    pub content: String,
+}
+
+/// The representation used to construct the process command.
+///
+/// Most commands retain structured arguments so tools can inspect them before
+/// the platform-specific command string is executed. Commands that deliberately
+/// use shell composition, such as prebuild commands, remain verbatim.
+#[derive(Debug, Clone)]
+pub(crate) enum LoweredCommandKind {
+    /// Structured argv rendered using the platform's command-line convention.
+    Args(Vec<String>),
+
+    /// A command string that intentionally relies on shell composition.
+    Verbatim,
+}
+
+/// How the process command should be transported to the executor.
+#[derive(Debug, Clone)]
+pub enum LoweredCommandExecution {
+    Inline(String),
+    ResponseFile {
+        command: String,
+        file: LoweredResponseFile,
+    },
+}
+
+/// A concrete process command and its selected process transport.
+///
+/// `kind` retains the logical form for metadata consumers. `execution` records
+/// whether the same command is sent inline or through a response file.
+#[derive(Debug, Clone)]
+pub struct LoweredCommand {
+    pub(crate) kind: LoweredCommandKind,
+    pub(crate) execution: LoweredCommandExecution,
+    pub(crate) cwd: Option<PathBuf>,
+    pub(crate) env: Vec<(String, String)>,
+}
+
+impl From<Vec<String>> for LoweredCommand {
+    fn from(args: Vec<String>) -> Self {
+        let command = moonutil::shlex::join_native(args.iter().map(String::as_str));
+        Self {
+            kind: LoweredCommandKind::Args(args),
+            execution: LoweredCommandExecution::Inline(command),
+            cwd: None,
+            env: Vec::new(),
+        }
+    }
+}
+
+impl LoweredCommand {
+    pub(crate) fn verbatim(command: String) -> Self {
+        Self {
+            kind: LoweredCommandKind::Verbatim,
+            execution: LoweredCommandExecution::Inline(command),
+            cwd: None,
+            env: Vec::new(),
+        }
+    }
+
+    pub(crate) fn inline_command(&self) -> &str {
+        let LoweredCommandExecution::Inline(command) = &self.execution else {
+            unreachable!("a response-file command is already lowered")
+        };
+        command
+    }
+
+    pub(crate) fn with_response_file(mut self, command: String, file: LoweredResponseFile) -> Self {
+        self.execution = LoweredCommandExecution::ResponseFile { command, file };
+        self
+    }
+
+    pub fn args(&self) -> Option<&[String]> {
+        match &self.kind {
+            LoweredCommandKind::Args(args) => Some(args),
+            LoweredCommandKind::Verbatim => None,
+        }
+    }
+
+    pub fn execution(&self) -> &LoweredCommandExecution {
+        &self.execution
+    }
+
+    pub fn cwd(&self) -> Option<&std::path::Path> {
+        self.cwd.as_deref()
+    }
+
+    pub fn env(&self) -> &[(String, String)] {
+        &self.env
+    }
+
+    fn with_cwd(mut self, cwd: PathBuf) -> Self {
+        self.cwd = Some(cwd);
+        self
+    }
+
+    fn with_env(mut self, env: Vec<(String, String)>) -> Self {
+        self.env.extend(env);
+        self
+    }
+}
+
+/// One concrete action after product paths and command construction have been
+/// resolved, but before its paths are registered with n2.
+///
+/// Dependency products retain their producer action and logical product so a
+/// preparation policy can identify the dependency without reconstructing it
+/// from n2 file edges.
+#[derive(Debug)]
+pub struct LoweredAction {
+    pub(crate) id: BuildActionId,
+    pub(crate) dependencies: Vec<LoweredProduct>,
+    pub(crate) external_inputs: Vec<PathBuf>,
+    pub(crate) outputs: Vec<LoweredProduct>,
+    pub(crate) command: LoweredCommand,
+    pub(crate) fileloc: String,
+    pub(crate) description: String,
+    pub(crate) can_dirty_on_output: bool,
+    pub(crate) error_package: OptionalPackageFQNWithSource,
+}
+
+impl LoweredAction {
+    pub fn id(&self) -> BuildActionId {
+        self.id
+    }
+
+    pub fn dependencies(&self) -> &[LoweredProduct] {
+        &self.dependencies
+    }
+
+    pub fn external_inputs(&self) -> &[PathBuf] {
+        &self.external_inputs
+    }
+
+    pub fn outputs(&self) -> &[LoweredProduct] {
+        &self.outputs
+    }
+
+    pub fn command(&self) -> &LoweredCommand {
+        &self.command
+    }
+
+    pub fn can_dirty_on_output(&self) -> bool {
+        self.can_dirty_on_output
+    }
+}
+
+/// Command data produced by action-specific lowering before the common action
+/// metadata and products are attached.
+pub(super) struct BuildCommand {
+    /// Input files in addition to products of dependency actions.
+    pub(super) extra_inputs: Vec<PathBuf>,
+    pub(super) commandline: LoweredCommand,
+}
+
+impl BuildCommand {
+    pub(super) fn with_cwd(mut self, cwd: PathBuf) -> Self {
+        self.commandline = self.commandline.with_cwd(cwd);
+        self
+    }
+
+    pub(super) fn with_env(mut self, env: Vec<(String, String)>) -> Self {
+        self.commandline = self.commandline.with_env(env);
+        self
+    }
+
+    pub(super) fn with_msvc_env(self, toolchain: &Toolchain) -> Self {
+        self.with_env(super::compiler::msvc::command_env(toolchain))
+    }
+}

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -16,27 +16,19 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Lowers the normalized action plan into `n2`'s build graph.
+//! Lowers the normalized action plan into concrete actions, then adapts them
+//! to `n2`'s build graph.
 
-use std::{
-    collections::{BTreeMap, HashSet},
-    path::PathBuf,
-    str::FromStr,
-    sync::OnceLock,
-};
+use std::{collections::BTreeMap, path::PathBuf, str::FromStr, sync::OnceLock};
 
 use log::{debug, info};
-use moonutil::{
-    build_options::RunMode,
-    compiler_flags::{CompilerPaths, Toolchain},
-    cond_expr::OptLevel,
-};
-use n2::graph::{Graph as N2Graph, RspFile};
+use moonutil::{build_options::RunMode, compiler_flags::CompilerPaths, cond_expr::OptLevel};
+use n2::graph::Graph as N2Graph;
 use tracing::instrument;
 
 use crate::{
     ResolveOutput,
-    build_action_plan::{BuildAction, BuildActionId, BuildActionPlan},
+    build_action_plan::{BuildActionId, BuildActionPlan},
     model::{NativeBackendMode, OperatingSystem, PackageId, RunBackend},
     pkg_name::OptionalPackageFQNWithSource,
     target_layout::{
@@ -49,14 +41,21 @@ mod compiler;
 mod context;
 mod lower_aux;
 mod lower_build;
+mod lowered_action;
 mod moonc_command;
+mod n2_adapter;
 mod utils;
 
+pub use lowered_action::{
+    LoweredAction, LoweredCommand, LoweredCommandExecution, LoweredProduct, LoweredResponseFile,
+};
 pub use utils::{build_ins, build_n2_fileloc, build_outs};
 
 pub(crate) use backend::{CExecutableRealization, CStubLibraryRealization, SelectedBackend};
 
 use context::LoweringContext;
+use lowered_action::{BuildCommand, LoweredCommandKind};
+use n2_adapter::N2GraphBuilder;
 
 /// Lazily resolved host/toolchain facts used during lowering.
 ///
@@ -230,153 +229,6 @@ pub struct LoweringResult {
     pub artifacts: Vec<(BuildActionId, Vec<PathBuf>)>,
 }
 
-/// The command to execute for n2.
-///
-/// # How n2 handles commandlines
-///
-/// N2 (and ninja) use different conventions for handling commandlines on
-/// different platforms.
-///
-/// - On Unix-like platforms, the command string will be fed into `sh -c`. Thus,
-///   shell features like variable expansion are supported.
-/// - On Windows, the command string will be directly passed to
-///   `CreateProcessA`. No shell features are supported.
-///
-/// For most build commands, this is not an issue. All executables and argument
-/// paths are absolute paths, and there's no shell features involved.
-///
-/// However, for prebuild commands, the commandline is expected to be copied
-/// verbatim (with minimal resolving) to the generated build script. Thus,
-/// splitting, resolving and quoting again may lead to e.g. shell features being
-/// lost.
-///
-/// Thus, we're currently providing a `Verbatim` variant to handle such cases.
-///
-/// # Future improvements
-///
-/// Future design might want to omit shell features entirely for better
-/// cross-platform consistency. Env var expansion are already used by some
-/// libraries, so maintainers must be careful not to break those while doing so.
-///
-/// An idea is to use unix-style shell splitting and expansion everywhere,
-/// performing the env var expansion ourselves during build graph execution
-/// time. Other shell features should be disallowed. The result will then be
-/// handled like `Args` native to the platform.
-#[derive(Debug, Clone)]
-enum CommandlineKind {
-    /// This commandline will be joined using the platform's default convention.
-    Args(Vec<String>),
-
-    /// This verbatim string will be plugged into the build graph as-is.
-    /// Use with caution.
-    ///
-    /// This variant is used for commands that intentionally rely on shell
-    /// composition, such as prebuild commands and follow-up tool invocations.
-    Verbatim,
-}
-
-/// How n2 should execute a logical command.
-#[derive(Debug, Clone)]
-enum CommandExecution {
-    Inline(String),
-    ResponseFile { command: String, file: RspFile },
-}
-
-#[derive(Debug, Clone)]
-struct Commandline {
-    /// Structured logical argv, when available for metadata and presentation.
-    kind: CommandlineKind,
-    execution: CommandExecution,
-    cwd: Option<PathBuf>,
-    env: Vec<(String, String)>,
-}
-
-impl From<Vec<String>> for Commandline {
-    fn from(v: Vec<String>) -> Self {
-        let command = moonutil::shlex::join_native(v.iter().map(String::as_str));
-        Commandline {
-            kind: CommandlineKind::Args(v),
-            execution: CommandExecution::Inline(command),
-            cwd: None,
-            env: Vec::new(),
-        }
-    }
-}
-
-impl Commandline {
-    fn verbatim(s: String) -> Self {
-        Self {
-            kind: CommandlineKind::Verbatim,
-            execution: CommandExecution::Inline(s),
-            cwd: None,
-            env: Vec::new(),
-        }
-    }
-
-    fn into_n2(self) -> (String, Option<RspFile>) {
-        match self.execution {
-            CommandExecution::Inline(command) => (command, None),
-            CommandExecution::ResponseFile { command, file } => (command, Some(file)),
-        }
-    }
-
-    fn inline_command(&self) -> &str {
-        let CommandExecution::Inline(command) = &self.execution else {
-            unreachable!("a response-file command is already lowered")
-        };
-        command
-    }
-
-    fn with_response_file(mut self, command: String, file: RspFile) -> Self {
-        self.execution = CommandExecution::ResponseFile { command, file };
-        self
-    }
-
-    fn args(&self) -> Option<&Vec<String>> {
-        match &self.kind {
-            CommandlineKind::Args(args) => Some(args),
-            CommandlineKind::Verbatim => None,
-        }
-    }
-
-    fn with_cwd(mut self, cwd: PathBuf) -> Self {
-        self.cwd = Some(cwd);
-        self
-    }
-
-    fn with_env(mut self, env: Vec<(String, String)>) -> Self {
-        self.env.extend(env);
-        self
-    }
-}
-
-/// Represents the essential information needed to construct an [`Build`] value
-/// that cannot be derived fromthe build plan graph.
-struct BuildCommand {
-    /// The **extra** input files needed for this command, **in addition to**
-    /// the artifacts of the build steps this command depends on.
-    extra_inputs: Vec<PathBuf>,
-
-    /// The command to execute.
-    commandline: Commandline,
-}
-
-impl BuildCommand {
-    fn with_cwd(mut self, cwd: PathBuf) -> Self {
-        self.commandline = self.commandline.with_cwd(cwd);
-        self
-    }
-
-    fn with_env(mut self, env: Vec<(String, String)>) -> Self {
-        self.commandline = self.commandline.with_env(env);
-        self
-    }
-
-    fn with_msvc_env(self, toolchain: &Toolchain) -> Self {
-        self.with_env(compiler::msvc::command_env(toolchain))
-    }
-}
-
 /// Lowers a normalized action plan into an n2 [Build Graph](n2::graph::Graph).
 #[instrument(skip_all)]
 pub fn lower_build_plan(
@@ -402,7 +254,7 @@ pub fn lower_build_plan(
     Ok(result)
 }
 
-/// Temporarily adapt one standalone action plan to two n2 execution graphs.
+/// Project one standalone action plan into dependency and script n2 graphs.
 ///
 /// The dependency graph contains every prerequisite outside the synthesized
 /// script package, including package-less shared actions reached by those
@@ -416,7 +268,7 @@ pub(crate) fn lower_standalone_build_plan(
     script_package: PackageId,
 ) -> Result<(LoweringResult, LoweringResult), LoweringError> {
     info!("Projecting standalone actions to dependency and script n2 graphs");
-    let (dependency_actions, script_actions) = standalone_action_projections(plan, script_package);
+    let (dependency_actions, script_actions) = plan.partition_standalone_actions(script_package);
     debug!(
         "Standalone execution projection contains {} dependency actions and {} script actions",
         dependency_actions.len(),
@@ -434,75 +286,6 @@ pub(crate) fn lower_standalone_build_plan(
     Ok((dependencies, script))
 }
 
-fn standalone_action_projections(
-    plan: &BuildActionPlan<'_>,
-    script_package: PackageId,
-) -> (Vec<BuildActionId>, Vec<BuildActionId>) {
-    let action_package = |action| match action {
-        BuildAction::Check { target, .. }
-        | BuildAction::EmitProof { target, .. }
-        | BuildAction::Prove { target, .. }
-        | BuildAction::BuildCore { target, .. }
-        | BuildAction::LinkCore { target, .. }
-        | BuildAction::MakeExecutable { target, .. }
-        | BuildAction::GenerateTestInfo { target, .. }
-        | BuildAction::GenerateMbti { target } => Some(target.package),
-        BuildAction::BuildCStub { package, .. }
-        | BuildAction::ArchiveOrLinkCStubs { package, .. }
-        | BuildAction::BuildVirtual { package }
-        | BuildAction::RunPrebuild { package, .. }
-        | BuildAction::RunMoonLexPrebuild { package, .. }
-        | BuildAction::RunMoonYaccPrebuild { package, .. } => Some(package),
-        BuildAction::Bundle { .. }
-        | BuildAction::BuildRuntimeLib { .. }
-        | BuildAction::BuildDocs { .. } => None,
-    };
-    let script_owned_actions = plan
-        .action_ids()
-        .filter(|&action| action_package(plan.action(action)) == Some(script_package))
-        .collect::<HashSet<_>>();
-    assert!(
-        !script_owned_actions.is_empty(),
-        "standalone action plan should contain work for the synthesized script package"
-    );
-
-    let mut dependency_actions = plan
-        .action_ids()
-        .filter(|&action| {
-            action_package(plan.action(action)).is_some_and(|package| package != script_package)
-        })
-        .collect::<HashSet<_>>();
-    let mut pending = dependency_actions.iter().copied().collect::<Vec<_>>();
-    while let Some(action) = pending.pop() {
-        for dependency in plan.dependency_action_ids(action) {
-            assert!(
-                !script_owned_actions.contains(&dependency),
-                "standalone dependency preparation action {action:?} depends on \
-                 script action {dependency:?}"
-            );
-            if dependency_actions.insert(dependency) {
-                pending.push(dependency);
-            }
-        }
-    }
-    assert!(
-        plan.input_action_ids()
-            .iter()
-            .all(|action| !dependency_actions.contains(action)),
-        "standalone root action should remain in the script execution phase"
-    );
-
-    let dependencies = plan
-        .action_ids()
-        .filter(|action| dependency_actions.contains(action))
-        .collect();
-    let script = plan
-        .action_ids()
-        .filter(|action| !dependency_actions.contains(action))
-        .collect();
-    (dependencies, script)
-}
-
 fn lower_actions(
     resolve_output: &ResolveOutput,
     plan: &BuildActionPlan<'_>,
@@ -511,10 +294,13 @@ fn lower_actions(
     artifact_actions: &[BuildActionId],
 ) -> Result<LoweringResult, LoweringError> {
     let mut ctx = LoweringContext::new(opt.artifact_paths.clone(), resolve_output, plan, opt);
+    let mut n2 = N2GraphBuilder::new();
 
     for id in actions {
         debug!("Lowering action: {:?}", id);
-        ctx.lower_action(id)?;
+        if let Some(action) = ctx.lower_action(id)? {
+            n2.add_action(action)?;
+        }
     }
 
     let mut out_artifacts = Vec::with_capacity(artifact_actions.len());
@@ -524,8 +310,8 @@ fn lower_actions(
     }
 
     Ok(LoweringResult {
-        build_graph: ctx.graph,
-        command_args_by_output: ctx.command_args_by_output,
+        build_graph: n2.graph,
+        command_args_by_output: n2.command_args_by_output,
         artifacts: out_artifacts,
     })
 }
@@ -783,7 +569,7 @@ mod tests {
 
         let action_plan = plan.build_action_plan();
         let (dependency_actions, script_actions) =
-            standalone_action_projections(&action_plan, script_package);
+            action_plan.partition_standalone_actions(script_package);
         let dependency_nodes = dependency_actions
             .into_iter()
             .map(|action| action_plan.build_plan_node(action))
@@ -817,7 +603,7 @@ mod tests {
 
         let action_plan = plan.build_action_plan();
         let (dependency_actions, script_actions) =
-            standalone_action_projections(&action_plan, script_package);
+            action_plan.partition_standalone_actions(script_package);
         let script_nodes = script_actions
             .into_iter()
             .map(|action| action_plan.build_plan_node(action))
@@ -850,7 +636,7 @@ mod tests {
         );
 
         let action_plan = plan.build_action_plan();
-        standalone_action_projections(&action_plan, script_package);
+        action_plan.partition_standalone_actions(script_package);
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/build_lower/moonc_command.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/moonc_command.rs
@@ -18,9 +18,7 @@
 
 use std::path::{Path, PathBuf};
 
-use n2::graph::RspFile;
-
-use super::{Commandline, LoweringError};
+use super::{LoweredCommand, LoweredResponseFile, LoweringError};
 
 // Keep a portable margin below Windows' 32,767 UTF-16-code-unit process limit.
 // UTF-8 byte length is a conservative approximation for this purpose.
@@ -29,8 +27,8 @@ const RESPONSE_FILE_THRESHOLD: usize = 16 * 1024;
 pub(super) fn lower(
     args: Vec<String>,
     primary_output: &Path,
-) -> Result<Commandline, LoweringError> {
-    let commandline = Commandline::from(args);
+) -> Result<LoweredCommand, LoweringError> {
+    let commandline = LoweredCommand::from(args);
     let (executable, response_args) = commandline
         .args()
         .expect("moonc commands are represented as argv")
@@ -51,7 +49,7 @@ pub(super) fn lower(
 
     Ok(commandline.with_response_file(
         command,
-        RspFile {
+        LoweredResponseFile {
             path: rsp_path,
             content,
         },
@@ -86,15 +84,17 @@ fn encode(args: &[String]) -> Result<String, LoweringError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::build_lower::LoweredCommandExecution;
 
     #[test]
     fn preserves_logical_args_while_selecting_execution_transport() {
         let output = Path::new("build/pkg.core");
         let short = vec!["moonc".to_owned(), "build-package".to_owned()];
         let lowered = lower(short.clone(), output).expect("short command should lower");
-        let (command, rspfile) = lowered.into_n2();
-        assert_eq!(moonutil::shlex::split_native(&command), short);
-        assert!(rspfile.is_none());
+        let LoweredCommandExecution::Inline(command) = lowered.execution() else {
+            panic!("short command should remain inline")
+        };
+        assert_eq!(moonutil::shlex::split_native(command), short);
 
         let long = vec![
             "moonc".to_owned(),
@@ -102,12 +102,17 @@ mod tests {
             "x".repeat(RESPONSE_FILE_THRESHOLD),
         ];
         let lowered = lower(long.clone(), output).expect("oversized command should lower");
-        assert_eq!(lowered.args(), Some(&long));
-        let (command, rspfile) = lowered.into_n2();
-        let rspfile = rspfile.expect("oversized command should use a response file");
+        assert_eq!(lowered.args(), Some(long.as_slice()));
+        let LoweredCommandExecution::ResponseFile {
+            command,
+            file: rspfile,
+        } = lowered.execution()
+        else {
+            panic!("oversized command should use a response file")
+        };
 
         assert_eq!(
-            moonutil::shlex::split_native(&command),
+            moonutil::shlex::split_native(command),
             [
                 "moonc".to_owned(),
                 "-rsp-file".to_owned(),

--- a/crates/moonbuild-rupes-recta/src/build_lower/n2_adapter.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/n2_adapter.rs
@@ -1,0 +1,169 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use log::debug;
+use n2::graph::{Build, Graph as N2Graph, RspFile};
+
+use super::{
+    CommandArgMap, LoweredAction, LoweredCommandExecution, LoweredCommandKind, LoweringError,
+    utils::{build_ins, build_n2_fileloc, build_outs},
+};
+
+pub(super) struct N2GraphBuilder {
+    pub(super) graph: N2Graph,
+    pub(super) command_args_by_output: CommandArgMap,
+}
+
+impl N2GraphBuilder {
+    pub(super) fn new() -> Self {
+        Self {
+            graph: N2Graph::default(),
+            command_args_by_output: CommandArgMap::new(),
+        }
+    }
+
+    pub(super) fn add_action(&mut self, action: LoweredAction) -> Result<(), LoweringError> {
+        let LoweredAction {
+            id,
+            dependencies,
+            external_inputs,
+            outputs,
+            command,
+            fileloc,
+            description,
+            can_dirty_on_output,
+            error_package,
+        } = action;
+
+        let mut input_paths = dependencies
+            .into_iter()
+            .flat_map(|product| product.paths)
+            .chain(external_inputs)
+            .collect::<Vec<_>>();
+        input_paths.sort();
+
+        let output_paths = outputs
+            .into_iter()
+            .flat_map(|product| product.paths)
+            .collect::<Vec<_>>();
+        if let LoweredCommandKind::Args(args) = &command.kind {
+            for output_path in &output_paths {
+                self.command_args_by_output
+                    .insert(output_path.clone(), args.clone());
+            }
+        }
+
+        let ins = build_ins(&mut self.graph, &input_paths);
+        let outs = build_outs(&mut self.graph, &output_paths);
+        let (commandline, rspfile) = match command.execution {
+            LoweredCommandExecution::Inline(command) => (command, None),
+            LoweredCommandExecution::ResponseFile { command, file } => (
+                command,
+                Some(RspFile {
+                    path: file.path,
+                    content: file.content,
+                }),
+            ),
+        };
+
+        let mut build = Build::new(build_n2_fileloc(fileloc), ins, outs);
+        build.cmdline = Some(commandline);
+        build.rspfile = rspfile;
+        build.cwd = command.cwd.map(|cwd| cwd.display().to_string());
+        build.env = command.env;
+        build.desc = Some(description);
+        build.can_dirty_on_output = can_dirty_on_output;
+
+        if log::log_enabled!(log::Level::Debug) {
+            debug!(
+                "lowered: {:?}\n into {:?};\n ins: {:?};\n outs: {:?}",
+                id, build.cmdline, input_paths, output_paths
+            );
+        }
+
+        self.graph
+            .add_build(build)
+            .map(|_| ())
+            .map_err(|source| LoweringError::N2 {
+                package: error_package,
+                action: id,
+                source,
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use n2::graph::BuildId;
+
+    use crate::{
+        build_action_plan::{BuildActionId, BuildProduct},
+        build_lower::{LoweredAction, LoweredCommand, LoweredProduct, LoweredResponseFile},
+        pkg_name::PackageFQN,
+    };
+
+    use super::N2GraphBuilder;
+
+    #[test]
+    fn preserves_lowered_action_data_in_n2() {
+        let action = BuildActionId(0);
+        let command_args = vec!["moonc".to_string(), "build-package".to_string()];
+        let lowered = LoweredAction {
+            id: action,
+            dependencies: Vec::new(),
+            external_inputs: vec![PathBuf::from("src/main.mbt")],
+            outputs: vec![LoweredProduct {
+                producer: action,
+                product: BuildProduct::PrebuildOutputPath {
+                    path: PathBuf::from("build/main.core"),
+                },
+                paths: vec![PathBuf::from("build/main.core")],
+            }],
+            command: LoweredCommand::from(command_args.clone()).with_response_file(
+                "moonc -rsp-file build/main.core.rsp".to_string(),
+                LoweredResponseFile {
+                    path: PathBuf::from("build/main.core.rsp"),
+                    content: "build-package\n".to_string(),
+                },
+            ),
+            fileloc: "build main".to_string(),
+            description: "build main".to_string(),
+            can_dirty_on_output: true,
+            error_package: None::<PackageFQN>.into(),
+        };
+
+        let mut n2 = N2GraphBuilder::new();
+        n2.add_action(lowered).expect("action should enter n2");
+
+        let build = &n2.graph.builds[BuildId::from(0)];
+        assert_eq!(
+            build.cmdline.as_deref(),
+            Some("moonc -rsp-file build/main.core.rsp")
+        );
+        let rspfile = build.rspfile.as_ref().expect("response file should remain");
+        assert_eq!(rspfile.path, Path::new("build/main.core.rsp"));
+        assert_eq!(rspfile.content, "build-package\n");
+        assert!(build.can_dirty_on_output);
+        assert_eq!(
+            n2.command_args_by_output.get(Path::new("build/main.core")),
+            Some(&command_args)
+        );
+    }
+}

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -446,14 +446,17 @@ During lowering:
   build-plan node has a stable action id and hydrated action metadata.
 - Each action’s command line is chosen based on its own metadata
   (package, backend, build target kind, action) and its dependencies.
-- Logical products are resolved to input/output files and attached to the
-  concrete build node.
+- Logical products are resolved to input/output files and attached to a
+  `LoweredAction` together with the command and execution metadata.
 - Additional inputs (such as source files) may be attached to represent files
   that are not produced by other build-graph nodes.
+- The n2 adapter consumes each `LoweredAction` by value and constructs the
+  concrete build node. Ordinary builds perform this incrementally and do not
+  retain a second complete graph.
 
-Each action is currently mapped to **zero or one** concrete build-graph node.
-Lowering a single action to multiple concrete nodes is not supported (hence the
-`index` field in the node declaration).
+Each action is currently mapped to **zero or one** `LoweredAction` and concrete
+build-graph node. Lowering a single action to multiple concrete nodes is not
+supported (hence the `index` field in the node declaration).
 
 The concrete rules of lowering is performed in [its module](/crates/moonbuild-rupes-recta/src/build_lower/mod.rs).
 

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -6,7 +6,8 @@ plan consumed by lowering, and backend graph construction:
 ```text
 BuildPlan       = planning IR: graph nodes, edge semantics, coalescing
 BuildActionPlan = action-level build plan: action ids, hydrated action data, logical products
-build_lower/n2  = backend IR: concrete paths, command lines, n2 graph
+LoweredAction   = concrete action: realized products, paths, and process command
+n2::Build       = executor representation produced by the n2 adapter
 ```
 
 The important invariant is that `build_lower` consumes `BuildActionPlan` only. It
@@ -143,7 +144,7 @@ For example, an archive/link C-stub action no longer scans raw build-plan
 edges in `build_lower`. Its object inputs are exposed by `BuildActionPlan` as
 `(object_action, BuildProduct::CStubObject { ... })` dependencies.
 
-## Backend Lowering
+## Action Lowering and n2 Adaptation
 
 `build_lower` matches on `BuildAction` and resolves `BuildProduct` paths
 through `ArtifactPathResolver`:
@@ -175,19 +176,26 @@ let dependencies = plan
     .map(|(dependency_action, product)| realize(dependency_action, product));
 ```
 
+The command, realized dependency products, external file inputs, outputs, and
+execution metadata are assembled into one `LoweredAction`. Ordinary builds move
+each action directly into the n2 adapter as soon as it is lowered; they do not
+retain a second complete graph in memory. The adapter alone registers n2 files,
+constructs `n2::Build`, and reports n2 graph errors.
+
 This keeps responsibilities separate:
 
 - `BuildPlan` owns graph edges, coalescing, and planning-only terminology.
 - `BuildActionPlan` owns the normalized action/product interface between phases.
 - `ArtifactPathResolver` owns logical product to path resolution.
-- `build_lower` owns command construction and n2 graph output.
+- action lowering owns concrete products, external inputs, and commands.
+- the n2 adapter owns n2 graph construction.
 
 ## Standalone script boundary
 
 Standalone `.mbt` and `.mbtx` execution starts from one complete `BuildPlan`.
 Package dependencies use the same edges as ordinary project compilation. After
-the plan is normalized once, a temporary action-level adapter projects it into
-two disjoint n2 graphs.
+the plan is normalized once, an action-level projection separates it into two
+disjoint n2 graphs.
 
 All actions owned by packages other than the synthesized script package seed
 the dependency projection. Following their producer edges to a fixed point


### PR DESCRIPTION
## Why

The standalone dependency cache currently has to reconstruct action semantics from the n2 graph. Before reworking #1948, lowering needs a boundary that still carries producer action IDs, logical products, concrete paths, and process commands.

## What changed

- Lower each BuildAction into a LoweredAction before executor registration.
- Move n2 graph construction into a focused adapter.
- Keep ordinary builds streaming one lowered action at a time into n2.
- Move the standalone action partition to BuildActionPlan, where its graph semantics belong.

## Why this is correct

The n2 adapter preserves the existing inputs, outputs, command transport, working directory, environment, diagnostics metadata, and command-argument map. The public lowering result and ordinary execution path are unchanged.

## Scope

This PR does not add hashing, caching, storage, or a second retained graph. It is the narrow prerequisite for replacing #1948s n2-graph introspection with action-level dependency preparation.