### PR TITLE
fix(moonrun): scope async guest exits to runtime

### DIFF
--- a/crates/moonrun/src/async_api/context.rs
+++ b/crates/moonrun/src/async_api/context.rs
@@ -21,12 +21,15 @@ use std::sync::OnceLock;
 
 use crate::async_host::{AsyncHost, AsyncHostError, AsyncHostResult};
 
+use super::ExitRequest;
+
 pub(super) struct AsyncContext {
     pub(super) host: AsyncHost,
     imports: v8::Global<v8::Object>,
     // The memory object is stable, but memory.grow may replace its buffer.
     // Cache the object while reacquiring buffer storage for every import.
     memory: OnceLock<v8::Global<v8::WasmMemoryObject>>,
+    exit_request: ExitRequest,
 }
 
 impl AsyncContext {
@@ -34,11 +37,13 @@ impl AsyncContext {
         scope: &mut v8::HandleScope<'s>,
         imports: v8::Local<'s, v8::Object>,
         host: AsyncHost,
+        exit_request: ExitRequest,
     ) -> Self {
         Self {
             host,
             imports: v8::Global::new(scope, imports),
             memory: OnceLock::new(),
+            exit_request,
         }
     }
 }
@@ -62,6 +67,7 @@ pub(super) struct ImportContext<'a, 'scope> {
     pub(super) host: &'a AsyncHost,
     imports: &'a v8::Global<v8::Object>,
     memory: &'a OnceLock<v8::Global<v8::WasmMemoryObject>>,
+    exit_request: &'a ExitRequest,
 }
 
 impl<'a, 'scope> ImportContext<'a, 'scope> {
@@ -71,7 +77,15 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
             host: &context.host,
             imports: &context.imports,
             memory: &context.memory,
+            exit_request: &context.exit_request,
         }
+    }
+
+    pub(super) fn request_exit(&mut self, code: i32) {
+        self.exit_request.request(code);
+        // Termination cannot be caught by the guest's JavaScript glue. The run
+        // loop converts the recorded request into its runtime outcome.
+        self.scope.terminate_execution();
     }
 
     pub(super) fn with_host_and_memory_mut<T>(

--- a/crates/moonrun/src/async_api/mod.rs
+++ b/crates/moonrun/src/async_api/mod.rs
@@ -48,6 +48,8 @@ mod time;
 mod tls;
 
 use std::any::Any;
+use std::cell::Cell;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::async_host::AsyncHost;
@@ -55,19 +57,37 @@ use crate::async_policy::AsyncPolicy;
 
 pub(crate) use registry::MOONBIT_ASYNC_MODULE;
 
+// V8 invokes async imports synchronously on one isolate thread, so the import
+// adapter and run loop can share a per-runtime exit request without a lock.
+#[derive(Clone, Default)]
+pub(crate) struct ExitRequest(Rc<Cell<Option<i32>>>);
+
+impl ExitRequest {
+    fn request(&self, code: i32) {
+        self.0.set(Some(code));
+    }
+
+    pub(crate) fn take(&self) -> Option<i32> {
+        self.0.take()
+    }
+}
+
 pub(crate) fn init_env<'s>(
     obj: v8::Local<'s, v8::Object>,
     scope: &mut v8::HandleScope<'s>,
     dtors: &mut Vec<Box<dyn Any>>,
     policy: Arc<AsyncPolicy>,
-) {
+) -> ExitRequest {
+    let exit_request = ExitRequest::default();
     let context = Box::new(context::AsyncContext::new(
         scope,
         obj,
         AsyncHost::new(policy),
+        exit_request.clone(),
     ));
     let context_ptr = &*context as *const context::AsyncContext;
     dtors.push(context);
 
     registry::register_imports(obj, scope, context_ptr);
+    exit_request
 }

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -362,7 +362,7 @@ fn init_env(
     wasm_file_name: &str,
     args: &[String],
     async_policy: Arc<async_policy::AsyncPolicy>,
-) {
+) -> async_api::ExitRequest {
     let global_proxy = scope.get_current_context().global(scope);
 
     let print_env_box = Box::<PrintEnv>::default();
@@ -392,10 +392,10 @@ fn init_env(
         time.set_func(scope, "now", now);
     }
 
-    {
+    let exit_request = {
         let async_runtime = global_proxy.child(scope, async_api::MOONBIT_ASYNC_MODULE);
-        async_api::init_env(async_runtime, scope, dtors, Arc::clone(&async_policy));
-    }
+        async_api::init_env(async_runtime, scope, dtors, Arc::clone(&async_policy))
+    };
 
     {
         let wasi = global_proxy.child(scope, "__moonbit_wasi_unstable");
@@ -440,6 +440,7 @@ fn init_env(
         sys.set_func(scope, "exit", exit);
         sys.set_func(scope, "is_windows", is_windows);
     }
+    exit_request
 }
 
 fn create_script_origin<'s>(scope: &mut v8::HandleScope<'s>, name: &str) -> v8::ScriptOrigin<'s> {
