### PR TITLE
test(moon): collapse native stub prefix cases

### DIFF
--- a/crates/moon/tests/test_cases/native_stub.in/native_1.in/lib/hello_test.mbt
+++ b/crates/moon/tests/test_cases/native_stub.in/native_1.in/lib/hello_test.mbt
@@ -1,4 +1,0 @@
-
-test "say_hello" {
-  @lib.say_hello_1()
-}

--- a/crates/moon/tests/test_cases/native_stub.in/native_1.in/main/main.mbt
+++ b/crates/moon/tests/test_cases/native_stub.in/native_1.in/main/main.mbt
@@ -1,3 +1,0 @@
-fn main {
-  @lib.say_hello_1()
-}

--- a/crates/moon/tests/test_cases/native_stub.in/native_1.in/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/native_stub.in/native_1.in/main/moon.pkg.json
@@ -1,6 +1,0 @@
-{
-  "is-main": true,
-  "import": [
-    "native_1/lib"
-  ]
-}

--- a/crates/moon/tests/test_cases/native_stub.in/native_2.in/libb/hello_test.mbt
+++ b/crates/moon/tests/test_cases/native_stub.in/native_2.in/libb/hello_test.mbt
@@ -1,5 +1,0 @@
-
-test "say_hello" {
-  @lib.say_hello_1()
-  @libb.say_hello_2()
-}

--- a/crates/moon/tests/test_cases/native_stub.in/native_2.in/main/main.mbt
+++ b/crates/moon/tests/test_cases/native_stub.in/native_2.in/main/main.mbt
@@ -1,3 +1,0 @@
-fn main {
-  @libb.say_hello_2()
-}

--- a/crates/moon/tests/test_cases/native_stub.in/native_2.in/main/moon.pkg.json
+++ b/crates/moon/tests/test_cases/native_stub.in/native_2.in/main/moon.pkg.json
@@ -1,6 +1,0 @@
-{
-  "is-main": true,
-  "import": [
-    "native_2/libb"
-  ]
-}

--- a/crates/moon/tests/test_cases/package_metadata.rs
+++ b/crates/moon/tests/test_cases/package_metadata.rs
@@ -68,40 +68,10 @@ fn test_supported_backends_in_pkg_json() {
 #[test]
 fn test_native_stub_in_pkg_json() {
     let dir = TestDir::new("native_stub.in");
-
-    let native_1 = dir.join("native_1.in");
-    let native_2 = dir.join("native_2.in");
     let native_3 = dir.join("native_3.in");
 
-    check(
-        get_stdout(&native_1, ["test", "--target", "native", "--sort-input"]),
-        expect![[r#"
-            Hello world from native_1/lib/stub.c!!!
-            Total tests: 1, passed: 1, failed: 0.
-        "#]],
-    );
-    check(
-        get_stdout(&native_1, ["run", "main", "--target", "native"]),
-        expect![[r#"
-            Hello world from native_1/lib/stub.c!!!
-        "#]],
-    );
-
-    check(
-        get_stdout(&native_2, ["test", "--target", "native", "--sort-input"]),
-        expect![[r#"
-            Hello world from native_1/lib/stub.c!!!
-            Hello world from native_2/libb/stub.c!!!
-            Total tests: 1, passed: 1, failed: 0.
-        "#]],
-    );
-    check(
-        get_stdout(&native_2, ["run", "main", "--target", "native"]),
-        expect![[r#"
-            Hello world from native_2/libb/stub.c!!!
-        "#]],
-    );
-
+    // The deepest fixture links stubs from all three modules, including the
+    // two-file stub in native_1. Running each prefix repeats the same shapes.
     check(
         get_stdout(&native_3, ["test", "--target", "native", "--sort-input"]),
         expect![[r#"
@@ -111,6 +81,8 @@ fn test_native_stub_in_pkg_json() {
             Total tests: 1, passed: 1, failed: 0.
         "#]],
     );
+    // Keep a run assertion because normal executables and test executables
+    // enter native linking through distinct build targets.
     check(
         get_stdout(&native_3, ["run", "main", "--target", "native"]),
         expect![[r#"

--- a/docs/dev/reference/testing-strategy.md
+++ b/docs/dev/reference/testing-strategy.md
@@ -455,6 +455,10 @@ though individual cases may still be split out:
 - `inline_test`
 - `value_tracing`
 - `native_abort_trace`
+- `package_metadata::test_native_stub_in_pkg_json`
+  - one native test on the deepest fixture covers C stubs across three modules
+    and a multi-file stub
+  - one native run remains for the distinct normal-executable linking path
 - `wbtest_coverage`
 - `prebuild`
 - `prebuild_config_script`


### PR DESCRIPTION
## Why

The native-stub metadata E2E ran the same growing fixture at all three dependency depths. Each prefix performed both a native test and a native run, even though the deepest test already links and executes every C stub from the lower levels.

## What changed

- run the native test only from the three-module fixture
- retain one native run for the distinct normal-executable linking path
- remove dependency test/main files that no command uses after the collapse
- record the retained coverage in the test-suite audit

## Why this is correct

The deepest test executes stubs from all three modules and includes the two-file C stub in the lowest module, so it covers the single-module and two-module prefixes as strict subsets. The retained run still verifies native-stub linkage for a normal executable, which has a different build target from test executables.

The JSON manifests remain intentionally unchanged because this case provides compatibility coverage for legacy `native-stub` package metadata.

This PR is stacked on #2039 and contains only the native-stub E2E reduction.
