### PR TITLE
fix(build): complete generator and C-stub action inputs

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -414,7 +414,7 @@ impl<'a> super::LoweringContext<'a> {
 
         BuildCommand {
             commandline: commandline.into(),
-            extra_inputs: vec![mbtlex_path],
+            extra_inputs: vec![mbtlex_path, BINARIES.moonlex.clone()],
         }
     }
 
@@ -438,7 +438,7 @@ impl<'a> super::LoweringContext<'a> {
 
         BuildCommand {
             commandline: commandline.into(),
-            extra_inputs: vec![mby_path],
+            extra_inputs: vec![mby_path, BINARIES.moonyacc.clone()],
         }
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -962,9 +962,13 @@ impl<'a> LoweringContext<'a> {
             self.opt.compiler_paths(),
         );
 
+        let mut extra_inputs = Vec::with_capacity(1 + package.c_stub_header_files.len());
+        extra_inputs.push(input_file.clone());
+        extra_inputs.extend(package.c_stub_header_files.iter().cloned());
+
         BuildCommand {
             commandline: cc_cmd.into(),
-            extra_inputs: vec![input_file.clone()],
+            extra_inputs,
         }
         .with_msvc_env(&info.effective_native_toolchain)
     }

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -505,6 +505,7 @@ mod tests {
             mbt_md_files: Vec::new(),
             mbtp_files: Vec::new(),
             c_stub_files: vec![PathBuf::from("main/native/stub.c")],
+            c_stub_header_files: vec![PathBuf::from("main/native/stub.h")],
             virtual_mbti: None,
             is_stdlib: false,
         };