@@ -460,13 +461,18 @@ fn create_script_origin<'s>(scope: &mut v8::HandleScope<'s>, name: &str) -> v8::
     )
 }
 
+enum RunOutcome {
+    Completed,
+    Exited(i32),
+}
+
 fn wasm_mode(
     file: &Path,
     args: &[String],
     no_stack_trace: bool,
     test_args: Option<String>,
     async_policy: Arc<async_policy::AsyncPolicy>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<RunOutcome> {
     let isolate = &mut v8::Isolate::new(Default::default());
     let scope = &mut v8::HandleScope::new(isolate);
     let context = v8::Context::new(scope, Default::default());
@@ -484,7 +490,7 @@ fn wasm_mode(
     let memory_sanitizer = memory_sanitizer_api::MemorySanitizer::default();
 
     let mut dtors = Vec::new();
-    init_env(&mut dtors, scope, &wasm_file_name, args, async_policy);
+    let exit_request = init_env(&mut dtors, scope, &wasm_file_name, args, async_policy);
 
     let memory_sanitizer_imports =
         global_proxy.child(scope, memory_sanitizer_api::MEMORY_SANITIZER_MODULE);
@@ -520,9 +526,13 @@ fn wasm_mode(
     let script = v8::Script::compile(scope, code, Some(&script_origin)).unwrap();
 
     script.run(scope);
+    let exit_code = exit_request.take();
     drop(dtors);
+    if let Some(code) = exit_code {
+        return Ok(RunOutcome::Exited(code));
+    }
     memory_sanitizer.check_for_leaks()?;
-    Ok(())
+    Ok(RunOutcome::Completed)
 }
 
 #[derive(serde::Deserialize, Clone)]
@@ -623,13 +633,16 @@ fn main() -> anyhow::Result<()> {
     match matches.path.extension().unwrap().to_str() {
         Some("wasm") => {
             initialize_v8();
-            wasm_mode(
+            match wasm_mode(
                 &matches.path,
                 &matches.args,
                 matches.no_stack_trace,
                 matches.test_args,
                 async_policy,
-            )
+            )? {
+                RunOutcome::Completed => Ok(()),
+                RunOutcome::Exited(code) => std::process::exit(code),
+            }
         }
         _ => anyhow::bail!("Unsupported file type"),
     }

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -326,6 +326,24 @@ fn test_moonrun_exits_with_guest_exit_code() {
 }
 
 #[test]
+fn test_moonrun_async_host_exit_returns_guest_exit_code() {
+    let dir = TestDir::new("test_async_exit.in");
+
+    moon_cmd()
+        .current_dir(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success();
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(dir.join("_build/wasm/debug/build/main/main.wasm"))
+        .assert()
+        .code(9)
+        .stdout_eq("")
+        .stderr_eq("");
+}
+
+#[test]
 fn test_moon_run_with_read_bytes_from_stdin() {
     let dir = TestDir::new("test_read_bytes.in");
 

--- a/crates/moonrun/tests/test_cases/test_async_exit.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_async_exit.in/main/main.mbt
@@ -16,8 +16,11 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use super::context::ImportContext;
+///|
+fn runtime_exit(code : Int) = "moonbitlang/async" "runtime/exit"
 
-pub(super) fn exit(context: &mut ImportContext<'_, '_>, code: i32) {
-    context.request_exit(code)
+///|
+fn main {
+  runtime_exit(9)
+  println("unreachable")
 }

--- a/crates/moonrun/tests/test_cases/test_async_exit.in/main/moon.pkg.json
+++ b/crates/moonrun/tests/test_cases/test_async_exit.in/main/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moonrun/tests/test_cases/test_async_exit.in/moon.mod.json
+++ b/crates/moonrun/tests/test_cases/test_async_exit.in/moon.mod.json
@@ -1,0 +1,3 @@
+{
+  "name": "username/async-exit"
+}


### PR DESCRIPTION
## Summary

Make `moonbitlang/async`'s `runtime/exit` terminate only the current guest runtime instead of exiting the moonrun process from inside the host callback.

The V8 adapter now records a per-runtime exit request and terminates the current V8 execution. The run loop converts that request into `RunOutcome::Exited(code)`, and only the CLI boundary maps the outcome to a process exit.

## Why this is necessary

Calling `std::process::exit` inside an ABI callback makes the runtime impossible to embed safely: one guest can terminate every runtime and bypass the caller's cleanup and outcome handling. It also gives the current V8 implementation a different control-flow model from the planned Wasmtime adapter.

## Why this is correct

V8 execution termination prevents guest JavaScript glue from catching the exit and continuing execution. The exit request belongs to one async runtime, and the existing CLI behavior remains the same because the returned code is still used as moonrun's process exit code.

A regression test verifies that the exit code is preserved and code following the exit import does not run.

## Scope

This change only covers `moonbitlang/async`'s `runtime/exit`. It does not change `__moonbit_sys_unstable.exit` or WASI `proc_exit`; those remain separate runtime boundaries.
