### PR TITLE
fix(moonrun): align poll fallback and TLS peer certificates

### DIFF
--- a/crates/moonrun/src/async_api/event_bus.rs
+++ b/crates/moonrun/src/async_api/event_bus.rs
@@ -20,7 +20,7 @@ use crate::async_host::AsyncHostResult;
 
 use super::context::ImportContext;
 #[cfg(test)]
-use super::provenance::{PortedImport, SourceLocation, SourceRoot};
+use super::provenance::{CompatImport, PortedImport, SourceLocation, SourceRoot};
 
 #[cfg(all(test, target_os = "linux"))]
 const EVENT_BUS_SOURCE: &str = "src/internal/event_loop/epoll.c";
@@ -55,7 +55,7 @@ pub(super) const PORTED_IMPORTS: &[PortedImport] = &[
     ),
     ported_from(
         EVENT_BUS_SOURCES,
-        "register",
+        "try_register",
         "moonbitlang_async_event_bus_register",
     ),
     #[cfg(target_os = "macos")]
@@ -106,6 +106,18 @@ pub(super) const PORTED_IMPORTS: &[PortedImport] = &[
 ];
 
 #[cfg(test)]
+pub(super) const COMPAT_IMPORTS: &[CompatImport] = &[CompatImport {
+    rust_module: module_path!(),
+    rust_symbol: "register_legacy",
+    original_symbol: "event_bus/register",
+    historical_source: "src/internal/event_loop/event_bus.wasm.mbt",
+    upstream_pr: 548,
+    replacement: "event_bus/try_register",
+    no_op: false,
+    api_only: true,
+}];
+
+#[cfg(test)]
 const fn ported_from(
     sources: &'static [SourceLocation],
     rust_symbol: &'static str,
@@ -127,13 +139,36 @@ pub(super) fn destroy(context: &mut ImportContext<'_, '_>, bus: u64) -> AsyncHos
     context.host.poll_destroy(bus)
 }
 
