### PR TITLE
fix(cram): resolve overrides from changed directory

### DIFF
--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -207,7 +207,7 @@ fn delegate_moon_cram_with_current_dir(
     current_dir: Option<&Path>,
     args: impl IntoIterator<Item = impl AsRef<OsStr>>,
 ) -> anyhow::Result<i32> {
-    let mut command = Command::new(resolve_moon_cram()?);
+    let mut command = Command::new(resolve_moon_cram_in(current_dir)?);
     if let Some(dir) = current_dir {
         command.current_dir(dir);
     }
@@ -280,11 +280,22 @@ fn is_external_cram_tail(tail: &[OsString]) -> bool {
 }
 
 fn resolve_moon_cram() -> anyhow::Result<PathBuf> {
-    let moon_cram = moonutil::toolchain::BINARIES.moon_cram.clone();
+    resolve_moon_cram_in(None)
+}
+
+fn resolve_moon_cram_in(current_dir: Option<&Path>) -> anyhow::Result<PathBuf> {
+    let moon_cram = current_dir.map_or_else(
+        || moonutil::toolchain::BINARIES.moon_cram.clone(),
+        moonutil::toolchain::moon_cram_in,
+    );
     if moon_cram.is_absolute() || moon_cram.components().count() > 1 {
         return Ok(moon_cram);
     }
-    which::which(&moon_cram).with_context(|| {
+    let resolved = match current_dir {
+        Some(dir) => moonutil::toolchain::resolve_executable_in(&moon_cram, dir),
+        None => which::which(&moon_cram).map_err(anyhow::Error::from),
+    };
+    resolved.with_context(|| {
         format!(
             "no such subcommand: `cram`, is `{}` a valid executable accessible via your `PATH`?",
             moon_cram.display()

--- a/crates/moon/tests/fixtures/cram-override-cwd/bin/fake-moon-cram
+++ b/crates/moon/tests/fixtures/cram-override-cwd/bin/fake-moon-cram
@@ -1,0 +1,2 @@
+#!/bin/sh
+printf 'fake-moon-cram-location=original\n'

--- a/crates/moon/tests/fixtures/cram-override-cwd/bin/fake-moon-cram.cmd
+++ b/crates/moon/tests/fixtures/cram-override-cwd/bin/fake-moon-cram.cmd
@@ -1,0 +1,1 @@
+@echo fake-moon-cram-location=original

--- a/crates/moon/tests/fixtures/cram-override-cwd/subdir/bin/fake-moon-cram
+++ b/crates/moon/tests/fixtures/cram-override-cwd/subdir/bin/fake-moon-cram
@@ -1,0 +1,2 @@
+#!/bin/sh
+printf 'fake-moon-cram-location=subdir\n'

--- a/crates/moon/tests/fixtures/cram-override-cwd/subdir/bin/fake-moon-cram.cmd
+++ b/crates/moon/tests/fixtures/cram-override-cwd/subdir/bin/fake-moon-cram.cmd
@@ -1,0 +1,1 @@
+@echo fake-moon-cram-location=subdir

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -808,6 +808,57 @@ fn test_cram_bare_override_resolves_from_path() {
 }
 
 #[test]
+fn test_cram_relative_override_resolves_after_change_directory() {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cram-override-cwd");
+
+    let early_stdout = get_stdout_with_envs(
+        &dir,
+        ["-C", "subdir", "cram", "--version"],
+        [("MOON_CRAM_OVERRIDE", "bin/fake-moon-cram")],
+    );
+    assert!(
+        early_stdout.contains("fake-moon-cram-location=subdir"),
+        "early moon-cram delegation should resolve the override from the -C directory:\n{early_stdout}"
+    );
+
+    let parsed_stdout = get_stdout_with_envs(
+        &dir,
+        ["-C", "subdir", "cram", "list"],
+        [("MOON_CRAM_OVERRIDE", "bin/fake-moon-cram")],
+    );
+    assert!(
+        parsed_stdout.contains("fake-moon-cram-location=subdir"),
+        "parsed moon-cram delegation should resolve the override from the -C directory:\n{parsed_stdout}"
+    );
+}
+
+#[test]
+fn test_cram_bare_override_on_relative_path_resolves_after_change_directory() {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cram-override-cwd");
+    let path = std::env::join_paths(std::iter::once(PathBuf::from("bin")).chain(
+        std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()),
+    ))
+    .expect("failed to build relative PATH");
+
+    let stdout = get_stdout_with_envs(
+        &dir,
+        ["-C", "subdir", "cram", "--version"],
+        [
+            (
+                std::ffi::OsString::from("MOON_CRAM_OVERRIDE"),
+                std::ffi::OsString::from("fake-moon-cram"),
+            ),
+            (std::ffi::OsString::from("PATH"), path),
+        ],
+    );
+
+    assert!(
+        stdout.contains("fake-moon-cram-location=subdir"),
+        "bare moon-cram override on a relative PATH should resolve from the -C directory:\n{stdout}"
+    );
+}
+
+#[test]
 fn test_cram_parent_flag_after_moon_global_delegates_to_moon_cram() {
     let dir = TestDir::new_empty();
     let fake_bin_dir = tempfile::TempDir::new().expect("failed to create fake bin dir");

--- a/crates/moonutil/src/binaries.rs
+++ b/crates/moonutil/src/binaries.rs
@@ -37,8 +37,18 @@ fn resolve_executable_override(path: &OsStr) -> PathBuf {
 }
 
 fn moon_executable(binary_name: &str, env_var: &str) -> PathBuf {
+    let current_dir =
+        std::env::current_dir().expect("failed to get current directory for executable resolution");
+    moon_executable_in(binary_name, env_var, &current_dir)
+}
+
+fn moon_executable_in(binary_name: &str, env_var: &str, current_dir: &std::path::Path) -> PathBuf {
     if let Some(path) = std::env::var_os(env_var) {
-        return resolve_executable_override(&path);
+        return crate::toolchain::resolve_executable_in(&path, current_dir).unwrap_or_else(|_| {
+            // Keep unresolved overrides intact so each command preserves its
+            // existing user-facing error path.
+            PathBuf::from(path)
+        });
     }
 
     if binary_name == "moon"
@@ -54,15 +64,17 @@ fn moon_executable(binary_name: &str, env_var: &str) -> PathBuf {
     // Try to find in the resolved toolchain root.
     let in_toolchain = ensure_exe_extension(crate::moon_dir::bin().join(binary_name));
     if in_toolchain.exists() {
-        return crate::toolchain::resolve_executable(&in_toolchain).unwrap_or_else(|error| {
-            panic!(
-                "failed to resolve MoonBit tool `{}`: {error:#}",
-                in_toolchain.display()
-            )
-        });
+        return crate::toolchain::resolve_executable_in(&in_toolchain, current_dir).unwrap_or_else(
+            |error| {
+                panic!(
+                    "failed to resolve MoonBit tool `{}`: {error:#}",
+                    in_toolchain.display()
+                )
+            },
+        );
     }
 
-    if let Ok(in_path) = crate::toolchain::resolve_executable(binary_name) {
+    if let Ok(in_path) = crate::toolchain::resolve_executable_in(binary_name, current_dir) {
         return in_path;
     }
 
@@ -71,6 +83,10 @@ fn moon_executable(binary_name: &str, env_var: &str) -> PathBuf {
          Install the MoonBit toolchain or set `{env_var}` to an explicit path.",
         in_toolchain.display()
     )
+}
+
+pub fn moon_cram_in(current_dir: &std::path::Path) -> PathBuf {
+    moon_executable_in("moon-cram", "MOON_CRAM_OVERRIDE", current_dir)
 }
 
 fn moon_payload(file_name: &str, env_var: &str) -> PathBuf {

--- a/crates/moonutil/src/toolchain.rs
+++ b/crates/moonutil/src/toolchain.rs
@@ -30,7 +30,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub use crate::binaries::{BINARIES, CachedBinaries};
+pub use crate::binaries::{BINARIES, CachedBinaries, moon_cram_in};
 pub use crate::moon_dir::{
     MOON_DIRS, MoonDirs, RESERVED_BIN_NAMES, abort_core_in, abort_mi_in, bin, core, core_bundle,
     core_bundle_in, core_core, core_core_in, core_package_mi_in, home, include, is_toolchain_root,
@@ -88,8 +88,60 @@ fn runtime_source_paths_in(lib_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
 /// Build actions can run from a different working directory, so executable
 /// paths crossing the toolchain boundary must be made absolute here.
 pub(crate) fn resolve_executable(tool: impl AsRef<OsStr>) -> anyhow::Result<PathBuf> {
-    let tool = tool.as_ref();
-    resolve_executable_with(tool, |tool| which::which(tool))
+    let current_dir = std::env::current_dir().context("failed to get current directory")?;
+    resolve_executable_in(tool, &current_dir)
+}
+
+/// Resolve an executable as if `current_dir` were the process working
+/// directory.
+///
+/// `which_in` uses `current_dir` for explicit relative paths, but relative
+/// `PATH` entries still need to be anchored before lookup.
+pub fn resolve_executable_in(
+    tool: impl AsRef<OsStr>,
+    current_dir: &Path,
+) -> anyhow::Result<PathBuf> {
+    resolve_executable_in_paths(
+        tool.as_ref(),
+        std::env::var_os("PATH").as_deref(),
+        current_dir,
+    )
+}
+
+fn resolve_executable_in_paths(
+    tool: &OsStr,
+    paths: Option<&OsStr>,
+    current_dir: &Path,
+) -> anyhow::Result<PathBuf> {
+    let current_dir = std::path::absolute(current_dir).with_context(|| {
+        format!(
+            "failed to make command directory `{}` absolute",
+            current_dir.display()
+        )
+    })?;
+    let paths = paths
+        .map(|paths| {
+            std::env::join_paths(std::env::split_paths(paths).map(|path| {
+                // Preserve `which`'s home-directory expansion for PATH entries
+                // whose first component is exactly `~`.
+                if path.is_absolute()
+                    || matches!(
+                        path.components().next(),
+                        Some(std::path::Component::Normal(component)) if component == OsStr::new("~")
+                    )
+                {
+                    path
+                } else {
+                    current_dir.join(path)
+                }
+            }))
+        })
+        .transpose()
+        .context("failed to resolve relative PATH entries")?;
+
+    resolve_executable_with(tool, |tool| {
+        which::which_in(tool, paths.as_deref(), &current_dir)
+    })
 }
 
 fn resolve_executable_with(
@@ -108,7 +160,7 @@ fn resolve_executable_with(
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_executable_with, runtime_source_paths_in};
+    use super::{resolve_executable_in_paths, resolve_executable_with, runtime_source_paths_in};
 
     #[test]
     fn runtime_sources_use_sorted_split_runtime_files() {
@@ -162,6 +214,23 @@ mod tests {
         .expect("resolve fixture executable");
 
         assert_eq!(resolved, fixture.join(executable_name));
+        assert!(resolved.is_absolute());
+    }
+
+    #[test]
+    fn relative_search_path_uses_given_current_directory() {
+        let current_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/native-toolchain");
+        let executable_name = test_executable_name("fake-gcc");
+
+        let resolved = resolve_executable_in_paths(
+            executable_name.as_ref(),
+            Some("bin".as_ref()),
+            &current_dir,
+        )
+        .expect("resolve fixture executable from the given current directory");
+
+        assert_eq!(resolved, current_dir.join("bin").join(executable_name));
         assert!(resolved.is_absolute());
     }
 

--- a/docs/dev/reference/binaries.md
+++ b/docs/dev/reference/binaries.md
@@ -15,6 +15,9 @@ resolution always produces an absolute path, including when `PATH` itself
 contains relative entries. An override that cannot be resolved is left intact
 so its command keeps the existing error-reporting behavior.
 
+Early `moon cram` delegation resolves `MOON_CRAM_OVERRIDE` and relative `PATH`
+entries from the effective `-C` directory before launching `moon-cram`.
+
 `moonlex.wasm` and `moonyacc.wasm` are payload files passed to `moonrun`, not
 executables. Their overrides therefore use file-path semantics instead of
 executable lookup.


### PR DESCRIPTION
## Why

#1956 resolves executable overrides before command construction, but `moon -C subdir cram --version` delegates during parse-error handling before the process applies `-C`. A relative `MOON_CRAM_OVERRIDE`, or a bare override found through a relative `PATH` entry, was therefore resolved from the original directory while the child ran from `subdir`.

## What changed

- Added explicit-current-directory executable resolution in `moonutil::toolchain`, including anchoring relative `PATH` entries.
- Used the effective `-C` directory when resolving `moon-cram` on the early delegation path.
- Added cross-platform fixtures covering both explicit relative overrides and bare overrides on a relative `PATH`, and documented the behavior.

## Why this is correct and minimal

The normal parsed path still resolves after the process applies `-C`; the early path now supplies that same effective directory explicitly. The change is limited to executable lookup and cram delegation, without changing command arguments, build planning, or other tool selection behavior.