### PR TITLE
feat(check): add complete JSON output

### DIFF
--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -158,7 +158,7 @@ fn run_build_rr(
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     );
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, dirs)?;
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, dirs, user_log)?;
     let resolve_output =
         moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
     let prebuild_list = if watch {

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -154,7 +154,7 @@ pub(crate) fn plan_bundle_rr(
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     );
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, dirs)?;
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, dirs, user_log)?;
     let resolve_output =
         moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
     plan_bundle_rr_from_resolved(

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -106,21 +106,37 @@ struct CheckJsonAccumulator {
     diagnostics: Vec<serde_json::Value>,
     messages: Vec<MoonMessage>,
     tasks_executed: Option<usize>,
+    build_failed: bool,
     diagnostic_errors: usize,
     diagnostic_warnings: usize,
 }
 
 impl CheckJsonAccumulator {
-    fn append_build(&mut self, result: rr_build::JsonBuildOutput, user_log: &UserLog) {
+    fn append_build(
+        &mut self,
+        target_backend: TargetBackend,
+        mut result: rr_build::JsonBuildOutput,
+        user_log: &UserLog,
+    ) {
         let successful = result.successful();
+        for diagnostic in &mut result.diagnostics {
+            diagnostic
+                .as_object_mut()
+                .expect("Moonc diagnostic should be a JSON object")
+                .insert(
+                    "target_backend".to_string(),
+                    serde_json::Value::String(target_backend.to_flag().to_string()),
+                );
+        }
         self.diagnostics.extend(result.diagnostics);
         self.diagnostic_errors += result.n_errors;
         self.diagnostic_warnings += result.n_warnings;
-        self.tasks_executed = match (self.tasks_executed, result.n_tasks_executed) {
-            (Some(total), Some(executed)) => Some(total + executed),
-            (None, Some(executed)) if successful => Some(executed),
-            _ => None,
+        self.tasks_executed = if successful && !self.build_failed {
+            Some(self.tasks_executed.unwrap_or_default() + result.n_tasks_executed.unwrap())
+        } else {
+            None
         };
+        self.build_failed |= !successful;
 
         for message in result.non_diagnostic_output {
             if successful {
@@ -566,13 +582,14 @@ fn run_check_for_single_file_rr(
     cfg.explain_errors |= cmd.explain;
 
     if let Some(json) = json {
+        let target_backend = build_meta.target_backend();
         let result = rr_build::execute_build_json(
             &cfg.with_suppressed_progress(true),
             build_graph,
             target_dir,
         )?;
         let successful = result.successful();
-        json.append_build(result, user_log);
+        json.append_build(target_backend, result, user_log);
         return Ok(if successful { 0 } else { 1 });
     }
 
@@ -738,17 +755,15 @@ fn run_check_normal_internal_rr(
             rr_build::generate_metadata(source_dir, target_dir, &build_meta, &build_graph, None)?;
 
             if let Some(json) = json.as_deref_mut() {
+                let target_backend = build_meta.target_backend();
                 let result = rr_build::execute_build_json(
                     &cfg.clone().with_suppressed_progress(true),
                     build_graph,
                     target_dir,
                 )?;
                 let successful = result.successful();
-                json.append_build(result, user_log);
+                json.append_build(target_backend, result, user_log);
                 ok &= successful;
-                if !successful {
-                    break;
-                }
             } else {
                 let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
                 result.print_info(cli.quiet, "checking")?;

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -42,7 +42,8 @@ use moonutil::locks::FileLock;
 use moonutil::project::{PackageDirs, ProjectProbe};
 use moonutil::target::TargetBackend;
 use moonutil::target::lower_surface_targets;
-use moonutil::user_log::UserLog;
+use moonutil::user_log::{UserLog, UserLogCapture, UserLogEntry, UserLogEntryLevel};
+use serde::Serialize;
 use std::path::{Path, PathBuf};
 use tracing::{Level, instrument};
 
@@ -62,6 +63,107 @@ use super::BuildFlags;
 struct ResolvedCheckSelection {
     packages: Vec<PackageId>,
     patch_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+struct MoonMessage {
+    #[serde(rename = "$message_type")]
+    message_type: &'static str,
+    level: UserLogEntryLevel,
+    message: String,
+}
+
+impl From<UserLogEntry> for MoonMessage {
+    fn from(entry: UserLogEntry) -> Self {
+        Self {
+            message_type: "moon",
+            level: entry.level,
+            message: entry.message,
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+struct CheckJsonSummary {
+    tasks_executed: Option<usize>,
+    moon_errors: usize,
+    moon_warnings: usize,
+    diagnostic_errors: usize,
+    diagnostic_warnings: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckJsonReport {
+    version: u32,
+    status: &'static str,
+    diagnostics: Vec<serde_json::Value>,
+    messages: Vec<MoonMessage>,
+    summary: CheckJsonSummary,
+}
+
+#[derive(Debug, Default)]
+struct CheckJsonAccumulator {
+    diagnostics: Vec<serde_json::Value>,
+    messages: Vec<MoonMessage>,
+    tasks_executed: Option<usize>,
+    diagnostic_errors: usize,
+    diagnostic_warnings: usize,
+}
+
+impl CheckJsonAccumulator {
+    fn append_build(&mut self, result: rr_build::JsonBuildOutput, user_log: &UserLog) {
+        let successful = result.successful();
+        self.diagnostics.extend(result.diagnostics);
+        self.diagnostic_errors += result.n_errors;
+        self.diagnostic_warnings += result.n_warnings;
+        self.tasks_executed = match (self.tasks_executed, result.n_tasks_executed) {
+            (Some(total), Some(executed)) => Some(total + executed),
+            (None, Some(executed)) if successful => Some(executed),
+            _ => None,
+        };
+
+        for message in result.non_diagnostic_output {
+            if successful {
+                user_log.info(message);
+            } else {
+                user_log.error(message);
+            }
+        }
+        if result.hidden_errors != 0 || result.hidden_warnings != 0 {
+            user_log.warn(format!(
+                    "diagnostic output limited by --diagnostic-limit: {} errors and {} warnings were not displayed.",
+                    result.hidden_errors, result.hidden_warnings
+                ));
+        }
+    }
+
+    fn error(&mut self, error: impl std::fmt::Display) {
+        self.messages.push(MoonMessage {
+            message_type: "moon",
+            level: UserLogEntryLevel::Error,
+            message: error.to_string(),
+        });
+    }
+}
+
+pub(crate) struct CheckJsonOutcome {
+    exit_code: i32,
+    accumulator: CheckJsonAccumulator,
+}
+
+impl CheckJsonOutcome {
+    pub(crate) fn from_error(exit_code: i32, error: impl std::fmt::Display) -> Self {
+        let mut accumulator = CheckJsonAccumulator::default();
+        accumulator.error(error);
+        Self {
+            exit_code,
+            accumulator,
+        }
+    }
+
+    pub(crate) fn exit_code(&self) -> i32 {
+        self.exit_code
+    }
 }
 
 impl ResolvedCheckSelection {
@@ -126,6 +228,93 @@ pub(crate) struct CheckSubcommand {
     /// Check whether the code is properly formatted
     #[clap(long)]
     pub fmt: bool,
+
+    /// Output one complete JSON result to stdout
+    #[clap(long)]
+    pub json: bool,
+}
+
+pub(crate) fn write_check_json(
+    output: &CommandOutput,
+    capture: &UserLogCapture,
+    mut outcome: CheckJsonOutcome,
+) -> anyhow::Result<()> {
+    let mut captured_messages = capture
+        .take()
+        .into_iter()
+        .map(MoonMessage::from)
+        .collect::<Vec<_>>();
+    captured_messages.append(&mut outcome.accumulator.messages);
+    let moon_errors = captured_messages
+        .iter()
+        .filter(|message| matches!(message.level, UserLogEntryLevel::Error))
+        .count();
+    let moon_warnings = captured_messages
+        .iter()
+        .filter(|message| matches!(message.level, UserLogEntryLevel::Warning))
+        .count();
+    let report = CheckJsonReport {
+        version: 1,
+        status: if outcome.exit_code == 0 {
+            "success"
+        } else {
+            "failure"
+        },
+        diagnostics: outcome.accumulator.diagnostics,
+        messages: captured_messages,
+        summary: CheckJsonSummary {
+            tasks_executed: outcome.accumulator.tasks_executed,
+            moon_errors,
+            moon_warnings,
+            diagnostic_errors: outcome.accumulator.diagnostic_errors,
+            diagnostic_warnings: outcome.accumulator.diagnostic_warnings,
+        },
+    };
+    output.write_result(|writer| -> anyhow::Result<()> {
+        serde_json::to_writer(&mut *writer, &report)?;
+        writeln!(writer)?;
+        Ok(())
+    })
+}
+
+pub(crate) fn run_check_json(
+    cli: &UniversalFlags,
+    cmd: &CheckSubcommand,
+    output: &CommandOutput,
+) -> CheckJsonOutcome {
+    let incompatible = [
+        (cmd.watch, "--watch"),
+        (cli.dry_run, "--dry-run"),
+        (cmd.fmt, "--fmt"),
+        (cmd.build_flags.no_render, "--no-render"),
+        (cmd.build_flags.output_json, "--output-json"),
+    ]
+    .into_iter()
+    .filter_map(|(enabled, flag)| enabled.then_some(flag))
+    .collect::<Vec<_>>();
+    if !incompatible.is_empty() {
+        return CheckJsonOutcome::from_error(
+            2,
+            format!("--json cannot be used with {}", incompatible.join(", ")),
+        );
+    }
+
+    let mut json_cmd = cmd.clone();
+    json_cmd.build_flags.output_json = true;
+    let mut accumulator = CheckJsonAccumulator::default();
+    match run_check_impl(cli, &json_cmd, output, Some(&mut accumulator)) {
+        Ok(exit_code) => CheckJsonOutcome {
+            exit_code,
+            accumulator,
+        },
+        Err(error) => {
+            accumulator.error(format!("{error:#}"));
+            CheckJsonOutcome {
+                exit_code: -1,
+                accumulator,
+            }
+        }
+    }
 }
 
 #[instrument(skip_all)]
@@ -133,6 +322,15 @@ pub(crate) fn run_check(
     cli: &UniversalFlags,
     cmd: &CheckSubcommand,
     output: &CommandOutput,
+) -> anyhow::Result<i32> {
+    run_check_impl(cli, cmd, output, None)
+}
+
+fn run_check_impl(
+    cli: &UniversalFlags,
+    cmd: &CheckSubcommand,
+    output: &CommandOutput,
+    mut json: Option<&mut CheckJsonAccumulator>,
 ) -> anyhow::Result<i32> {
     let user_log = output.user_log();
     if cmd.fmt {
@@ -191,6 +389,7 @@ pub(crate) fn run_check(
             single_file.as_deref(),
             None,
             output,
+            json,
         );
     }
 
@@ -206,6 +405,7 @@ pub(crate) fn run_check(
             single_file.as_deref(),
             Some(t),
             output,
+            json.as_deref_mut(),
         )
         .context(format!("failed to run check for target {t:?}"))?;
         ret_value = ret_value.max(x);
@@ -223,6 +423,7 @@ fn run_check_internal(
     single_file: Option<&Path>,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
+    json: Option<&mut CheckJsonAccumulator>,
 ) -> anyhow::Result<i32> {
     if let Some(single_file_path) = single_file {
         run_check_for_single_file_rr(
@@ -232,6 +433,7 @@ fn run_check_internal(
             dirs,
             selected_target_backend,
             output,
+            json,
         )
     } else {
         run_check_normal_internal(
@@ -241,6 +443,7 @@ fn run_check_internal(
             watch_ignored_subtree,
             selected_target_backend,
             output,
+            json,
         )
     }
 }
@@ -253,6 +456,7 @@ fn run_check_for_single_file_rr(
     dirs: &PackageDirs,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
+    json: Option<&mut CheckJsonAccumulator>,
 ) -> anyhow::Result<i32> {
     let user_log = output.user_log();
     let PackageDirs {
@@ -273,7 +477,8 @@ fn run_check_for_single_file_rr(
         false,
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
-    );
+    )
+    .with_captured_sync_child_output(cmd.json);
     let (resolved, backend) = moonbuild_rupes_recta::resolve::resolve_single_file_project(
         &resolve_cfg,
         dirs,
@@ -326,7 +531,12 @@ fn run_check_for_single_file_rr(
         return Ok(0);
     }
 
-    let _lock = FileLock::lock(target_dir).with_context(|| {
+    let lock = if json.is_some() {
+        FileLock::lock_with_user_log(target_dir, user_log)
+    } else {
+        FileLock::lock(target_dir)
+    };
+    let _lock = lock.with_context(|| {
         format!(
             "failed to acquire build lock in target directory `{}`",
             target_dir.display()
@@ -347,9 +557,24 @@ fn run_check_for_single_file_rr(
         filename.as_deref(),
     )?;
 
-    let mut cfg = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose);
+    let mut cfg = BuildConfig::from_flags(
+        &cmd.build_flags,
+        &cli.unstable_feature,
+        cli.verbose && json.is_none(),
+    );
     cfg.patch_file = cmd.patch_file.clone();
     cfg.explain_errors |= cmd.explain;
+
+    if let Some(json) = json {
+        let result = rr_build::execute_build_json(
+            &cfg.with_suppressed_progress(true),
+            build_graph,
+            target_dir,
+        )?;
+        let successful = result.successful();
+        json.append_build(result, user_log);
+        return Ok(if successful { 0 } else { 1 });
+    }
 
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
     result.print_info(cli.quiet, "checking")?;
@@ -383,9 +608,30 @@ fn run_check_normal_internal(
     watch_ignored_subtree: &Path,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
+    json: Option<&mut CheckJsonAccumulator>,
 ) -> anyhow::Result<i32> {
+    if let Some(json) = json {
+        return run_check_normal_internal_rr(
+            cli,
+            cmd,
+            dirs,
+            false,
+            selected_target_backend,
+            output,
+            Some(json),
+        )
+        .map(|output| if output.ok { 0 } else { 1 });
+    }
     let run_once = || -> anyhow::Result<WatchOutput> {
-        run_check_normal_internal_rr(cli, cmd, dirs, cmd.watch, selected_target_backend, output)
+        run_check_normal_internal_rr(
+            cli,
+            cmd,
+            dirs,
+            cmd.watch,
+            selected_target_backend,
+            output,
+            None,
+        )
     };
     if cmd.watch {
         watching(run_once, &dirs.source_dir, watch_ignored_subtree)
@@ -403,6 +649,7 @@ fn run_check_normal_internal_rr(
     watch: bool,
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
+    mut json: Option<&mut CheckJsonAccumulator>,
 ) -> anyhow::Result<WatchOutput> {
     let user_log = output.user_log();
     let PackageDirs {
@@ -423,8 +670,9 @@ fn run_check_normal_internal_rr(
         !cmd.build_flags.std(),
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
-    );
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, dirs)
+    )
+    .with_captured_sync_child_output(json.is_some());
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, dirs, user_log)
         .context("Failed to calculate build plan")?;
     let resolve_output =
         moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)
@@ -464,13 +712,22 @@ fn run_check_normal_internal_rr(
         })?;
         true
     } else {
-        let _lock = FileLock::lock(target_dir).with_context(|| {
+        let lock = if json.is_some() {
+            FileLock::lock_with_user_log(target_dir, user_log)
+        } else {
+            FileLock::lock(target_dir)
+        };
+        let _lock = lock.with_context(|| {
             format!(
                 "failed to acquire build lock in target directory `{}`",
                 target_dir.display()
             )
         })?;
-        let mut cfg = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose);
+        let mut cfg = BuildConfig::from_flags(
+            &cmd.build_flags,
+            &cli.unstable_feature,
+            cli.verbose && json.is_none(),
+        );
         cfg.patch_file = cmd.patch_file.clone();
         cfg.explain_errors |= cmd.explain;
         let mut ok = true;
@@ -480,9 +737,23 @@ fn run_check_normal_internal_rr(
             // Generate metadata for IDE. The last executed backend wins.
             rr_build::generate_metadata(source_dir, target_dir, &build_meta, &build_graph, None)?;
 
-            let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
-            result.print_info(cli.quiet, "checking")?;
-            ok &= result.successful();
+            if let Some(json) = json.as_deref_mut() {
+                let result = rr_build::execute_build_json(
+                    &cfg.clone().with_suppressed_progress(true),
+                    build_graph,
+                    target_dir,
+                )?;
+                let successful = result.successful();
+                json.append_build(result, user_log);
+                ok &= successful;
+                if !successful {
+                    break;
+                }
+            } else {
+                let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
+                result.print_info(cli.quiet, "checking")?;
+                ok &= result.successful();
+            }
         }
         ok
     };

--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -143,7 +143,7 @@ fn run_cram_test(
         build_cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     );
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs)?;
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
     let resolve_output =
         moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
 

--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -84,7 +84,8 @@ pub(crate) fn install_cli(
         mooncake::pkg::sync::auto_sync(
             &dirs,
             &AutoSyncFlags { frozen: false },
-            SyncOutputOptions::new(cli.quiet, true),
+            SyncOutputOptions::default(),
+            user_log,
             true,
             cli.workspace_env.clone(),
             true,
@@ -192,7 +193,7 @@ pub(crate) fn remove_cli(
     }
     let username = parts[0];
     let pkgname = parts[1];
-    mooncake::pkg::remove::remove(&module_dir, &project_manifest, username, pkgname)
+    mooncake::pkg::remove::remove(&module_dir, &project_manifest, username, pkgname, user_log)
 }
 
 pub(crate) fn add_cli(
@@ -256,8 +257,8 @@ pub(crate) fn add_cli(
             &pkg_name,
             cmd.bin,
             &version,
-            cli.quiet,
             cmd.upgrade,
+            user_log,
         )
     } else {
         mooncake::pkg::add::add_latest(
@@ -265,9 +266,9 @@ pub(crate) fn add_cli(
             &dirs,
             &pkg_name,
             cmd.bin,
-            cli.quiet,
             index_updated,
             cmd.upgrade,
+            user_log,
         )
     }
 }
@@ -283,7 +284,7 @@ pub(crate) fn tree_cli(
     let PackageDirs {
         project_manifest, ..
     } = query.package_dirs(user_log)?;
-    mooncake::pkg::tree::tree(&module_dir, &project_manifest)
+    mooncake::pkg::tree::tree(&module_dir, &project_manifest, user_log)
 }
 
 #[cfg(test)]

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -134,7 +134,7 @@ pub(crate) fn run_doc_rr(
     preconfig.docs_serve = cmd.serve;
 
     let resolve_cfg = preconfig.resolve_config();
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs)?;
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
     let resolve_output =
         moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
 

--- a/crates/moon/src/cli/fetch.rs
+++ b/crates/moon/src/cli/fetch.rs
@@ -135,7 +135,7 @@ pub(crate) fn fetch_cli(
         println!("Fetching {}@{version} to {}", pkg_name, pkg_dir.display());
     }
 
-    registry.install_to(&pkg_name, &version, &pkg_dir, cli.quiet)?;
+    registry.install_to(&pkg_name, &version, &pkg_dir, user_log)?;
 
     if !cli.quiet {
         println!(

--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -75,8 +75,9 @@ fn run_fmt_rr(
         .query(cli.workspace_env.clone())?
         .package_dirs(user_log)?;
 
-    let resolved = moonbuild_rupes_recta::fmt::resolve_for_fmt(&source_dir, &project_manifest)
-        .context("Failed to resolve environment")?;
+    let resolved =
+        moonbuild_rupes_recta::fmt::resolve_for_fmt(&source_dir, &project_manifest, user_log)
+            .context("Failed to resolve environment")?;
 
     let mut selected_packages = Vec::new();
 

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -295,7 +295,7 @@ pub(crate) fn run_info(
         build_flags.enable_coverage,
         cli.workspace_env.clone(),
     );
-    let synced_env = sync_dependencies(&resolve_cfg, &dirs)?;
+    let synced_env = sync_dependencies(&resolve_cfg, &dirs, output.user_log())?;
     let resolve_output = resolve_synced_project(&resolve_cfg, synced_env, output.user_log())?;
     let selection = PackageSelection::new(&cmd, &resolve_output, output.user_log())?;
 

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -240,8 +240,6 @@ pub(super) fn install_binary(
     install_all: bool,
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
-    let quiet = cli.quiet;
-
     let index_dir = moonutil::registry::index();
     let registry_config = RegistryConfig::load();
     let had_index = index_dir.exists();
@@ -276,7 +274,7 @@ pub(super) fn install_binary(
     let tmp_dir = tempfile::TempDir::new().context("Failed to create temporary directory")?;
     let module_dir = tmp_dir.path();
 
-    registry.install_to(&spec.module_name, &version, module_dir, quiet)?;
+    registry.install_to(&spec.module_name, &version, module_dir, user_log)?;
 
     let filter =
         PackageFilter::package_path(spec.package_path.clone().unwrap_or_default(), install_all);
@@ -496,7 +494,8 @@ fn prepare_native_build(
     let resolve_cfg =
         ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone())
             .with_sync_output(sync_output);
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &package_dirs)?;
+    let synced_env =
+        moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &package_dirs, user_log)?;
     let resolve_output =
         moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
     let target_dir = package_dirs.target_dir;
@@ -652,7 +651,7 @@ fn build_native_executable_to(
         module_name,
         module_dir,
         package_dirs,
-        SyncOutputOptions::new(!cli.verbose, cli.verbose),
+        SyncOutputOptions::default(),
         PackageFilter::package_path(package_path.to_string(), false),
         user_log,
     )?;
@@ -714,7 +713,7 @@ pub(super) fn build_registry_native_executable_to(
     // installation hooks or let acquisition progress precede program stdout.
     let registry = OnlineRegistry::mooncakes_io();
     let checksum = registry.source_archive_checksum(module_name, version)?;
-    registry.acquire_source_to(module_name, version, &checksum, source.path(), !verbose)?;
+    registry.acquire_source_to(module_name, version, &checksum, source.path(), user_log)?;
 
     let cli = UniversalFlags {
         source_tgt_dir: SourceTargetDirs {
@@ -778,7 +777,7 @@ fn build_and_install_packages(
         module_name,
         module_dir,
         package_dirs,
-        SyncOutputOptions::new(cli.quiet, cli.verbose),
+        SyncOutputOptions::default(),
         filter,
         user_log,
     )?;

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -151,7 +151,7 @@ pub(crate) fn run_prove(
     let prove_why3_config = why3_config_path.clone();
 
     let resolve_cfg = preconfig.resolve_config();
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs)?;
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
     let resolve_output =
         moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
 

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -134,7 +134,7 @@ impl RunOutputVerbosity {
     }
 
     fn sync_output(self) -> SyncOutputOptions {
-        SyncOutputOptions::new(!self.verbose, self.verbose)
+        SyncOutputOptions::default()
     }
 
     fn suppress_build_progress(self) -> bool {
@@ -486,7 +486,7 @@ fn build_package_executable(
         cli.workspace_env.clone(),
     )
     .with_sync_output(options.output.sync_output());
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs)?;
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
     let resolve_output =
         moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
     let (build_meta, build_graph) = plan_run_rr_from_resolved(

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -134,7 +134,7 @@ impl RunOutputVerbosity {
     }
 
     fn sync_output(self) -> SyncOutputOptions {
-        SyncOutputOptions::default()
+        SyncOutputOptions::default().with_quiet(!self.verbose)
     }
 
     fn suppress_build_progress(self) -> bool {

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -964,7 +964,7 @@ fn run_test_rr(
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     );
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, dirs)?;
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, dirs, user_log)?;
     let resolve_output =
         moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
     let planned_runs = plan_test_or_bench_rr_from_resolved_all(

--- a/crates/moon/src/cli/tool.rs
+++ b/crates/moon/src/cli/tool.rs
@@ -54,7 +54,7 @@ pub(crate) fn run_tool(
 ) -> anyhow::Result<i32> {
     match cmd.subcommand {
         ToolSubcommands::FormatAndDiff(subcmd) => run_format_and_diff(subcmd),
-        ToolSubcommands::FormatWorkspace(subcmd) => run_format_workspace(subcmd),
+        ToolSubcommands::FormatWorkspace(subcmd) => run_format_workspace(subcmd, user_log),
         ToolSubcommands::Embed(subcmd) => run_embed(subcmd),
         ToolSubcommands::WriteTccRspFile(subcmd) => write_tcc_rsp_file(subcmd),
         ToolSubcommands::BuildBinaryDep(subcmd) => {

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -89,7 +89,7 @@ pub(crate) fn run_build_binary_dep(
     let resolve_cfg =
         ResolveConfig::new_with_load_defaults(false, false, false, cli.workspace_env.clone())
             .without_bin_deps();
-    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs)?;
+    let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, user_log)?;
     let resolve_output =
         moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, user_log)?;
 

--- a/crates/moon/src/cli/tool/format_workspace.rs
+++ b/crates/moon/src/cli/tool/format_workspace.rs
@@ -23,6 +23,7 @@ use std::{
 };
 
 use anyhow::Context;
+use moonutil::user_log::UserLog;
 
 #[derive(Debug, clap::Parser)]
 pub(crate) struct FormatWorkspaceSubcommand {
@@ -47,8 +48,11 @@ pub(crate) struct FormatWorkspaceSubcommand {
     warn: bool,
 }
 
-pub(crate) fn run_format_workspace(cmd: FormatWorkspaceSubcommand) -> anyhow::Result<i32> {
-    let formatted = moonutil::workspace::format_workspace_file(&cmd.old)?;
+pub(crate) fn run_format_workspace(
+    cmd: FormatWorkspaceSubcommand,
+    user_log: &UserLog,
+) -> anyhow::Result<i32> {
+    let formatted = moonutil::workspace::format_workspace_file(&cmd.old, user_log)?;
 
     if let Some(parent) = cmd.new.parent() {
         std::fs::create_dir_all(parent)?;

--- a/crates/moon/src/cli/work.rs
+++ b/crates/moon/src/cli/work.rs
@@ -66,7 +66,7 @@ pub(crate) fn work_cli(
             }
 
             let workspace_root = work_root(&cli, WorkRootSelection::CreateWorkspace, user_log)?;
-            mooncake::pkg::init_workspace(&workspace_root, &cmd.paths, cli.quiet)
+            mooncake::pkg::init_workspace(&workspace_root, &cmd.paths, cli.quiet, user_log)
         }
         WorkSubcommands::Use(cmd) => {
             if cli.dry_run {
@@ -75,7 +75,7 @@ pub(crate) fn work_cli(
 
             let workspace_root =
                 work_root(&cli, WorkRootSelection::ReuseExistingWorkspace, user_log)?;
-            mooncake::pkg::use_workspace(&workspace_root, &cmd.paths, cli.quiet)
+            mooncake::pkg::use_workspace(&workspace_root, &cmd.paths, cli.quiet, user_log)
         }
         WorkSubcommands::Sync => {
             if cli.dry_run {
@@ -86,7 +86,7 @@ pub(crate) fn work_cli(
                 .source_tgt_dir
                 .query(cli.workspace_env.clone())?
                 .package_dirs(user_log)?;
-            mooncake::pkg::sync_workspace(&source_dir, cli.quiet)
+            mooncake::pkg::sync_workspace(&source_dir, cli.quiet, user_log)
         }
     }
 }

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -581,21 +581,17 @@ mod tests {
 
     fn resolve_output(source_dir: &Path) -> moonbuild_rupes_recta::ResolveOutput {
         let cfg = ResolveConfig::new_with_load_defaults(false, false, false, WorkspaceEnv::Auto);
+        let user_log = UserLog::new(LevelFilter::Error);
         let dirs = SourceTargetDirs {
             cwd: None,
             target_dir: None,
         }
         .query_from(source_dir, WorkspaceEnv::Auto)
         .unwrap()
-        .package_dirs(&UserLog::new(LevelFilter::Error))
+        .package_dirs(&user_log)
         .unwrap();
-        let synced_env = moonbuild_rupes_recta::sync_dependencies(&cfg, &dirs).unwrap();
-        moonbuild_rupes_recta::resolve_synced_project(
-            &cfg,
-            synced_env,
-            &moonutil::user_log::UserLog::new(log::LevelFilter::Error),
-        )
-        .unwrap()
+        let synced_env = moonbuild_rupes_recta::sync_dependencies(&cfg, &dirs, &user_log).unwrap();
+        moonbuild_rupes_recta::resolve_synced_project(&cfg, synced_env, &user_log).unwrap()
     }
 
     #[test]

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -25,7 +25,7 @@ use std::{
 
 use clap::{CommandFactory, Parser};
 use cli::MoonBuildSubcommands;
-use moonutil::{command_output::CommandOutput, user_log::UserLog};
+use moonutil::{command_output::CommandOutput, user_log::UserLogCapture};
 
 mod build_flags;
 mod cli;
@@ -50,15 +50,19 @@ use tracing_subscriber::{Layer, layer::SubscriberExt};
 ///   `--trace` is used together with `MOON_TRACE`, the latter takes precedence.
 ///
 /// Returns a boxed guard that keeps the tracing system alive.
-fn init_tracing(trace_flag: bool) -> Box<dyn Any> {
+fn init_tracing(trace_flag: bool, suppress_terminal_output: bool) -> Box<dyn Any> {
     // usage example: only show debug logs for moonbuild::runtest module
     // env RUST_LOG=moonbuild::runtest=debug cargo run -- -C ./tests/test_cases/moon_new.in test
 
     let log_env_set = std::env::var("RUST_LOG").is_ok();
     let moon_tracing_env = std::env::var("MOON_TRACE").ok();
-    let filter = tracing_subscriber::EnvFilter::builder()
-        .with_default_directive(tracing::Level::WARN.into())
-        .from_env_lossy();
+    let filter = if suppress_terminal_output {
+        tracing_subscriber::EnvFilter::new("off")
+    } else {
+        tracing_subscriber::EnvFilter::builder()
+            .with_default_directive(tracing::Level::WARN.into())
+            .from_env_lossy()
+    };
 
     let fmt = tracing_subscriber::fmt::layer()
         .with_ansi(std::io::stderr().is_terminal())
@@ -109,6 +113,18 @@ fn init_tracing(trace_flag: bool) -> Box<dyn Any> {
     Box::new(chrome_guard)
 }
 
+fn exit_check_json(
+    output: &CommandOutput,
+    capture: &UserLogCapture,
+    outcome: cli::CheckJsonOutcome,
+) -> ! {
+    let exit_code = outcome.exit_code();
+    if cli::write_check_json(output, capture, outcome).is_err() {
+        std::process::exit(-1);
+    }
+    std::process::exit(exit_code)
+}
+
 pub fn main() {
     panic::setup_panic_hook();
 
@@ -146,32 +162,48 @@ pub fn main() {
         let _ = writeln!(stderr);
         std::process::exit(2);
     };
-    let bootstrap_output = UserLog::new(flags.user_log_level());
+    let check_json = matches!(&subcommand, MoonBuildSubcommands::Check(cmd) if cmd.json);
+    let (output, check_json_capture) = if check_json {
+        let (output, capture) = CommandOutput::captured(flags.user_log_level());
+        (output, Some(capture))
+    } else {
+        (CommandOutput::new(flags.user_log_level()), None)
+    };
 
     if let Some(dir) = &flags.source_tgt_dir.cwd {
         // `-C` changes the process working directory early.
         if let Err(err) = std::env::set_current_dir(dir) {
-            bootstrap_output.error(format!(
-                "failed to change directory to {}: {}",
-                dir.display(),
-                err
-            ));
-            std::process::exit(-1);
+            let message = format!("failed to change directory to {}: {}", dir.display(), err);
+            if let Some(capture) = &check_json_capture {
+                exit_check_json(
+                    &output,
+                    capture,
+                    cli::CheckJsonOutcome::from_error(-1, message),
+                );
+            }
+            output.user_log().error(message);
+            std::process::exit(-1)
         }
     }
 
-    let _trace_guard = init_tracing(flags.trace);
+    let _trace_guard = init_tracing(flags.trace, check_json);
 
     let (workspace_env, workspace_env_deprecation_warning) =
         match moonutil::project::current_workspace_env() {
             Ok(result) => result,
             Err(err) => {
-                bootstrap_output.error(format!("{:?}", err));
-                std::process::exit(-1);
+                if let Some(capture) = &check_json_capture {
+                    exit_check_json(
+                        &output,
+                        capture,
+                        cli::CheckJsonOutcome::from_error(-1, format!("{err:#}")),
+                    );
+                }
+                output.user_log().error(format!("{:?}", err));
+                std::process::exit(-1)
             }
         };
     flags.workspace_env = workspace_env;
-    let output = CommandOutput::new(flags.user_log_level());
 
     // Check for deprecated flags and emit warnings (after tracing is initialized)
     for warning in flags.deprecation_warnings() {
@@ -179,6 +211,20 @@ pub fn main() {
     }
     if let Some(warning) = workspace_env_deprecation_warning {
         output.user_log().warn(warning);
+    }
+
+    if let MoonBuildSubcommands::Check(cmd) = &subcommand
+        && cmd.json
+    {
+        let outcome = cli::run_check_json(&flags, cmd, &output);
+        drop(_trace_guard);
+        exit_check_json(
+            &output,
+            check_json_capture
+                .as_ref()
+                .expect("JSON check should have a captured UserLog"),
+            outcome,
+        );
     }
 
     use MoonBuildSubcommands::*;

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -913,6 +913,7 @@ pub fn generate_all_pkgs_json(build_meta: &BuildMeta) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[derive(Clone)]
 pub struct BuildConfig {
     /// The level of parallelism to use. If `None`, will use the number of
     /// available CPU cores.
@@ -1047,6 +1048,51 @@ pub fn execute_build(
 ) -> anyhow::Result<N2RunStats> {
     let execution = execute_build_capturing(cfg, input, target_dir)?;
     Ok(finish_captured_build(cfg, &execution, None, user_log))
+}
+
+/// Structured output from one build execution for a command-level JSON
+/// renderer. The executor does not write diagnostics or summaries itself.
+pub struct JsonBuildOutput {
+    pub n_tasks_executed: Option<usize>,
+    pub n_errors: usize,
+    pub n_warnings: usize,
+    pub hidden_errors: usize,
+    pub hidden_warnings: usize,
+    pub diagnostics: Vec<serde_json::Value>,
+    pub non_diagnostic_output: Vec<String>,
+}
+
+impl JsonBuildOutput {
+    pub fn successful(&self) -> bool {
+        self.n_tasks_executed.is_some()
+    }
+}
+
+/// Execute a build while returning all Moonc diagnostics to the CLI seam.
+pub fn execute_build_json(
+    cfg: &BuildConfig,
+    input: BuildInput,
+    target_dir: &Path,
+) -> anyhow::Result<JsonBuildOutput> {
+    let execution = execute_build_capturing(cfg, input, target_dir)?;
+    let collected =
+        collect_json_diagnostics(&[CapturedDiagnosticSource::new(&execution, None)], cfg);
+    Ok(JsonBuildOutput {
+        n_tasks_executed: execution.n_tasks_executed,
+        n_errors: collected.processed.n_errors,
+        n_warnings: collected.processed.n_warnings,
+        hidden_errors: collected.processed.hidden_errors,
+        hidden_warnings: collected.processed.hidden_warnings,
+        diagnostics: collected
+            .diagnostics
+            .into_iter()
+            .map(|content| {
+                serde_json::from_str(&content)
+                    .expect("collected Moonc diagnostic should remain valid JSON")
+            })
+            .collect(),
+        non_diagnostic_output: collected.non_diagnostic_output,
+    })
 }
 
 /// Execute standalone dependency-package work before script-package work.
@@ -1303,6 +1349,12 @@ struct ProcessedDiagnostics {
     hidden_warnings: usize,
 }
 
+struct CollectedJsonDiagnostics {
+    processed: ProcessedDiagnostics,
+    diagnostics: Vec<String>,
+    non_diagnostic_output: Vec<String>,
+}
+
 impl ProcessedDiagnostics {
     fn warn_if_limited(&self, user_log: &UserLog) {
         if self.hidden_errors != 0 || self.hidden_warnings != 0 {
@@ -1371,10 +1423,128 @@ fn rewrite_captured_diagnostic(
     format!("{}{}", physical.display(), &content[path_end..])
 }
 
+fn collect_json_diagnostics(
+    sources: &[CapturedDiagnosticSource<'_>],
+    cfg: &BuildConfig,
+) -> CollectedJsonDiagnostics {
+    let mut catcher = ResultCatcher::default();
+    for source in sources {
+        catcher.n_errors += source.diagnostics.n_errors;
+        catcher.n_warnings += source.diagnostics.n_warnings;
+    }
+
+    let mut by_file = BTreeMap::<String, BTreeSet<(MooncDiagnostic, String)>>::new();
+    let mut non_diagnostic_output = Vec::new();
+    for source in sources {
+        for content in &source.diagnostics.content_writer {
+            let content = rewrite_captured_diagnostic(content, cfg, source.build_meta);
+            match serde_json::from_str::<MooncDiagnostic>(&content) {
+                Ok(diagnostic) => {
+                    if diagnostic_is_generated_test_driver_warning(&diagnostic) {
+                        continue;
+                    }
+                    by_file
+                        .entry(diagnostic.path.clone())
+                        .or_default()
+                        .insert((diagnostic, content));
+                }
+                Err(_) => {
+                    if should_render_non_diagnostic_build_output(cfg, source.build_succeeded) {
+                        non_diagnostic_output.push(content);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut diagnostics = Vec::new();
+    let (hidden_errors, hidden_warnings) = match cfg.diagnostic_limit {
+        None => {
+            for file_diagnostics in by_file.values() {
+                for (diagnostic, content) in file_diagnostics {
+                    diagnostics.push(content.clone());
+                    catcher.append_diag(diagnostic);
+                }
+            }
+            (0, 0)
+        }
+        Some(limit) => {
+            let mut displayed = 0;
+            let mut hidden_errors = 0;
+            let mut total_warnings = 0;
+            let mut displayed_warnings = 0;
+            let mut non_errors = Vec::new();
+
+            for file_diagnostics in by_file.values() {
+                for (diagnostic, content) in file_diagnostics {
+                    if diagnostic_is_error(diagnostic) {
+                        if displayed < limit {
+                            diagnostics.push(content.clone());
+                            catcher.append_diag(diagnostic);
+                            displayed += 1;
+                        } else {
+                            hidden_errors += 1;
+                        }
+                        continue;
+                    }
+
+                    if diagnostic_is_warning(diagnostic) {
+                        total_warnings += 1;
+                    }
+                    if displayed < limit {
+                        non_errors.push((diagnostic, content));
+                    }
+                }
+            }
+
+            if displayed < limit {
+                for (diagnostic, content) in non_errors {
+                    diagnostics.push(content.clone());
+                    catcher.append_diag(diagnostic);
+                    displayed += 1;
+                    if diagnostic_is_warning(diagnostic) {
+                        displayed_warnings += 1;
+                    }
+                    if displayed == limit {
+                        break;
+                    }
+                }
+            }
+
+            let hidden_warnings = total_warnings - displayed_warnings;
+            catcher.n_errors += hidden_errors;
+            catcher.n_warnings += hidden_warnings;
+            (hidden_errors, hidden_warnings)
+        }
+    };
+
+    CollectedJsonDiagnostics {
+        processed: ProcessedDiagnostics {
+            n_errors: catcher.n_errors,
+            n_warnings: catcher.n_warnings,
+            hidden_errors,
+            hidden_warnings,
+        },
+        diagnostics,
+        non_diagnostic_output,
+    }
+}
+
 fn process_captured_diagnostics(
     sources: &[CapturedDiagnosticSource<'_>],
     cfg: &BuildConfig,
 ) -> ProcessedDiagnostics {
+    if cfg.output_style == OutputStyle::Json {
+        let collected = collect_json_diagnostics(sources, cfg);
+        for content in &collected.non_diagnostic_output {
+            eprintln!("{content}");
+        }
+        for content in &collected.diagnostics {
+            println!("{content}");
+        }
+        return collected.processed;
+    }
+
     let mut catcher = ResultCatcher::default();
     for source in sources {
         catcher.n_errors += source.diagnostics.n_errors;
@@ -1396,88 +1566,7 @@ fn process_captured_diagnostics(
     });
 
     match cfg.output_style {
-        OutputStyle::Json => {
-            let mut by_file = BTreeMap::<String, BTreeSet<(MooncDiagnostic, String)>>::new();
-            for (content, build_succeeded) in captured {
-                match serde_json::from_str::<moonutil::render::MooncDiagnostic>(&content) {
-                    Ok(d) => {
-                        if diagnostic_is_generated_test_driver_warning(&d) {
-                            continue;
-                        }
-                        let file_key = d.path.clone();
-                        by_file.entry(file_key).or_default().insert((d, content));
-                    }
-                    Err(_) => {
-                        // Non-diagnostics output, just print as-is
-                        // This could happen for installing binaries dependencies etc.
-                        if should_render_non_diagnostic_build_output(cfg, build_succeeded) {
-                            eprintln!("{content}");
-                        }
-                    }
-                };
-            }
-
-            // In JSON mode, just print raw content after dedup.
-            match cfg.diagnostic_limit {
-                None => {
-                    for file_diagnostics in by_file.values() {
-                        for (diag, content) in file_diagnostics {
-                            println!("{content}");
-                            catcher.append_diag(diag);
-                        }
-                    }
-                }
-                Some(limit) => {
-                    let mut displayed = 0;
-                    let mut hidden_errors = 0;
-                    let mut total_warnings = 0;
-                    let mut displayed_warnings = 0;
-                    let mut non_errors = Vec::new();
-
-                    for file_diagnostics in by_file.values() {
-                        for (diag, content) in file_diagnostics {
-                            if diagnostic_is_error(diag) {
-                                if displayed < limit {
-                                    println!("{content}");
-                                    catcher.append_diag(diag);
-                                    displayed += 1;
-                                } else {
-                                    hidden_errors += 1;
-                                }
-                                continue;
-                            }
-
-                            if diagnostic_is_warning(diag) {
-                                total_warnings += 1;
-                            }
-                            if displayed < limit {
-                                non_errors.push((diag, content));
-                            }
-                        }
-                    }
-
-                    if displayed < limit {
-                        for (diag, content) in non_errors {
-                            println!("{content}");
-                            catcher.append_diag(diag);
-                            displayed += 1;
-                            if diagnostic_is_warning(diag) {
-                                displayed_warnings += 1;
-                            }
-                            if displayed == limit {
-                                break;
-                            }
-                        }
-                    }
-
-                    let hidden_warnings = total_warnings - displayed_warnings;
-                    hidden_errors_total += hidden_errors;
-                    hidden_warnings_total += hidden_warnings;
-                    catcher.n_errors += hidden_errors;
-                    catcher.n_warnings += hidden_warnings;
-                }
-            }
-        }
+        OutputStyle::Json => unreachable!(),
         OutputStyle::Fancy => {
             let mut by_file = BTreeMap::<String, BTreeSet<MooncDiagnostic>>::new();
             for (content, build_succeeded) in captured {

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -1075,8 +1075,11 @@ pub fn execute_build_json(
     target_dir: &Path,
 ) -> anyhow::Result<JsonBuildOutput> {
     let execution = execute_build_capturing(cfg, input, target_dir)?;
-    let collected =
-        collect_json_diagnostics(&[CapturedDiagnosticSource::new(&execution, None)], cfg);
+    let collected = collect_json_diagnostics(
+        &[CapturedDiagnosticSource::new(&execution, None)],
+        cfg,
+        true,
+    );
     Ok(JsonBuildOutput {
         n_tasks_executed: execution.n_tasks_executed,
         n_errors: collected.processed.n_errors,
@@ -1426,6 +1429,7 @@ fn rewrite_captured_diagnostic(
 fn collect_json_diagnostics(
     sources: &[CapturedDiagnosticSource<'_>],
     cfg: &BuildConfig,
+    retain_suppressed_output: bool,
 ) -> CollectedJsonDiagnostics {
     let mut catcher = ResultCatcher::default();
     for source in sources {
@@ -1449,7 +1453,9 @@ fn collect_json_diagnostics(
                         .insert((diagnostic, content));
                 }
                 Err(_) => {
-                    if should_render_non_diagnostic_build_output(cfg, source.build_succeeded) {
+                    if retain_suppressed_output
+                        || should_render_non_diagnostic_build_output(cfg, source.build_succeeded)
+                    {
                         non_diagnostic_output.push(content);
                     }
                 }
@@ -1535,7 +1541,7 @@ fn process_captured_diagnostics(
     cfg: &BuildConfig,
 ) -> ProcessedDiagnostics {
     if cfg.output_style == OutputStyle::Json {
-        let collected = collect_json_diagnostics(sources, cfg);
+        let collected = collect_json_diagnostics(sources, cfg, false);
         for content in &collected.non_diagnostic_output {
             eprintln!("{content}");
         }
@@ -1801,5 +1807,23 @@ mod tests {
         assert_eq!(processed.n_warnings, 0);
         assert_eq!(processed.hidden_errors, 1);
         assert_eq!(processed.hidden_warnings, 0);
+    }
+
+    #[test]
+    fn structured_json_retains_successful_output_when_progress_is_suppressed() {
+        let mut catcher = ResultCatcher::default();
+        catcher.append_content("PREBUILD_SUCCESS", None);
+        let cfg = BuildConfig::default().with_suppressed_progress(true);
+        let sources = [CapturedDiagnosticSource {
+            diagnostics: &catcher,
+            build_succeeded: true,
+            build_meta: None,
+        }];
+
+        let collected = collect_json_diagnostics(&sources, &cfg, true);
+        assert_eq!(collected.non_diagnostic_output, ["PREBUILD_SUCCESS"]);
+
+        let rendered = collect_json_diagnostics(&sources, &cfg, false);
+        assert!(rendered.non_diagnostic_output.is_empty());
     }
 }

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -90,7 +90,7 @@ impl PlanningFixture {
             false,
             WorkspaceEnv::Auto,
         );
-        let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs)?;
+        let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, &dirs, &user_log)?;
         let resolve_output =
             moonbuild_rupes_recta::resolve_synced_project(&resolve_cfg, synced_env, &user_log)?;
         let source_dir = dirs.source_dir;

--- a/crates/moon/src/watch/prebuild_output.rs
+++ b/crates/moon/src/watch/prebuild_output.rs
@@ -115,7 +115,7 @@ mod tests {
         .unwrap()
         .package_dirs(&user_log)
         .unwrap();
-        let synced_env = sync_dependencies(&resolve_cfg, &dirs).unwrap();
+        let synced_env = sync_dependencies(&resolve_cfg, &dirs, &user_log).unwrap();
         let resolved = resolve_synced_project(&resolve_cfg, synced_env, &user_log).unwrap();
 
         let watch_paths = rr_get_prebuild_watch_paths(&resolved);
@@ -158,7 +158,7 @@ mod tests {
         .unwrap()
         .package_dirs(&user_log)
         .unwrap();
-        let synced_env = sync_dependencies(&resolve_cfg, &dirs).unwrap();
+        let synced_env = sync_dependencies(&resolve_cfg, &dirs, &user_log).unwrap();
         let resolved = resolve_synced_project(&resolve_cfg, synced_env, &user_log).unwrap();
 
         let watch_paths = rr_get_prebuild_watch_paths(&resolved);

--- a/crates/moon/tests/test_cases/diagnostics_format/check.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/check.rs
@@ -310,8 +310,9 @@ fn test_moon_check_complete_json_starts_after_argument_parsing() {
         .assert()
         .success()
         .stderr_eq("");
+    let help = String::from_utf8_lossy(&help.get_output().stdout);
     assert!(
-        String::from_utf8_lossy(&help.get_output().stdout).contains("Usage: moon check"),
+        help.contains("Usage:") && help.contains("--json"),
         "--help should keep Clap's human-readable output"
     );
 

--- a/crates/moon/tests/test_cases/diagnostics_format/check.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/check.rs
@@ -1,6 +1,289 @@
 use expect_test::expect;
 
-use crate::{TestDir, get_stderr, get_stdout, util::check};
+use crate::{TestDir, get_stderr, get_stdout, moon_cmd, util::check};
+
+fn parse_complete_json(assert: snapbox::cmd::OutputAssert) -> serde_json::Value {
+    let assert = assert.stderr_eq("");
+    let output = assert.get_output();
+    serde_json::from_slice(&output.stdout).expect("stdout should contain one complete JSON value")
+}
+
+#[test]
+fn test_moon_check_complete_json_success() {
+    let dir = TestDir::new("warns/deny_warn");
+    let report = parse_complete_json(
+        moon_cmd(&dir)
+            .args(["check", "--json", "--sort-input", "-j1"])
+            .assert()
+            .success(),
+    );
+
+    assert_eq!(report["version"], 1);
+    assert_eq!(report["status"], "success");
+    assert_eq!(report["messages"], serde_json::json!([]));
+    assert_eq!(report["diagnostics"].as_array().unwrap().len(), 4);
+    assert_eq!(report["summary"]["diagnostic_errors"], 0);
+    assert_eq!(report["summary"]["diagnostic_warnings"], 4);
+    assert!(
+        report["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|diagnostic| diagnostic["$message_type"] == "diagnostic")
+    );
+}
+
+#[test]
+fn test_moon_check_complete_json_compiler_failure() {
+    let dir = TestDir::new("dedup_diag_error_limit.in");
+    let report = parse_complete_json(
+        moon_cmd(&dir)
+            .args(["check", "--json", "--diagnostic-limit", "1", "-j1"])
+            .assert()
+            .failure(),
+    );
+
+    assert_eq!(report["status"], "failure");
+    assert_eq!(report["diagnostics"].as_array().unwrap().len(), 1);
+    assert_eq!(report["diagnostics"][0]["level"], "error");
+    assert_eq!(report["messages"][0]["$message_type"], "moon");
+    assert_eq!(report["messages"][0]["level"], "warning");
+    assert_eq!(report["summary"]["moon_warnings"], 1);
+    assert_eq!(report["summary"]["diagnostic_errors"], 1);
+    assert_eq!(report["summary"]["diagnostic_warnings"], 3);
+}
+
+#[test]
+fn test_moon_check_complete_json_quiet_filters_moon_warnings() {
+    let dir = TestDir::new("dedup_diag_error_limit.in");
+    let report = parse_complete_json(
+        moon_cmd(&dir)
+            .args([
+                "check",
+                "--json",
+                "--diagnostic-limit",
+                "1",
+                "--quiet",
+                "-j1",
+            ])
+            .assert()
+            .failure(),
+    );
+
+    assert_eq!(report["messages"], serde_json::json!([]));
+    assert_eq!(report["summary"]["moon_warnings"], 0);
+    assert_eq!(report["summary"]["diagnostic_errors"], 1);
+    assert_eq!(report["summary"]["diagnostic_warnings"], 3);
+}
+
+#[test]
+fn test_moon_check_complete_json_project_not_found() {
+    let dir = TestDir::new_empty();
+    let report = parse_complete_json(moon_cmd(&dir).args(["check", "--json"]).assert().failure());
+
+    assert_eq!(report["status"], "failure");
+    assert_eq!(report["diagnostics"], serde_json::json!([]));
+    assert_eq!(report["messages"][0]["$message_type"], "moon");
+    assert_eq!(report["messages"][0]["level"], "error");
+    assert!(
+        report["messages"][0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("not in a Moon project")
+    );
+    assert_eq!(report["summary"]["tasks_executed"], serde_json::Value::Null);
+    assert_eq!(report["summary"]["moon_errors"], 1);
+}
+
+#[test]
+fn test_moon_check_complete_json_captures_moon_warnings() {
+    let dir = TestDir::new("fmt_moon_work_existing.in");
+    let report = parse_complete_json(moon_cmd(&dir).args(["check", "--json"]).assert().success());
+
+    assert_eq!(report["status"], "success");
+    assert_eq!(report["messages"][0]["$message_type"], "moon");
+    assert_eq!(report["messages"][0]["level"], "warning");
+    assert!(
+        report["messages"][0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("preferred_target")
+    );
+    assert_eq!(report["summary"]["moon_warnings"], 1);
+}
+
+#[test]
+fn test_moon_check_complete_json_captures_manifest_warnings() {
+    let dir = TestDir::new("fmt_moon_mod_both.in");
+    let report = parse_complete_json(moon_cmd(&dir).args(["check", "--json"]).assert().success());
+
+    assert_eq!(report["messages"][0]["level"], "warning");
+    assert!(
+        report["messages"][0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Both moon.mod.json and moon.mod exist")
+    );
+    assert_eq!(report["summary"]["moon_warnings"], 1);
+}
+
+#[test]
+fn test_moon_check_complete_json_captures_resolution_failure() {
+    let dir = TestDir::new_empty();
+    std::fs::write(
+        dir.join("moon.mod.json"),
+        r#"{
+            "name": "test/root",
+            "version": "0.1.0",
+            "deps": {
+                "this_user_should_not_exist/this_module_should_not_exist": "0.1.0"
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let report = parse_complete_json(moon_cmd(&dir).args(["check", "--json"]).assert().failure());
+
+    assert_eq!(report["status"], "failure");
+    assert_eq!(report["diagnostics"], serde_json::json!([]));
+    assert!(
+        report["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|message| {
+                message["level"] == "warning"
+                    && message["message"].as_str().unwrap().contains("moon update")
+            })
+    );
+    assert!(
+        report["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|message| {
+                message["level"] == "error"
+                    && message["message"]
+                        .as_str()
+                        .unwrap()
+                        .contains("module was not found in the registry")
+            })
+    );
+    assert_eq!(report["summary"]["moon_errors"], 1);
+    assert_eq!(report["summary"]["moon_warnings"], 1);
+}
+
+#[test]
+fn test_moon_check_complete_json_captures_workspace_override_warning() {
+    let dir = TestDir::new("workspace_basic.in");
+    let app_manifest = dir.join("app/moon.mod.json");
+    let content = std::fs::read_to_string(&app_manifest)
+        .unwrap()
+        .replace(r#""alice/liba": "0.1.0""#, r#""alice/liba": "2.0.0""#);
+    std::fs::write(app_manifest, content).unwrap();
+
+    let report = parse_complete_json(moon_cmd(&dir).args(["check", "--json"]).assert().success());
+
+    assert_eq!(report["status"], "success");
+    assert!(
+        report["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|message| {
+                message["level"] == "warning"
+                    && message["message"]
+                        .as_str()
+                        .unwrap()
+                        .contains("overrides dependency requirement")
+            })
+    );
+}
+
+#[test]
+fn test_moon_check_complete_json_captures_bin_dep_prebuild_failure() {
+    let top_dir = TestDir::new("prebuild_config_script/check_skip_bin_dep.in");
+    let dir = top_dir.join("user.in");
+    std::fs::write(
+        top_dir.join("author.in/build.js"),
+        "console.error('BIN_DEP_JSON_SENTINEL')\nprocess.exit(1)\n",
+    )
+    .unwrap();
+
+    let report = parse_complete_json(moon_cmd(&dir).args(["check", "--json"]).assert().failure());
+
+    assert_eq!(report["status"], "failure");
+    assert!(
+        report["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|message| {
+                message["level"] == "error"
+                    && message["message"]
+                        .as_str()
+                        .unwrap()
+                        .contains("BIN_DEP_JSON_SENTINEL")
+            })
+    );
+}
+
+#[test]
+fn test_moon_check_complete_json_runs_bin_dep_prebuild() {
+    let top_dir = TestDir::new("prebuild_config_script/check_skip_bin_dep.in");
+    let dir = top_dir.join("user.in");
+    let generated_stub = top_dir.join("author.in/src/main/generated_stub.c");
+    assert!(!generated_stub.exists());
+
+    let report = parse_complete_json(moon_cmd(&dir).args(["check", "--json"]).assert().success());
+
+    assert_eq!(report["status"], "success");
+    assert!(generated_stub.exists());
+}
+
+#[test]
+fn test_moon_check_complete_json_rejects_other_output_modes() {
+    let dir = TestDir::new_empty();
+    let report = parse_complete_json(
+        moon_cmd(&dir)
+            .args(["check", "--json", "--output-json"])
+            .assert()
+            .code(2),
+    );
+
+    assert_eq!(report["status"], "failure");
+    assert_eq!(report["messages"][0]["level"], "error");
+    assert!(
+        report["messages"][0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("--output-json")
+    );
+}
+
+#[test]
+fn test_moon_check_complete_json_starts_after_argument_parsing() {
+    let dir = TestDir::new_empty();
+    let help = moon_cmd(&dir)
+        .args(["check", "--json", "--help"])
+        .assert()
+        .success()
+        .stderr_eq("");
+    assert!(
+        String::from_utf8_lossy(&help.get_output().stdout).contains("Usage: moon check"),
+        "--help should keep Clap's human-readable output"
+    );
+
+    let error = moon_cmd(&dir)
+        .args(["check", "--json", "--not-a-real-option"])
+        .assert()
+        .code(2)
+        .stdout_eq("");
+    assert!(
+        String::from_utf8_lossy(&error.get_output().stderr).contains("unexpected argument"),
+        "argument errors should keep Clap's native stderr output"
+    );
+}
 
 #[test]
 fn test_moon_check_json_output() {

--- a/crates/moon/tests/test_cases/diagnostics_format/check.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/check.rs
@@ -274,11 +274,35 @@ fn test_moon_check_complete_json_runs_bin_dep_prebuild() {
     let top_dir = TestDir::new("prebuild_config_script/check_skip_bin_dep.in");
     let dir = top_dir.join("user.in");
     let generated_stub = top_dir.join("author.in/src/main/generated_stub.c");
+    std::fs::write(
+        top_dir.join("author.in/moon.work"),
+        "members = [\".\"]\npreferred_target = \"wasm-gc\"\n",
+    )
+    .unwrap();
     assert!(!generated_stub.exists());
 
-    let report = parse_complete_json(moon_cmd(&dir).args(["check", "--json"]).assert().success());
+    let report = parse_complete_json(
+        moon_cmd(&dir)
+            .args(["check", "--json", "--verbose"])
+            .assert()
+            .success(),
+    );
 
     assert_eq!(report["status"], "success");
+    assert_eq!(report["summary"]["moon_warnings"], 0);
+    assert!(
+        report["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|message| {
+                message["level"] == "info"
+                    && message["message"]
+                        .as_str()
+                        .unwrap()
+                        .contains("preferred_target")
+            })
+    );
     assert!(generated_stub.exists());
 }
 

--- a/crates/moon/tests/test_cases/diagnostics_format/check.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/check.rs
@@ -46,11 +46,52 @@ fn test_moon_check_complete_json_compiler_failure() {
     assert_eq!(report["status"], "failure");
     assert_eq!(report["diagnostics"].as_array().unwrap().len(), 1);
     assert_eq!(report["diagnostics"][0]["level"], "error");
+    assert_eq!(report["diagnostics"][0]["target_backend"], "wasm");
     assert_eq!(report["messages"][0]["$message_type"], "moon");
     assert_eq!(report["messages"][0]["level"], "warning");
     assert_eq!(report["summary"]["moon_warnings"], 1);
     assert_eq!(report["summary"]["diagnostic_errors"], 1);
     assert_eq!(report["summary"]["diagnostic_warnings"], 3);
+}
+
+#[test]
+fn test_moon_check_complete_json_collects_every_planned_backend() {
+    let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
+    std::fs::write(
+        dir.join("js_preferred/src/lib/lib.mbt"),
+        "pub fn broken_js() -> Int { \"js\" }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("native_preferred/src/lib/lib.mbt"),
+        "pub fn broken_native() -> Int { \"native\" }\n",
+    )
+    .unwrap();
+
+    let report = parse_complete_json(
+        moon_cmd(&dir)
+            .args(["check", "--json", "--sort-input", "-j1"])
+            .assert()
+            .failure(),
+    );
+    let diagnostics = report["diagnostics"].as_array().unwrap();
+
+    assert_eq!(report["status"], "failure");
+    assert_eq!(report["summary"]["tasks_executed"], serde_json::Value::Null);
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["target_backend"] == "js"
+            && diagnostic["path"]
+                .as_str()
+                .unwrap()
+                .contains("js_preferred")
+    }));
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["target_backend"] == "native"
+            && diagnostic["path"]
+                .as_str()
+                .unwrap()
+                .contains("native_preferred")
+    }));
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/package_management.rs
+++ b/crates/moon/tests/test_cases/package_management.rs
@@ -94,11 +94,18 @@ fn mooncakes_io_smoke_test() {
     )
     .unwrap();
 
+    std::fs::remove_dir_all(&mooncakes_dir).unwrap();
+    let assert = moon_cmd(&dir).args(["run", "main"]).assert().success();
     check(
-        get_stdout(&dir, ["run", "main"]),
+        std::str::from_utf8(&assert.get_output().stdout).unwrap(),
         expect![[r#"
             Hello, world!Hello, world2!
         "#]],
+    );
+    let stderr = std::str::from_utf8(&assert.get_output().stderr).unwrap();
+    assert!(
+        !stderr.contains("Using cached ") && !stderr.contains("Downloading "),
+        "moon run should keep dependency sync quiet by default, got:\n{stderr}"
     );
 }
 

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -413,6 +413,13 @@ preferred_target = "wasm-gc"
             Warning: `preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.
         "#]],
     );
+
+    check(
+        get_stderr(&dir, ["-C", "app", "clean"]),
+        expect![[r#"
+            Warning: `preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.
+        "#]],
+    );
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -411,7 +411,6 @@ preferred_target = "wasm-gc"
         get_stderr(&dir, ["-C", "app", "build", "--dry-run", "--sort-input"]),
         expect![[r#"
             Warning: `preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.
-            Warning: `preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.
         "#]],
     );
 }

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -125,12 +125,13 @@ impl<'a> BuildPlanConstructor<'a> {
         debug_assert!(self.build_env.target_backend().is_native());
         if self.build_env.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
             self.warn_incompatible_windows_msvc_env_override();
-            return compiler_flags::windows_msvc_native_toolchain(package_cc);
+            return compiler_flags::windows_msvc_native_toolchain(package_cc, self.user_log);
         }
 
         compiler_flags::effective_native_toolchain(
             package_cc,
             self.build_env.tcc_run().map(|config| config.internal_tcc()),
+            self.user_log,
         )
     }
 

--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -60,6 +60,7 @@ use moonutil::{
         warn_if_shadowed_manifest, warn_known_shadowed_manifest,
     },
     package::resolve_supported_targets,
+    user_log::UserLog,
     workspace::{canonical_workspace_module_dirs, read_workspace_file},
 };
 use relative_path::{PathExt, RelativePath};
@@ -79,6 +80,7 @@ use self::package_files::DiscoveredPackageFiles;
 pub fn discover_packages(
     env: &ResolvedEnv,
     dirs: &DirSyncResult,
+    user_log: &UserLog,
 ) -> Result<DiscoverResult, DiscoverError> {
     info!("Starting package discovery across all modules");
     let mut res = DiscoverResult::default();
@@ -94,13 +96,9 @@ pub fn discover_packages(
         };
 
         let dir = dirs.get(id).expect("Bad module ID to get directory");
-        warn_if_shadowed_manifest(
-            dir,
-            MOON_MOD_JSON,
-            MOON_MOD,
-            &format!("at module root '{}'", dir.display()),
-        );
-        discover_packages_for_mod(&mut res, dir, id, env.resolved_module(id))?;
+        let location = format!("at module root '{}'", dir.display());
+        warn_if_shadowed_manifest(dir, MOON_MOD_JSON, MOON_MOD, &location, user_log);
+        discover_packages_for_mod(&mut res, dir, id, env.resolved_module(id), user_log)?;
     }
 
     if let Some(id) = res.get_package_id_by_name(MOONBITLANG_ABORT) {
@@ -124,6 +122,7 @@ pub fn discover_packages(
 pub fn discover_local_project(
     source_dir: &Path,
     project_manifest: &ProjectManifest,
+    user_log: &UserLog,
 ) -> Result<DiscoveredLocalProject, DiscoverError> {
     info!(
         "Starting local project discovery for {}",
@@ -131,7 +130,7 @@ pub fn discover_local_project(
     );
 
     let workspace = if let ProjectManifest::Workspace(workspace_manifest_path) = project_manifest {
-        read_workspace_file(workspace_manifest_path)
+        read_workspace_file(workspace_manifest_path, user_log)
             .map(Some)
             .map_err(|inner| DiscoverError::CantReadLocalWorkspace {
                 path: workspace_manifest_path.to_owned(),
@@ -170,6 +169,7 @@ pub fn discover_local_project(
             MOON_MOD_JSON,
             MOON_MOD,
             &format!("at module root '{}'", module_dir.display()),
+            user_log,
         );
         let module = read_module_desc_file_in_dir(&module_dir).map_err(|inner| {
             DiscoverError::CantReadLocalModuleFile {
@@ -182,7 +182,7 @@ pub fn discover_local_project(
         let id = root_modules.insert(ResolvedModule::new(source, module));
         root_module_ids.push(id);
 
-        discover_packages_for_mod(&mut pkg_dirs, &module_dir, id, &root_modules[id])?;
+        discover_packages_for_mod(&mut pkg_dirs, &module_dir, id, &root_modules[id], user_log)?;
     }
 
     if let Some(id) = pkg_dirs.get_package_id_by_name(MOONBITLANG_ABORT) {
@@ -208,6 +208,7 @@ pub(crate) fn discover_packages_for_mod(
     dir: &Path,
     id: ModuleId,
     module: &ResolvedModule,
+    user_log: &UserLog,
 ) -> Result<(), DiscoverError> {
     // This information is the one we get from the registry. We will read again
     // from the resolved directory
@@ -306,11 +307,13 @@ pub(crate) fn discover_packages_for_mod(
         let moon_pkg_json_path = abs_path.join(MOON_PKG_JSON);
         let pkg_manifest_path = if moon_pkg_path.exists() {
             if moon_pkg_json_path.exists() {
+                let location = format!("at package root '{}'", abs_path.display());
                 warn_known_shadowed_manifest(
                     abs_path,
                     MOON_PKG_JSON,
                     MOON_PKG,
-                    &format!("at package root '{}'", abs_path.display()),
+                    &location,
+                    user_log,
                 );
             }
             moon_pkg_path
@@ -335,6 +338,7 @@ pub(crate) fn discover_packages_for_mod(
             is_stdlib_pkg,
             &module_supported_targets,
             &pkg_manifest_path,
+            user_log,
         )?;
         debug!(
             "Found package: {} with {} source files",
@@ -353,6 +357,7 @@ pub(crate) fn discover_packages_for_mod(
 /// Discover one package and get its basic information. This does *not* create
 /// e.g. subpackages.
 #[instrument(level = Level::DEBUG, skip(m, rel, pkg_manifest_path))]
+#[allow(clippy::too_many_arguments)]
 fn discover_one_package(
     mid: ModuleId,
     m: &ModuleSource,
@@ -361,6 +366,7 @@ fn discover_one_package(
     pkg_is_stdlib: bool, // Whether the package being discovered is inside the stdlib (core) module.
     module_supported_targets: &IndexSet<TargetBackend>,
     pkg_manifest_path: &Path,
+    user_log: &UserLog,
 ) -> Result<(DiscoveredPackage, Option<PathBuf>), DiscoverError> {
     let abs = pkg_manifest_path
         .parent()
@@ -371,14 +377,13 @@ fn discover_one_package(
 
     // Discover the package config
     let (pkg_json, supported_targets_decl) =
-        read_package_desc_file_from_path_with_supported_targets_decl(pkg_manifest_path).map_err(
-            |e| DiscoverError::CantReadPackageFile {
-                module: m.clone(),
-                package: fqn.package().clone(),
-                path: abs.to_path_buf(),
-                inner: e,
-            },
-        )?;
+        read_package_desc_file_from_path_with_supported_targets_decl(pkg_manifest_path, user_log)
+            .map_err(|e| DiscoverError::CantReadPackageFile {
+            module: m.clone(),
+            package: fqn.package().clone(),
+            path: abs.to_path_buf(),
+            inner: e,
+        })?;
     let pkg_json = if is_core {
         add_prelude_as_import_for_core(pkg_json)
     } else {
@@ -501,6 +506,7 @@ mod tests {
     use moonutil::{
         manifest::MoonMod,
         resolution::{DirSyncResult, ModuleSource, ResolvedEnv},
+        user_log::UserLog,
     };
 
     use super::discover_packages;
@@ -548,7 +554,8 @@ mod tests {
         dirs.insert(id, dir.clone());
 
         let discovered =
-            discover_packages(&resolved_env, &dirs).expect("failed to discover test packages");
+            discover_packages(&resolved_env, &dirs, &UserLog::new(log::LevelFilter::Error))
+                .expect("failed to discover test packages");
 
         let module = discovered.module_info(id);
         assert_eq!(
@@ -604,7 +611,8 @@ mod tests {
         dirs.insert(id, dir.clone());
 
         let discovered =
-            discover_packages(&resolved_env, &dirs).expect("failed to discover test packages");
+            discover_packages(&resolved_env, &dirs, &UserLog::new(log::LevelFilter::Error))
+                .expect("failed to discover test packages");
 
         assert!(discovered.get_package_id_by_name("example/pkg").is_some());
         assert!(
@@ -670,7 +678,8 @@ mod tests {
         let mut dirs = DirSyncResult::default();
         dirs.insert(id, dir.clone());
 
-        let discovered = discover_packages(&resolved_env, &dirs)?;
+        let discovered =
+            discover_packages(&resolved_env, &dirs, &UserLog::new(log::LevelFilter::Error))?;
         let package_id = discovered
             .get_package_id_by_name("example/pkg/app")
             .expect("expected executable package");

--- a/crates/moonbuild-rupes-recta/src/fmt.rs
+++ b/crates/moonbuild-rupes-recta/src/fmt.rs
@@ -63,12 +63,13 @@ pub type FmtResolveOutput = DiscoveredLocalProject;
 pub fn resolve_for_fmt(
     source_dir: &Path,
     project_manifest: &ProjectManifest,
+    user_log: &UserLog,
 ) -> Result<FmtResolveOutput, ResolveError> {
     info!(
         "Resolving formatter environment for {}",
         source_dir.display()
     );
-    discover_local_project(source_dir, project_manifest).map_err(ResolveError::from)
+    discover_local_project(source_dir, project_manifest, user_log).map_err(ResolveError::from)
 }
 
 pub struct FmtConfig {

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -292,11 +292,6 @@ impl ResolveConfig {
         }
     }
 
-    pub fn with_quiet_sync(mut self, quiet_sync: bool) -> Self {
-        self.sync_output = self.sync_output.with_quiet(quiet_sync);
-        self
-    }
-
     pub fn with_sync_output(mut self, sync_output: SyncOutputOptions) -> Self {
         self.sync_output = sync_output;
         self
@@ -304,6 +299,11 @@ impl ResolveConfig {
 
     pub fn with_dependency_source_cache(mut self, cache: CacheRoot) -> Self {
         self.dependency_source_cache = cache;
+        self
+    }
+
+    pub fn with_captured_sync_child_output(mut self, capture: bool) -> Self {
+        self.sync_output = self.sync_output.with_captured_child_output(capture);
         self
     }
 
@@ -334,6 +334,7 @@ pub enum ResolveError {
 pub fn sync_dependencies(
     cfg: &ResolveConfig,
     dirs: &PackageDirs,
+    user_log: &UserLog,
 ) -> Result<(ResolvedEnv, DirSyncResult), ResolveError> {
     info!(
         "Starting dependency sync for source directory: {}",
@@ -345,6 +346,7 @@ pub fn sync_dependencies(
         dirs,
         &cfg.sync_flags,
         cfg.sync_output,
+        user_log,
         cfg.no_std,
         cfg.workspace_env.clone(),
         cfg.include_bin_deps,
@@ -365,7 +367,7 @@ pub fn resolve_synced_project(
 ) -> Result<ResolveOutput, ResolveError> {
     let (resolved_env, dir_sync_result) = synced_dependencies;
 
-    let mut discover_result = discover_packages(&resolved_env, &dir_sync_result)?;
+    let mut discover_result = discover_packages(&resolved_env, &dir_sync_result, user_log)?;
     let main_is_core = {
         let ids = resolved_env.input_module_ids();
         ids.len() == 1 && *resolved_env.module_source(ids[0]).name() == CORE_MODULE_TUPLE
@@ -464,10 +466,11 @@ Use moonbit.import with 'username/module@version[/package]' entries to opt in to
         front_matter_config.deps_to_sync.as_ref(),
         cfg.sync_output,
         &cfg.dependency_source_cache,
+        user_log,
     )
     .map_err(ResolveError::SyncModulesError)?;
     // Discover all packages in resolved modules
-    let mut discover_result = discover_packages(&resolved_env, &dir_sync_result)?;
+    let mut discover_result = discover_packages(&resolved_env, &dir_sync_result, user_log)?;
     warn_virtual_mbti_deprecations(&discover_result, user_log);
 
     // Synthesize the single-file package that imports everything from discovered modules

--- a/crates/moonbuild-rupes-recta/tests/discover_moon_mod.rs
+++ b/crates/moonbuild-rupes-recta/tests/discover_moon_mod.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 use moonbuild_rupes_recta::discover::discover_packages;
 use moonutil::manifest::read_module_desc_file_in_dir;
 use moonutil::resolution::{DirSyncResult, ModuleSource, ResolvedEnv};
+use moonutil::user_log::UserLog;
 
 fn fixture_dir(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -40,7 +41,8 @@ fn discover_skips_nested_module_with_moon_mod() {
     let mut dirs = DirSyncResult::new();
     dirs.insert(module_id, root.clone());
 
-    let discovered = discover_packages(&resolved, &dirs).expect("discover packages");
+    let discovered = discover_packages(&resolved, &dirs, &UserLog::new(log::LevelFilter::Error))
+        .expect("discover packages");
     let mut packages = discovered
         .all_packages(false)
         .map(|(_, pkg)| pkg.fqn.to_string())

--- a/crates/mooncake/src/dependency_source.rs
+++ b/crates/mooncake/src/dependency_source.rs
@@ -168,7 +168,7 @@ options(
             name: &ModuleName,
             version: &Version,
             to: &Path,
-            _quiet: bool,
+            _user_log: &UserLog,
         ) -> anyhow::Result<()> {
             std::fs::create_dir_all(to)?;
             self.install_source(name, version, to)
@@ -180,7 +180,7 @@ options(
             version: &Version,
             expected_checksum: &str,
             to: &Path,
-            _quiet: bool,
+            _user_log: &UserLog,
         ) -> anyhow::Result<()> {
             self.install_source(name, version, to)?;
             std::fs::write(to.join("acquired-archive-checksum"), expected_checksum)?;

--- a/crates/mooncake/src/dependency_source/global.rs
+++ b/crates/mooncake/src/dependency_source/global.rs
@@ -107,7 +107,7 @@ impl<'a> ImmutableDependencySource<'a> {
                     module.version(),
                     checksum,
                     staging.path(),
-                    !user_log.is_enabled(log::Level::Info),
+                    user_log,
                 )?;
                 validate_source(staging.path(), module)?;
                 std::fs::write(staging.path().join(SOURCE_ARCHIVE_CHECKSUM_FILE), checksum)?;

--- a/crates/mooncake/src/dependency_source/project.rs
+++ b/crates/mooncake/src/dependency_source/project.rs
@@ -279,12 +279,7 @@ fn sync(
             let ModuleSourceKind::Registry = version.source() else {
                 unreachable!()
             };
-            registry.install_to(
-                version.name(),
-                version.version(),
-                &pkg_path,
-                !user_log.is_enabled(log::Level::Info),
-            )?;
+            registry.install_to(version.name(), version.version(), &pkg_path, user_log)?;
             // TODO: parallelize this
         }
     }

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -17,7 +17,6 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use anyhow::bail;
-use colored::Colorize;
 use indexmap::IndexMap;
 use moonutil::constants::{MOON_MOD, MOONBITLANG_CORE};
 use moonutil::dependency::{BinaryDependencyInfo, SourceDependencyInfo};
@@ -27,6 +26,7 @@ use moonutil::manifest::{
 use moonutil::moon_mod_patch::{MoonModPatch, patch_module_dsl_to_file};
 use moonutil::project::PackageDirs;
 use moonutil::resolution::ModuleName;
+use moonutil::user_log::UserLog;
 use semver::Version;
 use std::path::Path;
 use std::sync::Arc;
@@ -60,17 +60,13 @@ pub fn add_latest(
     dirs: &PackageDirs,
     pkg_name: &ModuleName,
     bin: bool,
-    quiet: bool,
     index_updated: bool,
     upgrade: bool,
+    user_log: &UserLog,
 ) -> anyhow::Result<i32> {
     let pkg_name_str = pkg_name.to_string();
     if pkg_name_str == MOONBITLANG_CORE {
-        eprintln!(
-            "{}: no need to add `{}` as dependency",
-            "Warning".yellow().bold(),
-            MOONBITLANG_CORE
-        );
+        user_log.warn(format!("no need to add `{MOONBITLANG_CORE}` as dependency"));
         std::process::exit(0);
     }
 
@@ -96,8 +92,8 @@ pub fn add_latest(
         pkg_name,
         bin,
         &latest_version,
-        quiet,
         upgrade,
+        user_log,
     )
 }
 
@@ -114,18 +110,14 @@ pub fn add(
     pkg_name: &ModuleName,
     bin: bool,
     version: &Version,
-    quiet: bool,
     upgrade: bool,
+    user_log: &UserLog,
 ) -> anyhow::Result<i32> {
     let mut m = read_module_desc_file_in_dir(module_dir)?;
 
     let pkg_name_str = pkg_name.to_string();
     if pkg_name_str == MOONBITLANG_CORE {
-        eprintln!(
-            "{}: no need to add `{}` as dependency",
-            "Warning".yellow().bold(),
-            MOONBITLANG_CORE
-        );
+        user_log.warn(format!("no need to add `{MOONBITLANG_CORE}` as dependency"));
         std::process::exit(0);
     }
 
@@ -141,10 +133,9 @@ pub fn add(
         }
 
         if dep.version() == Some(version) {
-            eprintln!(
-                "{}: dependency `{pkg_name_str}` is already at version {version}",
-                "Warning".yellow().bold(),
-            );
+            user_log.warn(format!(
+                "dependency `{pkg_name_str}` is already at version {version}"
+            ));
             return Ok(0);
         }
 
@@ -160,11 +151,11 @@ pub fn add(
         );
     } else {
         if m.deps.contains_key(&pkg_name_str) {
-            eprintln!(
-                "{}: dependency `{pkg_name_str}` already exists, `moon add` will not update it. \
-                To update the dependency, run `moon add --upgrade {pkg_name_str}@<version>` or `moon add --upgrade {pkg_name_str}` for the latest version.",
-                "Warning".yellow().bold(),
-            );
+            user_log.warn(format!(
+                "dependency `{pkg_name_str}` already exists, `moon add` will not update it. \
+                 To update the dependency, run `moon add --upgrade {pkg_name_str}@<version>` or \
+                 `moon add --upgrade {pkg_name_str}` for the latest version."
+            ));
             return Ok(0);
         }
 
@@ -188,12 +179,13 @@ pub fn add(
     }
 
     let m = Arc::new(m);
-    let roots = roots_for_selected_module(module_dir, Arc::clone(&m), &dirs.project_manifest)?;
+    let roots =
+        roots_for_selected_module(module_dir, Arc::clone(&m), &dirs.project_manifest, user_log)?;
     install_impl(
         dirs,
         roots,
-        SyncOutputOptions::new(quiet, true),
-        false,
+        SyncOutputOptions::default(),
+        user_log,
         false,
         true,
         &moonutil::cache::CacheRoot::Disabled,

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -30,6 +30,7 @@ use moonutil::{
     resolution::{
         DependencyKind, DirSyncResult, ModuleSourceKind, ResolvedEnv, ResolvedRootModules,
     },
+    user_log::UserLog,
 };
 use std::path::{Path, PathBuf};
 
@@ -91,7 +92,7 @@ pub(crate) fn install_impl(
     dirs: &PackageDirs,
     roots: ResolvedRootModules,
     output_options: SyncOutputOptions,
-    verbose: bool,
+    user_log: &UserLog,
     dont_sync: bool,
     no_std: bool,
     source_cache: &CacheRoot,
@@ -108,30 +109,32 @@ pub(crate) fn install_impl(
         inject_std: !includes_core && !no_std,
     };
 
-    let res = resolve_with_default_env_and_resolver(&resolve_config, roots)?;
+    let res = resolve_with_default_env_and_resolver(&resolve_config, roots, user_log)?;
     let dependency_source = dependency_source::select(&dirs.mooncakes_dir, source_cache, &res)?;
-    let user_log = output_options.user_log();
     let dependency_paths =
-        dependency_source.ensure(resolve_config.registry.as_ref(), &res, dont_sync, &user_log)?;
+        dependency_source.ensure(resolve_config.registry.as_ref(), &res, dont_sync, user_log)?;
 
     install_bin_deps(
-        verbose,
+        output_options.capture_child_output(),
         &res,
         &dependency_paths,
         &dirs.target_dir,
         &dirs.mooncake_bin_dir,
+        user_log,
     )?;
 
     Ok((res, dependency_paths))
 }
 
 fn install_bin_deps(
-    verbose: bool,
+    capture_child_output: bool,
     res: &ResolvedEnv,
     dependency_paths: &DirSyncResult,
     target_dir: &Path,
     mooncake_bin_dir: &Path,
+    user_log: &UserLog,
 ) -> Result<(), anyhow::Error> {
+    let verbose = user_log.is_enabled(log::Level::Info);
     for &main_module in res.input_module_ids() {
         let Some(bin_deps) = res.module_info(main_module).bin_deps.as_ref() else {
             continue;
@@ -176,23 +179,48 @@ fn install_bin_deps(
 
             // Run it
             if verbose {
-                eprintln!("Installing binary dependency `{}`", edge.name);
+                user_log.info(format!("Installing binary dependency `{}`", edge.name));
             }
-            let status = cmd
-                .spawn()
-                .with_context(|| {
-                    format!(
-                        "Failed to spawn build process for binary dep `{}`",
-                        edge.name
-                    )
-                })?
-                .wait()
-                .with_context(|| {
-                    format!(
-                        "Failed to wait for build process of binary dep `{}`",
-                        edge.name
-                    )
+            let status = if capture_child_output {
+                let output = cmd.output().with_context(|| {
+                    format!("Failed to run build process for binary dep `{}`", edge.name)
                 })?;
+                for (channel, content) in [
+                    ("stdout", output.stdout.as_slice()),
+                    ("stderr", output.stderr.as_slice()),
+                ] {
+                    let content = String::from_utf8_lossy(content);
+                    let content = content.trim();
+                    if content.is_empty() {
+                        continue;
+                    }
+                    let message = format!(
+                        "binary dependency `{}` wrote to {channel}:\n{content}",
+                        edge.name
+                    );
+                    if output.status.success() {
+                        user_log.warn(message);
+                    } else {
+                        user_log.error(message);
+                    }
+                }
+                output.status
+            } else {
+                cmd.spawn()
+                    .with_context(|| {
+                        format!(
+                            "Failed to spawn build process for binary dep `{}`",
+                            edge.name
+                        )
+                    })?
+                    .wait()
+                    .with_context(|| {
+                        format!(
+                            "Failed to wait for build process of binary dep `{}`",
+                            edge.name
+                        )
+                    })?
+            };
             if !status.success() {
                 return Err(anyhow::anyhow!(
                     "Building binary dependency `{}` failed",

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -111,8 +111,17 @@ pub(crate) fn install_impl(
 
     let res = resolve_with_default_env_and_resolver(&resolve_config, roots, user_log)?;
     let dependency_source = dependency_source::select(&dirs.mooncakes_dir, source_cache, &res)?;
-    let dependency_paths =
-        dependency_source.ensure(resolve_config.registry.as_ref(), &res, dont_sync, user_log)?;
+    let dependency_user_log = if output_options.quiet() {
+        user_log.with_level(log::LevelFilter::Error)
+    } else {
+        user_log.clone()
+    };
+    let dependency_paths = dependency_source.ensure(
+        resolve_config.registry.as_ref(),
+        &res,
+        dont_sync,
+        &dependency_user_log,
+    )?;
 
     install_bin_deps(
         output_options.capture_child_output(),

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -208,7 +208,7 @@ fn install_bin_deps(
                         edge.name
                     );
                     if output.status.success() {
-                        user_log.warn(message);
+                        user_log.status(message);
                     } else {
                         user_log.error(message);
                     }

--- a/crates/mooncake/src/pkg/mod.rs
+++ b/crates/mooncake/src/pkg/mod.rs
@@ -23,6 +23,7 @@ use moonutil::{
     manifest::{MoonMod, read_module_desc_file_in_dir},
     project::{ProjectManifest, canonical_workspace_module_dirs, read_workspace_file},
     resolution::{ModuleSource, ResolvedModule, ResolvedRootModules},
+    user_log::UserLog,
 };
 
 pub mod add;
@@ -38,12 +39,13 @@ pub(crate) fn roots_for_selected_module(
     module_dir: &Path,
     module: Arc<MoonMod>,
     project_manifest: &ProjectManifest,
+    user_log: &UserLog,
 ) -> anyhow::Result<ResolvedRootModules> {
     if let ProjectManifest::Workspace(project_manifest) = project_manifest {
         let workspace_root = project_manifest
             .parent()
             .context("workspace manifest path has no parent directory")?;
-        let workspace = read_workspace_file(project_manifest)?;
+        let workspace = read_workspace_file(project_manifest, user_log)?;
         let mut roots = ResolvedRootModules::with_key();
         for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {
             let member = if member_dir == module_dir {

--- a/crates/mooncake/src/pkg/remove.rs
+++ b/crates/mooncake/src/pkg/remove.rs
@@ -26,6 +26,7 @@ use moonutil::{
     },
     moon_mod_patch::{MoonModPatch, patch_module_dsl_to_file},
     project::ProjectManifest,
+    user_log::UserLog,
 };
 
 use crate::{
@@ -47,6 +48,7 @@ pub fn remove(
     project_manifest: &ProjectManifest,
     username: &str,
     pkgname: &str,
+    user_log: &UserLog,
 ) -> anyhow::Result<i32> {
     let mut m = read_module_desc_file_in_dir(module_dir)?;
     let dep_name = format!("{username}/{pkgname}");
@@ -59,13 +61,13 @@ pub fn remove(
         )
     }
     let m = Arc::new(m);
-    let roots = roots_for_selected_module(module_dir, Arc::clone(&m), project_manifest)?;
+    let roots = roots_for_selected_module(module_dir, Arc::clone(&m), project_manifest, user_log)?;
 
     let resolve_cfg = ResolveConfig {
         registry: registry::default_registry(),
         inject_std: false, // no need to inject
     };
-    resolve_with_default_env_and_resolver(&resolve_cfg, roots)?;
+    resolve_with_default_env_and_resolver(&resolve_cfg, roots, user_log)?;
 
     if module_dir.join(MOON_MOD).exists() {
         patch_module_dsl_to_file(

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -37,39 +37,19 @@ use moonutil::{
 };
 use semver::Version;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct SyncOutputOptions {
-    quiet: bool,
-    verbose: bool,
+    capture_child_output: bool,
 }
 
 impl SyncOutputOptions {
-    pub fn new(quiet: bool, verbose: bool) -> Self {
-        Self { quiet, verbose }
-    }
-
-    pub fn with_quiet(mut self, quiet: bool) -> Self {
-        self.quiet = quiet;
+    pub fn with_captured_child_output(mut self, capture: bool) -> Self {
+        self.capture_child_output = capture;
         self
     }
 
-    pub(crate) fn user_log(self) -> UserLog {
-        // Preserve the existing sync policy while expressing it as one log
-        // level: acquisition is informational, while lock waits are verbose.
-        let level = if self.quiet {
-            log::LevelFilter::Error
-        } else if self.verbose {
-            log::LevelFilter::Debug
-        } else {
-            log::LevelFilter::Info
-        };
-        UserLog::new(level)
-    }
-}
-
-impl Default for SyncOutputOptions {
-    fn default() -> Self {
-        Self::new(false, true)
+    pub fn capture_child_output(self) -> bool {
+        self.capture_child_output
     }
 }
 
@@ -81,6 +61,7 @@ pub fn auto_sync(
     dirs: &PackageDirs,
     cli: &AutoSyncFlags,
     output_options: SyncOutputOptions,
+    user_log: &UserLog,
     no_std: bool,
     workspace_env: WorkspaceEnv,
     include_bin_deps: bool,
@@ -88,16 +69,14 @@ pub fn auto_sync(
     if let ProjectManifest::Workspace(project_manifest) = &dirs.project_manifest
         && !matches!(workspace_env, WorkspaceEnv::Off)
     {
-        let workspace_root = project_manifest
-            .parent()
-            .context("workspace manifest path has no parent directory")?;
+        let workspace = read_workspace_file(project_manifest, user_log)?;
         return resolve_workspace_sync(
             dirs,
             cli,
             output_options,
+            user_log,
             no_std,
-            workspace_root,
-            read_workspace_file(project_manifest)?,
+            workspace,
             include_bin_deps,
         );
     }
@@ -114,7 +93,7 @@ pub fn auto_sync(
         dirs,
         roots,
         output_options,
-        false,
+        user_log,
         cli.dont_sync(),
         no_std,
         &CacheRoot::Disabled,
@@ -127,11 +106,17 @@ fn resolve_workspace_sync(
     dirs: &PackageDirs,
     cli: &AutoSyncFlags,
     output_options: SyncOutputOptions,
+    user_log: &UserLog,
     no_std: bool,
-    workspace_root: &Path,
     workspace: MoonWork,
     include_bin_deps: bool,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult, Option<MoonWork>)> {
+    let ProjectManifest::Workspace(project_manifest) = &dirs.project_manifest else {
+        unreachable!("workspace sync requires a workspace manifest");
+    };
+    let workspace_root = project_manifest
+        .parent()
+        .context("workspace manifest path has no parent directory")?;
     let mut roots = ResolvedRootModules::with_key();
     for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {
         let mut module = read_module_desc_file_in_dir(&member_dir)?;
@@ -147,7 +132,7 @@ fn resolve_workspace_sync(
         dirs,
         roots,
         output_options,
-        false,
+        user_log,
         cli.dont_sync(),
         no_std,
         &CacheRoot::Disabled,
@@ -162,6 +147,7 @@ pub fn auto_sync_for_single_mbt_md(
     mooncake_bin_dir: &Path,
     mooncakes_dir: &Path,
     front_matter_config: Option<MbtMdHeader>,
+    user_log: &UserLog,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult, Arc<MoonMod>)> {
     let mut deps = IndexMap::new();
 
@@ -196,8 +182,8 @@ pub fn auto_sync_for_single_mbt_md(
     let (resolved_env, dir_sync_result) = super::install::install_impl(
         &dirs,
         roots,
-        SyncOutputOptions::new(moonbuild_opt.quiet, true),
-        moonbuild_opt.verbose,
+        SyncOutputOptions::default(),
+        user_log,
         dont_sync,
         false,
         &CacheRoot::Disabled,
@@ -212,6 +198,7 @@ pub fn auto_sync_for_single_file_rr(
     front_matter_deps: Option<&IndexMap<String, moonutil::dependency::SourceDependencyInfo>>,
     output_options: SyncOutputOptions,
     source_cache: &CacheRoot,
+    user_log: &UserLog,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult)> {
     let mut synth_deps = IndexMap::new();
     if let Some(deps_map) = front_matter_deps {
@@ -233,7 +220,7 @@ pub fn auto_sync_for_single_file_rr(
         dirs,
         roots,
         output_options,
-        false,
+        user_log,
         sync_flags.dont_sync(),
         false,
         source_cache,
@@ -241,22 +228,4 @@ pub fn auto_sync_for_single_file_rr(
 
     log::debug!("Dir sync result: {:?}", dir_sync_result);
     Ok((resolved_env, dir_sync_result))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::SyncOutputOptions;
-
-    #[test]
-    fn sync_output_options_configure_user_log() {
-        let normal = SyncOutputOptions::new(false, false).user_log();
-        assert!(normal.is_enabled(log::Level::Info));
-        assert!(!normal.is_enabled(log::Level::Debug));
-
-        let verbose = SyncOutputOptions::new(false, true).user_log();
-        assert!(verbose.is_enabled(log::Level::Debug));
-
-        let quiet = SyncOutputOptions::new(true, true).user_log();
-        assert!(!quiet.is_enabled(log::Level::Info));
-    }
 }

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -39,10 +39,20 @@ use semver::Version;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SyncOutputOptions {
+    quiet: bool,
     capture_child_output: bool,
 }
 
 impl SyncOutputOptions {
+    pub fn with_quiet(mut self, quiet: bool) -> Self {
+        self.quiet = quiet;
+        self
+    }
+
+    pub fn quiet(self) -> bool {
+        self.quiet
+    }
+
     pub fn with_captured_child_output(mut self, capture: bool) -> Self {
         self.capture_child_output = capture;
         self

--- a/crates/mooncake/src/pkg/tree.rs
+++ b/crates/mooncake/src/pkg/tree.rs
@@ -24,6 +24,7 @@ use anyhow::Context;
 use moonutil::manifest::read_module_desc_file_in_dir;
 use moonutil::project::ProjectManifest;
 use moonutil::resolution::{ModuleId, ModuleName, ResolvedEnv};
+use moonutil::user_log::UserLog;
 
 use crate::pkg::roots_for_selected_module;
 use crate::registry;
@@ -124,14 +125,19 @@ fn format_module_label(
     label
 }
 
-pub fn tree(module_dir: &Path, project_manifest: &ProjectManifest) -> anyhow::Result<i32> {
+pub fn tree(
+    module_dir: &Path,
+    project_manifest: &ProjectManifest,
+    user_log: &UserLog,
+) -> anyhow::Result<i32> {
     let module = Arc::new(read_module_desc_file_in_dir(module_dir)?);
-    let roots = roots_for_selected_module(module_dir, Arc::clone(&module), project_manifest)?;
+    let roots =
+        roots_for_selected_module(module_dir, Arc::clone(&module), project_manifest, user_log)?;
     let resolve_cfg = ResolveConfig {
         registry: registry::default_registry(),
         inject_std: false,
     };
-    let resolved = resolve_with_default_env_and_resolver(&resolve_cfg, roots)?;
+    let resolved = resolve_with_default_env_and_resolver(&resolve_cfg, roots, user_log)?;
 
     let module_name: ModuleName = module.name.as_str().into();
     let selected_root = resolved

--- a/crates/mooncake/src/pkg/work.rs
+++ b/crates/mooncake/src/pkg/work.rs
@@ -39,6 +39,7 @@ use moonutil::{
         DependencyEdge, DependencyKind, ModuleId, ModuleName, ModuleSource, ModuleSourceKind,
         ResolvedEnv, ResolvedModule, ResolvedRootModules,
     },
+    user_log::UserLog,
 };
 
 use crate::{
@@ -50,6 +51,7 @@ pub fn init_workspace(
     workspace_root: &Path,
     paths: &[PathBuf],
     quiet: bool,
+    user_log: &UserLog,
 ) -> anyhow::Result<i32> {
     if let Some(workspace_path) = workspace_manifest_path(workspace_root) {
         bail!(
@@ -63,7 +65,7 @@ pub fn init_workspace(
     } else {
         let mut use_paths = BTreeSet::new();
         for path in paths {
-            let member_dir = resolve_workspace_member(path)?;
+            let member_dir = resolve_workspace_member(path, user_log)?;
             use_paths.insert(workspace_use_path(workspace_root, &member_dir));
         }
         use_paths.into_iter().collect()
@@ -84,8 +86,13 @@ pub fn init_workspace(
     Ok(0)
 }
 
-pub fn use_workspace(workspace_root: &Path, paths: &[PathBuf], quiet: bool) -> anyhow::Result<i32> {
-    let existing = read_workspace(workspace_root)?;
+pub fn use_workspace(
+    workspace_root: &Path,
+    paths: &[PathBuf],
+    quiet: bool,
+    user_log: &UserLog,
+) -> anyhow::Result<i32> {
+    let existing = read_workspace(workspace_root, user_log)?;
     let preferred_target = existing
         .as_ref()
         .and_then(|workspace| workspace.preferred_target);
@@ -119,7 +126,7 @@ pub fn use_workspace(workspace_root: &Path, paths: &[PathBuf], quiet: bool) -> a
 
     let previous_len = use_paths.len();
     for path in paths {
-        let member_dir = resolve_workspace_member(path)?;
+        let member_dir = resolve_workspace_member(path, user_log)?;
         if member_dirs.insert(member_dir.clone()) {
             use_paths.push(workspace_use_path(workspace_root, &member_dir));
         }
@@ -147,15 +154,15 @@ pub fn use_workspace(workspace_root: &Path, paths: &[PathBuf], quiet: bool) -> a
     Ok(0)
 }
 
-pub fn sync_workspace(source_dir: &Path, quiet: bool) -> anyhow::Result<i32> {
-    let workspace = read_workspace(source_dir)?.context(format!(
+pub fn sync_workspace(source_dir: &Path, quiet: bool, user_log: &UserLog) -> anyhow::Result<i32> {
+    let workspace = read_workspace(source_dir, user_log)?.context(format!(
         "`moon work sync` requires `{}` at `{}`",
         MOON_WORK,
         source_dir.display()
     ))?;
     let member_dirs = canonical_workspace_module_dirs(source_dir, &workspace)?;
-    let roots = workspace_roots(&member_dirs)?;
-    let resolved_env = resolve_workspace(roots)?;
+    let roots = workspace_roots(&member_dirs, user_log)?;
+    let resolved_env = resolve_workspace(roots, user_log)?;
     let updated = sync_workspace_manifests(&resolved_env)?;
 
     if !quiet {
@@ -173,7 +180,7 @@ pub fn sync_workspace(source_dir: &Path, quiet: bool) -> anyhow::Result<i32> {
     Ok(0)
 }
 
-fn resolve_workspace_member(path: &Path) -> anyhow::Result<PathBuf> {
+fn resolve_workspace_member(path: &Path, user_log: &UserLog) -> anyhow::Result<PathBuf> {
     let member_dir = dunce::canonicalize(path)
         .with_context(|| format!("failed to resolve workspace member `{}`", path.display()))?;
     if !member_dir.is_dir() {
@@ -184,6 +191,7 @@ fn resolve_workspace_member(path: &Path) -> anyhow::Result<PathBuf> {
         MOON_MOD_JSON,
         MOON_MOD,
         &format!("at module root '{}'", member_dir.display()),
+        user_log,
     );
     read_module_desc_file_in_dir(&member_dir).with_context(|| {
         format!(
@@ -208,7 +216,10 @@ fn workspace_use_path(workspace_root: &Path, member_dir: &Path) -> PathBuf {
     PathBuf::from(".").join(relative)
 }
 
-fn resolve_workspace(roots: ResolvedRootModules) -> anyhow::Result<ResolvedEnv> {
+fn resolve_workspace(
+    roots: ResolvedRootModules,
+    user_log: &UserLog,
+) -> anyhow::Result<ResolvedEnv> {
     let mut includes_core = false;
     for (_, module) in roots.iter() {
         if module.module_info().name == MOONBITLANG_CORE {
@@ -225,10 +236,13 @@ fn resolve_workspace(roots: ResolvedRootModules) -> anyhow::Result<ResolvedEnv> 
         registry: registry::default_registry(),
         inject_std: !includes_core,
     };
-    resolve_with_default_env_and_resolver(&resolve_config, roots).map_err(Into::into)
+    resolve_with_default_env_and_resolver(&resolve_config, roots, user_log).map_err(Into::into)
 }
 
-fn workspace_roots(member_dirs: &[PathBuf]) -> anyhow::Result<ResolvedRootModules> {
+fn workspace_roots(
+    member_dirs: &[PathBuf],
+    user_log: &UserLog,
+) -> anyhow::Result<ResolvedRootModules> {
     let mut roots = ResolvedRootModules::with_key();
 
     for member_dir in member_dirs {
@@ -237,6 +251,7 @@ fn workspace_roots(member_dirs: &[PathBuf]) -> anyhow::Result<ResolvedRootModule
             MOON_MOD_JSON,
             MOON_MOD,
             &format!("at module root '{}'", member_dir.display()),
+            user_log,
         );
         let module = Arc::new(read_module_desc_file_in_dir(member_dir)?);
         let source = ModuleSource::from_local_module(&module, member_dir);

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -26,6 +26,7 @@ use std::{collections::BTreeMap, path::Path, sync::Arc};
 use indexmap::IndexMap;
 use moonutil::dependency::SourceDependencyInfo;
 use moonutil::resolution::ModuleName;
+use moonutil::user_log::UserLog;
 pub use online::*;
 use semver::Version;
 
@@ -75,7 +76,7 @@ pub trait Registry {
         name: &ModuleName,
         version: &Version,
         to: &Path,
-        quiet: bool,
+        user_log: &UserLog,
     ) -> anyhow::Result<()>;
 
     /// Ensure the published source archive is available, verify it against the
@@ -90,7 +91,7 @@ pub trait Registry {
         version: &Version,
         expected_checksum: &str,
         to: &Path,
-        quiet: bool,
+        user_log: &UserLog,
     ) -> anyhow::Result<()>;
 
     /// Return the registry index's SHA-256 checksum for the published source
@@ -118,9 +119,9 @@ where
         name: &ModuleName,
         version: &Version,
         to: &Path,
-        quiet: bool,
+        user_log: &UserLog,
     ) -> anyhow::Result<()> {
-        (**self).install_to(name, version, to, quiet)
+        (**self).install_to(name, version, to, user_log)
     }
 
     fn acquire_source_to(
@@ -129,9 +130,9 @@ where
         version: &Version,
         expected_checksum: &str,
         to: &Path,
-        quiet: bool,
+        user_log: &UserLog,
     ) -> anyhow::Result<()> {
-        (**self).acquire_source_to(name, version, expected_checksum, to, quiet)
+        (**self).acquire_source_to(name, version, expected_checksum, to, user_log)
     }
 
     fn source_archive_checksum(
@@ -167,9 +168,9 @@ where
         name: &ModuleName,
         version: &Version,
         to: &Path,
-        quiet: bool,
+        user_log: &UserLog,
     ) -> anyhow::Result<()> {
-        (**self).install_to(name, version, to, quiet)
+        (**self).install_to(name, version, to, user_log)
     }
 
     fn acquire_source_to(
@@ -178,9 +179,9 @@ where
         version: &Version,
         expected_checksum: &str,
         to: &Path,
-        quiet: bool,
+        user_log: &UserLog,
     ) -> anyhow::Result<()> {
-        (**self).acquire_source_to(name, version, expected_checksum, to, quiet)
+        (**self).acquire_source_to(name, version, expected_checksum, to, user_log)
     }
 
     fn source_archive_checksum(

--- a/crates/mooncake/src/registry/mock.rs
+++ b/crates/mooncake/src/registry/mock.rs
@@ -175,7 +175,7 @@ impl Registry for MockRegistry {
         _name: &ModuleName,
         _version: &Version,
         _to: &std::path::Path,
-        _quiet: bool,
+        _user_log: &moonutil::user_log::UserLog,
     ) -> anyhow::Result<()> {
         panic!("Mock registry does not support installing")
     }
@@ -186,7 +186,7 @@ impl Registry for MockRegistry {
         _version: &Version,
         _expected_checksum: &str,
         _to: &std::path::Path,
-        _quiet: bool,
+        _user_log: &moonutil::user_log::UserLog,
     ) -> anyhow::Result<()> {
         panic!("Mock registry does not support extracting sources")
     }

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -267,7 +267,7 @@ impl OnlineRegistry {
         let cache_file = self.archive_cache_file_of(name, version);
         match open_verified_archive(&cache_file, expected_checksum) {
             Ok(Some(archive)) => {
-                user_log.info(format!("Using cached {name}@{version}"));
+                user_log.status(format!("Using cached {name}@{version}"));
                 return Ok(archive);
             }
             Ok(None) => {}
@@ -281,7 +281,7 @@ impl OnlineRegistry {
                 });
             }
         }
-        user_log.info(format!("Downloading {name}@{version}"));
+        user_log.status(format!("Downloading {name}@{version}"));
         let filepath = form_urlencoded::Serializer::new(String::new())
             .append_key_only(&format!("{}/{}/{}", name.username, name.unqual, version))
             .finish();
@@ -323,7 +323,7 @@ impl OnlineRegistry {
     ) -> anyhow::Result<()> {
         let checksum = self.read_checksum_from_index_file(name, version)?;
         self.acquire_source_to(name, version, &checksum, pkg_install_dir, user_log)?;
-        execute_postadd_script(pkg_install_dir)?;
+        execute_postadd_script(pkg_install_dir, user_log)?;
         Ok(())
     }
 

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -29,7 +29,7 @@ use anyhow::{Context, bail};
 use indexmap::map::IndexMap;
 use moonutil::{
     dependency::SourceDependencyInfo, registry::RegistryConfig, resolution::ModuleName,
-    scripts::execute_postadd_script,
+    scripts::execute_postadd_script, user_log::UserLog,
 };
 use reqwest::header::USER_AGENT;
 use semver::Version;
@@ -137,9 +137,9 @@ impl super::Registry for OnlineRegistry {
         name: &ModuleName,
         version: &Version,
         to: &Path,
-        quiet: bool,
+        user_log: &UserLog,
     ) -> anyhow::Result<()> {
-        self.install_to_impl(name, version, to, quiet)
+        self.install_to_impl(name, version, to, user_log)
     }
 
     fn acquire_source_to(
@@ -148,9 +148,9 @@ impl super::Registry for OnlineRegistry {
         version: &Version,
         expected_checksum: &str,
         to: &Path,
-        quiet: bool,
+        user_log: &UserLog,
     ) -> anyhow::Result<()> {
-        OnlineRegistry::acquire_source_to(self, name, version, expected_checksum, to, quiet)
+        OnlineRegistry::acquire_source_to(self, name, version, expected_checksum, to, user_log)
     }
 
     fn source_archive_checksum(
@@ -258,7 +258,7 @@ impl OnlineRegistry {
         name: &ModuleName,
         version: &Version,
         expected_checksum: &str,
-        quiet: bool,
+        user_log: &UserLog,
     ) -> anyhow::Result<File> {
         let pkg_index = self.index_file_of(name);
         if !pkg_index.exists() {
@@ -267,9 +267,7 @@ impl OnlineRegistry {
         let cache_file = self.archive_cache_file_of(name, version);
         match open_verified_archive(&cache_file, expected_checksum) {
             Ok(Some(archive)) => {
-                if !quiet {
-                    eprintln!("Using cached {name}@{version}");
-                }
+                user_log.info(format!("Using cached {name}@{version}"));
                 return Ok(archive);
             }
             Ok(None) => {}
@@ -283,9 +281,7 @@ impl OnlineRegistry {
                 });
             }
         }
-        if !quiet {
-            eprintln!("Downloading {name}@{version}");
-        }
+        user_log.info(format!("Downloading {name}@{version}"));
         let filepath = form_urlencoded::Serializer::new(String::new())
             .append_key_only(&format!("{}/{}/{}", name.username, name.unqual, version))
             .finish();
@@ -323,10 +319,10 @@ impl OnlineRegistry {
         name: &ModuleName,
         version: &Version,
         pkg_install_dir: &Path,
-        quiet: bool,
+        user_log: &UserLog,
     ) -> anyhow::Result<()> {
         let checksum = self.read_checksum_from_index_file(name, version)?;
-        self.acquire_source_to(name, version, &checksum, pkg_install_dir, quiet)?;
+        self.acquire_source_to(name, version, &checksum, pkg_install_dir, user_log)?;
         execute_postadd_script(pkg_install_dir)?;
         Ok(())
     }
@@ -339,7 +335,7 @@ impl OnlineRegistry {
         version: &Version,
         expected_checksum: &str,
         pkg_install_dir: &Path,
-        quiet: bool,
+        user_log: &UserLog,
     ) -> anyhow::Result<()> {
         // ensure dir exists and is empty
         if !pkg_install_dir.exists() {
@@ -349,7 +345,7 @@ impl OnlineRegistry {
             std::fs::create_dir_all(pkg_install_dir).unwrap();
         }
 
-        let archive = self.download_or_use_cache(name, version, expected_checksum, quiet)?;
+        let archive = self.download_or_use_cache(name, version, expected_checksum, user_log)?;
         extract_zip_to_dir(pkg_install_dir, archive)?;
         Ok(())
     }
@@ -375,6 +371,10 @@ mod tests {
 
     use super::*;
     use crate::registry::Registry;
+
+    fn quiet_user_log() -> UserLog {
+        UserLog::new(log::LevelFilter::Error)
+    }
 
     #[test]
     fn official_registry_uses_download_service() {
@@ -476,7 +476,7 @@ mod tests {
         let destination = sandbox.path().join("source");
 
         registry
-            .acquire_source_to(&name, &version, &checksum, &destination, true)
+            .acquire_source_to(&name, &version, &checksum, &destination, &quiet_user_log())
             .unwrap();
 
         assert_eq!(
@@ -523,7 +523,7 @@ mod tests {
                 &version,
                 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
                 &destination,
-                true,
+                &quiet_user_log(),
             )
             .unwrap_err();
 

--- a/crates/mooncake/src/resolver.rs
+++ b/crates/mooncake/src/resolver.rs
@@ -23,6 +23,7 @@ use anyhow::Context;
 use moonutil::manifest::read_module_desc_file_in_dir;
 use moonutil::resolution::{ModuleId, ModuleName, ModuleSource, ResolvedEnv, ResolvedRootModules};
 use moonutil::toolchain;
+use moonutil::user_log::UserLog;
 use semver::Version;
 use thiserror::Error;
 
@@ -91,7 +92,8 @@ pub(crate) trait Resolver {
     ///
     /// If the dependencies cannot be resolved, this function should return
     /// `false`. The errors should be emitted in `env`.
-    fn resolve(&mut self, env: &mut ResolverEnv, res: &mut ResolvedEnv) -> bool;
+    fn resolve(&mut self, env: &mut ResolverEnv, res: &mut ResolvedEnv, user_log: &UserLog)
+    -> bool;
 }
 
 /// Goes through the resolved environment and checks for any duplicate module names.
@@ -239,6 +241,7 @@ pub(crate) fn resolve_with_default_env(
     config: &ResolveConfig,
     resolver: &mut dyn Resolver,
     root: ResolvedRootModules,
+    user_log: &UserLog,
 ) -> Result<ResolvedEnv, ResolverErrors> {
     let mut env = env::ResolverEnv::new(config.registry.as_ref());
     let mut res = ResolvedEnv::from_root_modules(root);
@@ -248,7 +251,7 @@ pub(crate) fn resolve_with_default_env(
             .map_err(|e| ResolverErrors(vec![ResolverError::CannotInjectCore(e)]))?;
     }
 
-    let status = resolver.resolve(&mut env, &mut res);
+    let status = resolver.resolve(&mut env, &mut res, user_log);
     if env.any_errors() {
         Err(ResolverErrors(env.into_errors()))
     } else {
@@ -276,7 +279,8 @@ fn inject_std(res: &mut ResolvedEnv) -> anyhow::Result<()> {
 pub(crate) fn resolve_with_default_env_and_resolver(
     config: &ResolveConfig,
     root: ResolvedRootModules,
+    user_log: &UserLog,
 ) -> Result<ResolvedEnv, ResolverErrors> {
     let mut resolver = MvsSolver;
-    resolve_with_default_env(config, &mut resolver, root)
+    resolve_with_default_env(config, &mut resolver, root, user_log)
 }

--- a/crates/mooncake/src/resolver/mvs.rs
+++ b/crates/mooncake/src/resolver/mvs.rs
@@ -23,7 +23,6 @@ use std::{
 };
 
 use anyhow::anyhow;
-use colored::Colorize;
 use moonutil::{
     constants::{MOON_MOD, MOON_MOD_JSON, is_moon_mod_exist},
     dependency::SourceDependencyInfo,
@@ -31,6 +30,7 @@ use moonutil::{
     resolution::{
         DependencyEdge, DependencyKind, ModuleName, ModuleSource, ModuleSourceKind, ResolvedEnv,
     },
+    user_log::UserLog,
 };
 use semver::Version;
 
@@ -44,8 +44,13 @@ type WorkspaceRoots = HashMap<ModuleName, (ModuleSource, Arc<MoonMod>)>;
 pub(crate) struct MvsSolver;
 
 impl Resolver for MvsSolver {
-    fn resolve(&mut self, env: &mut ResolverEnv, res: &mut ResolvedEnv) -> bool {
-        mvs_resolve(env, res)
+    fn resolve(
+        &mut self,
+        env: &mut ResolverEnv,
+        res: &mut ResolvedEnv,
+        user_log: &UserLog,
+    ) -> bool {
+        mvs_resolve(env, res, user_log)
     }
 }
 
@@ -69,6 +74,7 @@ fn select_min_version_satisfying<'a>(
     dependant: &ModuleName,
     req: &SourceDependencyInfo,
     versions: impl Iterator<Item = &'a Version> + 'a,
+    user_log: &UserLog,
 ) -> Result<Version, ResolverError> {
     let required = req.version().ok_or_else(|| {
         ResolverError::Other(anyhow!(
@@ -85,10 +91,7 @@ fn select_min_version_satisfying<'a>(
         }
     }
 
-    eprintln!(
-        "{}: you may need to run `moon update` to update the registry",
-        "Hint".yellow()
-    );
+    user_log.warn("you may need to run `moon update` to update the registry");
     Err(ResolverError::NoSatisfiedVersion {
         dependency: dependency.clone(),
         dependant: dependant.clone(),
@@ -101,12 +104,10 @@ fn select_min_version_satisfying_in_env(
     dependency: &ModuleName,
     dependant: &ModuleName,
     req: &SourceDependencyInfo,
+    user_log: &UserLog,
 ) -> Result<(Version, Arc<MoonMod>), ResolverError> {
     let all_versions = env.all_versions_of(dependency).ok_or_else(|| {
-        eprintln!(
-            "{}: you may need to run `moon update` to update the registry",
-            "Hint".yellow()
-        );
+        user_log.warn("you may need to run `moon update` to update the registry");
         ResolverError::ModuleMissing {
             dependency: dependency.clone(),
             dependant: dependant.clone(),
@@ -114,7 +115,7 @@ fn select_min_version_satisfying_in_env(
     })?;
 
     let min_version_satisfying =
-        select_min_version_satisfying(dependency, dependant, req, all_versions.keys());
+        select_min_version_satisfying(dependency, dependant, req, all_versions.keys(), user_log);
     match min_version_satisfying {
         Ok(version) => {
             let source = ModuleSource::from_version(dependency.clone(), version.clone());
@@ -201,19 +202,17 @@ impl From<ModuleSourceOrdWrapper> for ModuleSource {
     }
 }
 
-fn warn_about_skipped_local_or_git_dep(ms: &ModuleSource) {
+fn warn_about_skipped_local_or_git_dep(ms: &ModuleSource, user_log: &UserLog) {
     match ms.source() {
         ModuleSourceKind::Local(_) => {
-            log::warn!(
-                "A local dependency was skipped during version resolution: {}",
-                ms
-            );
+            user_log.warn(format!(
+                "A local dependency was skipped during version resolution: {ms}"
+            ));
         }
         ModuleSourceKind::Git(_) => {
-            log::warn!(
-                "A git dependency was skipped during version selection: {}",
-                ms
-            )
+            user_log.warn(format!(
+                "A git dependency was skipped during version selection: {ms}"
+            ));
         }
         _ => (),
     }
@@ -238,7 +237,7 @@ fn workspace_version_override_warning(
     ))
 }
 
-fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv) -> bool {
+fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv, user_log: &UserLog) -> bool {
     let workspace_roots = res
         .input_module_ids()
         .iter()
@@ -294,13 +293,14 @@ fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv) -> bool {
         for (name, req) in all_deps {
             let pkg_name = name.as_str().into();
 
-            let (ms, module) = match resolve_pkg(req, &source, env, &workspace_roots, &pkg_name) {
-                Ok(value) => value,
-                Err(e) => {
-                    env.report_error(e);
-                    continue;
-                }
-            };
+            let (ms, module) =
+                match resolve_pkg(req, &source, env, &workspace_roots, &pkg_name, user_log) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        env.report_error(e);
+                        continue;
+                    }
+                };
 
             // Add module to working list
             if visited.insert(ms.clone()) {
@@ -334,7 +334,7 @@ fn mvs_resolve(env: &mut ResolverEnv, res: &mut ResolvedEnv) -> bool {
             if same_mvs_compatibility_set(curr.version(), v.version()) {
                 // v >= curr, as implied by btreeset
                 // Emit a warning if the skipped dep is local or git, as they are manually specified
-                warn_about_skipped_local_or_git_dep(&curr);
+                warn_about_skipped_local_or_git_dep(&curr, user_log);
                 curr = v;
             } else {
                 log::debug!("---- selected {}", curr);
@@ -465,10 +465,11 @@ fn resolve_pkg(
     env: &mut ResolverEnv,
     workspace_roots: &WorkspaceRoots,
     pkg_name: &ModuleName,
+    user_log: &UserLog,
 ) -> Result<(ModuleSource, Arc<MoonMod>), ResolverError> {
     if let Some((source, module)) = workspace_roots.get(pkg_name) {
         if let Some(warning) = workspace_version_override_warning(req, dependant, source) {
-            log::warn!("{warning}");
+            user_log.warn(warning);
         }
         log::debug!(
             "---- Dependency {} resolved to workspace module {}",
@@ -547,7 +548,7 @@ fn resolve_pkg(
     // didn't specify it at all, or because the repo comes from a registry), we fallback
     // to resolving from a registry.
     let (version, module) =
-        select_min_version_satisfying_in_env(env, pkg_name, dependant.name(), req)?;
+        select_min_version_satisfying_in_env(env, pkg_name, dependant.name(), req, user_log)?;
     log::debug!(
         "---- Dependency {}, required {:?}, selected {}",
         pkg_name,
@@ -594,6 +595,14 @@ mod test {
         Box::new(registry)
     }
 
+    fn resolve_silently(
+        resolver: &mut MvsSolver,
+        env: &mut ResolverEnv,
+        result: &mut ResolvedEnv,
+    ) -> bool {
+        resolver.resolve(env, result, &UserLog::new(log::LevelFilter::Error))
+    }
+
     #[test]
     fn api_walkthrough() {
         let registry = create_mock_registry();
@@ -610,7 +619,7 @@ mod test {
         let (roots, _) = ResolvedModule::only_one_module(root_ms.clone(), root);
         let mut env = ResolverEnv::new(registry.as_ref());
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
 
@@ -815,7 +824,7 @@ mod test {
         let root = create_mock_module("root/module", "0.1.0", [("dep/one", "0.1.1")]);
         let roots = create_mock_root(root);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
         assert_depends_on(&result, "root/module@0.1.0", "dep/one@0.1.1");
@@ -847,7 +856,7 @@ mod test {
         let root = create_mock_module("root/module", "0.1.0", [("dep/regular", "0.1.0")]);
         let roots = create_mock_root(root);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
 
@@ -872,7 +881,7 @@ mod test {
         );
         let roots = create_mock_root(root);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
 
@@ -895,7 +904,7 @@ mod test {
         );
         let roots = create_mock_root(root);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
 
@@ -919,7 +928,7 @@ mod test {
         );
         let roots = create_mock_root(root);
         let mut res_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut res_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut res_env);
         assert!(!status);
     }
 
@@ -931,7 +940,7 @@ mod test {
         let root = create_mock_module("root/module", "0.1.0", [("dep/three", "0.2.0")]);
         let roots = create_mock_root(root);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
 
@@ -951,7 +960,7 @@ mod test {
         let root = create_mock_module("root/module", "0.1.0", [("dep/one", "0.1.1")]);
         let roots = create_mock_root(root);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
 
@@ -975,7 +984,7 @@ mod test {
         );
         let roots = create_mock_root(root);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
 
@@ -1002,7 +1011,7 @@ mod test {
         );
         let roots = create_mock_root(root);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
 
@@ -1024,7 +1033,7 @@ mod test {
         let root = create_mock_module("root/module", "0.1.0", [("dep/one", "0.1.0")]);
         let roots = create_mock_root(root);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
 
@@ -1044,7 +1053,7 @@ mod test {
         let root = create_mock_module("root/module", "0.1.0", [("dep/one", "0.1.0-rc.1")]);
         let roots = create_mock_root(root);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
 
@@ -1070,7 +1079,7 @@ mod test {
         );
         let roots = create_mock_root(root);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(
             status,
             "Resolve failed unexpectedly, errors: {}",
@@ -1103,7 +1112,7 @@ mod test {
             ("/workspace/shared", Arc::clone(&shared)),
         ]);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
         let app_src = create_mock_workspace_source(&app, "/workspace/app");
@@ -1132,7 +1141,7 @@ mod test {
             ("/workspace/shared", Arc::clone(&shared)),
         ]);
         let mut result_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut result_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut result_env);
         assert!(status, "Resolve failed");
         let result = result_env;
         let app_src = create_mock_workspace_source(&app, "/workspace/app");
@@ -1184,7 +1193,7 @@ mod test {
         let mut env = ResolverEnv::new(registry);
         let roots = create_mock_root(root);
         let mut res_env = ResolvedEnv::from_root_modules(roots);
-        let status = resolver.resolve(&mut env, &mut res_env);
+        let status = resolve_silently(&mut resolver, &mut env, &mut res_env);
         if status {
             res_env.all_modules().cloned().collect::<Vec<_>>()
         } else {

--- a/crates/moonutil/src/command_output.rs
+++ b/crates/moonutil/src/command_output.rs
@@ -20,7 +20,7 @@ use std::io::Write;
 
 use log::LevelFilter;
 
-use crate::user_log::UserLog;
+use crate::user_log::{UserLog, UserLogCapture};
 
 /// Owns the two MoonBuild-authored communication channels for one command.
 ///
@@ -38,6 +38,13 @@ impl CommandOutput {
         Self {
             user_log: UserLog::new(user_log_level),
         }
+    }
+
+    /// Construct an output facade whose User Logs are captured for later
+    /// inclusion in a structured Command Result.
+    pub fn captured(user_log_level: LevelFilter) -> (Self, UserLogCapture) {
+        let (user_log, capture) = UserLog::captured(user_log_level);
+        (Self { user_log }, capture)
     }
 
     pub fn user_log(&self) -> &UserLog {

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::moon_dir::MOON_DIRS;
+use crate::{moon_dir::MOON_DIRS, user_log::UserLog};
 use anyhow::Context;
 use colored::Colorize;
 use derive_builder::Builder;
@@ -31,6 +31,12 @@ use std::{
 
 const ENV_MOON_CC: &str = "MOON_CC";
 const ENV_MOON_AR: &str = "MOON_AR";
+const MOON_CC_PRECEDENCE_WARNING: &str = "Both MOON_CC environment variable and user-specified CC are provided. \
+     MOON_CC takes precedence.";
+
+fn warn_moon_cc_precedence(user_log: &UserLog) {
+    user_log.warn_once(MOON_CC_PRECEDENCE_WARNING);
+}
 
 #[derive(Copy, Clone, Debug)]
 pub enum CCKind {
@@ -187,17 +193,7 @@ impl Toolchain {
 
     pub fn with_package_override(&self, package_cc: Option<&CC>) -> Toolchain {
         match (self.source, package_cc) {
-            (ToolchainSource::EnvOverride, Some(_)) => {
-                static WARN_ONCE: std::sync::Once = std::sync::Once::new();
-                WARN_ONCE.call_once(|| {
-                    eprintln!(
-                        "{}: Both MOON_CC environment variable and user-specified CC are provided. \
-                        MOON_CC takes precedence.",
-                        "Warning".yellow().bold(),
-                    );
-                });
-                self.clone()
-            }
+            (ToolchainSource::EnvOverride, Some(_)) => self.clone(),
             (ToolchainSource::EnvOverride, None) | (_, None) => self.clone(),
             (_, Some(package_cc)) => Toolchain::from_package_override(package_cc.clone()),
         }
@@ -311,8 +307,14 @@ fn ensure_windows_msvc_compatible(cc: &CC) -> anyhow::Result<()> {
     }
 }
 
-pub fn windows_msvc_native_toolchain(package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
+pub fn windows_msvc_native_toolchain(
+    package_cc: Option<&CC>,
+    user_log: &UserLog,
+) -> anyhow::Result<Toolchain> {
     if let Some(env_cc) = ENV_CC.as_ref().filter(|cc| cc.is_msvc()) {
+        if package_cc.is_some() {
+            warn_moon_cc_precedence(user_log);
+        }
         let override_toolchain = Toolchain::from_env_override(env_cc.clone());
         let resolved = if is_path_like_tool(&env_cc.cc_path) {
             override_toolchain
@@ -916,8 +918,12 @@ pub fn default_native_toolchain(internal_tcc_fallback: Option<&CC>) -> anyhow::R
 pub fn effective_native_toolchain(
     package_cc: Option<&CC>,
     internal_tcc_fallback: Option<&CC>,
+    user_log: &UserLog,
 ) -> anyhow::Result<Toolchain> {
     let selected = if let Some(env_cc) = ENV_CC.as_ref() {
+        if package_cc.is_some() {
+            warn_moon_cc_precedence(user_log);
+        }
         Toolchain::from_env_override(env_cc.clone()).with_package_override(package_cc)
     } else if let Some(package_cc) = package_cc {
         Toolchain::from_package_override(package_cc.clone())
@@ -1810,6 +1816,22 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn moon_cc_precedence_warning_uses_user_log_once() {
+        let (user_log, capture) = UserLog::captured(log::LevelFilter::Warn);
+
+        warn_moon_cc_precedence(&user_log);
+        warn_moon_cc_precedence(&user_log);
+
+        let entries = capture.take();
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(
+            entries[0].level,
+            crate::user_log::UserLogEntryLevel::Warning
+        ));
+        assert_eq!(entries[0].message, MOON_CC_PRECEDENCE_WARNING);
+    }
 
     fn native_toolchain_fixture() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/native-toolchain")

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -698,8 +698,11 @@ impl ProjectQuery {
             return Ok(None);
         };
         if workspace.members.is_none() {
-            let moon_work =
-                read_workspace_file(&workspace.manifest_path).map_err(PackageDirsError::from)?;
+            let moon_work = read_workspace_file(
+                &workspace.manifest_path,
+                &UserLog::new(log::LevelFilter::Error),
+            )
+            .map_err(PackageDirsError::from)?;
             let member_dirs = canonical_workspace_module_dirs(&workspace.root, &moon_work)
                 .map_err(PackageDirsError::from)?;
             workspace.members = Some(member_dirs);
@@ -828,7 +831,8 @@ fn find_applicable_workspace(source_dir: &Path) -> anyhow::Result<Option<Workspa
         };
 
         if let Some(module_root) = module_root {
-            let workspace = read_workspace_file(&workspace_path)?;
+            let workspace =
+                read_workspace_file(&workspace_path, &UserLog::new(log::LevelFilter::Error))?;
             let members = canonical_workspace_module_dirs(dir, &workspace)?;
             if members.iter().any(|member_dir| member_dir == module_root) {
                 return Ok(Some(WorkspaceFacts {
@@ -842,7 +846,8 @@ fn find_applicable_workspace(source_dir: &Path) -> anyhow::Result<Option<Workspa
         }
 
         if has_module_manifest(dir) {
-            let workspace = read_workspace_file(&workspace_path)?;
+            let workspace =
+                read_workspace_file(&workspace_path, &UserLog::new(log::LevelFilter::Error))?;
             let members = canonical_workspace_module_dirs(dir, &workspace)?;
             let module_not_member = !members.iter().any(|member_dir| member_dir == dir);
             return Ok(Some(WorkspaceFacts {

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -32,7 +32,8 @@ use crate::constants::{
 };
 use crate::user_log::UserLog;
 use crate::workspace::{
-    canonical_workspace_module_dirs, read_workspace_file, workspace_manifest_path,
+    PREFERRED_TARGET_DEPRECATION_WARNING, canonical_workspace_module_dirs, read_workspace_file,
+    workspace_manifest_path,
 };
 
 const COLOCATED_MODULE_NOT_IN_WORKSPACE_WARNING: &str = "`moon.work` takes precedence over the module manifest in the same directory, but that module is not listed as a workspace member. Add `.` to `members` to select it from the workspace root.";
@@ -364,6 +365,7 @@ struct WorkspaceFacts {
     members: Option<Vec<PathBuf>>,
     // Discovery stays side-effect free. The command consumes this through its
     // own UserLog when it uses the selected project.
+    preferred_target_deprecation: bool,
     pending_warning: Option<ProjectDiscoveryWarning>,
 }
 
@@ -408,6 +410,7 @@ impl WorkspaceFacts {
             manifest_path,
             root,
             members: None,
+            preferred_target_deprecation: false,
             pending_warning: None,
         })
     }
@@ -465,7 +468,7 @@ impl ProjectQuery {
     pub fn project(&mut self, user_log: &UserLog) -> Result<ProjectContext, PackageDirsError> {
         match self.probe_project()? {
             ProjectProbe::Found(project) => {
-                self.emit_pending_warning(user_log);
+                self.emit_pending_warnings(user_log);
                 Ok(project)
             }
             ProjectProbe::NotFound(not_found) => Err(not_found.into_error()),
@@ -502,7 +505,7 @@ impl ProjectQuery {
         if selection.prefers_existing_workspace()
             && let Some(work_root) = self.workspace_root_for_sync()?
         {
-            self.emit_pending_warning(user_log);
+            self.emit_pending_warnings(user_log);
             return Ok(work_root);
         }
 
@@ -683,12 +686,14 @@ impl ProjectQuery {
         }))
     }
 
-    fn emit_pending_warning(&mut self, user_log: &UserLog) {
-        if let Some(warning) = self
-            .workspace
-            .as_mut()
-            .and_then(|workspace| workspace.pending_warning.take())
-        {
+    fn emit_pending_warnings(&mut self, user_log: &UserLog) {
+        let Some(workspace) = self.workspace.as_mut() else {
+            return;
+        };
+        if std::mem::take(&mut workspace.preferred_target_deprecation) {
+            user_log.warn_once(PREFERRED_TARGET_DEPRECATION_WARNING);
+        }
+        if let Some(warning) = workspace.pending_warning.take() {
             user_log.warn(warning);
         }
     }
@@ -703,6 +708,9 @@ impl ProjectQuery {
                 &UserLog::new(log::LevelFilter::Error),
             )
             .map_err(PackageDirsError::from)?;
+            if moon_work.preferred_target.is_some() {
+                workspace.preferred_target_deprecation = true;
+            }
             let member_dirs = canonical_workspace_module_dirs(&workspace.root, &moon_work)
                 .map_err(PackageDirsError::from)?;
             workspace.members = Some(member_dirs);
@@ -839,6 +847,7 @@ fn find_applicable_workspace(source_dir: &Path) -> anyhow::Result<Option<Workspa
                     manifest_path: workspace_path,
                     root: dir.to_path_buf(),
                     members: Some(members),
+                    preferred_target_deprecation: workspace.preferred_target.is_some(),
                     pending_warning: None,
                 }));
             }
@@ -854,6 +863,7 @@ fn find_applicable_workspace(source_dir: &Path) -> anyhow::Result<Option<Workspa
                 manifest_path: workspace_path,
                 root: dir.to_path_buf(),
                 members: Some(members),
+                preferred_target_deprecation: workspace.preferred_target.is_some(),
                 pending_warning: module_not_member
                     .then_some(ProjectDiscoveryWarning::ColocatedModuleNotInWorkspace),
             }));
@@ -863,6 +873,7 @@ fn find_applicable_workspace(source_dir: &Path) -> anyhow::Result<Option<Workspa
             manifest_path: workspace_path,
             root: dir.to_path_buf(),
             members: None,
+            preferred_target_deprecation: false,
             pending_warning: None,
         }));
     }

--- a/crates/moonutil/src/locks.rs
+++ b/crates/moonutil/src/locks.rs
@@ -52,7 +52,7 @@ impl FileLock {
                 #[cfg(test)]
                 let _ = user_log;
                 #[cfg(not(test))]
-                user_log.debug(format!(
+                user_log.status(format!(
                     "Blocking waiting for file lock {} ...",
                     path.join(MOON_LOCK).display()
                 ));

--- a/crates/moonutil/src/manifest.rs
+++ b/crates/moonutil/src/manifest.rs
@@ -35,6 +35,7 @@ use crate::{
         convert_pkg_dsl_to_package_with_supported_targets_decl,
         convert_pkg_json_to_package_with_supported_targets_decl,
     },
+    user_log::UserLog,
 };
 
 pub use crate::module::{
@@ -357,23 +358,25 @@ pub fn read_module_from_json(path: &Path) -> Result<MoonMod, MoonModJSONFormatEr
 
 fn read_package_from_json_with_supported_targets_decl(
     path: &Path,
+    user_log: &UserLog,
 ) -> anyhow::Result<(MoonPkg, SupportedTargetsDeclKind)> {
     let file = File::open(path)?;
     let reader = BufReader::new(file);
     let j = serde_json_lenient::from_reader(reader).context(format!("Failed to parse {path:?}"))?;
     let emit_warnings = should_warn_manifest(path);
-    convert_pkg_json_to_package_with_supported_targets_decl(j, emit_warnings)
+    convert_pkg_json_to_package_with_supported_targets_decl(j, emit_warnings, user_log)
 }
 
 /// Reads a moon.pkg from the given path.
 fn read_package_from_dsl_with_supported_targets_decl(
     path: &Path,
+    user_log: &UserLog,
 ) -> anyhow::Result<(MoonPkg, SupportedTargetsDeclKind)> {
     let file = File::open(path)?;
     let str = std::io::read_to_string(file)?;
     let dsl = moon_pkg::parse(&str)?;
     let emit_warnings = should_warn_manifest(path);
-    convert_pkg_dsl_to_package_with_supported_targets_decl(dsl, emit_warnings)
+    convert_pkg_dsl_to_package_with_supported_targets_decl(dsl, emit_warnings, user_log)
 }
 
 /// Avoid emitting manifest warnings for dependency cache files in .mooncakes.
@@ -408,9 +411,10 @@ pub fn warn_if_shadowed_manifest(
     legacy_manifest: &'static str,
     new_manifest: &'static str,
     location: &str,
+    user_log: &UserLog,
 ) {
     if dir.join(new_manifest).exists() && dir.join(legacy_manifest).exists() {
-        warn_known_shadowed_manifest(dir, legacy_manifest, new_manifest, location);
+        warn_known_shadowed_manifest(dir, legacy_manifest, new_manifest, location, user_log);
     }
 }
 
@@ -419,14 +423,24 @@ pub fn warn_known_shadowed_manifest(
     legacy_manifest: &'static str,
     new_manifest: &'static str,
     location: &str,
+    user_log: &UserLog,
 ) {
-    if !should_warn_manifest(dir) {
-        return;
+    if let Some(warning) = shadowed_manifest_warning(dir, legacy_manifest, new_manifest, location) {
+        user_log.warn(warning);
     }
+}
 
-    eprintln!(
-        "Warning: Both {legacy_manifest} and {new_manifest} exist {location}, using the new format {new_manifest}. Please remove the deprecated {legacy_manifest}."
-    );
+fn shadowed_manifest_warning(
+    dir: &Path,
+    legacy_manifest: &'static str,
+    new_manifest: &'static str,
+    location: &str,
+) -> Option<String> {
+    should_warn_manifest(dir).then(|| {
+        format!(
+            "Both {legacy_manifest} and {new_manifest} exist {location}, using the new format {new_manifest}. Please remove the deprecated {legacy_manifest}."
+        )
+    })
 }
 
 pub fn write_module_json_to_file(m: &MoonModJSON, source_dir: &Path) -> anyhow::Result<()> {
@@ -503,15 +517,18 @@ pub fn read_module_desc_file_in_dir(dir: &Path) -> anyhow::Result<MoonMod> {
     }
 }
 
-pub fn read_package_desc_file_in_dir(dir: &Path) -> anyhow::Result<MoonPkg> {
-    Ok(read_package_desc_file_in_dir_with_supported_targets_decl(dir)?.0)
+pub fn read_package_desc_file_in_dir(dir: &Path, user_log: &UserLog) -> anyhow::Result<MoonPkg> {
+    Ok(read_package_desc_file_in_dir_with_supported_targets_decl(dir, user_log)?.0)
 }
 
 pub fn read_package_desc_file_in_dir_with_supported_targets_decl(
     dir: &Path,
+    user_log: &UserLog,
 ) -> anyhow::Result<(MoonPkg, SupportedTargetsDeclKind)> {
     match preferred_manifest_in_dir(dir, MOON_PKG, MOON_PKG_JSON) {
-        Some((path, _)) => read_package_desc_file_from_path_with_supported_targets_decl(&path),
+        Some((path, _)) => {
+            read_package_desc_file_from_path_with_supported_targets_decl(&path, user_log)
+        }
         None => bail!(
             "Failed to find `{}` or `{}` for package at path `{}`",
             MOON_PKG,
@@ -523,13 +540,14 @@ pub fn read_package_desc_file_in_dir_with_supported_targets_decl(
 
 pub fn read_package_desc_file_from_path_with_supported_targets_decl(
     path: &Path,
+    user_log: &UserLog,
 ) -> anyhow::Result<(MoonPkg, SupportedTargetsDeclKind)> {
     match path.file_name() {
         Some(filename) if filename == OsStr::new(MOON_PKG) => {
-            read_package_from_dsl_with_supported_targets_decl(path)
+            read_package_from_dsl_with_supported_targets_decl(path, user_log)
         }
         Some(filename) if filename == OsStr::new(MOON_PKG_JSON) => {
-            read_package_from_json_with_supported_targets_decl(path)
+            read_package_from_json_with_supported_targets_decl(path, user_log)
                 .context(format!("Failed to load {:?}", path))
         }
         _ => bail!(

--- a/crates/moonutil/src/package.rs
+++ b/crates/moonutil/src/package.rs
@@ -22,7 +22,6 @@ use std::{
 };
 
 use anyhow::{Context, bail};
-use colored::Colorize;
 use indexmap::{IndexMap, IndexSet};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -34,6 +33,7 @@ use crate::{
     module::MoonModRule,
     moon_pkg,
     target::TargetBackend::{self, Js, LLVM, Native, Wasm, WasmGC},
+    user_log::UserLog,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -778,13 +778,17 @@ impl Import {
 }
 
 /// Convert moon.pkg DSL (with `options` key) to MoonPkg struct
-pub fn convert_pkg_dsl_to_package(dsl: moon_pkg::Dsl) -> anyhow::Result<MoonPkg> {
-    Ok(convert_pkg_dsl_to_package_with_supported_targets_decl(dsl, true)?.0)
+pub fn convert_pkg_dsl_to_package(
+    dsl: moon_pkg::Dsl,
+    user_log: &UserLog,
+) -> anyhow::Result<MoonPkg> {
+    Ok(convert_pkg_dsl_to_package_with_supported_targets_decl(dsl, true, user_log)?.0)
 }
 
 pub fn convert_pkg_dsl_to_package_with_supported_targets_decl(
     dsl: moon_pkg::Dsl,
     emit_warnings: bool,
+    user_log: &UserLog,
 ) -> anyhow::Result<(MoonPkg, SupportedTargetsDeclKind)> {
     // It will validate the top-level keys and merge `options` into the root level.
     // Might be removed in the future, after we remove the moon.pkg.json and have an
@@ -847,12 +851,8 @@ pub fn convert_pkg_dsl_to_package_with_supported_targets_decl(
     match (supported_targets, legacy_supported_targets) {
         (Some(supported_targets), Some(_)) => {
             if emit_warnings {
-                eprintln!(
-                    "{}",
-                    "Warning: Both `supported_targets = ...` and `options(\"supported-targets\": ...)` are set in `moon.pkg`. Using `supported_targets` and ignoring the old `options(\"supported-targets\")` value."
-                        .yellow()
-                        .bold()
-                );
+                let warning = "Both `supported_targets = ...` and `options(\"supported-targets\": ...)` are set in `moon.pkg`. Using `supported_targets` and ignoring the old `options(\"supported-targets\")` value.";
+                user_log.warn(warning);
             }
             map.insert(String::from("supported-targets"), supported_targets);
         }
@@ -861,12 +861,8 @@ pub fn convert_pkg_dsl_to_package_with_supported_targets_decl(
         }
         (None, Some(legacy_supported_targets)) => {
             if emit_warnings {
-                eprintln!(
-                    "{}",
-                    "Warning: `options(\"supported-targets\": ...)` in `moon.pkg` is deprecated. Please use `supported_targets = ...` instead."
-                        .yellow()
-                        .bold()
-                );
+                let warning = "`options(\"supported-targets\": ...)` in `moon.pkg` is deprecated. Please use `supported_targets = ...` instead.";
+                user_log.warn(warning);
             }
             map.insert(String::from("supported-targets"), legacy_supported_targets);
         }
@@ -881,7 +877,7 @@ pub fn convert_pkg_dsl_to_package_with_supported_targets_decl(
     }
     let json = Value::Object(map);
     let pkg_json: MoonPkgJSON = serde_json_lenient::from_value(json)?;
-    convert_pkg_json_to_package_with_supported_targets_decl(pkg_json, emit_warnings)
+    convert_pkg_json_to_package_with_supported_targets_decl(pkg_json, emit_warnings, user_log)
 }
 
 pub fn pkg_json_imports_to_imports(source: Option<PkgJSONImport>) -> Vec<Import> {
@@ -942,6 +938,7 @@ pub fn pkg_json_imports_to_imports(source: Option<PkgJSONImport>) -> Vec<Import>
 pub fn convert_pkg_json_to_package_with_supported_targets_decl(
     j: MoonPkgJSON,
     emit_warnings: bool,
+    user_log: &UserLog,
 ) -> anyhow::Result<(MoonPkg, SupportedTargetsDeclKind)> {
     let get_imports =
         |source: Option<PkgJSONImport>| -> Vec<Import> { pkg_json_imports_to_imports(source) };
@@ -965,12 +962,8 @@ pub fn convert_pkg_json_to_package_with_supported_targets_decl(
     {
         legacy_is_main = true;
         if emit_warnings {
-            eprintln!(
-                "{}",
-                "Warning: The `name` field in `moon.pkg` is now deprecated. For the main package, please use `\"is-main\": true` instead. Refer to the latest documentation at https://www.moonbitlang.com/docs/build-system-tutorial for more information."
-                    .yellow()
-                    .bold()
-            );
+            let warning = "The `name` field in `moon.pkg` is now deprecated. For the main package, please use `\"is-main\": true` instead. Refer to the latest documentation at https://www.moonbitlang.com/docs/build-system-tutorial for more information.";
+            user_log.warn(warning);
         }
     }
     // Legacy `force_link` from the boolean `link: true` (a structured
@@ -996,15 +989,11 @@ pub fn convert_pkg_json_to_package_with_supported_targets_decl(
                         is_main_flag
                     );
                 } else if emit_warnings {
-                    eprintln!(
-                        "{}",
-                        format!(
-                            "Warning: `is-main` is redundant with `pkgtype(kind: \"{}\")` in `moon.pkg`. `is-main` is deprecated; please remove it.",
-                            kind.as_str()
-                        )
-                        .yellow()
-                        .bold()
+                    let warning = format!(
+                        "`is-main` is redundant with `pkgtype(kind: \"{}\")` in `moon.pkg`. `is-main` is deprecated; please remove it.",
+                        kind.as_str()
                     );
+                    user_log.warn(warning);
                 }
             }
             if let Some(BoolOrLink::Bool(link_flag)) = &j.link {
@@ -1015,16 +1004,12 @@ pub fn convert_pkg_json_to_package_with_supported_targets_decl(
                         link_flag
                     );
                 } else if emit_warnings {
-                    eprintln!(
-                        "{}",
-                        format!(
-                            "Warning: `link: {}` is redundant with `pkgtype(kind: \"{}\")` in `moon.pkg`. The boolean `link` is deprecated; please remove it.",
-                            link_flag,
-                            kind.as_str()
-                        )
-                        .yellow()
-                        .bold()
+                    let warning = format!(
+                        "`link: {}` is redundant with `pkgtype(kind: \"{}\")` in `moon.pkg`. The boolean `link` is deprecated; please remove it.",
+                        link_flag,
+                        kind.as_str()
                     );
+                    user_log.warn(warning);
                 }
             }
             (want_main, want_force_link)
@@ -1138,11 +1123,34 @@ pub fn validate_data_directory(package_root: &Path, data_dir: &str) -> anyhow::R
     Ok(path)
 }
 
+#[cfg(test)]
+fn convert_test_pkg_dsl(
+    dsl: moon_pkg::Dsl,
+    emit_warnings: bool,
+) -> anyhow::Result<(MoonPkg, SupportedTargetsDeclKind)> {
+    convert_pkg_dsl_to_package_with_supported_targets_decl(
+        dsl,
+        emit_warnings,
+        &UserLog::new(log::LevelFilter::Error),
+    )
+}
+
+#[cfg(test)]
+fn convert_test_pkg_json(
+    json: MoonPkgJSON,
+    emit_warnings: bool,
+) -> anyhow::Result<(MoonPkg, SupportedTargetsDeclKind)> {
+    convert_pkg_json_to_package_with_supported_targets_decl(
+        json,
+        emit_warnings,
+        &UserLog::new(log::LevelFilter::Error),
+    )
+}
+
 #[test]
 fn convert_pkg_dsl_supports_supported_targets_shorthand() {
     let json = crate::moon_pkg::parse(r#"supported_targets = "js""#).unwrap();
-    let (pkg, decl_kind) =
-        convert_pkg_dsl_to_package_with_supported_targets_decl(json, true).unwrap();
+    let (pkg, decl_kind) = convert_test_pkg_dsl(json, true).unwrap();
 
     assert_eq!(
         pkg.supported_targets.iter().copied().collect::<Vec<_>>(),
@@ -1162,8 +1170,7 @@ options(
 "#,
     )
     .unwrap();
-    let (pkg, decl_kind) =
-        convert_pkg_dsl_to_package_with_supported_targets_decl(json, true).unwrap();
+    let (pkg, decl_kind) = convert_test_pkg_dsl(json, true).unwrap();
 
     assert_eq!(
         pkg.supported_targets.iter().copied().collect::<Vec<_>>(),
@@ -1182,7 +1189,7 @@ fn convert_pkgtype_derives_is_main_and_force_link() {
     for (kind, want_is_main, want_force_link) in cases {
         let src = format!(r#"pkgtype(kind: "{kind}")"#);
         let json = crate::moon_pkg::parse(&src).unwrap();
-        let (pkg, _) = convert_pkg_dsl_to_package_with_supported_targets_decl(json, false).unwrap();
+        let (pkg, _) = convert_test_pkg_dsl(json, false).unwrap();
         assert_eq!(pkg.is_main, want_is_main, "is_main for kind {kind}");
         assert_eq!(
             pkg.force_link, want_force_link,
@@ -1194,7 +1201,7 @@ fn convert_pkgtype_derives_is_main_and_force_link() {
 #[test]
 fn convert_pkgtype_defaults_to_library_when_absent() {
     let json = crate::moon_pkg::parse("").unwrap();
-    let (pkg, _) = convert_pkg_dsl_to_package_with_supported_targets_decl(json, false).unwrap();
+    let (pkg, _) = convert_test_pkg_dsl(json, false).unwrap();
     assert!(!pkg.is_main);
     assert!(!pkg.force_link);
 }
@@ -1208,7 +1215,7 @@ options("is-main": true)
 "#,
     )
     .unwrap();
-    let err = convert_pkg_dsl_to_package_with_supported_targets_decl(json, false).unwrap_err();
+    let err = convert_test_pkg_dsl(json, false).unwrap_err();
     assert!(
         err.to_string().contains("conflicts with `is-main"),
         "unexpected error: {err}"
@@ -1224,7 +1231,7 @@ options("link": true)
 "#,
     )
     .unwrap();
-    let err = convert_pkg_dsl_to_package_with_supported_targets_decl(json, false).unwrap_err();
+    let err = convert_test_pkg_dsl(json, false).unwrap_err();
     assert!(
         err.to_string().contains("conflicts with `link"),
         "unexpected error: {err}"
@@ -1240,7 +1247,7 @@ options("is-main": true)
 "#,
     )
     .unwrap();
-    let (pkg, _) = convert_pkg_dsl_to_package_with_supported_targets_decl(json, false).unwrap();
+    let (pkg, _) = convert_test_pkg_dsl(json, false).unwrap();
     assert!(pkg.is_main);
     assert!(!pkg.force_link);
 }
@@ -1256,7 +1263,7 @@ options("link": { "js": { "format": "esm" } })
 "#,
     )
     .unwrap();
-    let (pkg, _) = convert_pkg_dsl_to_package_with_supported_targets_decl(json, false).unwrap();
+    let (pkg, _) = convert_test_pkg_dsl(json, false).unwrap();
     assert!(!pkg.is_main);
     assert!(pkg.force_link);
     assert!(pkg.link.is_some());
@@ -1272,7 +1279,7 @@ options(
 "#,
     )
     .unwrap();
-    let (pkg, _) = convert_pkg_dsl_to_package_with_supported_targets_decl(json, true).unwrap();
+    let (pkg, _) = convert_test_pkg_dsl(json, true).unwrap();
 
     assert!(pkg.proof_enabled);
 }
@@ -1286,7 +1293,7 @@ dev_build(rule: "rule1", input: "abc", output: "def")
     )
     .unwrap();
 
-    let (pkg, _) = convert_pkg_dsl_to_package_with_supported_targets_decl(json, true).unwrap();
+    let (pkg, _) = convert_test_pkg_dsl(json, true).unwrap();
     let pre_build = pkg.pre_build.unwrap();
     let MoonPkgGenerate::Rule {
         rule,
@@ -1317,7 +1324,7 @@ dev_build(rule: "rule1", input: "abc", output: "def")
     )
     .unwrap();
 
-    let (pkg, _) = convert_pkg_dsl_to_package_with_supported_targets_decl(json, true).unwrap();
+    let (pkg, _) = convert_test_pkg_dsl(json, true).unwrap();
     let rules = pkg.local_rules.as_ref().expect("expected local rules");
     assert_eq!(rules.len(), 1);
     assert_eq!(rules[0].name, "rule1");
@@ -1334,7 +1341,7 @@ rule(name: "rule1", command: "exe2")
     )
     .unwrap();
 
-    let err = convert_pkg_dsl_to_package_with_supported_targets_decl(json, true).unwrap_err();
+    let err = convert_test_pkg_dsl(json, true).unwrap_err();
     assert!(
         err.to_string()
             .contains("Duplicate rule name `rule1` found in moon.pkg.")
@@ -1353,7 +1360,7 @@ options(
     )
     .unwrap();
 
-    let err = convert_pkg_dsl_to_package_with_supported_targets_decl(json, true).unwrap_err();
+    let err = convert_test_pkg_dsl(json, true).unwrap_err();
     assert!(
         err.to_string()
             .contains("`dev_build` cannot be used together with `pre-build`")
@@ -1370,7 +1377,7 @@ fn convert_pkg_json_supports_proof_enabled_hyphenated() {
 "#,
     )
     .unwrap();
-    let (pkg, _) = convert_pkg_json_to_package_with_supported_targets_decl(json, true).unwrap();
+    let (pkg, _) = convert_test_pkg_json(json, true).unwrap();
 
     assert!(pkg.proof_enabled);
 }

--- a/crates/moonutil/src/scripts.rs
+++ b/crates/moonutil/src/scripts.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 
 use anyhow::bail;
 
-use crate::manifest::read_module_desc_file_in_dir;
+use crate::{manifest::read_module_desc_file_in_dir, user_log::UserLog};
 
 pub enum PrePostBuild {
     PreBuild,
@@ -57,7 +57,7 @@ pub fn is_moon_script_ignored(script: IgnoredMoonScript) -> bool {
     std::env::var_os(script.env_var()).is_some()
 }
 
-pub fn execute_postadd_script(dir: &Path) -> anyhow::Result<()> {
+pub fn execute_postadd_script(dir: &Path, user_log: &UserLog) -> anyhow::Result<()> {
     if is_moon_script_ignored(IgnoredMoonScript::Postadd) {
         return Ok(());
     }
@@ -73,21 +73,118 @@ pub fn execute_postadd_script(dir: &Path) -> anyhow::Result<()> {
         if !postadd.is_empty() {
             let command = postadd[0];
             let args = &postadd[1..];
-            let output = std::process::Command::new(command)
-                .args(args)
-                .current_dir(dir)
-                .stdout(std::process::Stdio::inherit())
-                .stderr(std::process::Stdio::inherit())
-                .output()?;
-            if !output.status.success() {
-                bail!(
-                    "failed to execute postadd script in {},\ncommand: {},\n{}",
-                    dir.display(),
-                    command,
-                    String::from_utf8_lossy(&output.stderr)
-                );
+            let mut process = std::process::Command::new(command);
+            process.args(args).current_dir(dir);
+            if user_log.is_captured() {
+                let output = process.output()?;
+                for (channel, content) in [
+                    ("stdout", output.stdout.as_slice()),
+                    ("stderr", output.stderr.as_slice()),
+                ] {
+                    let content = String::from_utf8_lossy(content);
+                    let content = content.trim();
+                    if content.is_empty() {
+                        continue;
+                    }
+                    let message = format!("postadd script wrote to {channel}:\n{content}");
+                    if output.status.success() {
+                        user_log.status(message);
+                    } else {
+                        user_log.error(message);
+                    }
+                }
+                if !output.status.success() {
+                    bail!(
+                        "failed to execute postadd script in {},\ncommand: {}",
+                        dir.display(),
+                        command
+                    );
+                }
+            } else {
+                let status = process
+                    .stdout(std::process::Stdio::inherit())
+                    .stderr(std::process::Stdio::inherit())
+                    .status()?;
+                if !status.success() {
+                    bail!(
+                        "failed to execute postadd script in {},\ncommand: {}",
+                        dir.display(),
+                        command
+                    );
+                }
             }
         }
     }
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use log::LevelFilter;
+
+    use super::execute_postadd_script;
+    use crate::user_log::{UserLog, UserLogEntryLevel};
+
+    #[test]
+    fn captured_postadd_output_is_routed_to_user_log() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let script = sandbox.path().join("postadd.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\necho POSTADD_STDOUT\necho POSTADD_STDERR >&2\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::write(
+            sandbox.path().join("moon.mod.json"),
+            format!(
+                r#"{{
+                    "name": "test/postadd",
+                    "version": "0.1.0",
+                    "scripts": {{ "postadd": "{}" }}
+                }}"#,
+                script.display()
+            ),
+        )
+        .unwrap();
+        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+
+        execute_postadd_script(sandbox.path(), &user_log).unwrap();
+
+        let entries = capture.take();
+        assert_eq!(entries.len(), 2);
+        assert!(
+            entries
+                .iter()
+                .all(|entry| matches!(entry.level, UserLogEntryLevel::Info))
+        );
+        assert!(entries[0].message.contains("POSTADD_STDOUT"));
+        assert!(entries[1].message.contains("POSTADD_STDERR"));
+
+        std::fs::write(
+            &script,
+            "#!/bin/sh\necho FAILED_STDOUT\necho FAILED_STDERR >&2\nexit 1\n",
+        )
+        .unwrap();
+        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+
+        let error = execute_postadd_script(sandbox.path(), &user_log).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to execute postadd script")
+        );
+        let entries = capture.take();
+        assert_eq!(entries.len(), 2);
+        assert!(
+            entries
+                .iter()
+                .all(|entry| matches!(entry.level, UserLogEntryLevel::Error))
+        );
+        assert!(entries[0].message.contains("FAILED_STDOUT"));
+        assert!(entries[1].message.contains("FAILED_STDERR"));
+    }
 }

--- a/crates/moonutil/src/user_log.rs
+++ b/crates/moonutil/src/user_log.rs
@@ -17,6 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use std::{
+    collections::HashSet,
     fmt::Display,
     io::Write,
     sync::{Arc, Mutex},
@@ -65,6 +66,7 @@ enum UserLogDestination {
 pub struct UserLog {
     level: LevelFilter,
     destination: UserLogDestination,
+    emitted_once: Arc<Mutex<HashSet<String>>>,
 }
 
 /// Maps legacy CLI verbosity flags to the shared user-log level.
@@ -85,6 +87,7 @@ impl UserLog {
         Self {
             level,
             destination: UserLogDestination::Stderr,
+            emitted_once: Default::default(),
         }
     }
 
@@ -94,9 +97,18 @@ impl UserLog {
             Self {
                 level,
                 destination: UserLogDestination::Capture(capture.clone()),
+                emitted_once: Default::default(),
             },
             capture,
         )
+    }
+
+    pub fn with_level(&self, level: LevelFilter) -> Self {
+        Self {
+            level,
+            destination: self.destination.clone(),
+            emitted_once: Arc::clone(&self.emitted_once),
+        }
     }
 
     pub fn is_enabled(&self, level: log::Level) -> bool {
@@ -142,6 +154,21 @@ impl UserLog {
                     message: message.to_string(),
                 }),
             UserLogDestination::Capture(_) => {}
+        }
+    }
+
+    pub fn warn_once(&self, message: impl Display) {
+        if self.level < LevelFilter::Warn {
+            return;
+        }
+        let message = message.to_string();
+        if self
+            .emitted_once
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(message.clone())
+        {
+            self.warn(message);
         }
     }
 
@@ -272,6 +299,22 @@ mod tests {
         let (quiet, capture) = UserLog::captured(LevelFilter::Error);
         quiet.status("hidden");
         assert!(capture.take().is_empty());
+    }
+
+    #[test]
+    fn cloned_logs_share_once_warnings_without_quiet_consuming_them() {
+        let (output, capture) = UserLog::captured(LevelFilter::Warn);
+
+        output
+            .with_level(LevelFilter::Error)
+            .warn_once("deprecated option");
+        output.clone().warn_once("deprecated option");
+        output.warn_once("deprecated option");
+
+        let entries = capture.take();
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(entries[0].level, UserLogEntryLevel::Warning));
+        assert_eq!(entries[0].message, "deprecated option");
     }
 
     #[test]

--- a/crates/moonutil/src/user_log.rs
+++ b/crates/moonutil/src/user_log.rs
@@ -103,6 +103,12 @@ impl UserLog {
         self.level >= level.to_level_filter()
     }
 
+    /// Whether user-facing output is being collected for a command result
+    /// instead of rendered directly to stderr.
+    pub fn is_captured(&self) -> bool {
+        matches!(&self.destination, UserLogDestination::Capture(_))
+    }
+
     pub fn error(&self, message: impl Display) {
         match &self.destination {
             UserLogDestination::Stderr => {
@@ -146,6 +152,30 @@ impl UserLog {
                 self.info_to(&mut stderr, message);
             }
             UserLogDestination::Capture(capture) if self.level >= LevelFilter::Info => capture
+                .entries
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(UserLogEntry {
+                    level: UserLogEntryLevel::Info,
+                    message: message.to_string(),
+                }),
+            UserLogDestination::Capture(_) => {}
+        }
+    }
+
+    /// Emit a normal-verbosity informational status line.
+    ///
+    /// Some long-running operations historically showed progress at the
+    /// default verbosity even though the message is informational. Keep that
+    /// visibility without misclassifying the event as a warning.
+    pub fn status(&self, message: impl Display) {
+        match &self.destination {
+            UserLogDestination::Stderr => {
+                if self.level >= LevelFilter::Warn {
+                    let _ = writeln!(anstream::stderr().lock(), "{message}");
+                }
+            }
+            UserLogDestination::Capture(capture) if self.level >= LevelFilter::Warn => capture
                 .entries
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
@@ -226,6 +256,22 @@ mod tests {
         assert_eq!(entries[1].message, "be careful");
         assert!(matches!(entries[2].level, UserLogEntryLevel::Error));
         assert_eq!(entries[2].message, "failed");
+    }
+
+    #[test]
+    fn captured_status_is_info_visible_at_normal_verbosity() {
+        let (output, capture) = UserLog::captured(LevelFilter::Warn);
+
+        output.status("Downloading example/pkg@1.0.0");
+
+        let entries = capture.take();
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(entries[0].level, UserLogEntryLevel::Info));
+        assert_eq!(entries[0].message, "Downloading example/pkg@1.0.0");
+
+        let (quiet, capture) = UserLog::captured(LevelFilter::Error);
+        quiet.status("hidden");
+        assert!(capture.take().is_empty());
     }
 
     #[test]

--- a/crates/moonutil/src/user_log.rs
+++ b/crates/moonutil/src/user_log.rs
@@ -16,7 +16,11 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::{fmt::Display, io::Write};
+use std::{
+    fmt::Display,
+    io::Write,
+    sync::{Arc, Mutex},
+};
 
 use anstyle::{AnsiColor, Style};
 use log::LevelFilter;
@@ -25,9 +29,42 @@ const ERROR_STYLE: Style = AnsiColor::Red.on_default().bold();
 const WARNING_STYLE: Style = AnsiColor::Yellow.on_default().bold();
 const DEBUG_STYLE: Style = AnsiColor::BrightBlack.on_default().bold();
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UserLogEntryLevel {
+    Error,
+    Warning,
+    Info,
+    Debug,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct UserLogEntry {
+    pub level: UserLogEntryLevel,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UserLogCapture {
+    entries: Arc<Mutex<Vec<UserLogEntry>>>,
+}
+
+impl UserLogCapture {
+    pub fn take(&self) -> Vec<UserLogEntry> {
+        std::mem::take(&mut *self.entries.lock().unwrap_or_else(|e| e.into_inner()))
+    }
+}
+
+#[derive(Debug, Clone)]
+enum UserLogDestination {
+    Stderr,
+    Capture(UserLogCapture),
+}
+
+#[derive(Debug, Clone)]
 pub struct UserLog {
     level: LevelFilter,
+    destination: UserLogDestination,
 }
 
 /// Maps legacy CLI verbosity flags to the shared user-log level.
@@ -45,7 +82,21 @@ pub fn user_log_level(verbose: bool, quiet: bool) -> LevelFilter {
 
 impl UserLog {
     pub fn new(level: LevelFilter) -> Self {
-        Self { level }
+        Self {
+            level,
+            destination: UserLogDestination::Stderr,
+        }
+    }
+
+    pub fn captured(level: LevelFilter) -> (Self, UserLogCapture) {
+        let capture = UserLogCapture::default();
+        (
+            Self {
+                level,
+                destination: UserLogDestination::Capture(capture.clone()),
+            },
+            capture,
+        )
     }
 
     pub fn is_enabled(&self, level: log::Level) -> bool {
@@ -53,23 +104,75 @@ impl UserLog {
     }
 
     pub fn error(&self, message: impl Display) {
-        let mut stderr = anstream::stderr().lock();
-        self.error_to(&mut stderr, message);
+        match &self.destination {
+            UserLogDestination::Stderr => {
+                let mut stderr = anstream::stderr().lock();
+                self.error_to(&mut stderr, message);
+            }
+            UserLogDestination::Capture(capture) if self.level >= LevelFilter::Error => capture
+                .entries
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(UserLogEntry {
+                    level: UserLogEntryLevel::Error,
+                    message: message.to_string(),
+                }),
+            UserLogDestination::Capture(_) => {}
+        }
     }
 
     pub fn warn(&self, message: impl Display) {
-        let mut stderr = anstream::stderr().lock();
-        self.warn_to(&mut stderr, message);
+        match &self.destination {
+            UserLogDestination::Stderr => {
+                let mut stderr = anstream::stderr().lock();
+                self.warn_to(&mut stderr, message);
+            }
+            UserLogDestination::Capture(capture) if self.level >= LevelFilter::Warn => capture
+                .entries
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(UserLogEntry {
+                    level: UserLogEntryLevel::Warning,
+                    message: message.to_string(),
+                }),
+            UserLogDestination::Capture(_) => {}
+        }
     }
 
     pub fn info(&self, message: impl Display) {
-        let mut stderr = anstream::stderr().lock();
-        self.info_to(&mut stderr, message);
+        match &self.destination {
+            UserLogDestination::Stderr => {
+                let mut stderr = anstream::stderr().lock();
+                self.info_to(&mut stderr, message);
+            }
+            UserLogDestination::Capture(capture) if self.level >= LevelFilter::Info => capture
+                .entries
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(UserLogEntry {
+                    level: UserLogEntryLevel::Info,
+                    message: message.to_string(),
+                }),
+            UserLogDestination::Capture(_) => {}
+        }
     }
 
     pub fn debug(&self, message: impl Display) {
-        let mut stderr = anstream::stderr().lock();
-        self.debug_to(&mut stderr, message);
+        match &self.destination {
+            UserLogDestination::Stderr => {
+                let mut stderr = anstream::stderr().lock();
+                self.debug_to(&mut stderr, message);
+            }
+            UserLogDestination::Capture(capture) if self.level >= LevelFilter::Debug => capture
+                .entries
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(UserLogEntry {
+                    level: UserLogEntryLevel::Debug,
+                    message: message.to_string(),
+                }),
+            UserLogDestination::Capture(_) => {}
+        }
     }
 
     fn error_to(&self, writer: &mut impl Write, message: impl Display) {
@@ -104,7 +207,26 @@ mod tests {
     use anstream::{AutoStream, ColorChoice};
     use log::LevelFilter;
 
-    use super::UserLog;
+    use super::{UserLog, UserLogEntryLevel};
+
+    #[test]
+    fn captured_log_preserves_filtered_levels_and_order() {
+        let (output, capture) = UserLog::captured(LevelFilter::Info);
+
+        output.info("starting");
+        output.warn("be careful");
+        output.debug("hidden");
+        output.error("failed");
+
+        let entries = capture.take();
+        assert_eq!(entries.len(), 3);
+        assert!(matches!(entries[0].level, UserLogEntryLevel::Info));
+        assert_eq!(entries[0].message, "starting");
+        assert!(matches!(entries[1].level, UserLogEntryLevel::Warning));
+        assert_eq!(entries[1].message, "be careful");
+        assert!(matches!(entries[2].level, UserLogEntryLevel::Error));
+        assert_eq!(entries[2].message, "failed");
+    }
 
     #[test]
     fn error_level_renders_error_and_suppresses_other_messages() {

--- a/crates/moonutil/src/workspace.rs
+++ b/crates/moonutil/src/workspace.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Deserializer};
 
 use crate::{constants::MOON_WORK, moon_pkg, target::TargetBackend, user_log::UserLog};
 
-const PREFERRED_TARGET_DEPRECATION_WARNING: &str = "`preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.";
+pub(crate) const PREFERRED_TARGET_DEPRECATION_WARNING: &str = "`preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.";
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -84,7 +84,7 @@ pub fn read_workspace_file(path: &Path, user_log: &UserLog) -> anyhow::Result<Mo
         .with_context(|| format!("failed to read workspace file `{}`", path.display()))?;
     let workspace = parse_workspace_file_content(path, &content)?;
     if workspace.preferred_target.is_some() {
-        user_log.warn(PREFERRED_TARGET_DEPRECATION_WARNING);
+        user_log.warn_once(PREFERRED_TARGET_DEPRECATION_WARNING);
     }
     Ok(workspace)
 }
@@ -94,7 +94,7 @@ pub fn format_workspace_file(path: &Path, user_log: &UserLog) -> anyhow::Result<
         .with_context(|| format!("failed to read workspace file `{}`", path.display()))?;
     let workspace = parse_workspace_file_content(path, &content)?;
     if workspace.preferred_target.is_some() {
-        user_log.warn(PREFERRED_TARGET_DEPRECATION_WARNING);
+        user_log.warn_once(PREFERRED_TARGET_DEPRECATION_WARNING);
     }
     format_workspace_dsl_for_moon_fmt(&workspace)
 }

--- a/crates/moonutil/src/workspace.rs
+++ b/crates/moonutil/src/workspace.rs
@@ -26,9 +26,9 @@ use std::{
 use anyhow::Context;
 use serde::{Deserialize, Deserializer};
 
-use crate::{constants::MOON_WORK, moon_pkg, target::TargetBackend};
+use crate::{constants::MOON_WORK, moon_pkg, target::TargetBackend, user_log::UserLog};
 
-const PREFERRED_TARGET_DEPRECATION_WARNING: &str = "Warning: `preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.";
+const PREFERRED_TARGET_DEPRECATION_WARNING: &str = "`preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.";
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -71,30 +71,30 @@ pub fn workspace_manifest_path(dir: &Path) -> Option<PathBuf> {
     dsl.exists().then_some(dsl)
 }
 
-pub fn read_workspace(dir: &Path) -> anyhow::Result<Option<MoonWork>> {
+pub fn read_workspace(dir: &Path, user_log: &UserLog) -> anyhow::Result<Option<MoonWork>> {
     let Some(path) = workspace_manifest_path(dir) else {
         return Ok(None);
     };
 
-    read_workspace_file(&path).map(Some)
+    read_workspace_file(&path, user_log).map(Some)
 }
 
-pub fn read_workspace_file(path: &Path) -> anyhow::Result<MoonWork> {
+pub fn read_workspace_file(path: &Path, user_log: &UserLog) -> anyhow::Result<MoonWork> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read workspace file `{}`", path.display()))?;
     let workspace = parse_workspace_file_content(path, &content)?;
     if workspace.preferred_target.is_some() {
-        eprintln!("{PREFERRED_TARGET_DEPRECATION_WARNING}");
+        user_log.warn(PREFERRED_TARGET_DEPRECATION_WARNING);
     }
     Ok(workspace)
 }
 
-pub fn format_workspace_file(path: &Path) -> anyhow::Result<String> {
+pub fn format_workspace_file(path: &Path, user_log: &UserLog) -> anyhow::Result<String> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read workspace file `{}`", path.display()))?;
     let workspace = parse_workspace_file_content(path, &content)?;
     if workspace.preferred_target.is_some() {
-        eprintln!("{PREFERRED_TARGET_DEPRECATION_WARNING}");
+        user_log.warn(PREFERRED_TARGET_DEPRECATION_WARNING);
     }
     format_workspace_dsl_for_moon_fmt(&workspace)
 }

--- a/crates/moonutil/tests/expect_moon_pkg.rs
+++ b/crates/moonutil/tests/expect_moon_pkg.rs
@@ -18,7 +18,12 @@
 
 fn run(source: &str) -> String {
     moonutil::moon_pkg::parse(source)
-        .and_then(moonutil::package::convert_pkg_dsl_to_package)
+        .and_then(|dsl| {
+            moonutil::package::convert_pkg_dsl_to_package(
+                dsl,
+                &moonutil::user_log::UserLog::new(log::LevelFilter::Error),
+            )
+        })
         .map(|pkg| format!("{:#?}", pkg))
         .unwrap_or_else(|e| format!("Error: {:?}", e))
 }

--- a/docs/adr/0004-separate-command-results-from-user-logs.md
+++ b/docs/adr/0004-separate-command-results-from-user-logs.md
@@ -15,6 +15,7 @@ MoonBuild will place a small `CommandOutput` interface at the CLI orchestration 
 - Color follows the actual destination channel. Redirecting stdout does not disable color on an interactive stderr, and redirecting stderr does not affect stdout.
 - The build engines do not receive the whole `CommandOutput` merely to print; they return data or accept the narrower `UserLog` or writer their operation requires.
 - Existing direct output migrates command by command. Explicitly classified passthrough, progress, and tracing sites are not mechanical conversion targets.
+- After CLI argument parsing selects a command, a command whose contract is one machine-readable result may capture its filtered User Logs at the CLI seam and embed them in that Command Result. Help and argument-parse failures retain the CLI parser's native output. In the machine-readable command mode, terminal-only progress and tracing output are suppressed, while lower layers still receive only `UserLog` or return structured data.
 
 ## Considered Options
 

--- a/docs/dev/command-output-migration.md
+++ b/docs/dev/command-output-migration.md
@@ -39,6 +39,8 @@ The facade does not own Process Passthrough, Progress Displays, compiler diagnos
 
 The quiet user-log level follows `UserLog` and suppresses warnings. Default levels and informational formatting remain command-specific until affected command snapshots make any intended behavior change visible.
 
+After argument parsing selects a command, commands that promise one complete machine-readable result are a scoped exception to the usual channel mapping: the CLI may construct a capturing `UserLog`, preserve its level filtering and event order, and serialize those events inside the stdout Command Result. Help and argument-parse failures remain on the parser's native output path. Build executors return compiler diagnostics as data for the same final render; they do not receive `CommandOutput`. Such a mode must suppress terminal progress and tracing output so stderr remains empty.
+
 ## Slices and Blocking Edges
 
 ### CO-1: Prove the seam with `moon info`

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -163,9 +163,10 @@ without rediscovery.
 
 Prebuild configuration is another environment-sensitive input. When prebuild
 configuration scripts run, `rr_build` captures the process environment
-explicitly and passes it to prebuild execution. Commands that skip prebuild,
-such as `check`, should not capture that environment just to construct a build
-plan.
+explicitly and passes it to prebuild execution. Commands that skip prebuild
+configuration, such as `check`, should not capture that environment just to
+construct a build plan. This does not disable package pre-build rules or the
+bin-dependencies that provide their tools.
 
 Dependency synchronization is explicit in the normal project path. Command
 adapters first call dependency sync, then pass the synced dependency result to

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -178,6 +178,7 @@ Check the current package, but don't build object files
 * `--patch-file <PATCH_FILE>` — The patch file to check. Only valid when the selector resolves to a single package
 * `--explain` — Whether to explain the error code with details
 * `--fmt` — Check whether the code is properly formatted
+* `--json` — Output one complete JSON result to stdout
 
 
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -178,6 +178,7 @@ Check the current package, but don't build object files
 * `--patch-file <PATCH_FILE>` — The patch file to check. Only valid when the selector resolves to a single package
 * `--explain` — Whether to explain the error code with details
 * `--fmt` — Check whether the code is properly formatted
+* `--json` — Output one complete JSON result to stdout
 
 
 


### PR DESCRIPTION
## Why

`moon check` does not currently provide a single machine-readable command result. The legacy `--output-json` mode emits compiler diagnostics as NDJSON while Moon-authored warnings and failures may still use separate terminal channels, so callers cannot reliably parse one complete response.

## What changed

Add `moon check --json`, which writes exactly one versioned JSON object to stdout after argument parsing. The result separates Moonc diagnostics from Moon messages, records success or failure, and includes summary counts. Moon-authored warnings and errors—including project discovery, manifest, dependency resolution, registry acquisition, and binary-dependency failures—flow through `UserLog` and are captured by the command renderer. Required child-process output is captured at the process boundary so it cannot corrupt stdout or stderr.

The existing `--output-json` behavior remains unchanged. `--json` rejects incompatible rendering/watch modes, while Clap help and argument errors keep their existing behavior.

## Why this is correct and scoped

The command boundary owns the only final serialization, while lower layers return structured diagnostics or emit typed user-log entries. This preserves existing human output paths and the Rupes Recta build behavior, including package pre-build tasks and binary-dependency installation. The change is limited to `check` complete-JSON rendering and the direct user-log plumbing needed to prevent terminal output from bypassing it.