-pub(super) fn register(
+pub(super) fn try_register(
     context: &mut ImportContext<'_, '_>,
     bus: u64,
     fd: u64,
     read_only: i32,
 ) -> i32 {
-    poll_errno_result(context, context.host.poll_register(bus, fd, read_only != 0))
+    match context.host.poll_register(bus, fd, read_only != 0) {
+        Ok(result) => result,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+// Older Wasm guests interpret every nonnegative result as successful
+// registration. Keep their 0/-1 contract separate from the tri-state import.
+pub(super) fn register_legacy(
+    context: &mut ImportContext<'_, '_>,
+    bus: u64,
+    fd: u64,
+    read_only: i32,
+) -> i32 {
+    match context.host.poll_register_legacy(bus, fd, read_only != 0) {
+        Ok(()) => 0,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -196,14 +231,4 @@ pub(super) fn event_bytes_transferred(
     event: u64,
 ) -> AsyncHostResult<i32> {
     context.host.poll_event_bytes_transferred(event)
-}
-
-fn poll_errno_result(context: &ImportContext<'_, '_>, result: AsyncHostResult<()>) -> i32 {
-    match result {
-        Ok(()) => 0,
-        Err(error) => {
-            context.host.record_error(error);
-            -1
-        }
-    }
 }

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -316,11 +316,17 @@ declare_async_imports! {
 
     ported event_bus::destroy(bus: u64) -> void => "event_bus/destroy";
 
-    ported event_bus::register(
+    compat event_bus::register_legacy(
         bus: u64,
         fd: u64,
         read_only: i32,
     ) -> i32 => "event_bus/register";
+
+    ported event_bus::try_register(
+        bus: u64,
+        fd: u64,
+        read_only: i32,
+    ) -> i32 => "event_bus/try_register";
 
     #[cfg(target_os = "macos")]
     ported event_bus::register_pid(bus: u64, pid: i32) -> i32 => "event_bus/register_pid";
@@ -1299,6 +1305,7 @@ fn async_api_ported_imports() -> Vec<PortedImport> {
 #[cfg(test)]
 fn async_api_compat_imports() -> Vec<super::provenance::CompatImport> {
     let mut imports = Vec::new();
+    imports.extend_from_slice(event_bus::COMPAT_IMPORTS);
     imports.extend_from_slice(thread_pool::COMPAT_IMPORTS);
     imports.extend_from_slice(fd_util::COMPAT_IMPORTS);
     imports.extend_from_slice(process::COMPAT_IMPORTS);
@@ -1667,8 +1674,16 @@ mod tests {
                 .join("third_party/moonbitlang_async")
                 .join(compat.historical_source);
             if let Ok(contents) = fs::read_to_string(historical_source) {
+                // Wasm import names are string literals. Include their quotes
+                // so a retained prefix such as `register_pid` does not look
+                // like the removed `register` import.
+                let original_symbol = if compat.api_only {
+                    format!("\"{}\"", compat.original_symbol)
+                } else {
+                    compat.original_symbol.to_owned()
+                };
                 assert!(
-                    !contents.contains(compat.original_symbol),
+                    !contents.contains(&original_symbol),
                     "compatibility symbol {} still exists upstream and should be ported",
                     compat.original_symbol
                 );

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -1583,12 +1583,14 @@ impl AsyncHost {
         Ok(())
     }
 
+    // Native's tri-state contract distinguishes a registered resource (1),
+    // an unsupported-but-valid resource (0), and an error (-1 at the ABI).
     pub(crate) fn poll_register(
         &self,
         poll_handle: u64,
         fd_handle: HostHandle,
         read_only: bool,
-    ) -> AsyncHostResult<()> {
+    ) -> AsyncHostResult<i32> {
         let handles = self.handles.borrow();
         let resource = handles.resource(fd_handle)?;
         #[cfg(unix)]
@@ -1597,7 +1599,42 @@ impl AsyncHost {
         let mut polls = self.polls.borrow_mut();
         let poll = polls.polls.get_mut(poll_key).ok_or(AsyncHostError::Badf)?;
         #[cfg(unix)]
-        poll::poll_register(&poll.instance, raw_fd, read_only, fd_handle)?;
+        let registered = poll::poll_register(&poll.instance, raw_fd, read_only, fd_handle)?;
+        #[cfg(windows)]
+        let registered = if resource.resource_class().is_socket() {
+            poll::poll_register_socket(&poll.instance, resource.as_socket()?, read_only, fd_handle)?
+        } else {
+            poll::poll_register_file(
+                &poll.instance,
+                resource.as_file()?.as_raw_handle(),
+                read_only,
+                fd_handle,
+            )?
+        };
+        #[cfg(unix)]
+        if registered > 0 {
+            poll.registered_fds.insert(raw_fd);
+        }
+        Ok(registered)
+    }
+
+    pub(crate) fn poll_register_legacy(
+        &self,
+        poll_handle: u64,
+        fd_handle: HostHandle,
+        read_only: bool,
+    ) -> AsyncHostResult<()> {
+        // The old import predates tri-state registration. Preserve its
+        // platform syscall behavior as well as its 0/-1 ABI result.
+        let handles = self.handles.borrow();
+        let resource = handles.resource(fd_handle)?;
+        #[cfg(unix)]
+        let raw_fd = resource.as_file()?.as_raw_fd();
+        let poll_key = handles.poll(poll_handle)?;
+        let mut polls = self.polls.borrow_mut();
+        let poll = polls.polls.get_mut(poll_key).ok_or(AsyncHostError::Badf)?;
+        #[cfg(unix)]
+        poll::poll_register_legacy(&poll.instance, raw_fd, read_only, fd_handle)?;
         #[cfg(windows)]
         if resource.resource_class().is_socket() {
             poll::poll_register_socket(
@@ -4058,7 +4095,13 @@ impl AsyncHost {
     }
 
     pub(crate) fn tls_peer_certificate(&self, handle: HostHandle) -> AsyncHostResult<HostHandle> {
-        self.tls_c_buffer(handle, |tls| tls.peer_certificate())
+        match self.with_tls_connection_mut(handle, Err(()), |tls| tls.peer_certificate())? {
+            Ok(Some(buffer)) => Ok(self.insert_c_buffer(buffer.into_boxed_slice())),
+            // The guest reserves the invalid handle for TLS errors and uses a
+            // valid zero-length buffer to represent an absent certificate.
+            Ok(None) => Ok(self.insert_c_buffer(Box::default())),
+            Err(()) => Ok(INVALID_HOST_HANDLE),
+        }
     }
 
     pub(crate) fn tls_unique_channel_binding(

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -64,7 +64,7 @@ ported_fns! {
         fd: RawFd,
         read_only: bool,
         fd_handle: u64,
-    ) -> AsyncHostResult<()> {
+    ) -> AsyncHostResult<i32> {
         let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
         if flags >= 0 && (flags & libc::O_NONBLOCK) == 0 {
             unsafe {
@@ -78,6 +78,40 @@ ported_fns! {
         };
         let mut event = libc::epoll_event {
             events: epoll_event_mask(events)?,
+            u64: fd_handle,
+        };
+        if unsafe { libc::epoll_ctl(instance.raw_fd(), libc::EPOLL_CTL_ADD, fd, &mut event) } < 0 {
+            let errno = super::last_errno();
+            if errno == libc::EPERM {
+                Ok(0)
+            } else {
+                Err(AsyncHostError::Native(errno))
+            }
+        } else {
+            Ok(1)
+        }
+    }
+
+    pub(crate) fn poll_register_legacy(
+        instance: &PollInstance,
+        fd: RawFd,
+        read_only: bool,
+        fd_handle: u64,
+    ) -> AsyncHostResult<()> {
+        // Keep the pre-#536 syscall shape for event_bus/register compatibility.
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags >= 0 && (flags & libc::O_NONBLOCK) == 0 {
+            unsafe {
+                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+        }
+
+        let mut events = (libc::EPOLLIN | libc::EPOLLET | libc::EPOLLRDHUP) as u32;
+        if !read_only {
+            events |= libc::EPOLLOUT as u32;
+        }
+        let mut event = libc::epoll_event {
+            events,
             u64: fd_handle,
         };
         if unsafe { libc::epoll_ctl(instance.raw_fd(), libc::EPOLL_CTL_ADD, fd, &mut event) } < 0 {
@@ -185,4 +219,38 @@ fn epoll_result_events(events: u32) -> i32 {
         result |= WRITE_EVENT;
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::OpenOptions;
+    use std::os::fd::AsRawFd;
+
+    #[test]
+    fn nonpollable_fd_is_reported_as_unsupported() {
+        let poll = poll_create().unwrap();
+        let null = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/null")
+            .unwrap();
+
+        assert_eq!(poll_register(&poll, null.as_raw_fd(), false, 1).unwrap(), 0);
+    }
+
+    #[test]
+    fn legacy_registration_preserves_nonpollable_error() {
+        let poll = poll_create().unwrap();
+        let null = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/null")
+            .unwrap();
+
+        assert_eq!(
+            poll_register_legacy(&poll, null.as_raw_fd(), false, 1),
+            Err(AsyncHostError::Native(libc::EPERM))
+        );
+    }
 }

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
@@ -78,7 +78,7 @@ ported_fns! {
         fd: RawFd,
         read_only: bool,
         fd_handle: u64,
-    ) -> AsyncHostResult<()> {
+    ) -> AsyncHostResult<i32> {
         use windows_sys::Win32::Storage::FileSystem::SetFileCompletionNotificationModes;
         use windows_sys::Win32::System::IO::CreateIoCompletionPort;
         use windows_sys::Win32::System::WindowsProgramming::FILE_SKIP_COMPLETION_PORT_ON_SUCCESS;
@@ -93,7 +93,7 @@ ported_fns! {
         if registered.is_null() {
             Err(last_native_error())
         } else {
-            Ok(())
+            Ok(1)
         }
     }
 
@@ -175,7 +175,7 @@ pub(crate) fn poll_register_file(
     handle: RawHandle,
     read_only: bool,
     fd_handle: u64,
-) -> AsyncHostResult<()> {
+) -> AsyncHostResult<i32> {
     poll_register(instance, handle, read_only, fd_handle)
 }
 
@@ -184,7 +184,7 @@ pub(crate) fn poll_register_socket(
     socket: BorrowedSocket<'_>,
     read_only: bool,
     fd_handle: u64,
-) -> AsyncHostResult<()> {
+) -> AsyncHostResult<i32> {
     // IOCP accepts a socket value in the HANDLE parameter. Keep that Windows
     // ABI conversion inside the IOCP adapter rather than the resource model.
     poll_register(

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
@@ -63,7 +63,61 @@ ported_fns! {
         fd: RawFd,
         read_only: bool,
         fd_handle: u64,
+    ) -> AsyncHostResult<i32> {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags >= 0 && (flags & libc::O_NONBLOCK) == 0 {
+            unsafe {
+                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+        }
+
+        let flags = libc::EV_ADD | libc::EV_CLEAR | libc::EV_RECEIPT;
+        let events = [
+            new_kevent(
+                fd as libc::uintptr_t,
+                libc::EVFILT_READ,
+                flags,
+                0,
+                0,
+                Some(fd_handle),
+            )?,
+            new_kevent(
+                fd as libc::uintptr_t,
+                libc::EVFILT_WRITE,
+                flags,
+                0,
+                0,
+                Some(fd_handle),
+            )?,
+        ];
+        let mut receipts = [empty_kevent(); 2];
+        let result = unsafe {
+            libc::kevent(
+                instance.raw_fd(),
+                events.as_ptr(),
+                if read_only { 1 } else { 2 },
+                receipts.as_mut_ptr(),
+                receipts.len() as i32,
+                std::ptr::null(),
+            )
+        };
+        if result < 0 {
+            return Err(last_native_error());
+        }
+        Ok(i32::from(
+            receipts[..result as usize]
+                .iter()
+                .any(|receipt| receipt.data == 0),
+        ))
+    }
+
+    pub(crate) fn poll_register_legacy(
+        instance: &PollInstance,
+        fd: RawFd,
+        read_only: bool,
+        fd_handle: u64,
     ) -> AsyncHostResult<()> {
+        // Keep the pre-#536 syscall shape for event_bus/register compatibility.
         let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
         if flags >= 0 && (flags & libc::O_NONBLOCK) == 0 {
             unsafe {
@@ -284,4 +338,35 @@ fn new_kevent(
 
 fn empty_kevent() -> libc::kevent {
     unsafe { std::mem::zeroed() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::OpenOptions;
+    use std::os::fd::AsRawFd;
+
+    #[test]
+    fn nonpollable_fd_is_reported_as_unsupported() {
+        let poll = poll_create().unwrap();
+        let null = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/null")
+            .unwrap();
+
+        assert_eq!(poll_register(&poll, null.as_raw_fd(), false, 1).unwrap(), 0);
+    }
+
+    #[test]
+    fn legacy_registration_preserves_nonpollable_error() {
+        let poll = poll_create().unwrap();
+        let null = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/null")
+            .unwrap();
+
+        assert!(poll_register_legacy(&poll, null.as_raw_fd(), false, 1).is_err());
+    }
 }

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -78,7 +78,7 @@ fn test_moonrun_against_upstream_async() {
         .args(["test", "--target", "wasm"])
         .assert()
         .success()
-        .stdout_eq("Total tests: 433, passed: 433, failed: 0.\n");
+        .stdout_eq("Total tests: 435, passed: 435, failed: 0.\n");
 }
 
 struct TestDir(moon_test_util::test_dir::TestDir);


### PR DESCRIPTION
## Why

Moonrun was missing two small native async behaviors. Event-bus registration only distinguished success from failure, so valid descriptors that cannot be polled, such as `/dev/null`, failed instead of falling back to the thread pool as specified by moonbitlang/async#536. TLS peer-certificate lookup also represented both an absent certificate and a TLS failure with the invalid handle, so the Wasm guest could not distinguish `None` from an error.

The existing `event_bus/register` import cannot simply adopt the native tri-state result: older Wasm guests interpret `0` as successful registration. Reusing that name would silently misclassify either old-host success or new-host fallback.

## What

- Add `event_bus/try_register` with the native result contract: `1` for registered, `0` for valid but unsupported, and `-1` for errors.
- Retain `event_bus/register` as a documented compatibility import with its historical `0`/`-1` contract and pre-#536 platform syscall behavior.
- Mirror the native epoll and kqueue fallback checks, and only track descriptors that were actually registered by the tri-state path.
- Return a valid zero-length buffer when a TLS peer certificate is absent, reserving the invalid handle for TLS errors.
- Update the async snapshot with the matching Wasm guest handling and enable the existing `/dev/null` and certificate tests on Wasm.

## Correctness and compatibility

Old guests continue to use `event_bus/register` without an ABI or semantic change. New guests use the separately named tri-state import, so a missing runtime capability fails explicitly at instantiation instead of silently interpreting `0` under the wrong contract. The retained epoll and kqueue compatibility paths preserve the old platform errors and registration side effects rather than approximating them with a generic error.

For TLS, a valid zero-length buffer is backward-compatible with the old guest, which already maps length zero to `None`; the invalid handle remains reserved for actual TLS errors.

This PR contains only these two parity fixes. Larger missing facilities such as file watching remain separate work. The guest-side companion is moonbitlang/async#548 and should merge after this PR.