### PR TITLE
refactor(build): complete package artifact requirements

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_action_plan/view.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/view.rs
@@ -21,7 +21,7 @@ use std::collections::{HashMap, HashSet};
 use moonutil::resolution::ResolvedEnv;
 
 use crate::{
-    build_plan::{BuildPlan, FileDependencyKind, PlanArtifactKind},
+    build_plan::{BuildPlan, FileDependencyKind, PlanArtifactNeed},
     discover::DiscoverResult,
     model::{BuildPlanNode, BuildTarget, PackageId},
 };
@@ -341,10 +341,15 @@ impl<'a> BuildActionPlan<'a> {
             FileDependencyKind::AllFiles => self.output_products_for_node(node),
             FileDependencyKind::Artifacts(need) => {
                 let mut products = Vec::new();
-                if need.contains(PlanArtifactKind::Interface) {
+                let (needs_interface, needs_core_ir) = match need {
+                    PlanArtifactNeed::Interface => (true, false),
+                    PlanArtifactNeed::CoreIr => (false, true),
+                    PlanArtifactNeed::InterfaceAndCoreIr => (true, true),
+                };
+                if needs_interface {
                     self.push_package_interface(node, &mut products);
                 }
-                if need.contains(PlanArtifactKind::CoreIr) {
+                if needs_core_ir {
                     self.push_package_core_ir(node, &mut products);
                 }
                 products

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -43,9 +43,7 @@ use relative_path::PathExt;
 use tracing::{Level, debug, instrument, trace, warn};
 
 use crate::{
-    build_plan::{
-        BuildBundleInfo, FileDependencyKind, PackagePrebuildPolicy, PlanArtifactNeed, PrebuildInfo,
-    },
+    build_plan::{BuildBundleInfo, FileDependencyKind, PackagePrebuildPolicy, PrebuildInfo},
     cond_comp,
     discover::DiscoveredPackage,
     model::{
@@ -977,12 +975,12 @@ impl<'a> BuildPlanConstructor<'a> {
         // Add edges to all dependencies
         // Note that we have already replaced unnecessary dependencies
         for target in &link_core_deps {
-            let dep_node = BuildPlanNode::BuildCore(*target);
-            self.need_node(dep_node);
-            self.add_edge_spec(
+            self.require_artifact(
                 link_core_node,
-                dep_node,
-                FileDependencyKind::Artifacts(PlanArtifactNeed::CoreIr),
+                ArtifactKey::CoreIr {
+                    package: target.package,
+                    target_kind: target.kind,
+                },
             );
         }
 
@@ -1318,7 +1316,7 @@ impl<'a> BuildPlanConstructor<'a> {
     #[instrument(level = Level::DEBUG, skip(self))]
     pub(super) fn build_bundle(
         &mut self,
-        _node: BuildPlanNode,
+        node: BuildPlanNode,
         module_id: ModuleId,
     ) -> Result<(), BuildPlanConstructError> {
         // Bundling a module gathers the build result of all its non-virtual packages, in topo order
@@ -1345,13 +1343,13 @@ impl<'a> BuildPlanConstructor<'a> {
                 continue;
             }
 
-            let build_node = BuildPlanNode::BuildCore(target);
             trace!(?module_id, ?target, "enqueuing bundle dependency");
-            self.need_node(build_node);
-            self.add_edge_spec(
-                _node,
-                build_node,
-                FileDependencyKind::Artifacts(PlanArtifactNeed::CoreIr),
+            self.require_artifact(
+                node,
+                ArtifactKey::CoreIr {
+                    package: target.package,
+                    target_kind: target.kind,
+                },
             );
 
             if pkg.is_virtual() {
@@ -1567,16 +1565,19 @@ impl<'a> BuildPlanConstructor<'a> {
     #[instrument(level = Level::DEBUG, skip(self))]
     pub(super) fn build_build_docs(
         &mut self,
-        _node: BuildPlanNode,
+        node: BuildPlanNode,
         _module_id: ModuleId,
     ) -> Result<(), BuildPlanConstructError> {
         // For now, `moondoc` depends on *every check*, as specified in its
         // packages.json input. I guess bad things might happen if you don't?
         for (pkg_id, _) in self.input.pkg_dirs.all_packages(true) {
-            let check_node = self.need_node(BuildPlanNode::Check(
-                pkg_id.build_target(TargetKind::Source),
-            ));
-            self.add_edge(_node, check_node);
+            self.require_artifact(
+                node,
+                ArtifactKey::CheckMi {
+                    package: pkg_id,
+                    target_kind: TargetKind::Source,
+                },
+            );
         }
         Ok(())
     }

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -137,20 +137,11 @@ pub struct BuildPlan {
     input_nodes: Vec<BuildPlanNode>,
 }
 
-/// Logical artifacts that can be requested from build-plan nodes.
+/// The logical package products needed from a compatibility dependency edge.
 ///
-/// These are planning-level package artifacts. `BuildActionPlan` expands them,
-/// together with node-specific edge selectors, into the logical artifact set
-/// consumed by backend lowering.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PlanArtifactKind {
-    /// Package interface artifact, currently written as a `.mi` file.
-    Interface,
-    /// Compiler Core IR artifact, currently written as a `.core` file.
-    CoreIr,
-}
-
-/// The logical artifacts needed from a dependency node.
+/// Build-plan builders name `ArtifactKey` values instead. The compatibility
+/// projection converts those Artifact Requirements to this selector, which
+/// `BuildActionPlan` expands for backend lowering.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PlanArtifactNeed {
     Interface,
@@ -159,14 +150,6 @@ pub enum PlanArtifactNeed {
 }
 
 impl PlanArtifactNeed {
-    pub fn contains(self, kind: PlanArtifactKind) -> bool {
-        match self {
-            Self::Interface => matches!(kind, PlanArtifactKind::Interface),
-            Self::CoreIr => matches!(kind, PlanArtifactKind::CoreIr),
-            Self::InterfaceAndCoreIr => true,
-        }
-    }
-
     pub fn is_subset_of(self, other: Self) -> bool {
         matches!(
             (self, other),
@@ -200,7 +183,7 @@ pub enum FileDependencyKind {
     /// Depending on all files available
     AllFiles,
 
-    /// Depending on logical artifacts produced by a node.
+    /// Depending on package products selected from a compatibility action edge.
     Artifacts(PlanArtifactNeed),
 
     /// Depending on proof artifacts of an `EmitProof`/`Prove` node.

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -84,6 +84,9 @@ self.require_artifact(
 Normal downstream `BuildCore` derivations require both Build MI and Core IR so
 a dependency implementation change that leaves its interface stable still
 rebuilds the dependent package. Check derivations require Check MI only.
+`LinkCore` and `Bundle` require Core IR, while `BuildDocs` requires Check MI.
+Builders do not choose the `Check` or `BuildCore` derivation that satisfies
+these requirements.
 
 Virtual-contract compilation chooses the dependency MI artifact from the
 invocation lifecycle:
@@ -101,10 +104,13 @@ match run_mode {
 There is no Check-to-Build coalescing. The two derivations provide different
 artifacts and can never substitute for one another.
 
-Proof, generated-test-info, prebuild, C-stub, runtime, link, and other
-not-yet-migrated dependencies continue to use `FileDependencyKind` edges. The
-derived MI/Core edges use the same representation after provider resolution so
-the action-plan and lowering interfaces remain unchanged during this migration.
+Every package MI and Core IR dependency is recorded as an Artifact Requirement.
+The compatibility projection is the only build-planning code that constructs
+`FileDependencyKind::Artifacts` edges. Proof, generated-test-info, prebuild,
+C-stub, runtime, and other not-yet-migrated dependencies continue to use other
+`FileDependencyKind` variants. The derived MI/Core edges use the same
+representation after provider resolution so the action-plan and lowering
+interfaces remain unchanged during this migration.
 
 ## Build Action Plan
 


### PR DESCRIPTION
## Why

Package MI and Core IR dependencies should be expressed by logical artifact identity rather than by selecting a `Check` or `BuildCore` provider in individual builders. A few consumers still constructed provider-specific action edges, leaving the artifact model incomplete and preserving unnecessary coupling between planning and action selection.

## What changed

- make `LinkCore` and `Bundle` require `CoreIr` artifacts
- make `BuildDocs` require `CheckMi` artifacts
- remove the redundant `PlanArtifactKind` compatibility type
- document that every package MI/Core dependency now enters the artifact plan first

## Why this is correct

The existing artifact plan already registers lifecycle-specific providers for Check MI, Build MI, and Core IR. Resolving these requirements after planning therefore preserves the same action graph and backend inputs while preventing callers from choosing providers themselves.

## Scope

The compatibility projection to `FileDependencyKind::Artifacts` remains unchanged. Moving `BuildActionPlan` to consume the artifact plan directly, and then deleting that compatibility representation, is intentionally left for a separate change.
