### PR TITLE
refactor(output): make process output lifecycle explicit

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -160,6 +160,27 @@ pub(crate) enum MoonBuildSubcommands {
     #[clap(external_subcommand)]
     External(Vec<String>),
 }
+
+impl MoonBuildSubcommands {
+    /// Return the delegated command name when Moon does not own its complete
+    /// tracing lifecycle.
+    ///
+    /// Delegated commands hand control to another executable, so accepting
+    /// `--trace` would either produce an incomplete Moon trace or imply that
+    /// Moon can observe work performed inside the delegated process.
+    pub(crate) fn delegated_name(&self) -> Option<&'static str> {
+        match self {
+            Self::RunWasm(_) => Some("runwasm"),
+            Self::Cram(_) => Some("cram"),
+            Self::Login(_) => Some("login"),
+            Self::Register(_) => Some("register"),
+            Self::Publish(_) => Some("publish"),
+            Self::Package(_) => Some("package"),
+            Self::External(_) => Some("external"),
+            _ => None,
+        }
+    }
+}
 #[test]
 fn gen_docs_for_moon_help_page() {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();

--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -56,6 +56,7 @@ pub(crate) use build::*;
 pub(crate) use build_matrix::*;
 pub(crate) use bundle::*;
 pub(crate) use check::*;
+use clap::CommandFactory;
 pub(crate) use clean::*;
 pub(crate) use coverage::*;
 pub(crate) use cram::*;
@@ -161,28 +162,16 @@ pub(crate) enum MoonBuildSubcommands {
     External(Vec<String>),
 }
 
-impl MoonBuildSubcommands {
-    /// Return the delegated command name when Moon does not own its complete
-    /// tracing lifecycle.
-    ///
-    /// Delegated commands hand control to another executable, so accepting
-    /// `--trace` would either produce an incomplete Moon trace or imply that
-    /// Moon can observe work performed inside the delegated process.
-    pub(crate) fn delegated_name(&self) -> Option<&'static str> {
-        match self {
-            // Local runwasm inputs are selected into `Run` before tracing
-            // ownership is decided, so only registry-asset mode reaches here.
-            Self::RunWasm(_) => Some("runwasm"),
-            Self::Cram(_) => Some("cram"),
-            Self::Login(_) => Some("login"),
-            Self::Register(_) => Some("register"),
-            Self::Publish(_) => Some("publish"),
-            Self::Package(_) => Some("package"),
-            Self::External(_) => Some("external"),
-            _ => None,
-        }
-    }
+pub(crate) fn report_delegated_trace_conflict(delegated_name: &str) -> i32 {
+    let error = MoonBuildCli::command().error(
+        clap::error::ErrorKind::ArgumentConflict,
+        format!("`--trace` is not supported for delegated command `{delegated_name}`"),
+    );
+    let exit_code = error.exit_code();
+    let _ = error.print();
+    exit_code
 }
+
 #[test]
 fn gen_docs_for_moon_help_page() {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();

--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -170,6 +170,8 @@ impl MoonBuildSubcommands {
     /// Moon can observe work performed inside the delegated process.
     pub(crate) fn delegated_name(&self) -> Option<&'static str> {
         match self {
+            // Local runwasm inputs are selected into `Run` before tracing
+            // ownership is decided, so only registry-asset mode reaches here.
             Self::RunWasm(_) => Some("runwasm"),
             Self::Cram(_) => Some("cram"),
             Self::Login(_) => Some("login"),

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -33,7 +33,9 @@ use anyhow::Context;
 use log::LevelFilter;
 use moonbuild_rupes_recta::intent::UserIntent;
 use moonbuild_rupes_recta::model::PackageId;
+use mooncake::pkg::sync::SyncOutputOptions;
 use moonutil::build_options::RunMode;
+use moonutil::child_process::ChildOutputMode;
 use moonutil::cli_support::AutoSyncFlags;
 use moonutil::cli_support::UniversalFlags;
 use moonutil::command_output::CommandOutput;
@@ -494,7 +496,14 @@ fn run_check_for_single_file_rr(
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     )
-    .with_captured_sync_child_output(cmd.json);
+    .with_sync_output(SyncOutputOptions {
+        quiet: false,
+        child_output: if cmd.json {
+            ChildOutputMode::Capture
+        } else {
+            ChildOutputMode::Inherit
+        },
+    });
     let (resolved, backend) = moonbuild_rupes_recta::resolve::resolve_single_file_project(
         &resolve_cfg,
         dirs,
@@ -688,7 +697,14 @@ fn run_check_normal_internal_rr(
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     )
-    .with_captured_sync_child_output(json.is_some());
+    .with_sync_output(SyncOutputOptions {
+        quiet: false,
+        child_output: if json.is_some() {
+            ChildOutputMode::Capture
+        } else {
+            ChildOutputMode::Inherit
+        },
+    });
     let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, dirs, user_log)
         .context("Failed to calculate build plan")?;
     let resolve_output =

--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -24,7 +24,6 @@ use std::{
 };
 
 use anyhow::Context;
-use clap::error::ErrorKind;
 use clap::{Subcommand, ValueEnum};
 use moonbuild_rupes_recta::model::BuildPlanNode;
 use moonutil::{
@@ -213,21 +212,12 @@ fn delegate_moon_cram_with_current_dir(
     Ok(process::delegate(&mut command)?.code().unwrap_or(0))
 }
 
-pub(crate) fn exit_if_cram_external_request(err: &clap::Error, raw_args: &[OsString]) {
-    if err.kind() != ErrorKind::UnknownArgument {
-        return;
-    }
-
-    let Some((current_dir, args)) = cram_external_args(raw_args) else {
-        return;
-    };
-    match delegate_moon_cram_with_current_dir(current_dir.as_deref(), args) {
-        Ok(code) => std::process::exit(code),
-        Err(err) => {
-            eprintln!("Error: {err:?}");
-            std::process::exit(-1);
-        }
-    }
+pub(crate) fn run_cram_external_if_requested(raw_args: &[OsString]) -> Option<anyhow::Result<i32>> {
+    let (current_dir, args) = cram_external_args(raw_args)?;
+    Some(delegate_moon_cram_with_current_dir(
+        current_dir.as_deref(),
+        args,
+    ))
 }
 
 fn cram_external_args(raw_args: &[OsString]) -> Option<(Option<PathBuf>, Vec<OsString>)> {
@@ -371,7 +361,7 @@ fn display_path_with_executable_dirs(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::Parser;
+    use clap::{Parser, error::ErrorKind};
 
     fn os(args: &[&str]) -> Vec<OsString> {
         args.iter().map(OsString::from).collect()

--- a/crates/moon/src/cli/cram.rs
+++ b/crates/moon/src/cli/cram.rs
@@ -212,22 +212,20 @@ fn delegate_moon_cram_with_current_dir(
     Ok(process::delegate(&mut command)?.code().unwrap_or(0))
 }
 
-pub(crate) fn run_cram_external_if_requested(raw_args: &[OsString]) -> Option<anyhow::Result<i32>> {
-    let (current_dir, args) = cram_external_args(raw_args)?;
-    Some(delegate_moon_cram_with_current_dir(
-        current_dir.as_deref(),
-        args,
-    ))
-}
-
-fn cram_external_args(raw_args: &[OsString]) -> Option<(Option<PathBuf>, Vec<OsString>)> {
+pub(crate) fn select_delegated_cram(raw_args: &[OsString]) -> Option<process::EarlySubcommand<'_>> {
     let early = process::early_subcommand(raw_args)?;
-    (early.name == OsStr::new("cram") && is_external_cram_tail(early.args))
-        .then(|| (early.current_dir, early.args.to_vec()))
+    (early.name == OsStr::new("cram") && is_delegated_cram_tail(early.args)).then_some(early)
 }
 
-fn is_external_cram_tail(tail: &[OsString]) -> bool {
-    matches!(tail.first(), Some(arg) if arg != OsStr::new("test"))
+pub(crate) fn run_delegated_cram(command: process::EarlySubcommand<'_>) -> anyhow::Result<i32> {
+    if command.moon_trace {
+        return Ok(super::report_delegated_trace_conflict("cram"));
+    }
+    delegate_moon_cram_with_current_dir(command.current_dir.as_deref(), command.args)
+}
+
+fn is_delegated_cram_tail(tail: &[OsString]) -> bool {
+    matches!(tail.first(), Some(arg) if !matches!(arg.to_str(), Some("test" | "-h" | "--help")))
 }
 
 fn resolve_moon_cram() -> anyhow::Result<PathBuf> {
@@ -367,6 +365,17 @@ mod tests {
         args.iter().map(OsString::from).collect()
     }
 
+    fn select_cram(args: &[&str]) -> Option<(Option<PathBuf>, bool, Vec<OsString>)> {
+        let args = os(args);
+        select_delegated_cram(&args).map(|command| {
+            (
+                command.current_dir,
+                command.moon_trace,
+                command.args.to_vec(),
+            )
+        })
+    }
+
     fn parse_command(args: &[&str]) -> CramCommand {
         CramSubcommand::try_parse_from(std::iter::once("moon cram").chain(args.iter().copied()))
             .unwrap()
@@ -456,52 +465,55 @@ mod tests {
     #[test]
     fn detects_parent_flag_as_external_cram_args() {
         assert_eq!(
-            cram_external_args(&os(&["moon", "cram", "--version"])),
-            Some((None, os(&["--version"])))
+            select_cram(&["moon", "cram", "--version"]),
+            Some((None, false, os(&["--version"])))
         );
     }
 
     #[test]
     fn detects_parent_flag_as_external_cram_args_after_global_flag() {
         assert_eq!(
-            cram_external_args(&os(&["moon", "-q", "cram", "--version"])),
-            Some((None, os(&["--version"])))
+            select_cram(&["moon", "-q", "cram", "--version"]),
+            Some((None, false, os(&["--version"])))
+        );
+    }
+
+    #[test]
+    fn leaves_delegated_trace_for_cram() {
+        assert_eq!(
+            select_cram(&["moon", "cram", "--version", "--trace"]),
+            Some((None, false, os(&["--version", "--trace"])))
+        );
+        assert_eq!(
+            select_cram(&["moon", "--trace", "cram", "--version"]),
+            Some((None, true, os(&["--version"])))
         );
     }
 
     #[test]
     fn detects_parent_flag_as_external_cram_args_after_global_value_flag() {
         assert_eq!(
-            cram_external_args(&os(&[
-                "moon",
-                "--target-dir",
-                "_build-alt",
-                "cram",
-                "--version"
-            ])),
-            Some((None, os(&["--version"])))
+            select_cram(&["moon", "--target-dir", "_build-alt", "cram", "--version"]),
+            Some((None, false, os(&["--version"])))
         );
     }
 
     #[test]
     fn preserves_chdir_for_external_cram_args() {
         assert_eq!(
-            cram_external_args(&os(&["moon", "-Csub", "cram", "--version"])),
-            Some((Some(PathBuf::from("sub")), os(&["--version"])))
+            select_cram(&["moon", "-Csub", "cram", "--version"]),
+            Some((Some(PathBuf::from("sub")), false, os(&["--version"])))
         );
     }
 
     #[test]
     fn ignores_cram_argument_under_other_top_level_subcommand() {
-        assert_eq!(
-            cram_external_args(&os(&["moon", "build", "cram", "--bad-flag"])),
-            None
-        );
+        assert_eq!(select_cram(&["moon", "build", "cram", "--bad-flag"]), None);
     }
 
     #[test]
     fn keeps_builtin_test_parse_errors_in_moon() {
-        assert_eq!(cram_external_args(&os(&["moon", "cram", "test"])), None);
+        assert_eq!(select_cram(&["moon", "cram", "test"]), None);
     }
 
     #[test]

--- a/crates/moon/src/cli/external.rs
+++ b/crates/moon/src/cli/external.rs
@@ -17,7 +17,6 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use anyhow::{Context as _, bail};
-use clap::error::ErrorKind;
 use std::{
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
@@ -80,21 +79,9 @@ fn run_external_command(
     process::delegate(cmd.args(args))
 }
 
-pub(crate) fn exit_if_ide_help_request(err: &clap::Error, raw_args: &[OsString]) {
-    if err.kind() != ErrorKind::InvalidSubcommand {
-        return;
-    }
-
-    let Some((current_dir, args)) = ide_help_args(raw_args) else {
-        return;
-    };
-    match run_external_help("ide", current_dir.as_deref(), args) {
-        Ok(code) => std::process::exit(code),
-        Err(err) => {
-            eprintln!("Error: {err:?}");
-            std::process::exit(-1);
-        }
-    }
+pub(crate) fn run_ide_help_if_requested(raw_args: &[OsString]) -> Option<anyhow::Result<i32>> {
+    let (current_dir, args) = ide_help_args(raw_args)?;
+    Some(run_external_help("ide", current_dir.as_deref(), args))
 }
 
 fn ide_help_args(raw_args: &[OsString]) -> Option<(Option<PathBuf>, Vec<OsString>)> {

--- a/crates/moon/src/cli/external.rs
+++ b/crates/moon/src/cli/external.rs
@@ -80,11 +80,14 @@ fn run_external_command(
 }
 
 pub(crate) fn run_ide_help_if_requested(raw_args: &[OsString]) -> Option<anyhow::Result<i32>> {
-    let (current_dir, args) = ide_help_args(raw_args)?;
+    let (current_dir, moon_trace, args) = ide_help_args(raw_args)?;
+    if moon_trace {
+        return Some(Ok(super::report_delegated_trace_conflict("ide")));
+    }
     Some(run_external_help("ide", current_dir.as_deref(), args))
 }
 
-fn ide_help_args(raw_args: &[OsString]) -> Option<(Option<PathBuf>, Vec<OsString>)> {
+fn ide_help_args(raw_args: &[OsString]) -> Option<(Option<PathBuf>, bool, Vec<OsString>)> {
     let early = process::early_subcommand(raw_args)?;
     if early.name != OsStr::new("help") {
         return None;
@@ -98,7 +101,7 @@ fn ide_help_args(raw_args: &[OsString]) -> Option<(Option<PathBuf>, Vec<OsString
 
     let mut delegated = tail.to_vec();
     delegated.push(OsString::from("--help"));
-    Some((early.current_dir, delegated))
+    Some((early.current_dir, early.moon_trace, delegated))
 }
 
 #[cfg(test)]
@@ -114,7 +117,7 @@ mod tests {
     fn delegates_top_level_help_for_ide() {
         assert_eq!(
             ide_help_args(&os(&["moon", "help", "ide"])),
-            Some((None, os(&["--help"])))
+            Some((None, false, os(&["--help"])))
         );
     }
 
@@ -122,7 +125,7 @@ mod tests {
     fn delegates_subcommand_help_for_ide() {
         assert_eq!(
             ide_help_args(&os(&["moon", "help", "ide", "doc"])),
-            Some((None, os(&["doc", "--help"])))
+            Some((None, false, os(&["doc", "--help"])))
         );
     }
 
@@ -138,7 +141,20 @@ mod tests {
                 "ide",
                 "doc"
             ])),
-            Some((Some(PathBuf::from(".")), os(&["doc", "--help"])))
+            Some((Some(PathBuf::from(".")), true, os(&["doc", "--help"])))
+        );
+    }
+
+    #[test]
+    fn leaves_delegated_trace_for_ide() {
+        assert_eq!(
+            ide_help_args(&os(&["moon", "help", "ide", "--trace"])),
+            Some((None, false, os(&["--trace", "--help"])))
+        );
+
+        assert_eq!(
+            ide_help_args(&os(&["moon", "help", "ide", "--", "--trace"])),
+            Some((None, false, os(&["--", "--trace", "--help"])))
         );
     }
 

--- a/crates/moon/src/cli/fetch.rs
+++ b/crates/moon/src/cli/fetch.rs
@@ -18,9 +18,10 @@
 
 use anyhow::bail;
 use colored::Colorize;
-use mooncake::registry::Registry;
+use mooncake::registry::{Registry, RegistryPackageInstaller};
 use moonutil::{
-    project::PackageDirs, registry::RegistryConfig, resolution::ModuleName, user_log::UserLog,
+    child_process::ChildOutputMode, project::PackageDirs, registry::RegistryConfig,
+    resolution::ModuleName, user_log::UserLog,
 };
 
 use super::UniversalFlags;
@@ -136,7 +137,8 @@ pub(crate) fn fetch_cli(
         println!("Fetching {}@{version} to {}", pkg_name, pkg_dir.display());
     }
 
-    registry.install_to(&pkg_name, &version, &pkg_dir, user_log)?;
+    RegistryPackageInstaller::new(&registry, ChildOutputMode::Inherit, user_log)
+        .install_to(&pkg_name, &version, &pkg_dir)?;
 
     if !cli.quiet {
         println!(

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -25,10 +25,11 @@ use moonbuild_rupes_recta::{
 };
 use mooncake::{
     pkg::sync::SyncOutputOptions,
-    registry::{OnlineRegistry, Registry, path as registry_path},
+    registry::{OnlineRegistry, Registry, RegistryPackageInstaller, path as registry_path},
 };
 use moonutil::{
     build_options::RunMode,
+    child_process::ChildOutputMode,
     cli_support::UniversalFlags,
     constants::{MOON_MOD, MOON_MOD_JSON},
     locks::FileLock,
@@ -274,7 +275,11 @@ pub(super) fn install_binary(
     let tmp_dir = tempfile::TempDir::new().context("Failed to create temporary directory")?;
     let module_dir = tmp_dir.path();
 
-    registry.install_to(&spec.module_name, &version, module_dir, user_log)?;
+    RegistryPackageInstaller::new(&registry, ChildOutputMode::Inherit, user_log).install_to(
+        &spec.module_name,
+        &version,
+        module_dir,
+    )?;
 
     let filter =
         PackageFilter::package_path(spec.package_path.clone().unwrap_or_default(), install_all);

--- a/crates/moon/src/cli/process.rs
+++ b/crates/moon/src/cli/process.rs
@@ -24,17 +24,20 @@ use std::{
 
 pub(crate) struct EarlySubcommand<'a> {
     pub(crate) current_dir: Option<PathBuf>,
+    pub(crate) moon_trace: bool,
     pub(crate) name: &'a OsStr,
     pub(crate) args: &'a [OsString],
 }
 
 /// Locate a top-level subcommand before clap has successfully parsed the CLI.
 ///
-/// Early delegation must interpret global options exactly far enough to derive
-/// the same effective `-C` directory that `main` would apply before a normally
-/// parsed subcommand runs.
+/// Early delegation must interpret global options exactly far enough to apply
+/// the same effective `-C` directory and explicit tracing policy as a normally
+/// parsed subcommand. Once the subcommand is found, its arguments are opaque:
+/// a later `--trace` belongs to the delegated command, not Moon.
 pub(crate) fn early_subcommand(raw_args: &[OsString]) -> Option<EarlySubcommand<'_>> {
     let mut current_dir = None;
+    let mut moon_trace = false;
     let mut index = 1;
     while index < raw_args.len() {
         let arg = &raw_args[index];
@@ -58,9 +61,10 @@ pub(crate) fn early_subcommand(raw_args: &[OsString]) -> Option<EarlySubcommand<
                 if arg.starts_with("--target-dir=")
                     || arg.starts_with("--unstable-feature=")
                     || (arg.starts_with("-Z") && arg.len() > 2) => {}
+            Some("--trace") => moon_trace = true,
             Some(
-                "-V" | "--version" | "-q" | "--quiet" | "-v" | "--verbose" | "--trace"
-                | "--dry-run" | "--build-graph",
+                "-V" | "--version" | "-q" | "--quiet" | "-v" | "--verbose" | "--dry-run"
+                | "--build-graph",
             ) => {}
             Some(arg) if arg.starts_with('-') && !arg.starts_with("--") && arg.len() > 2 => {
                 let mut flags = &arg[1..];
@@ -85,6 +89,7 @@ pub(crate) fn early_subcommand(raw_args: &[OsString]) -> Option<EarlySubcommand<
                 } else if !flags.starts_with('Z') {
                     return Some(EarlySubcommand {
                         current_dir,
+                        moon_trace,
                         name: &raw_args[index],
                         args: &raw_args[index + 1..],
                     });
@@ -93,6 +98,7 @@ pub(crate) fn early_subcommand(raw_args: &[OsString]) -> Option<EarlySubcommand<
             _ => {
                 return Some(EarlySubcommand {
                     current_dir,
+                    moon_trace,
                     name: arg,
                     args: &raw_args[index + 1..],
                 });

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -134,7 +134,10 @@ impl RunOutputVerbosity {
     }
 
     fn sync_output(self) -> SyncOutputOptions {
-        SyncOutputOptions::default().with_quiet(!self.verbose)
+        SyncOutputOptions {
+            quiet: !self.verbose,
+            ..SyncOutputOptions::default()
+        }
     }
 
     fn suppress_build_progress(self) -> bool {

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -70,6 +70,25 @@ pub(crate) struct RunWasmSubcommand {
     pub args: Vec<String>,
 }
 
+pub(crate) enum SelectedRunWasm {
+    Local(RunSubcommand),
+    RegistryAsset(RunWasmSubcommand),
+}
+
+impl RunWasmSubcommand {
+    /// Select the lifecycle owner before tracing is initialized.
+    ///
+    /// Local packages become ordinary `moon run` commands. Registry assets
+    /// retain the `runwasm` variant because they delegate to another process.
+    pub(crate) fn select(self) -> anyhow::Result<SelectedRunWasm> {
+        if should_run_as_local_package(&self.package)? {
+            Ok(SelectedRunWasm::Local(runwasm_as_run_subcommand(self)))
+        } else {
+            Ok(SelectedRunWasm::RegistryAsset(self))
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ResolvedRunWasmAsset {
     url: String,
@@ -116,10 +135,6 @@ pub(crate) fn run_runwasm(
     cmd: RunWasmSubcommand,
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
-    if should_run_as_local_package(&cmd.package)? {
-        return super::run_run(cli, runwasm_as_run_subcommand(cmd), output);
-    }
-
     if cli.dry_run {
         bail!("--dry-run is not supported for Mooncakes assets in `moon runwasm`");
     }

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -40,6 +40,8 @@ mod watch;
 
 use tracing_subscriber::{Layer, layer::SubscriberExt};
 
+const FAILURE_EXIT_CODE: i32 = -1;
+
 /// Initialize logging and tracing-related functionality.
 ///
 /// This includes configuration based on multiple flags and configs:
@@ -120,9 +122,19 @@ fn finish_check_json(
 ) -> i32 {
     let exit_code = outcome.exit_code();
     if cli::write_check_json(output, capture, outcome).is_err() {
-        return -1;
+        return FAILURE_EXIT_CODE;
     }
     exit_code
+}
+
+fn finish_command(result: anyhow::Result<i32>, user_log: &moonutil::user_log::UserLog) -> i32 {
+    match result {
+        Ok(code) => code,
+        Err(error) => {
+            user_log.error(format!("{error:?}"));
+            FAILURE_EXIT_CODE
+        }
+    }
 }
 
 pub fn main() {
@@ -140,17 +152,18 @@ fn run() -> i32 {
             Ok(code) => code,
             Err(err) => {
                 eprintln!("Error: {err:?}");
-                -1
+                FAILURE_EXIT_CODE
             }
         };
     }
-
     let cli = match cli::MoonBuildCli::try_parse_from(&raw_args) {
         Ok(cli) => cli,
         Err(err) => {
             let delegated = match err.kind() {
                 ErrorKind::InvalidSubcommand => cli::run_ide_help_if_requested(&raw_args),
-                ErrorKind::UnknownArgument => cli::run_cram_external_if_requested(&raw_args),
+                ErrorKind::UnknownArgument => {
+                    cli::select_delegated_cram(&raw_args).map(cli::run_delegated_cram)
+                }
                 _ => None,
             };
             if let Some(result) = delegated {
@@ -158,13 +171,24 @@ fn run() -> i32 {
                     Ok(code) => code,
                     Err(err) => {
                         eprintln!("Error: {err:?}");
-                        -1
+                        FAILURE_EXIT_CODE
                     }
                 };
             }
             err.exit();
         }
     };
+    if !cli.version
+        && let Some(command) = cli::select_delegated_cram(&raw_args)
+    {
+        return match cli::run_delegated_cram(command) {
+            Ok(code) => code,
+            Err(err) => {
+                eprintln!("Error: {err:?}");
+                FAILURE_EXIT_CODE
+            }
+        };
+    }
     let mut flags = cli.flags;
     let subcommand = if cli.version {
         MoonBuildSubcommands::Version(cli::VersionSubcommand {
@@ -196,11 +220,10 @@ fn run() -> i32 {
                 return finish_check_json(
                     &output,
                     capture,
-                    cli::CheckJsonOutcome::from_error(-1, message),
+                    cli::CheckJsonOutcome::from_error(FAILURE_EXIT_CODE, message),
                 );
             }
-            output.user_log().error(message);
-            return -1;
+            return finish_command(Err(anyhow::anyhow!(message)), output.user_log());
         }
     }
 
@@ -209,27 +232,11 @@ fn run() -> i32 {
             Ok(cli::SelectedRunWasm::Local(cmd)) => MoonBuildSubcommands::Run(cmd),
             Ok(cli::SelectedRunWasm::RegistryAsset(cmd)) => MoonBuildSubcommands::RunWasm(cmd),
             Err(err) => {
-                output.user_log().error(format!("{err:?}"));
-                return -1;
+                return finish_command(Err(err), output.user_log());
             }
         },
         subcommand => subcommand,
     };
-    let delegated_name = subcommand.delegated_name();
-    if flags.trace
-        && let Some(delegated_name) = delegated_name
-    {
-        let error = cli::MoonBuildCli::command().error(
-            clap::error::ErrorKind::ArgumentConflict,
-            format!("`--trace` is not supported for delegated command `{delegated_name}`"),
-        );
-        let exit_code = error.exit_code();
-        let _ = error.print();
-        return exit_code;
-    }
-    let owns_tracing = delegated_name.is_none();
-
-    let _trace_guard = owns_tracing.then(|| init_tracing(flags.trace, check_json));
 
     let (workspace_env, workspace_env_deprecation_warning) =
         match moonutil::project::current_workspace_env() {
@@ -239,11 +246,10 @@ fn run() -> i32 {
                     return finish_check_json(
                         &output,
                         capture,
-                        cli::CheckJsonOutcome::from_error(-1, format!("{err:#}")),
+                        cli::CheckJsonOutcome::from_error(FAILURE_EXIT_CODE, format!("{err:#}")),
                     );
                 }
-                output.user_log().error(format!("{:?}", err));
-                return -1;
+                return finish_command(Err(err), output.user_log());
             }
         };
     flags.workspace_env = workspace_env;
@@ -259,6 +265,7 @@ fn run() -> i32 {
     if let MoonBuildSubcommands::Check(cmd) = &subcommand
         && cmd.json
     {
+        let _trace_guard = init_tracing(flags.trace, true);
         let outcome = cli::run_check_json(&flags, cmd, &output);
         return finish_check_json(
             &output,
@@ -269,6 +276,69 @@ fn run() -> i32 {
         );
     }
 
+    let subcommand = match subcommand {
+        MoonBuildSubcommands::RunWasm(command) => {
+            if flags.trace {
+                return cli::report_delegated_trace_conflict("runwasm");
+            }
+            return finish_command(
+                cli::run_runwasm(&flags, command, &output),
+                output.user_log(),
+            );
+        }
+        MoonBuildSubcommands::Cram(command) => {
+            if flags.trace {
+                return cli::report_delegated_trace_conflict("cram");
+            }
+            return finish_command(cli::run_cram(&flags, command, &output), output.user_log());
+        }
+        MoonBuildSubcommands::Login(command) => {
+            if flags.trace {
+                return cli::report_delegated_trace_conflict("login");
+            }
+            return finish_command(
+                cli::mooncake_adapter::login_cli(flags, command),
+                output.user_log(),
+            );
+        }
+        MoonBuildSubcommands::Register(command) => {
+            if flags.trace {
+                return cli::report_delegated_trace_conflict("register");
+            }
+            return finish_command(
+                cli::mooncake_adapter::register_cli(flags, command),
+                output.user_log(),
+            );
+        }
+        MoonBuildSubcommands::Publish(command) => {
+            if flags.trace {
+                return cli::report_delegated_trace_conflict("publish");
+            }
+            return finish_command(
+                cli::mooncake_adapter::publish_cli(flags, command, output.user_log()),
+                output.user_log(),
+            );
+        }
+        MoonBuildSubcommands::Package(command) => {
+            if flags.trace {
+                return cli::report_delegated_trace_conflict("package");
+            }
+            return finish_command(
+                cli::mooncake_adapter::package_cli(flags, command, output.user_log()),
+                output.user_log(),
+            );
+        }
+        MoonBuildSubcommands::External(args) => {
+            if flags.trace {
+                return cli::report_delegated_trace_conflict("external");
+            }
+            return finish_command(cli::run_external(args), output.user_log());
+        }
+        subcommand => subcommand,
+    };
+
+    let _trace_guard = init_tracing(flags.trace, false);
+
     use MoonBuildSubcommands::*;
     let res = match subcommand {
         Add(a) => cli::add_cli(flags, a, output.user_log()),
@@ -278,7 +348,9 @@ fn run() -> i32 {
         Check(c) => cli::run_check(&flags, &c, &output),
         Prove(p) => cli::run_prove(&flags, &p, &output),
         Clean(cmd) => cli::run_clean(&flags, &cmd, output.user_log()),
-        Cram(c) => cli::run_cram(&flags, c, &output),
+        Cram(_) | Login(_) | Register(_) | Publish(_) | Package(_) | RunWasm(_) | External(_) => {
+            unreachable!("delegated commands return before tracing initialization")
+        }
         Coverage(c) => cli::run_coverage(flags, c, &output),
         Doc(d) => cli::run_doc(flags, d, &output),
         Fetch(f) => cli::fetch_cli(flags, f, output.user_log()),
@@ -289,15 +361,10 @@ fn run() -> i32 {
         Info(i) => cli::run_info(flags, i, &output),
         Explain(e) => cli::run_explain(&flags, e),
         Install(i) => cli::install_cli(flags, i, output.user_log()),
-        Login(l) => cli::mooncake_adapter::login_cli(flags, l),
         Whoami(w) => cli::run_whoami(&flags, w),
         New(n) => cli::run_new(&flags, n, output.user_log()),
-        Publish(p) => cli::mooncake_adapter::publish_cli(flags, p, output.user_log()),
-        Package(p) => cli::mooncake_adapter::package_cli(flags, p, output.user_log()),
-        Register(r) => cli::mooncake_adapter::register_cli(flags, r),
         Remove(r) => cli::remove_cli(flags, r, output.user_log()),
         Run(r) => cli::run_run(&flags, r, &output),
-        RunWasm(r) => cli::run_runwasm(&flags, r, &output),
         Test(t) => cli::run_test(flags, t, &output),
         Tree(t) => cli::tree_cli(flags, t, output.user_log()),
         Update(u) => cli::update_cli(flags, u),
@@ -305,14 +372,6 @@ fn run() -> i32 {
         ShellCompletion(gs) => cli::gen_shellcomp(&flags, gs),
         Version(v) => cli::run_version(&flags, v),
         Tool(v) => cli::run_tool(&flags, v, output.user_log()),
-        External(args) => cli::run_external(args),
     };
-
-    match res {
-        Ok(code) => code,
-        Err(e) => {
-            output.user_log().error(format!("{:?}", e));
-            -1
-        }
-    }
+    finish_command(res, output.user_log())
 }

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -180,19 +180,6 @@ fn run() -> i32 {
         let _ = writeln!(stderr);
         return 2;
     };
-    let delegated_name = subcommand.delegated_name();
-    if flags.trace
-        && let Some(delegated_name) = delegated_name
-    {
-        let error = cli::MoonBuildCli::command().error(
-            clap::error::ErrorKind::ArgumentConflict,
-            format!("`--trace` is not supported for delegated command `{delegated_name}`"),
-        );
-        let exit_code = error.exit_code();
-        let _ = error.print();
-        return exit_code;
-    }
-    let owns_tracing = delegated_name.is_none();
     let check_json = matches!(&subcommand, MoonBuildSubcommands::Check(cmd) if cmd.json);
     let (output, check_json_capture) = if check_json {
         let (output, capture) = CommandOutput::captured(flags.user_log_level());
@@ -216,6 +203,31 @@ fn run() -> i32 {
             return -1;
         }
     }
+
+    let subcommand = match subcommand {
+        MoonBuildSubcommands::RunWasm(cmd) => match cmd.select() {
+            Ok(cli::SelectedRunWasm::Local(cmd)) => MoonBuildSubcommands::Run(cmd),
+            Ok(cli::SelectedRunWasm::RegistryAsset(cmd)) => MoonBuildSubcommands::RunWasm(cmd),
+            Err(err) => {
+                output.user_log().error(format!("{err:?}"));
+                return -1;
+            }
+        },
+        subcommand => subcommand,
+    };
+    let delegated_name = subcommand.delegated_name();
+    if flags.trace
+        && let Some(delegated_name) = delegated_name
+    {
+        let error = cli::MoonBuildCli::command().error(
+            clap::error::ErrorKind::ArgumentConflict,
+            format!("`--trace` is not supported for delegated command `{delegated_name}`"),
+        );
+        let exit_code = error.exit_code();
+        let _ = error.print();
+        return exit_code;
+    }
+    let owns_tracing = delegated_name.is_none();
 
     let _trace_guard = owns_tracing.then(|| init_tracing(flags.trace, check_json));
 

--- a/crates/moon/src/main.rs
+++ b/crates/moon/src/main.rs
@@ -23,7 +23,7 @@ use std::{
     io::{IsTerminal, Write},
 };
 
-use clap::{CommandFactory, Parser};
+use clap::{CommandFactory, Parser, error::ErrorKind};
 use cli::MoonBuildSubcommands;
 use moonutil::{command_output::CommandOutput, user_log::UserLogCapture};
 
@@ -113,40 +113,58 @@ fn init_tracing(trace_flag: bool, suppress_terminal_output: bool) -> Box<dyn Any
     Box::new(chrome_guard)
 }
 
-fn exit_check_json(
+fn finish_check_json(
     output: &CommandOutput,
     capture: &UserLogCapture,
     outcome: cli::CheckJsonOutcome,
-) -> ! {
+) -> i32 {
     let exit_code = outcome.exit_code();
     if cli::write_check_json(output, capture, outcome).is_err() {
-        std::process::exit(-1);
+        return -1;
     }
-    std::process::exit(exit_code)
+    exit_code
 }
 
 pub fn main() {
     panic::setup_panic_hook();
+    std::process::exit(run());
+}
 
+fn run() -> i32 {
     let raw_args = std::env::args_os().collect::<Vec<_>>();
     if cli::moonx::is_moonx_invocation(&raw_args) {
-        std::process::exit(cli::moonx::run_from_args(&raw_args));
+        return cli::moonx::run_from_args(&raw_args);
     }
     if cli::tool::exec::is_tool_exec(&raw_args) {
-        match cli::tool::exec::run_from_raw_args(&raw_args) {
-            Ok(code) => std::process::exit(code),
+        return match cli::tool::exec::run_from_raw_args(&raw_args) {
+            Ok(code) => code,
             Err(err) => {
                 eprintln!("Error: {err:?}");
-                std::process::exit(-1);
+                -1
             }
-        }
+        };
     }
 
-    let cli = cli::MoonBuildCli::try_parse_from(&raw_args).unwrap_or_else(|err| {
-        cli::exit_if_ide_help_request(&err, &raw_args);
-        cli::exit_if_cram_external_request(&err, &raw_args);
-        err.exit();
-    });
+    let cli = match cli::MoonBuildCli::try_parse_from(&raw_args) {
+        Ok(cli) => cli,
+        Err(err) => {
+            let delegated = match err.kind() {
+                ErrorKind::InvalidSubcommand => cli::run_ide_help_if_requested(&raw_args),
+                ErrorKind::UnknownArgument => cli::run_cram_external_if_requested(&raw_args),
+                _ => None,
+            };
+            if let Some(result) = delegated {
+                return match result {
+                    Ok(code) => code,
+                    Err(err) => {
+                        eprintln!("Error: {err:?}");
+                        -1
+                    }
+                };
+            }
+            err.exit();
+        }
+    };
     let mut flags = cli.flags;
     let subcommand = if cli.version {
         MoonBuildSubcommands::Version(cli::VersionSubcommand {
@@ -160,8 +178,21 @@ pub fn main() {
         let mut stderr = std::io::stderr().lock();
         let _ = cli::MoonBuildCli::command().write_long_help(&mut stderr);
         let _ = writeln!(stderr);
-        std::process::exit(2);
+        return 2;
     };
+    let delegated_name = subcommand.delegated_name();
+    if flags.trace
+        && let Some(delegated_name) = delegated_name
+    {
+        let error = cli::MoonBuildCli::command().error(
+            clap::error::ErrorKind::ArgumentConflict,
+            format!("`--trace` is not supported for delegated command `{delegated_name}`"),
+        );
+        let exit_code = error.exit_code();
+        let _ = error.print();
+        return exit_code;
+    }
+    let owns_tracing = delegated_name.is_none();
     let check_json = matches!(&subcommand, MoonBuildSubcommands::Check(cmd) if cmd.json);
     let (output, check_json_capture) = if check_json {
         let (output, capture) = CommandOutput::captured(flags.user_log_level());
@@ -175,32 +206,32 @@ pub fn main() {
         if let Err(err) = std::env::set_current_dir(dir) {
             let message = format!("failed to change directory to {}: {}", dir.display(), err);
             if let Some(capture) = &check_json_capture {
-                exit_check_json(
+                return finish_check_json(
                     &output,
                     capture,
                     cli::CheckJsonOutcome::from_error(-1, message),
                 );
             }
             output.user_log().error(message);
-            std::process::exit(-1)
+            return -1;
         }
     }
 
-    let _trace_guard = init_tracing(flags.trace, check_json);
+    let _trace_guard = owns_tracing.then(|| init_tracing(flags.trace, check_json));
 
     let (workspace_env, workspace_env_deprecation_warning) =
         match moonutil::project::current_workspace_env() {
             Ok(result) => result,
             Err(err) => {
                 if let Some(capture) = &check_json_capture {
-                    exit_check_json(
+                    return finish_check_json(
                         &output,
                         capture,
                         cli::CheckJsonOutcome::from_error(-1, format!("{err:#}")),
                     );
                 }
                 output.user_log().error(format!("{:?}", err));
-                std::process::exit(-1)
+                return -1;
             }
         };
     flags.workspace_env = workspace_env;
@@ -217,8 +248,7 @@ pub fn main() {
         && cmd.json
     {
         let outcome = cli::run_check_json(&flags, cmd, &output);
-        drop(_trace_guard);
-        exit_check_json(
+        return finish_check_json(
             &output,
             check_json_capture
                 .as_ref()
@@ -266,13 +296,11 @@ pub fn main() {
         External(args) => cli::run_external(args),
     };
 
-    drop(_trace_guard);
-
     match res {
-        Ok(code) => std::process::exit(code),
+        Ok(code) => code,
         Err(e) => {
             output.user_log().error(format!("{:?}", e));
-            std::process::exit(-1);
+            -1
         }
     }
 }

--- a/crates/moon/tests/test_cases/diagnostics_format/check.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/check.rs
@@ -34,6 +34,23 @@ fn test_moon_check_complete_json_success() {
 }
 
 #[test]
+fn test_moon_check_complete_json_flushes_trace_on_success() {
+    let dir = TestDir::new("warns/deny_warn");
+    let report = parse_complete_json(
+        moon_cmd(&dir)
+            .args(["check", "--json", "--trace", "--sort-input", "-j1"])
+            .assert()
+            .success(),
+    );
+
+    assert_eq!(report["status"], "success");
+    let trace: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(dir.join("trace.json")).unwrap())
+            .expect("trace should be complete JSON after a successful check");
+    assert!(trace.as_array().is_some_and(|events| !events.is_empty()));
+}
+
+#[test]
 fn test_moon_check_complete_json_compiler_failure() {
     let dir = TestDir::new("dedup_diag_error_limit.in");
     let report = parse_complete_json(
@@ -52,6 +69,30 @@ fn test_moon_check_complete_json_compiler_failure() {
     assert_eq!(report["summary"]["moon_warnings"], 1);
     assert_eq!(report["summary"]["diagnostic_errors"], 1);
     assert_eq!(report["summary"]["diagnostic_warnings"], 3);
+}
+
+#[test]
+fn test_moon_check_complete_json_flushes_trace_on_failure() {
+    let dir = TestDir::new("dedup_diag_error_limit.in");
+    let report = parse_complete_json(
+        moon_cmd(&dir)
+            .args([
+                "check",
+                "--json",
+                "--trace",
+                "--diagnostic-limit",
+                "1",
+                "-j1",
+            ])
+            .assert()
+            .failure(),
+    );
+
+    assert_eq!(report["status"], "failure");
+    let trace: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(dir.join("trace.json")).unwrap())
+            .expect("trace should be complete JSON after a failed check");
+    assert!(trace.as_array().is_some_and(|events| !events.is_empty()));
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -683,6 +683,8 @@ fn test_external_subcommand_delegation_handles_interrupt() {
 fn test_delegated_commands_reject_trace_before_initializing_tracing() {
     for args in [
         &["--trace", "not-a-real-subcommand"][..],
+        &["--trace", "help", "ide"],
+        &["--trace", "cram", "--version"],
         &["--trace", "cram", "list"],
         &["--trace", "runwasm", "not-a-real-package"],
         &["--trace", "login"],
@@ -843,6 +845,28 @@ fn test_cram_parent_flag_delegates_to_moon_cram() {
         stdout.contains("fake-moon-cram-args=--version"),
         "moon cram parent flags should be handled by moon-cram:\n{stdout}"
     );
+}
+
+#[test]
+fn test_cram_parses_trace_after_delegation_boundary() {
+    let dir = TestDir::new_empty();
+    let fake_bin_dir = tempfile::TempDir::new().expect("failed to create fake bin dir");
+    let fake_cram = compile_fake_cram_fixture(fake_bin_dir.path());
+
+    let stdout = get_stdout_with_envs(
+        &dir,
+        ["cram", "--trace"],
+        [(
+            "MOON_CRAM_OVERRIDE",
+            fake_cram.to_string_lossy().into_owned(),
+        )],
+    );
+
+    assert!(
+        stdout.contains("fake-moon-cram-args=--trace"),
+        "trace after `cram` should be handled by moon-cram:\n{stdout}"
+    );
+    assert!(!dir.join("trace.json").exists());
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -94,7 +94,7 @@ fn test_moon_help() {
               -v, --verbose
                       Increase verbosity
                   --trace
-                      Trace the execution of the program
+                      Record Moon's internal execution trace
                   --dry-run
                       Do not actually run the command
               -Z, --unstable-feature <UNSTABLE_FEATURE>
@@ -662,6 +662,44 @@ fn test_external_subcommand_delegation_handles_interrupt() {
         Some(42),
         "fake moon-test-behavior did not handle interrupt itself; status was {status}"
     );
+}
+
+#[test]
+fn test_delegated_commands_reject_trace_before_initializing_tracing() {
+    for args in [
+        &["--trace", "not-a-real-subcommand"][..],
+        &["--trace", "cram", "list"],
+        &["--trace", "runwasm", "not-a-real-package"],
+        &["--trace", "login"],
+        &["--trace", "register"],
+        &["--trace", "publish"],
+        &["--trace", "package"],
+    ] {
+        let dir = TestDir::new_empty();
+        moon_cmd(&dir)
+            .args(args)
+            .assert()
+            .code(2)
+            .stdout_eq("")
+            .stderr_eq(
+                "error: `--trace` is not supported for delegated command `[..]`\n\n\
+                 Usage: moon [OPTIONS] <COMMAND>\n\n\
+                 For more information, try '--help'.\n",
+            );
+        assert!(!dir.join("trace.json").exists());
+    }
+}
+
+#[test]
+fn test_delegated_commands_ignore_moon_trace_environment() {
+    let dir = TestDir::new_empty();
+    moon_cmd(&dir)
+        .env("MOON_TRACE", "trace")
+        .arg("not-a-real-subcommand")
+        .assert()
+        .failure();
+
+    assert!(!dir.join("trace.json").exists());
 }
 
 #[test]
@@ -1245,7 +1283,7 @@ fn test_moon_explain_without_flags_shows_guidance() {
                   --target-dir <TARGET_DIR>  The target directory. Defaults to `<project-root>/_build`
               -q, --quiet                    Suppress output
               -v, --verbose                  Increase verbosity
-                  --trace                    Trace the execution of the program
+                  --trace                    Record Moon's internal execution trace
                   --dry-run                  Do not actually run the command
 
             Resources:

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -420,6 +420,21 @@ arg2
 }
 
 #[test]
+fn test_runwasm_local_package_flushes_trace() {
+    let dir = TestDir::new("moon_run_with_cli_args.in");
+
+    moon_cmd(&dir)
+        .args(["--trace", "runwasm", "./main", "--arg1", "arg2"])
+        .assert()
+        .success();
+
+    let trace: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(dir.join("trace.json")).unwrap())
+            .expect("local runwasm trace should be complete JSON");
+    assert!(trace.as_array().is_some_and(|events| !events.is_empty()));
+}
+
+#[test]
 fn test_runwasm_help_marks_policy_as_experimental() {
     let dir = TestDir::new_empty();
     let help = get_stdout(&dir, ["runwasm", "--help"]);

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -302,11 +302,6 @@ impl ResolveConfig {
         self
     }
 
-    pub fn with_captured_sync_child_output(mut self, capture: bool) -> Self {
-        self.sync_output = self.sync_output.with_captured_child_output(capture);
-        self
-    }
-
     pub fn without_bin_deps(mut self) -> Self {
         self.include_bin_deps = false;
         self

--- a/crates/mooncake/src/dependency_source.rs
+++ b/crates/mooncake/src/dependency_source.rs
@@ -25,6 +25,7 @@ use std::path::PathBuf;
 
 use moonutil::{
     cache::CacheRoot,
+    child_process::ChildOutputMode,
     resolution::{DirSyncResult, ModuleSourceKind, ResolvedEnv},
     user_log::UserLog,
 };
@@ -53,6 +54,7 @@ pub(crate) fn select<'a>(
     project_dir: impl Into<PathBuf>,
     cache: &'a CacheRoot,
     resolved: &ResolvedEnv,
+    child_output: ChildOutputMode,
 ) -> anyhow::Result<Box<dyn DependencySource + 'a>> {
     let has_registry_sources = resolved
         .all_modules()
@@ -61,14 +63,17 @@ pub(crate) fn select<'a>(
         return Ok(Box::new(ImmutableDependencySource::new(root)));
     }
 
-    Ok(Box::new(ProjectDependencySource::new(project_dir)))
+    Ok(Box::new(ProjectDependencySource::new(
+        project_dir,
+        child_output,
+    )))
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
         collections::BTreeMap,
-        path::Path,
+        path::{Path, PathBuf},
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -77,6 +82,7 @@ mod tests {
 
     use moonutil::{
         cache::{CacheKind, CacheRoot},
+        child_process::ChildOutputMode,
         manifest::MoonMod,
         resolution::{ModuleName, ModuleSource, ModuleSourceKind, ResolvedEnv},
         user_log::UserLog,
@@ -84,6 +90,7 @@ mod tests {
     use semver::Version;
 
     use super::{
+        DependencySource,
         global::{ImmutableDependencySource, SOURCE_ARCHIVE_CHECKSUM_FILE},
         select,
     };
@@ -163,17 +170,6 @@ options(
             )])))
         }
 
-        fn install_to(
-            &self,
-            name: &ModuleName,
-            version: &Version,
-            to: &Path,
-            _user_log: &UserLog,
-        ) -> anyhow::Result<()> {
-            std::fs::create_dir_all(to)?;
-            self.install_source(name, version, to)
-        }
-
         fn acquire_source_to(
             &self,
             name: &ModuleName,
@@ -182,6 +178,7 @@ options(
             to: &Path,
             _user_log: &UserLog,
         ) -> anyhow::Result<()> {
+            std::fs::create_dir_all(to)?;
             self.install_source(name, version, to)?;
             std::fs::write(to.join("acquired-archive-checksum"), expected_checksum)?;
             Ok(())
@@ -232,6 +229,14 @@ options(
         }
     }
 
+    fn select_source<'a>(
+        project_dir: impl Into<PathBuf>,
+        cache: &'a CacheRoot,
+        resolved: &ResolvedEnv,
+    ) -> Box<dyn DependencySource + 'a> {
+        select(project_dir, cache, resolved, ChildOutputMode::Inherit).unwrap()
+    }
+
     #[test]
     fn source_layout_is_canonical() {
         let cache = tempfile::TempDir::new().unwrap();
@@ -250,7 +255,7 @@ options(
         let cache = global_cache(&sandbox.path().join("cache"));
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let source = select_source(sandbox.path().join(".mooncakes"), &cache, &resolved);
 
         let first = source
             .ensure(&registry, &resolved, false, &user_log())
@@ -277,7 +282,7 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(true);
         let (resolved, module) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let source = select_source(sandbox.path().join(".mooncakes"), &cache, &resolved);
         let directory =
             ImmutableDependencySource::new(&cache_dir).source_dir(resolved.module_source(module));
 
@@ -299,7 +304,7 @@ options(
         let cache = global_cache(&sandbox.path().join("cache"));
         let registry = TestRegistry::new(false);
         let (resolved, _) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let source = select_source(sandbox.path().join(".mooncakes"), &cache, &resolved);
 
         let error = source
             .ensure(&registry, &resolved, true, &user_log())
@@ -322,13 +327,13 @@ options(
 
         std::thread::scope(|scope| {
             let first = scope.spawn(|| {
-                let source = select(&project_dir, &cache, &resolved).unwrap();
+                let source = select_source(&project_dir, &cache, &resolved);
                 source
                     .ensure(registry.as_ref(), &resolved, false, &user_log())
                     .unwrap();
             });
             let second = scope.spawn(|| {
-                let source = select(&project_dir, &cache, &resolved).unwrap();
+                let source = select_source(&project_dir, &cache, &resolved);
                 source
                     .ensure(registry.as_ref(), &resolved, false, &user_log())
                     .unwrap();
@@ -351,7 +356,7 @@ options(
         let first_registry = TestRegistry::new(false);
         let second_registry = TestRegistry::new(false).with_checksum(SECOND_CHECKSUM);
         let (resolved, module) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let source = select_source(sandbox.path().join(".mooncakes"), &cache, &resolved);
 
         let first = source
             .ensure(&first_registry, &resolved, false, &user_log())
@@ -382,7 +387,7 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(false).with_checksum_after_first_read(SECOND_CHECKSUM);
         let (resolved, module) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let source = select_source(sandbox.path().join(".mooncakes"), &cache, &resolved);
 
         let paths = source
             .ensure(&registry, &resolved, false, &user_log())
@@ -410,7 +415,7 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let source = select_source(sandbox.path().join(".mooncakes"), &cache, &resolved);
         let directory =
             ImmutableDependencySource::new(&cache_dir).source_dir(resolved.module_source(module));
         std::fs::create_dir_all(&directory).unwrap();
@@ -450,7 +455,7 @@ options(
         let cache = CacheRoot::Disabled;
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
-        let source = select(&project_dir, &cache, &resolved).unwrap();
+        let source = select_source(&project_dir, &cache, &resolved);
 
         let paths = source
             .ensure(&registry, &resolved, false, &user_log())

--- a/crates/mooncake/src/dependency_source/project.rs
+++ b/crates/mooncake/src/dependency_source/project.rs
@@ -26,6 +26,7 @@ use std::{
 use anyhow::Context;
 use arcstr::ArcStr;
 use moonutil::{
+    child_process::ChildOutputMode,
     constants::MOONBITLANG_CORE,
     locks::FileLock,
     resolution::{DirSyncResult, ModuleSource, ModuleSourceKind, ResolvedEnv},
@@ -34,7 +35,7 @@ use moonutil::{
 };
 use semver::Version;
 
-use crate::registry::Registry;
+use crate::registry::{Registry, RegistryPackageInstaller};
 
 use super::DependencySource;
 
@@ -53,11 +54,15 @@ type NewDepDirState<'a> = HashMap<ArcStr, HashMap<ArcStr, &'a ModuleSource>>;
 /// `foo/bar/baz` will be stored in the directory `foo/bar+baz`.
 pub(super) struct ProjectDependencySource {
     path: PathBuf,
+    child_output: ChildOutputMode,
 }
 
 impl ProjectDependencySource {
-    pub(super) fn new(path: impl Into<PathBuf>) -> Self {
-        Self { path: path.into() }
+    pub(super) fn new(path: impl Into<PathBuf>, child_output: ChildOutputMode) -> Self {
+        Self {
+            path: path.into(),
+            child_output,
+        }
     }
 
     fn path(&self) -> &Path {
@@ -268,6 +273,7 @@ fn sync(
         std::fs::create_dir_all(user_path)?;
     }
     // Finally, Download and install packages that are needed.
+    let installer = RegistryPackageInstaller::new(registry, dep_dir.child_output, user_log);
     for (user, pkgs) in diff.add_pkg {
         for (pkg, version) in pkgs {
             let pkg_path = pkg_to_dir(dep_dir, &user, &pkg);
@@ -279,7 +285,7 @@ fn sync(
             let ModuleSourceKind::Registry = version.source() else {
                 unreachable!()
             };
-            registry.install_to(version.name(), version.version(), &pkg_path, user_log)?;
+            installer.install_to(version.name(), version.version(), &pkg_path)?;
             // TODO: parallelize this
         }
     }

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -67,7 +67,7 @@ pub fn add_latest(
     let pkg_name_str = pkg_name.to_string();
     if pkg_name_str == MOONBITLANG_CORE {
         user_log.warn(format!("no need to add `{MOONBITLANG_CORE}` as dependency"));
-        std::process::exit(0);
+        return Ok(0);
     }
 
     let registry = registry::OnlineRegistry::mooncakes_io();
@@ -118,7 +118,7 @@ pub fn add(
     let pkg_name_str = pkg_name.to_string();
     if pkg_name_str == MOONBITLANG_CORE {
         user_log.warn(format!("no need to add `{MOONBITLANG_CORE}` as dependency"));
-        std::process::exit(0);
+        return Ok(0);
     }
 
     if upgrade {

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -25,6 +25,7 @@ use super::sync::SyncOutputOptions;
 use anyhow::Context;
 use moonutil::{
     cache::CacheRoot,
+    child_process::{ChildOutputMode, run_managed_child},
     constants::MOONBITLANG_CORE,
     project::PackageDirs,
     resolution::{
@@ -110,8 +111,13 @@ pub(crate) fn install_impl(
     };
 
     let res = resolve_with_default_env_and_resolver(&resolve_config, roots, user_log)?;
-    let dependency_source = dependency_source::select(&dirs.mooncakes_dir, source_cache, &res)?;
-    let dependency_user_log = if output_options.quiet() {
+    let dependency_source = dependency_source::select(
+        &dirs.mooncakes_dir,
+        source_cache,
+        &res,
+        output_options.child_output,
+    )?;
+    let dependency_user_log = if output_options.quiet {
         user_log.with_level(log::LevelFilter::Error)
     } else {
         user_log.clone()
@@ -124,7 +130,7 @@ pub(crate) fn install_impl(
     )?;
 
     install_bin_deps(
-        output_options.capture_child_output(),
+        output_options.child_output,
         &res,
         &dependency_paths,
         &dirs.target_dir,
@@ -136,7 +142,7 @@ pub(crate) fn install_impl(
 }
 
 fn install_bin_deps(
-    capture_child_output: bool,
+    child_output: ChildOutputMode,
     res: &ResolvedEnv,
     dependency_paths: &DirSyncResult,
     target_dir: &Path,
@@ -190,46 +196,11 @@ fn install_bin_deps(
             if verbose {
                 user_log.info(format!("Installing binary dependency `{}`", edge.name));
             }
-            let status = if capture_child_output {
-                let output = cmd.output().with_context(|| {
+            let subject = format!("binary dependency `{}`", edge.name);
+            let status = run_managed_child(&mut cmd, child_output, user_log, &subject)
+                .with_context(|| {
                     format!("Failed to run build process for binary dep `{}`", edge.name)
                 })?;
-                for (channel, content) in [
-                    ("stdout", output.stdout.as_slice()),
-                    ("stderr", output.stderr.as_slice()),
-                ] {
-                    let content = String::from_utf8_lossy(content);
-                    let content = content.trim();
-                    if content.is_empty() {
-                        continue;
-                    }
-                    let message = format!(
-                        "binary dependency `{}` wrote to {channel}:\n{content}",
-                        edge.name
-                    );
-                    if output.status.success() {
-                        user_log.status(message);
-                    } else {
-                        user_log.error(message);
-                    }
-                }
-                output.status
-            } else {
-                cmd.spawn()
-                    .with_context(|| {
-                        format!(
-                            "Failed to spawn build process for binary dep `{}`",
-                            edge.name
-                        )
-                    })?
-                    .wait()
-                    .with_context(|| {
-                        format!(
-                            "Failed to wait for build process of binary dep `{}`",
-                            edge.name
-                        )
-                    })?
-            };
             if !status.success() {
                 return Err(anyhow::anyhow!(
                     "Building binary dependency `{}` failed",

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -24,6 +24,7 @@ use indexmap::IndexMap;
 use moonutil::{
     build_options::{MoonbuildOpt, MooncOpt},
     cache::CacheRoot,
+    child_process::ChildOutputMode,
     cli_support::AutoSyncFlags,
     front_matter::MbtMdHeader,
     manifest::{MoonMod, read_module_desc_file_in_dir},
@@ -35,28 +36,8 @@ use semver::Version;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SyncOutputOptions {
-    quiet: bool,
-    capture_child_output: bool,
-}
-
-impl SyncOutputOptions {
-    pub fn with_quiet(mut self, quiet: bool) -> Self {
-        self.quiet = quiet;
-        self
-    }
-
-    pub fn quiet(self) -> bool {
-        self.quiet
-    }
-
-    pub fn with_captured_child_output(mut self, capture: bool) -> Self {
-        self.capture_child_output = capture;
-        self
-    }
-
-    pub fn capture_child_output(self) -> bool {
-        self.capture_child_output
-    }
+    pub quiet: bool,
+    pub child_output: ChildOutputMode,
 }
 
 /// Given the specified source directory, resolve the module dependency relation

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -24,15 +24,52 @@ pub mod path;
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 use indexmap::IndexMap;
-use moonutil::dependency::SourceDependencyInfo;
-use moonutil::resolution::ModuleName;
-use moonutil::user_log::UserLog;
+use moonutil::{
+    child_process::ChildOutputMode, dependency::SourceDependencyInfo, resolution::ModuleName,
+    scripts::execute_postadd_script, user_log::UserLog,
+};
 pub use online::*;
 use semver::Version;
 
 #[derive(Debug, Clone, Default)]
 pub struct RegistryVersionInfo {
     pub deps: IndexMap<String, SourceDependencyInfo>,
+}
+
+/// Install a registry package and run its package-controlled setup hook.
+///
+/// Registry adapters only acquire verified source. This module owns the
+/// separate execution policy required by `scripts.postadd`.
+pub struct RegistryPackageInstaller<'a> {
+    registry: &'a dyn Registry,
+    child_output: ChildOutputMode,
+    user_log: &'a UserLog,
+}
+
+impl<'a> RegistryPackageInstaller<'a> {
+    pub fn new(
+        registry: &'a dyn Registry,
+        child_output: ChildOutputMode,
+        user_log: &'a UserLog,
+    ) -> Self {
+        Self {
+            registry,
+            child_output,
+            user_log,
+        }
+    }
+
+    pub fn install_to(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        to: &Path,
+    ) -> anyhow::Result<()> {
+        let checksum = self.registry.source_archive_checksum(name, version)?;
+        self.registry
+            .acquire_source_to(name, version, &checksum, to, self.user_log)?;
+        execute_postadd_script(to, self.child_output, self.user_log)
+    }
 }
 
 pub trait Registry {
@@ -71,14 +108,6 @@ pub trait Registry {
             .map(|(version, _)| version.clone())
     }
 
-    fn install_to(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        to: &Path,
-        user_log: &UserLog,
-    ) -> anyhow::Result<()>;
-
     /// Ensure the published source archive is available, verify it against the
     /// checksum selected by the caller, and extract it without executing
     /// package-controlled hooks such as `scripts.postadd`.
@@ -112,16 +141,6 @@ where
         name: &ModuleName,
     ) -> anyhow::Result<Arc<BTreeMap<Version, RegistryVersionInfo>>> {
         (**self).all_versions_of(name)
-    }
-
-    fn install_to(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        to: &Path,
-        user_log: &UserLog,
-    ) -> anyhow::Result<()> {
-        (**self).install_to(name, version, to, user_log)
     }
 
     fn acquire_source_to(
@@ -161,16 +180,6 @@ where
         name: &ModuleName,
     ) -> anyhow::Result<Arc<BTreeMap<Version, RegistryVersionInfo>>> {
         (**self).all_versions_of(name)
-    }
-
-    fn install_to(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        to: &Path,
-        user_log: &UserLog,
-    ) -> anyhow::Result<()> {
-        (**self).install_to(name, version, to, user_log)
     }
 
     fn acquire_source_to(

--- a/crates/mooncake/src/registry/mock.rs
+++ b/crates/mooncake/src/registry/mock.rs
@@ -170,16 +170,6 @@ impl Registry for MockRegistry {
             .map(Arc::new)
     }
 
-    fn install_to(
-        &self,
-        _name: &ModuleName,
-        _version: &Version,
-        _to: &std::path::Path,
-        _user_log: &moonutil::user_log::UserLog,
-    ) -> anyhow::Result<()> {
-        panic!("Mock registry does not support installing")
-    }
-
     fn acquire_source_to(
         &self,
         _name: &ModuleName,

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -29,7 +29,7 @@ use anyhow::{Context, bail};
 use indexmap::map::IndexMap;
 use moonutil::{
     dependency::SourceDependencyInfo, registry::RegistryConfig, resolution::ModuleName,
-    scripts::execute_postadd_script, user_log::UserLog,
+    user_log::UserLog,
 };
 use reqwest::header::USER_AGENT;
 use semver::Version;
@@ -130,16 +130,6 @@ impl super::Registry for OnlineRegistry {
             .insert(name.clone(), Arc::clone(&res));
 
         Ok(res)
-    }
-
-    fn install_to(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        to: &Path,
-        user_log: &UserLog,
-    ) -> anyhow::Result<()> {
-        self.install_to_impl(name, version, to, user_log)
     }
 
     fn acquire_source_to(
@@ -317,19 +307,6 @@ impl OnlineRegistry {
             .error_for_status()?;
 
         persist_verified_archive(&mut response, &cache_file, name, version, expected_checksum)
-    }
-
-    pub fn install_to_impl(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        pkg_install_dir: &Path,
-        user_log: &UserLog,
-    ) -> anyhow::Result<()> {
-        let checksum = self.read_checksum_from_index_file(name, version)?;
-        self.acquire_source_to(name, version, &checksum, pkg_install_dir, user_log)?;
-        execute_postadd_script(pkg_install_dir, user_log)?;
-        Ok(())
     }
 
     /// Reuse or download, verify, and extract a registry package without

--- a/crates/moonutil/src/child_process.rs
+++ b/crates/moonutil/src/child_process.rs
@@ -47,7 +47,10 @@ pub fn run_managed_child(
             command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
         }
         ChildOutputMode::Capture => {
-            command.stdout(Stdio::piped()).stderr(Stdio::piped());
+            command
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
         }
     }
 
@@ -79,40 +82,44 @@ pub fn run_managed_child(
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+
     use log::LevelFilter;
 
     use super::{ChildOutputMode, run_managed_child};
     use crate::user_log::{UserLog, UserLogEntryLevel};
 
+    const EMIT_HELPER_ENV: &str = "MOON_CHILD_OUTPUT_EMIT_HELPER";
     const INHERIT_HELPER_ENV: &str = "MOON_CHILD_OUTPUT_INHERIT_HELPER";
+    const CAPTURE_STDIN_HELPER_ENV: &str = "MOON_CHILD_OUTPUT_CAPTURE_STDIN_HELPER";
 
     fn emitting_command(success: bool) -> std::process::Command {
-        #[cfg(unix)]
-        {
-            let mut command = std::process::Command::new("/bin/sh");
-            command.args([
-                "-c",
-                if success {
-                    "printf CHILD_STDOUT; printf CHILD_STDERR >&2"
-                } else {
-                    "printf CHILD_STDOUT; printf CHILD_STDERR >&2; exit 7"
-                },
-            ]);
-            command
-        }
-        #[cfg(windows)]
-        {
-            let mut command = std::process::Command::new("cmd");
-            command.args([
-                "/C",
-                if success {
-                    "<nul set /p =CHILD_STDOUT & <nul set /p =CHILD_STDERR 1>&2"
-                } else {
-                    "<nul set /p =CHILD_STDOUT & <nul set /p =CHILD_STDERR 1>&2 & exit /b 7"
-                },
-            ]);
-            command
-        }
+        let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                "--exact",
+                "child_process::tests::emit_helper",
+                "--nocapture",
+            ])
+            .env(EMIT_HELPER_ENV, success.to_string());
+        command
+    }
+
+    #[test]
+    fn emit_helper() -> Result<(), &'static str> {
+        let Ok(success) = std::env::var(EMIT_HELPER_ENV) else {
+            return Ok(());
+        };
+
+        print!("CHILD_STDOUT");
+        eprint!("CHILD_STDERR");
+        std::io::stdout().flush().unwrap();
+        std::io::stderr().flush().unwrap();
+        success
+            .parse::<bool>()
+            .unwrap()
+            .then_some(())
+            .ok_or("requested failure")
     }
 
     #[test]
@@ -135,8 +142,73 @@ mod tests {
             } else {
                 matches!(entry.level, UserLogEntryLevel::Error)
             }));
-            assert!(entries[0].message.contains("stdout:\nCHILD_STDOUT"));
-            assert!(entries[1].message.contains("stderr:\nCHILD_STDERR"));
+            assert!(
+                entries[0]
+                    .message
+                    .starts_with("test child wrote to stdout:\n")
+            );
+            assert!(entries[0].message.contains("CHILD_STDOUT"));
+            assert!(
+                entries[1]
+                    .message
+                    .starts_with("test child wrote to stderr:\n")
+            );
+            assert!(entries[1].message.contains("CHILD_STDERR"));
+        }
+    }
+
+    #[test]
+    fn captured_output_closes_child_stdin() {
+        let mut input = tempfile::NamedTempFile::new().unwrap();
+        input.write_all(b"PARENT_STDIN").unwrap();
+
+        let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                "--exact",
+                "child_process::tests::capture_stdin_helper",
+                "--nocapture",
+            ])
+            .env(CAPTURE_STDIN_HELPER_ENV, "1")
+            .stdin(std::fs::File::open(input.path()).unwrap());
+        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+
+        let status = run_managed_child(
+            &mut command,
+            ChildOutputMode::Capture,
+            &user_log,
+            "test child",
+        )
+        .unwrap();
+
+        assert!(status.success());
+        let entries = capture.take();
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.message.contains("STDIN_EOF")),
+            "captured child inherited parent input: {entries:#?}"
+        );
+        assert!(
+            entries
+                .iter()
+                .all(|entry| !entry.message.contains("PARENT_STDIN")),
+            "captured child consumed parent input: {entries:#?}"
+        );
+    }
+
+    #[test]
+    fn capture_stdin_helper() {
+        if std::env::var_os(CAPTURE_STDIN_HELPER_ENV).is_none() {
+            return;
+        }
+
+        let mut input = String::new();
+        std::io::stdin().read_to_string(&mut input).unwrap();
+        if input.is_empty() {
+            print!("STDIN_EOF");
+        } else {
+            print!("STDIN:{input}");
         }
     }
 

--- a/crates/moonutil/src/child_process.rs
+++ b/crates/moonutil/src/child_process.rs
@@ -1,0 +1,178 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::process::{Command, ExitStatus, Stdio};
+
+use crate::user_log::UserLog;
+
+/// Output policy for Moon-managed child processes.
+///
+/// This does not apply to user programs, whose output remains Process
+/// Passthrough. Capture is reserved for command modes that must incorporate
+/// all Moon-visible output into one structured Command Result.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ChildOutputMode {
+    #[default]
+    Inherit,
+    Capture,
+}
+
+/// Run a Moon-managed child and classify captured output as User Logs.
+///
+/// Inherited output retains its original byte stream and channel. Captured
+/// output becomes informational status on success and an error on failure.
+pub fn run_managed_child(
+    command: &mut Command,
+    output_mode: ChildOutputMode,
+    user_log: &UserLog,
+    subject: &str,
+) -> std::io::Result<ExitStatus> {
+    match output_mode {
+        ChildOutputMode::Inherit => {
+            command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+        }
+        ChildOutputMode::Capture => {
+            command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        }
+    }
+
+    let mut child = command.spawn()?;
+    match output_mode {
+        ChildOutputMode::Inherit => child.wait(),
+        ChildOutputMode::Capture => {
+            let output = child.wait_with_output()?;
+            for (channel, content) in [
+                ("stdout", output.stdout.as_slice()),
+                ("stderr", output.stderr.as_slice()),
+            ] {
+                let content = String::from_utf8_lossy(content);
+                let content = content.trim();
+                if content.is_empty() {
+                    continue;
+                }
+                let message = format!("{subject} wrote to {channel}:\n{content}");
+                if output.status.success() {
+                    user_log.status(message);
+                } else {
+                    user_log.error(message);
+                }
+            }
+            Ok(output.status)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use log::LevelFilter;
+
+    use super::{ChildOutputMode, run_managed_child};
+    use crate::user_log::{UserLog, UserLogEntryLevel};
+
+    const INHERIT_HELPER_ENV: &str = "MOON_CHILD_OUTPUT_INHERIT_HELPER";
+
+    fn emitting_command(success: bool) -> std::process::Command {
+        #[cfg(unix)]
+        {
+            let mut command = std::process::Command::new("/bin/sh");
+            command.args([
+                "-c",
+                if success {
+                    "printf CHILD_STDOUT; printf CHILD_STDERR >&2"
+                } else {
+                    "printf CHILD_STDOUT; printf CHILD_STDERR >&2; exit 7"
+                },
+            ]);
+            command
+        }
+        #[cfg(windows)]
+        {
+            let mut command = std::process::Command::new("cmd");
+            command.args([
+                "/C",
+                if success {
+                    "<nul set /p =CHILD_STDOUT & <nul set /p =CHILD_STDERR 1>&2"
+                } else {
+                    "<nul set /p =CHILD_STDOUT & <nul set /p =CHILD_STDERR 1>&2 & exit /b 7"
+                },
+            ]);
+            command
+        }
+    }
+
+    #[test]
+    fn captured_output_uses_status_on_success_and_error_on_failure() {
+        for success in [true, false] {
+            let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+            let status = run_managed_child(
+                &mut emitting_command(success),
+                ChildOutputMode::Capture,
+                &user_log,
+                "test child",
+            )
+            .unwrap();
+
+            assert_eq!(status.success(), success);
+            let entries = capture.take();
+            assert_eq!(entries.len(), 2);
+            assert!(entries.iter().all(|entry| if success {
+                matches!(entry.level, UserLogEntryLevel::Info)
+            } else {
+                matches!(entry.level, UserLogEntryLevel::Error)
+            }));
+            assert!(entries[0].message.contains("stdout:\nCHILD_STDOUT"));
+            assert!(entries[1].message.contains("stderr:\nCHILD_STDERR"));
+        }
+    }
+
+    #[test]
+    fn inherited_output_keeps_parent_channels_on_success_and_failure() {
+        for success in [true, false] {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "child_process::tests::inherit_helper",
+                    "--nocapture",
+                ])
+                .env(INHERIT_HELPER_ENV, success.to_string())
+                .output()
+                .unwrap();
+
+            assert!(output.status.success());
+            assert!(String::from_utf8_lossy(&output.stdout).contains("CHILD_STDOUT"));
+            assert!(String::from_utf8_lossy(&output.stderr).contains("CHILD_STDERR"));
+        }
+    }
+
+    #[test]
+    fn inherit_helper() {
+        let Ok(success) = std::env::var(INHERIT_HELPER_ENV) else {
+            return;
+        };
+        let success = success.parse().unwrap();
+        let status = run_managed_child(
+            &mut emitting_command(success),
+            ChildOutputMode::Inherit,
+            &UserLog::new(LevelFilter::Warn),
+            "test child",
+        )
+        .unwrap();
+
+        assert_eq!(status.success(), success);
+    }
+}

--- a/crates/moonutil/src/cli.rs
+++ b/crates/moonutil/src/cli.rs
@@ -46,7 +46,7 @@ pub struct UniversalFlags {
     #[clap(long, short = 'v', global = true)]
     pub verbose: bool,
 
-    /// Trace the execution of the program
+    /// Record Moon's internal execution trace
     // The module `n2::trace` doesn't suppose parallelism now, so `--trace`
     // should be used in conjunction with `--serial` and `--no-parallelize`.
     #[clap(long, global = true)]

--- a/crates/moonutil/src/lib.rs
+++ b/crates/moonutil/src/lib.rs
@@ -22,6 +22,7 @@ mod binaries;
 pub mod build_options;
 pub mod build_script;
 pub mod cache;
+pub mod child_process;
 mod cli;
 pub mod cli_support;
 pub mod command_output;

--- a/crates/moonutil/src/scripts.rs
+++ b/crates/moonutil/src/scripts.rs
@@ -20,7 +20,11 @@ use std::path::Path;
 
 use anyhow::bail;
 
-use crate::{manifest::read_module_desc_file_in_dir, user_log::UserLog};
+use crate::{
+    child_process::{ChildOutputMode, run_managed_child},
+    manifest::read_module_desc_file_in_dir,
+    user_log::UserLog,
+};
 
 pub enum PrePostBuild {
     PreBuild,
@@ -57,7 +61,11 @@ pub fn is_moon_script_ignored(script: IgnoredMoonScript) -> bool {
     std::env::var_os(script.env_var()).is_some()
 }
 
-pub fn execute_postadd_script(dir: &Path, user_log: &UserLog) -> anyhow::Result<()> {
+pub fn execute_postadd_script(
+    dir: &Path,
+    output_mode: ChildOutputMode,
+    user_log: &UserLog,
+) -> anyhow::Result<()> {
     if is_moon_script_ignored(IgnoredMoonScript::Postadd) {
         return Ok(());
     }
@@ -75,43 +83,13 @@ pub fn execute_postadd_script(dir: &Path, user_log: &UserLog) -> anyhow::Result<
             let args = &postadd[1..];
             let mut process = std::process::Command::new(command);
             process.args(args).current_dir(dir);
-            if user_log.is_captured() {
-                let output = process.output()?;
-                for (channel, content) in [
-                    ("stdout", output.stdout.as_slice()),
-                    ("stderr", output.stderr.as_slice()),
-                ] {
-                    let content = String::from_utf8_lossy(content);
-                    let content = content.trim();
-                    if content.is_empty() {
-                        continue;
-                    }
-                    let message = format!("postadd script wrote to {channel}:\n{content}");
-                    if output.status.success() {
-                        user_log.status(message);
-                    } else {
-                        user_log.error(message);
-                    }
-                }
-                if !output.status.success() {
-                    bail!(
-                        "failed to execute postadd script in {},\ncommand: {}",
-                        dir.display(),
-                        command
-                    );
-                }
-            } else {
-                let status = process
-                    .stdout(std::process::Stdio::inherit())
-                    .stderr(std::process::Stdio::inherit())
-                    .status()?;
-                if !status.success() {
-                    bail!(
-                        "failed to execute postadd script in {},\ncommand: {}",
-                        dir.display(),
-                        command
-                    );
-                }
+            let status = run_managed_child(&mut process, output_mode, user_log, "postadd script")?;
+            if !status.success() {
+                bail!(
+                    "failed to execute postadd script in {},\ncommand: {}",
+                    dir.display(),
+                    command
+                );
             }
         }
     }
@@ -125,7 +103,10 @@ mod tests {
     use log::LevelFilter;
 
     use super::execute_postadd_script;
-    use crate::user_log::{UserLog, UserLogEntryLevel};
+    use crate::{
+        child_process::ChildOutputMode,
+        user_log::{UserLog, UserLogEntryLevel},
+    };
 
     #[test]
     fn captured_postadd_output_is_routed_to_user_log() {
@@ -151,7 +132,7 @@ mod tests {
         .unwrap();
         let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
 
-        execute_postadd_script(sandbox.path(), &user_log).unwrap();
+        execute_postadd_script(sandbox.path(), ChildOutputMode::Capture, &user_log).unwrap();
 
         let entries = capture.take();
         assert_eq!(entries.len(), 2);
@@ -170,7 +151,8 @@ mod tests {
         .unwrap();
         let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
 
-        let error = execute_postadd_script(sandbox.path(), &user_log).unwrap_err();
+        let error = execute_postadd_script(sandbox.path(), ChildOutputMode::Capture, &user_log)
+            .unwrap_err();
 
         assert!(
             error

--- a/crates/moonutil/src/user_log.rs
+++ b/crates/moonutil/src/user_log.rs
@@ -110,12 +110,6 @@ impl UserLog {
         self.level >= level.to_level_filter()
     }
 
-    /// Whether user-facing output is being collected for a command result
-    /// instead of rendered directly to stderr.
-    pub fn is_captured(&self) -> bool {
-        matches!(&self.destination, UserLogDestination::Capture(_))
-    }
-
     pub fn error(&self, message: impl Display) {
         match &self.destination {
             UserLogDestination::Stderr => {

--- a/docs/dev/command-output-migration.md
+++ b/docs/dev/command-output-migration.md
@@ -41,6 +41,8 @@ The quiet user-log level follows `UserLog` and suppresses warnings. Default leve
 
 After argument parsing selects a command, commands that promise one complete machine-readable result are a scoped exception to the usual channel mapping: the CLI may construct a capturing `UserLog`, preserve its level filtering and event order, and serialize those events inside the stdout Command Result. Help and argument-parse failures remain on the parser's native output path. Build executors return compiler diagnostics as data for the same final render; they do not receive `CommandOutput`. Such a mode must suppress terminal progress and tracing output so stderr remains empty.
 
+Moon-managed setup children, such as dependency hooks and binary-dependency builds, receive an explicit output mode from that command boundary. Inherit mode remains Process Passthrough. Capture mode pipes both channels and turns non-empty successful output into informational User Logs and failed output into error User Logs. The child-output policy must not be inferred from the `UserLog` destination. User programs remain Process Passthrough in every command mode.
+
 ## Slices and Blocking Edges
 
 ### CO-1: Prove the seam with `moon info`

--- a/docs/dev/reference/debugging.md
+++ b/docs/dev/reference/debugging.md
@@ -67,4 +67,10 @@ For timing/task/thread details, set `MOON_TRACE=<level>`
 Moon writes a Chromium trace JSON file to the working directory;
 open it in <https://ui.perfetto.dev> to inspect the timeline.
 
+Tracing covers commands whose execution lifecycle is owned by Moon. Commands
+that delegate their work to another executable reject an explicit `--trace`
+instead of producing an incomplete trace; `MOON_TRACE` is ignored for those
+commands. Cross-process tracing requires a separate propagation and collection
+protocol and is not implied by process passthrough.
+
 [tracing]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html


### PR DESCRIPTION
## Why

Machine-readable check output needs one complete stdout result and an empty stderr stream, including when setup children run or the command fails. Direct exits could bypass normal guard destruction, while child-output capture was inferred indirectly from UserLog and did not express which subprocesses Moon owns.

## What changed

- Make the CLI return an exit code through one normal lifecycle, leaving the outer main as the only normal process-exit boundary.
- Keep native Clap parse exits, and classify fully delegated command families as outside Moon tracing ownership.
- Add an explicit ChildOutputMode for Moon-managed setup children and pass it from check JSON through dependency sync, registries, postadd hooks, and binary dependencies.
- Share one child execution path: inherited output preserves its channels, while captured successful output becomes informational User Logs and failed output becomes error User Logs.
- Remove UserLog destination introspection and trivial sync-output wrappers.

## Why this is correct and scoped

The command boundary alone chooses capture for check JSON; ordinary commands retain inherited child streams and existing quiet policy. Trace and JSON guards now leave scope normally on success and failure. The new child policy applies only to Moon-managed setup work; user programs remain process passthrough, and cross-process tracing remains a separate future protocol.

The change is split into two commits: CLI lifecycle first, explicit managed-child output second.