### PR TITLE
refactor(output): make managed child output explicit

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -497,7 +497,7 @@ fn run_check_for_single_file_rr(
     )
     .with_sync_output(mooncake::pkg::sync::SyncOutputOptions {
         quiet: false,
-        child_output: if cmd.json {
+        child_output: if json.is_some() {
             ChildOutputMode::Capture
         } else {
             ChildOutputMode::Inherit

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -34,6 +34,7 @@ use log::LevelFilter;
 use moonbuild_rupes_recta::intent::UserIntent;
 use moonbuild_rupes_recta::model::PackageId;
 use moonutil::build_options::RunMode;
+use moonutil::child_process::ChildOutputMode;
 use moonutil::cli_support::AutoSyncFlags;
 use moonutil::cli_support::UniversalFlags;
 use moonutil::command_output::CommandOutput;
@@ -494,7 +495,14 @@ fn run_check_for_single_file_rr(
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     )
-    .with_captured_sync_child_output(cmd.json);
+    .with_sync_output(mooncake::pkg::sync::SyncOutputOptions {
+        quiet: false,
+        child_output: if cmd.json {
+            ChildOutputMode::Capture
+        } else {
+            ChildOutputMode::Inherit
+        },
+    });
     let (resolved, backend) = moonbuild_rupes_recta::resolve::resolve_single_file_project(
         &resolve_cfg,
         dirs,
@@ -688,7 +696,14 @@ fn run_check_normal_internal_rr(
         cmd.build_flags.enable_coverage,
         cli.workspace_env.clone(),
     )
-    .with_captured_sync_child_output(json.is_some());
+    .with_sync_output(mooncake::pkg::sync::SyncOutputOptions {
+        quiet: false,
+        child_output: if json.is_some() {
+            ChildOutputMode::Capture
+        } else {
+            ChildOutputMode::Inherit
+        },
+    });
     let synced_env = moonbuild_rupes_recta::sync_dependencies(&resolve_cfg, dirs, user_log)
         .context("Failed to calculate build plan")?;
     let resolve_output =

--- a/crates/moon/src/cli/fetch.rs
+++ b/crates/moon/src/cli/fetch.rs
@@ -20,7 +20,11 @@ use anyhow::bail;
 use colored::Colorize;
 use mooncake::{pkg::legacy_postadd, registry::Registry};
 use moonutil::{
-    project::PackageDirs, registry::RegistryConfig, resolution::ModuleName, user_log::UserLog,
+    child_process::{ChildOutputMode, ManagedChildRunner},
+    project::PackageDirs,
+    registry::RegistryConfig,
+    resolution::ModuleName,
+    user_log::UserLog,
 };
 
 use super::UniversalFlags;
@@ -137,7 +141,8 @@ pub(crate) fn fetch_cli(
     }
 
     registry.materialize_source_to(&pkg_name, &version, &pkg_dir, user_log)?;
-    legacy_postadd::run(&pkg_dir, user_log)?;
+    let child = ManagedChildRunner::new(ChildOutputMode::Inherit, user_log);
+    legacy_postadd::run(&pkg_dir, &child)?;
 
     if !cli.quiet {
         println!(

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -29,6 +29,7 @@ use mooncake::{
 };
 use moonutil::{
     build_options::RunMode,
+    child_process::{ChildOutputMode, ManagedChildRunner},
     cli_support::UniversalFlags,
     constants::{MOON_MOD, MOON_MOD_JSON},
     locks::FileLock,
@@ -275,7 +276,8 @@ pub(super) fn install_binary(
     let module_dir = tmp_dir.path();
 
     registry.materialize_source_to(&spec.module_name, &version, module_dir, user_log)?;
-    legacy_postadd::run(module_dir, user_log)?;
+    let child = ManagedChildRunner::new(ChildOutputMode::Inherit, user_log);
+    legacy_postadd::run(module_dir, &child)?;
 
     let filter =
         PackageFilter::package_path(spec.package_path.clone().unwrap_or_default(), install_all);

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -28,6 +28,7 @@ use moonbuild_rupes_recta::{
     model::{BackendConfig, PackageId},
 };
 use mooncake::pkg::sync::SyncOutputOptions;
+use moonutil::child_process::ChildOutputMode;
 use moonutil::cli_support::AutoSyncFlags;
 use moonutil::command_output::CommandOutput;
 use moonutil::project::{PackageDirs, ProjectProbe};
@@ -134,7 +135,10 @@ impl RunOutputVerbosity {
     }
 
     fn sync_output(self) -> SyncOutputOptions {
-        SyncOutputOptions::default().with_quiet(!self.verbose)
+        SyncOutputOptions {
+            quiet: !self.verbose,
+            child_output: ChildOutputMode::Inherit,
+        }
     }
 
     fn suppress_build_progress(self) -> bool {

--- a/crates/moon/tests/test_cases/diagnostics_format/check.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/check.rs
@@ -1,11 +1,64 @@
 use expect_test::expect;
 
-use crate::{TestDir, get_stderr, get_stdout, moon_cmd, util::check};
+use crate::{
+    TestDir, get_stderr, get_stdout, moon_bin, moon_cmd,
+    util::{cache_registry_package, check},
+};
 
 fn parse_complete_json(assert: snapbox::cmd::OutputAssert) -> serde_json::Value {
     let assert = assert.stderr_eq("");
     let output = assert.get_output();
     serde_json::from_slice(&output.stdout).expect("stdout should contain one complete JSON value")
+}
+
+fn check_json_with_postadd(postadd: &str) -> snapbox::cmd::OutputAssert {
+    let dir = TestDir::new_empty();
+    let moon_home = tempfile::TempDir::new().expect("failed to create temporary MOON_HOME");
+    let moon_path = std::env::join_paths(
+        std::iter::once(
+            moon_bin()
+                .parent()
+                .expect("test moon binary should have a parent directory")
+                .to_path_buf(),
+        )
+        .chain(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        )),
+    )
+    .expect("test PATH should be valid");
+    std::fs::create_dir_all(dir.join("src/lib")).unwrap();
+    std::fs::write(
+        dir.join("moon.mod.json"),
+        r#"{
+            "name": "test/root",
+            "version": "0.1.0",
+            "source": "src",
+            "deps": { "testuser/postadd": "1.0.0" }
+        }"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("src/lib/moon.pkg.json"), "{}").unwrap();
+    std::fs::write(dir.join("src/lib/lib.mbt"), "pub fn answer() -> Int { 42 }").unwrap();
+
+    let dependency_manifest = serde_json::json!({
+        "name": "testuser/postadd",
+        "version": "1.0.0",
+        "scripts": { "postadd": postadd }
+    })
+    .to_string()
+    .into_bytes();
+    cache_registry_package(
+        moon_home.path(),
+        "testuser/postadd",
+        "1.0.0",
+        &[("moon.mod.json", dependency_manifest)],
+    );
+
+    moon_cmd(&dir)
+        .env("MOON_HOME", moon_home.path())
+        .env("PATH", moon_path)
+        .args(["check", "--json"])
+        .assert()
 }
 
 #[test]
@@ -251,6 +304,51 @@ fn test_moon_check_complete_json_captures_resolution_failure() {
     );
     assert_eq!(report["summary"]["moon_errors"], 1);
     assert_eq!(report["summary"]["moon_warnings"], 1);
+}
+
+#[test]
+fn test_moon_check_complete_json_captures_postadd_output() {
+    let report = parse_complete_json(check_json_with_postadd("moon --version").success());
+
+    assert_eq!(report["status"], "success");
+    assert!(
+        report["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|message| {
+                message["level"] == "info"
+                    && message["message"]
+                        .as_str()
+                        .unwrap()
+                        .contains("postadd script wrote to stdout")
+            })
+    );
+}
+
+#[test]
+fn test_moon_check_complete_json_captures_postadd_failure() {
+    let report =
+        parse_complete_json(check_json_with_postadd("moon check --not-a-real-option").failure());
+
+    assert_eq!(report["status"], "failure");
+    assert!(
+        report["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|message| {
+                message["level"] == "error"
+                    && message["message"]
+                        .as_str()
+                        .unwrap()
+                        .contains("postadd script wrote to stderr")
+                    && message["message"]
+                        .as_str()
+                        .unwrap()
+                        .contains("--not-a-real-option")
+            })
+    );
 }
 
 #[test]

--- a/crates/moonbuild-rupes-recta/src/resolve/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/resolve/mod.rs
@@ -302,11 +302,6 @@ impl ResolveConfig {
         self
     }
 
-    pub fn with_captured_sync_child_output(mut self, capture: bool) -> Self {
-        self.sync_output = self.sync_output.with_captured_child_output(capture);
-        self
-    }
-
     pub fn without_bin_deps(mut self) -> Self {
         self.include_bin_deps = false;
         self

--- a/crates/mooncake/src/dependency_source.rs
+++ b/crates/mooncake/src/dependency_source.rs
@@ -25,7 +25,7 @@ use std::path::PathBuf;
 
 use moonutil::{
     cache::CacheRoot,
-    child_process::ManagedChildRunner,
+    child_process::ChildOutputMode,
     resolution::{DirSyncResult, ModuleSourceKind, ResolvedEnv},
     user_log::UserLog,
 };
@@ -50,13 +50,13 @@ pub(crate) trait DependencySource {
 ///
 /// The project-local `.mooncakes` directory and the shared immutable cache are
 /// hidden behind the same [`DependencySource`] seam. The project implementation
-/// receives the runner needed to preserve its legacy postadd behavior; the
-/// immutable implementation never receives or executes that hook.
+/// stores the output mode for its legacy postadd behavior; the immutable
+/// implementation never executes that hook.
 pub(crate) fn select<'a>(
     project_dir: impl Into<PathBuf>,
     cache: &'a CacheRoot,
     resolved: &ResolvedEnv,
-    child: &'a ManagedChildRunner,
+    postadd_output: ChildOutputMode,
 ) -> anyhow::Result<Box<dyn DependencySource + 'a>> {
     let has_registry_sources = resolved
         .all_modules()
@@ -65,7 +65,10 @@ pub(crate) fn select<'a>(
         return Ok(Box::new(ImmutableDependencySource::new(root)));
     }
 
-    Ok(Box::new(ProjectDependencySource::new(project_dir, child)))
+    Ok(Box::new(ProjectDependencySource::new(
+        project_dir,
+        postadd_output,
+    )))
 }
 
 #[cfg(test)]
@@ -81,7 +84,7 @@ mod tests {
 
     use moonutil::{
         cache::{CacheKind, CacheRoot},
-        child_process::{ChildOutputMode, ManagedChildRunner},
+        child_process::ChildOutputMode,
         manifest::MoonMod,
         resolution::{ModuleName, ModuleSource, ModuleSourceKind, ResolvedEnv},
         user_log::UserLog,
@@ -220,10 +223,6 @@ options(
         UserLog::new(log::LevelFilter::Error)
     }
 
-    fn managed_child() -> ManagedChildRunner {
-        ManagedChildRunner::new(ChildOutputMode::Inherit, &user_log())
-    }
-
     fn global_cache(path: &Path) -> CacheRoot {
         CacheRoot::Path {
             kind: CacheKind::DependencySources,
@@ -249,8 +248,13 @@ options(
         let cache = global_cache(&sandbox.path().join("cache"));
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
-        let child = managed_child();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
+        let source = select(
+            sandbox.path().join(".mooncakes"),
+            &cache,
+            &resolved,
+            ChildOutputMode::Inherit,
+        )
+        .unwrap();
 
         let first = source
             .ensure(&registry, &resolved, false, &user_log())
@@ -277,8 +281,13 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(true);
         let (resolved, module) = test_env();
-        let child = managed_child();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
+        let source = select(
+            sandbox.path().join(".mooncakes"),
+            &cache,
+            &resolved,
+            ChildOutputMode::Inherit,
+        )
+        .unwrap();
         let directory =
             ImmutableDependencySource::new(&cache_dir).source_dir(resolved.module_source(module));
 
@@ -300,8 +309,13 @@ options(
         let cache = global_cache(&sandbox.path().join("cache"));
         let registry = TestRegistry::new(false);
         let (resolved, _) = test_env();
-        let child = managed_child();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
+        let source = select(
+            sandbox.path().join(".mooncakes"),
+            &cache,
+            &resolved,
+            ChildOutputMode::Inherit,
+        )
+        .unwrap();
 
         let error = source
             .ensure(&registry, &resolved, true, &user_log())
@@ -324,15 +338,15 @@ options(
 
         std::thread::scope(|scope| {
             let first = scope.spawn(|| {
-                let child = managed_child();
-                let source = select(&project_dir, &cache, &resolved, &child).unwrap();
+                let source =
+                    select(&project_dir, &cache, &resolved, ChildOutputMode::Inherit).unwrap();
                 source
                     .ensure(registry.as_ref(), &resolved, false, &user_log())
                     .unwrap();
             });
             let second = scope.spawn(|| {
-                let child = managed_child();
-                let source = select(&project_dir, &cache, &resolved, &child).unwrap();
+                let source =
+                    select(&project_dir, &cache, &resolved, ChildOutputMode::Inherit).unwrap();
                 source
                     .ensure(registry.as_ref(), &resolved, false, &user_log())
                     .unwrap();
@@ -355,8 +369,13 @@ options(
         let first_registry = TestRegistry::new(false);
         let second_registry = TestRegistry::new(false).with_checksum(SECOND_CHECKSUM);
         let (resolved, module) = test_env();
-        let child = managed_child();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
+        let source = select(
+            sandbox.path().join(".mooncakes"),
+            &cache,
+            &resolved,
+            ChildOutputMode::Inherit,
+        )
+        .unwrap();
 
         let first = source
             .ensure(&first_registry, &resolved, false, &user_log())
@@ -387,8 +406,13 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(false).with_checksum_after_first_read(SECOND_CHECKSUM);
         let (resolved, module) = test_env();
-        let child = managed_child();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
+        let source = select(
+            sandbox.path().join(".mooncakes"),
+            &cache,
+            &resolved,
+            ChildOutputMode::Inherit,
+        )
+        .unwrap();
 
         let paths = source
             .ensure(&registry, &resolved, false, &user_log())
@@ -416,8 +440,13 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
-        let child = managed_child();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
+        let source = select(
+            sandbox.path().join(".mooncakes"),
+            &cache,
+            &resolved,
+            ChildOutputMode::Inherit,
+        )
+        .unwrap();
         let directory =
             ImmutableDependencySource::new(&cache_dir).source_dir(resolved.module_source(module));
         std::fs::create_dir_all(&directory).unwrap();
@@ -458,8 +487,7 @@ options(
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
         let user_log = user_log();
-        let child = ManagedChildRunner::new(ChildOutputMode::Inherit, &user_log);
-        let source = select(&project_dir, &cache, &resolved, &child).unwrap();
+        let source = select(&project_dir, &cache, &resolved, ChildOutputMode::Inherit).unwrap();
 
         let paths = source
             .ensure(&registry, &resolved, false, &user_log)

--- a/crates/mooncake/src/dependency_source.rs
+++ b/crates/mooncake/src/dependency_source.rs
@@ -25,43 +25,38 @@ use std::path::PathBuf;
 
 use moonutil::{
     cache::CacheRoot,
-    resolution::{DirSyncResult, ModuleSourceKind, ResolvedEnv},
-    user_log::UserLog,
+    resolution::{ModuleSourceKind, ResolvedEnv},
 };
-
-use crate::registry::Registry;
 
 use self::{global::ImmutableDependencySource, project::ProjectDependencySource};
 
-pub(crate) trait DependencySource {
-    /// Ensure that every resolved dependency has a source directory and return
-    /// those directories indexed by module ID.
-    fn ensure(
-        &self,
-        registry: &dyn Registry,
-        resolved: &ResolvedEnv,
-        frozen: bool,
-        user_log: &UserLog,
-    ) -> anyhow::Result<DirSyncResult>;
+pub(crate) enum SelectedDependencySource<'a> {
+    Immutable(ImmutableDependencySource<'a>),
+    Project(ProjectDependencySource),
 }
 
 /// Select the dependency source adapter for one resolution.
 ///
-/// The project-local `.mooncakes` directory and the shared immutable cache are
-/// hidden behind the same [`DependencySource`] seam.
+/// Selection has no hook-execution policy. The caller supplies a managed-child
+/// runner only when the selected project source may run legacy postadd;
+/// immutable sources reject postadd and never receive that policy.
 pub(crate) fn select<'a>(
     project_dir: impl Into<PathBuf>,
     cache: &'a CacheRoot,
     resolved: &ResolvedEnv,
-) -> anyhow::Result<Box<dyn DependencySource + 'a>> {
+) -> anyhow::Result<SelectedDependencySource<'a>> {
     let has_registry_sources = resolved
         .all_modules()
         .any(|module| matches!(module.source(), ModuleSourceKind::Registry) && !module.is_core());
     if has_registry_sources && let Some(root) = cache.initialize()? {
-        return Ok(Box::new(ImmutableDependencySource::new(root)));
+        return Ok(SelectedDependencySource::Immutable(
+            ImmutableDependencySource::new(root),
+        ));
     }
 
-    Ok(Box::new(ProjectDependencySource::new(project_dir)))
+    Ok(SelectedDependencySource::Project(
+        ProjectDependencySource::new(project_dir),
+    ))
 }
 
 #[cfg(test)]
@@ -77,6 +72,7 @@ mod tests {
 
     use moonutil::{
         cache::{CacheKind, CacheRoot},
+        child_process::{ChildOutputMode, ManagedChildRunner},
         manifest::MoonMod,
         resolution::{ModuleName, ModuleSource, ModuleSourceKind, ResolvedEnv},
         user_log::UserLog,
@@ -84,6 +80,7 @@ mod tests {
     use semver::Version;
 
     use super::{
+        SelectedDependencySource,
         global::{ImmutableDependencySource, SOURCE_ARCHIVE_CHECKSUM_FILE},
         select,
     };
@@ -240,7 +237,11 @@ options(
         let cache = global_cache(&sandbox.path().join("cache"));
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let SelectedDependencySource::Immutable(source) =
+            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
+        else {
+            panic!("global cache should select immutable sources")
+        };
 
         let first = source
             .ensure(&registry, &resolved, false, &user_log())
@@ -267,7 +268,11 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(true);
         let (resolved, module) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let SelectedDependencySource::Immutable(source) =
+            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
+        else {
+            panic!("global cache should select immutable sources")
+        };
         let directory =
             ImmutableDependencySource::new(&cache_dir).source_dir(resolved.module_source(module));
 
@@ -289,7 +294,11 @@ options(
         let cache = global_cache(&sandbox.path().join("cache"));
         let registry = TestRegistry::new(false);
         let (resolved, _) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let SelectedDependencySource::Immutable(source) =
+            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
+        else {
+            panic!("global cache should select immutable sources")
+        };
 
         let error = source
             .ensure(&registry, &resolved, true, &user_log())
@@ -312,13 +321,21 @@ options(
 
         std::thread::scope(|scope| {
             let first = scope.spawn(|| {
-                let source = select(&project_dir, &cache, &resolved).unwrap();
+                let SelectedDependencySource::Immutable(source) =
+                    select(&project_dir, &cache, &resolved).unwrap()
+                else {
+                    panic!("global cache should select immutable sources")
+                };
                 source
                     .ensure(registry.as_ref(), &resolved, false, &user_log())
                     .unwrap();
             });
             let second = scope.spawn(|| {
-                let source = select(&project_dir, &cache, &resolved).unwrap();
+                let SelectedDependencySource::Immutable(source) =
+                    select(&project_dir, &cache, &resolved).unwrap()
+                else {
+                    panic!("global cache should select immutable sources")
+                };
                 source
                     .ensure(registry.as_ref(), &resolved, false, &user_log())
                     .unwrap();
@@ -341,7 +358,11 @@ options(
         let first_registry = TestRegistry::new(false);
         let second_registry = TestRegistry::new(false).with_checksum(SECOND_CHECKSUM);
         let (resolved, module) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let SelectedDependencySource::Immutable(source) =
+            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
+        else {
+            panic!("global cache should select immutable sources")
+        };
 
         let first = source
             .ensure(&first_registry, &resolved, false, &user_log())
@@ -372,7 +393,11 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(false).with_checksum_after_first_read(SECOND_CHECKSUM);
         let (resolved, module) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let SelectedDependencySource::Immutable(source) =
+            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
+        else {
+            panic!("global cache should select immutable sources")
+        };
 
         let paths = source
             .ensure(&registry, &resolved, false, &user_log())
@@ -400,7 +425,11 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
-        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap();
+        let SelectedDependencySource::Immutable(source) =
+            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
+        else {
+            panic!("global cache should select immutable sources")
+        };
         let directory =
             ImmutableDependencySource::new(&cache_dir).source_dir(resolved.module_source(module));
         std::fs::create_dir_all(&directory).unwrap();
@@ -440,10 +469,16 @@ options(
         let cache = CacheRoot::Disabled;
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
-        let source = select(&project_dir, &cache, &resolved).unwrap();
+        let SelectedDependencySource::Project(source) =
+            select(&project_dir, &cache, &resolved).unwrap()
+        else {
+            panic!("disabled cache should select project sources")
+        };
+        let user_log = user_log();
+        let child = ManagedChildRunner::new(ChildOutputMode::Inherit, &user_log);
 
         let paths = source
-            .ensure(&registry, &resolved, false, &user_log())
+            .ensure(&registry, &resolved, false, &child, &user_log)
             .unwrap();
 
         assert_eq!(paths[module], project_dir.join("test/module"));

--- a/crates/mooncake/src/dependency_source.rs
+++ b/crates/mooncake/src/dependency_source.rs
@@ -25,38 +25,47 @@ use std::path::PathBuf;
 
 use moonutil::{
     cache::CacheRoot,
-    resolution::{ModuleSourceKind, ResolvedEnv},
+    child_process::ManagedChildRunner,
+    resolution::{DirSyncResult, ModuleSourceKind, ResolvedEnv},
+    user_log::UserLog,
 };
+
+use crate::registry::Registry;
 
 use self::{global::ImmutableDependencySource, project::ProjectDependencySource};
 
-pub(crate) enum SelectedDependencySource<'a> {
-    Immutable(ImmutableDependencySource<'a>),
-    Project(ProjectDependencySource),
+pub(crate) trait DependencySource {
+    /// Ensure that every resolved dependency has a source directory and return
+    /// those directories indexed by module ID.
+    fn ensure(
+        &self,
+        registry: &dyn Registry,
+        resolved: &ResolvedEnv,
+        frozen: bool,
+        user_log: &UserLog,
+    ) -> anyhow::Result<DirSyncResult>;
 }
 
 /// Select the dependency source adapter for one resolution.
 ///
-/// Selection has no hook-execution policy. The caller supplies a managed-child
-/// runner only when the selected project source may run legacy postadd;
-/// immutable sources reject postadd and never receive that policy.
+/// The project-local `.mooncakes` directory and the shared immutable cache are
+/// hidden behind the same [`DependencySource`] seam. The project implementation
+/// receives the runner needed to preserve its legacy postadd behavior; the
+/// immutable implementation never receives or executes that hook.
 pub(crate) fn select<'a>(
     project_dir: impl Into<PathBuf>,
     cache: &'a CacheRoot,
     resolved: &ResolvedEnv,
-) -> anyhow::Result<SelectedDependencySource<'a>> {
+    child: &'a ManagedChildRunner,
+) -> anyhow::Result<Box<dyn DependencySource + 'a>> {
     let has_registry_sources = resolved
         .all_modules()
         .any(|module| matches!(module.source(), ModuleSourceKind::Registry) && !module.is_core());
     if has_registry_sources && let Some(root) = cache.initialize()? {
-        return Ok(SelectedDependencySource::Immutable(
-            ImmutableDependencySource::new(root),
-        ));
+        return Ok(Box::new(ImmutableDependencySource::new(root)));
     }
 
-    Ok(SelectedDependencySource::Project(
-        ProjectDependencySource::new(project_dir),
-    ))
+    Ok(Box::new(ProjectDependencySource::new(project_dir, child)))
 }
 
 #[cfg(test)]
@@ -80,7 +89,6 @@ mod tests {
     use semver::Version;
 
     use super::{
-        SelectedDependencySource,
         global::{ImmutableDependencySource, SOURCE_ARCHIVE_CHECKSUM_FILE},
         select,
     };
@@ -212,6 +220,10 @@ options(
         UserLog::new(log::LevelFilter::Error)
     }
 
+    fn managed_child() -> ManagedChildRunner {
+        ManagedChildRunner::new(ChildOutputMode::Inherit, &user_log())
+    }
+
     fn global_cache(path: &Path) -> CacheRoot {
         CacheRoot::Path {
             kind: CacheKind::DependencySources,
@@ -237,11 +249,8 @@ options(
         let cache = global_cache(&sandbox.path().join("cache"));
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
-        let SelectedDependencySource::Immutable(source) =
-            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
-        else {
-            panic!("global cache should select immutable sources")
-        };
+        let child = managed_child();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
 
         let first = source
             .ensure(&registry, &resolved, false, &user_log())
@@ -268,11 +277,8 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(true);
         let (resolved, module) = test_env();
-        let SelectedDependencySource::Immutable(source) =
-            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
-        else {
-            panic!("global cache should select immutable sources")
-        };
+        let child = managed_child();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
         let directory =
             ImmutableDependencySource::new(&cache_dir).source_dir(resolved.module_source(module));
 
@@ -294,11 +300,8 @@ options(
         let cache = global_cache(&sandbox.path().join("cache"));
         let registry = TestRegistry::new(false);
         let (resolved, _) = test_env();
-        let SelectedDependencySource::Immutable(source) =
-            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
-        else {
-            panic!("global cache should select immutable sources")
-        };
+        let child = managed_child();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
 
         let error = source
             .ensure(&registry, &resolved, true, &user_log())
@@ -321,21 +324,15 @@ options(
 
         std::thread::scope(|scope| {
             let first = scope.spawn(|| {
-                let SelectedDependencySource::Immutable(source) =
-                    select(&project_dir, &cache, &resolved).unwrap()
-                else {
-                    panic!("global cache should select immutable sources")
-                };
+                let child = managed_child();
+                let source = select(&project_dir, &cache, &resolved, &child).unwrap();
                 source
                     .ensure(registry.as_ref(), &resolved, false, &user_log())
                     .unwrap();
             });
             let second = scope.spawn(|| {
-                let SelectedDependencySource::Immutable(source) =
-                    select(&project_dir, &cache, &resolved).unwrap()
-                else {
-                    panic!("global cache should select immutable sources")
-                };
+                let child = managed_child();
+                let source = select(&project_dir, &cache, &resolved, &child).unwrap();
                 source
                     .ensure(registry.as_ref(), &resolved, false, &user_log())
                     .unwrap();
@@ -358,11 +355,8 @@ options(
         let first_registry = TestRegistry::new(false);
         let second_registry = TestRegistry::new(false).with_checksum(SECOND_CHECKSUM);
         let (resolved, module) = test_env();
-        let SelectedDependencySource::Immutable(source) =
-            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
-        else {
-            panic!("global cache should select immutable sources")
-        };
+        let child = managed_child();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
 
         let first = source
             .ensure(&first_registry, &resolved, false, &user_log())
@@ -393,11 +387,8 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(false).with_checksum_after_first_read(SECOND_CHECKSUM);
         let (resolved, module) = test_env();
-        let SelectedDependencySource::Immutable(source) =
-            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
-        else {
-            panic!("global cache should select immutable sources")
-        };
+        let child = managed_child();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
 
         let paths = source
             .ensure(&registry, &resolved, false, &user_log())
@@ -425,11 +416,8 @@ options(
         let cache = global_cache(&cache_dir);
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
-        let SelectedDependencySource::Immutable(source) =
-            select(sandbox.path().join(".mooncakes"), &cache, &resolved).unwrap()
-        else {
-            panic!("global cache should select immutable sources")
-        };
+        let child = managed_child();
+        let source = select(sandbox.path().join(".mooncakes"), &cache, &resolved, &child).unwrap();
         let directory =
             ImmutableDependencySource::new(&cache_dir).source_dir(resolved.module_source(module));
         std::fs::create_dir_all(&directory).unwrap();
@@ -469,16 +457,12 @@ options(
         let cache = CacheRoot::Disabled;
         let registry = TestRegistry::new(false);
         let (resolved, module) = test_env();
-        let SelectedDependencySource::Project(source) =
-            select(&project_dir, &cache, &resolved).unwrap()
-        else {
-            panic!("disabled cache should select project sources")
-        };
         let user_log = user_log();
         let child = ManagedChildRunner::new(ChildOutputMode::Inherit, &user_log);
+        let source = select(&project_dir, &cache, &resolved, &child).unwrap();
 
         let paths = source
-            .ensure(&registry, &resolved, false, &child, &user_log)
+            .ensure(&registry, &resolved, false, &user_log)
             .unwrap();
 
         assert_eq!(paths[module], project_dir.join("test/module"));

--- a/crates/mooncake/src/dependency_source/global.rs
+++ b/crates/mooncake/src/dependency_source/global.rs
@@ -31,6 +31,8 @@ use moonutil::{
 
 use crate::registry::Registry;
 
+use super::DependencySource;
+
 const LAYOUT_VERSION: &str = "v1";
 const SOURCES_DIRECTORY: &str = "sources";
 pub(super) const SOURCE_ARCHIVE_CHECKSUM_FILE: &str = ".moon-source-archive-checksum";
@@ -39,7 +41,7 @@ pub(super) const SOURCE_ARCHIVE_CHECKSUM_FILE: &str = ".moon-source-archive-chec
 ///
 /// This module owns the complete on-disk layout and publication protocol. A
 /// caller only asks for the resolved module directories returned by `ensure`.
-pub(crate) struct ImmutableDependencySource<'a> {
+pub(super) struct ImmutableDependencySource<'a> {
     root: &'a Path,
 }
 
@@ -126,7 +128,7 @@ impl<'a> ImmutableDependencySource<'a> {
     }
 }
 
-impl super::DependencySource for ImmutableDependencySource<'_> {
+impl DependencySource for ImmutableDependencySource<'_> {
     fn ensure(
         &self,
         registry: &dyn Registry,

--- a/crates/mooncake/src/dependency_source/global.rs
+++ b/crates/mooncake/src/dependency_source/global.rs
@@ -31,8 +31,6 @@ use moonutil::{
 
 use crate::registry::Registry;
 
-use super::DependencySource;
-
 const LAYOUT_VERSION: &str = "v1";
 const SOURCES_DIRECTORY: &str = "sources";
 pub(super) const SOURCE_ARCHIVE_CHECKSUM_FILE: &str = ".moon-source-archive-checksum";
@@ -41,7 +39,7 @@ pub(super) const SOURCE_ARCHIVE_CHECKSUM_FILE: &str = ".moon-source-archive-chec
 ///
 /// This module owns the complete on-disk layout and publication protocol. A
 /// caller only asks for the resolved module directories returned by `ensure`.
-pub(super) struct ImmutableDependencySource<'a> {
+pub(crate) struct ImmutableDependencySource<'a> {
     root: &'a Path,
 }
 
@@ -128,8 +126,8 @@ impl<'a> ImmutableDependencySource<'a> {
     }
 }
 
-impl DependencySource for ImmutableDependencySource<'_> {
-    fn ensure(
+impl ImmutableDependencySource<'_> {
+    pub(crate) fn ensure(
         &self,
         registry: &dyn Registry,
         resolved: &ResolvedEnv,

--- a/crates/mooncake/src/dependency_source/global.rs
+++ b/crates/mooncake/src/dependency_source/global.rs
@@ -126,8 +126,8 @@ impl<'a> ImmutableDependencySource<'a> {
     }
 }
 
-impl ImmutableDependencySource<'_> {
-    pub(crate) fn ensure(
+impl super::DependencySource for ImmutableDependencySource<'_> {
+    fn ensure(
         &self,
         registry: &dyn Registry,
         resolved: &ResolvedEnv,

--- a/crates/mooncake/src/dependency_source/project.rs
+++ b/crates/mooncake/src/dependency_source/project.rs
@@ -26,7 +26,7 @@ use std::{
 use anyhow::Context;
 use arcstr::ArcStr;
 use moonutil::{
-    child_process::ManagedChildRunner,
+    child_process::{ChildOutputMode, ManagedChildRunner},
     constants::MOONBITLANG_CORE,
     locks::FileLock,
     resolution::{DirSyncResult, ModuleSource, ModuleSourceKind, ResolvedEnv},
@@ -36,6 +36,8 @@ use moonutil::{
 use semver::Version;
 
 use crate::{pkg::legacy_postadd, registry::Registry};
+
+use super::DependencySource;
 
 type DepDirState = HashMap<ArcStr, HashMap<ArcStr, Option<Version>>>;
 type NewDepDirState<'a> = HashMap<ArcStr, HashMap<ArcStr, &'a ModuleSource>>;
@@ -50,16 +52,16 @@ type NewDepDirState<'a> = HashMap<ArcStr, HashMap<ArcStr, &'a ModuleSource>>;
 /// dependencies directory for ease of scanning. Instead, we replace all slashes
 /// in the `pkgname` part with plus `+` sign. For example, a package
 /// `foo/bar/baz` will be stored in the directory `foo/bar+baz`.
-pub(crate) struct ProjectDependencySource<'a> {
+pub(super) struct ProjectDependencySource {
     path: PathBuf,
-    child: &'a ManagedChildRunner,
+    postadd_output: ChildOutputMode,
 }
 
-impl<'a> ProjectDependencySource<'a> {
-    pub(super) fn new(path: impl Into<PathBuf>, child: &'a ManagedChildRunner) -> Self {
+impl ProjectDependencySource {
+    pub(super) fn new(path: impl Into<PathBuf>, postadd_output: ChildOutputMode) -> Self {
         Self {
             path: path.into(),
-            child,
+            postadd_output,
         }
     }
 
@@ -100,7 +102,7 @@ impl<'a> ProjectDependencySource<'a> {
     }
 }
 
-impl super::DependencySource for ProjectDependencySource<'_> {
+impl DependencySource for ProjectDependencySource {
     fn ensure(
         &self,
         registry: &dyn Registry,
@@ -108,7 +110,8 @@ impl super::DependencySource for ProjectDependencySource<'_> {
         frozen: bool,
         user_log: &UserLog,
     ) -> anyhow::Result<DirSyncResult> {
-        sync(self, registry, resolved, frozen, self.child, user_log)
+        let postadd_runner = ManagedChildRunner::new(self.postadd_output, user_log);
+        sync(self, registry, resolved, frozen, &postadd_runner, user_log)
             .context("When installing packages")?;
         resolve_paths(self, resolved)
     }
@@ -217,11 +220,11 @@ fn diff_dep_dir_state<'a>(
 /// dependency directory. If the desired dependency list cannot be created
 /// from the current directory, this function will return an error.
 fn sync(
-    dep_dir: &ProjectDependencySource<'_>,
+    dep_dir: &ProjectDependencySource,
     registry: &dyn Registry,
     pkg_list: &ResolvedEnv,
     frozen: bool,
-    child: &ManagedChildRunner,
+    postadd_runner: &ManagedChildRunner,
     user_log: &UserLog,
 ) -> anyhow::Result<()> {
     // If nothing needs to be installed, don't bother
@@ -290,7 +293,7 @@ fn sync(
                 &pkg_path,
                 user_log,
             )?;
-            legacy_postadd::run(&pkg_path, child)?;
+            legacy_postadd::run(&pkg_path, postadd_runner)?;
             // TODO: parallelize this
         }
     }
@@ -300,7 +303,7 @@ fn sync(
     Ok(())
 }
 
-fn pkg_to_dir(dep_dir: &ProjectDependencySource<'_>, username: &str, pkgname: &str) -> PathBuf {
+fn pkg_to_dir(dep_dir: &ProjectDependencySource, username: &str, pkgname: &str) -> PathBuf {
     // Special case: core library locates in ~/.moon
     if format!("{username}/{pkgname}") == MOONBITLANG_CORE {
         return toolchain::core();
@@ -311,7 +314,7 @@ fn pkg_to_dir(dep_dir: &ProjectDependencySource<'_>, username: &str, pkgname: &s
 
 /// The result of a directory sync.
 fn map_source_to_dir(
-    dep_dir: &ProjectDependencySource<'_>,
+    dep_dir: &ProjectDependencySource,
     module: &ModuleSource,
 ) -> anyhow::Result<PathBuf> {
     Ok(match module.source() {
@@ -332,7 +335,7 @@ fn map_source_to_dir(
 /// Assumes [`sync`] is already called. Otherwise, modules might point to
 /// directories that don't exist yet because they are not synced yet.
 fn resolve_paths(
-    dep_dir: &ProjectDependencySource<'_>,
+    dep_dir: &ProjectDependencySource,
     pkg_list: &ResolvedEnv,
 ) -> anyhow::Result<DirSyncResult> {
     let mut res = DirSyncResult::default();

--- a/crates/mooncake/src/dependency_source/project.rs
+++ b/crates/mooncake/src/dependency_source/project.rs
@@ -26,6 +26,7 @@ use std::{
 use anyhow::Context;
 use arcstr::ArcStr;
 use moonutil::{
+    child_process::ManagedChildRunner,
     constants::MOONBITLANG_CORE,
     locks::FileLock,
     resolution::{DirSyncResult, ModuleSource, ModuleSourceKind, ResolvedEnv},
@@ -35,8 +36,6 @@ use moonutil::{
 use semver::Version;
 
 use crate::{pkg::legacy_postadd, registry::Registry};
-
-use super::DependencySource;
 
 type DepDirState = HashMap<ArcStr, HashMap<ArcStr, Option<Version>>>;
 type NewDepDirState<'a> = HashMap<ArcStr, HashMap<ArcStr, &'a ModuleSource>>;
@@ -51,7 +50,7 @@ type NewDepDirState<'a> = HashMap<ArcStr, HashMap<ArcStr, &'a ModuleSource>>;
 /// dependencies directory for ease of scanning. Instead, we replace all slashes
 /// in the `pkgname` part with plus `+` sign. For example, a package
 /// `foo/bar/baz` will be stored in the directory `foo/bar+baz`.
-pub(super) struct ProjectDependencySource {
+pub(crate) struct ProjectDependencySource {
     path: PathBuf,
 }
 
@@ -95,17 +94,16 @@ impl ProjectDependencySource {
 
         Ok(user_list)
     }
-}
-
-impl DependencySource for ProjectDependencySource {
-    fn ensure(
+    pub(crate) fn ensure(
         &self,
         registry: &dyn Registry,
         resolved: &ResolvedEnv,
         frozen: bool,
+        child: &ManagedChildRunner,
         user_log: &UserLog,
     ) -> anyhow::Result<DirSyncResult> {
-        sync(self, registry, resolved, frozen, user_log).context("When installing packages")?;
+        sync(self, registry, resolved, frozen, child, user_log)
+            .context("When installing packages")?;
         resolve_paths(self, resolved)
     }
 }
@@ -217,6 +215,7 @@ fn sync(
     registry: &dyn Registry,
     pkg_list: &ResolvedEnv,
     frozen: bool,
+    child: &ManagedChildRunner,
     user_log: &UserLog,
 ) -> anyhow::Result<()> {
     // If nothing needs to be installed, don't bother
@@ -285,7 +284,7 @@ fn sync(
                 &pkg_path,
                 user_log,
             )?;
-            legacy_postadd::run(&pkg_path, user_log)?;
+            legacy_postadd::run(&pkg_path, child)?;
             // TODO: parallelize this
         }
     }

--- a/crates/mooncake/src/dependency_source/project.rs
+++ b/crates/mooncake/src/dependency_source/project.rs
@@ -50,13 +50,17 @@ type NewDepDirState<'a> = HashMap<ArcStr, HashMap<ArcStr, &'a ModuleSource>>;
 /// dependencies directory for ease of scanning. Instead, we replace all slashes
 /// in the `pkgname` part with plus `+` sign. For example, a package
 /// `foo/bar/baz` will be stored in the directory `foo/bar+baz`.
-pub(crate) struct ProjectDependencySource {
+pub(crate) struct ProjectDependencySource<'a> {
     path: PathBuf,
+    child: &'a ManagedChildRunner,
 }
 
-impl ProjectDependencySource {
-    pub(super) fn new(path: impl Into<PathBuf>) -> Self {
-        Self { path: path.into() }
+impl<'a> ProjectDependencySource<'a> {
+    pub(super) fn new(path: impl Into<PathBuf>, child: &'a ManagedChildRunner) -> Self {
+        Self {
+            path: path.into(),
+            child,
+        }
     }
 
     fn path(&self) -> &Path {
@@ -94,15 +98,17 @@ impl ProjectDependencySource {
 
         Ok(user_list)
     }
-    pub(crate) fn ensure(
+}
+
+impl super::DependencySource for ProjectDependencySource<'_> {
+    fn ensure(
         &self,
         registry: &dyn Registry,
         resolved: &ResolvedEnv,
         frozen: bool,
-        child: &ManagedChildRunner,
         user_log: &UserLog,
     ) -> anyhow::Result<DirSyncResult> {
-        sync(self, registry, resolved, frozen, child, user_log)
+        sync(self, registry, resolved, frozen, self.child, user_log)
             .context("When installing packages")?;
         resolve_paths(self, resolved)
     }
@@ -211,7 +217,7 @@ fn diff_dep_dir_state<'a>(
 /// dependency directory. If the desired dependency list cannot be created
 /// from the current directory, this function will return an error.
 fn sync(
-    dep_dir: &ProjectDependencySource,
+    dep_dir: &ProjectDependencySource<'_>,
     registry: &dyn Registry,
     pkg_list: &ResolvedEnv,
     frozen: bool,
@@ -294,7 +300,7 @@ fn sync(
     Ok(())
 }
 
-fn pkg_to_dir(dep_dir: &ProjectDependencySource, username: &str, pkgname: &str) -> PathBuf {
+fn pkg_to_dir(dep_dir: &ProjectDependencySource<'_>, username: &str, pkgname: &str) -> PathBuf {
     // Special case: core library locates in ~/.moon
     if format!("{username}/{pkgname}") == MOONBITLANG_CORE {
         return toolchain::core();
@@ -305,7 +311,7 @@ fn pkg_to_dir(dep_dir: &ProjectDependencySource, username: &str, pkgname: &str) 
 
 /// The result of a directory sync.
 fn map_source_to_dir(
-    dep_dir: &ProjectDependencySource,
+    dep_dir: &ProjectDependencySource<'_>,
     module: &ModuleSource,
 ) -> anyhow::Result<PathBuf> {
     Ok(match module.source() {
@@ -326,7 +332,7 @@ fn map_source_to_dir(
 /// Assumes [`sync`] is already called. Otherwise, modules might point to
 /// directories that don't exist yet because they are not synced yet.
 fn resolve_paths(
-    dep_dir: &ProjectDependencySource,
+    dep_dir: &ProjectDependencySource<'_>,
     pkg_list: &ResolvedEnv,
 ) -> anyhow::Result<DirSyncResult> {
     let mut res = DirSyncResult::default();

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -25,6 +25,7 @@ use super::sync::SyncOutputOptions;
 use anyhow::Context;
 use moonutil::{
     cache::CacheRoot,
+    child_process::ManagedChildRunner,
     constants::MOONBITLANG_CORE,
     project::PackageDirs,
     resolution::{
@@ -124,21 +125,33 @@ pub(crate) fn install_impl(
     };
 
     let res = resolve_with_default_env_and_resolver(&resolve_config, roots, user_log)?;
+    // Child output follows the command's User Log policy. Sync quietness only
+    // narrows dependency acquisition progress below this point.
+    let managed_child = ManagedChildRunner::new(output_options.child_output, user_log);
     let dependency_source = dependency_source::select(&dirs.mooncakes_dir, source_cache, &res)?;
-    let dependency_user_log = if output_options.quiet() {
+    let dependency_user_log = if output_options.quiet {
         user_log.with_level(log::LevelFilter::Error)
     } else {
         user_log.clone()
     };
-    let dependency_paths = dependency_source.ensure(
-        resolve_config.registry.as_ref(),
-        &res,
-        dont_sync,
-        &dependency_user_log,
-    )?;
+    let dependency_paths = match dependency_source {
+        dependency_source::SelectedDependencySource::Immutable(source) => source.ensure(
+            resolve_config.registry.as_ref(),
+            &res,
+            dont_sync,
+            &dependency_user_log,
+        )?,
+        dependency_source::SelectedDependencySource::Project(source) => source.ensure(
+            resolve_config.registry.as_ref(),
+            &res,
+            dont_sync,
+            &managed_child,
+            &dependency_user_log,
+        )?,
+    };
 
     install_bin_deps(
-        output_options.capture_child_output(),
+        &managed_child,
         &res,
         &dependency_paths,
         &dirs.target_dir,
@@ -150,7 +163,7 @@ pub(crate) fn install_impl(
 }
 
 fn install_bin_deps(
-    capture_child_output: bool,
+    child: &ManagedChildRunner,
     res: &ResolvedEnv,
     dependency_paths: &DirSyncResult,
     target_dir: &Path,
@@ -204,46 +217,10 @@ fn install_bin_deps(
             if verbose {
                 user_log.info(format!("Installing binary dependency `{}`", edge.name));
             }
-            let status = if capture_child_output {
-                let output = cmd.output().with_context(|| {
-                    format!("Failed to run build process for binary dep `{}`", edge.name)
-                })?;
-                for (channel, content) in [
-                    ("stdout", output.stdout.as_slice()),
-                    ("stderr", output.stderr.as_slice()),
-                ] {
-                    let content = String::from_utf8_lossy(content);
-                    let content = content.trim();
-                    if content.is_empty() {
-                        continue;
-                    }
-                    let message = format!(
-                        "binary dependency `{}` wrote to {channel}:\n{content}",
-                        edge.name
-                    );
-                    if output.status.success() {
-                        user_log.status(message);
-                    } else {
-                        user_log.error(message);
-                    }
-                }
-                output.status
-            } else {
-                cmd.spawn()
-                    .with_context(|| {
-                        format!(
-                            "Failed to spawn build process for binary dep `{}`",
-                            edge.name
-                        )
-                    })?
-                    .wait()
-                    .with_context(|| {
-                        format!(
-                            "Failed to wait for build process of binary dep `{}`",
-                            edge.name
-                        )
-                    })?
-            };
+            let subject = format!("binary dependency `{}`", edge.name);
+            let status = child.run(&mut cmd, &subject).with_context(|| {
+                format!("Failed to run build process for binary dep `{}`", edge.name)
+            })?;
             if !status.success() {
                 return Err(anyhow::anyhow!(
                     "Building binary dependency `{}` failed",

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -128,27 +128,19 @@ pub(crate) fn install_impl(
     // Child output follows the command's User Log policy. Sync quietness only
     // narrows dependency acquisition progress below this point.
     let managed_child = ManagedChildRunner::new(output_options.child_output, user_log);
-    let dependency_source = dependency_source::select(&dirs.mooncakes_dir, source_cache, &res)?;
+    let dependency_source =
+        dependency_source::select(&dirs.mooncakes_dir, source_cache, &res, &managed_child)?;
     let dependency_user_log = if output_options.quiet {
         user_log.with_level(log::LevelFilter::Error)
     } else {
         user_log.clone()
     };
-    let dependency_paths = match dependency_source {
-        dependency_source::SelectedDependencySource::Immutable(source) => source.ensure(
-            resolve_config.registry.as_ref(),
-            &res,
-            dont_sync,
-            &dependency_user_log,
-        )?,
-        dependency_source::SelectedDependencySource::Project(source) => source.ensure(
-            resolve_config.registry.as_ref(),
-            &res,
-            dont_sync,
-            &managed_child,
-            &dependency_user_log,
-        )?,
-    };
+    let dependency_paths = dependency_source.ensure(
+        resolve_config.registry.as_ref(),
+        &res,
+        dont_sync,
+        &dependency_user_log,
+    )?;
 
     install_bin_deps(
         &managed_child,

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -125,16 +125,17 @@ pub(crate) fn install_impl(
     };
 
     let res = resolve_with_default_env_and_resolver(&resolve_config, roots, user_log)?;
-    // Child output follows the command's User Log policy. Sync quietness only
-    // narrows dependency acquisition progress below this point.
-    let managed_child = ManagedChildRunner::new(output_options.child_output, user_log);
-    let dependency_source =
-        dependency_source::select(&dirs.mooncakes_dir, source_cache, &res, &managed_child)?;
     let dependency_user_log = if output_options.quiet {
         user_log.with_level(log::LevelFilter::Error)
     } else {
         user_log.clone()
     };
+    let dependency_source = dependency_source::select(
+        &dirs.mooncakes_dir,
+        source_cache,
+        &res,
+        output_options.child_output,
+    )?;
     let dependency_paths = dependency_source.ensure(
         resolve_config.registry.as_ref(),
         &res,
@@ -142,13 +143,14 @@ pub(crate) fn install_impl(
         &dependency_user_log,
     )?;
 
+    let managed_child = ManagedChildRunner::new(output_options.child_output, &dependency_user_log);
     install_bin_deps(
         &managed_child,
         &res,
         &dependency_paths,
         &dirs.target_dir,
         &dirs.mooncake_bin_dir,
-        user_log,
+        &dependency_user_log,
     )?;
 
     Ok((res, dependency_paths))

--- a/crates/mooncake/src/pkg/legacy_postadd.rs
+++ b/crates/mooncake/src/pkg/legacy_postadd.rs
@@ -28,11 +28,12 @@ use std::path::Path;
 use anyhow::bail;
 use moonutil::{child_process::ManagedChildRunner, manifest::read_module_desc_file_in_dir};
 
-pub fn run(dir: &Path, child: &ManagedChildRunner) -> anyhow::Result<()> {
+/// Run the legacy hook declared by the materialized module at `module_dir`.
+pub fn run(module_dir: &Path, child: &ManagedChildRunner) -> anyhow::Result<()> {
     if std::env::var_os("MOON_IGNORE_POSTADD").is_some() {
         return Ok(());
     }
-    let module = read_module_desc_file_in_dir(dir)?;
+    let module = read_module_desc_file_in_dir(module_dir)?;
     let Some(postadd) = module
         .scripts
         .as_ref()
@@ -46,12 +47,12 @@ pub fn run(dir: &Path, child: &ManagedChildRunner) -> anyhow::Result<()> {
         return Ok(());
     };
     let mut process = std::process::Command::new(command);
-    process.args(args).current_dir(dir);
+    process.args(args).current_dir(module_dir);
     let status = child.run(&mut process, "postadd script")?;
     if !status.success() {
         bail!(
             "failed to execute postadd script in {},\ncommand: {}",
-            dir.display(),
+            module_dir.display(),
             command
         );
     }

--- a/crates/mooncake/src/pkg/legacy_postadd.rs
+++ b/crates/mooncake/src/pkg/legacy_postadd.rs
@@ -29,7 +29,7 @@ use anyhow::bail;
 use moonutil::{child_process::ManagedChildRunner, manifest::read_module_desc_file_in_dir};
 
 /// Run the legacy hook declared by the materialized module at `module_dir`.
-pub fn run(module_dir: &Path, child: &ManagedChildRunner) -> anyhow::Result<()> {
+pub fn run(module_dir: &Path, runner: &ManagedChildRunner) -> anyhow::Result<()> {
     if std::env::var_os("MOON_IGNORE_POSTADD").is_some() {
         return Ok(());
     }
@@ -48,7 +48,7 @@ pub fn run(module_dir: &Path, child: &ManagedChildRunner) -> anyhow::Result<()> 
     };
     let mut process = std::process::Command::new(command);
     process.args(args).current_dir(module_dir);
-    let status = child.run(&mut process, "postadd script")?;
+    let status = runner.run(&mut process, "postadd script")?;
     if !status.success() {
         bail!(
             "failed to execute postadd script in {},\ncommand: {}",

--- a/crates/mooncake/src/pkg/legacy_postadd.rs
+++ b/crates/mooncake/src/pkg/legacy_postadd.rs
@@ -21,16 +21,14 @@
 //! Registry source acquisition deliberately does not call this module. The
 //! remaining command paths opt into the legacy behavior after source has been
 //! materialized, so rejecting postadd in the future does not change the
-//! Registry interface. This compatibility module preserves the existing child
-//! output behavior; making that lifecycle explicit belongs to the separate
-//! command-output migration.
+//! Registry interface.
 
 use std::path::Path;
 
 use anyhow::bail;
-use moonutil::{manifest::read_module_desc_file_in_dir, user_log::UserLog};
+use moonutil::{child_process::ManagedChildRunner, manifest::read_module_desc_file_in_dir};
 
-pub fn run(dir: &Path, user_log: &UserLog) -> anyhow::Result<()> {
+pub fn run(dir: &Path, child: &ManagedChildRunner) -> anyhow::Result<()> {
     if std::env::var_os("MOON_IGNORE_POSTADD").is_some() {
         return Ok(());
     }
@@ -49,43 +47,13 @@ pub fn run(dir: &Path, user_log: &UserLog) -> anyhow::Result<()> {
     };
     let mut process = std::process::Command::new(command);
     process.args(args).current_dir(dir);
-    if user_log.is_captured() {
-        let output = process.output()?;
-        for (channel, content) in [
-            ("stdout", output.stdout.as_slice()),
-            ("stderr", output.stderr.as_slice()),
-        ] {
-            let content = String::from_utf8_lossy(content);
-            let content = content.trim();
-            if content.is_empty() {
-                continue;
-            }
-            let message = format!("postadd script wrote to {channel}:\n{content}");
-            if output.status.success() {
-                user_log.status(message);
-            } else {
-                user_log.error(message);
-            }
-        }
-        if !output.status.success() {
-            bail!(
-                "failed to execute postadd script in {},\ncommand: {}",
-                dir.display(),
-                command
-            );
-        }
-    } else {
-        let status = process
-            .stdout(std::process::Stdio::inherit())
-            .stderr(std::process::Stdio::inherit())
-            .status()?;
-        if !status.success() {
-            bail!(
-                "failed to execute postadd script in {},\ncommand: {}",
-                dir.display(),
-                command
-            );
-        }
+    let status = child.run(&mut process, "postadd script")?;
+    if !status.success() {
+        bail!(
+            "failed to execute postadd script in {},\ncommand: {}",
+            dir.display(),
+            command
+        );
     }
     Ok(())
 }
@@ -95,7 +63,10 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     use log::LevelFilter;
-    use moonutil::user_log::{UserLog, UserLogEntryLevel};
+    use moonutil::{
+        child_process::{ChildOutputMode, ManagedChildRunner},
+        user_log::{UserLog, UserLogEntryLevel},
+    };
 
     use super::run;
 
@@ -122,8 +93,9 @@ mod tests {
         )
         .unwrap();
         let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+        let child = ManagedChildRunner::new(ChildOutputMode::Capture, &user_log);
 
-        run(sandbox.path(), &user_log).unwrap();
+        run(sandbox.path(), &child).unwrap();
 
         let entries = capture.take();
         assert_eq!(entries.len(), 2);
@@ -141,8 +113,9 @@ mod tests {
         )
         .unwrap();
         let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+        let child = ManagedChildRunner::new(ChildOutputMode::Capture, &user_log);
 
-        let error = run(sandbox.path(), &user_log).unwrap_err();
+        let error = run(sandbox.path(), &child).unwrap_err();
 
         assert!(
             error

--- a/crates/mooncake/src/pkg/sync.rs
+++ b/crates/mooncake/src/pkg/sync.rs
@@ -24,6 +24,7 @@ use indexmap::IndexMap;
 use moonutil::{
     build_options::{MoonbuildOpt, MooncOpt},
     cache::CacheRoot,
+    child_process::ChildOutputMode,
     cli_support::AutoSyncFlags,
     front_matter::MbtMdHeader,
     manifest::{MoonMod, read_module_desc_file_in_dir},
@@ -33,30 +34,17 @@ use moonutil::{
 };
 use semver::Version;
 
+/// User-visible output policy while synchronizing dependencies.
+///
+/// Dependency progress and Moon-managed setup children are independent: a
+/// quiet human command may still let a child inherit the terminal, while a
+/// structured command captures child output without hiding sync warnings.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SyncOutputOptions {
-    quiet: bool,
-    capture_child_output: bool,
-}
-
-impl SyncOutputOptions {
-    pub fn with_quiet(mut self, quiet: bool) -> Self {
-        self.quiet = quiet;
-        self
-    }
-
-    pub fn quiet(self) -> bool {
-        self.quiet
-    }
-
-    pub fn with_captured_child_output(mut self, capture: bool) -> Self {
-        self.capture_child_output = capture;
-        self
-    }
-
-    pub fn capture_child_output(self) -> bool {
-        self.capture_child_output
-    }
+    /// Suppress dependency acquisition progress below error level.
+    pub quiet: bool,
+    /// Output policy for setup children such as postadd and bin-dep builds.
+    pub child_output: ChildOutputMode,
 }
 
 /// Given the specified source directory, resolve the module dependency relation

--- a/crates/moonutil/src/child_process.rs
+++ b/crates/moonutil/src/child_process.rs
@@ -1,0 +1,241 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Execution policy for child processes managed by Moon itself.
+
+use std::process::{Command, ExitStatus, Stdio};
+
+use crate::user_log::UserLog;
+
+/// Controls where a Moon-managed child sends its output.
+///
+/// This policy does not apply to user programs, whose output remains process
+/// passthrough. Capture is for command modes that must incorporate all
+/// Moon-visible output into a structured command result.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ChildOutputMode {
+    #[default]
+    Inherit,
+    Capture,
+}
+
+/// Runs Moon-managed children under one explicit output policy.
+#[derive(Debug)]
+pub struct ManagedChildRunner {
+    output_mode: ChildOutputMode,
+    user_log: UserLog,
+}
+
+impl ManagedChildRunner {
+    pub fn new(output_mode: ChildOutputMode, user_log: &UserLog) -> Self {
+        Self {
+            output_mode,
+            user_log: user_log.clone(),
+        }
+    }
+
+    /// Run a child and classify captured output as user-visible messages.
+    ///
+    /// Inherited output retains its original bytes and channel. Captured output
+    /// is informational when the child succeeds and an error when it fails.
+    pub fn run(&self, command: &mut Command, subject: &str) -> std::io::Result<ExitStatus> {
+        match self.output_mode {
+            ChildOutputMode::Inherit => {
+                command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+                command.spawn()?.wait()
+            }
+            ChildOutputMode::Capture => {
+                command
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped());
+                let output = command.spawn()?.wait_with_output()?;
+                for (channel, content) in [
+                    ("stdout", output.stdout.as_slice()),
+                    ("stderr", output.stderr.as_slice()),
+                ] {
+                    let content = String::from_utf8_lossy(content);
+                    let content = content.trim();
+                    if content.is_empty() {
+                        continue;
+                    }
+                    let message = format!("{subject} wrote to {channel}:\n{content}");
+                    if output.status.success() {
+                        self.user_log.status(message);
+                    } else {
+                        self.user_log.error(message);
+                    }
+                }
+                Ok(output.status)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+
+    use log::LevelFilter;
+
+    use super::{ChildOutputMode, ManagedChildRunner};
+    use crate::user_log::{UserLog, UserLogEntryLevel};
+
+    const EMIT_HELPER_ENV: &str = "MOON_CHILD_OUTPUT_EMIT_HELPER";
+    const INHERIT_HELPER_ENV: &str = "MOON_CHILD_OUTPUT_INHERIT_HELPER";
+    const CAPTURE_STDIN_HELPER_ENV: &str = "MOON_CHILD_OUTPUT_CAPTURE_STDIN_HELPER";
+
+    fn emitting_command(success: bool) -> std::process::Command {
+        let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                "--exact",
+                "child_process::tests::emit_helper",
+                "--nocapture",
+            ])
+            .env(EMIT_HELPER_ENV, success.to_string());
+        command
+    }
+
+    #[test]
+    fn emit_helper() -> Result<(), &'static str> {
+        let Ok(success) = std::env::var(EMIT_HELPER_ENV) else {
+            return Ok(());
+        };
+
+        print!("CHILD_STDOUT");
+        eprint!("CHILD_STDERR");
+        std::io::stdout().flush().unwrap();
+        std::io::stderr().flush().unwrap();
+        success
+            .parse::<bool>()
+            .unwrap()
+            .then_some(())
+            .ok_or("requested failure")
+    }
+
+    #[test]
+    fn capture_classifies_success_and_failure() {
+        for success in [true, false] {
+            let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+            let child = ManagedChildRunner::new(ChildOutputMode::Capture, &user_log);
+
+            let status = child
+                .run(&mut emitting_command(success), "test child")
+                .unwrap();
+
+            assert_eq!(status.success(), success);
+            let entries = capture.take();
+            assert_eq!(entries.len(), 2);
+            assert!(entries.iter().all(|entry| if success {
+                matches!(entry.level, UserLogEntryLevel::Info)
+            } else {
+                matches!(entry.level, UserLogEntryLevel::Error)
+            }));
+            assert!(entries[0].message.contains("stdout:\n"));
+            assert!(entries[0].message.contains("CHILD_STDOUT"));
+            assert!(entries[1].message.contains("stderr:\n"));
+            assert!(entries[1].message.contains("CHILD_STDERR"));
+        }
+    }
+
+    #[test]
+    fn capture_closes_child_stdin() {
+        let mut input = tempfile::NamedTempFile::new().unwrap();
+        input.write_all(b"PARENT_STDIN").unwrap();
+
+        let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                "--exact",
+                "child_process::tests::capture_stdin_helper",
+                "--nocapture",
+            ])
+            .env(CAPTURE_STDIN_HELPER_ENV, "1")
+            .stdin(std::fs::File::open(input.path()).unwrap());
+        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+        let child = ManagedChildRunner::new(ChildOutputMode::Capture, &user_log);
+
+        let status = child.run(&mut command, "test child").unwrap();
+
+        assert!(status.success());
+        let entries = capture.take();
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.message.contains("STDIN_EOF")),
+            "captured child inherited parent input: {entries:#?}"
+        );
+        assert!(
+            entries
+                .iter()
+                .all(|entry| !entry.message.contains("PARENT_STDIN")),
+            "captured child consumed parent input: {entries:#?}"
+        );
+    }
+
+    #[test]
+    fn capture_stdin_helper() {
+        if std::env::var_os(CAPTURE_STDIN_HELPER_ENV).is_none() {
+            return;
+        }
+
+        let mut input = String::new();
+        std::io::stdin().read_to_string(&mut input).unwrap();
+        if input.is_empty() {
+            print!("STDIN_EOF");
+        } else {
+            print!("STDIN:{input}");
+        }
+    }
+
+    #[test]
+    fn inherit_preserves_parent_channels_on_success_and_failure() {
+        for success in [true, false] {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "child_process::tests::inherit_helper",
+                    "--nocapture",
+                ])
+                .env(INHERIT_HELPER_ENV, success.to_string())
+                .output()
+                .unwrap();
+
+            assert!(output.status.success());
+            assert!(String::from_utf8_lossy(&output.stdout).contains("CHILD_STDOUT"));
+            assert!(String::from_utf8_lossy(&output.stderr).contains("CHILD_STDERR"));
+        }
+    }
+
+    #[test]
+    fn inherit_helper() {
+        let Ok(success) = std::env::var(INHERIT_HELPER_ENV) else {
+            return;
+        };
+        let success = success.parse().unwrap();
+        let user_log = UserLog::new(LevelFilter::Warn);
+        let child = ManagedChildRunner::new(ChildOutputMode::Inherit, &user_log);
+
+        let status = child
+            .run(&mut emitting_command(success), "test child")
+            .unwrap();
+
+        assert_eq!(status.success(), success);
+    }
+}

--- a/crates/moonutil/src/child_process.rs
+++ b/crates/moonutil/src/child_process.rs
@@ -43,6 +43,8 @@ pub struct ManagedChildRunner {
 
 impl ManagedChildRunner {
     pub fn new(output_mode: ChildOutputMode, user_log: &UserLog) -> Self {
+        // Captured UserLog clones retain the same Arc-backed destination, so a
+        // runner can own its handle without imposing a lifetime on callers.
         Self {
             output_mode,
             user_log: user_log.clone(),

--- a/crates/moonutil/src/lib.rs
+++ b/crates/moonutil/src/lib.rs
@@ -22,6 +22,7 @@ mod binaries;
 pub mod build_options;
 pub mod build_script;
 pub mod cache;
+pub mod child_process;
 mod cli;
 pub mod cli_support;
 pub mod command_output;

--- a/crates/moonutil/src/user_log.rs
+++ b/crates/moonutil/src/user_log.rs
@@ -110,12 +110,6 @@ impl UserLog {
         self.level >= level.to_level_filter()
     }
 
-    /// Whether user-facing output is being collected for a command result
-    /// instead of rendered directly to stderr.
-    pub fn is_captured(&self) -> bool {
-        matches!(&self.destination, UserLogDestination::Capture(_))
-    }
-
     pub fn error(&self, message: impl Display) {
         match &self.destination {
             UserLogDestination::Stderr => {

--- a/docs/dev/design/cli-execution-lifecycle.md
+++ b/docs/dev/design/cli-execution-lifecycle.md
@@ -158,15 +158,43 @@ This lifecycle does not merge the communication categories defined by
 Command Results, User Logs, Process Passthrough, Progress Displays, tracing,
 and Moon-managed setup-child output remain separate mechanisms.
 
-In particular, this change does not select or infer setup-child output capture.
-That policy belongs to the later child-output slice built on top of this
-lifecycle.
+## Moon-managed setup children
+
+Moon-managed setup children currently include legacy `postadd` hooks and the
+nested Moon process used for deprecated binary dependencies. Their output mode
+is selected explicitly at the command seam:
+
+```rust
+enum ChildOutputMode {
+    Inherit,
+    Capture,
+}
+```
+
+Human commands inherit the child's stdout and stderr. JSON check captures both
+channels, closes the child's stdin, and waits for completion before producing
+the Command Result. Non-empty output from a successful child becomes an
+informational User Log entry; output from a failed child becomes an error.
+User Log filtering and child-output mode remain independent decisions: capture
+is never inferred from the User Log destination.
+
+Registry adapters only acquire and verify source. Project-local dependency
+installation invokes the isolated legacy-postadd module after materialization,
+while immutable cached sources reject postadd and never receive process-output
+policy. Package prebuild tasks, including custom `pre-build`, moonlex, and
+moonyacc, remain build-graph work owned by the build executor. An unstable
+module prebuild script run by a nested binary-dependency build is covered by
+the output mode of that nested Moon process as a whole. User programs remain
+Process Passthrough.
 
 ## Regression coverage
 
 Selection tests use raw argument vectors and cover ordinary commands, JSON
 selection, executable-name dispatch, tool exec, IDE help, cram ownership, and
 trace placement.
+
+Managed-child runner tests cover inherited and captured output on both output
+channels, stdin EOF, and success/failure classification.
 
 Public CLI tests cover:
 
@@ -175,5 +203,6 @@ Public CLI tests cover:
 - trace ownership around the cram delegation point;
 - complete traces before `cram test` and registry `runwasm` delegation;
 - complete JSON stdout and trace files for successful and failed JSON checks;
-  and
+- JSON check capture for successful and failed legacy postadd hooks and nested
+  binary-dependency builds; and
 - existing `moon run` trace and temporary-project cleanup invariants.


### PR DESCRIPTION
## Why

Moon-managed setup children can write directly to stdout and stderr while Moon is still preparing a command result. That is especially unsafe for `moon check --json`, which must emit one complete JSON value on stdout and nothing on stderr. The existing implementation also inferred capture from the `UserLog` destination, coupling two independent policies.

## What changed

- Add explicit `ChildOutputMode::{Inherit, Capture}` and one `ManagedChildRunner` for Moon-owned setup children.
- In capture mode, close child stdin, pipe both output channels, and classify non-empty output through the selected `UserLog`: informational on success and error on failure.
- Select capture from the JSON check execution path and inherit for human commands. Dependency-sync quietness remains a separate setting.
- Route legacy postadd hooks and deprecated binary-dependency builds through the runner.
- Keep postadd isolated from Registry acquisition. `DependencySource` remains an opaque trait-object seam; only the project adapter stores the postadd output mode, while immutable cached sources reject postadd.
- Remove `UserLog::is_captured()` and the trivial sync-output getter/setter wrappers.
- Record the implemented managed-child lifecycle and ownership rules in the accepted CLI lifecycle design.

## Why this is correct

The output mode is chosen before dependency synchronization and is passed explicitly instead of being inferred from logging state. Captured children cannot consume caller input or leak bytes around the JSON result, and their output remains subject to the same effective `UserLog` filtering as the dependency operation that launched them.

Registry adapters still only acquire and verify source. Package prebuild rules remain build-graph work owned by the build executor, and user programs remain process passthrough. A nested binary-dependency Moon invocation is captured as one managed child, including its permitted unstable module prebuild configuration.

## Scope

This PR is the managed-child-output slice built on the CLI lifecycle merged in #2001. It does not introduce a generic JSON result abstraction or change user-program process handling.