### PR TITLE
Fix macOS system proxy panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-io"
@@ -1024,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1138,13 +1138,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1196,14 +1197,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1320,16 +1320,6 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
-
-[[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -2335,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -2832,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation 0.9.4",
@@ -3106,20 +3096,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ find-msvc-tools = "0.1.9"
 snapbox = "0.6.23"
 futures = { version = "0.3.29", features = ["std"], default-features = false }
 indexmap = { version = "2.2.6", features = ["serde"] }
-reqwest = { version = "0.12.24", default-features = false, features = [
+reqwest = { version = "0.12.28", default-features = false, features = [
     "multipart",
     "blocking",
     "json",
@@ -91,7 +91,7 @@ chrono = { version = "0.4.31", features = [
     "std",
 ], default-features = false }
 hyper = "1.3.1"
-hyper-util = { version = "0.1.3", features = ["http1", "server", "tokio"] }
+hyper-util = { version = "0.1.20", features = ["http1", "server", "tokio"] }
 hyper-staticfile = "0.10.0"
 http = "1.1.0"
 bytes = "1.6"

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -397,6 +397,69 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn registry_download_returns_error_when_system_proxy_service_is_unavailable() {
+        const CHILD_PROCESS: &str = "MOON_TEST_SYSTEM_PROXY_UNAVAILABLE_CHILD";
+
+        if std::env::var_os(CHILD_PROCESS).is_some() {
+            let sandbox = tempfile::TempDir::new().unwrap();
+            let (mut registry, name, version) = test_registry(&sandbox);
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let unavailable_address = listener.local_addr().unwrap();
+            drop(listener);
+            registry.url_base = format!("http://{unavailable_address}");
+
+            registry
+                .acquire_source_to(
+                    &name,
+                    &version,
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                    &sandbox.path().join("source"),
+                    &quiet_user_log(),
+                )
+                .unwrap_err();
+            return;
+        }
+
+        // Apply the macOS profile to a child process, then run only this test there.
+        let mut child = std::process::Command::new("/usr/bin/sandbox-exec");
+        child
+            .args([
+                "-p",
+                r#"(version 1)
+(allow default)
+(deny mach-lookup (global-name "com.apple.SystemConfiguration.configd"))"#,
+            ])
+            .arg(std::env::current_exe().unwrap())
+            .args([
+                "registry_download_returns_error_when_system_proxy_service_is_unavailable",
+                "--nocapture",
+            ])
+            .env(CHILD_PROCESS, "1");
+        for name in [
+            "ALL_PROXY",
+            "all_proxy",
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ] {
+            child.env_remove(name);
+        }
+
+        let output = child.output().unwrap();
+        assert!(
+            output.status.success(),
+            "sandboxed registry download failed with {}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn verified_archive_handle_survives_cache_path_replacement() {


### PR DESCRIPTION
## Why

`moon add` enables reqwest's system proxy support. On macOS, the previously resolved `hyper-util` and `system-configuration` versions could panic while constructing the HTTP client when access to `com.apple.SystemConfiguration.configd` was denied, instead of returning a normal download error.

## What changed

- Update reqwest within the existing 0.12 release line.
- Require `hyper-util` 0.1.20, which handles unavailable macOS system proxy configuration without panicking.
- Add a macOS regression test that denies access to `configd`, enters the real registry download path, and verifies that an unavailable destination produces an error rather than a panic.

## Why this is correct

The updated system proxy implementation treats an unavailable dynamic store as no usable system proxy configuration, allowing reqwest to continue to the connection attempt. The regression test isolates that behavior without external network access.

The change is limited to dependency patch updates, their lockfile consequences, and focused regression coverage; it does not alter registry download policy or the documentation server architecture.
