### PR TITLE
feat(moonrun): port async generic stat ABI

### DIFF
--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -828,7 +828,7 @@ fn test_async_wasm_upstream_fs_package() {
     check(
         run_upstream_async_wasm_package("moonbitlang/async/fs"),
         expect![[r#"
-        Total tests: 31, passed: 31, failed: 0.
+        Total tests: 39, passed: 39, failed: 0.
         "#]],
     );
 }
@@ -888,7 +888,7 @@ fn test_async_wasm_upstream_process_package() {
     check(
         run_upstream_async_wasm_package("moonbitlang/async/process"),
         expect![[r#"
-            Total tests: 4, passed: 4, failed: 0.
+            Total tests: 31, passed: 31, failed: 0.
         "#]],
     );
 }

--- a/crates/moonrun/docs/adr/0011-use-a-stable-host-owned-generic-stat-result.md
+++ b/crates/moonrun/docs/adr/0011-use-a-stable-host-owned-generic-stat-result.md
@@ -8,6 +8,11 @@ never retain the guest destination supplied to `make_open_job`,
 through `thread_pool/get_stat_result`, following the same completion ownership
 rule as read jobs.
 
+Open jobs use one completion shape: an `OpenJobResource` plus the host-owned
+`PackedStat`. The pre-527 open adapter requests the fixed identity mask and
+serves its legacy getters from that packed result; it does not maintain a
+second set of kind, device, and file-id fields.
+
 The packed format is stable for a given request: an eight-byte little-endian
 header contains the result length and returned-property mask, followed by fixed
 slots in property-bit order. Unsupported properties keep their slots zeroed

--- a/crates/moonrun/docs/adr/0011-use-a-stable-host-owned-generic-stat-result.md
+++ b/crates/moonrun/docs/adr/0011-use-a-stable-host-owned-generic-stat-result.md
@@ -3,10 +3,16 @@
 Moonrun ports the generic filesystem metadata ABI introduced by
 `moonbitlang/async` PR 527 through one `StatRequest`/`StatValues`/`PackedStat`
 module. Jobs retain the request and produce a host-owned packed result; they
-never retain the guest destination supplied to `make_open_job`,
-`make_fstatx_job`, or `make_statx_job`. The guest copies a completed result
-through `thread_pool/get_stat_result`, following the same completion ownership
-rule as read jobs.
+do not receive a guest destination through `make_open_stat_job`,
+`make_fstatx_job`, or `make_statx_job`. The guest supplies current Guest Memory
+only when copying a completed result through `thread_pool/get_stat_result`,
+following the same completion ownership rule as read jobs.
+
+The pre-527 seven-argument `thread_pool/make_open_job` import keeps its original
+name and signature. Generic open metadata uses the distinct
+`thread_pool/make_open_stat_job` import. Do not multiplex both signatures under
+one import name: a new guest must fail linking against an old runtime before an
+open operation can produce filesystem side effects.
 
 Open jobs use one completion shape: an `OpenJobResource` plus the host-owned
 `PackedStat`. The pre-527 open adapter requests the fixed identity mask and

--- a/crates/moonrun/docs/adr/0011-use-a-stable-host-owned-generic-stat-result.md
+++ b/crates/moonrun/docs/adr/0011-use-a-stable-host-owned-generic-stat-result.md
@@ -1,0 +1,33 @@
+# Use a Stable Host-Owned Generic Stat Result
+
+Moonrun ports the generic filesystem metadata ABI introduced by
+`moonbitlang/async` PR 527 through one `StatRequest`/`StatValues`/`PackedStat`
+module. Jobs retain the request and produce a host-owned packed result; they
+never retain the guest destination supplied to `make_open_job`,
+`make_fstatx_job`, or `make_statx_job`. The guest copies a completed result
+through `thread_pool/get_stat_result`, following the same completion ownership
+rule as read jobs.
+
+The packed format is stable for a given request: an eight-byte little-endian
+header contains the result length and returned-property mask, followed by fixed
+slots in property-bit order. Unsupported properties keep their slots zeroed
+and are omitted from the returned mask. Unknown request bits and undersized
+buffers produce a failed Job before filesystem side effects.
+
+Platform adapters return typed `StatValues`; only the shared codec writes the
+ABI representation. Linux uses `statx` directly, macOS uses the selective
+`getattrlist` family with the native non-vnode fallback, and Windows performs
+selective handle queries. Windows timestamps are converted from FILETIME's
+1601 epoch to the Unix epoch required by the cross-platform contract.
+
+Metadata access remains subject to the runtime filesystem policy. Handle
+queries require metadata-read authority for the acquired Resource, and path
+queries use the parent Resource as their policy base. Open jobs continue to use
+the open policy for the identity mask (kind, device id, and file id); requesting
+additional metadata also requires metadata-read authority.
+
+The pre-527 imports remain available for older wasm guests, but their
+implementations use `#[compat]` provenance that names PR 527 and the generic
+replacement. They must not be relabeled as `#[ported]`, because their original
+upstream symbols no longer exist. The current generic imports use exact
+`#[ported]` provenance.

--- a/crates/moonrun/docs/adr/0011-use-a-stable-host-owned-generic-stat-result.md
+++ b/crates/moonrun/docs/adr/0011-use-a-stable-host-owned-generic-stat-result.md
@@ -31,6 +31,16 @@ ABI representation. Linux uses `statx` directly, macOS uses the selective
 selective handle queries. Windows timestamps are converted from FILETIME's
 1601 epoch to the Unix epoch required by the cross-platform contract.
 
+Within those ownership and codec boundaries, keep syscall selection,
+returned-property masks, and error behavior aligned with upstream
+`moonbit_generic_stat`. Host-specific deviations must stay narrow and tested:
+Moonrun resolves Windows parent-relative paths, returns every requested field
+available from macOS's non-vnode `fstat` fallback, and recognizes Winsock
+sockets before propagating `GetFileType` errors. Native-runtime correctness
+gaps found while preserving this parity are tracked in
+[`moonbitlang/async#442`](https://github.com/moonbitlang/async/issues/442)
+instead of becoming undocumented wasm-only behavior.
+
 Metadata access remains subject to the runtime filesystem policy. Handle
 queries require metadata-read authority for the acquired Resource, and path
 queries use the parent Resource as their policy base. Open jobs continue to use

--- a/crates/moonrun/docs/dev/README.md
+++ b/crates/moonrun/docs/dev/README.md
@@ -1,5 +1,11 @@
 # Contributing Quick Start
 
+## Developer workflows
+
+- [Porting `moonbitlang/async` changes](async-upstream-porting.md): audit the
+  runtime-port label queue, preserve exact provenance, deliver one upstream
+  port at a time, and update completed labels after the Moon change lands.
+
 ## How to Build and Test
 
 ```bash

--- a/crates/moonrun/docs/dev/async-upstream-porting.md
+++ b/crates/moonrun/docs/dev/async-upstream-porting.md
@@ -49,15 +49,20 @@ behavior accurate; it is not evidence that the port is complete by itself.
 
 ## Provenance annotations
 
-`#[ported]` records the exact upstream source path and native symbol tracked by
-an implementation. `#[compat]` records a retained ABI whose upstream symbol was
-removed or replaced, including the upstream PR and its replacement.
+`#[ported]` records the exact upstream source path and symbol tracked by an
+implementation. `#[compat]` records a retained ABI whose upstream implementation
+or import was removed or replaced, including the upstream PR and its
+replacement. It describes the provenance of the adapter, not whether the
+currently pinned wasm wrapper still calls it during a staged migration.
 
 - If a symbol only moved to another file, update `source` after confirming that
   its signature and behavior did not change.
 - If a symbol was removed, replaced, or generalized, do not point `original`
   at a surviving successor merely to satisfy the provenance test. Preserve it
   as `#[compat]` when older wasm guests still need the ABI.
+- If a removed import intentionally does no work because ownership has already
+  transferred, record it as a no-op `#[compat]` adapter instead of a generic
+  helper.
 - For a replacement, audit the new ABI, ownership, errors, platform behavior,
   and observable MoonBit API semantics. Add the new `#[ported]` implementation
   separately from the compatibility adapter.

--- a/crates/moonrun/docs/dev/async-upstream-porting.md
+++ b/crates/moonrun/docs/dev/async-upstream-porting.md
@@ -70,6 +70,24 @@ currently pinned wasm wrapper still calls it during a staged migration.
 The annotations must continue to expose unported upstream work. A passing
 substring check is not proof that two symbols are equivalent.
 
+## Wasm ABI discipline
+
+Treat every wasm import as an exact typed interface. The current V8 adapter
+uses JavaScript callbacks internally, but imports must also link correctly in a
+runtime such as Wasmtime that validates the complete function type.
+
+- Do not multiplex multiple arities under one import name.
+- Do not rely on missing arguments, ignored extra arguments, or JavaScript
+  value coercion.
+- Declare every field produced by MoonBit aggregate lowering. If a field is
+  constrained by the operation, validate the constraint instead of silently
+  discarding the field.
+- When an operation needs a new signature, add a distinct import and retain the
+  old import as `#[compat]` while older wasm guests remain supported.
+- Record and test the exact parameter and result types of the old and new
+  imports. Compatibility must be decided at link time, before a mismatched call
+  can produce host side effects.
+
 ## Verification
 
 Add regression coverage for behavior that upstream tests restrict to native

--- a/crates/moonrun/docs/dev/async-upstream-porting.md
+++ b/crates/moonrun/docs/dev/async-upstream-porting.md
@@ -1,0 +1,73 @@
+# Porting `moonbitlang/async` changes
+
+Moonrun implements the wasm host side of `moonbitlang/async`. Upstream changes
+must be audited against the Native-Shaped Async Boundary instead of being
+accepted by updating the submodule and making provenance checks pass.
+
+## Port queue
+
+Use the upstream
+[`wasm-runtime-port-required`](https://github.com/moonbitlang/async/issues?q=state%3Aopen%20label%3Awasm-runtime-port-required)
+label as the incoming queue. Do not use mentions as a substitute for the
+label. Also search merged and closed pull requests carrying the label: GitHub
+allows a merged pull request to retain it, so the open queue is not a complete
+audit history.
+
+The workflow labels mean:
+
+- `wasm-runtime-port-required`: runtime work or investigation is still needed.
+- `wasm-runtime-port-completed`: the behavior is available on Moon's `main`, or
+  an audit proved that Moon already implements it and no change is necessary.
+
+A partial port, local branch, or open Moon pull request remains
+`wasm-runtime-port-required`. After the corresponding change lands on Moon's
+`main`, replace that label on the upstream pull request with
+`wasm-runtime-port-completed`. If any guest or runtime work remains, keep the
+required label and record the gap in the Moon pull request.
+
+## Separate discovery from delivery
+
+Audit an upstream update before preparing the commits that will deliver it:
+
+1. Start from the latest Moon `main` and temporarily update
+   `third_party/moonbitlang_async` to async's latest `main`.
+2. Inspect the complete upstream commit range and every pull request carrying
+   `wasm-runtime-port-required`.
+3. Run the provenance checks before changing annotations. A missing source or
+   symbol is an audit signal, not a formatting failure.
+4. Compare the native C implementation together with its MoonBit wrapper to
+   Moonrun's Async API, Async Host, and Async Sys behavior.
+5. Classify each change as an exact move, an already-matching behavior change,
+   or a required port. Do not commit the audit bump while it has unresolved
+   provenance or behavior changes.
+
+Deliver required ports one upstream pull request at a time. Restore the pinned
+submodule when necessary, implement the behavior and regression coverage in a
+focused change, and keep that change independently buildable and testable. A
+submodule bump belongs with the port that makes its affected provenance and
+behavior accurate; it is not evidence that the port is complete by itself.
+
+## Provenance annotations
+
+`#[ported]` records the exact upstream source path and native symbol tracked by
+an implementation. `#[compat]` records a retained ABI whose upstream symbol was
+removed or replaced, including the upstream PR and its replacement.
+
+- If a symbol only moved to another file, update `source` after confirming that
+  its signature and behavior did not change.
+- If a symbol was removed, replaced, or generalized, do not point `original`
+  at a surviving successor merely to satisfy the provenance test. Preserve it
+  as `#[compat]` when older wasm guests still need the ABI.
+- For a replacement, audit the new ABI, ownership, errors, platform behavior,
+  and observable MoonBit API semantics. Add the new `#[ported]` implementation
+  separately from the compatibility adapter.
+
+The annotations must continue to expose unported upstream work. A passing
+substring check is not proof that two symbols are equivalent.
+
+## Verification
+
+Add regression coverage for behavior that upstream tests restrict to native
+targets. Run the Moonrun test and lint checks, then run the synced async wasm
+test suite against the built Moonrun when guest-visible behavior or the async
+boundary changed.

--- a/crates/moonrun/src/async_api/fd_util.rs
+++ b/crates/moonrun/src/async_api/fd_util.rs
@@ -34,9 +34,11 @@ pub(super) fn invalid_fd(context: &mut ImportContext<'_, '_>) -> u64 {
     context.host.invalid_fd()
 }
 
-#[ported(
+#[compat(
     source = "src/internal/event_loop/detect_file_kind.c",
-    original = "moonbitlang_async_kind_of_fd"
+    original = "moonbitlang_async_kind_of_fd",
+    upstream_pr = 527,
+    replacement = "thread_pool/make_fstatx_job with STAT_FILE_KIND"
 )]
 pub(super) fn kind_of_fd(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
     match context.host.kind_of_fd(fd) {

--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -108,13 +108,25 @@ pub(super) fn allocate_env_block(
     Ok(context.host.insert_process_env(vec![0; size]))
 }
 
-// Deprecated. We'll remove it later.
+#[compat(
+    source = "src/process/wasm.mbt",
+    original = "process/free_env",
+    upstream_pr = 511,
+    replacement = "spawn ownership transfer",
+    no_op = true
+)]
 pub(super) fn free_env(_context: &mut ImportContext<'_, '_>, _env: u64) -> AsyncHostResult<()> {
     Ok(())
 }
 
+#[compat(
+    source = "src/process/wasm.mbt",
+    original = "process/free_argv",
+    upstream_pr = 511,
+    replacement = "spawn ownership transfer",
+    no_op = true
+)]
 #[cfg(unix)]
-// Deprecated. We'll remove it later.
 pub(super) fn free_argv(_context: &mut ImportContext<'_, '_>, _argv: u64) -> AsyncHostResult<()> {
     Ok(())
 }

--- a/crates/moonrun/src/async_api/provenance.rs
+++ b/crates/moonrun/src/async_api/provenance.rs
@@ -44,10 +44,11 @@ pub(crate) struct PortedImport {
 pub(crate) struct CompatImport {
     pub(crate) rust_module: &'static str,
     pub(crate) rust_symbol: &'static str,
-    pub(crate) native_symbol: &'static str,
+    pub(crate) original_symbol: &'static str,
     pub(crate) historical_source: &'static str,
     pub(crate) upstream_pr: u32,
     pub(crate) replacement: &'static str,
+    pub(crate) no_op: bool,
 }
 
 macro_rules! ported_imports {
@@ -193,6 +194,39 @@ macro_rules! ported_imports {
             source = $source:literal,
             original = $original:literal,
             upstream_pr = $upstream_pr:literal,
+            replacement = $replacement:literal,
+            no_op = true
+        )]
+        $(#[$meta:meta])*
+        $vis:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+        $($rest:tt)*
+    ) => {
+        ported_imports!(
+            @collect [$($entries)*] [
+                $($compat_entries)*
+                $crate::async_api::provenance::CompatImport {
+                    rust_module: module_path!(),
+                    rust_symbol: stringify!($name),
+                    original_symbol: $original,
+                    historical_source: $source,
+                    upstream_pr: $upstream_pr,
+                    replacement: $replacement,
+                    no_op: true,
+                },
+            ] [
+                $($out)*
+                $(#[$meta])*
+                $vis fn $name($($args)*) $(-> $ret)? $body
+            ]
+            $($rest)*
+        );
+    };
+    (
+        @collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]
+        #[compat(
+            source = $source:literal,
+            original = $original:literal,
+            upstream_pr = $upstream_pr:literal,
             replacement = $replacement:literal
         )]
         $(#[$meta:meta])*
@@ -205,10 +239,11 @@ macro_rules! ported_imports {
                 $crate::async_api::provenance::CompatImport {
                     rust_module: module_path!(),
                     rust_symbol: stringify!($name),
-                    native_symbol: $original,
+                    original_symbol: $original,
                     historical_source: $source,
                     upstream_pr: $upstream_pr,
                     replacement: $replacement,
+                    no_op: false,
                 },
             ] [
                 $($out)*

--- a/crates/moonrun/src/async_api/provenance.rs
+++ b/crates/moonrun/src/async_api/provenance.rs
@@ -17,6 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 #[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceRoot {
     MoonbitAsync,
@@ -38,17 +39,34 @@ pub(crate) struct PortedImport {
     pub(crate) sources: &'static [SourceLocation],
 }
 
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompatImport {
+    pub(crate) rust_module: &'static str,
+    pub(crate) rust_symbol: &'static str,
+    pub(crate) native_symbol: &'static str,
+    pub(crate) historical_source: &'static str,
+    pub(crate) upstream_pr: u32,
+    pub(crate) replacement: &'static str,
+}
+
 macro_rules! ported_imports {
-    (@collect [$($entries:tt)*] [$($out:tt)*]) => {
+    (@collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]) => {
         #[cfg(test)]
         pub(super) const PORTED_IMPORTS: &[$crate::async_api::provenance::PortedImport] = &[
             $($entries)*
         ];
 
+        #[cfg(test)]
+        #[allow(dead_code)]
+        pub(super) const COMPAT_IMPORTS: &[$crate::async_api::provenance::CompatImport] = &[
+            $($compat_entries)*
+        ];
+
         $($out)*
     };
     (
-        @collect [$($entries:tt)*] [$($out:tt)*]
+        @collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]
         #[ported(source = $source_path:literal, original = $original:literal)]
         #[cfg($($cfg:tt)*)]
         $(#[$meta:meta])*
@@ -70,7 +88,7 @@ macro_rules! ported_imports {
                         },
                     ],
                 },
-            ] [
+            ] [$($compat_entries)*] [
                 $($out)*
                 #[cfg($($cfg)*)]
                 $(#[$meta])*
@@ -80,7 +98,7 @@ macro_rules! ported_imports {
         );
     };
     (
-        @collect [$($entries:tt)*] [$($out:tt)*]
+        @collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]
         #[ported(source = $source_path:literal, original = $original:literal)]
         $(#[$meta:meta])*
         $vis:vis fn $function:ident($($params:tt)*) $(-> $ret:ty)? $body:block
@@ -100,7 +118,7 @@ macro_rules! ported_imports {
                         },
                     ],
                 },
-            ] [
+            ] [$($compat_entries)*] [
                 $($out)*
                 $(#[$meta])*
                 $vis fn $function($($params)*) $(-> $ret)? $body
@@ -109,7 +127,7 @@ macro_rules! ported_imports {
         );
     };
     (
-        @collect [$($entries:tt)*] [$($out:tt)*]
+        @collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]
         #[ported(source = $source_path:literal)]
         #[cfg($($cfg:tt)*)]
         $(#[$meta:meta])*
@@ -131,7 +149,7 @@ macro_rules! ported_imports {
                         },
                     ],
                 },
-            ] [
+            ] [$($compat_entries)*] [
                 $($out)*
                 #[cfg($($cfg)*)]
                 $(#[$meta])*
@@ -141,7 +159,7 @@ macro_rules! ported_imports {
         );
     };
     (
-        @collect [$($entries:tt)*] [$($out:tt)*]
+        @collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]
         #[ported(source = $source_path:literal)]
         $(#[$meta:meta])*
         $vis:vis fn $function:ident($($params:tt)*) $(-> $ret:ty)? $body:block
@@ -161,7 +179,7 @@ macro_rules! ported_imports {
                         },
                     ],
                 },
-            ] [
+            ] [$($compat_entries)*] [
                 $($out)*
                 $(#[$meta])*
                 $vis fn $function($($params)*) $(-> $ret)? $body
@@ -169,11 +187,42 @@ macro_rules! ported_imports {
             $($rest)*
         );
     };
-    (@collect [$($entries:tt)*] [$($out:tt)*] $item:item $($rest:tt)*) => {
-        ported_imports!(@collect [$($entries)*] [$($out)* $item] $($rest)*);
+    (
+        @collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]
+        #[compat(
+            source = $source:literal,
+            original = $original:literal,
+            upstream_pr = $upstream_pr:literal,
+            replacement = $replacement:literal
+        )]
+        $(#[$meta:meta])*
+        $vis:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+        $($rest:tt)*
+    ) => {
+        ported_imports!(
+            @collect [$($entries)*] [
+                $($compat_entries)*
+                $crate::async_api::provenance::CompatImport {
+                    rust_module: module_path!(),
+                    rust_symbol: stringify!($name),
+                    native_symbol: $original,
+                    historical_source: $source,
+                    upstream_pr: $upstream_pr,
+                    replacement: $replacement,
+                },
+            ] [
+                $($out)*
+                $(#[$meta])*
+                $vis fn $name($($args)*) $(-> $ret)? $body
+            ]
+            $($rest)*
+        );
+    };
+    (@collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*] $item:item $($rest:tt)*) => {
+        ported_imports!(@collect [$($entries)*] [$($compat_entries)*] [$($out)* $item] $($rest)*);
     };
     ($($items:tt)*) => {
-        ported_imports!(@collect [] [] $($items)*);
+        ported_imports!(@collect [] [] [] $($items)*);
     };
 }
 

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -37,6 +37,7 @@ const NATIVE_ASYNC_PREFIX: &str = "moonbitlang_async_";
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AsyncImportKind {
     Ported,
+    Compat,
     Helper,
     Fake,
 }
