### PR TITLE
feat(build): cache standalone dependency outputs

### DIFF
--- a/crates/moon/src/rr_build/action_cache.rs
+++ b/crates/moon/src/rr_build/action_cache.rs
@@ -1,0 +1,689 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Content-addressed storage for complete lowered-action output sets.
+//!
+//! The store knows only an action digest and its concrete output paths. It does
+//! not decide which actions exist, interpret producer edges, or construct an
+//! execution graph.
+
+use std::{
+    fs::File,
+    io::{ErrorKind, Read, Write},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, bail};
+use serde::{Deserialize, Serialize};
+
+const FORMAT_VERSION: u32 = 1;
+const OUTPUT_MANIFEST: &str = "manifest.json";
+const PUBLISH_ATTEMPTS: usize = 8;
+
+#[derive(Clone)]
+pub(super) struct CacheAction {
+    key: String,
+    outputs: Vec<PathBuf>,
+}
+
+impl CacheAction {
+    pub(super) fn new(key: String, mut outputs: Vec<PathBuf>) -> Option<Self> {
+        outputs.sort();
+        outputs.dedup();
+        (!outputs.is_empty()).then_some(Self { key, outputs })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum RestoreOutcome {
+    Hit,
+    Miss,
+}
+
+#[derive(Clone)]
+pub(super) struct ActionCache {
+    root: PathBuf,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ActionEntry {
+    version: u32,
+    action_key: String,
+    output_id: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct OutputManifest {
+    version: u32,
+    files: Vec<OutputFile>,
+}
+
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct OutputFile {
+    size: u64,
+    digest: String,
+}
+
+impl ActionCache {
+    pub(super) fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    fn action_entry_path(&self, action: &CacheAction) -> PathBuf {
+        self.root
+            .join("actions")
+            .join(format!("{}.json", action.key))
+    }
+
+    pub(super) fn restore(&self, action: &CacheAction) -> anyhow::Result<RestoreOutcome> {
+        let entry_path = self.action_entry_path(action);
+        let contents = match std::fs::read(&entry_path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                return Ok(RestoreOutcome::Miss);
+            }
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to read {}", entry_path.display()));
+            }
+        };
+        let Ok(entry) = serde_json::from_slice::<ActionEntry>(&contents) else {
+            return Ok(RestoreOutcome::Miss);
+        };
+        if entry.version != FORMAT_VERSION
+            || entry.action_key != action.key
+            || !is_blake3_hex(&entry.output_id)
+        {
+            return Ok(RestoreOutcome::Miss);
+        }
+
+        let object_dir = self.root.join("objects").join(&entry.output_id);
+        let Some(manifest) = read_output_manifest(&object_dir, &entry.output_id)? else {
+            return Ok(RestoreOutcome::Miss);
+        };
+        if manifest.files.len() != action.outputs.len()
+            || !object_files_match(&object_dir, &manifest.files)?
+        {
+            return Ok(RestoreOutcome::Miss);
+        }
+
+        let mut staged = Vec::new();
+        for (index, (destination, expected)) in
+            action.outputs.iter().zip(&manifest.files).enumerate()
+        {
+            if file_matches(destination, expected)? {
+                continue;
+            }
+            let parent = destination.parent().with_context(|| {
+                format!("cached output has no parent: {}", destination.display())
+            })?;
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create cached output directory {}",
+                    parent.display()
+                )
+            })?;
+            let staged_file = tempfile::NamedTempFile::new_in(parent).with_context(|| {
+                format!("failed to stage cached output {}", destination.display())
+            })?;
+            std::fs::copy(object_dir.join(index.to_string()), staged_file.path()).with_context(
+                || format!("failed to copy cached output {}", destination.display()),
+            )?;
+            staged.push((staged_file, destination, expected));
+        }
+
+        for (mut staged_file, destination, expected) in staged {
+            let parent = destination.parent().expect("staged outputs have parents");
+            let mut last_error = None;
+            let mut materialized = false;
+            for _ in 0..PUBLISH_ATTEMPTS {
+                match staged_file.persist(destination) {
+                    Ok(_) => {
+                        materialized = true;
+                        break;
+                    }
+                    Err(error) => {
+                        last_error = Some(error.error);
+                        staged_file = error.file;
+                        if file_matches(destination, expected)? {
+                            materialized = true;
+                            break;
+                        }
+                        if let Err(error) = quarantine_path(destination, parent) {
+                            last_error = Some(error);
+                        }
+                    }
+                }
+            }
+            if !materialized {
+                return Err(last_error.expect("materialization attempted at least once"))
+                    .with_context(|| {
+                        format!(
+                            "failed to materialize cached output {}",
+                            destination.display()
+                        )
+                    });
+            }
+        }
+
+        for (destination, expected) in action.outputs.iter().zip(&manifest.files) {
+            if !file_matches(destination, expected)? {
+                return Ok(RestoreOutcome::Miss);
+            }
+        }
+        Ok(RestoreOutcome::Hit)
+    }
+
+    pub(super) fn publish(&self, action: &CacheAction) -> anyhow::Result<()> {
+        let mut files = Vec::with_capacity(action.outputs.len());
+        for path in &action.outputs {
+            let metadata = std::fs::metadata(path)
+                .with_context(|| format!("action did not produce {}", path.display()))?;
+            if !metadata.is_file() {
+                // The first cache slice stores regular compiler artifacts.
+                // Directory outputs continue through the miss executor.
+                return Ok(());
+            }
+            files.push(OutputFile {
+                size: metadata.len(),
+                digest: digest_file(path)?.to_hex().to_string(),
+            });
+        }
+
+        let manifest = OutputManifest {
+            version: FORMAT_VERSION,
+            files,
+        };
+        let manifest_contents =
+            serde_json::to_vec(&manifest).context("failed to serialize output manifest")?;
+        let output_id = blake3::hash(&manifest_contents).to_hex().to_string();
+
+        self.publish_output_object(action, &output_id, &manifest, &manifest_contents)?;
+        self.publish_action_entry(action, &output_id)
+    }
+
+    fn publish_output_object(
+        &self,
+        action: &CacheAction,
+        output_id: &str,
+        manifest: &OutputManifest,
+        manifest_contents: &[u8],
+    ) -> anyhow::Result<()> {
+        let objects_root = self.root.join("objects");
+        std::fs::create_dir_all(&objects_root).with_context(|| {
+            format!(
+                "failed to create cache object directory {}",
+                objects_root.display()
+            )
+        })?;
+        let object_dir = objects_root.join(output_id);
+        if output_object_matches(&object_dir, output_id, &manifest.files)? {
+            return Ok(());
+        }
+
+        let staging = tempfile::Builder::new()
+            .prefix(".staging-")
+            .tempdir_in(&objects_root)
+            .context("failed to stage cache object")?;
+        for (index, output) in action.outputs.iter().enumerate() {
+            std::fs::copy(output, staging.path().join(index.to_string()))
+                .with_context(|| format!("failed to stage output {}", output.display()))?;
+        }
+        std::fs::write(staging.path().join(OUTPUT_MANIFEST), manifest_contents)
+            .context("failed to stage output manifest")?;
+        if !output_object_matches(staging.path(), output_id, &manifest.files)? {
+            bail!("action outputs changed while publishing cache object {output_id}");
+        }
+
+        let mut last_error = None;
+        for _ in 0..PUBLISH_ATTEMPTS {
+            match std::fs::rename(staging.path(), &object_dir) {
+                Ok(()) => return Ok(()),
+                Err(error) => {
+                    last_error = Some(error);
+                    if output_object_matches(&object_dir, output_id, &manifest.files)? {
+                        return Ok(());
+                    }
+                    if let Err(error) = quarantine_path(&object_dir, &objects_root) {
+                        last_error = Some(error);
+                    }
+                }
+            }
+        }
+        Err(last_error.expect("publishing attempted at least once"))
+            .with_context(|| format!("failed to publish cache object {}", object_dir.display()))
+    }
+
+    fn publish_action_entry(&self, action: &CacheAction, output_id: &str) -> anyhow::Result<()> {
+        let actions_root = self.root.join("actions");
+        std::fs::create_dir_all(&actions_root).with_context(|| {
+            format!(
+                "failed to create cache action directory {}",
+                actions_root.display()
+            )
+        })?;
+        let entry_path = self.action_entry_path(action);
+        let entry = ActionEntry {
+            version: FORMAT_VERSION,
+            action_key: action.key.clone(),
+            output_id: output_id.to_owned(),
+        };
+
+        let mut last_error = None;
+        for _ in 0..PUBLISH_ATTEMPTS {
+            let mut staged_entry = tempfile::NamedTempFile::new_in(&actions_root)
+                .context("failed to stage cache action entry")?;
+            serde_json::to_writer(&mut staged_entry, &entry)
+                .context("failed to serialize cache action entry")?;
+            staged_entry
+                .flush()
+                .context("failed to flush cache action entry")?;
+            match staged_entry.persist(&entry_path) {
+                Ok(_) => return Ok(()),
+                Err(error) => {
+                    last_error = Some(error.error);
+                    if self.action_entry_is_usable(&entry_path, action)? {
+                        return Ok(());
+                    }
+                    if let Err(error) = quarantine_path(&entry_path, &actions_root) {
+                        last_error = Some(error);
+                    }
+                }
+            }
+        }
+        Err(last_error.expect("publishing attempted at least once")).with_context(|| {
+            format!(
+                "failed to publish cache action entry {}",
+                entry_path.display()
+            )
+        })
+    }
+
+    fn action_entry_is_usable(
+        &self,
+        entry_path: &Path,
+        action: &CacheAction,
+    ) -> anyhow::Result<bool> {
+        let contents = match std::fs::read(entry_path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error.into()),
+        };
+        let Ok(entry) = serde_json::from_slice::<ActionEntry>(&contents) else {
+            return Ok(false);
+        };
+        if entry.version != FORMAT_VERSION
+            || entry.action_key != action.key
+            || !is_blake3_hex(&entry.output_id)
+        {
+            return Ok(false);
+        }
+        let object_dir = self.root.join("objects").join(&entry.output_id);
+        let Some(manifest) = read_output_manifest(&object_dir, &entry.output_id)? else {
+            return Ok(false);
+        };
+        Ok(manifest.files.len() == action.outputs.len()
+            && object_files_match(&object_dir, &manifest.files)?)
+    }
+}
+
+fn quarantine_path(path: &Path, parent: &Path) -> std::io::Result<()> {
+    let quarantine = tempfile::Builder::new()
+        .prefix(".replaced-")
+        .tempdir_in(parent)?;
+    match std::fs::rename(path, quarantine.path().join("entry")) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn read_output_manifest(
+    object_dir: &Path,
+    output_id: &str,
+) -> anyhow::Result<Option<OutputManifest>> {
+    let manifest_path = object_dir.join(OUTPUT_MANIFEST);
+    let contents = match std::fs::read(&manifest_path) {
+        Ok(contents) => contents,
+        Err(error) if is_missing_or_wrong_type(error.kind()) => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("failed to read output manifest {}", manifest_path.display())
+            });
+        }
+    };
+    if blake3::hash(&contents).to_hex().as_str() != output_id {
+        return Ok(None);
+    }
+    let Ok(manifest) = serde_json::from_slice::<OutputManifest>(&contents) else {
+        return Ok(None);
+    };
+    Ok((manifest.version == FORMAT_VERSION
+        && manifest
+            .files
+            .iter()
+            .all(|file| is_blake3_hex(&file.digest)))
+    .then_some(manifest))
+}
+
+fn output_object_matches(
+    object_dir: &Path,
+    output_id: &str,
+    expected: &[OutputFile],
+) -> anyhow::Result<bool> {
+    let Some(manifest) = read_output_manifest(object_dir, output_id)? else {
+        return Ok(false);
+    };
+    Ok(manifest.files == expected && object_files_match(object_dir, &manifest.files)?)
+}
+
+fn object_files_match(object_dir: &Path, files: &[OutputFile]) -> anyhow::Result<bool> {
+    for (index, expected) in files.iter().enumerate() {
+        if !file_matches(&object_dir.join(index.to_string()), expected)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn is_blake3_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn file_matches(path: &Path, expected: &OutputFile) -> anyhow::Result<bool> {
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if is_missing_or_wrong_type(error.kind()) => return Ok(false),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to inspect cached output {}", path.display()));
+        }
+    };
+    if !metadata.is_file() || metadata.len() != expected.size {
+        return Ok(false);
+    }
+    match digest_file(path) {
+        Ok(digest) => Ok(digest.to_hex().as_str() == expected.digest),
+        Err(error)
+            if error
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|error| is_missing_or_wrong_type(error.kind())) =>
+        {
+            Ok(false)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn digest_file(path: &Path) -> anyhow::Result<blake3::Hash> {
+    let mut file = File::open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hasher.finalize())
+}
+
+fn is_missing_or_wrong_type(kind: ErrorKind) -> bool {
+    matches!(
+        kind,
+        ErrorKind::NotFound
+            | ErrorKind::NotADirectory
+            | ErrorKind::IsADirectory
+            | ErrorKind::InvalidInput
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+
+    use super::*;
+
+    fn cached_action(root: &Path, outputs: &[(&str, &str)]) -> (ActionCache, CacheAction) {
+        let store = ActionCache::new(root.join("cache"));
+        let output_paths = outputs
+            .iter()
+            .map(|(name, content)| {
+                let path = root.join("build").join(name);
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                std::fs::write(&path, content).unwrap();
+                path
+            })
+            .collect();
+        (
+            store,
+            CacheAction::new(blake3::hash(b"action").to_hex().to_string(), output_paths).unwrap(),
+        )
+    }
+
+    fn action_entry(store: &ActionCache, action: &CacheAction) -> ActionEntry {
+        serde_json::from_slice(&std::fs::read(store.action_entry_path(action)).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn corrupted_manifest_is_a_miss() {
+        let root = tempfile::tempdir().unwrap();
+        let (store, action) = cached_action(root.path(), &[("dependency.mi", "interface")]);
+        store.publish(&action).unwrap();
+        let entry = action_entry(&store, &action);
+        std::fs::write(
+            store
+                .root
+                .join("objects")
+                .join(entry.output_id)
+                .join(OUTPUT_MANIFEST),
+            b"corrupt",
+        )
+        .unwrap();
+
+        assert_eq!(store.restore(&action).unwrap(), RestoreOutcome::Miss);
+    }
+
+    #[test]
+    fn damaged_missing_and_partial_objects_are_safe_misses() {
+        let root = tempfile::tempdir().unwrap();
+        let (store, action) = cached_action(
+            root.path(),
+            &[("dependency.mi", "interface"), ("dependency.core", "core")],
+        );
+        store.publish(&action).unwrap();
+        let entry = action_entry(&store, &action);
+        let object_dir = store.root.join("objects").join(entry.output_id);
+
+        std::fs::write(object_dir.join("1"), "bad!").unwrap();
+        assert_eq!(store.restore(&action).unwrap(), RestoreOutcome::Miss);
+        store
+            .publish(&action)
+            .expect("publishing should repair a damaged object");
+        assert_eq!(store.restore(&action).unwrap(), RestoreOutcome::Hit);
+
+        std::fs::remove_file(object_dir.join("1")).unwrap();
+        assert_eq!(store.restore(&action).unwrap(), RestoreOutcome::Miss);
+
+        std::fs::remove_dir_all(object_dir).unwrap();
+        assert_eq!(store.restore(&action).unwrap(), RestoreOutcome::Miss);
+    }
+
+    #[test]
+    fn malformed_and_old_action_entries_are_misses() {
+        let root = tempfile::tempdir().unwrap();
+        let (store, action) = cached_action(root.path(), &[("dependency.mi", "interface")]);
+        let entry_path = store.action_entry_path(&action);
+        std::fs::create_dir_all(entry_path.parent().unwrap()).unwrap();
+        std::fs::write(&entry_path, b"not-json").unwrap();
+        assert_eq!(store.restore(&action).unwrap(), RestoreOutcome::Miss);
+
+        std::fs::write(
+            &entry_path,
+            serde_json::to_vec(&ActionEntry {
+                version: FORMAT_VERSION - 1,
+                action_key: action.key.clone(),
+                output_id: blake3::hash(b"old").to_hex().to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(store.restore(&action).unwrap(), RestoreOutcome::Miss);
+
+        std::fs::write(
+            &entry_path,
+            serde_json::to_vec(&ActionEntry {
+                version: FORMAT_VERSION,
+                action_key: blake3::hash(b"different-action").to_hex().to_string(),
+                output_id: blake3::hash(b"old").to_hex().to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(store.restore(&action).unwrap(), RestoreOutcome::Miss);
+    }
+
+    #[test]
+    fn duplicate_publish_restores_complete_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        let (store, action) = cached_action(
+            root.path(),
+            &[("dependency.mi", "interface"), ("dependency.core", "core")],
+        );
+        store.publish(&action).unwrap();
+        store.publish(&action).unwrap();
+        for output in &action.outputs {
+            std::fs::remove_file(output).unwrap();
+        }
+
+        assert_eq!(store.restore(&action).unwrap(), RestoreOutcome::Hit);
+        assert_eq!(std::fs::read_to_string(&action.outputs[0]).unwrap(), "core");
+        assert_eq!(
+            std::fs::read_to_string(&action.outputs[1]).unwrap(),
+            "interface"
+        );
+    }
+
+    #[test]
+    fn restore_replaces_stale_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        let (store, action) = cached_action(root.path(), &[("dependency.mi", "interface")]);
+        store.publish(&action).unwrap();
+        std::fs::write(&action.outputs[0], "stale").unwrap();
+
+        assert_eq!(store.restore(&action).unwrap(), RestoreOutcome::Hit);
+        assert_eq!(
+            std::fs::read_to_string(&action.outputs[0]).unwrap(),
+            "interface"
+        );
+    }
+
+    #[test]
+    fn concurrent_publish_loser_validates_winner() {
+        let root = tempfile::tempdir().unwrap();
+        let (store, action) = cached_action(root.path(), &[("dependency.mi", "interface")]);
+        let store = Arc::new(store);
+        let action = Arc::new(action);
+        let barrier = Arc::new(Barrier::new(8));
+        let writers = (0..8)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let action = Arc::clone(&action);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store.publish(&action)
+                })
+            })
+            .collect::<Vec<_>>();
+        for writer in writers {
+            writer.join().unwrap().unwrap();
+        }
+        std::fs::remove_file(&action.outputs[0]).unwrap();
+        assert_eq!(store.restore(&action).unwrap(), RestoreOutcome::Hit);
+    }
+
+    #[test]
+    fn concurrent_restore_and_publish_remain_successful() {
+        let root = tempfile::tempdir().unwrap();
+        let (store, action) = cached_action(root.path(), &[("dependency.mi", "interface")]);
+        store.publish(&action).unwrap();
+        let store = Arc::new(store);
+        let action = Arc::new(action);
+        let barrier = Arc::new(Barrier::new(3));
+
+        let publisher = {
+            let store = Arc::clone(&store);
+            let action = Arc::clone(&action);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..20 {
+                    store.publish(&action)?;
+                }
+                anyhow::Ok(())
+            })
+        };
+        let restorer = {
+            let store = Arc::clone(&store);
+            let action = Arc::clone(&action);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..20 {
+                    assert_eq!(store.restore(&action)?, RestoreOutcome::Hit);
+                }
+                anyhow::Ok(())
+            })
+        };
+        barrier.wait();
+        publisher.join().unwrap().unwrap();
+        restorer.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn concurrent_restores_materialize_the_same_output() {
+        let root = tempfile::tempdir().unwrap();
+        let (store, action) = cached_action(root.path(), &[("dependency.mi", "interface")]);
+        store.publish(&action).unwrap();
+        std::fs::remove_file(&action.outputs[0]).unwrap();
+
+        let store = Arc::new(store);
+        let action = Arc::new(action);
+        let barrier = Arc::new(Barrier::new(8));
+        let restorers = (0..8)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let action = Arc::clone(&action);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store.restore(&action)
+                })
+            })
+            .collect::<Vec<_>>();
+        for restorer in restorers {
+            assert_eq!(restorer.join().unwrap().unwrap(), RestoreOutcome::Hit);
+        }
+        assert_eq!(
+            std::fs::read_to_string(&action.outputs[0]).unwrap(),
+            "interface"
+        );
+    }
+}

