### PR TITLE
test: bump MBTI snapshots

### DIFF
--- a/crates/moon/tests/test_cases/mbti/mod.rs
+++ b/crates/moon/tests/test_cases/mbti/mod.rs
@@ -26,7 +26,6 @@ fn test_mbti() {
         // Type aliases
 
         // Traits
-
     "#]]
     .assert_eq(lib_mi_out);
 
@@ -44,7 +43,6 @@ fn test_mbti() {
         // Type aliases
 
         // Traits
-
     "#]]
     .assert_eq(main_mi_out);
 }
@@ -70,7 +68,6 @@ fn test_mbti_no_alias() {
         // Type aliases
 
         // Traits
-
     "#]]
     .assert_eq(lib_mi_out);
 
@@ -88,7 +85,6 @@ fn test_mbti_no_alias() {
         // Type aliases
 
         // Traits
-
     "#]]
     .assert_eq(main_mi_out);
 }


### PR DESCRIPTION
## Why

The MBTI integration snapshots still expect an extra trailing newline that `moon info` no longer emits, causing the assertions to fail with the current toolchain.

## What changed

Updated the four inline expectations covering library and main-package output, with and without import aliases.

## Why this is correct

The expectations now match the generated MBTI output exactly. This is limited to snapshot text and does not change command behavior.
