### PR TITLE
refactor(fmt): route formatting through execution plans

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,7 +93,7 @@ The build-plan derivation registered as producing a Build Artifact. Every requir
 _Avoid_: Choosing a provider separately at each requirement call site
 
 **Execution Plan**:
-The executor-neutral graph produced by lowering one backend-specific Build Plan. It owns concrete execution actions, input paths, declared physical outputs, and the realized outputs of requested Build Artifacts.
+The executor-neutral graph of concrete execution actions, input paths, and declared physical outputs. Project builds produce it by lowering one backend-specific Build Plan; lightweight commands without logical Build Artifacts may construct it directly.
 _Avoid_: n2 graph, Build Plan, list of lowered commands
 
 **Execution Action**:

--- a/crates/moon/src/cli/fmt.rs
+++ b/crates/moon/src/cli/fmt.rs
@@ -99,7 +99,7 @@ fn run_fmt_rr(
         migrate_moon_mod_json: cli.unstable_feature.rr_moon_mod,
         migrate_moon_pkg_json: cli.unstable_feature.rr_moon_pkg,
     };
-    let graph = plan_fmt(
+    let build_input = plan_fmt(
         &resolved,
         &fmt_config,
         &target_dir,
@@ -110,13 +110,14 @@ fn run_fmt_rr(
 
     if cli.dry_run {
         output.write_result(|writer| {
-            rr_build::write_fmt_dry_run(writer, &graph, &source_dir, &target_dir)
+            rr_build::write_dry_run_all(writer, &build_input, &source_dir, &target_dir)
         })?;
         Ok(0)
     } else {
         std::fs::create_dir_all(&target_dir)?;
         let _lock = FileLock::lock_with_user_log(&target_dir, user_log)?;
-        let res = rr_build::execute_fmt(&BuildConfig::default(), graph, &target_dir, user_log)?;
+        let res =
+            rr_build::execute_build(&BuildConfig::default(), build_input, &target_dir, user_log)?;
         res.print_info(cli.quiet, "formatting")?;
         Ok(res.return_code_for_success())
     }

--- a/crates/moon/src/cli/tool.rs
+++ b/crates/moon/src/cli/tool.rs
@@ -22,12 +22,14 @@ pub(crate) mod embed;
 pub(crate) mod exec;
 pub(crate) mod format_and_diff;
 pub(crate) mod format_workspace;
+pub(crate) mod migrate_manifest;
 pub(crate) mod write_rsp_file;
 
 use demangle::*;
 use embed::*;
 use format_and_diff::*;
 use format_workspace::*;
+use migrate_manifest::*;
 use moonutil::{cli_support::UniversalFlags, user_log::UserLog};
 use write_rsp_file::*;
 
@@ -41,6 +43,8 @@ pub(crate) struct ToolSubcommand {
 pub(crate) enum ToolSubcommands {
     FormatAndDiff(FormatAndDiffSubcommand),
     FormatWorkspace(FormatWorkspaceSubcommand),
+    #[clap(hide = true)]
+    MigrateManifest(MigrateManifestSubcommand),
     Embed(Embed),
     WriteTccRspFile(WriteTccRspFile),
     BuildBinaryDep(build_binary_dep::BuildBinaryDepArgs),
@@ -55,6 +59,7 @@ pub(crate) fn run_tool(
     match cmd.subcommand {
         ToolSubcommands::FormatAndDiff(subcmd) => run_format_and_diff(subcmd),
         ToolSubcommands::FormatWorkspace(subcmd) => run_format_workspace(subcmd, user_log),
+        ToolSubcommands::MigrateManifest(subcmd) => run_migrate_manifest(subcmd),
         ToolSubcommands::Embed(subcmd) => run_embed(subcmd),
         ToolSubcommands::WriteTccRspFile(subcmd) => write_tcc_rsp_file(subcmd),
         ToolSubcommands::BuildBinaryDep(subcmd) => {

--- a/crates/moon/src/cli/tool/migrate_manifest.rs
+++ b/crates/moon/src/cli/tool/migrate_manifest.rs
@@ -1,0 +1,76 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, ensure};
+
+/// Format a legacy JSON manifest, install its replacement, and remove the old file.
+#[derive(Debug, clap::Parser)]
+pub(crate) struct MigrateManifestSubcommand {
+    /// Legacy manifest consumed by the formatter.
+    #[clap(long)]
+    old: PathBuf,
+
+    /// New source manifest installed beside the legacy manifest.
+    #[clap(long)]
+    dest: PathBuf,
+}
+
+pub(crate) fn run_migrate_manifest(cmd: MigrateManifestSubcommand) -> anyhow::Result<i32> {
+    ensure!(
+        !cmd.dest.exists(),
+        "refusing to overwrite existing manifest {}",
+        cmd.dest.display()
+    );
+    let dest_dir = cmd
+        .dest
+        .parent()
+        .context("migrated manifest destination should have a parent directory")?;
+    let temp_dir = tempfile::Builder::new()
+        .prefix(".moon-manifest-migration-")
+        .tempdir_in(dest_dir)
+        .context("failed to create temporary directory for manifest migration")?;
+    let formatted = temp_dir.path().join(
+        cmd.dest
+            .file_name()
+            .context("migrated manifest destination should have a file name")?,
+    );
+    let status = std::process::Command::new(&*moonutil::toolchain::BINARIES.moonfmt)
+        .arg(&cmd.old)
+        .arg("-o")
+        .arg(&formatted)
+        .status()
+        .context("failed to run moonfmt while migrating a manifest")?;
+    if !status.success() {
+        return Ok(status.code().unwrap_or(1));
+    }
+
+    std::fs::rename(&formatted, &cmd.dest).with_context(|| {
+        format!(
+            "failed to install migrated manifest at {}",
+            cmd.dest.display()
+        )
+    })?;
+    if let Err(source) = std::fs::remove_file(&cmd.old) {
+        let _ = std::fs::remove_file(&cmd.dest);
+        return Err(source)
+            .with_context(|| format!("failed to remove legacy manifest {}", cmd.old.display()));
+    }
+    Ok(0)
+}

--- a/crates/moon/src/rr_build/dry_run.rs
+++ b/crates/moon/src/rr_build/dry_run.rs
@@ -24,7 +24,7 @@ use std::{
     process::Command,
 };
 
-use crate::rr_build::{BuildInput, FmtBuildInput, StandaloneBuildInput};
+use crate::rr_build::{BuildInput, StandaloneBuildInput};
 
 /// Write what would be executed in a dry-run.
 ///
@@ -79,24 +79,6 @@ pub fn write_dry_run_all(
         &graph,
         &default_files,
         &command_args_by_output,
-        source_dir,
-        target_dir,
-    )
-}
-
-/// Write formatter commands from its direct n2 graph.
-pub fn write_fmt_dry_run(
-    output: &mut dyn Write,
-    input: &FmtBuildInput,
-    source_dir: &Path,
-    target_dir: &Path,
-) -> std::io::Result<()> {
-    let default_files = input.graph.get_start_nodes();
-    moonbuild::dry_run::write_build_commands(
-        output,
-        &input.graph,
-        &default_files,
-        &Default::default(),
         source_dir,
         target_dir,
     )

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -73,8 +73,7 @@ use crate::build_flags::{BuildFlags, OutputStyle};
 pub mod action_identity;
 mod dry_run;
 pub use dry_run::{
-    format_dry_run_command, write_dry_run, write_dry_run_all, write_fmt_dry_run,
-    write_standalone_dry_run,
+    format_dry_run_command, write_dry_run, write_dry_run_all, write_standalone_dry_run,
 };
 
 /// Synchronize dependencies and return resolved project data.
@@ -842,22 +841,28 @@ pub fn plan_fmt(
     selected_packages: &[PackageId],
     project_manifest: &ProjectManifest,
     user_log: &UserLog,
-) -> anyhow::Result<FmtBuildInput> {
-    let graph = moonbuild_rupes_recta::fmt::build_graph_for_fmt(
+) -> anyhow::Result<BuildInput> {
+    let execution_plan = Arc::new(moonbuild_rupes_recta::fmt::build_execution_plan_for_fmt(
         resolved,
         cfg,
         target_dir,
         selected_packages,
         project_manifest,
         user_log,
-    )?;
+    )?);
     let layout = TargetLayout::from_fmt_resolve_output(
         target_dir.to_path_buf(),
         resolved,
         BuildProfile::Debug,
     );
-    let db_path = layout.n2_db_path();
-    Ok(FmtBuildInput { graph, db_path })
+    let action_ids = execution_plan.action_ids().collect::<Vec<_>>();
+    let action_backends = action_ids.iter().map(|&action| (action, None)).collect();
+    Ok(BuildInput {
+        execution_plan,
+        action_ids,
+        action_backends,
+        db_path: layout.n2_db_path(),
+    })
 }
 
 /// Generate `packages.json` at both its legacy and configuration-scoped paths.
@@ -1066,15 +1071,6 @@ pub struct BuildInput {
     db_path: PathBuf,
 }
 
-/// Formatting still constructs n2 actions directly.
-/// FIXME(execution-plan-fmt): Remove this boundary when formatter lowering
-/// produces an Execution Plan.
-#[derive(Debug)]
-pub struct FmtBuildInput {
-    graph: n2::graph::Graph,
-    db_path: PathBuf,
-}
-
 /// Dependency-package and script-package inputs for standalone execution.
 ///
 /// Keeping this orchestration outside [`BuildInput`] lets ordinary workspace
@@ -1206,30 +1202,6 @@ pub fn execute_build(
     user_log: &UserLog,
 ) -> anyhow::Result<N2RunStats> {
     let execution = execute_build_capturing(cfg, input, target_dir)?;
-    Ok(finish_captured_build(cfg, &execution, None, user_log))
-}
-
-/// Execute formatter work that has not yet migrated to Execution Plan.
-pub fn execute_fmt(
-    cfg: &BuildConfig,
-    input: FmtBuildInput,
-    target_dir: &Path,
-    user_log: &UserLog,
-) -> anyhow::Result<N2RunStats> {
-    let start_nodes = input.graph.get_start_nodes();
-    let execution = execute_n2_graph_capturing(
-        cfg,
-        input.graph,
-        input.db_path,
-        HashMap::new(),
-        target_dir,
-        Box::new(|work| {
-            for file_id in start_nodes {
-                work.want_file(file_id)?;
-            }
-            Ok(())
-        }),
-    )?;
     Ok(finish_captured_build(cfg, &execution, None, user_log))
 }
 

--- a/crates/moon/tests/test_cases/fmt/mod.rs
+++ b/crates/moon/tests/test_cases/fmt/mod.rs
@@ -119,85 +119,31 @@ fn test_moon_fmt_002() {
 fn test_moon_fmt_extra_args() {
     let dir = TestDir::new("fmt");
     let output = get_stdout(&dir, ["fmt", "--dry-run", "--sort-input"]);
-    if cfg!(windows) {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./lib/test.mbt.md -w -o ./_build/wasm-gc/release/format/lib/test.mbt.md
-                moonfmt ./main/moon.pkg.json -o ./_build/wasm-gc/release/format/main/moon.pkg
-                cmd /c copy ./_build/wasm-gc/release/format/main/moon.pkg ./main/moon.pkg
-                cmd /c del ./main/moon.pkg.json
-                moonfmt ./lib/moon.pkg.json -o ./_build/wasm-gc/release/format/lib/moon.pkg
-                cmd /c copy ./_build/wasm-gc/release/format/lib/moon.pkg ./lib/moon.pkg
-                cmd /c del ./lib/moon.pkg.json
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cmd /c copy ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                cmd /c del ./moon.mod.json
-                moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
-                moonfmt ./lib/hello_wbtest.mbt -w -o ./_build/wasm-gc/release/format/lib/hello_wbtest.mbt
-                moonfmt ./lib/hello.mbt -w -o ./_build/wasm-gc/release/format/lib/hello.mbt
-            "#]],
-        );
-    } else {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./lib/test.mbt.md -w -o ./_build/wasm-gc/release/format/lib/test.mbt.md
-                moonfmt ./main/moon.pkg.json -o ./_build/wasm-gc/release/format/main/moon.pkg
-                cp ./_build/wasm-gc/release/format/main/moon.pkg ./main/moon.pkg
-                rm ./main/moon.pkg.json
-                moonfmt ./lib/moon.pkg.json -o ./_build/wasm-gc/release/format/lib/moon.pkg
-                cp ./_build/wasm-gc/release/format/lib/moon.pkg ./lib/moon.pkg
-                rm ./lib/moon.pkg.json
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cp ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                rm ./moon.mod.json
-                moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
-                moonfmt ./lib/hello_wbtest.mbt -w -o ./_build/wasm-gc/release/format/lib/hello_wbtest.mbt
-                moonfmt ./lib/hello.mbt -w -o ./_build/wasm-gc/release/format/lib/hello.mbt
-            "#]],
-        );
-    }
+    check(
+        output,
+        expect![[r#"
+            moonfmt ./lib/test.mbt.md -w -o ./_build/wasm-gc/release/format/lib/test.mbt.md
+            moon tool migrate-manifest --old ./main/moon.pkg.json --dest ./main/moon.pkg
+            moon tool migrate-manifest --old ./lib/moon.pkg.json --dest ./lib/moon.pkg
+            moon tool migrate-manifest --old ./moon.mod.json --dest ./moon.mod
+            moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
+            moonfmt ./lib/hello_wbtest.mbt -w -o ./_build/wasm-gc/release/format/lib/hello_wbtest.mbt
+            moonfmt ./lib/hello.mbt -w -o ./_build/wasm-gc/release/format/lib/hello.mbt
+        "#]],
+    );
     let output = get_stdout(&dir, ["fmt", "--dry-run", "--sort-input", "--", "a", "b"]);
-    if cfg!(windows) {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./lib/test.mbt.md -w -o ./_build/wasm-gc/release/format/lib/test.mbt.md a b
-                moonfmt ./main/moon.pkg.json -o ./_build/wasm-gc/release/format/main/moon.pkg
-                cmd /c copy ./_build/wasm-gc/release/format/main/moon.pkg ./main/moon.pkg
-                cmd /c del ./main/moon.pkg.json
-                moonfmt ./lib/moon.pkg.json -o ./_build/wasm-gc/release/format/lib/moon.pkg
-                cmd /c copy ./_build/wasm-gc/release/format/lib/moon.pkg ./lib/moon.pkg
-                cmd /c del ./lib/moon.pkg.json
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cmd /c copy ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                cmd /c del ./moon.mod.json
-                moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt a b
-                moonfmt ./lib/hello_wbtest.mbt -w -o ./_build/wasm-gc/release/format/lib/hello_wbtest.mbt a b
-                moonfmt ./lib/hello.mbt -w -o ./_build/wasm-gc/release/format/lib/hello.mbt a b
-            "#]],
-        );
-    } else {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./lib/test.mbt.md -w -o ./_build/wasm-gc/release/format/lib/test.mbt.md a b
-                moonfmt ./main/moon.pkg.json -o ./_build/wasm-gc/release/format/main/moon.pkg
-                cp ./_build/wasm-gc/release/format/main/moon.pkg ./main/moon.pkg
-                rm ./main/moon.pkg.json
-                moonfmt ./lib/moon.pkg.json -o ./_build/wasm-gc/release/format/lib/moon.pkg
-                cp ./_build/wasm-gc/release/format/lib/moon.pkg ./lib/moon.pkg
-                rm ./lib/moon.pkg.json
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cp ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                rm ./moon.mod.json
-                moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt a b
-                moonfmt ./lib/hello_wbtest.mbt -w -o ./_build/wasm-gc/release/format/lib/hello_wbtest.mbt a b
-                moonfmt ./lib/hello.mbt -w -o ./_build/wasm-gc/release/format/lib/hello.mbt a b
-            "#]],
-        );
-    }
+    check(
+        output,
+        expect![[r#"
+            moonfmt ./lib/test.mbt.md -w -o ./_build/wasm-gc/release/format/lib/test.mbt.md a b
+            moon tool migrate-manifest --old ./main/moon.pkg.json --dest ./main/moon.pkg
+            moon tool migrate-manifest --old ./lib/moon.pkg.json --dest ./lib/moon.pkg
+            moon tool migrate-manifest --old ./moon.mod.json --dest ./moon.mod
+            moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt a b
+            moonfmt ./lib/hello_wbtest.mbt -w -o ./_build/wasm-gc/release/format/lib/hello_wbtest.mbt a b
+            moonfmt ./lib/hello.mbt -w -o ./_build/wasm-gc/release/format/lib/hello.mbt a b
+        "#]],
+    );
     check(
         get_stdout(&dir, ["fmt", "--check", "--sort-input", "--dry-run"]),
         expect![[r#"

--- a/crates/moon/tests/test_cases/fmt_moon_mod/mod.rs
+++ b/crates/moon/tests/test_cases/fmt_moon_mod/mod.rs
@@ -118,29 +118,14 @@ fn test_fmt_migrates_moon_mod_by_default() {
 
     let output = get_stdout(&dir, ["fmt", "--dry-run", "--sort-input"]);
 
-    if cfg!(windows) {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./main/moon.pkg -w -o ./_build/wasm-gc/release/format/main/moon.pkg
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cmd /c copy ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                cmd /c del ./moon.mod.json
-                moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
-            "#]],
-        );
-    } else {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./main/moon.pkg -w -o ./_build/wasm-gc/release/format/main/moon.pkg
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cp ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                rm ./moon.mod.json
-                moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
-            "#]],
-        );
-    }
+    check(
+        output,
+        expect![[r#"
+            moonfmt ./main/moon.pkg -w -o ./_build/wasm-gc/release/format/main/moon.pkg
+            moon tool migrate-manifest --old ./moon.mod.json --dest ./moon.mod
+            moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
+        "#]],
+    );
 }
 
 #[test]
@@ -196,29 +181,14 @@ fn test_fmt_moon_mod_json_migration_dry_run() {
         ],
     );
 
-    if cfg!(windows) {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./main/moon.pkg -w -o ./_build/wasm-gc/release/format/main/moon.pkg
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cmd /c copy ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                cmd /c del ./moon.mod.json
-                moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
-            "#]],
-        );
-    } else {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./main/moon.pkg -w -o ./_build/wasm-gc/release/format/main/moon.pkg
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cp ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                rm ./moon.mod.json
-                moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
-            "#]],
-        );
-    }
+    check(
+        output,
+        expect![[r#"
+            moonfmt ./main/moon.pkg -w -o ./_build/wasm-gc/release/format/main/moon.pkg
+            moon tool migrate-manifest --old ./moon.mod.json --dest ./moon.mod
+            moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
+        "#]],
+    );
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/fmt_moon_pkg/mod.rs
+++ b/crates/moon/tests/test_cases/fmt_moon_pkg/mod.rs
@@ -41,38 +41,30 @@ fn test_fmt_moon_pkg_json_migration_dry_run() {
         ],
     );
 
-    // Test dry run output with rr_moon_pkg feature (no rm command)
-    if cfg!(windows) {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./lib/moon.pkg.json -o ./_build/wasm-gc/release/format/lib/moon.pkg
-                cmd /c copy ./_build/wasm-gc/release/format/lib/moon.pkg ./lib/moon.pkg
-                cmd /c del ./lib/moon.pkg.json
-                moonfmt ./main/moon.pkg -w -o ./_build/wasm-gc/release/format/main/moon.pkg
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cmd /c copy ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                cmd /c del ./moon.mod.json
-                moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
-                moonfmt ./lib/hello.mbt -w -o ./_build/wasm-gc/release/format/lib/hello.mbt
-            "#]],
-        );
-    } else {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./lib/moon.pkg.json -o ./_build/wasm-gc/release/format/lib/moon.pkg
-                cp ./_build/wasm-gc/release/format/lib/moon.pkg ./lib/moon.pkg
-                rm ./lib/moon.pkg.json
-                moonfmt ./main/moon.pkg -w -o ./_build/wasm-gc/release/format/main/moon.pkg
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cp ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                rm ./moon.mod.json
-                moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
-                moonfmt ./lib/hello.mbt -w -o ./_build/wasm-gc/release/format/lib/hello.mbt
-            "#]],
-        );
-    }
+    check(
+        output,
+        expect![[r#"
+            moon tool migrate-manifest --old ./lib/moon.pkg.json --dest ./lib/moon.pkg
+            moonfmt ./main/moon.pkg -w -o ./_build/wasm-gc/release/format/main/moon.pkg
+            moon tool migrate-manifest --old ./moon.mod.json --dest ./moon.mod
+            moonfmt ./main/main.mbt -w -o ./_build/wasm-gc/release/format/main/main.mbt
+            moonfmt ./lib/hello.mbt -w -o ./_build/wasm-gc/release/format/lib/hello.mbt
+        "#]],
+    );
+}
+
+#[test]
+fn test_fmt_moon_pkg_json_migration_replaces_legacy_file() {
+    let dir = TestDir::new("fmt_moon_pkg.in");
+
+    snapbox::cmd::Command::new(moon_bin())
+        .current_dir(&dir)
+        .args(["--unstable-feature", "rr_moon_pkg", "fmt"])
+        .assert()
+        .success();
+
+    assert!(dir.join("lib/moon.pkg").exists());
+    assert!(!dir.join("lib/moon.pkg.json").exists());
 }
 
 #[test]
@@ -150,33 +142,13 @@ fn test_fmt_moon_pkg_both_exist() {
     );
 
     // Stdout should still show the formatting commands (using moon.pkg for both/, migrating for root)
-    if cfg!(windows) {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./moon.pkg.json -o ./_build/wasm-gc/release/format/moon.pkg
-                cmd /c copy ./_build/wasm-gc/release/format/moon.pkg ./moon.pkg
-                cmd /c del ./moon.pkg.json
-                moonfmt ./both/moon.pkg -w -o ./_build/wasm-gc/release/format/both/moon.pkg
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cmd /c copy ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                cmd /c del ./moon.mod.json
-                moonfmt ./both/lib.mbt -w -o ./_build/wasm-gc/release/format/both/lib.mbt
-            "#]],
-        );
-    } else {
-        check(
-            output,
-            expect![[r#"
-                moonfmt ./moon.pkg.json -o ./_build/wasm-gc/release/format/moon.pkg
-                cp ./_build/wasm-gc/release/format/moon.pkg ./moon.pkg
-                rm ./moon.pkg.json
-                moonfmt ./both/moon.pkg -w -o ./_build/wasm-gc/release/format/both/moon.pkg
-                moonfmt ./moon.mod.json -o ./_build/wasm-gc/release/format/moon.mod
-                cp ./_build/wasm-gc/release/format/moon.mod ./moon.mod
-                rm ./moon.mod.json
-                moonfmt ./both/lib.mbt -w -o ./_build/wasm-gc/release/format/both/lib.mbt
-            "#]],
-        );
-    }
+    check(
+        output,
+        expect![[r#"
+            moon tool migrate-manifest --old ./moon.pkg.json --dest ./moon.pkg
+            moonfmt ./both/moon.pkg -w -o ./_build/wasm-gc/release/format/both/moon.pkg
+            moon tool migrate-manifest --old ./moon.mod.json --dest ./moon.mod
+            moonfmt ./both/lib.mbt -w -o ./_build/wasm-gc/release/format/both/lib.mbt
+        "#]],
+    );
 }

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -218,53 +218,20 @@ fn test_workspace_commands() {
         "#]],
     );
 
-    if cfg!(windows) {
-        check(
-            get_stdout(&dir, ["fmt", "--dry-run", "--sort-input"]),
-            expect![[r#"
-                moon tool format-workspace --old ./moon.work --write --new ./_build/wasm-gc/release/format/moon.work
-                moonfmt ./liba/src/lib/moon.pkg.json -o ./_build/wasm-gc/release/format/alice/liba/lib/moon.pkg
-                cmd /c copy ./_build/wasm-gc/release/format/alice/liba/lib/moon.pkg ./liba/src/lib/moon.pkg
-                cmd /c del ./liba/src/lib/moon.pkg.json
-                moonfmt ./app/src/main/moon.pkg.json -o ./_build/wasm-gc/release/format/alice/app/main/moon.pkg
-                cmd /c copy ./_build/wasm-gc/release/format/alice/app/main/moon.pkg ./app/src/main/moon.pkg
-                cmd /c del ./app/src/main/moon.pkg.json
-                moonfmt ./liba/moon.mod.json -o ./_build/wasm-gc/release/format/alice/liba/moon.mod
-                cmd /c copy ./_build/wasm-gc/release/format/alice/liba/moon.mod ./liba/moon.mod
-                cmd /c del ./liba/moon.mod.json
-                moonfmt ./app/moon.mod.json -o ./_build/wasm-gc/release/format/alice/app/moon.mod
-                cmd /c copy ./_build/wasm-gc/release/format/alice/app/moon.mod ./app/moon.mod
-                cmd /c del ./app/moon.mod.json
-                moonfmt ./app/src/main/main_test.mbt -w -o ./_build/wasm-gc/release/format/alice/app/main/main_test.mbt
-                moonfmt ./app/src/main/main.mbt -w -o ./_build/wasm-gc/release/format/alice/app/main/main.mbt
-                moonfmt ./liba/src/lib/lib_test.mbt -w -o ./_build/wasm-gc/release/format/alice/liba/lib/lib_test.mbt
-                moonfmt ./liba/src/lib/lib.mbt -w -o ./_build/wasm-gc/release/format/alice/liba/lib/lib.mbt
-            "#]],
-        );
-    } else {
-        check(
-            get_stdout(&dir, ["fmt", "--dry-run", "--sort-input"]),
-            expect![[r#"
-                moon tool format-workspace --old ./moon.work --write --new ./_build/wasm-gc/release/format/moon.work
-                moonfmt ./liba/src/lib/moon.pkg.json -o ./_build/wasm-gc/release/format/alice/liba/lib/moon.pkg
-                cp ./_build/wasm-gc/release/format/alice/liba/lib/moon.pkg ./liba/src/lib/moon.pkg
-                rm ./liba/src/lib/moon.pkg.json
-                moonfmt ./app/src/main/moon.pkg.json -o ./_build/wasm-gc/release/format/alice/app/main/moon.pkg
-                cp ./_build/wasm-gc/release/format/alice/app/main/moon.pkg ./app/src/main/moon.pkg
-                rm ./app/src/main/moon.pkg.json
-                moonfmt ./liba/moon.mod.json -o ./_build/wasm-gc/release/format/alice/liba/moon.mod
-                cp ./_build/wasm-gc/release/format/alice/liba/moon.mod ./liba/moon.mod
-                rm ./liba/moon.mod.json
-                moonfmt ./app/moon.mod.json -o ./_build/wasm-gc/release/format/alice/app/moon.mod
-                cp ./_build/wasm-gc/release/format/alice/app/moon.mod ./app/moon.mod
-                rm ./app/moon.mod.json
-                moonfmt ./app/src/main/main_test.mbt -w -o ./_build/wasm-gc/release/format/alice/app/main/main_test.mbt
-                moonfmt ./app/src/main/main.mbt -w -o ./_build/wasm-gc/release/format/alice/app/main/main.mbt
-                moonfmt ./liba/src/lib/lib_test.mbt -w -o ./_build/wasm-gc/release/format/alice/liba/lib/lib_test.mbt
-                moonfmt ./liba/src/lib/lib.mbt -w -o ./_build/wasm-gc/release/format/alice/liba/lib/lib.mbt
-            "#]],
-        );
-    }
+    check(
+        get_stdout(&dir, ["fmt", "--dry-run", "--sort-input"]),
+        expect![[r#"
+            moon tool format-workspace --old ./moon.work --write --new ./_build/wasm-gc/release/format/moon.work
+            moon tool migrate-manifest --old ./liba/src/lib/moon.pkg.json --dest ./liba/src/lib/moon.pkg
+            moon tool migrate-manifest --old ./app/src/main/moon.pkg.json --dest ./app/src/main/moon.pkg
+            moon tool migrate-manifest --old ./liba/moon.mod.json --dest ./liba/moon.mod
+            moon tool migrate-manifest --old ./app/moon.mod.json --dest ./app/moon.mod
+            moonfmt ./app/src/main/main_test.mbt -w -o ./_build/wasm-gc/release/format/alice/app/main/main_test.mbt
+            moonfmt ./app/src/main/main.mbt -w -o ./_build/wasm-gc/release/format/alice/app/main/main.mbt
+            moonfmt ./liba/src/lib/lib_test.mbt -w -o ./_build/wasm-gc/release/format/alice/liba/lib/lib_test.mbt
+            moonfmt ./liba/src/lib/lib.mbt -w -o ./_build/wasm-gc/release/format/alice/liba/lib/lib.mbt
+        "#]],
+    );
 
     let stderr = get_stderr(&dir, ["check", "--target", "wasm-gc", "--sort-input"]);
     assert!(stderr.contains("Finished. moon: ran "));

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -32,7 +32,7 @@ use crate::{
     ResolveOutput,
     build_plan::{ArtifactKey, BuildAction, BuildPlan, PackagePrebuildAction},
     discover::{DiscoverResult, DiscoveredPackage},
-    execution_plan::{ExecutionActionDraft, ExternalInput},
+    execution_plan::{ActionId, ExecutionAction, ExecutionPlanBuilder, ExternalInput},
     model::{BackendConfig, BuildPlanNode, BuildTarget},
     pkg_solve::DepRelationship,
     target_layout::ArtifactPathResolver,
@@ -377,11 +377,12 @@ impl<'a> LoweringContext<'a> {
         }
     }
 
-    #[instrument(level = Level::DEBUG, skip(self))]
+    #[instrument(level = Level::DEBUG, skip(self, execution))]
     pub(super) fn lower_action(
         &mut self,
         node: BuildPlanNode,
-    ) -> Result<ExecutionActionDraft, LoweringError> {
+        execution: &mut ExecutionPlanBuilder,
+    ) -> Result<ActionId, LoweringError> {
         let action = self.action(node);
         let action_artifacts = ActionArtifacts::new(self, node);
 
@@ -592,28 +593,36 @@ impl<'a> LoweringContext<'a> {
             ],
             _ => Vec::new(),
         };
-        Ok(ExecutionActionDraft {
-            artifact_inputs: action_artifacts
-                .dependencies
-                .into_iter()
-                .map(|artifact| artifact.artifact)
-                .collect(),
-            semantic_outputs: action_artifacts
-                .outputs
-                .into_iter()
-                .map(|artifact| (artifact.artifact, artifact.paths))
-                .collect(),
-            declared_outputs,
-            external_inputs,
+        let inputs = action_artifacts
+            .dependencies
+            .into_iter()
+            .flat_map(|artifact| artifact.paths)
+            .collect();
+        let semantic_outputs = action_artifacts
+            .outputs
+            .into_iter()
+            .map(|artifact| (artifact.artifact, artifact.paths))
+            .collect::<Vec<_>>();
+        let outputs = semantic_outputs
+            .iter()
+            .flat_map(|(_, paths)| paths.iter().cloned())
+            .chain(declared_outputs)
+            .collect();
+        let execution_action = ExecutionAction::new(
+            inputs,
+            outputs,
             command,
-            cache_eligible,
-            fileloc: node.string_id(self.modules, self.packages),
-            description: self.human_desc(node, action),
-            can_dirty_on_output: matches!(
-                node,
-                BuildPlanNode::Check(_) | BuildPlanNode::EmitProof(_) | BuildPlanNode::Prove(_)
-            ),
-            error_package,
-        })
+            node.string_id(self.modules, self.packages),
+            self.human_desc(node, action),
+        )
+        .with_external_inputs(external_inputs)
+        .with_cache_eligible(cache_eligible)
+        .with_can_dirty_on_output(matches!(
+            node,
+            BuildPlanNode::Check(_) | BuildPlanNode::EmitProof(_) | BuildPlanNode::Prove(_)
+        ))
+        .with_error_package(error_package);
+
+        Ok(execution.add_action(execution_action, semantic_outputs))
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -270,7 +270,7 @@ fn lower_actions(
 
     for node in plan.all_nodes() {
         debug!("Lowering action: {:?}", node);
-        let action = execution.add_action(ctx.lower_action(node)?);
+        let action = ctx.lower_action(node, &mut execution)?;
         action_ids.insert(node, action);
     }
 
@@ -784,9 +784,22 @@ mod tests {
         };
 
         let mut context = LoweringContext::new(artifact_paths, &resolve_output, &plan, &options);
-        for node in [check_node, link_core_node] {
-            let action = context.lower_action(node).expect("lowering should succeed");
-            assert!(!action.is_cache_eligible(), "{node:?} should be ineligible");
+        let mut execution = ExecutionPlanBuilder::default();
+        let nodes = [check_node, link_core_node];
+        let actions = nodes
+            .into_iter()
+            .map(|node| {
+                context
+                    .lower_action(node, &mut execution)
+                    .expect("lowering should succeed")
+            })
+            .collect::<Vec<_>>();
+        let execution = execution.finish([]);
+        for (node, action) in nodes.into_iter().zip(actions) {
+            assert!(
+                !execution.action(action).is_cache_eligible(),
+                "{node:?} should be ineligible"
+            );
         }
     }
 
@@ -1054,10 +1067,20 @@ mod tests {
 
         let mut context =
             LoweringContext::new(artifact_paths.clone(), &resolve_output, &plan, &options);
-        for node in [c_stub_node, exe_node] {
-            let action = context.lower_action(node).expect("lowering should succeed");
+        let mut execution = ExecutionPlanBuilder::default();
+        let nodes = [c_stub_node, exe_node];
+        let actions = nodes
+            .into_iter()
+            .map(|node| {
+                context
+                    .lower_action(node, &mut execution)
+                    .expect("lowering should succeed")
+            })
+            .collect::<Vec<_>>();
+        let execution = execution.finish([]);
+        for (node, action) in nodes.into_iter().zip(actions) {
             assert!(
-                !action.is_cache_eligible(),
+                !execution.action(action).is_cache_eligible(),
                 "{node:?} with opaque flags should be ineligible"
             );
         }

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -1065,22 +1065,12 @@ mod tests {
             lowering_environment,
         };
 
-        let mut context =
-            LoweringContext::new(artifact_paths.clone(), &resolve_output, &plan, &options);
-        let mut execution = ExecutionPlanBuilder::default();
         let nodes = [c_stub_node, exe_node];
-        let actions = nodes
-            .into_iter()
-            .map(|node| {
-                context
-                    .lower_action(node, &mut execution)
-                    .expect("lowering should succeed")
-            })
-            .collect::<Vec<_>>();
-        let execution = execution.finish([]);
-        for (node, action) in nodes.into_iter().zip(actions) {
+        let (execution, actions) =
+            lower_actions(&resolve_output, &plan, &options).expect("lowering should succeed");
+        for node in nodes {
             assert!(
-                !execution.action(action).is_cache_eligible(),
+                !execution.action(actions[&node]).is_cache_eligible(),
                 "{node:?} with opaque flags should be ineligible"
             );
         }

--- a/crates/moonbuild-rupes-recta/src/execution_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/execution_plan/mod.rs
@@ -265,6 +265,7 @@ impl ExecutionAction {
         self
     }
 
+    /// Declared output paths produced by other actions in this plan.
     pub fn inputs(&self) -> &[PathBuf] {
         &self.inputs
     }
@@ -507,6 +508,17 @@ impl ExecutionPlanBuilder {
         self,
         requested_artifacts: impl IntoIterator<Item = ArtifactKey>,
     ) -> ExecutionPlan {
+        for (index, action) in self.actions.iter().enumerate() {
+            for input in action.inputs() {
+                assert!(
+                    self.outputs.contains_key(input),
+                    "execution action {:?} depends on an undeclared producer output: {}",
+                    ActionId(index),
+                    input.display()
+                );
+            }
+        }
+
         let mut seen = HashSet::new();
         let mut requested = Vec::new();
         for artifact in requested_artifacts {
@@ -638,6 +650,20 @@ mod tests {
             "archive-runtime",
         );
         ExecutionPlanBuilder::default().add_action(action, outputs);
+    }
+
+    #[test]
+    #[should_panic(expected = "depends on an undeclared producer output")]
+    fn execution_inputs_require_a_producer_in_the_same_plan() {
+        let mut builder = ExecutionPlanBuilder::default();
+        let (action, outputs) = execution_action(
+            vec![PathBuf::from("src/main.mbt")],
+            Vec::new(),
+            vec![PathBuf::from("build/main.mi")],
+            "compile-main",
+        );
+        builder.add_action(action, outputs);
+        builder.finish([]);
     }
 
     #[test]

--- a/crates/moonbuild-rupes-recta/src/execution_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/execution_plan/mod.rs
@@ -222,6 +222,49 @@ pub struct ExecutionAction {
 }
 
 impl ExecutionAction {
+    pub(crate) fn new(
+        inputs: Vec<PathBuf>,
+        outputs: Vec<PathBuf>,
+        command: LoweredCommand,
+        fileloc: String,
+        description: String,
+    ) -> Self {
+        Self {
+            inputs,
+            external_inputs: Vec::new(),
+            outputs,
+            command,
+            cache_eligible: true,
+            fileloc,
+            description,
+            can_dirty_on_output: false,
+            error_package: None::<crate::pkg_name::PackageFQN>.into(),
+        }
+    }
+
+    pub(crate) fn with_external_inputs(mut self, external_inputs: Vec<ExternalInput>) -> Self {
+        self.external_inputs = external_inputs;
+        self
+    }
+
+    pub(crate) fn with_cache_eligible(mut self, cache_eligible: bool) -> Self {
+        self.cache_eligible = cache_eligible;
+        self
+    }
+
+    pub(crate) fn with_can_dirty_on_output(mut self, can_dirty_on_output: bool) -> Self {
+        self.can_dirty_on_output = can_dirty_on_output;
+        self
+    }
+
+    pub(crate) fn with_error_package(
+        mut self,
+        error_package: OptionalPackageFQNWithSource,
+    ) -> Self {
+        self.error_package = error_package;
+        self
+    }
+
     pub fn inputs(&self) -> &[PathBuf] {
         &self.inputs
     }
@@ -390,81 +433,52 @@ pub enum ExecutionPlanMergeError {
     ConflictingOutput { path: PathBuf },
 }
 
-pub(crate) struct ExecutionActionDraft {
-    pub(crate) artifact_inputs: Vec<ArtifactKey>,
-    pub(crate) semantic_outputs: Vec<(ArtifactKey, Vec<PathBuf>)>,
-    pub(crate) declared_outputs: Vec<PathBuf>,
-    pub(crate) external_inputs: Vec<ExternalInput>,
-    pub(crate) command: LoweredCommand,
-    pub(crate) cache_eligible: bool,
-    pub(crate) fileloc: String,
-    pub(crate) description: String,
-    pub(crate) can_dirty_on_output: bool,
-    pub(crate) error_package: OptionalPackageFQNWithSource,
-}
-
-impl ExecutionActionDraft {
-    #[cfg(test)]
-    pub(crate) fn is_cache_eligible(&self) -> bool {
-        self.cache_eligible
-    }
-}
-
 #[derive(Default)]
 pub(crate) struct ExecutionPlanBuilder {
-    actions: Vec<PendingAction>,
+    actions: Vec<ExecutionAction>,
     outputs: HashMap<PathBuf, DeclaredOutput>,
     artifacts: HashMap<ArtifactKey, Vec<PathBuf>>,
 }
 
-struct PendingAction {
-    action: ExecutionAction,
-    requirements: Vec<ArtifactKey>,
-}
-
 impl ExecutionPlanBuilder {
-    pub(crate) fn add_action(&mut self, draft: ExecutionActionDraft) -> ActionId {
-        let action = ActionId(self.actions.len());
-        let mut output_paths = Vec::new();
+    pub(crate) fn add_action(
+        &mut self,
+        action: ExecutionAction,
+        semantic_outputs: impl IntoIterator<Item = (ArtifactKey, Vec<PathBuf>)>,
+    ) -> ActionId {
+        let action_id = ActionId(self.actions.len());
+        let mut artifacts_by_path = HashMap::new();
 
-        for (artifact, paths) in draft.semantic_outputs {
+        for (artifact, paths) in semantic_outputs {
             assert!(
                 !paths.is_empty(),
                 "execution artifact has no physical outputs: {artifact:?}"
             );
-            let outputs = paths
-                .into_iter()
-                .map(|path| self.add_output(action, path, Some(artifact.clone())))
-                .collect::<Vec<_>>();
-            let previous = self.artifacts.insert(artifact.clone(), outputs.clone());
+            for path in &paths {
+                let previous = artifacts_by_path.insert(path.clone(), artifact.clone());
+                assert!(
+                    previous.is_none(),
+                    "declared execution output realizes multiple artifacts: {}",
+                    path.display()
+                );
+            }
+            let previous = self.artifacts.insert(artifact.clone(), paths);
             assert!(
                 previous.is_none(),
                 "execution artifact has multiple providers: {artifact:?}"
             );
-            output_paths.extend(outputs);
         }
-        output_paths.extend(
-            draft
-                .declared_outputs
-                .into_iter()
-                .map(|path| self.add_output(action, path, None)),
+
+        for path in &action.outputs {
+            self.add_output(action_id, path.clone(), artifacts_by_path.remove(path));
+        }
+        assert!(
+            artifacts_by_path.is_empty(),
+            "artifact output paths should be declared by their execution action"
         );
 
-        self.actions.push(PendingAction {
-            action: ExecutionAction {
-                inputs: Vec::new(),
-                external_inputs: draft.external_inputs,
-                outputs: output_paths,
-                command: draft.command,
-                cache_eligible: draft.cache_eligible,
-                fileloc: draft.fileloc,
-                description: draft.description,
-                can_dirty_on_output: draft.can_dirty_on_output,
-                error_package: draft.error_package,
-            },
-            requirements: draft.artifact_inputs,
-        });
-        action
+        self.actions.push(action);
+        action_id
     }
 
     fn add_output(
@@ -493,26 +507,6 @@ impl ExecutionPlanBuilder {
         self,
         requested_artifacts: impl IntoIterator<Item = ArtifactKey>,
     ) -> ExecutionPlan {
-        let actions = self
-            .actions
-            .into_iter()
-            .map(|pending| ExecutionAction {
-                inputs: pending
-                    .requirements
-                    .into_iter()
-                    .flat_map(|artifact| {
-                        let outputs = self.artifacts.get(&artifact).unwrap_or_else(|| {
-                        panic!(
-                            "execution action requires artifact without a provider: {artifact:?}"
-                        )
-                    });
-                        outputs.iter().cloned()
-                    })
-                    .collect(),
-                ..pending.action
-            })
-            .collect();
-
         let mut seen = HashSet::new();
         let mut requested = Vec::new();
         for artifact in requested_artifacts {
@@ -527,7 +521,7 @@ impl ExecutionPlanBuilder {
             requested.push((artifact, outputs));
         }
         ExecutionPlan {
-            actions,
+            actions: self.actions,
             outputs: self.outputs,
             requested_artifacts: requested,
         }
@@ -538,33 +532,34 @@ impl ExecutionPlanBuilder {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use crate::pkg_name::PackageFQN;
-
     use super::*;
 
-    fn draft(
-        artifact_inputs: Vec<ArtifactKey>,
+    fn execution_action(
+        inputs: Vec<PathBuf>,
         semantic_outputs: Vec<(ArtifactKey, Vec<PathBuf>)>,
         declared_outputs: Vec<PathBuf>,
         command: &str,
-    ) -> ExecutionActionDraft {
-        ExecutionActionDraft {
-            artifact_inputs,
+    ) -> (ExecutionAction, Vec<(ArtifactKey, Vec<PathBuf>)>) {
+        let outputs = semantic_outputs
+            .iter()
+            .flat_map(|(_, paths)| paths.iter().cloned())
+            .chain(declared_outputs)
+            .collect();
+        (
+            ExecutionAction::new(
+                inputs,
+                outputs,
+                LoweredCommand::from(vec![command.to_string()]),
+                command.to_string(),
+                command.to_string(),
+            ),
             semantic_outputs,
-            declared_outputs,
-            external_inputs: Vec::new(),
-            command: LoweredCommand::from(vec![command.to_string()]),
-            cache_eligible: true,
-            fileloc: command.to_string(),
-            description: command.to_string(),
-            can_dirty_on_output: false,
-            error_package: None::<PackageFQN>.into(),
-        }
+        )
     }
 
     fn producer_and_consumer_plan() -> (ExecutionPlan, ActionId, ActionId) {
         let mut builder = ExecutionPlanBuilder::default();
-        let producer = builder.add_action(draft(
+        let (action, outputs) = execution_action(
             Vec::new(),
             vec![(
                 ArtifactKey::RuntimeLibrary,
@@ -572,13 +567,15 @@ mod tests {
             )],
             Vec::new(),
             "archive-runtime",
-        ));
-        let consumer = builder.add_action(draft(
-            vec![ArtifactKey::RuntimeLibrary],
+        );
+        let producer = builder.add_action(action, outputs);
+        let (action, outputs) = execution_action(
+            vec![PathBuf::from("build/libmoonbitrun.a")],
             Vec::new(),
             vec![PathBuf::from("build/app.dSYM")],
             "generate-debug-symbols",
-        ));
+        );
+        let consumer = builder.add_action(action, outputs);
         let plan = builder.finish([ArtifactKey::RuntimeLibrary]);
         (plan, producer, consumer)
     }
@@ -634,12 +631,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "execution artifact has no physical outputs")]
     fn semantic_artifact_requires_a_physical_output() {
-        ExecutionPlanBuilder::default().add_action(draft(
+        let (action, outputs) = execution_action(
             Vec::new(),
             vec![(ArtifactKey::RuntimeLibrary, Vec::new())],
             Vec::new(),
             "archive-runtime",
-        ));
+        );
+        ExecutionPlanBuilder::default().add_action(action, outputs);
     }
 
     #[test]
@@ -681,12 +679,13 @@ mod tests {
     fn merge_remaps_plan_local_action_ids() {
         let (first, _, _) = producer_and_consumer_plan();
         let mut builder = ExecutionPlanBuilder::default();
-        builder.add_action(draft(
+        let (action, outputs) = execution_action(
             Vec::new(),
             Vec::new(),
             vec![PathBuf::from("build/other-output")],
             "other-command",
-        ));
+        );
+        builder.add_action(action, outputs);
         let second = builder.finish([]);
         let mut composed = ExecutionPlan::default();
 

--- a/crates/moonbuild-rupes-recta/src/fmt.rs
+++ b/crates/moonbuild-rupes-recta/src/fmt.rs
@@ -163,7 +163,7 @@ pub fn build_execution_plan_for_fmt(
 
 fn add_format_action<I, O>(
     execution: &mut ExecutionPlanBuilder,
-    inputs: I,
+    external_files: I,
     outputs: O,
     args: Vec<String>,
     description: String,
@@ -176,12 +176,19 @@ fn add_format_action<I, O>(
     O::Item: Into<std::path::PathBuf>,
 {
     let command = LoweredCommand::from(args);
-    let external_inputs = command
-        .executable()
-        .map(|path| vec![ExternalInput::File(path.to_path_buf())])
-        .unwrap_or_default();
+    let mut external_inputs = external_files
+        .into_iter()
+        .map(|path| ExternalInput::File(path.into()))
+        .chain(
+            command
+                .executable()
+                .map(|path| ExternalInput::File(path.to_path_buf())),
+        )
+        .collect::<Vec<_>>();
+    external_inputs.sort();
+    external_inputs.dedup();
     let action = ExecutionAction::new(
-        inputs.into_iter().map(Into::into).collect(),
+        Vec::new(),
         outputs.into_iter().map(Into::into).collect(),
         command,
         description.clone(),
@@ -710,4 +717,38 @@ fn format_moon_pkg_json_migrate(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn formatter_sources_are_external_inputs() {
+        let source = PathBuf::from("src/main.mbt");
+        let executable = PathBuf::from("bin/moonfmt");
+        let mut builder = ExecutionPlanBuilder::default();
+        add_format_action(
+            &mut builder,
+            [&source],
+            ["_build/main.mbt"],
+            vec![
+                executable.display().to_string(),
+                source.display().to_string(),
+            ],
+            "format src/main.mbt".to_string(),
+            true,
+            false,
+        );
+
+        let plan = builder.finish([]);
+        let action = plan.action(plan.action_ids().next().expect("one formatter action"));
+        assert!(action.inputs().is_empty());
+        assert_eq!(
+            action.external_inputs(),
+            &[ExternalInput::File(executable), ExternalInput::File(source),]
+        );
+    }
 }

--- a/crates/moonbuild-rupes-recta/src/fmt.rs
+++ b/crates/moonbuild-rupes-recta/src/fmt.rs
@@ -19,7 +19,7 @@
 //! The formatter's pipeline
 //!
 //! The formatter only needs a bare minimum project to run, so its pipeline
-//! bypasses thew regular compilation pipeline of resolving and discovering
+//! bypasses the regular compilation pipeline of resolving and discovering
 //! modules and packages.
 //!
 //! This pipeline still strives to use as much of the existing infrastructure
@@ -42,11 +42,12 @@ use moonutil::{
     manifest::validate_module_dsl_deps,
     user_log::UserLog,
 };
-use n2::graph::Build;
 
 use crate::{
-    build_lower::{build_ins, build_n2_fileloc, build_outs},
     discover::{DiscoveredLocalProject, DiscoveredPackage, discover_local_project},
+    execution_plan::{
+        ExecutionAction, ExecutionPlan, ExecutionPlanBuilder, ExternalInput, LoweredCommand,
+    },
     model::PackageId,
     pkg_name::{PackageFQN, PackagePath},
     resolve::ResolveError,
@@ -88,20 +89,20 @@ pub struct FmtConfig {
     pub migrate_moon_pkg_json: bool,
 }
 
-/// Generate the necessary build graph for the formatter operation.
+/// Generate the executor-neutral actions for the formatter operation.
 ///
 /// If `selected_packages` is non-empty, only the specified packages will be formatted.
 /// Otherwise, all packages in the current module or workspace will be formatted.
-pub fn build_graph_for_fmt(
+pub fn build_execution_plan_for_fmt(
     resolved: &FmtResolveOutput,
     cfg: &FmtConfig,
     target_dir: &Path,
     selected_packages: &[PackageId],
     project_manifest: &ProjectManifest,
     user_log: &UserLog,
-) -> anyhow::Result<n2::graph::Graph> {
+) -> anyhow::Result<ExecutionPlan> {
     info!(
-        "Building format graph for {} root modules",
+        "Building format execution plan for {} root modules",
         resolved.root_module_ids.len()
     );
 
@@ -110,12 +111,12 @@ pub fn build_graph_for_fmt(
 
     debug!("Layout built for formatting");
 
-    let mut graph = n2::graph::Graph::default();
+    let mut execution = ExecutionPlanBuilder::default();
     let mut package_count = 0;
     let selected_packages = (!selected_packages.is_empty())
         .then(|| selected_packages.iter().copied().collect::<HashSet<_>>());
     let has_workspace_manifest = selected_packages.is_none()
-        && format_workspace_node(&mut graph, cfg, &layout, project_manifest)?;
+        && format_workspace_node(&mut execution, cfg, &layout, project_manifest)?;
     let mut has_module_manifest = false;
 
     // If no path filter is provided, find and format `moon.mod`/`moon.mod.json`.
@@ -125,7 +126,7 @@ pub fn build_graph_for_fmt(
             match module.source().source() {
                 ModuleSourceKind::Local(path) | ModuleSourceKind::Stdlib(path) => {
                     has_module_manifest |=
-                        format_moon_mod_node(&mut graph, cfg, &layout, module, path, user_log)?
+                        format_moon_mod_node(&mut execution, cfg, &layout, module, path, user_log)?
                 }
                 ModuleSourceKind::Registry
                 | ModuleSourceKind::Git(_)
@@ -148,7 +149,7 @@ pub fn build_graph_for_fmt(
 
             let pkg = resolved.pkg_dirs.get_package(id);
             info!("Processing package {}", pkg.fqn);
-            build_for_package(&mut graph, cfg, &layout, pkg, user_log)?;
+            build_for_package(&mut execution, cfg, &layout, pkg, user_log)?;
             package_count += 1;
         }
     }
@@ -157,11 +158,43 @@ pub fn build_graph_for_fmt(
         anyhow::bail!("No packages found in workspace to format");
     }
 
-    Ok(graph)
+    Ok(execution.finish([]))
+}
+
+fn add_format_action<I, O>(
+    execution: &mut ExecutionPlanBuilder,
+    inputs: I,
+    outputs: O,
+    args: Vec<String>,
+    description: String,
+    cache_eligible: bool,
+    can_dirty_on_output: bool,
+) where
+    I: IntoIterator,
+    I::Item: Into<std::path::PathBuf>,
+    O: IntoIterator,
+    O::Item: Into<std::path::PathBuf>,
+{
+    let command = LoweredCommand::from(args);
+    let external_inputs = command
+        .executable()
+        .map(|path| vec![ExternalInput::File(path.to_path_buf())])
+        .unwrap_or_default();
+    let action = ExecutionAction::new(
+        inputs.into_iter().map(Into::into).collect(),
+        outputs.into_iter().map(Into::into).collect(),
+        command,
+        description.clone(),
+        description,
+    )
+    .with_external_inputs(external_inputs)
+    .with_cache_eligible(cache_eligible)
+    .with_can_dirty_on_output(can_dirty_on_output);
+    execution.add_action(action, []);
 }
 
 fn format_moon_mod_node(
-    graph: &mut n2::graph::Graph,
+    execution: &mut ExecutionPlanBuilder,
     cfg: &FmtConfig,
     layout: &TargetLayout,
     module: &ResolvedModule,
@@ -183,7 +216,7 @@ fn format_moon_mod_node(
     );
 
     if has_dsl {
-        format_moon_mod_dsl(graph, cfg, &moon_mod, &target_moon_mod, module_dir)?;
+        format_moon_mod_dsl(execution, cfg, &moon_mod, &target_moon_mod, module_dir)?;
     } else if cfg.migrate_moon_mod_json {
         user_log.warn(format!(
             "Migrating to {} at module root '{}', deprecated {} is removed.",
@@ -192,7 +225,7 @@ fn format_moon_mod_node(
             MOON_MOD_JSON
         ));
         format_moon_mod_json_migrate(
-            graph,
+            execution,
             cfg,
             &moon_mod_json,
             &target_moon_mod,
@@ -206,7 +239,7 @@ fn format_moon_mod_node(
 }
 
 fn format_moon_mod_dsl(
-    graph: &mut n2::graph::Graph,
+    execution: &mut ExecutionPlanBuilder,
     cfg: &FmtConfig,
     moon_mod: &Path,
     target_moon_mod: &Path,
@@ -226,20 +259,17 @@ fn format_moon_mod_dsl(
             cmd.push("--warn".into());
         }
 
-        let ins = build_ins(graph, [moon_mod]);
-        let outs = build_outs(graph, [target_moon_mod]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!("check moon.mod format {}", module_dir.display())),
-            ins,
-            outs,
+        add_format_action(
+            execution,
+            [moon_mod],
+            [target_moon_mod],
+            cmd,
+            format!("check moon.mod format {}", module_dir.display()),
+            true,
+            cfg.warn_only,
         );
-        build.cmdline = Some(moonutil::shlex::join_native(cmd.iter().map(|x| x.as_str())));
-        if cfg.warn_only {
-            build.can_dirty_on_output = true;
-        }
-        graph.add_build(build)?;
     } else {
-        let fmt_cmd = [
+        let fmt_cmd = vec![
             BINARIES.moonfmt.to_string_lossy().into_owned(),
             moon_mod.to_string_lossy().into_owned(),
             "-w".into(),
@@ -247,24 +277,22 @@ fn format_moon_mod_dsl(
             target_moon_mod.to_string_lossy().into_owned(),
         ];
 
-        let ins = build_ins(graph, [moon_mod]);
-        let outs = build_outs(graph, [target_moon_mod]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!("format moon.mod {}", module_dir.display())),
-            ins,
-            outs,
+        add_format_action(
+            execution,
+            [moon_mod],
+            [target_moon_mod],
+            fmt_cmd,
+            format!("format moon.mod {}", module_dir.display()),
+            false,
+            false,
         );
-        build.cmdline = Some(moonutil::shlex::join_native(
-            fmt_cmd.iter().map(|x| x.as_str()),
-        ));
-        graph.add_build(build)?;
     }
 
     Ok(())
 }
 
 fn format_moon_mod_json_migrate(
-    graph: &mut n2::graph::Graph,
+    execution: &mut ExecutionPlanBuilder,
     cfg: &FmtConfig,
     moon_mod_json: &Path,
     target_moon_mod: &Path,
@@ -289,99 +317,41 @@ fn format_moon_mod_json_migrate(
             cmd.push("--warn".into());
         }
 
-        let ins = build_ins(graph, [moon_mod_json]);
-        let outs = build_outs(graph, [target_moon_mod]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!(
-                "check moon.mod.json migration {}",
-                module_dir.display()
-            )),
-            ins,
-            outs,
+        add_format_action(
+            execution,
+            [moon_mod_json],
+            [target_moon_mod],
+            cmd,
+            format!("check moon.mod.json migration {}", module_dir.display()),
+            true,
+            cfg.warn_only,
         );
-        build.cmdline = Some(moonutil::shlex::join_native(cmd.iter().map(|x| x.as_str())));
-        if cfg.warn_only {
-            build.can_dirty_on_output = true;
-        }
-        graph.add_build(build)?;
     } else {
-        let fmt_cmd = [
-            BINARIES.moonfmt.to_string_lossy().into_owned(),
+        let migrate_cmd = vec![
+            BINARIES.moonbuild.to_string_lossy().into_owned(),
+            "tool".into(),
+            "migrate-manifest".into(),
+            "--old".into(),
             moon_mod_json.to_string_lossy().into_owned(),
-            "-o".into(),
-            target_moon_mod.to_string_lossy().into_owned(),
+            "--dest".into(),
+            moon_mod.to_string_lossy().into_owned(),
         ];
-
-        let ins = build_ins(graph, [moon_mod_json]);
-        let outs = build_outs(graph, [target_moon_mod]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!("format moon.mod.json {}", module_dir.display())),
-            ins,
-            outs,
+        add_format_action(
+            execution,
+            [moon_mod_json],
+            [moon_mod],
+            migrate_cmd,
+            format!("migrate moon.mod.json {}", module_dir.display()),
+            false,
+            false,
         );
-        build.cmdline = Some(moonutil::shlex::join_native(
-            fmt_cmd.iter().map(|x| x.as_str()),
-        ));
-        graph.add_build(build)?;
-
-        let cp_cmd: Vec<String> = if cfg!(windows) {
-            vec![
-                "cmd".into(),
-                "/c".into(),
-                "copy".into(),
-                target_moon_mod.to_string_lossy().into_owned(),
-                moon_mod.to_string_lossy().into_owned(),
-            ]
-        } else {
-            vec![
-                "cp".into(),
-                target_moon_mod.to_string_lossy().into_owned(),
-                moon_mod.to_string_lossy().into_owned(),
-            ]
-        };
-
-        let ins = build_ins(graph, [target_moon_mod]);
-        let outs = build_outs(graph, [moon_mod]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!("copy moon.mod {}", module_dir.display())),
-            ins,
-            outs,
-        );
-        build.cmdline = Some(moonutil::shlex::join_native(
-            cp_cmd.iter().map(|x| x.as_str()),
-        ));
-        graph.add_build(build)?;
-
-        let rm_cmd: Vec<String> = if cfg!(windows) {
-            vec![
-                "cmd".into(),
-                "/c".into(),
-                "del".into(),
-                moon_mod_json.to_string_lossy().into_owned(),
-            ]
-        } else {
-            vec!["rm".into(), moon_mod_json.to_string_lossy().into_owned()]
-        };
-
-        let ins = build_ins(graph, [moon_mod]);
-        let faked_rm_output = format!("{}.removed", moon_mod_json.to_string_lossy());
-        let outs = build_outs(graph, [&faked_rm_output]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!("remove moon.mod.json {}", module_dir.display())),
-            ins,
-            outs,
-        );
-        build.cmdline = Some(moonutil::shlex::join_native(
-            rm_cmd.iter().map(|x| x.as_str()),
-        ));
-        graph.add_build(build)?;
     }
 
     Ok(())
 }
 
 fn format_workspace_node(
-    graph: &mut n2::graph::Graph,
+    execution: &mut ExecutionPlanBuilder,
     cfg: &FmtConfig,
     layout: &TargetLayout,
     project_manifest: &ProjectManifest,
@@ -391,12 +361,12 @@ fn format_workspace_node(
     };
 
     let target_moon_work = layout.format_root_artifact_path(std::ffi::OsStr::new(MOON_WORK));
-    format_moon_work_dsl(graph, cfg, workspace.manifest_path(), &target_moon_work)?;
+    format_moon_work_dsl(execution, cfg, workspace.manifest_path(), &target_moon_work)?;
     Ok(true)
 }
 
 fn build_for_package(
-    graph: &mut n2::graph::Graph,
+    execution: &mut ExecutionPlanBuilder,
     cfg: &FmtConfig,
     layout: &TargetLayout,
     pkg: &DiscoveredPackage,
@@ -432,7 +402,7 @@ fn build_for_package(
             return Ok(());
         }
 
-        format_node(graph, cfg, layout, pkg, file)?;
+        format_node(execution, cfg, layout, pkg, file)?;
         Ok(())
     };
 
@@ -444,13 +414,13 @@ fn build_for_package(
     }
 
     // Always format moon.pkg when present; migration from moon.pkg.json is gated.
-    format_moon_pkg_node(graph, cfg, layout, pkg, user_log)?;
+    format_moon_pkg_node(execution, cfg, layout, pkg, user_log)?;
 
     Ok(())
 }
 
 fn format_node(
-    graph: &mut n2::graph::Graph,
+    execution: &mut ExecutionPlanBuilder,
     cfg: &FmtConfig,
     layout: &TargetLayout,
     pkg: &DiscoveredPackage,
@@ -487,26 +457,20 @@ fn format_node(
         cmd
     };
 
-    let ins = build_ins(graph, [file]);
-    let outs = build_outs(graph, [&out_file]);
-    let mut build = Build::new(
-        build_n2_fileloc(format!("format {}", file.display())),
-        ins,
-        outs,
+    add_format_action(
+        execution,
+        [file],
+        [out_file],
+        cmd,
+        format!("format {}", file.display()),
+        cfg.check_only || cfg.warn_only,
+        cfg.warn_only,
     );
-    build.cmdline = Some(moonutil::shlex::join_native(cmd.iter().map(|x| x.as_str())));
-
-    // When `warn_only` is enabled, the artifact is marked as dirty
-    // if there are differences, so the command will rerun on the next run.
-    if cfg.warn_only {
-        build.can_dirty_on_output = true;
-    }
-    graph.add_build(build)?;
     Ok(())
 }
 
 fn format_moon_work_dsl(
-    graph: &mut n2::graph::Graph,
+    execution: &mut ExecutionPlanBuilder,
     cfg: &FmtConfig,
     moon_work: &std::path::Path,
     target_moon_work: &std::path::Path,
@@ -527,14 +491,15 @@ fn format_moon_work_dsl(
             cmd.push("--warn".into());
         }
 
-        let ins = build_ins(graph, [moon_work]);
-        let outs = build_outs(graph, [target_moon_work]);
-        let mut build = Build::new(build_n2_fileloc("check moon.work format"), ins, outs);
-        build.cmdline = Some(moonutil::shlex::join_native(cmd.iter().map(|x| x.as_str())));
-        if cfg.warn_only {
-            build.can_dirty_on_output = true;
-        }
-        graph.add_build(build)?;
+        add_format_action(
+            execution,
+            [moon_work],
+            [target_moon_work],
+            cmd,
+            "check moon.work format".to_string(),
+            true,
+            cfg.warn_only,
+        );
     } else {
         let fmt_cmd: Vec<String> = vec![
             BINARIES.moonbuild.to_string_lossy().into_owned(),
@@ -547,13 +512,15 @@ fn format_moon_work_dsl(
             target_moon_work.to_string_lossy().into_owned(),
         ];
 
-        let ins = build_ins(graph, [moon_work]);
-        let outs = build_outs(graph, [target_moon_work.to_string_lossy().into_owned()]);
-        let mut build = Build::new(build_n2_fileloc("format moon.work"), ins, outs);
-        build.cmdline = Some(moonutil::shlex::join_native(
-            fmt_cmd.iter().map(|x| x.as_str()),
-        ));
-        graph.add_build(build)?;
+        add_format_action(
+            execution,
+            [moon_work],
+            [target_moon_work],
+            fmt_cmd,
+            "format moon.work".to_string(),
+            false,
+            false,
+        );
     }
 
     Ok(())
@@ -566,7 +533,7 @@ fn format_moon_work_dsl(
 /// 2. Only `moon.pkg.json` exists: migrate to `moon.pkg` format if enabled
 /// 3. Only `moon.pkg` exists: format it in place
 fn format_moon_pkg_node(
-    graph: &mut n2::graph::Graph,
+    execution: &mut ExecutionPlanBuilder,
     cfg: &FmtConfig,
     layout: &TargetLayout,
     pkg: &DiscoveredPackage,
@@ -593,11 +560,11 @@ fn format_moon_pkg_node(
 
     if has_dsl {
         // Format moon.pkg (new format)
-        format_moon_pkg_dsl(graph, cfg, &moon_pkg_dsl, &target_moon_pkg, pkg)
+        format_moon_pkg_dsl(execution, cfg, &moon_pkg_dsl, &target_moon_pkg, pkg)
     } else if cfg.migrate_moon_pkg_json {
         // Only moon.pkg.json exists: migrate to moon.pkg
         format_moon_pkg_json_migrate(
-            graph,
+            execution,
             cfg,
             &moon_pkg_json,
             &target_moon_pkg,
@@ -619,7 +586,7 @@ fn format_moon_pkg_node(
 /// - moon_pkg: Path to the source moon.pkg file
 /// - target_moon_pkg: Path to the output formatted moon.pkg file
 fn format_moon_pkg_dsl(
-    graph: &mut n2::graph::Graph,
+    execution: &mut ExecutionPlanBuilder,
     cfg: &FmtConfig,
     moon_pkg: &std::path::Path,
     target_moon_pkg: &std::path::Path,
@@ -640,18 +607,15 @@ fn format_moon_pkg_dsl(
             cmd.push("--warn".into());
         }
 
-        let ins = build_ins(graph, [moon_pkg]);
-        let outs = build_outs(graph, [target_moon_pkg]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!("check moon.pkg format {}", pkg.fqn)),
-            ins,
-            outs,
+        add_format_action(
+            execution,
+            [moon_pkg],
+            [target_moon_pkg],
+            cmd,
+            format!("check moon.pkg format {}", pkg.fqn),
+            true,
+            cfg.warn_only,
         );
-        build.cmdline = Some(moonutil::shlex::join_native(cmd.iter().map(|x| x.as_str())));
-        if cfg.warn_only {
-            build.can_dirty_on_output = true;
-        }
-        graph.add_build(build)?;
     } else {
         // Format moon.pkg - use -w to write back to source and -o to target
         // This is consistent with how .mbt files are formatted
@@ -663,17 +627,15 @@ fn format_moon_pkg_dsl(
             target_moon_pkg.to_string_lossy().into_owned(),
         ];
 
-        let ins = build_ins(graph, [moon_pkg]);
-        let outs = build_outs(graph, [target_moon_pkg]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!("format moon.pkg {}", pkg.fqn)),
-            ins,
-            outs,
+        add_format_action(
+            execution,
+            [moon_pkg],
+            [target_moon_pkg],
+            fmt_cmd,
+            format!("format moon.pkg {}", pkg.fqn),
+            false,
+            false,
         );
-        build.cmdline = Some(moonutil::shlex::join_native(
-            fmt_cmd.iter().map(|x| x.as_str()),
-        ));
-        graph.add_build(build)?;
     }
 
     Ok(())
@@ -688,7 +650,7 @@ fn format_moon_pkg_dsl(
 /// - target_moon_pkg: Path to the output formatted moon.pkg file in the target directory
 /// - moon_pkg: Path to the destination moon.pkg file in the source directory
 fn format_moon_pkg_json_migrate(
-    graph: &mut n2::graph::Graph,
+    execution: &mut ExecutionPlanBuilder,
     cfg: &FmtConfig,
     moon_pkg_json: &std::path::Path,
     target_moon_pkg: &std::path::Path,
@@ -717,94 +679,34 @@ fn format_moon_pkg_json_migrate(
             cmd.push("--warn".into());
         }
 
-        let ins = build_ins(graph, [moon_pkg_json]);
-        let outs = build_outs(graph, [target_moon_pkg]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!("check moon.pkg.json migration {}", pkg.fqn)),
-            ins,
-            outs,
+        add_format_action(
+            execution,
+            [moon_pkg_json],
+            [target_moon_pkg],
+            cmd,
+            format!("check moon.pkg.json migration {}", pkg.fqn),
+            true,
+            cfg.warn_only,
         );
-        build.cmdline = Some(moonutil::shlex::join_native(cmd.iter().map(|x| x.as_str())));
-        if cfg.warn_only {
-            build.can_dirty_on_output = true;
-        }
-        graph.add_build(build)?;
     } else {
-        // Step 1: Format moon.pkg.json to target directory
-        let fmt_cmd: Vec<String> = vec![
-            BINARIES.moonfmt.to_string_lossy().into_owned(),
+        let migrate_cmd = vec![
+            BINARIES.moonbuild.to_string_lossy().into_owned(),
+            "tool".into(),
+            "migrate-manifest".into(),
+            "--old".into(),
             moon_pkg_json.to_string_lossy().into_owned(),
-            "-o".into(),
-            target_moon_pkg.to_string_lossy().into_owned(),
+            "--dest".into(),
+            moon_pkg.to_string_lossy().into_owned(),
         ];
-
-        let ins = build_ins(graph, [moon_pkg_json]);
-        let outs = build_outs(graph, [target_moon_pkg.to_string_lossy().into_owned()]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!("format moon.pkg.json {}", pkg.fqn)),
-            ins,
-            outs,
+        add_format_action(
+            execution,
+            [moon_pkg_json],
+            [moon_pkg],
+            migrate_cmd,
+            format!("migrate moon.pkg.json {}", pkg.fqn),
+            false,
+            false,
         );
-        build.cmdline = Some(moonutil::shlex::join_native(
-            fmt_cmd.iter().map(|x| x.as_str()),
-        ));
-        graph.add_build(build)?;
-
-        // Step 2: Copy from target to source directory
-        let cp_cmd: Vec<String> = if cfg!(windows) {
-            vec![
-                "cmd".into(),
-                "/c".into(),
-                "copy".into(),
-                target_moon_pkg.to_string_lossy().into_owned(),
-                moon_pkg.to_string_lossy().into_owned(),
-            ]
-        } else {
-            vec![
-                "cp".into(),
-                target_moon_pkg.to_string_lossy().into_owned(),
-                moon_pkg.to_string_lossy().into_owned(),
-            ]
-        };
-
-        let ins = build_ins(graph, [target_moon_pkg]);
-        let outs = build_outs(graph, [moon_pkg.to_string_lossy().into_owned()]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!("copy moon.pkg {}", pkg.fqn)),
-            ins,
-            outs,
-        );
-        build.cmdline = Some(moonutil::shlex::join_native(
-            cp_cmd.iter().map(|x| x.as_str()),
-        ));
-        graph.add_build(build)?;
-
-        // Step 3: Remove the original JSON file
-        let rm_cmd: Vec<String> = if cfg!(windows) {
-            vec![
-                "cmd".into(),
-                "/c".into(),
-                "del".into(),
-                moon_pkg_json.to_string_lossy().into_owned(),
-            ]
-        } else {
-            vec!["rm".into(), moon_pkg_json.to_string_lossy().into_owned()]
-        };
-
-        let ins = build_ins(graph, [moon_pkg]);
-        // The `rm` command does not actually produce an output file, so we fake one to ensure this build task will run in n2.
-        // If moon.pkg.json is removed successfully, this branch will not be executed again next time.
-        let faked_rm_output = format!("{}.removed", moon_pkg_json.to_string_lossy());
-        let outs = build_outs(graph, [&faked_rm_output]);
-        let mut build = Build::new(
-            build_n2_fileloc(format!("remove moon.pkg.json {}", pkg.fqn)),
-            ins,
-            outs,
-        );
-        build.cmdline = Some(moonutil::shlex::join_native(
-            rm_cmd.iter().map(|x| x.as_str()),
-        ));
-        graph.add_build(build)?;
     }
 
     Ok(())

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -518,6 +518,16 @@ declaration).
 
 The concrete rules of lowering is performed in [its module](/crates/moonbuild-rupes-recta/src/build_lower/mod.rs).
 
+Lightweight commands that do not select logical Build Artifacts do not need a
+synthetic Build Plan. `moon fmt` performs its lightweight project discovery and
+constructs complete execution actions directly. Formatter execution and
+dry-run then use the same Execution Plan adapters as project builds.
+
+Legacy manifest migration is one formatter execution action. Its internal
+formatting and legacy-file removal are encapsulated by the internal
+`migrate-manifest` tool command rather than represented as separate execution
+actions or a fake removal output.
+
 The layout of the target directory (the paths of all artifacts)
 is defined in [its module](/crates/moonbuild-rupes-recta/src/target_layout.rs).
 

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -209,12 +209,15 @@ semantic planning and execution lowering.
 
 `ExecutionPlan` assigns an `ActionId` to each concrete `ExecutionAction`.
 Declared outputs are instead keyed by their concrete paths, which are already
-required to be unique within the plan. Each execution action names the paths it
-consumes, and every declared output retains its producer `ActionId` and optional
-`ArtifactKey`. Adapters and identity consumers can therefore follow the
-relationship without another dependency object, output arena, or plan-wide
-artifact registry. One action may provide several Build Artifacts, and a Build
-Artifact may realize to one or several physical outputs.
+required to be unique within the plan. An execution action's `inputs` are
+declared outputs produced by other actions in the same plan. Source files,
+manifests, tools, and other paths not produced by the plan are
+`ExternalInput` observations instead. Every declared output retains its
+producer `ActionId` and optional `ArtifactKey`, so adapters and identity
+consumers can follow the relationship without another dependency object,
+output arena, or plan-wide artifact registry. One action may provide several
+Build Artifacts, and a Build Artifact may realize to one or several physical
+outputs.
 
 The builder's artifact registry exists only while actions are inserted. It
 annotates declared outputs and resolves requested artifacts to output paths for

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -201,10 +201,11 @@ when it realizes the action's output.
 
 ## Execution Plan
 
-Lowering consumes `BuildPlan` directly. A borrowed `BuildAction` value may be
-hydrated on demand while constructing a command, but there is no stored
-`BuildActionPlan` and no second action topology between semantic planning and
-execution lowering.
+Lowering consumes `BuildPlan` directly and inserts complete `ExecutionAction`
+values into the Execution Plan. A borrowed `BuildAction` value may be hydrated
+on demand while constructing a command, but there is no stored
+`BuildActionPlan`, draft execution action, or second action topology between
+semantic planning and execution lowering.
 
 `ExecutionPlan` assigns an `ActionId` to each concrete `ExecutionAction`.
 Declared outputs are instead keyed by their concrete paths, which are already
@@ -215,10 +216,18 @@ relationship without another dependency object, output arena, or plan-wide
 artifact registry. One action may provide several Build Artifacts, and a Build
 Artifact may realize to one or several physical outputs.
 
-The builder's artifact registry exists only while the plan is finalized. It
-also resolves requested artifacts to output paths for command results. The final
-Execution Plan therefore does not impose one global `ArtifactKey` namespace on
-future composition of independently scoped Build Plans.
+The builder's artifact registry exists only while actions are inserted. It
+annotates declared outputs and resolves requested artifacts to output paths for
+command results. Artifact requirements have already been realized as concrete
+action inputs before insertion; finalization does not hold or repair partial
+actions. The final Execution Plan therefore does not impose one global
+`ArtifactKey` namespace on future composition of independently scoped Build
+Plans.
+
+`moon fmt` is a Lightweight Command with no logical Build Artifact selection,
+so it constructs complete Execution Actions directly after its lightweight
+project discovery. It does not synthesize a Build Plan, but shares the same
+Execution Plan, n2 adapter, dry-run, and execution path.
 
 Multi-backend invocations keep one independently scoped Build Plan and
 Execution Plan per backend through lowering. The command layer then composes


### PR DESCRIPTION
## Why

ExecutionActionDraft and PendingAction formed a transient third representation between BuildPlan lowering and ExecutionPlan. At the same time, moon fmt still built n2 graphs directly, which required formatter-specific input, execution, and dry-run paths. Legacy manifest migration also exposed format, copy, and delete as separate platform-dependent graph actions with a fake removal output.

## What changed

- Construct complete ExecutionAction values before inserting them into ExecutionPlan, removing the draft and pending action types.
- Let moon fmt construct a complete ExecutionPlan directly after lightweight discovery, then use the ordinary BuildInput, n2 adapter, executor, and dry-run path.
- Encapsulate legacy manifest replacement as one internal migrate-manifest action instead of leaking copy, delete, and fake-output details into the plan.
- Update the architecture references and formatter dry-run expectations for the unified path.

## Why this is correct and minimal

Project builds still use the existing BuildPlan to ExecutionPlan lowering boundary; this only removes an intermediate construction state. Formatting does not select logical Build Artifacts, so it does not synthesize a BuildPlan. Its discovery and command selection remain unchanged. Manifest migration formats into a temporary directory beside the destination, installs the new manifest only after moonfmt succeeds, and rolls the destination back if removing the legacy file fails.

The change is limited to the ExecutionPlan construction API and formatter orchestration. Other lightweight commands remain out of scope.