--- a/crates/moon/src/rr_build/dependency_preparation.rs
+++ b/crates/moon/src/rr_build/dependency_preparation.rs
@@ -1,0 +1,168 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Materialize every dependency product required by a standalone script graph.
+//!
+//! Cache restoration and n2 execution are implementation choices behind this
+//! boundary. Successful completion means the following script graph can consume
+//! all lowered dependency paths without knowing how they were produced.
+
+use std::path::Path;
+
+use anyhow::{Context, bail};
+use moonbuild_rupes_recta::build_lower::{LoweredAction, lowered_actions_to_n2_graph};
+use moonutil::{
+    cache::{CacheKind, CacheRoot, initialize_cache_root, resolve_cache_root},
+    user_log::UserLog,
+};
+
+use super::{
+    BuildConfig, BuildInput, CapturedBuildExecution, StandaloneDependencyPreparation,
+    action_cache::{ActionCache, CacheAction, RestoreOutcome},
+    action_identity::{ActionIdentityContext, compute_action_identities},
+    execute_build_capturing, finish_captured_build,
+};
+
+pub(super) fn execute(
+    cfg: &BuildConfig,
+    input: StandaloneDependencyPreparation,
+    target_dir: &Path,
+    user_log: &UserLog,
+) -> anyhow::Result<CapturedBuildExecution> {
+    let CacheRoot::Path(cache_root) = resolve_cache_root(CacheKind::BuildArtifacts)? else {
+        return execute_actions(cfg, input.actions, &input.fallback_db_path, target_dir);
+    };
+    initialize_cache_root(CacheKind::BuildArtifacts, &cache_root)?;
+
+    let identity_context = ActionIdentityContext::new(
+        std::env::current_dir().context("failed to determine build working directory")?,
+        std::env::vars_os().collect(),
+    );
+    let initial_identities = compute_action_identities(&input.actions, &identity_context)?;
+    let cache = ActionCache::new(cache_root);
+    let mut misses = Vec::new();
+    let mut publish_after_execution = Vec::new();
+
+    for (action, identity) in input.actions.iter().zip(&initial_identities) {
+        let cache_action = if identity.is_cacheable() {
+            CacheAction::new(
+                identity.digest().to_hex(),
+                action
+                    .outputs()
+                    .iter()
+                    .flat_map(|product| product.paths().iter().cloned())
+                    .collect(),
+            )
+        } else {
+            None
+        };
+        let restore = match cache_action.as_ref() {
+            Some(cache_action) => cache.restore(cache_action)?,
+            None => RestoreOutcome::Miss,
+        };
+        if restore == RestoreOutcome::Miss {
+            misses.push(action.clone());
+            if let Some(cache_action) = cache_action {
+                publish_after_execution.push(cache_action);
+            }
+        }
+    }
+
+    let execution = execute_misses(cfg, misses, &input.fallback_db_path, target_dir)?;
+    if !execution.successful() {
+        return Ok(execution);
+    }
+    if publish_after_execution.is_empty() {
+        return Ok(execution);
+    }
+
+    let final_identities = match compute_action_identities(&input.actions, &identity_context) {
+        Ok(identities) => identities,
+        Err(error) => {
+            finish_captured_build(cfg, &execution, None, user_log);
+            return Err(error.context("failed to revalidate dependency action inputs"));
+        }
+    };
+    if final_identities != initial_identities {
+        finish_captured_build(cfg, &execution, None, user_log);
+        bail!("dependency action inputs changed while their outputs were being prepared");
+    }
+
+    for action in &publish_after_execution {
+        if let Err(error) = cache.publish(action) {
+            finish_captured_build(cfg, &execution, None, user_log);
+            return Err(error);
+        }
+    }
+    Ok(execution)
+}
+
+fn execute_misses(
+    cfg: &BuildConfig,
+    actions: Vec<LoweredAction>,
+    fallback_db_path: &Path,
+    target_dir: &Path,
+) -> anyhow::Result<CapturedBuildExecution> {
+    if actions.is_empty() {
+        return Ok(CapturedBuildExecution {
+            n_tasks_executed: Some(0),
+            diagnostics: Default::default(),
+        });
+    }
+
+    let state_parent = fallback_db_path.parent().with_context(|| {
+        format!(
+            "dependency executor state path has no parent: {}",
+            fallback_db_path.display()
+        )
+    })?;
+    std::fs::create_dir_all(state_parent).with_context(|| {
+        format!(
+            "failed to create dependency executor state directory {}",
+            state_parent.display()
+        )
+    })?;
+    let executor_state = tempfile::Builder::new()
+        .prefix(".dependency-misses-")
+        .tempdir_in(state_parent)
+        .context("failed to create dependency miss executor state")?;
+    execute_actions(
+        cfg,
+        actions,
+        &executor_state.path().join("dependencies.moon_db"),
+        target_dir,
+    )
+}
+
+fn execute_actions(
+    cfg: &BuildConfig,
+    actions: Vec<LoweredAction>,
+    db_path: &Path,
+    target_dir: &Path,
+) -> anyhow::Result<CapturedBuildExecution> {
+    let (graph, command_args_by_output) = lowered_actions_to_n2_graph(actions)?;
+    execute_build_capturing(
+        cfg,
+        BuildInput {
+            graph,
+            command_args_by_output,
+            db_path: db_path.to_owned(),
+        },
+        target_dir,
+    )
+}

