### PR TITLE
fix(build): run embed prebuilds without a shell

### DIFF
--- a/crates/moon/tests/package_prebuild_plan.rs
+++ b/crates/moon/tests/package_prebuild_plan.rs
@@ -51,6 +51,84 @@ fn unconsumed_package_prebuild_output_remains_an_execution_root() {
 }
 
 #[test]
+fn builtin_embed_handles_moon_path_with_spaces() {
+    let dir = test_dir("unconsumed_output");
+    let moon_bin_dir = dir.join("moon bin");
+    std::fs::create_dir(&moon_bin_dir).expect("failed to create moon bin directory");
+    let moon = moon_bin_dir.join(format!("moon{}", std::env::consts::EXE_SUFFIX));
+    std::fs::copy(snapbox::cargo_bin!("moon"), &moon).expect("failed to copy moon executable");
+
+    assert!(!dir.join("src/main/generated.txt").exists());
+    snapbox::cmd::Command::new(&moon)
+        .args(["check", "--target", "wasm-gc"])
+        .env("MOON_TOOLCHAIN_ROOT", moonutil::toolchain::toolchain_root())
+        .env("MOON_DEP_CACHE", "off")
+        .current_dir(&dir)
+        .assert()
+        .success();
+    assert!(dir.join("src/main/generated.txt").exists());
+}
+
+#[test]
+fn builtin_embed_rejects_shell_syntax() {
+    let dir = test_dir("unconsumed_output");
+    let manifest = dir.join("src/main/moon.pkg.json");
+    let original = std::fs::read_to_string(&manifest).expect("failed to read package manifest");
+    let modified = original.replace(
+        ":embed --text -i $input -o $output --name ignored",
+        r#":embed --text -i $input -o $output --name \"$(touch shell-substitution; printf ignored)\" && touch shell-list"#,
+    );
+    assert_ne!(modified, original, "failed to modify prebuild command");
+    std::fs::write(manifest, modified).expect("failed to write package manifest");
+
+    moon_check(&dir)
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+error: unexpected argument '&&' found
+Usage: moon[EXE] tool embed [OPTIONS] --input <INPUT> --output <OUTPUT>
+For more information, try '--help'.
+Failed with 0 warnings, 0 errors.
+Error: failed to run check for target WasmGC
+
+Caused by:
+    failed when checking project
+
+"#]]);
+    assert!(!dir.join("src/main/generated.txt").exists());
+    assert!(!dir.join("shell-substitution").exists());
+    assert!(!dir.join("shell-list").exists());
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn builtin_embed_rejects_malformed_quoting() {
+    let dir = test_dir("unconsumed_output");
+    let manifest = dir.join("src/main/moon.pkg.json");
+    let original = std::fs::read_to_string(&manifest).expect("failed to read package manifest");
+    let modified = original.replace(
+        ":embed --text -i $input -o $output --name ignored",
+        r#":embed --text -i $input -o $output --name ignored \"unterminated"#,
+    );
+    assert_ne!(modified, original, "failed to modify prebuild command");
+    std::fs::write(manifest, modified).expect("failed to write package manifest");
+
+    moon_check(&dir)
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: failed to run check for target WasmGC
+
+Caused by:
+    0: Failed to calculate build plan
+    1: Failed to lower the build plan
+    2: failed to parse built-in :embed prebuild arguments: unterminated quote or escape
+
+"#]]);
+    assert!(!dir.join("src/main/generated.txt").exists());
+}
+
+#[test]
 fn generated_mbtp_is_a_check_input() {
     let dir = test_dir("generated_mbtp");
 
@@ -59,7 +137,7 @@ fn generated_mbtp_is_a_check_input() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-moon tool exec --shell '[..]moon[EXE] tool embed --text -i ./src/main/proof.txt -o ./src/main/generated.mbtp --name ignored'
+moon tool embed --text -i ./src/main/proof.txt -o ./src/main/generated.mbtp --name ignored
   cwd: .
 moonc check ./src/main/main.mbt ./src/main/generated.mbtp [..]
 [..]
@@ -76,7 +154,7 @@ fn generated_mbti_supplies_a_virtual_package_contract() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-moon tool exec --shell '[..]moon[EXE] tool embed --text -i ./src/virtual/contract.txt -o ./src/virtual/pkg.mbti --name ignored'
+moon tool embed --text -i ./src/virtual/contract.txt -o ./src/virtual/pkg.mbti --name ignored
   cwd: .
 moonc build-interface ./src/virtual/pkg.mbti [..]
 
@@ -92,7 +170,7 @@ fn generated_moonlex_input_forms_a_prebuild_pipeline() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-moon tool exec --shell '[..]moon[EXE] tool embed --text -i ./src/main/lexer.txt -o ./src/main/generated.mbl --name ignored'
+moon tool embed --text -i ./src/main/lexer.txt -o ./src/main/generated.mbl --name ignored
   cwd: .
 moonrun [..]moonlex[..] -- ./src/main/generated.mbl -o ./src/main/generated.mbt
 moonc check ./src/main/generated.mbt ./src/main/main.mbt [..]
@@ -114,7 +192,7 @@ fn generated_mbt_md_is_a_blackbox_test_input() {
 [..]
 [..]
 [..]
-moon tool exec --shell '[..]moon[EXE] tool embed --text -i ./src/lib/guide.txt -o ./src/lib/generated.mbt.md --name ignored'
+moon tool embed --text -i ./src/lib/guide.txt -o ./src/lib/generated.mbt.md --name ignored
   cwd: .
 moon generate-test-driver [..] ./src/lib/generated.mbt.md [..]
 moonc build-package ./src/lib/generated.mbt.md [..]
@@ -132,7 +210,7 @@ fn generated_moonyacc_input_forms_a_prebuild_pipeline() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-moon tool exec --shell '[..]moon[EXE] tool embed --text -i ./src/main/parser.txt -o ./src/main/generated.mby --name ignored'
+moon tool embed --text -i ./src/main/parser.txt -o ./src/main/generated.mby --name ignored
   cwd: .
 moonrun [..]moonyacc[..] -- ./src/main/generated.mby -o ./src/main/generated.mbt
 moonc check ./src/main/generated.mbt ./src/main/main.mbt [..]

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -326,7 +326,7 @@ impl<'a> LoweringContext<'a> {
                 self.lower_build_runtime_lib(&action_products, info)
             }
             BuildAction::BuildDocs { module } => self.lower_build_docs(module),
-            BuildAction::RunPrebuild { info, .. } => self.lower_run_prebuild(info),
+            BuildAction::RunPrebuild { info, .. } => self.lower_run_prebuild(info)?,
             BuildAction::RunMoonLexPrebuild { input, output, .. } => {
                 self.lower_moon_lex_prebuild(input, output)
             }

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -377,23 +377,39 @@ impl<'a> super::LoweringContext<'a> {
     }
 
     #[instrument(level = Level::DEBUG, skip(self))]
-    pub(super) fn lower_run_prebuild(&self, info: &PrebuildInfo) -> BuildCommand {
+    pub(super) fn lower_run_prebuild(
+        &self,
+        info: &PrebuildInfo,
+    ) -> Result<BuildCommand, LoweringError> {
         // Note: we are tracking dependencies between prebuild commands via n2.
         // Ideally we can do this ourselves, but n2 does it anyway so we don't bother.
 
-        let commandline = vec![
-            BINARIES.moonbuild.display().to_string(),
-            "tool".to_string(),
-            "exec".to_string(),
-            "--shell".to_string(),
-            info.command.clone(),
-        ];
+        let commandline = if let Some(embed_args) = info.command.strip_prefix(":embed ") {
+            let mut commandline = vec![
+                BINARIES.moonbuild.display().to_string(),
+                "tool".to_string(),
+                "embed".to_string(),
+            ];
+            commandline.extend(
+                moonutil::shlex::split_native_args(embed_args)
+                    .ok_or(LoweringError::MalformedEmbedArguments)?,
+            );
+            commandline
+        } else {
+            vec![
+                BINARIES.moonbuild.display().to_string(),
+                "tool".to_string(),
+                "exec".to_string(),
+                "--shell".to_string(),
+                info.command.clone(),
+            ]
+        };
 
-        BuildCommand {
+        Ok(BuildCommand {
             commandline: commandline.into(),
             extra_inputs: info.resolved_inputs.clone(),
         }
-        .with_cwd(info.cwd.clone())
+        .with_cwd(info.cwd.clone()))
     }
 
     pub(super) fn lower_moon_lex_prebuild(&self, input: &Path, output: &Path) -> BuildCommand {

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -192,6 +192,9 @@ pub enum LoweringError {
     #[error("moonc response files cannot represent argument {index}: {reason}")]
     MooncResponseFile { index: usize, reason: &'static str },
 
+    #[error("failed to parse built-in :embed prebuild arguments: unterminated quote or escape")]
+    MalformedEmbedArguments,
+
     #[error("failed to inspect MoonBit toolchain include directory {path}")]
     ToolchainInclude {
         path: PathBuf,

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -39,7 +39,7 @@ use moonutil::{
     package::{MoonPkgGenerate, SupportedTargetsDeclKind},
     resolution::ModuleId,
     scripts::{IgnoredMoonScript, is_moon_script_ignored},
-    toolchain::{self, BINARIES},
+    toolchain,
 };
 use regex::Regex;
 use relative_path::{PathExt, RelativePath};
@@ -1753,8 +1753,7 @@ impl<'a> BuildPlanConstructor<'a> {
             }
         };
 
-        // Handle command expansion and tokenization
-        let command = handle_build_command_new(
+        let command = resolve_prebuild_command(
             &command,
             module,
             self.mooncake_bin_dir,
@@ -1817,8 +1816,10 @@ static PREBUILD_AUTOMATA: LazyLock<aho_corasick::AhoCorasick> = LazyLock::new(||
         .expect("Failed to build automata")
 });
 
-/// Handle the prebuild command replacement, outputs a single string that should
-/// be `sh -c`'ed.
+/// Substitute prebuild command placeholders and resolve a relative shell argv0.
+///
+/// The `:embed ` discriminator remains intact so lowering can emit that built-in
+/// invocation as structured argv instead of treating it as a shell program.
 ///
 /// # Note about binary dependency artifacts
 ///
@@ -1840,7 +1841,7 @@ static PREBUILD_AUTOMATA: LazyLock<aho_corasick::AhoCorasick> = LazyLock::new(||
 /// Windows puts another issue on top of this: binary dependencies are
 /// Powershell scripts appended with `.ps1` extension. Therefore, we need to
 /// resolve `argv[0]` and append a `.ps1` if such file exists.
-fn handle_build_command_new(
+fn resolve_prebuild_command(
     command: &str,
     mod_source: &Path,
     mooncake_bin_dir: &Path,
@@ -1850,23 +1851,14 @@ fn handle_build_command_new(
 ) -> String {
     use std::fmt::Write;
 
-    let mut reconstructed = String::new();
-
-    let moon_bin_path = BINARIES.moonbuild.to_string_lossy();
-
-    let command = if let Some(command) = command.strip_prefix(":embed ") {
-        reconstructed.push_str(&format!("{} tool embed ", moon_bin_path));
-        command
-    } else {
-        command
-    };
+    let mut resolved = String::new();
 
     // Perform replacements
     let mut last_end = 0usize;
     for magic in PREBUILD_AUTOMATA.find_iter(command) {
         // Commit previous segment
         if magic.start() > last_end {
-            reconstructed.push_str(&command[last_end..magic.start()]);
+            resolved.push_str(&command[last_end..magic.start()]);
         }
 
         // Insert replacement
@@ -1874,31 +1866,31 @@ fn handle_build_command_new(
         match magic.pattern().as_usize() {
             // $mooncake_bin => <project target dir>/__moonbin__
             0 => {
-                write!(reconstructed, "{}", mooncake_bin_dir.display()).expect("write can't fail");
+                write!(resolved, "{}", mooncake_bin_dir.display()).expect("write can't fail");
             }
             // $mod_dir => <mod_source>
             1 => {
-                write!(reconstructed, "{}", mod_source.display()).expect("write can't fail");
+                write!(resolved, "{}", mod_source.display()).expect("write can't fail");
             }
             // $pkg_dir => <pkg_source>
             2 => {
-                write!(reconstructed, "{}", pkg_source.display()).expect("write can't fail");
+                write!(resolved, "{}", pkg_source.display()).expect("write can't fail");
             }
             // $input => (existing)<input_1>, <input_2>, ...
             3 => {
                 for (i, f) in input_files.iter().enumerate() {
                     if i != 0 {
-                        write!(reconstructed, " ").expect("write can't fail");
+                        write!(resolved, " ").expect("write can't fail");
                     }
-                    write!(reconstructed, "{f}").expect("write can't fail");
+                    write!(resolved, "{f}").expect("write can't fail");
                 }
             }
             4 => {
                 for (i, f) in output_files.iter().enumerate() {
                     if i != 0 {
-                        write!(reconstructed, " ").expect("write can't fail");
+                        write!(resolved, " ").expect("write can't fail");
                     }
-                    write!(reconstructed, "{f}").expect("write can't fail");
+                    write!(resolved, "{f}").expect("write can't fail");
                 }
             }
             _ => unreachable!("Unexpected pattern id from CHECK_AUTOMATA"),
@@ -1907,11 +1899,11 @@ fn handle_build_command_new(
     }
 
     if last_end < command.len() {
-        reconstructed.push_str(&command[last_end..]);
+        resolved.push_str(&command[last_end..]);
     }
 
     // Resolve argv[0]
-    let argv0 = moonutil::shlex::get_argv0_native(&reconstructed);
+    let argv0 = moonutil::shlex::get_argv0_native(&resolved);
     // Check if argv[0] looks like a relative path.
     let looks_like_path = argv0.contains(std::path::is_separator);
     let is_relative = looks_like_path && !Path::new(&argv0).is_absolute();
@@ -1921,11 +1913,11 @@ fn handle_build_command_new(
     // command.
     #[cfg(not(windows))]
     if is_relative {
-        reconstructed = format!(
+        resolved = format!(
             "{}{}{}",
             mod_source.display(),
             std::path::MAIN_SEPARATOR,
-            reconstructed
+            resolved
         );
     }
     // For windows, we also need to check if the resolved path with `.ps1` exists.
@@ -1937,14 +1929,14 @@ fn handle_build_command_new(
         {
             use moonutil::shlex::split_argv0_windows;
 
-            let (_argv0, rest) = split_argv0_windows(&reconstructed);
+            let (_argv0, rest) = split_argv0_windows(&resolved);
             // This is safe because '"' is not a valid path character on Windows,
             // and the original argv[0] must be a path-like string.
-            reconstructed = format!("powershell \"{}\" {}", new_argv0.display(), rest);
+            resolved = format!("powershell \"{}\" {}", new_argv0.display(), rest);
         }
     }
 
-    reconstructed
+    resolved
 }
 
 fn prebuild_command_path(cwd: &Path, path: &Path) -> String {
@@ -2072,8 +2064,8 @@ mod tests {
     }
 
     #[test]
-    fn handle_build_command_uses_relative_input_and_output_placeholders() {
-        let command = handle_build_command_new(
+    fn resolve_prebuild_command_uses_relative_input_and_output_placeholders() {
+        let command = resolve_prebuild_command(
             "generate --inputs $input --outputs $output",
             Path::new("module"),
             Path::new("module/_build/__moonbin__"),

--- a/crates/moonutil/src/shlex.rs
+++ b/crates/moonutil/src/shlex.rs
@@ -50,17 +50,39 @@ pub use split_unix as split_native;
 #[cfg(target_os = "windows")]
 pub use split_windows as split_native;
 
+/// Split an argument tail according to native quoting rules, reporting
+/// malformed quoting or escaping when the platform grammar supports it.
+#[cfg(not(target_os = "windows"))]
+pub fn split_native_args(args: &str) -> Option<Vec<String>> {
+    shlex::split(args)
+}
+
+/// Split an argument tail according to native quoting rules, reporting
+/// malformed quoting or escaping when the platform grammar supports it.
+#[cfg(target_os = "windows")]
+pub fn split_native_args(args: &str) -> Option<Vec<String>> {
+    Some(split_windows_args(args))
+}
+
 /// Split the given command line according to Windows rules.
 ///
 /// Reference:
 /// https://learn.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments?view=msvc-170
 pub fn split_windows(args: &str) -> Vec<String> {
-    let (argv0, mut rest) = parse_windows_argv0(args);
+    let (argv0, rest) = parse_windows_argv0(args);
     let mut result = vec![argv0];
+    result.extend(split_windows_args(rest));
+    result
+}
 
-    while let Some((arg, new_rest)) = next_windows_arg(rest) {
+/// Split an argument tail according to Windows rules, without applying the
+/// special parsing rules for `argv[0]`.
+pub fn split_windows_args(mut args: &str) -> Vec<String> {
+    let mut result = Vec::new();
+
+    while let Some((arg, new_rest)) = next_windows_arg(args) {
         result.push(arg);
-        rest = new_rest;
+        args = new_rest;
     }
 
     result

--- a/crates/moonutil/src/shlex/tests.rs
+++ b/crates/moonutil/src/shlex/tests.rs
@@ -17,24 +17,21 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use super::parse_windows_argv0;
-use super::{join_windows, split_windows};
+#[cfg(not(target_os = "windows"))]
+use super::split_native_args;
+use super::{join_windows, split_windows, split_windows_args};
 
 fn assert_parse_tail(tail: &str, expected: &[&str]) {
-    let input = format!("program.exe {}", tail);
-    let got = split_windows(&input);
-    assert_eq!(
-        got.first().unwrap(),
-        "program.exe",
-        "argv[0] mismatch for input: {}",
-        tail
-    );
+    let got = split_windows_args(tail);
     let expected_vec: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
-    assert_eq!(
-        &got[1..],
-        expected_vec.as_slice(),
-        "argv[1..] mismatch for input: {}",
-        tail
-    );
+    assert_eq!(got, expected_vec, "argument mismatch for input: {}", tail);
+}
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn native_argument_tail_rejects_unterminated_quote() {
+    assert_eq!(split_native_args(r#"a "unterminated"#), None);
+    assert_eq!(split_native_args("a \\"), None);
 }
 
 // MS official doc examples

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -116,6 +116,8 @@ the remaining arguments and substituted placeholders.
 Behavior:
 
 - `:embed` is a syntactic alias; after substitution, it represents the same arguments a direct embed invocation would receive.
+- Moon lowers `:embed` directly to structured `moon tool embed` arguments; it does not execute the built-in invocation through a shell.
+- The argument tail supports platform-native quoting and escaping, but not shell expansion, redirection, pipelines, or command lists. Use a custom prebuild command when platform-specific shell behavior is required.
 - The generated outputs are consumed as package sources in the same build.
 
 ## Ordering and Inclusion
@@ -153,6 +155,7 @@ holds after substitution and tool semantics:
 
 - Any declared `input` path does not exist.
 - Any declared `output` cannot be created or written by the invoked tool.
+- A built-in `:embed` argument tail contains malformed native quoting or escaping.
 - The invoked tool fails to produce all declared outputs.
 
 ## Compatibility and Caveats
@@ -160,8 +163,9 @@ holds after substitution and tool semantics:
 - `:embed` detection is prefix-based and requires the literal prefix `:embed `.
 - Substitution does not add quoting. Quote `$input`, `$output`, or directories inside `command` if paths may contain spaces.
 - Using arrays for `output` expands to a space-separated list; ensure your tool’s CLI accepts the intended arity.
-- On Unix-like platforms, the final prebuild command string is executed through `sh -c`.
-- On Windows, the final prebuild command string is passed directly to `CreateProcessA`.
+- On Unix-like platforms, custom prebuild command strings are executed through `sh -c`.
+- On Windows, custom prebuild command strings are passed directly to `CreateProcessW`.
+- The `:embed` shorthand is a standalone structured built-in invocation on every platform and does not use either custom-command path. Shell syntax in its argument tail is never evaluated.
 - On Unix-like platforms, if the first word of the command looks like a relative path,
   it is currently resolved against the module root directory.
 - Windows (PowerShell):  


### PR DESCRIPTION
## Why

The `:embed` prebuild shorthand was expanded into a shell command string before lowering. That discarded the command's argv structure, so a Moon executable path containing spaces could be split by the shell and fail. It also accidentally gave `:embed` Unix-only shell expansion and command-composition behavior that never existed on Windows.

## What changed

- Preserve the exact leading `:embed ` discriminator while resolving prebuild placeholders.
- Lower that standalone built-in directly to structured `moon tool embed` arguments.
- Parse only its argument tail with platform-native quoting rules, rejecting malformed Unix quoting instead of silently dropping the final argument.
- Never evaluate shell expansion, redirection, pipelines, or command lists in the `:embed` argument tail.
- Keep ordinary prebuild commands on the existing platform-specific `tool exec --shell` path.
- Cover Moon executable paths containing spaces, malformed quoting, and shell syntax that must not execute side effects.

## Why this is correct and minimal

The existing prefix contract remains the dispatch boundary: only commands beginning with the literal `:embed ` use the built-in path. Its arguments are parsed once and serialized at the normal lowering boundary; on Windows, parsing the argument tail also avoids applying the special `argv[0]` rules to the first embed option. This gives the Moon-owned shorthand one portable meaning without introducing a metacharacter blacklist or changing custom-command semantics. Users requiring platform-specific shell behavior can continue to use an ordinary prebuild command.
