### PR TITLE
feat(cache): reuse standalone dependency sources

### DIFF
--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -713,8 +713,8 @@ pub(super) fn build_registry_native_executable_to(
     // Moonx needs the sources for its temporary build, but must not run package
     // installation hooks or let acquisition progress precede program stdout.
     let registry = OnlineRegistry::mooncakes_io();
-    let checksum = registry.source_checksum(module_name, version)?;
-    registry.extract_to(module_name, version, &checksum, source.path(), !verbose)?;
+    let checksum = registry.source_archive_checksum(module_name, version)?;
+    registry.acquire_source_to(module_name, version, &checksum, source.path(), !verbose)?;
 
     let cli = UniversalFlags {
         source_tgt_dir: SourceTargetDirs {

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -712,7 +712,9 @@ pub(super) fn build_registry_native_executable_to(
     let source = tempfile::TempDir::new().context("Failed to create temporary directory")?;
     // Moonx needs the sources for its temporary build, but must not run package
     // installation hooks or let acquisition progress precede program stdout.
-    OnlineRegistry::mooncakes_io().extract_to(module_name, version, source.path(), !verbose)?;
+    let registry = OnlineRegistry::mooncakes_io();
+    let checksum = registry.source_checksum(module_name, version)?;
+    registry.extract_to(module_name, version, &checksum, source.path(), !verbose)?;
 
     let cli = UniversalFlags {
         source_tgt_dir: SourceTargetDirs {

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -33,6 +33,7 @@ use moonutil::command_output::CommandOutput;
 use moonutil::project::{PackageDirs, ProjectProbe};
 use moonutil::{
     build_options::{RunMode, TestArtifacts},
+    cache::{CacheKind, resolve_cache_root},
     constants::is_moon_pkg_exist,
     locks::FileLock,
     target::TargetBackend,
@@ -669,7 +670,11 @@ fn build_single_file_executable(
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     )
-    .with_sync_output(options.output.sync_output());
+    .with_sync_output(options.output.sync_output())
+    .with_dependency_source_cache(
+        resolve_cache_root(CacheKind::DependencySources)
+            .context("Failed to resolve the module dependency graph")?,
+    );
     let (resolved, backend) = moonbuild_rupes_recta::resolve::resolve_single_file_project(
         &resolve_cfg,
         &dirs,

--- a/crates/moon/tests/mod.rs
+++ b/crates/moon/tests/mod.rs
@@ -56,6 +56,7 @@ pub fn moon_cmd(dir: &impl AsRef<Path>) -> snapbox::cmd::Command {
     snapbox::cmd::Command::new(moon_bin())
         .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
         .env("MOONRUN_OVERRIDE", moonrun_bin())
+        .env("MOON_DEP_CACHE", "off")
         .current_dir(dir)
 }
 
@@ -63,6 +64,7 @@ pub fn moon_process_cmd(dir: &impl AsRef<Path>) -> std::process::Command {
     let mut cmd = std::process::Command::new(moon_bin());
     cmd.env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
         .env("MOONRUN_OVERRIDE", moonrun_bin())
+        .env("MOON_DEP_CACHE", "off")
         .current_dir(dir);
     cmd
 }

--- a/crates/moon/tests/test_cases/clean/mod.rs
+++ b/crates/moon/tests/test_cases/clean/mod.rs
@@ -139,6 +139,33 @@ fn test_clean_refuses_unowned_custom_cache_root() {
 }
 
 #[test]
+fn test_clean_refuses_malformed_ownership_marker() {
+    let dir = TestDir::new_empty();
+    let cache = tempfile::TempDir::new().unwrap();
+    std::fs::write(cache.path().join(".moon-cache"), "user data").unwrap();
+    std::fs::write(cache.path().join("must-survive"), "contents").unwrap();
+
+    moon_cmd(&dir)
+        .env("MOON_DEP_CACHE", cache.path())
+        .args(["clean", "--dep-cache"])
+        .assert()
+        .failure()
+        .stdout_eq("")
+        .stderr_eq(
+            "Error: refusing to use Moon cache root `[..]` with an incompatible ownership marker\n",
+        );
+
+    assert_eq!(
+        std::fs::read_to_string(cache.path().join(".moon-cache")).unwrap(),
+        "user data"
+    );
+    assert_eq!(
+        std::fs::read_to_string(cache.path().join("must-survive")).unwrap(),
+        "contents"
+    );
+}
+
+#[test]
 fn test_clean_uses_default_cache_roots() {
     let dir = TestDir::new_empty();
     let moon_home = tempfile::TempDir::new().unwrap();

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -94,6 +94,15 @@ fn test_single_file_run_inputs_share_immutable_dependency_sources() {
         .stdout_eq("hello\n");
 
     assert!(!mbtx_dir.join(".mooncakes/moonbitlang/x").exists());
+    let cached_source = dependency_cache
+        .path()
+        .join("v1/sources/moonbitlang/x/0.4.38");
+    assert!(
+        cached_source.join("moon.mod").is_file() || cached_source.join("moon.mod.json").is_file()
+    );
+    let checksum = fs::read_to_string(cached_source.join(".moon-source-archive-checksum")).unwrap();
+    assert_eq!(checksum.len(), 64);
+    assert!(checksum.bytes().all(|byte| byte.is_ascii_hexdigit()));
 
     moon_cmd(&inline_dir)
         .env("MOON_DEP_CACHE", dependency_cache.path())

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -61,6 +61,56 @@ fn test_single_file_mbtx_run() {
     let dir = TestDir::new("moon_test_single_file.in");
     let stdout = get_stdout(&dir, ["run", "import_ok.mbtx"]);
     assert!(stdout.contains("hello"));
+    assert!(dir.join(".mooncakes/moonbitlang/x").is_dir());
+}
+
+#[test]
+fn test_standalone_mbt_run_rejects_relative_dependency_cache() {
+    let dir = TestDir::new("moon_test_single_file.in");
+
+    moon_cmd(&dir)
+        .env("MOON_DEP_CACHE", "relative")
+        .args(["run", "with_main.mbt"])
+        .assert()
+        .failure()
+        .stderr_eq(
+            "Error: Failed to resolve the module dependency graph\n\nCaused by:\n    MOON_DEP_CACHE must be an absolute path or `off`\n",
+        );
+}
+
+#[test]
+fn test_single_file_run_inputs_share_immutable_dependency_sources() {
+    let mbtx_dir = TestDir::new("moon_test_single_file.in");
+    let inline_dir = TestDir::new_empty();
+    let stdin_dir = TestDir::new_empty();
+    let dependency_cache = tempfile::TempDir::new().unwrap();
+    let source = fs::read_to_string(mbtx_dir.join("import_ok.mbtx")).unwrap();
+
+    moon_cmd(&mbtx_dir)
+        .env("MOON_DEP_CACHE", dependency_cache.path())
+        .args(["run", "import_ok.mbtx"])
+        .assert()
+        .success()
+        .stdout_eq("hello\n");
+
+    assert!(!mbtx_dir.join(".mooncakes/moonbitlang/x").exists());
+
+    moon_cmd(&inline_dir)
+        .env("MOON_DEP_CACHE", dependency_cache.path())
+        .args(["run", "--frozen", "-e", &source])
+        .assert()
+        .success()
+        .stdout_eq("hello\n");
+    assert!(!inline_dir.join(".mooncakes/moonbitlang/x").exists());
+
+    moon_cmd(&stdin_dir)
+        .env("MOON_DEP_CACHE", dependency_cache.path())
+        .args(["run", "--frozen", "-"])
+        .stdin(source)
+        .assert()
+        .success()
+        .stdout_eq("hello\n");
+    assert!(!stdin_dir.join(".mooncakes/moonbitlang/x").exists());
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/third_party/mod.rs
+++ b/crates/moon/tests/test_cases/third_party/mod.rs
@@ -8,7 +8,6 @@ use crate::{
 fn test_third_party() {
     let dir = TestDir::new("third_party");
     get_stdout(&dir, ["update"]);
-    get_stdout(&dir, ["install"]);
     get_stdout(&dir, ["build", "--target", "wasm-gc"]);
     get_stdout(&dir, ["clean"]);
 

--- a/crates/moon/tests/test_cases/third_party/moon.mod.json
+++ b/crates/moon/tests/test_cases/third_party/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "username/hello",
   "version": "0.1.0",
   "deps": {
-    "lijunchen/hello18": "0.1.30"
+    "lijunchen/hello18": "0.1.31"
   },
   "readme": "README.md",
   "repository": "",

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -35,6 +35,7 @@ use mooncake::{
     registry::path as registry_path,
 };
 use moonutil::{
+    cache::CacheRoot,
     cli_support::AutoSyncFlags,
     constants::{MBTI_USER_WRITTEN, MOONBITLANG_CORE},
     dependency::SourceDependencyInfo,
@@ -88,6 +89,7 @@ impl ResolveOutput {
 pub struct ResolveConfig {
     sync_flags: AutoSyncFlags,
     sync_output: SyncOutputOptions,
+    dependency_source_cache: CacheRoot,
     no_std: bool,
     /// Whether direct bin-deps of the input modules participate in resolution
     /// and are installed during dependency sync.
@@ -264,6 +266,7 @@ impl ResolveConfig {
         Self {
             sync_flags: AutoSyncFlags { frozen },
             sync_output: SyncOutputOptions::default(),
+            dependency_source_cache: CacheRoot::Disabled,
             no_std,
             include_bin_deps: true,
             enable_coverage,
@@ -281,6 +284,7 @@ impl ResolveConfig {
         Self {
             sync_flags,
             sync_output: SyncOutputOptions::default(),
+            dependency_source_cache: CacheRoot::Disabled,
             no_std,
             include_bin_deps: true,
             enable_coverage,
@@ -295,6 +299,11 @@ impl ResolveConfig {
 
     pub fn with_sync_output(mut self, sync_output: SyncOutputOptions) -> Self {
         self.sync_output = sync_output;
+        self
+    }
+
+    pub fn with_dependency_source_cache(mut self, cache: CacheRoot) -> Self {
+        self.dependency_source_cache = cache;
         self
     }
 
@@ -449,12 +458,12 @@ Use moonbit.import with 'username/module@version[/package]' entries to opt in to
         );
     }
 
-    // Sync modules as usual
     let (resolved_env, dir_sync_result) = auto_sync_for_single_file_rr(
         dirs,
         &cfg.sync_flags,
         front_matter_config.deps_to_sync.as_ref(),
         cfg.sync_output,
+        &cfg.dependency_source_cache,
     )
     .map_err(ResolveError::SyncModulesError)?;
     // Discover all packages in resolved modules

--- a/crates/mooncake/src/dependency_source.rs
+++ b/crates/mooncake/src/dependency_source.rs
@@ -83,8 +83,15 @@ mod tests {
     };
     use semver::Version;
 
-    use super::{global::ImmutableDependencySource, select};
+    use super::{
+        global::{ImmutableDependencySource, SOURCE_ARCHIVE_CHECKSUM_FILE},
+        select,
+    };
     use crate::registry::{Registry, RegistryVersionInfo};
+
+    const FIRST_CHECKSUM: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const SECOND_CHECKSUM: &str =
+        "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
 
     struct TestRegistry {
         version: Version,
@@ -99,7 +106,7 @@ mod tests {
         fn new(postadd: bool) -> Self {
             Self {
                 version: Version::new(1, 2, 3),
-                checksum: "0123456789abcdef".to_string(),
+                checksum: FIRST_CHECKSUM.to_string(),
                 checksum_after_first_read: None,
                 checksum_reads: AtomicUsize::new(0),
                 postadd,
@@ -125,13 +132,19 @@ mod tests {
         ) -> anyhow::Result<()> {
             self.installations.fetch_add(1, Ordering::SeqCst);
             let scripts = if self.postadd {
-                r#", "scripts": {"postadd": "must-not-run"}"#
+                r#"
+options(
+  "scripts": {
+    "postadd": "must-not-run",
+  },
+)
+"#
             } else {
                 ""
             };
             std::fs::write(
-                to.join("moon.mod.json"),
-                format!(r#"{{"name":"{name}","version":"{version}"{scripts}}}"#),
+                to.join("moon.mod"),
+                format!("name = \"{name}\"\nversion = \"{version}\"\n{scripts}"),
             )?;
             Ok(())
         }
@@ -161,7 +174,7 @@ mod tests {
             self.install_source(name, version, to)
         }
 
-        fn extract_to(
+        fn acquire_source_to(
             &self,
             name: &ModuleName,
             version: &Version,
@@ -170,11 +183,11 @@ mod tests {
             _quiet: bool,
         ) -> anyhow::Result<()> {
             self.install_source(name, version, to)?;
-            std::fs::write(to.join("archive-checksum"), expected_checksum)?;
+            std::fs::write(to.join("acquired-archive-checksum"), expected_checksum)?;
             Ok(())
         }
 
-        fn source_checksum(
+        fn source_archive_checksum(
             &self,
             _name: &ModuleName,
             _version: &Version,
@@ -226,10 +239,8 @@ mod tests {
         let (resolved, module) = test_env();
 
         assert_eq!(
-            store.source_dir(resolved.module_source(module), "0123456789abcdef"),
-            cache
-                .path()
-                .join("v1/sources/test/module/1.2.3/0123456789abcdef")
+            store.source_dir(resolved.module_source(module)),
+            cache.path().join("v1/sources/test/module/1.2.3")
         );
     }
 
@@ -253,6 +264,10 @@ mod tests {
         assert_eq!(first[module], second[module]);
         assert_eq!(registry.installations.load(Ordering::SeqCst), 1);
         assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "keep");
+        assert_eq!(
+            std::fs::read_to_string(first[module].join(SOURCE_ARCHIVE_CHECKSUM_FILE)).unwrap(),
+            FIRST_CHECKSUM
+        );
     }
 
     #[test]
@@ -263,8 +278,8 @@ mod tests {
         let registry = TestRegistry::new(true);
         let (resolved, module) = test_env();
         let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
-        let directory = ImmutableDependencySource::new(&cache_dir)
-            .source_dir(resolved.module_source(module), &registry.checksum);
+        let directory =
+            ImmutableDependencySource::new(&cache_dir).source_dir(resolved.module_source(module));
 
         let error = source
             .ensure(&registry, &resolved, false, &user_log())
@@ -326,35 +341,46 @@ mod tests {
     }
 
     #[test]
-    fn changed_checksum_publishes_a_distinct_source() {
+    fn changed_checksum_is_rejected_without_replacing_the_source() {
         // `lijunchen/hello18@0.1.30` was historically replaced after
-        // publication, so module and version alone are not a safe physical
-        // cache identity even though registry versions should be immutable.
+        // publication. Registry versions are nevertheless immutable from the
+        // dependency source cache's perspective: accepting the replacement
+        // requires an explicit cache clean.
         let sandbox = tempfile::TempDir::new().unwrap();
         let cache = global_cache(&sandbox.path().join("cache"));
         let first_registry = TestRegistry::new(false);
-        let second_registry = TestRegistry::new(false).with_checksum("fedcba9876543210");
+        let second_registry = TestRegistry::new(false).with_checksum(SECOND_CHECKSUM);
         let (resolved, module) = test_env();
         let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
 
         let first = source
             .ensure(&first_registry, &resolved, false, &user_log())
             .unwrap();
-        let second = source
-            .ensure(&second_registry, &resolved, false, &user_log())
-            .unwrap();
+        let sentinel = first[module].join("must-survive");
+        std::fs::write(&sentinel, "original source").unwrap();
 
-        assert_ne!(first[module], second[module]);
-        assert!(first[module].join("moon.mod.json").is_file());
-        assert!(second[module].join("moon.mod.json").is_file());
+        let error = source
+            .ensure(&second_registry, &resolved, false, &user_log())
+            .unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("registry archive checksum changed"),
+            "{error:#}"
+        );
+        assert!(format!("{error:#}").contains("moon clean --dep-cache"));
+        assert_eq!(
+            std::fs::read_to_string(sentinel).unwrap(),
+            "original source"
+        );
+        assert_eq!(second_registry.installations.load(Ordering::SeqCst), 0);
     }
 
     #[test]
-    fn extraction_uses_the_checksum_selected_for_the_source_path() {
+    fn extraction_and_metadata_use_one_archive_checksum_read() {
         let sandbox = tempfile::TempDir::new().unwrap();
         let cache_dir = sandbox.path().join("cache");
         let cache = global_cache(&cache_dir);
-        let registry = TestRegistry::new(false).with_checksum_after_first_read("fedcba9876543210");
+        let registry = TestRegistry::new(false).with_checksum_after_first_read(SECOND_CHECKSUM);
         let (resolved, module) = test_env();
         let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
 
@@ -364,14 +390,57 @@ mod tests {
 
         assert_eq!(
             paths[module],
-            ImmutableDependencySource::new(&cache_dir)
-                .source_dir(resolved.module_source(module), "0123456789abcdef")
+            ImmutableDependencySource::new(&cache_dir).source_dir(resolved.module_source(module))
         );
         assert_eq!(
-            std::fs::read_to_string(paths[module].join("archive-checksum")).unwrap(),
-            "0123456789abcdef"
+            std::fs::read_to_string(paths[module].join("acquired-archive-checksum")).unwrap(),
+            FIRST_CHECKSUM
+        );
+        assert_eq!(
+            std::fs::read_to_string(paths[module].join(SOURCE_ARCHIVE_CHECKSUM_FILE)).unwrap(),
+            FIRST_CHECKSUM
         );
         assert_eq!(registry.checksum_reads.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn source_with_missing_or_invalid_checksum_metadata_is_rejected() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let cache_dir = sandbox.path().join("cache");
+        let cache = global_cache(&cache_dir);
+        let registry = TestRegistry::new(false);
+        let (resolved, module) = test_env();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let directory =
+            ImmutableDependencySource::new(&cache_dir).source_dir(resolved.module_source(module));
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(
+            directory.join("moon.mod"),
+            "name = \"test/module\"\nversion = \"1.2.3\"\n",
+        )
+        .unwrap();
+
+        let missing_error = source
+            .ensure(&registry, &resolved, false, &user_log())
+            .unwrap_err();
+
+        assert!(
+            format!("{missing_error:#}").contains("missing archive checksum metadata"),
+            "{missing_error:#}"
+        );
+        assert!(format!("{missing_error:#}").contains("moon clean --dep-cache"));
+
+        std::fs::write(directory.join(SOURCE_ARCHIVE_CHECKSUM_FILE), "not-a-sha256").unwrap();
+        let invalid_error = source
+            .ensure(&registry, &resolved, false, &user_log())
+            .unwrap_err();
+
+        assert!(
+            format!("{invalid_error:#}").contains("invalid archive checksum metadata"),
+            "{invalid_error:#}"
+        );
+        assert!(format!("{invalid_error:#}").contains("moon clean --dep-cache"));
+        assert_eq!(registry.installations.load(Ordering::SeqCst), 0);
     }
 
     #[test]
@@ -388,7 +457,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(paths[module], project_dir.join("test/module"));
-        assert!(paths[module].join("moon.mod.json").is_file());
+        assert!(paths[module].join("moon.mod").is_file());
         assert_eq!(registry.installations.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/mooncake/src/dependency_source.rs
+++ b/crates/mooncake/src/dependency_source.rs
@@ -89,6 +89,8 @@ mod tests {
     struct TestRegistry {
         version: Version,
         checksum: String,
+        checksum_after_first_read: Option<String>,
+        checksum_reads: AtomicUsize,
         postadd: bool,
         installations: AtomicUsize,
     }
@@ -98,6 +100,8 @@ mod tests {
             Self {
                 version: Version::new(1, 2, 3),
                 checksum: "0123456789abcdef".to_string(),
+                checksum_after_first_read: None,
+                checksum_reads: AtomicUsize::new(0),
                 postadd,
                 installations: AtomicUsize::new(0),
             }
@@ -105,6 +109,11 @@ mod tests {
 
         fn with_checksum(mut self, checksum: &str) -> Self {
             self.checksum = checksum.to_string();
+            self
+        }
+
+        fn with_checksum_after_first_read(mut self, checksum: &str) -> Self {
+            self.checksum_after_first_read = Some(checksum.to_string());
             self
         }
 
@@ -156,10 +165,13 @@ mod tests {
             &self,
             name: &ModuleName,
             version: &Version,
+            expected_checksum: &str,
             to: &Path,
             _quiet: bool,
         ) -> anyhow::Result<()> {
-            self.install_source(name, version, to)
+            self.install_source(name, version, to)?;
+            std::fs::write(to.join("archive-checksum"), expected_checksum)?;
+            Ok(())
         }
 
         fn source_checksum(
@@ -167,7 +179,15 @@ mod tests {
             _name: &ModuleName,
             _version: &Version,
         ) -> anyhow::Result<String> {
-            Ok(self.checksum.clone())
+            let read = self.checksum_reads.fetch_add(1, Ordering::SeqCst);
+            Ok(if read == 0 {
+                &self.checksum
+            } else {
+                self.checksum_after_first_read
+                    .as_ref()
+                    .unwrap_or(&self.checksum)
+            }
+            .clone())
         }
     }
 
@@ -327,6 +347,31 @@ mod tests {
         assert_ne!(first[module], second[module]);
         assert!(first[module].join("moon.mod.json").is_file());
         assert!(second[module].join("moon.mod.json").is_file());
+    }
+
+    #[test]
+    fn extraction_uses_the_checksum_selected_for_the_source_path() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let cache_dir = sandbox.path().join("cache");
+        let cache = global_cache(&cache_dir);
+        let registry = TestRegistry::new(false).with_checksum_after_first_read("fedcba9876543210");
+        let (resolved, module) = test_env();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+
+        let paths = source
+            .ensure(&registry, &resolved, false, &user_log())
+            .unwrap();
+
+        assert_eq!(
+            paths[module],
+            ImmutableDependencySource::new(&cache_dir)
+                .source_dir(resolved.module_source(module), "0123456789abcdef")
+        );
+        assert_eq!(
+            std::fs::read_to_string(paths[module].join("archive-checksum")).unwrap(),
+            "0123456789abcdef"
+        );
+        assert_eq!(registry.checksum_reads.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/crates/mooncake/src/dependency_source.rs
+++ b/crates/mooncake/src/dependency_source.rs
@@ -1,0 +1,349 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Selection of dependency sources used by one resolution.
+
+mod global;
+mod project;
+
+use std::path::PathBuf;
+
+use moonutil::{
+    cache::CacheRoot,
+    resolution::{DirSyncResult, ModuleSourceKind, ResolvedEnv},
+    user_log::UserLog,
+};
+
+use crate::registry::Registry;
+
+use self::{global::ImmutableDependencySource, project::ProjectDependencySource};
+
+pub(crate) trait DependencySource {
+    /// Ensure that every resolved dependency has a source directory and return
+    /// those directories indexed by module ID.
+    fn ensure(
+        &self,
+        registry: &dyn Registry,
+        resolved: &ResolvedEnv,
+        frozen: bool,
+        user_log: &UserLog,
+    ) -> anyhow::Result<DirSyncResult>;
+}
+
+/// Select the dependency source adapter for one resolution.
+///
+/// The project-local `.mooncakes` directory and the shared immutable cache are
+/// hidden behind the same [`DependencySource`] seam.
+pub(crate) fn select<'a>(
+    project_dir: impl Into<PathBuf>,
+    cache: &'a CacheRoot,
+    resolved: &ResolvedEnv,
+) -> anyhow::Result<Box<dyn DependencySource + 'a>> {
+    let has_registry_sources = resolved
+        .all_modules()
+        .any(|module| matches!(module.source(), ModuleSourceKind::Registry) && !module.is_core());
+    if has_registry_sources && let Some(root) = cache.initialize()? {
+        return Ok(Box::new(ImmutableDependencySource::new(root)));
+    }
+
+    Ok(Box::new(ProjectDependencySource::new(project_dir)))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        path::Path,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    use moonutil::{
+        cache::{CacheKind, CacheRoot},
+        manifest::MoonMod,
+        resolution::{ModuleName, ModuleSource, ModuleSourceKind, ResolvedEnv},
+        user_log::UserLog,
+    };
+    use semver::Version;
+
+    use super::{global::ImmutableDependencySource, select};
+    use crate::registry::{Registry, RegistryVersionInfo};
+
+    struct TestRegistry {
+        version: Version,
+        checksum: String,
+        postadd: bool,
+        installations: AtomicUsize,
+    }
+
+    impl TestRegistry {
+        fn new(postadd: bool) -> Self {
+            Self {
+                version: Version::new(1, 2, 3),
+                checksum: "0123456789abcdef".to_string(),
+                postadd,
+                installations: AtomicUsize::new(0),
+            }
+        }
+
+        fn with_checksum(mut self, checksum: &str) -> Self {
+            self.checksum = checksum.to_string();
+            self
+        }
+
+        fn install_source(
+            &self,
+            name: &ModuleName,
+            version: &Version,
+            to: &Path,
+        ) -> anyhow::Result<()> {
+            self.installations.fetch_add(1, Ordering::SeqCst);
+            let scripts = if self.postadd {
+                r#", "scripts": {"postadd": "must-not-run"}"#
+            } else {
+                ""
+            };
+            std::fs::write(
+                to.join("moon.mod.json"),
+                format!(r#"{{"name":"{name}","version":"{version}"{scripts}}}"#),
+            )?;
+            Ok(())
+        }
+    }
+
+    impl Registry for TestRegistry {
+        fn all_versions_of(
+            &self,
+            _name: &ModuleName,
+        ) -> anyhow::Result<Arc<BTreeMap<Version, RegistryVersionInfo>>> {
+            Ok(Arc::new(BTreeMap::from([(
+                self.version.clone(),
+                RegistryVersionInfo {
+                    deps: Default::default(),
+                },
+            )])))
+        }
+
+        fn install_to(
+            &self,
+            name: &ModuleName,
+            version: &Version,
+            to: &Path,
+            _quiet: bool,
+        ) -> anyhow::Result<()> {
+            std::fs::create_dir_all(to)?;
+            self.install_source(name, version, to)
+        }
+
+        fn extract_to(
+            &self,
+            name: &ModuleName,
+            version: &Version,
+            to: &Path,
+            _quiet: bool,
+        ) -> anyhow::Result<()> {
+            self.install_source(name, version, to)
+        }
+
+        fn source_checksum(
+            &self,
+            _name: &ModuleName,
+            _version: &Version,
+        ) -> anyhow::Result<String> {
+            Ok(self.checksum.clone())
+        }
+    }
+
+    fn test_env() -> (ResolvedEnv, moonutil::resolution::ModuleId) {
+        let version = Version::new(1, 2, 3);
+        let source = ModuleSource::new_full(
+            "test/module".into(),
+            version.clone(),
+            ModuleSourceKind::Registry,
+        );
+        ResolvedEnv::only_one_module(
+            source,
+            MoonMod {
+                name: "test/module".to_string(),
+                version: Some(version),
+                ..Default::default()
+            },
+        )
+    }
+
+    fn user_log() -> UserLog {
+        UserLog::new(log::LevelFilter::Error)
+    }
+
+    fn global_cache(path: &Path) -> CacheRoot {
+        CacheRoot::Path {
+            kind: CacheKind::DependencySources,
+            path: path.to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn source_layout_is_canonical() {
+        let cache = tempfile::TempDir::new().unwrap();
+        let store = ImmutableDependencySource::new(cache.path());
+        let (resolved, module) = test_env();
+
+        assert_eq!(
+            store.source_dir(resolved.module_source(module), "0123456789abcdef"),
+            cache
+                .path()
+                .join("v1/sources/test/module/1.2.3/0123456789abcdef")
+        );
+    }
+
+    #[test]
+    fn source_is_published_once_and_reused() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let cache = global_cache(&sandbox.path().join("cache"));
+        let registry = TestRegistry::new(false);
+        let (resolved, module) = test_env();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+
+        let first = source
+            .ensure(&registry, &resolved, false, &user_log())
+            .unwrap();
+        let sentinel = first[module].join("reuse-sentinel");
+        std::fs::write(&sentinel, "keep").unwrap();
+        let second = source
+            .ensure(&registry, &resolved, false, &user_log())
+            .unwrap();
+
+        assert_eq!(first[module], second[module]);
+        assert_eq!(registry.installations.load(Ordering::SeqCst), 1);
+        assert_eq!(std::fs::read_to_string(sentinel).unwrap(), "keep");
+    }
+
+    #[test]
+    fn postadd_is_rejected_before_publication() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let cache_dir = sandbox.path().join("cache");
+        let cache = global_cache(&cache_dir);
+        let registry = TestRegistry::new(true);
+        let (resolved, module) = test_env();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let directory = ImmutableDependencySource::new(&cache_dir)
+            .source_dir(resolved.module_source(module), &registry.checksum);
+
+        let error = source
+            .ensure(&registry, &resolved, false, &user_log())
+            .unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("scripts.postadd"),
+            "{error:#}"
+        );
+        assert_eq!(registry.installations.load(Ordering::SeqCst), 1);
+        assert!(!directory.exists());
+    }
+
+    #[test]
+    fn frozen_mode_rejects_a_missing_source() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let cache = global_cache(&sandbox.path().join("cache"));
+        let registry = TestRegistry::new(false);
+        let (resolved, _) = test_env();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+
+        let error = source
+            .ensure(&registry, &resolved, true, &user_log())
+            .unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("`frozen` is set"),
+            "{error:#}"
+        );
+        assert_eq!(registry.installations.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn concurrent_publication_installs_once() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let project_dir = sandbox.path().join(".mooncakes");
+        let cache = global_cache(&sandbox.path().join("cache"));
+        let registry = Arc::new(TestRegistry::new(false));
+        let (resolved, _) = test_env();
+
+        std::thread::scope(|scope| {
+            let first = scope.spawn(|| {
+                let source = select(&project_dir, &cache, &resolved).unwrap();
+                source
+                    .ensure(registry.as_ref(), &resolved, false, &user_log())
+                    .unwrap();
+            });
+            let second = scope.spawn(|| {
+                let source = select(&project_dir, &cache, &resolved).unwrap();
+                source
+                    .ensure(registry.as_ref(), &resolved, false, &user_log())
+                    .unwrap();
+            });
+            first.join().unwrap();
+            second.join().unwrap();
+        });
+
+        assert_eq!(registry.installations.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn changed_checksum_publishes_a_distinct_source() {
+        // `lijunchen/hello18@0.1.30` was historically replaced after
+        // publication, so module and version alone are not a safe physical
+        // cache identity even though registry versions should be immutable.
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let cache = global_cache(&sandbox.path().join("cache"));
+        let first_registry = TestRegistry::new(false);
+        let second_registry = TestRegistry::new(false).with_checksum("fedcba9876543210");
+        let (resolved, module) = test_env();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+
+        let first = source
+            .ensure(&first_registry, &resolved, false, &user_log())
+            .unwrap();
+        let second = source
+            .ensure(&second_registry, &resolved, false, &user_log())
+            .unwrap();
+
+        assert_ne!(first[module], second[module]);
+        assert!(first[module].join("moon.mod.json").is_file());
+        assert!(second[module].join("moon.mod.json").is_file());
+    }
+
+    #[test]
+    fn disabled_cache_uses_project_sources() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let project_dir = sandbox.path().join(".mooncakes");
+        let cache = CacheRoot::Disabled;
+        let registry = TestRegistry::new(false);
+        let (resolved, module) = test_env();
+        let source = select(&project_dir, &cache, &resolved).unwrap();
+
+        let paths = source
+            .ensure(&registry, &resolved, false, &user_log())
+            .unwrap();
+
+        assert_eq!(paths[module], project_dir.join("test/module"));
+        assert!(paths[module].join("moon.mod.json").is_file());
+        assert_eq!(registry.installations.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/mooncake/src/dependency_source/global.rs
+++ b/crates/mooncake/src/dependency_source/global.rs
@@ -35,6 +35,7 @@ use super::DependencySource;
 
 const LAYOUT_VERSION: &str = "v1";
 const SOURCES_DIRECTORY: &str = "sources";
+pub(super) const SOURCE_ARCHIVE_CHECKSUM_FILE: &str = ".moon-source-archive-checksum";
 
 /// The append-only global store for registry source trees.
 ///
@@ -49,17 +50,13 @@ impl<'a> ImmutableDependencySource<'a> {
         Self { root }
     }
 
-    pub(super) fn source_dir(&self, module: &ModuleSource, checksum: &str) -> PathBuf {
+    pub(super) fn source_dir(&self, module: &ModuleSource) -> PathBuf {
         self.root
             .join(LAYOUT_VERSION)
             .join(SOURCES_DIRECTORY)
             .join(module.name().username.as_str())
             .join(module.name().unqual.replace('/', "+"))
             .join(module.version().to_string())
-            // Registry versions are intended to be immutable, but keeping the
-            // checksum in the physical identity also isolates historical
-            // archives that were replaced after publication.
-            .join(checksum)
     }
 
     fn prepare_source(
@@ -73,7 +70,7 @@ impl<'a> ImmutableDependencySource<'a> {
     ) -> anyhow::Result<()> {
         match std::fs::symlink_metadata(directory) {
             Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
-                validate_source(directory, module)
+                validate_cached_source(directory, module, checksum)
             }
             Ok(_) => anyhow::bail!(
                 "Dependency source cache entry is not a directory: `{}`",
@@ -105,7 +102,7 @@ impl<'a> ImmutableDependencySource<'a> {
                     module.version(),
                     directory.display()
                 );
-                registry.extract_to(
+                registry.acquire_source_to(
                     module.name(),
                     module.version(),
                     checksum,
@@ -113,6 +110,7 @@ impl<'a> ImmutableDependencySource<'a> {
                     !user_log.is_enabled(log::Level::Info),
                 )?;
                 validate_source(staging.path(), module)?;
+                std::fs::write(staging.path().join(SOURCE_ARCHIVE_CHECKSUM_FILE), checksum)?;
                 let staging = staging.into_path();
                 if let Err(error) = std::fs::rename(&staging, directory) {
                     let _ = std::fs::remove_dir_all(&staging);
@@ -150,16 +148,18 @@ impl DependencySource for ImmutableDependencySource<'_> {
             let directory = match module.source() {
                 ModuleSourceKind::Registry if module.is_core() => toolchain::core(),
                 ModuleSourceKind::Registry => {
-                    let checksum = registry.source_checksum(module.name(), module.version())?;
-                    if checksum.is_empty() || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit())
+                    let checksum =
+                        registry.source_archive_checksum(module.name(), module.version())?;
+                    if checksum.len() != 64
+                        || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit())
                     {
                         anyhow::bail!(
-                            "Registry returned an invalid checksum for {}@{}",
+                            "Registry returned an invalid source archive checksum for {}@{}",
                             module.name(),
                             module.version()
                         );
                     }
-                    let directory = self.source_dir(module, &checksum);
+                    let directory = self.source_dir(module);
                     self.prepare_source(registry, module, &checksum, &directory, frozen, user_log)?;
                     directory
                 }
@@ -175,6 +175,48 @@ impl DependencySource for ImmutableDependencySource<'_> {
 
         Ok(result)
     }
+}
+
+fn validate_cached_source(
+    directory: &Path,
+    module: &ModuleSource,
+    expected_checksum: &str,
+) -> anyhow::Result<()> {
+    let checksum_file = directory.join(SOURCE_ARCHIVE_CHECKSUM_FILE);
+    let cached_checksum = match std::fs::read_to_string(&checksum_file) {
+        Ok(checksum) => checksum,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            anyhow::bail!(
+                "dependency source cache entry for {}@{} is missing archive checksum metadata; run `moon clean --dep-cache` before retrying",
+                module.name(),
+                module.version()
+            )
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "Unable to read dependency source cache metadata `{}`",
+                    checksum_file.display()
+                )
+            });
+        }
+    };
+    if cached_checksum.len() != 64 || !cached_checksum.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        anyhow::bail!(
+            "dependency source cache entry for {}@{} has invalid archive checksum metadata; run `moon clean --dep-cache` before retrying",
+            module.name(),
+            module.version()
+        );
+    }
+    if cached_checksum != expected_checksum {
+        anyhow::bail!(
+            "registry archive checksum changed for {}@{}; run `moon clean --dep-cache` before retrying",
+            module.name(),
+            module.version()
+        );
+    }
+    validate_source(directory, module)
 }
 
 fn validate_source(directory: &Path, module: &ModuleSource) -> anyhow::Result<()> {

--- a/crates/mooncake/src/dependency_source/global.rs
+++ b/crates/mooncake/src/dependency_source/global.rs
@@ -66,6 +66,7 @@ impl<'a> ImmutableDependencySource<'a> {
         &self,
         registry: &dyn Registry,
         module: &ModuleSource,
+        checksum: &str,
         directory: &Path,
         frozen: bool,
         user_log: &UserLog,
@@ -107,6 +108,7 @@ impl<'a> ImmutableDependencySource<'a> {
                 registry.extract_to(
                     module.name(),
                     module.version(),
+                    checksum,
                     staging.path(),
                     !user_log.is_enabled(log::Level::Info),
                 )?;
@@ -158,7 +160,7 @@ impl DependencySource for ImmutableDependencySource<'_> {
                         );
                     }
                     let directory = self.source_dir(module, &checksum);
-                    self.prepare_source(registry, module, &directory, frozen, user_log)?;
+                    self.prepare_source(registry, module, &checksum, &directory, frozen, user_log)?;
                     directory
                 }
                 ModuleSourceKind::Local(path)

--- a/crates/mooncake/src/dependency_source/global.rs
+++ b/crates/mooncake/src/dependency_source/global.rs
@@ -1,0 +1,201 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Immutable dependency sources stored in the shared global cache.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use moonutil::{
+    locks::FileLock,
+    manifest::read_module_desc_file_in_dir,
+    resolution::{DirSyncResult, ModuleSource, ModuleSourceKind, ResolvedEnv},
+    toolchain,
+    user_log::UserLog,
+};
+
+use crate::registry::Registry;
+
+use super::DependencySource;
+
+const LAYOUT_VERSION: &str = "v1";
+const SOURCES_DIRECTORY: &str = "sources";
+
+/// The append-only global store for registry source trees.
+///
+/// This module owns the complete on-disk layout and publication protocol. A
+/// caller only asks for the resolved module directories returned by `ensure`.
+pub(super) struct ImmutableDependencySource<'a> {
+    root: &'a Path,
+}
+
+impl<'a> ImmutableDependencySource<'a> {
+    pub(super) fn new(root: &'a Path) -> Self {
+        Self { root }
+    }
+
+    pub(super) fn source_dir(&self, module: &ModuleSource, checksum: &str) -> PathBuf {
+        self.root
+            .join(LAYOUT_VERSION)
+            .join(SOURCES_DIRECTORY)
+            .join(module.name().username.as_str())
+            .join(module.name().unqual.replace('/', "+"))
+            .join(module.version().to_string())
+            // Registry versions are intended to be immutable, but keeping the
+            // checksum in the physical identity also isolates historical
+            // archives that were replaced after publication.
+            .join(checksum)
+    }
+
+    fn prepare_source(
+        &self,
+        registry: &dyn Registry,
+        module: &ModuleSource,
+        directory: &Path,
+        frozen: bool,
+        user_log: &UserLog,
+    ) -> anyhow::Result<()> {
+        match std::fs::symlink_metadata(directory) {
+            Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+                validate_source(directory, module)
+            }
+            Ok(_) => anyhow::bail!(
+                "Dependency source cache entry is not a directory: `{}`",
+                directory.display()
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                if frozen {
+                    anyhow::bail!(
+                        "Failed to sync dependencies: `frozen` is set, so the build system cannot prepare missing shared source {}@{}",
+                        module.name(),
+                        module.version()
+                    );
+                }
+                let parent = directory.parent().expect("cache entry must have a parent");
+                std::fs::create_dir_all(parent)?;
+                let staging = tempfile::Builder::new()
+                    .prefix(".source-")
+                    .tempdir_in(parent)
+                    .with_context(|| {
+                        format!(
+                            "Unable to create staging directory for {}@{}",
+                            module.name(),
+                            module.version()
+                        )
+                    })?;
+                log::info!(
+                    "Preparing immutable package {}@{} at {}",
+                    module.name(),
+                    module.version(),
+                    directory.display()
+                );
+                registry.extract_to(
+                    module.name(),
+                    module.version(),
+                    staging.path(),
+                    !user_log.is_enabled(log::Level::Info),
+                )?;
+                validate_source(staging.path(), module)?;
+                let staging = staging.into_path();
+                if let Err(error) = std::fs::rename(&staging, directory) {
+                    let _ = std::fs::remove_dir_all(&staging);
+                    return Err(error).with_context(|| {
+                        format!(
+                            "Unable to publish dependency source cache entry `{}`",
+                            directory.display()
+                        )
+                    });
+                }
+                Ok(())
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+impl DependencySource for ImmutableDependencySource<'_> {
+    fn ensure(
+        &self,
+        registry: &dyn Registry,
+        resolved: &ResolvedEnv,
+        frozen: bool,
+        user_log: &UserLog,
+    ) -> anyhow::Result<DirSyncResult> {
+        let _lock = FileLock::lock_with_user_log(self.root, user_log).with_context(|| {
+            format!(
+                "Unable to lock dependency source cache `{}`",
+                self.root.display()
+            )
+        })?;
+        let mut result = DirSyncResult::default();
+
+        for (id, module) in resolved.all_modules_and_id() {
+            let directory = match module.source() {
+                ModuleSourceKind::Registry if module.is_core() => toolchain::core(),
+                ModuleSourceKind::Registry => {
+                    let checksum = registry.source_checksum(module.name(), module.version())?;
+                    if checksum.is_empty() || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit())
+                    {
+                        anyhow::bail!(
+                            "Registry returned an invalid checksum for {}@{}",
+                            module.name(),
+                            module.version()
+                        );
+                    }
+                    let directory = self.source_dir(module, &checksum);
+                    self.prepare_source(registry, module, &directory, frozen, user_log)?;
+                    directory
+                }
+                ModuleSourceKind::Local(path)
+                | ModuleSourceKind::Stdlib(path)
+                | ModuleSourceKind::SingleFile(path) => path.clone(),
+                ModuleSourceKind::Git(url) => {
+                    anyhow::bail!("Git dependencies are not supported: {url}")
+                }
+            };
+            result.insert(id, directory);
+        }
+
+        Ok(result)
+    }
+}
+
+fn validate_source(directory: &Path, module: &ModuleSource) -> anyhow::Result<()> {
+    let manifest = read_module_desc_file_in_dir(directory)?;
+    if manifest.name != module.name().to_string()
+        || manifest.version.as_ref() != Some(module.version())
+    {
+        anyhow::bail!(
+            "registry source for {}@{} contains a mismatched module manifest",
+            module.name(),
+            module.version()
+        );
+    }
+    if manifest
+        .scripts
+        .as_ref()
+        .is_some_and(|scripts| scripts.contains_key("postadd"))
+    {
+        anyhow::bail!(
+            "cannot prepare {}@{} in the shared dependency source cache because it declares scripts.postadd",
+            module.name(),
+            module.version()
+        );
+    }
+    Ok(())
+}

--- a/crates/mooncake/src/dependency_source/project.rs
+++ b/crates/mooncake/src/dependency_source/project.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Utilities to handle the local package directory, `.mooncakes`.
+//! Project-local dependency sources stored in `.mooncakes`.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -30,10 +30,13 @@ use moonutil::{
     locks::FileLock,
     resolution::{DirSyncResult, ModuleSource, ModuleSourceKind, ResolvedEnv},
     toolchain,
+    user_log::UserLog,
 };
 use semver::Version;
 
 use crate::registry::Registry;
+
+use super::DependencySource;
 
 type DepDirState = HashMap<ArcStr, HashMap<ArcStr, Option<Version>>>;
 type NewDepDirState<'a> = HashMap<ArcStr, HashMap<ArcStr, &'a ModuleSource>>;
@@ -48,21 +51,21 @@ type NewDepDirState<'a> = HashMap<ArcStr, HashMap<ArcStr, &'a ModuleSource>>;
 /// dependencies directory for ease of scanning. Instead, we replace all slashes
 /// in the `pkgname` part with plus `+` sign. For example, a package
 /// `foo/bar/baz` will be stored in the directory `foo/bar+baz`.
-pub(crate) struct DepDir {
+pub(super) struct ProjectDependencySource {
     path: PathBuf,
 }
 
-impl DepDir {
-    pub(crate) fn new(path: impl Into<PathBuf>) -> Self {
-        DepDir { path: path.into() }
+impl ProjectDependencySource {
+    pub(super) fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
     }
 
-    pub(crate) fn path(&self) -> &Path {
+    fn path(&self) -> &Path {
         &self.path
     }
 
     /// Returns a list of currently installed packages.
-    pub(crate) fn get_current_state(&self) -> std::io::Result<DepDirState> {
+    fn get_current_state(&self) -> std::io::Result<DepDirState> {
         let it = self.path().read_dir()?;
         let mut user_list = HashMap::new();
         for entry in it {
@@ -91,6 +94,19 @@ impl DepDir {
         }
 
         Ok(user_list)
+    }
+}
+
+impl DependencySource for ProjectDependencySource {
+    fn ensure(
+        &self,
+        registry: &dyn Registry,
+        resolved: &ResolvedEnv,
+        frozen: bool,
+        user_log: &UserLog,
+    ) -> anyhow::Result<DirSyncResult> {
+        sync(self, registry, resolved, frozen, user_log).context("When installing packages")?;
+        resolve_paths(self, resolved)
     }
 }
 
@@ -196,13 +212,12 @@ fn diff_dep_dir_state<'a>(
 /// If `frozen` is true, the function will not change anything in the current
 /// dependency directory. If the desired dependency list cannot be created
 /// from the current directory, this function will return an error.
-pub(crate) fn sync_deps(
-    dep_dir: &DepDir,
+fn sync(
+    dep_dir: &ProjectDependencySource,
     registry: &dyn Registry,
     pkg_list: &ResolvedEnv,
-    quiet: bool,
     frozen: bool,
-    verbose: bool,
+    user_log: &UserLog,
 ) -> anyhow::Result<()> {
     // If nothing needs to be installed, don't bother
     let target_dep_dir = pkg_list_to_dep_dir_state(pkg_list.all_modules());
@@ -214,7 +229,7 @@ pub(crate) fn sync_deps(
     // Ensure the directory exists.
     std::fs::create_dir_all(dep_dir.path())?;
     // Lock with a file within the directory
-    let _lock = FileLock::lock_with_verbosity(dep_dir.path(), verbose).with_context(|| {
+    let _lock = FileLock::lock_with_user_log(dep_dir.path(), user_log).with_context(|| {
         format!(
             "Unable to lock folder `{}` for downloading dependencies",
             dep_dir.path().display()
@@ -264,7 +279,12 @@ pub(crate) fn sync_deps(
             let ModuleSourceKind::Registry = version.source() else {
                 unreachable!()
             };
-            registry.install_to(version.name(), version.version(), &pkg_path, quiet)?;
+            registry.install_to(
+                version.name(),
+                version.version(),
+                &pkg_path,
+                !user_log.is_enabled(log::Level::Info),
+            )?;
             // TODO: parallelize this
         }
     }
@@ -274,7 +294,7 @@ pub(crate) fn sync_deps(
     Ok(())
 }
 
-fn pkg_to_dir(dep_dir: &DepDir, username: &str, pkgname: &str) -> PathBuf {
+fn pkg_to_dir(dep_dir: &ProjectDependencySource, username: &str, pkgname: &str) -> PathBuf {
     // Special case: core library locates in ~/.moon
     if format!("{username}/{pkgname}") == MOONBITLANG_CORE {
         return toolchain::core();
@@ -284,30 +304,36 @@ fn pkg_to_dir(dep_dir: &DepDir, username: &str, pkgname: &str) -> PathBuf {
 }
 
 /// The result of a directory sync.
-fn map_source_to_dir(dep_dir: &DepDir, module: &ModuleSource) -> PathBuf {
-    match module.source() {
+fn map_source_to_dir(
+    dep_dir: &ProjectDependencySource,
+    module: &ModuleSource,
+) -> anyhow::Result<PathBuf> {
+    Ok(match module.source() {
         ModuleSourceKind::Registry => {
             pkg_to_dir(dep_dir, &module.name().username, &module.name().unqual)
         }
         ModuleSourceKind::Local(path) => path.clone(),
         ModuleSourceKind::Git(url) => {
-            todo!("Git dependency is not yet supported. Got git url: {}", url)
+            anyhow::bail!("Git dependencies are not supported: {url}")
         }
         ModuleSourceKind::Stdlib(path) => path.clone(),
         ModuleSourceKind::SingleFile(path) => path.clone(),
-    }
+    })
 }
 
 /// Resolve the directory for each module in this build.
 ///
-/// Assumes [`sync_deps`] is already called. Otherwise, modules might point to
+/// Assumes [`sync`] is already called. Otherwise, modules might point to
 /// directories that don't exist yet because they are not synced yet.
-pub(crate) fn resolve_dep_dirs(dep_dir: &DepDir, pkg_list: &ResolvedEnv) -> DirSyncResult {
+fn resolve_paths(
+    dep_dir: &ProjectDependencySource,
+    pkg_list: &ResolvedEnv,
+) -> anyhow::Result<DirSyncResult> {
     let mut res = DirSyncResult::default();
     for (id, module) in pkg_list.all_modules_and_id() {
-        res.insert(id, map_source_to_dir(dep_dir, module));
+        res.insert(id, map_source_to_dir(dep_dir, module)?);
     }
-    res
+    Ok(res)
 }
 
 #[cfg(test)]

--- a/crates/mooncake/src/lib.rs
+++ b/crates/mooncake/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![warn(clippy::clone_on_ref_ptr)]
 
-pub(crate) mod dep_dir;
+pub(crate) mod dependency_source;
 pub mod pkg;
 pub mod registry;
 pub(crate) mod resolver;

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -196,6 +196,7 @@ pub fn add(
         false,
         false,
         true,
+        &moonutil::cache::CacheRoot::Disabled,
     )?;
 
     if module_dir.join(MOON_MOD).exists() {

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -17,14 +17,14 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::{
-    dep_dir::resolve_dep_dirs,
-    registry,
+    dependency_source, registry,
     resolver::{ResolveConfig, resolve_with_default_env_and_resolver},
 };
 
 use super::sync::SyncOutputOptions;
 use anyhow::Context;
 use moonutil::{
+    cache::CacheRoot,
     constants::MOONBITLANG_CORE,
     project::PackageDirs,
     resolution::{
@@ -94,6 +94,7 @@ pub(crate) fn install_impl(
     verbose: bool,
     dont_sync: bool,
     no_std: bool,
+    source_cache: &CacheRoot,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult)> {
     let includes_core = roots
         .iter()
@@ -108,35 +109,26 @@ pub(crate) fn install_impl(
     };
 
     let res = resolve_with_default_env_and_resolver(&resolve_config, roots)?;
-    let dep_dir = crate::dep_dir::DepDir::new(dirs.mooncakes_dir.clone());
-
-    crate::dep_dir::sync_deps(
-        &dep_dir,
-        resolve_config.registry.as_ref(),
-        &res,
-        output_options.quiet(),
-        dont_sync,
-        output_options.verbose(),
-    )
-    .context("When installing packages")?;
-
-    let dir_sync_result = resolve_dep_dirs(&dep_dir, &res);
+    let dependency_source = dependency_source::select(&dirs.mooncakes_dir, source_cache, &res)?;
+    let user_log = output_options.user_log();
+    let dependency_paths =
+        dependency_source.ensure(resolve_config.registry.as_ref(), &res, dont_sync, &user_log)?;
 
     install_bin_deps(
         verbose,
         &res,
-        &dir_sync_result,
+        &dependency_paths,
         &dirs.target_dir,
         &dirs.mooncake_bin_dir,
     )?;
 
-    Ok((res, dir_sync_result))
+    Ok((res, dependency_paths))
 }
 
 fn install_bin_deps(
     verbose: bool,
     res: &ResolvedEnv,
-    dep_dir: &DirSyncResult,
+    dependency_paths: &DirSyncResult,
     target_dir: &Path,
     mooncake_bin_dir: &Path,
 ) -> Result<(), anyhow::Error> {
@@ -154,7 +146,9 @@ fn install_bin_deps(
                 .get(&edge.name.to_string()) // inefficient but fine for now
                 .unwrap();
 
-            let path = dep_dir.get(id).expect("Failed to get dep dir");
+            let path = dependency_paths
+                .get(id)
+                .expect("Failed to get dependency source path");
             let module_source = res.module_source(id);
             let prepared =
                 prepare_bin_dep(path, target_dir, mooncake_bin_dir, module_source.source())?;

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -24,6 +24,7 @@ use anyhow::Context;
 use indexmap::IndexMap;
 use moonutil::{
     build_options::{MoonbuildOpt, MooncOpt},
+    cache::CacheRoot,
     cli_support::AutoSyncFlags,
     front_matter::MbtMdHeader,
     manifest::{MoonMod, read_module_desc_file_in_dir},
@@ -32,6 +33,7 @@ use moonutil::{
         read_workspace_file,
     },
     resolution::{DirSyncResult, ModuleSource, ResolvedEnv, ResolvedModule, ResolvedRootModules},
+    user_log::UserLog,
 };
 use semver::Version;
 
@@ -46,17 +48,22 @@ impl SyncOutputOptions {
         Self { quiet, verbose }
     }
 
-    pub fn quiet(self) -> bool {
-        self.quiet
-    }
-
-    pub fn verbose(self) -> bool {
-        self.verbose
-    }
-
     pub fn with_quiet(mut self, quiet: bool) -> Self {
         self.quiet = quiet;
         self
+    }
+
+    pub(crate) fn user_log(self) -> UserLog {
+        // Preserve the existing sync policy while expressing it as one log
+        // level: acquisition is informational, while lock waits are verbose.
+        let level = if self.quiet {
+            log::LevelFilter::Error
+        } else if self.verbose {
+            log::LevelFilter::Debug
+        } else {
+            log::LevelFilter::Info
+        };
+        UserLog::new(level)
     }
 }
 
@@ -103,8 +110,15 @@ pub fn auto_sync(
     let source = ModuleSource::from_local_module(&module, &dirs.source_dir);
     let (roots, _) = ResolvedModule::only_one_module(source, module);
 
-    let (resolved_env, sync_result) =
-        super::install::install_impl(dirs, roots, output_options, false, cli.dont_sync(), no_std)?;
+    let (resolved_env, sync_result) = super::install::install_impl(
+        dirs,
+        roots,
+        output_options,
+        false,
+        cli.dont_sync(),
+        no_std,
+        &CacheRoot::Disabled,
+    )?;
     log::debug!("Dir sync result: {:?}", sync_result);
     Ok((resolved_env, sync_result, None))
 }
@@ -129,8 +143,15 @@ fn resolve_workspace_sync(
         roots.insert(ResolvedModule::new(source, module));
     }
 
-    let (resolved_env, sync_result) =
-        super::install::install_impl(dirs, roots, output_options, false, cli.dont_sync(), no_std)?;
+    let (resolved_env, sync_result) = super::install::install_impl(
+        dirs,
+        roots,
+        output_options,
+        false,
+        cli.dont_sync(),
+        no_std,
+        &CacheRoot::Disabled,
+    )?;
     log::debug!("Dir sync result: {:?}", sync_result);
     Ok((resolved_env, sync_result, Some(workspace)))
 }
@@ -179,6 +200,7 @@ pub fn auto_sync_for_single_mbt_md(
         moonbuild_opt.verbose,
         dont_sync,
         false,
+        &CacheRoot::Disabled,
     )?;
     log::debug!("Dir sync result: {:?}", dir_sync_result);
     Ok((resolved_env, dir_sync_result, m))
@@ -189,6 +211,7 @@ pub fn auto_sync_for_single_file_rr(
     sync_flags: &AutoSyncFlags,
     front_matter_deps: Option<&IndexMap<String, moonutil::dependency::SourceDependencyInfo>>,
     output_options: SyncOutputOptions,
+    source_cache: &CacheRoot,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult)> {
     let mut synth_deps = IndexMap::new();
     if let Some(deps_map) = front_matter_deps {
@@ -213,8 +236,27 @@ pub fn auto_sync_for_single_file_rr(
         false,
         sync_flags.dont_sync(),
         false,
+        source_cache,
     )?;
 
     log::debug!("Dir sync result: {:?}", dir_sync_result);
     Ok((resolved_env, dir_sync_result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SyncOutputOptions;
+
+    #[test]
+    fn sync_output_options_configure_user_log() {
+        let normal = SyncOutputOptions::new(false, false).user_log();
+        assert!(normal.is_enabled(log::Level::Info));
+        assert!(!normal.is_enabled(log::Level::Debug));
+
+        let verbose = SyncOutputOptions::new(false, true).user_log();
+        assert!(verbose.is_enabled(log::Level::Debug));
+
+        let quiet = SyncOutputOptions::new(true, true).user_log();
+        assert!(!quiet.is_enabled(log::Level::Info));
+    }
 }

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -77,6 +77,19 @@ pub trait Registry {
         to: &Path,
         quiet: bool,
     ) -> anyhow::Result<()>;
+
+    /// Extract the published package source without executing
+    /// package-controlled hooks such as `scripts.postadd`.
+    fn extract_to(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        to: &Path,
+        quiet: bool,
+    ) -> anyhow::Result<()>;
+
+    /// Return the checksum that identifies the published source archive.
+    fn source_checksum(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String>;
 }
 
 impl<R> Registry for &mut R
@@ -98,6 +111,20 @@ where
         quiet: bool,
     ) -> anyhow::Result<()> {
         (**self).install_to(name, version, to, quiet)
+    }
+
+    fn extract_to(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        to: &Path,
+        quiet: bool,
+    ) -> anyhow::Result<()> {
+        (**self).extract_to(name, version, to, quiet)
+    }
+
+    fn source_checksum(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {
+        (**self).source_checksum(name, version)
     }
 
     fn get_latest_version(&self, name: &ModuleName) -> Option<Version> {
@@ -128,6 +155,20 @@ where
         quiet: bool,
     ) -> anyhow::Result<()> {
         (**self).install_to(name, version, to, quiet)
+    }
+
+    fn extract_to(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        to: &Path,
+        quiet: bool,
+    ) -> anyhow::Result<()> {
+        (**self).extract_to(name, version, to, quiet)
+    }
+
+    fn source_checksum(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {
+        (**self).source_checksum(name, version)
     }
 
     fn get_latest_version(&self, name: &ModuleName) -> Option<Version> {

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -78,12 +78,14 @@ pub trait Registry {
         quiet: bool,
     ) -> anyhow::Result<()>;
 
-    /// Extract the published package source without executing
-    /// package-controlled hooks such as `scripts.postadd`.
+    /// Extract the published package source verified against the checksum
+    /// selected by the caller, without executing package-controlled hooks such
+    /// as `scripts.postadd`.
     fn extract_to(
         &self,
         name: &ModuleName,
         version: &Version,
+        expected_checksum: &str,
         to: &Path,
         quiet: bool,
     ) -> anyhow::Result<()>;
@@ -117,10 +119,11 @@ where
         &self,
         name: &ModuleName,
         version: &Version,
+        expected_checksum: &str,
         to: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
-        (**self).extract_to(name, version, to, quiet)
+        (**self).extract_to(name, version, expected_checksum, to, quiet)
     }
 
     fn source_checksum(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {
@@ -161,10 +164,11 @@ where
         &self,
         name: &ModuleName,
         version: &Version,
+        expected_checksum: &str,
         to: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
-        (**self).extract_to(name, version, to, quiet)
+        (**self).extract_to(name, version, expected_checksum, to, quiet)
     }
 
     fn source_checksum(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -78,10 +78,13 @@ pub trait Registry {
         quiet: bool,
     ) -> anyhow::Result<()>;
 
-    /// Extract the published package source verified against the checksum
-    /// selected by the caller, without executing package-controlled hooks such
-    /// as `scripts.postadd`.
-    fn extract_to(
+    /// Ensure the published source archive is available, verify it against the
+    /// checksum selected by the caller, and extract it without executing
+    /// package-controlled hooks such as `scripts.postadd`.
+    ///
+    /// The registry adapter decides whether to reuse a downloaded archive or
+    /// acquire it remotely; callers do not need to prepare an archive first.
+    fn acquire_source_to(
         &self,
         name: &ModuleName,
         version: &Version,
@@ -90,8 +93,13 @@ pub trait Registry {
         quiet: bool,
     ) -> anyhow::Result<()>;
 
-    /// Return the checksum that identifies the published source archive.
-    fn source_checksum(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String>;
+    /// Return the registry index's SHA-256 checksum for the published source
+    /// ZIP archive.
+    fn source_archive_checksum(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+    ) -> anyhow::Result<String>;
 }
 
 impl<R> Registry for &mut R
@@ -115,7 +123,7 @@ where
         (**self).install_to(name, version, to, quiet)
     }
 
-    fn extract_to(
+    fn acquire_source_to(
         &self,
         name: &ModuleName,
         version: &Version,
@@ -123,11 +131,15 @@ where
         to: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
-        (**self).extract_to(name, version, expected_checksum, to, quiet)
+        (**self).acquire_source_to(name, version, expected_checksum, to, quiet)
     }
 
-    fn source_checksum(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {
-        (**self).source_checksum(name, version)
+    fn source_archive_checksum(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+    ) -> anyhow::Result<String> {
+        (**self).source_archive_checksum(name, version)
     }
 
     fn get_latest_version(&self, name: &ModuleName) -> Option<Version> {
@@ -160,7 +172,7 @@ where
         (**self).install_to(name, version, to, quiet)
     }
 
-    fn extract_to(
+    fn acquire_source_to(
         &self,
         name: &ModuleName,
         version: &Version,
@@ -168,11 +180,15 @@ where
         to: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
-        (**self).extract_to(name, version, expected_checksum, to, quiet)
+        (**self).acquire_source_to(name, version, expected_checksum, to, quiet)
     }
 
-    fn source_checksum(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {
-        (**self).source_checksum(name, version)
+    fn source_archive_checksum(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+    ) -> anyhow::Result<String> {
+        (**self).source_archive_checksum(name, version)
     }
 
     fn get_latest_version(&self, name: &ModuleName) -> Option<Version> {

--- a/crates/mooncake/src/registry/mock.rs
+++ b/crates/mooncake/src/registry/mock.rs
@@ -179,6 +179,20 @@ impl Registry for MockRegistry {
     ) -> anyhow::Result<()> {
         panic!("Mock registry does not support installing")
     }
+
+    fn extract_to(
+        &self,
+        _name: &ModuleName,
+        _version: &Version,
+        _to: &std::path::Path,
+        _quiet: bool,
+    ) -> anyhow::Result<()> {
+        panic!("Mock registry does not support extracting sources")
+    }
+
+    fn source_checksum(&self, _name: &ModuleName, _version: &Version) -> anyhow::Result<String> {
+        panic!("Mock registry does not provide source checksums")
+    }
 }
 
 #[cfg(test)]

--- a/crates/mooncake/src/registry/mock.rs
+++ b/crates/mooncake/src/registry/mock.rs
@@ -184,6 +184,7 @@ impl Registry for MockRegistry {
         &self,
         _name: &ModuleName,
         _version: &Version,
+        _expected_checksum: &str,
         _to: &std::path::Path,
         _quiet: bool,
     ) -> anyhow::Result<()> {

--- a/crates/mooncake/src/registry/mock.rs
+++ b/crates/mooncake/src/registry/mock.rs
@@ -180,7 +180,7 @@ impl Registry for MockRegistry {
         panic!("Mock registry does not support installing")
     }
 
-    fn extract_to(
+    fn acquire_source_to(
         &self,
         _name: &ModuleName,
         _version: &Version,
@@ -191,7 +191,11 @@ impl Registry for MockRegistry {
         panic!("Mock registry does not support extracting sources")
     }
 
-    fn source_checksum(&self, _name: &ModuleName, _version: &Version) -> anyhow::Result<String> {
+    fn source_archive_checksum(
+        &self,
+        _name: &ModuleName,
+        _version: &Version,
+    ) -> anyhow::Result<String> {
         panic!("Mock registry does not provide source checksums")
     }
 }

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -19,12 +19,12 @@
 use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap},
-    io::BufRead,
-    path::Path,
+    io::{BufRead, Read, Write},
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
-use anyhow::bail;
+use anyhow::{Context, bail};
 use indexmap::map::IndexMap;
 use moonutil::{
     dependency::SourceDependencyInfo, registry::RegistryConfig, resolution::ModuleName,
@@ -131,6 +131,20 @@ impl super::Registry for OnlineRegistry {
     ) -> anyhow::Result<()> {
         self.install_to_impl(name, version, to, quiet)
     }
+
+    fn extract_to(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        to: &Path,
+        quiet: bool,
+    ) -> anyhow::Result<()> {
+        OnlineRegistry::extract_to(self, name, version, to, quiet)
+    }
+
+    fn source_checksum(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {
+        self.read_checksum_from_index_file(name, version)
+    }
 }
 
 fn calc_sha2(p: &Path) -> anyhow::Result<String> {
@@ -188,20 +202,20 @@ impl OnlineRegistry {
         );
     }
 
-    fn download_or_using_cache(
+    fn download_or_use_cache(
         &self,
         name: &ModuleName,
         version: &Version,
         quiet: bool,
-    ) -> anyhow::Result<bytes::Bytes> {
+    ) -> anyhow::Result<PathBuf> {
         let pkg_index = self.index_file_of(name);
         if !pkg_index.exists() {
             anyhow::bail!("Module {}@{} not found", name, version);
         }
         let cache_file = cache_of(name, version);
+        let checksum = self.read_checksum_from_index_file(name, version)?;
         let mut checksum_ok = false;
         if cache_file.exists() {
-            let checksum = self.read_checksum_from_index_file(name, version)?;
             let current_checksum = calc_sha2(&cache_file);
             if current_checksum.is_ok() && current_checksum.unwrap() == checksum {
                 checksum_ok = true;
@@ -211,8 +225,7 @@ impl OnlineRegistry {
             if !quiet {
                 eprintln!("Using cached {name}@{version}");
             }
-            let data = std::fs::read(cache_file)?;
-            return Ok(bytes::Bytes::from(data));
+            return Ok(cache_file);
         }
         if !quiet {
             eprintln!("Downloading {name}@{version}");
@@ -222,18 +235,40 @@ impl OnlineRegistry {
             .finish();
         let url = format!("{}/{}.zip", self.url_base, filepath);
         let client = reqwest::blocking::Client::new();
-        let data = client
+        let mut response = client
             .get(url)
             .header(
                 USER_AGENT,
                 format!("mooncake/{}", env!("CARGO_PKG_VERSION")),
             )
             .send()?
-            .error_for_status()?
-            .bytes()?;
-        std::fs::create_dir_all(cache_file.parent().unwrap())?;
-        std::fs::write(cache_file, &data)?;
-        Ok(data)
+            .error_for_status()?;
+
+        let parent = cache_file
+            .parent()
+            .expect("registry cache file has a parent");
+        std::fs::create_dir_all(parent)?;
+        let mut archive = tempfile::NamedTempFile::new_in(parent)?;
+        use sha2::Digest;
+        let mut hasher = sha2::Sha256::new();
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let bytes_read = response.read(&mut buffer)?;
+            if bytes_read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..bytes_read]);
+            archive.write_all(&buffer[..bytes_read])?;
+        }
+        let actual_checksum = format!("{:x}", hasher.finalize());
+        if actual_checksum != checksum {
+            bail!(
+                "Checksum mismatch for {name}@{version}: expected {checksum}, got {actual_checksum}"
+            );
+        }
+        archive.flush()?;
+        archive.persist(&cache_file).map_err(|error| error.error)?;
+        Ok(cache_file)
     }
 
     pub fn install_to_impl(
@@ -264,8 +299,14 @@ impl OnlineRegistry {
             std::fs::create_dir_all(pkg_install_dir).unwrap();
         }
 
-        let data = self.download_or_using_cache(name, version, quiet)?;
-        extract_zip_to_dir(pkg_install_dir, data)?;
+        let archive_path = self.download_or_use_cache(name, version, quiet)?;
+        let archive = std::fs::File::open(&archive_path).with_context(|| {
+            format!(
+                "failed to open cached registry archive `{}`",
+                archive_path.display()
+            )
+        })?;
+        extract_zip_to_dir(pkg_install_dir, archive)?;
         Ok(())
     }
 }

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -191,6 +191,35 @@ fn open_verified_archive(path: &Path, expected_checksum: &str) -> std::io::Resul
     Ok(Some(archive))
 }
 
+fn copy_archive_and_verify_checksum(
+    source: &mut impl Read,
+    destination: &mut impl Write,
+    name: &ModuleName,
+    version: &Version,
+    expected_checksum: &str,
+) -> anyhow::Result<()> {
+    use sha2::Digest;
+
+    let mut hasher = sha2::Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let bytes_read = source.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+        destination.write_all(&buffer[..bytes_read])?;
+    }
+
+    let actual_checksum = format!("{:x}", hasher.finalize());
+    if actual_checksum != expected_checksum {
+        bail!(
+            "Checksum mismatch for {name}@{version}: expected {expected_checksum}, got {actual_checksum}"
+        );
+    }
+    Ok(())
+}
+
 impl OnlineRegistry {
     fn read_checksum_from_index_file(
         &self,
@@ -276,23 +305,13 @@ impl OnlineRegistry {
             .expect("registry cache file has a parent");
         std::fs::create_dir_all(parent)?;
         let mut archive = tempfile::NamedTempFile::new_in(parent)?;
-        use sha2::Digest;
-        let mut hasher = sha2::Sha256::new();
-        let mut buffer = [0_u8; 64 * 1024];
-        loop {
-            let bytes_read = response.read(&mut buffer)?;
-            if bytes_read == 0 {
-                break;
-            }
-            hasher.update(&buffer[..bytes_read]);
-            archive.write_all(&buffer[..bytes_read])?;
-        }
-        let actual_checksum = format!("{:x}", hasher.finalize());
-        if actual_checksum != expected_checksum {
-            bail!(
-                "Checksum mismatch for {name}@{version}: expected {expected_checksum}, got {actual_checksum}"
-            );
-        }
+        copy_archive_and_verify_checksum(
+            &mut response,
+            &mut archive,
+            name,
+            version,
+            expected_checksum,
+        )?;
         archive.flush()?;
         let mut archive = archive.persist(&cache_file).map_err(|error| error.error)?;
         archive.rewind()?;
@@ -347,10 +366,12 @@ fn test_urlencode() {
 #[cfg(test)]
 mod tests {
     use std::{
-        io::{Cursor, Read, Write},
-        net::TcpListener,
+        io::{Cursor, Write},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    #[cfg(unix)]
+    use std::io::Read;
 
     use super::*;
     use crate::registry::Registry;
@@ -371,6 +392,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn verified_archive_handle_survives_cache_path_replacement() {
         let cache = tempfile::TempDir::new().unwrap();
@@ -391,6 +413,25 @@ mod tests {
         let mut contents = String::new();
         archive.read_to_string(&mut contents).unwrap();
         assert_eq!(contents, "verified archive");
+    }
+
+    #[test]
+    fn cached_archive_checksum_mismatch_is_rejected() {
+        let cache = tempfile::TempDir::new().unwrap();
+        let archive_path = cache.path().join("archive.zip");
+        std::fs::write(&archive_path, "cached archive").unwrap();
+
+        let archive = open_verified_archive(
+            &archive_path,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .unwrap();
+
+        assert!(archive.is_none());
+        assert_eq!(
+            std::fs::read_to_string(archive_path).unwrap(),
+            "cached archive"
+        );
     }
 
     fn test_registry(sandbox: &tempfile::TempDir) -> (OnlineRegistry, ModuleName, Version) {
@@ -445,41 +486,27 @@ mod tests {
     }
 
     #[test]
-    fn acquire_source_to_rejects_cached_and_downloaded_checksum_mismatches() {
-        let sandbox = tempfile::TempDir::new().unwrap();
-        let (mut registry, name, version) = test_registry(&sandbox);
+    fn downloaded_archive_checksum_mismatch_is_rejected() {
+        let name: ModuleName = "test/module".into();
+        let version = Version::new(1, 2, 3);
         let archive = test_archive();
-        let archive_path = registry.archive_cache_file_of(&name, &version);
-        std::fs::create_dir_all(archive_path.parent().unwrap()).unwrap();
-        std::fs::write(&archive_path, &archive).unwrap();
-
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        registry.url_base = format!("http://{}", listener.local_addr().unwrap());
-        let response_archive = archive.clone();
-        let server = std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            write!(
-                stream,
-                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                response_archive.len()
-            )
-            .unwrap();
-            stream.write_all(&response_archive).unwrap();
-        });
-        let destination = sandbox.path().join("source");
+        let mut downloaded = Vec::new();
         let expected_checksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
-        let error = registry
-            .acquire_source_to(&name, &version, expected_checksum, &destination, true)
-            .unwrap_err();
-        server.join().unwrap();
+        let error = copy_archive_and_verify_checksum(
+            &mut Cursor::new(&archive),
+            &mut downloaded,
+            &name,
+            &version,
+            expected_checksum,
+        )
+        .unwrap_err();
 
         assert!(
             format!("{error:#}").contains("Checksum mismatch for test/module@1.2.3"),
             "{error:#}"
         );
-        assert!(!destination.join("moon.mod").exists());
-        assert_eq!(std::fs::read(archive_path).unwrap(), archive);
+        assert_eq!(downloaded, archive);
     }
 
     #[test]

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -19,12 +19,13 @@
 use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap},
-    io::{BufRead, Read, Write},
-    path::{Path, PathBuf},
+    fs::File,
+    io::{BufRead, Read, Seek, Write},
+    path::Path,
     sync::Arc,
 };
 
-use anyhow::{Context, bail};
+use anyhow::bail;
 use indexmap::map::IndexMap;
 use moonutil::{
     dependency::SourceDependencyInfo, registry::RegistryConfig, resolution::ModuleName,
@@ -148,17 +149,13 @@ impl super::Registry for OnlineRegistry {
     }
 }
 
-fn calc_sha2(p: &Path) -> anyhow::Result<String> {
+fn calc_sha2(reader: &mut impl Read) -> anyhow::Result<String> {
     use sha2::{Digest, Sha256};
-    use std::fs::File;
-    use std::io::prelude::*;
-
-    let mut file = File::open(p)?;
 
     let mut hasher = Sha256::new();
     let mut buffer = [0; 1024];
     loop {
-        let bytes_read = file.read(&mut buffer)?;
+        let bytes_read = reader.read(&mut buffer)?;
         if bytes_read == 0 {
             break;
         }
@@ -168,6 +165,17 @@ fn calc_sha2(p: &Path) -> anyhow::Result<String> {
     // read hash digest and consume hasher
     let result = hasher.finalize();
     Ok(format!("{result:x}"))
+}
+
+/// Keep the file that was hashed open so a concurrent cache-path replacement
+/// cannot change the bytes later consumed by extraction.
+fn open_verified_archive(path: &Path, expected_checksum: &str) -> anyhow::Result<Option<File>> {
+    let mut archive = File::open(path)?;
+    if calc_sha2(&mut archive)? != expected_checksum {
+        return Ok(None);
+    }
+    archive.rewind()?;
+    Ok(Some(archive))
 }
 
 impl OnlineRegistry {
@@ -209,24 +217,17 @@ impl OnlineRegistry {
         version: &Version,
         expected_checksum: &str,
         quiet: bool,
-    ) -> anyhow::Result<PathBuf> {
+    ) -> anyhow::Result<File> {
         let pkg_index = self.index_file_of(name);
         if !pkg_index.exists() {
             anyhow::bail!("Module {}@{} not found", name, version);
         }
         let cache_file = cache_of(name, version);
-        let mut checksum_ok = false;
-        if cache_file.exists() {
-            let current_checksum = calc_sha2(&cache_file);
-            if current_checksum.is_ok() && current_checksum.unwrap() == expected_checksum {
-                checksum_ok = true;
-            }
-        }
-        if checksum_ok {
+        if let Ok(Some(archive)) = open_verified_archive(&cache_file, expected_checksum) {
             if !quiet {
                 eprintln!("Using cached {name}@{version}");
             }
-            return Ok(cache_file);
+            return Ok(archive);
         }
         if !quiet {
             eprintln!("Downloading {name}@{version}");
@@ -268,8 +269,9 @@ impl OnlineRegistry {
             );
         }
         archive.flush()?;
-        archive.persist(&cache_file).map_err(|error| error.error)?;
-        Ok(cache_file)
+        let mut archive = archive.persist(&cache_file).map_err(|error| error.error)?;
+        archive.rewind()?;
+        Ok(archive)
     }
 
     pub fn install_to_impl(
@@ -302,13 +304,7 @@ impl OnlineRegistry {
             std::fs::create_dir_all(pkg_install_dir).unwrap();
         }
 
-        let archive_path = self.download_or_use_cache(name, version, expected_checksum, quiet)?;
-        let archive = std::fs::File::open(&archive_path).with_context(|| {
-            format!(
-                "failed to open cached registry archive `{}`",
-                archive_path.display()
-            )
-        })?;
+        let archive = self.download_or_use_cache(name, version, expected_checksum, quiet)?;
         extract_zip_to_dir(pkg_install_dir, archive)?;
         Ok(())
     }
@@ -333,7 +329,10 @@ fn test_urlencode() {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{
+        io::Read,
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     use super::*;
     use crate::registry::Registry;
@@ -352,6 +351,28 @@ mod tests {
             registry_download_base("https://registry.example.com/"),
             "https://registry.example.com/user"
         );
+    }
+
+    #[test]
+    fn verified_archive_handle_survives_cache_path_replacement() {
+        let cache = tempfile::TempDir::new().unwrap();
+        let archive_path = cache.path().join("archive.zip");
+        std::fs::write(&archive_path, "verified archive").unwrap();
+
+        let mut archive = open_verified_archive(
+            &archive_path,
+            "040a1170825ade3ff37b189dd280153ecfafb99ee929d1cbebb40fe135afdf26",
+        )
+        .unwrap()
+        .unwrap();
+
+        let mut replacement = tempfile::NamedTempFile::new_in(cache.path()).unwrap();
+        replacement.write_all(b"replacement archive").unwrap();
+        replacement.persist(&archive_path).unwrap();
+
+        let mut contents = String::new();
+        archive.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "verified archive");
     }
 
     fn temp_index_dir() -> std::path::PathBuf {

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -136,10 +136,11 @@ impl super::Registry for OnlineRegistry {
         &self,
         name: &ModuleName,
         version: &Version,
+        expected_checksum: &str,
         to: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
-        OnlineRegistry::extract_to(self, name, version, to, quiet)
+        OnlineRegistry::extract_to(self, name, version, expected_checksum, to, quiet)
     }
 
     fn source_checksum(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {
@@ -206,6 +207,7 @@ impl OnlineRegistry {
         &self,
         name: &ModuleName,
         version: &Version,
+        expected_checksum: &str,
         quiet: bool,
     ) -> anyhow::Result<PathBuf> {
         let pkg_index = self.index_file_of(name);
@@ -213,11 +215,10 @@ impl OnlineRegistry {
             anyhow::bail!("Module {}@{} not found", name, version);
         }
         let cache_file = cache_of(name, version);
-        let checksum = self.read_checksum_from_index_file(name, version)?;
         let mut checksum_ok = false;
         if cache_file.exists() {
             let current_checksum = calc_sha2(&cache_file);
-            if current_checksum.is_ok() && current_checksum.unwrap() == checksum {
+            if current_checksum.is_ok() && current_checksum.unwrap() == expected_checksum {
                 checksum_ok = true;
             }
         }
@@ -261,9 +262,9 @@ impl OnlineRegistry {
             archive.write_all(&buffer[..bytes_read])?;
         }
         let actual_checksum = format!("{:x}", hasher.finalize());
-        if actual_checksum != checksum {
+        if actual_checksum != expected_checksum {
             bail!(
-                "Checksum mismatch for {name}@{version}: expected {checksum}, got {actual_checksum}"
+                "Checksum mismatch for {name}@{version}: expected {expected_checksum}, got {actual_checksum}"
             );
         }
         archive.flush()?;
@@ -278,7 +279,8 @@ impl OnlineRegistry {
         pkg_install_dir: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
-        self.extract_to(name, version, pkg_install_dir, quiet)?;
+        let checksum = self.read_checksum_from_index_file(name, version)?;
+        self.extract_to(name, version, &checksum, pkg_install_dir, quiet)?;
         execute_postadd_script(pkg_install_dir)?;
         Ok(())
     }
@@ -288,6 +290,7 @@ impl OnlineRegistry {
         &self,
         name: &ModuleName,
         version: &Version,
+        expected_checksum: &str,
         pkg_install_dir: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
@@ -299,7 +302,7 @@ impl OnlineRegistry {
             std::fs::create_dir_all(pkg_install_dir).unwrap();
         }
 
-        let archive_path = self.download_or_use_cache(name, version, quiet)?;
+        let archive_path = self.download_or_use_cache(name, version, expected_checksum, quiet)?;
         let archive = std::fs::File::open(&archive_path).with_context(|| {
             format!(
                 "failed to open cached registry archive `{}`",

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -25,7 +25,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::bail;
+use anyhow::{Context, bail};
 use indexmap::map::IndexMap;
 use moonutil::{
     dependency::SourceDependencyInfo, registry::RegistryConfig, resolution::ModuleName,
@@ -48,6 +48,7 @@ struct RegistryIndexEntry {
 pub struct OnlineRegistry {
     index: std::path::PathBuf,
     url_base: String, // TODO: add download feature to registry interface
+    archive_cache: std::path::PathBuf,
     cache: RefCell<HashMap<ModuleName, Arc<BTreeMap<Version, RegistryVersionInfo>>>>,
 }
 
@@ -57,6 +58,7 @@ impl OnlineRegistry {
         OnlineRegistry {
             index: moonutil::registry::index(),
             url_base: registry_download_base(&registry),
+            archive_cache: moonutil::registry::cache(),
             cache: RefCell::new(HashMap::new()),
         }
     }
@@ -66,6 +68,13 @@ impl OnlineRegistry {
             .join("user")
             .join(name.username.as_str())
             .join(format!("{}.index", name.unqual))
+    }
+
+    fn archive_cache_file_of(&self, name: &ModuleName, version: &Version) -> std::path::PathBuf {
+        self.archive_cache
+            .join(name.username.as_str())
+            .join(name.unqual.as_str())
+            .join(format!("{version}.zip"))
     }
 }
 
@@ -133,7 +142,7 @@ impl super::Registry for OnlineRegistry {
         self.install_to_impl(name, version, to, quiet)
     }
 
-    fn extract_to(
+    fn acquire_source_to(
         &self,
         name: &ModuleName,
         version: &Version,
@@ -141,15 +150,19 @@ impl super::Registry for OnlineRegistry {
         to: &Path,
         quiet: bool,
     ) -> anyhow::Result<()> {
-        OnlineRegistry::extract_to(self, name, version, expected_checksum, to, quiet)
+        OnlineRegistry::acquire_source_to(self, name, version, expected_checksum, to, quiet)
     }
 
-    fn source_checksum(&self, name: &ModuleName, version: &Version) -> anyhow::Result<String> {
+    fn source_archive_checksum(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+    ) -> anyhow::Result<String> {
         self.read_checksum_from_index_file(name, version)
     }
 }
 
-fn calc_sha2(reader: &mut impl Read) -> anyhow::Result<String> {
+fn calc_sha2(reader: &mut impl Read) -> std::io::Result<String> {
     use sha2::{Digest, Sha256};
 
     let mut hasher = Sha256::new();
@@ -169,7 +182,7 @@ fn calc_sha2(reader: &mut impl Read) -> anyhow::Result<String> {
 
 /// Keep the file that was hashed open so a concurrent cache-path replacement
 /// cannot change the bytes later consumed by extraction.
-fn open_verified_archive(path: &Path, expected_checksum: &str) -> anyhow::Result<Option<File>> {
+fn open_verified_archive(path: &Path, expected_checksum: &str) -> std::io::Result<Option<File>> {
     let mut archive = File::open(path)?;
     if calc_sha2(&mut archive)? != expected_checksum {
         return Ok(None);
@@ -222,12 +235,24 @@ impl OnlineRegistry {
         if !pkg_index.exists() {
             anyhow::bail!("Module {}@{} not found", name, version);
         }
-        let cache_file = cache_of(name, version);
-        if let Ok(Some(archive)) = open_verified_archive(&cache_file, expected_checksum) {
-            if !quiet {
-                eprintln!("Using cached {name}@{version}");
+        let cache_file = self.archive_cache_file_of(name, version);
+        match open_verified_archive(&cache_file, expected_checksum) {
+            Ok(Some(archive)) => {
+                if !quiet {
+                    eprintln!("Using cached {name}@{version}");
+                }
+                return Ok(archive);
             }
-            return Ok(archive);
+            Ok(None) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Unable to read cached registry archive `{}`",
+                        cache_file.display()
+                    )
+                });
+            }
         }
         if !quiet {
             eprintln!("Downloading {name}@{version}");
@@ -282,13 +307,14 @@ impl OnlineRegistry {
         quiet: bool,
     ) -> anyhow::Result<()> {
         let checksum = self.read_checksum_from_index_file(name, version)?;
-        self.extract_to(name, version, &checksum, pkg_install_dir, quiet)?;
+        self.acquire_source_to(name, version, &checksum, pkg_install_dir, quiet)?;
         execute_postadd_script(pkg_install_dir)?;
         Ok(())
     }
 
-    /// Download and extract a registry package without running `scripts.postadd`.
-    pub fn extract_to(
+    /// Reuse or download, verify, and extract a registry package without
+    /// running `scripts.postadd`.
+    pub fn acquire_source_to(
         &self,
         name: &ModuleName,
         version: &Version,
@@ -310,15 +336,6 @@ impl OnlineRegistry {
     }
 }
 
-fn cache_of(name: &ModuleName, version: &Version) -> std::path::PathBuf {
-    let cache_dir = moonutil::registry::cache();
-
-    cache_dir
-        .join(name.username.as_str())
-        .join(name.unqual.as_str())
-        .join(format!("{version}.zip"))
-}
-
 #[test]
 fn test_urlencode() {
     let s = form_urlencoded::Serializer::new(String::new())
@@ -330,7 +347,8 @@ fn test_urlencode() {
 #[cfg(test)]
 mod tests {
     use std::{
-        io::Read,
+        io::{Cursor, Read, Write},
+        net::TcpListener,
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -375,6 +393,120 @@ mod tests {
         assert_eq!(contents, "verified archive");
     }
 
+    fn test_registry(sandbox: &tempfile::TempDir) -> (OnlineRegistry, ModuleName, Version) {
+        let name: ModuleName = "test/module".into();
+        let version = Version::new(1, 2, 3);
+        let index = sandbox.path().join("index");
+        let index_file = index.join("user/test/module.index");
+        std::fs::create_dir_all(index_file.parent().unwrap()).unwrap();
+        std::fs::write(&index_file, "registry entry exists").unwrap();
+        (
+            OnlineRegistry {
+                index,
+                url_base: String::new(),
+                archive_cache: sandbox.path().join("archive-cache"),
+                cache: RefCell::new(HashMap::new()),
+            },
+            name,
+            version,
+        )
+    }
+
+    fn test_archive() -> Vec<u8> {
+        let mut archive = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        archive
+            .start_file("moon.mod", zip::write::FileOptions::default())
+            .unwrap();
+        archive
+            .write_all(b"name = \"test/module\"\nversion = \"1.2.3\"\n")
+            .unwrap();
+        archive.finish().unwrap().into_inner()
+    }
+
+    #[test]
+    fn acquire_source_to_reuses_and_extracts_a_verified_cached_zip() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let (registry, name, version) = test_registry(&sandbox);
+        let archive = test_archive();
+        let checksum = calc_sha2(&mut Cursor::new(&archive)).unwrap();
+        let archive_path = registry.archive_cache_file_of(&name, &version);
+        std::fs::create_dir_all(archive_path.parent().unwrap()).unwrap();
+        std::fs::write(archive_path, archive).unwrap();
+        let destination = sandbox.path().join("source");
+
+        registry
+            .acquire_source_to(&name, &version, &checksum, &destination, true)
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(destination.join("moon.mod")).unwrap(),
+            "name = \"test/module\"\nversion = \"1.2.3\"\n"
+        );
+    }
+
+    #[test]
+    fn acquire_source_to_rejects_cached_and_downloaded_checksum_mismatches() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let (mut registry, name, version) = test_registry(&sandbox);
+        let archive = test_archive();
+        let archive_path = registry.archive_cache_file_of(&name, &version);
+        std::fs::create_dir_all(archive_path.parent().unwrap()).unwrap();
+        std::fs::write(&archive_path, &archive).unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        registry.url_base = format!("http://{}", listener.local_addr().unwrap());
+        let response_archive = archive.clone();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                response_archive.len()
+            )
+            .unwrap();
+            stream.write_all(&response_archive).unwrap();
+        });
+        let destination = sandbox.path().join("source");
+        let expected_checksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+        let error = registry
+            .acquire_source_to(&name, &version, expected_checksum, &destination, true)
+            .unwrap_err();
+        server.join().unwrap();
+
+        assert!(
+            format!("{error:#}").contains("Checksum mismatch for test/module@1.2.3"),
+            "{error:#}"
+        );
+        assert!(!destination.join("moon.mod").exists());
+        assert_eq!(std::fs::read(archive_path).unwrap(), archive);
+    }
+
+    #[test]
+    fn acquire_source_to_reports_cached_archive_io_errors() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let (registry, name, version) = test_registry(&sandbox);
+        let archive_path = registry.archive_cache_file_of(&name, &version);
+        std::fs::create_dir_all(&archive_path).unwrap();
+        let destination = sandbox.path().join("source");
+
+        let error = registry
+            .acquire_source_to(
+                &name,
+                &version,
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                &destination,
+                true,
+            )
+            .unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("Unable to read cached registry archive"),
+            "{error:#}"
+        );
+        assert!(!destination.join("moon.mod").exists());
+    }
+
     fn temp_index_dir() -> std::path::PathBuf {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -401,6 +533,7 @@ mod tests {
         let registry = OnlineRegistry {
             index: index.clone(),
             url_base: String::new(),
+            archive_cache: index.join("archive-cache"),
             cache: RefCell::new(HashMap::new()),
         };
         let versions = registry

--- a/crates/mooncake/src/update.rs
+++ b/crates/mooncake/src/update.rs
@@ -354,7 +354,7 @@ fn update_symbols(registry_dir: &Path, output: UpdateOutput) -> anyhow::Result<(
         .context("failed to create temp directory for symbols")?;
     std::fs::create_dir_all(&tmp_dir)?;
 
-    if let Err(e) = extract_zip_to_dir(&tmp_dir, data) {
+    if let Err(e) = extract_zip_to_dir(&tmp_dir, std::io::Cursor::new(data)) {
         let _ = std::fs::remove_dir_all(&tmp_dir);
         return Err(e);
     }

--- a/crates/mooncake/src/zip_util.rs
+++ b/crates/mooncake/src/zip_util.rs
@@ -16,11 +16,13 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::path::Path;
+use std::{
+    io::{Read, Seek},
+    path::Path,
+};
 
-pub(crate) fn extract_zip_to_dir(dest: &Path, data: bytes::Bytes) -> anyhow::Result<()> {
-    let cursor = std::io::Cursor::new(data);
-    let mut zip = zip::ZipArchive::new(cursor)?;
+pub(crate) fn extract_zip_to_dir(dest: &Path, archive: impl Read + Seek) -> anyhow::Result<()> {
+    let mut zip = zip::ZipArchive::new(archive)?;
     for i in 0..zip.len() {
         let mut file = zip.by_index(i)?;
         let outpath = dest.join(file.mangled_name());

--- a/crates/moonutil/Cargo.toml
+++ b/crates/moonutil/Cargo.toml
@@ -54,13 +54,13 @@ slotmap.workspace = true
 shlex.workspace = true
 logos = "0.15.1"
 globset = "0.4"
+tempfile.workspace = true
 
 [target."cfg(windows)".dependencies]
 find-msvc-tools.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true
-tempfile.workspace = true
 
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }

--- a/crates/moonutil/src/cache.rs
+++ b/crates/moonutil/src/cache.rs
@@ -21,9 +21,14 @@
 //! Cache contents are intentionally opaque here. Source and artifact stores
 //! may choose their own representations without changing the CLI contract.
 
-use std::path::PathBuf;
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
 
-use anyhow::bail;
+use anyhow::{Context, bail};
+
+use crate::{constants::MOON_LOCK, locks::FileLock};
 
 const OWNERSHIP_MARKER: &str = ".moon-cache";
 
@@ -59,7 +64,47 @@ impl CacheKind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CacheRoot {
     Disabled,
-    Path(PathBuf),
+    Path { kind: CacheKind, path: PathBuf },
+}
+
+impl CacheRoot {
+    /// Claim this configured root for one Moon cache kind before writing data.
+    ///
+    /// Disabled roots return `None`. Enabled roots are created if necessary and
+    /// accepted only when empty or already owned by the requested cache kind.
+    pub fn initialize(&self) -> anyhow::Result<Option<&Path>> {
+        let Self::Path { kind, path: root } = self else {
+            return Ok(None);
+        };
+
+        match std::fs::symlink_metadata(root) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                bail!(
+                    "refusing to use symlinked Moon cache root `{}`",
+                    root.display()
+                )
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                bail!(
+                    "refusing to use non-directory Moon cache root `{}`",
+                    root.display()
+                )
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                std::fs::create_dir_all(root)?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+
+        // Claiming an empty root and writing its ownership marker is one
+        // operation. Without the lock, another process can observe the marker
+        // after creation but before its contents have been written.
+        let _lock = FileLock::lock_with_verbosity(root, false)
+            .with_context(|| format!("Unable to lock Moon cache root `{}`", root.display()))?;
+        initialize_ownership_marker(root, *kind)?;
+        Ok(Some(root))
+    }
 }
 
 pub fn resolve_cache_root(kind: CacheKind) -> anyhow::Result<CacheRoot> {
@@ -71,18 +116,66 @@ pub fn resolve_cache_root(kind: CacheKind) -> anyhow::Result<CacheRoot> {
             if !path.is_absolute() {
                 bail!("{environment} must be an absolute path or `off`");
             }
-            Ok(CacheRoot::Path(path))
+            Ok(CacheRoot::Path { kind, path })
         }
-        None => Ok(CacheRoot::Path(
-            crate::moon_dir::home()
+        None => Ok(CacheRoot::Path {
+            kind,
+            path: crate::moon_dir::home()
                 .join("cache")
                 .join(kind.default_directory()),
-        )),
+        }),
     }
 }
 
+fn initialize_ownership_marker(root: &Path, kind: CacheKind) -> anyhow::Result<()> {
+    let marker = root.join(OWNERSHIP_MARKER);
+    match std::fs::read(&marker) {
+        Ok(contents) if contents == kind.ownership() => return Ok(()),
+        Ok(_) => {
+            bail!(
+                "refusing to use Moon cache root `{}` with an incompatible ownership marker",
+                root.display()
+            )
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+
+    let mut contains_unrecognized_entry = false;
+    for entry in std::fs::read_dir(root)? {
+        if entry?.file_name() != MOON_LOCK {
+            contains_unrecognized_entry = true;
+            break;
+        }
+    }
+    if contains_unrecognized_entry {
+        bail!(
+            "refusing to use unrecognized non-empty Moon cache root `{}`",
+            root.display()
+        );
+    }
+
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&marker)
+    {
+        Ok(mut file) => file.write_all(kind.ownership())?,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            if std::fs::read(&marker)? != kind.ownership() {
+                bail!(
+                    "refusing to use Moon cache root `{}` with an incompatible ownership marker",
+                    root.display()
+                );
+            }
+        }
+        Err(error) => return Err(error.into()),
+    }
+    Ok(())
+}
+
 pub fn clean_cache(kind: CacheKind) -> anyhow::Result<()> {
-    let CacheRoot::Path(root) = resolve_cache_root(kind)? else {
+    let CacheRoot::Path { path: root, .. } = resolve_cache_root(kind)? else {
         return Ok(());
     };
     let metadata = match std::fs::symlink_metadata(&root) {
@@ -113,4 +206,67 @@ pub fn clean_cache(kind: CacheKind) -> anyhow::Result<()> {
         "refusing to clean unrecognized Moon cache root `{}`",
         root.display()
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initializes_ownership_only_for_empty_directory() {
+        let parent = tempfile::TempDir::new().unwrap();
+        let empty = parent.path().join("empty");
+        std::fs::create_dir(&empty).unwrap();
+        initialize_ownership_marker(&empty, CacheKind::DependencySources).unwrap();
+        assert_eq!(
+            std::fs::read(empty.join(OWNERSHIP_MARKER)).unwrap(),
+            b"dependency-sources\n"
+        );
+
+        let unowned = parent.path().join("unowned");
+        std::fs::create_dir(&unowned).unwrap();
+        std::fs::write(unowned.join("user-data"), "keep").unwrap();
+        let error =
+            initialize_ownership_marker(&unowned, CacheKind::DependencySources).unwrap_err();
+        assert!(error.to_string().contains("unrecognized non-empty"));
+        assert_eq!(
+            std::fs::read_to_string(unowned.join("user-data")).unwrap(),
+            "keep"
+        );
+        assert!(!unowned.join(OWNERSHIP_MARKER).exists());
+    }
+
+    #[test]
+    fn rejects_incompatible_ownership_marker() {
+        let root = tempfile::TempDir::new().unwrap();
+        std::fs::write(root.path().join(OWNERSHIP_MARKER), b"build-artifacts\n").unwrap();
+
+        let error =
+            initialize_ownership_marker(root.path(), CacheKind::DependencySources).unwrap_err();
+        assert!(error.to_string().contains("incompatible ownership marker"));
+    }
+
+    #[test]
+    fn initializes_ownership_concurrently() {
+        let parent = tempfile::TempDir::new().unwrap();
+        let root = CacheRoot::Path {
+            kind: CacheKind::DependencySources,
+            path: parent.path().join("cache"),
+        };
+
+        std::thread::scope(|scope| {
+            let first = scope.spawn(|| root.initialize().unwrap());
+            let second = scope.spawn(|| root.initialize().unwrap());
+            first.join().unwrap();
+            second.join().unwrap();
+        });
+
+        let CacheRoot::Path { path, .. } = root else {
+            unreachable!()
+        };
+        assert_eq!(
+            std::fs::read(path.join(OWNERSHIP_MARKER)).unwrap(),
+            b"dependency-sources\n"
+        );
+    }
 }

--- a/crates/moonutil/src/cache.rs
+++ b/crates/moonutil/src/cache.rs
@@ -26,9 +26,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, bail};
-
-use crate::{constants::MOON_LOCK, locks::FileLock};
+use anyhow::bail;
 
 const OWNERSHIP_MARKER: &str = ".moon-cache";
 
@@ -97,11 +95,6 @@ impl CacheRoot {
             Err(error) => return Err(error.into()),
         }
 
-        // Claiming an empty root and writing its ownership marker is one
-        // operation. Without the lock, another process can observe the marker
-        // after creation but before its contents have been written.
-        let _lock = FileLock::lock_with_verbosity(root, false)
-            .with_context(|| format!("Unable to lock Moon cache root `{}`", root.display()))?;
         initialize_ownership_marker(root, *kind)?;
         Ok(Some(root))
     }
@@ -128,50 +121,71 @@ pub fn resolve_cache_root(kind: CacheKind) -> anyhow::Result<CacheRoot> {
 }
 
 fn initialize_ownership_marker(root: &Path, kind: CacheKind) -> anyhow::Result<()> {
-    let marker = root.join(OWNERSHIP_MARKER);
-    match std::fs::read(&marker) {
-        Ok(contents) if contents == kind.ownership() => return Ok(()),
-        Ok(_) => {
-            bail!(
-                "refusing to use Moon cache root `{}` with an incompatible ownership marker",
-                root.display()
-            )
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => return Err(error.into()),
+    if validate_existing_ownership_marker(root, kind)? {
+        return Ok(());
     }
 
-    let mut contains_unrecognized_entry = false;
-    for entry in std::fs::read_dir(root)? {
-        if entry?.file_name() != MOON_LOCK {
-            contains_unrecognized_entry = true;
-            break;
+    if std::fs::read_dir(root)?.next().transpose()?.is_some() {
+        // Another initializer may have published the marker after our first
+        // lookup. Recheck before classifying the root as unowned.
+        if validate_existing_ownership_marker(root, kind)? {
+            return Ok(());
         }
-    }
-    if contains_unrecognized_entry {
         bail!(
             "refusing to use unrecognized non-empty Moon cache root `{}`",
             root.display()
         );
     }
 
-    match std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&marker)
-    {
-        Ok(mut file) => file.write_all(kind.ownership())?,
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            if std::fs::read(&marker)? != kind.ownership() {
+    // Build the complete marker next to the root, then publish it without
+    // replacing an existing claim. Keeping the temporary file outside `root`
+    // means another initializer never mistakes our staging file for user data.
+    let parent = root.parent().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Moon cache root `{}` must have a parent directory",
+            root.display()
+        )
+    })?;
+    let mut marker = tempfile::NamedTempFile::new_in(parent)?;
+    marker.write_all(kind.ownership())?;
+    marker.flush()?;
+    match marker.persist_noclobber(root.join(OWNERSHIP_MARKER)) {
+        Ok(_) => Ok(()),
+        Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+            if !validate_existing_ownership_marker(root, kind)? {
                 bail!(
-                    "refusing to use Moon cache root `{}` with an incompatible ownership marker",
+                    "Moon cache ownership marker disappeared while initializing `{}`",
                     root.display()
                 );
             }
+            Ok(())
         }
-        Err(error) => return Err(error.into()),
+        Err(error) => Err(error.error.into()),
     }
-    Ok(())
+}
+
+fn validate_existing_ownership_marker(root: &Path, kind: CacheKind) -> anyhow::Result<bool> {
+    let marker = root.join(OWNERSHIP_MARKER);
+    match std::fs::symlink_metadata(&marker) {
+        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {
+            if std::fs::read(marker)? == kind.ownership() {
+                Ok(true)
+            } else {
+                bail!(
+                    "refusing to use Moon cache root `{}` with an incompatible ownership marker",
+                    root.display()
+                )
+            }
+        }
+        Ok(_) => {
+            bail!(
+                "refusing to use Moon cache root `{}` with an incompatible ownership marker",
+                root.display()
+            )
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
 }
 
 pub fn clean_cache(kind: CacheKind) -> anyhow::Result<()> {
@@ -193,12 +207,7 @@ pub fn clean_cache(kind: CacheKind) -> anyhow::Result<()> {
         std::fs::remove_dir(root)?;
         return Ok(());
     }
-    if metadata.is_dir()
-        && matches!(
-            std::fs::read(root.join(OWNERSHIP_MARKER)),
-            Ok(contents) if contents == kind.ownership()
-        )
-    {
+    if metadata.is_dir() && validate_existing_ownership_marker(&root, kind)? {
         std::fs::remove_dir_all(root)?;
         return Ok(());
     }
@@ -210,6 +219,8 @@ pub fn clean_cache(kind: CacheKind) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use crate::constants::MOON_LOCK;
+
     use super::*;
 
     #[test]
@@ -220,7 +231,7 @@ mod tests {
         initialize_ownership_marker(&empty, CacheKind::DependencySources).unwrap();
         assert_eq!(
             std::fs::read(empty.join(OWNERSHIP_MARKER)).unwrap(),
-            b"dependency-sources\n"
+            CacheKind::DependencySources.ownership()
         );
 
         let unowned = parent.path().join("unowned");
@@ -239,11 +250,39 @@ mod tests {
     #[test]
     fn rejects_incompatible_ownership_marker() {
         let root = tempfile::TempDir::new().unwrap();
-        std::fs::write(root.path().join(OWNERSHIP_MARKER), b"build-artifacts\n").unwrap();
+        std::fs::write(
+            root.path().join(OWNERSHIP_MARKER),
+            CacheKind::BuildArtifacts.ownership(),
+        )
+        .unwrap();
 
         let error =
             initialize_ownership_marker(root.path(), CacheKind::DependencySources).unwrap_err();
         assert!(error.to_string().contains("incompatible ownership marker"));
+    }
+
+    #[test]
+    fn initialize_does_not_modify_an_unowned_root() {
+        let root = tempfile::TempDir::new().unwrap();
+        std::fs::write(root.path().join("user-data"), "keep").unwrap();
+        std::fs::write(root.path().join(MOON_LOCK), "unrelated lock contents").unwrap();
+        let cache = CacheRoot::Path {
+            kind: CacheKind::DependencySources,
+            path: root.path().to_path_buf(),
+        };
+
+        let error = cache.initialize().unwrap_err();
+
+        assert!(error.to_string().contains("unrecognized non-empty"));
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("user-data")).unwrap(),
+            "keep"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.path().join(MOON_LOCK)).unwrap(),
+            "unrelated lock contents"
+        );
+        assert!(!root.path().join(OWNERSHIP_MARKER).exists());
     }
 
     #[test]
@@ -266,7 +305,44 @@ mod tests {
         };
         assert_eq!(
             std::fs::read(path.join(OWNERSHIP_MARKER)).unwrap(),
-            b"dependency-sources\n"
+            CacheKind::DependencySources.ownership()
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_ownership_marker() {
+        let root = tempfile::TempDir::new().unwrap();
+        std::fs::write(root.path().join(OWNERSHIP_MARKER), "user data").unwrap();
+
+        let error =
+            initialize_ownership_marker(root.path(), CacheKind::DependencySources).unwrap_err();
+
+        assert!(error.to_string().contains("incompatible ownership marker"));
+        assert_eq!(
+            std::fs::read_to_string(root.path().join(OWNERSHIP_MARKER)).unwrap(),
+            "user data"
+        );
+    }
+
+    #[test]
+    fn different_cache_kinds_cannot_claim_the_same_root() {
+        let parent = tempfile::TempDir::new().unwrap();
+        let root = parent.path().join("cache");
+        std::fs::create_dir(&root).unwrap();
+
+        let (dependency_result, build_result) = std::thread::scope(|scope| {
+            let dependency =
+                scope.spawn(|| initialize_ownership_marker(&root, CacheKind::DependencySources));
+            let build =
+                scope.spawn(|| initialize_ownership_marker(&root, CacheKind::BuildArtifacts));
+            (dependency.join().unwrap(), build.join().unwrap())
+        });
+
+        assert_ne!(dependency_result.is_ok(), build_result.is_ok());
+        let ownership = std::fs::read(root.join(OWNERSHIP_MARKER)).unwrap();
+        assert!(
+            ownership == CacheKind::DependencySources.ownership()
+                || ownership == CacheKind::BuildArtifacts.ownership()
         );
     }
 }

--- a/crates/moonutil/src/locks.rs
+++ b/crates/moonutil/src/locks.rs
@@ -18,7 +18,7 @@
 
 use fs4::fs_std::FileExt;
 
-use crate::constants::MOON_LOCK;
+use crate::{constants::MOON_LOCK, user_log::UserLog};
 
 pub struct FileLock {
     _file: std::fs::File,
@@ -36,17 +36,26 @@ impl FileLock {
     }
 
     pub fn lock_with_verbosity(path: &std::path::Path, verbose: bool) -> std::io::Result<Self> {
+        let user_log = UserLog::new(if verbose {
+            log::LevelFilter::Debug
+        } else {
+            log::LevelFilter::Error
+        });
+        Self::lock_with_user_log(path, &user_log)
+    }
+
+    pub fn lock_with_user_log(path: &std::path::Path, user_log: &UserLog) -> std::io::Result<Self> {
         let file = std::fs::File::create(path.join(MOON_LOCK))?;
         match file.try_lock_exclusive() {
             Ok(_) => Ok(FileLock { _file: file }),
             Err(_) => {
-                if verbose {
-                    #[cfg(not(test))]
-                    eprintln!(
-                        "Blocking waiting for file lock {} ...",
-                        path.join(MOON_LOCK).display()
-                    );
-                }
+                #[cfg(test)]
+                let _ = user_log;
+                #[cfg(not(test))]
+                user_log.debug(format!(
+                    "Blocking waiting for file lock {} ...",
+                    path.join(MOON_LOCK).display()
+                ));
                 file.lock_exclusive()
                     .map_err(|e| std::io::Error::new(e.kind(), "failed to lock target dir"))?;
                 Ok(FileLock { _file: file })

--- a/crates/moonutil/src/user_log.rs
+++ b/crates/moonutil/src/user_log.rs
@@ -48,6 +48,10 @@ impl UserLog {
         Self { level }
     }
 
+    pub fn is_enabled(&self, level: log::Level) -> bool {
+        self.level >= level.to_level_filter()
+    }
+
     pub fn error(&self, message: impl Display) {
         let mut stderr = anstream::stderr().lock();
         self.error_to(&mut stderr, message);

--- a/docs/dev/design/global-build-cache.md
+++ b/docs/dev/design/global-build-cache.md
@@ -233,8 +233,10 @@ intended to be immutable, but the checksum remains part of the physical
 identity so a replaced historical archive cannot alias the source tree that
 was originally published under that version. Source acquisition observes the
 checksum once and uses that value for both the physical path and archive
-verification; it does not follow registry-index changes during extraction. A
-miss is extracted in a same-filesystem staging directory and published by
+verification; it does not follow registry-index changes during extraction.
+Verification and extraction consume the same open archive handle, so replacing
+the version-keyed download-cache path cannot change the source being published.
+A miss is extracted in a same-filesystem staging directory and published by
 rename while holding the dependency-cache lock. Existing entries are never
 replaced or pruned during resolution. Package installation uses one
 dependency-source interface to ensure the resolved sources exist and obtain

--- a/docs/dev/design/global-build-cache.md
+++ b/docs/dev/design/global-build-cache.md
@@ -3,10 +3,11 @@
 ## Status
 
 This document records the intended direction for global dependency and build
-caches. Cache-root configuration and cleaning are implemented, as is the pure
-canonical identity calculation for lowered actions. Builds do not yet read
-from or write to either global cache, and identity calculation is not connected
-to execution.
+caches. Cache-root configuration and cleaning are implemented. Standalone
+`moon run` inputs reuse immutable registry dependency sources through the
+dependency cache. The pure canonical identity calculation for lowered actions
+is also implemented, but builds do not yet read from or write to the global
+artifact cache and identity calculation is not connected to execution.
 
 ## Problem
 
@@ -49,14 +50,18 @@ Two environment variables select the cache roots:
 | `MOON_DEP_CACHE` | `$MOON_HOME/cache/deps` | Disable dependency caching | Use that dependency-cache root |
 | `MOON_BUILD_CACHE` | `$MOON_HOME/cache/build` | Disable build caching | Use that build-cache root |
 
-A relative path is rejected. `off` means that a future build must use
-invocation-private temporary state instead of the corresponding global cache.
-For a disabled dependency cache, dependencies still have to be downloaded and
-prepared somewhere private; disabling the cache must not disable dependency
+A relative path is rejected. `off` means that a build uses project-local or
+invocation-private state instead of the corresponding global cache. For a
+disabled dependency cache, dependencies still have to be downloaded and
+prepared privately; disabling the cache does not disable dependency
 resolution.
 
-The environment variables currently configure and clean roots only. Their
-presence does not yet change build execution.
+`MOON_DEP_CACHE` currently affects registry dependencies of standalone
+`moon run` inputs: persistent `.mbt` and `.mbtx` files, inline `-e` programs,
+and stdin programs passed as `-`. Single-file check and test commands, ordinary
+projects, and workspaces retain their existing project-local dependency
+directories.
+`MOON_BUILD_CACHE` still configures and cleans its future root only.
 
 Canonical action identity is also implemented as a pure consumer of Rupes
 Recta `LoweredAction` values. It is not connected to build execution or either
@@ -222,6 +227,19 @@ The script's own rapidly changing compilation may often miss, but its stable
 dependencies can still be hits. This is the main opportunity for faster script
 startup.
 
+The implemented source-only step resolves each registry package to an entry
+addressed by module, version, and registry checksum. Registry versions are
+intended to be immutable, but the checksum remains part of the physical
+identity so a replaced historical archive cannot alias the source tree that
+was originally published under that version. A miss is extracted in a
+same-filesystem staging directory and published by rename while holding the
+dependency-cache lock. Existing entries are never replaced or pruned during
+resolution. Package installation uses one dependency-source interface to
+ensure the resolved sources exist and obtain their paths; project-local
+`.mooncakes` and the shared immutable cache are internal storage choices.
+Compiler outputs remain invocation-local and continue through the standalone
+n2 dependency graph.
+
 `post-add` hooks will not run in globally shared prepared sources. They make
 source state mutable and can have effects that are not captured by an artifact
 key. The initial shared-source flow should reject a dependency that requires
@@ -243,8 +261,9 @@ Each stage should be useful and reviewable without requiring the next:
 
 1. **Root contract and lifecycle (implemented):** environment selection,
    disabled semantics, safe explicit cleaning, and no internal data layout.
-2. **Prepared dependency sources:** immutable publication in the dependency
-   cache, no shared `post-add`, and private fallback when caching is off.
+2. **Prepared dependency sources (implemented for standalone `moon run`):**
+   immutable publication in the dependency cache, no shared `post-add`, and
+   private fallback when caching is off. Other command families remain local.
 3. **Private standalone work:** stop sharing mutable `_build` trees between
    standalone invocations; place `__moonbin__` there.
 4. **Action model (implemented, not execution-wired):** define and test

--- a/docs/dev/design/global-build-cache.md
+++ b/docs/dev/design/global-build-cache.md
@@ -41,6 +41,13 @@ and cleanup rules, so they use separate caches. An artifact is reusable only
 when all compiler-observable inputs have the same identity. Directory names
 are for storage organization, not correctness.
 
+“Immutable after publication” is currently a cache contract, not filesystem
+enforcement. Module prebuild configuration still runs with the shared source
+directory as its working directory and can mutate it. Such mutation is
+unsupported; package authors and users are responsible for keeping prebuild
+configuration read-only with respect to dependency sources until Moon gains a
+private-copy or sandboxed prebuild model.
+
 ## Implemented public seam
 
 Two environment variables select the cache roots:
@@ -82,11 +89,24 @@ When either cache flag is present, only the selected global cache roots are
 cleaned; the local `_build` is left alone. A disabled or missing root is a
 successful no-op, so these commands work outside a project.
 
+Cleaning is an explicit maintenance operation and does not acquire a lease
+from active readers. Users must not run `moon clean --dep-cache` concurrently
+with a command consuming shared dependency sources; doing so may make the
+active command fail. Consumption-lifetime coordination is deferred until the
+cache needs stronger operational guarantees.
+
 Deleting a user-configurable absolute path is dangerous. Moon therefore
 removes a non-empty root only when it contains Moon's matching ownership
 marker. Empty roots may be removed, and symlinked or unrecognized roots are
 refused. The marker is lifecycle safety metadata, not a promise about the
 future data layout.
+
+Initialization performs the same ownership checks before writing anything
+inside an existing root. An unrecognized non-empty directory is therefore left
+byte-for-byte unchanged, including any unrelated `.moon.lock`. An empty root
+is claimed with an exclusively created ownership marker; concurrent
+initializers may observe and validate that marker, but do not need to create a
+lock file before the root is owned.
 
 ## Why `module@version` is not an artifact key
 
@@ -227,21 +247,33 @@ The script's own rapidly changing compilation may often miss, but its stable
 dependencies can still be hits. This is the main opportunity for faster script
 startup.
 
-The implemented source-only step resolves each registry package to an entry
-addressed by module, version, and registry checksum. Registry versions are
-intended to be immutable, but the checksum remains part of the physical
-identity so a replaced historical archive cannot alias the source tree that
-was originally published under that version. Source acquisition observes the
-checksum once and uses that value for both the physical path and archive
-verification; it does not follow registry-index changes during extraction.
-Verification and extraction consume the same open archive handle, so replacing
-the version-keyed download-cache path cannot change the source being published.
-A miss is extracted in a same-filesystem staging directory and published by
-rename while holding the dependency-cache lock. Existing entries are never
-replaced or pruned during resolution. Package installation uses one
-dependency-source interface to ensure the resolved sources exist and obtain
-their paths; project-local `.mooncakes` and the shared immutable cache are
-internal storage choices.
+The implemented source-only step gives each registry `module@version` one
+canonical directory:
+
+```text
+<dependency-cache>/v1/sources/<username>/<unqualified-name>/<version>
+```
+
+As in project-local `.mooncakes`, `/` inside a legacy unqualified module name
+is escaped as `+`. The archive checksum is deliberately not a path component.
+Registry versions are treated as immutable: each published directory contains
+cache-private `.moon-source-archive-checksum` metadata recording the registry
+index's SHA-256 for the ZIP archive that produced it. Reuse requires that
+recorded value to equal the current index value and validates the module
+manifest (`moon.mod` or `moon.mod.json`). If a registry republishes the same
+version with another checksum, Moon refuses to replace or coexist with the new
+source and asks the user to run `moon clean --dep-cache` explicitly.
+
+Source acquisition reads the archive checksum once and uses that value for
+both archive verification and the published metadata. Verification and
+extraction consume the same open archive handle, so replacing the
+version-keyed download-cache path cannot change the source being published. A
+miss is extracted in a same-filesystem staging directory, validated, annotated
+with the checksum, and published by rename while holding the dependency-cache
+lock. Existing entries are never replaced or pruned during resolution. Package
+installation uses one dependency-source interface to ensure the resolved
+sources exist and obtain their paths; project-local `.mooncakes` and the shared
+immutable cache are internal storage choices.
 Compiler outputs remain invocation-local and continue through the standalone
 n2 dependency graph.
 

--- a/docs/dev/design/global-build-cache.md
+++ b/docs/dev/design/global-build-cache.md
@@ -231,12 +231,15 @@ The implemented source-only step resolves each registry package to an entry
 addressed by module, version, and registry checksum. Registry versions are
 intended to be immutable, but the checksum remains part of the physical
 identity so a replaced historical archive cannot alias the source tree that
-was originally published under that version. A miss is extracted in a
-same-filesystem staging directory and published by rename while holding the
-dependency-cache lock. Existing entries are never replaced or pruned during
-resolution. Package installation uses one dependency-source interface to
-ensure the resolved sources exist and obtain their paths; project-local
-`.mooncakes` and the shared immutable cache are internal storage choices.
+was originally published under that version. Source acquisition observes the
+checksum once and uses that value for both the physical path and archive
+verification; it does not follow registry-index changes during extraction. A
+miss is extracted in a same-filesystem staging directory and published by
+rename while holding the dependency-cache lock. Existing entries are never
+replaced or pruned during resolution. Package installation uses one
+dependency-source interface to ensure the resolved sources exist and obtain
+their paths; project-local `.mooncakes` and the shared immutable cache are
+internal storage choices.
 Compiler outputs remain invocation-local and continue through the standalone
 n2 dependency graph.
 

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -277,10 +277,13 @@ For `moon run` standalone inputs, registry package acquisition is separate from
 that build projection. Persistent standalone `.mbt` and `.mbtx` files, inline
 `-e` programs, and stdin programs passed as `-` resolve registry modules to
 immutable entries in the global dependency source cache. Entries are addressed
-by module, version, and registry checksum, published atomically, and reused
-without replacing other versions or checksum variants. Registry acquisition
-verifies the published archive checksum before extraction. `MOON_DEP_CACHE=off`
-retains the previous
+by module and version and published atomically. Each entry records the SHA-256
+of the registry ZIP archive that produced it. Reuse compares that metadata with
+the current registry index and validates the `moon.mod` or `moon.mod.json`
+manifest; a checksum change is an error that requires an explicit dependency
+cache clean rather than a replacement or a second path. Registry acquisition
+uses one selected checksum to verify and extract one open archive handle.
+`MOON_DEP_CACHE=off` retains the previous
 project-local or temporary `.mooncakes` preparation. Single-file check and test
 commands do not use this global source path.
 

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -273,6 +273,17 @@ work as `LoweredAction` values and lowers script work into an n2 graph. Moon
 passes the dependency actions through the current n2 adapter before execution,
 producing the same two disjoint n2 graphs as before.
 
+For `moon run` standalone inputs, registry package acquisition is separate from
+that build projection. Persistent standalone `.mbt` and `.mbtx` files, inline
+`-e` programs, and stdin programs passed as `-` resolve registry modules to
+immutable entries in the global dependency source cache. Entries are addressed
+by module, version, and registry checksum, published atomically, and reused
+without replacing other versions or checksum variants. Registry acquisition
+verifies the published archive checksum before extraction. `MOON_DEP_CACHE=off`
+retains the previous
+project-local or temporary `.mooncakes` preparation. Single-file check and test
+commands do not use this global source path.
+
 All actions owned by packages other than the synthesized script package seed
 the dependency projection. Following their producer edges to a fixed point
 also includes package-less shared prerequisites such as `BuildRuntimeLib` and
@@ -300,9 +311,9 @@ dependency product contract.
 For `.mbt` and `.mbtx` files built from persistent paths, the dependency n2
 database remains available to later invocations. `moon run -e` and
 `moon run -` also use the split graphs, but their synthesized temporary projects
-are removed after each invocation, so they do not currently reuse the
-dependency database across invocations. Stable or global cache storage for
-those entry points remains future work.
+are removed after each invocation. They reuse globally prepared registry
+sources but do not yet reuse the dependency n2 database or compiled dependency
+artifacts across invocations.
 
 Ordinary project and workspace commands continue to produce and execute one
 plan and one n2 graph.


### PR DESCRIPTION
## Why

Standalone `moon run` builds repeatedly prepare the same registry dependency sources in command-local `.mooncakes` directories. Reusing those sources is the smallest useful step toward a global cache without coupling this change to compiled-artifact or action caching.

## What changed

- Route the existing standalone run boundary through the global dependency source store. This covers standalone `.mbt` and `.mbtx` files, inline `-e` programs, and stdin programs passed as `-` without adding another file-extension-based classification.
- Hide project-local `.mooncakes` and the global store behind one dependency-source interface that ensures resolved sources exist and returns their module directories.
- Give each registry `module@version` one canonical path under `v1/sources`. The archive checksum is cache-private provenance metadata, not part of the path.
- Record the registry ZIP archive's SHA-256 in each published source. Reuse compares it with the current index checksum and validates `moon.mod` or `moon.mod.json`. A changed, missing, or malformed checksum is an explicit error that asks the user to run `moon clean --dep-cache`; it does not create a second variant or silently replace the source.
- Read the selected archive checksum once, pass that exact value through acquisition, and verify and extract from the same open archive handle.
- Publish sources through same-filesystem staging and atomic rename while holding the dependency-cache lock, so readers cannot observe partial entries.
- Preserve the existing `.moon-cache` ownership contract. Initialization validates an existing root before writing inside it and publishes a complete marker with no-clobber semantics; cleaning requires the exact matching marker and refuses symlinks or unrecognized roots.
- Reject registry packages with `scripts.postadd`, because their installed trees are not immutable registry sources.
- Preserve project-local `.mooncakes` behavior when `MOON_DEP_CACHE=off`, and avoid initializing the global cache when there are no registry dependencies.
- Document the implemented source-store boundary and its relationship to future action and artifact caching.

## Why this is correct

Resolution still selects dependencies by module and version. The source store treats a published registry version as immutable and records which verified ZIP produced the canonical directory. The historical `lijunchen/hello18@0.1.30` replacement demonstrates that this invariant can be violated by registry data; the cache now detects that situation and requires an explicit clean instead of treating republished contents as another supported identity.

Archive verification is bound to the checksum selected by the caller, and extraction consumes the already-verified handle. Manifest validation then binds the extracted tree to the expected module and version before publication. Existing entries must pass both provenance and manifest validation before reuse.

Source publication and cache-root ownership are complete before they become visible. Concurrent initializers of the same cache kind converge on the same ownership marker, while different cache kinds cannot claim the same root.

The cache policy follows Moon's existing standalone execution classification. Ordinary project and workspace builds, single-file check and test flows, and explicit `MOON_DEP_CACHE=off` retain project-local dependency preparation.

## Why this remains minimal

This PR changes only registry source preparation for standalone `moon run`. It reuses the existing resolution and build graphs, keeps compiler outputs invocation-local, and introduces no action-key or artifact-cache policy. The `Registry` index and source-acquisition responsibilities remain in one interface for now; separating them can be considered independently later.

## Current limitations

- Module-level `--moonbit-unstable-prebuild` scripts remain trusted configuration code and run with the module source directory as their working directory. A script that mutates its module source may therefore mutate a shared entry; source-mutating prebuild scripts are unsupported with the global cache for now.
- `moon clean --dep-cache` is an explicit maintenance operation and is not coordinated with in-flight readers. Users should not run it concurrently with a standalone build.
- `.mi`, `.core`, other compiler outputs, and action results are not cached by this PR.
