### PR TITLE
test: update warning index snapshot

### DIFF
--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -38,7 +38,7 @@ Warning name: `{mnemonic}`
     }
 }
 
-// Snapshot generated from `moonc check -warn-help` on 2026-07-26.
+// Snapshot generated from `moonc check -warn-help` on 2026-07-28.
 // Update this file manually when the compiler's warning table changes.
 const WARNING_ENTRIES: &[WarningEntry] = &[
     WarningEntry {
@@ -435,6 +435,21 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
         mnemonic: "unqualified_record",
         description: "Struct literal in a `let` binding without a type prefix.",
         id: 84,
+    },
+    WarningEntry {
+        mnemonic: "guard_inexhaustive",
+        description: "`guard` condition is not exhaustive and may panic.",
+        id: 87,
+    },
+    WarningEntry {
+        mnemonic: "guard_redundant_bang",
+        description: "Redundant `!` on an exhaustive `guard`.",
+        id: 88,
+    },
+    WarningEntry {
+        mnemonic: "guard_redundant_else",
+        description: "Redundant `else` on an exhaustive `guard`.",
+        id: 89,
     },
 ];
 

--- a/crates/moon/src/cli/snapshots/explain_warning_index.txt
+++ b/crates/moon/src/cli/snapshots/explain_warning_index.txt
@@ -77,3 +77,6 @@
 0082	ambiguous_braces	Ambiguous `{}` braces.
 0083	type_param_method	Calling method of type parameter in a deprecated way.
 0084	unqualified_record	Struct literal in a `let` binding without a type prefix.
+0087	guard_inexhaustive	`guard` condition is not exhaustive and may panic.
+0088	guard_redundant_bang	Redundant `!` on an exhaustive `guard`.
+0089	guard_redundant_else	Redundant `else` on an exhaustive `guard`.


### PR DESCRIPTION
## Why

The current nightly compiler adds three `guard` diagnostics, so the checked-in `moon explain` warning index no longer matches `moonc check -warn-help` and does not expose those warnings through the integrated diagnostic documentation.

## What changed

- Add E0087 `guard_inexhaustive`, E0088 `guard_redundant_bang`, and E0089 `guard_redundant_else` to the integrated warning index.
- Refresh the corresponding warning-index snapshot and generation date.

The change is limited to the compiler-derived warning entries and their snapshot.