### PR TITLE
Relocate Why3 data dir to share/why3

### DIFF
--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -795,8 +795,8 @@ mod tests {
     fn generate_config(solvers: &[DetectedSolver]) -> String {
         generate_why3_config(
             solvers,
-            Path::new("/moon/lib/why3/share/why3"),
-            Path::new("/moon/lib/why3/lib/why3"),
+            Path::new("/moon/share/why3"),
+            Path::new("/moon/lib/why3"),
         )
     }
 
@@ -856,8 +856,8 @@ mod tests {
     fn test_generate_config_single_solver() {
         let solvers = vec![make_solver("Z3", "/usr/bin/z3", "4.15.3")];
         let config = generate_config(&solvers);
-        assert!(config.contains("datadir = \"/moon/lib/why3/share/why3\""));
-        assert!(config.contains("libdir = \"/moon/lib/why3/lib/why3\""));
+        assert!(config.contains("datadir = \"/moon/share/why3\""));
+        assert!(config.contains("libdir = \"/moon/lib/why3\""));
         assert!(config.contains("[partial_prover]\nname = \"Z3\""));
         assert!(config.contains("name = \"MoonBit_Auto\""));
         assert!(!config.contains("Alt-Ergo"));
@@ -868,11 +868,11 @@ mod tests {
         let solvers = vec![make_solver("Z3", r"C:\Users\guest\bin\z3.exe", "4.16.0")];
         let config = generate_why3_config(
             &solvers,
-            Path::new(r"C:\Users\guest\.moon\lib\why3\share\why3"),
-            Path::new(r"C:\Users\guest\.moon\lib\why3\lib\why3"),
+            Path::new(r"C:\Users\guest\.moon\share\why3"),
+            Path::new(r"C:\Users\guest\.moon\lib\why3"),
         );
-        assert!(config.contains(r#"datadir = "C:/Users/guest/.moon/lib/why3/share/why3""#));
-        assert!(config.contains(r#"libdir = "C:/Users/guest/.moon/lib/why3/lib/why3""#));
+        assert!(config.contains(r#"datadir = "C:/Users/guest/.moon/share/why3""#));
+        assert!(config.contains(r#"libdir = "C:/Users/guest/.moon/lib/why3""#));
         assert!(config.contains(r#"path = "C:/Users/guest/bin/z3.exe""#));
     }
 

--- a/crates/moonutil/src/moon_dir.rs
+++ b/crates/moonutil/src/moon_dir.rs
@@ -284,8 +284,8 @@ fn test_moon_dir() {
             "bin",
             "include",
             "lib",
-            "lib|why3|share|why3",
-            "lib|why3|lib|why3",
+            "share|why3",
+            "lib|why3",
             "lib|core|_build|wasm|release|bundle",
         ]
     "#]]

--- a/crates/moonutil/src/moon_dir.rs
+++ b/crates/moonutil/src/moon_dir.rs
@@ -121,12 +121,16 @@ pub fn lib() -> PathBuf {
     toolchain_root().join("lib")
 }
 
+pub fn share() -> PathBuf {
+    toolchain_root().join("share")
+}
+
 pub fn why3_datadir() -> PathBuf {
-    lib().join("why3").join("share").join("why3")
+    share().join("why3")
 }
 
 pub fn why3_libdir() -> PathBuf {
-    lib().join("why3").join("lib").join("why3")
+    lib().join("why3")
 }
 
 pub fn core() -> PathBuf {


### PR DESCRIPTION
Relocates the Why3 data directory from `lib/why3/share/why3` to `share/why3` and the lib dir from `lib/why3/lib/why3` to `lib/why3`, matching the bundled toolchain layout. Updates the `test_moon_dir` expectations and `prove` unit tests accordingly.