### PR TITLE
fix(registry): coalesce concurrent archive downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,16 +861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs4"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
-dependencies = [
- "rustix",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,7 +1798,6 @@ dependencies = [
  "dunce",
  "expect-test",
  "find-msvc-tools",
- "fs4",
  "globset",
  "home",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ text-size = "1.1.1"
 log = "0.4.20"
 thiserror = "1.0"
 test-log = "0.2"
-fs4 = { version = "0.12.0", features = ["sync"] }
 ariadne = { version = "0.5.1", features = ["auto-color"] }
 clap_complete = { version = "4.5.4" }
 schemars = "0.8"

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -561,6 +561,9 @@ mod tests {
                 loop {
                     match listener.accept() {
                         Ok((mut stream, _)) => {
+                            // Accepted sockets inherit the listener's non-blocking mode on
+                            // Windows, but request handling below is intentionally blocking.
+                            stream.set_nonblocking(false).unwrap();
                             let mut request = [0; 2048];
                             assert_ne!(stream.read(&mut request).unwrap(), 0);
                             if request_count.fetch_add(1, Ordering::Relaxed) == 0 {

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -28,8 +28,8 @@ use std::{
 use anyhow::{Context, bail};
 use indexmap::map::IndexMap;
 use moonutil::{
-    dependency::SourceDependencyInfo, registry::RegistryConfig, resolution::ModuleName,
-    user_log::UserLog,
+    dependency::SourceDependencyInfo, locks::FileLock, registry::RegistryConfig,
+    resolution::ModuleName, user_log::UserLog,
 };
 use reqwest::header::USER_AGENT;
 use semver::Version;
@@ -275,6 +275,16 @@ impl OnlineRegistry {
             anyhow::bail!("Module {}@{} not found", name, version);
         }
         let cache_file = self.archive_cache_file_of(name, version);
+        let cache_dir = cache_file
+            .parent()
+            .expect("registry cache file has a parent");
+        std::fs::create_dir_all(cache_dir)?;
+        let _cache_lock = FileLock::lock_with_user_log(cache_dir, user_log).with_context(|| {
+            format!(
+                "Unable to lock registry archive cache directory `{}`",
+                cache_dir.display()
+            )
+        })?;
         match open_verified_archive(&cache_file, expected_checksum) {
             Ok(Some(archive)) => {
                 user_log.status(format!("Using cached {name}@{version}"));
@@ -344,12 +354,14 @@ fn test_urlencode() {
 #[cfg(test)]
 mod tests {
     use std::{
-        io::{Cursor, Write},
-        time::{SystemTime, UNIX_EPOCH},
+        io::{Cursor, Read, Write},
+        net::TcpListener,
+        sync::{
+            Arc, Barrier,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        time::{Duration, SystemTime, UNIX_EPOCH},
     };
-
-    #[cfg(unix)]
-    use std::io::Read;
 
     use super::*;
     use crate::registry::Registry;
@@ -528,6 +540,98 @@ mod tests {
             std::fs::read_to_string(destination.join("moon.mod")).unwrap(),
             "name = \"test/module\"\nversion = \"1.2.3\"\n"
         );
+    }
+
+    #[test]
+    fn concurrent_archive_acquisitions_are_coalesced() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let (registry, name, version) = test_registry(&sandbox);
+        let archive = test_archive();
+        let checksum = calc_sha2(&mut Cursor::new(&archive)).unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let url_base = format!("http://{}", listener.local_addr().unwrap());
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let stop_server = Arc::new(AtomicBool::new(false));
+        let server = {
+            let request_count = Arc::clone(&request_count);
+            let stop_server = Arc::clone(&stop_server);
+            std::thread::spawn(move || {
+                loop {
+                    match listener.accept() {
+                        Ok((mut stream, _)) => {
+                            let mut request = [0; 2048];
+                            assert_ne!(stream.read(&mut request).unwrap(), 0);
+                            if request_count.fetch_add(1, Ordering::Relaxed) == 0 {
+                                // Keep the first request in flight long enough for both
+                                // callers to observe the initially empty cache.
+                                std::thread::sleep(Duration::from_millis(200));
+                            }
+                            let response = format!(
+                                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                                archive.len()
+                            );
+                            stream.write_all(response.as_bytes()).unwrap();
+                            stream.write_all(&archive).unwrap();
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            if stop_server.load(Ordering::Relaxed) {
+                                break;
+                            }
+                            std::thread::sleep(Duration::from_millis(5));
+                        }
+                        Err(error) => panic!("registry test server failed: {error}"),
+                    }
+                }
+            })
+        };
+
+        let barrier = Arc::new(Barrier::new(2));
+        let clients = (0..2)
+            .map(|client| {
+                let index = registry.index.clone();
+                let archive_cache = registry.archive_cache.clone();
+                let url_base = url_base.clone();
+                let name = name.clone();
+                let version = version.clone();
+                let checksum = checksum.clone();
+                let destination = sandbox.path().join(format!("source-{client}"));
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let registry = OnlineRegistry {
+                        index,
+                        url_base,
+                        archive_cache,
+                        cache: RefCell::new(HashMap::new()),
+                    };
+                    barrier.wait();
+                    registry.acquire_source_to(
+                        &name,
+                        &version,
+                        &checksum,
+                        &destination,
+                        &quiet_user_log(),
+                    )?;
+                    anyhow::ensure!(
+                        std::fs::read_to_string(destination.join("moon.mod"))?
+                            == "name = \"test/module\"\nversion = \"1.2.3\"\n"
+                    );
+                    Ok::<_, anyhow::Error>(())
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let client_results = clients
+            .into_iter()
+            .map(|client| client.join().unwrap())
+            .collect::<Vec<_>>();
+        stop_server.store(true, Ordering::Relaxed);
+        server.join().unwrap();
+        for result in client_results {
+            result.unwrap();
+        }
+        assert_eq!(request_count.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/crates/mooncake/src/registry/online.rs
+++ b/crates/mooncake/src/registry/online.rs
@@ -181,6 +181,19 @@ fn open_verified_archive(path: &Path, expected_checksum: &str) -> std::io::Resul
     Ok(Some(archive))
 }
 
+fn open_cached_archive(path: &Path, expected_checksum: &str) -> anyhow::Result<Option<File>> {
+    match open_verified_archive(path, expected_checksum) {
+        Ok(archive) => Ok(archive),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "Unable to read cached registry archive `{}`",
+                path.display()
+            )
+        }),
+    }
+}
+
 fn copy_archive_and_verify_checksum(
     source: &mut impl Read,
     destination: &mut impl Write,
@@ -275,31 +288,26 @@ impl OnlineRegistry {
             anyhow::bail!("Module {}@{} not found", name, version);
         }
         let cache_file = self.archive_cache_file_of(name, version);
+        if let Some(archive) = open_cached_archive(&cache_file, expected_checksum)? {
+            user_log.status(format!("Using cached {name}@{version}"));
+            return Ok(archive);
+        }
+
         let cache_dir = cache_file
             .parent()
             .expect("registry cache file has a parent");
         std::fs::create_dir_all(cache_dir)?;
-        let _cache_lock = FileLock::lock_with_user_log(cache_dir, user_log).with_context(|| {
-            format!(
-                "Unable to lock registry archive cache directory `{}`",
-                cache_dir.display()
-            )
-        })?;
-        match open_verified_archive(&cache_file, expected_checksum) {
-            Ok(Some(archive)) => {
-                user_log.status(format!("Using cached {name}@{version}"));
-                return Ok(archive);
-            }
-            Ok(None) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(error).with_context(|| {
-                    format!(
-                        "Unable to read cached registry archive `{}`",
-                        cache_file.display()
-                    )
-                });
-            }
+        let cache_lock_file = cache_file.with_extension("zip.lock");
+        let _cache_lock = FileLock::lock_file_with_user_log(&cache_lock_file, user_log)
+            .with_context(|| {
+                format!(
+                    "Unable to lock registry archive cache file `{}`",
+                    cache_lock_file.display()
+                )
+            })?;
+        if let Some(archive) = open_cached_archive(&cache_file, expected_checksum)? {
+            user_log.status(format!("Using cached {name}@{version}"));
+            return Ok(archive);
         }
         user_log.status(format!("Downloading {name}@{version}"));
         let filepath = form_urlencoded::Serializer::new(String::new())
@@ -543,6 +551,58 @@ mod tests {
     }
 
     #[test]
+    fn verified_cached_archive_does_not_wait_for_download_lock() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let (registry, name, version) = test_registry(&sandbox);
+        let archive = test_archive();
+        let checksum = calc_sha2(&mut Cursor::new(&archive)).unwrap();
+        let archive_path = registry.archive_cache_file_of(&name, &version);
+        std::fs::create_dir_all(archive_path.parent().unwrap()).unwrap();
+        std::fs::write(&archive_path, archive).unwrap();
+
+        let open_lock = |path: &Path| {
+            let lock = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(path)
+                .unwrap();
+            lock.lock().unwrap();
+            lock
+        };
+        let module_lock = open_lock(
+            &archive_path
+                .parent()
+                .unwrap()
+                .join(moonutil::constants::MOON_LOCK),
+        );
+        let version_lock = open_lock(&archive_path.with_extension("zip.lock"));
+
+        let destination = sandbox.path().join("source");
+        let (result_sender, result_receiver) = std::sync::mpsc::channel();
+        let client = std::thread::spawn(move || {
+            result_sender
+                .send(registry.acquire_source_to(
+                    &name,
+                    &version,
+                    &checksum,
+                    &destination,
+                    &quiet_user_log(),
+                ))
+                .unwrap();
+        });
+
+        let result = result_receiver.recv_timeout(Duration::from_secs(5));
+        drop(version_lock);
+        drop(module_lock);
+        client.join().unwrap();
+        result
+            .expect("verified cache hits should not wait for the download lock")
+            .unwrap();
+    }
+
+    #[test]
     fn concurrent_archive_acquisitions_are_coalesced() {
         let sandbox = tempfile::TempDir::new().unwrap();
         let (registry, name, version) = test_registry(&sandbox);
@@ -635,6 +695,12 @@ mod tests {
             result.unwrap();
         }
         assert_eq!(request_count.load(Ordering::Relaxed), 1);
+        assert!(
+            registry
+                .archive_cache_file_of(&name, &version)
+                .with_extension("zip.lock")
+                .is_file()
+        );
     }
 
     #[test]

--- a/crates/moonutil/Cargo.toml
+++ b/crates/moonutil/Cargo.toml
@@ -38,7 +38,6 @@ clap.workspace = true
 dialoguer.workspace = true
 dunce.workspace = true
 semver.workspace = true
-fs4.workspace = true
 petgraph.workspace = true
 ariadne.workspace = true
 log.workspace = true

--- a/crates/moonutil/src/locks.rs
+++ b/crates/moonutil/src/locks.rs
@@ -16,18 +16,10 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use fs4::fs_std::FileExt;
-
 use crate::{constants::MOON_LOCK, user_log::UserLog};
 
 pub struct FileLock {
     _file: std::fs::File,
-}
-
-impl Drop for FileLock {
-    fn drop(&mut self) {
-        fs4::fs_std::FileExt::unlock(&self._file).unwrap();
-    }
 }
 
 impl FileLock {
@@ -45,21 +37,40 @@ impl FileLock {
     }
 
     pub fn lock_with_user_log(path: &std::path::Path, user_log: &UserLog) -> std::io::Result<Self> {
-        let file = std::fs::File::create(path.join(MOON_LOCK))?;
-        match file.try_lock_exclusive() {
+        Self::lock_file_with_user_log(&path.join(MOON_LOCK), user_log)
+    }
+
+    /// Lock a stable file path.
+    ///
+    /// Callers must not remove the lock file after unlocking it. A waiter may
+    /// still hold the old file open while a new caller creates and locks a
+    /// different file at the same path, splitting one lock domain into two.
+    pub fn lock_file_with_user_log(
+        path: &std::path::Path,
+        user_log: &UserLog,
+    ) -> std::io::Result<Self> {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        match file.try_lock() {
             Ok(_) => Ok(FileLock { _file: file }),
-            Err(_) => {
+            Err(std::fs::TryLockError::WouldBlock) => {
                 #[cfg(test)]
                 let _ = user_log;
                 #[cfg(not(test))]
                 user_log.status(format!(
                     "Blocking waiting for file lock {} ...",
-                    path.join(MOON_LOCK).display()
+                    path.display()
                 ));
-                file.lock_exclusive()
-                    .map_err(|e| std::io::Error::new(e.kind(), "failed to lock target dir"))?;
+                file.lock().map_err(|error| {
+                    std::io::Error::new(error.kind(), "failed to acquire file lock")
+                })?;
                 Ok(FileLock { _file: file })
             }
+            Err(std::fs::TryLockError::Error(error)) => Err(error),
         }
     }
 }

--- a/docs/dev/design/global-build-cache.md
+++ b/docs/dev/design/global-build-cache.md
@@ -272,13 +272,17 @@ source and asks the user to run `moon clean --dep-cache` explicitly.
 Source acquisition reads the archive checksum once and uses that value for
 both archive verification and the published metadata. Verification and
 extraction consume the same open archive handle, so replacing the
-version-keyed download-cache path cannot change the source being published. A
-miss is extracted in a same-filesystem staging directory, validated, annotated
-with the checksum, and published by rename while holding the dependency-cache
-lock. Existing entries are never replaced or pruned during resolution. Package
-installation uses one dependency-source interface to ensure the resolved
-sources exist and obtain their paths; project-local `.mooncakes` and the shared
-immutable cache are internal storage choices.
+version-keyed download-cache path cannot change the source being published.
+Verified download-cache hits do not acquire a lock. A miss uses a persistent
+version-ZIP sibling lock file, rechecks the cache, and holds the download lock
+only through download, verification, and publication; extraction proceeds from
+the verified open handle after releasing that lock. A miss is extracted in a
+same-filesystem staging directory, validated, annotated with the checksum, and
+published by rename while holding the dependency-cache lock. Existing entries
+are never replaced or pruned during resolution. Package installation uses one
+dependency-source interface to ensure the resolved sources exist and obtain
+their paths; project-local `.mooncakes` and the shared immutable cache are
+internal storage choices.
 Compiler outputs remain invocation-local and continue through the standalone
 n2 dependency graph.
 


### PR DESCRIPTION
## Summary

- let verified archive-cache hits bypass the download lock
- coalesce cold downloads with a persistent lock file beside each version ZIP
- use Rust standard-library file locking and remove fs4
- cover concurrent cold acquisition and non-blocking hot-cache reuse

## Why

Parallel Moon processes can miss the same cold archive cache and download the same package simultaneously. On Windows, one process can then fail with Access is denied while replacing a cache path whose verified archive is still open in another process.

## Why this is correct

A cache hit keeps the verified ZIP handle and extracts from those exact bytes without taking a lock. A miss locks only the sibling version.zip.lock file, rechecks the cache, then holds the lock through download, checksum verification, and atomic publication. Waiting processes therefore reuse the first published archive instead of replacing it. Lock files remain as stable empty coordination points after the OS lock is released.

## Scope

The change is confined to registry archive acquisition and the shared file-lock adapter. Different versions no longer block each other, extraction remains outside the download lock, and the existing FileLock API retains its directory-lock and waiting-log behavior while using the Rust standard library underneath.