### PR TITLE
fix(moonrun): port async process environment and spawn builders

### DIFF
--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -46,6 +46,7 @@ libc.workspace = true
 version = "0.59.0"
 features = [
     "Win32_Foundation",
+    "Win32_Globalization",
     "Win32_NetworkManagement_IpHelper",
     "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",

--- a/crates/moonrun/docs/dev/async-upstream-porting.md
+++ b/crates/moonrun/docs/dev/async-upstream-porting.md
@@ -99,6 +99,10 @@ currently pinned wasm wrapper still calls it during a staged migration.
 - If a removed import intentionally does no work because ownership has already
   transferred, record it as a no-op `#[compat]` adapter instead of a generic
   helper.
+- If compatibility only translates a historical Wasm ABI before calling the
+  current ported Async Sys implementation, record it as an `api_only = true`
+  `#[compat]` adapter. Do not add a duplicate Async Sys wrapper solely for
+  provenance.
 - For a replacement, audit the new ABI, ownership, errors, platform behavior,
   and observable MoonBit API semantics. Add the new `#[ported]` implementation
   separately from the compatibility adapter.

--- a/crates/moonrun/src/async_api/os_string.rs
+++ b/crates/moonrun/src/async_api/os_string.rs
@@ -16,9 +16,42 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::async_host::{AsyncHostError, AsyncHostResult, write_u16};
+use std::ffi::OsString;
+
+use crate::async_host::{AsyncHostError, AsyncHostResult, read_u16, write_u16};
 
 use super::context::ImportContext;
+
+// Async OsString imports pass MoonBit String data and a UTF-16 code-unit
+// length. Unix needs valid Unicode before encoding it as native UTF-8, while
+// Windows OsString preserves the original UTF-16 code units.
+pub(super) fn read_guest(
+    context: &mut ImportContext<'_, '_>,
+    ptr: i32,
+    len: i32,
+) -> AsyncHostResult<OsString> {
+    context.with_memory_mut(|memory| {
+        let units = read_u16(memory, ptr, len)?;
+        guest_os_string_from_utf16(&units)
+    })
+}
+
+#[cfg(unix)]
+fn guest_os_string_from_utf16(units: &[u16]) -> AsyncHostResult<OsString> {
+    use std::os::unix::ffi::OsStringExt;
+
+    let value = char::decode_utf16(units.iter().copied())
+        .collect::<Result<String, _>>()
+        .map_err(|_| AsyncHostError::Inval)?;
+    Ok(OsString::from_vec(value.into_bytes()))
+}
+
+#[cfg(windows)]
+fn guest_os_string_from_utf16(units: &[u16]) -> AsyncHostResult<OsString> {
+    use std::os::windows::ffi::OsStringExt;
+
+    Ok(OsString::from_wide(units))
+}
 
 pub(super) fn decode_len(
     context: &mut ImportContext<'_, '_>,
@@ -111,6 +144,15 @@ fn decode_native_string_bytes(bytes: &[u8]) -> AsyncHostResult<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_guest_os_string_rejects_unpaired_surrogate() {
+        assert_eq!(
+            guest_os_string_from_utf16(&[0xd800]),
+            Err(AsyncHostError::Inval)
+        );
+    }
 
     #[cfg(unix)]
     #[test]

--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -16,56 +16,33 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-#[cfg(unix)]
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 
-use crate::async_host::{
-    AsyncHostError, AsyncHostResult, GuestMemory, INVALID_HOST_HANDLE, read_u16,
-};
+#[cfg(windows)]
+use crate::async_host::read_u16;
+use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory, INVALID_HOST_HANDLE};
 use crate::async_sys::process;
 
 use super::context::ImportContext;
+use super::os_string::read_guest as read_guest_os_string;
 use super::provenance::ported_imports;
 
 ported_imports! {
 #[ported(source = "src/process/unix.c", original = "moonbitlang_async_get_curr_env")]
 #[cfg(unix)]
 pub(super) fn get_curr_env(context: &mut ImportContext<'_, '_>) -> u64 {
-    let env = if context.host.policy().has_env_policy() {
-        context
-            .host
-            .policy()
-            .env_vars()
-            .into_iter()
-            .map(|(key, value)| Some(OsString::from(format!("{key}={value}"))))
-            .collect()
-    } else {
-        current_unix_env()
-    };
+    let env = inherited_unix_env(context).into_iter().map(Some).collect();
     context.host.insert_process_env(env)
 }
 
 #[ported(source = "src/process/windows.c", original = "moonbitlang_async_get_curr_env")]
 #[cfg(windows)]
 pub(super) fn get_curr_env(context: &mut ImportContext<'_, '_>) -> AsyncHostResult<u64> {
-    let env = if context.host.policy().has_env_policy() {
-        let mut block = Vec::new();
-        for (key, value) in context.host.policy().env_vars() {
-            block.extend(format!("{key}={value}").encode_utf16());
-            block.push(0);
-        }
-        if block.is_empty() {
-            block.push(0);
-        }
-        block.push(0);
-        block
-    } else {
-        current_windows_env()?
-    };
+    let env = windows_env_block(inherited_windows_env(context)?);
     Ok(context.host.insert_process_env(env))
 }
 
@@ -162,8 +139,9 @@ pub(super) fn env_block_add_entry(
     value: i32,
     value_len: i32,
 ) -> AsyncHostResult<()> {
-    let entry = unix_env_entry(context, key, key_len, value, value_len)?;
-    context.host.process_env_add_entry(env, index, entry)
+    let key = read_guest_os_string(context, key, key_len)?;
+    let value = read_guest_os_string(context, value, value_len)?;
+    context.host.process_env_add_entry(env, index, key, value)
 }
 
 #[ported(source = "src/process/windows.c", original = "moonbitlang_async_env_block_add_entry")]
@@ -182,6 +160,72 @@ pub(super) fn env_block_add_entry(
     context
         .host
         .process_env_add_entry(env, offset, &key, &value)
+}
+
+#[ported(source = "src/process/wasm.mbt", original = "process/make_env")]
+#[cfg(unix)]
+pub(super) fn make_env(
+    context: &mut ImportContext<'_, '_>,
+    inherit_env: i32,
+) -> AsyncHostResult<u64> {
+    let inherited = if inherit_env == 0 {
+        Vec::new()
+    } else {
+        inherited_unix_env(context)
+    };
+    Ok(context.host.insert_process_env_builder(inherited))
+}
+
+#[ported(source = "src/process/wasm.mbt", original = "process/make_env")]
+#[cfg(windows)]
+pub(super) fn make_env(
+    context: &mut ImportContext<'_, '_>,
+    inherit_env: i32,
+) -> AsyncHostResult<u64> {
+    let inherited = if inherit_env == 0 {
+        Vec::new()
+    } else {
+        inherited_windows_env(context)?
+    };
+    Ok(context.host.insert_process_env_builder(inherited))
+}
+
+#[ported(
+    source = "src/process/unix.c",
+    original = "moonbitlang_async_env_block_add_entry"
+)]
+#[cfg(unix)]
+pub(super) fn env_add_entry(
+    context: &mut ImportContext<'_, '_>,
+    env: u64,
+    key: i32,
+    key_len: i32,
+    value: i32,
+    value_len: i32,
+) -> AsyncHostResult<()> {
+    let key = read_guest_os_string(context, key, key_len)?;
+    let value = read_guest_os_string(context, value, value_len)?;
+    context.host.process_env_builder_add_entry(env, key, value)
+}
+
+#[ported(
+    source = "src/process/windows.c",
+    original = "moonbitlang_async_env_block_add_entry"
+)]
+#[cfg(windows)]
+pub(super) fn env_add_entry(
+    context: &mut ImportContext<'_, '_>,
+    env: u64,
+    key: i32,
+    key_len: i32,
+    value: i32,
+    value_len: i32,
+) -> AsyncHostResult<()> {
+    let key = read_guest_os_string(context, key, key_len)?;
+    let value = read_guest_os_string(context, value, value_len)?;
+    context
+        .host
+        .process_env_builder_add_entry(env, key, value)
 }
 
 #[ported(source = "src/process/unix.c", original = "moonbitlang_async_make_argv_array")]
