### PR TITLE
chore: update warning index snapshot

### DIFF
--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -451,6 +451,11 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
         description: "Redundant `else` on an exhaustive `guard`.",
         id: 89,
     },
+    WarningEntry {
+        mnemonic: "unused_lexcase",
+        description: "`lexmatch`/`lexscan` branch that can never be selected because other branches takes precedence or its pattern matches nothing.",
+        id: 90,
+    },
 ];
 
 pub(crate) fn get_warning_entry(id: u16) -> Option<&'static WarningEntry> {

--- a/crates/moon/src/cli/snapshots/explain_warning_index.txt
+++ b/crates/moon/src/cli/snapshots/explain_warning_index.txt
@@ -80,3 +80,4 @@
 0087	guard_inexhaustive	`guard` condition is not exhaustive and may panic.
 0088	guard_redundant_bang	Redundant `!` on an exhaustive `guard`.
 0089	guard_redundant_else	Redundant `else` on an exhaustive `guard`.
+0090	unused_lexcase	`lexmatch`/`lexscan` branch that can never be selected because other branches takes precedence or its pattern matches nothing.


### PR DESCRIPTION
## Summary

The compiler warning index now includes warning 90, `unused_lexcase`, causing the checked-in warning snapshot to fall out of sync with `moonc check -warn-help`.

This PR adds the same warning entry to Moon's warning table and refreshes the corresponding snapshot. The change is limited to the synchronized table and snapshot.