--- a/crates/moon/src/rr_build/dry_run.rs
+++ b/crates/moon/src/rr_build/dry_run.rs
@@ -83,7 +83,21 @@ pub fn write_standalone_dry_run<'a>(
     target_dir: &Path,
 ) -> std::io::Result<()> {
     if let Some(dependencies) = input.dependencies.as_ref() {
-        write_dry_run_all(output, dependencies, source_dir, target_dir)?;
+        let (graph, command_args_by_output) =
+            moonbuild_rupes_recta::build_lower::lowered_actions_to_n2_graph(
+                dependencies.actions.clone(),
+            )
+            .map_err(std::io::Error::other)?;
+        write_dry_run_all(
+            output,
+            &BuildInput {
+                graph,
+                command_args_by_output,
+                db_path: dependencies.fallback_db_path.clone(),
+            },
+            source_dir,
+            target_dir,
+        )?;
     }
     write_dry_run(output, &input.script, artifacts, source_dir, target_dir)
 }

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -69,7 +69,9 @@ use tracing::{Level, info, instrument};
 
 use crate::build_flags::{BuildFlags, OutputStyle};
 
+mod action_cache;
 pub mod action_identity;
+mod dependency_preparation;
 mod dry_run;
 pub use dry_run::{
     format_dry_run_command, write_dry_run, write_dry_run_all, write_standalone_dry_run,
@@ -761,19 +763,11 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
     };
     let backend = cx.backend.target_backend();
     let layout = cx.artifact_paths.target_layout();