@@ -391,7 +435,22 @@ pub(super) fn kill(context: &mut ImportContext<'_, '_>, pid: i32) -> AsyncHostRe
 }
 
 #[cfg(unix)]
-fn current_unix_env() -> Vec<Option<OsString>> {
+fn inherited_unix_env(context: &ImportContext<'_, '_>) -> Vec<OsString> {
+    if context.host.policy().has_env_policy() {
+        context
+            .host
+            .policy()
+            .env_vars()
+            .into_iter()
+            .map(|(key, value)| OsString::from(format!("{key}={value}")))
+            .collect()
+    } else {
+        current_unix_env()
+    }
+}
+
+#[cfg(unix)]
+fn current_unix_env() -> Vec<OsString> {
     use std::ffi::CStr;
     use std::os::unix::ffi::OsStringExt;
 
@@ -406,16 +465,32 @@ fn current_unix_env() -> Vec<Option<OsString>> {
         if entry.is_null() {
             break;
         }
-        entries.push(Some(OsString::from_vec(
+        entries.push(OsString::from_vec(
             unsafe { CStr::from_ptr(entry) }.to_bytes().to_vec(),
-        )));
+        ));
         cursor = unsafe { cursor.add(1) };
     }
     entries
 }
 
 #[cfg(windows)]
-fn current_windows_env() -> AsyncHostResult<Vec<u16>> {
+fn inherited_windows_env(context: &ImportContext<'_, '_>) -> AsyncHostResult<Vec<OsString>> {
+    if context.host.policy().has_env_policy() {
+        Ok(context
+            .host
+            .policy()
+            .env_vars()
+            .into_iter()
+            .map(|(key, value)| OsString::from(format!("{key}={value}")))
+            .collect())
+    } else {
+        current_windows_env()
+    }
+}
+
+#[cfg(windows)]
+fn current_windows_env() -> AsyncHostResult<Vec<OsString>> {
+    use std::os::windows::ffi::OsStringExt;
     use windows_sys::Win32::Foundation::GetLastError;
     use windows_sys::Win32::System::Environment::{
         FreeEnvironmentStringsW, GetEnvironmentStringsW,
@@ -438,8 +513,7 @@ fn current_windows_env() -> AsyncHostResult<Vec<u16>> {
         }
         if unsafe { *cursor } != b'=' as u16 {
             let entry = unsafe { std::slice::from_raw_parts(cursor, len) };
-            entries.extend_from_slice(entry);
-            entries.push(0);
+            entries.push(OsString::from_wide(entry));
         }
         cursor = unsafe { cursor.add(len + 1) };
     }
@@ -447,47 +521,23 @@ fn current_windows_env() -> AsyncHostResult<Vec<u16>> {
         FreeEnvironmentStringsW(block);
     }
 
-    if entries.is_empty() {
-        entries.push(0);
-    }
-    entries.push(0);
     Ok(entries)
 }
 
-#[cfg(unix)]
-fn unix_env_entry(
-    context: &mut ImportContext<'_, '_>,
-    key: i32,
-    key_len: i32,
-    value: i32,
-    value_len: i32,
-) -> AsyncHostResult<OsString> {
-    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+#[cfg(windows)]
+fn windows_env_block(entries: Vec<OsString>) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
 
-    let key = read_guest_os_string(context, key, key_len)?;
-    let value = read_guest_os_string(context, value, value_len)?;
-    let mut entry = key.as_os_str().as_bytes().to_vec();
-    entry.push(b'=');
-    entry.extend_from_slice(value.as_os_str().as_bytes());
-    Ok(OsString::from_vec(entry))
-}
-
-#[cfg(unix)]
-fn read_guest_os_string(
-    context: &mut ImportContext<'_, '_>,
-    ptr: i32,
-    len: i32,
-) -> AsyncHostResult<OsString> {
-    context.with_memory_mut(|memory| {
-        let units = read_u16(memory, ptr, len)?;
-
-        use std::os::unix::ffi::OsStringExt;
-
-        let value = char::decode_utf16(units)
-            .map(Result::unwrap)
-            .collect::<String>();
-        Ok(OsString::from_vec(value.into_bytes()))
-    })
+    let mut block = Vec::new();
+    for entry in entries {
+        block.extend(entry.encode_wide());
+        block.push(0);
+    }
+    if block.is_empty() {
+        block.push(0);
+    }
+    block.push(0);
+    block
 }
 
 #[cfg(windows)]

--- a/crates/moonrun/src/async_api/provenance.rs
+++ b/crates/moonrun/src/async_api/provenance.rs
@@ -49,6 +49,7 @@ pub(crate) struct CompatImport {
     pub(crate) upstream_pr: u32,
     pub(crate) replacement: &'static str,
     pub(crate) no_op: bool,
+    pub(crate) api_only: bool,
 }
 
 macro_rules! ported_imports {
@@ -212,6 +213,41 @@ macro_rules! ported_imports {
                     upstream_pr: $upstream_pr,
                     replacement: $replacement,
                     no_op: true,
+                    api_only: false,
+                },
+            ] [
+                $($out)*
+                $(#[$meta])*
+                $vis fn $name($($args)*) $(-> $ret)? $body
+            ]
+            $($rest)*
+        );
+    };
+    (
+        @collect [$($entries:tt)*] [$($compat_entries:tt)*] [$($out:tt)*]
+        #[compat(
+            source = $source:literal,
+            original = $original:literal,
+            upstream_pr = $upstream_pr:literal,
+            replacement = $replacement:literal,
+            api_only = true
+        )]
+        $(#[$meta:meta])*
+        $vis:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)? $body:block
+        $($rest:tt)*
+    ) => {
+        ported_imports!(
+            @collect [$($entries)*] [
+                $($compat_entries)*
+                $crate::async_api::provenance::CompatImport {
+                    rust_module: module_path!(),
+                    rust_symbol: stringify!($name),
+                    original_symbol: $original,
+                    historical_source: $source,
+                    upstream_pr: $upstream_pr,
+                    replacement: $replacement,
+                    no_op: false,
+                    api_only: true,
                 },
             ] [
                 $($out)*
@@ -244,6 +280,7 @@ macro_rules! ported_imports {
                     upstream_pr: $upstream_pr,
                     replacement: $replacement,
                     no_op: false,
+                    api_only: false,
                 },
             ] [
                 $($out)*

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -1063,7 +1063,7 @@ declare_async_imports! {
     ported thread_pool::get_realpath_result(job: u64) -> u64 => "thread_pool/get_realpath_result";
 
     #[cfg(unix)]
-    ported thread_pool::make_spawn_job_unix(
+    compat thread_pool::make_spawn_job_unix(
         path: i32,
         path_len: i32,
         args: u64,
@@ -1092,8 +1092,30 @@ declare_async_imports! {
         has_cwd: i32,
     ) -> u64 => "thread_pool/make_spawn_job/unix";
 
+    #[cfg(unix)]
+    ported thread_pool::spawn_job_unix(
+        path: i32,
+        path_len: i32,
+        args: u64,
+        env: u64,
+        stdin: u64,
+        stdout: u64,
+        stderr: u64,
+    ) -> u64 => "thread_pool/spawn_job/unix";
+
     #[cfg(windows)]
-    ported thread_pool::make_spawn_job_windows(
+    fake thread_pool::spawn_job_unix(
+        path: i32,
+        path_len: i32,
+        args: u64,
+        env: u64,
+        stdin: u64,
+        stdout: u64,
+        stderr: u64,
+    ) -> u64 => "thread_pool/spawn_job/unix";
+
+    #[cfg(windows)]
+    compat thread_pool::make_spawn_job_windows(
         command_line: i32,
         command_line_len: i32,
         env: u64,
@@ -1121,6 +1143,44 @@ declare_async_imports! {
         no_console_window: i32,
         is_orphan: i32,
     ) -> u64 => "thread_pool/make_spawn_job/windows";
+
+    #[cfg(windows)]
+    ported thread_pool::spawn_job_windows(
+        command_line: i32,
+        command_line_len: i32,
+        env: u64,
+        stdin: u64,
+        stdout: u64,
+        stderr: u64,
+        is_orphan: i32,
+    ) -> u64 => "thread_pool/spawn_job/windows";
+
+    #[cfg(unix)]
+    fake thread_pool::spawn_job_windows(
+        command_line: i32,
+        command_line_len: i32,
+        env: u64,
+        stdin: u64,
+        stdout: u64,
+        stderr: u64,
+        is_orphan: i32,
+    ) -> u64 => "thread_pool/spawn_job/windows";
+
+    ported thread_pool::spawn_job_set_cwd(
+        job: u64,
+        cwd: i32,
+        cwd_len: i32,
+    ) -> void => "thread_pool/spawn_job/set_cwd";
+
+    #[cfg(windows)]
+    ported thread_pool::spawn_job_set_no_console_window(
+        job: u64,
+    ) -> void => "thread_pool/spawn_job/set_no_console_window";
+
+    #[cfg(unix)]
+    fake thread_pool::spawn_job_set_no_console_window(
+        job: u64,
+    ) -> void => "thread_pool/spawn_job/set_no_console_window";
 
     ported thread_pool::spawn_job_get_result_handle(job: u64) -> u64 => "thread_pool/spawn_job_get_result_handle";
 
@@ -1152,6 +1212,16 @@ declare_async_imports! {
         value: i32,
         value_len: i32,
     ) -> void => "process/env_block_add_entry";
+
+    helper process::make_env(inherit_env: i32) -> u64 => "process/make_env";
+
+    ported process::env_add_entry(
+        env: u64,
+        key: i32,
+        key_len: i32,
+        value: i32,
+        value_len: i32,
+    ) -> void => "process/env_add_entry";
 
     #[cfg(unix)]
     helper process::make_argv_array_unix(len: i32) -> u64 => "process/make_argv_array/unix";
@@ -1478,29 +1548,6 @@ mod tests {
     }
 
     #[test]
-    fn removed_process_cleanup_imports_are_no_op_compatibility_adapters() {
-        let compat_imports = async_api_compat_imports();
-        for wasm_symbol in ["process/free_env", "process/free_argv"] {
-            let registered = ASYNC_IMPORTS
-                .iter()
-                .find(|import| import.wasm_symbol == wasm_symbol)
-                .expect("cleanup import must remain linkable");
-            if registered.kind == AsyncImportKind::Fake {
-                continue;
-            }
-            let provenance = compat_imports
-                .iter()
-                .find(|compat| {
-                    module_leaf(compat.rust_module) == Some(registered.callback_module)
-                        && compat.rust_symbol == registered.callback_symbol
-                })
-                .expect("cleanup compatibility import must record provenance");
-            assert!(provenance.no_op);
-            assert_eq!(provenance.upstream_pr, 511);
-        }
-    }
-
-    #[test]
     fn wasm_import_names_are_namespaced() {
         for import in ASYNC_IMPORTS {
             let Some((_namespace, _)) = import.wasm_symbol.split_once('/') else {
@@ -1595,17 +1642,24 @@ mod tests {
         for compat in compat_imports {
             assert_ne!(compat.upstream_pr, 0);
             assert!(!compat.replacement.is_empty());
-            if !compat.no_op {
+            assert!(!(compat.no_op && compat.api_only));
+            let has_matching_sys_compat = compat_symbols.iter().any(|symbol| {
+                symbol.native_symbol == compat.original_symbol
+                    && symbol.historical_source == compat.historical_source
+                    && symbol.upstream_pr == compat.upstream_pr
+                    && !symbol.replacement.is_empty()
+            });
+            if compat.api_only {
                 assert!(
-                    compat_symbols.iter().any(|symbol| {
-                        symbol.native_symbol == compat.original_symbol
-                            && symbol.historical_source == compat.historical_source
-                            && symbol.upstream_pr == compat.upstream_pr
-                            && !symbol.replacement.is_empty()
-                    }),
+                    !has_matching_sys_compat,
+                    "API-only compatibility adapter {}::{} has a redundant Async Sys adapter",
+                    compat.rust_module, compat.rust_symbol
+                );
+            } else if !compat.no_op {
+                assert!(
+                    has_matching_sys_compat,
                     "compatibility adapter {}::{} has no matching Async Sys implementation",
-                    compat.rust_module,
-                    compat.rust_symbol
+                    compat.rust_module, compat.rust_symbol
                 );
             }
 

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -16,12 +16,11 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::ffi::OsString;
-
-use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory, read_u16};
+use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory};
 use crate::async_sys::internal::event_loop::thread_pool::{self, ResourceClass, ResourceRef};
 
 use super::context::ImportContext;
+use super::os_string::read_guest as read_guest_os_string;
 use super::provenance::ported_imports;
 
 ported_imports! {
@@ -559,7 +558,13 @@ pub(super) fn make_getaddrinfo_job(
     }
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[compat(
+    source = "src/internal/event_loop/thread_pool.wasm.mbt",
+    original = "thread_pool/make_spawn_job/unix",
+    upstream_pr = 546,
+    replacement = "thread_pool/spawn_job/unix + thread_pool/spawn_job/set_cwd",
+    api_only = true
+)]
 #[cfg(unix)]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_spawn_job_unix(
@@ -576,8 +581,11 @@ pub(super) fn make_spawn_job_unix(
     cwd_len: i32,
     has_cwd: i32,
 ) -> AsyncHostResult<u64> {
-    let _ = inherited_env_entry_count;
-    let (args, env) = context.host.take_process_spawn_buffers(args, env)?;
+    let (args, env) = context.host.take_legacy_process_spawn_inputs(
+        args,
+        env,
+        inherited_env_entry_count,
+    )?;
     let path = read_guest_os_string(context, path, path_len)?;
     let cwd = if has_cwd == 0 {
         None
@@ -590,19 +598,67 @@ pub(super) fn make_spawn_job_unix(
     let options = thread_pool::SpawnOptions {
         child_signal_mask: context.host.thread_pool_child_signal_mask()?,
     };
-    context.host.insert_job(thread_pool::make_spawn_job_unix(
-        path,
-        args,
-        env,
-        stdin,
-        stdout,
-        stderr,
-        cwd,
-        options,
-    ))
+    context
+        .host
+        .insert_job(thread_pool::make_spawn_job_unix(
+            path, args, env, stdin, stdout, stderr, cwd, options,
+        ))
 }
 
-#[ported(source = "src/internal/event_loop/thread_pool.c")]
+#[ported(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_make_spawn_job"
+)]
+#[cfg(unix)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn spawn_job_unix(
+    context: &mut ImportContext<'_, '_>,
+    path: i32,
+    path_len: i32,
+    args: u64,
+    env: u64,
+    stdin: u64,
+    stdout: u64,
+    stderr: u64,
+) -> AsyncHostResult<u64> {
+    let (args, env) = context
+        .host
+        .take_process_spawn_inputs(args, env)?;
+    let path = read_guest_os_string(context, path, path_len)?;
+    let stdin = optional_resource(context, stdin)?;
+    let stdout = optional_resource(context, stdout)?;
+    let stderr = optional_resource(context, stderr)?;
+    let options = thread_pool::SpawnOptions {
+        child_signal_mask: context.host.thread_pool_child_signal_mask()?,
+    };
+    context
+        .host
+        .insert_job(thread_pool::make_spawn_job_unix(
+            path, args, env, stdin, stdout, stderr, None, options,
+        ))
+}
+
+#[ported(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_spawn_job_set_cwd"
+)]
+pub(super) fn spawn_job_set_cwd(
+    context: &mut ImportContext<'_, '_>,
+    job: u64,
+    cwd: i32,
+    cwd_len: i32,
+) -> AsyncHostResult<()> {
+    let cwd = read_guest_os_string(context, cwd, cwd_len)?;
+    context.host.spawn_job_set_cwd(job, cwd)
+}
+
+#[compat(
+    source = "src/internal/event_loop/thread_pool.wasm.mbt",
+    original = "thread_pool/make_spawn_job/windows",
+    upstream_pr = 546,
+    replacement = "thread_pool/spawn_job/windows + spawn-job setters",
+    api_only = true
+)]
 #[cfg(windows)]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_spawn_job_windows(
@@ -633,15 +689,67 @@ pub(super) fn make_spawn_job_windows(
         no_console_window: no_console_window != 0,
         is_orphan: is_orphan != 0,
     };
-    context.host.insert_job(thread_pool::make_spawn_job_windows(
-        command_line,
-        env,
-        stdin,
-        stdout,
-        stderr,
-        cwd,
-        options,
-    ))
+    context
+        .host
+        .insert_job(thread_pool::make_spawn_job_windows(
+            command_line,
+            env,
+            stdin,
+            stdout,
+            stderr,
+            cwd,
+            options,
+        ))
+}
+
+#[ported(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_make_spawn_job"
+)]
+#[cfg(windows)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn spawn_job_windows(
+    context: &mut ImportContext<'_, '_>,
+    command_line: i32,
+    command_line_len: i32,
+    env: u64,
+    stdin: u64,
+    stdout: u64,
+    stderr: u64,
+    is_orphan: i32,
+) -> AsyncHostResult<u64> {
+    let env = context.host.take_process_env_builder(env)?;
+    let command_line = read_guest_os_string(context, command_line, command_line_len)?;
+    let stdin = optional_resource(context, stdin)?;
+    let stdout = optional_resource(context, stdout)?;
+    let stderr = optional_resource(context, stderr)?;
+    let options = thread_pool::SpawnOptions {
+        no_console_window: false,
+        is_orphan: is_orphan != 0,
+    };
+    context
+        .host
+        .insert_job(thread_pool::make_spawn_job_windows(
+            command_line,
+            env,
+            stdin,
+            stdout,
+            stderr,
+            None,
+            options,
+        ))
+}
+
+#[ported(
+    source = "src/internal/event_loop/thread_pool.c",
+    original = "moonbitlang_async_spawn_job_set_no_console_window"
+)]
+#[cfg(windows)]
+pub(super) fn spawn_job_set_no_console_window(
+    context: &mut ImportContext<'_, '_>,
+    job: u64,
+) -> AsyncHostResult<()> {
+    context.host.spawn_job_set_no_console_window(job)
 }
 
 #[ported(
@@ -655,7 +763,7 @@ pub(super) fn spawn_job_get_result_handle(
     context.host.get_spawn_job_result_handle(job)
 }
 
-// The current wasm wrapper passes SpawnJob by value. Its nested Job is a
+// The legacy wasm wrapper passes SpawnJob by value. Its nested Job is a
 // two-field valtype, so MoonBit lowers both the JobHandle and its optional
 // copy-output closure into this import. Spawn jobs never install that closure;
 // validate the representation invariant while this guest ABI remains in use.
@@ -797,31 +905,6 @@ pub(super) fn open_job_get_dev_id(context: &mut ImportContext<'_, '_>, job: u64)
 )]
 pub(super) fn open_job_get_file_id(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_file_id(job)
-}
-
-fn read_guest_os_string(context: &mut ImportContext<'_, '_>, ptr: i32, len: i32) -> AsyncHostResult<OsString> {
-    // Async OsString imports pass MoonBit String data, so `len` is UTF-16 code
-    // units. Do not treat this as UTF-8 bytes or a native C string.
-    context.with_memory_mut(|memory| {
-        let units = read_u16(memory, ptr, len)?;
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::ffi::OsStringExt;
-
-            let path = char::decode_utf16(units)
-                .map(Result::unwrap)
-                .collect::<String>();
-            Ok(OsString::from_vec(path.into_bytes()))
-        }
-
-        #[cfg(windows)]
-        {
-            use std::os::windows::ffi::OsStringExt;
-
-            Ok(OsString::from_wide(&units))
-        }
-    })
 }
 
 }

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -28,7 +28,6 @@
 
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
-#[cfg(unix)]
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
@@ -102,9 +101,10 @@ impl CBufferLease {
 #[cfg(unix)]
 type HostProcessArgv = Vec<Option<OsString>>;
 #[cfg(unix)]
-type HostProcessEnv = Vec<Option<OsString>>;
+type HostProcessEnv = Vec<Option<crate::async_sys::process::LegacyProcessEnvEntry>>;
 #[cfg(windows)]
 type HostProcessEnv = Vec<u16>;
+type HostProcessEnvBuilder = crate::async_sys::process::ProcessEnvBuilder;
 
 #[derive(Default)]
 struct ProcessPolicyState {
@@ -327,6 +327,7 @@ enum HandleKind {
     #[cfg(unix)]
     ProcessArgv,
     ProcessEnv,
+    ProcessEnvBuilder,
     AddrInfo,
     TlsConnection,
     #[cfg(windows)]
@@ -534,6 +535,14 @@ impl HandleTable {
         self.remove(handle, HandleKind::ProcessEnv)
     }
 
+    fn process_env_builder(&self, handle: HostHandle) -> AsyncHostResult<HandleKey> {
+        self.key(handle, HandleKind::ProcessEnvBuilder)
+    }
+
+    fn remove_process_env_builder(&mut self, handle: HostHandle) -> AsyncHostResult<HandleKey> {
+        self.remove(handle, HandleKind::ProcessEnvBuilder)
+    }
+
     fn addrinfo(&self, handle: HostHandle) -> AsyncHostResult<HandleKey> {
         self.key(handle, HandleKind::AddrInfo)
     }
@@ -646,6 +655,13 @@ impl JobTable {
     fn visible_job_mut(&mut self, key: HandleKey) -> AsyncHostResult<&mut Job> {
         match self.jobs.get_mut(key) {
             Some(HostJobState::Ready(job) | HostJobState::ResultReady(job)) => Ok(job),
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    fn ready_job_mut(&mut self, key: HandleKey) -> AsyncHostResult<&mut Job> {
+        match self.jobs.get_mut(key) {
+            Some(HostJobState::Ready(job)) => Ok(job),
             _ => Err(AsyncHostError::Badf),
         }
     }
@@ -1202,6 +1218,7 @@ pub(crate) struct AsyncHost {
     #[cfg(unix)]
     process_argvs: RefCell<SecondaryMap<HandleKey, HostProcessArgv>>,
     process_envs: RefCell<SecondaryMap<HandleKey, HostProcessEnv>>,
+    process_env_builders: RefCell<SecondaryMap<HandleKey, HostProcessEnvBuilder>>,
     // The unrestricted path leaves this absent, avoiding registry allocation and locking.
     process_policy_state: Option<Arc<ProcessPolicyState>>,
     #[cfg(windows)]
@@ -1237,6 +1254,7 @@ impl AsyncHost {
             #[cfg(unix)]
             process_argvs: RefCell::new(SecondaryMap::new()),
             process_envs: RefCell::new(SecondaryMap::new()),
+            process_env_builders: RefCell::new(SecondaryMap::new()),
             process_policy_state,
             #[cfg(windows)]
             io_results: RefCell::new(IoResultTable::default()),
@@ -1902,14 +1920,17 @@ impl AsyncHost {
     }
 
     #[cfg(unix)]
-    pub(crate) fn take_process_spawn_buffers(
+    pub(crate) fn take_legacy_process_spawn_inputs(
         &self,
         argv_handle: u64,
         env_handle: u64,
+        inherited_env_entry_count: i32,
     ) -> AsyncHostResult<(Vec<OsString>, Vec<OsString>)> {
         if argv_handle == INVALID_HOST_HANDLE || env_handle == INVALID_HOST_HANDLE {
             return Err(AsyncHostError::Badf);
         }
+        let inherited_env_entry_count =
+            usize::try_from(inherited_env_entry_count).map_err(|_| AsyncHostError::Inval)?;
 
         // Validate both buffers before consuming either handle. A malformed
         // spawn request must not partially transfer ownership.
@@ -1920,7 +1941,10 @@ impl AsyncHost {
         let argv = process_argvs.get(argv_key).ok_or(AsyncHostError::Badf)?;
         let mut process_envs = self.process_envs.borrow_mut();
         let env = process_envs.get(env_key).ok_or(AsyncHostError::Badf)?;
-        if argv.iter().any(Option::is_none) || env.iter().any(Option::is_none) {
+        if inherited_env_entry_count > env.len()
+            || argv.iter().any(Option::is_none)
+            || env.iter().any(Option::is_none)
+        {
             return Err(AsyncHostError::Inval);
         }
 
@@ -1938,13 +1962,61 @@ impl AsyncHost {
             .into_iter()
             .map(Option::unwrap)
             .collect();
+        // The legacy ABI materializes inherited entries first and appends
+        // extras. Convert that layout into the current builder model so both
+        // ABIs use the same override and ordering semantics from here on.
+        let env = HostProcessEnvBuilder::from_legacy_env(env, inherited_env_entry_count);
+        let env = crate::async_sys::process::finish_process_env_builder(env);
+        Ok((argv, env))
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn take_process_spawn_inputs(
+        &self,
+        argv_handle: u64,
+        env_handle: u64,
+    ) -> AsyncHostResult<(Vec<OsString>, Vec<OsString>)> {
+        if argv_handle == INVALID_HOST_HANDLE || env_handle == INVALID_HOST_HANDLE {
+            return Err(AsyncHostError::Badf);
+        }
+
+        let mut handles = self.handles.borrow_mut();
+        let argv_key = handles.process_argv(argv_handle)?;
+        let env_key = handles.process_env_builder(env_handle)?;
+        let mut process_argvs = self.process_argvs.borrow_mut();
+        let argv = process_argvs.get(argv_key).ok_or(AsyncHostError::Badf)?;
+        let mut process_env_builders = self.process_env_builders.borrow_mut();
+        if argv.iter().any(Option::is_none) || process_env_builders.get(env_key).is_none() {
+            return Err(AsyncHostError::Inval);
+        }
+
+        handles.remove_process_argv(argv_handle)?;
+        handles.remove_process_env_builder(env_handle)?;
+        let argv = process_argvs
+            .remove(argv_key)
+            .ok_or(AsyncHostError::Badf)?
+            .into_iter()
+            .map(Option::unwrap)
+            .collect();
+        let env = process_env_builders
+            .remove(env_key)
+            .ok_or(AsyncHostError::Badf)?;
+        let env = crate::async_sys::process::finish_process_env_builder(env);
         Ok((argv, env))
     }
 
     #[cfg(unix)]
     pub(crate) fn insert_process_env(&self, entries: Vec<Option<OsString>>) -> u64 {
         let key = self.handles.borrow_mut().insert(HandleKind::ProcessEnv);
-        self.process_envs.borrow_mut().insert(key, entries);
+        self.process_envs.borrow_mut().insert(
+            key,
+            entries
+                .into_iter()
+                .map(|entry| {
+                    entry.map(crate::async_sys::process::LegacyProcessEnvEntry::Materialized)
+                })
+                .collect(),
+        );
         handle_from_key(key)
     }
 
@@ -1953,6 +2025,30 @@ impl AsyncHost {
         let key = self.handles.borrow_mut().insert(HandleKind::ProcessEnv);
         self.process_envs.borrow_mut().insert(key, env);
         handle_from_key(key)
+    }
+
+    pub(crate) fn insert_process_env_builder(&self, inherited: Vec<OsString>) -> u64 {
+        let key = self
+            .handles
+            .borrow_mut()
+            .insert(HandleKind::ProcessEnvBuilder);
+        self.process_env_builders
+            .borrow_mut()
+            .insert(key, HostProcessEnvBuilder::new(inherited));
+        handle_from_key(key)
+    }
+
+    pub(crate) fn process_env_builder_add_entry(
+        &self,
+        handle: u64,
+        key: OsString,
+        value: OsString,
+    ) -> AsyncHostResult<()> {
+        let builder_key = self.handles.borrow().process_env_builder(handle)?;
+        let mut builders = self.process_env_builders.borrow_mut();
+        let builder = builders.get_mut(builder_key).ok_or(AsyncHostError::Badf)?;
+        crate::async_sys::process::process_env_builder_add_entry(builder, key, value);
+        Ok(())
     }
 
     #[cfg(unix)]
@@ -2030,14 +2126,15 @@ impl AsyncHost {
         &self,
         handle: u64,
         index: i32,
-        entry: OsString,
+        key: OsString,
+        value: OsString,
     ) -> AsyncHostResult<()> {
         let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
-        let key = self.process_env(handle)?;
+        let env_key = self.process_env(handle)?;
         let mut process_envs = self.process_envs.borrow_mut();
-        let env = process_envs.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        let env = process_envs.get_mut(env_key).ok_or(AsyncHostError::Badf)?;
         let slot = env.get_mut(index).ok_or(AsyncHostError::Fault)?;
-        *slot = Some(entry);
+        *slot = Some(crate::async_sys::process::LegacyProcessEnvEntry::Added { key, value });
         Ok(())
     }
 
@@ -2074,6 +2171,22 @@ impl AsyncHost {
     #[cfg(windows)]
     pub(crate) fn take_process_env(&self, handle: u64) -> AsyncHostResult<Vec<u16>> {
         self.take_process_env_buffer(handle)
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn take_process_env_builder(&self, handle: u64) -> AsyncHostResult<Vec<u16>> {
+        if handle == INVALID_HOST_HANDLE {
+            return Err(AsyncHostError::Badf);
+        }
+        let key = self
+            .handles
+            .borrow_mut()
+            .remove_process_env_builder(handle)?;
+        self.process_env_builders
+            .borrow_mut()
+            .remove(key)
+            .map(crate::async_sys::process::finish_process_env_builder)
+            .ok_or(AsyncHostError::Badf)
     }
 
     fn take_process_env_buffer(&self, handle: u64) -> AsyncHostResult<HostProcessEnv> {
@@ -2234,6 +2347,21 @@ impl AsyncHost {
         }
         thread_pool::set_spawn_job_result(job, OpenJobResource::Published(fd))?;
         thread_pool::get_spawn_job_result_handle(job)
+    }
+
+    pub(crate) fn spawn_job_set_cwd(&self, handle: u64, cwd: OsString) -> AsyncHostResult<()> {
+        let key = self.handles.borrow().job(handle)?;
+        let mut jobs = self.jobs.borrow_mut();
+        let job = jobs.ready_job_mut(key)?;
+        thread_pool::spawn_job_set_cwd(job, cwd)
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn spawn_job_set_no_console_window(&self, handle: u64) -> AsyncHostResult<()> {
+        let key = self.handles.borrow().job(handle)?;
+        let mut jobs = self.jobs.borrow_mut();
+        let job = jobs.ready_job_mut(key)?;
+        thread_pool::spawn_job_set_no_console_window(job)
     }
 
     pub(crate) fn addrinfo_next(&self, handle: u64) -> AsyncHostResult<u64> {
@@ -4248,6 +4376,69 @@ mod tests {
     }
 
     #[test]
+    fn spawn_job_builder_only_mutates_ready_spawn_jobs() {
+        let host = AsyncHost::default();
+        #[cfg(unix)]
+        let spawn_job = successful_process_job();
+        #[cfg(windows)]
+        let spawn_job = thread_pool::make_spawn_job_windows(
+            OsString::from("cmd.exe /D /C exit 0"),
+            vec![0, 0],
+            None,
+            None,
+            None,
+            None,
+            thread_pool::SpawnOptions {
+                no_console_window: false,
+                is_orphan: false,
+            },
+        );
+        let handle = host.insert_job(spawn_job).unwrap();
+
+        host.spawn_job_set_cwd(handle, OsString::from("working-directory"))
+            .unwrap();
+        #[cfg(windows)]
+        host.spawn_job_set_no_console_window(handle).unwrap();
+
+        {
+            let jobs = host.jobs.borrow();
+            let job = jobs.visible_job(job_key(&host, handle)).unwrap();
+            match job.payload() {
+                #[cfg(unix)]
+                JobPayload::SpawnUnix { cwd, .. } => {
+                    assert_eq!(
+                        cwd.as_deref(),
+                        Some(std::ffi::OsStr::new("working-directory"))
+                    );
+                }
+                #[cfg(windows)]
+                JobPayload::SpawnWindows { cwd, options, .. } => {
+                    assert_eq!(
+                        cwd.as_deref(),
+                        Some(std::ffi::OsStr::new("working-directory"))
+                    );
+                    assert!(options.no_console_window);
+                }
+                _ => panic!("expected spawn job"),
+            }
+        }
+
+        let key = job_key(&host, handle);
+        let job = host.jobs.borrow_mut().take_ready_job(key).unwrap();
+        assert_eq!(
+            host.spawn_job_set_cwd(handle, OsString::from("too-late")),
+            Err(AsyncHostError::Badf)
+        );
+        assert!(host.jobs.borrow_mut().restore_unrun_job(key, job).is_none());
+
+        let sleep = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
+        assert_eq!(
+            host.spawn_job_set_cwd(sleep, OsString::from("wrong-job")),
+            Err(AsyncHostError::Badf)
+        );
+    }
+
+    #[test]
     fn process_policy_denies_spawn_before_running_the_job() {
         let tmp = tempfile::tempdir().unwrap();
         let policy_file = tmp.path().join("policy.toml");
@@ -4446,6 +4637,61 @@ mod tests {
         host.free_job(job).unwrap();
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn process_env_builder_places_extra_entries_before_filtered_inherited_entries() {
+        let mut builder = HostProcessEnvBuilder::new(vec![
+            OsString::from("OVERRIDE=old"),
+            OsString::from("KEEP=value"),
+            OsString::from("WITHOUT_SEPARATOR"),
+        ]);
+        crate::async_sys::process::process_env_builder_add_entry(
+            &mut builder,
+            OsString::from("OVERRIDE"),
+            OsString::from("new"),
+        );
+
+        assert_eq!(
+            crate::async_sys::process::finish_process_env_builder(builder),
+            vec![
+                OsString::from("OVERRIDE=new"),
+                OsString::from("KEEP=value"),
+                OsString::from("WITHOUT_SEPARATOR"),
+            ]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn process_env_builder_filters_inherited_entries_case_insensitively() {
+        fn block(entries: &[&str]) -> Vec<u16> {
+            let mut block = Vec::new();
+            for entry in entries {
+                block.extend(entry.encode_utf16());
+                block.push(0);
+            }
+            block.push(0);
+            block
+        }
+
+        let mut builder = HostProcessEnvBuilder::new(vec![
+            OsString::from("Path=old"),
+            OsString::from("KEEP=value"),
+            OsString::from("WITHOUT_SEPARATOR"),
+            OsString::from("=PSEUDO"),
+        ]);
+        crate::async_sys::process::process_env_builder_add_entry(
+            &mut builder,
+            OsString::from("PATH"),
+            OsString::from("new"),
+        );
+
+        assert_eq!(
+            crate::async_sys::process::finish_process_env_builder(builder),
+            block(&["PATH=new", "KEEP=value"])
+        );
+    }
+
     #[test]
     fn process_env_block_transfer_consumes_source() {
         let host = AsyncHost::default();
@@ -4468,7 +4714,14 @@ mod tests {
                 .get(host.process_env(dst).unwrap())
                 .unwrap()
                 .as_slice(),
-            &[Some(OsString::from("A=B")), None]
+            &[
+                Some(
+                    crate::async_sys::process::LegacyProcessEnvEntry::Materialized(OsString::from(
+                        "A=B"
+                    ))
+                ),
+                None,
+            ]
         );
         #[cfg(windows)]
         assert_eq!(
@@ -4502,24 +4755,76 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn process_spawn_buffers_transfer_ownership_together() {
+    fn legacy_process_spawn_inputs_use_inherited_count_to_build_environment() {
         let host = AsyncHost::default();
         let argv = host.insert_process_argv(2).unwrap();
         host.process_argv_add_entry(argv, 0, OsString::from("command"))
             .unwrap();
         host.process_argv_add_entry(argv, 1, OsString::from("argument"))
             .unwrap();
-        let env = host.insert_process_env(vec![Some(OsString::from("A=B"))]);
+        let env = host.insert_process_env(vec![
+            Some(OsString::from("OVERRIDE=old")),
+            Some(OsString::from("KEEP=value")),
+            Some(OsString::from("OVERRIDE=new")),
+        ]);
 
-        let (args, entries) = host.take_process_spawn_buffers(argv, env).unwrap();
+        let (args, entries) = host.take_legacy_process_spawn_inputs(argv, env, 2).unwrap();
 
         assert_eq!(
             args,
             vec![OsString::from("command"), OsString::from("argument")]
         );
-        assert_eq!(entries, vec![OsString::from("A=B")]);
+        assert_eq!(
+            entries,
+            vec![OsString::from("OVERRIDE=new"), OsString::from("KEEP=value")]
+        );
         assert!(matches!(host.process_argv(argv), Err(AsyncHostError::Badf)));
         assert!(matches!(host.process_env(env), Err(AsyncHostError::Badf)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn legacy_process_spawn_inputs_apply_current_nul_handling() {
+        let host = AsyncHost::default();
+        let argv = host.insert_process_argv(1).unwrap();
+        host.process_argv_add_entry(argv, 0, OsString::from("command"))
+            .unwrap();
+        let env = host.insert_process_env(vec![None, None]);
+        host.process_env_add_entry(
+            env,
+            0,
+            OsString::from("BAD=PREFIX\0KEY"),
+            OsString::from("value"),
+        )
+        .unwrap();
+        host.process_env_add_entry(
+            env,
+            1,
+            OsString::from("GOOD"),
+            OsString::from("before\0INJECTED=value"),
+        )
+        .unwrap();
+
+        let (_, entries) = host.take_legacy_process_spawn_inputs(argv, env, 0).unwrap();
+
+        assert_eq!(entries, vec![OsString::from("GOOD=before")]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invalid_legacy_process_spawn_inherited_count_does_not_consume_buffers() {
+        let host = AsyncHost::default();
+        let argv = host.insert_process_argv(1).unwrap();
+        host.process_argv_add_entry(argv, 0, OsString::from("command"))
+            .unwrap();
+        let env = host.insert_process_env(vec![Some(OsString::from("A=B"))]);
+
+        assert_eq!(
+            host.take_legacy_process_spawn_inputs(argv, env, 2),
+            Err(AsyncHostError::Inval)
+        );
+        assert!(host.process_argv(argv).is_ok());
+        assert!(host.process_env(env).is_ok());
     }
 
     #[cfg(unix)]
@@ -4532,11 +4837,36 @@ mod tests {
         let env = host.insert_process_env(vec![None]);
 
         assert_eq!(
-            host.take_process_spawn_buffers(argv, env),
+            host.take_legacy_process_spawn_inputs(argv, env, 0),
             Err(AsyncHostError::Inval)
         );
         assert!(host.process_argv(argv).is_ok());
         assert!(host.process_env(env).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_spawn_abis_reject_the_other_environment_handle_kind() {
+        let host = AsyncHost::default();
+        let argv = host.insert_process_argv(1).unwrap();
+        host.process_argv_add_entry(argv, 0, OsString::from("command"))
+            .unwrap();
+        let builder = host.insert_process_env_builder(Vec::new());
+
+        assert_eq!(
+            host.take_legacy_process_spawn_inputs(argv, builder, 0),
+            Err(AsyncHostError::Badf)
+        );
+        assert!(host.process_argv(argv).is_ok());
+        assert!(host.handles.borrow().process_env_builder(builder).is_ok());
+
+        let legacy = host.insert_process_env(vec![Some(OsString::from("A=B"))]);
+        assert_eq!(
+            host.take_process_spawn_inputs(argv, legacy),
+            Err(AsyncHostError::Badf)
+        );
+        assert!(host.process_argv(argv).is_ok());
+        assert!(host.process_env(legacy).is_ok());
     }
 
     #[cfg(windows)]
@@ -4548,6 +4878,22 @@ mod tests {
 
         assert_eq!(host.take_process_env(env).unwrap(), block);
         assert!(matches!(host.process_env(env), Err(AsyncHostError::Badf)));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn process_spawn_abis_reject_the_other_environment_handle_kind() {
+        let host = AsyncHost::default();
+        let builder = host.insert_process_env_builder(Vec::new());
+        assert_eq!(host.take_process_env(builder), Err(AsyncHostError::Badf));
+        assert!(host.handles.borrow().process_env_builder(builder).is_ok());
+
+        let legacy = host.insert_process_env(vec![0, 0]);
+        assert_eq!(
+            host.take_process_env_builder(legacy),
+            Err(AsyncHostError::Badf)
+        );
+        assert!(host.process_env(legacy).is_ok());
     }
 
     #[cfg(windows)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -549,6 +549,41 @@ ported_fns! {
 
     #[ported(
         source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_spawn_job_set_cwd"
+    )]
+    pub(crate) fn spawn_job_set_cwd(job: &mut Job, cwd: OsString) -> AsyncHostResult<()> {
+        match job.payload_mut() {
+            #[cfg(unix)]
+            JobPayload::SpawnUnix { cwd: job_cwd, .. } => {
+                *job_cwd = Some(cwd);
+                Ok(())
+            }
+            #[cfg(windows)]
+            JobPayload::SpawnWindows { cwd: job_cwd, .. } => {
+                *job_cwd = Some(cwd);
+                Ok(())
+            }
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
+        original = "moonbitlang_async_spawn_job_set_no_console_window"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn spawn_job_set_no_console_window(job: &mut Job) -> AsyncHostResult<()> {
+        match job.payload_mut() {
+            JobPayload::SpawnWindows { options, .. } => {
+                options.no_console_window = true;
+                Ok(())
+            }
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    #[ported(
+        source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_get_spawn_job_result_handle"
     )]
     pub(crate) fn get_spawn_job_result_handle(job: &Job) -> AsyncHostResult<HostHandle> {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -34,6 +34,9 @@ pub(crate) use jobs::make_sigwait_job;
 pub(crate) use jobs::make_spawn_job_unix;
 #[cfg(windows)]
 pub(crate) use jobs::make_spawn_job_windows;
+pub(crate) use jobs::spawn_job_set_cwd;
+#[cfg(windows)]
+pub(crate) use jobs::spawn_job_set_no_console_window;
 #[cfg(windows)]
 pub(crate) use jobs::{cancel_job_resource, job_cancel_resource};
 pub(crate) use jobs::{

--- a/crates/moonrun/src/async_sys/process.rs
+++ b/crates/moonrun/src/async_sys/process.rs
@@ -19,7 +19,215 @@
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::ported_fns;
 
+use std::ffi::OsString;
+
+#[cfg(unix)]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum LegacyProcessEnvEntry {
+    // Entries copied from the host environment are already materialized as
+    // `key=value`. Guest-provided entries keep their boundary until the
+    // legacy buffer is converted into the current builder.
+    Materialized(OsString),
+    Added { key: OsString, value: OsString },
+}
+
+#[cfg(unix)]
+impl LegacyProcessEnvEntry {
+    fn into_materialized(self) -> Option<OsString> {
+        match self {
+            Self::Materialized(entry) => Some(entry),
+            Self::Added { key, value } => unix_process_env_entry(key, value),
+        }
+    }
+}
+
+// Keep the inherited snapshot separate until spawn: native writes user entries
+// first, then copies only inherited entries whose keys were not overridden.
+pub(crate) struct ProcessEnvBuilder {
+    extra: Vec<OsString>,
+    inherited: Vec<OsString>,
+}
+
+impl ProcessEnvBuilder {
+    pub(crate) fn new(inherited: Vec<OsString>) -> Self {
+        Self {
+            extra: Vec::new(),
+            inherited,
+        }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn from_legacy_env(
+        mut entries: Vec<LegacyProcessEnvEntry>,
+        inherited_entry_count: usize,
+    ) -> Self {
+        let extra = entries.split_off(inherited_entry_count);
+        Self {
+            extra: extra
+                .into_iter()
+                .filter_map(LegacyProcessEnvEntry::into_materialized)
+                .collect(),
+            inherited: entries
+                .into_iter()
+                .filter_map(LegacyProcessEnvEntry::into_materialized)
+                .collect(),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn unix_process_env_entry(key: OsString, value: OsString) -> Option<OsString> {
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    let key = key.as_os_str().as_bytes();
+    if key.contains(&0) {
+        return None;
+    }
+    let value = value.as_os_str().as_bytes();
+    let value = &value[..value
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(value.len())];
+    let mut entry = Vec::with_capacity(key.len() + value.len() + 1);
+    entry.extend_from_slice(key);
+    entry.push(b'=');
+    entry.extend_from_slice(value);
+    Some(OsString::from_vec(entry))
+}
+
 ported_fns! {
+    #[ported(
+        source = "src/process/unix.c",
+        original = "moonbitlang_async_env_block_add_entry"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn process_env_builder_add_entry(
+        builder: &mut ProcessEnvBuilder,
+        key: OsString,
+        value: OsString,
+    ) {
+        if let Some(entry) = unix_process_env_entry(key, value) {
+            builder.extra.push(entry);
+        }
+    }
+
+    #[ported(
+        source = "src/process/windows.c",
+        original = "moonbitlang_async_env_block_add_entry"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn process_env_builder_add_entry(
+        builder: &mut ProcessEnvBuilder,
+        mut key: OsString,
+        value: OsString,
+    ) {
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+        if key.encode_wide().any(|unit| unit == 0) {
+            return;
+        }
+        let value = value
+            .encode_wide()
+            .take_while(|unit| *unit != 0)
+            .collect::<Vec<_>>();
+        key.push("=");
+        key.push(OsString::from_wide(&value));
+        builder.extra.push(key);
+    }
+
+    #[ported(
+        source = "src/process/unix.c",
+        original = "moonbitlang_async_write_env_block"
+    )]
+    #[cfg(unix)]
+    pub(crate) fn finish_process_env_builder(mut builder: ProcessEnvBuilder) -> Vec<OsString> {
+        use std::os::unix::ffi::OsStrExt;
+
+        let extra_len = builder.extra.len();
+        let inherited = builder
+            .inherited
+            .into_iter()
+            .filter(|entry| {
+                let entry = entry.as_os_str().as_bytes();
+                let duplicate = if let Some(key_end) = entry.iter().position(|byte| *byte == b'=')
+                {
+                    builder.extra[..extra_len].iter().any(|extra| {
+                        extra
+                            .as_os_str()
+                            .as_bytes()
+                            .get(..=key_end)
+                            .is_some_and(|key| key == &entry[..=key_end])
+                    })
+                } else {
+                    builder.extra[..extra_len]
+                        .iter()
+                        .any(|extra| extra.as_os_str().as_bytes() == entry)
+                };
+                !duplicate
+            })
+            .collect::<Vec<_>>();
+        builder.extra.extend(inherited);
+        builder.extra
+    }
+
+    #[ported(
+        source = "src/process/windows.c",
+        original = "moonbitlang_async_write_env_block"
+    )]
+    #[cfg(windows)]
+    pub(crate) fn finish_process_env_builder(builder: ProcessEnvBuilder) -> Vec<u16> {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Globalization::{CSTR_EQUAL, CompareStringOrdinal};
+
+        let extra_keys = builder
+            .extra
+            .iter()
+            .filter_map(|entry| {
+                let entry = entry.encode_wide().collect::<Vec<_>>();
+                let key_len = entry.iter().position(|unit| *unit == b'=' as u16)?;
+                Some(entry[..key_len].to_vec())
+            })
+            .collect::<Vec<_>>();
+        let inherited = builder
+            .inherited
+            .into_iter()
+            .filter(|entry| {
+                let entry = entry.encode_wide().collect::<Vec<_>>();
+                let Some(key_len) = entry.iter().position(|unit| *unit == b'=' as u16) else {
+                    return false;
+                };
+                if key_len == 0 {
+                    return false;
+                }
+                !extra_keys.iter().any(|extra_key| {
+                    key_len == extra_key.len()
+                        && unsafe {
+                            CompareStringOrdinal(
+                                extra_key.as_ptr(),
+                                extra_key.len() as i32,
+                                entry.as_ptr(),
+                                key_len as i32,
+                                1,
+                            )
+                        } == CSTR_EQUAL
+                })
+            })
+            .collect::<Vec<_>>();
+
+        // Create the one contiguous block only when ownership moves to the
+        // spawn job. Until this point the builder contains native OsStrings.
+        let mut block = Vec::new();
+        for entry in builder.extra.into_iter().chain(inherited) {
+            block.extend(entry.encode_wide());
+            block.push(0);
+        }
+        if block.is_empty() {
+            block.push(0);
+        }
+        block.push(0);
+        block
+    }
+
     #[ported(
         source = "src/internal/event_loop/process.c",
         original = "moonbitlang_async_open_pid_handle"
@@ -270,7 +478,29 @@ fn last_native_error() -> AsyncHostError {
 
 #[cfg(all(test, unix))]
 mod tests {
+    use std::ffi::OsString;
+
     use super::*;
+
+    #[test]
+    fn unix_process_env_discards_nul_keys_and_truncates_nul_values() {
+        let mut builder = ProcessEnvBuilder::new(Vec::new());
+        process_env_builder_add_entry(
+            &mut builder,
+            OsString::from("BAD\0INJECTED"),
+            OsString::from("value"),
+        );
+        process_env_builder_add_entry(
+            &mut builder,
+            OsString::from("GOOD"),
+            OsString::from("before\0INJECTED=value"),
+        );
+
+        assert_eq!(
+            finish_process_env_builder(builder),
+            vec![OsString::from("GOOD=before")]
+        );
+    }
 
     #[test]
     fn unix_wait_status_distinguishes_exit_from_signal() {
@@ -300,10 +530,31 @@ fn last_native_errno() -> i32 {
 
 #[cfg(all(test, windows))]
 mod windows_tests {
+    use std::ffi::OsString;
     use std::os::windows::io::AsRawHandle;
     use std::process::Command;
 
     use super::*;
+
+    #[test]
+    fn windows_process_env_discards_nul_keys_and_truncates_nul_values() {
+        let mut builder = ProcessEnvBuilder::new(Vec::new());
+        process_env_builder_add_entry(
+            &mut builder,
+            OsString::from("BAD\0INJECTED"),
+            OsString::from("value"),
+        );
+        process_env_builder_add_entry(
+            &mut builder,
+            OsString::from("GOOD"),
+            OsString::from("before\0INJECTED=value"),
+        );
+
+        assert_eq!(
+            finish_process_env_builder(builder),
+            "GOOD=before\0\0".encode_utf16().collect::<Vec<_>>()
+        );
+    }
 
     #[test]
     fn running_process_result_is_pending() {

--- a/crates/moonrun/src/async_sys/socket.rs
+++ b/crates/moonrun/src/async_sys/socket.rs
@@ -1495,8 +1495,8 @@ ported_fns! {
     #[cfg(unix)]
     pub(crate) fn if_nametoindex(name: &[u16]) -> AsyncHostResult<i32> {
         let name = char::decode_utf16(name.iter().copied())
-            .map(Result::unwrap)
-            .collect::<String>();
+            .collect::<Result<String, _>>()
+            .map_err(|_| AsyncHostError::Inval)?;
         let name = std::ffi::CString::new(name).map_err(|_| AsyncHostError::Inval)?;
         let index = unsafe { libc::if_nametoindex(name.as_ptr()) };
         if index == 0 {
@@ -1811,6 +1811,11 @@ fn set_tcp_int(fd: RawSocket, option: libc::c_int, value: i32) -> AsyncHostResul
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn if_nametoindex_rejects_unpaired_surrogate() {
+        assert_eq!(if_nametoindex(&[0xd800]), Err(AsyncHostError::Inval));
+    }
 
     #[test]
     fn addr_get_ipv6_bytes_offset_uses_sin6_addr_offset() {

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -78,7 +78,7 @@ fn test_moonrun_against_upstream_async() {
         .args(["test", "--target", "wasm"])
         .assert()
         .success()
-        .stdout_eq("Total tests: 430, passed: 430, failed: 0.\n");
+        .stdout_eq("Total tests: 433, passed: 433, failed: 0.\n");
 }
 
 struct TestDir(moon_test_util::test_dir::TestDir);


### PR DESCRIPTION
## Why

moonbitlang/async#518 fixed process environment overrides, inherited-environment snapshotting, and NUL injection handling in the native runtime. Moonrun still implemented the old Wasm inherited-first buffer protocol, so extra variables did not reliably override inherited values and the native-only regression tests could not run on Wasm.

moonbitlang/async#523 then moved native process spawning to a builder-style `SpawnJob` API. The Wasm guest and Moonrun still used the historical monolithic spawn imports, leaving the two backends with different construction interfaces and making future spawn options harder to port consistently.

The boundary audit for these new imports also found that malformed guest UTF-16 could panic the embedding runner instead of returning a host error.

## Why this is correct

Moonrun now owns an explicit environment builder. It snapshots inherited entries before worker submission, preserves the native extra-first order, filters overridden inherited keys case-sensitively on Unix and with `CompareStringOrdinal` on Windows, discards entries whose key contains NUL, and truncates values at the first NUL. The builder has a distinct handle kind and transfers ownership when the spawn job is created.

The canonical Wasm interface follows the native `SpawnJob` builder directly. `thread_pool/spawn_job/unix` and `thread_pool/spawn_job/windows` create the base job; `thread_pool/spawn_job/set_cwd` and the Windows `thread_pool/spawn_job/set_no_console_window` mutate it before submission. Moonrun accepts those setters only while the job is Ready, so an untrusted guest cannot mutate a submitted or completed job.

Guest `OsString` imports use one checked decoder on Unix, so malformed UTF-16 returns an import error instead of panicking the embedding runner. Windows keeps the original UTF-16 code units in `OsString`, preserving its platform representation. The same boundary audit removes the equivalent panic from `socket/if_nametoindex`.

Historical imports remain compatibility adapters. The old Unix spawn import validates its inherited-entry count, converts `[inherited..., extra...]` into the current environment builder, and then follows the canonical merge and NUL-handling path. A zero count remains valid for guests that stopped reporting the boundary. The old Windows import continues to consume its final UTF-16 block because that ABI does not carry an inherited/extra boundary. API-only shims are recorded explicitly without inventing duplicate Async Sys implementations.

The coordinated guest in moonbitlang/async#546 adopts both the #518 environment builder and the #523 spawn builder, enables the previously native-only process environment tests on Wasm, and passes `JobHandle` across the spawn-result import so aggregate lowering cannot add hidden parameters.

## Scope

This PR contains the Moon runtime backports of moonbitlang/async#518 and moonbitlang/async#523, plus the boundary-safety and compatibility plumbing required to expose their exact Wasm ABIs. It pins the coordinating guest commit for end-to-end coverage.

This PR must merge before moonbitlang/async#546.
