### PR TITLE
fix(metadata): publish scoped packages.json copies

### DIFF
--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -817,7 +817,7 @@ pub fn plan_fmt(
     })
 }
 
-/// Generate metadata file `packages.json` in the target directory.
+/// Generate `packages.json` at both its legacy and configuration-scoped paths.
 ///
 /// To ensure the correct paths are generated, `build_meta` should come from the
 /// same configuration used in [`plan_build`].
@@ -832,11 +832,17 @@ pub fn generate_metadata(
     build_input: &BuildInput,
     single_file_filename: Option<&str>,
 ) -> anyhow::Result<()> {
-    let metadata_file = if let Some(filename) = single_file_filename {
-        target_dir.join(format!("{}.packages.json", filename))
+    let metadata_filename = if let Some(filename) = single_file_filename {
+        format!("{}.packages.json", filename)
     } else {
-        target_dir.join("packages.json")
+        "packages.json".to_string()
     };
+    let scoped_metadata_file = build_meta
+        .artifact_paths
+        .target_layout()
+        .run_mode_dir(build_meta.target_backend())
+        .join(&metadata_filename);
+    let legacy_metadata_file = target_dir.join(&metadata_filename);
 
     let check_commands = collect_check_commands_by_output(build_input);
     let metadata = moonbuild_rupes_recta::metadata::gen_metadata_json(
@@ -847,17 +853,28 @@ pub fn generate_metadata(
         build_meta.target_backend(),
         &check_commands,
     );
-    let orig_meta = std::fs::read_to_string(&metadata_file);
     let meta = serde_json::to_string_pretty(&metadata).context("Failed to serialize metadata")?;
 
-    // Only overwrite if changed
-    if !orig_meta.is_ok_and(|o| o == meta) {
-        std::fs::write(&metadata_file, meta).with_context(|| {
-            format!(
-                "Failed to write build metadata to {}",
-                metadata_file.display()
-            )
-        })?;
+    // Both paths are projections of the same metadata value. Preserve the
+    // existing behavior of leaving either file untouched when its bytes match.
+    for metadata_file in [scoped_metadata_file, legacy_metadata_file] {
+        let orig_meta = std::fs::read_to_string(&metadata_file);
+        if !orig_meta.is_ok_and(|o| o == meta) {
+            if let Some(parent) = metadata_file.parent() {
+                std::fs::create_dir_all(parent).with_context(|| {
+                    format!(
+                        "Failed to create directory for build metadata at {}",
+                        parent.display()
+                    )
+                })?;
+            }
+            std::fs::write(&metadata_file, &meta).with_context(|| {
+                format!(
+                    "Failed to write build metadata to {}",
+                    metadata_file.display()
+                )
+            })?;
+        }
     }
     Ok(())
 }

--- a/crates/moon/tests/test_cases/build_workflow.rs
+++ b/crates/moon/tests/test_cases/build_workflow.rs
@@ -137,21 +137,37 @@ fn test_check_failed_should_write_pkg_json() {
 fn test_packages_json_full_check_and_focused_check_behavior() {
     let dir = TestDir::new("hello");
     let pkg_json = dir.join("_build/packages.json");
+    let scoped_pkg_json = dir.join("_build/wasm-gc/release/check/packages.json");
     std::fs::create_dir_all(pkg_json.parent().unwrap()).unwrap();
     std::fs::write(&pkg_json, "existing metadata").unwrap();
 
-    moon_cmd(&dir).args(["check"]).assert().success();
+    moon_cmd(&dir)
+        .args(["check", "--target", "wasm-gc", "--release"])
+        .assert()
+        .success();
     assert_ne!(
         std::fs::read_to_string(&pkg_json).unwrap(),
         "existing metadata"
     );
+    assert_eq!(
+        std::fs::read_to_string(&scoped_pkg_json).unwrap(),
+        std::fs::read_to_string(&pkg_json).unwrap()
+    );
 
     std::fs::write(&pkg_json, "existing metadata").unwrap();
+    std::fs::write(&scoped_pkg_json, "existing scoped metadata").unwrap();
 
-    moon_cmd(&dir).args(["check", "main"]).assert().success();
+    moon_cmd(&dir)
+        .args(["check", "main", "--target", "wasm-gc", "--release"])
+        .assert()
+        .success();
     assert_eq!(
         std::fs::read_to_string(&pkg_json).unwrap(),
         "existing metadata"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&scoped_pkg_json).unwrap(),
+        "existing scoped metadata"
     );
 }
 

--- a/crates/moon/tests/test_cases/indirect_dep/mod.rs
+++ b/crates/moon/tests/test_cases/indirect_dep/mod.rs
@@ -128,11 +128,14 @@ fn test_indirect_dep_bundle() {
             Finished. moon: ran 7 tasks, now up to date
         "#]],
     );
-    let packages_json: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(dir.join("_build/packages.json")).unwrap())
-            .unwrap();
+    let legacy_packages_json = std::fs::read_to_string(dir.join("_build/packages.json")).unwrap();
+    let packages_json: serde_json::Value = serde_json::from_str(&legacy_packages_json).unwrap();
     assert_eq!(packages_json["backend"], serde_json::json!("wasm-gc"));
     assert_eq!(packages_json["opt_level"], serde_json::json!("release"));
+    assert_eq!(
+        std::fs::read_to_string(dir.join("_build/wasm-gc/release/bundle/packages.json")).unwrap(),
+        legacy_packages_json
+    );
     let all_pkgs_path = dir.join("_build/wasm-gc/release/bundle/all_pkgs.json");
     let all_pkgs_json = normalize_all_pkgs_json(&dir, &all_pkgs_path);
     expect_file!["bundle_all_pkgs.json"].assert_eq(&all_pkgs_json);

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -532,7 +532,7 @@ fn test_single_file_commands_work_with_workspace_disabled() {
 
     let check_result = moon_cmd(&dir)
         .env(MOON_NO_WORKSPACE, "1")
-        .args(["check", "hello.mbt"])
+        .args(["check", "hello.mbt", "--target", "wasm-gc"])
         .assert()
         .success()
         .get_output()
@@ -546,7 +546,12 @@ fn test_single_file_commands_work_with_workspace_disabled() {
         "#]],
     );
     assert!(!dir.join("_build/packages.json").exists());
-    assert!(dir.join("_build/hello.mbt.packages.json").exists());
+    let legacy_pkg_json = dir.join("_build/hello.mbt.packages.json");
+    let scoped_pkg_json = dir.join("_build/wasm-gc/debug/check/hello.mbt.packages.json");
+    assert_eq!(
+        std::fs::read_to_string(scoped_pkg_json).unwrap(),
+        std::fs::read_to_string(legacy_pkg_json).unwrap()
+    );
 
     check(
         get_stdout_with_envs(&dir, ["test", "test.mbt"], [(MOON_NO_WORKSPACE, "1")]),

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -781,15 +781,25 @@ fn test_check_paths_split_by_module_preferred_targets() {
 }
 
 #[test]
-fn test_check_last_executed_backend_wins_for_packages_json() {
+fn test_check_publishes_backend_scoped_packages_json() {
     let dir = TestDir::new("workspace_conflicting_preferred_targets.in");
 
     get_stdout(&dir, ["check", "--sort-input"]);
-    let packages_json: serde_json::Value =
+    let legacy_packages_json: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(dir.join("_build/packages.json")).unwrap())
             .unwrap();
+    let js_packages_json: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.join("_build/js/debug/check/packages.json")).unwrap(),
+    )
+    .unwrap();
+    let native_packages_json: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.join("_build/native/debug/check/packages.json")).unwrap(),
+    )
+    .unwrap();
 
-    assert_eq!(packages_json["backend"], serde_json::json!("native"));
+    assert_eq!(legacy_packages_json["backend"], serde_json::json!("native"));
+    assert_eq!(js_packages_json["backend"], serde_json::json!("js"));
+    assert_eq!(native_packages_json["backend"], serde_json::json!("native"));
 }
 
 #[test]

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -512,8 +512,19 @@ one item per input build plan node.
 
 `packages.json` is the legacy metadata file shared with IDE tooling.
 Its top-level shape remains single-module-oriented for compatibility.