@@ -61,6 +62,12 @@ struct AsyncImport {
 
 #[cfg(test)]
 macro_rules! import_kind {
+    (compat) => {
+        AsyncImportKind::Compat
+    };
+    (compat_open) => {
+        AsyncImportKind::Ported
+    };
     (ported) => {
         AsyncImportKind::Ported
     };
@@ -183,6 +190,90 @@ macro_rules! declare_async_imports {
 }
 
 macro_rules! register_async_import {
+    (
+        compat_open,
+        $obj:ident,
+        $scope:ident,
+        $context_ptr:ident,
+        $wasm_symbol:literal,
+        u64,
+        thread_pool::make_open_job,
+        ($($arg:ident : $arg_ty:ident),* $(,)?)
+    ) => {{
+        fn callback(
+            scope: &mut v8::HandleScope,
+            args: v8::FunctionCallbackArguments,
+            mut ret: v8::ReturnValue,
+        ) {
+            let host_context = callback_context(&args);
+            if args.length() == 7 {
+                let decoded_args = decode_wasm_args!(
+                    scope,
+                    args,
+                    path_ptr: i32,
+                    path_len: i32,
+                    access: i32,
+                    create_mode: i32,
+                    append: i32,
+                    sync: i32,
+                    mode: i32,
+                );
+                match decoded_args {
+                    Ok((path_ptr, path_len, access, create_mode, append, sync, mode)) => {
+                        let result = {
+                            let mut context = ImportContext::new(scope, host_context);
+                            thread_pool::make_open_job_legacy(
+                                &mut context,
+                                path_ptr,
+                                path_len,
+                                access,
+                                create_mode,
+                                append,
+                                sync,
+                                mode,
+                            )
+                        };
+                        finish_wasm_import!(
+                            scope,
+                            ret,
+                            $wasm_symbol,
+                            u64,
+                            result
+                        );
+                    }
+                    Err(error) => {
+                        throw_import_error(scope, $wasm_symbol, error)
+                    }
+                }
+                return;
+            }
+
+            let decoded_args = decode_wasm_args!(scope, args, $($arg : $arg_ty),*);
+            match decoded_args {
+                Ok(($($arg,)*)) => {
+                    let result = {
+                        let mut context = ImportContext::new(scope, host_context);
+                        thread_pool::make_open_job(&mut context, $($arg),*)
+                    };
+                    finish_wasm_import!(
+                        scope,
+                        ret,
+                        $wasm_symbol,
+                        u64,
+                        result
+                    );
+                }
+                Err(error) => throw_import_error(scope, $wasm_symbol, error),
+            }
+        }
+        register_func_impl(
+            $obj,
+            $scope,
+            $wasm_symbol,
+            callback,
+            $context_ptr,
+        );
+    }};
     (
         fake,
         $obj:ident,
@@ -420,7 +511,7 @@ declare_async_imports! {
     #[cfg(unix)]
     fake signal::set_console_control_handler(add: i32) -> i32 => "signal/set_console_control_handler";
 
-    ported fd_util::kind_of_fd(fd: u64) -> i32 => "fd_util/kind_of_fd";
+    compat fd_util::kind_of_fd(fd: u64) -> i32 => "fd_util/kind_of_fd";
 
     #[cfg(unix)]
     ported fd_util::pipe(
@@ -918,7 +1009,7 @@ declare_async_imports! {
 
     // thread_pool.c FS jobs. Path-taking jobs use the Guest String Path ABI:
     // MoonBit String pointer plus UTF-16 code-unit length.
-    ported thread_pool::make_open_job(
+    compat_open thread_pool::make_open_job(
         path_ptr: i32,
         path_len: i32,
         access: i32,
@@ -926,15 +1017,37 @@ declare_async_imports! {
         append: i32,
         sync: i32,
         mode: i32,
+        stat_request: i32,
+        stat_result: i32,
+        stat_result_len: i32,
     ) -> u64 => "thread_pool/make_open_job";
+
+    ported thread_pool::make_fstatx_job(
+        fd: u64,
+        stat_request: i32,
+        stat_result: i32,
+        stat_result_len: i32,
+    ) -> u64 => "thread_pool/make_fstatx_job";
+
+    ported thread_pool::make_statx_job(
+        path_ptr: i32,
+        path_len: i32,
+        stat_request: i32,
+        stat_result: i32,
+        stat_result_len: i32,
+        parent: u64,
+        follow_symlink: i32,
+    ) -> u64 => "thread_pool/make_statx_job";
+
+    helper thread_pool::get_stat_result(job: u64, dst: i32, dst_len: i32) -> void => "thread_pool/get_stat_result";
 
     ported thread_pool::open_job_get_fd(job: u64) -> u64 => "thread_pool/open_job_get_fd";
 
-    ported thread_pool::open_job_get_kind(job: u64) -> i32 => "thread_pool/open_job_get_kind";
+    compat thread_pool::open_job_get_kind(job: u64) -> i32 => "thread_pool/open_job_get_kind";
 
-    ported thread_pool::open_job_get_dev_id(job: u64) -> u64 => "thread_pool/open_job_get_dev_id";
+    compat thread_pool::open_job_get_dev_id(job: u64) -> u64 => "thread_pool/open_job_get_dev_id";
 
-    ported thread_pool::open_job_get_file_id(job: u64) -> u64 => "thread_pool/open_job_get_file_id";
+    compat thread_pool::open_job_get_file_id(job: u64) -> u64 => "thread_pool/open_job_get_file_id";
 
     ported thread_pool::make_read_job(fd: u64, len: i32, position: i64) -> u64 => "thread_pool/make_read_job";
 
@@ -942,20 +1055,20 @@ declare_async_imports! {
 
     helper thread_pool::get_read_result(job: u64, dst: i32, offset: i32, len: i32) -> void => "thread_pool/get_read_result";
 
-    ported thread_pool::make_file_kind_by_path_job(
+    compat thread_pool::make_file_kind_by_path_job(
         parent: u64,
         path_ptr: i32,
         path_len: i32,
         follow_symlink: i32,
     ) -> u64 => "thread_pool/make_file_kind_by_path_job";
 
-    ported thread_pool::make_file_size_job(fd: u64) -> u64 => "thread_pool/make_file_size_job";
+    compat thread_pool::make_file_size_job(fd: u64) -> u64 => "thread_pool/make_file_size_job";
 
-    ported thread_pool::get_file_size_result(job: u64) -> i64 => "thread_pool/get_file_size_result";
+    compat thread_pool::get_file_size_result(job: u64) -> i64 => "thread_pool/get_file_size_result";
 
-    ported thread_pool::make_file_time_job(fd: u64) -> u64 => "thread_pool/make_file_time_job";
+    compat thread_pool::make_file_time_job(fd: u64) -> u64 => "thread_pool/make_file_time_job";
 
-    ported thread_pool::make_file_time_by_path_job(
+    compat thread_pool::make_file_time_by_path_job(
         path_ptr: i32,
         path_len: i32,
         follow_symlink: i32,
@@ -1167,6 +1280,14 @@ fn async_api_ported_imports() -> Vec<PortedImport> {
 }
 
 #[cfg(test)]
+fn async_api_compat_imports() -> Vec<super::provenance::CompatImport> {
+    let mut imports = Vec::new();
+    imports.extend_from_slice(thread_pool::COMPAT_IMPORTS);
+    imports.extend_from_slice(fd_util::COMPAT_IMPORTS);
+    imports
+}
+
+#[cfg(test)]
 mod tests {
     use std::{collections::BTreeSet, fs, path::Path};
 
@@ -1289,6 +1410,51 @@ mod tests {
     }
 
     #[test]
+    fn generic_stat_imports_replace_but_do_not_remove_the_legacy_abi() {
+        for wasm_symbol in [
+            "thread_pool/make_open_job",
+            "thread_pool/make_fstatx_job",
+            "thread_pool/make_statx_job",
+        ] {
+            assert_eq!(
+                ASYNC_IMPORTS
+                    .iter()
+                    .find(|import| import.wasm_symbol == wasm_symbol)
+                    .map(|import| import.kind),
+                Some(AsyncImportKind::Ported),
+                "generic stat import {wasm_symbol} must track the current upstream ABI"
+            );
+        }
+        assert_eq!(
+            ASYNC_IMPORTS
+                .iter()
+                .find(|import| import.wasm_symbol == "thread_pool/get_stat_result")
+                .map(|import| import.kind),
+            Some(AsyncImportKind::Helper)
+        );
+        for wasm_symbol in [
+            "fd_util/kind_of_fd",
+            "thread_pool/open_job_get_kind",
+            "thread_pool/open_job_get_dev_id",
+            "thread_pool/open_job_get_file_id",
+            "thread_pool/make_file_kind_by_path_job",
+            "thread_pool/make_file_size_job",
+            "thread_pool/get_file_size_result",
+            "thread_pool/make_file_time_job",
+            "thread_pool/make_file_time_by_path_job",
+        ] {
+            assert_eq!(
+                ASYNC_IMPORTS
+                    .iter()
+                    .find(|import| import.wasm_symbol == wasm_symbol)
+                    .map(|import| import.kind),
+                Some(AsyncImportKind::Compat),
+                "legacy stat import {wasm_symbol} must remain a compatibility ABI"
+            );
+        }
+    }
+
+    #[test]
     fn wasm_import_names_are_namespaced() {
         for import in ASYNC_IMPORTS {
             let Some((_namespace, _)) = import.wasm_symbol.split_once('/') else {
@@ -1358,6 +1524,53 @@ mod tests {
                 "fake import {} has active ported provenance",
                 import.wasm_symbol
             );
+        }
+    }
+
+    #[test]
+    fn compatibility_imports_record_the_upstream_replacement() {
+        let compat_imports = async_api_compat_imports();
+        let compat_symbols = crate::async_sys::compat_symbols();
+
+        for import in ASYNC_IMPORTS
+            .iter()
+            .filter(|import| import.kind == AsyncImportKind::Compat)
+        {
+            assert!(
+                compat_imports.iter().any(|compat| {
+                    module_leaf(compat.rust_module) == Some(import.callback_module)
+                        && compat.rust_symbol == import.callback_symbol
+                }),
+                "compatibility import {} has no compatibility provenance",
+                import.wasm_symbol
+            );
+        }
+
+        for compat in compat_imports {
+            assert_ne!(compat.upstream_pr, 0);
+            assert!(!compat.replacement.is_empty());
+            assert!(
+                compat_symbols.iter().any(|symbol| {
+                    symbol.native_symbol == compat.native_symbol
+                        && symbol.historical_source == compat.historical_source
+                        && symbol.upstream_pr == compat.upstream_pr
+                        && !symbol.replacement.is_empty()
+                }),
+                "compatibility adapter {}::{} has no matching Async Sys implementation",
+                compat.rust_module,
+                compat.rust_symbol
+            );
+
+            let historical_source = repo_root()
+                .join("third_party/moonbitlang_async")
+                .join(compat.historical_source);
+            if let Ok(contents) = fs::read_to_string(historical_source) {
+                assert!(
+                    !contents.contains(compat.native_symbol),
+                    "compatibility symbol {} still exists upstream and should be ported",
+                    compat.native_symbol
+                );
+            }
         }
     }
 

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -65,9 +65,6 @@ macro_rules! import_kind {
     (compat) => {
         AsyncImportKind::Compat
     };
-    (compat_open) => {
-        AsyncImportKind::Ported
-    };
     (ported) => {
         AsyncImportKind::Ported
     };
@@ -128,6 +125,15 @@ macro_rules! decode_wasm_args {
         })();
         decoded_args
     }};
+}
+
+macro_rules! wasm_arg_count {
+    () => {
+        0_i32
+    };
+    ($head:ident $(, $tail:ident)*) => {
+        1_i32 + wasm_arg_count!($($tail),*)
+    };
 }
 
 macro_rules! finish_wasm_import {
@@ -191,90 +197,6 @@ macro_rules! declare_async_imports {
 
 macro_rules! register_async_import {
     (
-        compat_open,
-        $obj:ident,
-        $scope:ident,
-        $context_ptr:ident,
-        $wasm_symbol:literal,
-        u64,
-        thread_pool::make_open_job,
-        ($($arg:ident : $arg_ty:ident),* $(,)?)
-    ) => {{
-        fn callback(
-            scope: &mut v8::HandleScope,
-            args: v8::FunctionCallbackArguments,
-            mut ret: v8::ReturnValue,
-        ) {
-            let host_context = callback_context(&args);
-            if args.length() == 7 {
-                let decoded_args = decode_wasm_args!(
-                    scope,
-                    args,
-                    path_ptr: i32,
-                    path_len: i32,
-                    access: i32,
-                    create_mode: i32,
-                    append: i32,
-                    sync: i32,
-                    mode: i32,
-                );
-                match decoded_args {
-                    Ok((path_ptr, path_len, access, create_mode, append, sync, mode)) => {
-                        let result = {
-                            let mut context = ImportContext::new(scope, host_context);
-                            thread_pool::make_open_job_legacy(
-                                &mut context,
-                                path_ptr,
-                                path_len,
-                                access,
-                                create_mode,
-                                append,
-                                sync,
-                                mode,
-                            )
-                        };
-                        finish_wasm_import!(
-                            scope,
-                            ret,
-                            $wasm_symbol,
-                            u64,
-                            result
-                        );
-                    }
-                    Err(error) => {
-                        throw_import_error(scope, $wasm_symbol, error)
-                    }
-                }
-                return;
-            }
-
-            let decoded_args = decode_wasm_args!(scope, args, $($arg : $arg_ty),*);
-            match decoded_args {
-                Ok(($($arg,)*)) => {
-                    let result = {
-                        let mut context = ImportContext::new(scope, host_context);
-                        thread_pool::make_open_job(&mut context, $($arg),*)
-                    };
-                    finish_wasm_import!(
-                        scope,
-                        ret,
-                        $wasm_symbol,
-                        u64,
-                        result
-                    );
-                }
-                Err(error) => throw_import_error(scope, $wasm_symbol, error),
-            }
-        }
-        register_func_impl(
-            $obj,
-            $scope,
-            $wasm_symbol,
-            callback,
-            $context_ptr,
-        );
-    }};
-    (
         fake,
         $obj:ident,
         $scope:ident,
@@ -308,6 +230,14 @@ macro_rules! register_async_import {
             args: v8::FunctionCallbackArguments,
             mut ret: v8::ReturnValue,
         ) {
+            if args.length() != wasm_arg_count!($($arg),*) {
+                throw_import_error(
+                    scope,
+                    $wasm_symbol,
+                    crate::async_host::AsyncHostError::Inval,
+                );
+                return;
+            }
             let _ = &args;
             let host_context = callback_context(&args);
             let decoded_args: crate::async_host::AsyncHostResult<_> =
@@ -1012,7 +942,17 @@ declare_async_imports! {
 
     // thread_pool.c FS jobs. Path-taking jobs use the Guest String Path ABI:
     // MoonBit String pointer plus UTF-16 code-unit length.
-    compat_open thread_pool::make_open_job(
+    compat thread_pool::make_open_job_legacy(
+        path_ptr: i32,
+        path_len: i32,
+        access: i32,
+        create_mode: i32,
+        append: i32,
+        sync: i32,
+        mode: i32,
+    ) -> u64 => "thread_pool/make_open_job";
+
+    ported thread_pool::make_open_stat_job(
         path_ptr: i32,
         path_len: i32,
         access: i32,
@@ -1021,14 +961,12 @@ declare_async_imports! {
         sync: i32,
         mode: i32,
         stat_request: i32,
-        stat_result: i32,
         stat_result_len: i32,
-    ) -> u64 => "thread_pool/make_open_job";
+    ) -> u64 => "thread_pool/make_open_stat_job";
 
     ported thread_pool::make_fstatx_job(
         fd: u64,
         stat_request: i32,
-        stat_result: i32,
         stat_result_len: i32,
     ) -> u64 => "thread_pool/make_fstatx_job";
 
@@ -1036,7 +974,6 @@ declare_async_imports! {
         path_ptr: i32,
         path_len: i32,
         stat_request: i32,
-        stat_result: i32,
         stat_result_len: i32,
         parent: u64,
         follow_symlink: i32,
@@ -1181,7 +1118,9 @@ declare_async_imports! {
         is_orphan: i32,
     ) -> u64 => "thread_pool/make_spawn_job/windows";
 
-    ported thread_pool::get_spawn_job_result_handle(job: u64) -> u64 => "thread_pool/get_spawn_job_result_handle";
+    ported thread_pool::spawn_job_get_result_handle(job: u64) -> u64 => "thread_pool/spawn_job_get_result_handle";
+
+    helper thread_pool::get_spawn_job_result_handle_legacy(job: u64, copy_output: i32) -> u64 => "thread_pool/get_spawn_job_result_handle";
 
     ported thread_pool::make_wait_for_process_job(handle: u64, pid: i32) -> u64 => "thread_pool/make_wait_for_process_job";
 
@@ -1415,28 +1354,72 @@ mod tests {
 
     #[test]
     fn generic_stat_imports_coexist_with_native_compatibility_adapters() {
+        let generic_imports: &[(&str, &[WasmType])] = &[
+            (
+                "thread_pool/make_open_stat_job",
+                &[
+                    WasmType::I32,
+                    WasmType::I32,
+                    WasmType::I32,
+                    WasmType::I32,
+                    WasmType::I32,
+                    WasmType::I32,
+                    WasmType::I32,
+                    WasmType::I32,
+                    WasmType::I32,
+                ],
+            ),
+            (
+                "thread_pool/make_fstatx_job",
+                &[WasmType::I64, WasmType::I32, WasmType::I32],
+            ),
+            (
+                "thread_pool/make_statx_job",
+                &[
+                    WasmType::I32,
+                    WasmType::I32,
+                    WasmType::I32,
+                    WasmType::I32,
+                    WasmType::I64,
+                    WasmType::I32,
+                ],
+            ),
+        ];
+        for &(wasm_symbol, parameter_types) in generic_imports {
+            let import = ASYNC_IMPORTS
+                .iter()
+                .find(|import| import.wasm_symbol == wasm_symbol)
+                .expect("generic stat import must be registered");
+            assert_eq!(
+                import.kind,
+                AsyncImportKind::Ported,
+                "generic stat import {wasm_symbol} must track the current upstream operation"
+            );
+            assert_eq!(
+                import.params, parameter_types,
+                "generic stat maker {wasm_symbol} must have an exact pointer-free Wasm ABI"
+            );
+            assert_eq!(import.result, Some(WasmType::I64));
+        }
+        let legacy_open = ASYNC_IMPORTS
+            .iter()
+            .find(|import| import.wasm_symbol == "thread_pool/make_open_job")
+            .expect("legacy open import must remain registered");
+        assert_eq!(legacy_open.params, &[WasmType::I32; 7]);
+        assert_eq!(legacy_open.result, Some(WasmType::I64));
+
+        let copy_result = ASYNC_IMPORTS
+            .iter()
+            .find(|import| import.wasm_symbol == "thread_pool/get_stat_result")
+            .expect("generic stat copy-out import must be registered");
+        assert_eq!(copy_result.kind, AsyncImportKind::Helper);
+        assert_eq!(
+            copy_result.params,
+            &[WasmType::I64, WasmType::I32, WasmType::I32]
+        );
+        assert_eq!(copy_result.result, None);
         for wasm_symbol in [
             "thread_pool/make_open_job",
-            "thread_pool/make_fstatx_job",
-            "thread_pool/make_statx_job",
-        ] {
-            assert_eq!(
-                ASYNC_IMPORTS
-                    .iter()
-                    .find(|import| import.wasm_symbol == wasm_symbol)
-                    .map(|import| import.kind),
-                Some(AsyncImportKind::Ported),
-                "generic stat import {wasm_symbol} must track the current upstream ABI"
-            );
-        }
-        assert_eq!(
-            ASYNC_IMPORTS
-                .iter()
-                .find(|import| import.wasm_symbol == "thread_pool/get_stat_result")
-                .map(|import| import.kind),
-            Some(AsyncImportKind::Helper)
-        );
-        for wasm_symbol in [
             "fd_util/kind_of_fd",
             "thread_pool/open_job_get_kind",
             "thread_pool/open_job_get_dev_id",
@@ -1456,6 +1439,28 @@ mod tests {
                 "removed native stat ABI {wasm_symbol} must remain available through a compatibility adapter"
             );
         }
+    }
+
+    #[test]
+    fn aggregate_wasm_arguments_are_fully_declared() {
+        let spawn_result = ASYNC_IMPORTS
+            .iter()
+            .find(|import| import.wasm_symbol == "thread_pool/spawn_job_get_result_handle")
+            .expect("canonical spawn result import must be registered");
+        assert_eq!(spawn_result.params, &[WasmType::I64]);
+        assert_eq!(spawn_result.result, Some(WasmType::I64));
+
+        let legacy_spawn_result = ASYNC_IMPORTS
+            .iter()
+            .find(|import| import.wasm_symbol == "thread_pool/get_spawn_job_result_handle")
+            .expect("legacy aggregate spawn result import must remain registered");
+        assert_eq!(legacy_spawn_result.kind, AsyncImportKind::Helper);
+        assert_eq!(
+            legacy_spawn_result.params,
+            &[WasmType::I64, WasmType::I32],
+            "SpawnJob lowers to its handle and copy-output closure fields"
+        );
+        assert_eq!(legacy_spawn_result.result, Some(WasmType::I64));
     }
 
     #[test]

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -356,6 +356,9 @@ fn register_func_impl<'s>(
 // Kind legend:
 // - ported: imports that have Rust ports corresponding to moonbitlang/async
 //   implementations. Tests require separate provenance entries for these imports.
+// - compat: retained adapters whose original upstream implementation or import
+//   was removed or replaced. A pinned wasm wrapper may still use one while a
+//   cross-repository migration is in progress.
 // - helper: auxiliary glue around ported ABI.
 // - fake: link-only import for runtime-dispatched wasm; the generated callback is unreachable.
 declare_async_imports! {
@@ -1194,7 +1197,7 @@ declare_async_imports! {
 
     helper process::allocate_env_block(size: i32) -> u64 => "process/allocate_env_block";
 
-    helper process::free_env(env: u64) -> void => "process/free_env";
+    compat process::free_env(env: u64) -> void => "process/free_env";
 
     helper process::write_env_block(dst: u64, src: u64) -> void => "process/write_env_block";
 
@@ -1214,7 +1217,7 @@ declare_async_imports! {
     fake process::make_argv_array_unix(len: i32) -> u64 => "process/make_argv_array/unix";
 
     #[cfg(unix)]
-    helper process::free_argv(argv: u64) -> void => "process/free_argv";
+    compat process::free_argv(argv: u64) -> void => "process/free_argv";
 
     #[cfg(windows)]
     fake process::free_argv(argv: u64) -> void => "process/free_argv";
@@ -1284,6 +1287,7 @@ fn async_api_compat_imports() -> Vec<super::provenance::CompatImport> {
     let mut imports = Vec::new();
     imports.extend_from_slice(thread_pool::COMPAT_IMPORTS);
     imports.extend_from_slice(fd_util::COMPAT_IMPORTS);
+    imports.extend_from_slice(process::COMPAT_IMPORTS);
     imports
 }
 
@@ -1410,7 +1414,7 @@ mod tests {
     }
 
     #[test]
-    fn generic_stat_imports_replace_but_do_not_remove_the_legacy_abi() {
+    fn generic_stat_imports_coexist_with_native_compatibility_adapters() {
         for wasm_symbol in [
             "thread_pool/make_open_job",
             "thread_pool/make_fstatx_job",
@@ -1449,8 +1453,31 @@ mod tests {
                     .find(|import| import.wasm_symbol == wasm_symbol)
                     .map(|import| import.kind),
                 Some(AsyncImportKind::Compat),
-                "legacy stat import {wasm_symbol} must remain a compatibility ABI"
+                "removed native stat ABI {wasm_symbol} must remain available through a compatibility adapter"
             );
+        }
+    }
+
+    #[test]
+    fn removed_process_cleanup_imports_are_no_op_compatibility_adapters() {
+        let compat_imports = async_api_compat_imports();
+        for wasm_symbol in ["process/free_env", "process/free_argv"] {
+            let registered = ASYNC_IMPORTS
+                .iter()
+                .find(|import| import.wasm_symbol == wasm_symbol)
+                .expect("cleanup import must remain linkable");
+            if registered.kind == AsyncImportKind::Fake {
+                continue;
+            }
+            let provenance = compat_imports
+                .iter()
+                .find(|compat| {
+                    module_leaf(compat.rust_module) == Some(registered.callback_module)
+                        && compat.rust_symbol == registered.callback_symbol
+                })
+                .expect("cleanup compatibility import must record provenance");
+            assert!(provenance.no_op);
+            assert_eq!(provenance.upstream_pr, 511);
         }
     }
 
@@ -1549,26 +1576,28 @@ mod tests {
         for compat in compat_imports {
             assert_ne!(compat.upstream_pr, 0);
             assert!(!compat.replacement.is_empty());
-            assert!(
-                compat_symbols.iter().any(|symbol| {
-                    symbol.native_symbol == compat.native_symbol
-                        && symbol.historical_source == compat.historical_source
-                        && symbol.upstream_pr == compat.upstream_pr
-                        && !symbol.replacement.is_empty()
-                }),
-                "compatibility adapter {}::{} has no matching Async Sys implementation",
-                compat.rust_module,
-                compat.rust_symbol
-            );
+            if !compat.no_op {
+                assert!(
+                    compat_symbols.iter().any(|symbol| {
+                        symbol.native_symbol == compat.original_symbol
+                            && symbol.historical_source == compat.historical_source
+                            && symbol.upstream_pr == compat.upstream_pr
+                            && !symbol.replacement.is_empty()
+                    }),
+                    "compatibility adapter {}::{} has no matching Async Sys implementation",
+                    compat.rust_module,
+                    compat.rust_symbol
+                );
+            }
 
             let historical_source = repo_root()
                 .join("third_party/moonbitlang_async")
                 .join(compat.historical_source);
             if let Ok(contents) = fs::read_to_string(historical_source) {
                 assert!(
-                    !contents.contains(compat.native_symbol),
+                    !contents.contains(compat.original_symbol),
                     "compatibility symbol {} still exists upstream and should be ported",
-                    compat.native_symbol
+                    compat.original_symbol
                 );
             }
         }

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -143,6 +143,10 @@ pub(super) fn make_open_job_legacy(
     ))
 }
 
+// The native ABI gives each stat maker its eventual output buffer. Moonrun
+// decodes that argument to keep the same ABI, but never retains the Guest
+// Memory pointer in a Job. The worker produces a Rust-owned PackedStat and the
+// wasm completion callback copies it out through get_stat_result.
 #[ported(
     source = "src/internal/event_loop/fs.c",
     original = "moonbitlang_async_make_open_job"

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -118,7 +118,7 @@ pub(super) fn make_sleep_job(
     source = "src/internal/event_loop/thread_pool.c",
     original = "moonbitlang_async_make_open_job",
     upstream_pr = 527,
-    replacement = "thread_pool/make_open_job (stat_request/stat_result ABI)"
+    replacement = "thread_pool/make_open_stat_job"
 )]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_open_job_legacy(
@@ -143,16 +143,15 @@ pub(super) fn make_open_job_legacy(
     ))
 }
 
-// The native ABI gives each stat maker its eventual output buffer. Moonrun
-// decodes that argument to keep the same ABI, but never retains the Guest
-// Memory pointer in a Job. The worker produces a Rust-owned PackedStat and the
-// wasm completion callback copies it out through get_stat_result.
+// Unlike the native ABI, the wasm maker does not receive the eventual output
+// buffer. The worker produces a Rust-owned PackedStat and the wasm completion
+// callback copies it into current Guest Memory through get_stat_result.
 #[ported(
     source = "src/internal/event_loop/fs.c",
     original = "moonbitlang_async_make_open_job"
 )]
 #[allow(clippy::too_many_arguments)]
-pub(super) fn make_open_job(
+pub(super) fn make_open_stat_job(
     context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
     path_len: i32,
@@ -162,7 +161,6 @@ pub(super) fn make_open_job(
     sync: i32,
     mode: i32,
     stat_request: i32,
-    _stat_result: i32,
     stat_result_len: i32,
 ) -> AsyncHostResult<u64> {
     let filename = read_guest_os_string(context, path_ptr, path_len)?;
@@ -186,7 +184,6 @@ pub(super) fn make_fstatx_job(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
     stat_request: i32,
-    _stat_result: i32,
     stat_result_len: i32,
 ) -> AsyncHostResult<u64> {
     let file = context.host.acquire_resource(fd)?;
@@ -207,7 +204,6 @@ pub(super) fn make_statx_job(
     path_ptr: i32,
     path_len: i32,
     stat_request: i32,
-    _stat_result: i32,
     stat_result_len: i32,
     parent: u64,
     follow_symlink: i32,
@@ -648,12 +644,30 @@ pub(super) fn make_spawn_job_windows(
     ))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
-pub(super) fn get_spawn_job_result_handle(
+#[ported(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_get_spawn_job_result_handle"
+)]
+pub(super) fn spawn_job_get_result_handle(
     context: &mut ImportContext<'_, '_>,
     job: u64,
 ) -> AsyncHostResult<u64> {
     context.host.get_spawn_job_result_handle(job)
+}
+
+// The current wasm wrapper passes SpawnJob by value. Its nested Job is a
+// two-field valtype, so MoonBit lowers both the JobHandle and its optional
+// copy-output closure into this import. Spawn jobs never install that closure;
+// validate the representation invariant while this guest ABI remains in use.
+pub(super) fn get_spawn_job_result_handle_legacy(
+    context: &mut ImportContext<'_, '_>,
+    job: u64,
+    copy_output: i32,
+) -> AsyncHostResult<u64> {
+    if copy_output != 0 {
+        return Err(AsyncHostError::Inval);
+    }
+    spawn_job_get_result_handle(context, job)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -114,9 +114,14 @@ pub(super) fn make_sleep_job(
         .insert_job(thread_pool::make_sleep_job(duration_ms))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_make_open_job",
+    upstream_pr = 527,
+    replacement = "thread_pool/make_open_job (stat_request/stat_result ABI)"
+)]
 #[allow(clippy::too_many_arguments)]
-pub(super) fn make_open_job(
+pub(super) fn make_open_job_legacy(
     context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
     path_len: i32,
@@ -136,6 +141,101 @@ pub(super) fn make_open_job(
         sync,
         mode,
     ))
+}
+
+#[ported(
+    source = "src/internal/event_loop/fs.c",
+    original = "moonbitlang_async_make_open_job"
+)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn make_open_job(
+    context: &mut ImportContext<'_, '_>,
+    path_ptr: i32,
+    path_len: i32,
+    access: i32,
+    create_mode: i32,
+    append: i32,
+    sync: i32,
+    mode: i32,
+    stat_request: i32,
+    _stat_result: i32,
+    stat_result_len: i32,
+) -> AsyncHostResult<u64> {
+    let filename = read_guest_os_string(context, path_ptr, path_len)?;
+    context.host.insert_job(thread_pool::make_open_stat_job(
+        filename,
+        access,
+        create_mode,
+        append != 0,
+        sync,
+        mode,
+        stat_request as u32,
+        stat_result_len,
+    ))
+}
+
+#[ported(
+    source = "src/internal/event_loop/fs.c",
+    original = "moonbitlang_async_make_fstatx_job"
+)]
+pub(super) fn make_fstatx_job(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    stat_request: i32,
+    _stat_result: i32,
+    stat_result_len: i32,
+) -> AsyncHostResult<u64> {
+    let file = context.host.acquire_resource(fd)?;
+    context.host.insert_job(thread_pool::make_fstatx_job(
+        file,
+        stat_request as u32,
+        stat_result_len,
+    ))
+}
+
+#[ported(
+    source = "src/internal/event_loop/fs.c",
+    original = "moonbitlang_async_make_statx_job"
+)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn make_statx_job(
+    context: &mut ImportContext<'_, '_>,
+    path_ptr: i32,
+    path_len: i32,
+    stat_request: i32,
+    _stat_result: i32,
+    stat_result_len: i32,
+    parent: u64,
+    follow_symlink: i32,
+) -> AsyncHostResult<u64> {
+    let parent = if parent == context.host.invalid_fd() {
+        None
+    } else {
+        Some(
+            context
+                .host
+                .acquire_resource_of_class(parent, ResourceClass::File)?,
+        )
+    };
+    let path = read_guest_os_string(context, path_ptr, path_len)?;
+    context.host.insert_job(thread_pool::make_statx_job(
+        parent,
+        path,
+        stat_request as u32,
+        stat_result_len,
+        follow_symlink != 0,
+    ))
+}
+
+pub(super) fn get_stat_result(
+    context: &mut ImportContext<'_, '_>,
+    job: u64,
+    dst: i32,
+    dst_len: i32,
+) -> AsyncHostResult<()> {
+    context.with_host_and_memory_mut(|host, memory| {
+        host.get_stat_result(memory, job, dst, dst_len)
+    })
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
@@ -184,7 +284,12 @@ pub(super) fn get_read_result(
     })
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_make_file_kind_by_path_job",
+    upstream_pr = 527,
+    replacement = "thread_pool/make_statx_job with STAT_FILE_KIND"
+)]
 pub(super) fn make_file_kind_by_path_job(
     context: &mut ImportContext<'_, '_>,
     parent: u64,
@@ -211,7 +316,12 @@ pub(super) fn make_file_kind_by_path_job(
         ))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_make_file_size_job",
+    upstream_pr = 527,
+    replacement = "thread_pool/make_fstatx_job with STAT_FILE_SIZE"
+)]
 pub(super) fn make_file_size_job(context: &mut ImportContext<'_, '_>, fd: u64) -> AsyncHostResult<u64> {
     let file = context
         .host
@@ -219,12 +329,22 @@ pub(super) fn make_file_size_job(context: &mut ImportContext<'_, '_>, fd: u64) -
     context.host.insert_job(thread_pool::make_file_size_job(file))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_get_file_size_result",
+    upstream_pr = 527,
+    replacement = "thread_pool/get_stat_result"
+)]
 pub(super) fn get_file_size_result(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<i64> {
     context.host.get_file_size_result(job)
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_make_file_time_job",
+    upstream_pr = 527,
+    replacement = "thread_pool/make_fstatx_job with timestamp properties"
+)]
 pub(super) fn make_file_time_job(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
@@ -236,7 +356,12 @@ pub(super) fn make_file_time_job(
         .insert_job(thread_pool::make_file_time_job(file))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_make_file_time_by_path_job",
+    upstream_pr = 527,
+    replacement = "thread_pool/make_statx_job with timestamp properties"
+)]
 pub(super) fn make_file_time_by_path_job(
     context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
@@ -262,7 +387,7 @@ pub(super) fn get_file_time_result(
     })
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_access_job(
     context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
@@ -275,7 +400,7 @@ pub(super) fn make_access_job(
         .insert_job(thread_pool::make_access_job(path, access))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_chmod_job(
     context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
@@ -288,7 +413,7 @@ pub(super) fn make_chmod_job(
         .insert_job(thread_pool::make_chmod_job(path, mode))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_fsync_job(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
@@ -301,7 +426,7 @@ pub(super) fn make_fsync_job(
         .insert_job(thread_pool::make_fsync_job(file, only_data != 0))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_flock_job(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
@@ -314,7 +439,7 @@ pub(super) fn make_flock_job(
         .insert_job(thread_pool::make_flock_job(file, exclusive != 0))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_remove_job(
     context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
@@ -324,7 +449,7 @@ pub(super) fn make_remove_job(
     context.host.insert_job(thread_pool::make_remove_job(path))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_rename_job(
     context: &mut ImportContext<'_, '_>,
     old_path_ptr: i32,
@@ -343,7 +468,7 @@ pub(super) fn make_rename_job(
     ))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_symlink_job(
     context: &mut ImportContext<'_, '_>,
     target_ptr: i32,
@@ -362,7 +487,7 @@ pub(super) fn make_symlink_job(
     ))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_mkdir_job(
     context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
@@ -375,7 +500,7 @@ pub(super) fn make_mkdir_job(
         .insert_job(thread_pool::make_mkdir_job(path, mode))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_rmdir_job(
     context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
@@ -385,7 +510,7 @@ pub(super) fn make_rmdir_job(
     context.host.insert_job(thread_pool::make_rmdir_job(path))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_readdir_job(
     context: &mut ImportContext<'_, '_>,
     dir: u64,
@@ -601,7 +726,7 @@ fn read_i32_array(
         .collect())
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_realpath_job(
     context: &mut ImportContext<'_, '_>,
     path_ptr: i32,
@@ -613,7 +738,7 @@ pub(super) fn make_realpath_job(
         .insert_job(thread_pool::make_realpath_job(path))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn get_realpath_result(
     context: &mut ImportContext<'_, '_>,
     job: u64,
@@ -621,22 +746,37 @@ pub(super) fn get_realpath_result(
     context.host.get_realpath_result(job)
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn open_job_get_fd(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_fd(job)
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_open_job_get_kind",
+    upstream_pr = 527,
+    replacement = "thread_pool/get_stat_result with STAT_FILE_KIND"
+)]
 pub(super) fn open_job_get_kind(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<i32> {
     context.host.open_job_get_kind(job)
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_open_job_get_dev_id",
+    upstream_pr = 527,
+    replacement = "thread_pool/get_stat_result with STAT_DEVICE_ID"
+)]
 pub(super) fn open_job_get_dev_id(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_dev_id(job)
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_open_job_get_file_id",
+    upstream_pr = 527,
+    replacement = "thread_pool/get_stat_result with STAT_FILE_ID"
+)]
 pub(super) fn open_job_get_file_id(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_file_id(job)
 }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -3275,6 +3275,40 @@ impl AsyncHost {
                 *create_mode,
                 *append,
             ),
+            JobPayload::OpenStat {
+                filename,
+                access,
+                create_mode,
+                append,
+                request,
+                ..
+            } => {
+                policy.open_path(
+                    RuntimePathBase::CurrentDirectory,
+                    filename,
+                    *access,
+                    *create_mode,
+                    *append,
+                )?;
+                if request.mask() & !thread_pool::STAT_OPEN_IDENTITY != 0 {
+                    policy.stat_path(RuntimePathBase::CurrentDirectory, filename)?;
+                }
+                Ok(())
+            }
+            JobPayload::Fstatx { file, .. } => {
+                Self::check_file_metadata_policy(policy, file.as_deref())
+            }
+            JobPayload::Statx {
+                parent,
+                path,
+                follow_symlink,
+                ..
+            } => Self::check_path_metadata_policy(
+                policy,
+                Self::resource_path_base(parent.as_deref()),
+                path,
+                *follow_symlink,
+            ),
             JobPayload::FileKindByPath {
                 parent,
                 path,
@@ -3618,6 +3652,19 @@ impl AsyncHost {
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         thread_pool::get_file_time_result(job, memory, dst)
+    }
+
+    pub(crate) fn get_stat_result(
+        &self,
+        memory: &mut (impl GuestMemory + ?Sized),
+        handle: u64,
+        dst: i32,
+        dst_len: i32,
+    ) -> AsyncHostResult<()> {
+        let key = self.handles.borrow().job(handle)?;
+        let jobs = self.jobs.borrow();
+        let job = jobs.visible_job(key)?;
+        thread_pool::get_stat_result(job, memory, dst, dst_len)
     }
 
     pub(crate) fn get_realpath_result(&self, handle: u64) -> AsyncHostResult<u64> {
@@ -5409,6 +5456,55 @@ mod tests {
         host.free_job(size_job).unwrap();
         host.close_fd(fd).unwrap();
         host.free_job(open_job).unwrap();
+    }
+
+    #[test]
+    fn open_stat_identity_uses_open_policy_but_extra_metadata_requires_read_policy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let writable = tmp.path().join("writable");
+        std::fs::create_dir(&writable).unwrap();
+        let file = writable.join("data.txt");
+        std::fs::write(&file, "secret").unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(&policy_file, "[fs]\nwrite = [\"writable\"]\n").unwrap();
+        let host = host_with_policy(&policy_file);
+        let identity_job = host
+            .insert_job(thread_pool::make_open_stat_job(
+                file.as_os_str().to_os_string(),
+                1,
+                0,
+                false,
+                0,
+                0,
+                thread_pool::STAT_OPEN_IDENTITY,
+                32,
+            ))
+            .unwrap();
+        let metadata_job = host
+            .insert_job(thread_pool::make_open_stat_job(
+                file.as_os_str().to_os_string(),
+                1,
+                0,
+                false,
+                0,
+                0,
+                thread_pool::STAT_OPEN_IDENTITY | 0x0002,
+                40,
+            ))
+            .unwrap();
+
+        host.run_job(identity_job).unwrap();
+        host.run_job(metadata_job).unwrap();
+
+        assert_eq!(host.job_get_err(identity_job).unwrap(), 0);
+        assert_eq!(
+            host.job_get_err(metadata_job).unwrap(),
+            AsyncHostError::PermissionDenied.errno()
+        );
+        let fd = host.open_job_get_fd(identity_job).unwrap();
+        host.close_fd(fd).unwrap();
+        host.free_job(metadata_job).unwrap();
+        host.free_job(identity_job).unwrap();
     }
 
     #[test]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -2157,7 +2157,7 @@ impl AsyncHost {
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         let result = thread_pool::open_job_result(job)?;
-        Ok(thread_pool::open_job_get_kind(result))
+        thread_pool::open_job_get_kind(result)
     }
 
     pub(crate) fn open_job_get_dev_id(&self, handle: u64) -> AsyncHostResult<u64> {
@@ -2165,7 +2165,7 @@ impl AsyncHost {
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         let result = thread_pool::open_job_result(job)?;
-        Ok(thread_pool::open_job_get_dev_id(result))
+        thread_pool::open_job_get_dev_id(result)
     }
 
     pub(crate) fn open_job_get_file_id(&self, handle: u64) -> AsyncHostResult<u64> {
@@ -2173,7 +2173,7 @@ impl AsyncHost {
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
         let result = thread_pool::open_job_result(job)?;
-        Ok(thread_pool::open_job_get_file_id(result))
+        thread_pool::open_job_get_file_id(result)
     }
 
     pub(crate) fn get_file_size_result(&self, handle: u64) -> AsyncHostResult<i64> {
@@ -3263,19 +3263,6 @@ impl AsyncHost {
     ) -> AsyncHostResult<()> {
         match job.payload() {
             JobPayload::Open {
-                filename,
-                access,
-                create_mode,
-                append,
-                ..
-            } => policy.open_path(
-                RuntimePathBase::CurrentDirectory,
-                filename,
-                *access,
-                *create_mode,
-                *append,
-            ),
-            JobPayload::OpenStat {
                 filename,
                 access,
                 create_mode,
@@ -5072,6 +5059,9 @@ mod tests {
 
         host.run_job(job).unwrap();
         assert_eq!(resource_count(&host), 0);
+        assert_eq!(host.open_job_get_kind(job).unwrap(), 1);
+        host.open_job_get_dev_id(job).unwrap();
+        host.open_job_get_file_id(job).unwrap();
 
         let opened = host.open_job_get_fd(job).unwrap();
         assert_eq!(host.open_job_get_fd(job).unwrap(), opened);

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -517,7 +517,7 @@ fn kind_of_raw_file(handle: RawFile) -> AsyncHostResult<i32> {
 }
 
 #[cfg(windows)]
-fn handle_is_socket(handle: RawFile) -> bool {
+pub(super) fn handle_is_socket(handle: RawFile) -> bool {
     use windows_sys::Win32::Networking::WinSock::{SO_TYPE, SOCKET, SOL_SOCKET, getsockopt};
 
     let mut opt = 0i32;
@@ -1087,6 +1087,7 @@ fn file_kind_by_path(
     if !follow_symlink {
         flags |= FILE_FLAG_OPEN_REPARSE_POINT;
     }
+    let parent = parent.map(raw_file_handle).transpose()?;
     let path = resolve_windows_path_for_parent(parent, path)?;
     let path = path_to_wide(path);
     let handle: HANDLE = unsafe {
@@ -1111,8 +1112,8 @@ fn file_kind_by_path(
 }
 
 #[cfg(windows)]
-fn resolve_windows_path_for_parent(
-    parent: Option<&Resource>,
+pub(super) fn resolve_windows_path_for_parent(
+    parent: Option<RawFile>,
     path: OsString,
 ) -> AsyncHostResult<OsString> {
     let Some(parent) = parent else {
@@ -1122,8 +1123,7 @@ fn resolve_windows_path_for_parent(
         return Ok(path);
     }
 
-    let mut parent_path =
-        std::path::PathBuf::from(final_path_from_handle(raw_file_handle(parent)?)?);
+    let mut parent_path = std::path::PathBuf::from(final_path_from_handle(parent)?);
     parent_path.push(path);
     Ok(parent_path.into_os_string())
 }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -29,6 +29,7 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util;
 use crate::async_sys::ported_fns;
 
+use super::stat::{StatRequest, run_fstatx_job};
 use super::{FileTimeResult, OpenJobResource, OpenJobResult, RealpathJobResult, Resource};
 
 type RawFile = fd_util::stub::RawFd;
@@ -44,9 +45,11 @@ fn raw_file_handle(file: &Resource) -> AsyncHostResult<RawFile> {
 }
 
 ported_fns! {
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "open_job_worker"
+        original = "open_job_worker",
+        upstream_pr = 527,
+        replacement = "open_job_worker with generic stat result"
     )]
     #[allow(clippy::too_many_arguments)]
     pub(super) fn run_open_job(
@@ -74,6 +77,37 @@ ported_fns! {
             kind,
             dev_id,
             file_id,
+            stat: None,
+        });
+        Ok(0)
+    }
+
+    #[ported(source = "src/internal/event_loop/fs.c", original = "open_job_worker")]
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn run_open_stat_job(
+        result: &mut Option<OpenJobResult>,
+        filename: OsString,
+        access: i32,
+        create_mode: i32,
+        append: bool,
+        sync: i32,
+        mode: i32,
+        request: StatRequest,
+    ) -> AsyncHostResult<i64> {
+        let filename_for_policy = filename.clone();
+        let file = open_raw_native_file(filename, access, create_mode, append, sync, mode)?;
+        let resource = Resource::new_with_policy_path(
+            file,
+            std::fs::canonicalize(filename_for_policy).ok(),
+        );
+        let mut stat = None;
+        run_fstatx_job(&resource, request, &mut stat)?;
+        *result = Some(OpenJobResult {
+            resource: OpenJobResource::Unpublished(resource),
+            kind: 0,
+            dev_id: 0,
+            file_id: 0,
+            stat,
         });
         Ok(0)
     }
@@ -108,9 +142,11 @@ ported_fns! {
         Ok(n as i64)
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "file_kind_by_path_job_worker"
+        original = "file_kind_by_path_job_worker",
+        upstream_pr = 527,
+        replacement = "statx_job_worker with STAT_FILE_KIND"
     )]
     pub(super) fn run_file_kind_by_path_job(
         parent: Option<&Resource>,
@@ -120,9 +156,11 @@ ported_fns! {
         file_kind_by_path(parent, path, follow_symlink).map(i64::from)
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "file_size_job_worker"
+        original = "file_size_job_worker",
+        upstream_pr = 527,
+        replacement = "fstatx_job_worker with STAT_FILE_SIZE"
     )]
     pub(super) fn run_file_size_job(
         file: &Resource,
@@ -132,9 +170,11 @@ ported_fns! {
         Ok(0)
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "file_time_job_worker"
+        original = "file_time_job_worker",
+        upstream_pr = 527,
+        replacement = "fstatx_job_worker with timestamp properties"
     )]
     pub(super) fn run_file_time_job(
         file: &Resource,
@@ -144,9 +184,11 @@ ported_fns! {
         Ok(0)
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "file_time_by_path_job_worker"
+        original = "file_time_by_path_job_worker",
+        upstream_pr = 527,
+        replacement = "statx_job_worker with timestamp properties"
     )]
     pub(super) fn run_file_time_by_path_job(
         path: OsString,
@@ -161,7 +203,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "access_job_worker"
     )]
     pub(super) fn run_access_job(path: OsString, access: i32) -> AsyncHostResult<i64> {
@@ -170,7 +212,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "chmod_job_worker"
     )]
     pub(super) fn run_chmod_job(path: OsString, mode: i32) -> AsyncHostResult<i64> {
@@ -179,7 +221,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "fsync_job_worker"
     )]
     pub(super) fn run_fsync_job(
@@ -191,7 +233,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "flock_job_worker"
     )]
     pub(super) fn run_flock_job(
@@ -203,7 +245,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "remove_job_worker"
     )]
     pub(super) fn run_remove_job(path: OsString) -> AsyncHostResult<i64> {
@@ -212,7 +254,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "rename_job_worker"
     )]
     pub(super) fn run_rename_job(
@@ -225,7 +267,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "symlink_job_worker"
     )]
     pub(super) fn run_symlink_job(
@@ -238,7 +280,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "mkdir_job_worker"
     )]
     pub(super) fn run_mkdir_job(path: OsString, mode: i32) -> AsyncHostResult<i64> {
@@ -247,7 +289,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "rmdir_job_worker"
     )]
     pub(super) fn run_rmdir_job(path: OsString) -> AsyncHostResult<i64> {
@@ -256,7 +298,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "readdir_job_worker"
     )]
     pub(super) fn run_readdir_job(
@@ -272,7 +314,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "realpath_job_worker"
     )]
     pub(super) fn run_realpath_job(
@@ -285,15 +327,14 @@ ported_fns! {
 }
 
 #[cfg(unix)]
-#[allow(clippy::unnecessary_cast)]
-fn open_native_file(
+fn open_raw_native_file(
     filename: OsString,
     access: i32,
     create_mode: i32,
     append: bool,
     sync: i32,
     mode: i32,
-) -> AsyncHostResult<OpenedFile> {
+) -> AsyncHostResult<RawFile> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStringExt;
 
@@ -330,6 +371,20 @@ fn open_native_file(
         return Err(last_native_error());
     }
 
+    Ok(fd)
+}
+
+#[cfg(unix)]
+#[allow(clippy::unnecessary_cast)]
+fn open_native_file(
+    filename: OsString,
+    access: i32,
+    create_mode: i32,
+    append: bool,
+    sync: i32,
+    mode: i32,
+) -> AsyncHostResult<OpenedFile> {
+    let fd = open_raw_native_file(filename, access, create_mode, append, sync, mode)?;
     let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
     if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } < 0 {
         let error = last_native_error();
@@ -362,24 +417,23 @@ fn file_kind_from_stat(stat: &libc::stat) -> i32 {
 }
 
 #[cfg(windows)]
-fn open_native_file(
+fn open_raw_native_file(
     filename: OsString,
     access: i32,
     create_mode: i32,
     append: bool,
     sync: i32,
     _mode: i32,
-) -> AsyncHostResult<OpenedFile> {
+) -> AsyncHostResult<RawFile> {
     use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Foundation::{
-        CloseHandle, ERROR_PIPE_BUSY, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
+        ERROR_PIPE_BUSY, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
     };
     use windows_sys::Win32::Storage::FileSystem::{
-        BY_HANDLE_FILE_INFORMATION, CREATE_ALWAYS, CREATE_NEW, CreateFileW, FILE_APPEND_DATA,
-        FILE_ATTRIBUTE_NORMAL, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OVERLAPPED,
-        FILE_FLAG_WRITE_THROUGH, FILE_LIST_DIRECTORY, FILE_SHARE_DELETE, FILE_SHARE_READ,
-        FILE_SHARE_WRITE, GetFileInformationByHandle, OPEN_ALWAYS, OPEN_EXISTING,
-        TRUNCATE_EXISTING,
+        CREATE_ALWAYS, CREATE_NEW, CreateFileW, FILE_APPEND_DATA, FILE_ATTRIBUTE_NORMAL,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OVERLAPPED, FILE_FLAG_WRITE_THROUGH,
+        FILE_LIST_DIRECTORY, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_ALWAYS,
+        OPEN_EXISTING, TRUNCATE_EXISTING,
     };
     use windows_sys::Win32::System::Pipes::{NMPWAIT_WAIT_FOREVER, WaitNamedPipeW};
 
@@ -442,6 +496,24 @@ fn open_native_file(
         }
     };
 
+    Ok(handle)
+}
+
+#[cfg(windows)]
+fn open_native_file(
+    filename: OsString,
+    access: i32,
+    create_mode: i32,
+    append: bool,
+    sync: i32,
+    mode: i32,
+) -> AsyncHostResult<OpenedFile> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+    };
+
+    let handle = open_raw_native_file(filename, access, create_mode, append, sync, mode)?;
     let mut info = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
     if unsafe { GetFileInformationByHandle(handle, info.as_mut_ptr()) } == 0 {
         let error = last_native_error();

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -45,46 +45,9 @@ fn raw_file_handle(file: &Resource) -> AsyncHostResult<RawFile> {
 }
 
 ported_fns! {
-    #[compat(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "open_job_worker",
-        upstream_pr = 527,
-        replacement = "open_job_worker with generic stat result"
-    )]
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn run_open_job(
-        result: &mut Option<OpenJobResult>,
-        filename: OsString,
-        access: i32,
-        create_mode: i32,
-        append: bool,
-        sync: i32,
-        mode: i32,
-    ) -> AsyncHostResult<i64> {
-        let filename_for_policy = filename.clone();
-        let OpenedFile {
-            file,
-            kind,
-            dev_id,
-            file_id,
-        } = open_native_file(filename, access, create_mode, append, sync, mode)?;
-        let policy_path = std::fs::canonicalize(filename_for_policy).ok();
-        *result = Some(OpenJobResult {
-            resource: OpenJobResource::Unpublished(Resource::new_with_policy_path(
-                file,
-                policy_path,
-            )),
-            kind,
-            dev_id,
-            file_id,
-            stat: None,
-        });
-        Ok(0)
-    }
-
     #[ported(source = "src/internal/event_loop/fs.c", original = "open_job_worker")]
     #[allow(clippy::too_many_arguments)]
-    pub(super) fn run_open_stat_job(
+    pub(super) fn run_open_job(
         result: &mut Option<OpenJobResult>,
         filename: OsString,
         access: i32,
@@ -104,10 +67,7 @@ ported_fns! {
         run_fstatx_job(&resource, request, &mut stat)?;
         *result = Some(OpenJobResult {
             resource: OpenJobResource::Unpublished(resource),
-            kind: 0,
-            dev_id: 0,
-            file_id: 0,
-            stat,
+            stat: stat.ok_or(AsyncHostError::Io)?,
         });
         Ok(0)
     }
@@ -375,34 +335,6 @@ fn open_raw_native_file(
 }
 
 #[cfg(unix)]
-#[allow(clippy::unnecessary_cast)]
-fn open_native_file(
-    filename: OsString,
-    access: i32,
-    create_mode: i32,
-    append: bool,
-    sync: i32,
-    mode: i32,
-) -> AsyncHostResult<OpenedFile> {
-    let fd = open_raw_native_file(filename, access, create_mode, append, sync, mode)?;
-    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-    if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } < 0 {
-        let error = last_native_error();
-        unsafe {
-            libc::close(fd);
-        }
-        return Err(error);
-    }
-    let stat = unsafe { stat.assume_init() };
-    Ok(OpenedFile {
-        file: fd,
-        kind: file_kind_from_stat(&stat),
-        dev_id: stat.st_dev as u64,
-        file_id: stat.st_ino as u64,
-    })
-}
-
-#[cfg(unix)]
 fn file_kind_from_stat(stat: &libc::stat) -> i32 {
     match stat.st_mode & libc::S_IFMT {
         libc::S_IFREG => 1,
@@ -497,38 +429,6 @@ fn open_raw_native_file(
     };
 
     Ok(handle)
-}
-
-#[cfg(windows)]
-fn open_native_file(
-    filename: OsString,
-    access: i32,
-    create_mode: i32,
-    append: bool,
-    sync: i32,
-    mode: i32,
-) -> AsyncHostResult<OpenedFile> {
-    use windows_sys::Win32::Foundation::CloseHandle;
-    use windows_sys::Win32::Storage::FileSystem::{
-        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
-    };
-
-    let handle = open_raw_native_file(filename, access, create_mode, append, sync, mode)?;
-    let mut info = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
-    if unsafe { GetFileInformationByHandle(handle, info.as_mut_ptr()) } == 0 {
-        let error = last_native_error();
-        unsafe {
-            CloseHandle(handle);
-        }
-        return Err(error);
-    }
-    let info = unsafe { info.assume_init() };
-    Ok(OpenedFile {
-        file: handle,
-        kind: file_kind_from_attr(info.dwFileAttributes),
-        dev_id: u64::from(info.dwVolumeSerialNumber),
-        file_id: (u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow),
-    })
 }
 
 #[cfg(windows)]
@@ -631,13 +531,6 @@ fn handle_is_socket(handle: RawFile) -> bool {
             &mut opt_len,
         ) == 0
     }
-}
-
-struct OpenedFile {
-    file: RawFile,
-    kind: i32,
-    dev_id: u64,
-    file_id: u64,
 }
 
 #[cfg(unix)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -25,7 +25,7 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 use crate::async_sys::ported_fns;
 
-use super::stat::{PackedStat, StatRequest};
+use super::stat::{PackedStat, STAT_DEVICE_ID, STAT_FILE_ID, STAT_FILE_KIND, StatRequest};
 use super::types::{
     HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult, RealpathJobResult, ResourceRef,
     SpawnOptions, platform,
@@ -134,6 +134,7 @@ ported_fns! {
             append,
             sync,
             mode,
+            request: StatRequest::open_identity(),
             result: None,
         })
     }
@@ -157,7 +158,7 @@ ported_fns! {
             Ok(request) => request,
             Err(error) => return make_failed_job(error.errno()),
         };
-        Job::new(JobPayload::OpenStat {
+        Job::new(JobPayload::Open {
             filename,
             access,
             create_mode,
@@ -248,8 +249,12 @@ ported_fns! {
         upstream_pr = 527,
         replacement = "get_stat_result with STAT_FILE_KIND"
     )]
-    pub(crate) fn open_job_get_kind(result: &OpenJobResult) -> i32 {
-        result.kind
+    pub(crate) fn open_job_get_kind(result: &OpenJobResult) -> AsyncHostResult<i32> {
+        result
+            .stat
+            .scalar(STAT_FILE_KIND)
+            .map(|value| value as i32)
+            .ok_or(AsyncHostError::Inval)
     }
 
     #[compat(
@@ -258,8 +263,11 @@ ported_fns! {
         upstream_pr = 527,
         replacement = "get_stat_result with STAT_DEVICE_ID"
     )]
-    pub(crate) fn open_job_get_dev_id(result: &OpenJobResult) -> u64 {
-        result.dev_id
+    pub(crate) fn open_job_get_dev_id(result: &OpenJobResult) -> AsyncHostResult<u64> {
+        result
+            .stat
+            .scalar(STAT_DEVICE_ID)
+            .ok_or(AsyncHostError::Inval)
     }
 
     #[compat(
@@ -268,8 +276,11 @@ ported_fns! {
         upstream_pr = 527,
         replacement = "get_stat_result with STAT_FILE_ID"
     )]
-    pub(crate) fn open_job_get_file_id(result: &OpenJobResult) -> u64 {
-        result.file_id
+    pub(crate) fn open_job_get_file_id(result: &OpenJobResult) -> AsyncHostResult<u64> {
+        result
+            .stat
+            .scalar(STAT_FILE_ID)
+            .ok_or(AsyncHostError::Inval)
     }
 
     #[compat(
@@ -627,12 +638,8 @@ pub(crate) fn open_job_result(job: &Job) -> AsyncHostResult<&OpenJobResult> {
         JobPayload::Open {
             result: Some(result),
             ..
-        }
-        | JobPayload::OpenStat {
-            result: Some(result),
-            ..
         } => Ok(result),
-        JobPayload::Open { .. } | JobPayload::OpenStat { .. } => Err(AsyncHostError::Inval),
+        JobPayload::Open { .. } => Err(AsyncHostError::Inval),
         _ => Err(AsyncHostError::Badf),
     }
 }
@@ -642,22 +649,16 @@ pub(crate) fn open_job_result_mut(job: &mut Job) -> AsyncHostResult<&mut OpenJob
         JobPayload::Open {
             result: Some(result),
             ..
-        }
-        | JobPayload::OpenStat {
-            result: Some(result),
-            ..
         } => Ok(result),
-        JobPayload::Open { .. } | JobPayload::OpenStat { .. } => Err(AsyncHostError::Inval),
+        JobPayload::Open { .. } => Err(AsyncHostError::Inval),
         _ => Err(AsyncHostError::Badf),
     }
 }
 
 pub(crate) fn stat_job_result(job: &Job) -> AsyncHostResult<&PackedStat> {
     match job.payload() {
-        JobPayload::OpenStat {
-            result: Some(OpenJobResult {
-                stat: Some(result), ..
-            }),
+        JobPayload::Open {
+            result: Some(OpenJobResult { stat: result, .. }),
             ..
         }
         | JobPayload::Fstatx {
@@ -668,7 +669,7 @@ pub(crate) fn stat_job_result(job: &Job) -> AsyncHostResult<&PackedStat> {
             result: Some(result),
             ..
         } => Ok(result),
-        JobPayload::OpenStat { .. } | JobPayload::Fstatx { .. } | JobPayload::Statx { .. } => {
+        JobPayload::Open { .. } | JobPayload::Fstatx { .. } | JobPayload::Statx { .. } => {
             Err(AsyncHostError::Inval)
         }
         _ => Err(AsyncHostError::Badf),
@@ -761,6 +762,7 @@ mod tests {
                 append,
                 sync,
                 mode,
+                request,
                 result: None,
             } => {
                 assert_eq!(filename, &OsString::from("/tmp/example"));
@@ -769,6 +771,7 @@ mod tests {
                 assert!(*append);
                 assert_eq!(*sync, 1);
                 assert_eq!(*mode, 0o644);
+                assert_eq!(request.mask(), super::super::stat::STAT_OPEN_IDENTITY);
             }
             other => panic!("unexpected payload: {other:?}"),
         }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -25,6 +25,7 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 use crate::async_sys::ported_fns;
 
+use super::stat::{PackedStat, StatRequest};
 use super::types::{
     HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult, RealpathJobResult, ResourceRef,
     SpawnOptions, platform,
@@ -112,9 +113,11 @@ ported_fns! {
         })
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_open_job"
+        original = "moonbitlang_async_make_open_job",
+        upstream_pr = 527,
+        replacement = "make_open_stat_job"
     )]
     pub(crate) fn make_open_job(
         filename: OsString,
@@ -136,8 +139,85 @@ ported_fns! {
     }
 
     #[ported(
+        source = "src/internal/event_loop/fs.c",
+        original = "moonbitlang_async_make_open_job"
+    )]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn make_open_stat_job(
+        filename: OsString,
+        access: i32,
+        create_mode: i32,
+        append: bool,
+        sync: i32,
+        mode: i32,
+        stat_request: u32,
+        stat_result_len: i32,
+    ) -> Job {
+        let request = match StatRequest::new(stat_request, stat_result_len) {
+            Ok(request) => request,
+            Err(error) => return make_failed_job(error.errno()),
+        };
+        Job::new(JobPayload::OpenStat {
+            filename,
+            access,
+            create_mode,
+            append,
+            sync,
+            mode,
+            request,
+            result: None,
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/fs.c",
+        original = "moonbitlang_async_make_fstatx_job"
+    )]
+    pub(crate) fn make_fstatx_job(
+        file: ResourceRef,
+        stat_request: u32,
+        stat_result_len: i32,
+    ) -> Job {
+        let request = match StatRequest::new(stat_request, stat_result_len) {
+            Ok(request) => request,
+            Err(error) => return make_failed_job(error.errno()),
+        };
+        Job::new(JobPayload::Fstatx {
+            file: Some(file),
+            request,
+            result: None,
+        })
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/fs.c",
+        original = "moonbitlang_async_make_statx_job"
+    )]
+    pub(crate) fn make_statx_job(
+        parent: Option<ResourceRef>,
+        path: OsString,
+        stat_request: u32,
+        stat_result_len: i32,
+        follow_symlink: bool,
+    ) -> Job {
+        let request = match StatRequest::new(stat_request, stat_result_len) {
+            Ok(request) => request,
+            Err(error) => return make_failed_job(error.errno()),
+        };
+        Job::new(JobPayload::Statx {
+            parent,
+            path,
+            request,
+            follow_symlink,
+            result: None,
+        })
+    }
+
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_file_kind_by_path_job"
+        original = "moonbitlang_async_make_file_kind_by_path_job",
+        upstream_pr = 527,
+        replacement = "make_statx_job with STAT_FILE_KIND"
     )]
     pub(crate) fn make_file_kind_by_path_job(
         parent: Option<ResourceRef>,
@@ -152,7 +232,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_open_job_get_fd"
     )]
     pub(crate) fn open_job_get_fd(result: &OpenJobResult) -> AsyncHostResult<HostHandle> {
@@ -162,33 +242,41 @@ ported_fns! {
         }
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_open_job_get_kind"
+        original = "moonbitlang_async_open_job_get_kind",
+        upstream_pr = 527,
+        replacement = "get_stat_result with STAT_FILE_KIND"
     )]
     pub(crate) fn open_job_get_kind(result: &OpenJobResult) -> i32 {
         result.kind
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_open_job_get_dev_id"
+        original = "moonbitlang_async_open_job_get_dev_id",
+        upstream_pr = 527,
+        replacement = "get_stat_result with STAT_DEVICE_ID"
     )]
     pub(crate) fn open_job_get_dev_id(result: &OpenJobResult) -> u64 {
         result.dev_id
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_open_job_get_file_id"
+        original = "moonbitlang_async_open_job_get_file_id",
+        upstream_pr = 527,
+        replacement = "get_stat_result with STAT_FILE_ID"
     )]
     pub(crate) fn open_job_get_file_id(result: &OpenJobResult) -> u64 {
         result.file_id
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_file_size_job"
+        original = "moonbitlang_async_make_file_size_job",
+        upstream_pr = 527,
+        replacement = "make_fstatx_job with STAT_FILE_SIZE"
     )]
     pub(crate) fn make_file_size_job(file: ResourceRef) -> Job {
         Job::new(JobPayload::FileSize {
@@ -197,9 +285,11 @@ ported_fns! {
         })
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_file_time_job"
+        original = "moonbitlang_async_make_file_time_job",
+        upstream_pr = 527,
+        replacement = "make_fstatx_job with timestamp properties"
     )]
     pub(crate) fn make_file_time_job(file: ResourceRef) -> Job {
         Job::new(JobPayload::FileTime {
@@ -208,9 +298,11 @@ ported_fns! {
         })
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_file_time_by_path_job"
+        original = "moonbitlang_async_make_file_time_by_path_job",
+        upstream_pr = 527,
+        replacement = "make_statx_job with timestamp properties"
     )]
     pub(crate) fn make_file_time_by_path_job(
         path: OsString,
@@ -224,7 +316,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_access_job"
     )]
     pub(crate) fn make_access_job(path: OsString, access: i32) -> Job {
@@ -232,16 +324,18 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_chmod_job"
     )]
     pub(crate) fn make_chmod_job(path: OsString, mode: i32) -> Job {
         Job::new(JobPayload::Chmod { path, mode })
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_get_file_size_result"
+        original = "moonbitlang_async_get_file_size_result",
+        upstream_pr = 527,
+        replacement = "get_stat_result"
     )]
     pub(crate) fn get_file_size_result(job: &Job) -> AsyncHostResult<i64> {
         match job.payload() {
@@ -251,7 +345,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_fsync_job"
     )]
     pub(crate) fn make_fsync_job(file: ResourceRef, only_data: bool) -> Job {
@@ -262,7 +356,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_flock_job"
     )]
     pub(crate) fn make_flock_job(file: ResourceRef, exclusive: bool) -> Job {
@@ -273,7 +367,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_remove_job"
     )]
     pub(crate) fn make_remove_job(path: OsString) -> Job {
@@ -281,7 +375,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_rename_job"
     )]
     pub(crate) fn make_rename_job(old_path: OsString, new_path: OsString, replace: bool) -> Job {
@@ -293,7 +387,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_symlink_job"
     )]
     pub(crate) fn make_symlink_job(target: OsString, path: OsString, force_symlink: bool) -> Job {
@@ -305,7 +399,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_mkdir_job"
     )]
     pub(crate) fn make_mkdir_job(path: OsString, mode: i32) -> Job {
@@ -313,7 +407,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_rmdir_job"
     )]
     pub(crate) fn make_rmdir_job(path: OsString) -> Job {
@@ -321,7 +415,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_readdir_job"
     )]
     pub(crate) fn make_readdir_job(
@@ -358,7 +452,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_realpath_job"
     )]
     pub(crate) fn make_realpath_job(path: OsString) -> Job {
@@ -366,7 +460,7 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
+        source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_get_realpath_result"
     )]
     pub(crate) fn publish_realpath_result(
@@ -533,8 +627,12 @@ pub(crate) fn open_job_result(job: &Job) -> AsyncHostResult<&OpenJobResult> {
         JobPayload::Open {
             result: Some(result),
             ..
+        }
+        | JobPayload::OpenStat {
+            result: Some(result),
+            ..
         } => Ok(result),
-        JobPayload::Open { .. } => Err(AsyncHostError::Inval),
+        JobPayload::Open { .. } | JobPayload::OpenStat { .. } => Err(AsyncHostError::Inval),
         _ => Err(AsyncHostError::Badf),
     }
 }
@@ -544,8 +642,35 @@ pub(crate) fn open_job_result_mut(job: &mut Job) -> AsyncHostResult<&mut OpenJob
         JobPayload::Open {
             result: Some(result),
             ..
+        }
+        | JobPayload::OpenStat {
+            result: Some(result),
+            ..
         } => Ok(result),
-        JobPayload::Open { .. } => Err(AsyncHostError::Inval),
+        JobPayload::Open { .. } | JobPayload::OpenStat { .. } => Err(AsyncHostError::Inval),
+        _ => Err(AsyncHostError::Badf),
+    }
+}
+
+pub(crate) fn stat_job_result(job: &Job) -> AsyncHostResult<&PackedStat> {
+    match job.payload() {
+        JobPayload::OpenStat {
+            result: Some(OpenJobResult {
+                stat: Some(result), ..
+            }),
+            ..
+        }
+        | JobPayload::Fstatx {
+            result: Some(result),
+            ..
+        }
+        | JobPayload::Statx {
+            result: Some(result),
+            ..
+        } => Ok(result),
+        JobPayload::OpenStat { .. } | JobPayload::Fstatx { .. } | JobPayload::Statx { .. } => {
+            Err(AsyncHostError::Inval)
+        }
         _ => Err(AsyncHostError::Badf),
     }
 }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -24,6 +24,7 @@ mod runner;
 mod signal;
 mod sleep;
 mod socket;
+mod stat;
 mod types;
 mod worker;
 
@@ -39,14 +40,16 @@ pub(crate) use jobs::{
     errno_is_cancelled, get_file_size_result, get_platform, get_spawn_job_result_handle,
     getaddrinfo_job_result, job_get_err, job_get_ret, make_access_job, make_bind_job,
     make_chmod_job, make_failed_job, make_file_kind_by_path_job, make_file_size_job,
-    make_file_time_by_path_job, make_file_time_job, make_flock_job, make_fsync_job,
-    make_getaddrinfo_job, make_mkdir_job, make_open_job, make_read_job, make_readdir_job,
-    make_realpath_job, make_remove_job, make_rename_job, make_rmdir_job, make_sleep_job,
-    make_symlink_job, make_wait_for_process_job, make_write_job, open_job_get_dev_id,
-    open_job_get_fd, open_job_get_file_id, open_job_get_kind, open_job_result, open_job_result_mut,
-    publish_realpath_result, set_spawn_job_result, take_spawn_job_result,
+    make_file_time_by_path_job, make_file_time_job, make_flock_job, make_fstatx_job,
+    make_fsync_job, make_getaddrinfo_job, make_mkdir_job, make_open_job, make_open_stat_job,
+    make_read_job, make_readdir_job, make_realpath_job, make_remove_job, make_rename_job,
+    make_rmdir_job, make_sleep_job, make_statx_job, make_symlink_job, make_wait_for_process_job,
+    make_write_job, open_job_get_dev_id, open_job_get_fd, open_job_get_file_id, open_job_get_kind,
+    open_job_result, open_job_result_mut, publish_realpath_result, set_spawn_job_result,
+    take_spawn_job_result,
 };
-pub(crate) use runner::{get_file_time_result, get_read_result, run_host_job};
+pub(crate) use runner::{get_file_time_result, get_read_result, get_stat_result, run_host_job};
+pub(crate) use stat::STAT_OPEN_IDENTITY;
 pub(crate) use types::{
     FileRef, FileTimeResult, HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult,
     RealpathJobResult, Resource, ResourceClass, ResourceRef, ResourceTable, SpawnOptions,
@@ -63,6 +66,14 @@ pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
     let mut symbols = Vec::new();
     symbols.extend_from_slice(jobs::PORTED_SYMBOLS);
     symbols.extend_from_slice(worker::PORTED_SYMBOLS);
+    symbols
+}
+
+#[cfg(test)]
+pub(crate) fn compat_symbols() -> Vec<crate::async_sys::CompatSymbol> {
+    let mut symbols = Vec::new();
+    symbols.extend_from_slice(jobs::COMPAT_SYMBOLS);
+    symbols.extend_from_slice(fs::COMPAT_SYMBOLS);
     symbols
 }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -22,8 +22,8 @@ use crate::async_sys::internal::fd_util;
 use super::fs::{
     run_access_job, run_chmod_job, run_file_kind_by_path_job, run_file_size_job,
     run_file_time_by_path_job, run_file_time_job, run_flock_job, run_fsync_job, run_mkdir_job,
-    run_open_job, run_read_job, run_readdir_job, run_realpath_job, run_remove_job, run_rename_job,
-    run_rmdir_job, run_symlink_job, run_write_job,
+    run_open_job, run_open_stat_job, run_read_job, run_readdir_job, run_realpath_job,
+    run_remove_job, run_rename_job, run_rmdir_job, run_symlink_job, run_write_job,
 };
 #[cfg(unix)]
 use super::process::run_spawn_job_unix;
@@ -34,6 +34,7 @@ use super::process::run_wait_for_process_job;
 use super::signal::run_sigwait_job;
 use super::sleep::run_sleep_job;
 use super::socket::{run_bind_job, run_getaddrinfo_job};
+use super::stat::{run_fstatx_job, run_statx_job};
 use super::types::{Job, JobPayload};
 
 pub(crate) fn run_host_job(job: &mut Job) {
@@ -62,6 +63,49 @@ pub(crate) fn run_host_job(job: &mut Job) {
             *sync,
             *mode,
         ),
+        JobPayload::OpenStat {
+            filename,
+            access,
+            create_mode,
+            append,
+            sync,
+            mode,
+            request,
+            result,
+        } => run_open_stat_job(
+            result,
+            std::mem::take(filename),
+            *access,
+            *create_mode,
+            *append,
+            *sync,
+            *mode,
+            *request,
+        ),
+        JobPayload::Fstatx {
+            file,
+            request,
+            result,
+        } => match file.take() {
+            Some(file) => run_fstatx_job(&file, *request, result),
+            None => Err(AsyncHostError::Badf),
+        },
+        JobPayload::Statx {
+            parent,
+            path,
+            request,
+            follow_symlink,
+            result,
+        } => {
+            let parent = parent.take();
+            run_statx_job(
+                parent.as_deref(),
+                std::mem::take(path),
+                *request,
+                *follow_symlink,
+                result,
+            )
+        }
         JobPayload::Read {
             file,
             len,
@@ -251,4 +295,17 @@ pub(crate) fn get_file_time_result(
     record[32..40].copy_from_slice(&fd_util::stub::get_ctime_sec(file_time).to_le_bytes());
     record[40..44].copy_from_slice(&fd_util::stub::get_ctime_nsec(file_time).to_le_bytes());
     memory.write_exact(dst, &record)
+}
+
+pub(crate) fn get_stat_result(
+    job: &Job,
+    memory: &mut (impl GuestMemory + ?Sized),
+    dst: i32,
+    dst_len: i32,
+) -> AsyncHostResult<()> {
+    if job.err() != 0 {
+        return Ok(());
+    }
+    let result = super::jobs::stat_job_result(job)?;
+    memory.write_with_capacity(dst, dst_len, result.as_bytes())
 }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -22,8 +22,8 @@ use crate::async_sys::internal::fd_util;
 use super::fs::{
     run_access_job, run_chmod_job, run_file_kind_by_path_job, run_file_size_job,
     run_file_time_by_path_job, run_file_time_job, run_flock_job, run_fsync_job, run_mkdir_job,
-    run_open_job, run_open_stat_job, run_read_job, run_readdir_job, run_realpath_job,
-    run_remove_job, run_rename_job, run_rmdir_job, run_symlink_job, run_write_job,
+    run_open_job, run_read_job, run_readdir_job, run_realpath_job, run_remove_job, run_rename_job,
+    run_rmdir_job, run_symlink_job, run_write_job,
 };
 #[cfg(unix)]
 use super::process::run_spawn_job_unix;
@@ -53,26 +53,9 @@ pub(crate) fn run_host_job(job: &mut Job) {
             append,
             sync,
             mode,
-            result,
-        } => run_open_job(
-            result,
-            std::mem::take(filename),
-            *access,
-            *create_mode,
-            *append,
-            *sync,
-            *mode,
-        ),
-        JobPayload::OpenStat {
-            filename,
-            access,
-            create_mode,
-            append,
-            sync,
-            mode,
             request,
             result,
-        } => run_open_stat_job(
+        } => run_open_job(
             result,
             std::mem::take(filename),
             *access,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/stat.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/stat.rs
@@ -50,6 +50,13 @@ pub(crate) struct StatRequest {
 }
 
 impl StatRequest {
+    pub(super) const fn open_identity() -> Self {
+        Self {
+            mask: STAT_OPEN_IDENTITY,
+            encoded_len: 32,
+        }
+    }
+
     pub(super) fn new(mask: u32, capacity: i32) -> AsyncHostResult<Self> {
         if mask & !STAT_SUPPORTED_PROPERTY_MASK != 0 || capacity < STAT_HEADER_LEN as i32 {
             return Err(AsyncHostError::Inval);
@@ -114,6 +121,7 @@ pub(super) struct StatValues {
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct PackedStat {
+    request: StatRequest,
     bytes: Box<[u8]>,
 }
 
@@ -188,12 +196,30 @@ impl PackedStat {
         bytes[0..4].copy_from_slice(&(request.encoded_len() as u32).to_le_bytes());
         bytes[4..8].copy_from_slice(&returned_mask.to_le_bytes());
         Self {
+            request,
             bytes: bytes.into_boxed_slice(),
         }
     }
 
     pub(super) fn as_bytes(&self) -> &[u8] {
         &self.bytes
+    }
+
+    pub(super) fn scalar(&self, property: u32) -> Option<u64> {
+        if property.count_ones() != 1 || self.request.mask() & property == 0 {
+            return None;
+        }
+        // Read the fixed slot, not the returned-property mask: legacy open
+        // getters exposed an unavailable identity value as zero.
+        let property_index = property.trailing_zeros();
+        let preceding_words = (0..property_index)
+            .filter(|bit| self.request.mask() & (1 << bit) != 0)
+            .map(|bit| if bit < 4 { 1 } else { 2 })
+            .sum::<usize>();
+        self.bytes
+            .get(STAT_HEADER_LEN + preceding_words * 8..STAT_HEADER_LEN + (preceding_words + 1) * 8)
+            .and_then(|bytes| bytes.try_into().ok())
+            .map(u64::from_le_bytes)
     }
 }
 
@@ -966,9 +992,11 @@ mod platform {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use crate::async_sys::internal::event_loop::thread_pool::{
-        JobPayload, Resource, get_stat_result, make_fstatx_job, make_open_stat_job, run_host_job,
+        JobPayload, Resource, get_stat_result, make_fstatx_job,
     };
+    use crate::async_sys::internal::event_loop::thread_pool::{make_open_stat_job, run_host_job};
 
     #[test]
     fn request_layout_is_stable_for_every_supported_mask() {
@@ -1025,6 +1053,9 @@ mod tests {
         assert_eq!(&packed.as_bytes()[24..32], &(-2_i64).to_le_bytes());
         assert_eq!(&packed.as_bytes()[32..40], &123_i64.to_le_bytes());
         assert_eq!(&packed.as_bytes()[40..56], &[0; 16]);
+        assert_eq!(packed.scalar(STAT_FILE_KIND), Some(2));
+        assert_eq!(packed.scalar(STAT_FILE_SIZE), Some(0));
+        assert_eq!(packed.scalar(STAT_DEVICE_ID), None);
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/stat.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/stat.rs
@@ -679,9 +679,25 @@ mod platform {
             return Err(last_native_error());
         }
         let stat = unsafe { stat.assume_init() };
+        let requested_time = |property, seconds, nanoseconds| {
+            (request.mask() & property != 0).then_some(StatTimestamp {
+                seconds,
+                nanoseconds,
+            })
+        };
         Ok(StatValues {
             kind: (request.mask() & STAT_FILE_KIND != 0).then(|| file_kind_from_mode(stat.st_mode)),
-            ..StatValues::default()
+            size: (request.mask() & STAT_FILE_SIZE != 0).then_some(stat.st_size),
+            device_id: (request.mask() & STAT_DEVICE_ID != 0).then_some(stat.st_dev as u64),
+            file_id: (request.mask() & STAT_FILE_ID != 0).then_some(stat.st_ino),
+            access_time: requested_time(STAT_ACCESS_TIME, stat.st_atime, stat.st_atime_nsec),
+            modify_time: requested_time(STAT_MODIFY_TIME, stat.st_mtime, stat.st_mtime_nsec),
+            change_time: requested_time(STAT_CHANGE_TIME, stat.st_ctime, stat.st_ctime_nsec),
+            create_time: requested_time(
+                STAT_CREATE_TIME,
+                stat.st_birthtime,
+                stat.st_birthtime_nsec,
+            ),
         })
     }
 
@@ -733,24 +749,25 @@ mod platform {
     use std::os::windows::ffi::OsStrExt;
 
     use windows_sys::Win32::Foundation::{
-        CloseHandle, ERROR_NOT_SUPPORTED, GetLastError, HANDLE, INVALID_HANDLE_VALUE, SetLastError,
+        CloseHandle, GetLastError, HANDLE, INVALID_HANDLE_VALUE, SetLastError,
     };
-    use windows_sys::Win32::Networking::WinSock::{SO_TYPE, SOL_SOCKET, getsockopt};
     use windows_sys::Win32::Storage::FileSystem::{
         BY_HANDLE_FILE_INFORMATION, CreateFileW, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_NORMAL,
         FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO, FILE_BASIC_INFO,
         FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_INFO_BY_HANDLE_CLASS,
-        FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
-        FILE_STANDARD_INFO, FILE_TYPE_CHAR, FILE_TYPE_DISK, FILE_TYPE_PIPE, FILE_TYPE_UNKNOWN,
-        FileAttributeTagInfo, FileBasicInfo, FileStandardInfo, GetFileInformationByHandle,
-        GetFileInformationByHandleEx, GetFileType, OPEN_EXISTING,
+        FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_TYPE_CHAR,
+        FILE_TYPE_DISK, FILE_TYPE_PIPE, FILE_TYPE_UNKNOWN, FileAttributeTagInfo, FileBasicInfo,
+        GetFileInformationByHandle, GetFileInformationByHandleEx, GetFileSize, GetFileType,
+        INVALID_FILE_SIZE, OPEN_EXISTING,
     };
 
+    use super::super::fs::{handle_is_socket, resolve_windows_path_for_parent};
     use super::*;
 
     #[derive(Default)]
     struct WindowsStat {
         file_type: Option<u32>,
+        is_socket: bool,
         attributes: Option<u32>,
         size: Option<i64>,
         device_id: Option<u64>,
@@ -765,7 +782,11 @@ mod platform {
         handle: HANDLE,
         request: StatRequest,
     ) -> AsyncHostResult<StatValues> {
-        query(handle, request)
+        let values = query(handle, request)?;
+        if values.returned_mask() == 0 {
+            get_file_type(handle)?;
+        }
+        Ok(values)
     }
 
     pub(super) fn query_path(
@@ -774,9 +795,7 @@ mod platform {
         follow_symlink: bool,
         request: StatRequest,
     ) -> AsyncHostResult<StatValues> {
-        if parent.is_some() {
-            return Err(AsyncHostError::Native(ERROR_NOT_SUPPORTED as i32));
-        }
+        let path = resolve_windows_path_for_parent(parent, path)?;
         let path: Vec<u16> = path.encode_wide().chain(std::iter::once(0)).collect();
         let flags = FILE_ATTRIBUTE_NORMAL
             | FILE_FLAG_BACKUP_SEMANTICS
@@ -810,18 +829,12 @@ mod platform {
         let mut stat = WindowsStat::default();
         let mut remaining = request.mask();
 
-        if request.mask() & STAT_FILE_KIND != 0 || request.mask() == 0 {
-            unsafe { SetLastError(0) };
-            let file_type = unsafe { GetFileType(handle) };
-            if file_type == FILE_TYPE_UNKNOWN && unsafe { GetLastError() } != 0 {
-                return Err(last_native_error());
-            }
+        if request.mask() & STAT_FILE_KIND != 0 {
+            let (file_type, is_socket) = get_file_type(handle)?;
             stat.file_type = Some(file_type);
-            if request.mask() & STAT_FILE_KIND != 0 {
-                remaining &= !STAT_FILE_KIND;
-            }
+            stat.is_socket = is_socket;
             if file_type != FILE_TYPE_DISK {
-                return Ok(to_values(handle, request, stat));
+                return Ok(to_values(request, stat));
             }
         }
 
@@ -830,26 +843,29 @@ mod platform {
             | STAT_MODIFY_TIME
             | STAT_CHANGE_TIME
             | STAT_CREATE_TIME;
-        if remaining != 0 && remaining & !STAT_FILE_KIND == 0 {
+        if remaining & !STAT_FILE_KIND == 0 {
             if let Some(info) = query_info::<FILE_ATTRIBUTE_TAG_INFO>(handle, FileAttributeTagInfo)
             {
                 stat.attributes = Some(info.FileAttributes);
                 remaining &= !STAT_FILE_KIND;
             }
-        } else if remaining & STAT_CHANGE_TIME != 0 || remaining & !BASIC_PROPERTIES == 0 {
-            if let Some(info) = query_info::<FILE_BASIC_INFO>(handle, FileBasicInfo) {
-                stat.attributes = Some(info.FileAttributes);
-                stat.access_time = Some(info.LastAccessTime);
-                stat.modify_time = Some(info.LastWriteTime);
-                stat.change_time = Some(info.ChangeTime);
-                stat.create_time = Some(info.CreationTime);
-                remaining &= !BASIC_PROPERTIES;
-            }
+        } else if (remaining & STAT_CHANGE_TIME != 0 || remaining & !BASIC_PROPERTIES == 0)
+            && let Some(info) = query_info::<FILE_BASIC_INFO>(handle, FileBasicInfo)
+        {
+            stat.attributes = Some(info.FileAttributes);
+            stat.access_time = Some(info.LastAccessTime);
+            stat.modify_time = Some(info.LastWriteTime);
+            stat.change_time = Some(info.ChangeTime);
+            stat.create_time = Some(info.CreationTime);
+            remaining &= !BASIC_PROPERTIES;
         }
 
         if remaining == STAT_FILE_SIZE {
-            if let Some(info) = query_info::<FILE_STANDARD_INFO>(handle, FileStandardInfo) {
-                stat.size = Some(info.EndOfFile);
+            unsafe { SetLastError(0) };
+            let mut high = 0;
+            let low = unsafe { GetFileSize(handle, &mut high) };
+            if low != INVALID_FILE_SIZE || unsafe { GetLastError() } == 0 {
+                stat.size = Some(i64::from(high) << 32 | i64::from(low));
             }
         } else if remaining != 0 {
             let mut info = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
@@ -867,23 +883,7 @@ mod platform {
             }
         }
 
-        if request.mask() & STAT_FILE_KIND != 0
-            && stat.file_type == Some(FILE_TYPE_DISK)
-            && stat.attributes.is_none()
-            && let Some(info) = query_info::<FILE_ATTRIBUTE_TAG_INFO>(handle, FileAttributeTagInfo)
-        {
-            stat.attributes = Some(info.FileAttributes);
-        }
-
-        let values = to_values(handle, request, stat);
-        if request.mask() != 0 && values.returned_mask() == 0 {
-            unsafe { SetLastError(0) };
-            if unsafe { GetFileType(handle) } == FILE_TYPE_UNKNOWN && unsafe { GetLastError() } != 0
-            {
-                return Err(last_native_error());
-            }
-        }
-        Ok(values)
+        Ok(to_values(request, stat))
     }
 
     fn query_info<T: Copy>(handle: HANDLE, class: FILE_INFO_BY_HANDLE_CLASS) -> Option<T> {
@@ -899,10 +899,10 @@ mod platform {
             .then(|| unsafe { info.assume_init() })
     }
 
-    fn to_values(handle: HANDLE, request: StatRequest, stat: WindowsStat) -> StatValues {
+    fn to_values(request: StatRequest, stat: WindowsStat) -> StatValues {
         StatValues {
             kind: (request.mask() & STAT_FILE_KIND != 0)
-                .then(|| windows_file_kind(handle, stat.file_type?, stat.attributes))
+                .then(|| windows_file_kind(stat.file_type?, stat.is_socket, stat.attributes))
                 .flatten(),
             size: (request.mask() & STAT_FILE_SIZE != 0)
                 .then_some(stat.size)
@@ -931,7 +931,7 @@ mod platform {
             .map(windows_timestamp)
     }
 
-    fn windows_file_kind(handle: HANDLE, file_type: u32, attributes: Option<u32>) -> Option<i32> {
+    fn windows_file_kind(file_type: u32, is_socket: bool, attributes: Option<u32>) -> Option<i32> {
         match file_type {
             FILE_TYPE_DISK => attributes.map(|attributes| {
                 if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
@@ -944,18 +944,7 @@ mod platform {
             }),
             FILE_TYPE_CHAR => Some(7),
             FILE_TYPE_PIPE | FILE_TYPE_UNKNOWN => {
-                let mut socket_type = 0;
-                let mut len = std::mem::size_of::<i32>() as i32;
-                if unsafe {
-                    getsockopt(
-                        handle as usize,
-                        SOL_SOCKET,
-                        SO_TYPE,
-                        std::ptr::from_mut(&mut socket_type).cast(),
-                        &mut len,
-                    )
-                } == 0
-                {
+                if is_socket {
                     Some(4)
                 } else if file_type == FILE_TYPE_PIPE {
                     Some(5)
@@ -964,6 +953,22 @@ mod platform {
                 }
             }
             _ => Some(0),
+        }
+    }
+
+    fn get_file_type(handle: HANDLE) -> AsyncHostResult<(u32, bool)> {
+        unsafe { SetLastError(0) };
+        let file_type = unsafe { GetFileType(handle) };
+        let get_file_type_error = unsafe { GetLastError() };
+        let is_socket =
+            matches!(file_type, FILE_TYPE_PIPE | FILE_TYPE_UNKNOWN) && handle_is_socket(handle);
+        if file_type == FILE_TYPE_UNKNOWN && get_file_type_error != 0 && !is_socket {
+            // A Winsock SOCKET is not a kernel HANDLE. Give getsockopt a chance
+            // before propagating GetFileType's ERROR_INVALID_HANDLE.
+            unsafe { SetLastError(get_file_type_error) };
+            Err(last_native_error())
+        } else {
+            Ok((file_type, is_socket))
         }
     }
 
@@ -1133,6 +1138,105 @@ mod tests {
 
         assert_eq!(link_values.kind, Some(3));
         assert_eq!(target_values.kind, Some(1));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_non_vnode_fallback_returns_all_fstat_metadata() {
+        use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+        let mut pipe = [0; 2];
+        assert_eq!(unsafe { libc::pipe(pipe.as_mut_ptr()) }, 0);
+        let read_end = unsafe { OwnedFd::from_raw_fd(pipe[0]) };
+        let _write_end = unsafe { OwnedFd::from_raw_fd(pipe[1]) };
+        let request = StatRequest::new(STAT_SUPPORTED_PROPERTY_MASK, 104).unwrap();
+
+        let values = platform::query_handle(read_end.as_raw_fd(), request).unwrap();
+
+        assert_eq!(values.kind, Some(5));
+        assert!(values.size.is_some());
+        assert!(values.device_id.is_some());
+        assert!(values.file_id.is_some());
+        assert!(values.access_time.is_some());
+        assert!(values.modify_time.is_some());
+        assert!(values.change_time.is_some());
+        assert!(values.create_time.is_some());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_parent_relative_query_resolves_from_directory_handle() {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+        use windows_sys::Win32::Storage::FileSystem::{
+            CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_BACKUP_SEMANTICS, FILE_READ_ATTRIBUTES,
+            FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("child"), b"child").unwrap();
+        let parent_path: Vec<u16> = temp
+            .path()
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        let parent = unsafe {
+            CreateFileW(
+                parent_path.as_ptr(),
+                FILE_READ_ATTRIBUTES,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                std::ptr::null(),
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_ne!(parent, INVALID_HANDLE_VALUE);
+        let request = StatRequest::new(STAT_FILE_KIND | STAT_FILE_SIZE, 24).unwrap();
+
+        let values = platform::query_path(Some(parent), OsString::from("child"), true, request);
+        unsafe {
+            CloseHandle(parent);
+        }
+        let values = values.unwrap();
+
+        assert_eq!(values.kind, Some(1));
+        assert_eq!(values.size, Some(5));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_fstatx_reports_socket_kind_before_get_file_type_error() {
+        use crate::async_sys::internal::event_loop::thread_pool::ResourceClass;
+
+        assert_eq!(crate::async_sys::internal::event_loop::io::init_wsa(), 0);
+        let raw_socket = crate::async_sys::socket::make_tcp_socket(4).unwrap();
+        let resource = Resource::new_socket(raw_socket, ResourceClass::TcpSocket, 4);
+        let request = StatRequest::new(STAT_FILE_KIND, 16).unwrap();
+        let mut result = None;
+
+        run_fstatx_job(&resource, request, &mut result).unwrap();
+
+        assert_eq!(result.unwrap().scalar(STAT_FILE_KIND), Some(4));
+
+        let request = StatRequest::new(STAT_FILE_SIZE, 16).unwrap();
+        let mut result = None;
+        run_fstatx_job(&resource, request, &mut result).unwrap();
+        assert_eq!(&result.unwrap().as_bytes()[4..8], &0_u32.to_le_bytes());
+
+        drop(resource);
+        assert_eq!(crate::async_sys::internal::event_loop::io::cleanup_wsa(), 0);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_empty_stat_request_still_validates_the_handle() {
+        use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+
+        let request = StatRequest::new(0, 8).unwrap();
+
+        assert!(platform::query_handle(INVALID_HANDLE_VALUE, request).is_err());
     }
 
     #[test]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/stat.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/stat.rs
@@ -1,0 +1,1126 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Stable generic-stat result layout shared by the platform adapters.
+
+use std::ffi::OsString;
+
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, AsRawSocket};
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+
+use super::Resource;
+
+pub(super) const STAT_FILE_KIND: u32 = 0x0001;
+pub(super) const STAT_FILE_SIZE: u32 = 0x0002;
+pub(super) const STAT_DEVICE_ID: u32 = 0x0004;
+pub(super) const STAT_FILE_ID: u32 = 0x0008;
+pub(super) const STAT_ACCESS_TIME: u32 = 0x0010;
+pub(super) const STAT_MODIFY_TIME: u32 = 0x0020;
+pub(super) const STAT_CHANGE_TIME: u32 = 0x0040;
+pub(super) const STAT_CREATE_TIME: u32 = 0x0080;
+
+pub(crate) const STAT_OPEN_IDENTITY: u32 = STAT_FILE_KIND | STAT_DEVICE_ID | STAT_FILE_ID;
+
+const STAT_SUPPORTED_PROPERTY_MASK: u32 = 0x00ff;
+const STAT_HEADER_LEN: usize = 8;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StatRequest {
+    mask: u32,
+    encoded_len: usize,
+}
+
+impl StatRequest {
+    pub(super) fn new(mask: u32, capacity: i32) -> AsyncHostResult<Self> {
+        if mask & !STAT_SUPPORTED_PROPERTY_MASK != 0 || capacity < STAT_HEADER_LEN as i32 {
+            return Err(AsyncHostError::Inval);
+        }
+        let property_words = (0..8)
+            .filter(|bit| mask & (1 << bit) != 0)
+            .map(|bit| if bit < 4 { 1 } else { 2 })
+            .sum::<usize>();
+        let encoded_len = STAT_HEADER_LEN + property_words * 8;
+        if encoded_len > capacity as usize {
+            return Err(AsyncHostError::Inval);
+        }
+        Ok(Self { mask, encoded_len })
+    }
+
+    pub(crate) fn mask(self) -> u32 {
+        self.mask
+    }
+
+    pub(super) fn encoded_len(self) -> usize {
+        self.encoded_len
+    }
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+mod platform {
+    use std::ffi::OsString;
+
+    use super::*;
+
+    pub(super) fn query_handle(_fd: i32, _request: StatRequest) -> AsyncHostResult<StatValues> {
+        Err(AsyncHostError::Native(libc::ENOSYS))
+    }
+
+    pub(super) fn query_path(
+        _parent: Option<i32>,
+        _path: OsString,
+        _follow_symlink: bool,
+        _request: StatRequest,
+    ) -> AsyncHostResult<StatValues> {
+        Err(AsyncHostError::Native(libc::ENOSYS))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct StatTimestamp {
+    pub(super) seconds: i64,
+    pub(super) nanoseconds: i64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct StatValues {
+    pub(super) kind: Option<i32>,
+    pub(super) size: Option<i64>,
+    pub(super) device_id: Option<u64>,
+    pub(super) file_id: Option<u64>,
+    pub(super) access_time: Option<StatTimestamp>,
+    pub(super) modify_time: Option<StatTimestamp>,
+    pub(super) change_time: Option<StatTimestamp>,
+    pub(super) create_time: Option<StatTimestamp>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct PackedStat {
+    bytes: Box<[u8]>,
+}
+
+impl PackedStat {
+    pub(super) fn new(request: StatRequest, values: StatValues) -> Self {
+        let mut bytes = vec![0; request.encoded_len()];
+        let mut returned_mask = 0_u32;
+        let mut offset = STAT_HEADER_LEN;
+
+        for bit in 0..8 {
+            let property = 1_u32 << bit;
+            if request.mask() & property == 0 {
+                continue;
+            }
+            let mut write_word = |value: [u8; 8]| {
+                bytes[offset..offset + 8].copy_from_slice(&value);
+                offset += 8;
+            };
+            match property {
+                STAT_FILE_KIND => {
+                    if let Some(value) = values.kind {
+                        returned_mask |= property;
+                        write_word(u64::from(value as u32).to_le_bytes());
+                    } else {
+                        offset += 8;
+                    }
+                }
+                STAT_FILE_SIZE => {
+                    if let Some(value) = values.size {
+                        returned_mask |= property;
+                        write_word(value.to_le_bytes());
+                    } else {
+                        offset += 8;
+                    }
+                }
+                STAT_DEVICE_ID => {
+                    if let Some(value) = values.device_id {
+                        returned_mask |= property;
+                        write_word(value.to_le_bytes());
+                    } else {
+                        offset += 8;
+                    }
+                }
+                STAT_FILE_ID => {
+                    if let Some(value) = values.file_id {
+                        returned_mask |= property;
+                        write_word(value.to_le_bytes());
+                    } else {
+                        offset += 8;
+                    }
+                }
+                STAT_ACCESS_TIME | STAT_MODIFY_TIME | STAT_CHANGE_TIME | STAT_CREATE_TIME => {
+                    let value = match property {
+                        STAT_ACCESS_TIME => values.access_time,
+                        STAT_MODIFY_TIME => values.modify_time,
+                        STAT_CHANGE_TIME => values.change_time,
+                        STAT_CREATE_TIME => values.create_time,
+                        _ => unreachable!(),
+                    };
+                    if let Some(value) = value {
+                        returned_mask |= property;
+                        write_word(value.seconds.to_le_bytes());
+                        write_word(value.nanoseconds.to_le_bytes());
+                    } else {
+                        offset += 16;
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        bytes[0..4].copy_from_slice(&(request.encoded_len() as u32).to_le_bytes());
+        bytes[4..8].copy_from_slice(&returned_mask.to_le_bytes());
+        Self {
+            bytes: bytes.into_boxed_slice(),
+        }
+    }
+
+    pub(super) fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+#[cfg(any(windows, test))]
+const WINDOWS_EPOCH_OFFSET_SECONDS: i64 = 11_644_473_600;
+
+#[cfg(any(windows, test))]
+fn windows_timestamp(ticks: i64) -> StatTimestamp {
+    StatTimestamp {
+        seconds: ticks.div_euclid(10_000_000) - WINDOWS_EPOCH_OFFSET_SECONDS,
+        nanoseconds: ticks.rem_euclid(10_000_000) * 100,
+    }
+}
+
+pub(super) fn run_fstatx_job(
+    file: &Resource,
+    request: StatRequest,
+    result: &mut Option<PackedStat>,
+) -> AsyncHostResult<i64> {
+    #[cfg(unix)]
+    let raw = file.as_file()?.as_raw_fd();
+    #[cfg(windows)]
+    let raw = if file.resource_class().is_socket() {
+        file.as_socket()?.as_raw_socket() as usize as windows_sys::Win32::Foundation::HANDLE
+    } else {
+        file.as_file()?.as_raw_handle()
+    };
+
+    *result = Some(PackedStat::new(
+        request,
+        platform::query_handle(raw, request)?,
+    ));
+    Ok(0)
+}
+
+pub(super) fn run_statx_job(
+    parent: Option<&Resource>,
+    path: OsString,
+    request: StatRequest,
+    follow_symlink: bool,
+    result: &mut Option<PackedStat>,
+) -> AsyncHostResult<i64> {
+    #[cfg(unix)]
+    let parent = parent
+        .map(|resource| resource.as_file().map(|file| file.as_raw_fd()))
+        .transpose()?;
+    #[cfg(windows)]
+    let parent = parent
+        .map(|resource| resource.as_file().map(|file| file.as_raw_handle()))
+        .transpose()?;
+
+    *result = Some(PackedStat::new(
+        request,
+        platform::query_path(parent, path, follow_symlink, request)?,
+    ));
+    Ok(0)
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use std::ffi::{CString, OsString};
+    use std::mem::MaybeUninit;
+    use std::os::unix::ffi::OsStrExt;
+
+    use super::*;
+
+    const AT_EMPTY_PATH: i32 = 0x1000;
+    const STATX_TYPE: u32 = 0x0000_0001;
+    const STATX_ATIME: u32 = 0x0000_0020;
+    const STATX_MTIME: u32 = 0x0000_0040;
+    const STATX_CTIME: u32 = 0x0000_0080;
+    const STATX_INO: u32 = 0x0000_0100;
+    const STATX_SIZE: u32 = 0x0000_0200;
+    const STATX_BTIME: u32 = 0x0000_0800;
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct LinuxStatxTimestamp {
+        tv_sec: i64,
+        tv_nsec: u32,
+        _reserved: i32,
+    }
+
+    #[repr(C)]
+    struct LinuxStatx {
+        stx_mask: u32,
+        stx_blksize: u32,
+        stx_attributes: u64,
+        stx_nlink: u32,
+        stx_uid: u32,
+        stx_gid: u32,
+        stx_mode: u16,
+        _pad1: u16,
+        stx_ino: u64,
+        stx_size: u64,
+        stx_blocks: u64,
+        stx_attributes_mask: u64,
+        stx_atime: LinuxStatxTimestamp,
+        stx_btime: LinuxStatxTimestamp,
+        stx_ctime: LinuxStatxTimestamp,
+        stx_mtime: LinuxStatxTimestamp,
+        stx_rdev_major: u32,
+        stx_rdev_minor: u32,
+        stx_dev_major: u32,
+        stx_dev_minor: u32,
+        _spare: [u64; 14],
+    }
+
+    pub(super) fn query_handle(fd: i32, request: StatRequest) -> AsyncHostResult<StatValues> {
+        query(fd, c"", AT_EMPTY_PATH, request)
+    }
+
+    pub(super) fn query_path(
+        parent: Option<i32>,
+        path: OsString,
+        follow_symlink: bool,
+        request: StatRequest,
+    ) -> AsyncHostResult<StatValues> {
+        let path = CString::new(path.as_bytes()).map_err(|_| AsyncHostError::Inval)?;
+        let flags = if follow_symlink {
+            0
+        } else {
+            libc::AT_SYMLINK_NOFOLLOW
+        };
+        query(parent.unwrap_or(libc::AT_FDCWD), &path, flags, request)
+    }
+
+    fn query(
+        dirfd: i32,
+        path: &std::ffi::CStr,
+        flags: i32,
+        request: StatRequest,
+    ) -> AsyncHostResult<StatValues> {
+        let requested_statx_mask = (if request.mask() & STAT_FILE_KIND != 0 {
+            STATX_TYPE
+        } else {
+            0
+        }) | (if request.mask() & STAT_FILE_SIZE != 0 {
+            STATX_SIZE
+        } else {
+            0
+        }) | (if request.mask() & STAT_FILE_ID != 0 {
+            STATX_INO
+        } else {
+            0
+        }) | (if request.mask() & STAT_ACCESS_TIME != 0 {
+            STATX_ATIME
+        } else {
+            0
+        }) | (if request.mask() & STAT_MODIFY_TIME != 0 {
+            STATX_MTIME
+        } else {
+            0
+        }) | (if request.mask() & STAT_CHANGE_TIME != 0 {
+            STATX_CTIME
+        } else {
+            0
+        }) | (if request.mask() & STAT_CREATE_TIME != 0 {
+            STATX_BTIME
+        } else {
+            0
+        });
+
+        let mut info = MaybeUninit::<LinuxStatx>::zeroed();
+        if unsafe {
+            libc::syscall(
+                libc::SYS_statx,
+                dirfd,
+                path.as_ptr(),
+                flags,
+                requested_statx_mask,
+                info.as_mut_ptr(),
+            )
+        } < 0
+        {
+            return Err(last_native_error());
+        }
+        let info = unsafe { info.assume_init() };
+        let supported = |property, statx_mask| {
+            request.mask() & property != 0 && (statx_mask == 0 || info.stx_mask & statx_mask != 0)
+        };
+        let timestamp = |value: LinuxStatxTimestamp| StatTimestamp {
+            seconds: value.tv_sec,
+            nanoseconds: i64::from(value.tv_nsec),
+        };
+
+        Ok(StatValues {
+            kind: supported(STAT_FILE_KIND, STATX_TYPE).then(|| file_kind(info.stx_mode)),
+            size: supported(STAT_FILE_SIZE, STATX_SIZE).then_some(info.stx_size as i64),
+            device_id: supported(STAT_DEVICE_ID, 0)
+                .then(|| libc::makedev(info.stx_dev_major, info.stx_dev_minor)),
+            file_id: supported(STAT_FILE_ID, STATX_INO).then_some(info.stx_ino),
+            access_time: supported(STAT_ACCESS_TIME, STATX_ATIME)
+                .then(|| timestamp(info.stx_atime)),
+            modify_time: supported(STAT_MODIFY_TIME, STATX_MTIME)
+                .then(|| timestamp(info.stx_mtime)),
+            change_time: supported(STAT_CHANGE_TIME, STATX_CTIME)
+                .then(|| timestamp(info.stx_ctime)),
+            create_time: supported(STAT_CREATE_TIME, STATX_BTIME)
+                .then(|| timestamp(info.stx_btime)),
+        })
+    }
+
+    fn file_kind(mode: u16) -> i32 {
+        match u32::from(mode) & libc::S_IFMT {
+            libc::S_IFREG => 1,
+            libc::S_IFDIR => 2,
+            libc::S_IFLNK => 3,
+            libc::S_IFSOCK => 4,
+            libc::S_IFIFO => 5,
+            libc::S_IFBLK => 6,
+            libc::S_IFCHR => 7,
+            _ => 0,
+        }
+    }
+
+    fn last_native_error() -> AsyncHostError {
+        AsyncHostError::Native(
+            std::io::Error::last_os_error()
+                .raw_os_error()
+                .unwrap_or(libc::EINVAL),
+        )
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use std::ffi::{CString, OsString};
+    use std::mem::{MaybeUninit, size_of};
+    use std::os::unix::ffi::OsStrExt;
+
+    use super::*;
+
+    type FsObjType = u32;
+    const VREG: FsObjType = 1;
+    const VDIR: FsObjType = 2;
+    const VBLK: FsObjType = 3;
+    const VCHR: FsObjType = 4;
+    const VLNK: FsObjType = 5;
+    const VSOCK: FsObjType = 6;
+    const VFIFO: FsObjType = 7;
+
+    #[derive(Clone, Copy)]
+    struct Attribute {
+        group: usize,
+        bit: libc::attrgroup_t,
+        size: usize,
+    }
+
+    const ATTRIBUTES: [Attribute; 8] = [
+        Attribute {
+            group: 0,
+            bit: libc::ATTR_CMN_OBJTYPE,
+            size: size_of::<FsObjType>(),
+        },
+        Attribute {
+            group: 3,
+            bit: libc::ATTR_FILE_DATALENGTH,
+            size: size_of::<i64>(),
+        },
+        Attribute {
+            group: 0,
+            bit: libc::ATTR_CMN_DEVID,
+            size: size_of::<libc::dev_t>(),
+        },
+        Attribute {
+            group: 0,
+            bit: libc::ATTR_CMN_FILEID,
+            size: size_of::<u64>(),
+        },
+        Attribute {
+            group: 0,
+            bit: libc::ATTR_CMN_ACCTIME,
+            size: size_of::<libc::timespec>(),
+        },
+        Attribute {
+            group: 0,
+            bit: libc::ATTR_CMN_MODTIME,
+            size: size_of::<libc::timespec>(),
+        },
+        Attribute {
+            group: 0,
+            bit: libc::ATTR_CMN_CHGTIME,
+            size: size_of::<libc::timespec>(),
+        },
+        Attribute {
+            group: 0,
+            bit: libc::ATTR_CMN_CRTIME,
+            size: size_of::<libc::timespec>(),
+        },
+    ];
+
+    pub(super) fn query_handle(fd: i32, request: StatRequest) -> AsyncHostResult<StatValues> {
+        query(QueryTarget::Handle(fd), request)
+    }
+
+    pub(super) fn query_path(
+        parent: Option<i32>,
+        path: OsString,
+        follow_symlink: bool,
+        request: StatRequest,
+    ) -> AsyncHostResult<StatValues> {
+        let path = CString::new(path.as_bytes()).map_err(|_| AsyncHostError::Inval)?;
+        query(
+            QueryTarget::Path {
+                parent,
+                path: &path,
+                follow_symlink,
+            },
+            request,
+        )
+    }
+
+    enum QueryTarget<'a> {
+        Handle(i32),
+        Path {
+            parent: Option<i32>,
+            path: &'a std::ffi::CStr,
+            follow_symlink: bool,
+        },
+    }
+
+    fn query(target: QueryTarget<'_>, request: StatRequest) -> AsyncHostResult<StatValues> {
+        // getattrlist packs attributes in a platform-defined order rather than request-bit order.
+        const ATTRIBUTE_ORDER: [usize; 8] = [2, 0, 7, 5, 6, 4, 3, 1];
+        let mut list = libc::attrlist {
+            bitmapcount: libc::ATTR_BIT_MAP_COUNT,
+            reserved: 0,
+            commonattr: libc::ATTR_CMN_RETURNED_ATTRS,
+            volattr: 0,
+            dirattr: 0,
+            fileattr: 0,
+            forkattr: 0,
+        };
+        let mut offsets = [0_usize; 8];
+        let mut offset = size_of::<u32>() + size_of::<libc::attribute_set_t>();
+        for index in ATTRIBUTE_ORDER {
+            if request.mask() & (1 << index) == 0 {
+                continue;
+            }
+            let attribute = ATTRIBUTES[index];
+            match attribute.group {
+                0 => list.commonattr |= attribute.bit,
+                3 => list.fileattr |= attribute.bit,
+                _ => unreachable!(),
+            }
+            offsets[index] = offset;
+            offset += attribute.size;
+        }
+
+        let mut buffer = [0_u8; 256];
+        let ret = unsafe {
+            match target {
+                QueryTarget::Handle(fd) => libc::fgetattrlist(
+                    fd,
+                    std::ptr::from_mut(&mut list).cast(),
+                    buffer.as_mut_ptr().cast(),
+                    buffer.len(),
+                    libc::FSOPT_PACK_INVAL_ATTRS,
+                ),
+                QueryTarget::Path {
+                    parent: None,
+                    path,
+                    follow_symlink,
+                } => libc::getattrlist(
+                    path.as_ptr(),
+                    std::ptr::from_mut(&mut list).cast(),
+                    buffer.as_mut_ptr().cast(),
+                    buffer.len(),
+                    libc::FSOPT_PACK_INVAL_ATTRS
+                        | if follow_symlink {
+                            0
+                        } else {
+                            libc::FSOPT_NOFOLLOW
+                        },
+                ),
+                QueryTarget::Path {
+                    parent: Some(parent),
+                    path,
+                    follow_symlink,
+                } => libc::getattrlistat(
+                    parent,
+                    path.as_ptr(),
+                    std::ptr::from_mut(&mut list).cast(),
+                    buffer.as_mut_ptr().cast(),
+                    buffer.len(),
+                    (libc::FSOPT_PACK_INVAL_ATTRS
+                        | if follow_symlink {
+                            0
+                        } else {
+                            libc::FSOPT_NOFOLLOW
+                        }) as libc::c_ulong,
+                ),
+            }
+        };
+        if ret < 0 {
+            let error = last_native_error();
+            if matches!(target, QueryTarget::Handle(_)) && error.errno() == libc::EINVAL {
+                return fallback_non_vnode(target, request);
+            }
+            return Err(error);
+        }
+
+        let result_len = read_unaligned::<u32>(&buffer, 0).unwrap_or(0) as usize;
+        let returned = read_unaligned::<libc::attribute_set_t>(&buffer, size_of::<u32>())
+            .ok_or(AsyncHostError::Io)?;
+        let is_returned = |index: usize| {
+            let attribute = ATTRIBUTES[index];
+            let group = match attribute.group {
+                0 => returned.commonattr,
+                3 => returned.fileattr,
+                _ => 0,
+            };
+            group & attribute.bit != 0 && offsets[index] + attribute.size <= result_len
+        };
+        let read_time = |index| {
+            is_returned(index)
+                .then(|| read_unaligned::<libc::timespec>(&buffer, offsets[index]))
+                .flatten()
+                .map(|value| StatTimestamp {
+                    seconds: value.tv_sec,
+                    nanoseconds: value.tv_nsec,
+                })
+        };
+
+        Ok(StatValues {
+            kind: is_returned(0)
+                .then(|| read_unaligned::<FsObjType>(&buffer, offsets[0]))
+                .flatten()
+                .map(file_kind_from_vnode),
+            size: is_returned(1)
+                .then(|| read_unaligned::<i64>(&buffer, offsets[1]))
+                .flatten(),
+            device_id: is_returned(2)
+                .then(|| read_unaligned::<libc::dev_t>(&buffer, offsets[2]))
+                .flatten()
+                .map(|value| value as u64),
+            file_id: is_returned(3)
+                .then(|| read_unaligned::<u64>(&buffer, offsets[3]))
+                .flatten(),
+            access_time: read_time(4),
+            modify_time: read_time(5),
+            change_time: read_time(6),
+            create_time: read_time(7),
+        })
+    }
+
+    fn fallback_non_vnode(
+        target: QueryTarget<'_>,
+        request: StatRequest,
+    ) -> AsyncHostResult<StatValues> {
+        let QueryTarget::Handle(fd) = target else {
+            unreachable!();
+        };
+        let mut stat = MaybeUninit::<libc::stat>::uninit();
+        if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } < 0 {
+            return Err(last_native_error());
+        }
+        let stat = unsafe { stat.assume_init() };
+        Ok(StatValues {
+            kind: (request.mask() & STAT_FILE_KIND != 0).then(|| file_kind_from_mode(stat.st_mode)),
+            ..StatValues::default()
+        })
+    }
+
+    fn read_unaligned<T: Copy>(buffer: &[u8], offset: usize) -> Option<T> {
+        buffer
+            .get(offset..offset.checked_add(size_of::<T>())?)
+            .map(|bytes| unsafe { std::ptr::read_unaligned(bytes.as_ptr().cast::<T>()) })
+    }
+
+    fn file_kind_from_vnode(kind: FsObjType) -> i32 {
+        match kind {
+            VREG => 1,
+            VDIR => 2,
+            VLNK => 3,
+            VSOCK => 4,
+            VFIFO => 5,
+            VBLK => 6,
+            VCHR => 7,
+            _ => 0,
+        }
+    }
+
+    fn file_kind_from_mode(mode: libc::mode_t) -> i32 {
+        match mode & libc::S_IFMT {
+            libc::S_IFREG => 1,
+            libc::S_IFDIR => 2,
+            libc::S_IFLNK => 3,
+            libc::S_IFSOCK => 4,
+            libc::S_IFIFO => 5,
+            libc::S_IFBLK => 6,
+            libc::S_IFCHR => 7,
+            _ => 0,
+        }
+    }
+
+    fn last_native_error() -> AsyncHostError {
+        AsyncHostError::Native(
+            std::io::Error::last_os_error()
+                .raw_os_error()
+                .unwrap_or(libc::EINVAL),
+        )
+    }
+}
+
+#[cfg(windows)]
+mod platform {
+    use std::ffi::OsString;
+    use std::mem::MaybeUninit;
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, ERROR_NOT_SUPPORTED, GetLastError, HANDLE, INVALID_HANDLE_VALUE, SetLastError,
+    };
+    use windows_sys::Win32::Networking::WinSock::{SO_TYPE, SOL_SOCKET, getsockopt};
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, CreateFileW, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_NORMAL,
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO, FILE_BASIC_INFO,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_INFO_BY_HANDLE_CLASS,
+        FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        FILE_STANDARD_INFO, FILE_TYPE_CHAR, FILE_TYPE_DISK, FILE_TYPE_PIPE, FILE_TYPE_UNKNOWN,
+        FileAttributeTagInfo, FileBasicInfo, FileStandardInfo, GetFileInformationByHandle,
+        GetFileInformationByHandleEx, GetFileType, OPEN_EXISTING,
+    };
+
+    use super::*;
+
+    #[derive(Default)]
+    struct WindowsStat {
+        file_type: Option<u32>,
+        attributes: Option<u32>,
+        size: Option<i64>,
+        device_id: Option<u64>,
+        file_id: Option<u64>,
+        access_time: Option<i64>,
+        modify_time: Option<i64>,
+        change_time: Option<i64>,
+        create_time: Option<i64>,
+    }
+
+    pub(super) fn query_handle(
+        handle: HANDLE,
+        request: StatRequest,
+    ) -> AsyncHostResult<StatValues> {
+        query(handle, request)
+    }
+
+    pub(super) fn query_path(
+        parent: Option<HANDLE>,
+        path: OsString,
+        follow_symlink: bool,
+        request: StatRequest,
+    ) -> AsyncHostResult<StatValues> {
+        if parent.is_some() {
+            return Err(AsyncHostError::Native(ERROR_NOT_SUPPORTED as i32));
+        }
+        let path: Vec<u16> = path.encode_wide().chain(std::iter::once(0)).collect();
+        let flags = FILE_ATTRIBUTE_NORMAL
+            | FILE_FLAG_BACKUP_SEMANTICS
+            | if follow_symlink {
+                0
+            } else {
+                FILE_FLAG_OPEN_REPARSE_POINT
+            };
+        let handle = unsafe {
+            CreateFileW(
+                path.as_ptr(),
+                FILE_READ_ATTRIBUTES,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                std::ptr::null(),
+                OPEN_EXISTING,
+                flags,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(last_native_error());
+        }
+        let result = query(handle, request);
+        unsafe {
+            CloseHandle(handle);
+        }
+        result
+    }
+
+    fn query(handle: HANDLE, request: StatRequest) -> AsyncHostResult<StatValues> {
+        let mut stat = WindowsStat::default();
+        let mut remaining = request.mask();
+
+        if request.mask() & STAT_FILE_KIND != 0 || request.mask() == 0 {
+            unsafe { SetLastError(0) };
+            let file_type = unsafe { GetFileType(handle) };
+            if file_type == FILE_TYPE_UNKNOWN && unsafe { GetLastError() } != 0 {
+                return Err(last_native_error());
+            }
+            stat.file_type = Some(file_type);
+            if request.mask() & STAT_FILE_KIND != 0 {
+                remaining &= !STAT_FILE_KIND;
+            }
+            if file_type != FILE_TYPE_DISK {
+                return Ok(to_values(handle, request, stat));
+            }
+        }
+
+        const BASIC_PROPERTIES: u32 = STAT_FILE_KIND
+            | STAT_ACCESS_TIME
+            | STAT_MODIFY_TIME
+            | STAT_CHANGE_TIME
+            | STAT_CREATE_TIME;
+        if remaining != 0 && remaining & !STAT_FILE_KIND == 0 {
+            if let Some(info) = query_info::<FILE_ATTRIBUTE_TAG_INFO>(handle, FileAttributeTagInfo)
+            {
+                stat.attributes = Some(info.FileAttributes);
+                remaining &= !STAT_FILE_KIND;
+            }
+        } else if remaining & STAT_CHANGE_TIME != 0 || remaining & !BASIC_PROPERTIES == 0 {
+            if let Some(info) = query_info::<FILE_BASIC_INFO>(handle, FileBasicInfo) {
+                stat.attributes = Some(info.FileAttributes);
+                stat.access_time = Some(info.LastAccessTime);
+                stat.modify_time = Some(info.LastWriteTime);
+                stat.change_time = Some(info.ChangeTime);
+                stat.create_time = Some(info.CreationTime);
+                remaining &= !BASIC_PROPERTIES;
+            }
+        }
+
+        if remaining == STAT_FILE_SIZE {
+            if let Some(info) = query_info::<FILE_STANDARD_INFO>(handle, FileStandardInfo) {
+                stat.size = Some(info.EndOfFile);
+            }
+        } else if remaining != 0 {
+            let mut info = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+            if unsafe { GetFileInformationByHandle(handle, info.as_mut_ptr()) } != 0 {
+                let info = unsafe { info.assume_init() };
+                stat.attributes = Some(info.dwFileAttributes);
+                stat.size =
+                    Some(i64::from(info.nFileSizeHigh) << 32 | i64::from(info.nFileSizeLow));
+                stat.device_id = Some(u64::from(info.dwVolumeSerialNumber));
+                stat.file_id =
+                    Some(u64::from(info.nFileIndexHigh) << 32 | u64::from(info.nFileIndexLow));
+                stat.access_time = Some(filetime_ticks(info.ftLastAccessTime));
+                stat.modify_time = Some(filetime_ticks(info.ftLastWriteTime));
+                stat.create_time = Some(filetime_ticks(info.ftCreationTime));
+            }
+        }
+
+        if request.mask() & STAT_FILE_KIND != 0
+            && stat.file_type == Some(FILE_TYPE_DISK)
+            && stat.attributes.is_none()
+            && let Some(info) = query_info::<FILE_ATTRIBUTE_TAG_INFO>(handle, FileAttributeTagInfo)
+        {
+            stat.attributes = Some(info.FileAttributes);
+        }
+
+        let values = to_values(handle, request, stat);
+        if request.mask() != 0 && values.returned_mask() == 0 {
+            unsafe { SetLastError(0) };
+            if unsafe { GetFileType(handle) } == FILE_TYPE_UNKNOWN && unsafe { GetLastError() } != 0
+            {
+                return Err(last_native_error());
+            }
+        }
+        Ok(values)
+    }
+
+    fn query_info<T: Copy>(handle: HANDLE, class: FILE_INFO_BY_HANDLE_CLASS) -> Option<T> {
+        let mut info = MaybeUninit::<T>::uninit();
+        (unsafe {
+            GetFileInformationByHandleEx(
+                handle,
+                class,
+                info.as_mut_ptr().cast(),
+                std::mem::size_of::<T>() as u32,
+            )
+        } != 0)
+            .then(|| unsafe { info.assume_init() })
+    }
+
+    fn to_values(handle: HANDLE, request: StatRequest, stat: WindowsStat) -> StatValues {
+        StatValues {
+            kind: (request.mask() & STAT_FILE_KIND != 0)
+                .then(|| windows_file_kind(handle, stat.file_type?, stat.attributes))
+                .flatten(),
+            size: (request.mask() & STAT_FILE_SIZE != 0)
+                .then_some(stat.size)
+                .flatten(),
+            device_id: (request.mask() & STAT_DEVICE_ID != 0)
+                .then_some(stat.device_id)
+                .flatten(),
+            file_id: (request.mask() & STAT_FILE_ID != 0)
+                .then_some(stat.file_id)
+                .flatten(),
+            access_time: requested_timestamp(request, STAT_ACCESS_TIME, stat.access_time),
+            modify_time: requested_timestamp(request, STAT_MODIFY_TIME, stat.modify_time),
+            change_time: requested_timestamp(request, STAT_CHANGE_TIME, stat.change_time),
+            create_time: requested_timestamp(request, STAT_CREATE_TIME, stat.create_time),
+        }
+    }
+
+    fn requested_timestamp(
+        request: StatRequest,
+        property: u32,
+        ticks: Option<i64>,
+    ) -> Option<StatTimestamp> {
+        (request.mask() & property != 0)
+            .then_some(ticks)
+            .flatten()
+            .map(windows_timestamp)
+    }
+
+    fn windows_file_kind(handle: HANDLE, file_type: u32, attributes: Option<u32>) -> Option<i32> {
+        match file_type {
+            FILE_TYPE_DISK => attributes.map(|attributes| {
+                if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                    3
+                } else if attributes & FILE_ATTRIBUTE_DIRECTORY != 0 {
+                    2
+                } else {
+                    1
+                }
+            }),
+            FILE_TYPE_CHAR => Some(7),
+            FILE_TYPE_PIPE | FILE_TYPE_UNKNOWN => {
+                let mut socket_type = 0;
+                let mut len = std::mem::size_of::<i32>() as i32;
+                if unsafe {
+                    getsockopt(
+                        handle as usize,
+                        SOL_SOCKET,
+                        SO_TYPE,
+                        std::ptr::from_mut(&mut socket_type).cast(),
+                        &mut len,
+                    )
+                } == 0
+                {
+                    Some(4)
+                } else if file_type == FILE_TYPE_PIPE {
+                    Some(5)
+                } else {
+                    Some(0)
+                }
+            }
+            _ => Some(0),
+        }
+    }
+
+    impl StatValues {
+        fn returned_mask(&self) -> u32 {
+            self.kind.map_or(0, |_| STAT_FILE_KIND)
+                | self.size.map_or(0, |_| STAT_FILE_SIZE)
+                | self.device_id.map_or(0, |_| STAT_DEVICE_ID)
+                | self.file_id.map_or(0, |_| STAT_FILE_ID)
+                | self.access_time.map_or(0, |_| STAT_ACCESS_TIME)
+                | self.modify_time.map_or(0, |_| STAT_MODIFY_TIME)
+                | self.change_time.map_or(0, |_| STAT_CHANGE_TIME)
+                | self.create_time.map_or(0, |_| STAT_CREATE_TIME)
+        }
+    }
+
+    fn filetime_ticks(value: windows_sys::Win32::Foundation::FILETIME) -> i64 {
+        i64::from(value.dwHighDateTime) << 32 | i64::from(value.dwLowDateTime)
+    }
+
+    fn last_native_error() -> AsyncHostError {
+        AsyncHostError::Native(unsafe { GetLastError() } as i32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::async_sys::internal::event_loop::thread_pool::{
+        JobPayload, Resource, get_stat_result, make_fstatx_job, make_open_stat_job, run_host_job,
+    };
+
+    #[test]
+    fn request_layout_is_stable_for_every_supported_mask() {
+        for mask in 0..=STAT_SUPPORTED_PROPERTY_MASK {
+            let expected_words = (0..8)
+                .filter(|bit| mask & (1 << bit) != 0)
+                .map(|bit| if bit < 4 { 1 } else { 2 })
+                .sum::<usize>();
+            let expected_len = STAT_HEADER_LEN + expected_words * 8;
+
+            let request = StatRequest::new(mask, expected_len as i32).unwrap();
+
+            assert_eq!(request.mask(), mask);
+            assert_eq!(request.encoded_len(), expected_len);
+        }
+    }
+
+    #[test]
+    fn request_rejects_unknown_properties_and_short_buffers() {
+        assert_eq!(StatRequest::new(0x0100, 8), Err(AsyncHostError::Inval));
+        assert_eq!(StatRequest::new(0, 7), Err(AsyncHostError::Inval));
+        assert_eq!(
+            StatRequest::new(STAT_CREATE_TIME, 23),
+            Err(AsyncHostError::Inval)
+        );
+    }
+
+    #[test]
+    fn packed_result_uses_fixed_little_endian_slots_and_returned_mask() {
+        let mask = STAT_FILE_KIND | STAT_FILE_SIZE | STAT_MODIFY_TIME | STAT_CREATE_TIME;
+        let request = StatRequest::new(mask, 56).unwrap();
+        let packed = PackedStat::new(
+            request,
+            StatValues {
+                kind: Some(2),
+                size: None,
+                modify_time: Some(StatTimestamp {
+                    seconds: -2,
+                    nanoseconds: 123,
+                }),
+                create_time: None,
+                ..StatValues::default()
+            },
+        );
+
+        assert_eq!(packed.as_bytes().len(), 56);
+        assert_eq!(&packed.as_bytes()[0..4], &56_u32.to_le_bytes());
+        assert_eq!(
+            &packed.as_bytes()[4..8],
+            &(STAT_FILE_KIND | STAT_MODIFY_TIME).to_le_bytes()
+        );
+        assert_eq!(&packed.as_bytes()[8..16], &2_u64.to_le_bytes());
+        assert_eq!(&packed.as_bytes()[16..24], &[0; 8]);
+        assert_eq!(&packed.as_bytes()[24..32], &(-2_i64).to_le_bytes());
+        assert_eq!(&packed.as_bytes()[32..40], &123_i64.to_le_bytes());
+        assert_eq!(&packed.as_bytes()[40..56], &[0; 16]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn completed_job_keeps_stat_in_host_memory_until_copy_out() {
+        use std::os::fd::AsRawFd;
+
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), b"moonrun stat").unwrap();
+        let raw = unsafe { libc::dup(temp.as_file().as_raw_fd()) };
+        assert!(raw >= 0);
+        let request = STAT_FILE_KIND | STAT_FILE_SIZE | STAT_DEVICE_ID | STAT_FILE_ID;
+        let mut job = make_fstatx_job(
+            std::sync::Arc::new(Resource::new(raw)),
+            request,
+            StatRequest::new(request, 40).unwrap().encoded_len() as i32,
+        );
+
+        run_host_job(&mut job);
+
+        assert_eq!(job.err(), 0);
+        let JobPayload::Fstatx {
+            result: Some(result),
+            ..
+        } = job.payload()
+        else {
+            panic!("expected a host-owned packed result");
+        };
+        assert_eq!(result.as_bytes()[0..4], 40_u32.to_le_bytes());
+
+        let mut guest = [0_u8; 48];
+        get_stat_result(&job, &mut guest[..], 4, 40).unwrap();
+        assert_eq!(guest[0..4], [0; 4]);
+        assert_eq!(guest[4..8], 40_u32.to_le_bytes());
+        assert_eq!(guest[8..12], request.to_le_bytes());
+        assert_eq!(i64::from_le_bytes(guest[20..28].try_into().unwrap()), 12);
+    }
+
+    #[test]
+    fn invalid_open_stat_request_fails_before_opening_the_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("must-not-be-created");
+        let mut job = make_open_stat_job(
+            path.clone().into_os_string(),
+            1,
+            3,
+            false,
+            0,
+            0o600,
+            0x0100,
+            8,
+        );
+
+        run_host_job(&mut job);
+
+        assert_eq!(job.ret(), -1);
+        assert_eq!(job.err(), AsyncHostError::Inval.errno());
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn platform_adapter_distinguishes_a_symlink_from_its_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target");
+        let link = temp.path().join("link");
+        std::fs::write(&target, b"target").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let request = StatRequest::new(STAT_FILE_KIND, 16).unwrap();
+
+        let link_values =
+            platform::query_path(None, link.into_os_string(), false, request).unwrap();
+        let target_values =
+            platform::query_path(None, target.into_os_string(), true, request).unwrap();
+
+        assert_eq!(link_values.kind, Some(3));
+        assert_eq!(target_values.kind, Some(1));
+    }
+
+    #[test]
+    fn windows_filetime_is_reported_relative_to_the_unix_epoch() {
+        let epoch = WINDOWS_EPOCH_OFFSET_SECONDS * 10_000_000;
+
+        assert_eq!(
+            windows_timestamp(epoch),
+            StatTimestamp {
+                seconds: 0,
+                nanoseconds: 0,
+            }
+        );
+        assert_eq!(
+            windows_timestamp(epoch + 12_345_678),
+            StatTimestamp {
+                seconds: 1,
+                nanoseconds: 234_567_800,
+            }
+        );
+    }
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -328,10 +328,7 @@ fn owned_raw_socket(raw: RawSocket) -> OwnedSocket {
 #[derive(Debug)]
 pub(crate) struct OpenJobResult {
     pub(crate) resource: OpenJobResource,
-    pub(crate) kind: i32,
-    pub(crate) dev_id: u64,
-    pub(crate) file_id: u64,
-    pub(super) stat: Option<PackedStat>,
+    pub(super) stat: PackedStat,
 }
 
 #[derive(Debug)]
@@ -430,15 +427,6 @@ pub(crate) enum JobPayload {
         position: i64,
     },
     Open {
-        filename: OsString,
-        access: i32,
-        create_mode: i32,
-        append: bool,
-        sync: i32,
-        mode: i32,
-        result: Option<OpenJobResult>,
-    },
-    OpenStat {
         filename: OsString,
         access: i32,
         create_mode: i32,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -25,6 +25,8 @@ use crate::async_host::{AsyncHostResult, CBufferLease};
 use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 use crate::async_sys::internal::fd_util;
 
+use super::stat::{PackedStat, StatRequest};
+
 #[cfg(unix)]
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 #[cfg(all(test, windows))]
@@ -329,6 +331,7 @@ pub(crate) struct OpenJobResult {
     pub(crate) kind: i32,
     pub(crate) dev_id: u64,
     pub(crate) file_id: u64,
+    pub(super) stat: Option<PackedStat>,
 }
 
 #[derive(Debug)]
@@ -434,6 +437,28 @@ pub(crate) enum JobPayload {
         sync: i32,
         mode: i32,
         result: Option<OpenJobResult>,
+    },
+    OpenStat {
+        filename: OsString,
+        access: i32,
+        create_mode: i32,
+        append: bool,
+        sync: i32,
+        mode: i32,
+        request: StatRequest,
+        result: Option<OpenJobResult>,
+    },
+    Fstatx {
+        file: Option<ResourceRef>,
+        request: StatRequest,
+        result: Option<PackedStat>,
+    },
+    Statx {
+        parent: Option<ResourceRef>,
+        path: OsString,
+        request: StatRequest,
+        follow_symlink: bool,
+        result: Option<PackedStat>,
     },
     FileKindByPath {
         parent: Option<ResourceRef>,

--- a/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/fd_util/stub.rs
@@ -127,9 +127,11 @@ ported_fns! {
         Ok(fds)
     }
 
-    #[ported(
+    #[compat(
         source = "src/internal/event_loop/detect_file_kind.c",
-        original = "moonbitlang_async_kind_of_fd"
+        original = "moonbitlang_async_kind_of_fd",
+        upstream_pr = 527,
+        replacement = "fstatx with STAT_FILE_KIND"
     )]
     pub(crate) fn kind_of_fd(fd: RawFd) -> AsyncHostResult<i32> {
         #[cfg(unix)]

--- a/crates/moonrun/src/async_sys/mod.rs
+++ b/crates/moonrun/src/async_sys/mod.rs
@@ -31,6 +31,7 @@ pub(crate) mod signal;
 pub(crate) mod socket;
 
 #[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct PortedSymbol {
     pub(crate) rust_module: &'static str,
@@ -39,17 +40,34 @@ pub(crate) struct PortedSymbol {
     pub(crate) source: &'static str,
 }
 
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct CompatSymbol {
+    pub(crate) rust_module: &'static str,
+    pub(crate) rust_symbol: &'static str,
+    pub(crate) native_symbol: &'static str,
+    pub(crate) historical_source: &'static str,
+    pub(crate) upstream_pr: u32,
+    pub(crate) replacement: &'static str,
+}
+
 macro_rules! ported_fns {
-    (@collect [$($entries:tt)*] [$($out:tt)*]) => {
+    (@collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]) => {
         #[cfg(test)]
         pub(crate) const PORTED_SYMBOLS: &[crate::async_sys::PortedSymbol] = &[
             $($entries)*
         ];
 
+        #[cfg(test)]
+        #[allow(dead_code)]
+        pub(crate) const COMPAT_SYMBOLS: &[crate::async_sys::CompatSymbol] = &[
+            $($compat_entries)*
+        ];
+
         $($out)*
     };
     (
-        @collect [$($entries:tt)*] [$($out:tt)*]
+        @collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]
         #[ported(source = $source:literal, original = $original:literal)]
         #[cfg($($cfg:tt)*)]
         $(#[$meta:meta])*
@@ -66,7 +84,7 @@ macro_rules! ported_fns {
                     native_symbol: $original,
                     source: $source,
                 },
-            ] [
+            ] [$($compat_entries)*] [
                 $($out)*
                 #[cfg($($cfg)*)]
                 $(#[$meta])*
@@ -76,7 +94,7 @@ macro_rules! ported_fns {
         );
     };
     (
-        @collect [$($entries:tt)*] [$($out:tt)*]
+        @collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]
         #[ported(source = $source:literal, original = $original:literal)]
         $(#[$meta:meta])*
         $vis:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
@@ -91,6 +109,37 @@ macro_rules! ported_fns {
                     native_symbol: $original,
                     source: $source,
                 },
+            ] [$($compat_entries)*] [
+                $($out)*
+                $(#[$meta])*
+                $vis fn $name($($args)*) $(-> $ret)? $body
+            ]
+            $($rest)*
+        );
+    };
+    (
+        @collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]
+        #[compat(
+            source = $source:literal,
+            original = $original:literal,
+            upstream_pr = $upstream_pr:literal,
+            replacement = $replacement:literal
+        )]
+        $(#[$meta:meta])*
+        $vis:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+        $($rest:tt)*
+    ) => {
+        ported_fns!(
+            @collect [$($entries)*] [
+                $($compat_entries)*
+                crate::async_sys::CompatSymbol {
+                    rust_module: module_path!(),
+                    rust_symbol: stringify!($name),
+                    native_symbol: $original,
+                    historical_source: $source,
+                    upstream_pr: $upstream_pr,
+                    replacement: $replacement,
+                },
             ] [
                 $($out)*
                 $(#[$meta])*
@@ -99,11 +148,11 @@ macro_rules! ported_fns {
             $($rest)*
         );
     };
-    (@collect [$($entries:tt)*] [$($out:tt)*] $item:item $($rest:tt)*) => {
-        ported_fns!(@collect [$($entries)*] [$($out)* $item] $($rest)*);
+    (@collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*] $item:item $($rest:tt)*) => {
+        ported_fns!(@collect [$($entries)*] [$($compat_entries)*] [$($out)* $item] $($rest)*);
     };
     ($($items:tt)*) => {
-        ported_fns!(@collect [] [] $($items)*);
+        ported_fns!(@collect [] [] [] $($items)*);
     };
 }
 
@@ -124,5 +173,13 @@ pub(crate) fn ported_symbols() -> Vec<PortedSymbol> {
     symbols.extend_from_slice(process::PORTED_SYMBOLS);
     symbols.extend_from_slice(signal::PORTED_SYMBOLS);
     symbols.extend_from_slice(socket::PORTED_SYMBOLS);
+    symbols
+}
+
+#[cfg(test)]
+pub(crate) fn compat_symbols() -> Vec<CompatSymbol> {
+    let mut symbols = Vec::new();
+    symbols.extend_from_slice(internal::fd_util::stub::COMPAT_SYMBOLS);
+    symbols.extend(internal::event_loop::thread_pool::compat_symbols());
     symbols
 }


### PR DESCRIPTION
## Why

moonbitlang/async#527 replaced its file-kind, size, and timestamp jobs with a generic stat ABI. Moonrun still exposed only the removed imports, so advancing the async submodule without the runtime half would leave the new guest ABI unsupported and would make moved or removed provenance ambiguous.

The boundary must also remain a strict Wasm function ABI. V8's JavaScript callbacks can otherwise accept missing or extra arguments that a future Wasmtime host would reject while linking.

## What changed

- add the generic `make_open_stat_job`, `make_fstatx_job`, and `make_statx_job` imports plus explicit completed-result copy-out
- keep worker threads independent of Guest Memory: makers receive only the request and result capacity, jobs retain packed results in host-owned storage, and the guest supplies its destination only to `get_stat_result`
- keep the exact seven-argument `make_open_job` compatibility import and give generic open-stat a distinct nine-argument symbol, so an incompatible guest fails before filesystem side effects
- validate every active V8 callback's exact argument count and record exact parameter and result types for the legacy and generic stat imports
- expose the native-shaped `spawn_job_get_result_handle(i64) -> i64` ABI while retaining the current guest's aggregate getter; the latter declares both lowered `SpawnJob` fields and rejects a non-null copy-output closure instead of silently ignoring it
- use one open completion shape for both ABIs: the pre-527 adapter requests the identity mask and serves legacy getters from the same packed result
- implement selective Linux `statx`, macOS `getattrlist`, and Windows handle queries, including Unix-epoch conversion for Windows FILETIME values
- preserve Windows parent-handle-relative stat queries and return all requested metadata available from the macOS non-vnode `fstat` fallback
- validate request masks and buffer sizes before filesystem side effects, and apply Moonrun filesystem policy to handle-, path-, and open-based metadata access
- retain the removed pre-527 Wasm ABI as compatibility imports with explicit `#[compat]` provenance, including the two no-op async#511 cleanup adapters after spawn ownership transfer
- advance the async submodule and update exact source annotations after the upstream `fs.c` move
- document the `wasm-runtime-port-required` queue, compatibility provenance, strict Wasm ABI rules, and the rule that the upstream label changes only after all required work is on Moon `main`

## Scope

This is the runtime half of the #527 backport. It deliberately preserves the old Wasm imports and does not yet change the async Wasm guest wrapper. That wrapper must switch to the distinct generic imports and copy-out path in a follow-up. The upstream PR must therefore keep `wasm-runtime-port-required` until the guest and runtime work have both landed; only then should it be replaced with `wasm-runtime-port-completed`.

The current async Wasm wrapper also still uses the pre-builder spawn imports and passes its aggregate `SpawnJob` to the result getter. This change exposes the correct single-handle result ABI but retains the current aggregate adapter. Porting the native builder-style spawn boundary and switching the wrapper remain separate follow-up work.

The audited upstream range also contains the macOS zone-aware realpath deallocation fix. Moonrun does not free a native `realpath` allocation: its result buffer is allocated and owned by Rust, so no allocator-crossing backport is needed here.

The implementation is isolated behind one stable stat codec and platform adapters, with regression coverage for layout, validation-before-side-effects, host-owned completion data, exact import types, legacy getter behavior, compatibility provenance, parent-relative paths, non-vnode metadata, symlink behavior, policy checks, and Windows timestamp conversion.
