### PR TITLE
fix(dry-run): normalize complete path tokens

### DIFF
--- a/crates/moon/tests/test_cases/prebuild/mod.rs
+++ b/crates/moon/tests/test_cases/prebuild/mod.rs
@@ -144,6 +144,38 @@ fn test_pre_build_dry_run_uses_cwd_relative_placeholders() {
             .any(|line| line.contains(" -i ./src/lib/a.txt -o ./src/lib/a.mbt")),
         "dry-run should show cwd-relative placeholders, got:\n{stdout}"
     );
+    assert!(
+        prebuild_lines
+            .iter()
+            .all(|line| line.contains(" --shell 'moon tool embed ")),
+        "dry-run should normalize the nested moon executable, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_pre_build_dry_run_renders_symbolic_binary_overrides() {
+    let dir = TestDir::new("pre_build.in");
+    let moonc = toolchain_root_for_tests()
+        .join("bin")
+        .join(if cfg!(windows) { "moonc.exe" } else { "moonc" });
+    let assert = moon_cmd(&dir)
+        .env("MOONC_OVERRIDE", moonc)
+        .args(["check", "--dry-run", "--sort-input"])
+        .assert()
+        .success();
+    let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();
+    let compiler_lines = stdout
+        .lines()
+        .filter(|line| line.contains(" check "))
+        .collect::<Vec<_>>();
+
+    assert!(
+        !compiler_lines.is_empty()
+            && compiler_lines
+                .iter()
+                .all(|line| line.starts_with("'$MOONC_OVERRIDE' ")),
+        "dry-run should render MOONC_OVERRIDE as a symbolic literal, got:\n{stdout}"
+    );
 }
 
 #[test]