-    let dependency_input = if compile_output.dependencies.is_empty() {
-        None
-    } else {
-        let (graph, command_args_by_output) =
-            moonbuild_rupes_recta::build_lower::lowered_actions_to_n2_graph(
-                compile_output.dependencies,
-            )?;
-        Some(BuildInput {
-            graph,
-            command_args_by_output,
-            db_path: layout.standalone_dependency_n2_db_path(backend),
-        })
-    };
+    let dependency_input =
+        (!compile_output.dependencies.is_empty()).then(|| StandaloneDependencyPreparation {
+            actions: compile_output.dependencies,
+            fallback_db_path: layout.standalone_dependency_n2_db_path(backend),
+        });
     let input = StandaloneBuildInput {
         dependencies: dependency_input,
         script: BuildInput {
@@ -1005,8 +999,19 @@ pub struct BuildInput {
 /// execution remain a single-graph operation.
 #[derive(Debug, Clone)]
 pub struct StandaloneBuildInput {
-    dependencies: Option<BuildInput>,
+    dependencies: Option<StandaloneDependencyPreparation>,
     script: BuildInput,
+}
+
+/// Work that must materialize dependency products before the script graph runs.
+///
+/// The implementation may restore products or execute actions, but successful
+/// completion always guarantees that the script graph's prerequisite files
+/// exist at their lowered paths.
+#[derive(Debug, Clone)]
+struct StandaloneDependencyPreparation {
+    actions: Vec<moonbuild_rupes_recta::build_lower::LoweredAction>,
+    fallback_db_path: PathBuf,
 }
 
 #[cfg(test)]
@@ -1061,7 +1066,8 @@ pub fn execute_standalone_build(
         return execute_build(cfg, input.script, target_dir, user_log);
     };
 
-    let dependency_execution = execute_build_capturing(cfg, dependencies, target_dir)?;
+    let dependency_execution =
+        dependency_preparation::execute(cfg, dependencies, target_dir, user_log)?;
     if !dependency_execution.successful() {
         return Ok(finish_captured_build(
             cfg,

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -761,18 +761,19 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
     };
     let backend = cx.backend.target_backend();
     let layout = cx.artifact_paths.target_layout();
-    let dependency_input = compile_output
-        .dependencies
-        .build_graph
-        .builds
-        .iter()
-        .next()
-        .is_some()
-        .then(|| BuildInput {
-            graph: compile_output.dependencies.build_graph,
-            command_args_by_output: compile_output.dependencies.command_args_by_output,
+    let dependency_input = if compile_output.dependencies.is_empty() {
+        None
+    } else {
+        let (graph, command_args_by_output) =
+            moonbuild_rupes_recta::build_lower::lowered_actions_to_n2_graph(
+                compile_output.dependencies,
+            )?;
+        Some(BuildInput {
+            graph,
+            command_args_by_output,
             db_path: layout.standalone_dependency_n2_db_path(backend),
-        });
+        })
+    };
     let input = StandaloneBuildInput {
         dependencies: dependency_input,
         script: BuildInput {

--- a/crates/moon/tests/mod.rs
+++ b/crates/moon/tests/mod.rs
@@ -56,6 +56,7 @@ pub fn moon_cmd(dir: &impl AsRef<Path>) -> snapbox::cmd::Command {
     snapbox::cmd::Command::new(moon_bin())
         .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
         .env("MOONRUN_OVERRIDE", moonrun_bin())
+        .env("MOON_BUILD_CACHE", "off")
         .current_dir(dir)
 }
 
@@ -63,6 +64,7 @@ pub fn moon_process_cmd(dir: &impl AsRef<Path>) -> std::process::Command {
     let mut cmd = std::process::Command::new(moon_bin());
     cmd.env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
         .env("MOONRUN_OVERRIDE", moonrun_bin())
+        .env("MOON_BUILD_CACHE", "off")
         .current_dir(dir);
     cmd
 }

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -66,9 +66,12 @@ fn test_single_file_mbtx_run() {
 #[test]
 fn test_single_file_mbtx_dry_run_prints_dependencies_before_script() {
     let dir = TestDir::new("moon_test_single_file.in");
-    let stdout = get_stdout(
+    let cache_parent = tempfile::TempDir::new().unwrap();
+    let build_cache = cache_parent.path().join("build-cache");
+    let stdout = get_stdout_with_envs(
         &dir,
         ["run", "import_ok.mbtx", "--target", "wasm", "--dry-run"],
+        [("MOON_BUILD_CACHE", build_cache.as_os_str())],
     );
     let dependency_command = stdout
         .lines()
@@ -82,6 +85,10 @@ fn test_single_file_mbtx_dry_run_prints_dependencies_before_script() {
     assert!(
         dependency_command < script_command,
         "dependency commands should be printed before script commands:\n{stdout}"
+    );
+    assert!(
+        !build_cache.exists(),
+        "dry run should not initialize or write the build cache"
     );
 }
 
@@ -126,6 +133,61 @@ fn test_single_file_mbtx_reuses_dependency_graph_after_script_change() {
         dependency_modified,
         "changing only the script should not rebuild dependency packages",
     );
+}
+
+#[test]
+fn test_single_file_mbtx_restores_dependency_outputs_before_running_script_graph() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let build_cache = tempfile::TempDir::new().unwrap();
+    let args = ["run", "import_ok.mbtx", "--target", "wasm"];
+
+    moon_cmd(&dir)
+        .env("MOON_BUILD_CACHE", build_cache.path())
+        .args(args)
+        .assert()
+        .success()
+        .stdout_eq("hello\n");
+    assert_eq!(
+        fs::read_to_string(build_cache.path().join(".moon-cache")).unwrap(),
+        "build-artifacts\n"
+    );
+
+    let build_dir = dir.join("_build/wasm/debug/build");
+    assert!(
+        !build_dir.join("standalone-dependencies.moon_db").exists(),
+        "cache-enabled misses should use private n2 state"
+    );
+    let dependency_outputs = [
+        ".mooncakes/moonbitlang/x/stack/stack.mi",
+        ".mooncakes/moonbitlang/x/stack/stack.core",
+    ]
+    .map(|output| build_dir.join(output));
+    let expected_outputs = dependency_outputs
+        .each_ref()
+        .map(|output| fs::read(output).unwrap());
+    for output in &dependency_outputs {
+        fs::remove_file(output).unwrap();
+    }
+    fs::remove_file(build_dir.join("build.moon_db")).unwrap();
+
+    let assert = moon_cmd(&dir)
+        .env("MOON_BUILD_CACHE", build_cache.path())
+        .args(["run", "import_ok.mbtx", "--target", "wasm", "--verbose"])
+        .assert()
+        .success()
+        .stdout_eq("hello\n");
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        !stderr.contains(".mooncakes/moonbitlang/x/stack/stack.mbt"),
+        "dependency command should not execute on a cache hit:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("moonrun "),
+        "the script artifact should still run after dependency preparation:\n{stderr}"
+    );
+    for (output, expected) in dependency_outputs.iter().zip(expected_outputs) {
+        assert_eq!(fs::read(output).unwrap(), expected);
+    }
 }
 
 #[test]

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -20,16 +20,13 @@
 
 use std::path::{Path, PathBuf};
 
-use moonutil::{
-    resolution::{DirSyncResult, ResolvedEnv},
-    target::TargetBackend,
-};
+use moonutil::resolution::{DirSyncResult, ResolvedEnv};
 use tracing::{Level, instrument};
 use walkdir::WalkDir;
 
 use super::{
-    BuildOptions, CExecutableRealization, CStubLibraryRealization, LoweredAction,
-    LoweredExternalInput, LoweredProduct, LoweringError,
+    BuildOptions, CExecutableRealization, LoweredAction, LoweredExternalInput, LoweredProduct,
+    LoweringError,
 };
 use crate::{
     ResolveOutput,
@@ -392,73 +389,24 @@ impl<'a> LoweringContext<'a> {
             .map(|target| self.get_package(target).fqn.clone())
             .into();
         // Keep this exhaustive: adding an action must require an explicit
-        // decision that lowering describes every filesystem observation.
+        // cache-eligibility decision at the lowering boundary.
         let cache_eligible = match action {
-            BuildAction::Check { target, .. }
-            | BuildAction::EmitProof { target, .. }
-            | BuildAction::BuildCore { target, .. } => {
-                let package = self.get_package(target);
-                self.packages
-                    .module_info(package.module)
-                    .compile_flags
-                    .as_deref()
-                    .is_none_or(<[_]>::is_empty)
-            }
-            BuildAction::BuildCStub { info, .. } => info.cc_flags.is_empty(),
-            BuildAction::ArchiveOrLinkCStubs { info, .. } => {
-                self.opt.backend.c_stub_library_realization()
-                    == CStubLibraryRealization::StaticArchive
-                    || info.link_flags.is_empty()
-            }
-            BuildAction::LinkCore { target, .. } => {
-                let package = self.get_package(target);
-                let package_link_flags =
-                    package
-                        .raw
-                        .link
-                        .as_ref()
-                        .and_then(|link| match self.opt.target_backend() {
-                            TargetBackend::Wasm => link
-                                .wasm
-                                .as_ref()
-                                .and_then(|config| config.flags.as_deref()),
-                            TargetBackend::WasmGC => link
-                                .wasm_gc
-                                .as_ref()
-                                .and_then(|config| config.flags.as_deref()),
-                            TargetBackend::Js | TargetBackend::Native | TargetBackend::LLVM => None,
-                        });
-                self.packages
-                    .module_info(package.module)
-                    .link_flags
-                    .as_deref()
-                    .is_none_or(<[_]>::is_empty)
-                    && package_link_flags.is_none_or(<[_]>::is_empty)
-            }
-            BuildAction::MakeExecutable {
-                info: Some(info), ..
-            } => match &self.opt.backend {
-                BackendConfig::Native(backend) => match backend.executable_realization() {
-                    CExecutableRealization::CompileAndLinkGeneratedC => {
-                        info.c_flags.is_empty() && info.link_flags.is_empty()
-                    }
-                    CExecutableRealization::LinkDirectObject => info.link_flags.is_empty(),
-                    CExecutableRealization::WriteTccRunResponseFile => true,
-                },
-                BackendConfig::Llvm => info.c_flags.is_empty() && info.link_flags.is_empty(),
-                BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } | BackendConfig::Js => {
-                    unreachable!("non-native make-executable actions are no-ops")
-                }
-            },
-            BuildAction::MakeExecutable { info: None, .. } => {
-                unreachable!("native MakeExecutable actions should have executable info")
-            }
-            BuildAction::GenerateDsym { .. }
+            BuildAction::Check { .. }
+            | BuildAction::EmitProof { .. }
+            | BuildAction::BuildCore { .. }
+            | BuildAction::BuildCStub { .. }
+            | BuildAction::ArchiveOrLinkCStubs { .. }
+            | BuildAction::LinkCore { .. }
+            | BuildAction::MakeExecutable { info: Some(_), .. }
+            | BuildAction::GenerateDsym { .. }
             | BuildAction::GenerateTestInfo { .. }
             | BuildAction::GenerateMbti { .. }
             | BuildAction::BuildVirtual { .. }
-            | BuildAction::Bundle { .. }
-            | BuildAction::BuildRuntimeObject { .. }
+            | BuildAction::Bundle { .. } => true,
+            BuildAction::MakeExecutable { info: None, .. } => {
+                unreachable!("native MakeExecutable actions should have executable info")
+            }
+            BuildAction::BuildRuntimeObject { .. }
             | BuildAction::BuildRuntimeLib { .. }
             | BuildAction::RunMoonLexPrebuild { .. }
             | BuildAction::RunMoonYaccPrebuild { .. } => true,

--- a/crates/moonbuild-rupes-recta/src/build_lower/lowered_action.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lowered_action.rs
@@ -52,7 +52,7 @@ impl LoweredExternalInput {
 }
 
 /// One logical product after its concrete artifact paths have been selected.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LoweredProduct {
     pub(crate) producer: BuildActionId,
     pub(crate) product: BuildProduct,
@@ -164,7 +164,7 @@ impl LoweredCommand {
 /// Dependency products retain their producer action and logical product so a
 /// preparation policy can identify the dependency without reconstructing it
 /// from n2 file edges.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LoweredAction {
     pub(crate) id: BuildActionId,
     pub(crate) dependencies: Vec<LoweredProduct>,

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -251,9 +251,10 @@ pub fn lower_build_plan(
     Ok(result)
 }
 
-/// Project one standalone action plan into dependency and script n2 graphs.
+/// Project one standalone action plan into retained dependency actions and a
+/// script n2 graph.
 ///
-/// The dependency graph contains every prerequisite outside the synthesized
+/// The dependency actions contain every prerequisite outside the synthesized
 /// script package, including package-less shared actions reached by those
 /// prerequisites. The script graph keeps the same action/product edges; when a
 /// dependency producer is omitted, its output path remains a concrete n2 input.
@@ -263,8 +264,8 @@ pub(crate) fn lower_standalone_build_plan(
     plan: &BuildActionPlan<'_>,
     opt: &BuildOptions,
     script_package: PackageId,
-) -> Result<(LoweringResult, LoweringResult), LoweringError> {
-    info!("Projecting standalone actions to dependency and script n2 graphs");
+) -> Result<(Vec<LoweredAction>, LoweringResult), LoweringError> {
+    info!("Projecting standalone dependency actions and script n2 graph");
     let (dependency_actions, script_actions) = plan.partition_standalone_actions(script_package);
     debug!(
         "Standalone execution projection contains {} dependency actions and {} script actions",
@@ -272,7 +273,7 @@ pub(crate) fn lower_standalone_build_plan(
         script_actions.len()
     );
 
-    let dependencies = lower_actions(resolve_output, plan, opt, dependency_actions, &[])?;
+    let dependencies = lower_actions_to_values(resolve_output, plan, opt, dependency_actions)?;
     let script = lower_actions(
         resolve_output,
         plan,
@@ -281,6 +282,36 @@ pub(crate) fn lower_standalone_build_plan(
         plan.input_action_ids(),
     )?;
     Ok((dependencies, script))
+}
+
+fn lower_actions_to_values(
+    resolve_output: &ResolveOutput,
+    plan: &BuildActionPlan<'_>,
+    opt: &BuildOptions,
+    actions: impl IntoIterator<Item = BuildActionId>,
+) -> Result<Vec<LoweredAction>, LoweringError> {
+    let mut ctx = LoweringContext::new(opt.artifact_paths.clone(), resolve_output, plan, opt);
+    actions
+        .into_iter()
+        .filter_map(|id| {
+            debug!("Lowering retained action: {:?}", id);
+            ctx.lower_action(id).transpose()
+        })
+        .collect()
+}
+
+/// Convert exactly the selected lowered actions into an n2 graph.
+///
+/// Callers must select a producer-closed action set or materialize every
+/// omitted producer output before executing the returned graph.
+pub fn lowered_actions_to_n2_graph(
+    actions: impl IntoIterator<Item = LoweredAction>,
+) -> Result<(N2Graph, CommandArgMap), LoweringError> {
+    let mut n2 = N2GraphBuilder::new();
+    for action in actions {
+        n2.add_action(action)?;
+    }
+    Ok((n2.graph, n2.command_args_by_output))
 }
 
 fn lower_actions(
@@ -628,7 +659,7 @@ mod tests {
     }
 
     #[test]
-    fn opaque_module_flags_make_compiler_actions_ineligible() {
+    fn opaque_module_flags_do_not_disqualify_lowered_actions() {
         let mut module_info = moon_mod("username/hello");
         module_info.compile_flags = Some(vec!["-include".to_string(), "config.mbt".to_string()]);
         module_info.link_flags = Some(vec!["-custom-link-input=layout.txt".to_string()]);
@@ -683,7 +714,7 @@ mod tests {
                 .lower_action(id)
                 .expect("lowering should succeed")
                 .expect("compiler action should not be a no-op");
-            assert!(!action.is_cache_eligible(), "{node:?} should be ineligible");
+            assert!(action.is_cache_eligible(), "{node:?} should be eligible");
         }
     }
 
@@ -908,8 +939,8 @@ mod tests {
                 .expect("lowering should succeed")
                 .expect("native action should not be a no-op");
             assert!(
-                !action.is_cache_eligible(),
-                "{node:?} with opaque flags should be ineligible"
+                action.is_cache_eligible(),
+                "{node:?} with opaque flags should be eligible"
             );
         }
 

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -86,10 +86,11 @@ pub struct CompileOutput {
     pub build_plan: Option<Box<build_plan::BuildPlan>>,
 }
 
-/// Two execution graphs projected from one logical standalone build plan.
+/// Dependency preparation and script execution projected from one logical
+/// standalone build plan.
 pub struct StandaloneCompileOutput {
-    /// Dependency-package work, executed before the script graph.
-    pub dependencies: CompileOutput,
+    /// Lowered dependency-package actions retained for preparation.
+    pub dependencies: Vec<build_lower::LoweredAction>,
     /// Work belonging to the synthesized script package.
     pub script: CompileOutput,
 }
@@ -190,12 +191,7 @@ pub fn compile_standalone(
             })
             .collect();
         (
-            CompileOutput {
-                build_graph: dependencies.build_graph,
-                command_args_by_output: dependencies.command_args_by_output,
-                artifacts: IndexMap::new(),
-                build_plan: None,
-            },
+            dependencies,
             CompileOutput {
                 build_graph: script.build_graph,
                 command_args_by_output: script.command_args_by_output,
@@ -419,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    fn standalone_compile_lowers_dependency_and_script_products_to_separate_graphs() {
+    fn standalone_compile_separates_dependency_preparation_from_script_graph() {
         let module_source = ModuleSource::local_path(
             "test/single"
                 .parse::<ModuleName>()
@@ -525,9 +521,8 @@ mod tests {
         )
         .expect("standalone plan should lower");
 
-        assert_eq!(output.dependencies.build_graph.builds.iter().count(), 1);
+        assert_eq!(output.dependencies.len(), 1);
         assert_eq!(output.script.build_graph.builds.iter().count(), 2);
-        assert!(output.dependencies.build_plan.is_none());
         let plan = output
             .script
             .build_plan
@@ -541,15 +536,10 @@ mod tests {
 
         let dependency_outputs = output
             .dependencies
-            .build_graph
-            .builds
             .iter()
-            .flat_map(|build| build.outs.ids.iter())
-            .map(|id| {
-                output.dependencies.build_graph.files.by_id[*id]
-                    .name
-                    .clone()
-            })
+            .flat_map(|action| action.outputs())
+            .flat_map(|product| product.paths())
+            .map(|path| path.to_string_lossy().into_owned())
             .collect::<Vec<_>>();
         assert!(
             dependency_outputs

--- a/crates/moonutil/src/cache.rs
+++ b/crates/moonutil/src/cache.rs
@@ -21,9 +21,14 @@
 //! Cache contents are intentionally opaque here. Source and artifact stores
 //! may choose their own representations without changing the CLI contract.
 
-use std::path::PathBuf;
+use std::{
+    fs::OpenOptions,
+    io::{ErrorKind, Read, Write},
+    path::{Path, PathBuf},
+};
 
-use anyhow::bail;
+use anyhow::{Context, bail};
+use fs4::fs_std::FileExt;
 
 const OWNERSHIP_MARKER: &str = ".moon-cache";
 
@@ -81,6 +86,82 @@ pub fn resolve_cache_root(kind: CacheKind) -> anyhow::Result<CacheRoot> {
     }
 }
 
+/// Claim an empty cache root for Moon or validate its existing ownership.
+///
+/// Cache writers call this before creating implementation-specific entries.
+/// Refusing a non-empty unowned directory keeps `moon clean` from later
+/// treating unrelated user data as Moon-owned state.
+pub fn initialize_cache_root(kind: CacheKind, root: &Path) -> anyhow::Result<()> {
+    match std::fs::symlink_metadata(root) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            bail!(
+                "refusing to use symlinked Moon cache root `{}`",
+                root.display()
+            )
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            bail!("Moon cache root is not a directory: `{}`", root.display())
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            std::fs::create_dir_all(root).with_context(|| {
+                format!("failed to create Moon cache root `{}`", root.display())
+            })?;
+        }
+        Err(error) => return Err(error.into()),
+    }
+
+    let marker = root.join(OWNERSHIP_MARKER);
+    if !marker.exists() && has_non_marker_entry(root, &marker)? {
+        bail!(
+            "refusing to use non-empty unrecognized Moon cache root `{}`",
+            root.display()
+        );
+    }
+
+    let mut marker_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&marker)
+        .with_context(|| format!("failed to open Moon cache marker `{}`", marker.display()))?;
+    marker_file
+        .lock_exclusive()
+        .with_context(|| format!("failed to lock Moon cache marker `{}`", marker.display()))?;
+
+    let mut contents = Vec::new();
+    marker_file.read_to_end(&mut contents)?;
+    if contents == kind.ownership() {
+        return Ok(());
+    }
+    if !contents.is_empty() {
+        bail!(
+            "Moon cache root has incompatible ownership: `{}`",
+            root.display()
+        );
+    }
+
+    if has_non_marker_entry(root, &marker)? {
+        bail!(
+            "refusing to use non-empty unrecognized Moon cache root `{}`",
+            root.display()
+        );
+    }
+    marker_file.write_all(kind.ownership())?;
+    marker_file.sync_all()?;
+    Ok(())
+}
+
+fn has_non_marker_entry(root: &Path, marker: &Path) -> std::io::Result<bool> {
+    for entry in std::fs::read_dir(root)? {
+        if entry?.path() != marker {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 pub fn clean_cache(kind: CacheKind) -> anyhow::Result<()> {
     let CacheRoot::Path(root) = resolve_cache_root(kind)? else {
         return Ok(());
@@ -113,4 +194,59 @@ pub fn clean_cache(kind: CacheKind) -> anyhow::Result<()> {
         "refusing to clean unrecognized Moon cache root `{}`",
         root.display()
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+
+    use super::*;
+
+    #[test]
+    fn initializes_empty_cache_root_and_reuses_it() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("build-cache");
+
+        initialize_cache_root(CacheKind::BuildArtifacts, &root).unwrap();
+        initialize_cache_root(CacheKind::BuildArtifacts, &root).unwrap();
+
+        assert_eq!(
+            std::fs::read(root.join(OWNERSHIP_MARKER)).unwrap(),
+            b"build-artifacts\n"
+        );
+    }
+
+    #[test]
+    fn refuses_to_claim_non_empty_unowned_root() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("user-data"), "keep").unwrap();
+
+        assert!(
+            initialize_cache_root(CacheKind::BuildArtifacts, root.path())
+                .unwrap_err()
+                .to_string()
+                .contains("non-empty unrecognized")
+        );
+    }
+
+    #[test]
+    fn concurrent_initializers_accept_the_same_owner() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = Arc::new(parent.path().join("build-cache"));
+        let barrier = Arc::new(Barrier::new(8));
+        let initializers = (0..8)
+            .map(|_| {
+                let root = Arc::clone(&root);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    initialize_cache_root(CacheKind::BuildArtifacts, &root)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for initializer in initializers {
+            initializer.join().unwrap().unwrap();
+        }
+    }
 }

--- a/docs/adr/0005-plan-standalone-dependencies-separately.md
+++ b/docs/adr/0005-plan-standalone-dependencies-separately.md
@@ -4,38 +4,45 @@ status: accepted
 
 # Prepare Standalone Dependencies Before Script Execution
 
-Standalone script builds have two stages: prepare the required dependency
-products, then plan, build, and run the synthesized script package using the
-materialized outputs. The durable boundary is dependency product requirements
-in and concrete outputs out; neither n2 nor a second `BuildPlan` is part of that
-long-term contract.
+Standalone script builds create one logical plan, then execute it in two stages:
+prepare the required dependency products, followed by building and running the
+synthesized script package from those materialized outputs. The durable
+boundary is dependency product requirements in and concrete outputs out;
+neither n2 nor a second `BuildPlan` is part of that long-term contract.
 
-The current incremental implementation constructs one complete logical
-`BuildPlan` and one normalized `BuildActionPlan`, then projects the actions into
-two disjoint n2 graphs. Package dependencies remain ordinary producer-consumer
-edges rather than a second planning vocabulary. All actions owned by dependency
-packages seed the dependency projection; their dependency closure also includes
-any package-less shared actions they need. The remaining actions form the script
-projection. A dependency action depending on a script-owned action is an invalid
-phase ordering.
+The implementation constructs one complete logical `BuildPlan` and one
+normalized `BuildActionPlan`, then projects it into retained dependency
+`LoweredAction` values and one script n2 graph. Package dependencies remain
+ordinary producer-consumer edges rather than a second planning vocabulary. All
+actions owned by dependency packages seed the dependency projection; their
+dependency closure also includes any package-less shared actions they need. The
+remaining actions form the script projection. A dependency action depending on
+a script-owned action is an invalid phase ordering.
 
 Dependency outputs remain under `_build/.../.mooncakes`. When their producer
 actions are omitted from the script n2 graph, the same concrete output paths
-remain ordinary file inputs to script actions. Moon executes the dependency
-graph first with its own persistent n2 database, then executes the script graph.
-There is no file-existence scan between the phases: n2 currently owns dependency
-freshness and guarantees that the requested products are materialized.
+remain ordinary file inputs to script actions. Moon first runs dependency
+preparation, whose success guarantees that every required product exists at its
+lowered path, then executes the script graph. The script graph does not know
+whether preparation restored an output or executed its producer.
 
-The dependency n2 projection is a temporary preparation adapter, not a permanent
-second planner. A future action-to-output implementation can replace this first
-stage and feed its concrete outputs into a narrower script plan.
+With the build cache enabled, preparation computes canonical identities from
+the retained actions, restores complete validated output sets, sends only
+misses through a controlled `LoweredAction`-to-n2 adapter, and publishes
+successful outputs. The miss executor uses temporary n2 state. With the build
+cache disabled, all retained dependency actions go through the same adapter and
+keep the existing persistent `standalone-dependencies.moon_db`.
 
-Standalone `.mbt` and `.mbtx` files built from persistent paths retain the
-dependency n2 database across invocations. `moon run -e` and `moon run -` use
-the same split planning path, but their synthesized temporary projects are
-deleted after each invocation, so they do not currently reuse dependency work
-across invocations. Stable or global cache storage for those entry points is
-deferred.
+The dependency n2 projection is a miss-execution adapter, not a permanent
+second planner. The preparation contract can outlive that adapter and the
+current action-to-output store.
+
+Standalone `.mbt` and `.mbtx` files built from persistent paths can reuse the
+global action-output store. `moon run -e` and `moon run -` use the same
+preparation path, but the initial identity hashes concrete paths exactly.
+Their changing synthesized temporary paths may therefore cause conservative
+misses. Relocatable identities are deliberately deferred until command path
+semantics can be modeled without textual rewriting.
 
 ## Consequences
 
@@ -44,10 +51,11 @@ deferred.
   single-n2-graph path.
 - Registry resolution remains unchanged.
 - Standalone planning uses the same complete build rules as ordinary planning.
-- The temporary dependency projection is isolated after action normalization,
-  where it can later be replaced without changing planning semantics.
-- SHA identities, action-to-outcome caching, global storage, and a generalized
-  dependency executor interface remain deferred.
+- Dependency preparation is isolated after action normalization. Cache
+  restoration and n2 miss execution remain hidden behind its
+  "materialize all required products" contract.
+- The first global action-to-output store is limited to regular-file outputs
+  needed by standalone dependencies.
 - Splitting execution introduces a phase barrier. Cold and warm performance
   must be measured against the single-graph implementation.
 
@@ -60,8 +68,8 @@ deferred.
 - Splitting or detaching nodes after n2 lowering was rejected because the phase
   boundary would be expressed through executor graph surgery rather than
   normalized build actions.
-- Projecting one complete normalized action plan is the selected temporary n2
-  adapter. It keeps one source of planning truth during this incremental change
-  while making dependency preparation independently replaceable.
-- Designing the complete action-to-output cache interface now was rejected
-  because it would expand this change before the required interface is known.
+- Projecting one complete normalized action plan is the selected boundary. It
+  keeps one source of planning truth while making dependency preparation
+  independently replaceable.
+- Exposing n2 graph-builder state to the cache was rejected. Only selected
+  lowered misses cross the controlled adapter boundary.

--- a/docs/dev/design/global-build-cache.md
+++ b/docs/dev/design/global-build-cache.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-This document records the intended direction for global dependency and build
-caches. Cache-root configuration and cleaning are implemented, as is the pure
-canonical identity calculation for lowered actions. Builds do not yet read
-from or write to either global cache, and identity calculation is not connected
-to execution.
+This document records the direction for global dependency and build caches.
+Cache-root configuration and cleaning are implemented. Canonical action
+identity and a global action-output store are connected to the standalone
+dependency-preparation phase. Ordinary project and workspace builds do not yet
+read or write that store. The dependency-source cache is not implemented.
 
 ## Problem
 
@@ -49,18 +49,14 @@ Two environment variables select the cache roots:
 | `MOON_DEP_CACHE` | `$MOON_HOME/cache/deps` | Disable dependency caching | Use that dependency-cache root |
 | `MOON_BUILD_CACHE` | `$MOON_HOME/cache/build` | Disable build caching | Use that build-cache root |
 
-A relative path is rejected. `off` means that a future build must use
-invocation-private temporary state instead of the corresponding global cache.
-For a disabled dependency cache, dependencies still have to be downloaded and
-prepared somewhere private; disabling the cache must not disable dependency
-resolution.
+A relative path is rejected. `off` disables the corresponding global cache. It
+does not disable dependency resolution or local incremental state. In
+particular, standalone dependency preparation falls back to its existing
+project-local n2 database when the build cache is off.
 
-The environment variables currently configure and clean roots only. Their
-presence does not yet change build execution.
-
-Canonical action identity is also implemented as a pure consumer of Rupes
-Recta `LoweredAction` values. It is not connected to build execution or either
-cache root yet.
+`MOON_BUILD_CACHE` currently affects only dependency preparation for standalone
+`.mbt` and `.mbtx` builds. Ordinary project and workspace builds are unchanged.
+`MOON_DEP_CACHE` currently configures and cleans its root only.
 
 ### Cleaning
 
@@ -163,10 +159,11 @@ discovered implicitly through system or SDK include paths remain a documented
 best-effort boundary in the initial model; they are not recursively scanned by
 Moon.
 
-User-provided compiler and linker flags remain unstructured strings and may
-name additional files with tool-specific syntax. An action that executes with
-such flags is cache-ineligible until those inputs have a structured lowering
-model. Moon does not guess paths by parsing arbitrary command arguments.
+User-provided compiler and linker flags remain unstructured strings. Their
+exact argument values are part of the action identity, but they may name
+additional files with tool-specific syntax. Moon does not guess paths by
+parsing arbitrary command arguments, so changes to such implicit inputs are a
+documented best-effort boundary.
 
 The identity deliberately excludes n2-only graph details, diagnostics metadata,
 descriptions, and dirty-output scheduling policy. Those attributes do not
@@ -176,6 +173,17 @@ All outputs of one action must be treated as a unit. Moon should publish
 objects first and the action record last, using staging and atomic rename where
 the platform permits. A reader must see either a complete validated result or
 a miss. Concurrent writers of the same action should be harmless.
+
+The implemented store follows that protocol for regular-file outputs. Each
+action entry names one content-addressed output manifest; every file is checked
+by size and BLAKE3 digest before a hit is accepted or materialized. Malformed,
+old, missing, partial, or damaged entries are misses. A writer that loses a
+publication race validates and accepts the winner instead of failing the
+build.
+
+This makes publication in the global store concurrency-tolerant. It does not
+make concurrent commands sharing the same mutable project `_build` tree or n2
+database safe.
 
 The command that requested compilation is not automatically part of the key.
 For dependency packages, `build`, `run`, and `test` may share artifacts when
@@ -209,7 +217,7 @@ effective programs cannot share an action ID.
 
 ## Standalone execution
 
-The desired standalone flow is:
+The long-term standalone flow is:
 
 1. Resolve the package graph.
 2. Reuse or prepare immutable dependency sources.
@@ -221,6 +229,14 @@ The desired standalone flow is:
 The script's own rapidly changing compilation may often miss, but its stable
 dependencies can still be hits. This is the main opportunity for faster script
 startup.
+
+The implemented first slice retains dependency `LoweredAction` values after
+planning. Dependency preparation restores reusable output sets and lowers only
+misses into a temporary n2 graph. Successful preparation guarantees that every
+concrete dependency path required by the script n2 graph has been materialized.
+The script phase therefore depends on that guarantee, not on cache internals.
+When the build cache is off, preparation lowers all dependency actions and
+uses the existing persistent dependency n2 database.
 
 `post-add` hooks will not run in globally shared prepared sources. They make
 source state mutable and can have effects that are not captured by an artifact
@@ -247,19 +263,19 @@ Each stage should be useful and reviewable without requiring the next:
    cache, no shared `post-add`, and private fallback when caching is off.
 3. **Private standalone work:** stop sharing mutable `_build` trees between
    standalone invocations; place `__moonbin__` there.
-4. **Action model (implemented, not execution-wired):** define and test
+4. **Action model (implemented):** define and test
    canonical action inputs at the Rupes Recta compiler boundary, including
    resolved interfaces and target facts.
-5. **Artifact cache:** publish and restore complete `.mi`/`.core` result sets
-   with concurrency and corruption tests.
+5. **Artifact cache (implemented for standalone dependency actions):** publish
+   and restore complete regular-file result sets with concurrency and
+   corruption tests. Extending this to ordinary builds is separate work.
 6. **Build constraints and cross compilation:** extend the target descriptor
    and action identity without changing storage-path semantics.
 7. **Operations:** add recency tracking, pruning, diagnostics, and format
    migration only after real cache data exists.
 
-The next implementation should choose one stage, write a failing end-to-end
-test first, and avoid introducing speculative directory structure for later
-stages.
+Later stages should remain independently reviewable and avoid introducing
+speculative directory structure before it has a consumer.
 
 ## References
 

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -239,10 +239,11 @@ Moon-owned runtime objects and archives when command construction selected
 their exact paths.
 
 Lowering marks actions with broader, not-yet-modeled observations as
-cache-ineligible. This covers proof execution, documentation generation,
-arbitrary prebuild shell commands, and actions that execute unstructured custom
-compiler or linker flags. Lowering does not infer file inputs by parsing those
-flags.
+cache-ineligible. This covers proof execution, documentation generation, and
+arbitrary prebuild shell commands. Custom compiler and linker flags remain
+opaque arguments: their exact strings enter the identity, but lowering does not
+infer additional file inputs by parsing tool-specific syntax. Such implicit
+inputs are a best-effort cache boundary.
 
 Lowering always exposes concrete paths. The cache identity layer hashes those
 paths and all command text exactly; it does not replace path roots or interpret
@@ -268,8 +269,8 @@ This keeps responsibilities separate:
 
 Standalone `.mbt` and `.mbtx` execution starts from one complete `BuildPlan`.
 Package dependencies use the same edges as ordinary project compilation. After
-the plan is normalized once, an action-level projection separates it into two
-disjoint n2 graphs.
+the plan is normalized once, an action-level projection retains dependency
+`LoweredAction` values and lowers the script actions into an n2 graph.
 
 All actions owned by packages other than the synthesized script package seed
 the dependency projection. Following their producer edges to a fixed point
@@ -285,22 +286,28 @@ concrete `.mooncakes` paths using that producer's action context. Those paths
 become ordinary n2 inputs with no producer in the script graph; no external
 product or path vocabulary is needed.
 
-Execution runs the dependency graph first using
-`standalone-dependencies.moon_db`, then runs the script graph using the existing
-mode database. There is no file-existence scan between the phases: n2 currently
-decides whether dependency actions are current.
+Execution first calls dependency preparation. Its contract is that successful
+completion has materialized every dependency product at the concrete paths
+already referenced by the script graph. The script phase does not inspect the
+cache or rescan those paths.
 
-The dependency n2 graph is an adapter for the current preparation mechanism.
-A future action-to-output implementation can replace that first stage, then
-feed the materialized outputs into a narrower script plan without changing the
-dependency product contract.
+When the global build cache is enabled, preparation computes identities from
+the retained actions, restores complete hits, converts only misses through a
+controlled `LoweredAction`-to-n2 adapter, and publishes successful outputs. The
+miss graph uses temporary n2 state because freshness has already been decided
+by action identity and store validation. When the cache is disabled,
+preparation sends all dependency actions through the adapter and uses the
+existing persistent `standalone-dependencies.moon_db`.
 
-For `.mbt` and `.mbtx` files built from persistent paths, the dependency n2
-database remains available to later invocations. `moon run -e` and
-`moon run -` also use the split graphs, but their synthesized temporary projects
-are removed after each invocation, so they do not currently reuse the
-dependency database across invocations. Stable or global cache storage for
-those entry points remains future work.
+The adapter is an execution mechanism behind preparation, not a second source
+of planning truth. The retained action boundary can survive replacing n2 for
+dependency misses.
+
+For `.mbt` and `.mbtx` files built from persistent paths, exact concrete paths
+can remain stable and allow global store hits. `moon run -e` and `moon run -`
+use the same preparation path, but their synthesized temporary paths can cause
+conservative misses because the identity deliberately performs no textual path
+rewriting.
 
 Ordinary project and workspace commands continue to produce and execute one
 plan and one n2 graph.

--- a/docs/dev/reference/dry-run.md
+++ b/docs/dev/reference/dry-run.md
@@ -10,4 +10,5 @@
 - **Project-relative paths**. Paths that live under the project root are emitted as a relative path from the project root, instead of absolute paths.
 - **Toolchain binary aliases**. Known Moon toolchain executables (e.g. `~/.moon/bin/moonc`) are shortened to their bare names (`moonc`). Other executables keep their original paths.
 - **`moon run --dry-run` extras**. After the build commands, the dry-run output also prints the command that would execute the produced binary (typically `moonrun`, `node`, or the final executable).
+- **Standalone dependency preparation**. Dry-run does not read or write the build cache. It prints every dependency action before the script actions, even when execution would restore some dependency outputs.
 - **`moon test --verbose` extras**. With `--verbose` set, `moon test` print the command that is executed for each test case.

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -4,6 +4,10 @@ Prebuild tasks let a package generate source files (typically `.mbt`) from other
 
 - Scope: Applies only to packages in the input module being built.
   Third-party dependencies are expected to already contain their generated outputs.
+- Planning may still use a third-party package's declared `.mbt` and `.mbt.md`
+  output paths when projecting its compiler sources. Because no prebuild action
+  is created for that package, files at those paths remain ordinary source
+  inputs rather than products of the current build.
 - A registry module being built as a direct bin-dep is the input module of its
   child build, so its package-level prebuild tasks run in the temporary source
   copy rather than in the registry cache.


### PR DESCRIPTION
## Why

Standalone dependency preparation currently relies only on a project-local n2 database. That preserves incremental work for persistent scripts, but it cannot restore deleted outputs or provide an action-to-output boundary for a global build cache.

## What changed

- Retain dependency `LoweredAction` values while continuing to lower ordinary builds and the script phase directly into n2.
- Define dependency preparation as the operation that guarantees every prerequisite of the script graph is materialized at its lowered path.
- Restore complete regular-file output sets from the global build cache and send only misses through a controlled `LoweredAction` to n2 adapter.
- Publish BLAKE3-addressed output manifests and validate malformed, old, missing, partial, or damaged state as a safe miss; concurrent publishers accept a validated winner.
- Keep dry-run cache-free and preserve the existing persistent dependency n2 database when `MOON_BUILD_CACHE=off`.

## Why this is correct

Canonical identity continues to come only from `LoweredAction`, including structured argv, effective cwd/environment, response files, external inputs, recursive producer digests, logical products, and concrete paths. The cache never reads or reconstructs an n2 graph. Objects are validated before materialization, outputs are published before action entries, and action inputs are revalidated before newly executed results are published.

## Scope

The integration is limited to dependency preparation for standalone `.mbt` and `.mbtx` builds. Ordinary project/workspace builds are unchanged. The initial store handles regular-file outputs and deliberately performs no path rewriting; implicit files referenced only through opaque custom flags remain a documented best-effort boundary. Concurrent publication in the global store is supported, but this does not claim that commands sharing one mutable project `_build` tree are safe.