### PR TITLE
fix(explain): sync warning index with moonc

### DIFF
--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -38,7 +38,7 @@ Warning name: `{mnemonic}`
     }
 }
 
-// Snapshot generated from `moonc check -warn-help` on 2026-08-03.
+// Snapshot generated from `moonc check -warn-help` on 2026-08-10.
 // Update this file manually when the compiler's warning table changes.
 const WARNING_ENTRIES: &[WarningEntry] = &[
     WarningEntry {
@@ -390,16 +390,6 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
         mnemonic: "unnecessary_view_op",
         description: "Unnecessary `[:]` view operator",
         id: 75,
-    },
-    WarningEntry {
-        mnemonic: "lexmatch_first_match",
-        description: "Deprecated `lexmatch` with first-match semantics.",
-        id: 76,
-    },
-    WarningEntry {
-        mnemonic: "lexmatch_longest_match",
-        description: "Deprecated `lexmatch` with longest-match semantics.",
-        id: 77,
     },
     WarningEntry {
         mnemonic: "result_error_return",

--- a/crates/moon/src/cli/snapshots/explain_warning_index.txt
+++ b/crates/moon/src/cli/snapshots/explain_warning_index.txt
@@ -68,8 +68,6 @@
 0073	unnecessary_annotation	unnecessary type annotation
 0074	missing_doc	Missing documentation for public definition
 0075	unnecessary_view_op	Unnecessary `[:]` view operator
-0076	lexmatch_first_match	Deprecated `lexmatch` with first-match semantics.
-0077	lexmatch_longest_match	Deprecated `lexmatch` with longest-match semantics.
 0078	result_error_return	Using `Result[T, E]` where `E` is an error type.
 0079	implicit_impl_as_method	`impl` implicitly promoted as method
 0080	regex_match_missing_before	Missing `before` binding in `regex match`.


### PR DESCRIPTION
## Summary

- synchronize the checked-in warning index with the current compiler warning table
- remove E0076 and E0077 after the corresponding `lexmatch` warnings were removed from `moonc`

## Why

The warning-index snapshot test started failing because `moonc check -warn-help` no longer reports these two warnings, while `moon explain` still retained them in its generated index.

## Correctness and scope

Both the source index and its text snapshot now reflect the same compiler output. The change is limited to the stale warning entries and the snapshot generation date.
