### PR TITLE
chore: bump Rust to 1.95.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.90.0
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
@@ -85,7 +85,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.90.0
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ env.LINUX_TARGET }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.90.0
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -232,7 +232,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.90.0
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -295,7 +295,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.90.0
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -371,7 +371,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.90.0
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -461,7 +461,7 @@ jobs:
   #       with:
   #         submodules: true
 
-  #     - uses: dtolnay/rust-toolchain@1.90.0
+  #     - uses: dtolnay/rust-toolchain@1.95.0
 
   #     - name: Checkout moonc-version
   #       uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 default-members = ["./crates/*"]
 
 [workspace.package]
-rust-version = "1.90"
+rust-version = "1.95"
 edition = "2024"
 
 [workspace.dependencies]

--- a/crates/moon/tests/fixtures/external_signal_handler.rs
+++ b/crates/moon/tests/fixtures/external_signal_handler.rs
@@ -40,7 +40,8 @@ mod signal {
 
     pub fn install() {
         unsafe {
-            signal(SIGINT, handler as usize);
+            let handler_fn: unsafe extern "C" fn(i32) = handler;
+            signal(SIGINT, handler_fn as usize);
         }
     }
 }

--- a/crates/mooncake/src/registry/mock.rs
+++ b/crates/mooncake/src/registry/mock.rs
@@ -215,11 +215,7 @@ mod test {
             .all_versions_of(&"foo/bar".parse().unwrap())
             .unwrap();
         assert_eq!(
-            module
-                .keys()
-                .cloned()
-                .map(|x| x.to_string())
-                .collect::<Vec<_>>(),
+            module.keys().map(|x| x.to_string()).collect::<Vec<_>>(),
             vec!["0.1.0", "0.1.2", "0.2.0"]
         )
     }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/worker.rs
@@ -135,7 +135,8 @@ fn init_worker_signal_handler() {
     INIT.call_once(|| unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_IGN);
         let mut action = std::mem::zeroed::<libc::sigaction>();
-        action.sa_sigaction = nop_signal_handler as usize;
+        let signal_handler: extern "C" fn(i32) = nop_signal_handler;
+        action.sa_sigaction = signal_handler as usize;
         libc::sigemptyset(&mut action.sa_mask);
         action.sa_flags = 0;
         libc::sigaction(libc::SIGUSR2, &action, std::ptr::null_mut());

--- a/crates/moonutil/src/dirs.rs
+++ b/crates/moonutil/src/dirs.rs
@@ -37,17 +37,12 @@ use crate::workspace::{
 
 const COLOCATED_MODULE_NOT_IN_WORKSPACE_WARNING: &str = "`moon.work` takes precedence over the module manifest in the same directory, but that module is not listed as a workspace member. Add `.` to `members` to select it from the workspace root.";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum WorkspaceEnv {
+    #[default]
     Auto,
     Off,
     Pinned(PathBuf),
-}
-
-impl Default for WorkspaceEnv {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 #[derive(Debug, Error)]
@@ -490,6 +485,10 @@ impl ProjectQuery {
             // normal project selection before a maintenance command edits them.
             self.project_context_from_start_dir()?;
             self.emit_workspace_warnings(user_log);
+            #[expect(
+                clippy::unnecessary_unwrap,
+                reason = "validation must borrow the workspace before it is moved into the result"
+            )]
             return Ok(WorkspaceEditTarget::Existing(
                 self.workspace
                     .expect("workspace was present before maintenance selection"),

--- a/crates/moonutil/src/error_code_docs.rs
+++ b/crates/moonutil/src/error_code_docs.rs
@@ -27,7 +27,7 @@ pub fn get_error_code_doc(error_code: &str) -> Option<&'static str> {
 
 pub fn get_all_error_code_docs() -> Vec<(&'static str, &'static str)> {
     let mut docs: Vec<_> = ERROR_DOCS.iter().map(|(code, doc)| (*code, *doc)).collect();
-    docs.sort_by(|(left, _), (right, _)| left.cmp(right));
+    docs.sort_by_key(|(code, _)| *code);
     docs
 }
 
@@ -36,6 +36,6 @@ pub fn get_all_attribute_docs() -> Vec<(&'static str, &'static str)> {
         .iter()
         .map(|(attribute, doc)| (*attribute, *doc))
         .collect();
-    docs.sort_by(|(left, _), (right, _)| left.cmp(right));
+    docs.sort_by_key(|(attribute, _)| *attribute);
     docs
 }

--- a/crates/moonutil/src/moon_mod_patch.rs
+++ b/crates/moonutil/src/moon_mod_patch.rs
@@ -62,14 +62,12 @@ struct MoonModImportBlock {
 }
 
 fn byte_offset_for_pos(contents: &str, pos: &moon_pkg::Pos) -> usize {
-    let mut line = 1usize;
     let mut offset = 0usize;
-    for segment in contents.split_inclusive('\n') {
+    for (line, segment) in (1usize..).zip(contents.split_inclusive('\n')) {
         if line == pos.line {
             return offset + pos.column.saturating_sub(1);
         }
         offset += segment.len();
-        line += 1;
     }
     contents.len()
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.95.0"
 components = [ "rustfmt", "clippy", "rust-analyzer" ]


### PR DESCRIPTION
## Summary

- bump the workspace Rust version and pinned toolchain from 1.90 to 1.95
- update CI and release workflows to use Rust 1.95.0
- apply behavior-preserving cleanups for diagnostics introduced by the newer toolchain

## Rationale

Wasmtime 48.0.0 is planned as the LTS runtime for replacing V8 and requires Rust 1.95. Landing the toolchain bump first establishes that baseline independently of the runtime migration.

## Why this change is minimal

All project and CI toolchain declarations move together, avoiding differences between local builds, CI, and release builds. The diagnostic cleanup is kept in a separate commit and does not intentionally change behavior. The Wasmtime migration remains follow-up work.