### PR TITLE
test: update mooncake package fixtures

### DIFF
--- a/crates/moon/tests/test_cases/test_exclude_001.in/moon.test
+++ b/crates/moon/tests/test_cases/test_exclude_001.in/moon.test
@@ -6,11 +6,16 @@
   README.md
   moon.mod.json
   moon.test
+  src
+  src/lib
   src/lib/hello.mbt
   src/lib/hello_test.mbt
   src/lib/moon.pkg.json
+  src/main
   src/main/main.mbt
   src/main/moon.pkg.json
+  test
+  test/b
   test/b/b.txt
   Package to [WORK_DIR]/_build/publish/username-hello-0.1.0.zip
   

--- a/crates/moon/tests/test_cases/test_exclude_002.in/moon.test
+++ b/crates/moon/tests/test_cases/test_exclude_002.in/moon.test
@@ -6,11 +6,18 @@
   README.md
   moon.mod.json
   moon.test
+  src
+  src/lib
   src/lib/hello.mbt
   src/lib/hello_test.mbt
   src/lib/moon.pkg.json
+  src/main
   src/main/main.mbt
   src/main/moon.pkg.json
+  test
+  test/a
+  test/b
+  test/c
   test/c/c.md
   Package to [WORK_DIR]/_build/publish/username-hello-0.1.0.zip
   

--- a/crates/moon/tests/test_cases/test_include_001.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/test_include_001.in/moon.mod.json
@@ -8,6 +8,7 @@
   "description": "",
   "source": "src",
   "include": [
+    "moon.mod.json",
     "src",
     "test"
   ]

--- a/crates/moon/tests/test_cases/test_include_002.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/test_include_002.in/moon.mod.json
@@ -8,6 +8,7 @@
   "description": "",
   "source": "src",
   "include": [
+    "moon.mod.json",
     "*.mbt",
     "*.txt"
   ]

--- a/crates/moon/tests/test_cases/test_include_003.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/test_include_003.in/moon.mod.json
@@ -13,6 +13,7 @@
     "*.txt"
   ],
   "include": [
+    "moon.mod.json",
     "*.mbt",
     "*.txt"
   ]


### PR DESCRIPTION
## Summary

- explicitly include `moon.mod.json` in package allowlist fixtures
- update package exclusion snapshots to include preserved directory entries

## Why

Mooncake’s new package ignore semantics treat `include` as the final allowlist and preserve selected directory entries. Nightly CI therefore reports stale expectations in the five package include/exclude fixtures.

## Why this is correct

The include fixtures keep producing valid packages by selecting their module manifest explicitly. The exclude snapshots retain the same file-filtering expectations while recording directory entries now emitted by Mooncake.

## Scope

This only synchronizes test fixtures with the upstream Mooncake behavior. It does not change Moon’s packaging implementation or the Rust 1.95 pull request.