-`moon doc` generates it because `moondoc` consumes it directly. Project checks
-without a selector publish it as well. Standalone-file checks continue to
-publish `<filename>.packages.json`; focused project checks leave metadata
-untouched. `moon bundle` continues to publish the legacy file for tooling
-compatibility.
+When metadata is generated, the same serialized document is published both at
+the legacy path and beside the corresponding build artifacts:
+
+```text
+_build/packages.json
+_build/<backend>/<profile>/<run-mode>/packages.json
+```
+
+Standalone-file checks similarly publish both
+`_build/<filename>.packages.json` and
+`_build/<backend>/<profile>/check/<filename>.packages.json`. Project checks
+without a selector publish metadata; focused project checks leave it untouched,
+and `moon bundle` continues to publish it for tooling compatibility. `moon doc`
+continues to consume the legacy path during migration. No metadata index is
+published; consumers choose the backend, profile, and run mode before reading
+the corresponding fixed path.


### PR DESCRIPTION
## Why

The legacy `_build/packages.json` path is shared by every backend and profile, so multi-backend checks overwrite one another and leave the file describing only the last planned configuration. This prevents downstream tooling from reliably combining build graphs across configurations.

## What changed

- Serialize package metadata once and publish identical bytes to both the legacy path and a backend/profile/run-mode-scoped path.
- Keep existing project-check, focused-check, standalone-file, doc, and bundle compatibility behavior.
- Preserve the existing write-if-changed behavior for both copies.
- Cover release checks, multi-backend checks, standalone files, and bundles with regression tests.

## Scope

This is intentionally an additive path split. It does not change the metadata schema, add an index, switch downstream consumers, or introduce additional resolve or build-plan work. Legacy paths remain available while downstream tooling migrates independently.
