### PR TITLE
refactor(build): expose standalone dependency actions

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -761,18 +761,19 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
     };
     let backend = cx.backend.target_backend();
     let layout = cx.artifact_paths.target_layout();
-    let dependency_input = compile_output
-        .dependencies
-        .build_graph
-        .builds
-        .iter()
-        .next()
-        .is_some()
-        .then(|| BuildInput {
-            graph: compile_output.dependencies.build_graph,
-            command_args_by_output: compile_output.dependencies.command_args_by_output,
+    let dependency_input = if compile_output.dependencies.is_empty() {
+        None
+    } else {
+        let (graph, command_args_by_output) =
+            moonbuild_rupes_recta::build_lower::lowered_actions_to_n2_graph(
+                compile_output.dependencies,
+            )?;
+        Some(BuildInput {
+            graph,
+            command_args_by_output,
             db_path: layout.standalone_dependency_n2_db_path(backend),
-        });
+        })
+    };
     let input = StandaloneBuildInput {
         dependencies: dependency_input,
         script: BuildInput {

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -251,9 +251,10 @@ pub fn lower_build_plan(
     Ok(result)
 }
 
-/// Project one standalone action plan into dependency and script n2 graphs.
+/// Project one standalone action plan into retained dependency actions and a
+/// script n2 graph.
 ///
-/// The dependency graph contains every prerequisite outside the synthesized
+/// The dependency actions contain every prerequisite outside the synthesized
 /// script package, including package-less shared actions reached by those
 /// prerequisites. The script graph keeps the same action/product edges; when a
 /// dependency producer is omitted, its output path remains a concrete n2 input.
@@ -263,8 +264,8 @@ pub(crate) fn lower_standalone_build_plan(
     plan: &BuildActionPlan<'_>,
     opt: &BuildOptions,
     script_package: PackageId,
-) -> Result<(LoweringResult, LoweringResult), LoweringError> {
-    info!("Projecting standalone actions to dependency and script n2 graphs");
+) -> Result<(Vec<LoweredAction>, LoweringResult), LoweringError> {
+    info!("Projecting standalone dependency actions and script n2 graph");
     let (dependency_actions, script_actions) = plan.partition_standalone_actions(script_package);
     debug!(
         "Standalone execution projection contains {} dependency actions and {} script actions",
@@ -272,7 +273,7 @@ pub(crate) fn lower_standalone_build_plan(
         script_actions.len()
     );
 
-    let dependencies = lower_actions(resolve_output, plan, opt, dependency_actions, &[])?;
+    let dependencies = lower_actions_to_values(resolve_output, plan, opt, dependency_actions)?;
     let script = lower_actions(
         resolve_output,
         plan,
@@ -281,6 +282,36 @@ pub(crate) fn lower_standalone_build_plan(
         plan.input_action_ids(),
     )?;
     Ok((dependencies, script))
+}
+
+fn lower_actions_to_values(
+    resolve_output: &ResolveOutput,
+    plan: &BuildActionPlan<'_>,
+    opt: &BuildOptions,
+    actions: impl IntoIterator<Item = BuildActionId>,
+) -> Result<Vec<LoweredAction>, LoweringError> {
+    let mut ctx = LoweringContext::new(opt.artifact_paths.clone(), resolve_output, plan, opt);
+    actions
+        .into_iter()
+        .filter_map(|id| {
+            debug!("Lowering retained action: {:?}", id);
+            ctx.lower_action(id).transpose()
+        })
+        .collect()
+}
+
+/// Convert exactly the selected lowered actions into an n2 graph.
+///
+/// Callers must select a producer-closed action set or materialize every
+/// omitted producer output before executing the returned graph.
+pub fn lowered_actions_to_n2_graph(
+    actions: impl IntoIterator<Item = LoweredAction>,
+) -> Result<(N2Graph, CommandArgMap), LoweringError> {
+    let mut n2 = N2GraphBuilder::new();
+    for action in actions {
+        n2.add_action(action)?;
+    }
+    Ok((n2.graph, n2.command_args_by_output))
 }
 
 fn lower_actions(

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -86,10 +86,11 @@ pub struct CompileOutput {
     pub build_plan: Option<Box<build_plan::BuildPlan>>,
 }
 
-/// Two execution graphs projected from one logical standalone build plan.
+/// Dependency preparation and script execution projected from one logical
+/// standalone build plan.
 pub struct StandaloneCompileOutput {
-    /// Dependency-package work, executed before the script graph.
-    pub dependencies: CompileOutput,
+    /// Lowered dependency-package actions retained for preparation.
+    pub dependencies: Vec<build_lower::LoweredAction>,
     /// Work belonging to the synthesized script package.
     pub script: CompileOutput,
 }
@@ -190,12 +191,7 @@ pub fn compile_standalone(
             })
             .collect();
         (
-            CompileOutput {
-                build_graph: dependencies.build_graph,
-                command_args_by_output: dependencies.command_args_by_output,
-                artifacts: IndexMap::new(),
-                build_plan: None,
-            },
+            dependencies,
             CompileOutput {
                 build_graph: script.build_graph,
                 command_args_by_output: script.command_args_by_output,
@@ -419,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    fn standalone_compile_lowers_dependency_and_script_products_to_separate_graphs() {
+    fn standalone_compile_separates_dependency_preparation_from_script_graph() {
         let module_source = ModuleSource::local_path(
             "test/single"
                 .parse::<ModuleName>()
@@ -525,9 +521,8 @@ mod tests {
         )
         .expect("standalone plan should lower");
 
-        assert_eq!(output.dependencies.build_graph.builds.iter().count(), 1);
+        assert_eq!(output.dependencies.len(), 1);
         assert_eq!(output.script.build_graph.builds.iter().count(), 2);
-        assert!(output.dependencies.build_plan.is_none());
         let plan = output
             .script
             .build_plan
@@ -541,15 +536,10 @@ mod tests {
 
         let dependency_outputs = output
             .dependencies
-            .build_graph
-            .builds
             .iter()
-            .flat_map(|build| build.outs.ids.iter())
-            .map(|id| {
-                output.dependencies.build_graph.files.by_id[*id]
-                    .name
-                    .clone()
-            })
+            .flat_map(|action| action.outputs())
+            .flat_map(|product| product.paths())
+            .map(|path| path.to_string_lossy().into_owned())
             .collect::<Vec<_>>();
         assert!(
             dependency_outputs

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -268,8 +268,10 @@ This keeps responsibilities separate:
 
 Standalone `.mbt` and `.mbtx` execution starts from one complete `BuildPlan`.
 Package dependencies use the same edges as ordinary project compilation. After
-the plan is normalized once, an action-level projection separates it into two
-disjoint n2 graphs.
+the plan is normalized once, an action-level projection retains dependency
+work as `LoweredAction` values and lowers script work into an n2 graph. Moon
+passes the dependency actions through the current n2 adapter before execution,
+producing the same two disjoint n2 graphs as before.
 
 All actions owned by packages other than the synthesized script package seed
 the dependency projection. Following their producer edges to a fixed point


### PR DESCRIPTION
## Why

Standalone script planning currently turns dependency preparation into an n2 graph inside Rupes Recta. That prevents Moon from observing the lowered dependency actions before choosing how to prepare them, which is the boundary needed by later preparation policy work.

## What changed

- Keep one complete `BuildActionPlan` for standalone dependency and script work.
- Return dependency work from Rupes Recta as `LoweredAction` values while continuing to lower script work to its existing n2 graph.
- Convert dependency actions through the existing controlled n2 adapter in Moon before execution.
- Document the implemented standalone lowering boundary.

## Why this is correct

The same action partition, product realization, n2 adapter, database paths, and dependency-before-script execution order remain in use. Dependency outputs therefore stay ordinary inputs to the script graph, and ordinary project and workspace builds continue through their existing single-graph path.

## Scope

This change does not add artifact caching or a global dependency source cache, alter action identity, or change the two-stage standalone dependency/script semantics. It only exposes dependency `LoweredAction` values at the Moon orchestration boundary.
