### PR TITLE
refactor(build): share target-directory n2 state

### DIFF
--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use moonbuild_rupes_recta::fmt::FmtConfig;
-use moonutil::{command_output::CommandOutput, project::PackageDirs};
+use moonutil::{command_output::CommandOutput, locks::FileLock, project::PackageDirs};
 
 use crate::filter::{filter_pkg_by_dir_for_fmt, select_packages};
 use crate::rr_build::{self, BuildConfig, plan_fmt};
@@ -114,6 +114,8 @@ fn run_fmt_rr(
         })?;
         Ok(0)
     } else {
+        std::fs::create_dir_all(&target_dir)?;
+        let _lock = FileLock::lock_with_user_log(&target_dir, user_log)?;
         let res = rr_build::execute_build(&BuildConfig::default(), graph, &target_dir, user_log)?;
         res.print_info(cli.quiet, "formatting")?;
         Ok(res.return_code_for_success())

--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -29,6 +29,7 @@ use moonutil::{
     build_options::RunMode,
     cli_support::AutoSyncFlags,
     command_output::CommandOutput,
+    locks::FileLock,
     project::PackageDirs,
     target::{SurfaceTarget, TargetBackend, lower_surface_targets},
     user_log::UserLog,
@@ -308,6 +309,8 @@ pub(crate) fn run_info(
     let output_plan =
         imp::plan_info_outputs(&resolve_output, selection.package_ids.iter().copied());
     let execution_targets = output_plan.execution_targets(&requested_targets);
+    std::fs::create_dir_all(target_dir)?;
+    let _lock = FileLock::lock_with_user_log(target_dir, output.user_log())?;
 
     let mut all_meta = vec![];
     let mut ok = true;

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -706,10 +706,7 @@ pub(crate) fn plan_resolved_build_from_intent(
         artifact_paths: cx.artifact_paths.clone(),
     };
 
-    let db_path = cx
-        .artifact_paths
-        .target_layout()
-        .n2_db_path(cx.backend.target_backend());
+    let db_path = cx.artifact_paths.target_layout().n2_db_path();
     let input = BuildInput {
         graph,
         command_args_by_output,
@@ -793,7 +790,6 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
         opt_level: cx.opt_level,
         artifact_paths: cx.artifact_paths.clone(),
     };
-    let backend = cx.backend.target_backend();
     let layout = cx.artifact_paths.target_layout();
     let dependency_input = if compile_output.dependency_actions.is_empty() {
         None
@@ -804,7 +800,7 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
         Some(BuildInput {
             graph,
             command_args_by_output,
-            db_path: layout.standalone_dependency_n2_db_path(backend),
+            db_path: layout.n2_db_path(),
         })
     };
     let (script_graph, script_command_args) = compile_output
@@ -815,7 +811,7 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
         script: BuildInput {
             graph: script_graph,
             command_args_by_output: script_command_args,
-            db_path: layout.n2_db_path(backend),
+            db_path: layout.n2_db_path(),
         },
     };
 
@@ -844,7 +840,7 @@ pub fn plan_fmt(
         resolved,
         BuildProfile::Debug,
     );
-    let db_path = layout.n2_db_path(TargetBackend::default());
+    let db_path = layout.n2_db_path();
     Ok(BuildInput {
         graph,
         command_args_by_output: Default::default(),
@@ -1047,9 +1043,7 @@ pub struct BuildInput {
     /// Structured command argv keyed by generated output path.
     command_args_by_output: moonbuild_rupes_recta::execution_plan::CommandArgMap,
 
-    /// The build cache database path for n2
-    ///
-    /// This path is passed here because it changes between different execution configurations.
+    /// The n2 database for the selected target directory.
     db_path: PathBuf,
 }
 
@@ -1092,6 +1086,9 @@ impl CapturedBuildExecution {
 /// Takes ownership of the build graph and executes the actual build tasks.
 /// Returns just the build result - callers should use the resolve data and
 /// artifacts from the planning phase for any metadata they need.
+///
+/// The caller must hold the target-directory lock. All ordinary executions in
+/// that directory share one n2 database, and n2 does not lock it internally.
 #[instrument(skip_all)]
 pub fn execute_build(
     cfg: &BuildConfig,

--- a/crates/moon/tests/test_cases/build_workflow.rs
+++ b/crates/moon/tests/test_cases/build_workflow.rs
@@ -184,7 +184,7 @@ fn test_failed_to_fill_whole_buffer() {
     );
 
     // corrupt the DB intentionally
-    let moon_db_path = dir.join("./_build/wasm-gc/debug/check/check.moon_db");
+    let moon_db_path = dir.join("./_build/.moon_db");
     if moon_db_path.exists() {
         std::fs::remove_file(&moon_db_path).unwrap();
     }

--- a/crates/moon/tests/test_cases/moon_test/mod.rs
+++ b/crates/moon/tests/test_cases/moon_test/mod.rs
@@ -342,6 +342,7 @@ fn test_moon_test_with_local_dep() {
             .gitignore
             _build
             _build/.moon-lock
+            _build/.moon_db
             _build/wasm-gc
             _build/wasm-gc/debug
             _build/wasm-gc/debug/build
@@ -360,7 +361,6 @@ fn test_moon_test_with_local_dep() {
             _build/wasm-gc/debug/build/.mooncakes/lijunchen/mooncake2/mooncake2.core
             _build/wasm-gc/debug/build/.mooncakes/lijunchen/mooncake2/mooncake2.mi
             _build/wasm-gc/debug/build/all_pkgs.json
-            _build/wasm-gc/debug/build/build.moon_db
             _build/wasm-gc/debug/build/lib
             _build/wasm-gc/debug/build/lib/lib.core
             _build/wasm-gc/debug/build/lib/lib.mi
@@ -389,7 +389,6 @@ fn test_moon_test_with_local_dep() {
             _build/wasm-gc/debug/check/.mooncakes/lijunchen/mooncake2/mooncake2.mi
             _build/wasm-gc/debug/check/.mooncakes/lijunchen/mooncake2/mooncake2.typechecked
             _build/wasm-gc/debug/check/all_pkgs.json
-            _build/wasm-gc/debug/check/check.moon_db
             _build/wasm-gc/debug/check/lib
             _build/wasm-gc/debug/check/lib/lib.ast
             _build/wasm-gc/debug/check/lib/lib.mbti
@@ -447,7 +446,6 @@ fn test_moon_test_with_local_dep() {
             _build/wasm-gc/debug/test/main/main.internal_test.wasm
             _build/wasm-gc/debug/test/main/main.internal_test.wasm.map
             _build/wasm-gc/debug/test/main/main.mi
-            _build/wasm-gc/debug/test/test.moon_db
             lib
             lib/hello.mbt
             lib/hello_wbtest.mbt

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -153,11 +153,9 @@ fn test_single_file_mbtx_reuses_dependency_graph_after_script_change() {
 
     let build_dir = dir.join("_build/wasm/debug/build");
     let dependency_core = build_dir.join(".mooncakes/moonbitlang/x/stack/stack.core");
-    let dependency_db = build_dir.join("standalone-dependencies.moon_db");
-    let script_db = build_dir.join("build.moon_db");
+    let n2_db = dir.join("_build/.moon_db");
     assert!(dependency_core.is_file());
-    assert!(dependency_db.is_file());
-    assert!(script_db.is_file());
+    assert!(n2_db.is_file());
 
     let dependency_modified = fs::metadata(&dependency_core)
         .expect("dependency artifact should have metadata")

--- a/crates/moon/tests/test_cases/targets/mod.rs
+++ b/crates/moon/tests/test_cases/targets/mod.rs
@@ -37,6 +37,54 @@ fn test_many_targets_sync_dependencies_once() {
 }
 
 #[test]
+fn test_targets_share_prebuild_execution_state() {
+    let dir = TestDir::new("targets/shared_n2_db");
+
+    moon_cmd(&dir)
+        .args(["check", "--target", "wasm"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![""])
+        .stderr_eq(snapbox::str![[r#"
+Finished. moon: ran 3 tasks, now up to date
+
+"#]]);
+
+    assert!(dir.join("_build/.moon_db").is_file());
+
+    moon_cmd(&dir)
+        .args(["build", "--target", "js", "--release"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![""])
+        .stderr_eq(snapbox::str![[r#"
+Finished. moon: ran 1 task, now up to date
+
+"#]]);
+
+    moon_cmd(&dir)
+        .args(["check", "--target", "js"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![""])
+        .stderr_eq(snapbox::str![[r#"
+Finished. moon: ran 2 tasks, now up to date
+
+"#]]);
+
+    moon_cmd(&dir)
+        .args(["check", "--target", "wasm,js"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![""])
+        .stderr_eq(snapbox::str![[r#"
+Finished. moon: no work to do
+Finished. moon: no work to do
+
+"#]]);
+}
+
+#[test]
 fn test_many_targets_auto_update_001() {
     let dir = TestDir::new("targets/auto_update");
     let _ = get_stdout(

--- a/crates/moon/tests/test_cases/targets/shared_n2_db/moon.mod.json
+++ b/crates/moon/tests/test_cases/targets/shared_n2_db/moon.mod.json
@@ -1,0 +1,5 @@
+{
+  "name": "test/shared_n2_db",
+  "version": "0.1.0",
+  "source": "src"
+}

--- a/crates/moon/tests/test_cases/targets/shared_n2_db/src/lib/input.txt
+++ b/crates/moon/tests/test_cases/targets/shared_n2_db/src/lib/input.txt
@@ -1,0 +1,1 @@
+generated once

--- a/crates/moon/tests/test_cases/targets/shared_n2_db/src/lib/lib.mbt
+++ b/crates/moon/tests/test_cases/targets/shared_n2_db/src/lib/lib.mbt
@@ -1,0 +1,3 @@
+pub fn answer() -> Int {
+  42
+}

--- a/crates/moon/tests/test_cases/targets/shared_n2_db/src/lib/moon.pkg.json
+++ b/crates/moon/tests/test_cases/targets/shared_n2_db/src/lib/moon.pkg.json
@@ -1,0 +1,9 @@
+{
+  "pre-build": [
+    {
+      "input": "input.txt",
+      "output": "generated.txt",
+      "command": ":embed --text -i $input -o $output --name generated"
+    }
+  ]
+}

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -640,16 +640,13 @@ impl TargetLayout {
         path
     }
 
-    pub fn n2_db_path(&self, target_backend: TargetBackend) -> PathBuf {
-        let mut path = self.run_mode_dir(target_backend);
-        path.push(format!("{}.moon_db", self.run_mode.to_dir_name()));
-        path
-    }
-
-    pub fn standalone_dependency_n2_db_path(&self, target_backend: TargetBackend) -> PathBuf {
-        let mut path = self.run_mode_dir(target_backend);
-        path.push("standalone-dependencies.moon_db");
-        path
+    /// Returns the n2 database shared by executions in this target directory.
+    ///
+    /// Backend, profile, and run-mode differences are already represented by
+    /// concrete output paths and build hashes. They are not separate n2 state
+    /// domains.
+    pub fn n2_db_path(&self) -> PathBuf {
+        self.target_base_dir.join(".moon_db")
     }
 }
 
@@ -1805,7 +1802,7 @@ mod tests {
     }
 
     #[test]
-    fn fmt_n2_db_path_uses_selected_profile() {
+    fn n2_db_path_is_scoped_to_the_target_directory() {
         let layout = TargetLayout::new(
             PathBuf::from("_build"),
             TargetLayoutMode::Workspace,
@@ -1813,29 +1810,7 @@ mod tests {
             RunMode::Format,
         );
 
-        assert_eq!(
-            layout.n2_db_path(TargetBackend::WasmGC),
-            PathBuf::from("_build/wasm-gc/debug/format/format.moon_db"),
-        );
-    }
-
-    #[test]
-    fn standalone_dependency_db_is_separate_from_script_db() {
-        let layout = TargetLayout::new(
-            PathBuf::from("_build"),
-            TargetLayoutMode::Workspace,
-            OptLevel::Debug,
-            RunMode::Run,
-        );
-
-        assert_eq!(
-            layout.standalone_dependency_n2_db_path(TargetBackend::Wasm),
-            PathBuf::from("_build/wasm/debug/build/standalone-dependencies.moon_db"),
-        );
-        assert_ne!(
-            layout.standalone_dependency_n2_db_path(TargetBackend::Wasm),
-            layout.n2_db_path(TargetBackend::Wasm),
-        );
+        assert_eq!(layout.n2_db_path(), PathBuf::from("_build/.moon_db"));
     }
 
     #[test]

--- a/docs/adr/0005-plan-standalone-dependencies-separately.md
+++ b/docs/adr/0005-plan-standalone-dependencies-separately.md
@@ -22,17 +22,19 @@ phase ordering.
 Dependency outputs remain under `_build/.../.mooncakes`. When their producer
 actions are omitted from the script n2 graph, the same concrete output paths
 remain ordinary file inputs to script actions. Moon executes the dependency
-graph first with its own persistent n2 database, then executes the script graph.
-There is no file-existence scan between the phases: n2 currently owns dependency
-freshness and guarantees that the requested products are materialized.
+graph first, then executes the script graph. Both graphs use the target
+directory's persistent n2 database; records whose outputs do not belong to the
+current graph are ignored when n2 loads them. There is no file-existence scan
+between the phases: n2 currently owns dependency freshness and guarantees that
+the requested products are materialized.
 
 The dependency n2 projection is a temporary preparation adapter, not a permanent
 second planner. A future action-to-output implementation can replace this first
 stage and feed its concrete outputs into a narrower script plan.
 
 Standalone `.mbt` and `.mbtx` files built from persistent paths retain the
-dependency n2 database across invocations. `moon run -e` and `moon run -` use
-the same split planning path, but their synthesized temporary projects are
+target-directory n2 database across invocations. `moon run -e` and `moon run -`
+use the same split planning path, but their synthesized temporary projects are
 deleted after each invocation, so they do not currently reuse dependency work
 across invocations. Stable or global cache storage for those entry points is
 deferred.

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -122,6 +122,14 @@ Implementation-wise:
 [rr_home]: /crates/moonbuild-rupes-recta/src/lib.rs
 [n2]: https://github.com/moonbitlang/n2
 
+Rupes Recta executions in one target directory share the n2 database at
+`<target-dir>/.moon_db`. Target backend, profile, run mode, and standalone build
+phase are represented by concrete output paths and build hashes rather than
+separate database files. Separately planned graphs still open and load that
+database for each execution; sharing persistent state does not compose the
+graphs or reuse one open database handle. The dependency and script graphs of a
+standalone build execute sequentially against this database.
+
 ### Directory and environment facts
 
 Directory discovery is intentionally front-loaded. Command entry points should

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -289,10 +289,11 @@ execution are two `ActionId` selections over that plan. Following artifact
 providers to a fixed point includes package-less prerequisites such as the
 runtime library and runtime objects.
 
-The dependency graph executes first using
-`standalone-dependencies.moon_db`, followed by the script graph using its mode
-database. If a provider belongs to dependency preparation, the script graph
-retains its realized path as an n2 input without duplicating the provider.
+The dependency graph executes first, followed by the script graph. Both use the
+target directory's `.moon_db`; n2 ignores records whose outputs do not belong
+to the graph it is currently loading. If a provider belongs to dependency
+preparation, the script graph retains its realized path as an n2 input without
+duplicating the provider.
 
 Ordinary project and workspace commands continue to produce and execute one
 plan and one n2 graph.

--- a/docs/dev/reference/supported-targets.md
+++ b/docs/dev/reference/supported-targets.md
@@ -80,7 +80,9 @@ Notes:
 * A non-watch, explicit multi-backend project invocation synchronizes and
   resolves dependencies once. Non-dry-run execution then holds one
   target-directory lock while it plans and executes each backend separately.
-  Single-file and watch-mode lifecycles are unchanged.
+  Those backend graphs remain separate, but use the target directory's shared
+  n2 database, so actions with identical physical outputs can reuse recorded
+  execution state.
 * `llvm` is still a valid value in `supported_targets`.
 * `moon info` writes `pkg.generated.mbti` only from the canonical backend of each selected package: module `preferred-backend`, then workspace preferred backend, then `wasm`.
 


### PR DESCRIPTION
## Why

Rupes Recta currently selects a separate n2 database for each backend, profile,
run mode, and standalone build phase. That prevents separately planned graphs
from reusing execution state for actions with the same physical outputs, such
as package prebuilds, and would require a second cache layout solely for
multi-backend graph composition.

## What changed

- use one `.moon_db` per target directory for Rupes Recta executions
- remove backend-, profile-, run-mode-, and standalone-phase database selection
- serialize `moon info` and `moon fmt` through the existing target-directory lock
- cover reuse across backend, profile, and run-mode boundaries
- keep standalone dependency and script graphs sequential while sharing their
  persistent n2 state

## Why this is correct

n2 associates records with concrete output paths and validates the current
build hash before treating an action as up to date. Backend, profile, and
run-mode differences already affect those paths or hashes, so they do not need
separate database files. Moon holds the target-directory lock while executing
these graphs because n2 does not lock the database internally.

Existing per-configuration databases are not migrated, so the first execution
after this change may rebuild once.

## Scope

This PR only unifies persistent executor state. Backend Build Plans and n2
graphs remain separate, and standalone dependency and script graphs still run
sequentially. The n2 dependency remains unchanged and its database remains
append-only; automatic compaction and multi-graph-safe retention are follow-up
work.
