### PR TITLE
chore: sync compiler warnings and Rust tooling

### DIFF
--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -38,7 +38,7 @@ Warning name: `{mnemonic}`
     }
 }
 
-// Snapshot generated from `moonc check -warn-help` on 2026-07-28.
+// Snapshot generated from `moonc check -warn-help` on 2026-08-03.
 // Update this file manually when the compiler's warning table changes.
 const WARNING_ENTRIES: &[WarningEntry] = &[
     WarningEntry {
@@ -212,13 +212,13 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
         id: 35,
     },
     WarningEntry {
-        mnemonic: "loop_label_shadowing",
-        description: "Loop label shadows another label.",
+        mnemonic: "block_label_shadowing",
+        description: "Block label shadows another label.",
         id: 36,
     },
     WarningEntry {
-        mnemonic: "unused_loop_label",
-        description: "Unused loop label.",
+        mnemonic: "unused_block_label",
+        description: "Unused block label.",
         id: 37,
     },
     WarningEntry {
@@ -437,6 +437,16 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
         id: 84,
     },
     WarningEntry {
+        mnemonic: "unlabelled_break_in_labelled_loop",
+        description: "Unlabelled `break` directly inside a labelled loop.",
+        id: 85,
+    },
+    WarningEntry {
+        mnemonic: "unlabelled_continue_in_labelled_loop",
+        description: "Unlabelled `continue` directly inside a labelled loop.",
+        id: 86,
+    },
+    WarningEntry {
         mnemonic: "guard_inexhaustive",
         description: "`guard` condition is not exhaustive and may panic.",
         id: 87,
@@ -495,11 +505,10 @@ mod tests {
         let description_start = header
             .find("description")
             .context("missing description column in `moonc check -warn-help`")?;
-        let id_start = header
+        header
             .find(" id ")
-            .map(|index| index + 1)
             .context("missing id column in `moonc check -warn-help`")?;
-        let state_start = header
+        header
             .find("state")
             .context("missing state column in `moonc check -warn-help`")?;
 
@@ -508,16 +517,24 @@ mod tests {
             .skip_while(|line| !line.starts_with("mnemonic"))
             .skip(1)
             .filter_map(|line| {
-                let id = line
-                    .get(id_start..state_start)
-                    .unwrap_or("")
-                    .trim()
-                    .parse::<u16>()
-                    .ok()?;
+                // Long mnemonics overflow their nominal column and shift the
+                // remaining fields, so parse the id and state from the right.
+                let (before_state, _) = line.trim_end().rsplit_once(' ')?;
+                let (entry, id) = before_state.trim_end().rsplit_once(' ')?;
+                let id = id.parse::<u16>().ok()?;
+                let entry = entry.trim_end();
+                let mnemonic_column = entry.get(..description_start)?;
+                let (mnemonic, description) = if mnemonic_column.ends_with(char::is_whitespace) {
+                    (mnemonic_column, entry.get(description_start..)?)
+                } else {
+                    let mnemonic_end = description_start
+                        + entry.get(description_start..)?.find(char::is_whitespace)?;
+                    (entry.get(..mnemonic_end)?, entry.get(mnemonic_end..)?)
+                };
                 Some(format!(
                     "{id:04}\t{}\t{}",
-                    line.get(..description_start).unwrap_or("").trim_end(),
-                    line.get(description_start..id_start).unwrap_or("").trim()
+                    mnemonic.trim_end(),
+                    description.trim()
                 ))
             })
             .collect::<Vec<_>>();

--- a/crates/moon/src/cli/snapshots/explain_warning_index.txt
+++ b/crates/moon/src/cli/snapshots/explain_warning_index.txt
@@ -32,8 +32,8 @@
 0033	text_segment_excceed	Text segment exceed the line or column limits.
 0034	implicit_use_builtin	Implicit use of definitions from `moonbitlang/core/builtin`.
 0035	reserved_keyword	Reserved keyword.
-0036	loop_label_shadowing	Loop label shadows another label.
-0037	unused_loop_label	Unused loop label.
+0036	block_label_shadowing	Block label shadows another label.
+0037	unused_block_label	Unused block label.
 0038	missing_invariant	For-loop is missing an invariant.
 0039	missing_reasoning	For-loop is missing a proof_reasoning.
 0040	multiline_string_escape	Deprecated escape sequence in multiline string.
@@ -77,6 +77,8 @@
 0082	ambiguous_braces	Ambiguous `{}` braces.
 0083	type_param_method	Calling method of type parameter in a deprecated way.
 0084	unqualified_record	Struct literal in a `let` binding without a type prefix.
+0085	unlabelled_break_in_labelled_loop	Unlabelled `break` directly inside a labelled loop.
+0086	unlabelled_continue_in_labelled_loop	Unlabelled `continue` directly inside a labelled loop.
 0087	guard_inexhaustive	`guard` condition is not exhaustive and may panic.
 0088	guard_redundant_bang	Redundant `!` on an exhaustive `guard`.
 0089	guard_redundant_else	Redundant `else` on an exhaustive `guard`.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.90.0"
-components = [ "rustfmt", "clippy" ]
+components = [ "rustfmt", "clippy", "rust-analyzer" ]


### PR DESCRIPTION
## Why

`moon explain` relies on a checked-in copy of the compiler warning table. The current `moonc` table renamed the block-label warnings and added two labelled-loop warnings, leaving the index stale. The new mnemonic lengths also exposed an assumption in the snapshot normalizer that every warning fits the table's nominal mnemonic column.

The repository pins Rust 1.90.0, while the latest standalone rust-analyzer no longer supports that compiler version. Installing rust-analyzer through the pinned Rust toolchain keeps editor tooling compatible.

## What changed

- synchronize the warning index and snapshot with `moonc check -warn-help`
- parse the trailing warning ID and state from the right so long mnemonics are retained
- add `rust-analyzer` to the pinned toolchain components

## Why this is correct

The updated entries mirror the compiler's warning names, descriptions, and IDs. Parsing the stable trailing fields from the right preserves the existing fixed-column behavior while handling rows whose mnemonic expands past that column. The rust-analyzer component is selected from the same pinned 1.90.0 toolchain as rustfmt and clippy.

## Scope

The change is limited to the generated warning index, its normalization test, and the existing Rust toolchain manifest.
