### PR TITLE
refactor(moonrun): extract host filesystem

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -37,6 +37,28 @@ _Avoid_: Guest UTF-8 path buffer
 Memory owned by moonrun while servicing guest jobs.
 _Avoid_: Native buffer, temporary buffer
 
+**Moonrun Policy**:
+The permission configuration enforced by moonrun-owned host imports, including
+`moonbitlang/async` and `__moonbit_fs_unstable`. It authorizes host paths and
+operations before moonrun performs them. It does not implicitly configure or
+restrict WASI descriptors.
+_Avoid_: WASI sandbox, virtual filesystem
+
+**WASI Capability Surface**:
+The files and directories reachable through WASI descriptors and preopens.
+WASI access is configured separately from Moonrun Policy, even when both
+surfaces ultimately access the same host filesystem. A runtime adapter must
+configure both explicitly instead of treating one as enforcement for the
+other.
+_Avoid_: Moonrun Policy, FFI permissions
+
+**Host Filesystem**:
+The runtime-engine-neutral implementation of moonrun's permission-backed
+filesystem imports. It owns authorization, host filesystem operations, and
+guest-visible error semantics; runtime adapters only convert values and expose
+imports. WASI does not pass through the Host Filesystem.
+_Avoid_: WASI filesystem, V8 filesystem
+
 **Handle**:
 An opaque value held by MoonBit code that names a moonrun object at the Native-Shaped Async Boundary, such as a Resource, Job, Worker, poll instance, Host Buffer, address-info result, or Completion Source.
 _Avoid_: Host Handle, Guest Handle, raw fd, pointer, id

--- a/crates/moonrun/src/fs_api_temp.rs
+++ b/crates/moonrun/src/fs_api_temp.rs
@@ -23,7 +23,7 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 use crate::async_policy::AsyncPolicy;
-use crate::host_fs::{HostFs, LegacyFsResults};
+use crate::host_fs::{FsOperationResults, HostFs};
 use crate::util::get_ref;
 use crate::v8_builder::{ArgsExt, ObjectExt, ScopeExt};
 
@@ -31,15 +31,15 @@ struct FsImports {
     filesystem: HostFs,
     // V8 invokes these imports synchronously on the isolate thread. Keep the
     // adapter's mutable protocol state local without imposing a threading
-    // model on the engine-neutral LegacyFsResults.
-    legacy_results: RefCell<LegacyFsResults>,
+    // model on the engine-neutral FsOperationResults.
+    operation_results: RefCell<FsOperationResults>,
 }
 
 impl FsImports {
     fn new(policy: Arc<AsyncPolicy>) -> Self {
         Self {
             filesystem: HostFs::new(policy),
-            legacy_results: RefCell::new(LegacyFsResults::default()),
+            operation_results: RefCell::new(FsOperationResults::default()),
         }
     }
 }