--- a/crates/moonutil/src/path_normalizer.rs
+++ b/crates/moonutil/src/path_normalizer.rs
@@ -101,7 +101,7 @@ impl PathNormalizer {
     pub fn normalize_command_program(&self, program: &str) -> String {
         let raw_program = program.replace('\\', "/");
         if let Some(alias) = Self::exact_alias(&self.override_aliases, &raw_program) {
-            return alias;
+            return alias.clone();
         }
         if let Some((path, alias)) = &self.current_program_alias
             && path == &raw_program
@@ -138,7 +138,10 @@ impl PathNormalizer {
 
     pub fn normalize_command_arg(&self, value: &str) -> String {
         let value = value.replace('\\', "/");
-        let value = Self::exact_alias(&self.override_aliases, &value).unwrap_or(value);
+        let mut value = Self::replace_complete_tokens(value, &self.override_aliases);
+        if let Some(alias) = &self.current_program_alias {
+            value = Self::replace_complete_tokens(value, std::slice::from_ref(alias));
+        }
         let value = if let Some(root) = &self.project_root {
             Self::replace_path_prefix(value, &Self::display_path(root), ".")
         } else {
@@ -150,7 +153,7 @@ impl PathNormalizer {
     pub fn normalize_path(&self, path: &str) -> String {
         let normalized = path.replace('\\', "/");
         if let Some(masked) = Self::exact_alias(&self.override_aliases, &normalized) {
-            return self.mask_roots(masked);
+            return self.mask_roots(masked.clone());
         }
         let path_obj = Path::new(path);
         if let Some(root) = &self.project_root
@@ -166,10 +169,10 @@ impl PathNormalizer {
         self.normalize_path(&normalized_path.to_string_lossy())
     }
 
-    fn exact_alias(aliases: &[(String, String)], value: &str) -> Option<String> {
+    fn exact_alias<'a>(aliases: &'a [(String, String)], value: &str) -> Option<&'a String> {
         aliases
             .iter()
-            .find_map(|(from, to)| (value == from).then(|| to.clone()))
+            .find_map(|(from, to)| (value == from).then_some(to))
     }
 
     fn mask_roots(&self, mut value: String) -> String {
@@ -200,25 +203,66 @@ impl PathNormalizer {
         }
     }
 
+    fn replace_complete_tokens(mut value: String, aliases: &[(String, String)]) -> String {
+        for (path, alias) in aliases {
+            if path.is_empty() {
+                continue;
+            }
+            let mut cursor = 0;
+            while let Some(offset) = value[cursor..].find(path) {
+                let start = cursor + offset;
+                let end = start + path.len();
+                let before = value[..start].chars().next_back();
+                let after = value[end..].chars().next();
+                if Self::is_shell_token_boundary(before) && Self::is_shell_token_boundary(after) {
+                    value.replace_range(start..end, alias);
+                    cursor = start + alias.len();
+                } else {
+                    cursor = end;
+                }
+            }
+        }
+        value
+    }
+
+    fn is_shell_token_boundary(character: Option<char>) -> bool {
+        character.is_none_or(|character| {
+            character.is_whitespace()
+                || matches!(
+                    character,
+                    '\'' | '"' | '|' | '&' | ';' | '(' | ')' | '<' | '>'
+                )
+        })
+    }
+
     fn replace_path_prefix(mut value: String, path: &str, replacement: &str) -> String {
         let path = path.trim_end_matches('/');
         if path.is_empty() {
             return value;
         }
-        // Roots are already path-like, so only their trailing boundary is
-        // ambiguous. This keeps compact flags such as `-I/path` working while
-        // avoiding textual prefixes such as `/tmp/home` in `/tmp/homebrew`.
-        let path_list_separator = if cfg!(windows) { ';' } else { ':' };
-        for separator in ['/', path_list_separator] {
-            value = value.replace(
-                &format!("{path}{separator}"),
-                &format!("{replacement}{separator}"),
-            );
+        // Roots may appear inside path lists and path-bearing compiler flags.
+        // Requiring both boundaries avoids treating ordinary text as a path.
+        let mut cursor = 0;
+        while let Some(offset) = value[cursor..].find(path) {
+            let start = cursor + offset;
+            let end = start + path.len();
+            let before = &value[..start];
+            let after = value[end..].chars().next();
+            let leading_boundary = Self::is_shell_token_boundary(before.chars().next_back())
+                || before.ends_with(['=', ':', ';', ','])
+                || ["-I", "-L", "/I", "/Fo", "/Fe", "/Fd", "@"]
+                    .iter()
+                    .any(|prefix| before.ends_with(prefix));
+            let trailing_boundary = Self::is_shell_token_boundary(after)
+                || after.is_some_and(|character| matches!(character, '/' | ':' | ';' | ','));
+            if leading_boundary && trailing_boundary {
+                value.replace_range(start..end, replacement);
+                cursor = start + replacement.len();
+            } else {
+                cursor = end;
+            }
         }
         value
-            .strip_suffix(path)
-            .map(|prefix| format!("{prefix}{replacement}"))
-            .unwrap_or(value)
     }
 
     fn display_path(path: &Path) -> String {
@@ -295,6 +339,72 @@ mod tests {
     }
 
     #[test]
+    fn renders_environment_aliases_as_symbolic_literals() {
+        let temp = tempfile::tempdir().unwrap();
+        let toolchain_root = PathNormalizer::display_path(&temp.path().join("toolchain"));
+        let moon_home = PathNormalizer::display_path(&temp.path().join("home"));
+        let override_program =
+            PathNormalizer::display_path(&temp.path().join("custom compiler/moonc"));
+        let normalizer = normalizer(
+            &toolchain_root,
+            &moon_home,
+            vec![(override_program.clone(), "$MOONC_OVERRIDE".to_owned())],
+            None,
+        );
+        let stdlib = format!("{moon_home}/lib/core");
+        let command = crate::shlex::join_native(
+            [override_program.as_str(), "--std-path", stdlib.as_str()].into_iter(),
+        );
+
+        assert_eq!(
+            normalizer.normalize_command(&command),
+            "'$MOONC_OVERRIDE' --std-path '$MOON_HOME/lib/core'"
+        );
+        assert_eq!(
+            normalizer.normalize_command_arg(&format!("exec {override_program} --version")),
+            "exec $MOONC_OVERRIDE --version"
+        );
+        assert_eq!(
+            normalizer.normalize_command_arg(&format!("--compiler={override_program}")),
+            format!("--compiler={override_program}")
+        );
+    }
+
+    #[test]
+    fn normalizes_the_current_program_when_it_is_a_complete_shell_token() {
+        let temp = tempfile::tempdir().unwrap();
+        let toolchain_root = PathNormalizer::display_path(&temp.path().join("toolchain"));
+        let moon_home = PathNormalizer::display_path(&temp.path().join("home"));
+        let current_program = PathNormalizer::display_path(&temp.path().join("build/moon"));
+        let normalizer = normalizer(
+            &toolchain_root,
+            &moon_home,
+            vec![],
+            Some((current_program.clone(), "moon".to_owned())),
+        );
+        let shell_command = format!("{current_program} tool embed -i input -o output");
+        let command = crate::shlex::join_native(
+            [
+                current_program.as_str(),
+                "tool",
+                "exec",
+                "--shell",
+                shell_command.as_str(),
+            ]
+            .into_iter(),
+        );
+
+        assert_eq!(
+            normalizer.normalize_command(&command),
+            "moon tool exec --shell 'moon tool embed -i input -o output'"
+        );
+        assert_eq!(
+            normalizer.normalize_command_arg(&format!("{current_program}-helper")),
+            format!("{current_program}-helper")
+        );
+    }
+
+    #[test]
     fn masks_only_complete_overrides_and_path_root_boundaries() {
         let temp = tempfile::tempdir().unwrap();
         let workspace = PathNormalizer::display_path(&dunce::canonicalize(".").unwrap());
@@ -323,6 +433,8 @@ mod tests {
         for root in [&workspace, &toolchain, &moon_home] {
             let sibling = format!("{root}-cache/data");
             assert_eq!(normalizer.normalize_command_arg(&sibling), sibling);
+            let embedded = format!("prefix{root}/lib");
+            assert_eq!(normalizer.normalize_command_arg(&embedded), embedded);
         }
         assert_eq!(
             normalizer.normalize_command_arg(&format!("--root={toolchain}/lib")),
@@ -337,12 +449,21 @@ mod tests {
             "/Fo./_build/main.o"
         );
         assert_eq!(
+            normalizer
+                .normalize_command_arg(&format!("-Wl,-rpath,{workspace}/_build/native/debug/test")),
+            "-Wl,-rpath,./_build/native/debug/test"
+        );
+        assert_eq!(
             normalizer.normalize_command_arg(&format!("--home={moon_home}")),
             "--home=$MOON_HOME"
         );
         assert_eq!(
             normalizer.normalize_command_arg(&format!("--home={moon_home}/lib")),
             "--home=$MOON_HOME/lib"
+        );
+        assert_eq!(
+            normalizer.normalize_command_arg(&format!("tool --root '{toolchain}/lib'")),
+            "tool --root '$MOON_TOOLCHAIN_ROOT/lib'"
         );
 
         let separator = if cfg!(windows) { ';' } else { ':' };
@@ -379,6 +500,32 @@ mod tests {
         assert_eq!(
             normalizer.normalize_command_program(&format!("{toolchain_spelling}/bin/moonc.exe")),
             "moonc"
+        );
+    }
+
+    #[test]
+    fn matches_windows_paths_at_shell_and_compiler_option_boundaries() {
+        let normalizer = normalizer(
+            "C:/Moon/toolchain",
+            "C:/Moon/home",
+            vec![(
+                "C:/Tools/moonc.exe".to_owned(),
+                "$MOONC_OVERRIDE".to_owned(),
+            )],
+            None,
+        );
+
+        assert_eq!(
+            normalizer.normalize_command_arg(r#"& "C:\Tools\moonc.exe" check"#),
+            r#"& "$MOONC_OVERRIDE" check"#
+        );
+        assert_eq!(
+            normalizer.normalize_command_arg(r#"/LIBPATH:C:\Moon\toolchain\lib"#),
+            "/LIBPATH:$MOON_TOOLCHAIN_ROOT/lib"
+        );
+        assert_eq!(
+            normalizer.normalize_command_arg(r#"prefixC:\Moon\toolchain\lib"#),
+            "prefixC:/Moon/toolchain/lib"
         );
     }
 

--- a/docs/dev/reference/dry-run.md
+++ b/docs/dev/reference/dry-run.md
@@ -3,13 +3,13 @@
 > **This output is intentionally unstable and meant only for maintainers.**
 > Do not build tools or workflows that depend on the exact formatting or ordering.
 
-- **Deterministic order**. Build commands are printed in a topologically sorted order; executing them sequentially produces the expected build artifacts.
-- **Unix-style command lines**. Every command line is rewritten using Unix shell quoting, even on Windows hosts.
+- **Deterministic order**. Build commands are printed in a topologically sorted order that reflects their execution dependencies.
+- **Unix-style command lines**. Every command line is displayed using POSIX shell quoting, even on Windows hosts. Generated environment placeholders are symbolic literals.
 - **Backslash normalize**. Backslashes `\` in the commandline is normalized to forward slash `/`.
 - **Home directory masking**. Any occurrence of the Moon home directory (`~/.moon` or a custom `$MOON_HOME`) is rewritten to the literal `$MOON_HOME`.
 - **Project-relative paths**. Paths that live under the project root are emitted as a relative path from the project root, instead of absolute paths.
-- **Best-effort path masking**. Project, Moon home, selected toolchain, and explicitly configured binary override paths are masked. Roots are replaced only when followed by a directory, end-of-value, or platform path-list boundary; missing or unresolvable override paths never make rendering fail.
+- **Best-effort path masking**. Project, Moon home, selected toolchain, and explicitly configured binary override paths are masked. File aliases are replaced only when the complete file path is a shell token. Directory roots require both a recognized leading boundary (including shell-token, path-list, assignment, and compact compiler-option boundaries) and a trailing directory, path-list, shell-token, or end-of-value boundary. Missing or unresolvable override paths never make rendering fail.
 - **Stable command programs**. A command program directly under the selected toolchain's `bin` directory is shortened to its file name. The running `moon` executable uses its file name. Other command programs remain unchanged unless an explicit override applies. Other occurrences of the same paths, such as build graph inputs, retain their masked or original path form. Platform executable suffixes on toolchain programs are omitted for stable cross-platform output.
-- **Explicit binary overrides**. Only override environment variables that are set are resolved and masked with the corresponding variable name, such as `$MOONC_OVERRIDE`.
+- **Explicit binary overrides**. Only override environment variables that are set are resolved and masked with a symbolic variable name, such as `$MOONC_OVERRIDE`.
 - **`moon run --dry-run` extras**. After the build commands, the dry-run output also prints the command that would execute the produced binary (typically `moonrun`, `node`, or the final executable).
 - **`moon test --verbose` extras**. With `--verbose` set, `moon test` print the command that is executed for each test case.


### PR DESCRIPTION
## Why

Dry-run path masking handled configured binary overrides only as whole arguments and recognized directory roots mainly by their trailing boundary. Nested shell commands could therefore retain a resolved `moon` path, while textual prefixes could be mistaken for directories, making output depend on host-specific absolute paths.

## What changed

- Replace configured binaries and the running `moon` path only when they form complete shell tokens, including inside nested command payloads.
- Require both leading and trailing boundaries when masking directory roots, with support for path lists and path-bearing compiler options.
- Keep environment-variable aliases as symbolic literals in the displayed command.
- Document the implemented dry-run masking rules.

## Why this is correct

The matching rules distinguish exact file tokens from directory prefixes and cover POSIX and Windows command shapes, compact compiler flags, linker path options, false textual prefixes, and the `:embed` prebuild expansion.

The change is limited to dry-run display normalization; command execution and build planning are unchanged.
