### PR TITLE
fix(prove): always load proof prelude

### DIFF
--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -229,7 +229,7 @@ fn calc_user_intent(
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
     let directive = moonbuild_rupes_recta::build_plan::InputDirective {
         prove_why3_config: prove_why3_config.map(Path::to_path_buf),
-        proof_prelude: Some(proof_prelude.to_path_buf()),
+        proof_prelude: proof_prelude.to_path_buf(),
         ..Default::default()
     };
 

--- a/crates/moon/src/cli/prove.rs
+++ b/crates/moon/src/cli/prove.rs
@@ -22,8 +22,9 @@ use anyhow::{Context, bail};
 use moonbuild_rupes_recta::{intent::UserIntent, model::BuildPlanNode};
 use moonutil::{
     build_options::RunMode, cli_support::AutoSyncFlags, cli_support::UniversalFlags,
-    command_output::CommandOutput, locks::FileLock, project::PackageDirs, resolution::ModuleId,
-    target::TargetBackend, test_metadata::DiagnosticLevel, user_log::UserLog,
+    command_output::CommandOutput, constants::PRELUDE_PROOF_FILE, locks::FileLock,
+    project::PackageDirs, resolution::ModuleId, target::TargetBackend,
+    test_metadata::DiagnosticLevel, user_log::UserLog,
 };
 use serde::Deserialize;
 use tracing::instrument;
@@ -37,7 +38,12 @@ use crate::{
     rr_build::{self, BuildConfig, CalcUserIntentOutput, preconfig_compile},
 };
 
+const MOON_PROVE_PRELUDE_OVERRIDE: &str = "MOON_PROVE_PRELUDE_OVERRIDE";
+
 /// Prove the current package
+///
+/// Set `MOON_PROVE_PRELUDE_OVERRIDE` to a directory containing
+/// `moonbit_builtin_prelude.mlw` to replace the toolchain's proof prelude.
 #[derive(Debug, clap::Parser, Clone)]
 pub(crate) struct ProveSubcommand {
     /// The file-system path to the package or file in package to prove
@@ -139,6 +145,7 @@ pub(crate) fn run_prove(
         .as_deref()
         .map(canonicalize_why3_config)
         .transpose()?;
+    let proof_prelude = resolve_proof_prelude()?;
     let generated_why3_config_path = verif_dir.join("why3.conf");
 
     if !cli.dry_run && why3_config_path.is_none() {
@@ -174,6 +181,7 @@ pub(crate) fn run_prove(
         &resolve_output,
         planning_context.target_backend(),
         prove_why3_config.as_deref(),
+        &proof_prelude,
         user_log,
     )?;
     let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
@@ -216,10 +224,12 @@ fn calc_user_intent(
     resolve_output: &moonbuild_rupes_recta::ResolveOutput,
     target_backend: TargetBackend,
     prove_why3_config: Option<&Path>,
+    proof_prelude: &Path,
     user_log: &UserLog,
 ) -> Result<CalcUserIntentOutput, anyhow::Error> {
     let directive = moonbuild_rupes_recta::build_plan::InputDirective {
         prove_why3_config: prove_why3_config.map(Path::to_path_buf),
+        proof_prelude: Some(proof_prelude.to_path_buf()),
         ..Default::default()
     };
 
@@ -268,6 +278,27 @@ fn calc_user_intent(
 fn canonicalize_why3_config(path: &Path) -> anyhow::Result<PathBuf> {
     dunce::canonicalize(path)
         .with_context(|| format!("failed to resolve why3 config `{}`", path.display()))
+}
+
+fn resolve_proof_prelude() -> anyhow::Result<PathBuf> {
+    let Some(override_path) = std::env::var_os(MOON_PROVE_PRELUDE_OVERRIDE) else {
+        return Ok(moonutil::toolchain::prelude_proof());
+    };
+    let override_path = PathBuf::from(override_path);
+    let resolved = dunce::canonicalize(&override_path).with_context(|| {
+        format!(
+            "failed to resolve {MOON_PROVE_PRELUDE_OVERRIDE} path `{}`",
+            override_path.display()
+        )
+    })?;
+    if !resolved.is_dir() || !resolved.join(PRELUDE_PROOF_FILE).is_file() {
+        bail!(
+            "{MOON_PROVE_PRELUDE_OVERRIDE} must point to a directory containing \
+             `{PRELUDE_PROOF_FILE}`; `{}` does not",
+            resolved.display()
+        );
+    }
+    Ok(resolved)
 }
 
 fn selected_main_module_id(

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -190,9 +190,7 @@ pub fn build_patch_directive_for_package(
         specify_no_mi_for: no_mi.then_some(pkg),
         specify_patch_file: patch_directive,
         value_tracing,
-        prove_why3_config: None,
-        proof_prelude: None,
-        package_prebuild: Default::default(),
+        ..Default::default()
     })
 }
 

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -191,6 +191,7 @@ pub fn build_patch_directive_for_package(
         specify_patch_file: patch_directive,
         value_tracing,
         prove_why3_config: None,
+        proof_prelude: None,
         package_prebuild: Default::default(),
     })
 }

--- a/crates/moon/tests/test_cases/moon_prove/core.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/moon_prove/core.in/moon.mod.json
@@ -1,0 +1,4 @@
+{
+  "name": "moonbitlang/core",
+  "preferred-target": "wasm-gc"
+}

--- a/crates/moon/tests/test_cases/moon_prove/core.in/prelude/moon.pkg.json
+++ b/crates/moon/tests/test_cases/moon_prove/core.in/prelude/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "proof-enabled": true
+}

--- a/crates/moon/tests/test_cases/moon_prove/core.in/prelude/prelude.mbt
+++ b/crates/moon/tests/test_cases/moon_prove/core.in/prelude/prelude.mbt
@@ -1,0 +1,3 @@
+pub fn id(x : Int) -> Int {
+  x
+}

--- a/crates/moon/tests/test_cases/moon_prove/mod.rs
+++ b/crates/moon/tests/test_cases/moon_prove/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
-    TestDir, assert_success, get_stderr, get_stdout,
-    util::{check, moon_bin, replace_dir, toolchain_root_for_tests},
+    TestDir, assert_success, get_err_stderr_with_envs, get_stderr, get_stdout,
+    get_stdout_with_envs,
+    util::{check, moon_bin, replace_dir},
 };
 use expect_test::{expect, expect_file};
 
@@ -45,11 +46,6 @@ fn assert_stdout_contains_mbtp(
 }
 
 fn assert_stdout_contains_prelude_proof(stdout: &str, label: &str) {
-    let prelude_proof = toolchain_root_for_tests().join("lib").join("prelude_proof");
-    if !prelude_proof.is_dir() {
-        return;
-    }
-
     assert!(
         stdout.contains("prelude_proof"),
         "{label} output should include `prelude_proof`, got:\n{stdout}"
@@ -94,6 +90,68 @@ fn test_moon_prove_dry_run() {
     let stdout = get_stdout(&dir, ["prove", "zzok", "--dry-run"]);
     expect_file!["snapshots/zzok.stdout"].assert_eq(&stdout);
     assert_stdout_contains_prelude_proof(&stdout, "dry-run");
+}
+
+#[test]
+fn test_moon_prove_core_always_loads_prelude_proof() {
+    if skip_unless_verification_tests_enabled("test_moon_prove_core_always_loads_prelude_proof") {
+        return;
+    }
+    let dir = TestDir::new("moon_prove/core.in");
+    let stdout = get_stdout(&dir, ["prove", "prelude", "--dry-run"]);
+
+    assert!(
+        stdout.contains("-why3-loadpath '$MOON_HOME/lib/prelude_proof'"),
+        "proving core should load the proof prelude without an injected stdlib, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_moon_prove_uses_prelude_override() {
+    if skip_unless_verification_tests_enabled("test_moon_prove_uses_prelude_override") {
+        return;
+    }
+    let dir = TestDir::new("moon_prove/mixed.in");
+    let override_dir = dir.join("custom-proof-prelude");
+    std::fs::create_dir(&override_dir).unwrap();
+    std::fs::write(override_dir.join("moonbit_builtin_prelude.mlw"), []).unwrap();
+
+    let stdout = get_stdout_with_envs(
+        &dir,
+        ["prove", "zzok", "--dry-run"],
+        [("MOON_PROVE_PRELUDE_OVERRIDE", override_dir.as_os_str())],
+    );
+
+    assert!(
+        stdout.contains("custom-proof-prelude"),
+        "prove should use the overridden proof prelude, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("$MOON_HOME/lib/prelude_proof"),
+        "prove should replace the default proof prelude, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_moon_prove_rejects_invalid_prelude_override() {
+    if skip_unless_verification_tests_enabled("test_moon_prove_rejects_invalid_prelude_override") {
+        return;
+    }
+    let dir = TestDir::new("moon_prove/mixed.in");
+    let override_dir = dir.join("invalid-proof-prelude");
+    std::fs::create_dir(&override_dir).unwrap();
+
+    let stderr = get_err_stderr_with_envs(
+        &dir,
+        ["prove", "zzok", "--dry-run"],
+        [("MOON_PROVE_PRELUDE_OVERRIDE", override_dir.as_os_str())],
+    );
+
+    assert!(
+        stderr.contains("MOON_PROVE_PRELUDE_OVERRIDE")
+            && stderr.contains("moonbit_builtin_prelude.mlw"),
+        "invalid proof prelude override should report the expected provider, got:\n{stderr}"
+    );
 }
 
 #[test]

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/tests.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/tests.rs
@@ -41,6 +41,7 @@ fn target_info() -> BuildTargetInfo {
         specified_no_mi: false,
         patch_file: None,
         why3_config: None,
+        proof_prelude: None,
         check_mi_against: None,
         value_tracing: false,
     }

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/tests.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/tests.rs
@@ -41,7 +41,7 @@ fn target_info() -> BuildTargetInfo {
         specified_no_mi: false,
         patch_file: None,
         why3_config: None,
-        proof_prelude: None,
+        proof_prelude: PathBuf::from("proof-prelude"),
         check_mi_against: None,
         value_tracing: false,
     }

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -284,14 +284,12 @@ impl<'a> LoweringContext<'a> {
         deps
     }
 
-    fn proof_loadpaths_of(&self, target: BuildTarget) -> Vec<PathBuf> {
+    fn proof_loadpaths_of(&self, target: BuildTarget, proof_prelude: &Path) -> Vec<PathBuf> {
         let mut visited = HashSet::new();
         let mut pending = vec![target];
         let mut loadpaths = BTreeSet::new();
 
-        if let Some(prelude_proof) = self.stdlib_prelude_proof_loadpath() {
-            loadpaths.insert(prelude_proof);
-        }
+        loadpaths.insert(proof_prelude.to_path_buf());
 
         while let Some(current) = pending.pop() {
             if !visited.insert(current) {
@@ -317,17 +315,6 @@ impl<'a> LoweringContext<'a> {
         }
 
         loadpaths.into_iter().collect()
-    }
-
-    fn stdlib_prelude_proof_loadpath(&self) -> Option<PathBuf> {
-        let prelude_proof = self
-            .opt
-            .stdlib_path
-            .as_ref()
-            .and_then(|stdlib_root| stdlib_root.parent())
-            .map(|lib_root| lib_root.join(moonutil::constants::PRELUDE_PROOF_DIR))?;
-
-        prelude_proof.is_dir().then_some(prelude_proof)
     }
 
     #[instrument(level = Level::DEBUG, skip(self, products, info))]
@@ -522,10 +509,14 @@ impl<'a> LoweringContext<'a> {
             )
         });
         let dep_proofs = self.dep_proofs_of(target);
+        let proof_prelude = info
+            .proof_prelude
+            .as_deref()
+            .expect("Prove actions should have a selected proof prelude");
         // Why3 needs every reachable non-stdlib proof directory on its loadpath
         // once emitted proof artifacts live alongside package-local verification
         // outputs under `_build/verif/<pkg>/...`.
-        let why3_loadpaths = self.proof_loadpaths_of(target);
+        let why3_loadpaths = self.proof_loadpaths_of(target, proof_prelude);
         let cmd = compiler::MooncProve {
             required: BuildCommonInput::new(
                 &files_vec,
@@ -553,6 +544,7 @@ impl<'a> LoweringContext<'a> {
         let mut extra_inputs = files_vec.clone();
         extra_inputs.extend(info.doctest_files.clone());
         extra_inputs.push(why3_config);
+        extra_inputs.push(proof_prelude.join(moonutil::constants::PRELUDE_PROOF_FILE));
         extra_inputs.extend(why3_loadpaths);
         if !package.is_single_file() {
             extra_inputs.push(package.config_path());

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -509,10 +509,7 @@ impl<'a> LoweringContext<'a> {
             )
         });
         let dep_proofs = self.dep_proofs_of(target);
-        let proof_prelude = info
-            .proof_prelude
-            .as_deref()
-            .expect("Prove actions should have a selected proof prelude");
+        let proof_prelude = info.proof_prelude.as_path();
         // Why3 needs every reachable non-stdlib proof directory on its loadpath
         // once emitted proof artifacts live alongside package-local verification
         // outputs under `_build/verif/<pkg>/...`.

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -518,6 +518,7 @@ mod tests {
             specified_no_mi: false,
             patch_file: None,
             why3_config: None,
+            proof_prelude: None,
             check_mi_against: None,
             value_tracing: false,
         }

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -518,7 +518,7 @@ mod tests {
             specified_no_mi: false,
             patch_file: None,
             why3_config: None,
-            proof_prelude: None,
+            proof_prelude: PathBuf::from("proof-prelude"),
             check_mi_against: None,
             value_tracing: false,
         }

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -742,6 +742,7 @@ impl<'a> BuildPlanConstructor<'a> {
             .filter(|(specify_target, _)| specify_target == &target)
             .map(|(_, path)| path.clone());
         let why3_config = self.input_directive.prove_why3_config.clone();
+        let proof_prelude = self.input_directive.proof_prelude.clone();
 
         let mi_check_target = self.mi_check_target(target, pkg);
 
@@ -754,6 +755,7 @@ impl<'a> BuildPlanConstructor<'a> {
             specified_no_mi,
             patch_file,
             why3_config,
+            proof_prelude,
             check_mi_against: mi_check_target,
             value_tracing: self
                 .input_directive

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -377,6 +377,9 @@ pub struct BuildTargetInfo {
     /// The Why3 configuration file to supply to proof commands.
     pub(crate) why3_config: Option<PathBuf>,
 
+    /// The directory containing the selected proof prelude provider.
+    pub(crate) proof_prelude: Option<PathBuf>,
+
     /// Check the `.mi` file against the given target. Used in virtual packages.
     /// Also implies that the target must not generate a `.mi` file.
     pub(crate) check_mi_against: Option<BuildTarget>,
@@ -657,6 +660,9 @@ pub struct InputDirective {
 
     /// Use the given Why3 config file for `moon prove`.
     pub prove_why3_config: Option<PathBuf>,
+
+    /// Use the proof prelude provider from this directory for `moon prove`.
+    pub proof_prelude: Option<PathBuf>,
 
     /// Control package-level prebuild for this invocation.
     pub package_prebuild: PackagePrebuildPolicy,

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -378,7 +378,7 @@ pub struct BuildTargetInfo {
     pub(crate) why3_config: Option<PathBuf>,
 
     /// The directory containing the selected proof prelude provider.
-    pub(crate) proof_prelude: Option<PathBuf>,
+    pub(crate) proof_prelude: PathBuf,
 
     /// Check the `.mi` file against the given target. Used in virtual packages.
     /// Also implies that the target must not generate a `.mi` file.
@@ -642,7 +642,7 @@ pub enum PackagePrebuildPolicy {
 }
 
 /// Directives provided along the input actions.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct InputDirective {
     /// Set `no_mi=true` for the given package.
     pub specify_no_mi_for: Option<PackageId>,
@@ -662,10 +662,23 @@ pub struct InputDirective {
     pub prove_why3_config: Option<PathBuf>,
 
     /// Use the proof prelude provider from this directory for `moon prove`.
-    pub proof_prelude: Option<PathBuf>,
+    pub proof_prelude: PathBuf,
 
     /// Control package-level prebuild for this invocation.
     pub package_prebuild: PackagePrebuildPolicy,
+}
+
+impl Default for InputDirective {
+    fn default() -> Self {
+        Self {
+            specify_no_mi_for: None,
+            specify_patch_file: None,
+            value_tracing: None,
+            prove_why3_config: None,
+            proof_prelude: moonutil::toolchain::prelude_proof(),
+            package_prebuild: PackagePrebuildPolicy::default(),
+        }
+    }
 }
 
 /// Represents errors that may occur during build graph construction.

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -594,4 +594,77 @@ mod tests {
                 .any(|path| path.ends_with("dependency.core"))
         );
     }
+
+    #[test]
+    fn compile_uses_default_proof_prelude() {
+        let module_source = ModuleSource::local_path(
+            "test/single"
+                .parse::<ModuleName>()
+                .expect("test module should parse"),
+            PathBuf::from("."),
+            DEFAULT_VERSION.clone(),
+        );
+        let (modules, module) = ResolvedEnv::only_one_module(module_source.clone(), moon_mod());
+        let mut packages = DiscoverResult::default();
+        packages.test_register_module(module, moon_mod());
+        let package = packages.test_add_package(
+            module,
+            PackagePath::new("proof").expect("proof path should parse"),
+            package(module, &module_source, "proof", false, false),
+        );
+        let target = package.build_target(TargetKind::Source);
+        let mut module_dirs = DirSyncResult::default();
+        module_dirs.insert(module, PathBuf::from("."));
+        let resolved = ResolveOutput {
+            module_rel: modules,
+            module_dirs,
+            pkg_dirs: packages,
+            pkg_rel: DepRelationship::default(),
+        };
+        let artifact_paths = ArtifactPathResolver::new(
+            TargetLayout::new(
+                PathBuf::from("_build"),
+                TargetLayoutMode::Mono {
+                    main_module: module_source,
+                },
+                OptLevel::Debug,
+                RunMode::Prove,
+            ),
+            None,
+        );
+        let config = CompileConfig {
+            target_dir: PathBuf::from("_build"),
+            backend: BackendConfig::WasmGc { use_wat: false },
+            opt_level: OptLevel::Debug,
+            action: RunMode::Prove,
+            debug_symbols: false,
+            stdlib_path: None,
+            artifact_paths,
+            lowering_environment: LoweringEnvironment::default(),
+            debug_export_build_plan: false,
+            enable_coverage: false,
+            moonc_output_json: false,
+            docs_serve: false,
+            warning_condition: WarningCondition::Default,
+            warn_list: None,
+            info_no_alias: false,
+        };
+
+        let output = compile(
+            &config,
+            Path::new("."),
+            &resolved,
+            &[BuildPlanNode::Prove(target)],
+            &InputDirective::default(),
+            None,
+            &UserLog::new(log::LevelFilter::Error),
+        )
+        .expect("the default directive should select the toolchain proof prelude");
+
+        let proof_prelude = moonutil::toolchain::prelude_proof().display().to_string();
+        assert!(output.command_args_by_output.values().any(|args| {
+            args.windows(2)
+                .any(|pair| pair[0] == "-why3-loadpath" && pair[1] == proof_prelude)
+        }));
+    }
 }

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -1416,6 +1416,7 @@ mod tests {
             specified_no_mi: false,
             patch_file: None,
             why3_config: None,
+            proof_prelude: None,
             check_mi_against: None,
             value_tracing: false,
         }

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -1416,7 +1416,7 @@ mod tests {
             specified_no_mi: false,
             patch_file: None,
             why3_config: None,
-            proof_prelude: None,
+            proof_prelude: PathBuf::from("proof-prelude"),
             check_mi_against: None,
             value_tracing: false,
         }

--- a/crates/moonutil/src/constants.rs
+++ b/crates/moonutil/src/constants.rs
@@ -83,6 +83,7 @@ pub const SINGLE_FILE_TEST_MODULE: &str = "moon/test";
 pub const SUB_PKG_POSTFIX: &str = "_sub";
 
 pub const PRELUDE_PROOF_DIR: &str = "prelude_proof";
+pub const PRELUDE_PROOF_FILE: &str = "moonbit_builtin_prelude.mlw";
 
 pub const O_EXT: &str = if cfg!(windows) { "obj" } else { "o" };
 #[allow(unused)]

--- a/crates/moonutil/src/moon_dir.rs
+++ b/crates/moonutil/src/moon_dir.rs
@@ -19,7 +19,10 @@
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
-use crate::{constants::BUILD_DIR, target::TargetBackend};
+use crate::{
+    constants::{BUILD_DIR, PRELUDE_PROOF_DIR},
+    target::TargetBackend,
+};
 
 pub struct MoonDirs {
     pub moon_home: PathBuf,
@@ -119,6 +122,10 @@ pub fn include() -> PathBuf {
 
 pub fn lib() -> PathBuf {
     toolchain_root().join("lib")
+}
+
+pub fn prelude_proof() -> PathBuf {
+    lib().join(PRELUDE_PROOF_DIR)
 }
 
 pub fn share() -> PathBuf {
@@ -268,6 +275,7 @@ fn test_moon_dir() {
         bin(),
         include(),
         lib(),
+        prelude_proof(),
         why3_datadir(),
         why3_libdir(),
         core_bundle(TargetBackend::default()),
@@ -288,6 +296,7 @@ fn test_moon_dir() {
             "bin",
             "include",
             "lib",
+            "lib|prelude_proof",
             "share|why3",
             "lib|why3",
             "lib|core|_build|wasm|release|bundle",

--- a/crates/moonutil/src/toolchain.rs
+++ b/crates/moonutil/src/toolchain.rs
@@ -34,7 +34,7 @@ pub use crate::binaries::{BINARIES, CachedBinaries, moon_cram_in, mooncake_in};
 pub use crate::moon_dir::{
     MOON_DIRS, MoonDirs, RESERVED_BIN_NAMES, abort_core_in, abort_mi_in, bin, core, core_bundle,
     core_bundle_in, core_core, core_core_in, core_package_mi_in, home, include, is_toolchain_root,
-    lib, toolchain_root, user_bin, why3_datadir, why3_libdir,
+    lib, prelude_proof, toolchain_root, user_bin, why3_datadir, why3_libdir,
 };
 
 /// Return the runtime C translation units shipped by the selected toolchain.

--- a/docs/dev/reference/rr-special-cases.md
+++ b/docs/dev/reference/rr-special-cases.md
@@ -86,9 +86,11 @@ important ones and why they exist.
   action adds one proof prelude provider directory to the Why3 loadpath. It
   defaults to the toolchain's `lib/prelude_proof`; when
   `MOON_PROVE_PRELUDE_OVERRIDE` is set, the command layer validates and selects
-  that directory instead. This also applies when proving `moonbitlang/core`,
-  where the installed stdlib is intentionally not injected; the proof prelude
-  is a toolchain resource rather than a prebuilt stdlib package artifact.
+  that directory instead. `InputDirective::default()` selects the same
+  toolchain provider for direct callers of the RR `compile` API. This also
+  applies when proving `moonbitlang/core`, where the installed stdlib is
+  intentionally not injected; the proof prelude is a toolchain resource rather
+  than a prebuilt stdlib package artifact.
 
 ## Runtime + tooling side effects
 

--- a/docs/dev/reference/rr-special-cases.md
+++ b/docs/dev/reference/rr-special-cases.md
@@ -82,6 +82,13 @@ important ones and why they exist.
   without a stdlib directory so package metadata and indirect dependency
   resolution use the locally built `.mi` files. For non-core projects, the
   stdlib directory is set so prebuilt artifacts can be used.
+- **The proof prelude is independent of stdlib injection.** Every `Prove`
+  action adds one proof prelude provider directory to the Why3 loadpath. It
+  defaults to the toolchain's `lib/prelude_proof`; when
+  `MOON_PROVE_PRELUDE_OVERRIDE` is set, the command layer validates and selects
+  that directory instead. This also applies when proving `moonbitlang/core`,
+  where the installed stdlib is intentionally not injected; the proof prelude
+  is a toolchain resource rather than a prebuilt stdlib package artifact.
 
 ## Runtime + tooling side effects
 

--- a/docs/dev/reference/toolchain-layout.md
+++ b/docs/dev/reference/toolchain-layout.md
@@ -34,7 +34,12 @@ Mutable user state must stay outside the package-managed prefix.
 In code, facts about the selected MoonBit toolchain tree should be accessed via
 `moonutil::toolchain`. This includes known tool executables, the toolchain root,
 `bin`/`lib`/`include`, shipped stdlib artifacts under `lib/core`, and shipped
-runtime translation units under `lib/runtime`.
+runtime translation units under `lib/runtime`. The proof prelude under
+`lib/prelude_proof` is also a toolchain fact and is available independently of
+whether a build injects the installed stdlib. `moon prove` may select an
+alternate provider directory through `MOON_PROVE_PRELUDE_OVERRIDE`; the
+directory must contain `moonbit_builtin_prelude.mlw` and replaces, rather than
+augments, the default provider.
 
 Project-local layout remains outside this module. For example, `.mooncakes`,
 `_build`, resolved package roots, and workspace discovery are project facts,

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -186,6 +186,8 @@ Check the current package, but don't build object files
 
 Prove the current package
 
+Set `MOON_PROVE_PRELUDE_OVERRIDE` to a directory containing `moonbit_builtin_prelude.mlw` to replace the toolchain's proof prelude.
+
 **Usage:** `moon prove [OPTIONS] [PATH]`
 
 ###### **Arguments:**

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -186,6 +186,8 @@ Check the current package, but don't build object files
 
 Prove the current package
 
+Set `MOON_PROVE_PRELUDE_OVERRIDE` to a directory containing `moonbit_builtin_prelude.mlw` to replace the toolchain's proof prelude.
+
 **Usage:** `moon prove [OPTIONS] [PATH]`
 
 ###### **Arguments:**


### PR DESCRIPTION
## Summary

- decouple the Why3 proof prelude from installed stdlib injection so every `moon prove` action loads a provider, including when proving `moonbitlang/core`
- add `MOON_PROVE_PRELUDE_OVERRIDE` for selecting an alternate provider such as the machine-int prelude, with validation for `moonbit_builtin_prelude.mlw`
- carry the selected provider explicitly through build planning, track its provider file as an input, and document the behavior

## Why

The proof prelude loadpath was derived from the installed stdlib path. Core builds intentionally omit that stdlib path, so proving core also lost the prelude and could not use its proof definitions. There was also no supported way to replace the default provider for configurations such as machine integers.

## Why this is correct

The command layer now always selects exactly one proof prelude: the toolchain default when the environment variable is absent, or a canonicalized and validated override when it is present. The build plan passes that choice to `Prove` lowering, which adds it to the Why3 loadpath and records the provider file as an action input. Regression coverage exercises core without stdlib injection, successful override replacement, and invalid override diagnostics.

The change is limited to proof-prelude selection and propagation; existing stdlib dependency selection remains unchanged.
