### PR TITLE
refactor: remove aggregate binary resolution

### DIFF
--- a/crates/moon/tests/support/util.rs
+++ b/crates/moon/tests/support/util.rs
@@ -156,17 +156,6 @@ pub(crate) fn toolchain_root_for_tests() -> PathBuf {
 
 pub(crate) fn replace_dir(s: &str, dir: impl AsRef<std::path::Path>) -> String {
     let s = s.replace("\\\\", "\\");
-    let s = moonutil::toolchain::BINARIES.all_moon_bins().iter().fold(
-        s.to_string(),
-        |s, (name, path)| {
-            let path = match *name {
-                #[allow(deprecated)]
-                "moon" | "moonrun" => snapbox::cmd::cargo_bin(name),
-                _ => path.clone(),
-            };
-            s.replace(path.to_string_lossy().as_ref(), name)
-        },
-    );
     let s = if let Some(path) = MOONRUN_BIN.get() {
         let path = path.to_string_lossy();
         let s = s.replace(path.as_ref(), "moonrun");

--- a/crates/moonutil/src/binaries.rs
+++ b/crates/moonutil/src/binaries.rs
@@ -163,6 +163,12 @@ fn get_fallback_binary(name: &str) -> PathBuf {
     ensure_exe_extension(PathBuf::from(name))
 }
 
+/// Lazily resolved programs used by Moon commands.
+///
+/// Entries are intentionally independent and demand-driven. Never add an
+/// aggregate API that enumerates this cache: touching every `LazyLock` would
+/// resolve the complete executable inventory and could make display,
+/// diagnostics, or tests fail because an unused program is unavailable.
 pub struct CachedBinaries {
     pub moonbuild: LazyLock<PathBuf>,
     pub moonc: LazyLock<PathBuf>,
@@ -182,23 +188,6 @@ pub struct CachedBinaries {
 }
 
 impl CachedBinaries {
-    pub fn all_moon_bins(&self) -> Vec<(&str, PathBuf)> {
-        vec![
-            ("moon", self.moonbuild.clone()),
-            ("moonc", self.moonc.clone()),
-            ("mooncake", self.mooncake.clone()),
-            ("moondoc", self.moondoc.clone()),
-            ("moonfmt", self.moonfmt.clone()),
-            ("mooninfo", self.mooninfo.clone()),
-            ("moonlex", self.moonlex.clone()),
-            ("moonrun", self.moonrun.clone()),
-            ("moonyacc", self.moonyacc.clone()),
-            ("moon_cove_report", self.moon_cove_report.clone()),
-            ("node", self.node_or_default()),
-            ("git", self.git_or_default()),
-        ]
-    }
-
     pub fn node_or_default(&self) -> PathBuf {
         self.node
             .clone()

--- a/docs/dev/reference/binaries.md
+++ b/docs/dev/reference/binaries.md
@@ -27,3 +27,8 @@ executable lookup.
 
 The cached entry point is `moonutil::toolchain::BINARIES`. Build engines should
 use it instead of duplicating tool lookup rules.
+
+Binary resolution is demand-driven. The cache must not expose an aggregate
+inventory API: code for display, diagnostics, or tests must never enumerate all
+entries or otherwise force resolution of the complete executable inventory.
+An unavailable unused executable must not make an operation fail.


### PR DESCRIPTION
## Why

`CachedBinaries::all_moon_bins` initialized every cached program when generic test output normalization ran. That coupled display-only cleanup to the availability and resolution of unrelated executables.

## What changed

- Remove the aggregate binary inventory API and its only caller.
- Keep the existing targeted test-output normalization for known paths and programs.
- Document that binary resolution is demand-driven and that callers must not force the complete executable inventory.

## Scope

This does not change runtime binary lookup rules or introduce new output aliases. It is a focused follow-up to #2013 that removes the eager-resolution escape hatch.
