### PR TITLE
refactor(build): unify backend configuration

### DIFF
--- a/crates/moon/src/cli/profile.rs
+++ b/crates/moon/src/cli/profile.rs
@@ -27,7 +27,6 @@ use std::{
 
 use anyhow::{Context, bail};
 use chrono::Local;
-use moonbuild_rupes_recta::model::RunBackend;
 use moonutil::{
     build_options::RunMode,
     command_output::CommandOutput,
@@ -260,7 +259,7 @@ pub(crate) struct ProfileRequest {
     /// Moon command mode that requested the profile.
     pub(crate) run_mode: RunMode,
     /// Backend used to build the profiled executable.
-    pub(crate) target_backend: RunBackend,
+    pub(crate) target_backend: TargetBackend,
     /// Optimization profile used to build the profiled executable.
     pub(crate) opt_level: OptLevel,
 }
@@ -296,13 +295,14 @@ fn run_profile_materialized(
     )?;
     built.ensure_build_success()?;
 
-    if built.target_backend != RunBackend::Native {
+    let target_backend = built.backend.target_backend();
+    if target_backend != TargetBackend::Native {
         bail!("{MOON_RUN_PROFILE_COMMAND} currently supports only the native backend");
     }
 
     let output_dir = default_output_dir(
         &built.target_dir,
-        built.target_backend,
+        target_backend,
         built.opt_level,
         RunMode::Run,
         &built.executable,
@@ -312,7 +312,7 @@ fn run_profile_materialized(
     }
     let request = ProfileRequest {
         run_mode: RunMode::Run,
-        target_backend: built.target_backend,
+        target_backend,
         opt_level: built.opt_level,
         executable: built.executable,
         display_executable: None,
@@ -531,7 +531,7 @@ pub(crate) fn profile_test_invocations(
 ) -> Result<i32, anyhow::Error> {
     ensure_profile_available(MOON_TEST_PROFILE_COMMAND)?;
 
-    if build_meta.target_backend() != RunBackend::Native {
+    if build_meta.target_backend() != TargetBackend::Native {
         bail!("{MOON_TEST_PROFILE_COMMAND} currently supports only the native backend");
     }
 
@@ -618,7 +618,7 @@ pub(crate) fn profile_test_invocations(
 
 fn default_test_profile_session_dir(
     target_dir: &Path,
-    target_backend: RunBackend,
+    target_backend: TargetBackend,
     opt_level: OptLevel,
 ) -> PathBuf {
     output_kind_dir(target_dir, target_backend, opt_level, "profile")
@@ -657,7 +657,7 @@ fn sanitize_path_component(input: &str) -> String {
 /// Place profile output beside the canonical artifact layout for the run mode.
 pub(crate) fn default_output_dir(
     target_dir: &Path,
-    target_backend: RunBackend,
+    target_backend: TargetBackend,
     opt_level: OptLevel,
     artifact_run_mode: RunMode,
     executable: &Path,
@@ -674,7 +674,7 @@ pub(crate) fn default_output_dir(
 
 fn default_output_parent_dir(
     target_dir: &Path,
-    target_backend: RunBackend,
+    target_backend: TargetBackend,
     opt_level: OptLevel,
     artifact_run_mode: RunMode,
     executable: &Path,
@@ -707,7 +707,7 @@ fn profile_timestamp() -> String {
 
 fn output_kind_dir(
     target_dir: &Path,
-    target_backend: RunBackend,
+    target_backend: TargetBackend,
     opt_level: OptLevel,
     kind: &str,
 ) -> PathBuf {
@@ -716,7 +716,7 @@ fn output_kind_dir(
         OptLevel::Release => "release",
     };
     target_dir
-        .join(target_backend.to_target().to_dir_name())
+        .join(target_backend.to_dir_name())
         .join(profile)
         .join(kind)
 }
@@ -1427,7 +1427,7 @@ fn build_report(
 
 fn build_test_report(
     profiler_backend: ProfileBackend,
-    target_backend: RunBackend,
+    target_backend: TargetBackend,
     opt_level: OptLevel,
     artifacts: ProfileArtifacts,
     captured_profiles: Vec<CapturedProfile>,
@@ -1564,7 +1564,7 @@ fn merge_profile(merged: &mut ParsedProfile, parsed: &ParsedProfile) {
 
 fn profile_target(
     run_mode: RunMode,
-    target_backend: RunBackend,
+    target_backend: TargetBackend,
     opt_level: OptLevel,
     executable: Option<PathBuf>,
     args: Vec<String>,
@@ -1572,7 +1572,7 @@ fn profile_target(
     ProfileTarget {
         command: format!("moon {} --profile", run_mode_label(run_mode)),
         run_mode: run_mode_label(run_mode).to_string(),
-        backend: target_backend.to_target().to_dir_name().to_string(),
+        backend: target_backend.to_dir_name().to_string(),
         optimization_profile: opt_level_label(opt_level).to_string(),
         executable,
         args,
@@ -1877,8 +1877,7 @@ fn render_attribution_entries(out: &mut String, entries: &[ProfileAttributionEnt
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use moonbuild_rupes_recta::model::RunBackend;
-    use moonutil::{build_options::RunMode, cond_expr::OptLevel};
+    use moonutil::{build_options::RunMode, cond_expr::OptLevel, target::TargetBackend};
 
     use super::{
         CapturedProfile, PROFILE_TEST_PERFORMANCE_ONLY_MESSAGE, ProfileArtifacts, ProfileBackend,
@@ -1983,7 +1982,7 @@ mod tests {
             parsed,
             profile_target(
                 RunMode::Run,
-                RunBackend::Native,
+                TargetBackend::Native,
                 OptLevel::Release,
                 Some(PathBuf::from("./_build/native/release/build/main/main.exe")),
                 vec!["--flag".to_string()],
@@ -2056,7 +2055,7 @@ mod tests {
             parsed,
             profile_target(
                 RunMode::Run,
-                RunBackend::Native,
+                TargetBackend::Native,
                 OptLevel::Release,
                 Some(PathBuf::from("./_build/native/release/build/main/main.exe")),
                 Vec::new(),
@@ -2120,7 +2119,7 @@ mod tests {
         );
         let report = build_test_report(
             ProfileBackend::Xctrace,
-            RunBackend::Native,
+            TargetBackend::Native,
             OptLevel::Release,
             with_json_report(
                 ProfileArtifacts::default(),
@@ -2170,7 +2169,7 @@ mod tests {
             output_dir: output_dir.clone(),
             target: profile_target(
                 RunMode::Test,
-                RunBackend::Native,
+                TargetBackend::Native,
                 OptLevel::Release,
                 Some(PathBuf::from(format!(
                     "./_build/native/release/test/main/{name}.exe"
@@ -2201,7 +2200,7 @@ mod tests {
     fn profile_output_reuses_run_artifact_package_dir() {
         let dir = default_output_dir(
             Path::new("./_build"),
-            RunBackend::Native,
+            TargetBackend::Native,
             OptLevel::Release,
             RunMode::Run,
             Path::new("./_build/native/release/build/cmd/main/main.exe"),

--- a/crates/moon/src/cli/profile.rs
+++ b/crates/moon/src/cli/profile.rs
@@ -531,7 +531,7 @@ pub(crate) fn profile_test_invocations(
 ) -> Result<i32, anyhow::Error> {
     ensure_profile_available(MOON_TEST_PROFILE_COMMAND)?;
 
-    if build_meta.target_backend != RunBackend::Native {
+    if build_meta.target_backend() != RunBackend::Native {
         bail!("{MOON_TEST_PROFILE_COMMAND} currently supports only the native backend");
     }
 
@@ -544,7 +544,7 @@ pub(crate) fn profile_test_invocations(
 
     let session_dir = default_test_profile_session_dir(
         target_dir,
-        build_meta.target_backend,
+        build_meta.target_backend(),
         build_meta.opt_level,
     );
     // Each selected test executable is a separate process and therefore a
@@ -573,7 +573,7 @@ pub(crate) fn profile_test_invocations(
                 current_dir: Some(module_root),
                 output_dir,
                 run_mode: RunMode::Test,
-                target_backend: build_meta.target_backend,
+                target_backend: build_meta.target_backend(),
                 opt_level: build_meta.opt_level,
             }
         })
@@ -599,7 +599,7 @@ pub(crate) fn profile_test_invocations(
     let profiler_backend = ensure_profile_available(MOON_TEST_PROFILE_COMMAND)?;
     let report = build_test_report(
         profiler_backend,
-        build_meta.target_backend,
+        build_meta.target_backend(),
         build_meta.opt_level,
         with_json_report(ProfileArtifacts::default(), json_path.clone()),
         captured_profiles,

--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -19,7 +19,6 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
-use moonbuild_rupes_recta::model::RunBackend;
 use mooncake::registry::{OnlineRegistry, Registry, path as registry_path};
 use moonutil::{
     locks::FileLock, registry::RegistryConfig, resolution::ModuleName, user_log::UserLog,
@@ -262,7 +261,7 @@ pub(crate) fn run(
         } => {
             let wasm_path = super::runwasm::cached_wasm_path(&package, user_log)?;
             run_artifact(
-                RunBackend::Wasm,
+                crate::run::ExecutionMode::MoonRun,
                 &wasm_path,
                 experimental_policy.as_deref(),
                 &args,
@@ -271,7 +270,13 @@ pub(crate) fn run(
         }
         RegistryRunTarget::Native => {
             let executable = cached_native_executable(&package, user_log, quiet, verbose)?;
-            run_artifact(RunBackend::Native, &executable, None, &args, user_log)
+            run_artifact(
+                crate::run::ExecutionMode::Native,
+                &executable,
+                None,
+                &args,
+                user_log,
+            )
         }
     }
 }
@@ -298,19 +303,14 @@ fn cached_native_executable(
 }
 
 fn run_artifact(
-    backend: RunBackend,
+    mode: crate::run::ExecutionMode<'_>,
     artifact: &Path,
     experimental_policy: Option<&Path>,
     args: &[String],
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
-    let mut run_cmd = crate::run::command_for_with_moonrun_policy(
-        backend,
-        None,
-        artifact,
-        None,
-        experimental_policy,
-    );
+    let mut run_cmd =
+        crate::run::command_for_with_moonrun_policy(mode, artifact, None, experimental_policy);
     run_cmd.args(args);
 
     user_log.info(rr_build::format_dry_run_command(&run_cmd, Path::new(".")));

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -22,7 +22,10 @@ use std::{io::Read, path::Path, path::PathBuf};
 
 use anyhow::{Context, bail};
 use moonbuild_rupes_recta::{
-    ResolveOutput, build_plan::InputDirective, intent::UserIntent, model::PackageId,
+    ResolveOutput,
+    build_plan::InputDirective,
+    intent::UserIntent,
+    model::{BackendConfig, PackageId},
 };
 use mooncake::pkg::sync::SyncOutputOptions;
 use moonutil::cli_support::AutoSyncFlags;
@@ -189,10 +192,8 @@ impl BuildRunExecutableOptions {
 pub(crate) struct RunExecutable {
     /// Path to the executable-like artifact that should be launched or reported.
     pub(crate) executable: PathBuf,
-    /// Backend-specific runner to use for this artifact.
-    pub(crate) target_backend: moonbuild_rupes_recta::model::RunBackend,
-    /// Present only when native debug execution selected `tcc -run`.
-    pub(crate) tcc_run: Option<moonbuild_rupes_recta::model::TccRunConfig>,
+    /// Backend configuration used to build and execute this artifact.
+    pub(crate) backend: BackendConfig,
     pub(crate) opt_level: moonutil::cond_expr::OptLevel,
     pub(crate) target_dir: PathBuf,
     source_dir: PathBuf,
@@ -344,8 +345,7 @@ fn build_wasm_file_executable_from_arg(
     let print_dir = std::env::current_dir().context("failed to get current directory")?;
     if cli.dry_run {
         let mut run_cmd = crate::run::command_for_with_moonrun_policy(
-            moonbuild_rupes_recta::model::RunBackend::WasmGC,
-            None,
+            crate::run::ExecutionMode::MoonRun,
             &wasm_path,
             None,
             cmd.moonrun_policy.as_deref(),
@@ -357,8 +357,7 @@ fn build_wasm_file_executable_from_arg(
 
     Ok(RunExecutable {
         executable: wasm_path,
-        target_backend: moonbuild_rupes_recta::model::RunBackend::WasmGC,
-        tcc_run: None,
+        backend: BackendConfig::WasmGc { use_wat: false },
         opt_level: moonutil::cond_expr::OptLevel::Debug,
         target_dir: print_dir.clone(),
         source_dir: print_dir,
@@ -585,8 +584,7 @@ fn get_run_cmd(
 ) -> std::process::Command {
     let executable = get_run_executable(build_meta);
     let mut cmd = crate::run::command_for_with_moonrun_policy(
-        build_meta.target_backend(),
-        build_meta.tcc_run(),
+        crate::run::ExecutionMode::from(&build_meta.backend),
         executable,
         None,
         moonrun_policy,
@@ -781,8 +779,7 @@ fn build_executable_from_plan(
         })?;
         return Ok(RunExecutable {
             executable: get_run_executable(build_meta).to_path_buf(),
-            target_backend: build_meta.target_backend(),
-            tcc_run: build_meta.tcc_run().cloned(),
+            backend: build_meta.backend.clone(),
             opt_level: build_meta.opt_level,
             target_dir: target_dir.to_path_buf(),
             source_dir: source_dir.to_path_buf(),
@@ -809,8 +806,7 @@ fn build_executable_from_plan(
 
     Ok(RunExecutable {
         executable: get_run_executable(build_meta).to_path_buf(),
-        target_backend: build_meta.target_backend(),
-        tcc_run: build_meta.tcc_run().cloned(),
+        backend: build_meta.backend.clone(),
         opt_level: build_meta.opt_level,
         target_dir: target_dir.to_path_buf(),
         source_dir: source_dir.to_path_buf(),
@@ -842,8 +838,7 @@ fn run_executable(
     }
 
     let mut run_cmd = crate::run::command_for_with_moonrun_policy(
-        executable.target_backend,
-        executable.tcc_run.as_ref(),
+        crate::run::ExecutionMode::from(&executable.backend),
         executable.executable.as_path(),
         None,
         cmd.moonrun_policy.as_deref(),

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -585,8 +585,8 @@ fn get_run_cmd(
 ) -> std::process::Command {
     let executable = get_run_executable(build_meta);
     let mut cmd = crate::run::command_for_with_moonrun_policy(
-        build_meta.target_backend,
-        build_meta.tcc_run.as_ref(),
+        build_meta.target_backend(),
+        build_meta.tcc_run(),
         executable,
         None,
         moonrun_policy,
@@ -781,8 +781,8 @@ fn build_executable_from_plan(
         })?;
         return Ok(RunExecutable {
             executable: get_run_executable(build_meta).to_path_buf(),
-            target_backend: build_meta.target_backend,
-            tcc_run: build_meta.tcc_run.clone(),
+            target_backend: build_meta.target_backend(),
+            tcc_run: build_meta.tcc_run().cloned(),
             opt_level: build_meta.opt_level,
             target_dir: target_dir.to_path_buf(),
             source_dir: source_dir.to_path_buf(),
@@ -809,8 +809,8 @@ fn build_executable_from_plan(
 
     Ok(RunExecutable {
         executable: get_run_executable(build_meta).to_path_buf(),
-        target_backend: build_meta.target_backend,
-        tcc_run: build_meta.tcc_run.clone(),
+        target_backend: build_meta.target_backend(),
+        tcc_run: build_meta.tcc_run().cloned(),
         opt_level: build_meta.opt_level,
         target_dir: target_dir.to_path_buf(),
         source_dir: source_dir.to_path_buf(),

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -1581,8 +1581,7 @@ fn rr_test_from_plan(
     )?;
     let _initial_summary = test_result.summary();
 
-    let backend_hint = display_backend_hint
-        .map(|_| TargetBackend::from(build_meta.target_backend()).to_backend_ext());
+    let backend_hint = display_backend_hint.map(|_| build_meta.target_backend().to_backend_ext());
 
     if cmd.update {
         let mut loop_count = 1; // matching legacy; we already have 1 test run before
@@ -1779,8 +1778,6 @@ fn collect_test_artifacts_for_build_only(
     include_skipped: bool,
     bench: bool,
 ) -> anyhow::Result<TestArtifacts> {
-    use moonbuild_rupes_recta::model::RunBackend;
-
     let mut artifacts_path = vec![];
     let mut test_filter_args = vec![];
 
@@ -1788,7 +1785,7 @@ fn collect_test_artifacts_for_build_only(
         crate::run::collect_test_invocations(build_meta, filter, include_skipped, bench)?
     {
         // For JS backend, create .cjs wrapper file (matching legacy behavior)
-        if matches!(build_meta.target_backend(), RunBackend::Js) {
+        if matches!(build_meta.target_backend(), TargetBackend::Js) {
             // Write package.json to prevent node from using outer "type": "module"
             let _ = std::fs::write(target_dir.join("package.json"), "{}");
             if let Some(parent) = invocation.executable.parent() {

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -990,7 +990,7 @@ fn run_test_rr(
     for (build_meta, build_graph, filter) in planned_runs {
         debug!(
             artifact_count = build_meta.artifacts.len(),
-            backend = ?build_meta.target_backend,
+            backend = ?build_meta.target_backend(),
             "planned rupes-recta build graph"
         );
 
@@ -1582,7 +1582,7 @@ fn rr_test_from_plan(
     let _initial_summary = test_result.summary();
 
     let backend_hint = display_backend_hint
-        .map(|_| TargetBackend::from(build_meta.target_backend).to_backend_ext());
+        .map(|_| TargetBackend::from(build_meta.target_backend()).to_backend_ext());
 
     if cmd.update {
         let mut loop_count = 1; // matching legacy; we already have 1 test run before
@@ -1788,7 +1788,7 @@ fn collect_test_artifacts_for_build_only(
         crate::run::collect_test_invocations(build_meta, filter, include_skipped, bench)?
     {
         // For JS backend, create .cjs wrapper file (matching legacy behavior)
-        if matches!(build_meta.target_backend, RunBackend::Js) {
+        if matches!(build_meta.target_backend(), RunBackend::Js) {
             // Write package.json to prevent node from using outer "type": "module"
             let _ = std::fs::write(target_dir.join("package.json"), "{}");
             if let Some(parent) = invocation.executable.parent() {

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -272,8 +272,8 @@ fn install_build_rr(
 
     // Build command using existing runtime mapping, then shlex-join
     let guard = crate::run::command_for(
-        meta.target_backend,
-        meta.tcc_run.as_ref(),
+        meta.target_backend(),
+        meta.tcc_run(),
         &installed_artifact,
         None,
     );

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -272,8 +272,7 @@ fn install_build_rr(
 
     // Build command using existing runtime mapping, then shlex-join
     let guard = crate::run::command_for(
-        meta.target_backend(),
-        meta.tcc_run(),
+        crate::run::ExecutionMode::from(&meta.backend),
         &installed_artifact,
         None,
     );

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -45,7 +45,7 @@ use moonbuild_rupes_recta::{
     intent::UserIntent,
     model::{
         Artifacts, BackendConfig, BuildPlanNode, DirectNativeMode, NativeBackendMode, NativeTarget,
-        PackageId, RunBackend, TargetKind, TccRunConfig,
+        PackageId, TargetKind, TccRunConfig,
     },
     prebuild::{PrebuildEnvironment, run_prebuild_config},
     target_layout::{ArtifactPathResolver, GENERATED_TEST_DRIVER_PREFIX, TargetLayout},
@@ -213,12 +213,8 @@ pub struct BuildMeta {
 }
 
 impl BuildMeta {
-    pub fn target_backend(&self) -> RunBackend {
-        self.backend.run_backend()
-    }
-
-    pub fn tcc_run(&self) -> Option<&TccRunConfig> {
-        self.backend.tcc_run()
+    pub fn target_backend(&self) -> TargetBackend {
+        self.backend.target_backend()
     }
 }
 
@@ -845,7 +841,7 @@ pub fn generate_metadata(
         source_dir,
         &build_meta.artifact_paths,
         build_meta.opt_level,
-        build_meta.target_backend().into(),
+        build_meta.target_backend(),
         &check_commands,
     );
     let orig_meta = std::fs::read_to_string(&metadata_file);
@@ -888,11 +884,11 @@ pub fn generate_all_pkgs_json(build_meta: &BuildMeta) -> anyhow::Result<()> {
     let all_pkgs_path = build_meta
         .artifact_paths
         .target_layout()
-        .all_pkgs_of_build_target(build_meta.target_backend().into());
+        .all_pkgs_of_build_target(build_meta.target_backend());
     let all_pkgs_json = moonbuild_rupes_recta::all_pkgs::gen_all_pkgs_json(
         &build_meta.resolve_output,
         &build_meta.artifact_paths,
-        build_meta.target_backend().into(),
+        build_meta.target_backend(),
     );
     let orig_all_pkgs = std::fs::read_to_string(&all_pkgs_path);
     let all_pkgs_str =
@@ -1326,7 +1322,7 @@ fn rewrite_captured_diagnostic(
     };
     let layout = meta.artifact_paths.target_layout();
     let packages = &meta.resolve_output.pkg_dirs;
-    let backend = meta.target_backend().into();
+    let backend = meta.target_backend();
 
     if cfg.output_style.needs_moonc_json() {
         let Ok(mut value) = serde_json::from_str::<serde_json::Value>(content) else {

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -44,8 +44,8 @@ use moonbuild_rupes_recta::{
     fmt::{FmtConfig, FmtResolveOutput},
     intent::UserIntent,
     model::{
-        Artifacts, BuildPlanNode, DirectNativeMode, NativeBackendMode, NativeTarget, PackageId,
-        RunBackend, TargetKind, TccRunConfig,
+        Artifacts, BackendConfig, BuildPlanNode, DirectNativeMode, NativeBackendMode, NativeTarget,
+        PackageId, RunBackend, TargetKind, TccRunConfig,
     },
     prebuild::{PrebuildEnvironment, run_prebuild_config},
     target_layout::{ArtifactPathResolver, GENERATED_TEST_DRIVER_PREFIX, TargetLayout},
@@ -202,18 +202,24 @@ pub struct BuildMeta {
     /// The list of artifacts that will be produced
     pub artifacts: IndexMap<BuildPlanNode, Artifacts>,
 
-    /// The target backend used in this compile process
-    pub target_backend: RunBackend,
-    /// Experimental direct object-code backend selected under native, if any.
-    pub native_target: Option<NativeTarget>,
-    /// Configuration for `tcc -run`, if this compile process selected it.
-    pub tcc_run: Option<TccRunConfig>,
+    /// The backend and backend-specific configuration used by this build.
+    pub backend: BackendConfig,
 
     /// The main optimization level used in this compile process
     pub opt_level: BuildProfile,
 
     /// Physical artifact path resolver selected for this build.
     pub artifact_paths: ArtifactPathResolver,
+}
+
+impl BuildMeta {
+    pub fn target_backend(&self) -> RunBackend {
+        self.backend.run_backend()
+    }
+
+    pub fn tcc_run(&self) -> Option<&TccRunConfig> {
+        self.backend.tcc_run()
+    }
 }
 
 /// Represents the result of the build process
@@ -315,21 +321,21 @@ impl CompilePreConfig {
             "The final selected target backend must either be default or match the explicit one"
         );
 
-        let native_mode = match target_backend {
-            TargetBackend::Native => Some(self.detect_mode(resolve_output, input_nodes, user_log)),
-            _ => None,
+        let backend = match target_backend {
+            TargetBackend::Wasm => BackendConfig::Wasm {
+                use_wat: self.output_wat,
+                wasi_link: self.wasi_link,
+            },
+            TargetBackend::WasmGC => BackendConfig::WasmGc {
+                use_wat: self.output_wat,
+            },
+            TargetBackend::Js => BackendConfig::Js,
+            TargetBackend::Native => {
+                BackendConfig::Native(self.detect_mode(resolve_output, input_nodes, user_log))
+            }
+            TargetBackend::LLVM => BackendConfig::Llvm,
         };
-        let run_backend = match target_backend {
-            TargetBackend::Wasm => RunBackend::Wasm,
-            TargetBackend::WasmGC => RunBackend::WasmGC,
-            TargetBackend::Js => RunBackend::Js,
-            TargetBackend::Native => RunBackend::Native,
-            TargetBackend::LLVM => RunBackend::Llvm,
-        };
-        info!(
-            "Final run backend: {:?}, native mode: {:?}",
-            run_backend, native_mode
-        );
+        info!("Final backend configuration: {:?}", backend);
         let stdlib_path = if std {
             Some(moonutil::toolchain::core())
         } else {
@@ -345,8 +351,7 @@ impl CompilePreConfig {
 
         Ok(CompileConfig {
             target_dir: self.target_dir,
-            target_backend: run_backend,
-            native_mode,
+            backend,
             opt_level: self.opt_level,
             action: self.action,
             debug_symbols: self.debug_symbols,
@@ -354,9 +359,7 @@ impl CompilePreConfig {
             artifact_paths,
             lowering_environment: LoweringEnvironment::default(),
             enable_coverage: self.enable_coverage,
-            output_wat: self.output_wat,
             debug_export_build_plan: self.debug_export_build_plan,
-            wasi_link: self.wasi_link,
             moonc_output_json: self.moonc_output_json,
             docs_serve: self.docs_serve,
             warning_condition: self.warning_condition,
@@ -372,9 +375,11 @@ impl CompilePreConfig {
         input_nodes: &[BuildPlanNode],
         user_log: &UserLog,
     ) -> NativeBackendMode {
-        // TODO: Native payload form is selected once per invocation. Move this
-        // decision into per-executable planning so one package's compiler flags
-        // do not force unrelated executables onto generated C.
+        // TODO: Native payload form is selected once per invocation. Before
+        // selecting it per executable, key the shared runtime and package C-stub
+        // products by their native toolchain and realization. Otherwise mixed
+        // payload forms can require incompatible shared artifacts, especially
+        // for the strict MSVC direct object target.
         let native_configs = input_nodes
             .iter()
             .filter_map(|node| {
@@ -662,16 +667,7 @@ pub(crate) fn plan_resolved_build_from_intent(
     let build_meta = BuildMeta {
         resolve_output,
         artifacts: compile_output.artifacts,
-        target_backend: cx.target_backend,
-        native_target: cx
-            .native_mode
-            .as_ref()
-            .and_then(NativeBackendMode::direct_target),
-        tcc_run: cx
-            .native_mode
-            .as_ref()
-            .and_then(NativeBackendMode::tcc_run)
-            .cloned(),
+        backend: cx.backend.clone(),
         opt_level: cx.opt_level,
         artifact_paths: cx.artifact_paths.clone(),
     };
@@ -679,7 +675,7 @@ pub(crate) fn plan_resolved_build_from_intent(
     let db_path = cx
         .artifact_paths
         .target_layout()
-        .n2_db_path(cx.target_backend.into());
+        .n2_db_path(cx.backend.target_backend());
     let input = BuildInput {
         graph: compile_output.build_graph,
         command_args_by_output: compile_output.command_args_by_output,
@@ -762,20 +758,11 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
     let build_meta = BuildMeta {
         resolve_output,
         artifacts: compile_output.script.artifacts,
-        target_backend: cx.target_backend,
-        native_target: cx
-            .native_mode
-            .as_ref()
-            .and_then(NativeBackendMode::direct_target),
-        tcc_run: cx
-            .native_mode
-            .as_ref()
-            .and_then(NativeBackendMode::tcc_run)
-            .cloned(),
+        backend: cx.backend.clone(),
         opt_level: cx.opt_level,
         artifact_paths: cx.artifact_paths.clone(),
     };
-    let backend = cx.target_backend.into();
+    let backend = cx.backend.target_backend();
     let layout = cx.artifact_paths.target_layout();
     let dependency_input = compile_output
         .dependencies
@@ -858,7 +845,7 @@ pub fn generate_metadata(
         source_dir,
         &build_meta.artifact_paths,
         build_meta.opt_level,
-        build_meta.target_backend.into(),
+        build_meta.target_backend().into(),
         &check_commands,
     );
     let orig_meta = std::fs::read_to_string(&metadata_file);
@@ -901,11 +888,11 @@ pub fn generate_all_pkgs_json(build_meta: &BuildMeta) -> anyhow::Result<()> {
     let all_pkgs_path = build_meta
         .artifact_paths
         .target_layout()
-        .all_pkgs_of_build_target(build_meta.target_backend.into());
+        .all_pkgs_of_build_target(build_meta.target_backend().into());
     let all_pkgs_json = moonbuild_rupes_recta::all_pkgs::gen_all_pkgs_json(
         &build_meta.resolve_output,
         &build_meta.artifact_paths,
-        build_meta.target_backend.into(),
+        build_meta.target_backend().into(),
     );
     let orig_all_pkgs = std::fs::read_to_string(&all_pkgs_path);
     let all_pkgs_str =
@@ -1339,7 +1326,7 @@ fn rewrite_captured_diagnostic(
     };
     let layout = meta.artifact_paths.target_layout();
     let packages = &meta.resolve_output.pkg_dirs;
-    let backend = meta.target_backend.into();
+    let backend = meta.target_backend().into();
 
     if cfg.output_style.needs_moonc_json() {
         let Ok(mut value) = serde_json::from_str::<serde_json::Value>(content) else {

--- a/crates/moon/src/run/mod.rs
+++ b/crates/moon/src/run/mod.rs
@@ -29,7 +29,7 @@ pub(crate) use runtest::{
     PackageFilter, TestFilter, TestIndex, TestOutlineEntry, collect_test_invocations,
     collect_test_outline, perform_promotion, run_tests,
 };
-pub(crate) use runtime::{command_for, command_for_with_moonrun_policy};
+pub(crate) use runtime::{ExecutionMode, command_for, command_for_with_moonrun_policy};
 
 use std::sync::OnceLock;
 

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -760,8 +760,7 @@ fn run_one_test_executable(
     };
 
     let mut cmd = crate::run::command_for(
-        ctx.build_meta.target_backend(),
-        ctx.build_meta.tcc_run(),
+        crate::run::ExecutionMode::from(&ctx.build_meta.backend),
         &executable,
         Some(&test.args),
     );

--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -760,8 +760,8 @@ fn run_one_test_executable(
     };
 
     let mut cmd = crate::run::command_for(
-        ctx.build_meta.target_backend,
-        ctx.build_meta.tcc_run.as_ref(),
+        ctx.build_meta.target_backend(),
+        ctx.build_meta.tcc_run(),
         &executable,
         Some(&test.args),
     );

--- a/crates/moon/src/run/runtime.rs
+++ b/crates/moon/src/run/runtime.rs
@@ -22,7 +22,30 @@ use std::path::Path;
 use std::process::Command;
 
 use moonbuild::entry::TestArgs;
-use moonbuild_rupes_recta::model::{RunBackend, TccRunConfig};
+use moonbuild_rupes_recta::model::{BackendConfig, NativeBackendMode, TccRunConfig};
+
+/// The concrete process used to execute one built artifact.
+#[derive(Clone, Copy)]
+pub(crate) enum ExecutionMode<'a> {
+    MoonRun,
+    Node,
+    Native,
+    TccRun(&'a TccRunConfig),
+}
+
+impl<'a> From<&'a BackendConfig> for ExecutionMode<'a> {
+    fn from(backend: &'a BackendConfig) -> Self {
+        match backend {
+            BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } => Self::MoonRun,
+            BackendConfig::Js => Self::Node,
+            BackendConfig::Native(NativeBackendMode::TccRun(config)) => Self::TccRun(config),
+            BackendConfig::Native(
+                NativeBackendMode::GeneratedC | NativeBackendMode::DirectObject(_),
+            )
+            | BackendConfig::Llvm => Self::Native,
+        }
+    }
+}
 
 /// Returns a command to run the given MoonBit executable of a specific
 /// `backend`. The returning command is suitable for adding more commandline
@@ -39,25 +62,21 @@ use moonbuild_rupes_recta::model::{RunBackend, TccRunConfig};
 /// ### Note
 ///
 pub(crate) fn command_for(
-    backend: RunBackend,
-    tcc_run: Option<&TccRunConfig>,
+    mode: ExecutionMode<'_>,
     mbt_executable: &Path,
     test: Option<&TestArgs>,
 ) -> Command {
-    command_for_with_moonrun_policy(backend, tcc_run, mbt_executable, test, None)
+    command_for_with_moonrun_policy(mode, mbt_executable, test, None)
 }
 
 pub(crate) fn command_for_with_moonrun_policy(
-    backend: RunBackend,
-    tcc_run: Option<&TccRunConfig>,
+    mode: ExecutionMode<'_>,
     mbt_executable: &Path,
     test: Option<&TestArgs>,
     moonrun_policy: Option<&Path>,
 ) -> Command {
-    debug_assert!(tcc_run.is_none() || backend == RunBackend::Native);
-
-    match (backend, tcc_run) {
-        (RunBackend::Wasm | RunBackend::WasmGC, _) => {
+    match mode {
+        ExecutionMode::MoonRun => {
             let mut cmd = Command::new(&*moonutil::toolchain::BINARIES.moonrun);
             if let Some(t) = test {
                 cmd.arg("--test-args");
@@ -71,7 +90,7 @@ pub(crate) fn command_for_with_moonrun_policy(
             cmd.arg("--");
             cmd
         }
-        (RunBackend::Js, _) => {
+        ExecutionMode::Node => {
             if test.is_some() {
                 // Also write package.json to the directory of the .js file being required
                 // to prevent node from finding the user's package.json with "type": "module"
@@ -88,7 +107,7 @@ pub(crate) fn command_for_with_moonrun_policy(
             }
             cmd
         }
-        (RunBackend::Native, Some(tcc_run)) => {
+        ExecutionMode::TccRun(tcc_run) => {
             let tcc = tcc_run.internal_tcc();
             let mut cmd = Command::new(tcc.cc_path());
             cmd.arg(format!("@{}", mbt_executable.display()));
@@ -97,7 +116,7 @@ pub(crate) fn command_for_with_moonrun_policy(
             }
             cmd
         }
-        (RunBackend::Native | RunBackend::Llvm, _) => {
+        ExecutionMode::Native => {
             let mut cmd = Command::new(mbt_executable);
             if let Some(t) = test {
                 cmd.arg(t.to_cli_args_for_native());

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -388,7 +388,7 @@ impl PlanningFixture {
 pub(super) fn planned_root_package_runs(runs: Vec<PlannedGraph>) -> Vec<PlannedPackageRun> {
     runs.into_iter()
         .map(|plan| PlannedPackageRun {
-            target_backend: plan.build_meta.target_backend().into(),
+            target_backend: plan.build_meta.target_backend(),
             packages: root_package_names(&plan.build_meta),
         })
         .collect()
@@ -397,7 +397,7 @@ pub(super) fn planned_root_package_runs(runs: Vec<PlannedGraph>) -> Vec<PlannedP
 pub(super) fn planned_check_package_runs(runs: Vec<PlannedGraph>) -> Vec<PlannedPackageRun> {
     runs.into_iter()
         .map(|plan| PlannedPackageRun {
-            target_backend: plan.build_meta.target_backend().into(),
+            target_backend: plan.build_meta.target_backend(),
             packages: check_package_names(&plan.build_meta),
         })
         .collect()
@@ -405,13 +405,13 @@ pub(super) fn planned_check_package_runs(runs: Vec<PlannedGraph>) -> Vec<Planned
 
 pub(super) fn planned_target_backends(runs: Vec<PlannedGraph>) -> Vec<TargetBackend> {
     runs.into_iter()
-        .map(|plan| plan.build_meta.target_backend().into())
+        .map(|plan| plan.build_meta.target_backend())
         .collect()
 }
 
 pub(super) fn planned_root_package_intent(plan: PlannedGraph) -> PlannedPackageIntent {
     PlannedPackageIntent {
-        target_backend: plan.build_meta.target_backend().into(),
+        target_backend: plan.build_meta.target_backend(),
         profile: plan.build_meta.opt_level,
         packages: root_package_names(&plan.build_meta),
     }

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -388,7 +388,7 @@ impl PlanningFixture {
 pub(super) fn planned_root_package_runs(runs: Vec<PlannedGraph>) -> Vec<PlannedPackageRun> {
     runs.into_iter()
         .map(|plan| PlannedPackageRun {
-            target_backend: plan.build_meta.target_backend.into(),
+            target_backend: plan.build_meta.target_backend().into(),
             packages: root_package_names(&plan.build_meta),
         })
         .collect()
@@ -397,7 +397,7 @@ pub(super) fn planned_root_package_runs(runs: Vec<PlannedGraph>) -> Vec<PlannedP
 pub(super) fn planned_check_package_runs(runs: Vec<PlannedGraph>) -> Vec<PlannedPackageRun> {
     runs.into_iter()
         .map(|plan| PlannedPackageRun {
-            target_backend: plan.build_meta.target_backend.into(),
+            target_backend: plan.build_meta.target_backend().into(),
             packages: check_package_names(&plan.build_meta),
         })
         .collect()
@@ -405,13 +405,13 @@ pub(super) fn planned_check_package_runs(runs: Vec<PlannedGraph>) -> Vec<Planned
 
 pub(super) fn planned_target_backends(runs: Vec<PlannedGraph>) -> Vec<TargetBackend> {
     runs.into_iter()
-        .map(|plan| plan.build_meta.target_backend.into())
+        .map(|plan| plan.build_meta.target_backend().into())
         .collect()
 }
 
 pub(super) fn planned_root_package_intent(plan: PlannedGraph) -> PlannedPackageIntent {
     PlannedPackageIntent {
-        target_backend: plan.build_meta.target_backend.into(),
+        target_backend: plan.build_meta.target_backend().into(),
         profile: plan.build_meta.opt_level,
         packages: root_package_names(&plan.build_meta),
     }

--- a/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
@@ -121,7 +121,7 @@ mod tests {
             wasi_link: false,
         };
 
-        assert!(backend.use_wat());
+        assert!(matches!(backend, BackendConfig::Wasm { use_wat: true, .. }));
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
@@ -22,16 +22,7 @@
 //! backend branch for command shape and runtime/linking behavior. Concrete
 //! product paths are resolved by `target_layout`.
 
-use crate::model::{NativeBackendMode, NativeTarget, RunBackend};
-
-#[derive(Clone, Debug)]
-pub(crate) enum SelectedBackend {
-    Wasm { use_wat: bool },
-    WasmGc { use_wat: bool },
-    Js,
-    C(NativeBackendMode),
-    Llvm,
-}
+use crate::model::{BackendConfig, NativeBackendMode};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum CExecutableRealization {
@@ -52,43 +43,10 @@ pub(crate) enum CStubLibraryRealization {
     SharedLibraryForTccRun,
 }
 
-impl SelectedBackend {
-    pub(crate) fn new(
-        target_backend: RunBackend,
-        native_mode: Option<&NativeBackendMode>,
-        output_wat: bool,
-    ) -> Self {
-        match (target_backend, native_mode) {
-            (RunBackend::Wasm, None) => Self::Wasm {
-                use_wat: output_wat,
-            },
-            (RunBackend::WasmGC, None) => Self::WasmGc {
-                use_wat: output_wat,
-            },
-            (RunBackend::Js, None) => Self::Js,
-            (RunBackend::Native, Some(native_mode)) => Self::C(native_mode.clone()),
-            (RunBackend::Llvm, None) => Self::Llvm,
-            (RunBackend::Native, None) => {
-                panic!("native backend requires a native implementation mode")
-            }
-            (_, Some(_)) => panic!("native implementation mode requires the native backend"),
-        }
-    }
-
-    pub(crate) fn direct_target(&self) -> Option<NativeTarget> {
-        match self {
-            Self::C(native_mode) => native_mode.direct_target(),
-            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js | Self::Llvm => None,
-        }
-    }
-
-    pub(crate) fn is_tcc_run(&self) -> bool {
-        matches!(self, Self::C(native_mode) if native_mode.is_tcc_run())
-    }
-
+impl BackendConfig {
     pub(crate) fn c_stub_library_realization(&self) -> CStubLibraryRealization {
         match self {
-            Self::C(backend) => backend.c_stub_library_realization(),
+            Self::Native(backend) => backend.c_stub_library_realization(),
             Self::Llvm => CStubLibraryRealization::StaticArchive,
             Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => {
                 unreachable!("C stubs are only realized for C or LLVM backends")
@@ -96,16 +54,9 @@ impl SelectedBackend {
         }
     }
 
-    pub(crate) fn use_wat(&self) -> bool {
-        match self {
-            Self::Wasm { use_wat } | Self::WasmGc { use_wat } => *use_wat,
-            Self::Js | Self::C(_) | Self::Llvm => false,
-        }
-    }
-
     pub(crate) fn uses_shared_runtime(&self) -> bool {
         match self {
-            Self::C(backend) => {
+            Self::Native(backend) => {
                 backend.runtime_realization() == CRuntimeRealization::SharedLibraryForTccRun
             }
             Self::Llvm => false,
@@ -165,17 +116,18 @@ mod tests {
 
     #[test]
     fn wasm_backend_carries_wat_setting() {
-        let backend = SelectedBackend::new(RunBackend::Wasm, None, true);
+        let backend = BackendConfig::Wasm {
+            use_wat: true,
+            wasi_link: false,
+        };
 
-        assert!(matches!(backend, SelectedBackend::Wasm { use_wat: true }));
+        assert!(backend.use_wat());
     }
 
     #[test]
     fn c_tcc_run_realizes_shared_runtime_and_response_file() {
-        let native_mode = NativeBackendMode::TccRun(fake_tcc_run());
-        let backend = SelectedBackend::new(RunBackend::Native, Some(&native_mode), false);
-
-        let SelectedBackend::C(ref native_mode) = backend else {
+        let backend = BackendConfig::Native(NativeBackendMode::TccRun(fake_tcc_run()));
+        let BackendConfig::Native(ref native_mode) = backend else {
             panic!("native backend should select C lowering")
         };
         assert_eq!(
@@ -191,12 +143,11 @@ mod tests {
 
     #[test]
     fn c_direct_object_realizes_linker_executable() {
-        let native_mode = NativeBackendMode::DirectObject(DirectNativeMode::Target(
-            crate::model::NativeTarget::Aarch64AppleDarwin,
+        let backend = BackendConfig::Native(NativeBackendMode::DirectObject(
+            DirectNativeMode::Target(crate::model::NativeTarget::Aarch64AppleDarwin),
         ));
-        let backend = SelectedBackend::new(RunBackend::Native, Some(&native_mode), false);
 
-        let SelectedBackend::C(ref native_mode) = backend else {
+        let BackendConfig::Native(ref native_mode) = backend else {
             panic!("native backend should select C lowering")
         };
         assert_eq!(
@@ -212,9 +163,9 @@ mod tests {
 
     #[test]
     fn llvm_backend_is_not_c_realization() {
-        let backend = SelectedBackend::new(RunBackend::Llvm, None, false);
+        let backend = BackendConfig::Llvm;
 
-        assert!(matches!(backend, SelectedBackend::Llvm));
+        assert!(matches!(backend, BackendConfig::Llvm));
         assert_eq!(
             backend.c_stub_library_realization(),
             CStubLibraryRealization::StaticArchive

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -188,7 +188,7 @@ impl<'a> LoweringContext<'a> {
 
     /// Some actions are no-op in n2 build graph. Early bailing.
     fn is_action_noop(&self, action: BuildAction<'_>) -> bool {
-        (!self.opt.target_backend.is_native())
+        (!self.opt.target_backend().is_native())
             && matches!(action, BuildAction::MakeExecutable { .. })
     }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -92,7 +92,7 @@ impl<'a> super::LoweringContext<'a> {
             enable_coverage,
             coverage_package_override: if self_coverage { Some("@self") } else { None },
             driver_kind,
-            target_backend: self.opt.target_backend.into(),
+            target_backend: self.opt.target_backend().into(),
             patch_file,
             pkg_name: &pkg_full_name,
             max_concurrent_tests: package.raw.max_concurrent_tests,
@@ -165,7 +165,7 @@ impl<'a> super::LoweringContext<'a> {
 
         let runtime_c_path = self.opt.runtime_dot_c_path();
 
-        let use_shared_runtime = self.opt.selected_backend.uses_shared_runtime();
+        let use_shared_runtime = self.opt.backend.uses_shared_runtime();
         let (output_ty, link_moonbitrun) = if use_shared_runtime {
             (CCOutputType::SharedLib, false)
         } else {
@@ -215,7 +215,7 @@ impl<'a> super::LoweringContext<'a> {
                     &self
                         .artifact_paths
                         .target_layout()
-                        .runtime_output_dir(self.opt.target_backend)
+                        .runtime_output_dir(self.opt.target_backend())
                         .display()
                         .to_string(),
                     Some(&artifact_path.display().to_string()),

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -92,7 +92,7 @@ impl<'a> super::LoweringContext<'a> {
             enable_coverage,
             coverage_package_override: if self_coverage { Some("@self") } else { None },
             driver_kind,
-            target_backend: self.opt.target_backend().into(),
+            target_backend: self.opt.target_backend(),
             patch_file,
             pkg_name: &pkg_full_name,
             max_concurrent_tests: package.raw.max_concurrent_tests,

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -34,6 +34,7 @@ use moonutil::{
     cond_expr::OptLevel,
     package::JsFormat,
     resolution::{CORE_MODULE, ModuleId},
+    target::TargetBackend,
     toolchain::BINARIES,
 };
 use petgraph::Direction;
@@ -50,10 +51,7 @@ use crate::{
     },
     build_plan::{BuildCStubsInfo, BuildTargetInfo, LinkCoreInfo, MakeExecutableInfo},
     discover::DiscoveredPackage,
-    model::{
-        BackendConfig, BuildTarget, NativeTarget, OperatingSystem, PackageId, RunBackend,
-        TargetKind,
-    },
+    model::{BackendConfig, BuildTarget, NativeTarget, OperatingSystem, PackageId, TargetKind},
     pkg_name::{PackageFQN, PackagePath},
     special_cases::{is_self_coverage_lib, should_skip_coverage},
     target_layout::proof_artifact_stem,
@@ -98,8 +96,7 @@ impl<'a> LoweringContext<'a> {
         compiler::CompilationFlags {
             no_opt: self.opt.opt_level == OptLevel::Debug,
             symbols: self.opt.debug_symbols,
-            source_map: self.opt.target_backend().to_target().supports_source_map()
-                && self.opt.debug_symbols,
+            source_map: self.opt.target_backend().supports_source_map() && self.opt.debug_symbols,
             enable_coverage: false,
             self_coverage: false,
             enable_value_tracing: false,
@@ -136,9 +133,11 @@ impl<'a> LoweringContext<'a> {
         is_main: bool,
     ) -> BuildCommonConfig<'a> {
         // Standard library settings
-        let stdlib_core_file = self.opt.stdlib_path.as_ref().map(|x| {
-            moonutil::toolchain::core_bundle_in(x, self.opt.target_backend().into()).into()
-        });
+        let stdlib_core_file = self
+            .opt
+            .stdlib_path
+            .as_ref()
+            .map(|x| moonutil::toolchain::core_bundle_in(x, self.opt.target_backend()).into());
 
         // Warning and error settings
         let error_format = if self.opt.moonc_output_json {
@@ -181,7 +180,7 @@ impl<'a> LoweringContext<'a> {
             let mi_path = self.artifact_paths.mi_of_build_target(
                 self.packages,
                 &v_target,
-                self.opt.target_backend().into(),
+                self.opt.target_backend(),
             );
 
             // If current package is NOT the same package as the virtual target,
@@ -265,7 +264,7 @@ impl<'a> LoweringContext<'a> {
                     self.artifact_paths.mi_of_build_target(
                         self.packages,
                         &dep,
-                        self.opt.target_backend().into(),
+                        self.opt.target_backend(),
                     )
                 } else {
                     self.artifact_paths
@@ -374,7 +373,7 @@ impl<'a> LoweringContext<'a> {
                         .mi_of_build_target_impl_virtual(
                             self.packages,
                             &target,
-                            self.opt.target_backend().into(),
+                            self.opt.target_backend(),
                         )
                         .into_path()
                 } else {
@@ -401,7 +400,7 @@ impl<'a> LoweringContext<'a> {
             | TargetKind::InlineTest
             | TargetKind::SubPackage => package.raw.is_main,
         };
-        let backend = self.opt.target_backend().into();
+        let backend = self.opt.target_backend();
         let cmd = compiler::MooncCheck {
             required: BuildCommonInput::new(
                 &files_vec,
@@ -453,7 +452,7 @@ impl<'a> LoweringContext<'a> {
 
         let files_vec = self.compiler_source_files(info);
 
-        let backend = self.opt.target_backend().into();
+        let backend = self.opt.target_backend();
         let whyml_output = products.single_output_path_matching(|product| {
             matches!(
                 product,
@@ -516,7 +515,7 @@ impl<'a> LoweringContext<'a> {
 
         let files_vec = self.compiler_source_files(info);
 
-        let backend = self.opt.target_backend().into();
+        let backend = self.opt.target_backend();
         let why3_config = info
             .why3_config
             .clone()
@@ -618,7 +617,7 @@ impl<'a> LoweringContext<'a> {
                 self.artifact_paths.mi_of_build_target(
                     self.packages,
                     &target,
-                    self.opt.target_backend().into(),
+                    self.opt.target_backend(),
                 )
             });
 
@@ -649,7 +648,7 @@ impl<'a> LoweringContext<'a> {
             TargetKind::Source | TargetKind::SubPackage => package.raw.is_main,
             TargetKind::InlineTest | TargetKind::WhiteboxTest | TargetKind::BlackboxTest => true,
         };
-        let backend = self.opt.target_backend().into();
+        let backend = self.opt.target_backend();
         let mut cmd = compiler::MooncBuildPackage {
             required: BuildCommonInput::new(
                 &files,
@@ -716,12 +715,12 @@ impl<'a> LoweringContext<'a> {
             if !info.abort_overridden {
                 core_input_files.push(moonutil::toolchain::abort_core_in(
                     stdlib,
-                    self.opt.target_backend().into(),
+                    self.opt.target_backend(),
                 ));
             }
             core_input_files.push(moonutil::toolchain::core_core_in(
                 stdlib,
-                self.opt.target_backend().into(),
+                self.opt.target_backend(),
             ));
         }
         // Linked core targets
@@ -776,13 +775,13 @@ impl<'a> LoweringContext<'a> {
             pkg_config_path: config_path.clone().into(),
             package_sources: &package_sources,
             stdlib_core_source: None,
-            target_backend: self.opt.target_backend().into(),
+            target_backend: self.opt.target_backend(),
             native_target: self.opt.backend.direct_native_target(),
             flags: self.set_flags(),
             test_mode: target.kind.is_test(),
             wasm_config: self.get_wasm_config(target, package),
             js_config: self.get_js_config(target, package),
-            exports: package.exported_functions(self.opt.target_backend().into()),
+            exports: package.exported_functions(self.opt.target_backend()),
             extra_link_opts: module.link_flags.as_deref().unwrap_or_default(),
             #[cfg(target_os = "windows")]
             native_toolchain_is_msvc: make_executable_info
@@ -794,11 +793,11 @@ impl<'a> LoweringContext<'a> {
         if let Some(stdlib) = &self.opt.stdlib_path {
             extra_inputs.push(moonutil::toolchain::abort_core_in(
                 stdlib,
-                self.opt.target_backend().into(),
+                self.opt.target_backend(),
             ));
             extra_inputs.push(moonutil::toolchain::core_core_in(
                 stdlib,
-                self.opt.target_backend().into(),
+                self.opt.target_backend(),
             ));
         }
         if !package.is_single_file() {
@@ -818,7 +817,7 @@ impl<'a> LoweringContext<'a> {
         target: BuildTarget,
         pkg: &'b DiscoveredPackage,
     ) -> compiler::WasmConfig<'b> {
-        let mut wasm_config = if self.opt.target_backend() == RunBackend::Wasm
+        let mut wasm_config = if self.opt.target_backend() == TargetBackend::Wasm
             && let Some(cfg) = pkg.raw.link.as_ref().and_then(|x| x.wasm.as_ref())
         {
             WasmConfig {
@@ -830,7 +829,7 @@ impl<'a> LoweringContext<'a> {
                 link_flags: cfg.flags.as_deref(),
                 wasi: false,
             }
-        } else if self.opt.target_backend() == RunBackend::WasmGC
+        } else if self.opt.target_backend() == TargetBackend::WasmGC
             && let Some(cfg) = pkg.raw.link.as_ref().and_then(|x| x.wasm_gc.as_ref())
         {
             WasmConfig {
@@ -870,7 +869,7 @@ impl<'a> LoweringContext<'a> {
 
     fn get_js_config(&self, target: BuildTarget, pkg: &DiscoveredPackage) -> Option<JsConfig> {
         let backend = self.opt.target_backend();
-        if backend != RunBackend::Js {
+        if backend != TargetBackend::Js {
             return None;
         }
 
@@ -948,7 +947,7 @@ impl<'a> LoweringContext<'a> {
         let intermediate_dir = self
             .artifact_paths
             .target_layout()
-            .package_dir(&package.fqn, self.opt.target_backend().into())
+            .package_dir(&package.fqn, self.opt.target_backend())
             .display()
             .to_string();
 
@@ -1225,10 +1224,7 @@ impl<'a> LoweringContext<'a> {
         let pkg_dir = self
             .artifact_paths
             .target_layout()
-            .package_dir(
-                &self.get_package(target).fqn,
-                self.opt.target_backend().into(),
-            )
+            .package_dir(&self.get_package(target).fqn, self.opt.target_backend())
             .display()
             .to_string();
 
@@ -1245,7 +1241,7 @@ impl<'a> LoweringContext<'a> {
 
         // On macOS with LLVM backend and debug symbols, run dsymutil after linking
         // to generate the dSYM bundle for better debugging experience
-        let commandline = if self.opt.target_backend() == RunBackend::Llvm
+        let commandline = if self.opt.target_backend() == TargetBackend::LLVM
             && self.opt.debug_symbols
             && self.opt.os() == OperatingSystem::MacOS
         {
@@ -1286,10 +1282,7 @@ impl<'a> LoweringContext<'a> {
         let pkg_dir = self
             .artifact_paths
             .target_layout()
-            .package_dir(
-                &self.get_package(target).fqn,
-                self.opt.target_backend().into(),
-            )
+            .package_dir(&self.get_package(target).fqn, self.opt.target_backend())
             .display()
             .to_string();
 
@@ -1428,7 +1421,7 @@ impl<'a> LoweringContext<'a> {
         let mi_out = self.artifact_paths.mi_of_build_target(
             self.packages,
             &target,
-            self.opt.target_backend().into(),
+            self.opt.target_backend(),
         );
 
         // Resolve interface dependencies from the dep graph (path:alias pairs)
@@ -1446,8 +1439,7 @@ impl<'a> LoweringContext<'a> {
         // Provide std path when stdlib is enabled
         if let Some(stdlib_root) = &self.opt.stdlib_path {
             cmd.stdlib_core_file = Some(
-                moonutil::toolchain::core_bundle_in(stdlib_root, self.opt.target_backend().into())
-                    .into(),
+                moonutil::toolchain::core_bundle_in(stdlib_root, self.opt.target_backend()).into(),
             );
         }
 
@@ -1470,7 +1462,7 @@ impl<'a> LoweringContext<'a> {
                 let in_file = self.artifact_paths.mi_of_build_target(
                     self.packages,
                     &it,
-                    self.opt.target_backend().into(),
+                    self.opt.target_backend(),
                 );
                 MiDependency::new(in_file, &w.short_alias)
             })

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -42,7 +42,7 @@ use tracing::{Level, instrument};
 use crate::{
     build_action_plan::BuildProduct,
     build_lower::{
-        CExecutableRealization, CStubLibraryRealization, SelectedBackend, WarningCondition,
+        CExecutableRealization, CStubLibraryRealization, WarningCondition,
         compiler::{
             BuildCommonConfig, BuildCommonInput, CmdlineAbstraction, ErrorFormat, JsConfig,
             MiDependency, PackageSource, WasmConfig,
@@ -50,7 +50,10 @@ use crate::{
     },
     build_plan::{BuildCStubsInfo, BuildTargetInfo, LinkCoreInfo, MakeExecutableInfo},
     discover::DiscoveredPackage,
-    model::{BuildTarget, NativeTarget, OperatingSystem, PackageId, RunBackend, TargetKind},
+    model::{
+        BackendConfig, BuildTarget, NativeTarget, OperatingSystem, PackageId, RunBackend,
+        TargetKind,
+    },
     pkg_name::{PackageFQN, PackagePath},
     special_cases::{is_self_coverage_lib, should_skip_coverage},
     target_layout::proof_artifact_stem,
@@ -95,7 +98,7 @@ impl<'a> LoweringContext<'a> {
         compiler::CompilationFlags {
             no_opt: self.opt.opt_level == OptLevel::Debug,
             symbols: self.opt.debug_symbols,
-            source_map: self.opt.target_backend.to_target().supports_source_map()
+            source_map: self.opt.target_backend().to_target().supports_source_map()
                 && self.opt.debug_symbols,
             enable_coverage: false,
             self_coverage: false,
@@ -133,10 +136,9 @@ impl<'a> LoweringContext<'a> {
         is_main: bool,
     ) -> BuildCommonConfig<'a> {
         // Standard library settings
-        let stdlib_core_file =
-            self.opt.stdlib_path.as_ref().map(|x| {
-                moonutil::toolchain::core_bundle_in(x, self.opt.target_backend.into()).into()
-            });
+        let stdlib_core_file = self.opt.stdlib_path.as_ref().map(|x| {
+            moonutil::toolchain::core_bundle_in(x, self.opt.target_backend().into()).into()
+        });
 
         // Warning and error settings
         let error_format = if self.opt.moonc_output_json {
@@ -179,7 +181,7 @@ impl<'a> LoweringContext<'a> {
             let mi_path = self.artifact_paths.mi_of_build_target(
                 self.packages,
                 &v_target,
-                self.opt.target_backend.into(),
+                self.opt.target_backend().into(),
             );
 
             // If current package is NOT the same package as the virtual target,
@@ -263,7 +265,7 @@ impl<'a> LoweringContext<'a> {
                     self.artifact_paths.mi_of_build_target(
                         self.packages,
                         &dep,
-                        self.opt.target_backend.into(),
+                        self.opt.target_backend().into(),
                     )
                 } else {
                     self.artifact_paths
@@ -372,7 +374,7 @@ impl<'a> LoweringContext<'a> {
                         .mi_of_build_target_impl_virtual(
                             self.packages,
                             &target,
-                            self.opt.target_backend.into(),
+                            self.opt.target_backend().into(),
                         )
                         .into_path()
                 } else {
@@ -399,7 +401,7 @@ impl<'a> LoweringContext<'a> {
             | TargetKind::InlineTest
             | TargetKind::SubPackage => package.raw.is_main,
         };
-        let backend = self.opt.target_backend.into();
+        let backend = self.opt.target_backend().into();
         let cmd = compiler::MooncCheck {
             required: BuildCommonInput::new(
                 &files_vec,
@@ -451,7 +453,7 @@ impl<'a> LoweringContext<'a> {
 
         let files_vec = self.compiler_source_files(info);
 
-        let backend = self.opt.target_backend.into();
+        let backend = self.opt.target_backend().into();
         let whyml_output = products.single_output_path_matching(|product| {
             matches!(
                 product,
@@ -514,7 +516,7 @@ impl<'a> LoweringContext<'a> {
 
         let files_vec = self.compiler_source_files(info);
 
-        let backend = self.opt.target_backend.into();
+        let backend = self.opt.target_backend().into();
         let why3_config = info
             .why3_config
             .clone()
@@ -616,7 +618,7 @@ impl<'a> LoweringContext<'a> {
                 self.artifact_paths.mi_of_build_target(
                     self.packages,
                     &target,
-                    self.opt.target_backend.into(),
+                    self.opt.target_backend().into(),
                 )
             });
 
@@ -647,7 +649,7 @@ impl<'a> LoweringContext<'a> {
             TargetKind::Source | TargetKind::SubPackage => package.raw.is_main,
             TargetKind::InlineTest | TargetKind::WhiteboxTest | TargetKind::BlackboxTest => true,
         };
-        let backend = self.opt.target_backend.into();
+        let backend = self.opt.target_backend().into();
         let mut cmd = compiler::MooncBuildPackage {
             required: BuildCommonInput::new(
                 &files,
@@ -714,12 +716,12 @@ impl<'a> LoweringContext<'a> {
             if !info.abort_overridden {
                 core_input_files.push(moonutil::toolchain::abort_core_in(
                     stdlib,
-                    self.opt.target_backend.into(),
+                    self.opt.target_backend().into(),
                 ));
             }
             core_input_files.push(moonutil::toolchain::core_core_in(
                 stdlib,
-                self.opt.target_backend.into(),
+                self.opt.target_backend().into(),
             ));
         }
         // Linked core targets
@@ -774,13 +776,13 @@ impl<'a> LoweringContext<'a> {
             pkg_config_path: config_path.clone().into(),
             package_sources: &package_sources,
             stdlib_core_source: None,
-            target_backend: self.opt.target_backend.into(),
-            native_target: self.opt.selected_backend.direct_target(),
+            target_backend: self.opt.target_backend().into(),
+            native_target: self.opt.backend.direct_native_target(),
             flags: self.set_flags(),
             test_mode: target.kind.is_test(),
             wasm_config: self.get_wasm_config(target, package),
             js_config: self.get_js_config(target, package),
-            exports: package.exported_functions(self.opt.target_backend.into()),
+            exports: package.exported_functions(self.opt.target_backend().into()),
             extra_link_opts: module.link_flags.as_deref().unwrap_or_default(),
             #[cfg(target_os = "windows")]
             native_toolchain_is_msvc: make_executable_info
@@ -792,11 +794,11 @@ impl<'a> LoweringContext<'a> {
         if let Some(stdlib) = &self.opt.stdlib_path {
             extra_inputs.push(moonutil::toolchain::abort_core_in(
                 stdlib,
-                self.opt.target_backend.into(),
+                self.opt.target_backend().into(),
             ));
             extra_inputs.push(moonutil::toolchain::core_core_in(
                 stdlib,
-                self.opt.target_backend.into(),
+                self.opt.target_backend().into(),
             ));
         }
         if !package.is_single_file() {
@@ -816,7 +818,7 @@ impl<'a> LoweringContext<'a> {
         target: BuildTarget,
         pkg: &'b DiscoveredPackage,
     ) -> compiler::WasmConfig<'b> {
-        let mut wasm_config = if self.opt.target_backend == RunBackend::Wasm
+        let mut wasm_config = if self.opt.target_backend() == RunBackend::Wasm
             && let Some(cfg) = pkg.raw.link.as_ref().and_then(|x| x.wasm.as_ref())
         {
             WasmConfig {
@@ -828,7 +830,7 @@ impl<'a> LoweringContext<'a> {
                 link_flags: cfg.flags.as_deref(),
                 wasi: false,
             }
-        } else if self.opt.target_backend == RunBackend::WasmGC
+        } else if self.opt.target_backend() == RunBackend::WasmGC
             && let Some(cfg) = pkg.raw.link.as_ref().and_then(|x| x.wasm_gc.as_ref())
         {
             WasmConfig {
@@ -852,7 +854,7 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn should_link_wasi(&self, target: BuildTarget, pkg: &DiscoveredPackage) -> bool {
-        if !self.opt.wasi_link || self.opt.target_backend != RunBackend::Wasm {
+        if !self.opt.backend.wasi_link() {
             return false;
         }
 
@@ -867,7 +869,7 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn get_js_config(&self, target: BuildTarget, pkg: &DiscoveredPackage) -> Option<JsConfig> {
-        let backend = self.opt.target_backend;
+        let backend = self.opt.target_backend();
         if backend != RunBackend::Js {
             return None;
         }
@@ -902,7 +904,7 @@ impl<'a> LoweringContext<'a> {
         index: u32,
         info: &BuildCStubsInfo,
     ) -> BuildCommand {
-        if !self.opt.target_backend.is_native() {
+        if !self.opt.target_backend().is_native() {
             unreachable!("C stubs are only lowered for C or LLVM backends")
         }
 
@@ -931,7 +933,7 @@ impl<'a> LoweringContext<'a> {
             (false, false) => CCOptLevel::None,
         };
         // `tcc run` uses shared runtime, others use static runtime
-        let use_shared_runtime = self.opt.selected_backend.uses_shared_runtime();
+        let use_shared_runtime = self.opt.backend.uses_shared_runtime();
 
         let config = CCConfigBuilder::default()
             .no_sys_header(true)
@@ -946,7 +948,7 @@ impl<'a> LoweringContext<'a> {
         let intermediate_dir = self
             .artifact_paths
             .target_layout()
-            .package_dir(&package.fqn, self.opt.target_backend.into())
+            .package_dir(&package.fqn, self.opt.target_backend().into())
             .display()
             .to_string();
 
@@ -975,7 +977,7 @@ impl<'a> LoweringContext<'a> {
         target: PackageId,
         info: &BuildCStubsInfo,
     ) -> BuildCommand {
-        if !self.opt.target_backend.is_native() {
+        if !self.opt.target_backend().is_native() {
             unreachable!("C stubs are only lowered for C or LLVM backends")
         }
 
@@ -997,7 +999,7 @@ impl<'a> LoweringContext<'a> {
             )
         });
 
-        match self.opt.selected_backend.c_stub_library_realization() {
+        match self.opt.backend.c_stub_library_realization() {
             CStubLibraryRealization::SharedLibraryForTccRun => {
                 self.lower_link_c_stubs(products, info, &object_files, output)
             }
@@ -1123,11 +1125,11 @@ impl<'a> LoweringContext<'a> {
                 })
         });
 
-        match &self.opt.selected_backend {
-            SelectedBackend::Wasm { .. } | SelectedBackend::WasmGc { .. } | SelectedBackend::Js => {
+        match &self.opt.backend {
+            BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } | BackendConfig::Js => {
                 unreachable!("non-native make-executable actions are no-ops during lowering")
             }
-            SelectedBackend::C(backend) => match backend.executable_realization() {
+            BackendConfig::Native(backend) => match backend.executable_realization() {
                 CExecutableRealization::WriteTccRunResponseFile => {
                     let tcc_run = backend
                         .tcc_run()
@@ -1142,7 +1144,7 @@ impl<'a> LoweringContext<'a> {
                     self.lower_build_exe_regular(products, target, info)
                 }
             },
-            SelectedBackend::Llvm => self.lower_build_exe_regular(products, target, info),
+            BackendConfig::Llvm => self.lower_build_exe_regular(products, target, info),
         }
     }
 
@@ -1225,7 +1227,7 @@ impl<'a> LoweringContext<'a> {
             .target_layout()
             .package_dir(
                 &self.get_package(target).fqn,
-                self.opt.target_backend.into(),
+                self.opt.target_backend().into(),
             )
             .display()
             .to_string();
@@ -1243,7 +1245,7 @@ impl<'a> LoweringContext<'a> {
 
         // On macOS with LLVM backend and debug symbols, run dsymutil after linking
         // to generate the dSYM bundle for better debugging experience
-        let commandline = if self.opt.target_backend == RunBackend::Llvm
+        let commandline = if self.opt.target_backend() == RunBackend::Llvm
             && self.opt.debug_symbols
             && self.opt.os() == OperatingSystem::MacOS
         {
@@ -1286,7 +1288,7 @@ impl<'a> LoweringContext<'a> {
             .target_layout()
             .package_dir(
                 &self.get_package(target).fqn,
-                self.opt.target_backend.into(),
+                self.opt.target_backend().into(),
             )
             .display()
             .to_string();
@@ -1303,7 +1305,7 @@ impl<'a> LoweringContext<'a> {
             .map(|path| path.display().to_string())
             .collect::<Vec<_>>();
         let run_dsymutil = should_run_new_native_dsymutil(
-            self.opt.selected_backend.direct_target(),
+            self.opt.backend.direct_native_target(),
             self.opt.debug_symbols,
             &cc,
         );
@@ -1426,7 +1428,7 @@ impl<'a> LoweringContext<'a> {
         let mi_out = self.artifact_paths.mi_of_build_target(
             self.packages,
             &target,
-            self.opt.target_backend.into(),
+            self.opt.target_backend().into(),
         );
 
         // Resolve interface dependencies from the dep graph (path:alias pairs)
@@ -1444,7 +1446,7 @@ impl<'a> LoweringContext<'a> {
         // Provide std path when stdlib is enabled
         if let Some(stdlib_root) = &self.opt.stdlib_path {
             cmd.stdlib_core_file = Some(
-                moonutil::toolchain::core_bundle_in(stdlib_root, self.opt.target_backend.into())
+                moonutil::toolchain::core_bundle_in(stdlib_root, self.opt.target_backend().into())
                     .into(),
             );
         }
@@ -1468,7 +1470,7 @@ impl<'a> LoweringContext<'a> {
                 let in_file = self.artifact_paths.mi_of_build_target(
                     self.packages,
                     &it,
-                    self.opt.target_backend.into(),
+                    self.opt.target_backend().into(),
                 );
                 MiDependency::new(in_file, &w.short_alias)
             })

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -22,14 +22,17 @@
 use std::{collections::BTreeMap, path::PathBuf, str::FromStr, sync::OnceLock};
 
 use log::{debug, info};
-use moonutil::{build_options::RunMode, compiler_flags::CompilerPaths, cond_expr::OptLevel};
+use moonutil::{
+    build_options::RunMode, compiler_flags::CompilerPaths, cond_expr::OptLevel,
+    target::TargetBackend,
+};
 use n2::graph::Graph as N2Graph;
 use tracing::instrument;
 
 use crate::{
     ResolveOutput,
     build_action_plan::{BuildActionId, BuildActionPlan},
-    model::{BackendConfig, OperatingSystem, PackageId, RunBackend},
+    model::{BackendConfig, OperatingSystem, PackageId},
     pkg_name::OptionalPackageFQNWithSource,
     target_layout::{
         ArtifactPathOptions, ArtifactPathResolver, ExecutableArtifact, LinkedCoreArtifact,
@@ -121,8 +124,8 @@ pub struct BuildOptions {
 }
 
 impl BuildOptions {
-    pub fn target_backend(&self) -> RunBackend {
-        self.backend.run_backend()
+    pub fn target_backend(&self) -> TargetBackend {
+        self.backend.target_backend()
     }
 
     pub fn os(&self) -> OperatingSystem {
@@ -138,42 +141,41 @@ impl BuildOptions {
     }
 
     pub fn artifact_path_options(&self) -> ArtifactPathOptions {
-        let use_tcc_run = self.backend.tcc_run().is_some();
-        let target_backend = self.target_backend();
-        let os = match target_backend {
-            RunBackend::Wasm | RunBackend::WasmGC | RunBackend::Js => OperatingSystem::None,
-            RunBackend::Native | RunBackend::Llvm => self.os(),
-        };
-        let executable = match target_backend {
-            RunBackend::Wasm => ExecutableArtifact::Wasm {
-                use_wat: self.backend.use_wat(),
-            },
-            RunBackend::WasmGC => ExecutableArtifact::WasmGC {
-                use_wat: self.backend.use_wat(),
-            },
-            RunBackend::Js => ExecutableArtifact::Js,
-            RunBackend::Native if use_tcc_run => ExecutableArtifact::TccRunResponseFile,
-            RunBackend::Native => ExecutableArtifact::NativeExecutable,
-            RunBackend::Llvm => ExecutableArtifact::LlvmExecutable,
-        };
-        let linked_core = match target_backend {
-            RunBackend::Wasm => LinkedCoreArtifact::Wasm {
-                use_wat: self.backend.use_wat(),
-            },
-            RunBackend::WasmGC => LinkedCoreArtifact::WasmGC {
-                use_wat: self.backend.use_wat(),
-            },
-            RunBackend::Js => LinkedCoreArtifact::Js,
-            RunBackend::Native if self.backend.direct_native_target().is_some() => {
-                LinkedCoreArtifact::NativeObject { os }
+        let os = match &self.backend {
+            BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } | BackendConfig::Js => {
+                OperatingSystem::None
             }
-            RunBackend::Native => LinkedCoreArtifact::NativeC,
-            RunBackend::Llvm => LinkedCoreArtifact::LlvmObject { os },
+            BackendConfig::Native(_) | BackendConfig::Llvm => self.os(),
+        };
+        let (executable, linked_core) = match &self.backend {
+            BackendConfig::Wasm { use_wat, .. } => (
+                ExecutableArtifact::Wasm { use_wat: *use_wat },
+                LinkedCoreArtifact::Wasm { use_wat: *use_wat },
+            ),
+            BackendConfig::WasmGc { use_wat } => (
+                ExecutableArtifact::WasmGC { use_wat: *use_wat },
+                LinkedCoreArtifact::WasmGC { use_wat: *use_wat },
+            ),
+            BackendConfig::Js => (ExecutableArtifact::Js, LinkedCoreArtifact::Js),
+            BackendConfig::Native(mode) => (
+                if mode.tcc_run().is_some() {
+                    ExecutableArtifact::TccRunResponseFile
+                } else {
+                    ExecutableArtifact::NativeExecutable
+                },
+                if mode.direct_target().is_some() {
+                    LinkedCoreArtifact::NativeObject { os }
+                } else {
+                    LinkedCoreArtifact::NativeC
+                },
+            ),
+            BackendConfig::Llvm => (
+                ExecutableArtifact::LlvmExecutable,
+                LinkedCoreArtifact::LlvmObject { os },
+            ),
         };
 
         ArtifactPathOptions {
-            target_backend,
-            use_tcc_run,
             os,
             executable,
             linked_core,
@@ -346,7 +348,14 @@ mod tests {
 
     #[test]
     fn non_native_artifact_options_do_not_resolve_operating_system() {
-        for target_backend in [RunBackend::Wasm, RunBackend::WasmGC, RunBackend::Js] {
+        for backend in [
+            BackendConfig::Wasm {
+                use_wat: false,
+                wasi_link: false,
+            },
+            BackendConfig::WasmGc { use_wat: false },
+            BackendConfig::Js,
+        ] {
             let artifact_paths = ArtifactPathResolver::new(
                 TargetLayout::new(
                     PathBuf::from("_build"),
@@ -358,15 +367,7 @@ mod tests {
             );
             let options = BuildOptions {
                 artifact_paths,
-                backend: match target_backend {
-                    RunBackend::Wasm => BackendConfig::Wasm {
-                        use_wat: false,
-                        wasi_link: false,
-                    },
-                    RunBackend::WasmGC => BackendConfig::WasmGc { use_wat: false },
-                    RunBackend::Js => BackendConfig::Js,
-                    RunBackend::Native | RunBackend::Llvm => unreachable!(),
-                },
+                backend,
                 opt_level: OptLevel::Debug,
                 action: RunMode::Build,
                 debug_symbols: false,

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -29,7 +29,7 @@ use tracing::instrument;
 use crate::{
     ResolveOutput,
     build_action_plan::{BuildActionId, BuildActionPlan},
-    model::{OperatingSystem, PackageId, RunBackend},
+    model::{BackendConfig, OperatingSystem, PackageId, RunBackend},
     pkg_name::OptionalPackageFQNWithSource,
     target_layout::{
         ArtifactPathOptions, ArtifactPathResolver, ExecutableArtifact, LinkedCoreArtifact,
@@ -51,7 +51,7 @@ pub use lowered_action::{
 };
 pub use utils::{build_ins, build_n2_fileloc, build_outs};
 
-pub(crate) use backend::{CExecutableRealization, CStubLibraryRealization, SelectedBackend};
+pub(crate) use backend::{CExecutableRealization, CStubLibraryRealization};
 
 use context::LoweringContext;
 use lowered_action::{BuildCommand, LoweredCommandKind};
@@ -102,20 +102,17 @@ impl LoweringEnvironment {
 pub struct BuildOptions {
     pub artifact_paths: ArtifactPathResolver,
     // FIXME: This overlaps with `crate::build_plan::BuildEnvironment`
-    pub target_backend: RunBackend,
-    pub(crate) selected_backend: SelectedBackend,
+    pub backend: BackendConfig,
     pub opt_level: OptLevel,
     pub action: RunMode,
 
     // Detailed configuration -- some of them might live better in configs
     pub debug_symbols: bool,
     pub enable_coverage: bool,
-    pub output_wat: bool,
     pub moonc_output_json: bool,
     pub docs_serve: bool,
     pub warning_condition: WarningCondition,
     pub info_no_alias: bool,
-    pub wasi_link: bool,
 
     // Environments
     /// Only `Some` if we import standard library.
@@ -124,6 +121,10 @@ pub struct BuildOptions {
 }
 
 impl BuildOptions {
+    pub fn target_backend(&self) -> RunBackend {
+        self.backend.run_backend()
+    }
+
     pub fn os(&self) -> OperatingSystem {
         self.lowering_environment.os()
     }
@@ -136,37 +137,34 @@ impl BuildOptions {
         self.lowering_environment.runtime_dot_c_path()
     }
 
-    pub fn use_tcc_run(&self) -> bool {
-        self.selected_backend.is_tcc_run()
-    }
-
     pub fn artifact_path_options(&self) -> ArtifactPathOptions {
-        let use_tcc_run = self.use_tcc_run();
-        let os = match self.target_backend {
+        let use_tcc_run = self.backend.tcc_run().is_some();
+        let target_backend = self.target_backend();
+        let os = match target_backend {
             RunBackend::Wasm | RunBackend::WasmGC | RunBackend::Js => OperatingSystem::None,
             RunBackend::Native | RunBackend::Llvm => self.os(),
         };
-        let executable = match self.target_backend {
+        let executable = match target_backend {
             RunBackend::Wasm => ExecutableArtifact::Wasm {
-                use_wat: self.selected_backend.use_wat(),
+                use_wat: self.backend.use_wat(),
             },
             RunBackend::WasmGC => ExecutableArtifact::WasmGC {
-                use_wat: self.selected_backend.use_wat(),
+                use_wat: self.backend.use_wat(),
             },
             RunBackend::Js => ExecutableArtifact::Js,
             RunBackend::Native if use_tcc_run => ExecutableArtifact::TccRunResponseFile,
             RunBackend::Native => ExecutableArtifact::NativeExecutable,
             RunBackend::Llvm => ExecutableArtifact::LlvmExecutable,
         };
-        let linked_core = match self.target_backend {
+        let linked_core = match target_backend {
             RunBackend::Wasm => LinkedCoreArtifact::Wasm {
-                use_wat: self.selected_backend.use_wat(),
+                use_wat: self.backend.use_wat(),
             },
             RunBackend::WasmGC => LinkedCoreArtifact::WasmGC {
-                use_wat: self.selected_backend.use_wat(),
+                use_wat: self.backend.use_wat(),
             },
             RunBackend::Js => LinkedCoreArtifact::Js,
-            RunBackend::Native if self.selected_backend.direct_target().is_some() => {
+            RunBackend::Native if self.backend.direct_native_target().is_some() => {
                 LinkedCoreArtifact::NativeObject { os }
             }
             RunBackend::Native => LinkedCoreArtifact::NativeC,
@@ -174,7 +172,7 @@ impl BuildOptions {
         };
 
         ArtifactPathOptions {
-            target_backend: self.target_backend,
+            target_backend,
             use_tcc_run,
             os,
             executable,
@@ -235,7 +233,9 @@ pub fn lower_build_plan(
     info!("Starting action plan lowering to n2 graph");
     debug!(
         "Build options: backend={:?}, opt_level={:?}, debug_symbols={}",
-        opt.target_backend, opt.opt_level, opt.debug_symbols
+        opt.target_backend(),
+        opt.opt_level,
+        opt.debug_symbols
     );
 
     let result = lower_actions(
@@ -333,8 +333,8 @@ mod tests {
         },
         discover::{DiscoverResult, DiscoveredPackage},
         model::{
-            BuildPlanNode, BuildTarget, DirectNativeMode, NativeBackendMode, NativeTarget,
-            TargetKind,
+            BackendConfig, BuildPlanNode, BuildTarget, DirectNativeMode, NativeBackendMode,
+            NativeTarget, TargetKind,
         },
         pkg_name::{PackageFQN, PackagePath},
         pkg_solve::DepRelationship,
@@ -358,18 +358,23 @@ mod tests {
             );
             let options = BuildOptions {
                 artifact_paths,
-                target_backend,
-                selected_backend: SelectedBackend::new(target_backend, None, false),
+                backend: match target_backend {
+                    RunBackend::Wasm => BackendConfig::Wasm {
+                        use_wat: false,
+                        wasi_link: false,
+                    },
+                    RunBackend::WasmGC => BackendConfig::WasmGc { use_wat: false },
+                    RunBackend::Js => BackendConfig::Js,
+                    RunBackend::Native | RunBackend::Llvm => unreachable!(),
+                },
                 opt_level: OptLevel::Debug,
                 action: RunMode::Build,
                 debug_symbols: false,
                 enable_coverage: false,
-                output_wat: false,
                 moonc_output_json: false,
                 docs_serve: false,
                 warning_condition: WarningCondition::Default,
                 info_no_alias: false,
-                wasi_link: false,
                 stdlib_path: None,
                 lowering_environment: LoweringEnvironment::default(),
             };
@@ -705,18 +710,15 @@ mod tests {
         ));
         let options = BuildOptions {
             artifact_paths: artifact_paths.clone(),
-            target_backend: RunBackend::Native,
-            selected_backend: SelectedBackend::new(RunBackend::Native, Some(&native_mode), false),
+            backend: BackendConfig::Native(native_mode),
             opt_level: OptLevel::Debug,
             action: RunMode::Build,
             debug_symbols: false,
             enable_coverage: false,
-            output_wat: false,
             moonc_output_json: false,
             docs_serve: false,
             warning_condition: WarningCondition::Default,
             info_no_alias: false,
-            wasi_link: false,
             stdlib_path: None,
             lowering_environment,
         };

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -34,7 +34,6 @@ use moonutil::{
     package::{MoonPkgGenerate, SupportedTargetsDeclKind},
     resolution::ModuleId,
     scripts::{IgnoredMoonScript, is_moon_script_ignored},
-    target::TargetBackend,
     toolchain::BINARIES,
 };
 use regex::Regex;
@@ -187,7 +186,7 @@ impl<'a> BuildPlanConstructor<'a> {
         importer_target: BuildTarget,
         dep: BuildTarget,
     ) -> Result<(), BuildPlanConstructError> {
-        let selected_backend: TargetBackend = self.build_env.target_backend().into();
+        let selected_backend = self.build_env.target_backend();
         let importer_pkg = self.input.pkg_dirs.get_package(importer_target.package);
         let dependency_pkg = self.input.pkg_dirs.get_package(dep.package);
 
@@ -568,7 +567,7 @@ impl<'a> BuildPlanConstructor<'a> {
                 .chain(mbtlex_iter)
                 .chain(mbtyacc_iter),
             self.build_env.opt_level,
-            self.build_env.target_backend().into(),
+            self.build_env.target_backend(),
         ) {
             match file_kind {
                 NoTest => no_test_files.insert(file.into_owned()),
@@ -1205,8 +1204,7 @@ impl<'a> BuildPlanConstructor<'a> {
         // Bundling a module gathers the build result of all its non-virtual packages, in topo order
         let topo_sorted_pkgs = self.topo_sort_module_packages(module_id);
         let mut bundle_targets = Vec::new();
-        let target_backend: moonutil::target::TargetBackend =
-            self.build_env.target_backend().into();
+        let target_backend = self.build_env.target_backend();
         for target in topo_sorted_pkgs.into_iter() {
             let pkg = self.input.pkg_dirs.get_package(target.package);
             if !pkg.effective_supported_targets.contains(&target_backend) {

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -104,7 +104,7 @@ impl<'a> BuildPlanConstructor<'a> {
     }
 
     fn effective_native_toolchain(&mut self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
-        debug_assert!(self.build_env.target_backend.is_native());
+        debug_assert!(self.build_env.target_backend().is_native());
         if self.build_env.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
             self.warn_incompatible_windows_msvc_env_override();
             return compiler_flags::windows_msvc_native_toolchain(package_cc);
@@ -187,7 +187,7 @@ impl<'a> BuildPlanConstructor<'a> {
         importer_target: BuildTarget,
         dep: BuildTarget,
     ) -> Result<(), BuildPlanConstructError> {
-        let selected_backend: TargetBackend = self.build_env.target_backend.into();
+        let selected_backend: TargetBackend = self.build_env.target_backend().into();
         let importer_pkg = self.input.pkg_dirs.get_package(importer_target.package);
         let dependency_pkg = self.input.pkg_dirs.get_package(dep.package);
 
@@ -568,7 +568,7 @@ impl<'a> BuildPlanConstructor<'a> {
                 .chain(mbtlex_iter)
                 .chain(mbtyacc_iter),
             self.build_env.opt_level,
-            self.build_env.target_backend.into(),
+            self.build_env.target_backend().into(),
         ) {
             match file_kind {
                 NoTest => no_test_files.insert(file.into_owned()),
@@ -922,7 +922,7 @@ impl<'a> BuildPlanConstructor<'a> {
         }
         let c_stub_deps = c_stub_deps.into_iter().collect::<Vec<_>>();
 
-        if !self.build_env.target_backend.is_native() {
+        if !self.build_env.target_backend().is_native() {
             self.resolved_node(make_exec_node);
             return Ok(());
         }
@@ -1119,7 +1119,8 @@ impl<'a> BuildPlanConstructor<'a> {
                         // Record emitted and collect c-stub if necessary
                         emitted.insert(cur);
                         let pkg = self.input.pkg_dirs.get_package(cur.package);
-                        if self.build_env.target_backend.is_native() && !pkg.c_stub_files.is_empty()
+                        if self.build_env.target_backend().is_native()
+                            && !pkg.c_stub_files.is_empty()
                         {
                             c_stub_deps.insert(cur.package);
                         }
@@ -1144,7 +1145,7 @@ impl<'a> BuildPlanConstructor<'a> {
                 emitted.insert(cur);
                 trace!(?cur, "Post-order: emitted");
 
-                if self.build_env.target_backend.is_native() && !pkg.c_stub_files.is_empty() {
+                if self.build_env.target_backend().is_native() && !pkg.c_stub_files.is_empty() {
                     c_stub_deps.insert(cur.package);
                 }
             }
@@ -1204,7 +1205,8 @@ impl<'a> BuildPlanConstructor<'a> {
         // Bundling a module gathers the build result of all its non-virtual packages, in topo order
         let topo_sorted_pkgs = self.topo_sort_module_packages(module_id);
         let mut bundle_targets = Vec::new();
-        let target_backend: moonutil::target::TargetBackend = self.build_env.target_backend.into();
+        let target_backend: moonutil::target::TargetBackend =
+            self.build_env.target_backend().into();
         for target in topo_sorted_pkgs.into_iter() {
             let pkg = self.input.pkg_dirs.get_package(target.package);
             if !pkg.effective_supported_targets.contains(&target_backend) {

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -373,7 +373,7 @@ impl<'a> BuildPlanConstructor<'a> {
                 // Non-native MakeExecutable nodes are final-artifact aliases over
                 // LinkCore output. Only native backends need extra lowering info
                 // for the C toolchain/runtime/stub linking step.
-                if self.build_env.target_backend.is_native() {
+                if self.build_env.target_backend().is_native() {
                     assert!(
                         self.res.make_executable_info.contains_key(&build_target),
                         "Make executable info for {:?} should be present when resolving node {:?}",

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -59,10 +59,7 @@ use tracing::instrument;
 
 use crate::{
     ResolveOutput,
-    model::{
-        BackendConfig, BuildPlanNode, BuildTarget, NativeTarget, PackageId, RunBackend,
-        TccRunConfig,
-    },
+    model::{BackendConfig, BuildPlanNode, BuildTarget, NativeTarget, PackageId, TccRunConfig},
     pkg_name::PackageFQNWithSource,
     prebuild::PrebuildOutput,
 };
@@ -455,8 +452,8 @@ pub struct BuildEnvironment {
 }
 
 impl BuildEnvironment {
-    pub(crate) fn target_backend(&self) -> RunBackend {
-        self.backend.run_backend()
+    pub(crate) fn target_backend(&self) -> TargetBackend {
+        self.backend.target_backend()
     }
 
     pub(crate) fn direct_native_target(&self) -> Option<NativeTarget> {

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -60,7 +60,7 @@ use tracing::instrument;
 use crate::{
     ResolveOutput,
     model::{
-        BuildPlanNode, BuildTarget, NativeBackendMode, NativeTarget, PackageId, RunBackend,
+        BackendConfig, BuildPlanNode, BuildTarget, NativeTarget, PackageId, RunBackend,
         TccRunConfig,
     },
     pkg_name::PackageFQNWithSource,
@@ -443,9 +443,7 @@ pub struct BuildBundleInfo {
 /// Represents the environment in which the build is being performed.
 pub struct BuildEnvironment {
     // FIXME: Target backend should go into the solver, not here
-    pub target_backend: RunBackend,
-    /// Native implementation selected only under `RunBackend::Native`.
-    pub native_mode: Option<NativeBackendMode>,
+    pub backend: BackendConfig,
     pub opt_level: OptLevel,
     pub action: RunMode,
     /// Whether compiling requires the standard library.
@@ -457,16 +455,16 @@ pub struct BuildEnvironment {
 }
 
 impl BuildEnvironment {
+    pub(crate) fn target_backend(&self) -> RunBackend {
+        self.backend.run_backend()
+    }
+
     pub(crate) fn direct_native_target(&self) -> Option<NativeTarget> {
-        self.native_mode
-            .as_ref()
-            .and_then(NativeBackendMode::direct_target)
+        self.backend.direct_native_target()
     }
 
     pub(crate) fn tcc_run(&self) -> Option<&TccRunConfig> {
-        self.native_mode
-            .as_ref()
-            .and_then(NativeBackendMode::tcc_run)
+        self.backend.tcc_run()
     }
 }
 
@@ -552,7 +550,8 @@ pub fn build_plan(
     info!("Constructing build plan");
     debug!(
         "Build environment: backend={:?}, opt_level={:?}",
-        build_env.target_backend, build_env.opt_level
+        build_env.target_backend(),
+        build_env.opt_level
     );
 
     let mut constructor = BuildPlanConstructor::new(

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -25,7 +25,7 @@ use tracing::{Level, instrument};
 use crate::{
     build_lower::{self, LoweringEnvironment, WarningCondition},
     build_plan::{self, BuildEnvironment, InputDirective},
-    model::{Artifacts, BuildPlanNode, NativeBackendMode, RunBackend},
+    model::{Artifacts, BackendConfig, BuildPlanNode},
     prebuild::PrebuildOutput,
     resolve::ResolveOutput,
     special_cases::should_skip_tests,
@@ -36,10 +36,8 @@ use crate::{
 pub struct CompileConfig {
     /// Target directory, i.e. `_build/`
     pub target_dir: PathBuf,
-    /// The backend selected for this build.
-    pub target_backend: RunBackend,
-    /// Native implementation selected only under `RunBackend::Native`.
-    pub native_mode: Option<NativeBackendMode>,
+    /// The backend and backend-specific configuration selected for this build.
+    pub backend: BackendConfig,
     /// The optimization level to use for the compilation.
     pub opt_level: OptLevel,
     /// The action done in this operation, currently only used in legacy directory layout
@@ -59,12 +57,8 @@ pub struct CompileConfig {
     /// Whether to export the build plan graph in the compile output.
     /// This should only be used in debugging scenarios.
     pub debug_export_build_plan: bool,
-    /// Whether to pass `-wasi` for wasi-oriented wasm builds.
-    pub wasi_link: bool,
     /// Enable code coverage instrumentation.
     pub enable_coverage: bool,
-    /// Output WAT instead of WASM binary format.
-    pub output_wat: bool,
     /// Whether to output JSON or human-readable error code
     pub moonc_output_json: bool,
     /// Whether to output HTML for docs (in serve mode)
@@ -226,8 +220,7 @@ pub fn compile_standalone(
 
 fn build_environment(cx: &CompileConfig) -> BuildEnvironment {
     BuildEnvironment {
-        target_backend: cx.target_backend,
-        native_mode: cx.native_mode.clone(),
+        backend: cx.backend.clone(),
         opt_level: cx.opt_level,
         action: cx.action,
         std: cx.stdlib_path.is_some(),
@@ -273,22 +266,15 @@ fn lower_plan(
 fn lowering_options(cx: &CompileConfig) -> build_lower::BuildOptions {
     build_lower::BuildOptions {
         artifact_paths: cx.artifact_paths.clone(),
-        target_backend: cx.target_backend,
-        selected_backend: build_lower::SelectedBackend::new(
-            cx.target_backend,
-            cx.native_mode.as_ref(),
-            cx.output_wat,
-        ),
+        backend: cx.backend.clone(),
         opt_level: cx.opt_level,
         action: cx.action,
         enable_coverage: cx.enable_coverage,
         debug_symbols: cx.debug_symbols,
-        output_wat: cx.output_wat,
         moonc_output_json: cx.moonc_output_json,
         docs_serve: cx.docs_serve,
         warning_condition: cx.warning_condition,
         info_no_alias: cx.info_no_alias,
-        wasi_link: cx.wasi_link,
         stdlib_path: cx.stdlib_path.clone(),
         lowering_environment: cx.lowering_environment.clone(),
     }
@@ -329,7 +315,7 @@ mod tests {
         build_lower::{LoweringEnvironment, WarningCondition},
         build_plan::InputDirective,
         discover::{DiscoverResult, DiscoveredPackage, SingleFileSourceKind},
-        model::{BuildPlanNode, RunBackend, TargetKind},
+        model::{BackendConfig, BuildPlanNode, TargetKind},
         pkg_name::{PackageFQN, PackagePath},
         pkg_solve::{DepEdge, DepRelationship},
         target_layout::{ArtifactPathResolver, TargetLayout, TargetLayoutMode},
@@ -486,8 +472,7 @@ mod tests {
         );
         let config = CompileConfig {
             target_dir: PathBuf::from("_build"),
-            target_backend: RunBackend::WasmGC,
-            native_mode: None,
+            backend: BackendConfig::WasmGc { use_wat: false },
             opt_level: OptLevel::Debug,
             action: RunMode::Run,
             debug_symbols: false,
@@ -495,9 +480,7 @@ mod tests {
             artifact_paths,
             lowering_environment: LoweringEnvironment::default(),
             debug_export_build_plan: true,
-            wasi_link: false,
             enable_coverage: false,
-            output_wat: false,
             moonc_output_json: false,
             docs_serve: false,
             warning_condition: WarningCondition::Default,

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -44,6 +44,21 @@ pub enum RunBackend {
     Llvm,
 }
 
+/// The selected backend and its backend-specific compile configuration.
+///
+/// This is the single source of truth after the user-visible target backend is
+/// resolved. Keeping backend-specific options inside the matching variant
+/// prevents invalid combinations such as a native implementation mode on a
+/// Wasm build.
+#[derive(Clone, Debug)]
+pub enum BackendConfig {
+    Wasm { use_wat: bool, wasi_link: bool },
+    WasmGc { use_wat: bool },
+    Js,
+    Native(NativeBackendMode),
+    Llvm,
+}
+
 pub const ENV_MOONBIT_NEW_NATIVE: &str = "MOONBIT_NEW_NATIVE";
 
 /// Concrete native object-code backend selected under the `native` surface target.
@@ -136,6 +151,53 @@ impl NativeBackendMode {
 
     pub fn is_tcc_run(&self) -> bool {
         self.tcc_run().is_some()
+    }
+}
+
+impl BackendConfig {
+    pub fn run_backend(&self) -> RunBackend {
+        match self {
+            Self::Wasm { .. } => RunBackend::Wasm,
+            Self::WasmGc { .. } => RunBackend::WasmGC,
+            Self::Js => RunBackend::Js,
+            Self::Native(_) => RunBackend::Native,
+            Self::Llvm => RunBackend::Llvm,
+        }
+    }
+
+    pub fn target_backend(&self) -> TargetBackend {
+        self.run_backend().into()
+    }
+
+    pub fn direct_native_target(&self) -> Option<NativeTarget> {
+        match self {
+            Self::Native(mode) => mode.direct_target(),
+            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js | Self::Llvm => None,
+        }
+    }
+
+    pub fn tcc_run(&self) -> Option<&TccRunConfig> {
+        match self {
+            Self::Native(mode) => mode.tcc_run(),
+            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js | Self::Llvm => None,
+        }
+    }
+
+    pub fn use_wat(&self) -> bool {
+        match self {
+            Self::Wasm { use_wat, .. } | Self::WasmGc { use_wat } => *use_wat,
+            Self::Js | Self::Native(_) | Self::Llvm => false,
+        }
+    }
+
+    pub fn wasi_link(&self) -> bool {
+        matches!(
+            self,
+            Self::Wasm {
+                wasi_link: true,
+                ..
+            }
+        )
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -31,19 +31,6 @@ slotmap::new_key_type! {
     pub struct PackageId;
 }
 
-/// User-visible backend selected for the build and run artifact shape.
-///
-/// This mirrors [`TargetBackend`] and intentionally does not encode native C
-/// compiler or execution-tool choices.
-#[derive(Clone, Debug, Copy, PartialEq)]
-pub enum RunBackend {
-    WasmGC,
-    Wasm,
-    Js,
-    Native,
-    Llvm,
-}
-
 /// The selected backend and its backend-specific compile configuration.
 ///
 /// This is the single source of truth after the user-visible target backend is
@@ -63,7 +50,7 @@ pub const ENV_MOONBIT_NEW_NATIVE: &str = "MOONBIT_NEW_NATIVE";
 
 /// Concrete native object-code backend selected under the `native` surface target.
 ///
-/// `RunBackend::Native` remains the user-visible native backend. This type
+/// `TargetBackend::Native` remains the user-visible native backend. This type
 /// only describes the experimental direct object-code lowering used behind it.
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum NativeTarget {
@@ -148,25 +135,17 @@ impl NativeBackendMode {
             Self::GeneratedC | Self::DirectObject(_) => None,
         }
     }
-
-    pub fn is_tcc_run(&self) -> bool {
-        self.tcc_run().is_some()
-    }
 }
 
 impl BackendConfig {
-    pub fn run_backend(&self) -> RunBackend {
-        match self {
-            Self::Wasm { .. } => RunBackend::Wasm,
-            Self::WasmGc { .. } => RunBackend::WasmGC,
-            Self::Js => RunBackend::Js,
-            Self::Native(_) => RunBackend::Native,
-            Self::Llvm => RunBackend::Llvm,
-        }
-    }
-
     pub fn target_backend(&self) -> TargetBackend {
-        self.run_backend().into()
+        match self {
+            Self::Wasm { .. } => TargetBackend::Wasm,
+            Self::WasmGc { .. } => TargetBackend::WasmGC,
+            Self::Js => TargetBackend::Js,
+            Self::Native(_) => TargetBackend::Native,
+            Self::Llvm => TargetBackend::LLVM,
+        }
     }
 
     pub fn direct_native_target(&self) -> Option<NativeTarget> {
@@ -180,13 +159,6 @@ impl BackendConfig {
         match self {
             Self::Native(mode) => mode.tcc_run(),
             Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js | Self::Llvm => None,
-        }
-    }
-
-    pub fn use_wat(&self) -> bool {
-        match self {
-            Self::Wasm { use_wat, .. } | Self::WasmGc { use_wat } => *use_wat,
-            Self::Js | Self::Native(_) | Self::Llvm => false,
         }
     }
 
@@ -225,28 +197,6 @@ impl TccRunConfig {
 
     pub fn internal_tcc(&self) -> &CC {
         &self.internal_tcc
-    }
-}
-
-impl RunBackend {
-    pub fn is_native(self) -> bool {
-        matches!(self, RunBackend::Native | RunBackend::Llvm)
-    }
-
-    pub fn to_target(self) -> TargetBackend {
-        self.into()
-    }
-}
-
-impl From<RunBackend> for TargetBackend {
-    fn from(val: RunBackend) -> Self {
-        match val {
-            RunBackend::WasmGC => TargetBackend::WasmGC,
-            RunBackend::Wasm => TargetBackend::Wasm,
-            RunBackend::Js => TargetBackend::Js,
-            RunBackend::Native => TargetBackend::Native,
-            RunBackend::Llvm => TargetBackend::LLVM,
-        }
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -40,7 +40,7 @@ use crate::{
     ResolveOutput,
     build_action_plan::{BuildAction, BuildProduct},
     discover::{DiscoverResult, DiscoveredLocalProject},
-    model::{BuildTarget, OperatingSystem, PackageId, RunBackend, TargetKind},
+    model::{BuildTarget, OperatingSystem, PackageId, TargetKind},
     pkg_name::PackageFQN,
 };
 
@@ -113,6 +113,10 @@ impl ExecutableArtifact {
             Self::NativeExecutable | Self::LlvmExecutable => ".exe",
             Self::TccRunResponseFile => ".rspfile",
         }
+    }
+
+    fn uses_tcc_run(self) -> bool {
+        matches!(self, Self::TccRunResponseFile)
     }
 }
 
@@ -406,30 +410,32 @@ impl TargetLayout {
         result
     }
 
-    pub fn runtime_output_dir(&self, backend: RunBackend) -> PathBuf {
+    pub fn runtime_output_dir(&self, backend: TargetBackend) -> PathBuf {
         match backend {
-            RunBackend::WasmGC | RunBackend::Wasm | RunBackend::Js => {
+            TargetBackend::WasmGC | TargetBackend::Wasm | TargetBackend::Js => {
                 panic!("Runtime output path is not applicable for non-native backends")
             }
-            RunBackend::Native | RunBackend::Llvm => self.run_mode_dir(backend.into()),
+            TargetBackend::Native | TargetBackend::LLVM => self.run_mode_dir(backend),
         }
     }
 
     pub fn runtime_output_path(
         &self,
-        backend: RunBackend,
-        use_tcc_run: bool,
+        executable: ExecutableArtifact,
         os: OperatingSystem,
     ) -> PathBuf {
+        let backend = executable.target_backend();
         let mut result = self.runtime_output_dir(backend);
-        match backend {
-            RunBackend::WasmGC | RunBackend::Wasm | RunBackend::Js => {
+        match executable {
+            ExecutableArtifact::Wasm { .. }
+            | ExecutableArtifact::WasmGC { .. }
+            | ExecutableArtifact::Js => {
                 panic!("Runtime output path is not applicable for non-native backends")
             }
-            RunBackend::Native if use_tcc_run => {
+            ExecutableArtifact::TccRunResponseFile => {
                 result.push(format!("libruntime{}", dynamic_library_ext(os)))
             }
-            RunBackend::Native | RunBackend::Llvm => {
+            ExecutableArtifact::NativeExecutable | ExecutableArtifact::LlvmExecutable => {
                 result.push(format!("runtime{}", object_file_ext(os)))
             }
         }
@@ -733,7 +739,7 @@ impl ArtifactPathResolver {
                 self.package_interface_paths(action_context, *target, packages, options)
             }
             BuildProduct::PackageCoreIr { target } => {
-                vec![self.core_of_build_target(packages, target, options.target_backend.into())]
+                vec![self.core_of_build_target(packages, target, options.target_backend())]
             }
             BuildProduct::ProofInterface { target } => match action_context {
                 BuildAction::EmitProof { .. } => {
@@ -766,24 +772,24 @@ impl ArtifactPathResolver {
                         file_name
                             .file_stem()
                             .expect("c stub file should have a file name"),
-                        options.target_backend.into(),
+                        options.target_backend(),
                         options.os,
                     ),
                 ]
             }
             BuildProduct::CStubLibrary { package } => {
-                if options.use_tcc_run {
+                if options.executable.uses_tcc_run() {
                     vec![self.target_layout.c_stub_link_dylib_path(
                         packages,
                         *package,
-                        options.target_backend.into(),
+                        options.target_backend(),
                         options.os,
                     )]
                 } else {
                     vec![self.target_layout.c_stub_archive_path(
                         packages,
                         *package,
-                        options.target_backend.into(),
+                        options.target_backend(),
                         options.os,
                     )]
                 }
@@ -806,39 +812,38 @@ impl ArtifactPathResolver {
                 vec![self.target_layout.generated_test_driver(
                     packages,
                     target,
-                    options.target_backend.into(),
+                    options.target_backend(),
                 )]
             }
             BuildProduct::GeneratedTestMetadata { target } => {
                 vec![self.target_layout.generated_test_driver_metadata(
                     packages,
                     target,
-                    options.target_backend.into(),
+                    options.target_backend(),
                 )]
             }
             BuildProduct::BundleResult { module } => {
                 let module_name = modules.module_source(*module);
                 vec![
                     self.target_layout
-                        .bundle_result_path(options.target_backend.into(), module_name.name()),
+                        .bundle_result_path(options.target_backend(), module_name.name()),
                 ]
             }
-            BuildProduct::RuntimeLib => vec![self.target_layout.runtime_output_path(
-                options.target_backend,
-                options.use_tcc_run,
-                options.os,
-            )],
+            BuildProduct::RuntimeLib => vec![
+                self.target_layout
+                    .runtime_output_path(options.executable, options.os),
+            ],
             BuildProduct::GeneratedMbti { target } => {
                 vec![self.target_layout.generated_mbti_path(
                     packages,
                     target,
-                    options.target_backend.into(),
+                    options.target_backend(),
                 )]
             }
             BuildProduct::DocsDir => vec![self.target_layout.doc_dir()],
             BuildProduct::VirtualPackageInterface { package } => {
                 let target = package.build_target(TargetKind::Source);
-                vec![self.mi_of_build_target(packages, &target, options.target_backend.into())]
+                vec![self.mi_of_build_target(packages, &target, options.target_backend())]
             }
             BuildProduct::MoonLexGeneratedSource { package, index } => {
                 let pkg_info = packages.get_package(*package);
@@ -988,7 +993,7 @@ impl ArtifactPathResolver {
                 match self.mi_of_build_target_impl_virtual(
                     packages,
                     &target,
-                    options.target_backend.into(),
+                    options.target_backend(),
                 ) {
                     MiPathResult::StdAbort(_) => Vec::new(),
                     MiPathResult::Std(p) => {
@@ -1004,7 +1009,7 @@ impl ArtifactPathResolver {
                 }
             }
             BuildAction::Check { .. } | BuildAction::BuildCore { .. } => {
-                vec![self.mi_of_build_target(packages, &target, options.target_backend.into())]
+                vec![self.mi_of_build_target(packages, &target, options.target_backend())]
             }
             _ => panic!("package interface action context should be Check or BuildCore"),
         }
@@ -1013,11 +1018,15 @@ impl ArtifactPathResolver {
 
 #[derive(Clone, Copy, Debug)]
 pub struct ArtifactPathOptions {
-    pub target_backend: RunBackend,
-    pub use_tcc_run: bool,
     pub os: OperatingSystem,
     pub executable: ExecutableArtifact,
     pub linked_core: LinkedCoreArtifact,
+}
+
+impl ArtifactPathOptions {
+    fn target_backend(self) -> TargetBackend {
+        self.executable.target_backend()
+    }
 }
 
 pub enum MiPathResult {
@@ -1196,13 +1205,22 @@ mod tests {
         )
     }
 
-    fn artifact_options(target_backend: RunBackend, use_tcc_run: bool) -> ArtifactPathOptions {
+    fn artifact_options(executable: ExecutableArtifact) -> ArtifactPathOptions {
+        let linked_core = match executable {
+            ExecutableArtifact::Wasm { use_wat } => LinkedCoreArtifact::Wasm { use_wat },
+            ExecutableArtifact::WasmGC { use_wat } => LinkedCoreArtifact::WasmGC { use_wat },
+            ExecutableArtifact::Js => LinkedCoreArtifact::Js,
+            ExecutableArtifact::NativeExecutable | ExecutableArtifact::TccRunResponseFile => {
+                LinkedCoreArtifact::NativeC
+            }
+            ExecutableArtifact::LlvmExecutable => LinkedCoreArtifact::LlvmObject {
+                os: OperatingSystem::Linux,
+            },
+        };
         ArtifactPathOptions {
-            target_backend,
-            use_tcc_run,
             os: OperatingSystem::Linux,
-            executable: ExecutableArtifact::NativeExecutable,
-            linked_core: LinkedCoreArtifact::NativeC,
+            executable,
+            linked_core,
         }
     }
 
@@ -1455,7 +1473,7 @@ mod tests {
                 action_plan.action(action_id),
                 &packages,
                 &modules,
-                artifact_options(RunBackend::WasmGC, false),
+                artifact_options(ExecutableArtifact::WasmGC { use_wat: false }),
             ),
             vec![PathBuf::from("_build/wasm-gc/debug/build/ffi/ffi.mi")],
         );
@@ -1482,7 +1500,7 @@ mod tests {
                 },
                 &packages,
                 &modules,
-                artifact_options(RunBackend::WasmGC, false),
+                artifact_options(ExecutableArtifact::WasmGC { use_wat: false }),
             ),
             vec![PathBuf::from("_build/wasm-gc/debug/build/ffi/ffi.mi")],
         );
@@ -1510,7 +1528,7 @@ mod tests {
                 },
                 &packages,
                 &modules,
-                artifact_options(RunBackend::WasmGC, false),
+                artifact_options(ExecutableArtifact::WasmGC { use_wat: false }),
             ),
             vec![PathBuf::from("_build/wasm-gc/debug/build/ffi/ffi.impl.mi")],
         );
@@ -1532,7 +1550,7 @@ mod tests {
                 },
                 &packages,
                 &modules,
-                artifact_options(RunBackend::WasmGC, false),
+                artifact_options(ExecutableArtifact::WasmGC { use_wat: false }),
             ),
             vec![
                 resolver
@@ -1549,7 +1567,7 @@ mod tests {
                 },
                 &packages,
                 &modules,
-                artifact_options(RunBackend::WasmGC, false),
+                artifact_options(ExecutableArtifact::WasmGC { use_wat: false }),
             ),
             vec![resolver.target_layout.prove_report_path(&packages, &target)],
         );
@@ -1571,7 +1589,7 @@ mod tests {
             },
             &packages,
             &modules,
-            artifact_options(RunBackend::WasmGC, false),
+            artifact_options(ExecutableArtifact::WasmGC { use_wat: false }),
         );
     }
 
@@ -1594,7 +1612,7 @@ mod tests {
                 },
                 &packages,
                 &modules,
-                artifact_options(RunBackend::Native, false),
+                artifact_options(ExecutableArtifact::NativeExecutable),
             ),
             vec![PathBuf::from("_build/native/debug/build/ffi/libffi.a")],
         );
@@ -1607,7 +1625,7 @@ mod tests {
                 },
                 &packages,
                 &modules,
-                artifact_options(RunBackend::Native, true),
+                artifact_options(ExecutableArtifact::TccRunResponseFile),
             ),
             vec![PathBuf::from("_build/native/debug/build/ffi/libffi.so")],
         );
@@ -1621,8 +1639,6 @@ mod tests {
         let prebuild_output = PathBuf::from("source/generated.mbt");
         let prebuild = prebuild_info(prebuild_output.clone());
         let options = ArtifactPathOptions {
-            target_backend: RunBackend::Native,
-            use_tcc_run: true,
             os: OperatingSystem::Linux,
             executable: ExecutableArtifact::TccRunResponseFile,
             linked_core: LinkedCoreArtifact::NativeC,

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -14,6 +14,31 @@ The important invariant is that `build_lower` consumes `BuildActionPlan` only. I
 does not import or match on planning internals such as `BuildPlanNode`,
 `FileDependencyKind`, or `PlanArtifactNeed`.
 
+## Backend configuration
+
+After command adapters resolve the Target Backend and expand user intent to
+concrete input nodes, Moon selects one `BackendConfig` value:
+
+```rust
+pub enum BackendConfig {
+    Wasm { use_wat: bool, wasi_link: bool },
+    WasmGc { use_wat: bool },
+    Js,
+    Native(NativeBackendMode),
+    Llvm,
+}
+```
+
+This value is the compile-wide source of truth passed through `CompileConfig`,
+`BuildEnvironment`, and `BuildOptions`. Backend-specific options stay inside
+their matching variant; lowering does not reconstruct a second backend enum
+from a Target Backend plus optional native and Wasm flags.
+
+The Native backend mode is currently compile-wide because the runtime product
+is shared by the plan and C-stub products are shared per package. Selecting a
+Native Payload Form per executable requires those shared products to be keyed
+by the Native Toolchain and realization they were built for first.
+
 ## Planning IR
 
 `BuildPlan` still owns graph traversal, action coalescing, and edge semantics.

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -32,7 +32,9 @@ pub enum BackendConfig {
 This value is the compile-wide source of truth passed through `CompileConfig`,
 `BuildEnvironment`, and `BuildOptions`. Backend-specific options stay inside
 their matching variant; lowering does not reconstruct a second backend enum
-from a Target Backend plus optional native and Wasm flags.
+from a Target Backend plus optional native and Wasm flags. Code that only needs
+the user-visible identity projects a `TargetBackend` directly from this value;
+there is no separate build/run backend mirror.
 
 The Native backend mode is currently compile-wide because the runtime product
 is shared by the plan and C-stub products are shared per package. Selecting a

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -105,9 +105,9 @@ When actually building a package, the pipeline has 2 or 3 steps depending on the
    This step reads in all CoreIR files produced by the package and all its transitive dependencies,
    and links into an executable output.
    For JS/WASM backends, this already outputs the final executable.
-3. **Make native executable**, via C compiler / `MakeExecutable` node.
+3. **Make native executable**, via the native toolchain / `MakeExecutable` node.
    For native (Native/LLVM) backends,
-   the output of `LinkCore` (C or object file) is compile/link by a C compiler,
+   the output of `LinkCore` (C or object file) is compiled or linked,
    together with C stubs and other build outputs,
    to produce the final executable.
    Non-native backends do not need this step.
@@ -142,7 +142,8 @@ containing all compiled MoonBit code for the package to build:
 
 - For JS, WASM and WASM-GC backend,
   this is the final executable to use: A JavaScript or WASM file.
-- The Native backend outputs a C file to be compiled with a C compiler.
+- The Native backend outputs either generated C or a direct object file,
+  according to the selected Native Payload Form.
 - The LLVM backend outputs an object file to be linked with the system library.
 
 ### Example

--- a/docs/dev/reference/native-c-toolchain-resolution.md
+++ b/docs/dev/reference/native-c-toolchain-resolution.md
@@ -219,7 +219,11 @@ Package-level `link.native.cc-flags` apply when compiling the C file emitted by 
 If any selected executable package sets these flags, Moon uses the generated-C native backend
 instead of direct object output so the configured flags are not skipped.
 This native payload form is currently selected once per invocation, so one such package makes every
-selected executable in that invocation use generated C.
+selected executable in that invocation use generated C. This scope also keeps the invocation-wide
+runtime product and package-wide C-stub products on one compatible native toolchain and realization.
+Selecting the payload form per executable requires those shared products to be keyed by their
+effective native toolchain and realization; changing only `LinkCore` and `MakeExecutable` would
+allow incompatible shared artifacts in mixed-mode builds.
 
 The direct object native target `x86_64-pc-windows-msvc` is stricter: it requires selecting a
 `cl`-compatible compiler driver and preserving the discovered Visual Studio command environment.

--- a/docs/dev/reference/tcc-run.md
+++ b/docs/dev/reference/tcc-run.md
@@ -68,7 +68,8 @@ unchanged and lets the later TCC invocation report any missing library normally.
 ## Execution at runtime
 
 When `moon` later executes the target,
-it detects the TCC run backend and launches the internal `TCC` with the response file recorded earlier,
+it derives the `TccRun` execution mode from the Native backend configuration
+and launches the internal `TCC` with the response file recorded earlier,
 `tcc @<response-file> [args...]`.
 
 This behavior is transparent to the user and the rest of the build system.

--- a/docs/dev/reference/tcc-run.md
+++ b/docs/dev/reference/tcc-run.md
@@ -23,7 +23,7 @@ The planner verifies three conditions before switching to the TCC run flow:
 - The requested action actually needs a runnable binary (for example, `run` or `test`).
   Pure build or check requests keep using the standard native backend.
 
-If every gate passes, the planner substitutes the backend with the dedicated TCC run backend.
+If every gate passes, the planner selects the TCC run mode inside the Native backend configuration.
 Otherwise, nothing changes and the regular linker path is used.
 
 ## How the pipeline diverges
@@ -38,8 +38,8 @@ TCC run mode keeps the logical build steps described in the [architecture][] and
    to produce a single C artifact for the selected target kind.
 3. Native-specific nodes prepare artifacts for execution.
 
-The first two stages behave identically across all native backends.
-Divergence happens in the native-specific step:
+TCC run keeps the generated-C Native Payload Form, so `LinkCore` emits C.
+It diverges from the regular generated-C realization in the native-specific step:
 
 - The runtime code is compiled into a shared library instead of an object file.
 - Each package's C stubs remain as object files, but are collected into shared libraries (`.so`/`.dylib`).


### PR DESCRIPTION
## Why

Backend selection was represented by parallel `RunBackend`, optional `NativeBackendMode`, WAT, and WASI fields, then reconstructed as another enum during lowering. That allowed invalid combinations and made backend-specific control flow harder to follow.

## What

- introduce a `BackendConfig` sum type and carry it through compile planning, `BuildEnvironment`, lowering, and `BuildMeta`
- remove the duplicate `RunBackend`; use `TargetBackend` only for user-visible identity and match `BackendConfig` for concrete build behavior
- derive artifact paths from concrete artifact enums instead of a separate TCC boolean
- give runtime launching a complete `ExecutionMode` derived from `BackendConfig`, replacing the `backend + Option<TccRunConfig>` pair
- document why native payload selection remains invocation-wide until shared runtime and C-stub products are keyed by toolchain and realization

## Why this is correct

Each backend variant now contains only its applicable configuration. Native mode detection remains at the same post-intent-expansion seam, so direct-object, generated-C, and TCC behavior is unchanged. Artifact and execution projections are total mappings from the selected configuration and cannot express mismatched backend/TCC combinations.

## Scope

This is a behavior-preserving refactor. Per-executable native payload selection is intentionally deferred until the shared-product graph can safely represent mixed native toolchains.