### PR TITLE
fix(moonrun): free realpath with owning malloc zone

### DIFF
--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -824,6 +824,18 @@ fn realpath_native_path(path: OsString) -> AsyncHostResult<Box<[u8]>> {
         .to_bytes_with_nul()
         .to_vec()
         .into_boxed_slice();
+    #[cfg(target_os = "macos")]
+    unsafe {
+        unsafe extern "C" {
+            fn malloc_zone_from_ptr(ptr: *const std::ffi::c_void) -> *mut std::ffi::c_void;
+            fn malloc_zone_free(zone: *mut std::ffi::c_void, ptr: *mut std::ffi::c_void);
+        }
+
+        // realpath may allocate from a non-default malloc zone on macOS.
+        let zone = malloc_zone_from_ptr(resolved.cast());
+        malloc_zone_free(zone, resolved.cast());
+    }
+    #[cfg(not(target_os = "macos"))]
     unsafe {
         libc::free(resolved.cast());
     }


### PR DESCRIPTION
On macOS, `realpath(path, NULL)` may return memory allocated from a non-default malloc zone. Releasing that pointer through the default `free` path can cross allocator boundaries.

This backports moonbitlang/async#530 by resolving the owning zone with `malloc_zone_from_ptr` and releasing the result with `malloc_zone_free`. Other platforms continue to use `libc::free`.

The change is intentionally limited to the `realpath` result cleanup path; it does not include the async submodule bump, provenance updates, or unrelated runtime ports.