### PR TITLE
fix: limit .mbtp inputs to check and prove

### DIFF
--- a/crates/moon/tests/test_cases/moon_prove/mod.rs
+++ b/crates/moon/tests/test_cases/moon_prove/mod.rs
@@ -348,25 +348,31 @@ fn test_moon_prove_selected_failed_package() {
 }
 
 #[test]
-fn test_invpred_package_threads_mbtp_into_compile_dry_runs() {
+fn test_invpred_package_only_threads_mbtp_into_check_and_prove_dry_runs() {
     if skip_unless_verification_tests_enabled(
-        "test_invpred_package_threads_mbtp_into_compile_dry_runs",
+        "test_invpred_package_only_threads_mbtp_into_check_and_prove_dry_runs",
     ) {
         return;
     }
     let dir = TestDir::new("moon_prove/mixed.in");
+    let mbtp = "./invpred/invpred.mbtp";
 
     for (label, args) in [
         (
             "check",
             vec!["check", "invpred", "--dry-run", "--sort-input"],
         ),
+        ("prove", vec!["prove", "invpred", "--dry-run"]),
+    ] {
+        assert_stdout_contains_mbtp(&dir, args, mbtp, label);
+    }
+
+    for (label, args) in [
         (
             "build",
             vec!["build", "invpred", "--dry-run", "--sort-input"],
         ),
         ("test", vec!["test", "invpred", "--dry-run", "--sort-input"]),
-        ("prove", vec!["prove", "invpred", "--dry-run"]),
         (
             "bench",
             vec![
@@ -380,7 +386,11 @@ fn test_invpred_package_threads_mbtp_into_compile_dry_runs() {
         ),
         ("bundle", vec!["bundle", "--dry-run", "--sort-input"]),
     ] {
-        assert_stdout_contains_mbtp(&dir, args, "./invpred/invpred.mbtp", label);
+        let stdout = get_stdout(&dir, args);
+        assert!(
+            !stdout.contains(mbtp),
+            "{label} output should not include `{mbtp}`, got:\n{stdout}"
+        );
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -662,17 +662,28 @@ impl<'a> BuildPlanConstructor<'a> {
         // artifact layout, so we might not be able to do that here, unless we
         // add some kind of `SpecialFile::TestDriver` or something.
         let (regular_files, mbtp_files, whitebox_files, doctest_files) = {
+            // Discovery keeps `.mbtp` files for metadata, but only verification
+            // commands project them into compiler inputs.
+            let uses_mbtp = matches!(
+                self.build_env.action,
+                moonutil::build_options::RunMode::Check | moonutil::build_options::RunMode::Prove
+            );
             let file_set = self.package_file_set(target.package);
+            let mbtp_files = if uses_mbtp {
+                file_set.mbtp_files.clone()
+            } else {
+                Vec::new()
+            };
             match target.kind {
                 Source | SubPackage | InlineTest => (
                     file_set.no_test_files.clone(),
-                    file_set.mbtp_files.clone(),
+                    mbtp_files,
                     Vec::new(),
                     Vec::new(),
                 ),
                 WhiteboxTest => (
                     file_set.no_test_files.clone(),
-                    file_set.mbtp_files.clone(),
+                    mbtp_files,
                     file_set.whitebox_files.clone(),
                     Vec::new(),
                 ),


### PR DESCRIPTION
## Summary

Proof helper files were unconditionally copied into every build target projection, so commands such as moon test passed them to moonc even though only moon check and moon prove should consume them.

This change gates .mbtp projection on the Check and Prove run modes while leaving package discovery and metadata unchanged. The existing verification fixture now asserts that check and prove include the helper, while build, test, bench, and bundle do not.

The change is limited to target file selection and its regression coverage.