### PR TITLE
fix(cli): unify early delegation directory resolution

### DIFF
--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -207,10 +207,7 @@ fn delegate_moon_cram_with_current_dir(
     current_dir: Option<&Path>,
     args: impl IntoIterator<Item = impl AsRef<OsStr>>,
 ) -> anyhow::Result<i32> {
-    let mut command = Command::new(resolve_moon_cram_in(current_dir)?);
-    if let Some(dir) = current_dir {
-        command.current_dir(dir);
-    }
+    let mut command = process::command_in_effective_dir(current_dir, resolve_moon_cram_in)?;
     command.args(args);
     Ok(process::delegate(&mut command)?.code().unwrap_or(0))
 }
@@ -233,46 +230,9 @@ pub(crate) fn exit_if_cram_external_request(err: &clap::Error, raw_args: &[OsStr
 }
 
 fn cram_external_args(raw_args: &[OsString]) -> Option<(Option<PathBuf>, Vec<OsString>)> {
-    let mut current_dir = None;
-    let mut index = 1;
-    while index < raw_args.len() {
-        let arg = &raw_args[index];
-
-        if arg == OsStr::new("-C") {
-            index += 1;
-            if let Some(dir) = raw_args.get(index) {
-                current_dir = Some(PathBuf::from(dir));
-            }
-        } else if matches!(
-            arg.to_str(),
-            Some("--target-dir" | "--unstable-feature" | "-Z")
-        ) {
-            index += 1;
-        } else if is_global_bool_arg(arg) {
-        } else {
-            let tail = &raw_args[index + 1..];
-            return (arg == OsStr::new("cram") && is_external_cram_tail(tail))
-                .then(|| (current_dir, tail.to_vec()));
-        }
-        index += 1;
-    }
-    None
-}
-
-fn is_global_bool_arg(arg: &OsStr) -> bool {
-    matches!(
-        arg.to_str(),
-        Some(
-            "-V" | "--version"
-                | "-q"
-                | "--quiet"
-                | "-v"
-                | "--verbose"
-                | "--trace"
-                | "--dry-run"
-                | "--build-graph"
-        )
-    )
+    let early = process::early_subcommand(raw_args)?;
+    (early.name == OsStr::new("cram") && is_external_cram_tail(early.args))
+        .then(|| (early.current_dir, early.args.to_vec()))
 }
 
 fn is_external_cram_tail(tail: &[OsString]) -> bool {
@@ -293,7 +253,7 @@ fn resolve_moon_cram_in(current_dir: Option<&Path>) -> anyhow::Result<PathBuf> {
     }
     let resolved = match current_dir {
         Some(dir) => moonutil::toolchain::resolve_executable_in(&moon_cram, dir),
-        None => which::which(&moon_cram).map_err(anyhow::Error::from),
+        None => moonutil::toolchain::resolve_executable(&moon_cram),
     };
     resolved.with_context(|| {
         format!(
@@ -535,7 +495,7 @@ mod tests {
     #[test]
     fn preserves_chdir_for_external_cram_args() {
         assert_eq!(
-            cram_external_args(&os(&["moon", "-C", "sub", "cram", "--version"])),
+            cram_external_args(&os(&["moon", "-Csub", "cram", "--version"])),
             Some((Some(PathBuf::from("sub")), os(&["--version"])))
         );
     }

--- a/crates/moon/src/cli/external.rs
+++ b/crates/moon/src/cli/external.rs
@@ -23,7 +23,6 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, ExitStatus},
 };
-use which::which_global;
 
 use super::process;
 
@@ -32,10 +31,10 @@ pub(crate) fn run_external(mut args: Vec<String>) -> anyhow::Result<i32> {
         bail!("no external subcommand provided");
     };
     let subcmd = args.remove(0);
-    let resolved = resolve_external_subcommand(&subcmd)?;
-    Ok(process::delegate(Command::new(resolved).args(args))?
-        .code()
-        .unwrap_or(0))
+    let mut command = process::command_in_effective_dir(None, |current_dir| {
+        resolve_external_subcommand_in(&subcmd, current_dir)
+    })?;
+    Ok(process::delegate(command.args(args))?.code().unwrap_or(0))
 }
 
 pub(crate) fn run_external_help(
@@ -43,17 +42,19 @@ pub(crate) fn run_external_help(
     current_dir: Option<&Path>,
     args: impl IntoIterator<Item = OsString>,
 ) -> anyhow::Result<i32> {
-    let mut cmd = Command::new(resolve_external_subcommand(subcmd)?);
-    if let Some(dir) = current_dir {
-        cmd.current_dir(dir);
-    }
+    let mut cmd = process::command_in_effective_dir(current_dir, |current_dir| {
+        resolve_external_subcommand_in(subcmd, current_dir)
+    })?;
     run_external_command(&mut cmd, args)
         .with_context(|| format!("Unable to get help from `{subcmd}` utility"))?
         .code()
         .ok_or_else(|| anyhow::anyhow!("Unable to get exit code"))
 }
 
-fn resolve_external_subcommand(subcmd: &str) -> anyhow::Result<PathBuf> {
+fn resolve_external_subcommand_in(
+    subcmd: &str,
+    current_dir: Option<&Path>,
+) -> anyhow::Result<PathBuf> {
     if subcmd == "-" {
         bail!(
             "`-` is only supported in `moon run -`, which reads `.mbtx` source from stdin.\n\
@@ -61,9 +62,15 @@ fn resolve_external_subcommand(subcmd: &str) -> anyhow::Result<PathBuf> {
         );
     }
     let bin = &format!("moon-{subcmd}");
-    which_global(bin).context(anyhow::format_err!(
-        "no such subcommand: `{subcmd}`, is `{bin}` a valid executable accessible via your `PATH`?"
-    ))
+    let resolved = match current_dir {
+        Some(dir) => moonutil::toolchain::resolve_executable_in(bin, dir),
+        None => moonutil::toolchain::resolve_executable(bin),
+    };
+    resolved.with_context(|| {
+        format!(
+            "no such subcommand: `{subcmd}`, is `{bin}` a valid executable accessible via your `PATH`?"
+        )
+    })
 }
 
 fn run_external_command(
@@ -91,23 +98,20 @@ pub(crate) fn exit_if_ide_help_request(err: &clap::Error, raw_args: &[OsString])
 }
 
 fn ide_help_args(raw_args: &[OsString]) -> Option<(Option<PathBuf>, Vec<OsString>)> {
-    match raw_args {
-        [_, help, ide, tail @ ..] if help == OsStr::new("help") && ide == OsStr::new("ide") => {
-            let mut delegated = tail.to_vec();
-            delegated.push(OsString::from("--help"));
-            Some((None, delegated))
-        }
-        [_, chdir, dir, help, ide, tail @ ..]
-            if chdir == OsStr::new("-C")
-                && help == OsStr::new("help")
-                && ide == OsStr::new("ide") =>
-        {
-            let mut delegated = tail.to_vec();
-            delegated.push(OsString::from("--help"));
-            Some((Some(PathBuf::from(dir)), delegated))
-        }
-        _ => None,
+    let early = process::early_subcommand(raw_args)?;
+    if early.name != OsStr::new("help") {
+        return None;
     }
+    let [ide, tail @ ..] = early.args else {
+        return None;
+    };
+    if ide != OsStr::new("ide") {
+        return None;
+    }
+
+    let mut delegated = tail.to_vec();
+    delegated.push(OsString::from("--help"));
+    Some((early.current_dir, delegated))
 }
 
 #[cfg(test)]
@@ -138,7 +142,15 @@ mod tests {
     #[test]
     fn delegates_help_for_ide_after_chdir() {
         assert_eq!(
-            ide_help_args(&os(&["moon", "-C", ".", "help", "ide", "doc"])),
+            ide_help_args(&os(&[
+                "moon",
+                "--target-dir=_build-alt",
+                "-qvC=.",
+                "--trace",
+                "help",
+                "ide",
+                "doc"
+            ])),
             Some((Some(PathBuf::from(".")), os(&["doc", "--help"])))
         );
     }

--- a/crates/moon/src/cli/process.rs
+++ b/crates/moon/src/cli/process.rs
@@ -16,7 +16,105 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::process::{Command, ExitStatus};
+use std::{
+    ffi::{OsStr, OsString},
+    path::{Path, PathBuf},
+    process::{Command, ExitStatus},
+};
+
+pub(crate) struct EarlySubcommand<'a> {
+    pub(crate) current_dir: Option<PathBuf>,
+    pub(crate) name: &'a OsStr,
+    pub(crate) args: &'a [OsString],
+}
+
+/// Locate a top-level subcommand before clap has successfully parsed the CLI.
+///
+/// Early delegation must interpret global options exactly far enough to derive
+/// the same effective `-C` directory that `main` would apply before a normally
+/// parsed subcommand runs.
+pub(crate) fn early_subcommand(raw_args: &[OsString]) -> Option<EarlySubcommand<'_>> {
+    let mut current_dir = None;
+    let mut index = 1;
+    while index < raw_args.len() {
+        let arg = &raw_args[index];
+        match arg.to_str() {
+            Some("-C") => {
+                index += 1;
+                current_dir = Some(PathBuf::from(raw_args.get(index)?));
+            }
+            Some(arg) if arg.starts_with("-C") && arg.len() > 2 => {
+                let dir = &arg[2..];
+                if dir.is_empty() || dir == "=" {
+                    return None;
+                }
+                current_dir = Some(PathBuf::from(dir.strip_prefix('=').unwrap_or(dir)));
+            }
+            Some("--target-dir" | "--unstable-feature" | "-Z") => {
+                index += 1;
+                raw_args.get(index)?;
+            }
+            Some(arg)
+                if arg.starts_with("--target-dir=")
+                    || arg.starts_with("--unstable-feature=")
+                    || (arg.starts_with("-Z") && arg.len() > 2) => {}
+            Some(
+                "-V" | "--version" | "-q" | "--quiet" | "-v" | "--verbose" | "--trace"
+                | "--dry-run" | "--build-graph",
+            ) => {}
+            Some(arg) if arg.starts_with('-') && !arg.starts_with("--") && arg.len() > 2 => {
+                let mut flags = &arg[1..];
+                while matches!(flags.as_bytes().first().copied(), Some(b'V' | b'q' | b'v')) {
+                    flags = &flags[1..];
+                }
+                if flags.is_empty() {
+                    index += 1;
+                    continue;
+                }
+                if let Some(dir) = flags.strip_prefix('C') {
+                    let dir = dir.strip_prefix('=').unwrap_or(dir);
+                    if dir.is_empty() {
+                        index += 1;
+                        current_dir = Some(PathBuf::from(raw_args.get(index)?));
+                    } else {
+                        current_dir = Some(PathBuf::from(dir));
+                    }
+                } else if flags == "Z" {
+                    index += 1;
+                    raw_args.get(index)?;
+                } else if !flags.starts_with('Z') {
+                    return Some(EarlySubcommand {
+                        current_dir,
+                        name: &raw_args[index],
+                        args: &raw_args[index + 1..],
+                    });
+                }
+            }
+            _ => {
+                return Some(EarlySubcommand {
+                    current_dir,
+                    name: arg,
+                    args: &raw_args[index + 1..],
+                });
+            }
+        }
+        index += 1;
+    }
+    None
+}
+
+/// Construct a delegated command whose executable lookup and child working
+/// directory use the same effective command directory.
+pub(crate) fn command_in_effective_dir(
+    current_dir: Option<&Path>,
+    resolve_program: impl FnOnce(Option<&Path>) -> anyhow::Result<PathBuf>,
+) -> anyhow::Result<Command> {
+    let mut command = Command::new(resolve_program(current_dir)?);
+    if let Some(dir) = current_dir {
+        command.current_dir(dir);
+    }
+    Ok(command)
+}
 
 /// Delegate to a command as directly as the platform allows.
 ///

--- a/crates/moon/tests/fixtures/chdir-executable-resolution/subdir/bin/moon-ide
+++ b/crates/moon/tests/fixtures/chdir-executable-resolution/subdir/bin/moon-ide
@@ -1,0 +1,2 @@
+#!/bin/sh
+printf 'fake-moon-ide-location=subdir\n'

--- a/crates/moon/tests/fixtures/chdir-executable-resolution/subdir/bin/moon-ide.cmd
+++ b/crates/moon/tests/fixtures/chdir-executable-resolution/subdir/bin/moon-ide.cmd
@@ -1,0 +1,1 @@
+@echo fake-moon-ide-location=subdir

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -665,6 +665,25 @@ fn test_external_subcommand_delegation_handles_interrupt() {
 }
 
 #[test]
+fn test_ide_delegation_resolves_from_change_directory() {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/chdir-executable-resolution");
+
+    let early_stdout = get_stdout_with_envs(&dir, ["-qCsubdir", "help", "ide"], [("PATH", "bin")]);
+    assert!(
+        early_stdout.contains("fake-moon-ide-location=subdir"),
+        "early moon-ide delegation should resolve from the -C directory:\n{early_stdout}"
+    );
+
+    let parsed_stdout =
+        get_stdout_with_envs(&dir, ["-C", "subdir", "ide", "--help"], [("PATH", "bin")]);
+    assert!(
+        parsed_stdout.contains("fake-moon-ide-location=subdir"),
+        "parsed moon-ide delegation should resolve from the -C directory:\n{parsed_stdout}"
+    );
+}
+
+#[test]
 fn test_cram_dry_run_builds_native_release_and_prints_delegation() {
     let dir = TestDir::new("hello");
     let stdout = get_stdout(

--- a/docs/dev/reference/binaries.md
+++ b/docs/dev/reference/binaries.md
@@ -15,8 +15,11 @@ resolution always produces an absolute path, including when `PATH` itself
 contains relative entries. An override that cannot be resolved is left intact
 so its command keeps the existing error-reporting behavior.
 
-Early `moon cram` delegation resolves `MOON_CRAM_OVERRIDE` and relative `PATH`
-entries from the effective `-C` directory before launching `moon-cram`.
+Whenever Moon delegates to a child before applying `-C` to its own process,
+executable lookup and the child's working directory use the same effective
+command directory. This applies to early `moon cram` and `moon help ide`
+delegation. Relative `moon-cram` overrides and relative `PATH` entries are
+resolved from that directory.
 
 `moonlex.wasm` and `moonyacc.wasm` are payload files passed to `moonrun`, not
 executables. Their overrides therefore use file-path semantics instead of


### PR DESCRIPTION
## Why

Moon applies the global `-C` after clap has parsed the command line, but parse-error delegation for `moon help ide` and some `moon cram` forms happens before that point. Those paths separately scanned global arguments, and `moon help ide` could resolve a relative `PATH` entry from the original directory or fail to delegate when other global flags preceded `-C`.

## What changed

- centralize the pre-parse scan for the top-level subcommand and effective `-C` directory
- construct early delegated commands so executable lookup and child working directory use that same effective directory
- route external subcommands and `moon-cram` through the shared executable resolver
- cover early and normally parsed IDE delegation with a relative `PATH` fixture
- document the shared early-delegation directory behavior

## Scope

This is a focused follow-up to #1963. It only changes early CLI child delegation and executable lookup; it does not alter build graph planning, action identity, caching, or native toolchain selection.