### PR TITLE
fix(mooncake): verify downloaded package checksum before install

### DIFF
--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -220,6 +220,26 @@ fn copy_archive_and_verify_checksum(
     Ok(())
 }
 
+fn persist_verified_archive(
+    source: &mut impl Read,
+    cache_file: &Path,
+    name: &ModuleName,
+    version: &Version,
+    expected_checksum: &str,
+) -> anyhow::Result<File> {
+    let parent = cache_file
+        .parent()
+        .expect("registry cache file has a parent");
+    std::fs::create_dir_all(parent)?;
+    let mut archive = tempfile::NamedTempFile::new_in(parent)?;
+    copy_archive_and_verify_checksum(source, &mut archive, name, version, expected_checksum)?;
+    archive.flush()?;
+    archive.as_file_mut().sync_all()?;
+    let mut archive = archive.persist(cache_file).map_err(|error| error.error)?;
+    archive.rewind()?;
+    Ok(archive)
+}
+
 impl OnlineRegistry {
     fn read_checksum_from_index_file(
         &self,
@@ -296,22 +316,7 @@ impl OnlineRegistry {
             .send()?
             .error_for_status()?;
 
-        let parent = cache_file
-            .parent()
-            .expect("registry cache file has a parent");
-        std::fs::create_dir_all(parent)?;
-        let mut archive = tempfile::NamedTempFile::new_in(parent)?;
-        copy_archive_and_verify_checksum(
-            &mut response,
-            &mut archive,
-            name,
-            version,
-            expected_checksum,
-        )?;
-        archive.flush()?;
-        let mut archive = archive.persist(&cache_file).map_err(|error| error.error)?;
-        archive.rewind()?;
-        Ok(archive)
+        persist_verified_archive(&mut response, &cache_file, name, version, expected_checksum)
     }
 
     pub fn install_to_impl(
@@ -507,6 +512,27 @@ mod tests {
             "{error:#}"
         );
         assert_eq!(downloaded, archive);
+    }
+
+    #[test]
+    fn checksum_mismatch_does_not_publish_archive_cache_file() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let cache_file = sandbox.path().join("archive.zip");
+        let archive = test_archive();
+        let name: ModuleName = "test/module".into();
+        let version = Version::new(1, 2, 3);
+
+        let error = persist_verified_archive(
+            &mut Cursor::new(&archive),
+            &cache_file,
+            &name,
+            &version,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("Checksum mismatch for test/module@1.2.3"));
+        assert!(!cache_file.exists());
     }
 
     #[test]


### PR DESCRIPTION
- Related issues: None <!-- write issue numbers here -->
- PR kind: <!-- Bugfix, feature, refactor, optimization, ... -->

## Summary

<!-- A brief summary of what the PR does -->

Verify newly downloaded registry packages against the checksum recorded in the registry index before caching, extracting, or executing their post-install scripts.

Previously, mooncake validated packages already present in the cache, but wrote newly downloaded data directly to the cache without verifying it. A structurally valid ZIP with an incorrect checksum could therefore be extracted and have its
`scripts.postadd` command executed.



- calculate the SHA-256 checksum of newly downloaded package data
- reject downloads that do not match the registry index checksum
- prevent mismatched packages from being cached, extracted, or executed
- stage cache writes in a temporary file in the cache directory
- atomically replace the final cache file after the staged file is fully written and synced
- add regression tests covering:
  - successful installation with a valid checksum
  - rejection of a newly downloaded package with an invalid checksum
  - checksum verification after detecting a corrupt cached package
  - prevention of extraction and `postadd` execution on checksum mismatch
  - atomic replacement under concurrent cache writers


## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
