### PR TITLE
feat(moonrun): accept JSON policy files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ dependencies = [
  "openssl-probe",
  "rand 0.8.5",
  "serde",
+ "serde_json",
  "serde_json_lenient",
  "slotmap",
  "snapbox",

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -40,7 +40,7 @@ Local package inputs are handled like `moon run --target wasm`:
   moon runwasm ./main
 
 Experimental moonrun policy forwarding:
-  moon runwasm --experimental-policy moonrun-policy.toml main
+  moon runwasm --experimental-policy moonrun-policy.json main
 
 Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
@@ -58,7 +58,7 @@ pub(crate) struct RunWasmSubcommand {
     #[clap(value_name = "LOCAL_PACKAGE|PACKAGE[@VERSION]")]
     pub package: String,
 
-    /// Experimental: pass a moonrun TOML policy file for moonbitlang/async runtime access.
+    /// Experimental: pass a moonrun JSON policy file for moonbitlang/async runtime access.
     ///
     /// The policy applies to moonbitlang/async and moonrun-owned unstable FFI;
     /// WASI is not covered.

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -428,8 +428,12 @@ fn test_runwasm_help_marks_policy_as_experimental() {
         "expected runwasm help to expose experimental policy flag, got:\n{help}"
     );
     assert!(
-        help.contains("Experimental: pass a moonrun TOML policy file"),
+        help.contains("Experimental: pass a moonrun JSON policy file"),
         "expected runwasm help to mark policy as experimental, got:\n{help}"
+    );
+    assert!(
+        !help.contains("TOML"),
+        "expected runwasm help to advertise only JSON policies, got:\n{help}"
     );
     assert!(
         help.contains("WASI is not covered"),

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -27,6 +27,7 @@ rust-version.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 serde_json_lenient.workspace = true
 slotmap.workspace = true
 toml = { workspace = true, features = ["parse", "serde", "std"] }

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -36,39 +36,38 @@ unsuccessfully.
 
 By default, running `moonrun` without `--policy` preserves existing behavior.
 
-Supplying `--policy <path>` enables an experimental policy system and switches
-supported moonrun-owned host surfaces into sandbox mode. The policy is
-deny-by-default: omitted or empty `[fs]`, `[net]`, and `[env]` sections deny
-that surface, and process spawning is disabled unless explicitly enabled. Add
-entries only for the access the program should have. The
-policy covers `moonbitlang/async` and moonrun's own `__moonbit_*_unstable` FFI
-surfaces. It does not apply to WASI
+Supplying a JSON file with `--policy <path>` enables an experimental policy
+system and switches supported moonrun-owned host surfaces into sandbox mode.
+The policy is deny-by-default: omitted or empty `fs`, `net`, and `env` objects
+deny that surface, and process spawning is disabled unless explicitly enabled.
+Add entries only for the access the program should have. The policy covers
+`moonbitlang/async` and moonrun's own `__moonbit_*_unstable` FFI surfaces. It
+does not apply to WASI
 (`wasi_snapshot_preview1` / `__moonbit_wasi_unstable`).
 
-An empty policy file denies all policy-covered filesystem, network, and
+An empty JSON object denies all policy-covered filesystem, network, and
 environment access:
 
-```toml
-# deny-all.toml
+```json
+{}
 ```
 
 To allow everything while still passing a policy file, use explicit wildcards:
 
-```toml
-[env]
-from_host = ["*"]
-
-[fs]
-read = ["*"]
-write = ["*"]
-
-[net]
-dns = ["*"]
-connect = ["*:*"]
-bind = ["*:*"]
-
-[process]
-spawn = true
+```json
+{
+  "env": { "from_host": ["*"] },
+  "fs": {
+    "read": ["*"],
+    "write": ["*"]
+  },
+  "net": {
+    "dns": ["*"],
+    "connect": ["*:*"],
+    "bind": ["*:*"]
+  },
+  "process": { "spawn": true }
+}
 ```
 
 The simplest way to preserve legacy allow-all behavior is still to run without
@@ -80,53 +79,59 @@ guest filesystem, mount table, or portable `/` namespace. Relative filesystem
 roots are resolved relative to the policy file. Runtime relative paths are
 resolved using the process current directory. Paths use the host platform's path
 syntax; Windows policies may use normal Windows paths such as `C:\work` or
-`C:/work`. The filesystem wildcard `"*"` allows every host path on every
-platform. List a root in both `read` and `write` to allow read-write filesystem
-access.
+`C:/work`; JSON strings must escape backslashes as `C:\\work`. The filesystem
+wildcard `"*"` allows every host path on every platform. List a root in both
+`read` and `write` to allow read-write filesystem access.
 
 The environment policy constructs the guest environment. Use `from_host` to copy
 selected host variables if present, `required_from_host` to require selected
-host variables, and `[env.set]` for literal values. `[env.set]` overrides values
+host variables, and `env.set` for literal values. `env.set` overrides values
 copied from the host. Do not put secrets directly in the policy file; pass them
 by name through `from_host` or `required_from_host`.
 
-Process spawning is disabled unless `[process] spawn = true` is present. This
-is a coarse escape hatch: a native child receives the host user's ambient
-filesystem, network, and process access. The `[fs]` and `[net]` sections do not
+Process spawning is disabled unless `process.spawn` is `true`. This is a coarse
+escape hatch: a native child receives the host user's ambient
+filesystem, network, and process access. The `fs` and `net` objects do not
 sandbox child processes. PID-based process operations are restricted to
 children spawned by the current moonrun instance while policy mode is active.
 
-```toml
-[env]
-from_host = ["PATH", "SSL_CERT_FILE", "SSL_CERT_DIR"]
-required_from_host = ["DEEPSEEK_API_KEY"]
-
-[env.set]
-APP_ENV = "prod"
-API_BASE = "https://api.deepseek.com"
-
-[fs]
-read = ["allowed"]
-write = ["scratch"]
-
-[net]
-connect = [
-  "api.deepseek.com:443",
-  "hacker-news.firebaseio.com:443",
-  "127.0.0.1:443",
-  "[::1]:*",
-]
-bind = ["127.0.0.1:*"]
+```json
+{
+  "env": {
+    "from_host": ["PATH", "SSL_CERT_FILE", "SSL_CERT_DIR"],
+    "required_from_host": ["DEEPSEEK_API_KEY"],
+    "set": {
+      "APP_ENV": "prod",
+      "API_BASE": "https://api.deepseek.com"
+    }
+  },
+  "fs": {
+    "read": ["allowed"],
+    "write": ["scratch"]
+  },
+  "net": {
+    "connect": [
+      "api.deepseek.com:443",
+      "hacker-news.firebaseio.com:443",
+      "127.0.0.1:443",
+      "[::1]:*"
+    ],
+    "bind": ["127.0.0.1:*"]
+  }
+}
 ```
 
 To allow outbound access only to DeepSeek and Hacker News:
 
-```toml
-[net]
-connect = [
-  "api.deepseek.com:443",
-  "hacker-news.firebaseio.com:443",
-]
+```json
+{
+  "net": {
+    "connect": [
+      "api.deepseek.com:443",
+      "hacker-news.firebaseio.com:443"
+    ]
+  }
+}
 ```
 
 Hostname entries in `connect` allow DNS lookup for that host and allow

--- a/crates/moonrun/src/async_policy/config.rs
+++ b/crates/moonrun/src/async_policy/config.rs
@@ -73,8 +73,16 @@ impl PolicyConfig {
     pub(super) fn from_file(path: &Path) -> anyhow::Result<Self> {
         let contents = std::fs::read_to_string(path)
             .with_context(|| format!("failed to read policy {}", path.display()))?;
-        toml::from_str(&contents)
-            .with_context(|| format!("failed to parse policy {}", path.display()))
+        if path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
+        {
+            serde_json::from_str(&contents)
+                .with_context(|| format!("failed to parse JSON policy {}", path.display()))
+        } else {
+            toml::from_str(&contents)
+                .with_context(|| format!("failed to parse policy {}", path.display()))
+        }
     }
 }
 
@@ -102,9 +110,9 @@ APP_ENV = "test"
     }
 
     #[test]
-    fn parses_process_spawn_permission() {
+    fn parses_toml_without_json_extension() {
         let tmp = tempfile::tempdir().unwrap();
-        let policy_file = tmp.path().join("policy.toml");
+        let policy_file = tmp.path().join("policy");
         std::fs::write(
             &policy_file,
             r#"
@@ -116,6 +124,34 @@ spawn = true
 
         let config = PolicyConfig::from_file(&policy_file).unwrap();
 
+        assert!(config.process.unwrap().spawn);
+    }
+
+    #[test]
+    fn parses_json_policy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let policy_file = tmp.path().join("policy.json");
+        std::fs::write(
+            &policy_file,
+            r#"{
+  "env": {
+    "set": {
+      "APP_ENV": "test"
+    }
+  },
+  "process": {
+    "spawn": true
+  }
+}"#,
+        )
+        .unwrap();
+
+        let config = PolicyConfig::from_file(&policy_file).unwrap();
+
+        assert_eq!(
+            config.env.unwrap().set.get("APP_ENV").map(String::as_str),
+            Some("test")
+        );
         assert!(config.process.unwrap().spawn);
     }
 

--- a/crates/moonrun/src/async_policy/config.rs
+++ b/crates/moonrun/src/async_policy/config.rs
@@ -76,6 +76,7 @@ impl PolicyConfig {
         if path
             .extension()
             .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
+            || contents.trim_start().starts_with('{')
         {
             serde_json::from_str(&contents)
                 .with_context(|| format!("failed to parse JSON policy {}", path.display()))
@@ -128,12 +129,13 @@ spawn = true
     }
 
     #[test]
-    fn parses_json_policy() {
+    fn parses_json_without_json_extension() {
         let tmp = tempfile::tempdir().unwrap();
-        let policy_file = tmp.path().join("policy.json");
+        let policy_file = tmp.path().join("policy");
         std::fs::write(
             &policy_file,
-            r#"{
+            r#"
+{
   "env": {
     "set": {
       "APP_ENV": "test"

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -570,37 +570,36 @@ struct Commandline {
     #[clap(long)]
     stack_size: Option<String>,
 
-    /// Experimental: sandbox wasm runtime host access using a TOML policy file.
+    /// Experimental: sandbox wasm runtime host access using a JSON policy file.
     #[clap(
         long,
         value_name = "PATH",
-        long_help = r#"Experimental: Sandbox wasm runtime host access using a TOML policy file. WASI is not covered.
+        long_help = r#"Experimental: Sandbox wasm runtime host access using a JSON policy file. WASI is not covered.
 
-Supplying --policy enables deny-by-default mode: omitted or empty [fs], [net], and [env] sections deny that surface, and process spawning is disabled unless explicitly enabled.
+Supplying --policy enables deny-by-default mode: omitted or empty fs, net, and env objects deny that surface, and process spawning is disabled unless explicitly enabled.
 
 Common allow-all policy:
-  [env]
-  from_host = ["*"]
-
-  [fs]
-  read = ["*"]
-  write = ["*"]
-
-  [net]
-  dns = ["*"]
-  connect = ["*:*"]
-  bind = ["*:*"]
-
-  [process]
-  spawn = true
+  {
+    "env": { "from_host": ["*"] },
+    "fs": {
+      "read": ["*"],
+      "write": ["*"]
+    },
+    "net": {
+      "dns": ["*"],
+      "connect": ["*:*"],
+      "bind": ["*:*"]
+    },
+    "process": { "spawn": true }
+  }
 
 Filesystem roots are host paths. Relative roots are resolved relative to the policy file. "*" allows every host path on every platform.
 
-Environment values default to empty in sandbox policy mode. Use from_host for optional host variables, required_from_host for required host variables and secrets, and [env.set] for non-secret literals. [env.set] overrides copied host values.
+Environment values default to empty in sandbox policy mode. Use env.from_host for optional host variables, env.required_from_host for required host variables and secrets, and env.set for non-secret literals. env.set overrides copied host values.
 
-Network connect controls outbound sockets; bind controls local bind/listen addresses. Hostname connect rules also permit DNS lookup for those hostnames, so connect = ["api.deepseek.com:443"] does not require a separate dns entry. Bind rules must use IP addresses or *.
+Network connect controls outbound sockets; bind controls local bind/listen addresses. Hostname connect rules also permit DNS lookup for those hostnames, so net.connect containing "api.deepseek.com:443" does not require a separate dns entry. Bind rules must use IP addresses or *.
 
-Process spawning is disabled by default. Setting [process] spawn = true grants child processes the host user's ambient filesystem, network, and process access; the other policy sections do not sandbox child processes."#
+Process spawning is disabled by default. Setting process.spawn to true grants child processes the host user's ambient filesystem, network, and process access; the other policy sections do not sandbox child processes."#
     )]
     policy: Option<PathBuf>,
 }

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -191,10 +191,11 @@ fn test_moonrun_help_describes_policy_shape() {
 
     assert!(stdout.contains("Experimental: Sandbox wasm runtime host access"));
     assert!(stdout.contains("deny-by-default mode"));
-    assert!(stdout.contains("from_host = [\"*\"]"));
-    assert!(stdout.contains("read = [\"*\"]"));
-    assert!(stdout.contains("spawn = true"));
-    assert!(stdout.contains("connect = [\"api.deepseek.com:443\"]"));
+    assert!(stdout.contains(r#""from_host": ["*"]"#));
+    assert!(stdout.contains(r#""read": ["*"]"#));
+    assert!(stdout.contains(r#""spawn": true"#));
+    assert!(stdout.contains(r#"net.connect containing "api.deepseek.com:443""#));
+    assert!(!stdout.contains("TOML"));
     assert!(stdout.contains("Hostname connect rules also permit DNS lookup"));
     assert!(stdout.contains("ambient filesystem, network, and process access"));
 }

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -263,7 +263,7 @@ Local package inputs are handled like `moon run --target wasm`:
   moon runwasm ./main
 
 Experimental moonrun policy forwarding:
-  moon runwasm --experimental-policy moonrun-policy.toml main
+  moon runwasm --experimental-policy moonrun-policy.json main
 
 Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
@@ -285,7 +285,7 @@ and reused on later runs.
 
 ###### **Options:**
 
-* `--experimental-policy <PATH>` — Experimental: pass a moonrun TOML policy file for moonbitlang/async runtime access.
+* `--experimental-policy <PATH>` — Experimental: pass a moonrun JSON policy file for moonbitlang/async runtime access.
 
    The policy applies to moonbitlang/async and moonrun-owned unstable FFI; WASI is not covered.
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -263,7 +263,7 @@ Local package inputs are handled like `moon run --target wasm`:
   moon runwasm ./main
 
 Experimental moonrun policy forwarding:
-  moon runwasm --experimental-policy moonrun-policy.toml main
+  moon runwasm --experimental-policy moonrun-policy.json main
 
 Accepted Mooncakes coordinate forms:
   moon runwasm moonbitlang/parser/cmd/moonfmt@0.3.3
@@ -285,7 +285,7 @@ and reused on later runs.
 
 ###### **Options:**
 
-* `--experimental-policy <PATH>` — Experimental: pass a moonrun TOML policy file for moonbitlang/async runtime access.
+* `--experimental-policy <PATH>` — Experimental: pass a moonrun JSON policy file for moonbitlang/async runtime access.
 
    The policy applies to moonbitlang/async and moonrun-owned unstable FFI; WASI is not covered.
 


### PR DESCRIPTION
## Summary

- accept strict JSON moonrun policy files by `.json` suffix or JSON object-shaped content, including extensionless and temporary paths
- preserve TOML parsing for existing non-JSON policy paths
- present JSON as the public policy format in CLI help and documentation

## Rationale

JSON is a better fit for AI-generated policies and common schema-driven tooling. The change is correct because both formats deserialize into the same policy configuration model with the existing unknown-field checks, while content detection allows JSON at any `<PATH>` without changing policy enforcement or relative-path resolution.

The implementation is limited to the policy parsing boundary, focused regression coverage, and the corresponding user-facing documentation.