### PR TITLE
Avoid unstable packages.json updates from focused checks

### DIFF
--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -127,8 +127,6 @@ pub(crate) fn run_bundle_internal_rr(
         let _lock = FileLock::lock(target_dir)?;
         // Generate all_pkgs.json for indirect dependency resolution
         rr_build::generate_all_pkgs_json(&build_meta)?;
-        // Generate metadata for IDE & bundler
-        rr_build::generate_metadata(source_dir, target_dir, &build_meta, &build_graph, None)?;
 
         let result = rr_build::execute_build(
             &BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose),

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -26,8 +26,8 @@
 //! 3. `plan_check_rr_from_resolved_all` turns those backend groups into an
 //!    ordered list of single-backend RR plans.
 //! 4. `plan_check_rr_from_resolved` still plans exactly one backend group.
-//! 5. The runtime executes planned runs in order; the last run updates
-//!    `packages.json`.
+//! 5. The runtime executes planned runs in order. Project checks without a
+//!    selector publish `packages.json`; focused checks leave it untouched.
 //!
 use anyhow::Context;
 use log::LevelFilter;
@@ -766,8 +766,15 @@ fn run_check_normal_internal_rr(
         for (build_meta, build_graph) in planned_runs {
             // Generate all_pkgs.json for indirect dependency resolution
             rr_build::generate_all_pkgs_json(&build_meta)?;
-            // Generate metadata for IDE. The last executed backend wins.
-            rr_build::generate_metadata(source_dir, target_dir, &build_meta, &build_graph, None)?;
+            if cmd.package_path.is_none() && cmd.path.is_empty() {
+                rr_build::generate_metadata(
+                    source_dir,
+                    target_dir,
+                    &build_meta,
+                    &build_graph,
+                    None,
+                )?;
+            }
 
             if let Some(json) = json.as_deref_mut() {
                 let target_backend = build_meta.target_backend();

--- a/crates/moon/tests/test_cases/build_workflow.rs
+++ b/crates/moon/tests/test_cases/build_workflow.rs
@@ -134,6 +134,28 @@ fn test_check_failed_should_write_pkg_json() {
 }
 
 #[test]
+fn test_packages_json_full_check_and_focused_check_behavior() {
+    let dir = TestDir::new("hello");
+    let pkg_json = dir.join("_build/packages.json");
+    std::fs::create_dir_all(pkg_json.parent().unwrap()).unwrap();
+    std::fs::write(&pkg_json, "existing metadata").unwrap();
+
+    moon_cmd(&dir).args(["check"]).assert().success();
+    assert_ne!(
+        std::fs::read_to_string(&pkg_json).unwrap(),
+        "existing metadata"
+    );
+
+    std::fs::write(&pkg_json, "existing metadata").unwrap();
+
+    moon_cmd(&dir).args(["check", "main"]).assert().success();
+    assert_eq!(
+        std::fs::read_to_string(&pkg_json).unwrap(),
+        "existing metadata"
+    );
+}
+
+#[test]
 fn test_failed_to_fill_whole_buffer() {
     // TODO: Do we really need to test about database corruption?!
 

--- a/crates/moon/tests/test_cases/indirect_dep/mod.rs
+++ b/crates/moon/tests/test_cases/indirect_dep/mod.rs
@@ -128,6 +128,7 @@ fn test_indirect_dep_bundle() {
             Finished. moon: ran 7 tasks, now up to date
         "#]],
     );
+    assert!(!dir.join("_build/packages.json").exists());
     let all_pkgs_path = dir.join("_build/wasm-gc/release/bundle/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);
     expect_file!["bundle_all_pkgs.json"].assert_eq(&all_pkgs_json);

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -545,6 +545,8 @@ fn test_single_file_commands_work_with_workspace_disabled() {
             Finished. moon: ran 2 tasks, now up to date
         "#]],
     );
+    assert!(!dir.join("_build/packages.json").exists());
+    assert!(dir.join("_build/hello.mbt.packages.json").exists());
 
     check(
         get_stdout_with_envs(&dir, ["test", "test.mbt"], [(MOON_NO_WORKSPACE, "1")]),

--- a/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
+++ b/crates/moon/tests/test_cases/virtual_pkg2/mod.rs
@@ -13,7 +13,7 @@ fn implement_third_party1() {
         expect_file!["./check_graph.jsonl"],
     );
 
-    let s = get_stderr(&dir, ["check", "--target", "wasm-gc", "."]);
+    let s = get_stderr(&dir, ["check", "--target", "wasm-gc"]);
     check(
         s,
         expect![[r#"

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -86,7 +86,8 @@ In a broad sense, `moon` subcommands follows this order when executing project-b
    - Expand the build graph according to rules into containing all transitive dependencies of these nodes.
    - Generate a concrete build graph containing the final commandlines to execute.
 3. Execute the build graph
-   - Generate metadata files required for the IDE and compilers to use.
+   - Generate metadata files required by compiler actions. Full project checks
+     also publish `packages.json` for tooling compatibility during migration.
    - Execute the concrete build graph in its executor ([n2][]).
      The executor ensures the graph is executed incrementally, rebuilding only the changed parts.
 4. Perform other operations required after build
@@ -511,3 +512,7 @@ one item per input build plan node.
 
 `packages.json` is the legacy metadata file shared with IDE tooling.
 Its top-level shape remains single-module-oriented for compatibility.
+`moon doc` generates it because `moondoc` consumes it directly. Project checks
+without a selector publish it as well. Standalone-file checks continue to
+publish `<filename>.packages.json`; focused project checks leave metadata
+untouched, and `moon bundle` does not publish it.

--- a/docs/dev/reference/rr-special-cases.md
+++ b/docs/dev/reference/rr-special-cases.md
@@ -77,11 +77,11 @@ important ones and why they exist.
   (use prebuilt paths vs local artifacts) are gated by whether stdlib is
   injected (`build_env.std` / `stdlib_dir.is_some()`), not by mutating
   `abort_pkg`.
-- **Metadata files respect stdlib mode.** When building the stdlib (core
-  module), `packages.json` and `all_pkgs.json` are generated without a stdlib
-  directory so package metadata and indirect dependency resolution use the
-  locally built `.mi` files. For non-core projects, the stdlib directory is set
-  so prebuilt artifacts can be used.
+- **Metadata files respect stdlib mode.** When either `packages.json` or
+  `all_pkgs.json` is generated for the stdlib (core module), it is generated
+  without a stdlib directory so package metadata and indirect dependency
+  resolution use the locally built `.mi` files. For non-core projects, the
+  stdlib directory is set so prebuilt artifacts can be used.
 
 ## Runtime + tooling side effects
 


### PR DESCRIPTION
## Why

`packages.json` is shared project metadata, but focused `moon check` invocations rewrote it from a selector-specific build graph. This made the file depend on the most recent command and undermined efforts to reuse and merge build graphs across backends. `moon bundle` also published the file even though bundling only requires `all_pkgs.json`.

## What changed

- Keep publishing `packages.json` for selector-free project checks.
- Leave existing project metadata untouched for focused checks with a package or path selector.
- Stop `moon bundle` from publishing `packages.json` while preserving `all_pkgs.json`.
- Preserve standalone-file metadata as `<filename>.packages.json`.
- Document and test the command-specific behavior.

## Why this is correct

Only checks with a complete project selection update the shared project file. Focused checks cannot replace it with a partial view, while standalone checks continue writing their separate filename-scoped metadata. Compiler-facing `all_pkgs.json` generation is unchanged.

## Scope

This is a minimal behavioral split: it does not change either metadata schema or introduce additional resolve, planning, or execution work.

Part of #1990.
