### PR TITLE
refactor: isolate legacy postadd and deprecate bin-deps

### DIFF
--- a/crates/moon/src/cli/fetch.rs
+++ b/crates/moon/src/cli/fetch.rs
@@ -18,7 +18,7 @@
 
 use anyhow::bail;
 use colored::Colorize;
-use mooncake::registry::Registry;
+use mooncake::{pkg::legacy_postadd, registry::Registry};
 use moonutil::{
     project::PackageDirs, registry::RegistryConfig, resolution::ModuleName, user_log::UserLog,
 };
@@ -136,7 +136,8 @@ pub(crate) fn fetch_cli(
         println!("Fetching {}@{version} to {}", pkg_name, pkg_dir.display());
     }
 
-    registry.install_to(&pkg_name, &version, &pkg_dir, user_log)?;
+    registry.materialize_source_to(&pkg_name, &version, &pkg_dir, user_log)?;
+    legacy_postadd::run(&pkg_dir, user_log)?;
 
     if !cli.quiet {
         println!(

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -24,7 +24,7 @@ use moonbuild_rupes_recta::{
     model::{BuildPlanNode, BuildTarget, PackageId, TargetKind},
 };
 use mooncake::{
-    pkg::sync::SyncOutputOptions,
+    pkg::{legacy_postadd, sync::SyncOutputOptions},
     registry::{OnlineRegistry, Registry, path as registry_path},
 };
 use moonutil::{
@@ -274,7 +274,8 @@ pub(super) fn install_binary(
     let tmp_dir = tempfile::TempDir::new().context("Failed to create temporary directory")?;
     let module_dir = tmp_dir.path();
 
-    registry.install_to(&spec.module_name, &version, module_dir, user_log)?;
+    registry.materialize_source_to(&spec.module_name, &version, module_dir, user_log)?;
+    legacy_postadd::run(module_dir, user_log)?;
 
     let filter =
         PackageFilter::package_path(spec.package_path.clone().unwrap_or_default(), install_all);

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -33,7 +33,11 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use moonbuild_rupes_recta::{
-    ResolveConfig, discover::DiscoveredPackage, intent::UserIntent, model::PackageId,
+    ResolveConfig,
+    build_plan::{InputDirective, PackagePrebuildPolicy},
+    discover::DiscoveredPackage,
+    intent::UserIntent,
+    model::PackageId,
 };
 use moonutil::{
     build_options::RunMode, cli_support::AutoSyncFlags, cli_support::UniversalFlags,
@@ -164,7 +168,14 @@ pub(crate) fn run_build_binary_dep(
             user_log,
             &resolve_output,
         )?;
-        let intent = vec![UserIntent::Build(pkg)].into();
+        let intent = (
+            vec![UserIntent::Build(pkg)],
+            InputDirective {
+                package_prebuild: PackagePrebuildPolicy::ConsumeExistingOutputs,
+                ..InputDirective::default()
+            },
+        )
+            .into();
         let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
             preconfig,
             &cli.unstable_feature,

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -34,7 +34,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use moonbuild_rupes_recta::{
     ResolveConfig,
-    build_plan::{InputDirective, PackagePrebuildPolicy},
+    build_plan::{InputDirective, PackageSourceGenerationPolicy},
     discover::DiscoveredPackage,
     intent::UserIntent,
     model::PackageId,
@@ -171,7 +171,7 @@ pub(crate) fn run_build_binary_dep(
         let intent = (
             vec![UserIntent::Build(pkg)],
             InputDirective {
-                package_prebuild: PackagePrebuildPolicy::ConsumeExistingOutputs,
+                package_source_generation: PackageSourceGenerationPolicy::ConsumeExistingOutputs,
                 ..InputDirective::default()
             },
         )

--- a/crates/moon/src/cli/tool/build_binary_dep.rs
+++ b/crates/moon/src/cli/tool/build_binary_dep.rs
@@ -34,7 +34,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use moonbuild_rupes_recta::{
     ResolveConfig,
-    build_plan::{InputDirective, PackageSourceGenerationPolicy},
+    build_plan::{InputDirective, PackagePrebuildPolicy},
     discover::DiscoveredPackage,
     intent::UserIntent,
     model::PackageId,
@@ -171,7 +171,7 @@ pub(crate) fn run_build_binary_dep(
         let intent = (
             vec![UserIntent::Build(pkg)],
             InputDirective {
-                package_source_generation: PackageSourceGenerationPolicy::ConsumeExistingOutputs,
+                package_prebuild: PackagePrebuildPolicy::ConsumeExistingOutputs,
                 ..InputDirective::default()
             },
         )

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -191,7 +191,7 @@ pub fn build_patch_directive_for_package(
         specify_patch_file: patch_directive,
         value_tracing,
         prove_why3_config: None,
-        package_prebuild: Default::default(),
+        package_source_generation: Default::default(),
     })
 }
 

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -191,7 +191,7 @@ pub fn build_patch_directive_for_package(
         specify_patch_file: patch_directive,
         value_tracing,
         prove_why3_config: None,
-        package_source_generation: Default::default(),
+        package_prebuild: Default::default(),
     })
 }
 

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -191,6 +191,7 @@ pub fn build_patch_directive_for_package(
         specify_patch_file: patch_directive,
         value_tracing,
         prove_why3_config: None,
+        package_prebuild: Default::default(),
     })
 }
 

--- a/crates/moon/tests/test_cases/diagnostics_format/check.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/check.rs
@@ -300,7 +300,7 @@ fn test_moon_check_complete_json_captures_bin_dep_prebuild_failure() {
 }
 
 #[test]
-fn test_moon_check_complete_json_runs_bin_dep_prebuild() {
+fn test_moon_check_complete_json_runs_bin_dep_unstable_prebuild_config() {
     let top_dir = TestDir::new("prebuild_config_script/check_skip_bin_dep.in");
     let dir = top_dir.join("user.in");
     let generated_stub = top_dir.join("author.in/src/main/generated_stub.c");
@@ -319,7 +319,20 @@ fn test_moon_check_complete_json_runs_bin_dep_prebuild() {
     );
 
     assert_eq!(report["status"], "success");
-    assert_eq!(report["summary"]["moon_warnings"], 0);
+    assert_eq!(report["summary"]["moon_warnings"], 1);
+    assert!(
+        report["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|message| {
+                message["level"] == "warning"
+                    && message["message"]
+                        .as_str()
+                        .unwrap()
+                        .contains("`bin-deps` is deprecated")
+            })
+    );
     assert!(
         report["messages"]
             .as_array()

--- a/crates/moon/tests/test_cases/diagnostics_format/check.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/check.rs
@@ -272,7 +272,7 @@ preferred_target = "wasm-gc"
 }
 
 #[test]
-fn test_moon_check_complete_json_captures_bin_dep_prebuild_failure() {
+fn test_moon_check_complete_json_captures_bin_dep_unstable_prebuild_config_failure() {
     let top_dir = TestDir::new("prebuild_config_script/check_skip_bin_dep.in");
     let dir = top_dir.join("user.in");
     std::fs::write(

--- a/crates/moon/tests/test_cases/package_management.rs
+++ b/crates/moon/tests/test_cases/package_management.rs
@@ -353,3 +353,68 @@ fn test_postadd_script() {
     let out = String::from_utf8(out.stderr).unwrap();
     assert!(!out.contains(".mooncakes/lijunchen/test_postadd"));
 }
+
+#[test]
+fn test_fetch_and_binary_install_run_legacy_postadd() {
+    let dir = TestDir::new_empty();
+    let moon_home = tempfile::TempDir::new().expect("failed to create temporary MOON_HOME");
+    let moon_path = std::env::join_paths(
+        std::iter::once(
+            moon_bin()
+                .parent()
+                .expect("test moon binary should have a parent directory")
+                .to_path_buf(),
+        )
+        .chain(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        )),
+    )
+    .expect("test PATH should be valid");
+    let manifest = serde_json::json!({
+        "name": "testuser/postadd",
+        "version": "1.0.0",
+        "source": "src",
+        "scripts": {
+            "postadd": "moon tool write-tcc-rsp-file src/tool/generated.mbt fn generated()->Int{42}"
+        }
+    })
+    .to_string()
+    .into_bytes();
+    cache_registry_package(
+        moon_home.path(),
+        "testuser/postadd",
+        "1.0.0",
+        &[
+            ("moon.mod.json", manifest),
+            ("src/tool/moon.pkg.json", br#"{"is-main":true}"#.to_vec()),
+            (
+                "src/tool/main.mbt",
+                br#"fn main { println(generated()) }"#.to_vec(),
+            ),
+        ],
+    );
+
+    moon_cmd(&dir)
+        .env("MOON_HOME", moon_home.path())
+        .env("PATH", &moon_path)
+        .args(["fetch", "--no-update", "testuser/postadd@1.0.0"])
+        .assert()
+        .success();
+    assert!(
+        dir.join(".repos/testuser/postadd/1.0.0/src/tool/generated.mbt")
+            .is_file()
+    );
+
+    let bin_dir = dir.join("bin");
+    moon_cmd(&dir)
+        .env("MOON_HOME", moon_home.path())
+        .env("PATH", &moon_path)
+        .args(["install", "testuser/postadd/tool@1.0.0", "--bin"])
+        .arg(&bin_dir)
+        .assert()
+        .success();
+    #[cfg(unix)]
+    assert!(bin_dir.join("tool").is_file());
+    #[cfg(windows)]
+    assert!(bin_dir.join("tool.exe").is_file());
+}

--- a/crates/moon/tests/test_cases/package_management.rs
+++ b/crates/moon/tests/test_cases/package_management.rs
@@ -358,6 +358,32 @@ fn test_postadd_script() {
 fn test_fetch_and_binary_install_run_legacy_postadd() {
     let dir = TestDir::new_empty();
     let moon_home = tempfile::TempDir::new().expect("failed to create temporary MOON_HOME");
+    let registry = tempfile::TempDir::new().expect("failed to create temporary registry");
+    let registry_index = registry.path().join("git/index");
+    std::fs::create_dir_all(registry_index.parent().unwrap()).unwrap();
+    let output = std::process::Command::new("git")
+        .args(["init", "--bare", "--initial-branch=main"])
+        .arg(&registry_index)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to initialize local registry index:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let local_index = moon_home.path().join("registry/index");
+    std::fs::create_dir_all(local_index.parent().unwrap()).unwrap();
+    let output = std::process::Command::new("git")
+        .arg("clone")
+        .arg(&registry_index)
+        .arg(&local_index)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to clone local registry index:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     let moon_path = std::env::join_paths(
         std::iter::once(
             moon_bin()
@@ -393,6 +419,49 @@ fn test_fetch_and_binary_install_run_legacy_postadd() {
             ),
         ],
     );
+    let output = std::process::Command::new("git")
+        .current_dir(&local_index)
+        .args(["add", "."])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let output = std::process::Command::new("git")
+        .current_dir(&local_index)
+        .args([
+            "-c",
+            "user.name=Moon Test",
+            "-c",
+            "user.email=moon-test@example.com",
+            "commit",
+            "-m",
+            "Add fixture package",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to commit local registry index:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output = std::process::Command::new("git")
+        .current_dir(&local_index)
+        .args(["push", "origin", "main"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to publish local registry index:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    std::fs::write(
+        moon_home.path().join("config.json"),
+        serde_json::json!({
+            "registry": "https://registry.invalid",
+            "index": registry_index,
+        })
+        .to_string(),
+    )
+    .unwrap();
 
     moon_cmd(&dir)
         .env("MOON_HOME", moon_home.path())
@@ -406,13 +475,18 @@ fn test_fetch_and_binary_install_run_legacy_postadd() {
     );
 
     let bin_dir = dir.join("bin");
-    moon_cmd(&dir)
+    let install = moon_cmd(&dir)
         .env("MOON_HOME", moon_home.path())
         .env("PATH", &moon_path)
         .args(["install", "testuser/postadd/tool@1.0.0", "--bin"])
         .arg(&bin_dir)
         .assert()
         .success();
+    let stderr = String::from_utf8_lossy(&install.get_output().stderr);
+    assert!(
+        stderr.contains("Registry index updated successfully"),
+        "local registry update did not succeed:\n{stderr}"
+    );
     #[cfg(unix)]
     assert!(bin_dir.join("tool").is_file());
     #[cfg(windows)]

--- a/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/generated.mbt
+++ b/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/generated.mbt
@@ -1,0 +1,3 @@
+fn generated() -> Int {
+  42
+}

--- a/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/lexer.mbl
+++ b/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/lexer.mbl
@@ -1,0 +1,1 @@
+this is not a valid lexer grammar

--- a/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/lexer.mbt
+++ b/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/lexer.mbt
@@ -1,0 +1,3 @@
+fn generated_by_lexer() -> Int {
+  1
+}

--- a/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/moon.pkg.json
+++ b/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/moon.pkg.json
@@ -1,5 +1,12 @@
 {
   "is-main": true,
   "bin-target": "js",
-  "bin-name": "shape-tool"
+  "bin-name": "shape-tool",
+  "pre-build": [
+    {
+      "input": [],
+      "output": ["generated.mbt"],
+      "command": "bin-dep-package-prebuild-must-not-run"
+    }
+  ]
 }

--- a/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/parser.mbt
+++ b/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/parser.mbt
@@ -1,0 +1,3 @@
+fn generated_by_parser() -> Int {
+  2
+}

--- a/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/parser.mby
+++ b/crates/moon/tests/test_cases/pre_build_mooncake_bin_shape.in/provider.in/src/main-js/parser.mby
@@ -1,0 +1,1 @@
+this is not a valid parser grammar

--- a/crates/moon/tests/test_cases/prebuild/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild/mod.rs
@@ -226,6 +226,10 @@ fn test_pre_build_mooncake_bin_shape() {
     let dir = top_dir.join("user.in");
     let target_dir = dir.join("artifacts");
     let moon_home = tempfile::TempDir::new().expect("failed to create temp MOON_HOME");
+    // The local fixture and cached registry module both carry invalid
+    // moonlex/moonyacc inputs alongside their generated outputs. The build can
+    // succeed only if bin-deps consume those outputs without rerunning source
+    // generation.
     cache_registry_package(
         moon_home.path(),
         "username/registry_shape_tool",
@@ -253,7 +257,7 @@ fn test_pre_build_mooncake_bin_shape() {
     {
       "input": [],
       "output": ["generated.mbt"],
-      "command": "moon tool write-tcc-rsp-file \"$output\" fn \"generated()->Int{42}\""
+      "command": "bin-dep-package-prebuild-must-not-run"
     }
   ]
 }"#
@@ -263,13 +267,38 @@ fn test_pre_build_mooncake_bin_shape() {
                 "src/main-js/main.mbt",
                 br#"fn main { println(generated()) }"#.to_vec(),
             ),
+            (
+                "src/main-js/generated.mbt",
+                br#"fn generated() -> Int { 42 }"#.to_vec(),
+            ),
+            (
+                "src/main-js/lexer.mbl",
+                br#"this is not a valid lexer grammar"#.to_vec(),
+            ),
+            (
+                "src/main-js/lexer.mbt",
+                br#"fn generated_by_lexer() -> Int { 1 }"#.to_vec(),
+            ),
+            (
+                "src/main-js/parser.mby",
+                br#"this is not a valid parser grammar"#.to_vec(),
+            ),
+            (
+                "src/main-js/parser.mbt",
+                br#"fn generated_by_parser() -> Int { 2 }"#.to_vec(),
+            ),
         ],
     );
 
-    get_stderr_with_envs(
+    let stderr = get_stderr_with_envs(
         &dir,
         ["--target-dir", "artifacts", "check"],
         [("MOON_HOME", moon_home.path())],
+    );
+    assert_eq!(
+        stderr.matches("`bin-deps` is deprecated").count(),
+        1,
+        "expected one bin-deps deprecation for the declaring module, got:\n{stderr}"
     );
 
     #[cfg(unix)]
@@ -277,6 +306,12 @@ fn test_pre_build_mooncake_bin_shape() {
     #[cfg(target_os = "windows")]
     let launcher = top_dir.join("provider.in").join("shape-tool.ps1");
     assert!(launcher.exists(), "expected bin-dep launcher: {launcher:?}");
+    assert!(
+        top_dir
+            .join("provider.in/src/main-js/generated.mbt")
+            .exists(),
+        "local bin-dep must use its already-generated source"
+    );
 
     #[cfg(unix)]
     let registry_launcher = target_dir.join(MOON_BIN_DIR).join("registry-shape-tool");
@@ -305,8 +340,8 @@ fn test_pre_build_mooncake_bin_shape() {
         "registry bin-dep build must not write under mooncakes_dir"
     );
     assert!(
-        !registry_source.join("src/main-js/generated.mbt").exists(),
-        "registry bin-dep pre-build must not write under mooncakes_dir"
+        registry_source.join("src/main-js/generated.mbt").exists(),
+        "published registry packages must contain generated sources"
     );
     let bin_dep_temp_dirs = std::fs::read_dir(&target_dir)
         .unwrap()

--- a/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild_config_script/mod.rs
@@ -98,7 +98,7 @@ fn test_prebuild_config_not_run_in_check() {
 }
 
 #[test]
-fn test_prebuild_config_in_bin_dep_runs_for_check_install() {
+fn test_unstable_prebuild_config_in_bin_dep_runs_for_check_install() {
     let top_dir = TestDir::new("prebuild_config_script/check_skip_bin_dep.in");
     let dir = top_dir.join("user.in");
     let generated_stub = top_dir.join("author.in/src/main/generated_stub.c");

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -43,7 +43,8 @@ use tracing::{Level, debug, instrument, trace, warn};
 
 use crate::{
     build_plan::{
-        BuildBundleInfo, FileDependencyKind, PackagePrebuildPolicy, PlanArtifactNeed, PrebuildInfo,
+        BuildBundleInfo, FileDependencyKind, PackageSourceGenerationPolicy, PlanArtifactNeed,
+        PrebuildInfo,
     },
     cond_comp,
     discover::DiscoveredPackage,
@@ -207,14 +208,14 @@ impl<'a> BuildPlanConstructor<'a> {
         })
     }
 
-    /// Add need to all prebuild scripts of the given package, and add edge to this node
+    /// Add the package's source-generation rules and edges to this node.
     ///
     /// According to the semantics, only local packages require prebuild scripts
     /// to be run. Remote packages should already have their prebuild outputs
     /// ready when they are fetched.
-    fn need_all_package_prebuild(&mut self, node: BuildPlanNode, pkg_id: PackageId) {
+    fn need_all_package_source_generation(&mut self, node: BuildPlanNode, pkg_id: PackageId) {
         let pkg = self.input.pkg_dirs.get_package(pkg_id);
-        if self.input_directive.package_prebuild != PackagePrebuildPolicy::Run
+        if self.input_directive.package_source_generation != PackageSourceGenerationPolicy::Run
             || !self.input.local_modules().contains(&pkg.module)
         {
             return;
@@ -438,7 +439,7 @@ impl<'a> BuildPlanConstructor<'a> {
             self.need_proof_of_dep(node, dep);
         }
 
-        self.need_all_package_prebuild(node, target.package);
+        self.need_all_package_source_generation(node, target.package);
         self.need_virtual_if_necessary(pkg, node, target);
         self.populate_target_info(target);
         self.resolved_node(node);
@@ -473,7 +474,7 @@ impl<'a> BuildPlanConstructor<'a> {
             self.need_interface_of_dep(node, dep, DependencyInterfaceMode::CheckOnly);
         }
 
-        self.need_all_package_prebuild(node, target.package);
+        self.need_all_package_source_generation(node, target.package);
 
         self.need_virtual_if_necessary(pkg, node, target);
         self.populate_target_info(target);
@@ -524,7 +525,7 @@ impl<'a> BuildPlanConstructor<'a> {
 
         self.need_virtual_if_necessary(pkg, node, target);
 
-        self.need_all_package_prebuild(node, target.package);
+        self.need_all_package_source_generation(node, target.package);
 
         self.populate_target_info(target);
         self.resolved_node(node);

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -42,7 +42,9 @@ use relative_path::PathExt;
 use tracing::{Level, debug, instrument, trace, warn};
 
 use crate::{
-    build_plan::{BuildBundleInfo, FileDependencyKind, PlanArtifactNeed, PrebuildInfo},
+    build_plan::{
+        BuildBundleInfo, FileDependencyKind, PackagePrebuildPolicy, PlanArtifactNeed, PrebuildInfo,
+    },
     cond_comp,
     discover::DiscoveredPackage,
     model::{
@@ -212,7 +214,9 @@ impl<'a> BuildPlanConstructor<'a> {
     /// ready when they are fetched.
     fn need_all_package_prebuild(&mut self, node: BuildPlanNode, pkg_id: PackageId) {
         let pkg = self.input.pkg_dirs.get_package(pkg_id);
-        if !self.input.local_modules().contains(&pkg.module) {
+        if self.input_directive.package_prebuild != PackagePrebuildPolicy::Run
+            || !self.input.local_modules().contains(&pkg.module)
+        {
             return;
         }
 

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -43,8 +43,7 @@ use tracing::{Level, debug, instrument, trace, warn};
 
 use crate::{
     build_plan::{
-        BuildBundleInfo, FileDependencyKind, PackageSourceGenerationPolicy, PlanArtifactNeed,
-        PrebuildInfo,
+        BuildBundleInfo, FileDependencyKind, PackagePrebuildPolicy, PlanArtifactNeed, PrebuildInfo,
     },
     cond_comp,
     discover::DiscoveredPackage,
@@ -208,14 +207,13 @@ impl<'a> BuildPlanConstructor<'a> {
         })
     }
 
-    /// Add the package's source-generation rules and edges to this node.
+    /// Add all package-level prebuild rules and edges to this node.
     ///
-    /// According to the semantics, only local packages require prebuild scripts
-    /// to be run. Remote packages should already have their prebuild outputs
-    /// ready when they are fetched.
-    fn need_all_package_source_generation(&mut self, node: BuildPlanNode, pkg_id: PackageId) {
+    /// According to the semantics, only local packages require package-level
+    /// prebuild to run. Remote packages should already contain their outputs.
+    fn need_all_package_prebuild(&mut self, node: BuildPlanNode, pkg_id: PackageId) {
         let pkg = self.input.pkg_dirs.get_package(pkg_id);
-        if self.input_directive.package_source_generation != PackageSourceGenerationPolicy::Run
+        if self.input_directive.package_prebuild != PackagePrebuildPolicy::Run
             || !self.input.local_modules().contains(&pkg.module)
         {
             return;
@@ -439,7 +437,7 @@ impl<'a> BuildPlanConstructor<'a> {
             self.need_proof_of_dep(node, dep);
         }
 
-        self.need_all_package_source_generation(node, target.package);
+        self.need_all_package_prebuild(node, target.package);
         self.need_virtual_if_necessary(pkg, node, target);
         self.populate_target_info(target);
         self.resolved_node(node);
@@ -474,7 +472,7 @@ impl<'a> BuildPlanConstructor<'a> {
             self.need_interface_of_dep(node, dep, DependencyInterfaceMode::CheckOnly);
         }
 
-        self.need_all_package_source_generation(node, target.package);
+        self.need_all_package_prebuild(node, target.package);
 
         self.need_virtual_if_necessary(pkg, node, target);
         self.populate_target_info(target);
@@ -525,7 +523,7 @@ impl<'a> BuildPlanConstructor<'a> {
 
         self.need_virtual_if_necessary(pkg, node, target);
 
-        self.need_all_package_source_generation(node, target.package);
+        self.need_all_package_prebuild(node, target.package);
 
         self.populate_target_info(target);
         self.resolved_node(node);

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -616,6 +616,19 @@ impl BuildEnvironment {
     }
 }
 
+/// How package-level source generation participates in this plan.
+///
+/// Distributed packages must already contain their generated outputs. The
+/// internal binary-dependency compatibility build therefore uses published
+/// outputs instead of running `pre-build`, `moonlex`, or `moonyacc`, even
+/// though it presents the distributed module as the build input.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum PackagePrebuildPolicy {
+    #[default]
+    Run,
+    ConsumeExistingOutputs,
+}
+
 /// Directives provided along the input actions.
 #[derive(Debug, Default)]
 pub struct InputDirective {
@@ -635,6 +648,9 @@ pub struct InputDirective {
 
     /// Use the given Why3 config file for `moon prove`.
     pub prove_why3_config: Option<PathBuf>,
+
+    /// Control package-level source generation for this invocation.
+    pub package_prebuild: PackagePrebuildPolicy,
 }
 
 /// Represents errors that may occur during build graph construction.

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -616,14 +616,14 @@ impl BuildEnvironment {
     }
 }
 
-/// How package-level source generation participates in this plan.
+/// How package-level prebuild participates in this plan.
 ///
-/// Binary dependencies must already contain their generated outputs. Their
-/// internal compatibility build therefore consumes existing outputs instead
-/// of running `pre-build`, `moonlex`, or `moonyacc`, even though it presents
-/// the binary-dependency module as the build input.
+/// Package-level prebuild includes custom `pre-build` rules, `moonlex`, and
+/// `moonyacc`. Binary dependencies must already contain their generated
+/// outputs, so their internal compatibility build consumes existing outputs
+/// instead of running any of these rules.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum PackageSourceGenerationPolicy {
+pub enum PackagePrebuildPolicy {
     #[default]
     Run,
     ConsumeExistingOutputs,
@@ -649,8 +649,8 @@ pub struct InputDirective {
     /// Use the given Why3 config file for `moon prove`.
     pub prove_why3_config: Option<PathBuf>,
 
-    /// Control package-level source generation for this invocation.
-    pub package_source_generation: PackageSourceGenerationPolicy,
+    /// Control package-level prebuild for this invocation.
+    pub package_prebuild: PackagePrebuildPolicy,
 }
 
 /// Represents errors that may occur during build graph construction.

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -618,12 +618,12 @@ impl BuildEnvironment {
 
 /// How package-level source generation participates in this plan.
 ///
-/// Distributed packages must already contain their generated outputs. The
-/// internal binary-dependency compatibility build therefore uses published
-/// outputs instead of running `pre-build`, `moonlex`, or `moonyacc`, even
-/// though it presents the distributed module as the build input.
+/// Binary dependencies must already contain their generated outputs. Their
+/// internal compatibility build therefore consumes existing outputs instead
+/// of running `pre-build`, `moonlex`, or `moonyacc`, even though it presents
+/// the binary-dependency module as the build input.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum PackagePrebuildPolicy {
+pub enum PackageSourceGenerationPolicy {
     #[default]
     Run,
     ConsumeExistingOutputs,
@@ -650,7 +650,7 @@ pub struct InputDirective {
     pub prove_why3_config: Option<PathBuf>,
 
     /// Control package-level source generation for this invocation.
-    pub package_prebuild: PackagePrebuildPolicy,
+    pub package_source_generation: PackageSourceGenerationPolicy,
 }
 
 /// Represents errors that may occur during build graph construction.

--- a/crates/moonbuild/template/mod.schema.json
+++ b/crates/moonbuild/template/mod.schema.json
@@ -15,7 +15,7 @@
       ]
     },
     "bin-deps": {
-      "description": "third-party binary dependencies of the module",
+      "description": "Deprecated third-party binary dependencies. Publish portable Wasm tools and run them with `moonx` instead.",
       "type": [
         "object",
         "null"

--- a/crates/mooncake/src/dependency_source.rs
+++ b/crates/mooncake/src/dependency_source.rs
@@ -163,17 +163,6 @@ options(
             )])))
         }
 
-        fn install_to(
-            &self,
-            name: &ModuleName,
-            version: &Version,
-            to: &Path,
-            _user_log: &UserLog,
-        ) -> anyhow::Result<()> {
-            std::fs::create_dir_all(to)?;
-            self.install_source(name, version, to)
-        }
-
         fn acquire_source_to(
             &self,
             name: &ModuleName,
@@ -182,6 +171,7 @@ options(
             to: &Path,
             _user_log: &UserLog,
         ) -> anyhow::Result<()> {
+            std::fs::create_dir_all(to)?;
             self.install_source(name, version, to)?;
             std::fs::write(to.join("acquired-archive-checksum"), expected_checksum)?;
             Ok(())

--- a/crates/mooncake/src/dependency_source/project.rs
+++ b/crates/mooncake/src/dependency_source/project.rs
@@ -34,7 +34,7 @@ use moonutil::{
 };
 use semver::Version;
 
-use crate::registry::Registry;
+use crate::{pkg::legacy_postadd, registry::Registry};
 
 use super::DependencySource;
 
@@ -279,7 +279,13 @@ fn sync(
             let ModuleSourceKind::Registry = version.source() else {
                 unreachable!()
             };
-            registry.install_to(version.name(), version.version(), &pkg_path, user_log)?;
+            registry.materialize_source_to(
+                version.name(),
+                version.version(),
+                &pkg_path,
+                user_log,
+            )?;
+            legacy_postadd::run(&pkg_path, user_log)?;
             // TODO: parallelize this
         }
     }

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -41,7 +41,7 @@ pub struct AddSubcommand {
     #[clap(value_name = "MODULE")]
     pub package_path: String,
 
-    /// Whether to add the dependency as a binary
+    /// Add the deprecated binary dependency (prefer portable Wasm with moonx)
     #[clap(long)]
     pub bin: bool,
 

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -97,6 +97,20 @@ pub(crate) fn install_impl(
     no_std: bool,
     source_cache: &CacheRoot,
 ) -> anyhow::Result<(ResolvedEnv, DirSyncResult)> {
+    for (_, module) in roots.iter() {
+        let module = module.module_info();
+        if module
+            .bin_deps
+            .as_ref()
+            .is_some_and(|dependencies| !dependencies.is_empty())
+        {
+            user_log.warn(format!(
+                "`bin-deps` is deprecated; publish portable Wasm tools and run them with `moonx` instead (declared by module `{}`)",
+                module.name
+            ));
+        }
+    }
+
     let includes_core = roots
         .iter()
         .any(|(_, module)| module.module_info().name == MOONBITLANG_CORE);

--- a/crates/mooncake/src/pkg/legacy_postadd.rs
+++ b/crates/mooncake/src/pkg/legacy_postadd.rs
@@ -1,0 +1,162 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Compatibility execution for the legacy `scripts.postadd` hook.
+//!
+//! Registry source acquisition deliberately does not call this module. The
+//! remaining command paths opt into the legacy behavior after source has been
+//! materialized, so rejecting postadd in the future does not change the
+//! Registry interface. This compatibility module preserves the existing child
+//! output behavior; making that lifecycle explicit belongs to the separate
+//! command-output migration.
+
+use std::path::Path;
+
+use anyhow::bail;
+use moonutil::{manifest::read_module_desc_file_in_dir, user_log::UserLog};
+
+pub fn run(dir: &Path, user_log: &UserLog) -> anyhow::Result<()> {
+    if std::env::var_os("MOON_IGNORE_POSTADD").is_some() {
+        return Ok(());
+    }
+    let module = read_module_desc_file_in_dir(dir)?;
+    let Some(postadd) = module
+        .scripts
+        .as_ref()
+        .and_then(|scripts| scripts.get("postadd"))
+    else {
+        return Ok(());
+    };
+
+    let postadd = postadd.split(' ').collect::<Vec<_>>();
+    let Some((command, args)) = postadd.split_first() else {
+        return Ok(());
+    };
+    let mut process = std::process::Command::new(command);
+    process.args(args).current_dir(dir);
+    if user_log.is_captured() {
+        let output = process.output()?;
+        for (channel, content) in [
+            ("stdout", output.stdout.as_slice()),
+            ("stderr", output.stderr.as_slice()),
+        ] {
+            let content = String::from_utf8_lossy(content);
+            let content = content.trim();
+            if content.is_empty() {
+                continue;
+            }
+            let message = format!("postadd script wrote to {channel}:\n{content}");
+            if output.status.success() {
+                user_log.status(message);
+            } else {
+                user_log.error(message);
+            }
+        }
+        if !output.status.success() {
+            bail!(
+                "failed to execute postadd script in {},\ncommand: {}",
+                dir.display(),
+                command
+            );
+        }
+    } else {
+        let status = process
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .status()?;
+        if !status.success() {
+            bail!(
+                "failed to execute postadd script in {},\ncommand: {}",
+                dir.display(),
+                command
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use log::LevelFilter;
+    use moonutil::user_log::{UserLog, UserLogEntryLevel};
+
+    use super::run;
+
+    #[test]
+    fn captured_output_is_routed_to_user_log() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let script = sandbox.path().join("postadd.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\necho POSTADD_STDOUT\necho POSTADD_STDERR >&2\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::write(
+            sandbox.path().join("moon.mod.json"),
+            format!(
+                r#"{{
+                    "name": "test/postadd",
+                    "version": "0.1.0",
+                    "scripts": {{ "postadd": "{}" }}
+                }}"#,
+                script.display()
+            ),
+        )
+        .unwrap();
+        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+
+        run(sandbox.path(), &user_log).unwrap();
+
+        let entries = capture.take();
+        assert_eq!(entries.len(), 2);
+        assert!(
+            entries
+                .iter()
+                .all(|entry| matches!(entry.level, UserLogEntryLevel::Info))
+        );
+        assert!(entries[0].message.contains("POSTADD_STDOUT"));
+        assert!(entries[1].message.contains("POSTADD_STDERR"));
+
+        std::fs::write(
+            &script,
+            "#!/bin/sh\necho FAILED_STDOUT\necho FAILED_STDERR >&2\nexit 1\n",
+        )
+        .unwrap();
+        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+
+        let error = run(sandbox.path(), &user_log).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to execute postadd script")
+        );
+        let entries = capture.take();
+        assert_eq!(entries.len(), 2);
+        assert!(
+            entries
+                .iter()
+                .all(|entry| matches!(entry.level, UserLogEntryLevel::Error))
+        );
+        assert!(entries[0].message.contains("FAILED_STDOUT"));
+        assert!(entries[1].message.contains("FAILED_STDERR"));
+    }
+}

--- a/crates/mooncake/src/pkg/mod.rs
+++ b/crates/mooncake/src/pkg/mod.rs
@@ -26,6 +26,7 @@ use moonutil::{
 
 pub mod add;
 pub mod install;
+pub mod legacy_postadd;
 pub mod remove;
 pub mod sync;
 pub mod tree;

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -71,13 +71,17 @@ pub trait Registry {
             .map(|(version, _)| version.clone())
     }
 
-    fn install_to(
+    /// Materialize verified published source without executing package hooks.
+    fn materialize_source_to(
         &self,
         name: &ModuleName,
         version: &Version,
         to: &Path,
         user_log: &UserLog,
-    ) -> anyhow::Result<()>;
+    ) -> anyhow::Result<()> {
+        let checksum = self.source_archive_checksum(name, version)?;
+        self.acquire_source_to(name, version, &checksum, to, user_log)
+    }
 
     /// Ensure the published source archive is available, verify it against the
     /// checksum selected by the caller, and extract it without executing
@@ -112,16 +116,6 @@ where
         name: &ModuleName,
     ) -> anyhow::Result<Arc<BTreeMap<Version, RegistryVersionInfo>>> {
         (**self).all_versions_of(name)
-    }
-
-    fn install_to(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        to: &Path,
-        user_log: &UserLog,
-    ) -> anyhow::Result<()> {
-        (**self).install_to(name, version, to, user_log)
     }
 
     fn acquire_source_to(
@@ -161,16 +155,6 @@ where
         name: &ModuleName,
     ) -> anyhow::Result<Arc<BTreeMap<Version, RegistryVersionInfo>>> {
         (**self).all_versions_of(name)
-    }
-
-    fn install_to(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        to: &Path,
-        user_log: &UserLog,
-    ) -> anyhow::Result<()> {
-        (**self).install_to(name, version, to, user_log)
     }
 
     fn acquire_source_to(

--- a/crates/mooncake/src/registry/mock.rs
+++ b/crates/mooncake/src/registry/mock.rs
@@ -170,16 +170,6 @@ impl Registry for MockRegistry {
             .map(Arc::new)
     }
 
-    fn install_to(
-        &self,
-        _name: &ModuleName,
-        _version: &Version,
-        _to: &std::path::Path,
-        _user_log: &moonutil::user_log::UserLog,
-    ) -> anyhow::Result<()> {
-        panic!("Mock registry does not support installing")
-    }
-
     fn acquire_source_to(
         &self,
         _name: &ModuleName,

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -29,7 +29,7 @@ use anyhow::{Context, bail};
 use indexmap::map::IndexMap;
 use moonutil::{
     dependency::SourceDependencyInfo, registry::RegistryConfig, resolution::ModuleName,
-    scripts::execute_postadd_script, user_log::UserLog,
+    user_log::UserLog,
 };
 use reqwest::header::USER_AGENT;
 use semver::Version;
@@ -130,16 +130,6 @@ impl super::Registry for OnlineRegistry {
             .insert(name.clone(), Arc::clone(&res));
 
         Ok(res)
-    }
-
-    fn install_to(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        to: &Path,
-        user_log: &UserLog,
-    ) -> anyhow::Result<()> {
-        self.install_to_impl(name, version, to, user_log)
     }
 
     fn acquire_source_to(
@@ -317,19 +307,6 @@ impl OnlineRegistry {
             .error_for_status()?;
 
         persist_verified_archive(&mut response, &cache_file, name, version, expected_checksum)
-    }
-
-    pub fn install_to_impl(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        pkg_install_dir: &Path,
-        user_log: &UserLog,
-    ) -> anyhow::Result<()> {
-        let checksum = self.read_checksum_from_index_file(name, version)?;
-        self.acquire_source_to(name, version, &checksum, pkg_install_dir, user_log)?;
-        execute_postadd_script(pkg_install_dir, user_log)?;
-        Ok(())
     }
 
     /// Reuse or download, verify, and extract a registry package without

--- a/crates/moonutil/src/module.rs
+++ b/crates/moonutil/src/module.rs
@@ -120,7 +120,8 @@ pub struct MoonModJSON {
     #[schemars(with = "Option<std::collections::HashMap<String, SourceDependencyInfo>>")]
     pub deps: Option<IndexMap<String, SourceDependencyInfo>>,
 
-    /// third-party binary dependencies of the module
+    /// Deprecated third-party binary dependencies. Publish portable Wasm tools
+    /// and run them with `moonx` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(with = "Option<std::collections::HashMap<String, BinaryDependencyInfoJson>>")]
     pub bin_deps: Option<IndexMap<String, BinaryDependencyInfoJson>>,

--- a/crates/moonutil/src/scripts.rs
+++ b/crates/moonutil/src/scripts.rs
@@ -16,12 +16,6 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::path::Path;
-
-use anyhow::bail;
-
-use crate::{manifest::read_module_desc_file_in_dir, user_log::UserLog};
-
 pub enum PrePostBuild {
     PreBuild,
 }
@@ -41,150 +35,16 @@ impl PrePostBuild {
 #[derive(Debug, Clone, Copy)]
 pub enum IgnoredMoonScript {
     Prebuild,
-    Postadd,
 }
 
 impl IgnoredMoonScript {
     pub fn env_var(self) -> &'static str {
         match self {
             IgnoredMoonScript::Prebuild => "MOON_IGNORE_PREBUILD",
-            IgnoredMoonScript::Postadd => "MOON_IGNORE_POSTADD",
         }
     }
 }
 
 pub fn is_moon_script_ignored(script: IgnoredMoonScript) -> bool {
     std::env::var_os(script.env_var()).is_some()
-}
-
-pub fn execute_postadd_script(dir: &Path, user_log: &UserLog) -> anyhow::Result<()> {
-    if is_moon_script_ignored(IgnoredMoonScript::Postadd) {
-        return Ok(());
-    }
-    let m = read_module_desc_file_in_dir(dir)?;
-    if let Some(scripts) = &m.scripts
-        && scripts.contains_key("postadd")
-    {
-        let postadd = scripts
-            .get("postadd")
-            .unwrap()
-            .split(' ')
-            .collect::<Vec<_>>();
-        if !postadd.is_empty() {
-            let command = postadd[0];
-            let args = &postadd[1..];
-            let mut process = std::process::Command::new(command);
-            process.args(args).current_dir(dir);
-            if user_log.is_captured() {
-                let output = process.output()?;
-                for (channel, content) in [
-                    ("stdout", output.stdout.as_slice()),
-                    ("stderr", output.stderr.as_slice()),
-                ] {
-                    let content = String::from_utf8_lossy(content);
-                    let content = content.trim();
-                    if content.is_empty() {
-                        continue;
-                    }
-                    let message = format!("postadd script wrote to {channel}:\n{content}");
-                    if output.status.success() {
-                        user_log.status(message);
-                    } else {
-                        user_log.error(message);
-                    }
-                }
-                if !output.status.success() {
-                    bail!(
-                        "failed to execute postadd script in {},\ncommand: {}",
-                        dir.display(),
-                        command
-                    );
-                }
-            } else {
-                let status = process
-                    .stdout(std::process::Stdio::inherit())
-                    .stderr(std::process::Stdio::inherit())
-                    .status()?;
-                if !status.success() {
-                    bail!(
-                        "failed to execute postadd script in {},\ncommand: {}",
-                        dir.display(),
-                        command
-                    );
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-#[cfg(all(test, unix))]
-mod tests {
-    use std::os::unix::fs::PermissionsExt;
-
-    use log::LevelFilter;
-
-    use super::execute_postadd_script;
-    use crate::user_log::{UserLog, UserLogEntryLevel};
-
-    #[test]
-    fn captured_postadd_output_is_routed_to_user_log() {
-        let sandbox = tempfile::TempDir::new().unwrap();
-        let script = sandbox.path().join("postadd.sh");
-        std::fs::write(
-            &script,
-            "#!/bin/sh\necho POSTADD_STDOUT\necho POSTADD_STDERR >&2\n",
-        )
-        .unwrap();
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
-        std::fs::write(
-            sandbox.path().join("moon.mod.json"),
-            format!(
-                r#"{{
-                    "name": "test/postadd",
-                    "version": "0.1.0",
-                    "scripts": {{ "postadd": "{}" }}
-                }}"#,
-                script.display()
-            ),
-        )
-        .unwrap();
-        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
-
-        execute_postadd_script(sandbox.path(), &user_log).unwrap();
-
-        let entries = capture.take();
-        assert_eq!(entries.len(), 2);
-        assert!(
-            entries
-                .iter()
-                .all(|entry| matches!(entry.level, UserLogEntryLevel::Info))
-        );
-        assert!(entries[0].message.contains("POSTADD_STDOUT"));
-        assert!(entries[1].message.contains("POSTADD_STDERR"));
-
-        std::fs::write(
-            &script,
-            "#!/bin/sh\necho FAILED_STDOUT\necho FAILED_STDERR >&2\nexit 1\n",
-        )
-        .unwrap();
-        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
-
-        let error = execute_postadd_script(sandbox.path(), &user_log).unwrap_err();
-
-        assert!(
-            error
-                .to_string()
-                .contains("failed to execute postadd script")
-        );
-        let entries = capture.take();
-        assert_eq!(entries.len(), 2);
-        assert!(
-            entries
-                .iter()
-                .all(|entry| matches!(entry.level, UserLogEntryLevel::Error))
-        );
-        assert!(entries[0].message.contains("FAILED_STDOUT"));
-        assert!(entries[1].message.contains("FAILED_STDERR"));
-    }
 }

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -267,7 +267,9 @@ There are two types of dependencies in a module.
 
 - A regular dependency is a dependency that can be accessed from code.
 - A **binary dependency** (bin-dep) is a dependency that is used for its executable.
-  Bin-deps are declared in `moon.mod.json` under `bin-deps`.
+  Bin-deps are declared in `moon.mod.json` under `bin-deps`, which is
+  deprecated. New tools should be published as portable Wasm executable
+  packages and run with `moonx` instead.
   They are resolved only for the input/root modules themselves: bin-deps of regular
   dependencies are not propagated transitively.
   After dependency sync, direct bin-deps of each workspace root are built and
@@ -276,11 +278,16 @@ There are two types of dependencies in a module.
   project target directory before that command runs. The child command uses
   the temporary directory as its target, copies the runnable artifact into
   private storage under `<project target dir>/__moonbin__`, and then removes
-  the work directory. Compilation, pre-build outputs, and nested dependency
-  state therefore do not modify the registry source under `.mooncakes`. Local
-  bin-deps retain their existing in-place build behavior. The child build
-  resolves the bin-dep's regular dependencies but excludes its own bin-deps,
-  preserving the non-transitive bin-dep model.
+  the work directory. Compilation and nested dependency state therefore do not
+  modify the registry source under `.mooncakes`. The compatibility build never
+  runs package-level source generation (`pre-build`, `moonlex`, or `moonyacc`);
+  distributed packages must already contain their generated outputs.
+  Experimental module-level prebuild configuration scripts still run so they
+  can provide build configuration such as native link flags. Local bin-deps
+  retain their existing in-place build behavior, subject to the same
+  package-level prebuild prohibition. The child build resolves the bin-dep's
+  regular dependencies but excludes its own bin-deps, preserving the
+  non-transitive bin-dep model.
 
 There are two kinds of sources that dependencies come from:
 

--- a/docs/dev/reference/moonx.md
+++ b/docs/dev/reference/moonx.md
@@ -87,9 +87,10 @@ selection, and release build behavior of `moon install`, but publishes the
 finished executable into the registry cache instead of the user's binary
 directory.
 
-Source acquisition for `moonx` does not execute the downloaded module's
-`scripts.postadd` hook. Normal registry installation retains its existing
-postadd behavior.
+Registry source acquisition never executes the downloaded module's
+`scripts.postadd` hook. `moonx` stops after source acquisition and therefore
+does not opt into the legacy hook. Existing project sync, `moon fetch`, and
+binary-install paths retain an explicit postadd compatibility step.
 
 By default, `moonx` emits no informational output of its own. With `--verbose`,
 registry acquisition, build progress, and execution details are written to

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -36,7 +36,9 @@ Notes:
 
 - `input`/`output` paths are package-relative in config and expand to prebuild-cwd-relative paths inside the command.
 - When arrays are used, placeholders expand to space-separated lists in declaration order.
-- All declared outputs are tracked as build outputs.
+- During ordinary input-module builds, all declared outputs are tracked as
+  build outputs. Bin-dep compatibility builds do not create source-generation
+  nodes; they consume existing `.mbt` and `.mbt.md` outputs as package sources.
 - Only `.mbt` and `.mbt.md` outputs are added back to the package's MoonBit source set.
 - An executable package's `data_dir` does not restrict prebuild paths. Inputs
   and outputs may be below it and retain the same dependency and source-set
@@ -106,7 +108,8 @@ Behavior:
 
 ## Ordering and Inclusion
 
-- Each `pre-build` entry becomes its own prebuild node in the build graph.
+- During ordinary input-module builds, each `pre-build` entry becomes its own
+  prebuild node in the build graph. Bin-dep compatibility builds create none.
 - There is no explicit build-graph edge between two prebuild tasks solely because one is
   written earlier in `pre-build`.
 - If one prebuild task consumes another task's declared output, the dependency is currently
@@ -124,7 +127,8 @@ Behavior:
 
 ## Failure Conditions
 
-A task is considered failed (for the build) if any of the following holds after substitution and tool semantics:
+When a task is scheduled, it is considered failed if any of the following
+holds after substitution and tool semantics:
 
 - Any declared `input` path does not exist.
 - Any declared `output` cannot be created or written by the invoked tool.

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -4,9 +4,13 @@ Prebuild tasks let a package generate source files (typically `.mbt`) from other
 
 - Scope: Applies only to packages in the input module being built.
   Third-party dependencies are expected to already contain their generated outputs.
-- A registry module being built as a direct bin-dep is the input module of its
-  child build, so its package-level prebuild tasks run in the temporary source
-  copy rather than in the registry cache.
+- The deprecated bin-dep compatibility build does not run package-level
+  source generation, including `pre-build`, `moonlex`, and `moonyacc`, even
+  though its child build presents the distributed module as an input module.
+  Published packages must contain their generated outputs.
+- Package-level prebuild tasks are separate from the experimental module-level
+  prebuild configuration script. The latter may still run for a bin-dep to
+  produce build configuration such as native link flags.
 
 ## Package Configuration
 
@@ -47,7 +51,9 @@ Notes:
   Project discovery computes this `mooncake_bin_dir` with the other
   authoritative project directories. Command adapters pass it unchanged
   through dependency sync and build planning; downstream stages do not
-  reconstruct it from another directory.
+  reconstruct it from another directory. `bin-deps` is deprecated; new tools
+  should be published as portable Wasm executable packages and run with
+  `moonx` instead.
 
 ## Placeholder Substitution
 

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -5,7 +5,7 @@ Prebuild tasks let a package generate source files (typically `.mbt`) from other
 - Scope: Applies only to packages in the input module being built.
   Third-party dependencies are expected to already contain their generated outputs.
 - The deprecated bin-dep compatibility build does not run package-level
-  source generation, including `pre-build`, `moonlex`, and `moonyacc`, even
+  prebuild, including custom `pre-build`, `moonlex`, and `moonyacc`, even
   though its child build presents the distributed module as an input module.
   Published packages must contain their generated outputs.
 - Package-level prebuild tasks are separate from the experimental module-level
@@ -37,8 +37,9 @@ Notes:
 - `input`/`output` paths are package-relative in config and expand to prebuild-cwd-relative paths inside the command.
 - When arrays are used, placeholders expand to space-separated lists in declaration order.
 - During ordinary input-module builds, all declared outputs are tracked as
-  build outputs. Bin-dep compatibility builds do not create source-generation
-  nodes; they consume existing `.mbt` and `.mbt.md` outputs as package sources.
+  build outputs. Bin-dep compatibility builds do not create package-level
+  prebuild nodes; they consume existing `.mbt` and `.mbt.md` outputs as package
+  sources.
 - Only `.mbt` and `.mbt.md` outputs are added back to the package's MoonBit source set.
 - An executable package's `data_dir` does not restrict prebuild paths. Inputs
   and outputs may be below it and retain the same dependency and source-set

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -503,7 +503,7 @@ Add a dependency
 
 ###### **Options:**
 
-* `--bin` — Whether to add the dependency as a binary
+* `--bin` — Add the deprecated binary dependency (prefer portable Wasm with moonx)
 * `-u`, `--upgrade` — Upgrade an existing dependency
 * `--no-update` — Do not update the registry index before adding the dependency
 

--- a/docs/manual-zh/src/source/mod_json_schema.html
+++ b/docs/manual-zh/src/source/mod_json_schema.html
@@ -53,7 +53,7 @@
       ]
     },
     "bin-deps": {
-      "description": "third-party binary dependencies of the module",
+      "description": "Deprecated third-party binary dependencies. Publish portable Wasm tools and run them with `moonx` instead.",
       "type": [
         "object",
         "null"

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -503,7 +503,7 @@ Add a dependency
 
 ###### **Options:**
 
-* `--bin` — Whether to add the dependency as a binary
+* `--bin` — Add the deprecated binary dependency (prefer portable Wasm with moonx)
 * `-u`, `--upgrade` — Upgrade an existing dependency
 * `--no-update` — Do not update the registry index before adding the dependency
 

--- a/docs/manual/src/source/mod_json_schema.html
+++ b/docs/manual/src/source/mod_json_schema.html
@@ -53,7 +53,7 @@
       ]
     },
     "bin-deps": {
-      "description": "third-party binary dependencies of the module",
+      "description": "Deprecated third-party binary dependencies. Publish portable Wasm tools and run them with `moonx` instead.",
       "type": [
         "object",
         "null"


### PR DESCRIPTION
## Why

Registry source acquisition currently also owns the package-controlled `postadd` side effect, while the deprecated `bin-deps` compatibility build can rerun source generators from a distributed package. That makes immutable source handling and script execution difficult to reason about, and encourages packaging incomplete tools.

Portable Wasm executable packages run through `moonx` are the replacement for `bin-deps`.

## What changed

- Make registry materialization acquire and verify source only. Project sync, `moon fetch`, and binary installation explicitly opt into the isolated legacy postadd compatibility step; the shared immutable cache and `moonx` do not.
- Add an explicit build-plan policy for consuming existing generated outputs. Bin-dep builds skip package `pre-build`, `moonlex`, and `moonyacc`, while retaining the unstable module-level prebuild configuration used for link flags.
- Emit one `bin-deps` deprecation warning per declaring root module through `UserLog`, including structured JSON output, and point users to portable Wasm plus `moonx`.
- Update the schema, generated command help, and developer behavioral references.

## Correctness and scope

The compatibility build still consumes declared generated files, so distributed packages must be complete instead of silently regenerating source. Regression fixtures cover local and registry bin-deps, all package source-generation mechanisms, the retained unstable prebuild configuration, and structured warning output.

This PR deliberately preserves the existing postadd child-output behavior. The generic child-output and CLI lifecycle redesign remains a separate follow-up, keeping this change focused on package script ownership.