@@ -207,7 +207,7 @@ fn write_bytes_to_file_new(
     let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
     let status = imports.filesystem.write_bytes_to_file_new(
-        &mut imports.legacy_results.borrow_mut(),
+        &mut imports.operation_results.borrow_mut(),
         &path,
         || match v8::Local::<v8::Uint8Array>::try_from(args.get(1)) {
             Ok(array) => Ok(copy_uint8_array(array)),
@@ -226,7 +226,7 @@ fn read_file_to_bytes_new(
     let path = args.string_lossy(scope, 0);
     let status = imports
         .filesystem
-        .read_file_to_bytes_new(&mut imports.legacy_results.borrow_mut(), &path);
+        .read_file_to_bytes_new(&mut imports.operation_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -236,7 +236,7 @@ fn get_file_content(
     mut ret: v8::ReturnValue,
 ) {
     let imports = fs_imports(&args);
-    let contents = imports.legacy_results.borrow().file_content().to_vec();
+    let contents = imports.operation_results.borrow().file_content().to_vec();
     let length = contents.len();
     let backing_store = v8::ArrayBuffer::new_backing_store_from_bytes(contents).make_shared();
     let array_buffer = v8::ArrayBuffer::with_backing_store(scope, &backing_store);
@@ -250,7 +250,7 @@ fn get_dir_files(
     mut ret: v8::ReturnValue,
 ) {
     let imports = fs_imports(&args);
-    let files = imports.legacy_results.borrow().dir_files().to_vec();
+    let files = imports.operation_results.borrow().dir_files().to_vec();
     let array = v8::Array::new(scope, 0);
     for (index, file) in files.iter().enumerate() {
         let file = scope.string(file);
@@ -268,7 +268,7 @@ fn create_dir_new(
     let path = args.string_lossy(scope, 0);
     let status = imports
         .filesystem
-        .create_dir_new(&mut imports.legacy_results.borrow_mut(), &path);
+        .create_dir_new(&mut imports.operation_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -281,7 +281,7 @@ fn read_dir_new(
     let path = args.string_lossy(scope, 0);
     let status = imports
         .filesystem
-        .read_dir_new(&mut imports.legacy_results.borrow_mut(), &path);
+        .read_dir_new(&mut imports.operation_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -294,7 +294,7 @@ fn is_file_new(
     let path = args.string_lossy(scope, 0);
     let status = imports
         .filesystem
-        .is_file_new(&mut imports.legacy_results.borrow_mut(), &path);
+        .is_file_new(&mut imports.operation_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -307,7 +307,7 @@ fn is_dir_new(
     let path = args.string_lossy(scope, 0);
     let status = imports
         .filesystem
-        .is_dir_new(&mut imports.legacy_results.borrow_mut(), &path);
+        .is_dir_new(&mut imports.operation_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -320,7 +320,7 @@ fn remove_file_new(
     let path = args.string_lossy(scope, 0);
     let status = imports
         .filesystem
-        .remove_file_new(&mut imports.legacy_results.borrow_mut(), &path);
+        .remove_file_new(&mut imports.operation_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -333,7 +333,7 @@ fn remove_dir_new(
     let path = args.string_lossy(scope, 0);
     let status = imports
         .filesystem
-        .remove_dir_new(&mut imports.legacy_results.borrow_mut(), &path);
+        .remove_dir_new(&mut imports.operation_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -343,7 +343,11 @@ fn get_error_message(
     mut ret: v8::ReturnValue,
 ) {
     let imports = fs_imports(&args);
-    let message = imports.legacy_results.borrow().error_message().to_owned();
+    let message = imports
+        .operation_results
+        .borrow()
+        .error_message()
+        .to_owned();
     ret.set(scope.string(&message).into());
 }
 

--- a/crates/moonrun/src/fs_api_temp.rs
+++ b/crates/moonrun/src/fs_api_temp.rs
@@ -23,25 +23,32 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 use crate::async_policy::AsyncPolicy;
-use crate::host_fs::{HostFs, HostFsState};
+use crate::host_fs::{HostFs, LegacyFsResults};
 use crate::util::get_ref;
 use crate::v8_builder::{ArgsExt, ObjectExt, ScopeExt};
 
 struct FsImports {
-    host: HostFs,
+    filesystem: HostFs,
     // V8 invokes these imports synchronously on the isolate thread. Keep the
     // adapter's mutable protocol state local without imposing a threading
-    // model on the engine-neutral HostFsState.
-    state: RefCell<HostFsState>,
+    // model on the engine-neutral LegacyFsResults.
+    legacy_results: RefCell<LegacyFsResults>,
 }
 
 impl FsImports {
     fn new(policy: Arc<AsyncPolicy>) -> Self {
         Self {
-            host: HostFs::new(policy),
-            state: RefCell::new(HostFsState::default()),
+            filesystem: HostFs::new(policy),
+            legacy_results: RefCell::new(LegacyFsResults::default()),
         }
     }
+}
+
+fn fs_imports<'a>(args: &v8::FunctionCallbackArguments<'a>) -> &'a FsImports {
+    // SAFETY: every callback using this helper is registered by `init_fs`
+    // through `set_host_func` with a pointer to the same boxed `FsImports`.
+    // `dtors` owns that box until after V8 can no longer invoke the callbacks.
+    unsafe { get_ref::<FsImports>(args) }
 }
 
 /// `fn read_file_to_string(path: JSString) -> JSString`
@@ -50,10 +57,10 @@ fn read_file_to_string(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    let contents = fs
-        .host
+    let contents = imports
+        .filesystem
         .read_file_to_string(&path)
         .unwrap_or_else(|error| panic!("{error}"));
     ret.set(scope.string(&contents).into());
@@ -65,10 +72,11 @@ fn write_string_to_file(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
     let contents = args.string_lossy(scope, 1);
-    fs.host
+    imports
+        .filesystem
         .write_string_to_file(&path, &contents)
         .unwrap_or_else(|error| panic!("{error}"));
     ret.set_undefined();
@@ -79,9 +87,10 @@ fn write_bytes_to_file(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    fs.host
+    imports
+        .filesystem
         .write_bytes_to_file(&path, || {
             let array = v8::Local::<v8::Uint8Array>::try_from(args.get(1)).unwrap();
             copy_uint8_array(array)
@@ -95,9 +104,10 @@ fn create_dir(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    fs.host
+    imports
+        .filesystem
         .create_dir(&path)
         .unwrap_or_else(|error| panic!("{error}"));
     ret.set_undefined();
@@ -108,10 +118,10 @@ fn read_dir(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    let entries = fs
-        .host
+    let entries = imports
+        .filesystem
         .read_dir(&path)
         .unwrap_or_else(|error| panic!("{error}"));
     let result = v8::Array::new(scope, 0);
@@ -127,9 +137,9 @@ fn is_file(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    ret.set_bool(fs.host.is_file(&path));
+    ret.set_bool(imports.filesystem.is_file(&path));
 }
 
 fn is_dir(
@@ -137,9 +147,9 @@ fn is_dir(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    ret.set_bool(fs.host.is_dir(&path));
+    ret.set_bool(imports.filesystem.is_dir(&path));
 }
 
 fn remove_file(
@@ -147,9 +157,10 @@ fn remove_file(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    fs.host
+    imports
+        .filesystem
         .remove_file(&path)
         .unwrap_or_else(|error| panic!("{error}"));
     ret.set_undefined();
@@ -160,9 +171,10 @@ fn remove_dir(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    fs.host
+    imports
+        .filesystem
         .remove_dir(&path)
         .unwrap_or_else(|error| panic!("{error}"));
     ret.set_undefined();
@@ -173,9 +185,9 @@ fn path_exists(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    ret.set_bool(fs.host.path_exists(&path));
+    ret.set_bool(imports.filesystem.path_exists(&path));
 }
 
 fn current_dir(
@@ -183,8 +195,8 @@ fn current_dir(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
-    ret.set(scope.string(&fs.host.current_dir()).into());
+    let imports = fs_imports(&args);
+    ret.set(scope.string(&imports.filesystem.current_dir()).into());
 }
 
 fn write_bytes_to_file_new(
@@ -192,16 +204,16 @@ fn write_bytes_to_file_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    let status = fs
-        .host
-        .write_bytes_to_file_new(&mut fs.state.borrow_mut(), &path, || {
-            match v8::Local::<v8::Uint8Array>::try_from(args.get(1)) {
-                Ok(array) => Ok(copy_uint8_array(array)),
-                Err(_) => Err("Failed to convert contents to Uint8Array".to_string()),
-            }
-        });
+    let status = imports.filesystem.write_bytes_to_file_new(
+        &mut imports.legacy_results.borrow_mut(),
+        &path,
+        || match v8::Local::<v8::Uint8Array>::try_from(args.get(1)) {
+            Ok(array) => Ok(copy_uint8_array(array)),
+            Err(_) => Err("Failed to convert contents to Uint8Array".to_string()),
+        },
+    );
     ret.set_int32(status);
 }
 
@@ -210,11 +222,11 @@ fn read_file_to_bytes_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    let status = fs
-        .host
-        .read_file_to_bytes_new(&mut fs.state.borrow_mut(), &path);
+    let status = imports
+        .filesystem
+        .read_file_to_bytes_new(&mut imports.legacy_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -223,8 +235,8 @@ fn get_file_content(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
-    let contents = fs.state.borrow().file_content().to_vec();
+    let imports = fs_imports(&args);
+    let contents = imports.legacy_results.borrow().file_content().to_vec();
     let length = contents.len();
     let backing_store = v8::ArrayBuffer::new_backing_store_from_bytes(contents).make_shared();
     let array_buffer = v8::ArrayBuffer::with_backing_store(scope, &backing_store);
@@ -237,8 +249,8 @@ fn get_dir_files(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
-    let files = fs.state.borrow().dir_files().to_vec();
+    let imports = fs_imports(&args);
+    let files = imports.legacy_results.borrow().dir_files().to_vec();
     let array = v8::Array::new(scope, 0);
     for (index, file) in files.iter().enumerate() {
         let file = scope.string(file);
@@ -252,9 +264,11 @@ fn create_dir_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    let status = fs.host.create_dir_new(&mut fs.state.borrow_mut(), &path);
+    let status = imports
+        .filesystem
+        .create_dir_new(&mut imports.legacy_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -263,9 +277,11 @@ fn read_dir_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    let status = fs.host.read_dir_new(&mut fs.state.borrow_mut(), &path);
+    let status = imports
+        .filesystem
+        .read_dir_new(&mut imports.legacy_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -274,9 +290,11 @@ fn is_file_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    let status = fs.host.is_file_new(&mut fs.state.borrow_mut(), &path);
+    let status = imports
+        .filesystem
+        .is_file_new(&mut imports.legacy_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -285,9 +303,11 @@ fn is_dir_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    let status = fs.host.is_dir_new(&mut fs.state.borrow_mut(), &path);
+    let status = imports
+        .filesystem
+        .is_dir_new(&mut imports.legacy_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -296,9 +316,11 @@ fn remove_file_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    let status = fs.host.remove_file_new(&mut fs.state.borrow_mut(), &path);
+    let status = imports
+        .filesystem
+        .remove_file_new(&mut imports.legacy_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -307,9 +329,11 @@ fn remove_dir_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let imports = fs_imports(&args);
     let path = args.string_lossy(scope, 0);
-    let status = fs.host.remove_dir_new(&mut fs.state.borrow_mut(), &path);
+    let status = imports
+        .filesystem
+        .remove_dir_new(&mut imports.legacy_results.borrow_mut(), &path);
     ret.set_int32(status);
 }
 
@@ -318,8 +342,8 @@ fn get_error_message(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let fs = unsafe { get_ref::<FsImports>(&args) };
-    let message = fs.state.borrow().error_message().to_owned();
+    let imports = fs_imports(&args);
+    let message = imports.legacy_results.borrow().error_message().to_owned();
     ret.set(scope.string(&message).into());
 }
 
@@ -335,62 +359,74 @@ pub(crate) fn init_fs<'s>(
     policy: Arc<AsyncPolicy>,
     dtors: &mut Vec<Box<dyn Any>>,
 ) {
-    let fs = Box::new(FsImports::new(policy));
-    let fs_ptr = &*fs as *const FsImports;
-    dtors.push(fs);
+    let imports = Box::new(FsImports::new(policy));
+    let imports_ptr = &*imports as *const FsImports;
+    dtors.push(imports);
 
     set_host_func(
         obj,
         scope,
         "read_file_to_string",
         read_file_to_string,
-        fs_ptr,
+        imports_ptr,
     );
     set_host_func(
         obj,
         scope,
         "write_string_to_file",
         write_string_to_file,
-        fs_ptr,
+        imports_ptr,
     );
     set_host_func(
         obj,
         scope,
         "write_bytes_to_file",
         write_bytes_to_file,
-        fs_ptr,
+        imports_ptr,
     );
-    set_host_func(obj, scope, "create_dir", create_dir, fs_ptr);
-    set_host_func(obj, scope, "read_dir", read_dir, fs_ptr);
-    set_host_func(obj, scope, "is_file", is_file, fs_ptr);
-    set_host_func(obj, scope, "is_dir", is_dir, fs_ptr);
-    set_host_func(obj, scope, "remove_file", remove_file, fs_ptr);
-    set_host_func(obj, scope, "remove_dir", remove_dir, fs_ptr);
-    set_host_func(obj, scope, "path_exists", path_exists, fs_ptr);
-    set_host_func(obj, scope, "current_dir", current_dir, fs_ptr);
+    set_host_func(obj, scope, "create_dir", create_dir, imports_ptr);
+    set_host_func(obj, scope, "read_dir", read_dir, imports_ptr);
+    set_host_func(obj, scope, "is_file", is_file, imports_ptr);
+    set_host_func(obj, scope, "is_dir", is_dir, imports_ptr);
+    set_host_func(obj, scope, "remove_file", remove_file, imports_ptr);
+    set_host_func(obj, scope, "remove_dir", remove_dir, imports_ptr);
+    set_host_func(obj, scope, "path_exists", path_exists, imports_ptr);
+    set_host_func(obj, scope, "current_dir", current_dir, imports_ptr);
     set_host_func(
         obj,
         scope,
         "read_file_to_bytes_new",
         read_file_to_bytes_new,
-        fs_ptr,
+        imports_ptr,
     );
     set_host_func(
         obj,
         scope,
         "write_bytes_to_file_new",
         write_bytes_to_file_new,
-        fs_ptr,
+        imports_ptr,
     );
-    set_host_func(obj, scope, "get_file_content", get_file_content, fs_ptr);
-    set_host_func(obj, scope, "get_dir_files", get_dir_files, fs_ptr);
-    set_host_func(obj, scope, "get_error_message", get_error_message, fs_ptr);
-    set_host_func(obj, scope, "create_dir_new", create_dir_new, fs_ptr);
-    set_host_func(obj, scope, "read_dir_new", read_dir_new, fs_ptr);
-    set_host_func(obj, scope, "is_file_new", is_file_new, fs_ptr);
-    set_host_func(obj, scope, "is_dir_new", is_dir_new, fs_ptr);
-    set_host_func(obj, scope, "remove_file_new", remove_file_new, fs_ptr);
-    set_host_func(obj, scope, "remove_dir_new", remove_dir_new, fs_ptr);
+    set_host_func(
+        obj,
+        scope,
+        "get_file_content",
+        get_file_content,
+        imports_ptr,
+    );
+    set_host_func(obj, scope, "get_dir_files", get_dir_files, imports_ptr);
+    set_host_func(
+        obj,
+        scope,
+        "get_error_message",
+        get_error_message,
+        imports_ptr,
+    );
+    set_host_func(obj, scope, "create_dir_new", create_dir_new, imports_ptr);
+    set_host_func(obj, scope, "read_dir_new", read_dir_new, imports_ptr);
+    set_host_func(obj, scope, "is_file_new", is_file_new, imports_ptr);
+    set_host_func(obj, scope, "is_dir_new", is_dir_new, imports_ptr);
+    set_host_func(obj, scope, "remove_file_new", remove_file_new, imports_ptr);
+    set_host_func(obj, scope, "remove_dir_new", remove_dir_new, imports_ptr);
 }
 
 fn set_host_func<'s>(
@@ -398,9 +434,9 @@ fn set_host_func<'s>(
     scope: &mut v8::HandleScope<'s>,
     name: &str,
     callback: impl v8::MapFnTo<v8::FunctionCallback>,
-    fs_ptr: *const FsImports,
+    imports_ptr: *const FsImports,
 ) {
-    let data = v8::External::new(scope, fs_ptr as *mut std::ffi::c_void);
+    let data = v8::External::new(scope, imports_ptr as *mut std::ffi::c_void);
     let function = v8::Function::builder(callback)
         .data(data.into())
         .build(scope)

--- a/crates/moonrun/src/fs_api_temp.rs
+++ b/crates/moonrun/src/fs_api_temp.rs
@@ -16,16 +16,33 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Temporary-use FS API. Only has whole-file read/write and no other features.
+//! V8 adapter for the temporary whole-file filesystem imports.
 
 use std::any::Any;
-use std::ffi::OsStr;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::cell::RefCell;
+use std::sync::Arc;
 
-use crate::async_host::AsyncHostResult;
-use crate::async_policy::{AsyncPolicy, RuntimePathBase};
+use crate::async_policy::AsyncPolicy;
+use crate::host_fs::{HostFs, HostFsState};
 use crate::util::get_ref;
 use crate::v8_builder::{ArgsExt, ObjectExt, ScopeExt};
+
+struct FsImports {
+    host: HostFs,
+    // V8 invokes these imports synchronously on the isolate thread. Keep the
+    // adapter's mutable protocol state local without imposing a threading
+    // model on the engine-neutral HostFsState.
+    state: RefCell<HostFsState>,
+}
+
+impl FsImports {
+    fn new(policy: Arc<AsyncPolicy>) -> Self {
+        Self {
+            host: HostFs::new(policy),
+            state: RefCell::new(HostFsState::default()),
+        }
+    }
+}
 
 /// `fn read_file_to_string(path: JSString) -> JSString`
 fn read_file_to_string(
@@ -33,13 +50,13 @@ fn read_file_to_string(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    ensure_read(&args, &path).unwrap_or_else(|_| panic!("Permission denied: {path}"));
-
-    let contents =
-        std::fs::read_to_string(&path).unwrap_or_else(|_| panic!("Failed to read file: {path}"));
-    let contents = scope.string(&contents);
-    ret.set(contents.into());
+    let contents = fs
+        .host
+        .read_file_to_string(&path)
+        .unwrap_or_else(|error| panic!("{error}"));
+    ret.set(scope.string(&contents).into());
 }
 
 /// `fn write_string_to_file(path: JSString, contents: JSString) -> Unit`
@@ -48,13 +65,13 @@ fn write_string_to_file(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
     let contents = args.string_lossy(scope, 1);
-    ensure_write(&args, &path).unwrap_or_else(|_| panic!("Permission denied: {path}"));
-
-    std::fs::write(&path, contents).unwrap_or_else(|_| panic!("Failed to write file: {path}"));
-
-    ret.set_undefined()
+    fs.host
+        .write_string_to_file(&path, &contents)
+        .unwrap_or_else(|error| panic!("{error}"));
+    ret.set_undefined();
 }
 
 fn write_bytes_to_file(
@@ -62,18 +79,15 @@ fn write_bytes_to_file(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    let contents = args.get(1);
-    ensure_write(&args, &path).unwrap_or_else(|_| panic!("Permission denied: {path}"));
-
-    let uint8_array = v8::Local::<v8::Uint8Array>::try_from(contents).unwrap();
-    let length = uint8_array.byte_length();
-    let mut buffer = vec![0; length];
-    uint8_array.copy_contents(&mut buffer);
-
-    std::fs::write(&path, buffer).unwrap_or_else(|_| panic!("Failed to write file: {path}"));
-
-    ret.set_undefined()
+    fs.host
+        .write_bytes_to_file(&path, || {
+            let array = v8::Local::<v8::Uint8Array>::try_from(args.get(1)).unwrap();
+            copy_uint8_array(array)
+        })
+        .unwrap_or_else(|error| panic!("{error}"));
+    ret.set_undefined();
 }
 
 fn create_dir(
@@ -81,41 +95,30 @@ fn create_dir(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    ensure_write(&args, &path).unwrap_or_else(|_| panic!("Permission denied: {path}"));
-
-    std::fs::create_dir_all(&path).unwrap_or_else(|_| panic!("Failed to create directory: {path}"));
-
-    ret.set_undefined()
+    fs.host
+        .create_dir(&path)
+        .unwrap_or_else(|error| panic!("{error}"));
+    ret.set_undefined();
 }
 
-#[allow(clippy::manual_flatten)]
 fn read_dir(
     scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    ensure_read(&args, &path).unwrap_or_else(|_| panic!("Permission denied: {path}"));
-
-    let entries =
-        std::fs::read_dir(&path).unwrap_or_else(|_| panic!("Failed to read directory: {path}"));
-
+    let entries = fs
+        .host
+        .read_dir(&path)
+        .unwrap_or_else(|error| panic!("{error}"));
     let result = v8::Array::new(scope, 0);
-    let mut index = 0;
-
-    for entry in entries {
-        if let Ok(entry) = entry {
-            let rust_style_path = entry.path();
-            let node_style_path = rust_style_path.strip_prefix(&path).unwrap();
-            if let Some(path_str) = node_style_path.to_str() {
-                let js_string = scope.string(path_str);
-                result.set_index(scope, index, js_string.into()).unwrap();
-                index += 1;
-            }
-        }
+    for (index, entry) in entries.iter().enumerate() {
+        let entry = scope.string(entry);
+        result.set_index(scope, index as u32, entry.into()).unwrap();
     }
-
     ret.set(result.into());
 }
 
@@ -124,14 +127,9 @@ fn is_file(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    if ensure_read(&args, &path).is_err() {
-        ret.set_bool(false);
-        return;
-    }
-
-    let is_file = std::path::Path::new(&path).is_file();
-    ret.set_bool(is_file);
+    ret.set_bool(fs.host.is_file(&path));
 }
 
 fn is_dir(
@@ -139,14 +137,9 @@ fn is_dir(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    if ensure_read(&args, &path).is_err() {
-        ret.set_bool(false);
-        return;
-    }
-
-    let is_dir = std::path::Path::new(&path).is_dir();
-    ret.set_bool(is_dir);
+    ret.set_bool(fs.host.is_dir(&path));
 }
 
 fn remove_file(
@@ -154,11 +147,11 @@ fn remove_file(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    ensure_remove(&args, &path).unwrap_or_else(|_| panic!("Permission denied: {path}"));
-
-    std::fs::remove_file(&path).unwrap_or_else(|_| panic!("Failed to remove file: {path}"));
-
+    fs.host
+        .remove_file(&path)
+        .unwrap_or_else(|error| panic!("{error}"));
     ret.set_undefined();
 }
 
@@ -167,11 +160,11 @@ fn remove_dir(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    ensure_remove(&args, &path).unwrap_or_else(|_| panic!("Permission denied: {path}"));
-
-    std::fs::remove_dir_all(&path).unwrap_or_else(|_| panic!("Failed to remove directory: {path}"));
-
+    fs.host
+        .remove_dir(&path)
+        .unwrap_or_else(|error| panic!("{error}"));
     ret.set_undefined();
 }
 
@@ -180,14 +173,9 @@ fn path_exists(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    if ensure_read(&args, &path).is_err() {
-        ret.set_bool(false);
-        return;
-    }
-
-    let exists = std::path::Path::new(&path).exists();
-    ret.set_bool(exists);
+    ret.set_bool(fs.host.path_exists(&path));
 }
 
 fn current_dir(
@@ -195,29 +183,8 @@ fn current_dir(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    if ensure_read(&args, ".").is_err() {
-        ret.set(scope.string("").into());
-        return;
-    }
-
-    let current_dir = std::env::current_dir().unwrap_or_default();
-    let current_dir = current_dir.to_str().unwrap();
-    let current_dir = scope.string(current_dir);
-    ret.set(current_dir.into());
-}
-
-static GLOBAL_STATE: LazyLock<Mutex<GlobalState>> = LazyLock::new(|| {
-    Mutex::new(GlobalState {
-        file_content: Vec::new(),
-        dir_files: Vec::new(),
-        error_message: String::new(),
-    })
-});
-
-struct GlobalState {
-    file_content: Vec<u8>,
-    dir_files: Vec<String>,
-    error_message: String,
+    let fs = unsafe { get_ref::<FsImports>(&args) };
+    ret.set(scope.string(&fs.host.current_dir()).into());
 }
 
 fn write_bytes_to_file_new(
@@ -225,36 +192,17 @@ fn write_bytes_to_file_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    if ensure_write_new(&args, &path, &mut ret) {
-        return;
-    }
-
-    let contents = args.get(1);
-    let uint8_array = match v8::Local::<v8::Uint8Array>::try_from(contents) {
-        Ok(array) => array,
-        Err(_) => {
-            GLOBAL_STATE.lock().unwrap().error_message =
-                "Failed to convert contents to Uint8Array".to_string();
-            ret.set_int32(-1);
-            return;
-        }
-    };
-
-    let length = uint8_array.byte_length();
-    let mut buffer = vec![0; length];
-    uint8_array.copy_contents(&mut buffer);
-
-    match std::fs::write(&path, buffer) {
-        Ok(_) => {
-            ret.set_int32(0);
-        }
-        Err(e) => {
-            GLOBAL_STATE.lock().unwrap().error_message =
-                format!("Failed to write file {path}: {e}");
-            ret.set_int32(-1);
-        }
-    }
+    let status = fs
+        .host
+        .write_bytes_to_file_new(&mut fs.state.borrow_mut(), &path, || {
+            match v8::Local::<v8::Uint8Array>::try_from(args.get(1)) {
+                Ok(array) => Ok(copy_uint8_array(array)),
+                Err(_) => Err("Failed to convert contents to Uint8Array".to_string()),
+            }
+        });
+    ret.set_int32(status);
 }
 
 fn read_file_to_bytes_new(
@@ -262,50 +210,39 @@ fn read_file_to_bytes_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    if ensure_read_new(&args, &path, &mut ret) {
-        return;
-    }
-
-    match std::fs::read(&path) {
-        Ok(contents) => {
-            GLOBAL_STATE.lock().unwrap().file_content = contents;
-            ret.set_int32(0);
-        }
-        Err(e) => {
-            GLOBAL_STATE.lock().unwrap().error_message = format!("Failed to read file {path}: {e}");
-            ret.set_int32(-1);
-        }
-    }
+    let status = fs
+        .host
+        .read_file_to_bytes_new(&mut fs.state.borrow_mut(), &path);
+    ret.set_int32(status);
 }
 
 fn get_file_content(
     scope: &mut v8::HandleScope,
-    _args: v8::FunctionCallbackArguments,
+    args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let state = GLOBAL_STATE.lock().unwrap();
-    let array_buffer = v8::ArrayBuffer::with_backing_store(
-        scope,
-        &v8::ArrayBuffer::new_backing_store_from_bytes(state.file_content.clone()).make_shared(),
-    );
-    let uint8_array =
-        v8::Uint8Array::new(scope, array_buffer, 0, state.file_content.len()).unwrap();
+    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let contents = fs.state.borrow().file_content().to_vec();
+    let length = contents.len();
+    let backing_store = v8::ArrayBuffer::new_backing_store_from_bytes(contents).make_shared();
+    let array_buffer = v8::ArrayBuffer::with_backing_store(scope, &backing_store);
+    let uint8_array = v8::Uint8Array::new(scope, array_buffer, 0, length).unwrap();
     ret.set(uint8_array.into());
 }
 
 fn get_dir_files(
     scope: &mut v8::HandleScope,
-    _args: v8::FunctionCallbackArguments,
+    args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let state = GLOBAL_STATE.lock().unwrap();
+    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let files = fs.state.borrow().dir_files().to_vec();
     let array = v8::Array::new(scope, 0);
-    for (index, file) in state.dir_files.iter().enumerate() {
-        let js_string = scope.string(file);
-        array
-            .set_index(scope, index as u32, js_string.into())
-            .unwrap();
+    for (index, file) in files.iter().enumerate() {
+        let file = scope.string(file);
+        array.set_index(scope, index as u32, file.into()).unwrap();
     }
     ret.set(array.into());
 }
@@ -315,58 +252,21 @@ fn create_dir_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    if ensure_write_new(&args, &path, &mut ret) {
-        return;
-    }
-
-    match std::fs::create_dir_all(&path) {
-        Ok(_) => {
-            ret.set_int32(0);
-        }
-        Err(e) => {
-            GLOBAL_STATE.lock().unwrap().error_message =
-                format!("Failed to create directory {path}: {e}");
-            ret.set_int32(-1);
-        }
-    }
+    let status = fs.host.create_dir_new(&mut fs.state.borrow_mut(), &path);
+    ret.set_int32(status);
 }
 
-#[allow(clippy::manual_flatten)]
 fn read_dir_new(
     scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    if ensure_read_new(&args, &path, &mut ret) {
-        return;
-    }
-
-    let entries = match std::fs::read_dir(&path) {
-        Ok(entries) => entries,
-        Err(e) => {
-            GLOBAL_STATE.lock().unwrap().error_message =
-                format!("Failed to read directory {path}: {e}");
-            ret.set_int32(-1);
-            return;
-        }
-    };
-
-    let mut dir_files = Vec::new();
-    for entry in entries {
-        if let Ok(entry) = entry {
-            let rust_style_path = entry.path();
-            let node_style_path = rust_style_path.strip_prefix(&path).unwrap();
-            if let Some(path_str) = node_style_path.to_str() {
-                dir_files.push(path_str.to_string());
-            }
-        }
-    }
-
-    GLOBAL_STATE.lock().unwrap().dir_files = dir_files;
-
-    ret.set_int32(0);
+    let status = fs.host.read_dir_new(&mut fs.state.borrow_mut(), &path);
+    ret.set_int32(status);
 }
 
 fn is_file_new(
@@ -374,25 +274,10 @@ fn is_file_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    if ensure_read_new(&args, &path, &mut ret) {
-        return;
-    }
-
-    let is_file = match std::fs::metadata(&path) {
-        Ok(metadata) => {
-            if metadata.is_file() {
-                1
-            } else {
-                0
-            }
-        }
-        Err(e) => {
-            GLOBAL_STATE.lock().unwrap().error_message = format!("{e}: {path}");
-            -1
-        }
-    };
-    ret.set_int32(is_file);
+    let status = fs.host.is_file_new(&mut fs.state.borrow_mut(), &path);
+    ret.set_int32(status);
 }
 
 fn is_dir_new(
@@ -400,25 +285,10 @@ fn is_dir_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    if ensure_read_new(&args, &path, &mut ret) {
-        return;
-    }
-
-    let is_dir = match std::fs::metadata(&path) {
-        Ok(metadata) => {
-            if metadata.is_dir() {
-                1
-            } else {
-                0
-            }
-        }
-        Err(e) => {
-            GLOBAL_STATE.lock().unwrap().error_message = format!("{e}: {path}");
-            -1
-        }
-    };
-    ret.set_int32(is_dir);
+    let status = fs.host.is_dir_new(&mut fs.state.borrow_mut(), &path);
+    ret.set_int32(status);
 }
 
 fn remove_file_new(
@@ -426,21 +296,10 @@ fn remove_file_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    if ensure_remove_new(&args, &path, &mut ret) {
-        return;
-    }
-
-    match std::fs::remove_file(&path) {
-        Ok(_) => {
-            ret.set_int32(0);
-        }
-        Err(e) => {
-            GLOBAL_STATE.lock().unwrap().error_message =
-                format!("Failed to remove file {path}: {e}");
-            ret.set_int32(-1);
-        }
-    }
+    let status = fs.host.remove_file_new(&mut fs.state.borrow_mut(), &path);
+    ret.set_int32(status);
 }
 
 fn remove_dir_new(
@@ -448,31 +307,26 @@ fn remove_dir_new(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
+    let fs = unsafe { get_ref::<FsImports>(&args) };
     let path = args.string_lossy(scope, 0);
-    if ensure_remove_new(&args, &path, &mut ret) {
-        return;
-    }
-
-    match std::fs::remove_dir_all(&path) {
-        Ok(_) => {
-            ret.set_int32(0);
-        }
-        Err(e) => {
-            GLOBAL_STATE.lock().unwrap().error_message =
-                format!("Failed to remove directory {path}: {e}");
-            ret.set_int32(-1);
-        }
-    }
+    let status = fs.host.remove_dir_new(&mut fs.state.borrow_mut(), &path);
+    ret.set_int32(status);
 }
 
 fn get_error_message(
     scope: &mut v8::HandleScope,
-    _args: v8::FunctionCallbackArguments,
+    args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let state = GLOBAL_STATE.lock().unwrap();
-    let error = scope.string(&state.error_message);
-    ret.set(error.into());
+    let fs = unsafe { get_ref::<FsImports>(&args) };
+    let message = fs.state.borrow().error_message().to_owned();
+    ret.set(scope.string(&message).into());
+}
+
+fn copy_uint8_array(array: v8::Local<'_, v8::Uint8Array>) -> Vec<u8> {
+    let mut buffer = vec![0; array.byte_length()];
+    array.copy_contents(&mut buffer);
+    buffer
 }
 
 pub(crate) fn init_fs<'s>(
@@ -481,168 +335,75 @@ pub(crate) fn init_fs<'s>(
     policy: Arc<AsyncPolicy>,
     dtors: &mut Vec<Box<dyn Any>>,
 ) {
-    let policy_ptr = Arc::as_ptr(&policy);
-    dtors.push(Box::new(policy));
+    let fs = Box::new(FsImports::new(policy));
+    let fs_ptr = &*fs as *const FsImports;
+    dtors.push(fs);
 
-    set_policy_func(
+    set_host_func(
         obj,
         scope,
         "read_file_to_string",
         read_file_to_string,
-        policy_ptr,
+        fs_ptr,
     );
-    set_policy_func(
+    set_host_func(
         obj,
         scope,
         "write_string_to_file",
         write_string_to_file,
-        policy_ptr,
+        fs_ptr,
     );
-    set_policy_func(
+    set_host_func(
         obj,
         scope,
         "write_bytes_to_file",
         write_bytes_to_file,
-        policy_ptr,
+        fs_ptr,
     );
-    set_policy_func(obj, scope, "create_dir", create_dir, policy_ptr);
-    set_policy_func(obj, scope, "read_dir", read_dir, policy_ptr);
-    set_policy_func(obj, scope, "is_file", is_file, policy_ptr);
-    set_policy_func(obj, scope, "is_dir", is_dir, policy_ptr);
-    set_policy_func(obj, scope, "remove_file", remove_file, policy_ptr);
-    set_policy_func(obj, scope, "remove_dir", remove_dir, policy_ptr);
-    set_policy_func(obj, scope, "path_exists", path_exists, policy_ptr);
-    set_policy_func(obj, scope, "current_dir", current_dir, policy_ptr);
-
-    set_policy_func(
+    set_host_func(obj, scope, "create_dir", create_dir, fs_ptr);
+    set_host_func(obj, scope, "read_dir", read_dir, fs_ptr);
+    set_host_func(obj, scope, "is_file", is_file, fs_ptr);
+    set_host_func(obj, scope, "is_dir", is_dir, fs_ptr);
+    set_host_func(obj, scope, "remove_file", remove_file, fs_ptr);
+    set_host_func(obj, scope, "remove_dir", remove_dir, fs_ptr);
+    set_host_func(obj, scope, "path_exists", path_exists, fs_ptr);
+    set_host_func(obj, scope, "current_dir", current_dir, fs_ptr);
+    set_host_func(
         obj,
         scope,
         "read_file_to_bytes_new",
         read_file_to_bytes_new,
-        policy_ptr,
+        fs_ptr,
     );
-    set_policy_func(
+    set_host_func(
         obj,
         scope,
         "write_bytes_to_file_new",
         write_bytes_to_file_new,
-        policy_ptr,
+        fs_ptr,
     );
-    obj.set_func(scope, "get_file_content", get_file_content);
-    obj.set_func(scope, "get_dir_files", get_dir_files);
-    obj.set_func(scope, "get_error_message", get_error_message);
-    set_policy_func(obj, scope, "create_dir_new", create_dir_new, policy_ptr);
-    set_policy_func(obj, scope, "read_dir_new", read_dir_new, policy_ptr);
-    set_policy_func(obj, scope, "is_file_new", is_file_new, policy_ptr);
-    set_policy_func(obj, scope, "is_dir_new", is_dir_new, policy_ptr);
-    set_policy_func(obj, scope, "remove_file_new", remove_file_new, policy_ptr);
-    set_policy_func(obj, scope, "remove_dir_new", remove_dir_new, policy_ptr);
+    set_host_func(obj, scope, "get_file_content", get_file_content, fs_ptr);
+    set_host_func(obj, scope, "get_dir_files", get_dir_files, fs_ptr);
+    set_host_func(obj, scope, "get_error_message", get_error_message, fs_ptr);
+    set_host_func(obj, scope, "create_dir_new", create_dir_new, fs_ptr);
+    set_host_func(obj, scope, "read_dir_new", read_dir_new, fs_ptr);
+    set_host_func(obj, scope, "is_file_new", is_file_new, fs_ptr);
+    set_host_func(obj, scope, "is_dir_new", is_dir_new, fs_ptr);
+    set_host_func(obj, scope, "remove_file_new", remove_file_new, fs_ptr);
+    set_host_func(obj, scope, "remove_dir_new", remove_dir_new, fs_ptr);
 }
 
-fn ensure_read(args: &v8::FunctionCallbackArguments<'_>, path: &str) -> AsyncHostResult<()> {
-    let policy = unsafe { get_ref::<AsyncPolicy>(args) };
-    policy.stat_path(RuntimePathBase::CurrentDirectory, OsStr::new(path))
-}
-
-fn ensure_write(args: &v8::FunctionCallbackArguments<'_>, path: &str) -> AsyncHostResult<()> {
-    let policy = unsafe { get_ref::<AsyncPolicy>(args) };
-    policy.open_path(
-        RuntimePathBase::CurrentDirectory,
-        OsStr::new(path),
-        1,
-        1,
-        false,
-    )
-}
-
-fn ensure_remove(args: &v8::FunctionCallbackArguments<'_>, path: &str) -> AsyncHostResult<()> {
-    let policy = unsafe { get_ref::<AsyncPolicy>(args) };
-    ensure_remove_policy(policy, path)
-}
-
-fn ensure_remove_policy(policy: &AsyncPolicy, path: &str) -> AsyncHostResult<()> {
-    policy.remove_path(OsStr::new(path))
-}
-
-fn ensure_read_new(
-    args: &v8::FunctionCallbackArguments<'_>,
-    path: &str,
-    ret: &mut v8::ReturnValue,
-) -> bool {
-    if ensure_read(args, path).is_ok() {
-        return false;
-    }
-    GLOBAL_STATE.lock().unwrap().error_message = format!("Permission denied: {path}");
-    ret.set_int32(-1);
-    true
-}
-
-fn ensure_write_new(
-    args: &v8::FunctionCallbackArguments<'_>,
-    path: &str,
-    ret: &mut v8::ReturnValue,
-) -> bool {
-    if ensure_write(args, path).is_ok() {
-        return false;
-    }
-    GLOBAL_STATE.lock().unwrap().error_message = format!("Permission denied: {path}");
-    ret.set_int32(-1);
-    true
-}
-
-fn ensure_remove_new(
-    args: &v8::FunctionCallbackArguments<'_>,
-    path: &str,
-    ret: &mut v8::ReturnValue,
-) -> bool {
-    if ensure_remove(args, path).is_ok() {
-        return false;
-    }
-    GLOBAL_STATE.lock().unwrap().error_message = format!("Permission denied: {path}");
-    ret.set_int32(-1);
-    true
-}
-
-fn set_policy_func<'s>(
+fn set_host_func<'s>(
     obj: v8::Local<'s, v8::Object>,
     scope: &mut v8::HandleScope<'s>,
     name: &str,
     callback: impl v8::MapFnTo<v8::FunctionCallback>,
-    policy_ptr: *const AsyncPolicy,
+    fs_ptr: *const FsImports,
 ) {
-    let data = v8::External::new(scope, policy_ptr as *mut std::ffi::c_void);
+    let data = v8::External::new(scope, fs_ptr as *mut std::ffi::c_void);
     let function = v8::Function::builder(callback)
         .data(data.into())
         .build(scope)
         .unwrap();
     obj.set_value(scope, name, function.into());
-}
-
-#[cfg(test)]
-mod tests {
-    #[cfg(unix)]
-    #[test]
-    fn temp_remove_policy_checks_link_path_not_target() {
-        use crate::async_host::AsyncHostError;
-
-        use super::*;
-
-        let tmp = tempfile::tempdir().unwrap();
-        let allowed = tmp.path().join("allowed");
-        let denied = tmp.path().join("denied");
-        std::fs::create_dir(&allowed).unwrap();
-        std::fs::create_dir(&denied).unwrap();
-        let allowed_file = allowed.join("target.txt");
-        let denied_link = denied.join("link.txt");
-        std::fs::write(&allowed_file, "target").unwrap();
-        std::os::unix::fs::symlink(&allowed_file, &denied_link).unwrap();
-        let policy_file = tmp.path().join("policy.toml");
-        std::fs::write(&policy_file, "[fs]\nwrite = [\"allowed\"]\n").unwrap();
-        let policy = AsyncPolicy::from_file(&policy_file).unwrap();
-
-        assert_eq!(
-            ensure_remove_policy(&policy, denied_link.to_str().unwrap()),
-            Err(AsyncHostError::PermissionDenied)
-        );
-    }
 }

--- a/crates/moonrun/src/host_fs.rs
+++ b/crates/moonrun/src/host_fs.rs
@@ -54,16 +54,15 @@ impl HostFsError {
     }
 }
 
-/// Results retained between an operation and its getter in the legacy
-/// status-then-getter filesystem import protocol.
+/// Results retained between a filesystem operation and its getter.
 #[derive(Default)]
-pub(crate) struct LegacyFsResults {
+pub(crate) struct FsOperationResults {
     file_content: Vec<u8>,
     dir_files: Vec<String>,
     error_message: String,
 }
 
-impl LegacyFsResults {
+impl FsOperationResults {
     pub(crate) fn file_content(&self) -> &[u8] {
         &self.file_content
     }
@@ -163,7 +162,11 @@ impl HostFs {
             .to_owned()
     }
 
-    pub(crate) fn read_file_to_bytes_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
+    pub(crate) fn read_file_to_bytes_new(
+        &self,
+        results: &mut FsOperationResults,
+        path: &str,
+    ) -> i32 {
         let result = self.ensure_read(path).and_then(|()| {
             std::fs::read(path).map_err(|error| {
                 HostFsError::operation(format!("Failed to read file {path}: {error}"))
@@ -180,7 +183,7 @@ impl HostFs {
 
     pub(crate) fn write_bytes_to_file_new(
         &self,
-        results: &mut LegacyFsResults,
+        results: &mut FsOperationResults,
         path: &str,
         contents: impl FnOnce() -> Result<Vec<u8>, String>,
     ) -> i32 {
@@ -197,7 +200,7 @@ impl HostFs {
         operation_status(results, result)
     }
 
-    pub(crate) fn create_dir_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
+    pub(crate) fn create_dir_new(&self, results: &mut FsOperationResults, path: &str) -> i32 {
         let result = self.ensure_write(path).and_then(|()| {
             std::fs::create_dir_all(path).map_err(|error| {
                 HostFsError::operation(format!("Failed to create directory {path}: {error}"))
@@ -206,7 +209,7 @@ impl HostFs {
         operation_status(results, result)
     }
 
-    pub(crate) fn read_dir_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
+    pub(crate) fn read_dir_new(&self, results: &mut FsOperationResults, path: &str) -> i32 {
         let result = self.ensure_read(path).and_then(|()| {
             read_dir_entries(path).map_err(|error| {
                 HostFsError::operation(format!("Failed to read directory {path}: {error}"))
@@ -221,15 +224,15 @@ impl HostFs {
         }
     }
 
-    pub(crate) fn is_file_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
+    pub(crate) fn is_file_new(&self, results: &mut FsOperationResults, path: &str) -> i32 {
         self.metadata_kind(results, path, std::fs::Metadata::is_file)
     }
 
-    pub(crate) fn is_dir_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
+    pub(crate) fn is_dir_new(&self, results: &mut FsOperationResults, path: &str) -> i32 {
         self.metadata_kind(results, path, std::fs::Metadata::is_dir)
     }
 
-    pub(crate) fn remove_file_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
+    pub(crate) fn remove_file_new(&self, results: &mut FsOperationResults, path: &str) -> i32 {
         let result = self.ensure_remove(path).and_then(|()| {
             std::fs::remove_file(path).map_err(|error| {
                 HostFsError::operation(format!("Failed to remove file {path}: {error}"))
@@ -238,7 +241,7 @@ impl HostFs {
         operation_status(results, result)
     }
 
-    pub(crate) fn remove_dir_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
+    pub(crate) fn remove_dir_new(&self, results: &mut FsOperationResults, path: &str) -> i32 {
         let result = self.ensure_remove(path).and_then(|()| {
             std::fs::remove_dir_all(path).map_err(|error| {
                 HostFsError::operation(format!("Failed to remove directory {path}: {error}"))
@@ -249,7 +252,7 @@ impl HostFs {
 
     fn metadata_kind(
         &self,
-        results: &mut LegacyFsResults,
+        results: &mut FsOperationResults,
         path: &str,
         kind: fn(&std::fs::Metadata) -> bool,
     ) -> i32 {
@@ -306,14 +309,14 @@ fn read_dir_entries(path: &str) -> std::io::Result<Vec<String>> {
         .collect())
 }
 
-fn operation_status(results: &mut LegacyFsResults, result: Result<(), HostFsError>) -> i32 {
+fn operation_status(results: &mut FsOperationResults, result: Result<(), HostFsError>) -> i32 {
     match result {
         Ok(()) => 0,
         Err(error) => set_error(results, error),
     }
 }
 
-fn set_error(results: &mut LegacyFsResults, error: HostFsError) -> i32 {
+fn set_error(results: &mut FsOperationResults, error: HostFsError) -> i32 {
     results.error_message = error.to_string();
     -1
 }
@@ -325,13 +328,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn legacy_results_belong_to_one_runtime() {
+    fn operation_results_belong_to_one_runtime() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("input.bin");
         std::fs::write(&path, [1, 2, 3]).unwrap();
         let host = HostFs::new(Arc::new(AsyncPolicy::allow_all()));
-        let mut first = LegacyFsResults::default();
-        let second = LegacyFsResults::default();
+        let mut first = FsOperationResults::default();
+        let second = FsOperationResults::default();
 
         assert_eq!(
             host.read_file_to_bytes_new(&mut first, path.to_str().unwrap()),
@@ -347,7 +350,7 @@ mod tests {
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\n").unwrap();
         let host = HostFs::new(Arc::new(AsyncPolicy::from_file(&policy_file).unwrap()));
-        let mut results = LegacyFsResults::default();
+        let mut results = FsOperationResults::default();
 
         assert_eq!(host.read_file_to_bytes_new(&mut results, "denied.bin"), -1);
         assert_eq!(results.error_message(), "Permission denied: denied.bin");
@@ -359,7 +362,7 @@ mod tests {
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\n").unwrap();
         let host = HostFs::new(Arc::new(AsyncPolicy::from_file(&policy_file).unwrap()));
-        let mut results = LegacyFsResults::default();
+        let mut results = FsOperationResults::default();
         let converted = Cell::new(false);
 
         let status = host.write_bytes_to_file_new(&mut results, "denied.bin", || {

--- a/crates/moonrun/src/host_fs.rs
+++ b/crates/moonrun/src/host_fs.rs
@@ -54,14 +54,16 @@ impl HostFsError {
     }
 }
 
+/// Results retained between an operation and its getter in the legacy
+/// status-then-getter filesystem import protocol.
 #[derive(Default)]
-pub(crate) struct HostFsState {
+pub(crate) struct LegacyFsResults {
     file_content: Vec<u8>,
     dir_files: Vec<String>,
     error_message: String,
 }
 
-impl HostFsState {
+impl LegacyFsResults {
     pub(crate) fn file_content(&self) -> &[u8] {
         &self.file_content
     }
@@ -75,6 +77,8 @@ impl HostFsState {
     }
 }
 
+/// Engine-neutral filesystem operations that enforce the runtime policy
+/// before accessing the operating system's filesystem.
 pub(crate) struct HostFs {
     policy: Arc<AsyncPolicy>,
 }
@@ -159,7 +163,7 @@ impl HostFs {
             .to_owned()
     }
 
-    pub(crate) fn read_file_to_bytes_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+    pub(crate) fn read_file_to_bytes_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
         let result = self.ensure_read(path).and_then(|()| {
             std::fs::read(path).map_err(|error| {
                 HostFsError::operation(format!("Failed to read file {path}: {error}"))
@@ -167,16 +171,16 @@ impl HostFs {
         });
         match result {
             Ok(contents) => {
-                state.file_content = contents;
+                results.file_content = contents;
                 0
             }
-            Err(error) => set_error(state, error),
+            Err(error) => set_error(results, error),
         }
     }
 
     pub(crate) fn write_bytes_to_file_new(
         &self,
-        state: &mut HostFsState,
+        results: &mut LegacyFsResults,
         path: &str,
         contents: impl FnOnce() -> Result<Vec<u8>, String>,
     ) -> i32 {
@@ -190,19 +194,19 @@ impl HostFs {
                     HostFsError::operation(format!("Failed to write file {path}: {error}"))
                 })
             });
-        operation_status(state, result)
+        operation_status(results, result)
     }
 
-    pub(crate) fn create_dir_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+    pub(crate) fn create_dir_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
         let result = self.ensure_write(path).and_then(|()| {
             std::fs::create_dir_all(path).map_err(|error| {
                 HostFsError::operation(format!("Failed to create directory {path}: {error}"))
             })
         });
-        operation_status(state, result)
+        operation_status(results, result)
     }
 
-    pub(crate) fn read_dir_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+    pub(crate) fn read_dir_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
         let result = self.ensure_read(path).and_then(|()| {
             read_dir_entries(path).map_err(|error| {
                 HostFsError::operation(format!("Failed to read directory {path}: {error}"))
@@ -210,42 +214,42 @@ impl HostFs {
         });
         match result {
             Ok(files) => {
-                state.dir_files = files;
+                results.dir_files = files;
                 0
             }
-            Err(error) => set_error(state, error),
+            Err(error) => set_error(results, error),
         }
     }
 
-    pub(crate) fn is_file_new(&self, state: &mut HostFsState, path: &str) -> i32 {
-        self.metadata_kind(state, path, std::fs::Metadata::is_file)
+    pub(crate) fn is_file_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
+        self.metadata_kind(results, path, std::fs::Metadata::is_file)
     }
 
-    pub(crate) fn is_dir_new(&self, state: &mut HostFsState, path: &str) -> i32 {
-        self.metadata_kind(state, path, std::fs::Metadata::is_dir)
+    pub(crate) fn is_dir_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
+        self.metadata_kind(results, path, std::fs::Metadata::is_dir)
     }
 
-    pub(crate) fn remove_file_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+    pub(crate) fn remove_file_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
         let result = self.ensure_remove(path).and_then(|()| {
             std::fs::remove_file(path).map_err(|error| {
                 HostFsError::operation(format!("Failed to remove file {path}: {error}"))
             })
         });
-        operation_status(state, result)
+        operation_status(results, result)
     }
 
-    pub(crate) fn remove_dir_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+    pub(crate) fn remove_dir_new(&self, results: &mut LegacyFsResults, path: &str) -> i32 {
         let result = self.ensure_remove(path).and_then(|()| {
             std::fs::remove_dir_all(path).map_err(|error| {
                 HostFsError::operation(format!("Failed to remove directory {path}: {error}"))
             })
         });
-        operation_status(state, result)
+        operation_status(results, result)
     }
 
     fn metadata_kind(
         &self,
-        state: &mut HostFsState,
+        results: &mut LegacyFsResults,
         path: &str,
         kind: fn(&std::fs::Metadata) -> bool,
     ) -> i32 {
@@ -256,7 +260,7 @@ impl HostFs {
         });
         match result {
             Ok(value) => value,
-            Err(error) => set_error(state, error),
+            Err(error) => set_error(results, error),
         }
     }
 
@@ -302,15 +306,15 @@ fn read_dir_entries(path: &str) -> std::io::Result<Vec<String>> {
         .collect())
 }
 
-fn operation_status(state: &mut HostFsState, result: Result<(), HostFsError>) -> i32 {
+fn operation_status(results: &mut LegacyFsResults, result: Result<(), HostFsError>) -> i32 {
     match result {
         Ok(()) => 0,
-        Err(error) => set_error(state, error),
+        Err(error) => set_error(results, error),
     }
 }
 
-fn set_error(state: &mut HostFsState, error: HostFsError) -> i32 {
-    state.error_message = error.to_string();
+fn set_error(results: &mut LegacyFsResults, error: HostFsError) -> i32 {
+    results.error_message = error.to_string();
     -1
 }
 
@@ -321,13 +325,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn state_belongs_to_one_runtime() {
+    fn legacy_results_belong_to_one_runtime() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("input.bin");
         std::fs::write(&path, [1, 2, 3]).unwrap();
         let host = HostFs::new(Arc::new(AsyncPolicy::allow_all()));
-        let mut first = HostFsState::default();
-        let second = HostFsState::default();
+        let mut first = LegacyFsResults::default();
+        let second = LegacyFsResults::default();
 
         assert_eq!(
             host.read_file_to_bytes_new(&mut first, path.to_str().unwrap()),
@@ -343,10 +347,10 @@ mod tests {
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\n").unwrap();
         let host = HostFs::new(Arc::new(AsyncPolicy::from_file(&policy_file).unwrap()));
-        let mut state = HostFsState::default();
+        let mut results = LegacyFsResults::default();
 
-        assert_eq!(host.read_file_to_bytes_new(&mut state, "denied.bin"), -1);
-        assert_eq!(state.error_message(), "Permission denied: denied.bin");
+        assert_eq!(host.read_file_to_bytes_new(&mut results, "denied.bin"), -1);
+        assert_eq!(results.error_message(), "Permission denied: denied.bin");
     }
 
     #[test]
@@ -355,17 +359,17 @@ mod tests {
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\n").unwrap();
         let host = HostFs::new(Arc::new(AsyncPolicy::from_file(&policy_file).unwrap()));
-        let mut state = HostFsState::default();
+        let mut results = LegacyFsResults::default();
         let converted = Cell::new(false);
 
-        let status = host.write_bytes_to_file_new(&mut state, "denied.bin", || {
+        let status = host.write_bytes_to_file_new(&mut results, "denied.bin", || {
             converted.set(true);
             Ok(Vec::new())
         });
 
         assert_eq!(status, -1);
         assert!(!converted.get());
-        assert_eq!(state.error_message(), "Permission denied: denied.bin");
+        assert_eq!(results.error_message(), "Permission denied: denied.bin");
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/host_fs.rs
+++ b/crates/moonrun/src/host_fs.rs
@@ -1,0 +1,394 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Engine-neutral implementation of moonrun's permission-backed filesystem imports.
+//!
+//! Runtime adapters convert guest values and expose imports. This module owns
+//! filesystem authorization, OS operations, and the guest-visible error text.
+//! WASI has its own descriptor and preopen capability model and does not pass
+//! through this module.
+
+use std::ffi::OsStr;
+use std::fmt;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::async_host::AsyncHostResult;
+use crate::async_policy::{AsyncPolicy, RuntimePathBase};
+
+#[derive(Debug)]
+pub(crate) struct HostFsError {
+    message: String,
+}
+
+impl fmt::Display for HostFsError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.message.fmt(formatter)
+    }
+}
+
+impl HostFsError {
+    fn permission_denied(path: &str) -> Self {
+        Self {
+            message: format!("Permission denied: {path}"),
+        }
+    }
+
+    fn operation(message: String) -> Self {
+        Self { message }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct HostFsState {
+    file_content: Vec<u8>,
+    dir_files: Vec<String>,
+    error_message: String,
+}
+
+impl HostFsState {
+    pub(crate) fn file_content(&self) -> &[u8] {
+        &self.file_content
+    }
+
+    pub(crate) fn dir_files(&self) -> &[String] {
+        &self.dir_files
+    }
+
+    pub(crate) fn error_message(&self) -> &str {
+        &self.error_message
+    }
+}
+
+pub(crate) struct HostFs {
+    policy: Arc<AsyncPolicy>,
+}
+
+impl HostFs {
+    pub(crate) fn new(policy: Arc<AsyncPolicy>) -> Self {
+        Self { policy }
+    }
+
+    pub(crate) fn read_file_to_string(&self, path: &str) -> Result<String, HostFsError> {
+        self.ensure_read(path)?;
+        std::fs::read_to_string(path)
+            .map_err(|_| HostFsError::operation(format!("Failed to read file: {path}")))
+    }
+
+    pub(crate) fn write_string_to_file(
+        &self,
+        path: &str,
+        contents: &str,
+    ) -> Result<(), HostFsError> {
+        self.ensure_write(path)?;
+        std::fs::write(path, contents)
+            .map_err(|_| HostFsError::operation(format!("Failed to write file: {path}")))
+    }
+
+    pub(crate) fn write_bytes_to_file(
+        &self,
+        path: &str,
+        contents: impl FnOnce() -> Vec<u8>,
+    ) -> Result<(), HostFsError> {
+        self.ensure_write(path)?;
+        // Decode guest-owned contents only after authorization, matching the
+        // existing import's observable failure order for untrusted guests.
+        std::fs::write(path, contents())
+            .map_err(|_| HostFsError::operation(format!("Failed to write file: {path}")))
+    }
+
+    pub(crate) fn create_dir(&self, path: &str) -> Result<(), HostFsError> {
+        self.ensure_write(path)?;
+        std::fs::create_dir_all(path)
+            .map_err(|_| HostFsError::operation(format!("Failed to create directory: {path}")))
+    }
+
+    pub(crate) fn read_dir(&self, path: &str) -> Result<Vec<String>, HostFsError> {
+        self.ensure_read(path)?;
+        read_dir_entries(path)
+            .map_err(|_| HostFsError::operation(format!("Failed to read directory: {path}")))
+    }
+
+    pub(crate) fn is_file(&self, path: &str) -> bool {
+        self.ensure_read(path).is_ok() && Path::new(path).is_file()
+    }
+
+    pub(crate) fn is_dir(&self, path: &str) -> bool {
+        self.ensure_read(path).is_ok() && Path::new(path).is_dir()
+    }
+
+    pub(crate) fn remove_file(&self, path: &str) -> Result<(), HostFsError> {
+        self.ensure_remove(path)?;
+        std::fs::remove_file(path)
+            .map_err(|_| HostFsError::operation(format!("Failed to remove file: {path}")))
+    }
+
+    pub(crate) fn remove_dir(&self, path: &str) -> Result<(), HostFsError> {
+        self.ensure_remove(path)?;
+        std::fs::remove_dir_all(path)
+            .map_err(|_| HostFsError::operation(format!("Failed to remove directory: {path}")))
+    }
+
+    pub(crate) fn path_exists(&self, path: &str) -> bool {
+        self.ensure_read(path).is_ok() && Path::new(path).exists()
+    }
+
+    pub(crate) fn current_dir(&self) -> String {
+        if self.ensure_read(".").is_err() {
+            return String::new();
+        }
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_str()
+            .unwrap()
+            .to_owned()
+    }
+
+    pub(crate) fn read_file_to_bytes_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+        let result = self.ensure_read(path).and_then(|()| {
+            std::fs::read(path).map_err(|error| {
+                HostFsError::operation(format!("Failed to read file {path}: {error}"))
+            })
+        });
+        match result {
+            Ok(contents) => {
+                state.file_content = contents;
+                0
+            }
+            Err(error) => set_error(state, error),
+        }
+    }
+
+    pub(crate) fn write_bytes_to_file_new(
+        &self,
+        state: &mut HostFsState,
+        path: &str,
+        contents: impl FnOnce() -> Result<Vec<u8>, String>,
+    ) -> i32 {
+        // As above, the adapter supplies conversion lazily so denial wins over
+        // an invalid guest byte-array value.
+        let result = self
+            .ensure_write(path)
+            .and_then(|()| contents().map_err(HostFsError::operation))
+            .and_then(|contents| {
+                std::fs::write(path, contents).map_err(|error| {
+                    HostFsError::operation(format!("Failed to write file {path}: {error}"))
+                })
+            });
+        operation_status(state, result)
+    }
+
+    pub(crate) fn create_dir_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+        let result = self.ensure_write(path).and_then(|()| {
+            std::fs::create_dir_all(path).map_err(|error| {
+                HostFsError::operation(format!("Failed to create directory {path}: {error}"))
+            })
+        });
+        operation_status(state, result)
+    }
+
+    pub(crate) fn read_dir_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+        let result = self.ensure_read(path).and_then(|()| {
+            read_dir_entries(path).map_err(|error| {
+                HostFsError::operation(format!("Failed to read directory {path}: {error}"))
+            })
+        });
+        match result {
+            Ok(files) => {
+                state.dir_files = files;
+                0
+            }
+            Err(error) => set_error(state, error),
+        }
+    }
+
+    pub(crate) fn is_file_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+        self.metadata_kind(state, path, std::fs::Metadata::is_file)
+    }
+
+    pub(crate) fn is_dir_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+        self.metadata_kind(state, path, std::fs::Metadata::is_dir)
+    }
+
+    pub(crate) fn remove_file_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+        let result = self.ensure_remove(path).and_then(|()| {
+            std::fs::remove_file(path).map_err(|error| {
+                HostFsError::operation(format!("Failed to remove file {path}: {error}"))
+            })
+        });
+        operation_status(state, result)
+    }
+
+    pub(crate) fn remove_dir_new(&self, state: &mut HostFsState, path: &str) -> i32 {
+        let result = self.ensure_remove(path).and_then(|()| {
+            std::fs::remove_dir_all(path).map_err(|error| {
+                HostFsError::operation(format!("Failed to remove directory {path}: {error}"))
+            })
+        });
+        operation_status(state, result)
+    }
+
+    fn metadata_kind(
+        &self,
+        state: &mut HostFsState,
+        path: &str,
+        kind: fn(&std::fs::Metadata) -> bool,
+    ) -> i32 {
+        let result = self.ensure_read(path).and_then(|()| {
+            std::fs::metadata(path)
+                .map(|metadata| i32::from(kind(&metadata)))
+                .map_err(|error| HostFsError::operation(format!("{error}: {path}")))
+        });
+        match result {
+            Ok(value) => value,
+            Err(error) => set_error(state, error),
+        }
+    }
+
+    fn ensure_read(&self, path: &str) -> Result<(), HostFsError> {
+        ensure_read_policy(&self.policy, path).map_err(|_| HostFsError::permission_denied(path))
+    }
+
+    fn ensure_write(&self, path: &str) -> Result<(), HostFsError> {
+        ensure_write_policy(&self.policy, path).map_err(|_| HostFsError::permission_denied(path))
+    }
+
+    fn ensure_remove(&self, path: &str) -> Result<(), HostFsError> {
+        ensure_remove_policy(&self.policy, path).map_err(|_| HostFsError::permission_denied(path))
+    }
+}
+
+fn ensure_read_policy(policy: &AsyncPolicy, path: &str) -> AsyncHostResult<()> {
+    policy.stat_path(RuntimePathBase::CurrentDirectory, OsStr::new(path))
+}
+
+fn ensure_write_policy(policy: &AsyncPolicy, path: &str) -> AsyncHostResult<()> {
+    policy.open_path(
+        RuntimePathBase::CurrentDirectory,
+        OsStr::new(path),
+        1,
+        1,
+        false,
+    )
+}
+
+fn ensure_remove_policy(policy: &AsyncPolicy, path: &str) -> AsyncHostResult<()> {
+    policy.remove_path(OsStr::new(path))
+}
+
+fn read_dir_entries(path: &str) -> std::io::Result<Vec<String>> {
+    Ok(std::fs::read_dir(path)?
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let entry_path = entry.path();
+            let relative_path = entry_path.strip_prefix(path).unwrap();
+            relative_path.to_str().map(ToOwned::to_owned)
+        })
+        .collect())
+}
+
+fn operation_status(state: &mut HostFsState, result: Result<(), HostFsError>) -> i32 {
+    match result {
+        Ok(()) => 0,
+        Err(error) => set_error(state, error),
+    }
+}
+
+fn set_error(state: &mut HostFsState, error: HostFsError) -> i32 {
+    state.error_message = error.to_string();
+    -1
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    #[test]
+    fn state_belongs_to_one_runtime() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("input.bin");
+        std::fs::write(&path, [1, 2, 3]).unwrap();
+        let host = HostFs::new(Arc::new(AsyncPolicy::allow_all()));
+        let mut first = HostFsState::default();
+        let second = HostFsState::default();
+
+        assert_eq!(
+            host.read_file_to_bytes_new(&mut first, path.to_str().unwrap()),
+            0
+        );
+        assert_eq!(first.file_content(), [1, 2, 3]);
+        assert!(second.file_content().is_empty());
+    }
+
+    #[test]
+    fn denied_status_operation_records_guest_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(&policy_file, "[fs]\n").unwrap();
+        let host = HostFs::new(Arc::new(AsyncPolicy::from_file(&policy_file).unwrap()));
+        let mut state = HostFsState::default();
+
+        assert_eq!(host.read_file_to_bytes_new(&mut state, "denied.bin"), -1);
+        assert_eq!(state.error_message(), "Permission denied: denied.bin");
+    }
+
+    #[test]
+    fn authorization_precedes_guest_byte_conversion() {
+        let tmp = tempfile::tempdir().unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(&policy_file, "[fs]\n").unwrap();
+        let host = HostFs::new(Arc::new(AsyncPolicy::from_file(&policy_file).unwrap()));
+        let mut state = HostFsState::default();
+        let converted = Cell::new(false);
+
+        let status = host.write_bytes_to_file_new(&mut state, "denied.bin", || {
+            converted.set(true);
+            Ok(Vec::new())
+        });
+
+        assert_eq!(status, -1);
+        assert!(!converted.get());
+        assert_eq!(state.error_message(), "Permission denied: denied.bin");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_policy_checks_link_path_not_target() {
+        use crate::async_host::AsyncHostError;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let allowed = tmp.path().join("allowed");
+        let denied = tmp.path().join("denied");
+        std::fs::create_dir(&allowed).unwrap();
+        std::fs::create_dir(&denied).unwrap();
+        let allowed_file = allowed.join("target.txt");
+        let denied_link = denied.join("link.txt");
+        std::fs::write(&allowed_file, "target").unwrap();
+        std::os::unix::fs::symlink(&allowed_file, &denied_link).unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(&policy_file, "[fs]\nwrite = [\"allowed\"]\n").unwrap();
+        let policy = AsyncPolicy::from_file(&policy_file).unwrap();
+
+        assert_eq!(
+            ensure_remove_policy(&policy, denied_link.to_str().unwrap()),
+            Err(AsyncHostError::PermissionDenied)
+        );
+    }
+}

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -32,6 +32,7 @@ mod async_sys;
 mod backtrace_api;
 mod demangle_js_template;
 mod fs_api_temp;
+mod host_fs;
 mod memory_sanitizer_api;
 mod sys_api;
 mod util;


### PR DESCRIPTION
## Why

The V8 filesystem import module currently mixes three concerns: V8 value conversion, moonrun policy enforcement, and host filesystem behavior. Replacing V8 in that shape would require rewriting permission checks and guest-visible error semantics at the same time as the runtime adapter.

WASI is a separate access surface: it is governed by descriptors and preopens, not implicitly by moonrun's permission-backed host imports. Keeping those models explicit avoids suggesting that configuring one also restricts the other.

## What changed

- Add an engine-neutral Host Filesystem that owns authorization, host operations, and guest-visible error text for `__moonbit_fs_unstable`.
- Reduce `fs_api_temp` to a V8 adapter responsible for value conversion and import registration.
- Move the legacy result buffers from a process-global singleton into per-runtime protocol state.
- Document Moonrun Policy, the WASI Capability Surface, and their relationship.

The byte-writing interface keeps guest conversion lazy so permission denial still takes precedence over an invalid guest byte-array value.

## Scope

This is a behavior-preserving preparation change. It does not add Wasmtime, change the WASI implementation, or alter the string/byte host-object representation. It complements #1981 but does not depend on it, so both PRs can be reviewed and merged independently.