### PR TITLE
refactor(build): resolve artifact dependencies directly

### DIFF
--- a/crates/moon/src/rr_build/action_identity.rs
+++ b/crates/moon/src/rr_build/action_identity.rs
@@ -36,6 +36,7 @@ use blake3::Hasher;
 use moonbuild_rupes_recta::{
     build_action_plan::BuildProduct,
     build_lower::{LoweredAction, LoweredCommandExecution, LoweredExternalInput},
+    build_plan::ArtifactKey,
     model::TargetKind,
 };
 
@@ -212,14 +213,17 @@ struct LogicalProduct {
 impl From<&BuildProduct> for LogicalProduct {
     fn from(product: &BuildProduct) -> Self {
         let (kind, target_kind, index, path) = match product {
-            BuildProduct::PackageInterface { target } => (
-                b"package-interface".as_slice(),
-                Some(target.kind),
-                None,
-                None,
-            ),
-            BuildProduct::PackageCoreIr { target } => {
-                (b"package-core-ir".as_slice(), Some(target.kind), None, None)
+            BuildProduct::Artifact(ArtifactKey::CheckMi { target_kind, .. }) => {
+                (b"check-mi".as_slice(), Some(*target_kind), None, None)
+            }
+            BuildProduct::Artifact(ArtifactKey::BuildMi { target_kind, .. }) => {
+                (b"build-mi".as_slice(), Some(*target_kind), None, None)
+            }
+            BuildProduct::Artifact(ArtifactKey::CoreIr { target_kind, .. }) => {
+                (b"core-ir".as_slice(), Some(*target_kind), None, None)
+            }
+            BuildProduct::Artifact(ArtifactKey::VirtualContractMi { .. }) => {
+                (b"virtual-contract-mi".as_slice(), None, None, None)
             }
             BuildProduct::ProofInterface { target } => {
                 (b"proof-interface".as_slice(), Some(target.kind), None, None)
@@ -264,9 +268,6 @@ impl From<&BuildProduct> for LogicalProduct {
                 (b"generated-mbti".as_slice(), Some(target.kind), None, None)
             }
             BuildProduct::DocsDir => (b"docs-dir".as_slice(), None, None, None),
-            BuildProduct::VirtualPackageInterface { .. } => {
-                (b"virtual-package-interface".as_slice(), None, None, None)
-            }
             BuildProduct::MoonLexGeneratedSource { index, .. } => (
                 b"moonlex-generated-source".as_slice(),
                 None,

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/product.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/product.rs
@@ -20,17 +20,19 @@ use std::path::PathBuf;
 
 use moonutil::resolution::ModuleId;
 
-use crate::model::{BuildTarget, PackageId};
+use crate::{
+    build_plan::ArtifactKey,
+    model::{BuildTarget, PackageId},
+};
 
-/// A logical product selected from a build node.
-#[derive(Clone, Debug, Eq, PartialEq)]
+/// An action-level output passed to backend lowering.
+///
+/// Migrated package compilation outputs retain their exact Build Artifact
+/// identity. The remaining variants are outputs whose dependencies have not
+/// yet migrated from action-coupled file selectors.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum BuildProduct {
-    PackageInterface {
-        target: BuildTarget,
-    },
-    PackageCoreIr {
-        target: BuildTarget,
-    },
+    Artifact(ArtifactKey),
     ProofInterface {
         target: BuildTarget,
     },
@@ -73,9 +75,6 @@ pub enum BuildProduct {
         target: BuildTarget,
     },
     DocsDir,
-    VirtualPackageInterface {
-        package: PackageId,
-    },
     MoonLexGeneratedSource {
         package: PackageId,
         index: u32,

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/tests.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/tests.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use slotmap::KeyData;
 
 use crate::{
-    build_plan::{BuildPlan, BuildTargetInfo, FileDependencyKind, PlanArtifactNeed, PrebuildInfo},
+    build_plan::{ArtifactKey, BuildPlan, BuildTargetInfo, FileDependencyKind, PrebuildInfo},
     model::{BuildPlanNode, PackageId, TargetKind},
 };
 
@@ -61,7 +61,10 @@ fn check_exposes_package_interface() {
 
     assert_eq!(
         action_plan.output_products(action_id),
-        vec![BuildProduct::PackageInterface { target }]
+        vec![BuildProduct::Artifact(ArtifactKey::CheckMi {
+            package,
+            target_kind: target.kind,
+        })]
     );
 }
 
@@ -80,8 +83,14 @@ fn build_core_exposes_core_and_interface_when_it_emits_mi() {
     assert_eq!(
         action_plan.output_products(action_id),
         vec![
-            BuildProduct::PackageInterface { target },
-            BuildProduct::PackageCoreIr { target },
+            BuildProduct::Artifact(ArtifactKey::BuildMi {
+                package,
+                target_kind: target.kind,
+            }),
+            BuildProduct::Artifact(ArtifactKey::CoreIr {
+                package,
+                target_kind: target.kind,
+            }),
         ]
     );
 }
@@ -102,7 +111,10 @@ fn build_core_omits_interface_when_mi_is_disabled() {
 
     assert_eq!(
         action_plan.output_products(action_id),
-        vec![BuildProduct::PackageCoreIr { target }]
+        vec![BuildProduct::Artifact(ArtifactKey::CoreIr {
+            package,
+            target_kind: target.kind,
+        })]
     );
 }
 
@@ -132,12 +144,13 @@ fn check_interface_dependency_uses_selected_check_action() {
     let consumer = package_id(2).build_target(TargetKind::Source);
     let dependency_node = BuildPlanNode::Check(dependency);
     let consumer_node = BuildPlanNode::BuildCore(consumer);
+    let check_mi = ArtifactKey::CheckMi {
+        package: dependency.package,
+        target_kind: dependency.kind,
+    };
     let mut plan = BuildPlan::default();
-    plan.test_add_edge(
-        consumer_node,
-        dependency_node,
-        FileDependencyKind::Artifacts(PlanArtifactNeed::Interface),
-    );
+    plan.test_require_artifact(consumer_node, check_mi);
+    plan.test_provide_artifact(dependency_node, check_mi);
 
     let action_plan = plan.build_action_plan();
     let consumer_id = action_plan.id_for_node(consumer_node);
@@ -145,10 +158,7 @@ fn check_interface_dependency_uses_selected_check_action() {
 
     assert_eq!(
         action_plan.dependency_products(consumer_id),
-        vec![(
-            dependency_id,
-            BuildProduct::PackageInterface { target: dependency },
-        )]
+        vec![(dependency_id, BuildProduct::Artifact(check_mi))]
     );
 }
 
@@ -158,13 +168,19 @@ fn build_core_dependency_can_track_interface_and_core_ir() {
     let consumer = package_id(2).build_target(TargetKind::Source);
     let dependency_node = BuildPlanNode::BuildCore(dependency);
     let consumer_node = BuildPlanNode::BuildCore(consumer);
+    let build_mi = ArtifactKey::BuildMi {
+        package: dependency.package,
+        target_kind: dependency.kind,
+    };
+    let core_ir = ArtifactKey::CoreIr {
+        package: dependency.package,
+        target_kind: dependency.kind,
+    };
     let mut plan = BuildPlan::default();
-    plan.test_add_edge(
-        consumer_node,
-        dependency_node,
-        FileDependencyKind::Artifacts(PlanArtifactNeed::InterfaceAndCoreIr),
-    );
-    plan.test_insert_build_target_info(dependency, target_info());
+    plan.test_require_artifact(consumer_node, build_mi);
+    plan.test_require_artifact(consumer_node, core_ir);
+    plan.test_provide_artifact(dependency_node, build_mi);
+    plan.test_provide_artifact(dependency_node, core_ir);
 
     let action_plan = plan.build_action_plan();
     let consumer_id = action_plan.id_for_node(consumer_node);
@@ -173,15 +189,41 @@ fn build_core_dependency_can_track_interface_and_core_ir() {
     assert_eq!(
         action_plan.dependency_products(consumer_id),
         vec![
-            (
-                dependency_id,
-                BuildProduct::PackageInterface { target: dependency },
-            ),
-            (
-                dependency_id,
-                BuildProduct::PackageCoreIr { target: dependency }
-            ),
+            (dependency_id, BuildProduct::Artifact(build_mi)),
+            (dependency_id, BuildProduct::Artifact(core_ir)),
         ]
+    );
+}
+
+#[test]
+fn artifact_dependencies_deduplicate_provider_action() {
+    let dependency = package_id(1).build_target(TargetKind::Source);
+    let consumer = package_id(2).build_target(TargetKind::Source);
+    let dependency_node = BuildPlanNode::BuildCore(dependency);
+    let consumer_node = BuildPlanNode::BuildCore(consumer);
+    let build_mi = ArtifactKey::BuildMi {
+        package: dependency.package,
+        target_kind: dependency.kind,
+    };
+    let core_ir = ArtifactKey::CoreIr {
+        package: dependency.package,
+        target_kind: dependency.kind,
+    };
+    let mut plan = BuildPlan::default();
+    plan.test_require_artifact(consumer_node, build_mi);
+    plan.test_require_artifact(consumer_node, core_ir);
+    plan.test_provide_artifact(dependency_node, build_mi);
+    plan.test_provide_artifact(dependency_node, core_ir);
+
+    let action_plan = plan.build_action_plan();
+    let consumer_id = action_plan.id_for_node(consumer_node);
+    let dependency_id = action_plan.id_for_node(dependency_node);
+
+    assert_eq!(
+        action_plan
+            .dependency_action_ids(consumer_id)
+            .collect::<Vec<_>>(),
+        vec![dependency_id]
     );
 }
 

--- a/crates/moonbuild-rupes-recta/src/build_action_plan/view.rs
+++ b/crates/moonbuild-rupes-recta/src/build_action_plan/view.rs
@@ -21,7 +21,7 @@ use std::collections::{HashMap, HashSet};
 use moonutil::resolution::ResolvedEnv;
 
 use crate::{
-    build_plan::{BuildPlan, FileDependencyKind, PlanArtifactNeed},
+    build_plan::{ArtifactKey, BuildPlan, FileDependencyKind},
     discover::DiscoverResult,
     model::{BuildPlanNode, BuildTarget, PackageId},
 };
@@ -259,14 +259,23 @@ impl<'a> BuildActionPlan<'a> {
     }
 
     pub fn dependency_products(&self, id: BuildActionId) -> Vec<(BuildActionId, BuildProduct)> {
-        self.plan
-            .dependency_edges(self.node(id))
-            .flat_map(|(node, kind)| {
-                let dependency_action = self.id_for_node(node);
-                self.products_for_edge(node, kind)
-                    .into_iter()
-                    .map(move |product| (dependency_action, product))
-            })
+        let node = self.node(id);
+        let file_dependencies = self.plan.file_dependencies(node).flat_map(|(node, kind)| {
+            let dependency_action = self.id_for_node(node);
+            self.products_for_edge(node, kind)
+                .into_iter()
+                .map(move |product| (dependency_action, product))
+        });
+        let artifact_dependencies =
+            self.plan
+                .artifact_dependencies(node)
+                .map(|(provider, artifact)| {
+                    (self.id_for_node(provider), BuildProduct::Artifact(artifact))
+                });
+        let mut seen = HashSet::new();
+        file_dependencies
+            .chain(artifact_dependencies)
+            .filter(move |dependency| seen.insert(dependency.clone()))
             .collect()
     }
 
@@ -339,21 +348,6 @@ impl<'a> BuildActionPlan<'a> {
     ) -> Vec<BuildProduct> {
         match kind {
             FileDependencyKind::AllFiles => self.output_products_for_node(node),
-            FileDependencyKind::Artifacts(need) => {
-                let mut products = Vec::new();
-                let (needs_interface, needs_core_ir) = match need {
-                    PlanArtifactNeed::Interface => (true, false),
-                    PlanArtifactNeed::CoreIr => (false, true),
-                    PlanArtifactNeed::InterfaceAndCoreIr => (true, true),
-                };
-                if needs_interface {
-                    self.push_package_interface(node, &mut products);
-                }
-                if needs_core_ir {
-                    self.push_package_core_ir(node, &mut products);
-                }
-                products
-            }
             FileDependencyKind::ProofArtifacts { mi, mlw, report } => {
                 let mut products = Vec::new();
                 if mi {
@@ -380,9 +374,10 @@ impl<'a> BuildActionPlan<'a> {
 
     fn output_products_for_node(&self, node: BuildPlanNode) -> Vec<BuildProduct> {
         match node {
-            BuildPlanNode::Check(target) => {
-                vec![BuildProduct::PackageInterface { target }]
-            }
+            BuildPlanNode::Check(target) => vec![BuildProduct::Artifact(ArtifactKey::CheckMi {
+                package: target.package,
+                target_kind: target.kind,
+            })],
             BuildPlanNode::EmitProof(target) => vec![
                 BuildProduct::ProofInterface { target },
                 BuildProduct::ProofWhyml { target },
@@ -395,7 +390,10 @@ impl<'a> BuildActionPlan<'a> {
             BuildPlanNode::BuildCore(target) => {
                 let mut products = Vec::new();
                 self.push_build_core_interface_if_emitted(target, &mut products);
-                products.push(BuildProduct::PackageCoreIr { target });
+                products.push(BuildProduct::Artifact(ArtifactKey::CoreIr {
+                    package: target.package,
+                    target_kind: target.kind,
+                }));
                 products
             }
             BuildPlanNode::BuildCStub(package, index) => {
@@ -438,7 +436,9 @@ impl<'a> BuildActionPlan<'a> {
                 .map(|path| BuildProduct::PrebuildOutputPath { path })
                 .collect(),
             BuildPlanNode::BuildVirtual(package) => {
-                vec![BuildProduct::VirtualPackageInterface { package }]
+                vec![BuildProduct::Artifact(ArtifactKey::VirtualContractMi {
+                    package,
+                })]
             }
             BuildPlanNode::RunMoonLexPrebuild(package, index) => {
                 vec![BuildProduct::MoonLexGeneratedSource { package, index }]
@@ -446,27 +446,6 @@ impl<'a> BuildActionPlan<'a> {
             BuildPlanNode::RunMoonYaccPrebuild(package, index) => {
                 vec![BuildProduct::MoonYaccGeneratedSource { package, index }]
             }
-        }
-    }
-
-    fn push_package_interface(&self, node: BuildPlanNode, products: &mut Vec<BuildProduct>) {
-        match node {
-            BuildPlanNode::Check(target) => {
-                products.push(BuildProduct::PackageInterface { target });
-            }
-            BuildPlanNode::BuildCore(target) => {
-                self.push_build_core_interface_if_emitted(target, products);
-            }
-            _ => panic!("Package interface product requested from non-package node"),
-        }
-    }
-
-    fn push_package_core_ir(&self, node: BuildPlanNode, products: &mut Vec<BuildProduct>) {
-        match node {
-            BuildPlanNode::BuildCore(target) => {
-                products.push(BuildProduct::PackageCoreIr { target });
-            }
-            _ => panic!("Core IR product requested from non-BuildCore node"),
         }
     }
 
@@ -480,7 +459,10 @@ impl<'a> BuildActionPlan<'a> {
             .get_build_target_info(&target)
             .expect("Build target info should be present for BuildCore nodes");
         if info.check_mi_against.is_none() && !info.no_mi() && !target.kind.is_test() {
-            products.push(BuildProduct::PackageInterface { target });
+            products.push(BuildProduct::Artifact(ArtifactKey::BuildMi {
+                package: target.package,
+                target_kind: target.kind,
+            }));
         }
     }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -32,7 +32,7 @@ use tracing::{Level, instrument};
 use crate::{
     build_action_plan::BuildProduct,
     build_lower::compiler::{CmdlineAbstraction, MoondocCommand, Mooninfo},
-    build_plan::{BuildRuntimeInfo, BuildTargetInfo, PrebuildInfo},
+    build_plan::{ArtifactKey, BuildRuntimeInfo, BuildTargetInfo, PrebuildInfo},
     model::{BuildTarget, OperatingSystem, PackageId, TargetKind},
 };
 
@@ -137,10 +137,10 @@ impl<'a> super::LoweringContext<'a> {
             inputs.push(products.single_dependency_path_matching(|product| {
                 matches!(
                     product,
-                    BuildProduct::PackageCoreIr {
-                        target: product_target,
-                        ..
-                    } if product_target == dep
+                    BuildProduct::Artifact(ArtifactKey::CoreIr {
+                        package,
+                        target_kind,
+                    }) if *package == dep.package && *target_kind == dep.kind
                 )
             }));
         }
@@ -308,10 +308,10 @@ impl<'a> super::LoweringContext<'a> {
         let input = products.single_dependency_path_matching(|product| {
             matches!(
                 product,
-                BuildProduct::PackageInterface {
-                    target: product_target,
-                    ..
-                } if *product_target == target
+                BuildProduct::Artifact(ArtifactKey::CheckMi {
+                    package,
+                    target_kind,
+                }) if *package == target.package && *target_kind == target.kind
             )
         });
         let output = products.single_output_path_matching(|product| {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -49,7 +49,7 @@ use crate::{
             MiDependency, PackageSource, WasmConfig,
         },
     },
-    build_plan::{BuildCStubsInfo, BuildTargetInfo, LinkCoreInfo, MakeExecutableInfo},
+    build_plan::{ArtifactKey, BuildCStubsInfo, BuildTargetInfo, LinkCoreInfo, MakeExecutableInfo},
     discover::DiscoveredPackage,
     model::{BackendConfig, BuildTarget, PackageId, TargetKind},
     pkg_name::{PackageFQN, PackagePath},
@@ -331,10 +331,10 @@ impl<'a> LoweringContext<'a> {
             .optional_single_output_path_matching(|product| {
                 matches!(
                     product,
-                    BuildProduct::PackageInterface {
-                        target: product_target,
-                        ..
-                    } if *product_target == target
+                    BuildProduct::Artifact(ArtifactKey::CheckMi {
+                        package,
+                        target_kind,
+                    }) if *package == target.package && *target_kind == target.kind
                 )
             })
             .unwrap_or_else(|| {
@@ -569,20 +569,20 @@ impl<'a> LoweringContext<'a> {
         let core_output = products.single_output_path_matching(|product| {
             matches!(
                 product,
-                BuildProduct::PackageCoreIr {
-                    target: product_target,
-                    ..
-                } if *product_target == target
+                BuildProduct::Artifact(ArtifactKey::CoreIr {
+                    package,
+                    target_kind,
+                }) if *package == target.package && *target_kind == target.kind
             )
         });
         let mi_output = products
             .optional_single_output_path_matching(|product| {
                 matches!(
                     product,
-                    BuildProduct::PackageInterface {
-                        target: product_target,
-                        ..
-                    } if *product_target == target
+                    BuildProduct::Artifact(ArtifactKey::BuildMi {
+                        package,
+                        target_kind,
+                    }) if *package == target.package && *target_kind == target.kind
                 )
             })
             .unwrap_or_else(|| {
@@ -700,10 +700,10 @@ impl<'a> LoweringContext<'a> {
             let core_path = products.single_dependency_path_matching(|product| {
                 matches!(
                     product,
-                    BuildProduct::PackageCoreIr {
-                        target: product_target,
-                        ..
-                    } if product_target == target
+                    BuildProduct::Artifact(ArtifactKey::CoreIr {
+                        package,
+                        target_kind,
+                    }) if *package == target.package && *target_kind == target.kind
                 )
             });
             core_input_files.push(core_path);

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -365,8 +365,8 @@ mod tests {
 
     use crate::{
         build_plan::{
-            BuildCStubsInfo, BuildPlan, BuildRuntimeInfo, BuildTargetInfo, FileDependencyKind,
-            LinkCoreInfo, MakeExecutableInfo, PlanArtifactNeed,
+            ArtifactKey, BuildCStubsInfo, BuildPlan, BuildRuntimeInfo, BuildTargetInfo,
+            FileDependencyKind, LinkCoreInfo, MakeExecutableInfo,
         },
         discover::{DiscoverResult, DiscoveredPackage},
         model::{
@@ -853,11 +853,12 @@ mod tests {
             runtime_object_node,
             FileDependencyKind::AllFiles,
         );
-        plan.test_add_edge(
-            link_core_node,
-            build_core_node,
-            FileDependencyKind::Artifacts(PlanArtifactNeed::CoreIr),
-        );
+        let core_ir = ArtifactKey::CoreIr {
+            package: target.package,
+            target_kind: target.kind,
+        };
+        plan.test_require_artifact(link_core_node, core_ir);
+        plan.test_provide_artifact(build_core_node, core_ir);
         plan.test_add_edge(exe_node, link_core_node, FileDependencyKind::AllFiles);
         plan.test_add_edge(exe_node, runtime_node, FileDependencyKind::AllFiles);
         plan.test_add_edge(exe_node, c_stubs_node, FileDependencyKind::AllFiles);

--- a/crates/moonbuild-rupes-recta/src/build_plan/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/artifact.rs
@@ -16,7 +16,9 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+
+use indexmap::IndexSet;
 
 use crate::model::{BuildPlanNode, PackageId, TargetKind};
 
@@ -26,7 +28,7 @@ use crate::model::{BuildPlanNode, PackageId, TargetKind};
 /// Check, build, and virtual-contract interfaces are distinct because they are
 /// not interchangeable inputs even though all three currently use `.mi` files.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(super) enum ArtifactKey {
+pub enum ArtifactKey {
     CheckMi {
         package: PackageId,
         target_kind: TargetKind,
@@ -44,29 +46,22 @@ pub(super) enum ArtifactKey {
     },
 }
 
-#[derive(Debug, Default)]
-struct Derivation {
-    requirements: HashSet<ArtifactKey>,
-    outputs: HashSet<ArtifactKey>,
-}
-
-/// A normalized form of `artifact -> (requirements, provider)`.
+/// Package artifact providers and the artifact requirements of each derivation.
 ///
-/// Derivations are keyed by the existing high-level [`BuildPlanNode`]. This
-/// lets multiple outputs share one requirement set without introducing a new
-/// positional or arena ID.
+/// The existing high-level [`BuildPlanNode`] identifies a derivation. Multiple
+/// artifacts may name the same provider without introducing a positional or
+/// arena ID.
 #[derive(Debug, Default)]
 pub(super) struct ArtifactPlan {
     providers: HashMap<ArtifactKey, BuildPlanNode>,
-    derivations: HashMap<BuildPlanNode, Derivation>,
+    requirements_by_consumer: HashMap<BuildPlanNode, IndexSet<ArtifactKey>>,
 }
 
 impl ArtifactPlan {
     pub(super) fn require(&mut self, consumer: BuildPlanNode, artifact: ArtifactKey) {
-        self.derivations
+        self.requirements_by_consumer
             .entry(consumer)
             .or_default()
-            .requirements
             .insert(artifact);
     }
 
@@ -79,37 +74,58 @@ impl ArtifactPlan {
         } else {
             self.providers.insert(artifact, provider);
         }
-
-        self.derivations
-            .entry(provider)
-            .or_default()
-            .outputs
-            .insert(artifact);
     }
 
+    #[cfg(test)]
     pub(super) fn provider(&self, artifact: ArtifactKey) -> Option<BuildPlanNode> {
         self.providers.get(&artifact).copied()
     }
 
     pub(super) fn requirements(&self) -> impl Iterator<Item = (BuildPlanNode, ArtifactKey)> + '_ {
-        self.derivations.iter().flat_map(|(&consumer, derivation)| {
-            derivation
-                .requirements
-                .iter()
-                .copied()
-                .map(move |artifact| (consumer, artifact))
-        })
+        self.requirements_by_consumer
+            .iter()
+            .flat_map(|(&consumer, requirements)| {
+                requirements
+                    .iter()
+                    .copied()
+                    .map(move |artifact| (consumer, artifact))
+            })
+    }
+
+    pub(super) fn validate(&self) {
+        for (_, artifact) in self.requirements() {
+            assert!(
+                self.providers.contains_key(&artifact),
+                "required artifact {artifact:?} has no provider in the build plan"
+            );
+        }
+    }
+
+    pub(super) fn dependencies(
+        &self,
+        consumer: BuildPlanNode,
+    ) -> impl Iterator<Item = (BuildPlanNode, ArtifactKey)> + '_ {
+        self.requirements_by_consumer
+            .get(&consumer)
+            .into_iter()
+            .flat_map(|requirements| requirements.iter().copied())
+            .map(|artifact| {
+                let provider = self.providers[&artifact];
+                (provider, artifact)
+            })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use slotmap::SlotMap;
 
     use super::*;
 
     #[test]
-    fn multiple_artifacts_share_one_derivation() {
+    fn multiple_artifacts_can_share_one_provider() {
         let mut packages = SlotMap::<PackageId, ()>::with_key();
         let package = packages.insert(());
         let target = package.build_target(TargetKind::Source);
@@ -129,8 +145,7 @@ mod tests {
 
         assert_eq!(plan.provider(build_mi), Some(provider));
         assert_eq!(plan.provider(core_ir), Some(provider));
-        assert_eq!(plan.derivations.len(), 1);
-        assert_eq!(plan.derivations[&provider].outputs.len(), 2);
+        assert_eq!(plan.providers.len(), 2);
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -25,7 +25,7 @@ use std::{
 
 use crate::{
     ResolveOutput,
-    build_plan::{FileDependencyKind, InputDirective, PlanArtifactNeed},
+    build_plan::{FileDependencyKind, InputDirective},
     model::{BuildPlanNode, BuildTarget, PackageId},
     prebuild::PrebuildOutput,
 };
@@ -69,50 +69,6 @@ pub(super) struct PackageFileSet {
     pub(super) blackbox_files: Vec<PathBuf>,
     pub(super) mbt_md_files: Vec<PathBuf>,
     pub(super) mbtp_files: Vec<PathBuf>,
-}
-
-fn merge_edge_kind(dst: &mut FileDependencyKind, src: FileDependencyKind) {
-    if matches!(src, FileDependencyKind::AllFiles) {
-        *dst = FileDependencyKind::AllFiles;
-        return;
-    }
-
-    match dst {
-        FileDependencyKind::AllFiles => {}
-        FileDependencyKind::Artifacts(dst_need) => {
-            let FileDependencyKind::Artifacts(need) = src else {
-                panic!(
-                    "Cannot merge incompatible edge kinds: {:?} and {:?}",
-                    dst, src
-                );
-            };
-            *dst_need = dst_need.union(need);
-        }
-        FileDependencyKind::ProofArtifacts {
-            mi: dst_mi,
-            mlw: dst_mlw,
-            report: dst_report,
-        } => {
-            let FileDependencyKind::ProofArtifacts { mi, mlw, report } = src else {
-                panic!(
-                    "Cannot merge incompatible edge kinds: {:?} and {:?}",
-                    dst, src
-                );
-            };
-            *dst_mi |= mi;
-            *dst_mlw |= mlw;
-            *dst_report |= report;
-        }
-        FileDependencyKind::GenerateTestInfo { meta: dst_meta } => {
-            let FileDependencyKind::GenerateTestInfo { meta } = src else {
-                panic!(
-                    "Cannot merge incompatible edge kinds: {:?} and {:?}",
-                    dst, src
-                );
-            };
-            *dst_meta |= meta;
-        }
-    }
 }
 
 impl<'a> BuildPlanConstructor<'a> {
@@ -184,36 +140,10 @@ impl<'a> BuildPlanConstructor<'a> {
             }
         }
 
-        self.materialize_artifact_requirements();
+        self.res.artifacts.validate();
         self.warn_moon_cc_overrides();
 
         Ok(())
-    }
-
-    /// Derive action edges from package artifact requirements after every
-    /// provider has been planned and has registered its outputs.
-    fn materialize_artifact_requirements(&mut self) {
-        let requirements = self.res.artifacts.requirements().collect::<Vec<_>>();
-        for (consumer, artifact) in requirements {
-            let provider = self.res.artifacts.provider(artifact).unwrap_or_else(|| {
-                panic!("required artifact {artifact:?} has no provider in the build plan")
-            });
-            let edge = match artifact {
-                ArtifactKey::CheckMi { .. } | ArtifactKey::BuildMi { .. } => {
-                    FileDependencyKind::Artifacts(PlanArtifactNeed::Interface)
-                }
-                ArtifactKey::CoreIr { .. } => {
-                    FileDependencyKind::Artifacts(PlanArtifactNeed::CoreIr)
-                }
-                ArtifactKey::VirtualContractMi { .. } => FileDependencyKind::AllFiles,
-            };
-
-            if let Some(existing) = self.res.graph.edge_weight_mut(consumer, provider) {
-                merge_edge_kind(existing, edge);
-            } else {
-                self.add_edge_spec(consumer, provider, edge);
-            }
-        }
     }
 
     /// Tell the build graph that we need to calculate the graph portion of a
@@ -461,16 +391,6 @@ impl<'a> BuildPlanConstructor<'a> {
     ) {
         // verify edge kind
         match (edge, end) {
-            (FileDependencyKind::Artifacts(need), BuildPlanNode::Check(..)) => {
-                assert!(
-                    need.is_subset_of(PlanArtifactNeed::Interface),
-                    "Check only produces an interface artifact"
-                );
-            }
-            (FileDependencyKind::Artifacts(_), BuildPlanNode::BuildCore(..)) => {}
-            (FileDependencyKind::Artifacts(_), _) => {
-                panic!("logical artifact edges can only point to Check or BuildCore nodes")
-            }
             (
                 FileDependencyKind::ProofArtifacts { .. },
                 BuildPlanNode::EmitProof(..) | BuildPlanNode::Prove(..),
@@ -577,26 +497,5 @@ impl<'a> BuildPlanConstructor<'a> {
             self.warn_if_main_package_uses_blackbox_inputs(pkg, &info.regular_files);
         }
         self.res.build_target_infos.insert(target, info);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::merge_edge_kind;
-    use crate::build_plan::{FileDependencyKind, PlanArtifactNeed};
-
-    #[test]
-    fn merging_logical_artifact_edges_unions_needs() {
-        let mut edge = FileDependencyKind::Artifacts(PlanArtifactNeed::Interface);
-
-        merge_edge_kind(
-            &mut edge,
-            FileDependencyKind::Artifacts(PlanArtifactNeed::CoreIr),
-        );
-
-        assert_eq!(
-            edge,
-            FileDependencyKind::Artifacts(PlanArtifactNeed::InterfaceAndCoreIr)
-        );
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -45,7 +45,7 @@
 //! [cu]: https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/unit.rs
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     ffi::OsStr,
     fmt::Write,
     path::{Path, PathBuf},
@@ -78,29 +78,31 @@ mod artifact;
 mod builders;
 mod constructor;
 
+pub use artifact::ArtifactKey;
 use artifact::ArtifactPlan;
 use constructor::BuildPlanConstructor;
 
-/// A directed graph representation of build dependencies and targets.
+/// A build plan of derivations, artifact requirements, and file dependencies.
 ///
-/// `BuildPlan` maintains a directed graph where nodes represent build
-/// components and edges represent dependencies between them. It also stores
-/// specifications for each build target, mapping targets to their detailed
-/// configuration and requirements.
+/// Derivations are represented by build-plan nodes. Package compilation
+/// dependencies name artifacts and their registered providers; dependencies
+/// that still select files by provider action remain in a directed graph. The
+/// plan also stores the metadata required to lower each derivation.
 #[derive(Default)]
 pub struct BuildPlan {
-    /// The build dependency graph.
+    /// The non-artifact build dependency graph.
     ///
-    /// Each node in this graph represents a step in building, and edges
-    /// represent the dependencies between build steps, pointing **from each
-    /// step to what it depends on**.
+    /// Each node in this graph represents a step in building. Edges represent
+    /// dependencies that still select files by provider action, pointing
+    /// **from each step to what it depends on**. Package compilation artifact
+    /// dependencies live in `artifacts` instead.
     graph: DiGraphMap<BuildPlanNode, FileDependencyKind>,
 
     /// Package compilation artifacts provided and required by derivations.
     ///
     /// The action graph keeps non-migrated dependency kinds. Package `.mi`,
-    /// `.core`, and virtual-contract dependencies are recorded here first and
-    /// materialized into compatible action edges after planning.
+    /// `.core`, and virtual-contract dependencies remain here through action
+    /// planning and are resolved directly by `BuildActionPlan`.
     artifacts: ArtifactPlan,
 
     /// The map of build target to its files and metadata.
@@ -137,54 +139,16 @@ pub struct BuildPlan {
     input_nodes: Vec<BuildPlanNode>,
 }
 
-/// The logical package products needed from a compatibility dependency edge.
+/// Output selector for a dependency that has not migrated to `ArtifactKey`.
 ///
-/// Build-plan builders name `ArtifactKey` values instead. The compatibility
-/// projection converts those Artifact Requirements to this selector, which
-/// `BuildActionPlan` expands for backend lowering.
+/// Package compilation dependencies use `ArtifactKey` instead. Proof and
+/// test-info edges still keep node-specific selectors here; `BuildActionPlan`
+/// translates them into logical build products before backend lowering sees
+/// them.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PlanArtifactNeed {
-    Interface,
-    CoreIr,
-    InterfaceAndCoreIr,
-}
-
-impl PlanArtifactNeed {
-    pub fn is_subset_of(self, other: Self) -> bool {
-        matches!(
-            (self, other),
-            (Self::Interface, Self::Interface)
-                | (Self::CoreIr, Self::CoreIr)
-                | (_, Self::InterfaceAndCoreIr)
-        )
-    }
-
-    pub fn union(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Interface, Self::Interface) => Self::Interface,
-            (Self::CoreIr, Self::CoreIr) => Self::CoreIr,
-            _ => Self::InterfaceAndCoreIr,
-        }
-    }
-}
-
-/// Additional information about a build plan's edge
-///
-/// `Artifacts` is the package-artifact selector shared by `Check` and
-/// `BuildCore`. Proof and test-info edges still keep node-specific selectors
-/// here; `BuildActionPlan` is responsible for translating all edge selectors into
-/// logical build products before backend lowering sees them.
-///
-/// A more generic solution might be involving creating associated types for
-/// each node kind, specifying their output file list and order, and then
-/// use a bitmap or index list to specify which files are being depended on.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum FileDependencyKind {
+pub(crate) enum FileDependencyKind {
     /// Depending on all files available
     AllFiles,
-
-    /// Depending on package products selected from a compatibility action edge.
-    Artifacts(PlanArtifactNeed),
 
     /// Depending on proof artifacts of an `EmitProof`/`Prove` node.
     ProofArtifacts { mi: bool, mlw: bool, report: bool },
@@ -199,12 +163,18 @@ impl BuildPlan {
         &self,
         node: BuildPlanNode,
     ) -> impl Iterator<Item = BuildPlanNode> + '_ {
+        let mut seen = HashSet::new();
         self.graph
             .neighbors_directed(node, petgraph::Direction::Outgoing)
+            .chain(
+                self.artifact_dependencies(node)
+                    .map(|(provider, _)| provider),
+            )
+            .filter(move |dependency| seen.insert(*dependency))
     }
 
-    /// Get the dependencies of a node together with their edge kinds.
-    pub fn dependency_edges(
+    /// Get non-artifact dependencies together with their file selectors.
+    pub(crate) fn file_dependencies(
         &self,
         node: BuildPlanNode,
     ) -> impl Iterator<Item = (BuildPlanNode, FileDependencyKind)> + '_ {
@@ -212,6 +182,13 @@ impl BuildPlan {
         self.graph
             .edges_directed(node, petgraph::Direction::Outgoing)
             .map(move |(_, dep, kind)| (dep, *kind))
+    }
+
+    pub(crate) fn artifact_dependencies(
+        &self,
+        node: BuildPlanNode,
+    ) -> impl Iterator<Item = (BuildPlanNode, ArtifactKey)> + '_ {
+        self.artifacts.dependencies(node)
     }
 
     /// Get build target information for the given target.
@@ -288,6 +265,16 @@ impl BuildPlan {
         kind: FileDependencyKind,
     ) {
         self.graph.add_edge(start, end, kind);
+    }
+
+    pub(crate) fn test_require_artifact(&mut self, consumer: BuildPlanNode, artifact: ArtifactKey) {
+        self.graph.add_node(consumer);
+        self.artifacts.require(consumer, artifact);
+    }
+
+    pub(crate) fn test_provide_artifact(&mut self, provider: BuildPlanNode, artifact: ArtifactKey) {
+        self.graph.add_node(provider);
+        self.artifacts.provide(provider, artifact);
     }
 
     pub(crate) fn test_insert_build_target_info(

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -39,6 +39,7 @@ use moonutil::{
 use crate::{
     ResolveOutput,
     build_action_plan::{BuildAction, BuildProduct},
+    build_plan::ArtifactKey,
     discover::{DiscoverResult, DiscoveredLocalProject},
     model::{BuildTarget, OperatingSystem, PackageId, TargetKind},
     pkg_name::PackageFQN,
@@ -815,12 +816,33 @@ impl ArtifactPathResolver {
     ) -> Vec<PathBuf> {
         Self::assert_product_matches_action(product, action_context);
         match product {
-            BuildProduct::PackageInterface { target } => {
-                self.package_interface_paths(action_context, *target, packages, options)
-            }
-            BuildProduct::PackageCoreIr { target } => {
-                vec![self.core_of_build_target(packages, target, options.target_backend())]
-            }
+            BuildProduct::Artifact(artifact) => match artifact {
+                ArtifactKey::CheckMi {
+                    package,
+                    target_kind,
+                }
+                | ArtifactKey::BuildMi {
+                    package,
+                    target_kind,
+                } => self.package_interface_paths(
+                    action_context,
+                    package.build_target(*target_kind),
+                    packages,
+                    options,
+                ),
+                ArtifactKey::CoreIr {
+                    package,
+                    target_kind,
+                } => vec![self.core_of_build_target(
+                    packages,
+                    &package.build_target(*target_kind),
+                    options.target_backend(),
+                )],
+                ArtifactKey::VirtualContractMi { package } => {
+                    let target = package.build_target(TargetKind::Source);
+                    vec![self.mi_of_build_target(packages, &target, options.target_backend())]
+                }
+            },
             BuildProduct::ProofInterface { target } => match action_context {
                 BuildAction::EmitProof { .. } => {
                     vec![self.target_layout.emit_proof_mi_path(packages, target)]
@@ -948,10 +970,6 @@ impl ArtifactPathResolver {
                 )]
             }
             BuildProduct::DocsDir => vec![self.target_layout.doc_dir()],
-            BuildProduct::VirtualPackageInterface { package } => {
-                let target = package.build_target(TargetKind::Source);
-                vec![self.mi_of_build_target(packages, &target, options.target_backend())]
-            }
             BuildProduct::MoonLexGeneratedSource { package, index } => {
                 let pkg_info = packages.get_package(*package);
                 let mbtlex_file = &pkg_info.mbt_lex_files[*index as usize];
@@ -969,23 +987,31 @@ impl ArtifactPathResolver {
     fn assert_product_matches_action(product: &BuildProduct, action_context: BuildAction<'_>) {
         let matches = match (product, action_context) {
             (
-                BuildProduct::PackageInterface { target },
+                BuildProduct::Artifact(ArtifactKey::CheckMi {
+                    package,
+                    target_kind,
+                }),
                 BuildAction::Check {
                     target: action_target,
                     ..
-                }
-                | BuildAction::BuildCore {
-                    target: action_target,
-                    ..
                 },
-            ) => *target == action_target,
+            ) => *package == action_target.package && *target_kind == action_target.kind,
             (
-                BuildProduct::PackageCoreIr { target },
+                BuildProduct::Artifact(
+                    ArtifactKey::BuildMi {
+                        package,
+                        target_kind,
+                    }
+                    | ArtifactKey::CoreIr {
+                        package,
+                        target_kind,
+                    },
+                ),
                 BuildAction::BuildCore {
                     target: action_target,
                     ..
                 },
-            ) => *target == action_target,
+            ) => *package == action_target.package && *target_kind == action_target.kind,
             (
                 BuildProduct::ProofInterface { target } | BuildProduct::ProofWhyml { target },
                 BuildAction::EmitProof {
@@ -1071,7 +1097,7 @@ impl ArtifactPathResolver {
             ) => *target == action_target,
             (BuildProduct::DocsDir, BuildAction::BuildDocs { .. }) => true,
             (
-                BuildProduct::VirtualPackageInterface { package },
+                BuildProduct::Artifact(ArtifactKey::VirtualContractMi { package }),
                 BuildAction::BuildVirtual {
                     package: action_package,
                 },
@@ -1596,7 +1622,10 @@ mod tests {
 
         assert_eq!(
             resolver.paths_for_product(
-                &BuildProduct::PackageInterface { target },
+                &BuildProduct::Artifact(ArtifactKey::CheckMi {
+                    package,
+                    target_kind: target.kind,
+                }),
                 action_plan.action(action_id),
                 &packages,
                 &modules,
@@ -1620,7 +1649,10 @@ mod tests {
 
         assert_eq!(
             resolver.paths_for_product(
-                &BuildProduct::PackageInterface { target },
+                &BuildProduct::Artifact(ArtifactKey::BuildMi {
+                    package,
+                    target_kind: target.kind,
+                }),
                 BuildAction::BuildCore {
                     target,
                     info: &info,
@@ -1648,7 +1680,10 @@ mod tests {
 
         assert_eq!(
             resolver.paths_for_product(
-                &BuildProduct::PackageInterface { target },
+                &BuildProduct::Artifact(ArtifactKey::CheckMi {
+                    package,
+                    target_kind: target.kind,
+                }),
                 BuildAction::Check {
                     target,
                     info: &info,
@@ -1717,7 +1752,7 @@ mod tests {
         let options = artifact_options(ExecutableArtifact::WasmGC { use_wat: false });
 
         let virtual_contract = resolver.paths_for_product(
-            &BuildProduct::VirtualPackageInterface { package },
+            &BuildProduct::Artifact(ArtifactKey::VirtualContractMi { package }),
             BuildAction::BuildVirtual { package },
             &packages,
             &modules,
@@ -1763,7 +1798,10 @@ mod tests {
         let info = build_target_info();
 
         let _ = resolver.paths_for_product(
-            &BuildProduct::PackageCoreIr { target },
+            &BuildProduct::Artifact(ArtifactKey::CoreIr {
+                package,
+                target_kind: target.kind,
+            }),
             BuildAction::Check {
                 target,
                 info: &info,

--- a/docs/dev/design/global-build-cache.md
+++ b/docs/dev/design/global-build-cache.md
@@ -158,6 +158,11 @@ producer identities. A producer edge contributes the producer digest, logical
 product kind, and concrete paths. Opaque numeric action IDs are only lookup
 keys within one lowering and never enter a persistent identity.
 
+For migrated package compilation outputs, the logical product kind is the
+exact `ArtifactKey` variant. Check MI, Build MI, Core IR, and virtual-contract
+MI therefore remain distinct through canonical action identity even when two
+variants currently resolve to the same physical suffix or path layout.
+
 The identity does not rewrite paths or interpret command text. Structured argv,
 the selected transport command, response-file contents, environment values,
 and every path are hashed exactly as lowering produced them. Moving a source,

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -5,14 +5,15 @@ plan consumed by lowering, and backend graph construction:
 
 ```text
 BuildPlan       = planning IR: derivations, artifact requirements, provider selection
-BuildActionPlan = action-level build plan: action ids, hydrated action data, logical products
+BuildActionPlan = action-level build plan: action ids, hydrated action data, artifacts and legacy outputs
 LoweredAction   = concrete action: realized products, paths, and process command
 n2::Build       = executor representation produced by the n2 adapter
 ```
 
-The important invariant is that `build_lower` consumes `BuildActionPlan` only. It
-does not import or match on planning internals such as `BuildPlanNode`,
-`FileDependencyKind`, or `PlanArtifactNeed`.
+The important invariant is that `build_lower` consumes `BuildActionPlan` only.
+It does not import or match on planning internals such as `BuildPlanNode` or
+`FileDependencyKind`. `ArtifactKey` is the Build Artifact identity carried
+across this seam for migrated outputs, not a planning-internal selector.
 
 ## Backend configuration
 
@@ -44,8 +45,8 @@ by the Native Toolchain and realization they were built for first.
 ## Planning IR
 
 `BuildPlan` owns graph traversal, exact package artifact requirements, provider
-registration, and the derived action graph. The migrated package compilation
-artifacts are:
+registration, and action topology. The migrated package compilation artifacts
+are:
 
 ```rust
 pub enum ArtifactKey {
@@ -66,9 +67,9 @@ use the `.mi` extension.
 
 Builders record Artifact Requirements. The artifact rule schedules the unique
 provider, and the provider registers its outputs when its derivation is fully
-planned. After all providers have been planned, BuildPlan validates each
-requirement and derives the compatible action edges consumed by
-`BuildActionPlan`:
+planned. After all providers have been planned, `BuildPlan` validates every
+requirement. `BuildActionPlan` then resolves requirements directly to their
+provider actions and logical products:
 
 ```rust
 self.require_artifact(
@@ -104,13 +105,11 @@ match run_mode {
 There is no Check-to-Build coalescing. The two derivations provide different
 artifacts and can never substitute for one another.
 
-Every package MI and Core IR dependency is recorded as an Artifact Requirement.
-The compatibility projection is the only build-planning code that constructs
-`FileDependencyKind::Artifacts` edges. Proof, generated-test-info, prebuild,
-C-stub, runtime, and other not-yet-migrated dependencies continue to use other
-`FileDependencyKind` variants. The derived MI/Core edges use the same
-representation after provider resolution so the action-plan and lowering
-interfaces remain unchanged during this migration.
+Every package MI and Core IR dependency remains an Artifact Requirement through
+action planning; there is no compatibility projection to an action edge. Proof,
+generated-test-info, prebuild, C-stub, runtime, and other not-yet-migrated
+dependencies continue to use `FileDependencyKind`. `BuildPlan` combines both
+representations when callers ask for action topology.
 
 ## Build Action Plan
 
@@ -133,12 +132,12 @@ pub enum BuildAction<'a> {
 backends, `MakeExecutable` remains a final-artifact alias over `LinkCore` and is
 a no-op in backend lowering.
 
-Logical outputs are exposed as producer-free `BuildProduct` values:
+Action outputs are exposed through `BuildProduct`. It is an action-level
+envelope, not a second Build Artifact identity:
 
 ```rust
 pub enum BuildProduct {
-    PackageInterface { target: BuildTarget },
-    PackageCoreIr { target: BuildTarget },
+    Artifact(ArtifactKey),
     GeneratedTestDriver { target: BuildTarget },
     CStubObject { package: PackageId, index: u32 },
     Executable { target: BuildTarget },
@@ -149,6 +148,13 @@ pub enum BuildProduct {
     // other logical outputs
 }
 ```
+
+Package compilation outputs use `BuildProduct::Artifact` and retain the exact
+`CheckMi`, `BuildMi`, `CoreIr`, or `VirtualContractMi` key selected during
+planning. In particular, Check MI and Build MI are never collapsed into a
+generic interface product and then recovered from their provider action. The
+remaining variants are outputs whose dependencies have not yet migrated from
+action-coupled file selectors.
 
 `PrebuildOutputPath` is the explicit exception: prebuild outputs are resolved
 when the prebuild command is planned, so the product carries the already
@@ -163,23 +169,23 @@ pub fn output_products(&self, id: BuildActionId) -> Vec<BuildProduct> {
 }
 ```
 
-Dependency edge selectors become `(dependency action, product)` pairs. The
-dependency action is edge context for path resolution; it is not stored inside
-the product:
+Artifact Requirements and remaining file selectors become `(dependency action,
+product)` pairs. The dependency action is context for path resolution; it is
+not part of Build Artifact identity:
 
 ```rust
 pub fn dependency_products(&self, id: BuildActionId) -> Vec<(BuildActionId, BuildProduct)> {
-    self.plan
-        .dependency_edges(self.node(id))
-        .flat_map(|(node, kind)| {
-            let dependency_action = self.id_for_node(node);
-            self.products_for_edge(node, kind)
-                .into_iter()
-                .map(move |product| (dependency_action, product))
-        })
-        .collect()
+    let node = self.node(id);
+    let file_dependencies = self.plan.file_dependencies(node).flat_map(/* ... */);
+    let artifact_dependencies = self.plan.artifact_dependencies(node).map(/* ... */);
+    file_dependencies.chain(artifact_dependencies).collect()
 }
 ```
+
+If one provider supplies multiple required artifacts, each
+`BuildProduct::Artifact` retains its separate key while action topology contains
+the provider only once. This lets Build MI and Core IR share a compiler
+invocation without collapsing their identities.
 
 For example, an archive/link C-stub action no longer scans raw build-plan
 edges in `build_lower`. Its object inputs are exposed by `BuildActionPlan` as
@@ -196,8 +202,10 @@ fingerprint unset and retain stable output paths.
 
 ## Action Lowering and n2 Adaptation
 
-`build_lower` matches on `BuildAction` and resolves `BuildProduct` paths
-through `ArtifactPathResolver`:
+`build_lower` matches on `BuildAction` and resolves `BuildProduct` paths through
+`ArtifactPathResolver`. Migrated products are resolved directly from their
+`ArtifactKey`; the provider action is checked as provider context rather than
+used to reconstruct artifact identity:
 
 ```rust
 let cmd = match self.plan.action(id) {
@@ -269,20 +277,20 @@ consumes the executable product and produces the `.dSYM` bundle.
 
 This keeps responsibilities separate:
 
-- `BuildPlan` owns Artifact Requirements, provider registration, and the derived action graph.
-- `BuildActionPlan` owns the normalized action/product interface between phases.
-- `ArtifactPathResolver` owns logical product to path resolution.
+- `BuildPlan` owns Artifact Requirements, provider registration, and combined action topology.
+- `BuildActionPlan` owns the normalized action/artifact interface between phases.
+- `ArtifactPathResolver` owns artifact and legacy output path resolution.
 - action lowering owns concrete products, external inputs, and commands.
 - the n2 adapter owns n2 graph construction.
 
 ## Standalone script boundary
 
 Standalone `.mbt` and `.mbtx` execution starts from one complete `BuildPlan`.
-Package dependencies use the same edges as ordinary project compilation. After
-the plan is normalized once, an action-level projection retains dependency
-work as `LoweredAction` values and lowers script work into an n2 graph. Moon
-passes the dependency actions through the current n2 adapter before execution,
-producing the same two disjoint n2 graphs as before.
+Package dependencies use the same Artifact Requirements as ordinary project
+compilation. After the plan is normalized once, an action-level projection
+retains dependency work as `LoweredAction` values and lowers script work into
+an n2 graph. Moon passes the dependency actions through the current n2 adapter
+before execution, producing the same two disjoint n2 graphs as before.
 
 For `moon run` standalone inputs, registry package acquisition is separate from
 that build projection. Persistent standalone `.mbt` and `.mbtx` files, inline


### PR DESCRIPTION
## Why

Package artifact requirements were still projected back into action edges before action planning. That compatibility layer duplicated artifact identity as `PlanArtifactNeed` and `FileDependencyKind::Artifacts`, coupled consumers back to provider actions, and collapsed lifecycle-specific interface artifacts into a generic product.

## What changed

- Resolve package artifact requirements directly to provider actions in `BuildActionPlan`.
- Preserve exact `CheckMi`, `BuildMi`, `CoreIr`, and `VirtualContractMi` identities through lowering, path resolution, and canonical action identity.
- Keep multiple artifacts from one provider as separate dependencies while deduplicating the provider in action topology.
- Remove the compatibility projection, its edge-merging logic, and `PlanArtifactNeed`.

## Why this is correct and focused

Each required package artifact still has exactly one registered provider within its backend-specific Build Plan. The provider action is used only as execution and path-resolution context; it no longer reconstructs artifact identity. Non-migrated proof, generated-test-info, prebuild, C-stub, and runtime dependencies retain their existing file-selector path, keeping this refactor limited to package compilation artifacts.
