### PR TITLE
test(moonrun): lock host value interop behavior

### DIFF
--- a/crates/moonrun/tests/test_cases/test_cli_args.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_cli_args.in/main/main.mbt
@@ -17,7 +17,17 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 fn main {
+  check_lossless_utf16_round_trip()
   let args = get_args()
+  let reader_args = get_args_from_reader()
+  if args.length() != reader_args.length() {
+    abort("String-array reader returned the wrong number of arguments")
+  }
+  for i in 0..<args.length() {
+    if args[i] != reader_args[i] {
+      abort("String-array reader returned different arguments")
+    }
+  }
   if args.length() > 1 && args[1] == "exit-7" {
     exit_with_code(7)
   }
@@ -71,6 +81,28 @@ fn JSArray::op_get(self : JSArray, idx : Int) -> JSValue {
   return array_get(self, idx)
 }
 
+#external
+type StringArrayReadHandle
+
+fn begin_read_string_array(arr : JSArray) -> StringArrayReadHandle = "__moonbit_fs_unstable" "begin_read_string_array"
+
+fn string_array_read_string(handle : StringArrayReadHandle) -> ExternString = "__moonbit_fs_unstable" "string_array_read_string"
+
+fn finish_read_string_array(handle : StringArrayReadHandle) = "__moonbit_fs_unstable" "finish_read_string_array"
+
+fn get_args_from_reader() -> Array[String] {
+  let handle = begin_read_string_array(args_get())
+  let result = []
+  while true {
+    let value = string_from_extern(string_array_read_string(handle))
+    if value == "ffi_end_of_/string_array" {
+      break
+    }
+    result.push(value)
+  }
+  finish_read_string_array(handle)
+  result
+}
 
 
 #external
@@ -85,6 +117,8 @@ type ExternString
 fn begin_create_string() -> StringCreateHandle = "__moonbit_fs_unstable" "begin_create_string"
 
 fn string_append_char(handle : StringCreateHandle, ch : Char) = "__moonbit_fs_unstable" "string_append_char"
+
+fn string_append_code_unit(handle : StringCreateHandle, code_unit : Int) = "__moonbit_fs_unstable" "string_append_char"
 
 fn finish_create_string(handle : StringCreateHandle) -> ExternString = "__moonbit_fs_unstable" "finish_create_string"
 
@@ -101,6 +135,24 @@ fn begin_read_string(s : ExternString) -> StringReadHandle = "__moonbit_fs_unsta
 fn string_read_char(handle : StringReadHandle) -> Int = "__moonbit_fs_unstable" "string_read_char"
 
 fn finish_read_string(handle : StringReadHandle) = "__moonbit_fs_unstable" "finish_read_string"
+
+fn check_lossless_utf16_round_trip() -> Unit {
+  let builder = begin_create_string()
+  let expected = [0x61, 0xd800, 0x62, 0xdc00, 0xd83d, 0xde00]
+  for code_unit in expected {
+    string_append_code_unit(builder, code_unit)
+  }
+  let reader = begin_read_string(finish_create_string(builder))
+  for code_unit in expected {
+    if string_read_char(reader) != code_unit {
+      abort("Extern string did not preserve its UTF-16 code units")
+    }
+  }
+  if string_read_char(reader) != -1 {
+    abort("Extern string reader did not stop at the end")
+  }
+  finish_read_string(reader)
+}
 
 fn string_from_extern(e : ExternString) -> String {
   let buf = @buffer.new()

--- a/crates/moonrun/tests/test_cases/test_read_bytes.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_read_bytes.in/main/main.mbt
@@ -59,8 +59,38 @@ fn byte_array_read_byte(handle : XByteArrayReadHandle) -> Int = "__moonbit_fs_un
 fn finish_read_byte_array(handle : XByteArrayReadHandle) = "__moonbit_fs_unstable" "finish_read_byte_array"
 
 
+///|
+fn begin_create_byte_array() -> XByteArrayCreateHandle = "__moonbit_fs_unstable" "begin_create_byte_array"
+
+///|
+fn byte_array_append_byte(handle : XByteArrayCreateHandle, byte : Int) = "__moonbit_fs_unstable" "byte_array_append_byte"
+
+///|
+fn finish_create_byte_array(handle : XByteArrayCreateHandle) -> XExternByteArray = "__moonbit_fs_unstable" "finish_create_byte_array"
+
+///|
+fn check_byte_array_round_trip() -> Unit {
+  let builder = begin_create_byte_array()
+  let input = [0, 1, 255, 256, -1]
+  for byte in input {
+    byte_array_append_byte(builder, byte)
+  }
+  let reader = begin_read_byte_array(finish_create_byte_array(builder))
+  let expected = [0, 1, 255, 0, 255]
+  for byte in expected {
+    if byte_array_read_byte(reader) != byte {
+      abort("Extern byte array did not preserve Uint8Array coercion")
+    }
+  }
+  if byte_array_read_byte(reader) != -1 {
+    abort("Extern byte array reader did not stop at the end")
+  }
+  finish_read_byte_array(reader)
+}
+
+///|
 fn main {
+  check_byte_array_round_trip()
   let bytes = read_bytes_from_stdin()
   println(bytes.iter().count())
 }
-


### PR DESCRIPTION
## Why

Replacing V8 with Wasmtime changes how host strings, arrays, and byte arrays are represented. Before changing that representation, moonrun needs executable contracts for the behavior that callers already observe.

## What changed

- Verify the generic array and string-array reader paths return identical CLI arguments.
- Verify string builder/reader helpers preserve raw UTF-16 code units, including unpaired surrogates, and report end-of-input as `-1`.
- Verify byte-array builder/reader helpers retain `Uint8Array` coercion semantics and report end-of-input as `-1`.

## Scope

This PR is deliberately test-only: it does not change the V8 runtime, introduce a Wasmtime dependency, or add a hypothetical runtime abstraction. Follow-up migration PRs can change the implementation while keeping these contracts intact.