### PR TITLE
refactor(moonbuild): request artifacts at compile entry

### DIFF
--- a/.agents/skills/moon-development/SKILL.md
+++ b/.agents/skills/moon-development/SKILL.md
@@ -41,6 +41,10 @@ Before adding a MoonBuild planning or lowering type, projection, or seam:
 - Design the merged end state before splitting the work. Intermediate commits
   may carry compatibility code, but the PR should replace or materially shrink
   the old model rather than merge two peer models into the default branch.
+- Mark every intentionally retained compatibility representation, known seam
+  violation, or deferred deletion in source with a searchable `FIXME` or
+  `TODO` that states the removal condition. Ordinary comments, design
+  documents, and PR descriptions do not replace the source marker.
 - Separate semantic changes from optional terminology cleanup. A rename is not
   an architectural benefit.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -92,6 +92,14 @@ _Avoid_: Action dependency, producer edge
 The build-plan derivation registered as producing a Build Artifact. Every required artifact has exactly one provider within a Build Plan.
 _Avoid_: Choosing a provider separately at each requirement call site
 
+**Declared Action Output**:
+A concrete file or directory that an execution action declares for dependency ordering, incremental execution, or caching. It may realize a Build Artifact, but it does not gain semantic identity merely because an executor tracks it.
+_Avoid_: Build Artifact, incidental output
+
+**Incidental Output**:
+A file or directory emitted as part of a tool's behavior but not declared independently to the execution layer. It cannot be requested, depended on, or cached independently by MoonBuild.
+_Avoid_: Build Artifact, declared action output
+
 ## Native Build
 
 **Target Backend**:

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -44,8 +44,8 @@ use moonbuild_rupes_recta::{
     fmt::{FmtConfig, FmtResolveOutput},
     intent::UserIntent,
     model::{
-        BackendConfig, BuildPlanNode, DirectNativeMode, NativeBackendMode, NativeTarget, PackageId,
-        TargetKind, TccRunConfig,
+        BackendConfig, DirectNativeMode, NativeBackendMode, NativeTarget, PackageId, TargetKind,
+        TccRunConfig,
     },
     prebuild::{PrebuildEnvironment, run_prebuild_config},
     target_layout::{ArtifactPathResolver, GENERATED_TEST_DRIVER_PREFIX, TargetLayout},
@@ -96,7 +96,7 @@ pub(crate) fn sync_and_resolve_project(
 
 /// The output of a calculate user intent operation.
 pub struct CalcUserIntentOutput {
-    /// The list of user intents; will be expanded to concrete BuildPlanNode(s) later.
+    /// The list of user intents; will be expanded to requested artifacts later.
     pub intents: Vec<UserIntent>,
     /// The input directive that the user wants to apply to the packages
     pub directive: InputDirective,
@@ -105,6 +105,25 @@ pub struct CalcUserIntentOutput {
 impl CalcUserIntentOutput {
     pub fn new(intents: Vec<UserIntent>, directive: InputDirective) -> Self {
         Self { intents, directive }
+    }
+
+    fn requested_artifacts(
+        &self,
+        resolve_output: &ResolveOutput,
+        user_log: &UserLog,
+        target_backend: TargetBackend,
+    ) -> Vec<ArtifactKey> {
+        let mut artifacts = Vec::new();
+        for intent in &self.intents {
+            intent.append_artifacts(
+                resolve_output,
+                &mut artifacts,
+                user_log,
+                &self.directive,
+                target_backend,
+            );
+        }
+        artifacts
     }
 }
 
@@ -316,7 +335,7 @@ impl CompilePreConfig {
         final_target_backend: TargetBackend,
         is_core: bool,
         resolve_output: &ResolveOutput,
-        input_nodes: &[BuildPlanNode],
+        requested_artifacts: &[ArtifactKey],
         user_log: &UserLog,
     ) -> anyhow::Result<CompileConfig> {
         info!("Determining compilation configuration");
@@ -346,9 +365,11 @@ impl CompilePreConfig {
                 use_wat: self.output_wat,
             },
             TargetBackend::Js => BackendConfig::Js,
-            TargetBackend::Native => {
-                BackendConfig::Native(self.detect_mode(resolve_output, input_nodes, user_log))
-            }
+            TargetBackend::Native => BackendConfig::Native(self.detect_mode(
+                resolve_output,
+                requested_artifacts,
+                user_log,
+            )),
             TargetBackend::LLVM => BackendConfig::Llvm,
         };
         info!("Final backend configuration: {:?}", backend);
@@ -388,7 +409,7 @@ impl CompilePreConfig {
     fn detect_mode(
         &self,
         resolve_output: &ResolveOutput,
-        input_nodes: &[BuildPlanNode],
+        requested_artifacts: &[ArtifactKey],
         user_log: &UserLog,
     ) -> NativeBackendMode {
         // TODO: Native payload form is selected once per invocation. Before
@@ -396,13 +417,13 @@ impl CompilePreConfig {
         // products by their native toolchain and realization. Otherwise mixed
         // payload forms can require incompatible shared artifacts, especially
         // for the strict MSVC direct object target.
-        let native_configs = input_nodes
+        let native_configs = requested_artifacts
             .iter()
-            .filter_map(|node| {
-                let BuildPlanNode::MakeExecutable(build_target) = node else {
+            .filter_map(|artifact| {
+                let ArtifactKey::Executable { package, .. } = artifact else {
                     return None;
                 };
-                let package = resolve_output.pkg_dirs.get_package(build_target.package);
+                let package = resolve_output.pkg_dirs.get_package(*package);
                 let native = package
                     .raw
                     .link
@@ -638,23 +659,14 @@ pub(crate) fn plan_resolved_build_from_intent(
         Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
     };
 
-    // Expand user intents to concrete BuildPlanNode inputs
-    info!("Expanding user intents to build plan nodes");
-    let mut input_nodes: Vec<BuildPlanNode> = Vec::new();
-    for i in &intent.intents {
-        i.append_nodes(
-            &resolve_output,
-            &mut input_nodes,
-            user_log,
-            &intent.directive,
-            planning_context.target_backend,
-        );
-    }
+    info!("Expanding user intents to requested artifacts");
+    let requested_artifacts =
+        intent.requested_artifacts(&resolve_output, user_log, planning_context.target_backend);
     let cx = preconfig.into_compile_config(
         planning_context.target_backend,
         planning_context.is_core,
         &resolve_output,
-        &input_nodes,
+        &requested_artifacts,
         user_log,
     )?;
     info!("Begin lowering to build graph");
@@ -662,7 +674,7 @@ pub(crate) fn plan_resolved_build_from_intent(
         &cx,
         mooncake_bin_dir,
         &resolve_output,
-        &input_nodes,
+        &requested_artifacts,
         &intent.directive,
         prebuild_config.as_ref(),
         user_log,
@@ -732,28 +744,20 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
         Some(run_prebuild_config(&resolve_output, &prebuild_environment)?)
     };
 
-    let mut input_nodes = Vec::new();
-    for user_intent in &intent.intents {
-        user_intent.append_nodes(
-            &resolve_output,
-            &mut input_nodes,
-            user_log,
-            &intent.directive,
-            planning_context.target_backend,
-        );
-    }
+    let requested_artifacts =
+        intent.requested_artifacts(&resolve_output, user_log, planning_context.target_backend);
     let cx = preconfig.into_compile_config(
         planning_context.target_backend,
         planning_context.is_core,
         &resolve_output,
-        &input_nodes,
+        &requested_artifacts,
         user_log,
     )?;
     let compile_output = moonbuild_rupes_recta::compile_standalone(
         &cx,
         mooncake_bin_dir,
         &resolve_output,
-        &input_nodes,
+        &requested_artifacts,
         script_package,
         &intent.directive,
         prebuild_config.as_ref(),

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -1248,10 +1248,6 @@ mod tests {
             package: target.package,
             target_kind: target.kind,
         });
-        plan.test_request_artifact(ArtifactKey::DsymBundle {
-            package: target.package,
-            target_kind: target.kind,
-        });
         plan.test_insert_make_executable_info(
             target,
             MakeExecutableInfo {
@@ -1341,6 +1337,13 @@ mod tests {
                 .files
                 .lookup(&dsym_bundle.to_string_lossy())
                 .expect("dSYM bundle should be registered");
+            assert!(
+                lowered
+                    .build_graph
+                    .get_start_nodes()
+                    .contains(&dsym_file_id),
+                "an unconsumed dSYM output should remain an execution root"
+            );
             let dsym_build_id = lowered.build_graph.files.by_id[dsym_file_id]
                 .input
                 .expect("dSYM bundle should have a producer");
@@ -1357,22 +1360,13 @@ mod tests {
 
             assert_eq!(
                 lowered.artifacts,
-                vec![
-                    (
-                        ArtifactKey::Executable {
-                            package: target.package,
-                            target_kind: target.kind,
-                        },
-                        vec![executable]
-                    ),
-                    (
-                        ArtifactKey::DsymBundle {
-                            package: target.package,
-                            target_kind: target.kind,
-                        },
-                        vec![dsym_bundle]
-                    ),
-                ]
+                vec![(
+                    ArtifactKey::Executable {
+                        package: target.package,
+                        target_kind: target.kind,
+                    },
+                    vec![executable]
+                )]
             );
         }
     }

--- a/crates/moonbuild-rupes-recta/src/build_plan/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/artifact.rs
@@ -24,7 +24,7 @@ use std::{
 use indexmap::IndexSet;
 use moonutil::resolution::ModuleId;
 
-use crate::model::{BuildPlanNode, PackageId, TargetKind};
+use crate::model::{BuildPlanNode, BuildTarget, PackageId, TargetKind};
 
 /// Normalize a package file declaration without retaining the package's
 /// physical root. Explicit paths outside the package remain absolute because
@@ -100,6 +100,9 @@ pub enum ArtifactKey {
         package: PackageId,
         target_kind: TargetKind,
     },
+    /// FIXME(execution-plan): This temporary execution-layer compatibility
+    /// output is not exposed as a caller-requested Build Artifact. Replace it
+    /// with a declared output of `GenerateDsym` in the execution plan.
     DsymBundle {
         package: PackageId,
         target_kind: TargetKind,
@@ -134,6 +137,69 @@ pub enum ArtifactKey {
         /// package root; an explicitly absolute declaration remains absolute.
         path: PathBuf,
     },
+}
+
+impl ArtifactKey {
+    /// The package target whose compilation lifecycle owns this artifact.
+    /// Module-wide, package-wide, runtime, and prebuild artifacts have no
+    /// `BuildTarget` identity.
+    pub(crate) fn package_target(&self) -> Option<BuildTarget> {
+        match self {
+            Self::CheckMi {
+                package,
+                target_kind,
+            }
+            | Self::BuildMi {
+                package,
+                target_kind,
+            }
+            | Self::CoreIr {
+                package,
+                target_kind,
+            }
+            | Self::ProofMi {
+                package,
+                target_kind,
+            }
+            | Self::ProofWhyml {
+                package,
+                target_kind,
+            }
+            | Self::ProofReport {
+                package,
+                target_kind,
+            }
+            | Self::LinkedCore {
+                package,
+                target_kind,
+            }
+            | Self::Executable {
+                package,
+                target_kind,
+            }
+            | Self::GeneratedTestDriver {
+                package,
+                target_kind,
+            }
+            | Self::GeneratedTestMetadata {
+                package,
+                target_kind,
+            }
+            | Self::GeneratedMbti {
+                package,
+                target_kind,
+            } => Some(package.build_target(*target_kind)),
+            Self::VirtualContractMi { .. }
+            | Self::CStubObject { .. }
+            | Self::CStubLibrary { .. }
+            | Self::BundleResult { .. }
+            | Self::RuntimeObject { .. }
+            | Self::RuntimeLibrary
+            | Self::DocsDir { .. }
+            | Self::DsymBundle { .. }
+            | Self::PrebuildOutput { .. } => None,
+        }
+    }
 }
 
 /// Artifact providers and the artifact requirements of each action.

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -55,9 +55,6 @@ pub(super) struct BuildPlanConstructor<'a> {
     /// Currently pending nodes that need to be processed.
     pub(super) pending: Vec<BuildPlanNode>,
     pub(super) resolved: HashSet<BuildPlanNode>,
-    /// Caller-selected action intents, retained only while provider choices are
-    /// being resolved. The finished plan exposes requested artifacts instead.
-    pub(super) requested_nodes: HashSet<BuildPlanNode>,
     pub(super) warned_incompatible_windows_msvc_env_override: bool,
     pub(super) warned_missing_supported_targets: HashSet<PackageId>,
     pub(super) package_file_sets: HashMap<PackageId, PackageFileSet>,
@@ -97,7 +94,6 @@ impl<'a> BuildPlanConstructor<'a> {
             res: BuildPlan::default(),
             pending: Vec::new(),
             resolved: HashSet::new(),
-            requested_nodes: HashSet::new(),
             warned_incompatible_windows_msvc_env_override: false,
             warned_missing_supported_targets: HashSet::new(),
             package_file_sets: HashMap::new(),
@@ -112,7 +108,7 @@ impl<'a> BuildPlanConstructor<'a> {
 
     pub(super) fn build(
         &mut self,
-        input: impl Iterator<Item = BuildPlanNode>,
+        input: impl Iterator<Item = ArtifactKey>,
     ) -> Result<(), BuildPlanConstructError> {
         assert!(
             self.pending.is_empty(),
@@ -120,22 +116,14 @@ impl<'a> BuildPlanConstructor<'a> {
         );
 
         let input = input.collect::<Vec<_>>();
-        self.requested_nodes.extend(input.iter().copied());
+        self.res.requested_artifacts.extend(input.iter().cloned());
 
-        // Normalize action-shaped caller intent to the action that really
-        // provides the requested result for this backend.
-        let mut root_nodes = Vec::new();
-        for node in input {
-            let root = match node {
-                BuildPlanNode::MakeExecutable(target)
-                    if !self.build_env.target_backend().is_native() =>
-                {
-                    BuildPlanNode::LinkCore(target)
-                }
-                _ => node,
-            };
-            self.need_node(root);
-            root_nodes.push(root);
+        // Record the complete caller-requested set before selecting providers.
+        // Some artifacts share a provider only for a particular request shape;
+        // for example, an explicit proof report makes `Prove` provide the proof
+        // surface that dependencies would otherwise get from `EmitProof`.
+        for artifact in &input {
+            self.need_artifact_provider(artifact);
         }
 
         while let Some(node) = self.pending.pop() {
@@ -160,25 +148,12 @@ impl<'a> BuildPlanConstructor<'a> {
             }
         }
 
-        for root in root_nodes {
-            self.res
-                .requested_artifacts
-                .extend(self.res.artifacts.provided_by(root).cloned());
-            if let BuildPlanNode::MakeExecutable(target) = root
-                && self
-                    .res
-                    .actions
-                    .contains(&BuildPlanNode::GenerateDsym(target))
-            {
-                self.res
-                    .requested_artifacts
-                    .insert(ArtifactKey::DsymBundle {
-                        package: target.package,
-                        target_kind: target.kind,
-                    });
-            }
+        for artifact in &self.res.requested_artifacts {
+            assert!(
+                self.res.artifacts.provider(artifact).is_some(),
+                "requested artifact {artifact:?} has no provider in the build plan"
+            );
         }
-
         self.res.artifacts.validate();
         self.warn_moon_cc_overrides();
 
@@ -482,7 +457,13 @@ impl<'a> BuildPlanConstructor<'a> {
     /// Record an artifact requirement and schedule the artifact rule's unique
     /// provider. The caller names only the artifact it consumes.
     pub(super) fn require_artifact(&mut self, consumer: BuildPlanNode, artifact: ArtifactKey) {
-        let provider = match &artifact {
+        self.need_artifact_provider(&artifact);
+        self.res.artifacts.require(consumer, artifact);
+    }
+
+    /// Schedule the action that provides one requested or required artifact.
+    fn need_artifact_provider(&mut self, artifact: &ArtifactKey) {
+        let provider = match artifact {
             ArtifactKey::CheckMi {
                 package,
                 target_kind,
@@ -505,7 +486,14 @@ impl<'a> BuildPlanConstructor<'a> {
                 target_kind,
             } => {
                 let target = package.build_target(*target_kind);
-                if self.requested_nodes.contains(&BuildPlanNode::Prove(target)) {
+                if self
+                    .res
+                    .requested_artifacts
+                    .contains(&ArtifactKey::ProofReport {
+                        package: *package,
+                        target_kind: *target_kind,
+                    })
+                {
                     BuildPlanNode::Prove(target)
                 } else {
                     BuildPlanNode::EmitProof(target)
@@ -576,16 +564,14 @@ impl<'a> BuildPlanConstructor<'a> {
                 let provider = self
                     .res
                     .artifacts
-                    .provider(&artifact)
+                    .provider(artifact)
                     .expect("prebuild artifact should name a planned output");
                 debug_assert!(is_package_prebuild_node(provider));
-                self.res.artifacts.require(consumer, artifact);
                 return;
             }
         };
 
         self.need_node(provider);
-        self.res.artifacts.require(consumer, artifact);
     }
 
     fn ensure_resolved(&self, node: BuildPlanNode) {

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -28,8 +28,9 @@
 //! check, build or test).
 //!
 //! In contrast, this module generates the actual build plan from a list of
-//! input action nodes. Irrelevant packages are not included in this graph,
-//! nor does irrelevant actions.
+//! requested artifacts. It selects their provider actions and expands
+//! transitive artifact requirements; irrelevant packages and actions are not
+//! included.
 //!
 //! The result of this module is analogous to Rust Cargo's [Compile unit graph][cu].
 //! The reason why this is two graphs here in MoonBuild and only one graph in
@@ -599,7 +600,7 @@ pub enum PackagePrebuildPolicy {
     ConsumeExistingOutputs,
 }
 
-/// Directives provided along the input actions.
+/// Command-specific directives provided alongside requested artifacts.
 #[derive(Debug)]
 pub struct InputDirective {
     /// Set `no_mi=true` for the given package.
@@ -693,13 +694,13 @@ pub enum BuildPlanConstructError {
     },
 }
 
-/// Construct an abstract build graph from the given packages and input actions.
+/// Construct a Build Plan that produces the requested artifacts.
 #[instrument(skip_all)]
 pub fn build_plan(
     resolved: &ResolveOutput,
     mooncake_bin_dir: &Path,
     build_env: &BuildEnvironment,
-    input: impl Iterator<Item = BuildPlanNode>,
+    input: impl Iterator<Item = ArtifactKey>,
     input_directive: &InputDirective,
     prebuild_config: Option<&PrebuildOutput>,
     user_log: &UserLog,

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -25,7 +25,7 @@ use tracing::{Level, instrument};
 use crate::{
     build_lower::{self, LoweringEnvironment, WarningCondition},
     build_plan::{self, ArtifactKey, BuildEnvironment, InputDirective},
-    model::{BackendConfig, BuildPlanNode, OperatingSystem},
+    model::{BackendConfig, OperatingSystem},
     prebuild::PrebuildOutput,
     resolve::ResolveOutput,
     special_cases::should_skip_tests,
@@ -108,20 +108,20 @@ pub fn compile(
     cx: &CompileConfig,
     mooncake_bin_dir: &Path,
     resolve_output: &ResolveOutput,
-    input_nodes: &[BuildPlanNode],
+    requested_artifacts: &[ArtifactKey],
     input_directive: &InputDirective,
     prebuild_config: Option<&PrebuildOutput>,
     user_log: &UserLog,
 ) -> Result<CompileOutput, CompileGraphError> {
     info!(
-        "Building compilation plan for {} build nodes",
-        input_nodes.len()
+        "Building compilation plan for {} requested artifacts",
+        requested_artifacts.len()
     );
 
-    let input_nodes = input_nodes
+    let requested_artifacts = requested_artifacts
         .iter()
+        .filter(|artifact| filter_special_case_requested_artifact(artifact, resolve_output))
         .cloned()
-        .filter(|x| filter_special_case_input_nodes(*x, resolve_output))
         .collect::<Vec<_>>();
 
     let build_env = build_environment(cx);
@@ -129,7 +129,7 @@ pub fn compile(
         resolve_output,
         mooncake_bin_dir,
         &build_env,
-        input_nodes.into_iter(),
+        requested_artifacts.into_iter(),
         input_directive,
         prebuild_config,
         user_log,
@@ -147,24 +147,24 @@ pub fn compile_standalone(
     cx: &CompileConfig,
     mooncake_bin_dir: &Path,
     resolve_output: &ResolveOutput,
-    input_nodes: &[BuildPlanNode],
+    requested_artifacts: &[ArtifactKey],
     script_package: crate::model::PackageId,
     input_directive: &InputDirective,
     prebuild_config: Option<&PrebuildOutput>,
     user_log: &UserLog,
 ) -> Result<StandaloneCompileOutput, CompileGraphError> {
     info!("Building one logical plan for standalone dependency and script work");
-    let input_nodes = input_nodes
+    let requested_artifacts = requested_artifacts
         .iter()
-        .copied()
-        .filter(|node| filter_special_case_input_nodes(*node, resolve_output))
+        .filter(|artifact| filter_special_case_requested_artifact(artifact, resolve_output))
+        .cloned()
         .collect::<Vec<_>>();
     let build_env = build_environment(cx);
     let plan = build_plan::build_plan(
         resolve_output,
         mooncake_bin_dir,
         &build_env,
-        input_nodes.into_iter(),
+        requested_artifacts.into_iter(),
         input_directive,
         prebuild_config,
         user_log,
@@ -271,13 +271,16 @@ fn lowering_options(cx: &CompileConfig) -> build_lower::BuildOptions {
     }
 }
 
-/// A filter to remove build plan nodes that are invalid. Returns `true` if the
-/// node should be retained.
+/// A filter to remove requested test artifacts that are invalid. Returns
+/// `true` if the artifact should be retained.
 ///
 /// See [`crate::special_cases`] for more information.
 #[instrument(level = Level::DEBUG, skip_all)]
-fn filter_special_case_input_nodes(node: BuildPlanNode, resolve_output: &ResolveOutput) -> bool {
-    match node.extract_target() {
+fn filter_special_case_requested_artifact(
+    artifact: &ArtifactKey,
+    resolve_output: &ResolveOutput,
+) -> bool {
+    match artifact.package_target() {
         Some(tgt) if tgt.kind.is_test() => {
             let pkg_name = &resolve_output.pkg_dirs.get_package(tgt.package).fqn;
             !should_skip_tests(pkg_name)
@@ -480,14 +483,17 @@ mod tests {
             info_no_alias: false,
         };
 
-        let input_nodes = [BuildPlanNode::MakeExecutable(script_target)];
+        let requested_artifacts = [ArtifactKey::Executable {
+            package: script_target.package,
+            target_kind: script_target.kind,
+        }];
         let input_directive = InputDirective::default();
         let user_log = UserLog::new(log::LevelFilter::Error);
         let ordinary = compile(
             &config,
             Path::new("."),
             &resolved,
-            &input_nodes,
+            &requested_artifacts,
             &input_directive,
             None,
             &user_log,
@@ -499,7 +505,7 @@ mod tests {
             &config,
             Path::new("."),
             &resolved,
-            &input_nodes,
+            &requested_artifacts,
             script,
             &input_directive,
             None,
@@ -652,7 +658,16 @@ mod tests {
             &config,
             Path::new("."),
             &resolved,
-            &[BuildPlanNode::Prove(target)],
+            &[
+                ArtifactKey::ProofWhyml {
+                    package: target.package,
+                    target_kind: target.kind,
+                },
+                ArtifactKey::ProofReport {
+                    package: target.package,
+                    target_kind: target.kind,
+                },
+            ],
             &InputDirective::default(),
             None,
             &UserLog::new(log::LevelFilter::Error),

--- a/crates/moonbuild-rupes-recta/src/intent.rs
+++ b/crates/moonbuild-rupes-recta/src/intent.rs
@@ -16,24 +16,23 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! User intent, a small shim to reduce friction between user commands and
-//! build plan nodes.
+//! User intent, a small shim from command semantics to requested artifacts.
 //!
-//! A user intent may map to 0 or more build plan nodes, based on the actual
-//! package definition and status. This is for simplifying the CLI command
-//! node generation logic.
+//! A user intent may map to zero or more logical results based on the resolved
+//! package. Build planning, rather than the CLI adapter, selects the actions
+//! that provide those results for the current backend.
 
 use moonutil::{resolution::ModuleId, target::TargetBackend, user_log::UserLog};
 
 use crate::{
-    build_plan::InputDirective,
+    build_plan::{ArtifactKey, InputDirective},
     cond_comp::get_file_target_backend,
     discover::DiscoveredPackage,
-    model::{BuildPlanNode, BuildTarget, PackageId, TargetKind},
+    model::{BuildTarget, PackageId, TargetKind},
     resolve::ResolveOutput,
 };
 
-/// A concise set of user actions that expand into concrete BuildPlanNode groups.
+/// A concise set of user actions that expand into requested artifact groups.
 #[derive(Clone, Copy, Debug)]
 pub enum UserIntent {
     /// Build a package (produce either .core or an executable).
@@ -46,7 +45,7 @@ pub enum UserIntent {
     Prove(PackageId),
     /// Test a package (emit test driver and build for all test targets).
     Test(PackageId),
-    /// Bench a package (same node set shape as Test; runtime behavior differs elsewhere).
+    /// Bench a package (same artifact set as Test; runtime behavior differs elsewhere).
     Bench(PackageId),
     /// Bundle all non-virtual packages in a module.
     Bundle(ModuleId),
@@ -57,13 +56,13 @@ pub enum UserIntent {
 }
 
 impl UserIntent {
-    /// Append the BuildPlanNode(s) represented by this intent to `out`.
+    /// Append the logical artifacts represented by this intent to `out`.
     ///
     /// This does not deduplicate; callers can handle that if necessary.
-    pub fn append_nodes(
+    pub fn append_artifacts(
         self,
         resolved: &ResolveOutput,
-        out: &mut Vec<BuildPlanNode>,
+        out: &mut Vec<ArtifactKey>,
         user_log: &UserLog,
         directive: &InputDirective,
         target_backend: TargetBackend,
@@ -73,13 +72,18 @@ impl UserIntent {
                 let pkg_info = resolved.pkg_dirs.get_package(pkg);
                 if !pkg_info.has_implementation() {
                     // Pure virtual package: compile its interface instead of building code
-                    out.push(BuildPlanNode::BuildVirtual(pkg));
+                    out.push(ArtifactKey::VirtualContractMi { package: pkg });
                 } else {
-                    let t = pkg.build_target(TargetKind::Source);
                     if is_linkable(pkg_info) {
-                        out.push(BuildPlanNode::make_executable(t));
+                        out.push(ArtifactKey::Executable {
+                            package: pkg,
+                            target_kind: TargetKind::Source,
+                        });
                     } else {
-                        out.push(BuildPlanNode::build_core(t));
+                        out.push(ArtifactKey::CoreIr {
+                            package: pkg,
+                            target_kind: TargetKind::Source,
+                        });
                     }
                 }
             }
@@ -88,8 +92,10 @@ impl UserIntent {
                 if !pkg_info.has_implementation() {
                     // Pure virtual package: we can't do anything
                 } else {
-                    let t = pkg.build_target(TargetKind::Source);
-                    out.push(BuildPlanNode::make_executable(t));
+                    out.push(ArtifactKey::Executable {
+                        package: pkg,
+                        target_kind: TargetKind::Source,
+                    });
                 }
             }
             UserIntent::Check(pkg) => {
@@ -107,7 +113,10 @@ impl UserIntent {
                     //   check tests (virtual impls cannot be tested).
                     // - When checking tests, always check blackbox tests, and
                     //   only check whitebox if it has related files.
-                    out.push(BuildPlanNode::check(source_target));
+                    out.push(ArtifactKey::CheckMi {
+                        package: pkg,
+                        target_kind: TargetKind::Source,
+                    });
                     if !pkg_info.is_virtual_impl()
                         && resolved.local_modules().contains(&pkg_info.module)
                     {
@@ -124,7 +133,10 @@ impl UserIntent {
                                 target_backend,
                                 user_log,
                             ) {
-                                out.push(BuildPlanNode::check(whitebox_target));
+                                out.push(ArtifactKey::CheckMi {
+                                    package: pkg,
+                                    target_kind: TargetKind::WhiteboxTest,
+                                });
                             }
                         }
                         let blackbox_target = pkg.build_target(TargetKind::BlackboxTest);
@@ -135,16 +147,26 @@ impl UserIntent {
                             target_backend,
                             user_log,
                         ) {
-                            out.push(BuildPlanNode::check(blackbox_target));
+                            out.push(ArtifactKey::CheckMi {
+                                package: pkg,
+                                target_kind: TargetKind::BlackboxTest,
+                            });
                         }
                     }
                 } else {
                     // Pure virtual package: compile its interface
-                    out.push(BuildPlanNode::BuildVirtual(pkg));
+                    out.push(ArtifactKey::VirtualContractMi { package: pkg });
                 }
             }
             UserIntent::Prove(pkg) => {
-                out.push(BuildPlanNode::prove(pkg.build_target(TargetKind::Source)));
+                out.push(ArtifactKey::ProofWhyml {
+                    package: pkg,
+                    target_kind: TargetKind::Source,
+                });
+                out.push(ArtifactKey::ProofReport {
+                    package: pkg,
+                    target_kind: TargetKind::Source,
+                });
             }
             UserIntent::Test(pkg) | UserIntent::Bench(pkg) => {
                 let pkg_info = resolved.pkg_dirs.get_package(pkg);
@@ -162,7 +184,8 @@ impl UserIntent {
                         target_backend,
                     );
 
-                    // Emit paired nodes per test target; skip Whitebox if no *_wbtest.mbt declared.
+                    // Request execution and test metadata per target; skip
+                    // Whitebox if no *_wbtest.mbt is declared.
                     for &k in TargetKind::all_tests() {
                         if k == TargetKind::WhiteboxTest
                             && !has_whitebox_decl(resolved, pkg, directive)
@@ -181,23 +204,34 @@ impl UserIntent {
                         {
                             continue;
                         }
-                        out.push(BuildPlanNode::make_executable(t));
-                        out.push(BuildPlanNode::generate_test_info(t));
+                        out.push(ArtifactKey::Executable {
+                            package: pkg,
+                            target_kind: k,
+                        });
+                        out.push(ArtifactKey::GeneratedTestDriver {
+                            package: pkg,
+                            target_kind: k,
+                        });
+                        out.push(ArtifactKey::GeneratedTestMetadata {
+                            package: pkg,
+                            target_kind: k,
+                        });
                     }
                 }
             }
             UserIntent::Bundle(m) => {
-                out.push(BuildPlanNode::Bundle(m));
+                out.push(ArtifactKey::BundleResult { module: m });
             }
             UserIntent::Doc(module_id) => {
-                out.push(BuildPlanNode::BuildDocs(module_id));
+                out.push(ArtifactKey::DocsDir { module: module_id });
             }
             UserIntent::Info(pkg) => {
                 let pkg_info = resolved.pkg_dirs.get_package(pkg);
                 if !(pkg_info.is_virtual_impl() || pkg_info.is_virtual()) {
-                    out.push(BuildPlanNode::GenerateMbti(
-                        pkg.build_target(TargetKind::Source),
-                    ));
+                    out.push(ArtifactKey::GeneratedMbti {
+                        package: pkg,
+                        target_kind: TargetKind::Source,
+                    });
                 }
                 // else: skip virtual packages to mirror `moon info` behavior
             }

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -361,34 +361,6 @@ pub enum BuildPlanNode {
 }
 
 impl BuildPlanNode {
-    pub fn check(target: BuildTarget) -> Self {
-        Self::Check(target)
-    }
-
-    pub fn prove(target: BuildTarget) -> Self {
-        Self::Prove(target)
-    }
-
-    pub fn emit_proof(target: BuildTarget) -> Self {
-        Self::EmitProof(target)
-    }
-
-    pub fn build_core(target: BuildTarget) -> Self {
-        Self::BuildCore(target)
-    }
-
-    pub fn link_core(target: BuildTarget) -> Self {
-        Self::LinkCore(target)
-    }
-
-    pub fn make_executable(target: BuildTarget) -> Self {
-        Self::MakeExecutable(target)
-    }
-
-    pub fn generate_test_info(target: BuildTarget) -> Self {
-        Self::GenerateTestInfo(target)
-    }
-
     /// Extract the target from a BuildPlanNode, if it has one
     pub fn extract_target(&self) -> Option<BuildTarget> {
         match *self {

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -58,11 +58,11 @@ We will use these terms in the document:
   The concrete definition and layout of modules and packages can be found in
   [Modules and Packages](./modules-packages.md).
 
-- The **build plan** is a logical representation of the commands to run.
-  It contains **build plan nodes** that represents build operations
-  (e.g. "compile package X", "check package Y"),
-  but not the actual command line to execute.
-  Nodes may depend on the output files of other nodes.
+- The **build plan** is a logical representation of requested artifacts and
+  the actions that produce them. It contains **build plan nodes** that
+  represent build operations (e.g. "compile package X", "check package Y"),
+  but not the actual command line to execute. Nodes require logical artifacts;
+  the plan records the action that provides each artifact.
 
 - The **build graph** is a concrete, [Ninja][]-like graph that contains
   the final command lines and input/output file paths to execute.
@@ -82,8 +82,8 @@ In a broad sense, `moon` subcommands follows this order when executing project-b
    - Resolve package-level dependencies.
 2. Generate build graph based on the intent of the user [^graph]
    - Determine the user intent ("build package X to executable", "check package Y", etc.)
-   - Determine the initial set build graph nodes (= commands to run) corresponding to the intent.
-   - Expand the build graph according to rules into containing all transitive dependencies of these nodes.
+   - Determine the logical artifacts requested by that intent.
+   - Select provider actions and expand their transitive artifact requirements.
    - Generate a concrete build graph containing the final commandlines to execute.
 3. Execute the build graph
    - Generate metadata files required by compiler actions. Full project checks
@@ -379,12 +379,12 @@ The dependency relationship between build targets is captured in
 
 ## User intent
 
-The RR pipeline uses the **user intent** as an intermediate layer
-between the CLI subcommand and the build-plan nodes.
+The RR pipeline uses the **user intent** as an intermediate layer between the
+CLI subcommand and the Build Artifact requests passed to Build Plan construction.
 
-User intents are the normalized, high-level constructs
-that allows CLI subcommands to describe the action they want to perform on packages,
-without committing to the details of which nodes to use.
+User intents are the normalized, high-level constructs that allow CLI
+subcommands to describe the results they want from packages without committing
+to the provider actions that produce those results.
 
 User intents are specified on individual packages.
 For project-wide subcommands like `moon check` and `moon build`, an intent is
@@ -392,14 +392,14 @@ emitted for each individual package.
 Filtering packages in subcommands operate by only emitting the intents of the target packages,
 instead of emitting for every (applicable) package in the project.
 
-The design of intents allows a single intent to be mapped to multiple build-plan nodes,
-and also into different node patterns based on the properties of the package.
+The design of intents allows a single intent to request multiple artifacts,
+and also different artifact sets based on the properties of the package.
 
 For example, for a `Check(package)` intent (`moon check -p package`),
 it will map into "check package source", "check package whitebox text" and "check package blackbox test".
 However, if the package does not contain whitebox test files,
-the "check whitebox" node will be omitted.
-If the package is virtual, then a list of virtual package checking nodes will be used instead.
+the whitebox Check MI artifact will be omitted.
+If the package is virtual, its virtual-contract MI artifact is requested instead.
 
 For `moon check` and `moon build` without an explicit `--target`, CLI planning
 may first split selected packages into multiple backend groups using
@@ -407,10 +407,10 @@ may first split selected packages into multiple backend groups using
 then emit intents separately for each backend group.
 
 This mapping is also on a migration path for main packages: release N keeps the
-current nodes so warnings can be surfaced, while release N+1 will omit blackbox
-check/test nodes for `is-main` packages.
+current artifacts so warnings can be surfaced, while release N+1 will omit
+blackbox check/test artifacts for `is-main` packages.
 
-The details of how an user intent is mapped to build plan nodes
+The details of how a user intent is mapped to requested artifacts
 is described in [its module](/crates/moonbuild-rupes-recta/src/intent.rs).
 
 ## Build plan node
@@ -435,8 +435,9 @@ The full list of build plan nodes are available in [its module](/crates/moonbuil
 
 ### Node dependency
 
-Build plan nodes depend on each other to form a directed acyclic graph called the **build plan**.
-The edge represents one node's dependency on the artifact produced by another node.
+Build plan nodes require artifacts to form a directed acyclic graph called the
+**build plan**. The artifact registry selects the provider node for each
+requirement.
 
 For example, if build target A depends on build target B,
 then `Check(A)` must first obtain the public interface of B,
@@ -444,18 +445,18 @@ and therefore depends on `Check(B)`.
 
 ### Generating the build plan
 
-The build plan in the pipeline is the transitive dependency closure
-of a list of initial nodes that were translated from the user intents.
+The build plan in the pipeline is the transitive dependency closure of the
+provider actions selected for artifacts translated from user intents.
 
-To generate this build plan, we start from the initial node list,
-and iteratively add the dependency of every new node generated,
-until no more nodes are added.
+To generate this build plan, we start from the requested artifact list, select
+each artifact's provider action, and iteratively add providers for every new
+artifact requirement until no more actions are added.
 
 This process of adding dependencies has the following properties:
 
 - Local. The dependency of each build plan node is only determined from
   the global config and its own metadata.
-- Monotonic. The process never deletes nodes, although it may coerce node to other types.
+- Monotonic. The process never deletes planned actions or artifact requirements.
 - Terminating. Because the dependency graph is finite, there can only be a finite number of nodes.
 
 The concrete rules of adding dependencies is available in [its module](/crates/moonbuild-rupes-recta/src/build_plan/mod.rs).
@@ -509,9 +510,12 @@ and with maximal parallelism subject to dependencies and its job limits.
 ## Artifacts handling
 
 `moon` may perform additional operations on the artifacts generated during the build.
-The list of requested artifacts is generated by the build graph lowering
-process and keyed by `ArtifactKey`. Callers therefore select results by logical
-identity rather than by provider action kind or position in an output vector.
+The requested results are keyed by `ArtifactKey` before build-plan construction;
+lowering realizes them into physical paths. Callers therefore select results by
+logical identity rather than by provider action kind or position in an output
+vector. Physical outputs required only for execution, such as a companion dSYM
+directory, are not caller-requested results; the current n2 graph still executes
+their producer when the output is an unconsumed graph root.
 
 `packages.json` is the legacy metadata file shared with IDE tooling.
 Its top-level shape remains single-module-oriented for compatibility.

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -1,9 +1,10 @@
 # Build plan artifact dependencies
 
-Rupes Recta uses one logical artifact model from planning through lowering:
+Rupes Recta uses one logical artifact dependency model in Build Plan. The
+current lowering representation realizes those artifacts as concrete paths:
 
 ```text
-BuildPlan       = requested actions + artifact providers + artifact requirements
+BuildPlan       = requested artifacts + provider actions + artifact requirements
 BuildActionPlan = stable action IDs + hydrated action data + artifact view
 LoweredAction   = realized artifact paths + external inputs + process command
 n2::Build       = executor representation produced by the n2 adapter
@@ -17,7 +18,7 @@ as the context needed to realize the artifact's physical path.
 ## Backend configuration
 
 After command adapters resolve the Target Backend and expand user intent to
-concrete input nodes, Moon selects one `BackendConfig` value:
+requested `ArtifactKey` values, Moon selects one `BackendConfig` value:
 
 ```rust
 pub enum BackendConfig {
@@ -96,10 +97,18 @@ package remains absolute because it has no package-relative identity. Runtime
 object keys use their stable path within the toolchain library layout, such as
 `runtime/foo.c`, rather than the installed toolchain root.
 
-Only outputs that are explicitly selected, consumed, or exposed as roots need
-artifact keys. Incidental compiler side files such as source maps or
-declaration files remain part of their producing action's physical behavior
-until Moon can independently request or suppress them.
+An output needs an artifact key only when Build Plan selects or consumes it as
+an independently meaningful result. Merely declaring a physical output to n2
+or a cache does not give it Build Artifact identity. Incidental compiler side
+files such as source maps or declaration files remain part of their producing
+action's physical behavior until Moon can independently request or consume
+them.
+
+`DsymBundle` is a known compatibility exception in the current implementation.
+It lets `GenerateDsym` describe its concrete n2 output through the existing
+`LoweredArtifact` representation, but it is not a caller-requested result and
+has no Build Plan consumer. The execution-plan migration will replace this
+physical-only `ArtifactKey` with a declared action output.
 
 ## Planning IR
 
@@ -122,8 +131,8 @@ struct ArtifactPlan {
 
 There is no weighted action-edge graph and no `FileDependencyKind`. A provider
 may expose multiple artifacts, but each artifact has at most one provider in a
-plan. At the end of planning, validation requires every Artifact Requirement
-to have a provider.
+plan. At the end of planning, validation requires every requested artifact and
+every Artifact Requirement to have a provider.
 
 Builders name only what they consume:
 
@@ -141,6 +150,14 @@ self.require_artifact(
 The central artifact rule maps each key to its provider action and schedules
 that action. Builders do not encode `Check`, `BuildCore`, or another provider
 in a dependency edge.
+
+The same rule handles invocation roots. `UserIntent` names results such as
+`CheckMi`, `CoreIr`, or `Executable`; it does not construct provider actions.
+For example, `Executable` selects `LinkCore` for Wasm/JS backends and
+`MakeExecutable` for native/LLVM backends. The complete caller-requested
+artifact set is recorded before provider expansion, so proof-surface artifacts
+select `Prove` when the invocation also requests `ProofReport`, and otherwise
+select `EmitProof`.
 
 Normal downstream `BuildCore` actions require both Build MI and Core IR, so an
 implementation change that leaves the interface stable still rebuilds the
@@ -286,21 +303,21 @@ plan and one n2 graph.
 
 ## Results above lowering
 
-Caller intent is still accepted as `BuildPlanNode` values at the compile entry
-point. During plan construction those action-shaped requests are normalized to
-requested `ArtifactKey` values. `LoweringResult`, `CompileOutput`, and
-`BuildMeta` preserve those keys alongside their realized physical paths, so
-upper layers no longer recover result meaning from provider nodes or output
-positions.
+Caller intent is accepted as `ArtifactKey` values at the compile entry point.
+Plan construction selects provider actions from those keys. `LoweringResult`,
+`CompileOutput`, and `BuildMeta` preserve the keys alongside their realized
+physical paths, so upper layers do not recover result meaning from provider
+nodes or output positions.
 
 For non-native backends, `LinkCore` directly provides `Executable`; there is no
 planning-only `MakeExecutable` alias and every planned action lowers exactly
 once. Native and LLVM plans retain the distinct `LinkedCore` intermediate and a
 real `MakeExecutable` provider.
 
-For native macOS debug targets, `Executable` and `DsymBundle` are separate
-requested results with separate providers. Requesting the dSYM path causes n2
-to run `GenerateDsym` without relying on a companion-path convention.
+For native macOS debug targets, `Executable` remains the requested Build
+Artifact. Planning also includes `GenerateDsym`; its unconsumed concrete output
+is an n2 start node, so ordinary execution and current dry-run still run
+`dsymutil` without exposing the dSYM directory as a caller result.
 
 ## Checks
 

--- a/docs/dev/reference/rr-special-cases.md
+++ b/docs/dev/reference/rr-special-cases.md
@@ -33,8 +33,8 @@ important ones and why they exist.
 
 - **Tests can be dropped per package.** `special_cases::should_skip_tests` lists
   packages that should not produce test targets (currently just
-  `moonbitlang/core/abort`). `compile::filter_special_case_input_nodes` uses
-  this to discard matching test build nodes before planning.
+  `moonbitlang/core/abort`). `compile::filter_special_case_requested_artifact`
+  uses this to discard matching test artifact requests before planning.
 - **Coverage rules differ per package.** `should_skip_coverage` ensures abort is
   never instrumented, while `is_self_coverage_lib` says builtin/coverage should
   use themselves when linking coverage support. These predicates are reused by


### PR DESCRIPTION
## Why

The compile boundary still accepted `BuildPlanNode` roots even though dependencies and lowered results were already artifact-oriented. Planning then normalized backend-specific root actions and inferred requested results from every output of those actions. That left two upper-level request models, made provider choice leak into command intent, and kept special state such as `requested_nodes`.

## What changed

- Expand `UserIntent` directly into requested `ArtifactKey` values.
- Use the same artifact-to-provider rule for invocation roots and action requirements.
- Record the complete request set before provider expansion so explicit proof reports select `Prove`, while dependency-only proof surfaces still select `EmitProof`.
- Select `LinkCore` or `MakeExecutable` from an `Executable` request inside planning instead of normalizing action roots.
- Keep caller-requested results semantic-only. Native dSYM generation remains an execution companion and its unconsumed output remains an n2 start node, but the dSYM path is not returned as a requested Build Artifact.
- Validate that every requested artifact has a provider.
- Remove `requested_nodes` and unused public `BuildPlanNode` constructor helpers.
- Document the distinction between Build Artifacts, declared action outputs, and incidental outputs.

## Why this is correct

Provider actions and the physical build graph remain unchanged. Build and prove intents now request the results consumed by their command layer; interface side outputs such as Build MI and Proof MI remain registered outputs of their provider actions. The dSYM regression test verifies that `dsymutil` still has the executable edge and remains an execution root while only `Executable` is returned to the caller. Existing special-case test filtering now derives the package target from `ArtifactKey`, and standalone compilation follows the same request path as ordinary compilation.

## Scope

This PR changes only the semantic request and planning interface. It does not introduce the future `ActionId`/`OutputId` execution plan or change n2 adaptation, execution, and dry-run rendering. The current lowering representation still carries dSYM through an internal physical-only `DsymBundle` compatibility variant; replacing that variant together with the shallow `BuildActionPlan`/`LoweredAction` split remains one execution-layer follow-up.