### PR TITLE
Support @latest for registry package execution

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,7 +61,7 @@ _Avoid_: User log, command result
 ## Package Execution
 
 **Executable Package Coordinate**:
-An exact registry selector containing a module, an optional package path, and an optional version that identifies one main package for direct execution.
+Registry selector containing a module, an optional package path, and an optional version selector that resolves to exactly one version of one main package for direct execution.
 _Avoid_: Install source, wildcard package selector, runwasm coordinate
 
 **Cached Executable Artifact**:

--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -36,10 +36,9 @@ pub(crate) enum MoonxTarget {
     about = "Run a package from the Mooncakes registry without installing it",
     long_about = r#"Run a package from the Mooncakes registry without installing it.
 
-Accepted package coordinate forms:
+Recommended package coordinate forms:
   moonx user/module/package
   moonx user/module/package@1.2.3
-  moonx user/module@1.2.3/package
   moonx user/module/package@latest
 
 Pinned coordinates use the requested version directly. `@latest` refreshes the

--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -34,6 +34,17 @@ pub(crate) enum MoonxTarget {
 #[command(
     name = "moonx",
     about = "Run a package from the Mooncakes registry without installing it",
+    long_about = r#"Run a package from the Mooncakes registry without installing it.
+
+Accepted package coordinate forms:
+  moonx user/module/package
+  moonx user/module/package@1.2.3
+  moonx user/module@1.2.3/package
+  moonx user/module/package@latest
+
+Pinned coordinates use the requested version directly. `@latest` refreshes the
+registry index before resolving the latest version. Unpinned coordinates use
+the latest version already known to the local registry index."#,
     override_usage = "moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...",
     version
 )]

