### PR TITLE
fix(discover): skip dot-prefixed directories

### DIFF
--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -51,8 +51,8 @@ use moonutil::resolution::{
 use moonutil::target::TargetBackend;
 use moonutil::{
     constants::{
-        IGNORE_DIRS, MBTI_USER_WRITTEN, MOON_MOD, MOON_MOD_JSON, MOON_PKG, MOON_PKG_JSON,
-        MOONBITLANG_ABORT,
+        MBTI_USER_WRITTEN, MOON_MOD, MOON_MOD_JSON, MOON_PKG, MOON_PKG_JSON, MOONBITLANG_ABORT,
+        is_ignored_directory_name,
     },
     manifest::{
         read_module_desc_file_in_dir, read_package_desc_file_from_path_with_supported_targets_decl,
@@ -266,12 +266,10 @@ pub(crate) fn discover_packages_for_mod(
             .relative_to(&scan_source_root)
             .expect("Walked directory should be a descendant of the scan source");
 
-        // Skip certain ignored directories
-        if let Some(filename) = rel_path.file_name()
-            && IGNORE_DIRS.contains(&filename)
-        {
+        // The configured source root is explicit, so only filter its descendants.
+        if entry.depth() != 0 && is_ignored_directory_name(entry.file_name()) {
             debug!(
-                "Skipping {} recursively because it is in the internal ignored list",
+                "Skipping {} recursively because its directory name is ignored",
                 abs_path.display()
             );
             walkdir.skip_current_dir();
@@ -494,11 +492,7 @@ fn discover_c_stub_headers(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
     while let Some(entry) = entries.next() {
         let entry = entry?;
         if entry.depth() != 0 && entry.file_type().is_dir() {
-            if entry
-                .file_name()
-                .to_str()
-                .is_some_and(|name| IGNORE_DIRS.contains(&name))
-            {
+            if is_ignored_directory_name(entry.file_name()) {
                 entries.skip_current_dir();
                 continue;
             }
@@ -634,6 +628,50 @@ mod tests {
     }
 
     #[test]
+    fn package_discovery_keeps_explicit_dot_source_root_but_skips_dot_descendants() {
+        let dir = temp_dir("dot-directories");
+        std::fs::write(
+            dir.join("moon.mod.json"),
+            r#"{
+  "name": "example/pkg",
+  "version": "0.2.1",
+  "source": ".src"
+}
+"#,
+        )
+        .expect("failed to write test moon.mod.json");
+        std::fs::create_dir_all(dir.join(".src/.hidden"))
+            .expect("failed to create test package directories");
+        std::fs::write(dir.join(".src/moon.pkg.json"), "{}")
+            .expect("failed to write root package manifest");
+        std::fs::write(dir.join(".src/.hidden/moon.pkg.json"), "{}")
+            .expect("failed to write hidden package manifest");
+
+        let source: ModuleSource = "example/pkg@0.2.1"
+            .parse()
+            .expect("failed to parse test module source");
+        let stub = MoonMod {
+            name: "example/pkg".to_string(),
+            version: Some(source.version().clone()),
+            ..Default::default()
+        };
+        let (resolved_env, id) = ResolvedEnv::only_one_module(source, stub);
+        let mut dirs = DirSyncResult::default();
+        dirs.insert(id, dir.clone());
+
+        let discovered =
+            discover_packages(&resolved_env, &dirs).expect("failed to discover test packages");
+
+        assert!(discovered.get_package_id_by_name("example/pkg").is_some());
+        assert!(
+            discovered
+                .get_package_id_by_name("example/pkg/.hidden")
+                .is_none()
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
     fn c_stub_headers_follow_package_file_set_boundaries() -> anyhow::Result<()> {
         let dir = temp_dir("c-stub-headers");
         std::fs::create_dir_all(dir.join("native/include"))?;
@@ -643,6 +681,9 @@ mod tests {
 
         std::fs::create_dir_all(dir.join("_build/generated"))?;
         std::fs::write(dir.join("_build/generated/stale.h"), "stale")?;
+
+        std::fs::create_dir_all(dir.join(".generated"))?;
+        std::fs::write(dir.join(".generated/stale.hpp"), "stale")?;
 
         std::fs::create_dir_all(dir.join("nested-module"))?;
         std::fs::write(

--- a/crates/moonutil/src/constants.rs
+++ b/crates/moonutil/src/constants.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::path::Path;
+use std::{ffi::OsStr, path::Path};
 
 use crate::mooncakes::ModuleName;
 
@@ -53,6 +53,11 @@ pub const DEP_PATH: &str = ".mooncakes";
 pub const BUILD_DIR: &str = "_build";
 
 pub const IGNORE_DIRS: &[&str] = &[BUILD_DIR, ".git", "node_modules", DEP_PATH];
+
+pub fn is_ignored_directory_name(name: &OsStr) -> bool {
+    name.as_encoded_bytes().starts_with(b".")
+        || IGNORE_DIRS.iter().any(|ignored_name| name == *ignored_name)
+}
 
 pub const WATCH_MODE_DIR: &str = "watch";
 
@@ -166,6 +171,15 @@ fn package_source_file_kind_detects_supported_package_inputs() {
         Some(PackageSourceFileKind::Mby)
     );
     assert_eq!(package_source_file_kind("moon.pkg"), None);
+}
+
+#[test]
+fn ignored_directory_names_cover_dot_and_generated_directories() {
+    assert!(is_ignored_directory_name(OsStr::new(".cache")));
+    assert!(is_ignored_directory_name(OsStr::new(".git")));
+    assert!(is_ignored_directory_name(OsStr::new("_build")));
+    assert!(is_ignored_directory_name(OsStr::new("node_modules")));
+    assert!(!is_ignored_directory_name(OsStr::new("src")));
 }
 
 #[test]

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -199,8 +199,9 @@ Compiling C stubs of a package involves 3 steps:
 1. `BuildCStub` -- The C files are compiled independently using a C compiler.
    Each action conservatively tracks every package-local `.h`, `.hh`, `.hpp`,
    and `.hxx` file because MoonBuild does not interpret transitive `#include`
-   directives. Headers outside the Package File Set are not discovered
-   automatically.
+   directives. Dot-prefixed directories, ignored generated directories, and
+   nested module or package roots are outside the Package File Set, so headers
+   under those boundaries are not discovered automatically.
 2. `ArchiveOrLinkCStubs` -- All C stubs in a package is archived using AR.
    If [TCC-run mode](./tcc-run.md) is enabled, this instead links the C stubs.
    This is out of scope of a regular compilation.

--- a/docs/dev/reference/modules-packages.md
+++ b/docs/dev/reference/modules-packages.md
@@ -122,8 +122,10 @@ Newer modules created by `moon new` by default sets this to `src`.
 To discover all package within the module,
 one recursively search from the scanning root for files named `moon.pkg.json`,
 unless the folder contains `moon.mod.json`.
-Common non-code folders will be skipped during this process,
-such as `.git`, `node_modules` and `target`.
+Dot-prefixed directories and common non-code folders such as `node_modules`
+and `_build` are skipped during this process. The configured scanning root
+itself remains explicit and is still scanned when its name starts with `.`;
+the filtering applies to its descendants.
 
 The followings are examples of folder structure and search result,
 for common folder layouts with root `.` and root `src`:


### PR DESCRIPTION
## Why

Package discovery and package-local C header collection only skipped a fixed
set of generated directories. Other dot-prefixed directories could therefore
silently contribute packages or native header inputs even though they are not
part of the intended source tree.

## What changed

- Treat every dot-prefixed descendant directory as ignored across platforms.
- Share the same directory-name predicate between package discovery and C
  header collection.
- Preserve explicitly configured dot-prefixed package scanning roots.
- Document the resulting Package File Set boundaries.

## Why this is correct

The rule is based on the directory name instead of platform-specific hidden
attributes, so discovery remains deterministic across operating systems. The
configured scanning root is exempt because it is an explicit project input;
only directories discovered beneath that root are filtered.
