### PR TITLE
feat(moonrun): integrate async generic stat guest ABI

### DIFF
--- a/crates/moonrun/docs/dev/README.md
+++ b/crates/moonrun/docs/dev/README.md
@@ -3,8 +3,9 @@
 ## Developer workflows
 
 - [Porting `moonbitlang/async` changes](async-upstream-porting.md): audit the
-  runtime-port label queue, preserve exact provenance, deliver one upstream
-  port at a time, and update completed labels after the Moon change lands.
+  one-way upstream runtime-port request queue, preserve exact provenance,
+  deliver one upstream port at a time, and mark the originating async pull
+  request completed after the Moon change lands.
 
 ## How to Build and Test
 

--- a/crates/moonrun/docs/dev/async-upstream-porting.md
+++ b/crates/moonrun/docs/dev/async-upstream-porting.md
@@ -6,24 +6,31 @@ accepted by updating the submodule and making provenance checks pass.
 
 ## Port queue
 
-Use the upstream
+The labels are a one-way communication channel from `moonbitlang/async` to
+Moonrun. An async pull request that requires a Moonrun audit or backport is
+marked with the upstream
 [`wasm-runtime-port-required`](https://github.com/moonbitlang/async/issues?q=state%3Aopen%20label%3Awasm-runtime-port-required)
-label as the incoming queue. Do not use mentions as a substitute for the
-label. Also search merged and closed pull requests carrying the label: GitHub
-allows a merged pull request to retain it, so the open queue is not a complete
+label. Moon consumes that queue; Moon pull requests do not use the label to
+publish their own state. Do not use mentions as a substitute for the label.
+Also search merged and closed pull requests carrying it: GitHub allows a
+merged pull request to retain its labels, so the open queue is not a complete
 audit history.
 
-The workflow labels mean:
+On an async pull request, the labels mean:
 
-- `wasm-runtime-port-required`: runtime work or investigation is still needed.
-- `wasm-runtime-port-completed`: the behavior is available on Moon's `main`, or
-  an audit proved that Moon already implements it and no change is necessary.
+- `wasm-runtime-port-required`: async is telling Moon that this upstream change
+  still needs runtime work or investigation.
+- `wasm-runtime-port-completed`: Moon has consumed that request because the
+  behavior is available on Moon's `main`, or an audit proved that Moon already
+  implements it and no change is necessary.
 
 A partial port, local branch, or open Moon pull request remains
 `wasm-runtime-port-required`. After the corresponding change lands on Moon's
 `main`, replace that label on the upstream pull request with
 `wasm-runtime-port-completed`. If any guest or runtime work remains, keep the
-required label and record the gap in the Moon pull request.
+required label and record the gap in the Moon pull request. If a later async
+pull request introduces another runtime requirement, label that pull request
+independently even when the earlier request is already completed.
 
 ## Separate discovery from delivery
 

--- a/crates/moonrun/docs/dev/async-upstream-porting.md
+++ b/crates/moonrun/docs/dev/async-upstream-porting.md
@@ -16,6 +16,12 @@ Also search merged and closed pull requests carrying it: GitHub allows a
 merged pull request to retain its labels, so the open queue is not a complete
 audit history.
 
+Do not self-apply either label to a coordinating async pull request opened as
+part of a Moon port. Such a pull request is an implementation dependency of
+the port, not a new upstream request to Moon. Reference the paired Moon pull
+request and state the merge order instead. Only update labels on the
+originating async pull request that placed work in the queue.
+
 On an async pull request, the labels mean:
 
 - `wasm-runtime-port-required`: async is telling Moon that this upstream change
@@ -30,7 +36,8 @@ A partial port, local branch, or open Moon pull request remains
 `wasm-runtime-port-completed`. If any guest or runtime work remains, keep the
 required label and record the gap in the Moon pull request. If a later async
 pull request introduces another runtime requirement, label that pull request
-independently even when the earlier request is already completed.
+independently when it is an upstream-originated request, even when the earlier
+request is already completed.
 
 ## Separate discovery from delivery
 
@@ -42,17 +49,39 @@ Audit an upstream update before preparing the commits that will deliver it:
    `wasm-runtime-port-required`.
 3. Run the provenance checks before changing annotations. A missing source or
    symbol is an audit signal, not a formatting failure.
-4. Compare the native C implementation together with its MoonBit wrapper to
-   Moonrun's Async API, Async Host, and Async Sys behavior.
-5. Classify each change as an exact move, an already-matching behavior change,
+4. Compare the native C implementation together with every target-specific
+   MoonBit wrapper, especially the wasm imports, to Moonrun's Async API, Async
+   Host, and Async Sys behavior. Do not assume an unchanged wasm wrapper
+   already represents the new native ABI.
+5. If the wasm wrapper still uses a replaced ABI, prepare the coordinating
+   async guest pull request during discovery. Compile that guest and audit its
+   complete import closure, including auxiliary imports initialized by shared
+   code, before finalizing the Moon implementation.
+6. Classify each change as an exact move, an already-matching behavior change,
    or a required port. Do not commit the audit bump while it has unresolved
    provenance or behavior changes.
+7. Treat the port as complete only when the upstream tests run against the
+   updated guest wrapper through the Moon change. Passing those tests with the
+   old compatibility wrapper does not exercise the new ABI.
 
 Deliver required ports one upstream pull request at a time. Restore the pinned
 submodule when necessary, implement the behavior and regression coverage in a
 focused change, and keep that change independently buildable and testable. A
 submodule bump belongs with the port that makes its affected provenance and
 behavior accurate; it is not evidence that the port is complete by itself.
+When the port also needs a coordinating async guest change:
+
+1. Open the unlabeled async pull request while developing the Moon port.
+2. Pin its reachable commit for end-to-end testing and include its complete
+   runtime requirements in the same Moon pull request that consumes the
+   originating queue item.
+3. Merge the Moon pull request first, so the runtime accepts the new guest.
+4. Merge the coordinating async pull request only after the Moon change is on
+   `main`.
+
+Do not defer a guest-visible import that compiling the coordinating guest
+could have revealed to a second Moon pull request. Such a follow-up means the
+original audit stopped before closing the end-to-end ABI boundary.
 
 ## Provenance annotations
 

--- a/crates/moonrun/src/async_api/os_error.rs
+++ b/crates/moonrun/src/async_api/os_error.rs
@@ -85,4 +85,9 @@ pub(super) fn get_enotdir(_context: &mut ImportContext<'_, '_>) -> i32 {
     stub::get_enotdir()
 }
 
+#[ported(source = "src/os_error/stub.c")]
+pub(super) fn get_enotsup(_context: &mut ImportContext<'_, '_>) -> i32 {
+    stub::get_enotsup()
+}
+
 }

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -414,6 +414,8 @@ declare_async_imports! {
 
     ported os_error::get_enotdir() -> i32 => "os_error/get_ENOTDIR";
 
+    ported os_error::get_enotsup() -> i32 => "os_error/get_ENOTSUP";
+
     ported os_error::errno_to_string(errno: i32) -> u64 => "os_error/errno_to_string";
 
     helper os_error::free_errno_str(ptr: u64) -> void => "os_error/free_errno_str";

--- a/crates/moonrun/src/async_sys/os_error/stub.rs
+++ b/crates/moonrun/src/async_sys/os_error/stub.rs
@@ -162,6 +162,22 @@ ported_fns! {
 
     #[ported(
         source = "src/os_error/stub.c",
+        original = "moonbitlang_async_get_ENOTSUP"
+    )]
+    pub(crate) fn get_enotsup() -> i32 {
+        #[cfg(unix)]
+        {
+            libc::ENOTSUP
+        }
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::ERROR_NOT_SUPPORTED;
+            ERROR_NOT_SUPPORTED as i32
+        }
+    }
+
+    #[ported(
+        source = "src/os_error/stub.c",
         original = "moonbitlang_async_errno_to_string"
     )]
     pub(crate) fn errno_to_string(errno: i32) -> Box<[u8]> {


### PR DESCRIPTION
## Why

Moon #2018 landed the runtime implementation of async's generic stat jobs, but its pinned async guest still called the legacy imports. async#539 switches the Wasm wrapper to the generic builders and completion-time `get_stat_result` copy-out path. It also exposes the `ENOTSUP` constant used by the now-shared native/Wasm result parser, which Moonrun did not yet provide.

Without this follow-up, the upstream filesystem e2e suite would continue exercising the compatibility ABI, and the updated guest would fail to link on the missing `os_error/get_ENOTSUP` import.

## What changed

- expose `os_error/get_ENOTSUP` with the same Unix and Windows values as async's native stub
- advance the async submodule to the async#539 commit so the existing upstream filesystem suite links and runs through the generic stat imports
- clarify that async's runtime-port labels are a one-way request channel to Moon and must not be self-applied to coordinating PRs created as part of a Moon port

## Why this is correct

The generic stat implementation, host-owned result storage, exact Wasm signatures, and compatibility imports remain in #2018. The only additional runtime surface required by the corrected guest is `ENOTSUP`, implemented directly from async's native platform mapping. Pinning the guest commit makes the existing 39 filesystem tests exercise the real guest → Wasm import → Moonrun path instead of the retained legacy adapters.

## Scope and merge order

This PR is the runtime-first integration follow-up to #2018 and async#539. It intentionally pins the reachable commit from async#539 before that PR merges. Merge this PR first so Moonrun accepts the new ABI, then merge async#539 to publish the updated guest.