### PR TITLE
refactor(moonutil): clarify warning ownership

### DIFF
--- a/crates/moon/src/cli/bench.rs
+++ b/crates/moon/src/cli/bench.rs
@@ -74,7 +74,8 @@ pub(crate) fn run_bench(
     let dirs = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
-        .package_dirs(output.user_log())?;
+        .select(output.user_log())?
+        .package_dirs()?;
 
     if cmd.build_flags.target.is_empty() {
         return run_bench_internal(&cli, &cmd, &dirs, None, None, output);

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -90,7 +90,8 @@ pub(crate) fn run_build(
     let dirs = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
-        .package_dirs(output.user_log())?;
+        .select(output.user_log())?
+        .package_dirs()?;
 
     if cmd.build_flags.target.is_empty() {
         return run_build_internal(cli, &cmd, &dirs, None, output);

--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -59,7 +59,8 @@ pub(crate) fn run_bundle(
     let dirs = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
-        .package_dirs(output.user_log())?;
+        .select(output.user_log())?
+        .package_dirs()?;
 
     let mut surface_targets = cmd.build_flags.target.clone();
     if cmd.all {

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -370,10 +370,10 @@ fn run_check_impl(
     }
 
     // Check if we're running within a project
-    let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
+    let query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
     let (mut dirs, single_file) = match query.probe_project()? {
         ProjectProbe::Found(_) => {
-            let dirs = query.package_dirs(user_log)?;
+            let dirs = query.select(user_log)?.package_dirs()?;
             (dirs, None)
         }
         ProjectProbe::NotFound(not_found) => {

--- a/crates/moon/src/cli/clean.rs
+++ b/crates/moon/src/cli/clean.rs
@@ -53,7 +53,8 @@ pub(crate) fn run_clean(
     let src_tgt = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
-        .package_dirs(user_log)?;
+        .select(user_log)?
+        .package_dirs()?;
 
     let _lock = FileLock::lock(&src_tgt.target_dir)?;
 

--- a/crates/moon/src/cli/coverage.rs
+++ b/crates/moon/src/cli/coverage.rs
@@ -123,7 +123,8 @@ fn run_coverage_clean(cli: UniversalFlags, user_log: &UserLog) -> Result<i32, an
     } = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
-        .package_dirs(user_log)?;
+        .select(user_log)?
+        .package_dirs()?;
     clean_coverage_artifacts(&src, &tgt)?;
     Ok(0)
 }
@@ -152,7 +153,8 @@ fn run_coverage_report(
     } = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
-        .package_dirs(output.user_log())?;
+        .select(output.user_log())?
+        .package_dirs()?;
 
     let mut command = coverage_report_command(args.args, &src);
     if cli.dry_run {

--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -121,7 +121,8 @@ fn run_cram_test(
     let dirs = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
-        .package_dirs(user_log)?;
+        .select(user_log)?
+        .package_dirs()?;
     let PackageDirs {
         source_dir,
         target_dir,

--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -80,7 +80,8 @@ pub(crate) fn install_cli(
         let dirs = cli
             .source_tgt_dir
             .query(cli.workspace_env.clone())?
-            .package_dirs(user_log)?;
+            .select(user_log)?
+            .package_dirs()?;
         mooncake::pkg::sync::auto_sync(
             &dirs,
             &AutoSyncFlags { frozen: false },
@@ -180,12 +181,14 @@ pub(crate) fn remove_cli(
     cmd: RemoveSubcommand,
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
-    let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
-    let project = query.project(user_log)?;
-    let module_dir = require_selected_module(&project, "remove")?;
+    let project = cli
+        .source_tgt_dir
+        .query(cli.workspace_env.clone())?
+        .select(user_log)?;
+    let module_dir = require_selected_module(project.context(), "remove")?;
     let PackageDirs {
         project_manifest, ..
-    } = query.package_dirs(user_log)?;
+    } = project.package_dirs()?;
     let package_path = cmd.package_path;
     let parts: Vec<&str> = package_path.splitn(2, '/').collect();
     if parts.len() != 2 {
@@ -201,10 +204,12 @@ pub(crate) fn add_cli(
     cmd: AddSubcommand,
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
-    let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
-    let project = query.project(user_log)?;
-    let module_dir = require_selected_module(&project, "add")?;
-    let dirs = query.package_dirs(user_log)?;
+    let project = cli
+        .source_tgt_dir
+        .query(cli.workspace_env.clone())?
+        .select(user_log)?;
+    let module_dir = require_selected_module(project.context(), "add")?;
+    let dirs = project.package_dirs()?;
 
     // Update registry index by default (issue #963).
     // - `--no-update` keeps the previous behavior.
@@ -278,12 +283,14 @@ pub(crate) fn tree_cli(
     _cmd: TreeSubcommand,
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
-    let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
-    let project = query.project(user_log)?;
-    let module_dir = require_selected_module(&project, "tree")?;
+    let project = cli
+        .source_tgt_dir
+        .query(cli.workspace_env.clone())?
+        .select(user_log)?;
+    let module_dir = require_selected_module(project.context(), "tree")?;
     let PackageDirs {
         project_manifest, ..
-    } = query.package_dirs(user_log)?;
+    } = project.package_dirs()?;
     mooncake::pkg::tree::tree(&module_dir, &project_manifest, user_log)
 }
 

--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -99,14 +99,17 @@ pub(crate) fn run_doc_rr(
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
     let user_log = output.user_log();
-    let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
-    let project = query.project(user_log)?;
+    let project = cli
+        .source_tgt_dir
+        .query(cli.workspace_env.clone())?
+        .select(user_log)?;
     let selected_module = project
+        .context()
         .selected_module()
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "`moon doc` cannot infer a target module in workspace `{}`. Run it from a workspace member or use `moon -C <member> doc ...`.",
-                project.root().display(),
+                project.context().root().display(),
             )
         })?;
     if selected_module.manifest_path.ends_with(MOON_MOD_JSON) {
@@ -114,7 +117,7 @@ pub(crate) fn run_doc_rr(
             "`moon doc` does not support the deprecated `moon.mod.json` manifest; run `moon fmt` to migrate it to `moon.mod` first"
         );
     }
-    let dirs = query.package_dirs(user_log)?;
+    let dirs = project.package_dirs()?;
     let PackageDirs {
         source_dir,
         target_dir,

--- a/crates/moon/src/cli/fetch.rs
+++ b/crates/moon/src/cli/fetch.rs
@@ -108,7 +108,8 @@ pub(crate) fn fetch_cli(
     let source_dir = match cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())
-        .and_then(|mut query| query.package_dirs(user_log))
+        .and_then(|query| query.select(user_log))
+        .and_then(|project| project.package_dirs())
     {
         Ok(PackageDirs { source_dir, .. }) => source_dir,
         Err(_) => std::env::current_dir()?,

--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -73,7 +73,8 @@ fn run_fmt_rr(
     } = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
-        .package_dirs(user_log)?;
+        .select(user_log)?
+        .package_dirs()?;
 
     let resolved =
         moonbuild_rupes_recta::fmt::resolve_for_fmt(&source_dir, &project_manifest, user_log)

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -281,7 +281,8 @@ pub(crate) fn run_info(
     let dirs = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
-        .package_dirs(output.user_log())?;
+        .select(output.user_log())?
+        .package_dirs()?;
     let PackageDirs {
         target_dir,
         mooncake_bin_dir,

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -306,11 +306,12 @@ pub(super) fn install_from_local(
         )
     })?;
 
-    let mut query = cli
+    let project = cli
         .source_tgt_dir
-        .query_from(&input_path, cli.workspace_env.clone())?;
-    let project = query.project(user_log)?;
+        .query_from(&input_path, cli.workspace_env.clone())?
+        .select(user_log)?;
     let module_root = project
+        .context()
         .selected_module()
         .map(|module| module.root)
         .ok_or_else(|| {
@@ -321,7 +322,7 @@ pub(super) fn install_from_local(
                 MOON_MOD_JSON
             )
         })?;
-    let package_dirs = query.package_dirs(user_log)?;
+    let package_dirs = project.package_dirs()?;
 
     let module = moonutil::manifest::read_module_desc_file_in_dir(&module_root)?;
     let module_name: ModuleName = module.name.parse().map_err(|e| anyhow::anyhow!("{}", e))?;

--- a/crates/moon/src/cli/mooncake_adapter.rs
+++ b/crates/moon/src/cli/mooncake_adapter.rs
@@ -131,8 +131,11 @@ fn single_module_mooncake_cli(
     command: &str,
     user_log: &UserLog,
 ) -> anyhow::Result<UniversalFlags> {
-    let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
-    let project = query.project(user_log)?;
+    let project = cli
+        .source_tgt_dir
+        .query(cli.workspace_env.clone())?
+        .select(user_log)?;
+    let project = project.context();
     if project.selected_module().is_none() {
         bail!(
             "`moon {command}` cannot infer a target module in workspace `{}`. Run it from a workspace member or use `moon -C <member> {command} ...`.",

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -102,24 +102,30 @@ pub(crate) fn run_prove(
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
     let user_log = output.user_log();
-    let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
-    let project = query.project(user_log)?;
+    let project = cli
+        .source_tgt_dir
+        .query(cli.workspace_env.clone())?
+        .select(user_log)?;
     let module_dir = if cmd.path.is_some() {
-        project.selected_module().map(|module| module.root.clone())
+        project
+            .context()
+            .selected_module()
+            .map(|module| module.root.clone())
     } else {
         Some(
             project
+                .context()
                 .selected_module()
                 .map(|module| module.root.clone())
                 .ok_or_else(|| {
                     anyhow::anyhow!(
                         "`moon prove` cannot infer a target module in workspace `{}`. Run it from a workspace member or use `moon -C <member> prove ...`.",
-                        project.root().display(),
+                        project.context().root().display(),
                     )
                 })?,
         )
     };
-    let dirs = query.package_dirs(user_log)?;
+    let dirs = project.package_dirs()?;
     let PackageDirs {
         source_dir: project_root,
         target_dir,

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -424,7 +424,7 @@ pub(crate) fn build_run_executable(
     let is_mbtx = input.ends_with(".mbtx");
     let run_start_dir = resolve_run_start_dir(input)?;
 
-    let mut query = cli
+    let query = cli
         .source_tgt_dir
         .query_from(&run_start_dir, cli.workspace_env.clone())?;
     match query.probe_project()? {
@@ -471,7 +471,8 @@ fn build_package_executable(
     let dirs = cli
         .source_tgt_dir
         .query_from(&run_start_dir, cli.workspace_env.clone())?
-        .package_dirs(user_log)?;
+        .select(user_log)?
+        .package_dirs()?;
     let PackageDirs {
         source_dir,
         target_dir,

--- a/crates/moon/src/cli/test.rs
+++ b/crates/moon/src/cli/test.rs
@@ -350,9 +350,9 @@ fn run_test_impl(
         "starting moon test command"
     );
     // Check if we're running within a project
-    let mut query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
+    let query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
     let dirs = match query.probe_project()? {
-        ProjectProbe::Found(_) => query.package_dirs(user_log)?,
+        ProjectProbe::Found(_) => query.select(user_log)?.package_dirs()?,
         ProjectProbe::NotFound(not_found) => {
             // Now we're talking about real single-file scenario.
             match cmd.path.as_slice() {

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -71,7 +71,8 @@ pub(crate) fn run_build_binary_dep(
     let dirs = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
-        .package_dirs(user_log)?;
+        .select(user_log)?
+        .package_dirs()?;
     let PackageDirs {
         target_dir,
         mooncake_bin_dir,

--- a/crates/moon/src/cli/tool/format_workspace.rs
+++ b/crates/moon/src/cli/tool/format_workspace.rs
@@ -56,7 +56,7 @@ pub(crate) fn run_format_workspace(
     if workspace.preferred_target.is_some() {
         user_log.warn(moonutil::workspace::PREFERRED_TARGET_DEPRECATION_WARNING);
     }
-    let formatted = moonutil::workspace::format_workspace(&workspace)?;
+    let formatted = moonutil::workspace::format_workspace_members(&workspace)?;
 
     if let Some(parent) = cmd.new.parent() {
         std::fs::create_dir_all(parent)?;

--- a/crates/moon/src/cli/tool/format_workspace.rs
+++ b/crates/moon/src/cli/tool/format_workspace.rs
@@ -52,7 +52,11 @@ pub(crate) fn run_format_workspace(
     cmd: FormatWorkspaceSubcommand,
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
-    let formatted = moonutil::workspace::format_workspace_file(&cmd.old, user_log)?;
+    let workspace = moonutil::workspace::read_workspace_file(&cmd.old)?;
+    if workspace.preferred_target.is_some() {
+        user_log.warn(moonutil::workspace::PREFERRED_TARGET_DEPRECATION_WARNING);
+    }
+    let formatted = moonutil::workspace::format_workspace(&workspace)?;
 
     if let Some(parent) = cmd.new.parent() {
         std::fs::create_dir_all(parent)?;

--- a/crates/moon/src/cli/tool/format_workspace.rs
+++ b/crates/moon/src/cli/tool/format_workspace.rs
@@ -52,7 +52,7 @@ pub(crate) fn run_format_workspace(
     cmd: FormatWorkspaceSubcommand,
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
-    let workspace = moonutil::workspace::read_workspace_file(&cmd.old)?;
+    let workspace = moonutil::workspace::MoonWork::read(&cmd.old)?;
     if workspace.preferred_target.is_some() {
         user_log.warn(moonutil::workspace::PREFERRED_TARGET_DEPRECATION_WARNING);
     }

--- a/crates/moon/src/cli/work.rs
+++ b/crates/moon/src/cli/work.rs
@@ -19,7 +19,8 @@
 use std::path::PathBuf;
 
 use anyhow::bail;
-use moonutil::project::{PackageDirs, WorkRootSelection};
+use moonutil::constants::MOON_WORK;
+use moonutil::project::WorkspaceEditTarget;
 use moonutil::user_log::UserLog;
 
 use super::UniversalFlags;
@@ -65,7 +66,7 @@ pub(crate) fn work_cli(
                 bail!("dry-run is not supported for work init")
             }
 
-            let workspace_root = work_root(&cli, WorkRootSelection::CreateWorkspace, user_log)?;
+            let workspace_root = cli.source_tgt_dir.workspace_creation_root()?;
             mooncake::pkg::init_workspace(&workspace_root, &cmd.paths, cli.quiet, user_log)
         }
         WorkSubcommands::Use(cmd) => {
@@ -73,30 +74,29 @@ pub(crate) fn work_cli(
                 bail!("dry-run is not supported for work use")
             }
 
-            let workspace_root =
-                work_root(&cli, WorkRootSelection::ReuseExistingWorkspace, user_log)?;
-            mooncake::pkg::use_workspace(&workspace_root, &cmd.paths, cli.quiet, user_log)
+            let target = cli
+                .source_tgt_dir
+                .workspace_edit_target(cli.workspace_env.clone(), user_log)?;
+            mooncake::pkg::use_workspace(target, &cmd.paths, cli.quiet, user_log)
         }
         WorkSubcommands::Sync => {
             if cli.dry_run {
                 bail!("dry-run is not supported for work sync")
             }
 
-            let PackageDirs { source_dir, .. } = cli
+            let target = cli
                 .source_tgt_dir
-                .query(cli.workspace_env.clone())?
-                .package_dirs(user_log)?;
-            mooncake::pkg::sync_workspace(&source_dir, cli.quiet, user_log)
+                .workspace_edit_target(cli.workspace_env.clone(), user_log)?;
+            match target {
+                WorkspaceEditTarget::Existing(workspace) => {
+                    mooncake::pkg::sync_workspace(&workspace, cli.quiet, user_log)
+                }
+                WorkspaceEditTarget::CreateAt(root) => Err(anyhow::anyhow!(
+                    "`moon work sync` requires `{}` at `{}`",
+                    MOON_WORK,
+                    root.display()
+                )),
+            }
         }
     }
-}
-
-fn work_root(
-    cli: &UniversalFlags,
-    selection: WorkRootSelection,
-    user_log: &UserLog,
-) -> anyhow::Result<PathBuf> {
-    Ok(cli
-        .source_tgt_dir
-        .work_root(selection, cli.workspace_env.clone(), user_log)?)
 }

--- a/crates/moon/src/filter.rs
+++ b/crates/moon/src/filter.rs
@@ -588,7 +588,9 @@ mod tests {
         }
         .query_from(source_dir, WorkspaceEnv::Auto)
         .unwrap()
-        .package_dirs(&user_log)
+        .select(&user_log)
+        .unwrap()
+        .package_dirs()
         .unwrap();
         let synced_env = moonbuild_rupes_recta::sync_dependencies(&cfg, &dirs, &user_log).unwrap();
         moonbuild_rupes_recta::resolve_synced_project(&cfg, synced_env, &user_log).unwrap()

--- a/crates/moon/src/tests/planner/fixture.rs
+++ b/crates/moon/src/tests/planner/fixture.rs
@@ -83,7 +83,8 @@ impl PlanningFixture {
             target_dir: None,
         }
         .query_from(&fixture_dir, WorkspaceEnv::Auto)?
-        .package_dirs(&user_log)?;
+        .select(&user_log)?
+        .package_dirs()?;
         let resolve_cfg = moonbuild_rupes_recta::ResolveConfig::new_with_load_defaults(
             true,
             false,

--- a/crates/moon/src/watch/prebuild_output.rs
+++ b/crates/moon/src/watch/prebuild_output.rs
@@ -113,7 +113,9 @@ mod tests {
         }
         .query_from(temp_dir.path(), WorkspaceEnv::Auto)
         .unwrap()
-        .package_dirs(&user_log)
+        .select(&user_log)
+        .unwrap()
+        .package_dirs()
         .unwrap();
         let synced_env = sync_dependencies(&resolve_cfg, &dirs, &user_log).unwrap();
         let resolved = resolve_synced_project(&resolve_cfg, synced_env, &user_log).unwrap();
@@ -156,7 +158,9 @@ mod tests {
         }
         .query_from(temp_dir.path(), WorkspaceEnv::Auto)
         .unwrap()
-        .package_dirs(&user_log)
+        .select(&user_log)
+        .unwrap()
+        .package_dirs()
         .unwrap();
         let synced_env = sync_dependencies(&resolve_cfg, &dirs, &user_log).unwrap();
         let resolved = resolve_synced_project(&resolve_cfg, synced_env, &user_log).unwrap();

--- a/crates/moon/tests/test_cases/diagnostics_format/check.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/check.rs
@@ -242,6 +242,36 @@ fn test_moon_check_complete_json_captures_workspace_override_warning() {
 }
 
 #[test]
+fn test_moon_check_complete_json_captures_workspace_deprecation_once() {
+    let dir = TestDir::new("workspace_basic.in");
+    std::fs::write(
+        dir.join("moon.work"),
+        r#"members = [
+  "./app",
+  "./liba",
+]
+preferred_target = "wasm-gc"
+"#,
+    )
+    .unwrap();
+
+    let report = parse_complete_json(moon_cmd(&dir).args(["check", "--json"]).assert().success());
+    let warnings = report["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|message| {
+            message["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("`preferred_target` in `moon.work`"))
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0]["level"], "warning");
+}
+
+#[test]
 fn test_moon_check_complete_json_captures_bin_dep_prebuild_failure() {
     let top_dir = TestDir::new("prebuild_config_script/check_skip_bin_dep.in");
     let dir = top_dir.join("user.in");

--- a/crates/moon/tests/test_cases/native_backend/cc_flags.rs
+++ b/crates/moon/tests/test_cases/native_backend/cc_flags.rs
@@ -2,7 +2,7 @@
 use std::process::Command;
 
 #[cfg(not(windows))]
-use crate::{TestDir, get_err_stderr_with_envs};
+use crate::{TestDir, get_err_stderr_with_envs, get_stderr_with_envs};
 #[cfg(windows)]
 use crate::{TestDir, get_stdout_with_envs};
 #[cfg(unix)]
@@ -184,6 +184,38 @@ fn test_native_backend_cc_flags_with_env_override() {
         &path_override_env,
         expect_file!["cc_flags/run_native_env_paths_graph.jsonl.snap"],
     );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_moon_cc_override_warning_is_reported_per_package() {
+    let dir = TestDir::new("native_backend/cc_flags");
+    let fake_path = dir.join("fake-toolchain/bin").display().to_string();
+    let stderr = get_stderr_with_envs(
+        &dir,
+        ["build", "--target", "native", "--dry-run", "--sort-input"],
+        [
+            ("MOONBIT_NEW_NATIVE", "0"),
+            ("MOON_CC", "x86_64-unknown-fake_os-fake_libc-gcc"),
+            ("PATH", fake_path.as_str()),
+        ],
+    );
+    let warnings = stderr
+        .lines()
+        .filter(|message| message.contains("`MOON_CC` overrides"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(warnings.len(), 2, "unexpected warnings: {warnings:#?}");
+    assert!(warnings.iter().any(|message| {
+        message.contains("`moon_new/lib`")
+            && message.contains("`link.native.cc`")
+            && message.contains("`link.native.stub-cc`")
+    }));
+    assert!(warnings.iter().any(|message| {
+        message.contains("`moon_new/main`")
+            && message.contains("`link.native.cc`")
+            && !message.contains("`link.native.stub-cc`")
+    }));
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -955,6 +955,30 @@ fn test_member_dir_can_disable_implicit_workspace_mode() {
 }
 
 #[test]
+fn test_workspace_maintenance_uses_local_manifest_when_workspace_mode_is_off() {
+    let dir = same_root_workspace_dir();
+
+    check(
+        get_stdout_with_envs(&dir, ["work", "use", "./dep"], [(MOON_WORK_ENV, "off")]),
+        expect![[r#"
+            moon.work is already up to date
+        "#]],
+    );
+    assert!(
+        std::fs::read_to_string(dir.join("moon.work"))
+            .unwrap()
+            .contains(r#"".""#),
+        "work use must preserve existing members"
+    );
+
+    let stdout = get_stdout_with_envs(&dir, ["work", "sync"], [(MOON_WORK_ENV, "off")]);
+    assert!(
+        stdout.contains("Synced workspace manifests:"),
+        "expected work sync to use the local workspace, got:\n{stdout}"
+    );
+}
+
+#[test]
 fn test_member_dir_targets_dsl_member_for_tree() {
     let dir = TestDir::new("workspace_basic.in");
     std::fs::remove_file(dir.join("app/moon.mod.json")).unwrap();

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -420,6 +420,18 @@ preferred_target = "wasm-gc"
             Warning: `preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.
         "#]],
     );
+
+    check(
+        get_stderr(&dir, ["work", "use", "app"]),
+        expect![[r#"
+            Warning: `preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.
+        "#]],
+    );
+
+    check(
+        get_stderr(&dir, ["--quiet", "build", "--dry-run"]),
+        expect![[r#""#]],
+    );
 }
 
 #[test]

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -28,11 +28,11 @@ use std::{
 
 use indexmap::{IndexSet, set::MutableValues};
 use moonutil::{
-    compiler_flags::{self, CC, Toolchain},
+    compiler_flags::{self, CC, Toolchain, ToolchainSource},
     cond_expr::OptLevel,
     constants::{DOT_MBT_DOT_MD, MOD_DIR, MOONCAKE_BIN, PKG_DIR, is_moon_mod, is_moon_pkg},
     manifest::{MoonMod, MoonModRule},
-    package::{MoonPkgGenerate, SupportedTargetsDeclKind},
+    package::{MoonPkgGenerate, NativeLinkConfig, SupportedTargetsDeclKind},
     resolution::ModuleId,
     scripts::{IgnoredMoonScript, is_moon_script_ignored},
     toolchain::{self, BINARIES},
@@ -62,6 +62,17 @@ use super::{
 static BUILD_VAR_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\$\{build\.([a-zA-Z0-9_]+)\}").expect("invalid build var regex"));
 const PROOF_ENABLED_WARN_SUPPRESSIONS: &str = "-1-2-3-29";
+
+fn moon_cc_override_fields(native: Option<&NativeLinkConfig>) -> Vec<&'static str> {
+    let mut fields = Vec::new();
+    if native.is_some_and(|native| native.cc.is_some()) {
+        fields.push("`link.native.cc`");
+    }
+    if native.is_some_and(|native| native.stub_cc.is_some()) {
+        fields.push("`link.native.stub-cc`");
+    }
+    fields
+}
 
 #[derive(Clone, Copy)]
 enum DependencyInterfaceMode {
@@ -121,18 +132,45 @@ impl<'a> BuildPlanConstructor<'a> {
         );
     }
 
-    fn effective_native_toolchain(&mut self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
+    fn effective_native_toolchain(
+        &mut self,
+        package: Option<PackageId>,
+        package_cc: Option<&CC>,
+    ) -> anyhow::Result<Toolchain> {
         debug_assert!(self.build_env.target_backend().is_native());
-        if self.build_env.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
-            self.warn_incompatible_windows_msvc_env_override();
-            return compiler_flags::windows_msvc_native_toolchain(package_cc, self.user_log);
+        let toolchain =
+            if self.build_env.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
+                self.warn_incompatible_windows_msvc_env_override();
+                compiler_flags::windows_msvc_native_toolchain(package_cc)?
+            } else {
+                compiler_flags::effective_native_toolchain(
+                    package_cc,
+                    self.build_env.tcc_run().map(|config| config.internal_tcc()),
+                )?
+            };
+
+        if package_cc.is_some()
+            && toolchain.source() == ToolchainSource::EnvOverride
+            && let Some(package) = package
+        {
+            self.warn_moon_cc_override(package);
+        }
+        Ok(toolchain)
+    }
+
+    fn warn_moon_cc_override(&mut self, package: PackageId) {
+        if !self.warned_moon_cc_overrides.insert(package) {
+            return;
         }
 
-        compiler_flags::effective_native_toolchain(
-            package_cc,
-            self.build_env.tcc_run().map(|config| config.internal_tcc()),
-            self.user_log,
-        )
+        let pkg = self.input.pkg_dirs.get_package(package);
+        let native = pkg.raw.link.as_ref().and_then(|link| link.native.as_ref());
+        let fields = moon_cc_override_fields(native);
+        self.user_log.warn(format!(
+            "`MOON_CC` overrides {} configured by package `{}`.",
+            fields.join(" and "),
+            pkg.fqn
+        ));
     }
 
     fn module_prebuild_vars(&self, module: ModuleId) -> Option<&HashMap<String, String>> {
@@ -843,7 +881,7 @@ impl<'a> BuildPlanConstructor<'a> {
             .unwrap_or_default();
 
         let effective_native_toolchain = self
-            .effective_native_toolchain(stub_cc.as_ref())
+            .effective_native_toolchain(Some(target), stub_cc.as_ref())
             .map_err(|e| {
                 BuildPlanConstructError::FailedToSetStubCC(
                     self.new_native_linker_context(e),
@@ -984,8 +1022,9 @@ impl<'a> BuildPlanConstructor<'a> {
             link_pkgs.push(target.package);
         }
 
-        let effective_native_toolchain =
-            self.effective_native_toolchain(cc.as_ref()).map_err(|e| {
+        let effective_native_toolchain = self
+            .effective_native_toolchain(Some(target.package), cc.as_ref())
+            .map_err(|e| {
                 BuildPlanConstructError::FailedToSetCC(
                     self.new_native_linker_context(e),
                     pkg.fqn.clone().into(),
@@ -1395,9 +1434,10 @@ impl<'a> BuildPlanConstructor<'a> {
         &mut self,
         node: BuildPlanNode,
     ) -> Result<(), BuildPlanConstructError> {
-        let effective_native_toolchain = self.effective_native_toolchain(None).map_err(|e| {
-            BuildPlanConstructError::FailedToSetRuntimeCC(self.new_native_linker_context(e))
-        })?;
+        let effective_native_toolchain =
+            self.effective_native_toolchain(None, None).map_err(|e| {
+                BuildPlanConstructError::FailedToSetRuntimeCC(self.new_native_linker_context(e))
+            })?;
         let source_files = toolchain::runtime_source_paths()
             .map_err(BuildPlanConstructError::FailedToFindRuntimeSources)?;
         let builds_static_archive = self.build_env.tcc_run().is_none();
@@ -1885,6 +1925,34 @@ mod tests {
             target_triple: Some(target_triple.to_string()),
             is_env_override: false,
         })
+    }
+
+    fn native_link_config(cc: Option<&str>, stub_cc: Option<&str>) -> NativeLinkConfig {
+        NativeLinkConfig {
+            exports: None,
+            cc: cc.map(str::to_owned),
+            cc_flags: None,
+            cc_link_flags: None,
+            stub_cc: stub_cc.map(str::to_owned),
+            stub_cc_flags: None,
+            stub_cc_link_flags: None,
+            stub_lib_deps: None,
+        }
+    }
+
+    #[test]
+    fn moon_cc_override_warning_groups_fields_per_package() {
+        let both = native_link_config(Some("package-cc"), Some("package-stub-cc"));
+        assert_eq!(
+            moon_cc_override_fields(Some(&both)),
+            vec!["`link.native.cc`", "`link.native.stub-cc`"]
+        );
+
+        let only_stub = native_link_config(None, Some("package-stub-cc"));
+        assert_eq!(
+            moon_cc_override_fields(Some(&only_stub)),
+            vec!["`link.native.stub-cc`"]
+        );
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -32,7 +32,7 @@ use moonutil::{
     cond_expr::OptLevel,
     constants::{DOT_MBT_DOT_MD, MOD_DIR, MOONCAKE_BIN, PKG_DIR, is_moon_mod, is_moon_pkg},
     manifest::{MoonMod, MoonModRule},
-    package::{MoonPkgGenerate, NativeLinkConfig, SupportedTargetsDeclKind},
+    package::{MoonPkgGenerate, SupportedTargetsDeclKind},
     resolution::ModuleId,
     scripts::{IgnoredMoonScript, is_moon_script_ignored},
     toolchain::{self, BINARIES},
@@ -62,17 +62,6 @@ use super::{
 static BUILD_VAR_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\$\{build\.([a-zA-Z0-9_]+)\}").expect("invalid build var regex"));
 const PROOF_ENABLED_WARN_SUPPRESSIONS: &str = "-1-2-3-29";
-
-fn moon_cc_override_fields(native: Option<&NativeLinkConfig>) -> Vec<&'static str> {
-    let mut fields = Vec::new();
-    if native.is_some_and(|native| native.cc.is_some()) {
-        fields.push("`link.native.cc`");
-    }
-    if native.is_some_and(|native| native.stub_cc.is_some()) {
-        fields.push("`link.native.stub-cc`");
-    }
-    fields
-}
 
 #[derive(Clone, Copy)]
 enum DependencyInterfaceMode {
@@ -132,45 +121,52 @@ impl<'a> BuildPlanConstructor<'a> {
         );
     }
 
-    fn effective_native_toolchain(
-        &mut self,
-        package: Option<PackageId>,
-        package_cc: Option<&CC>,
-    ) -> anyhow::Result<Toolchain> {
+    fn effective_native_toolchain(&mut self, package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
         debug_assert!(self.build_env.target_backend().is_native());
-        let toolchain =
-            if self.build_env.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
-                self.warn_incompatible_windows_msvc_env_override();
-                compiler_flags::windows_msvc_native_toolchain(package_cc)?
-            } else {
-                compiler_flags::effective_native_toolchain(
-                    package_cc,
-                    self.build_env.tcc_run().map(|config| config.internal_tcc()),
-                )?
-            };
-
-        if package_cc.is_some()
-            && toolchain.source() == ToolchainSource::EnvOverride
-            && let Some(package) = package
-        {
-            self.warn_moon_cc_override(package);
+        if self.build_env.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
+            self.warn_incompatible_windows_msvc_env_override();
+            return compiler_flags::windows_msvc_native_toolchain(package_cc);
         }
-        Ok(toolchain)
+
+        compiler_flags::effective_native_toolchain(
+            package_cc,
+            self.build_env.tcc_run().map(|config| config.internal_tcc()),
+        )
     }
 
-    fn warn_moon_cc_override(&mut self, package: PackageId) {
-        if !self.warned_moon_cc_overrides.insert(package) {
+    pub(super) fn warn_moon_cc_overrides(&self) {
+        if !self.build_env.target_backend().is_native() {
             return;
         }
 
-        let pkg = self.input.pkg_dirs.get_package(package);
-        let native = pkg.raw.link.as_ref().and_then(|link| link.native.as_ref());
-        let fields = moon_cc_override_fields(native);
-        self.user_log.warn(format!(
-            "`MOON_CC` overrides {} configured by package `{}`.",
-            fields.join(" and "),
-            pkg.fqn
-        ));
+        for (package, pkg) in self.input.pkg_dirs.all_packages(true) {
+            let Some(native) = pkg.raw.link.as_ref().and_then(|link| link.native.as_ref()) else {
+                continue;
+            };
+            let cc_overridden = native.cc.is_some()
+                && self.res.make_executable_info.iter().any(|(target, info)| {
+                    target.package == package
+                        && info.effective_native_toolchain.source() == ToolchainSource::EnvOverride
+                });
+            let stub_cc_overridden = native.stub_cc.is_some()
+                && self.res.c_stubs_info.get(&package).is_some_and(|info| {
+                    info.effective_native_toolchain.source() == ToolchainSource::EnvOverride
+                });
+            let fields = [
+                cc_overridden.then_some("`link.native.cc`"),
+                stub_cc_overridden.then_some("`link.native.stub-cc`"),
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+            if !fields.is_empty() {
+                self.user_log.warn(format!(
+                    "`MOON_CC` overrides {} configured by package `{}`.",
+                    fields.join(" and "),
+                    pkg.fqn
+                ));
+            }
+        }
     }
 
     fn module_prebuild_vars(&self, module: ModuleId) -> Option<&HashMap<String, String>> {
@@ -881,7 +877,7 @@ impl<'a> BuildPlanConstructor<'a> {
             .unwrap_or_default();
 
         let effective_native_toolchain = self
-            .effective_native_toolchain(Some(target), stub_cc.as_ref())
+            .effective_native_toolchain(stub_cc.as_ref())
             .map_err(|e| {
                 BuildPlanConstructError::FailedToSetStubCC(
                     self.new_native_linker_context(e),
@@ -1022,9 +1018,8 @@ impl<'a> BuildPlanConstructor<'a> {
             link_pkgs.push(target.package);
         }
 
-        let effective_native_toolchain = self
-            .effective_native_toolchain(Some(target.package), cc.as_ref())
-            .map_err(|e| {
+        let effective_native_toolchain =
+            self.effective_native_toolchain(cc.as_ref()).map_err(|e| {
                 BuildPlanConstructError::FailedToSetCC(
                     self.new_native_linker_context(e),
                     pkg.fqn.clone().into(),
@@ -1434,10 +1429,9 @@ impl<'a> BuildPlanConstructor<'a> {
         &mut self,
         node: BuildPlanNode,
     ) -> Result<(), BuildPlanConstructError> {
-        let effective_native_toolchain =
-            self.effective_native_toolchain(None, None).map_err(|e| {
-                BuildPlanConstructError::FailedToSetRuntimeCC(self.new_native_linker_context(e))
-            })?;
+        let effective_native_toolchain = self.effective_native_toolchain(None).map_err(|e| {
+            BuildPlanConstructError::FailedToSetRuntimeCC(self.new_native_linker_context(e))
+        })?;
         let source_files = toolchain::runtime_source_paths()
             .map_err(BuildPlanConstructError::FailedToFindRuntimeSources)?;
         let builds_static_archive = self.build_env.tcc_run().is_none();
@@ -1925,34 +1919,6 @@ mod tests {
             target_triple: Some(target_triple.to_string()),
             is_env_override: false,
         })
-    }
-
-    fn native_link_config(cc: Option<&str>, stub_cc: Option<&str>) -> NativeLinkConfig {
-        NativeLinkConfig {
-            exports: None,
-            cc: cc.map(str::to_owned),
-            cc_flags: None,
-            cc_link_flags: None,
-            stub_cc: stub_cc.map(str::to_owned),
-            stub_cc_flags: None,
-            stub_cc_link_flags: None,
-            stub_lib_deps: None,
-        }
-    }
-
-    #[test]
-    fn moon_cc_override_warning_groups_fields_per_package() {
-        let both = native_link_config(Some("package-cc"), Some("package-stub-cc"));
-        assert_eq!(
-            moon_cc_override_fields(Some(&both)),
-            vec!["`link.native.cc`", "`link.native.stub-cc`"]
-        );
-
-        let only_stub = native_link_config(None, Some("package-stub-cc"));
-        assert_eq!(
-            moon_cc_override_fields(Some(&only_stub)),
-            vec!["`link.native.stub-cc`"]
-        );
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -53,6 +53,7 @@ pub(super) struct BuildPlanConstructor<'a> {
     pub(super) pending: Vec<BuildPlanNode>,
     pub(super) resolved: HashSet<BuildPlanNode>,
     pub(super) warned_incompatible_windows_msvc_env_override: bool,
+    pub(super) warned_moon_cc_overrides: HashSet<PackageId>,
     pub(super) warned_missing_supported_targets: HashSet<PackageId>,
     pub(super) package_file_sets: HashMap<PackageId, PackageFileSet>,
 
@@ -151,6 +152,7 @@ impl<'a> BuildPlanConstructor<'a> {
             pending: Vec::new(),
             resolved: HashSet::new(),
             warned_incompatible_windows_msvc_env_override: false,
+            warned_moon_cc_overrides: HashSet::new(),
             warned_missing_supported_targets: HashSet::new(),
             package_file_sets: HashMap::new(),
             #[cfg(debug_assertions)]

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -53,7 +53,6 @@ pub(super) struct BuildPlanConstructor<'a> {
     pub(super) pending: Vec<BuildPlanNode>,
     pub(super) resolved: HashSet<BuildPlanNode>,
     pub(super) warned_incompatible_windows_msvc_env_override: bool,
-    pub(super) warned_moon_cc_overrides: HashSet<PackageId>,
     pub(super) warned_missing_supported_targets: HashSet<PackageId>,
     pub(super) package_file_sets: HashMap<PackageId, PackageFileSet>,
 
@@ -152,7 +151,6 @@ impl<'a> BuildPlanConstructor<'a> {
             pending: Vec::new(),
             resolved: HashSet::new(),
             warned_incompatible_windows_msvc_env_override: false,
-            warned_moon_cc_overrides: HashSet::new(),
             warned_missing_supported_targets: HashSet::new(),
             package_file_sets: HashMap::new(),
             #[cfg(debug_assertions)]
@@ -202,6 +200,7 @@ impl<'a> BuildPlanConstructor<'a> {
         }
 
         self.postprocess_coalesce();
+        self.warn_moon_cc_overrides();
 
         Ok(())
     }

--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -61,7 +61,6 @@ use moonutil::{
     },
     package::resolve_supported_targets,
     user_log::UserLog,
-    workspace::{canonical_workspace_module_dirs, read_workspace_file},
 };
 use relative_path::{PathExt, RelativePath};
 use tracing::{Level, instrument};
@@ -129,34 +128,9 @@ pub fn discover_local_project(
         source_dir.display()
     );
 
-    let workspace = if let ProjectManifest::Workspace(workspace_manifest_path) = project_manifest {
-        read_workspace_file(workspace_manifest_path)
-            .map(Some)
-            .map_err(|inner| DiscoverError::CantReadLocalWorkspace {
-                path: workspace_manifest_path.to_owned(),
-                inner,
-            })?
-    } else {
-        None
-    };
-    let workspace_root = match project_manifest {
-        ProjectManifest::Workspace(workspace_manifest_path) => workspace_manifest_path
-            .parent()
-            .ok_or_else(|| DiscoverError::CantReadLocalWorkspace {
-                path: workspace_manifest_path.to_owned(),
-                inner: anyhow::anyhow!("workspace manifest path has no parent directory"),
-            })?,
-        ProjectManifest::None | ProjectManifest::Module(_) => source_dir,
-    };
-    let module_dirs = if let Some(workspace) = workspace.as_ref() {
-        canonical_workspace_module_dirs(workspace_root, workspace).map_err(|inner| {
-            DiscoverError::CantReadLocalWorkspace {
-                path: workspace_root.to_owned(),
-                inner,
-            }
-        })?
-    } else {
-        vec![source_dir.to_path_buf()]
+    let module_dirs = match project_manifest {
+        ProjectManifest::Workspace(workspace) => workspace.members().to_vec(),
+        ProjectManifest::None | ProjectManifest::Module(_) => vec![source_dir.to_path_buf()],
     };
 
     let mut root_modules = ResolvedRootModules::with_key();

--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -130,7 +130,7 @@ pub fn discover_local_project(
     );
 
     let workspace = if let ProjectManifest::Workspace(workspace_manifest_path) = project_manifest {
-        read_workspace_file(workspace_manifest_path, user_log)
+        read_workspace_file(workspace_manifest_path)
             .map(Some)
             .map_err(|inner| DiscoverError::CantReadLocalWorkspace {
                 path: workspace_manifest_path.to_owned(),

--- a/crates/moonbuild-rupes-recta/src/fmt.rs
+++ b/crates/moonbuild-rupes-recta/src/fmt.rs
@@ -33,7 +33,6 @@
 use log::*;
 use std::{collections::HashSet, ffi::OsStr, path::Path};
 
-use anyhow::Context;
 use moonutil::project::ProjectManifest;
 use moonutil::resolution::{ModuleSourceKind, ResolvedModule};
 use moonutil::toolchain::BINARIES;
@@ -387,15 +386,12 @@ fn format_workspace_node(
     layout: &TargetLayout,
     project_manifest: &ProjectManifest,
 ) -> anyhow::Result<bool> {
-    let ProjectManifest::Workspace(workspace_manifest_path) = project_manifest else {
+    let ProjectManifest::Workspace(workspace) = project_manifest else {
         return Ok(false);
     };
-    workspace_manifest_path
-        .parent()
-        .context("workspace manifest path has no parent directory")?;
 
     let target_moon_work = layout.format_root_artifact_path(std::ffi::OsStr::new(MOON_WORK));
-    format_moon_work_dsl(graph, cfg, workspace_manifest_path, &target_moon_work)?;
+    format_moon_work_dsl(graph, cfg, workspace.manifest_path(), &target_moon_work)?;
     Ok(true)
 }
 

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -179,8 +179,7 @@ pub fn add(
     }
 
     let m = Arc::new(m);
-    let roots =
-        roots_for_selected_module(module_dir, Arc::clone(&m), &dirs.project_manifest, user_log)?;
+    let roots = roots_for_selected_module(module_dir, Arc::clone(&m), &dirs.project_manifest)?;
     install_impl(
         dirs,
         roots,

--- a/crates/mooncake/src/pkg/mod.rs
+++ b/crates/mooncake/src/pkg/mod.rs
@@ -18,10 +18,9 @@
 
 use std::{path::Path, sync::Arc};
 
-use anyhow::Context;
 use moonutil::{
     manifest::{MoonMod, read_module_desc_file_in_dir},
-    project::{ProjectManifest, canonical_workspace_module_dirs, read_workspace_file},
+    project::ProjectManifest,
     resolution::{ModuleSource, ResolvedModule, ResolvedRootModules},
 };
 
@@ -39,21 +38,15 @@ pub(crate) fn roots_for_selected_module(
     module: Arc<MoonMod>,
     project_manifest: &ProjectManifest,
 ) -> anyhow::Result<ResolvedRootModules> {
-    if let ProjectManifest::Workspace(project_manifest) = project_manifest {
-        let workspace_root = project_manifest
-            .parent()
-            .context("workspace manifest path has no parent directory")?;
-        // Project discovery owns workspace deprecation warnings. Package
-        // operations can reread the manifest here without producing output.
-        let workspace = read_workspace_file(project_manifest)?;
+    if let ProjectManifest::Workspace(workspace) = project_manifest {
         let mut roots = ResolvedRootModules::with_key();
-        for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {
+        for member_dir in workspace.members() {
             let member = if member_dir == module_dir {
                 Arc::clone(&module)
             } else {
-                Arc::new(read_module_desc_file_in_dir(&member_dir)?)
+                Arc::new(read_module_desc_file_in_dir(member_dir)?)
             };
-            let source = ModuleSource::from_local_module(&member, &member_dir);
+            let source = ModuleSource::from_local_module(&member, member_dir);
             roots.insert(ResolvedModule::new(source, member));
         }
         return Ok(roots);

--- a/crates/mooncake/src/pkg/mod.rs
+++ b/crates/mooncake/src/pkg/mod.rs
@@ -43,6 +43,8 @@ pub(crate) fn roots_for_selected_module(
         let workspace_root = project_manifest
             .parent()
             .context("workspace manifest path has no parent directory")?;
+        // Project discovery owns workspace deprecation warnings. Package
+        // operations can reread the manifest here without producing output.
         let workspace = read_workspace_file(project_manifest)?;
         let mut roots = ResolvedRootModules::with_key();
         for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {

--- a/crates/mooncake/src/pkg/mod.rs
+++ b/crates/mooncake/src/pkg/mod.rs
@@ -23,7 +23,6 @@ use moonutil::{
     manifest::{MoonMod, read_module_desc_file_in_dir},
     project::{ProjectManifest, canonical_workspace_module_dirs, read_workspace_file},
     resolution::{ModuleSource, ResolvedModule, ResolvedRootModules},
-    user_log::UserLog,
 };
 
 pub mod add;
@@ -39,13 +38,12 @@ pub(crate) fn roots_for_selected_module(
     module_dir: &Path,
     module: Arc<MoonMod>,
     project_manifest: &ProjectManifest,
-    user_log: &UserLog,
 ) -> anyhow::Result<ResolvedRootModules> {
     if let ProjectManifest::Workspace(project_manifest) = project_manifest {
         let workspace_root = project_manifest
             .parent()
             .context("workspace manifest path has no parent directory")?;
-        let workspace = read_workspace_file(project_manifest, user_log)?;
+        let workspace = read_workspace_file(project_manifest)?;
         let mut roots = ResolvedRootModules::with_key();
         for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {
             let member = if member_dir == module_dir {

--- a/crates/mooncake/src/pkg/remove.rs
+++ b/crates/mooncake/src/pkg/remove.rs
@@ -61,7 +61,7 @@ pub fn remove(
         )
     }
     let m = Arc::new(m);
-    let roots = roots_for_selected_module(module_dir, Arc::clone(&m), project_manifest, user_log)?;
+    let roots = roots_for_selected_module(module_dir, Arc::clone(&m), project_manifest)?;
 
     let resolve_cfg = ResolveConfig {
         registry: registry::default_registry(),

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -79,7 +79,7 @@ pub fn auto_sync(
     if let ProjectManifest::Workspace(project_manifest) = &dirs.project_manifest
         && !matches!(workspace_env, WorkspaceEnv::Off)
     {
-        let workspace = read_workspace_file(project_manifest, user_log)?;
+        let workspace = read_workspace_file(project_manifest)?;
         return resolve_workspace_sync(
             dirs,
             cli,

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -20,7 +20,6 @@
 
 use std::{path::Path, sync::Arc};
 
-use anyhow::Context;
 use indexmap::IndexMap;
 use moonutil::{
     build_options::{MoonbuildOpt, MooncOpt},
@@ -28,10 +27,7 @@ use moonutil::{
     cli_support::AutoSyncFlags,
     front_matter::MbtMdHeader,
     manifest::{MoonMod, read_module_desc_file_in_dir},
-    project::{
-        MoonWork, PackageDirs, ProjectManifest, WorkspaceEnv, canonical_workspace_module_dirs,
-        read_workspace_file,
-    },
+    project::{MoonWork, PackageDirs, ProjectManifest, WorkspaceEnv, WorkspaceLayout},
     resolution::{DirSyncResult, ModuleSource, ResolvedEnv, ResolvedModule, ResolvedRootModules},
     user_log::UserLog,
 };
@@ -76,10 +72,9 @@ pub fn auto_sync(
     workspace_env: WorkspaceEnv,
     include_bin_deps: bool,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult, Option<MoonWork>)> {
-    if let ProjectManifest::Workspace(project_manifest) = &dirs.project_manifest
+    if let ProjectManifest::Workspace(workspace) = &dirs.project_manifest
         && !matches!(workspace_env, WorkspaceEnv::Off)
     {
-        let workspace = read_workspace_file(project_manifest)?;
         return resolve_workspace_sync(
             dirs,
             cli,
@@ -118,23 +113,17 @@ fn resolve_workspace_sync(
     output_options: SyncOutputOptions,
     user_log: &UserLog,
     no_std: bool,
-    workspace: MoonWork,
+    workspace: &WorkspaceLayout,
     include_bin_deps: bool,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult, Option<MoonWork>)> {
-    let ProjectManifest::Workspace(project_manifest) = &dirs.project_manifest else {
-        unreachable!("workspace sync requires a workspace manifest");
-    };
-    let workspace_root = project_manifest
-        .parent()
-        .context("workspace manifest path has no parent directory")?;
     let mut roots = ResolvedRootModules::with_key();
-    for member_dir in canonical_workspace_module_dirs(workspace_root, &workspace)? {
-        let mut module = read_module_desc_file_in_dir(&member_dir)?;
+    for member_dir in workspace.members() {
+        let mut module = read_module_desc_file_in_dir(member_dir)?;
         if !include_bin_deps {
             module.bin_deps = None;
         }
         let module = Arc::new(module);
-        let source = ModuleSource::from_local_module(&module, &member_dir);
+        let source = ModuleSource::from_local_module(&module, member_dir);
         roots.insert(ResolvedModule::new(source, module));
     }
 
@@ -148,7 +137,11 @@ fn resolve_workspace_sync(
         &CacheRoot::Disabled,
     )?;
     log::debug!("Dir sync result: {:?}", sync_result);
-    Ok((resolved_env, sync_result, Some(workspace)))
+    Ok((
+        resolved_env,
+        sync_result,
+        Some(workspace.manifest().clone()),
+    ))
 }
 
 pub fn auto_sync_for_single_mbt_md(

--- a/crates/mooncake/src/pkg/tree.rs
+++ b/crates/mooncake/src/pkg/tree.rs
@@ -131,8 +131,7 @@ pub fn tree(
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
     let module = Arc::new(read_module_desc_file_in_dir(module_dir)?);
-    let roots =
-        roots_for_selected_module(module_dir, Arc::clone(&module), project_manifest, user_log)?;
+    let roots = roots_for_selected_module(module_dir, Arc::clone(&module), project_manifest)?;
     let resolve_cfg = ResolveConfig {
         registry: registry::default_registry(),
         inject_std: false,

--- a/crates/mooncake/src/pkg/work.rs
+++ b/crates/mooncake/src/pkg/work.rs
@@ -32,7 +32,7 @@ use moonutil::{
     },
     moon_mod_patch::{MoonModPatch, patch_module_dsl_to_file},
     project::{
-        MoonWork, canonical_workspace_module_dirs, read_workspace, workspace_manifest_path,
+        MoonWork, canonical_workspace_module_dirs, read_workspace_file, workspace_manifest_path,
         write_workspace,
     },
     resolution::{
@@ -92,7 +92,9 @@ pub fn use_workspace(
     quiet: bool,
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
-    let existing = read_workspace(workspace_root, user_log)?;
+    let existing = workspace_manifest_path(workspace_root)
+        .map(|path| read_workspace_file(&path))
+        .transpose()?;
     let preferred_target = existing
         .as_ref()
         .and_then(|workspace| workspace.preferred_target);
@@ -155,11 +157,14 @@ pub fn use_workspace(
 }
 
 pub fn sync_workspace(source_dir: &Path, quiet: bool, user_log: &UserLog) -> anyhow::Result<i32> {
-    let workspace = read_workspace(source_dir, user_log)?.context(format!(
-        "`moon work sync` requires `{}` at `{}`",
-        MOON_WORK,
-        source_dir.display()
-    ))?;
+    let workspace = workspace_manifest_path(source_dir)
+        .map(|path| read_workspace_file(&path))
+        .transpose()?
+        .context(format!(
+            "`moon work sync` requires `{}` at `{}`",
+            MOON_WORK,
+            source_dir.display()
+        ))?;
     let member_dirs = canonical_workspace_module_dirs(source_dir, &workspace)?;
     let roots = workspace_roots(&member_dirs, user_log)?;
     let resolved_env = resolve_workspace(roots, user_log)?;

--- a/crates/mooncake/src/pkg/work.rs
+++ b/crates/mooncake/src/pkg/work.rs
@@ -32,8 +32,7 @@ use moonutil::{
     },
     moon_mod_patch::{MoonModPatch, patch_module_dsl_to_file},
     project::{
-        MoonWork, canonical_workspace_module_dirs, read_workspace_file, workspace_manifest_path,
-        write_workspace,
+        MoonWork, WorkspaceEditTarget, WorkspaceLayout, workspace_manifest_path, write_workspace,
     },
     resolution::{
         DependencyEdge, DependencyKind, ModuleId, ModuleName, ModuleSource, ModuleSourceKind,
@@ -87,50 +86,27 @@ pub fn init_workspace(
 }
 
 pub fn use_workspace(
-    workspace_root: &Path,
+    target: WorkspaceEditTarget,
     paths: &[PathBuf],
     quiet: bool,
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
-    let existing = workspace_manifest_path(workspace_root)
-        .map(|path| read_workspace_file(&path))
-        .transpose()?;
-    let preferred_target = existing
-        .as_ref()
-        .and_then(|workspace| workspace.preferred_target);
-
-    let mut use_paths = Vec::new();
-    let mut member_dirs = BTreeSet::new();
-    if let Some(workspace) = existing.as_ref() {
-        for use_path in &workspace.use_paths {
-            let member_dir = if use_path.is_absolute() {
-                use_path.to_path_buf()
-            } else {
-                workspace_root.join(use_path)
-            };
-            let member_dir = dunce::canonicalize(&member_dir).with_context(|| {
-                format!(
-                    "failed to resolve workspace member `{}` from `{}`",
-                    use_path.display(),
-                    workspace_root.display()
-                )
-            })?;
-            if !member_dir.is_dir() {
-                bail!(
-                    "workspace member `{}` is not a directory",
-                    use_path.display()
-                );
-            }
-            member_dirs.insert(member_dir);
-            use_paths.push(use_path.clone());
-        }
-    }
+    let (workspace_root, preferred_target, mut use_paths, mut member_dirs, existed) = match target {
+        WorkspaceEditTarget::CreateAt(root) => (root, None, Vec::new(), BTreeSet::new(), false),
+        WorkspaceEditTarget::Existing(workspace) => (
+            workspace.root().to_path_buf(),
+            workspace.manifest().preferred_target,
+            workspace.manifest().use_paths.clone(),
+            workspace.members().iter().cloned().collect(),
+            true,
+        ),
+    };
 
     let previous_len = use_paths.len();
     for path in paths {
         let member_dir = resolve_workspace_member(path, user_log)?;
         if member_dirs.insert(member_dir.clone()) {
-            use_paths.push(workspace_use_path(workspace_root, &member_dir));
+            use_paths.push(workspace_use_path(&workspace_root, &member_dir));
         }
     }
 
@@ -138,13 +114,13 @@ pub fn use_workspace(
         use_paths,
         preferred_target,
     };
-    write_workspace(workspace_root, &workspace).context(format!(
+    write_workspace(&workspace_root, &workspace).context(format!(
         "failed to write `{}`",
         workspace_root.join(MOON_WORK).display()
     ))?;
 
     if !quiet {
-        if existing.is_none() {
+        if !existed {
             println!("Created {}", MOON_WORK);
         } else if workspace.use_paths.len() == previous_len {
             println!("{} is already up to date", MOON_WORK);
@@ -156,17 +132,12 @@ pub fn use_workspace(
     Ok(0)
 }
 
-pub fn sync_workspace(source_dir: &Path, quiet: bool, user_log: &UserLog) -> anyhow::Result<i32> {
-    let workspace = workspace_manifest_path(source_dir)
-        .map(|path| read_workspace_file(&path))
-        .transpose()?
-        .context(format!(
-            "`moon work sync` requires `{}` at `{}`",
-            MOON_WORK,
-            source_dir.display()
-        ))?;
-    let member_dirs = canonical_workspace_module_dirs(source_dir, &workspace)?;
-    let roots = workspace_roots(&member_dirs, user_log)?;
+pub fn sync_workspace(
+    workspace: &WorkspaceLayout,
+    quiet: bool,
+    user_log: &UserLog,
+) -> anyhow::Result<i32> {
+    let roots = workspace_roots(workspace.members(), user_log)?;
     let resolved_env = resolve_workspace(roots, user_log)?;
     let updated = sync_workspace_manifests(&resolved_env)?;
 
@@ -176,7 +147,7 @@ pub fn sync_workspace(source_dir: &Path, quiet: bool, user_log: &UserLog) -> any
         } else {
             println!("Synced workspace manifests:");
             for path in updated {
-                let display = path.strip_prefix(source_dir).unwrap_or(&path);
+                let display = path.strip_prefix(workspace.root()).unwrap_or(&path);
                 println!("{}", display.display());
             }
         }

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::{moon_dir::MOON_DIRS, user_log::UserLog};
+use crate::moon_dir::MOON_DIRS;
 use anyhow::Context;
 use colored::Colorize;
 use derive_builder::Builder;
@@ -31,13 +31,6 @@ use std::{
 
 const ENV_MOON_CC: &str = "MOON_CC";
 const ENV_MOON_AR: &str = "MOON_AR";
-const MOON_CC_PRECEDENCE_WARNING: &str = "Both MOON_CC environment variable and user-specified CC are provided. \
-     MOON_CC takes precedence.";
-
-fn warn_moon_cc_precedence(user_log: &UserLog) {
-    user_log.warn_once(MOON_CC_PRECEDENCE_WARNING);
-}
-
 #[derive(Copy, Clone, Debug)]
 pub enum CCKind {
     Msvc,     // cl-compatible driver, such as cl.exe or clang-cl.exe
@@ -307,14 +300,8 @@ fn ensure_windows_msvc_compatible(cc: &CC) -> anyhow::Result<()> {
     }
 }
 
-pub fn windows_msvc_native_toolchain(
-    package_cc: Option<&CC>,
-    user_log: &UserLog,
-) -> anyhow::Result<Toolchain> {
+pub fn windows_msvc_native_toolchain(package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
     if let Some(env_cc) = ENV_CC.as_ref().filter(|cc| cc.is_msvc()) {
-        if package_cc.is_some() {
-            warn_moon_cc_precedence(user_log);
-        }
         let override_toolchain = Toolchain::from_env_override(env_cc.clone());
         let resolved = if is_path_like_tool(&env_cc.cc_path) {
             override_toolchain
@@ -918,12 +905,8 @@ pub fn default_native_toolchain(internal_tcc_fallback: Option<&CC>) -> anyhow::R
 pub fn effective_native_toolchain(
     package_cc: Option<&CC>,
     internal_tcc_fallback: Option<&CC>,
-    user_log: &UserLog,
 ) -> anyhow::Result<Toolchain> {
     let selected = if let Some(env_cc) = ENV_CC.as_ref() {
-        if package_cc.is_some() {
-            warn_moon_cc_precedence(user_log);
-        }
         Toolchain::from_env_override(env_cc.clone()).with_package_override(package_cc)
     } else if let Some(package_cc) = package_cc {
         Toolchain::from_package_override(package_cc.clone())
@@ -1816,22 +1799,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn moon_cc_precedence_warning_uses_user_log_once() {
-        let (user_log, capture) = UserLog::captured(log::LevelFilter::Warn);
-
-        warn_moon_cc_precedence(&user_log);
-        warn_moon_cc_precedence(&user_log);
-
-        let entries = capture.take();
-        assert_eq!(entries.len(), 1);
-        assert!(matches!(
-            entries[0].level,
-            crate::user_log::UserLogEntryLevel::Warning
-        ));
-        assert_eq!(entries[0].message, MOON_CC_PRECEDENCE_WARNING);
-    }
 
     fn native_toolchain_fixture() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/native-toolchain")

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -18,7 +18,6 @@
 
 use std::{
     ffi::OsString,
-    fmt::Display,
     path::{Path, PathBuf},
 };
 
@@ -33,7 +32,7 @@ use crate::constants::{
 use crate::user_log::UserLog;
 use crate::workspace::{
     MoonWork, PREFERRED_TARGET_DEPRECATION_WARNING, canonical_workspace_module_dirs,
-    read_workspace_file, workspace_manifest_path,
+    workspace_manifest_path,
 };
 
 const COLOCATED_MODULE_NOT_IN_WORKSPACE_WARNING: &str = "`moon.work` takes precedence over the module manifest in the same directory, but that module is not listed as a workspace member. Add `.` to `members` to select it from the workspace root.";
@@ -111,7 +110,7 @@ impl SourceTargetDirs {
         let source_dir = dunce::canonicalize(source_root.as_ref())
             .context("failed to resolve source directory")
             .map_err(PackageDirsError::from)?;
-        let target_dir = self.resolve_target_dir(&source_dir)?;
+        let target_dir = resolve_target_dir(self.target_dir.as_deref(), &source_dir)?;
         let mooncake_bin_dir = target_dir.join(MOON_BIN_DIR);
         let mooncakes_dir = source_dir.join(DEP_PATH);
         Ok(PackageDirs {
@@ -163,19 +162,21 @@ impl SourceTargetDirs {
         })
     }
 
-    pub fn work_root(
+    pub fn workspace_creation_root(&self) -> Result<PathBuf, PackageDirsError> {
+        let start_dir = Self::current_dir()?;
+        Ok(self
+            .query_from(&start_dir, WorkspaceEnv::Off)?
+            .workspace_creation_root())
+    }
+
+    pub fn workspace_edit_target(
         &self,
-        selection: WorkRootSelection,
         workspace_env: WorkspaceEnv,
         user_log: &UserLog,
-    ) -> Result<PathBuf, PackageDirsError> {
+    ) -> Result<WorkspaceEditTarget, PackageDirsError> {
         let start_dir = Self::current_dir()?;
-        let mut query = if selection.prefers_existing_workspace() {
-            self.query_from(&start_dir, workspace_env)?
-        } else {
-            self.query_from(&start_dir, WorkspaceEnv::Off)?
-        };
-        query.work_root(selection, user_log)
+        self.query_from(&start_dir, workspace_env)?
+            .workspace_edit_target(user_log)
     }
 
     fn current_dir() -> Result<PathBuf, PackageDirsError> {
@@ -186,32 +187,81 @@ impl SourceTargetDirs {
             .context("failed to resolve current directory")
             .map_err(PackageDirsError::from)
     }
+}
 
-    fn resolve_target_dir(&self, project_root: &Path) -> Result<PathBuf, PackageDirsError> {
-        let target_dir = self
-            .target_dir
-            .clone()
-            .unwrap_or_else(|| project_root.join(BUILD_DIR));
-        if !target_dir.exists() {
-            std::fs::create_dir_all(&target_dir)
-                .context("failed to create target directory")
-                .map_err(PackageDirsError::from)?;
-        }
-        dunce::canonicalize(target_dir)
-            .context("failed to set target directory")
-            .map_err(PackageDirsError::from)
+fn resolve_target_dir(
+    configured_target_dir: Option<&Path>,
+    project_root: &Path,
+) -> Result<PathBuf, PackageDirsError> {
+    let target_dir = configured_target_dir
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| project_root.join(BUILD_DIR));
+    if !target_dir.exists() {
+        std::fs::create_dir_all(&target_dir)
+            .context("failed to create target directory")
+            .map_err(PackageDirsError::from)?;
     }
+    dunce::canonicalize(target_dir)
+        .context("failed to set target directory")
+        .map_err(PackageDirsError::from)
 }
 
 /// The project manifest selected during project query.
 ///
 /// Downstream stages should treat this as authoritative instead of rediscovering
 /// whether a directory belongs to a module or workspace.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ProjectManifest {
     None,
     Module(PathBuf),
-    Workspace(PathBuf),
+    Workspace(WorkspaceLayout),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct WorkspaceLayout {
+    manifest_path: PathBuf,
+    root: PathBuf,
+    manifest: MoonWork,
+    members: Vec<PathBuf>,
+}
+
+impl WorkspaceLayout {
+    fn read(manifest_path: PathBuf) -> Result<Self, PackageDirsError> {
+        let root = manifest_path
+            .parent()
+            .context("workspace manifest path has no parent directory")
+            .map(Path::to_path_buf)
+            .map_err(PackageDirsError::from)?;
+        let manifest = MoonWork::read(&manifest_path).map_err(PackageDirsError::from)?;
+        let members =
+            canonical_workspace_module_dirs(&root, &manifest).map_err(PackageDirsError::from)?;
+        Ok(Self {
+            manifest_path,
+            root,
+            manifest,
+            members,
+        })
+    }
+
+    pub fn manifest_path(&self) -> &Path {
+        &self.manifest_path
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn manifest(&self) -> &MoonWork {
+        &self.manifest
+    }
+
+    pub fn members(&self) -> &[PathBuf] {
+        &self.members
+    }
+
+    fn contains_member(&self, module_dir: &Path) -> bool {
+        self.members.iter().any(|member| member == module_dir)
+    }
 }
 
 /// Authoritative directories resolved at the start of a project operation.
@@ -226,6 +276,36 @@ pub struct PackageDirs {
     pub project_manifest: ProjectManifest,
 }
 
+pub struct SelectedProject {
+    context: ProjectContext,
+    target_dir: Option<PathBuf>,
+    workspace: Option<WorkspaceLayout>,
+}
+
+impl SelectedProject {
+    pub fn context(&self) -> &ProjectContext {
+        &self.context
+    }
+
+    pub fn package_dirs(self) -> Result<PackageDirs, PackageDirsError> {
+        let source_dir = self.context.root().to_path_buf();
+        let target_dir = resolve_target_dir(self.target_dir.as_deref(), &source_dir)?;
+        let mooncake_bin_dir = target_dir.join(MOON_BIN_DIR);
+        let mooncakes_dir = source_dir.join(DEP_PATH);
+        let project_manifest = match self.workspace {
+            Some(workspace) => ProjectManifest::Workspace(workspace),
+            None => ProjectManifest::Module(self.context.manifest_path().to_path_buf()),
+        };
+        Ok(PackageDirs {
+            source_dir,
+            target_dir,
+            mooncake_bin_dir,
+            mooncakes_dir,
+            project_manifest,
+        })
+    }
+}
+
 pub struct SingleFilePackageDirs {
     pub file_path: PathBuf,
     pub package_dirs: PackageDirs,
@@ -236,16 +316,11 @@ pub struct SourceModulePackageDirs {
     pub package_dirs: PackageDirs,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WorkRootSelection {
-    CreateWorkspace,
-    ReuseExistingWorkspace,
-}
-
-impl WorkRootSelection {
-    fn prefers_existing_workspace(self) -> bool {
-        matches!(self, Self::ReuseExistingWorkspace)
-    }
+/// Existing workspace state, or the directory where a maintenance command
+/// should create it.
+pub enum WorkspaceEditTarget {
+    CreateAt(PathBuf),
+    Existing(WorkspaceLayout),
 }
 
 #[derive(Debug)]
@@ -267,12 +342,6 @@ impl ProjectNotFound {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModuleRef {
-    pub root: PathBuf,
-    pub manifest_path: PathBuf,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WorkspaceRef {
     pub root: PathBuf,
     pub manifest_path: PathBuf,
 }
@@ -319,31 +388,6 @@ impl ProjectContext {
             }),
         }
     }
-
-    pub fn workspace_ref(&self) -> Option<WorkspaceRef> {
-        match self {
-            Self::Workspace {
-                root,
-                manifest_path,
-                ..
-            } => Some(WorkspaceRef {
-                root: root.clone(),
-                manifest_path: manifest_path.clone(),
-            }),
-            Self::Module { .. } => None,
-        }
-    }
-}
-
-impl From<&ProjectContext> for ProjectManifest {
-    fn from(project: &ProjectContext) -> Self {
-        match project {
-            ProjectContext::Workspace { manifest_path, .. } => {
-                Self::Workspace(manifest_path.clone())
-            }
-            ProjectContext::Module { manifest_path, .. } => Self::Module(manifest_path.clone()),
-        }
-    }
 }
 
 fn has_module_manifest(source_dir: &Path) -> bool {
@@ -357,43 +401,13 @@ fn find_enclosing_module_root(source_dir: &Path) -> Option<PathBuf> {
         .map(|p| p.to_path_buf())
 }
 
-struct WorkspaceFacts {
-    manifest_path: PathBuf,
-    root: PathBuf,
-    manifest: Option<MoonWork>,
-    // Applicability checks already parse and canonicalize members. Retain that
-    // work so selecting the member does not read the manifest a second time.
-    members: Option<Vec<PathBuf>>,
-    // Discovery stays side-effect free. The command consumes this through its
-    // own UserLog when it uses the selected project.
-    preferred_target_deprecation: bool,
-    pending_warning: Option<ProjectDiscoveryWarning>,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum ProjectDiscoveryWarning {
-    ColocatedModuleNotInWorkspace,
-}
-
-impl Display for ProjectDiscoveryWarning {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ColocatedModuleNotInWorkspace => {
-                f.write_str(COLOCATED_MODULE_NOT_IN_WORKSPACE_WARNING)
-            }
-        }
-    }
-}
-
 pub struct ProjectQuery {
-    // Inputs and cheap markers are captured once, then higher-level methods
-    // project only the artifacts their callers ask for.
     target_dir: Option<PathBuf>,
     start_dir: PathBuf,
     workspace_env: WorkspaceEnv,
     module_dir: Option<PathBuf>,
     module_manifest_path: Option<PathBuf>,
-    workspace: Option<WorkspaceFacts>,
+    workspace: Option<WorkspaceLayout>,
 }
 
 fn module_manifest_path(module_dir: &Path) -> PathBuf {
@@ -401,20 +415,6 @@ fn module_manifest_path(module_dir: &Path) -> PathBuf {
         module_dir.join(MOON_MOD)
     } else {
         module_dir.join(MOON_MOD_JSON)
-    }
-}
-
-impl WorkspaceFacts {
-    fn from_manifest_path(manifest_path: PathBuf) -> Result<Self, PackageDirsError> {
-        let root = manifest_root(&manifest_path).map_err(PackageDirsError::from)?;
-        Ok(Self {
-            manifest_path,
-            root,
-            manifest: None,
-            members: None,
-            preferred_target_deprecation: false,
-            pending_warning: None,
-        })
     }
 }
 
@@ -440,9 +440,9 @@ impl ProjectQuery {
                 let manifest_path = dunce::canonicalize(workspace_path)
                     .context("failed to resolve pinned workspace path")
                     .map_err(PackageDirsError::from)?;
-                Some(WorkspaceFacts::from_manifest_path(manifest_path)?)
+                Some(WorkspaceLayout::read(manifest_path)?)
             }
-            WorkspaceEnv::Auto => None,
+            WorkspaceEnv::Auto => find_applicable_workspace(&start_dir)?,
         };
 
         Ok(Self {
@@ -455,7 +455,7 @@ impl ProjectQuery {
         })
     }
 
-    pub fn probe_project(&mut self) -> Result<ProjectProbe, PackageDirsError> {
+    pub fn probe_project(&self) -> Result<ProjectProbe, PackageDirsError> {
         let project_context = self.project_context_from_start_dir();
 
         match project_context {
@@ -467,84 +467,78 @@ impl ProjectQuery {
         }
     }
 
-    pub fn project(&mut self, user_log: &UserLog) -> Result<ProjectContext, PackageDirsError> {
+    pub fn select(self, user_log: &UserLog) -> Result<SelectedProject, PackageDirsError> {
         match self.probe_project()? {
             ProjectProbe::Found(project) => {
-                if matches!(&project, ProjectContext::Workspace { .. }) {
-                    self.ensure_workspace_manifest()?;
-                }
-                self.emit_pending_warnings(user_log);
-                Ok(project)
+                self.emit_workspace_warnings(user_log);
+                Ok(SelectedProject {
+                    context: project,
+                    target_dir: self.target_dir,
+                    workspace: self.workspace,
+                })
             }
             ProjectProbe::NotFound(not_found) => Err(not_found.into_error()),
         }
     }
 
-    pub fn package_dirs(&mut self, user_log: &UserLog) -> Result<PackageDirs, PackageDirsError> {
-        let project = self.project(user_log)?;
-        let target_dir = self.resolve_target_dir(project.root())?;
-        let mooncake_bin_dir = target_dir.join(MOON_BIN_DIR);
-        let source_dir = project.root().to_path_buf();
-        let mooncakes_dir = source_dir.join(DEP_PATH);
-        Ok(PackageDirs {
-            source_dir,
-            target_dir,
-            mooncake_bin_dir,
-            mooncakes_dir,
-            project_manifest: ProjectManifest::from(&project),
-        })
-    }
-
-    pub fn workspace_ref(
-        &mut self,
+    fn workspace_edit_target(
+        self,
         user_log: &UserLog,
-    ) -> Result<Option<WorkspaceRef>, PackageDirsError> {
-        Ok(self.project(user_log)?.workspace_ref())
-    }
-
-    pub fn work_root(
-        &mut self,
-        selection: WorkRootSelection,
-        user_log: &UserLog,
-    ) -> Result<PathBuf, PackageDirsError> {
-        if selection.prefers_existing_workspace()
-            && let Some(work_root) = self.workspace_root_for_sync()?
-        {
-            self.ensure_workspace_manifest()?;
-            self.emit_pending_warnings(user_log);
-            return Ok(work_root);
+    ) -> Result<WorkspaceEditTarget, PackageDirsError> {
+        if self.workspace.is_some() {
+            // Pinned workspaces still need the same applicability validation as
+            // normal project selection before a maintenance command edits them.
+            self.project_context_from_start_dir()?;
+            self.emit_workspace_warnings(user_log);
+            return Ok(WorkspaceEditTarget::Existing(
+                self.workspace
+                    .expect("workspace was present before maintenance selection"),
+            ));
         }
 
-        let start_dir = self.work_start_dir();
-        if let Some(module_dir) = find_enclosing_module_root(&start_dir) {
-            Ok(module_dir)
-        } else {
-            Ok(start_dir)
+        let root = self.workspace_creation_root();
+        let Some(manifest_path) = workspace_manifest_path(&root) else {
+            return Ok(WorkspaceEditTarget::CreateAt(root));
+        };
+
+        // `MOON_WORK=off` disables project selection, but workspace maintenance
+        // still operates on an existing moon.work at the local module root.
+        let workspace = WorkspaceLayout::read(manifest_path)?;
+        if workspace.manifest().preferred_target.is_some() {
+            user_log.warn(PREFERRED_TARGET_DEPRECATION_WARNING);
         }
+        Ok(WorkspaceEditTarget::Existing(workspace))
     }
 
-    fn project_context_from_start_dir(&mut self) -> Result<ProjectContext, PackageDirsError> {
+    fn workspace_creation_root(self) -> PathBuf {
+        self.module_dir.unwrap_or(self.start_dir)
+    }
+
+    fn project_context_from_start_dir(&self) -> Result<ProjectContext, PackageDirsError> {
         match &self.workspace_env {
             WorkspaceEnv::Off => {
                 self.module_context_with_workspace_disabled(self.start_dir.clone())
             }
             WorkspaceEnv::Pinned(_) => {
-                let workspace = self.pinned_workspace_ref();
+                let workspace = self
+                    .workspace
+                    .as_ref()
+                    .expect("pinned workspace discovery must include a workspace layout");
                 let module_dir = match self.module_dir.clone() {
                     // When invoked at a pinned workspace root nested under an
                     // unrelated module, the outer module is not the selection.
                     Some(module_dir)
-                        if self.start_dir.starts_with(&workspace.root)
-                            && !module_dir.starts_with(&workspace.root) =>
+                        if self.start_dir.starts_with(workspace.root())
+                            && !module_dir.starts_with(workspace.root()) =>
                     {
                         None
                     }
                     Some(module_dir) => {
-                        if self.workspace_contains_member(&module_dir)? {
+                        if workspace.contains_member(&module_dir) {
                             Some(module_dir)
                         } else {
                             return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
-                                workspace: workspace.manifest_path.clone(),
+                                workspace: workspace.manifest_path().to_path_buf(),
                                 module: module_dir,
                             });
                         }
@@ -553,8 +547,8 @@ impl ProjectQuery {
                 };
 
                 Ok(ProjectContext::Workspace {
-                    root: workspace.root.clone(),
-                    manifest_path: workspace.manifest_path.clone(),
+                    root: workspace.root().to_path_buf(),
+                    manifest_path: workspace.manifest_path().to_path_buf(),
                     selected_module: module_dir.map(|root| ModuleRef {
                         manifest_path: module_manifest_path(&root),
                         root,
@@ -562,22 +556,19 @@ impl ProjectQuery {
                 })
             }
             WorkspaceEnv::Auto => {
-                let start_dir = self.start_dir.clone();
-                if let Some(workspace) = self.find_applicable_workspace_from(&start_dir)? {
+                if let Some(workspace) = &self.workspace {
                     return Ok(ProjectContext::Workspace {
-                        root: workspace.root.clone(),
-                        manifest_path: workspace.manifest_path.clone(),
+                        root: workspace.root().to_path_buf(),
+                        manifest_path: workspace.manifest_path().to_path_buf(),
                         // Only explicit workspace members may become selected modules.
                         selected_module: match self.module_dir.clone() {
-                            Some(root) if self.workspace_contains_member(&root)? => {
-                                Some(ModuleRef {
-                                    manifest_path: self
-                                        .module_manifest_path
-                                        .clone()
-                                        .unwrap_or_else(|| module_manifest_path(&root)),
-                                    root,
-                                })
-                            }
+                            Some(root) if workspace.contains_member(&root) => Some(ModuleRef {
+                                manifest_path: self
+                                    .module_manifest_path
+                                    .clone()
+                                    .unwrap_or_else(|| module_manifest_path(&root)),
+                                root,
+                            }),
                             _ => None,
                         },
                     });
@@ -617,141 +608,18 @@ impl ProjectQuery {
         })
     }
 
-    fn workspace_root_for_sync(&mut self) -> Result<Option<PathBuf>, PackageDirsError> {
-        match &self.workspace_env {
-            WorkspaceEnv::Off => Ok(None),
-            WorkspaceEnv::Auto => {
-                let start_dir = self.work_start_dir();
-                Ok(self
-                    .find_applicable_workspace_from(&start_dir)?
-                    .map(|workspace| workspace.root))
-            }
-            WorkspaceEnv::Pinned(_) => {
-                let workspace = self.pinned_workspace_ref();
-                let start_dir = self.work_start_dir();
-                if start_dir.starts_with(&workspace.root) {
-                    if let Some(module_dir) = self.module_dir.clone()
-                        && module_dir.starts_with(&workspace.root)
-                        && !self.workspace_contains_member(&module_dir)?
-                    {
-                        return Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
-                            workspace: workspace.manifest_path.clone(),
-                            module: module_dir,
-                        });
-                    }
-                    return Ok(Some(workspace.root.clone()));
-                }
-
-                let Some(module_dir) = self.module_dir.clone() else {
-                    return Ok(Some(workspace.root.clone()));
-                };
-                if self.workspace_contains_member(&module_dir)? {
-                    Ok(Some(workspace.root.clone()))
-                } else {
-                    Err(PackageDirsError::PinnedWorkspaceDoesNotApply {
-                        workspace: workspace.manifest_path.clone(),
-                        module: module_dir,
-                    })
-                }
-            }
-        }
-    }
-
-    fn resolve_target_dir(&self, project_root: &Path) -> Result<PathBuf, PackageDirsError> {
-        let target_dir = self
-            .target_dir
-            .clone()
-            .unwrap_or_else(|| project_root.join(BUILD_DIR));
-        if !target_dir.exists() {
-            std::fs::create_dir_all(&target_dir)
-                .context("failed to create target directory")
-                .map_err(PackageDirsError::from)?;
-        }
-        dunce::canonicalize(target_dir)
-            .context("failed to set target directory")
-            .map_err(PackageDirsError::from)
-    }
-
-    fn workspace_contains_member(&mut self, module_dir: &Path) -> Result<bool, PackageDirsError> {
-        Ok(self
-            .ensure_workspace_members()?
-            .is_some_and(|members| members.iter().any(|member_dir| member_dir == module_dir)))
-    }
-
-    fn find_applicable_workspace_from(
-        &mut self,
-        source_dir: &Path,
-    ) -> Result<Option<WorkspaceRef>, PackageDirsError> {
-        if self.workspace.is_none() {
-            self.workspace =
-                find_applicable_workspace(source_dir).map_err(PackageDirsError::from)?;
-        }
-        Ok(self.workspace.as_ref().map(|workspace| WorkspaceRef {
-            root: workspace.root.clone(),
-            manifest_path: workspace.manifest_path.clone(),
-        }))
-    }
-
-    fn emit_pending_warnings(&mut self, user_log: &UserLog) {
-        let Some(workspace) = self.workspace.as_mut() else {
+    fn emit_workspace_warnings(&self, user_log: &UserLog) {
+        let Some(workspace) = &self.workspace else {
             return;
         };
-        if std::mem::take(&mut workspace.preferred_target_deprecation) {
+        if workspace.manifest().preferred_target.is_some() {
             user_log.warn(PREFERRED_TARGET_DEPRECATION_WARNING);
         }
-        if let Some(warning) = workspace.pending_warning.take() {
-            user_log.warn(warning);
-        }
-    }
-
-    fn ensure_workspace_members(&mut self) -> Result<Option<&[PathBuf]>, PackageDirsError> {
-        let Some(workspace) = &self.workspace else {
-            return Ok(None);
-        };
-        if workspace.members.is_none() {
-            let moon_work = self.ensure_workspace_manifest()?.clone();
-            let workspace = self
-                .workspace
-                .as_mut()
-                .expect("workspace was present before loading its manifest");
-            let member_dirs = canonical_workspace_module_dirs(&workspace.root, &moon_work)
-                .map_err(PackageDirsError::from)?;
-            workspace.members = Some(member_dirs);
-        }
-        Ok(self
-            .workspace
-            .as_ref()
-            .and_then(|workspace| workspace.members.as_deref()))
-    }
-
-    fn ensure_workspace_manifest(&mut self) -> Result<&MoonWork, PackageDirsError> {
-        let Some(workspace) = &mut self.workspace else {
-            unreachable!("workspace manifest requested outside workspace mode");
-        };
-        if workspace.manifest.is_none() {
-            let manifest =
-                read_workspace_file(&workspace.manifest_path).map_err(PackageDirsError::from)?;
-            workspace.preferred_target_deprecation = manifest.preferred_target.is_some();
-            workspace.manifest = Some(manifest);
-        }
-        Ok(workspace
-            .manifest
-            .as_ref()
-            .expect("workspace manifest was just loaded"))
-    }
-
-    fn work_start_dir(&self) -> PathBuf {
-        self.start_dir.clone()
-    }
-
-    fn pinned_workspace_ref(&self) -> WorkspaceRef {
-        let workspace = self
-            .workspace
-            .as_ref()
-            .expect("pinned workspace discovery must include workspace facts");
-        WorkspaceRef {
-            root: workspace.root.clone(),
-            manifest_path: workspace.manifest_path.clone(),
+        if matches!(self.workspace_env, WorkspaceEnv::Auto)
+            && self.module_dir.as_deref() == Some(workspace.root())
+            && !workspace.contains_member(workspace.root())
+        {
+            user_log.warn(COLOCATED_MODULE_NOT_IN_WORKSPACE_WARNING);
         }
     }
 }
@@ -773,8 +641,9 @@ fn resolve_project_context_from_start_dir(
     start_dir: PathBuf,
     workspace_env: &WorkspaceEnv,
 ) -> Result<ProjectContext, PackageDirsError> {
-    project_query_from_start_dir(start_dir, workspace_env)?
-        .project(&UserLog::new(log::LevelFilter::Error))
+    let selected = project_query_from_start_dir(start_dir, workspace_env)?
+        .select(&UserLog::new(log::LevelFilter::Error))?;
+    Ok(selected.context)
 }
 
 pub fn current_workspace_env() -> anyhow::Result<(WorkspaceEnv, Option<&'static str>)> {
@@ -849,7 +718,9 @@ fn canonicalize_workspace_env_path(path: PathBuf) -> anyhow::Result<PathBuf> {
 
     Ok(path)
 }
-fn find_applicable_workspace(source_dir: &Path) -> anyhow::Result<Option<WorkspaceFacts>> {
+fn find_applicable_workspace(
+    source_dir: &Path,
+) -> Result<Option<WorkspaceLayout>, PackageDirsError> {
     let mut module_root = None;
 
     for dir in source_dir.ancestors() {
@@ -860,64 +731,31 @@ fn find_applicable_workspace(source_dir: &Path) -> anyhow::Result<Option<Workspa
             continue;
         };
 
+        let workspace = WorkspaceLayout::read(workspace_path)?;
+
         if let Some(module_root) = module_root {
-            let workspace = read_workspace_file(&workspace_path)?;
-            let members = canonical_workspace_module_dirs(dir, &workspace)?;
-            if members.iter().any(|member_dir| member_dir == module_root) {
-                let preferred_target_deprecation = workspace.preferred_target.is_some();
-                return Ok(Some(WorkspaceFacts {
-                    manifest_path: workspace_path,
-                    root: dir.to_path_buf(),
-                    manifest: Some(workspace),
-                    members: Some(members),
-                    preferred_target_deprecation,
-                    pending_warning: None,
-                }));
+            if workspace
+                .members()
+                .iter()
+                .any(|member_dir| member_dir == module_root)
+            {
+                return Ok(Some(workspace));
             }
             continue;
         }
 
-        if has_module_manifest(dir) {
-            let workspace = read_workspace_file(&workspace_path)?;
-            let members = canonical_workspace_module_dirs(dir, &workspace)?;
-            let module_not_member = !members.iter().any(|member_dir| member_dir == dir);
-            let preferred_target_deprecation = workspace.preferred_target.is_some();
-            return Ok(Some(WorkspaceFacts {
-                manifest_path: workspace_path,
-                root: dir.to_path_buf(),
-                manifest: Some(workspace),
-                members: Some(members),
-                preferred_target_deprecation,
-                pending_warning: module_not_member
-                    .then_some(ProjectDiscoveryWarning::ColocatedModuleNotInWorkspace),
-            }));
-        }
-
-        return Ok(Some(WorkspaceFacts {
-            manifest_path: workspace_path,
-            root: dir.to_path_buf(),
-            manifest: None,
-            members: None,
-            preferred_target_deprecation: false,
-            pending_warning: None,
-        }));
+        return Ok(Some(workspace));
     }
 
     Ok(None)
 }
 
-fn manifest_root(manifest_path: &Path) -> anyhow::Result<PathBuf> {
-    manifest_path
-        .parent()
-        .context("manifest path has no parent directory")
-        .map(Path::to_path_buf)
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
-        PackageDirsError, ProjectContext, ProjectProbe, SourceTargetDirs, WorkspaceEnv,
-        parse_workspace_env, project_query_from_start_dir, resolve_project_context_from_start_dir,
+        PackageDirsError, ProjectContext, ProjectManifest, ProjectProbe, SourceTargetDirs,
+        WorkspaceEnv, parse_workspace_env, project_query_from_start_dir,
+        resolve_project_context_from_start_dir,
     };
     use crate::constants::{DEP_PATH, MOON_BIN_DIR, MOON_MOD, MOON_MOD_JSON};
     use std::{
@@ -1027,9 +865,8 @@ version = "0.1.0"
     #[test]
     fn project_probe_reports_not_found_without_project() {
         let project = tempfile::tempdir().expect("create test project");
-        let mut query =
-            project_query_from_start_dir(project.path().to_path_buf(), &WorkspaceEnv::Auto)
-                .unwrap();
+        let query = project_query_from_start_dir(project.path().to_path_buf(), &WorkspaceEnv::Auto)
+            .unwrap();
 
         let ProjectProbe::NotFound(not_found) = query.probe_project().unwrap() else {
             panic!("expected project probe to report not found");
@@ -1038,6 +875,39 @@ version = "0.1.0"
             not_found.into_error(),
             PackageDirsError::NotInProject(path) if path == canonical(project.path())
         ));
+    }
+
+    #[test]
+    fn selected_workspace_uses_the_layout_loaded_during_query() {
+        let project = tempfile::tempdir().expect("create test project");
+        write_file(
+            &project.path().join("moon.work"),
+            r#"members = [
+  "./app",
+]
+"#,
+        );
+        write_json_module(&project.path().join("app"), "alice/app");
+
+        let query =
+            project_query_from_start_dir(project.path().join("app"), &WorkspaceEnv::Auto).unwrap();
+
+        // Once discovery has selected a workspace, later phases consume that
+        // exact layout instead of reopening moon.work.
+        write_file(&project.path().join("moon.work"), "invalid = [");
+        let dirs = query
+            .select(&crate::user_log::UserLog::new(log::LevelFilter::Error))
+            .unwrap()
+            .package_dirs()
+            .unwrap();
+
+        let ProjectManifest::Workspace(workspace) = dirs.project_manifest else {
+            panic!("expected workspace project manifest");
+        };
+        assert_eq!(
+            workspace.members(),
+            &[canonical(project.path().join("app"))]
+        );
     }
 
     #[test]

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -32,8 +32,8 @@ use crate::constants::{
 };
 use crate::user_log::UserLog;
 use crate::workspace::{
-    PREFERRED_TARGET_DEPRECATION_WARNING, canonical_workspace_module_dirs, read_workspace_file,
-    workspace_manifest_path,
+    MoonWork, PREFERRED_TARGET_DEPRECATION_WARNING, canonical_workspace_module_dirs,
+    read_workspace_file, workspace_manifest_path,
 };
 
 const COLOCATED_MODULE_NOT_IN_WORKSPACE_WARNING: &str = "`moon.work` takes precedence over the module manifest in the same directory, but that module is not listed as a workspace member. Add `.` to `members` to select it from the workspace root.";
@@ -360,6 +360,7 @@ fn find_enclosing_module_root(source_dir: &Path) -> Option<PathBuf> {
 struct WorkspaceFacts {
     manifest_path: PathBuf,
     root: PathBuf,
+    manifest: Option<MoonWork>,
     // Applicability checks already parse and canonicalize members. Retain that
     // work so selecting the member does not read the manifest a second time.
     members: Option<Vec<PathBuf>>,
@@ -409,6 +410,7 @@ impl WorkspaceFacts {
         Ok(Self {
             manifest_path,
             root,
+            manifest: None,
             members: None,
             preferred_target_deprecation: false,
             pending_warning: None,
@@ -468,6 +470,9 @@ impl ProjectQuery {
     pub fn project(&mut self, user_log: &UserLog) -> Result<ProjectContext, PackageDirsError> {
         match self.probe_project()? {
             ProjectProbe::Found(project) => {
+                if matches!(&project, ProjectContext::Workspace { .. }) {
+                    self.ensure_workspace_manifest()?;
+                }
                 self.emit_pending_warnings(user_log);
                 Ok(project)
             }
@@ -505,6 +510,7 @@ impl ProjectQuery {
         if selection.prefers_existing_workspace()
             && let Some(work_root) = self.workspace_root_for_sync()?
         {
+            self.ensure_workspace_manifest()?;
             self.emit_pending_warnings(user_log);
             return Ok(work_root);
         }
@@ -691,7 +697,7 @@ impl ProjectQuery {
             return;
         };
         if std::mem::take(&mut workspace.preferred_target_deprecation) {
-            user_log.warn_once(PREFERRED_TARGET_DEPRECATION_WARNING);
+            user_log.warn(PREFERRED_TARGET_DEPRECATION_WARNING);
         }
         if let Some(warning) = workspace.pending_warning.take() {
             user_log.warn(warning);
@@ -699,23 +705,39 @@ impl ProjectQuery {
     }
 
     fn ensure_workspace_members(&mut self) -> Result<Option<&[PathBuf]>, PackageDirsError> {
-        let Some(workspace) = &mut self.workspace else {
+        let Some(workspace) = &self.workspace else {
             return Ok(None);
         };
         if workspace.members.is_none() {
-            let moon_work = read_workspace_file(
-                &workspace.manifest_path,
-                &UserLog::new(log::LevelFilter::Error),
-            )
-            .map_err(PackageDirsError::from)?;
-            if moon_work.preferred_target.is_some() {
-                workspace.preferred_target_deprecation = true;
-            }
+            let moon_work = self.ensure_workspace_manifest()?.clone();
+            let workspace = self
+                .workspace
+                .as_mut()
+                .expect("workspace was present before loading its manifest");
             let member_dirs = canonical_workspace_module_dirs(&workspace.root, &moon_work)
                 .map_err(PackageDirsError::from)?;
             workspace.members = Some(member_dirs);
         }
-        Ok(workspace.members.as_deref())
+        Ok(self
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.members.as_deref()))
+    }
+
+    fn ensure_workspace_manifest(&mut self) -> Result<&MoonWork, PackageDirsError> {
+        let Some(workspace) = &mut self.workspace else {
+            unreachable!("workspace manifest requested outside workspace mode");
+        };
+        if workspace.manifest.is_none() {
+            let manifest =
+                read_workspace_file(&workspace.manifest_path).map_err(PackageDirsError::from)?;
+            workspace.preferred_target_deprecation = manifest.preferred_target.is_some();
+            workspace.manifest = Some(manifest);
+        }
+        Ok(workspace
+            .manifest
+            .as_ref()
+            .expect("workspace manifest was just loaded"))
     }
 
     fn work_start_dir(&self) -> PathBuf {
@@ -839,15 +861,16 @@ fn find_applicable_workspace(source_dir: &Path) -> anyhow::Result<Option<Workspa
         };
 
         if let Some(module_root) = module_root {
-            let workspace =
-                read_workspace_file(&workspace_path, &UserLog::new(log::LevelFilter::Error))?;
+            let workspace = read_workspace_file(&workspace_path)?;
             let members = canonical_workspace_module_dirs(dir, &workspace)?;
             if members.iter().any(|member_dir| member_dir == module_root) {
+                let preferred_target_deprecation = workspace.preferred_target.is_some();
                 return Ok(Some(WorkspaceFacts {
                     manifest_path: workspace_path,
                     root: dir.to_path_buf(),
+                    manifest: Some(workspace),
                     members: Some(members),
-                    preferred_target_deprecation: workspace.preferred_target.is_some(),
+                    preferred_target_deprecation,
                     pending_warning: None,
                 }));
             }
@@ -855,15 +878,16 @@ fn find_applicable_workspace(source_dir: &Path) -> anyhow::Result<Option<Workspa
         }
 
         if has_module_manifest(dir) {
-            let workspace =
-                read_workspace_file(&workspace_path, &UserLog::new(log::LevelFilter::Error))?;
+            let workspace = read_workspace_file(&workspace_path)?;
             let members = canonical_workspace_module_dirs(dir, &workspace)?;
             let module_not_member = !members.iter().any(|member_dir| member_dir == dir);
+            let preferred_target_deprecation = workspace.preferred_target.is_some();
             return Ok(Some(WorkspaceFacts {
                 manifest_path: workspace_path,
                 root: dir.to_path_buf(),
+                manifest: Some(workspace),
                 members: Some(members),
-                preferred_target_deprecation: workspace.preferred_target.is_some(),
+                preferred_target_deprecation,
                 pending_warning: module_not_member
                     .then_some(ProjectDiscoveryWarning::ColocatedModuleNotInWorkspace),
             }));
@@ -872,6 +896,7 @@ fn find_applicable_workspace(source_dir: &Path) -> anyhow::Result<Option<Workspa
         return Ok(Some(WorkspaceFacts {
             manifest_path: workspace_path,
             root: dir.to_path_buf(),
+            manifest: None,
             members: None,
             preferred_target_deprecation: false,
             pending_warning: None,

--- a/crates/moonutil/src/package.rs
+++ b/crates/moonutil/src/package.rs
@@ -777,14 +777,6 @@ impl Import {
     }
 }
 
-/// Convert moon.pkg DSL (with `options` key) to MoonPkg struct
-pub fn convert_pkg_dsl_to_package(
-    dsl: moon_pkg::Dsl,
-    user_log: &UserLog,
-) -> anyhow::Result<MoonPkg> {
-    Ok(convert_pkg_dsl_to_package_with_supported_targets_decl(dsl, true, user_log)?.0)
-}
-
 pub fn convert_pkg_dsl_to_package_with_supported_targets_decl(
     dsl: moon_pkg::Dsl,
     emit_warnings: bool,

--- a/crates/moonutil/src/package.rs
+++ b/crates/moonutil/src/package.rs
@@ -777,7 +777,18 @@ impl Import {
     }
 }
 
-pub fn convert_pkg_dsl_to_package_with_supported_targets_decl(
+/// Convert a parsed `moon.pkg` into the package model used by ordinary callers.
+///
+/// Whether `supported_targets` used the legacy or current spelling is migration
+/// metadata needed by manifest loading, not part of normal package conversion.
+pub fn convert_pkg_dsl_to_package(
+    dsl: moon_pkg::Dsl,
+    user_log: &UserLog,
+) -> anyhow::Result<MoonPkg> {
+    Ok(convert_pkg_dsl_to_package_with_supported_targets_decl(dsl, true, user_log)?.0)
+}
+
+pub(crate) fn convert_pkg_dsl_to_package_with_supported_targets_decl(
     dsl: moon_pkg::Dsl,
     emit_warnings: bool,
     user_log: &UserLog,

--- a/crates/moonutil/src/project.rs
+++ b/crates/moonutil/src/project.rs
@@ -27,6 +27,6 @@ pub use crate::dirs::{
     WorkRootSelection, WorkspaceEnv, WorkspaceRef, current_workspace_env,
 };
 pub use crate::workspace::{
-    MoonWork, canonical_workspace_module_dirs, format_workspace, read_workspace_file,
-    workspace_manifest_path, write_workspace,
+    MoonWork, canonical_workspace_module_dirs, read_workspace_file, workspace_manifest_path,
+    write_workspace,
 };

--- a/crates/moonutil/src/project.rs
+++ b/crates/moonutil/src/project.rs
@@ -27,6 +27,6 @@ pub use crate::dirs::{
     WorkRootSelection, WorkspaceEnv, WorkspaceRef, current_workspace_env,
 };
 pub use crate::workspace::{
-    MoonWork, canonical_workspace_module_dirs, format_workspace_file, read_workspace,
-    read_workspace_file, workspace_manifest_path, write_workspace,
+    MoonWork, canonical_workspace_module_dirs, format_workspace, read_workspace_file,
+    workspace_manifest_path, write_workspace,
 };

--- a/crates/moonutil/src/project.rs
+++ b/crates/moonutil/src/project.rs
@@ -23,10 +23,9 @@
 
 pub use crate::dirs::{
     ModuleRef, PackageDirs, PackageDirsError, ProjectContext, ProjectManifest, ProjectNotFound,
-    ProjectProbe, ProjectQuery, SingleFilePackageDirs, SourceModulePackageDirs, SourceTargetDirs,
-    WorkRootSelection, WorkspaceEnv, WorkspaceRef, current_workspace_env,
+    ProjectProbe, ProjectQuery, SelectedProject, SingleFilePackageDirs, SourceModulePackageDirs,
+    SourceTargetDirs, WorkspaceEditTarget, WorkspaceEnv, WorkspaceLayout, current_workspace_env,
 };
 pub use crate::workspace::{
-    MoonWork, canonical_workspace_module_dirs, read_workspace_file, workspace_manifest_path,
-    write_workspace,
+    MoonWork, canonical_workspace_module_dirs, workspace_manifest_path, write_workspace,
 };

--- a/crates/moonutil/src/user_log.rs
+++ b/crates/moonutil/src/user_log.rs
@@ -17,7 +17,6 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use std::{
-    collections::HashSet,
     fmt::Display,
     io::Write,
     sync::{Arc, Mutex},
@@ -66,7 +65,6 @@ enum UserLogDestination {
 pub struct UserLog {
     level: LevelFilter,
     destination: UserLogDestination,
-    emitted_once: Arc<Mutex<HashSet<String>>>,
 }
 
 /// Maps legacy CLI verbosity flags to the shared user-log level.
@@ -87,7 +85,6 @@ impl UserLog {
         Self {
             level,
             destination: UserLogDestination::Stderr,
-            emitted_once: Default::default(),
         }
     }
 
@@ -97,7 +94,6 @@ impl UserLog {
             Self {
                 level,
                 destination: UserLogDestination::Capture(capture.clone()),
-                emitted_once: Default::default(),
             },
             capture,
         )
@@ -107,7 +103,6 @@ impl UserLog {
         Self {
             level,
             destination: self.destination.clone(),
-            emitted_once: Arc::clone(&self.emitted_once),
         }
     }
 
@@ -154,21 +149,6 @@ impl UserLog {
                     message: message.to_string(),
                 }),
             UserLogDestination::Capture(_) => {}
-        }
-    }
-
-    pub fn warn_once(&self, message: impl Display) {
-        if self.level < LevelFilter::Warn {
-            return;
-        }
-        let message = message.to_string();
-        if self
-            .emitted_once
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(message.clone())
-        {
-            self.warn(message);
         }
     }
 
@@ -299,22 +279,6 @@ mod tests {
         let (quiet, capture) = UserLog::captured(LevelFilter::Error);
         quiet.status("hidden");
         assert!(capture.take().is_empty());
-    }
-
-    #[test]
-    fn cloned_logs_share_once_warnings_without_quiet_consuming_them() {
-        let (output, capture) = UserLog::captured(LevelFilter::Warn);
-
-        output
-            .with_level(LevelFilter::Error)
-            .warn_once("deprecated option");
-        output.clone().warn_once("deprecated option");
-        output.warn_once("deprecated option");
-
-        let entries = capture.take();
-        assert_eq!(entries.len(), 1);
-        assert!(matches!(entries[0].level, UserLogEntryLevel::Warning));
-        assert_eq!(entries[0].message, "deprecated option");
     }
 
     #[test]

--- a/crates/moonutil/src/workspace.rs
+++ b/crates/moonutil/src/workspace.rs
@@ -26,9 +26,9 @@ use std::{
 use anyhow::Context;
 use serde::{Deserialize, Deserializer};
 
-use crate::{constants::MOON_WORK, moon_pkg, target::TargetBackend, user_log::UserLog};
+use crate::{constants::MOON_WORK, moon_pkg, target::TargetBackend};
 
-pub(crate) const PREFERRED_TARGET_DEPRECATION_WARNING: &str = "`preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.";
+pub const PREFERRED_TARGET_DEPRECATION_WARNING: &str = "`preferred_target` in `moon.work` is deprecated. Set `preferred_target` in each module manifest instead.";
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -71,32 +71,14 @@ pub fn workspace_manifest_path(dir: &Path) -> Option<PathBuf> {
     dsl.exists().then_some(dsl)
 }
 
-pub fn read_workspace(dir: &Path, user_log: &UserLog) -> anyhow::Result<Option<MoonWork>> {
-    let Some(path) = workspace_manifest_path(dir) else {
-        return Ok(None);
-    };
-
-    read_workspace_file(&path, user_log).map(Some)
-}
-
-pub fn read_workspace_file(path: &Path, user_log: &UserLog) -> anyhow::Result<MoonWork> {
+pub fn read_workspace_file(path: &Path) -> anyhow::Result<MoonWork> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read workspace file `{}`", path.display()))?;
-    let workspace = parse_workspace_file_content(path, &content)?;
-    if workspace.preferred_target.is_some() {
-        user_log.warn_once(PREFERRED_TARGET_DEPRECATION_WARNING);
-    }
-    Ok(workspace)
+    parse_workspace_file_content(path, &content)
 }
 
-pub fn format_workspace_file(path: &Path, user_log: &UserLog) -> anyhow::Result<String> {
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read workspace file `{}`", path.display()))?;
-    let workspace = parse_workspace_file_content(path, &content)?;
-    if workspace.preferred_target.is_some() {
-        user_log.warn_once(PREFERRED_TARGET_DEPRECATION_WARNING);
-    }
-    format_workspace_dsl_for_moon_fmt(&workspace)
+pub fn format_workspace(workspace: &MoonWork) -> anyhow::Result<String> {
+    format_workspace_dsl_for_moon_fmt(workspace)
 }
 
 fn parse_workspace_file_content(path: &Path, content: &str) -> anyhow::Result<MoonWork> {

--- a/crates/moonutil/src/workspace.rs
+++ b/crates/moonutil/src/workspace.rs
@@ -39,6 +39,23 @@ pub struct MoonWork {
     pub preferred_target: Option<TargetBackend>,
 }
 
+impl MoonWork {
+    pub fn read(path: &Path) -> anyhow::Result<Self> {
+        if path.file_name().and_then(|name| name.to_str()) != Some(MOON_WORK) {
+            anyhow::bail!(
+                "expected workspace file to be `{}`, got `{}`",
+                MOON_WORK,
+                path.display()
+            );
+        }
+
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read workspace file `{}`", path.display()))?;
+        parse_workspace_dsl(&content)
+            .with_context(|| format!("failed to parse workspace file `{}`", path.display()))
+    }
+}
+
 fn deserialize_preferred_target<'de, D>(deserializer: D) -> Result<Option<TargetBackend>, D::Error>
 where
     D: Deserializer<'de>,
@@ -71,24 +88,6 @@ pub fn workspace_manifest_path(dir: &Path) -> Option<PathBuf> {
     dsl.exists().then_some(dsl)
 }
 
-pub fn read_workspace_file(path: &Path) -> anyhow::Result<MoonWork> {
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read workspace file `{}`", path.display()))?;
-    parse_workspace_file_content(path, &content)
-}
-
-fn parse_workspace_file_content(path: &Path, content: &str) -> anyhow::Result<MoonWork> {
-    match path.file_name().and_then(|name| name.to_str()) {
-        Some(MOON_WORK) => parse_workspace_dsl(content),
-        _ => anyhow::bail!(
-            "expected workspace file to be `{}`, got `{}`",
-            MOON_WORK,
-            path.display()
-        ),
-    }
-    .with_context(|| format!("failed to parse workspace file `{}`", path.display()))
-}
-
 pub fn write_workspace(dir: &Path, work: &MoonWork) -> anyhow::Result<()> {
     let path = dir.join(MOON_WORK);
     let file = File::create(path)?;
@@ -115,6 +114,12 @@ pub fn canonical_workspace_module_dirs(
                 workspace_root.display()
             )
         })?;
+        if !path.is_dir() {
+            anyhow::bail!(
+                "workspace member `{}` is not a directory",
+                use_path.display()
+            );
+        }
         deduped.insert(path);
     }
 
@@ -201,6 +206,23 @@ mod tests {
 
         assert!(parsed.use_paths.is_empty());
         assert_eq!(parsed.preferred_target, None);
+    }
+
+    #[test]
+    fn workspace_members_must_be_directories() {
+        let workspace_root = tempfile::tempdir().unwrap();
+        std::fs::write(workspace_root.path().join("member.mbt"), "").unwrap();
+        let workspace = MoonWork {
+            use_paths: vec![PathBuf::from("member.mbt")],
+            preferred_target: None,
+        };
+
+        let error = canonical_workspace_module_dirs(workspace_root.path(), &workspace).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "workspace member `member.mbt` is not a directory"
+        );
     }
 
     #[test]

--- a/crates/moonutil/src/workspace.rs
+++ b/crates/moonutil/src/workspace.rs
@@ -77,10 +77,6 @@ pub fn read_workspace_file(path: &Path) -> anyhow::Result<MoonWork> {
     parse_workspace_file_content(path, &content)
 }
 
-pub fn format_workspace(workspace: &MoonWork) -> anyhow::Result<String> {
-    format_workspace_dsl_for_moon_fmt(workspace)
-}
-
 fn parse_workspace_file_content(path: &Path, content: &str) -> anyhow::Result<MoonWork> {
     match path.file_name().and_then(|name| name.to_str()) {
         Some(MOON_WORK) => parse_workspace_dsl(content),
@@ -138,7 +134,7 @@ fn parse_workspace_dsl(content: &str) -> anyhow::Result<MoonWork> {
     Ok(workspace)
 }
 
-fn format_workspace_members(work: &MoonWork) -> anyhow::Result<String> {
+pub fn format_workspace_members(work: &MoonWork) -> anyhow::Result<String> {
     let mut out = String::new();
 
     if work.use_paths.is_empty() {
@@ -168,10 +164,6 @@ fn format_workspace_dsl(work: &MoonWork) -> anyhow::Result<String> {
     }
 
     Ok(out)
-}
-
-fn format_workspace_dsl_for_moon_fmt(work: &MoonWork) -> anyhow::Result<String> {
-    format_workspace_members(work)
 }
 
 fn write_text_with_trailing_newline(writer: &mut impl Write, content: &str) -> anyhow::Result<()> {
@@ -232,7 +224,7 @@ mod tests {
             preferred_target: Some(TargetBackend::WasmGC),
         };
 
-        let json = format_workspace_dsl_for_moon_fmt(&workspace).unwrap();
+        let json = format_workspace_members(&workspace).unwrap();
         assert_eq!(json, "members = [\n  \"./app/main\",\n]\n");
     }
 

--- a/crates/moonutil/tests/expect_moon_pkg.rs
+++ b/crates/moonutil/tests/expect_moon_pkg.rs
@@ -19,12 +19,13 @@
 fn run(source: &str) -> String {
     moonutil::moon_pkg::parse(source)
         .and_then(|dsl| {
-            moonutil::package::convert_pkg_dsl_to_package(
+            moonutil::package::convert_pkg_dsl_to_package_with_supported_targets_decl(
                 dsl,
+                true,
                 &moonutil::user_log::UserLog::new(log::LevelFilter::Error),
             )
         })
-        .map(|pkg| format!("{:#?}", pkg))
+        .map(|(pkg, _)| format!("{:#?}", pkg))
         .unwrap_or_else(|e| format!("Error: {:?}", e))
 }
 

--- a/crates/moonutil/tests/expect_moon_pkg.rs
+++ b/crates/moonutil/tests/expect_moon_pkg.rs
@@ -19,13 +19,12 @@
 fn run(source: &str) -> String {
     moonutil::moon_pkg::parse(source)
         .and_then(|dsl| {
-            moonutil::package::convert_pkg_dsl_to_package_with_supported_targets_decl(
+            moonutil::package::convert_pkg_dsl_to_package(
                 dsl,
-                true,
                 &moonutil::user_log::UserLog::new(log::LevelFilter::Error),
             )
         })
-        .map(|(pkg, _)| format!("{:#?}", pkg))
+        .map(|pkg| format!("{:#?}", pkg))
         .unwrap_or_else(|e| format!("Error: {:?}", e))
 }
 

--- a/crates/moonutil/tests/project_facade.rs
+++ b/crates/moonutil/tests/project_facade.rs
@@ -28,7 +28,7 @@ fn project_facade_exposes_selected_module_ref() {
     };
     let project = ProjectContext::Workspace {
         root: PathBuf::from("."),
-        manifest_path: PathBuf::from("moon.work.json"),
+        manifest_path: PathBuf::from("moon.work"),
         selected_module: Some(selected_module.clone()),
     };
 

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -129,6 +129,9 @@ project paths, the command layer captures user input and passes the result
 forward instead of letting later phases infer it again. In particular:
 
 - project and workspace selection are captured before package discovery;
+- the selected workspace manifest and canonical member list are carried as one
+  completed layout, so dependency sync and package discovery do not reopen
+  `moon.work`;
 - the `.mooncakes` directory is computed during project discovery and passed
   into dependency sync;
 - `$mooncake_bin` is resolved by the command adapter to a `mooncake_bin_dir`

--- a/docs/dev/reference/workspace.md
+++ b/docs/dev/reference/workspace.md
@@ -23,8 +23,9 @@ Workspace support is meant to provide one consistent model for:
 3. deciding whether the command needs one selected member module or the whole
    selected project
 
-The design intentionally avoids a separate enum like "project mode". The source
-of truth is the selected manifest path itself.
+The selected project is represented explicitly. A module selection carries its
+module manifest path; a workspace selection carries one completed workspace
+layout.
 
 ## Manifest Model
 
@@ -46,30 +47,33 @@ A workspace manifest defines:
   - the module directories contained by the workspace
 
 Workspace members are canonicalized relative to the workspace root and deduped.
-`preferred_target` in `moon.work` is deprecated: commands warn when they read
-it, but they do not use it for backend selection. `moon fmt` removes it. Use
+Project discovery reads the selected `moon.work` and resolves its members once;
+dependency sync, package discovery, and workspace maintenance receive that
+completed layout instead of reopening the manifest. `preferred_target` in
+`moon.work` is deprecated: commands warn once when they select that layout, but
+they do not use it for backend selection. `moon fmt` removes it. Use
 module-level `preferred_target` instead.
 
 The workspace root may or may not also contain a module manifest.
 
 ## Selection Result
 
-`SourceTargetDirs` resolves command input into:
+`ProjectQuery` resolves command input into a `SelectedProject` containing:
 
-- `project_manifest_path`
-  - one of `moon.mod`, `moon.mod.json`, or `moon.work`
-- `project_root`
-  - the parent directory of `project_manifest_path`
-- `module_dir`
-  - `Some(member_dir)` when the selected workspace explicitly lists the module
-    containing the command's start point, including a colocated root module
-  - `None` when a workspace was selected without an applicable member module
+- a `ProjectContext`, with:
+  - `project_manifest_path`: one of `moon.mod`, `moon.mod.json`, or `moon.work`
+  - `project_root`: the parent directory of `project_manifest_path`
+  - `module_dir`: `Some(member_dir)` when the selected workspace explicitly
+    lists the module containing the command's start point, including a
+    colocated root module; otherwise `None`
+- a completed workspace layout when `project_manifest_path` is `moon.work`,
+  containing the parsed manifest and canonical member directories
 
-The intended interpretation is simple:
+When commands create `PackageDirs`, this becomes a `ProjectManifest` value:
 
-- `project_manifest_path = moon.mod` or `moon.mod.json`
+- `ProjectManifest::Module(path)`
   - single-module behavior
-- `project_manifest_path = moon.work`
+- `ProjectManifest::Workspace(layout)`
   - workspace behavior
 
 `module_dir` is orthogonal:


### PR DESCRIPTION
## Why

Workspace parsing, project selection, and warning emission had become entangled. Partial cached state and output-producing readers made repeated reads observable, while output-level de-duplication could hide unrelated warnings.

## What changed

- make workspace parsing output-free and represent a selected workspace as one complete `WorkspaceLayout` containing the manifest and canonical members
- make `ProjectQuery::select` consume the query and emit workspace warnings at the command boundary, with no pending-warning or `UserLog::warn_once` state
- pass the selected layout through dependency sync, package discovery, formatting, and workspace maintenance instead of reopening `moon.work`
- report `MOON_CC` precedence from build-plan construction once per affected package, grouping both native CC fields for the same package
- keep the ordinary `moon.pkg` conversion API while hiding migration-only supported-target metadata from ordinary callers

## Why this is correct and minimal

A selected workspace is now a complete value with one owner, so later phases cannot observe a half-loaded manifest or accidentally emit the same warning again. Warning filtering and JSON capture still use the existing `UserLog` boundary. Process lifecycle and child-output cleanup remain isolated to the planned follow-up PR.