@@ -920,6 +921,12 @@ mod tests {
                 .filter(|input| input.as_path() == Path::new(toolchain.cc().cc_path()))
                 .count(),
             1
+        );
+        assert!(
+            compiler_inputs
+                .iter()
+                .any(|input| input == Path::new("main/native/stub.h")),
+            "package-local C headers should be inputs of every C-stub action"
         );
 
         let archiver_inputs = n2_input_paths_for_command(&lowered, |command| {

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -500,8 +500,8 @@ mod tests {
             supported_targets_decl: SupportedTargetsDeclKind::Omitted,
             effective_supported_targets: supported_targets,
             source_files: Vec::new(),
-            mbt_lex_files: Vec::new(),
-            mbt_yacc_files: Vec::new(),
+            mbt_lex_files: vec![PathBuf::from("main/lexer.mbl")],
+            mbt_yacc_files: vec![PathBuf::from("main/parser.mby")],
             mbt_md_files: Vec::new(),
             mbtp_files: Vec::new(),
             c_stub_files: vec![PathBuf::from("main/native/stub.c")],
@@ -558,6 +558,58 @@ mod tests {
             .iter()
             .map(|id| PathBuf::from(&lowered.build_graph.files.by_id[*id].name))
             .collect()
+    }
+
+    #[test]
+    fn lowered_generator_actions_track_host_and_payload_executables() {
+        let (resolve_output, target) = single_package_resolve_output();
+        let mut plan = BuildPlan::default();
+        plan.test_add_node(BuildPlanNode::RunMoonLexPrebuild(target.package, 0));
+        plan.test_add_node(BuildPlanNode::RunMoonYaccPrebuild(target.package, 0));
+
+        let artifact_paths = ArtifactPathResolver::new(
+            TargetLayout::new(
+                PathBuf::from("_build"),
+                TargetLayoutMode::Workspace,
+                OptLevel::Debug,
+                RunMode::Check,
+            ),
+            None,
+        );
+        let options = BuildOptions {
+            artifact_paths,
+            backend: BackendConfig::WasmGc { use_wat: false },
+            opt_level: OptLevel::Debug,
+            action: RunMode::Check,
+            debug_symbols: false,
+            enable_coverage: false,
+            moonc_output_json: false,
+            docs_serve: false,
+            warning_condition: WarningCondition::Default,
+            info_no_alias: false,
+            stdlib_path: None,
+            lowering_environment: LoweringEnvironment::default(),
+        };
+
+        let action_plan = plan.build_action_plan();
+        let lowered = lower_build_plan(&resolve_output, &action_plan, &options)
+            .expect("lowering should succeed");
+
+        for (payload, source) in [
+            (BINARIES.moonlex.as_path(), Path::new("main/lexer.mbl")),
+            (BINARIES.moonyacc.as_path(), Path::new("main/parser.mby")),
+        ] {
+            let inputs = n2_input_paths_for_command(&lowered, |command| {
+                command.get(1).map(Path::new) == Some(payload)
+            });
+            assert!(
+                inputs
+                    .iter()
+                    .any(|input| input == BINARIES.moonrun.as_path())
+            );
+            assert!(inputs.iter().any(|input| input == payload));
+            assert!(inputs.iter().any(|input| input == source));
+        }
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -406,6 +406,7 @@ mod tests {
             mbt_md_files: Vec::new(),
             mbtp_files: Vec::new(),
             c_stub_files: Vec::new(),
+            c_stub_header_files: Vec::new(),
             virtual_mbti: None,
             is_stdlib: false,
         }

--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -444,6 +444,16 @@ fn discover_one_package(
             c_stubs.push(rel_path.to_path(abs));
         }
     };
+    let c_stub_headers = if c_stubs.is_empty() {
+        Vec::new()
+    } else {
+        discover_c_stub_headers(abs).map_err(|inner| DiscoverError::CantListPackageDir {
+            module: m.clone(),
+            package: fqn.package().clone(),
+            path: abs.to_owned(),
+            inner,
+        })?
+    };
 
     // Sort the source files for repeatable results
     let _sort_guard = tracing::debug_span!("sorting_files").entered();
@@ -472,9 +482,47 @@ fn discover_one_package(
         mbt_md_files,
         mbtp_files,
         c_stub_files: c_stubs,
+        c_stub_header_files: c_stub_headers,
         virtual_mbti,
         is_stdlib: pkg_is_stdlib,
     })
+}
+
+fn discover_c_stub_headers(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let mut headers = Vec::new();
+    let mut entries = WalkDir::new(root).sort_by_file_name().into_iter();
+    while let Some(entry) = entries.next() {
+        let entry = entry?;
+        if entry.depth() != 0 && entry.file_type().is_dir() {
+            if entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| IGNORE_DIRS.contains(&name))
+            {
+                entries.skip_current_dir();
+                continue;
+            }
+
+            let path = entry.path();
+            if [MOON_MOD, MOON_MOD_JSON, MOON_PKG, MOON_PKG_JSON]
+                .iter()
+                .any(|manifest| path.join(manifest).exists())
+            {
+                entries.skip_current_dir();
+                continue;
+            }
+        }
+
+        if (entry.file_type().is_file() || entry.file_type().is_symlink())
+            && entry.path().extension().is_some_and(|extension| {
+                matches!(extension.to_str(), Some("h" | "hh" | "hpp" | "hxx"))
+            })
+        {
+            headers.push(entry.into_path());
+        }
+    }
+    headers.sort();
+    Ok(headers)
 }
 
 fn discover_virtual_mbti(
@@ -510,12 +558,14 @@ fn discover_virtual_mbti(
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
     use moonutil::{
         manifest::MoonMod,
         resolution::{DirSyncResult, ModuleSource, ResolvedEnv},
     };
 
-    use super::discover_packages;
+    use super::{discover_c_stub_headers, discover_packages};
 
     fn temp_dir(name: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join(format!(
@@ -581,5 +631,47 @@ mod tests {
         assert_eq!(rule[0].name, "gen");
         assert_eq!(rule[0].command, "tool $input -o $output");
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn c_stub_headers_follow_package_file_set_boundaries() -> anyhow::Result<()> {
+        let dir = temp_dir("c-stub-headers");
+        std::fs::create_dir_all(dir.join("native/include"))?;
+        std::fs::write(dir.join("native/stub.h"), "stub")?;
+        std::fs::write(dir.join("native/include/detail.hpp"), "detail")?;
+        std::fs::write(dir.join("native/ignored.txt"), "ignored")?;
+
+        std::fs::create_dir_all(dir.join("_build/generated"))?;
+        std::fs::write(dir.join("_build/generated/stale.h"), "stale")?;
+
+        std::fs::create_dir_all(dir.join("nested-module"))?;
+        std::fs::write(
+            dir.join("nested-module/moon.mod.json"),
+            r#"{"name":"nested/module"}"#,
+        )?;
+        std::fs::write(dir.join("nested-module/foreign.h"), "foreign")?;
+
+        std::fs::create_dir_all(dir.join("nested-package"))?;
+        std::fs::write(dir.join("nested-package/moon.pkg.json"), "{}")?;
+        std::fs::write(dir.join("nested-package/foreign.hpp"), "foreign")?;
+
+        let headers = discover_c_stub_headers(&dir)?
+            .into_iter()
+            .map(|path| {
+                path.strip_prefix(&dir)
+                    .map(Path::to_path_buf)
+                    .map_err(anyhow::Error::from)
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        assert_eq!(
+            headers,
+            [
+                PathBuf::from("native/include/detail.hpp"),
+                PathBuf::from("native/stub.h"),
+            ]
+        );
+        let _ = std::fs::remove_dir_all(dir);
+        Ok(())
     }
 }

--- a/crates/moonbuild-rupes-recta/src/discover/model.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/model.rs
@@ -105,6 +105,12 @@ pub struct DiscoveredPackage {
     /// is generated from the package json, instead of directly collected from
     /// the folder.
     pub c_stub_files: Vec<PathBuf>,
+    /// Package-local header files that may be observed while compiling C
+    /// stubs.
+    ///
+    /// Every C-stub action conservatively depends on this complete set because
+    /// MoonBuild does not interpret transitive `#include` directives.
+    pub c_stub_header_files: Vec<PathBuf>,
 
     /// The text-format module interface file for virtual packages.
     ///

--- a/crates/moonbuild-rupes-recta/src/discover/synth.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/synth.rs
@@ -166,6 +166,7 @@ pub fn build_synth_single_file_package(
         mbt_md_files,
         mbtp_files: Vec::new(),
         c_stub_files: Vec::new(),
+        c_stub_header_files: Vec::new(),
         virtual_mbti: None,
         is_stdlib: false,
     };

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -1406,6 +1406,7 @@ mod tests {
             mbt_md_files: Vec::new(),
             mbtp_files: Vec::new(),
             c_stub_files: vec![PathBuf::from("native/stub.c")],
+            c_stub_header_files: vec![PathBuf::from("native/stub.h")],
             virtual_mbti: None,
             is_stdlib: false,
         };

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -190,7 +190,10 @@ MoonBit code might reference the functions defined in them in e.g. `extern "C" f
 Compiling C stubs of a package involves 3 steps:
 
 1. `BuildCStub` -- The C files are compiled independently using a C compiler.
-   They do not have any dependency on their own.
+   Each action conservatively tracks every package-local `.h`, `.hh`, `.hpp`,
+   and `.hxx` file because MoonBuild does not interpret transitive `#include`
+   directives. Headers outside the Package File Set are not discovered
+   automatically.
 2. `ArchiveOrLinkCStubs` -- All C stubs in a package is archived using AR.
    If [TCC-run mode](./tcc-run.md) is enabled, this instead links the C stubs.
    This is out of scope of a regular compilation.


### PR DESCRIPTION
## Why

`LoweredAction` derives the executable input of structured commands from `argv[0]`, but generator actions run `moonlex` and `moonyacc` through `moonrun`, leaving the payload executable untracked. C-stub actions likewise tracked their declared `.c` source but not package-local headers that can affect compilation. Both gaps can leave n2—and a future action cache—with an incomplete input set.

## What changed

- Explicitly add the `moonlex` and `moonyacc` payload executables to their generator actions.
- Discover package-local `.h`, `.hh`, `.hpp`, and `.hxx` files only for packages that declare C stubs.
- Add that complete header set to every C-stub compilation action.
- Stop header discovery at ignored directories and nested module/package boundaries.
- Document that headers outside the Package File Set remain a best-effort boundary.

## Why this shape

The cache layer remains domain-agnostic and consumes the completed `LoweredAction`. Wrapper construction declares its hidden payload, while package discovery owns the Package File Set and lowering attaches those concrete files to C-stub actions. The two concerns are kept as independent commits and do not introduce a new action-identity abstraction.