### PR TITLE
test: refresh snapshots for latest toolchain

### DIFF
--- a/crates/moon/tests/test_cases/native_abort_trace/mod.rs
+++ b/crates/moon/tests/test_cases/native_abort_trace/mod.rs
@@ -13,11 +13,11 @@ fn test_native_abort_trace() {
     let expected_stderr = if exits_via_signal {
         snapbox::str![[r#"
 PanicError
-    at @moonbitlang/core/option.Option::unwrap[Int] (/option.mbt:[..])
-    at @username/scratch/cmd/main.g (/main.mbt:[..])
-    at @username/scratch/cmd/main.f (/main.mbt:[..])
-    at moonbit_main (/main.mbt:[..])
-    at main (/main.mbt:[..])
+    at @moonbitlang/core/option.Option::unwrap[Int] ([CORE_PATH]/builtin/option.mbt:[..])
+    at @username/scratch/cmd/main.g ([..]/cmd/main/main.mbt:[..])
+    at @username/scratch/cmd/main.f ([..]/cmd/main/main.mbt:[..])
+    at moonbit_main ([..]/cmd/main/main.mbt:[..])
+    at main ([..]/cmd/main/main.mbt:[..])
 ...
 
 "#]]

--- a/crates/moon/tests/test_cases/package_management.rs
+++ b/crates/moon/tests/test_cases/package_management.rs
@@ -187,12 +187,9 @@ fn test_moon_package_list() {
             Check passed
             README.md
             moon.mod.json
-            src
-            src/lib
             src/lib/hello.mbt
             src/lib/hello_test.mbt
             src/lib/moon.pkg.json
-            src/main
             src/main/main.mbt
             src/main/moon.pkg.json
             Package to $ROOT/_build/publish/username-hello-0.1.0.zip

--- a/crates/moon/tests/test_cases/test_exclude_001.in/moon.test
+++ b/crates/moon/tests/test_cases/test_exclude_001.in/moon.test
@@ -6,16 +6,11 @@
   README.md
   moon.mod.json
   moon.test
-  src
-  src/lib
   src/lib/hello.mbt
   src/lib/hello_test.mbt
   src/lib/moon.pkg.json
-  src/main
   src/main/main.mbt
   src/main/moon.pkg.json
-  test
-  test/b
   test/b/b.txt
   Package to [WORK_DIR]/_build/publish/username-hello-0.1.0.zip
   

--- a/crates/moon/tests/test_cases/test_exclude_002.in/moon.test
+++ b/crates/moon/tests/test_cases/test_exclude_002.in/moon.test
@@ -6,18 +6,11 @@
   README.md
   moon.mod.json
   moon.test
-  src
-  src/lib
   src/lib/hello.mbt
   src/lib/hello_test.mbt
   src/lib/moon.pkg.json
-  src/main
   src/main/main.mbt
   src/main/moon.pkg.json
-  test
-  test/a
-  test/b
-  test/c
   test/c/c.md
   Package to [WORK_DIR]/_build/publish/username-hello-0.1.0.zip
   


### PR DESCRIPTION
## Summary

- Refresh package-list snapshots for the latest toolchain output, which no longer includes directory-only entries.
- Update the native abort trace snapshot for full source paths while retaining focused redactions for toolchain roots, temporary directories, and line numbers.

## Why

The latest nightly toolchain changed package-list output and native stack-trace source locations, leaving the snapshots on `main` stale.

## Correctness

The updated expectations match the current toolchain output. The native trace still checks every semantic frame and source-file suffix while wildcarding only environment-specific path prefixes and line numbers.

## Scope

This is a snapshot-only update and does not change production behavior.
