### PR TITLE
Restore legacy packages.json generation for moon bundle

### DIFF
--- a/crates/moon/src/cli/bundle.rs
+++ b/crates/moon/src/cli/bundle.rs
@@ -127,6 +127,8 @@ pub(crate) fn run_bundle_internal_rr(
         let _lock = FileLock::lock(target_dir)?;
         // Generate all_pkgs.json for indirect dependency resolution
         rr_build::generate_all_pkgs_json(&build_meta)?;
+        // Generate legacy metadata for tooling compatibility
+        rr_build::generate_metadata(source_dir, target_dir, &build_meta, &build_graph, None)?;
 
         let result = rr_build::execute_build(
             &BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose),

--- a/crates/moon/tests/test_cases/indirect_dep/mod.rs
+++ b/crates/moon/tests/test_cases/indirect_dep/mod.rs
@@ -128,7 +128,11 @@ fn test_indirect_dep_bundle() {
             Finished. moon: ran 7 tasks, now up to date
         "#]],
     );
-    assert!(!dir.join("_build/packages.json").exists());
+    let packages_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dir.join("_build/packages.json")).unwrap())
+            .unwrap();
+    assert_eq!(packages_json["backend"], serde_json::json!("wasm-gc"));
+    assert_eq!(packages_json["opt_level"], serde_json::json!("release"));
     let all_pkgs_path = dir.join("_build/wasm-gc/release/bundle/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);
     expect_file!["bundle_all_pkgs.json"].assert_eq(&all_pkgs_json);

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -515,4 +515,5 @@ Its top-level shape remains single-module-oriented for compatibility.
 `moon doc` generates it because `moondoc` consumes it directly. Project checks
 without a selector publish it as well. Standalone-file checks continue to
 publish `<filename>.packages.json`; focused project checks leave metadata
-untouched, and `moon bundle` does not publish it.
+untouched. `moon bundle` continues to publish the legacy file for tooling
+compatibility.


### PR DESCRIPTION
## Why

#2004 stopped `moon bundle` from publishing the legacy `_build/packages.json`. We subsequently confirmed that existing tooling still relies on bundle producing this file, so removing it before consumer migration was a compatibility break.

## What changed

- Restore legacy `packages.json` generation in the Rupes Recta bundle path.
- Keep `all_pkgs.json` generation unchanged.
- Verify that bundle metadata records the requested backend and release profile.
- Update the implemented-behavior reference.

## Why this is correct

This restores the exact publication point used before #2004, after planning and before executing the bundle graph. It does not change the metadata schema, bundle planning, or the focused-check stability fix.

## Scope

This is a minimal compatibility follow-up. Backend/profile-scoped metadata publication remains separate work.
