### PR TITLE
refactor(build): split macOS dSYM generation

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_action_plan/action.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/action.rs
@@ -16,6 +16,8 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use std::path::Path;
+
 use moonutil::resolution::ModuleId;
 
 use crate::{
@@ -66,6 +68,10 @@ pub enum BuildAction<'a> {
     MakeExecutable {
         target: BuildTarget,
         info: Option<&'a MakeExecutableInfo>,
+    },
+    GenerateDsym {
+        target: BuildTarget,
+        dsymutil: &'a Path,
     },
     GenerateTestInfo {
         target: BuildTarget,

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/product.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/product.rs
@@ -53,6 +53,9 @@ pub enum BuildProduct {
     Executable {
         target: BuildTarget,
     },
+    DsymBundle {
+        target: BuildTarget,
+    },
     GeneratedTestDriver {
         target: BuildTarget,
     },

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/view.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/view.rs
@@ -85,6 +85,7 @@ impl<'a> BuildActionPlan<'a> {
             | BuildAction::BuildCore { target, .. }
             | BuildAction::LinkCore { target, .. }
             | BuildAction::MakeExecutable { target, .. }
+            | BuildAction::GenerateDsym { target, .. }
             | BuildAction::GenerateTestInfo { target, .. }
             | BuildAction::GenerateMbti { target } => Some(target.package),
             BuildAction::BuildCStub { package, .. }
@@ -202,6 +203,13 @@ impl<'a> BuildActionPlan<'a> {
                 target,
                 info: self.plan.get_make_executable_info(&target),
             },
+            BuildPlanNode::GenerateDsym(target) => BuildAction::GenerateDsym {
+                target,
+                dsymutil: self
+                    .plan
+                    .get_dsymutil()
+                    .expect("dsymutil should be present for GenerateDsym nodes"),
+            },
             BuildPlanNode::GenerateTestInfo(target) => BuildAction::GenerateTestInfo {
                 target,
                 info: self
@@ -304,6 +312,11 @@ impl<'a> BuildActionPlan<'a> {
         )
     }
 
+    pub(crate) fn generates_dsym_for_target(&self, target: &BuildTarget) -> bool {
+        self.action_ids_by_node
+            .contains_key(&BuildPlanNode::GenerateDsym(*target))
+    }
+
     pub fn build_plan_node(&self, id: BuildActionId) -> BuildPlanNode {
         self.node(id)
     }
@@ -391,6 +404,9 @@ impl<'a> BuildActionPlan<'a> {
             }
             BuildPlanNode::MakeExecutable(target) => {
                 vec![BuildProduct::Executable { target }]
+            }
+            BuildPlanNode::GenerateDsym(target) => {
+                vec![BuildProduct::DsymBundle { target }]
             }
             BuildPlanNode::GenerateTestInfo(target) => vec![
                 BuildProduct::GeneratedTestDriver { target },

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -195,7 +195,8 @@ impl<'a> LoweringContext<'a> {
     }
 
     pub(super) fn output_paths_for_action(&self, action: BuildActionId) -> Vec<PathBuf> {
-        self.plan
+        let mut paths = self
+            .plan
             .output_products(action)
             .into_iter()
             .flat_map(|product| {
@@ -207,7 +208,21 @@ impl<'a> LoweringContext<'a> {
                     self.opt.artifact_path_options(),
                 )
             })
-            .collect()
+            .collect::<Vec<_>>();
+        if let BuildAction::MakeExecutable { target, .. } = self.plan.action(action)
+            && self.plan.generates_dsym_for_target(&target)
+        {
+            paths.push(
+                self.artifact_paths
+                    .target_layout()
+                    .dsym_bundle_of_build_target(
+                        self.packages,
+                        &target,
+                        self.opt.artifact_path_options().executable,
+                    ),
+            );
+        }
+        paths
     }
 
     #[instrument(level = Level::DEBUG, skip(self))]
@@ -254,6 +269,9 @@ impl<'a> LoweringContext<'a> {
             } => self.lower_make_exe(&action_products, target, info),
             BuildAction::MakeExecutable { info: None, .. } => {
                 panic!("native MakeExecutable actions should have executable info")
+            }
+            BuildAction::GenerateDsym { target, dsymutil } => {
+                self.lower_generate_dsym(&action_products, target, dsymutil)
             }
             BuildAction::GenerateTestInfo { target, info } => {
                 self.lower_gen_test_driver(&action_products, target, info)

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -51,34 +51,17 @@ use crate::{
     },
     build_plan::{BuildCStubsInfo, BuildTargetInfo, LinkCoreInfo, MakeExecutableInfo},
     discover::DiscoveredPackage,
-    model::{BackendConfig, BuildTarget, NativeTarget, OperatingSystem, PackageId, TargetKind},
+    model::{BackendConfig, BuildTarget, PackageId, TargetKind},
     pkg_name::{PackageFQN, PackagePath},
     special_cases::{is_self_coverage_lib, should_skip_coverage},
     target_layout::proof_artifact_stem,
 };
 
 use super::{
-    BuildCommand, LoweredCommand, LoweringError, compiler,
+    BuildCommand, LoweringError, compiler,
     context::{ActionProducts, LoweringContext},
     moonc_command,
 };
-
-fn commandline_with_dsymutil(cmd: &[String], dest: &str) -> LoweredCommand {
-    let cmd_str = moonutil::shlex::join_unix(cmd.iter().map(|x| x.as_str()));
-    let dsymutil_args = ["dsymutil", dest];
-    let dsymutil_cmd_str = moonutil::shlex::join_unix(dsymutil_args.iter().copied());
-    LoweredCommand::verbatim(format!("{cmd_str} && {dsymutil_cmd_str}"))
-}
-
-fn should_run_new_native_dsymutil(
-    native_target: Option<NativeTarget>,
-    debug_symbols: bool,
-    cc: &CC,
-) -> bool {
-    native_target == Some(NativeTarget::Aarch64AppleDarwin)
-        && debug_symbols
-        && cc.targets_apple_darwin()
-}
 
 impl<'a> LoweringContext<'a> {
     fn compiler_source_files(&self, info: &BuildTargetInfo) -> Vec<PathBuf> {
@@ -1150,6 +1133,30 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
+    pub(super) fn lower_generate_dsym(
+        &self,
+        products: &ActionProducts,
+        target: BuildTarget,
+        dsymutil: &Path,
+    ) -> BuildCommand {
+        let executable = products.single_dependency_path_matching(|product| {
+            matches!(
+                product,
+                BuildProduct::Executable {
+                    target: product_target,
+                } if *product_target == target
+            )
+        });
+        BuildCommand {
+            extra_inputs: vec![],
+            commandline: vec![
+                dsymutil.display().to_string(),
+                executable.display().to_string(),
+            ]
+            .into(),
+        }
+    }
+
     fn native_executable_dependency_paths(
         &self,
         products: &ActionProducts,
@@ -1241,20 +1248,9 @@ impl<'a> LoweringContext<'a> {
             self.opt.compiler_paths(),
         );
 
-        // On macOS with LLVM backend and debug symbols, run dsymutil after linking
-        // to generate the dSYM bundle for better debugging experience
-        let commandline = if self.opt.target_backend() == TargetBackend::LLVM
-            && self.opt.debug_symbols
-            && self.opt.os() == OperatingSystem::MacOS
-        {
-            commandline_with_dsymutil(&cc_cmd, &dest)
-        } else {
-            cc_cmd.into()
-        };
-
         BuildCommand {
             extra_inputs: vec![],
-            commandline,
+            commandline: cc_cmd.into(),
         }
         .with_msvc_env(&info.effective_native_toolchain)
     }
@@ -1288,12 +1284,6 @@ impl<'a> LoweringContext<'a> {
             .iter()
             .map(|path| path.display().to_string())
             .collect::<Vec<_>>();
-        let run_dsymutil = should_run_new_native_dsymutil(
-            self.opt.backend.direct_native_target(),
-            self.opt.debug_symbols,
-            &cc,
-        );
-
         let commandline = if info.effective_native_toolchain.uses_msvc_driver() {
             compiler::msvc::link_executable_command(
                 &info.effective_native_toolchain,
@@ -1313,11 +1303,7 @@ impl<'a> LoweringContext<'a> {
                 &dest,
                 &self.opt.compiler_paths().lib_path,
             );
-            if run_dsymutil {
-                commandline_with_dsymutil(&linker_cmd, &dest)
-            } else {
-                linker_cmd.into()
-            }
+            linker_cmd.into()
         };
 
         BuildCommand {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lowered_action.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lowered_action.rs
@@ -56,20 +56,6 @@ pub struct LoweredResponseFile {
     pub content: String,
 }
 
-/// The representation used to construct the process command.
-///
-/// Most commands retain structured arguments so tools can inspect them before
-/// the platform-specific command string is executed. Commands that deliberately
-/// use shell composition, such as prebuild commands, remain verbatim.
-#[derive(Debug, Clone)]
-pub(crate) enum LoweredCommandKind {
-    /// Structured argv rendered using the platform's command-line convention.
-    Args(Vec<String>),
-
-    /// A command string that intentionally relies on shell composition.
-    Verbatim,
-}
-
 /// How the process command should be transported to the executor.
 #[derive(Debug, Clone)]
 pub enum LoweredCommandExecution {
@@ -82,11 +68,11 @@ pub enum LoweredCommandExecution {
 
 /// A concrete process command and its selected process transport.
 ///
-/// `kind` retains the logical form for metadata consumers. `execution` records
+/// `args` retains the logical form for metadata consumers. `execution` records
 /// whether the same command is sent inline or through a response file.
 #[derive(Debug, Clone)]
 pub struct LoweredCommand {
-    pub(crate) kind: LoweredCommandKind,
+    pub(crate) args: Vec<String>,
     pub(crate) execution: LoweredCommandExecution,
     pub(crate) cwd: Option<PathBuf>,
     pub(crate) env: Vec<(String, String)>,
@@ -96,7 +82,7 @@ impl From<Vec<String>> for LoweredCommand {
     fn from(args: Vec<String>) -> Self {
         let command = moonutil::shlex::join_native(args.iter().map(String::as_str));
         Self {
-            kind: LoweredCommandKind::Args(args),
+            args,
             execution: LoweredCommandExecution::Inline(command),
             cwd: None,
             env: Vec::new(),
@@ -105,15 +91,6 @@ impl From<Vec<String>> for LoweredCommand {
 }
 
 impl LoweredCommand {
-    pub(crate) fn verbatim(command: String) -> Self {
-        Self {
-            kind: LoweredCommandKind::Verbatim,
-            execution: LoweredCommandExecution::Inline(command),
-            cwd: None,
-            env: Vec::new(),
-        }
-    }
-
     pub(crate) fn inline_command(&self) -> &str {
         let LoweredCommandExecution::Inline(command) = &self.execution else {
             unreachable!("a response-file command is already lowered")
@@ -127,17 +104,11 @@ impl LoweredCommand {
     }
 
     fn executable(&self) -> Option<&Path> {
-        match &self.kind {
-            LoweredCommandKind::Args(args) => args.first().map(Path::new),
-            LoweredCommandKind::Verbatim => None,
-        }
+        self.args.first().map(Path::new)
     }
 
-    pub fn args(&self) -> Option<&[String]> {
-        match &self.kind {
-            LoweredCommandKind::Args(args) => Some(args),
-            LoweredCommandKind::Verbatim => None,
-        }
+    pub fn args(&self) -> &[String] {
+        &self.args
     }
 
     pub fn execution(&self) -> &LoweredCommandExecution {
@@ -295,21 +266,6 @@ mod tests {
         assert_eq!(
             external_inputs,
             vec![PathBuf::from("a.mbt"), executable, PathBuf::from("z.mbt")]
-        );
-    }
-
-    #[test]
-    fn verbatim_command_does_not_derive_an_executable() {
-        let (commandline, external_inputs) = BuildCommand {
-            extra_inputs: vec![PathBuf::from("z"), PathBuf::from("a")],
-            commandline: LoweredCommand::verbatim("tool && other-tool".to_string()),
-        }
-        .into_lowered_parts(&[]);
-
-        assert_eq!(commandline.executable(), None);
-        assert_eq!(
-            external_inputs,
-            vec![PathBuf::from("a"), PathBuf::from("z")]
         );
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -57,7 +57,7 @@ pub use utils::{build_ins, build_n2_fileloc, build_outs};
 pub(crate) use backend::{CExecutableRealization, CStubLibraryRealization};
 
 use context::LoweringContext;
-use lowered_action::{BuildCommand, LoweredCommandKind};
+use lowered_action::BuildCommand;
 use n2_adapter::N2GraphBuilder;
 
 /// Lazily resolved host/toolchain facts used during lowering.
@@ -952,5 +952,124 @@ mod tests {
                 .iter()
                 .any(|(key, value)| key == "LIB" && value == "crt/lib;sdk/lib")
         );
+    }
+
+    #[test]
+    fn macos_debug_link_and_dsymutil_are_separate_structured_actions() {
+        let (resolve_output, target) = single_package_resolve_output();
+        let executable_node = BuildPlanNode::MakeExecutable(target);
+        let dsym_node = BuildPlanNode::GenerateDsym(target);
+        let dsymutil = PathBuf::from("/toolchain/bin/dsymutil");
+
+        let mut plan = BuildPlan::default();
+        plan.test_add_input_node(executable_node);
+        plan.test_add_node(dsym_node);
+        plan.test_add_edge(dsym_node, executable_node, FileDependencyKind::AllFiles);
+        plan.test_insert_make_executable_info(
+            target,
+            MakeExecutableInfo {
+                effective_native_toolchain: Toolchain::from_path_probe(CC {
+                    cc_kind: CCKind::Clang,
+                    cc_path: "/toolchain/bin/clang".to_string(),
+                    ar_kind: ARKind::AppleLibtool,
+                    ar_path: "/toolchain/bin/libtool".to_string(),
+                    target_triple: Some("arm64-apple-darwin".to_string()),
+                    is_env_override: false,
+                }),
+                c_flags: Vec::new(),
+                link_flags: Vec::new(),
+                link_c_stubs: Vec::new(),
+            },
+        );
+        plan.test_insert_dsymutil(dsymutil.clone());
+
+        for backend in [
+            BackendConfig::Llvm,
+            BackendConfig::Native(NativeBackendMode::DirectObject(DirectNativeMode::Target(
+                NativeTarget::Aarch64AppleDarwin,
+            ))),
+        ] {
+            let lowering_environment = LoweringEnvironment::default();
+            lowering_environment
+                .os
+                .set(OperatingSystem::MacOS)
+                .expect("test OS should be set once");
+            let artifact_paths = ArtifactPathResolver::new(
+                TargetLayout::new(
+                    PathBuf::from("_build"),
+                    TargetLayoutMode::Workspace,
+                    OptLevel::Debug,
+                    RunMode::Build,
+                ),
+                None,
+            );
+            let options = BuildOptions {
+                artifact_paths: artifact_paths.clone(),
+                backend,
+                opt_level: OptLevel::Debug,
+                action: RunMode::Build,
+                debug_symbols: true,
+                enable_coverage: false,
+                moonc_output_json: false,
+                docs_serve: false,
+                warning_condition: WarningCondition::Default,
+                info_no_alias: false,
+                stdlib_path: None,
+                lowering_environment,
+            };
+
+            let action_plan = plan.build_action_plan();
+            let lowered = lower_build_plan(&resolve_output, &action_plan, &options)
+                .expect("lowering should succeed");
+            let executable = artifact_paths.target_layout().executable_of_build_target(
+                &resolve_output.pkg_dirs,
+                &target,
+                options.artifact_path_options().executable,
+            );
+            let dsym_bundle = artifact_paths.target_layout().dsym_bundle_of_build_target(
+                &resolve_output.pkg_dirs,
+                &target,
+                options.artifact_path_options().executable,
+            );
+
+            let link_args = lowered
+                .command_args_by_output
+                .get(&executable)
+                .expect("link command should retain structured argv");
+            assert_eq!(
+                link_args.first().map(String::as_str),
+                Some("/toolchain/bin/clang")
+            );
+            assert!(!link_args.iter().any(|arg| arg == "&&"));
+            assert_eq!(
+                lowered.command_args_by_output.get(&dsym_bundle),
+                Some(&vec![
+                    dsymutil.display().to_string(),
+                    executable.display().to_string(),
+                ])
+            );
+
+            let dsym_file_id = lowered
+                .build_graph
+                .files
+                .lookup(&dsym_bundle.to_string_lossy())
+                .expect("dSYM bundle should be registered");
+            let dsym_build_id = lowered.build_graph.files.by_id[dsym_file_id]
+                .input
+                .expect("dSYM bundle should have a producer");
+            let dsym_inputs = lowered.build_graph.builds[dsym_build_id]
+                .ins
+                .ids
+                .iter()
+                .map(|id| Path::new(&lowered.build_graph.files.by_id[*id].name))
+                .collect::<HashSet<_>>();
+            assert_eq!(
+                dsym_inputs,
+                HashSet::from([dsymutil.as_path(), executable.as_path()])
+            );
+
+            assert_eq!(lowered.artifacts.len(), 1);
+            assert_eq!(lowered.artifacts[0].1, vec![executable, dsym_bundle]);
+        }
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/moonc_command.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/moonc_command.rs
@@ -31,7 +31,6 @@ pub(super) fn lower(
     let commandline = LoweredCommand::from(args);
     let (executable, response_args) = commandline
         .args()
-        .expect("moonc commands are represented as argv")
         .split_first()
         .expect("moonc command builders always provide an executable");
     if commandline.inline_command().len() < RESPONSE_FILE_THRESHOLD {
@@ -102,7 +101,7 @@ mod tests {
             "x".repeat(RESPONSE_FILE_THRESHOLD),
         ];
         let lowered = lower(long.clone(), output).expect("oversized command should lower");
-        assert_eq!(lowered.args(), Some(long.as_slice()));
+        assert_eq!(lowered.args(), long.as_slice());
         let LoweredCommandExecution::ResponseFile {
             command,
             file: rspfile,

--- a/crates/moonbuild-rupes-recta/src/build_lower/n2_adapter.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/n2_adapter.rs
@@ -20,7 +20,7 @@ use log::debug;
 use n2::graph::{Build, Graph as N2Graph, RspFile};
 
 use super::{
-    CommandArgMap, LoweredAction, LoweredCommandExecution, LoweredCommandKind, LoweringError,
+    CommandArgMap, LoweredAction, LoweredCommandExecution, LoweringError,
     utils::{build_ins, build_n2_fileloc, build_outs},
 };
 
@@ -61,11 +61,9 @@ impl N2GraphBuilder {
             .into_iter()
             .flat_map(|product| product.paths)
             .collect::<Vec<_>>();
-        if let LoweredCommandKind::Args(args) = &command.kind {
-            for output_path in &output_paths {
-                self.command_args_by_output
-                    .insert(output_path.clone(), args.clone());
-            }
+        for output_path in &output_paths {
+            self.command_args_by_output
+                .insert(output_path.clone(), command.args.clone());
         }
 
         let ins = build_ins(&mut self.graph, &input_paths);

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -45,7 +45,10 @@ use crate::{
     build_plan::{BuildBundleInfo, FileDependencyKind, PlanArtifactNeed, PrebuildInfo},
     cond_comp,
     discover::DiscoveredPackage,
-    model::{BuildPlanNode, BuildTarget, NativeTarget, PackageId, TargetKind},
+    model::{
+        BackendConfig, BuildPlanNode, BuildTarget, DirectNativeMode, NativeBackendMode,
+        NativeTarget, OperatingSystem, PackageId, TargetKind,
+    },
     pkg_name::PackageFQNWithSource,
 };
 
@@ -74,6 +77,20 @@ impl DependencyInterfaceMode {
     fn core_as_input(self) -> bool {
         matches!(self, Self::BuildWithCoreInput)
     }
+}
+
+fn should_generate_llvm_dsym(debug_symbols: bool, os: OperatingSystem) -> bool {
+    debug_symbols && os == OperatingSystem::MacOS
+}
+
+fn should_generate_direct_native_dsym(
+    mode: &DirectNativeMode,
+    debug_symbols: bool,
+    toolchain: &Toolchain,
+) -> bool {
+    debug_symbols
+        && mode.target() == NativeTarget::Aarch64AppleDarwin
+        && toolchain.cc().targets_apple_darwin()
 }
 
 impl<'a> BuildPlanConstructor<'a> {
@@ -980,6 +997,32 @@ impl<'a> BuildPlanConstructor<'a> {
             &mut link_flags,
         );
 
+        let generate_dsym = match &self.build_env.backend {
+            BackendConfig::Llvm => {
+                should_generate_llvm_dsym(self.build_env.debug_symbols, self.build_env.os)
+            }
+            BackendConfig::Native(NativeBackendMode::DirectObject(mode)) => {
+                should_generate_direct_native_dsym(
+                    mode,
+                    self.build_env.debug_symbols,
+                    &effective_native_toolchain,
+                )
+            }
+            BackendConfig::Native(NativeBackendMode::GeneratedC | NativeBackendMode::TccRun(_)) => {
+                false
+            }
+            BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } | BackendConfig::Js => {
+                unreachable!("non-native MakeExecutable actions return before toolchain planning")
+            }
+        };
+        if generate_dsym && self.res.dsymutil.is_none() {
+            self.res.dsymutil = Some(moonutil::toolchain::resolve_executable("dsymutil").map_err(
+                |error| {
+                    BuildPlanConstructError::FailedToResolveDsymutil(error, pkg.fqn.clone().into())
+                },
+            )?);
+        }
+
         let v = MakeExecutableInfo {
             link_c_stubs: c_stub_deps.clone(),
             effective_native_toolchain,
@@ -990,6 +1033,12 @@ impl<'a> BuildPlanConstructor<'a> {
 
         let rt_node = self.need_node(BuildPlanNode::BuildRuntimeLib);
         self.add_edge(make_exec_node, rt_node);
+
+        if generate_dsym {
+            let dsym_node = self.need_node(BuildPlanNode::GenerateDsym(target));
+            self.add_edge(dsym_node, make_exec_node);
+            self.resolved_node(dsym_node);
+        }
 
         self.resolved_node(make_exec_node);
 
@@ -1804,6 +1853,8 @@ fn prebuild_command_paths(cwd: &Path, paths: &[PathBuf]) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use moonutil::compiler_flags::{ARKind, CCKind};
+
     use super::*;
 
     fn test_module(rules: Vec<moonutil::manifest::MoonModRule>) -> MoonMod {
@@ -1822,6 +1873,44 @@ mod tests {
             ),
             crate::pkg_name::PackagePath::new("").expect("empty package path should parse"),
         )
+    }
+
+    fn toolchain(target_triple: &str) -> Toolchain {
+        Toolchain::from_path_probe(CC {
+            cc_kind: CCKind::Clang,
+            cc_path: "/toolchain/bin/clang".to_string(),
+            ar_kind: ARKind::AppleLibtool,
+            ar_path: "/toolchain/bin/libtool".to_string(),
+            target_triple: Some(target_triple.to_string()),
+            is_env_override: false,
+        })
+    }
+
+    #[test]
+    fn dsym_generation_policy_is_backend_specific() {
+        let apple_toolchain = toolchain("arm64-apple-darwin");
+        let linux_toolchain = toolchain("x86_64-unknown-linux-gnu");
+        let direct_apple = DirectNativeMode::Target(NativeTarget::Aarch64AppleDarwin);
+
+        assert!(should_generate_llvm_dsym(true, OperatingSystem::MacOS));
+        assert!(!should_generate_llvm_dsym(true, OperatingSystem::Linux));
+        assert!(!should_generate_llvm_dsym(false, OperatingSystem::MacOS));
+
+        assert!(should_generate_direct_native_dsym(
+            &direct_apple,
+            true,
+            &apple_toolchain
+        ));
+        assert!(!should_generate_direct_native_dsym(
+            &direct_apple,
+            false,
+            &apple_toolchain
+        ));
+        assert!(!should_generate_direct_native_dsym(
+            &direct_apple,
+            true,
+            &linux_toolchain
+        ));
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -369,7 +369,8 @@ impl<'a> BuildPlanConstructor<'a> {
                     node
                 );
             }
-            BuildPlanNode::MakeExecutable(build_target) => {
+            BuildPlanNode::MakeExecutable(build_target)
+            | BuildPlanNode::GenerateDsym(build_target) => {
                 // Non-native MakeExecutable nodes are final-artifact aliases over
                 // LinkCore output. Only native backends need extra lowering info
                 // for the C toolchain/runtime/stub linking step.
@@ -377,6 +378,14 @@ impl<'a> BuildPlanConstructor<'a> {
                     assert!(
                         self.res.make_executable_info.contains_key(&build_target),
                         "Make executable info for {:?} should be present when resolving node {:?}",
+                        build_target,
+                        node
+                    );
+                }
+                if matches!(node, BuildPlanNode::GenerateDsym(_)) {
+                    assert!(
+                        self.res.dsymutil.is_some(),
+                        "dSYM info for {:?} should be present when resolving node {:?}",
                         build_target,
                         node
                     );
@@ -532,6 +541,9 @@ impl<'a> BuildPlanConstructor<'a> {
                 )
             }
             BuildPlanNode::MakeExecutable(target) => self.build_make_exec_link_core(node, target),
+            BuildPlanNode::GenerateDsym(_) => {
+                panic!("GenerateDsym nodes are resolved with their MakeExecutable node")
+            }
             BuildPlanNode::GenerateTestInfo(target) => self.build_gen_test_info(node, target),
             BuildPlanNode::Bundle(module_id) => self.build_bundle(node, module_id),
             BuildPlanNode::BuildRuntimeObject(index) => self.build_runtime_object(node, index),

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -65,7 +65,10 @@ use tracing::instrument;
 
 use crate::{
     ResolveOutput,
-    model::{BackendConfig, BuildPlanNode, BuildTarget, NativeTarget, PackageId, TccRunConfig},
+    model::{
+        BackendConfig, BuildPlanNode, BuildTarget, NativeTarget, OperatingSystem, PackageId,
+        TccRunConfig,
+    },
     pkg_name::PackageFQNWithSource,
     prebuild::PrebuildOutput,
 };
@@ -107,6 +110,9 @@ pub struct BuildPlan {
 
     /// The map of build target to the information needed to make it executable
     make_executable_info: HashMap<BuildTarget, MakeExecutableInfo>,
+
+    /// The resolved dsymutil executable, when the plan generates dSYM bundles.
+    dsymutil: Option<PathBuf>,
 
     /// The information needed to build the native runtime library.
     runtime_info: Option<BuildRuntimeInfo>,
@@ -235,6 +241,11 @@ impl BuildPlan {
         self.make_executable_info.get(target)
     }
 
+    /// Get the resolved dsymutil executable.
+    pub fn get_dsymutil(&self) -> Option<&Path> {
+        self.dsymutil.as_deref()
+    }
+
     /// Get runtime library build information.
     pub fn get_runtime_info(&self) -> Option<&BuildRuntimeInfo> {
         self.runtime_info.as_ref()
@@ -270,6 +281,11 @@ impl BuildPlan {
 impl BuildPlan {
     pub(crate) fn test_add_node(&mut self, node: BuildPlanNode) {
         self.graph.add_node(node);
+    }
+
+    pub(crate) fn test_add_input_node(&mut self, node: BuildPlanNode) {
+        self.test_add_node(node);
+        self.input_nodes.push(node);
     }
 
     pub(crate) fn test_add_edge(
@@ -311,6 +327,10 @@ impl BuildPlan {
         info: MakeExecutableInfo,
     ) {
         self.make_executable_info.insert(target, info);
+    }
+
+    pub(crate) fn test_insert_dsymutil(&mut self, dsymutil: PathBuf) {
+        self.dsymutil = Some(dsymutil);
     }
 
     pub(crate) fn test_insert_runtime_info(&mut self, info: BuildRuntimeInfo) {
@@ -533,6 +553,8 @@ pub struct BuildEnvironment {
     pub backend: BackendConfig,
     pub opt_level: OptLevel,
     pub action: RunMode,
+    pub debug_symbols: bool,
+    pub os: OperatingSystem,
     /// Toolchain include/lib paths selected for native-oriented backends.
     pub compiler_paths: Option<CompilerPaths>,
     /// Whether compiling requires the standard library.
@@ -587,6 +609,8 @@ pub enum BuildPlanConstructError {
     FailedToSetRuntimeCC(#[source] anyhow::Error),
     #[error("Failed to locate runtime C sources")]
     FailedToFindRuntimeSources(#[source] anyhow::Error),
+    #[error("Failed to resolve dsymutil when linking {1}")]
+    FailedToResolveDsymutil(#[source] anyhow::Error, PackageFQNWithSource),
     #[error("Failed to set stub C compiler when compiling {1}")]
     FailedToSetStubCC(#[source] anyhow::Error, PackageFQNWithSource),
     #[error("Malformed cc flags in package {0}")]

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -25,7 +25,7 @@ use tracing::{Level, instrument};
 use crate::{
     build_lower::{self, LoweringEnvironment, WarningCondition},
     build_plan::{self, BuildEnvironment, InputDirective},
-    model::{Artifacts, BackendConfig, BuildPlanNode},
+    model::{Artifacts, BackendConfig, BuildPlanNode, OperatingSystem},
     prebuild::PrebuildOutput,
     resolve::ResolveOutput,
     special_cases::should_skip_tests,
@@ -219,12 +219,18 @@ pub fn compile_standalone(
 }
 
 fn build_environment(cx: &CompileConfig) -> BuildEnvironment {
-    let compiler_paths = matches!(&cx.backend, BackendConfig::Native(_) | BackendConfig::Llvm)
-        .then(|| cx.lowering_environment.compiler_paths().clone());
+    let native_or_llvm = matches!(&cx.backend, BackendConfig::Native(_) | BackendConfig::Llvm);
+    let compiler_paths = native_or_llvm.then(|| cx.lowering_environment.compiler_paths().clone());
     BuildEnvironment {
         backend: cx.backend.clone(),
         opt_level: cx.opt_level,
         action: cx.action,
+        debug_symbols: cx.debug_symbols,
+        os: if native_or_llvm {
+            cx.lowering_environment.os()
+        } else {
+            OperatingSystem::None
+        },
         compiler_paths,
         std: cx.stdlib_path.is_some(),
         warn_list: cx.warn_list.clone(),

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -323,6 +323,9 @@ pub enum BuildPlanNode {
     /// execution logic.
     MakeExecutable(BuildTarget),
 
+    /// Generate the macOS dSYM bundle for a linked executable.
+    GenerateDsym(BuildTarget),
+
     /// Generate test driver and metadata for the given test target.
     GenerateTestInfo(BuildTarget),
 
@@ -399,6 +402,7 @@ impl BuildPlanNode {
             | BuildPlanNode::BuildCore(target)
             | BuildPlanNode::LinkCore(target)
             | BuildPlanNode::MakeExecutable(target)
+            | BuildPlanNode::GenerateDsym(target)
             | BuildPlanNode::GenerateTestInfo(target)
             | BuildPlanNode::GenerateMbti(target) => Some(target),
             BuildPlanNode::BuildCStub(_, _)
@@ -464,6 +468,10 @@ impl BuildPlanNode {
             BuildPlanNode::MakeExecutable(build_target) => {
                 let fqn = packages.fqn(build_target.package);
                 format!("make executable {}{}", fqn, kind_suffix(build_target.kind))
+            }
+            BuildPlanNode::GenerateDsym(build_target) => {
+                let fqn = packages.fqn(build_target.package);
+                format!("generate dSYM {}{}", fqn, kind_suffix(build_target.kind))
             }
             BuildPlanNode::GenerateTestInfo(build_target) => {
                 let fqn = packages.fqn(build_target.package);
@@ -571,6 +579,10 @@ impl BuildPlanNode {
             BuildPlanNode::MakeExecutable(t) => {
                 let fqn = packages.fqn(t.package);
                 format!("{}@{:?}@MakeExecutable", fqn, t.kind)
+            }
+            BuildPlanNode::GenerateDsym(t) => {
+                let fqn = packages.fqn(t.package);
+                format!("{}@{:?}@GenerateDsym", fqn, t.kind)
             }
             BuildPlanNode::GenerateTestInfo(t) => {
                 let fqn = packages.fqn(t.package);

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -355,6 +355,18 @@ impl TargetLayout {
         base_dir
     }
 
+    pub fn dsym_bundle_of_build_target(
+        &self,
+        pkg_list: &DiscoverResult,
+        target: &BuildTarget,
+        executable: ExecutableArtifact,
+    ) -> PathBuf {
+        let executable = self.executable_of_build_target(pkg_list, target, executable);
+        let mut bundle = executable.into_os_string();
+        bundle.push(".dSYM");
+        bundle.into()
+    }
+
     pub fn generated_test_driver(
         &self,
         pkg_list: &DiscoverResult,
@@ -832,6 +844,13 @@ impl ArtifactPathResolver {
                     options.executable,
                 )]
             }
+            BuildProduct::DsymBundle { target } => {
+                vec![self.target_layout.dsym_bundle_of_build_target(
+                    packages,
+                    target,
+                    options.executable,
+                )]
+            }
             BuildProduct::GeneratedTestDriver { target } => {
                 vec![self.target_layout.generated_test_driver(
                     packages,
@@ -962,6 +981,13 @@ impl ArtifactPathResolver {
             (
                 BuildProduct::Executable { target },
                 BuildAction::MakeExecutable {
+                    target: action_target,
+                    ..
+                },
+            ) => *target == action_target,
+            (
+                BuildProduct::DsymBundle { target },
+                BuildAction::GenerateDsym {
                     target: action_target,
                     ..
                 },

--- a/crates/moonbuild-rupes-recta/src/util.rs
+++ b/crates/moonbuild-rupes-recta/src/util.rs
@@ -188,6 +188,7 @@ impl BuildPlanNode {
             BuildPlanNode::ArchiveOrLinkCStubs(target) => format!("{:?}@ArchiveCStubs", target),
             BuildPlanNode::LinkCore(target) => format!("{:?}@LinkCore", target),
             BuildPlanNode::MakeExecutable(target) => format!("{:?}@MakeExecutable", target),
+            BuildPlanNode::GenerateDsym(target) => format!("{:?}@GenerateDsym", target),
             BuildPlanNode::GenerateTestInfo(target) => format!("{:?}@GenerateTestInfo", target),
             BuildPlanNode::Bundle(module_id) => format!("{:?}@Bundle", module_id),
             BuildPlanNode::GenerateMbti(target) => format!("{:?}@GenerateMbti", target),
@@ -243,6 +244,10 @@ impl BuildPlanNode {
                 let fqn = packages.fqn(target.package);
                 format!("{}\\nMakeExecutable", fqn)
             }
+            BuildPlanNode::GenerateDsym(target) => {
+                let fqn = packages.fqn(target.package);
+                format!("{}\\nGenerateDsym", fqn)
+            }
             BuildPlanNode::GenerateTestInfo(target) => {
                 let fqn = packages.fqn(target.package);
                 format!("{}\\nGenerateTestInfo", fqn)
@@ -292,6 +297,7 @@ impl BuildPlanNode {
             BuildPlanNode::ArchiveOrLinkCStubs(_) => "lightyellow",
             BuildPlanNode::LinkCore(_) => "lightcoral",
             BuildPlanNode::MakeExecutable(_) => "lightpink",
+            BuildPlanNode::GenerateDsym(_) => "pink",
             BuildPlanNode::GenerateTestInfo(_) => "lightgray",
             BuildPlanNode::Bundle(_) => "wheat",
             BuildPlanNode::GenerateMbti(_) => "lightcyan",

--- a/crates/moonutil/src/toolchain.rs
+++ b/crates/moonutil/src/toolchain.rs
@@ -87,7 +87,7 @@ fn runtime_source_paths_in(lib_path: &Path) -> anyhow::Result<Vec<PathBuf>> {
 /// `which` may return a relative path when `PATH` contains relative entries.
 /// Build actions can run from a different working directory, so executable
 /// paths crossing the toolchain boundary must be made absolute here.
-pub(crate) fn resolve_executable(tool: impl AsRef<OsStr>) -> anyhow::Result<PathBuf> {
+pub fn resolve_executable(tool: impl AsRef<OsStr>) -> anyhow::Result<PathBuf> {
     let current_dir = std::env::current_dir().context("failed to get current directory")?;
     resolve_executable_in(tool, &current_dir)
 }

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -115,6 +115,7 @@ pub enum BuildAction<'a> {
     BuildCore { target: BuildTarget, info: &'a BuildTargetInfo },
     LinkCore { target: BuildTarget, info: &'a LinkCoreInfo, make_executable_info: Option<&'a MakeExecutableInfo> },
     MakeExecutable { target: BuildTarget, info: Option<&'a MakeExecutableInfo> },
+    GenerateDsym { target: BuildTarget, dsymutil: &'a Path },
     // other action variants carry the same hydrated planning metadata
 }
 ```
@@ -131,6 +132,8 @@ pub enum BuildProduct {
     PackageCoreIr { target: BuildTarget },
     GeneratedTestDriver { target: BuildTarget },
     CStubObject { package: PackageId, index: u32 },
+    Executable { target: BuildTarget },
+    DsymBundle { target: BuildTarget },
     RuntimeObject { index: u32 },
     RuntimeLib,
     PrebuildOutputPath { path: PathBuf },
@@ -218,12 +221,18 @@ each action directly into the n2 adapter as soon as it is lowered; they do not
 retain a second complete graph in memory. The adapter alone registers n2 files,
 constructs `n2::Build`, and reports n2 graph errors.
 
-At this common boundary, a structured command contributes its first argument,
-the concrete executable path, to the action's external file inputs. External
-inputs are sorted and deduplicated before the action reaches n2. This uses the
-original structured arguments even when command transport switches to a
-response file. Verbatim shell commands remain opaque and do not contribute an
-inferred executable.
+Every lowered command retains structured argv. Response files change only the
+transport recorded alongside that argv. At the common lowering boundary, the
+first argument's concrete executable path becomes an external file input.
+External inputs are sorted and deduplicated before the action reaches n2, and
+the original argv remains authoritative when transport switches to a response
+file.
+
+When one build result requires two processes, planning represents them as
+separate actions instead of joining rendered command strings with shell
+operators. For example, macOS debug builds use `MakeExecutable` for the linker
+invocation and a dependent `GenerateDsym` action for `dsymutil`. The latter
+consumes the executable product and produces the `.dSYM` bundle.
 
 This keeps responsibilities separate:
 
@@ -281,6 +290,11 @@ in input action order. The compile layer re-keys those artifacts back to
 `BuildPlanNode` for the existing public `CompileOutput` shape. That keeps
 compatibility above lowering while proving that backend lowering no longer sees
 planning internals.
+
+For a native macOS debug target, the existing `MakeExecutable` root reports the
+executable first and its follow-up `.dSYM` bundle second. Requesting both paths
+causes n2 to run the dependent `GenerateDsym` action without changing the
+caller-visible executable artifact position.
 
 ## Checks
 

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -98,7 +98,7 @@ This policy is centralized in `BuildFlags::effective_profile()` in
 `crates/moon/src/cli.rs`. Individual commands may still layer additional
 symbol or strip behavior on top of that default profile.
 
-When actually building a package, the pipeline has 2 or 3 steps depending on the backend to use:
+When actually building a package, the pipeline has 2 or 3 main steps depending on the backend:
 
 1. **Build** each individual package, via `moonc build-package` / `BuildPackage` node, into CoreIR.
 2. **Link** into executable, via `moonc link-core` / `LinkCore` node.
@@ -111,6 +111,13 @@ When actually building a package, the pipeline has 2 or 3 steps depending on the
    together with C stubs and other build outputs,
    to produce the final executable.
    Non-native backends do not need this step.
+
+macOS debug builds that emit native object code add one post-link step:
+
+4. **Generate debug symbols**, via `dsymutil` / `GenerateDsym`.
+   This action depends on the completed executable and produces its `.dSYM`
+   bundle. The linker and `dsymutil` remain separate structured commands, so
+   n2 can schedule and track each tool invocation independently.
 
 A package needs all its transitive dependencies' interface files to be built
 before running `BuildPackage` for any of its build targets.
@@ -326,6 +333,7 @@ The following is a table
 | `BuildPackage(BuildTarget)`     | `moonc build-package`       | `.mi`, `.core`        | same as above                              | Build the target                               |
 | `LinkCore(BuildTarget)`         | `moonc link-core`           | backend-specific      | `.core` of all transitive deps             | Links all transitive deps into output          |
 | `MakeExecutable(BuildTarget)`   | C compiler                  | executable            | `LinkCore` outputs, C stubs, runtime       | Compiles/links the final executable (optional) |
+| `GenerateDsym(BuildTarget)`     | `dsymutil`                  | `.dSYM` bundle        | executable                                 | Generates macOS debug symbols (optional)       |
 | `BuildCStub(PackageId, int)`    | C compiler                  | object file           | N/A                                        | Builds a single C stub file                    |
 | `ArchiveOrLinkCStub(PackageId)` | C compiler                  | archive file          | `BuildCStub` outputs                       | Collect C stub output                          |
 | `BuildRuntimeObject(int)`       | C compiler                  | object file           | N/A                                        | Builds one runtime translation unit            |

--- a/docs/dev/reference/native-c-toolchain-resolution.md
+++ b/docs/dev/reference/native-c-toolchain-resolution.md
@@ -21,6 +21,12 @@ both roles because archiving is performed with `tcc -ar`.
 Moon does not resolve a standalone linker executable such as `ld` or `lld-link` in this path.
 Linking is performed through the selected compiler driver.
 
+`dsymutil` is a post-link debug-symbol tool, not a fourth C-toolchain role.
+When planning an LLVM macOS debug build or an AArch64 Apple direct-object debug
+build, Moon resolves `dsymutil` through the same shared executable resolver and
+stores its concrete absolute path as planning metadata for the `GenerateDsym`
+action. Other builds do not resolve it.
+
 ## Standard C Pipeline
 
 The ordinary C pipeline is:
@@ -324,6 +330,19 @@ fresh path. Build lowering then invokes the resolved librarian directly.
 
 This fingerprint is specific to the runtime archive introduced for the split runtime. Existing
 package C-stub archives retain their stable paths and direct librarian invocation.
+
+### Generate macOS debug symbols
+
+For LLVM macOS debug builds and AArch64 Apple direct-object debug builds, Moon
+models debug-symbol generation as a separate `GenerateDsym` action:
+
+1. `MakeExecutable` invokes the resolved compiler driver and produces the executable.
+2. `GenerateDsym` depends on that executable, invokes the resolved `dsymutil`,
+   and produces `<executable>.dSYM`.
+
+The commands are not joined with `&&`. This keeps the linker invocation as
+structured argv, makes the executable-to-dSYM dependency explicit, and records
+the `dsymutil` executable as an n2 file input.
 
 ## Maintenance Notes
 


### PR DESCRIPTION
## Why

macOS debug linking currently renders the linker invocation and `dsymutil` as one verbatim `a && b` command. That hides both process boundaries from structured lowering, prevents the executable-to-dSYM relationship from being represented in the graph, and defeats the executable-input derivation added in #1957.

## What

- add a `GenerateDsym` action and `DsymBundle` product after `MakeExecutable`
- resolve `dsymutil` to a concrete executable path only for the existing LLVM/macOS and AArch64 Apple direct-object debug paths
- keep linker and `dsymutil` invocations as separate structured argv commands
- remove the now-unused verbatim lowered-command representation
- preserve the executable as the first caller-visible artifact and add the dSYM bundle as the follow-up artifact

## Historical behavior and artifact purpose

Before this change, the build graph modeled the composite command as a single `MakeExecutable` action:

```text
<link command> && dsymutil <executable>
```

Only the executable was declared as an n2 output. The adjacent `<executable>.dSYM` bundle was an undeclared side effect, and the literal `dsymutil` hidden in the verbatim shell command was not a tool file input.

The dSYM is a debugger side artifact rather than an input to another build action. Normal `moon run` and test execution use the executable; LLDB/Xcode can discover the adjacent bundle and match it to the executable by build UUID for debugging and symbolication.

## Correctness and scope

The generation predicate matches the two paths that previously appended `dsymutil`. The new action consumes the executable, produces `<executable>.dSYM`, and lets the common lowering boundary register both the linker and `dsymutil` executable files as n2 inputs. Rebuilding the executable therefore makes the dependent dSYM action run again and regenerate a matching bundle.

n2 continues to track the dSYM bundle root rather than individual `Contents/Resources/DWARF` or `Info.plist` members. No downstream build action consumes those files, and normal executable rebuilds already regenerate the bundle. Detecting external deletion or mutation of an individual bundle member is intentionally outside this PR's scope.

This PR only separates the composed macOS command; it reuses #1957 rather than adding another tool-input mechanism.

## Checks

Regression coverage exercises both affected backends, verifies separate structured argv, verifies the executable and `dsymutil` n2 input edges, and checks root artifact ordering.