--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -36,7 +36,7 @@ pub(crate) enum MoonxTarget {
     about = "Run a package from the Mooncakes registry without installing it",
     long_about = r#"Run a package from the Mooncakes registry without installing it.
 
-Recommended package coordinate forms:
+Accepted package coordinate forms:
   moonx user/module/package
   moonx user/module/package@1.2.3
   moonx user/module/package@latest

--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -48,6 +48,19 @@ enum LatestVersionLookup {
     NotFound,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExecutablePackageVersionSelector {
+    Exact(Version),
+    LocallyKnownLatest,
+    RefreshLatest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LatestVersionResolutionPolicy {
+    PreferLocal,
+    Refresh,
+}
+
 impl ResolvedExecutablePackage {
     pub(super) fn artifact_name(&self, suffix: &str) -> String {
         let stem = if self.package_path.is_empty() {
@@ -88,8 +101,17 @@ fn resolve_registry_package(
     let (module_name, package_path, requested_version) =
         parse_executable_package_coordinate(package)?;
     let version = match requested_version {
-        Some(version) => version,
-        None => resolve_latest_version(&module_name, user_log)?,
+        ExecutablePackageVersionSelector::Exact(version) => version,
+        ExecutablePackageVersionSelector::LocallyKnownLatest => resolve_latest_version(
+            &module_name,
+            LatestVersionResolutionPolicy::PreferLocal,
+            user_log,
+        )?,
+        ExecutablePackageVersionSelector::RefreshLatest => resolve_latest_version(
+            &module_name,
+            LatestVersionResolutionPolicy::Refresh,
+            user_log,
+        )?,
     };
     Ok(ResolvedExecutablePackage {
         module_name,
@@ -98,7 +120,11 @@ fn resolve_registry_package(
     })
 }
 
-fn resolve_latest_version(module_name: &ModuleName, user_log: &UserLog) -> anyhow::Result<Version> {
+fn resolve_latest_version(
+    module_name: &ModuleName,
+    policy: LatestVersionResolutionPolicy,
+    user_log: &UserLog,
+) -> anyhow::Result<Version> {
     let index_dir = moonutil::registry::index();
     let registry_config = RegistryConfig::load();
     let had_index = index_dir.exists();
@@ -107,6 +133,7 @@ fn resolve_latest_version(module_name: &ModuleName, user_log: &UserLog) -> anyho
         module_name,
         user_log,
         had_index,
+        policy,
         || latest_version_from_local_registry(module_name),
         || {
             mooncake::update::update_with_output(
@@ -135,10 +162,13 @@ fn resolve_latest_version_with(
     module_name: &ModuleName,
     user_log: &UserLog,
     had_index: bool,
+    policy: LatestVersionResolutionPolicy,
     mut lookup_latest_version: impl FnMut() -> LatestVersionLookup,
     mut update_registry: impl FnMut() -> anyhow::Result<()>,
 ) -> anyhow::Result<Version> {
-    if let LatestVersionLookup::Found(version) = lookup_latest_version() {
+    if policy == LatestVersionResolutionPolicy::PreferLocal
+        && let LatestVersionLookup::Found(version) = lookup_latest_version()
+    {
         user_log.info(format!(
             "Resolved {module_name} latest version to {version}"
         ));
@@ -147,6 +177,9 @@ fn resolve_latest_version_with(
 
     match update_registry() {
         Ok(_) => user_log.info("Updated registry index"),
+        Err(e) if policy == LatestVersionResolutionPolicy::Refresh => {
+            return Err(e).context("Failed to update registry index");
+        }
         Err(e) => {
             if had_index {
                 user_log.warn(format!(
@@ -179,7 +212,7 @@ fn resolve_latest_version_with(
 
 fn parse_executable_package_coordinate(
     input: &str,
-) -> anyhow::Result<(ModuleName, String, Option<Version>)> {
+) -> anyhow::Result<(ModuleName, String, ExecutablePackageVersionSelector)> {
     if input.ends_with("...") {
         bail!("Invalid package coordinate `{input}`: wildcard package paths are not supported");
     }
@@ -192,15 +225,23 @@ fn parse_executable_package_coordinate(
         } else {
             bail!("Invalid package coordinate `{input}`");
         };
-        let version = Version::parse(&parsed.version).with_context(|| {
-            format!("Invalid version `{}` in package coordinate", parsed.version)
-        })?;
-        return Ok((parsed.module, parsed.package, Some(version)));
+        let version = if parsed.version == "latest" {
+            ExecutablePackageVersionSelector::RefreshLatest
+        } else {
+            ExecutablePackageVersionSelector::Exact(Version::parse(&parsed.version).with_context(
+                || format!("Invalid version `{}` in package coordinate", parsed.version),
+            )?)
+        };
+        return Ok((parsed.module, parsed.package, version));
     }
 
     let parsed = registry_path::parse_install_style_path(input)
         .with_context(|| format!("Invalid package coordinate `{input}`"))?;
-    Ok((parsed.module, parsed.package, None))
+    Ok((
+        parsed.module,
+        parsed.package,
+        ExecutablePackageVersionSelector::LocallyKnownLatest,
+    ))
 }
 
 pub(super) fn ensure_cached_file(
@@ -324,14 +365,17 @@ fn run_artifact(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Arc, Barrier,
-        atomic::{AtomicUsize, Ordering},
+    use std::{
+        cell::Cell,
+        sync::{
+            Arc, Barrier,
+            atomic::{AtomicUsize, Ordering},
+        },
     };
 
     use super::*;
 
-    fn parse(input: &str) -> (ModuleName, String, Option<Version>) {
+    fn parse(input: &str) -> (ModuleName, String, ExecutablePackageVersionSelector) {
         parse_executable_package_coordinate(input).unwrap()
     }
 
@@ -340,7 +384,10 @@ mod tests {
         let (module_name, package_path, version) = parse("moonbitlang/parser/cmd/moonfmt@0.3.3");
         assert_eq!(module_name.to_string(), "moonbitlang/parser");
         assert_eq!(package_path, "cmd/moonfmt");
-        assert_eq!(version.unwrap().to_string(), "0.3.3");
+        assert_eq!(
+            version,
+            ExecutablePackageVersionSelector::Exact("0.3.3".parse().unwrap())
+        );
     }
 
     #[test]
@@ -348,15 +395,34 @@ mod tests {
         let (module_name, package_path, version) = parse("moonbitlang/parser@0.3.3/cmd/moonfmt");
         assert_eq!(module_name.to_string(), "moonbitlang/parser");
         assert_eq!(package_path, "cmd/moonfmt");
-        assert_eq!(version.unwrap().to_string(), "0.3.3");
+        assert_eq!(
+            version,
+            ExecutablePackageVersionSelector::Exact("0.3.3".parse().unwrap())
+        );
     }
 
     #[test]
-    fn parse_latest_coordinate() {
+    fn parse_unpinned_coordinate() {
         let (module_name, package_path, version) = parse("moonbitlang/parser/cmd/moonfmt");
         assert_eq!(module_name.to_string(), "moonbitlang/parser");
         assert_eq!(package_path, "cmd/moonfmt");
-        assert_eq!(version, None);
+        assert_eq!(
+            version,
+            ExecutablePackageVersionSelector::LocallyKnownLatest
+        );
+    }
+
+    #[test]
+    fn parse_explicit_latest_coordinates() {
+        let (module_name, package_path, version) = parse("moonbitlang/parser/cmd/moonfmt@latest");
+        assert_eq!(module_name.to_string(), "moonbitlang/parser");
+        assert_eq!(package_path, "cmd/moonfmt");
+        assert_eq!(version, ExecutablePackageVersionSelector::RefreshLatest);
+
+        let (module_name, package_path, version) = parse("moonbitlang/parser@latest/cmd/moonfmt");
+        assert_eq!(module_name.to_string(), "moonbitlang/parser");
+        assert_eq!(package_path, "cmd/moonfmt");
+        assert_eq!(version, ExecutablePackageVersionSelector::RefreshLatest);
     }
 
     #[test]
@@ -368,6 +434,7 @@ mod tests {
             &module_name,
             &UserLog::new(log::LevelFilter::Warn),
             true,
+            LatestVersionResolutionPolicy::PreferLocal,
             || LatestVersionLookup::Found("0.3.3".parse().unwrap()),
             || {
                 update_called = true;
@@ -390,6 +457,7 @@ mod tests {
             &module_name,
             &UserLog::new(log::LevelFilter::Warn),
             true,
+            LatestVersionResolutionPolicy::PreferLocal,
             || {
                 lookup_count += 1;
                 if lookup_count > 1 {
@@ -411,6 +479,64 @@ mod tests {
     }
 
     #[test]
+    fn explicit_latest_refreshes_before_resolving() {
+        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
+        let registry_updated = Cell::new(false);
+        let lookup_count = Cell::new(0);
+
+        let version = resolve_latest_version_with(
+            &module_name,
+            &UserLog::new(log::LevelFilter::Warn),
+            true,
+            LatestVersionResolutionPolicy::Refresh,
+            || {
+                lookup_count.set(lookup_count.get() + 1);
+                LatestVersionLookup::Found(
+                    if registry_updated.get() {
+                        "0.4.0"
+                    } else {
+                        "0.3.3"
+                    }
+                    .parse()
+                    .unwrap(),
+                )
+            },
+            || {
+                registry_updated.set(true);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(version.to_string(), "0.4.0");
+        assert!(registry_updated.get());
+        assert_eq!(lookup_count.get(), 1);
+    }
+
+    #[test]
+    fn explicit_latest_fails_when_refresh_fails() {
+        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
+        let lookup_called = Cell::new(false);
+
+        let err = resolve_latest_version_with(
+            &module_name,
+            &UserLog::new(log::LevelFilter::Warn),
+            true,
+            LatestVersionResolutionPolicy::Refresh,
+            || {
+                lookup_called.set(true);
+                LatestVersionLookup::Found("0.3.3".parse().unwrap())
+            },
+            || Err(anyhow::anyhow!("offline")),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), "Failed to update registry index");
+        assert_eq!(err.source().unwrap().to_string(), "offline");
+        assert!(!lookup_called.get());
+    }
+
+    #[test]
     fn latest_resolution_preserves_no_version_information_after_update() {
         let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
         let mut update_called = false;
@@ -419,6 +545,7 @@ mod tests {
             &module_name,
             &UserLog::new(log::LevelFilter::Warn),
             true,
+            LatestVersionResolutionPolicy::PreferLocal,
             || LatestVersionLookup::NoVersionInformation,
             || {
                 update_called = true;

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -42,9 +42,8 @@ Local package inputs are handled like `moon run --target wasm`:
 Experimental moonrun policy forwarding:
   moon runwasm --experimental-policy moonrun-policy.toml main
 
-Accepted Mooncakes coordinate forms:
+Recommended Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
-  moon runwasm moonbitlang/parser@0.3.3/cmd/moonfmt
   moon runwasm moonbitlang/parser/cmd/moonfmt@latest
   moon runwasm moonbitlang/parser/cmd/moonfmt
 

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -42,7 +42,7 @@ Local package inputs are handled like `moon run --target wasm`:
 Experimental moonrun policy forwarding:
   moon runwasm --experimental-policy moonrun-policy.toml main
 
-Recommended Mooncakes coordinate forms:
+Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
   moon runwasm moonbitlang/parser/cmd/moonfmt@latest
   moon runwasm moonbitlang/parser/cmd/moonfmt

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -45,12 +45,14 @@ Experimental moonrun policy forwarding:
 Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
   moon runwasm moonbitlang/parser@0.3.3/cmd/moonfmt
+  moon runwasm moonbitlang/parser/cmd/moonfmt@latest
   moon runwasm moonbitlang/parser/cmd/moonfmt
 
-Pinned coordinates use the given version directly. Unpinned coordinates resolve
-the latest version from the registry index, updating it only when the module is
-absent from the local index. Fetched wasm files are cached under
-$MOON_HOME/registry/cache/assets and reused on later runs."#
+Pinned coordinates use the given version directly. `@latest` refreshes the
+registry index before resolving the latest version. Unpinned coordinates use
+the latest version already in the local index, updating it only when the module
+is absent. Fetched wasm files are cached under $MOON_HOME/registry/cache/assets
+and reused on later runs."#
 )]
 pub(crate) struct RunWasmSubcommand {
     /// Local package path or Mooncakes package coordinate of the prebuilt wasm binary

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -117,10 +117,9 @@ fn test_moonx_uses_its_own_command_line_interface() {
         .stdout_eq(snapbox::str![[r#"
 Run a package from the Mooncakes registry without installing it.
 
-Accepted package coordinate forms:
+Recommended package coordinate forms:
   moonx user/module/package
   moonx user/module/package@1.2.3
-  moonx user/module@1.2.3/package
   moonx user/module/package@latest
 
 Pinned coordinates use the requested version directly. `@latest` refreshes the

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -117,7 +117,7 @@ fn test_moonx_uses_its_own_command_line_interface() {
         .stdout_eq(snapbox::str![[r#"
 Run a package from the Mooncakes registry without installing it.
 
-Recommended package coordinate forms:
+Accepted package coordinate forms:
   moonx user/module/package
   moonx user/module/package@1.2.3
   moonx user/module/package@latest

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -115,16 +115,36 @@ fn test_moonx_uses_its_own_command_line_interface() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Run a package from the Mooncakes registry without installing it
+Run a package from the Mooncakes registry without installing it.
+
+Accepted package coordinate forms:
+  moonx user/module/package
+  moonx user/module/package@1.2.3
+  moonx user/module@1.2.3/package
+  moonx user/module/package@latest
+
+Pinned coordinates use the requested version directly. `@latest` refreshes the
+registry index before resolving the latest version. Unpinned coordinates use
+the latest version already known to the local registry index.
 
 Usage: moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...
 
 Options:
-      --target <TARGET>             [default: wasm] [possible values: wasm, native]
-      --experimental-policy <PATH>  Experimental moonrun policy file; only valid for wasm
-  -v, --verbose                     Show progress and execution details
-  -h, --help                        Print help
-  -V, --version                     Print version
+      --target <TARGET>
+          [default: wasm]
+          [possible values: wasm, native]
+
+      --experimental-policy <PATH>
+          Experimental moonrun policy file; only valid for wasm
+
+  -v, --verbose
+          Show progress and execution details
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 "#]]);
 }

--- a/docs/dev/reference/moonx.md
+++ b/docs/dev/reference/moonx.md
@@ -50,9 +50,18 @@ user/module/package@1.2.3
 user/module@1.2.3/package
 ```
 
-Documentation should prefer the first form. Unpinned coordinates resolve the
-latest version already known to the local registry index. The index is updated
-only when the module cannot be resolved locally, matching `moon runwasm`.
+An explicit latest request accepts the corresponding forms:
+
+```text
+user/module/package@latest
+user/module@latest/package
+```
+
+Documentation should prefer the first form. `@latest` refreshes the registry
+index before resolving the newest version and fails if the refresh fails.
+Unpinned coordinates resolve the latest version already known to the local
+registry index. The index is updated only when the module cannot be resolved
+locally, matching `moon runwasm`.
 
 ## Wasm target
 

--- a/docs/dev/reference/runwasm.md
+++ b/docs/dev/reference/runwasm.md
@@ -24,12 +24,21 @@ A **pinned coordinate** includes an explicit version:
 - `user/module/package@1.2.3`
 - `user/module@1.2.3/package`
 
+An **explicit latest coordinate** uses the `latest` version selector:
+
+- `user/module/package@latest`
+- `user/module@latest/package`
+
 An **unpinned coordinate** omits the version:
 
 - `user/module/package`
 
 Pinned coordinates use the supplied version directly. They do not need the
 registry index for version resolution.
+
+Explicit latest coordinates refresh the registry index before resolving the
+newest version. The command fails if the refresh fails, even when an older local
+index is available.
 
 Unpinned coordinates must resolve the latest module version from the local
 registry index before the asset URL and cache path can be computed.
@@ -47,6 +56,8 @@ The registry update policy optimizes the common rerun case:
 Rules:
 
 - For pinned coordinates, skip registry index update.
+- For explicit latest coordinates, update the registry index before version
+  lookup and fail if that update fails.
 - For unpinned coordinates, read the local registry index first.
 - If the local index contains usable version metadata for the module, use that
   version and skip registry index update.
@@ -63,9 +74,11 @@ After retrying any needed registry update, version lookup has three outcomes:
 - Module found but no version metadata: fail with a no-version-information error.
 - Module not found: fail with a module-not-found error.
 
-If a registry update fails while a local index already exists, the command warns
-and continues with the existing local index. If no local index exists, registry
-update failure is fatal because there is no cached metadata to use.
+For unpinned coordinates, if a registry update fails while a local index already
+exists, the command warns and continues with the existing local index. If no
+local index exists, registry update failure is fatal because there is no cached
+metadata to use. An explicit latest coordinate always treats update failure as
+fatal because falling back would not satisfy the requested refresh.
 
 Unreadable or corrupt local index data follows the existing registry behavior:
 it is treated as not resolving a latest version, so `runwasm` attempts the

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -264,7 +264,7 @@ Local package inputs are handled like `moon run --target wasm`:
 Experimental moonrun policy forwarding:
   moon runwasm --experimental-policy moonrun-policy.toml main
 
-Recommended Mooncakes coordinate forms:
+Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
   moon runwasm moonbitlang/parser/cmd/moonfmt@latest
   moon runwasm moonbitlang/parser/cmd/moonfmt

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -267,12 +267,14 @@ Experimental moonrun policy forwarding:
 Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
   moon runwasm moonbitlang/parser@0.3.3/cmd/moonfmt
+  moon runwasm moonbitlang/parser/cmd/moonfmt@latest
   moon runwasm moonbitlang/parser/cmd/moonfmt
 
-Pinned coordinates use the given version directly. Unpinned coordinates resolve
-the latest version from the registry index, updating it only when the module is
-absent from the local index. Fetched wasm files are cached under
-$MOON_HOME/registry/cache/assets and reused on later runs.
+Pinned coordinates use the given version directly. `@latest` refreshes the
+registry index before resolving the latest version. Unpinned coordinates use
+the latest version already in the local index, updating it only when the module
+is absent. Fetched wasm files are cached under $MOON_HOME/registry/cache/assets
+and reused on later runs.
 
 **Usage:** `moon runwasm [OPTIONS] <LOCAL_PACKAGE|PACKAGE[@VERSION]> [ARGS]...`
 

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -264,9 +264,8 @@ Local package inputs are handled like `moon run --target wasm`:
 Experimental moonrun policy forwarding:
   moon runwasm --experimental-policy moonrun-policy.toml main
 
-Accepted Mooncakes coordinate forms:
+Recommended Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
-  moon runwasm moonbitlang/parser@0.3.3/cmd/moonfmt
   moon runwasm moonbitlang/parser/cmd/moonfmt@latest
   moon runwasm moonbitlang/parser/cmd/moonfmt
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -264,7 +264,7 @@ Local package inputs are handled like `moon run --target wasm`:
 Experimental moonrun policy forwarding:
   moon runwasm --experimental-policy moonrun-policy.toml main
 
-Recommended Mooncakes coordinate forms:
+Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
   moon runwasm moonbitlang/parser/cmd/moonfmt@latest
   moon runwasm moonbitlang/parser/cmd/moonfmt

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -267,12 +267,14 @@ Experimental moonrun policy forwarding:
 Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
   moon runwasm moonbitlang/parser@0.3.3/cmd/moonfmt
+  moon runwasm moonbitlang/parser/cmd/moonfmt@latest
   moon runwasm moonbitlang/parser/cmd/moonfmt
 
-Pinned coordinates use the given version directly. Unpinned coordinates resolve
-the latest version from the registry index, updating it only when the module is
-absent from the local index. Fetched wasm files are cached under
-$MOON_HOME/registry/cache/assets and reused on later runs.
+Pinned coordinates use the given version directly. `@latest` refreshes the
+registry index before resolving the latest version. Unpinned coordinates use
+the latest version already in the local index, updating it only when the module
+is absent. Fetched wasm files are cached under $MOON_HOME/registry/cache/assets
+and reused on later runs.
 
 **Usage:** `moon runwasm [OPTIONS] <LOCAL_PACKAGE|PACKAGE[@VERSION]> [ARGS]...`
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -264,9 +264,8 @@ Local package inputs are handled like `moon run --target wasm`:
 Experimental moonrun policy forwarding:
   moon runwasm --experimental-policy moonrun-policy.toml main
 
-Accepted Mooncakes coordinate forms:
+Recommended Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
-  moon runwasm moonbitlang/parser@0.3.3/cmd/moonfmt
   moon runwasm moonbitlang/parser/cmd/moonfmt@latest
   moon runwasm moonbitlang/parser/cmd/moonfmt
 


### PR DESCRIPTION
## Why

`moonx` and registry-backed `moon runwasm` accepted exact versions and unpinned coordinates, but parsed `latest` as an invalid semantic version. Users therefore had no explicit way to request a fresh registry resolution while retaining the cheaper local-index behavior for unpinned invocations.

## What changed

- Recognize `user/module/package@latest` and `user/module@latest/package` in the shared executable-package coordinate parser.
- Refresh the registry index before resolving an explicit `@latest` request, and fail when that refresh fails.
- Preserve existing behavior for exact versions, unpinned coordinates, and cached executable artifacts.
- Update CLI help, behavioral references, generated manuals, and regression coverage.

## Why this is correct and minimal

Both commands already share the same registry package resolver, so the change is confined to that boundary and models the three version-selection policies explicitly. Existing exact-version and unpinned paths are unchanged; only the previously unsupported `latest` selector takes the forced-refresh path.