### PR TITLE
refactor(registry): consolidate registry access

### DIFF
--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -17,14 +17,16 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use anyhow::bail;
-use mooncake::pkg::{
-    add::AddSubcommand, install::InstallSubcommand, remove::RemoveSubcommand,
-    sync::SyncOutputOptions, tree::TreeSubcommand,
+use mooncake::{
+    pkg::{
+        add::AddSubcommand, install::InstallSubcommand, remove::RemoveSubcommand,
+        sync::SyncOutputOptions, tree::TreeSubcommand,
+    },
+    registry::RegistryClient,
 };
 use moonutil::{
     cli_support::AutoSyncFlags,
     project::{PackageDirs, ProjectContext},
-    registry::RegistryConfig,
     resolution::ModuleName,
     toolchain,
     user_log::UserLog,
@@ -215,15 +217,13 @@ pub(crate) fn add_cli(
     // - `--no-update` keeps the previous behavior.
     // - If an index already exists, update failures are treated as warnings so users can proceed
     //   with the existing local index.
-    let index_dir = moonutil::registry::index();
+    let registry = RegistryClient::configured();
     let mut index_updated = false;
     if !cmd.no_update && (!cmd.upgrade || !cmd.package_path.contains('@')) {
-        let had_index = index_dir.exists();
-        let registry_config = RegistryConfig::load();
-        match mooncake::update::update(&index_dir, &registry_config, user_log) {
-            Ok(outcome) => {
+        let had_index = registry.has_cached_index();
+        match registry.sync(user_log) {
+            Ok(()) => {
                 index_updated = true;
-                super::log_registry_update(outcome, user_log);
             }
             Err(e) => {
                 if had_index {
@@ -270,6 +270,7 @@ pub(crate) fn add_cli(
         )
     } else {
         mooncake::pkg::add::add_latest(
+            &registry,
             &module_dir,
             &dirs,
             &pkg_name,

--- a/crates/moon/src/cli/fetch.rs
+++ b/crates/moon/src/cli/fetch.rs
@@ -18,11 +18,13 @@
 
 use anyhow::bail;
 use colored::Colorize;
-use mooncake::{pkg::legacy_postadd, registry::Registry};
+use mooncake::{
+    pkg::legacy_postadd,
+    registry::{Registry, RegistryClient},
+};
 use moonutil::{
     child_process::{ChildOutputMode, ManagedChildRunner},
     project::PackageDirs,
-    registry::RegistryConfig,
     resolution::ModuleName,
     user_log::UserLog,
 };
@@ -49,16 +51,14 @@ pub(crate) fn fetch_cli(
     cmd: FetchSubcommand,
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
-    let index_dir = moonutil::registry::index();
+    let registry = RegistryClient::configured();
     let mut index_updated = false;
 
     if !cmd.no_update {
-        let had_index = index_dir.exists();
-        let registry_config = RegistryConfig::load();
-        match mooncake::update::update(&index_dir, &registry_config, user_log) {
-            Ok(outcome) => {
+        let had_index = registry.has_cached_index();
+        match registry.sync(user_log) {
+            Ok(()) => {
                 index_updated = true;
-                super::log_registry_update(outcome, user_log);
             }
             Err(e) => {
                 if had_index {
@@ -85,8 +85,6 @@ pub(crate) fn fetch_cli(
         username: username.into(),
         unqual: pkgname.into(),
     };
-
-    let registry = mooncake::registry::OnlineRegistry::mooncakes_io();
 
     let version = if parts.len() == 2 {
         let version_str = parts[1];

--- a/crates/moon/src/cli/install_binary.rs
+++ b/crates/moon/src/cli/install_binary.rs
@@ -26,7 +26,7 @@ use moonbuild_rupes_recta::{
 };
 use mooncake::{
     pkg::{legacy_postadd, sync::SyncOutputOptions},
-    registry::{OnlineRegistry, Registry, path as registry_path},
+    registry::{Registry, RegistryClient, path as registry_path},
 };
 use moonutil::{
     build_options::RunMode,
@@ -35,7 +35,6 @@ use moonutil::{
     constants::{MOON_MOD, MOON_MOD_JSON},
     locks::FileLock,
     project::{PackageDirs, SourceTargetDirs, WorkspaceEnv},
-    registry::RegistryConfig,
     resolution::{ModuleName, ModuleSourceKind},
     target::TargetBackend,
     user_log::UserLog,
@@ -242,14 +241,11 @@ pub(super) fn install_binary(
     install_all: bool,
     user_log: &UserLog,
 ) -> anyhow::Result<i32> {
-    let index_dir = moonutil::registry::index();
-    let registry_config = RegistryConfig::load();
-    let had_index = index_dir.exists();
+    let registry = RegistryClient::configured();
+    let had_index = registry.has_cached_index();
 
-    match mooncake::update::update(&index_dir, &registry_config, user_log) {
-        Ok(outcome) => {
-            crate::cli::log_registry_update(outcome, user_log);
-        }
+    match registry.sync(user_log) {
+        Ok(()) => {}
         Err(e) => {
             if had_index {
                 user_log.warn(format!(
@@ -262,7 +258,6 @@ pub(super) fn install_binary(
         }
     }
 
-    let registry = OnlineRegistry::mooncakes_io();
     let version = if let Some(v) = &spec.version {
         v.clone()
     } else {
@@ -698,29 +693,21 @@ pub(super) fn build_registry_native_executable_to(
     verbose: bool,
     user_log: &UserLog,
 ) -> anyhow::Result<()> {
+    let registry = RegistryClient::configured();
     ensure_registry_version_available(
         module_name,
         version,
-        user_log,
         || {
-            OnlineRegistry::mooncakes_io()
+            registry
                 .all_versions_of(module_name)
                 .is_ok_and(|versions| versions.contains_key(version))
         },
-        || {
-            mooncake::update::update(
-                &moonutil::registry::index(),
-                &RegistryConfig::load(),
-                user_log,
-            )
-            .map(|_| ())
-        },
+        || registry.sync(user_log),
     )?;
 
     let source = tempfile::TempDir::new().context("Failed to create temporary directory")?;
     // Moonx needs the sources for its temporary build, but must not run package
     // installation hooks or let acquisition progress precede program stdout.
-    let registry = OnlineRegistry::mooncakes_io();
     let checksum = registry.source_archive_checksum(module_name, version)?;
     registry.acquire_source_to(module_name, version, &checksum, source.path(), user_log)?;
 
@@ -754,7 +741,6 @@ pub(super) fn build_registry_native_executable_to(
 fn ensure_registry_version_available(
     module_name: &ModuleName,
     version: &Version,
-    user_log: &UserLog,
     mut version_is_available: impl FnMut() -> bool,
     mut update_registry: impl FnMut() -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
@@ -763,7 +749,6 @@ fn ensure_registry_version_available(
     }
 
     update_registry().context("Failed to update registry index")?;
-    user_log.info("Updated registry index");
     if !version_is_available() {
         bail!("Module `{module_name}` version `{version}` not found in registry");
     }
@@ -944,7 +929,6 @@ mod tests {
         ensure_registry_version_available(
             &"testuser/runner".parse().unwrap(),
             &"1.2.3".parse().unwrap(),
-            &UserLog::new(log::LevelFilter::Warn),
             || true,
             || {
                 updated.set(true);
@@ -962,7 +946,6 @@ mod tests {
         ensure_registry_version_available(
             &"testuser/runner".parse().unwrap(),
             &"1.2.3".parse().unwrap(),
-            &UserLog::new(log::LevelFilter::Warn),
             || updated.get(),
             || {
                 updated.set(true);

--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -19,10 +19,8 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
-use mooncake::registry::{OnlineRegistry, Registry, path as registry_path};
-use moonutil::{
-    locks::FileLock, registry::RegistryConfig, resolution::ModuleName, user_log::UserLog,
-};
+use mooncake::registry::{Registry, RegistryClient, path as registry_path};
+use moonutil::{locks::FileLock, resolution::ModuleName, user_log::UserLog};
 use semver::Version;
 
 use crate::rr_build;
@@ -125,22 +123,23 @@ fn resolve_latest_version(
     policy: LatestVersionResolutionPolicy,
     user_log: &UserLog,
 ) -> anyhow::Result<Version> {
-    let index_dir = moonutil::registry::index();
-    let registry_config = RegistryConfig::load();
-    let had_index = index_dir.exists();
+    let registry = RegistryClient::configured();
+    let had_index = registry.has_cached_index();
 
     resolve_latest_version_with(
         module_name,
         user_log,
         had_index,
         policy,
-        || latest_version_from_local_registry(module_name),
-        || mooncake::update::update(&index_dir, &registry_config, user_log).map(|_| ()),
+        || latest_version_from_registry(&registry, module_name),
+        || registry.sync(user_log),
     )
 }
 
-fn latest_version_from_local_registry(module_name: &ModuleName) -> LatestVersionLookup {
-    let registry = OnlineRegistry::mooncakes_io();
+fn latest_version_from_registry(
+    registry: &impl Registry,
+    module_name: &ModuleName,
+) -> LatestVersionLookup {
     let versions = match registry.all_versions_of(module_name) {
         Ok(versions) => versions,
         Err(_) => return LatestVersionLookup::NotFound,
@@ -169,7 +168,7 @@ fn resolve_latest_version_with(
     }
 
     match update_registry() {
-        Ok(_) => user_log.info("Updated registry index"),
+        Ok(()) => {}
         Err(e) if policy == LatestVersionResolutionPolicy::Refresh => {
             return Err(e).context("Failed to update registry index");
         }

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -18,14 +18,12 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, bail};
+use anyhow::bail;
+use mooncake::registry::RegistryClient;
 use moonutil::{
     cli_support::AutoSyncFlags, cli_support::UniversalFlags, command_output::CommandOutput,
-    constants::is_moon_pkg_exist, registry::RegistryConfig, target::SurfaceTarget,
-    user_log::UserLog,
+    constants::is_moon_pkg_exist, target::SurfaceTarget, user_log::UserLog,
 };
-use reqwest::StatusCode;
-use sha2::{Digest, Sha256};
 use tracing::instrument;
 
 use super::{BuildFlags, RunSubcommand, registry_runner::ResolvedExecutablePackage};
@@ -71,46 +69,6 @@ pub(crate) struct RunWasmSubcommand {
     pub args: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ResolvedRunWasmAsset {
-    url: String,
-    checksum_url: String,
-    cache_path: PathBuf,
-}
-
-struct RegistryAssetClient<'a> {
-    http: reqwest::blocking::Client,
-    user_log: &'a UserLog,
-}
-
-impl<'a> RegistryAssetClient<'a> {
-    fn new(user_log: &'a UserLog) -> anyhow::Result<Self> {
-        let http = reqwest::blocking::Client::builder()
-            .user_agent(format!("moon/{}", env!("CARGO_PKG_VERSION")))
-            .build()
-            .context("failed to create registry asset HTTP client")?;
-        Ok(Self { http, user_log })
-    }
-
-    fn download(&self, url: &str) -> anyhow::Result<Vec<u8>> {
-        self.user_log.info(format!("Downloading {url}"));
-        let response = self
-            .http
-            .get(url)
-            .send()
-            .with_context(|| format!("failed to download registry asset from {url}"))?;
-        if response.status() == StatusCode::NOT_FOUND {
-            bail!("Prebuilt wasm asset does not exist");
-        }
-        let data = response
-            .error_for_status()
-            .with_context(|| format!("registry asset download returned error status for {url}"))?
-            .bytes()
-            .with_context(|| format!("failed to read registry asset response from {url}"))?;
-        Ok(data.to_vec())
-    }
-}
-
 #[instrument(skip_all)]
 pub(crate) fn run_runwasm(
     cli: &UniversalFlags,
@@ -142,30 +100,12 @@ pub(super) fn cached_wasm_path(
     package: &ResolvedExecutablePackage,
     user_log: &UserLog,
 ) -> anyhow::Result<PathBuf> {
-    let registry_config = RegistryConfig::load();
-    let asset = resolve_wasm_asset(package, &registry_config.registry);
-    ensure_cached_wasm(&asset, user_log)
-}
-
-fn resolve_wasm_asset(package: &ResolvedExecutablePackage, registry: &str) -> ResolvedRunWasmAsset {
-    let artifact_name = package.artifact_name(".wasm");
-    let base = registry.trim_end_matches('/');
-    let module = package.module_name.to_string();
-    let url = if package.package_path.is_empty() {
-        format!("{base}/assets/{module}@{}/{artifact_name}", package.version)
-    } else {
-        format!(
-            "{base}/assets/{module}@{}/{}/{}",
-            package.version, package.package_path, artifact_name
-        )
-    };
-
-    let checksum_url = format!("{url}.sha256");
-    ResolvedRunWasmAsset {
-        url,
-        checksum_url,
-        cache_path: package.cache_path(".wasm"),
-    }
+    RegistryClient::configured().acquire_wasm_asset(
+        &package.module_name,
+        &package.version,
+        &package.package_path,
+        user_log,
+    )
 }
 
 fn should_run_as_local_package(input: &str) -> anyhow::Result<bool> {
@@ -198,63 +138,9 @@ fn runwasm_as_run_subcommand(cmd: RunWasmSubcommand) -> RunSubcommand {
     }
 }
 
-fn ensure_cached_wasm(asset: &ResolvedRunWasmAsset, user_log: &UserLog) -> anyhow::Result<PathBuf> {
-    let client = RegistryAssetClient::new(user_log)?;
-    ensure_cached_wasm_with(asset, user_log, |url| client.download(url))
-}
-
-fn ensure_cached_wasm_with(
-    asset: &ResolvedRunWasmAsset,
-    user_log: &UserLog,
-    mut download: impl FnMut(&str) -> anyhow::Result<Vec<u8>>,
-) -> anyhow::Result<PathBuf> {
-    super::registry_runner::ensure_cached_file(&asset.cache_path, user_log, |staged| {
-        let checksum_bytes = download(&asset.checksum_url)?;
-        let expected_checksum = parse_sha256_checksum(&checksum_bytes)
-            .with_context(|| format!("invalid SHA-256 checksum from {}", asset.checksum_url))?;
-        let bytes = download(&asset.url)?;
-        let actual_checksum = sha256_hex(&bytes);
-        if actual_checksum != expected_checksum {
-            bail!(
-                "prebuilt wasm checksum mismatch for {}: expected {}, got {}",
-                asset.url,
-                expected_checksum,
-                actual_checksum
-            );
-        }
-        std::fs::write(staged, bytes)
-            .with_context(|| format!("failed to write cache file {}", staged.display()))?;
-        Ok(())
-    })
-}
-
-fn parse_sha256_checksum(bytes: &[u8]) -> anyhow::Result<String> {
-    let text = std::str::from_utf8(bytes).context("SHA-256 checksum is not valid UTF-8")?;
-    let checksum = text
-        .split_whitespace()
-        .next()
-        .context("SHA-256 checksum is empty")?;
-    if checksum.len() != 64 || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        bail!("SHA-256 checksum must be a 64-character hex digest");
-    }
-    Ok(checksum.to_ascii_lowercase())
-}
-
-fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn resolved(package_path: &str) -> ResolvedExecutablePackage {
-        ResolvedExecutablePackage {
-            module_name: "moonbitlang/parser".parse().unwrap(),
-            package_path: package_path.to_string(),
-            version: "0.3.3".parse().unwrap(),
-        }
-    }
 
     #[test]
     fn local_package_paths_are_run_locally() {
@@ -284,112 +170,5 @@ mod tests {
         assert!(!should_run_as_local_package("missing.mbt").unwrap());
         assert!(!should_run_as_local_package("missing.mbtx").unwrap());
         assert!(!should_run_as_local_package("missing.wasm").unwrap());
-    }
-
-    #[test]
-    fn build_asset_url() {
-        let resolved = resolve_wasm_asset(&resolved("cmd/moonfmt"), "https://mooncakes.io/");
-        assert_eq!(
-            resolved.url,
-            "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm"
-        );
-        assert_eq!(
-            resolved.checksum_url,
-            "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm.sha256"
-        );
-    }
-
-    #[test]
-    fn build_root_asset_url() {
-        let resolved = resolve_wasm_asset(&resolved(""), "https://mooncakes.io");
-        assert_eq!(
-            resolved.url,
-            "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/parser.wasm"
-        );
-    }
-
-    #[test]
-    fn parse_sha256sum_output() {
-        let checksum = "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789";
-        assert_eq!(
-            parse_sha256_checksum(format!("{checksum}  moonfmt.wasm\n").as_bytes()).unwrap(),
-            checksum.to_ascii_lowercase()
-        );
-        assert!(parse_sha256_checksum(b"not-a-checksum").is_err());
-        assert!(parse_sha256_checksum(b"").is_err());
-    }
-
-    #[test]
-    fn cache_miss_downloads_checksum_and_writes_file() {
-        let cache_dir = tempfile::TempDir::new().unwrap();
-        let mut asset = resolve_wasm_asset(&resolved("cmd/moonfmt"), "https://mooncakes.io");
-        asset.cache_path = cache_dir.path().join("moonfmt.wasm");
-        let wasm = b"\0asmtest".to_vec();
-        let checksum = sha256_hex(&wasm);
-        let mut urls = Vec::new();
-        let user_log = UserLog::new(log::LevelFilter::Warn);
-        let path = ensure_cached_wasm_with(&asset, &user_log, |url| {
-            urls.push(url.to_string());
-            if url.ends_with(".sha256") {
-                Ok(format!("{checksum}  moonfmt.wasm\n").into_bytes())
-            } else {
-                Ok(wasm.clone())
-            }
-        })
-        .unwrap();
-        assert_eq!(std::fs::read(path).unwrap(), b"\0asmtest");
-        assert!(!cache_dir.path().join("moonfmt.wasm.sha256").exists());
-        assert_eq!(
-            urls,
-            [
-                "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm.sha256",
-                "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm",
-            ]
-        );
-    }
-
-    #[test]
-    fn cache_hit_uses_existing_wasm_without_downloading() {
-        let cache_dir = tempfile::TempDir::new().unwrap();
-        let mut asset = resolve_wasm_asset(&resolved("cmd/moonfmt"), "https://mooncakes.io");
-        asset.cache_path = cache_dir.path().join("moonfmt.wasm");
-        let wasm = b"\0asmtest";
-        std::fs::write(&asset.cache_path, wasm).unwrap();
-
-        let user_log = UserLog::new(log::LevelFilter::Warn);
-        let path = ensure_cached_wasm_with(&asset, &user_log, |_| {
-            bail!("cache hit should not download")
-        })
-        .unwrap();
-
-        assert_eq!(path, asset.cache_path);
-        assert!(
-            !cache_dir
-                .path()
-                .join(moonutil::constants::MOON_LOCK)
-                .exists()
-        );
-    }
-
-    #[test]
-    fn checksum_mismatch_rejects_download() {
-        let cache_dir = tempfile::TempDir::new().unwrap();
-        let mut asset = resolve_wasm_asset(&resolved("cmd/moonfmt"), "https://mooncakes.io");
-        asset.cache_path = cache_dir.path().join("moonfmt.wasm");
-        let expected_checksum = sha256_hex(b"expected wasm");
-
-        let user_log = UserLog::new(log::LevelFilter::Warn);
-        let err = ensure_cached_wasm_with(&asset, &user_log, |url| {
-            if url.ends_with(".sha256") {
-                Ok(format!("{expected_checksum}\n").into_bytes())
-            } else {
-                Ok(b"different wasm".to_vec())
-            }
-        })
-        .unwrap_err()
-        .to_string();
-
-        assert!(err.contains("prebuilt wasm checksum mismatch"));
-        assert!(!asset.cache_path.exists());
     }
 }

--- a/crates/moon/src/cli/update.rs
+++ b/crates/moon/src/cli/update.rs
@@ -17,8 +17,8 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use anyhow::bail;
-use mooncake::update::{RegistryIndexRecloneReason, RegistryIndexUpdate, UpdateOutcome};
-use moonutil::{registry::RegistryConfig, user_log::UserLog};
+use mooncake::registry::RegistryClient;
+use moonutil::user_log::UserLog;
 
 use super::UniversalFlags;
 
@@ -34,116 +34,6 @@ pub(crate) fn update_cli(
     if cli.dry_run {
         bail!("dry-run is not supported for update")
     }
-    let registry_config = RegistryConfig::load();
-    let target_dir = moonutil::registry::index();
-    let outcome = mooncake::update::update(&target_dir, &registry_config, user_log)?;
-    log_registry_update(outcome, user_log);
+    RegistryClient::configured().sync(user_log)?;
     Ok(0)
-}
-
-pub(crate) fn log_registry_update(outcome: UpdateOutcome, user_log: &UserLog) {
-    match outcome.registry_index {
-        RegistryIndexUpdate::Cloned => user_log.status("Registry index cloned successfully"),
-        RegistryIndexUpdate::Updated => user_log.status("Registry index updated successfully"),
-        RegistryIndexUpdate::Recloned(reason) => {
-            let reason = match reason {
-                RegistryIndexRecloneReason::PullFailed => "Failed to update registry index",
-                RegistryIndexRecloneReason::RemoteMismatch => {
-                    "Registry index remote does not match the configured URL"
-                }
-                RegistryIndexRecloneReason::NotGitRepository => {
-                    "Registry index is not a Git repository"
-                }
-                RegistryIndexRecloneReason::MissingOrigin => "Registry index has no origin remote",
-            };
-            user_log.status(format!("{reason}, re-cloning"));
-            user_log.status("Registry index re-cloned successfully");
-        }
-        RegistryIndexUpdate::ConcurrentUpdateReused => {
-            user_log.status("Registry update already completed by another process");
-            return;
-        }
-    }
-    if outcome.symbols_updated {
-        user_log.status("Symbols updated successfully");
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use log::LevelFilter;
-    use moonutil::user_log::UserLogEntryLevel;
-
-    use super::*;
-
-    #[test]
-    fn registry_update_status_respects_quiet_user_log() {
-        let (user_log, capture) = UserLog::captured(LevelFilter::Error);
-
-        log_registry_update(
-            UpdateOutcome {
-                registry_index: RegistryIndexUpdate::Cloned,
-                symbols_updated: true,
-            },
-            &user_log,
-        );
-
-        assert!(capture.take().is_empty());
-    }
-
-    #[test]
-    fn registry_update_status_describes_reclone() {
-        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
-
-        log_registry_update(
-            UpdateOutcome {
-                registry_index: RegistryIndexUpdate::Recloned(
-                    RegistryIndexRecloneReason::NotGitRepository,
-                ),
-                symbols_updated: true,
-            },
-            &user_log,
-        );
-
-        let entries = capture.take();
-        assert_eq!(entries.len(), 3);
-        assert!(
-            entries
-                .iter()
-                .all(|entry| matches!(entry.level, UserLogEntryLevel::Info))
-        );
-        assert_eq!(
-            entries
-                .into_iter()
-                .map(|entry| entry.message)
-                .collect::<Vec<_>>(),
-            [
-                "Registry index is not a Git repository, re-cloning",
-                "Registry index re-cloned successfully",
-                "Symbols updated successfully",
-            ]
-        );
-    }
-
-    #[test]
-    fn registry_update_status_describes_concurrent_reuse() {
-        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
-
-        log_registry_update(
-            UpdateOutcome {
-                registry_index: RegistryIndexUpdate::ConcurrentUpdateReused,
-                symbols_updated: true,
-            },
-            &user_log,
-        );
-
-        assert_eq!(
-            capture
-                .take()
-                .into_iter()
-                .map(|entry| entry.message)
-                .collect::<Vec<_>>(),
-            ["Registry update already completed by another process"]
-        );
-    }
 }

--- a/crates/moon/tests/add_updates_index.rs
+++ b/crates/moon/tests/add_updates_index.rs
@@ -50,11 +50,13 @@ fn init_empty_local_registry() -> tempfile::TempDir {
     base
 }
 
-fn write_minimal_moon_mod_json(dir: &std::path::Path) {
-    // NOTE: `moon add` only requires `moon.mod.json` to exist for project discovery.
+fn write_minimal_moon_mod(dir: &std::path::Path) {
     std::fs::write(
-        dir.join("moon.mod.json"),
-        r#"{"name":"test/empty","version":"0.0.1"}"#,
+        dir.join("moon.mod"),
+        r#"name = "test/empty"
+
+version = "0.0.1"
+"#,
     )
     .unwrap();
 }
@@ -63,7 +65,7 @@ fn write_minimal_moon_mod_json(dir: &std::path::Path) {
 fn test_moon_add_no_update_skips_registry_update() {
     // Setup: isolated Moon project + empty MOON_HOME.
     let project = tempfile::tempdir().unwrap();
-    write_minimal_moon_mod_json(project.path());
+    write_minimal_moon_mod(project.path());
 
     let moon_home = tempfile::tempdir().unwrap();
 
@@ -103,7 +105,7 @@ fn test_moon_add_updates_registry_index_by_default() {
 
     // Setup: isolated Moon project + fresh MOON_HOME.
     let project = tempfile::tempdir().unwrap();
-    write_minimal_moon_mod_json(project.path());
+    write_minimal_moon_mod(project.path());
 
     let moon_home = tempfile::tempdir().unwrap();
 
@@ -144,7 +146,7 @@ fn test_moon_add_updates_registry_index_by_default() {
 fn test_moon_add_no_update_suggests_update_on_failure() {
     // Setup: isolated Moon project + empty MOON_HOME.
     let project = tempfile::tempdir().unwrap();
-    write_minimal_moon_mod_json(project.path());
+    write_minimal_moon_mod(project.path());
 
     let moon_home = tempfile::tempdir().unwrap();
 

--- a/crates/moonbuild-rupes-recta/src/mbtx.rs
+++ b/crates/moonbuild-rupes-recta/src/mbtx.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 
 use anyhow::Context;
 use indexmap::IndexMap;
-use mooncake::registry::{Registry, path as registry_path};
+use mooncake::registry::{Registry, RegistryClient, path as registry_path};
 use moonutil::{constants::MOONBITLANG_CORE, dependency::SourceDependencyInfo, package::Import};
 
 #[derive(Default)]
@@ -38,7 +38,7 @@ pub(super) fn parse_mbtx_imports(file: &Path) -> anyhow::Result<MbtxFrontMatterI
 
     let content = std::fs::read_to_string(file)
         .with_context(|| format!("failed to read .mbtx file `{}`", file.display()))?;
-    let registry = mooncake::registry::OnlineRegistry::mooncakes_io();
+    let registry = RegistryClient::configured();
     let Some(import_source) = extract_mbtx_import_source(&content) else {
         return Ok(MbtxFrontMatterImports::default());
     };
@@ -185,7 +185,7 @@ mod tests {
         MbtxFrontMatterImports, extract_mbtx_import_source, parse_mbtx_imports,
         split_mbtx_import_path,
     };
-    use mooncake::registry::OnlineRegistry;
+    use mooncake::registry::RegistryClient;
     use moonutil::package::Import;
     use moonutil::resolution::DEFAULT_VERSION;
 
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn split_mbtx_import_path_supports_module_package() {
-        let registry = OnlineRegistry::mooncakes_io();
+        let registry = RegistryClient::configured();
         let (module, version, package) =
             split_mbtx_import_path("path/module@0.4.38/package/path", &registry)
                 .expect("module package import should parse");
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn split_mbtx_import_path_normalizes_relative_package_with_module_prefix() {
-        let registry = OnlineRegistry::mooncakes_io();
+        let registry = RegistryClient::configured();
         let (module, version, package) = split_mbtx_import_path("a/b@version/c/d/e", &registry)
             .expect("module package import should parse");
         assert_eq!(module, "a/b");
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn split_mbtx_import_path_supports_module_root() {
-        let registry = OnlineRegistry::mooncakes_io();
+        let registry = RegistryClient::configured();
         let (module, version, package) = split_mbtx_import_path("path/module@0.4.38", &registry)
             .expect("module root import should parse");
         assert_eq!(module, "path/module");
@@ -236,13 +236,13 @@ mod tests {
 
     #[test]
     fn split_mbtx_import_path_rejects_three_segment_module_with_version() {
-        let registry = OnlineRegistry::mooncakes_io();
+        let registry = RegistryClient::configured();
         assert!(split_mbtx_import_path("moonbitlang/x/fs@0.4.39/path", &registry).is_err());
     }
 
     #[test]
     fn split_mbtx_import_path_supports_core_without_version() {
-        let registry = OnlineRegistry::mooncakes_io();
+        let registry = RegistryClient::configured();
         let (module, version, package) = split_mbtx_import_path("moonbitlang/core/env", &registry)
             .expect("core import without version should parse");
         assert_eq!(module, "moonbitlang/core");

--- a/crates/mooncake/src/dependency_source.rs
+++ b/crates/mooncake/src/dependency_source.rs
@@ -30,7 +30,7 @@ use moonutil::{
     user_log::UserLog,
 };
 
-use crate::registry::Registry;
+use crate::registry::RegistrySource;
 
 use self::{global::ImmutableDependencySource, project::ProjectDependencySource};
 
@@ -39,7 +39,7 @@ pub(crate) trait DependencySource {
     /// those directories indexed by module ID.
     fn ensure(
         &self,
-        registry: &dyn Registry,
+        registry: &dyn RegistrySource,
         resolved: &ResolvedEnv,
         frozen: bool,
         user_log: &UserLog,
@@ -74,7 +74,6 @@ pub(crate) fn select<'a>(
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::BTreeMap,
         path::Path,
         sync::{
             Arc,
@@ -95,14 +94,13 @@ mod tests {
         global::{ImmutableDependencySource, SOURCE_ARCHIVE_CHECKSUM_FILE},
         select,
     };
-    use crate::registry::{Registry, RegistryVersionInfo};
+    use crate::registry::RegistrySource;
 
     const FIRST_CHECKSUM: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     const SECOND_CHECKSUM: &str =
         "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
 
     struct TestRegistry {
-        version: Version,
         checksum: String,
         checksum_after_first_read: Option<String>,
         checksum_reads: AtomicUsize,
@@ -113,7 +111,6 @@ mod tests {
     impl TestRegistry {
         fn new(postadd: bool) -> Self {
             Self {
-                version: Version::new(1, 2, 3),
                 checksum: FIRST_CHECKSUM.to_string(),
                 checksum_after_first_read: None,
                 checksum_reads: AtomicUsize::new(0),
@@ -158,19 +155,7 @@ options(
         }
     }
 
-    impl Registry for TestRegistry {
-        fn all_versions_of(
-            &self,
-            _name: &ModuleName,
-        ) -> anyhow::Result<Arc<BTreeMap<Version, RegistryVersionInfo>>> {
-            Ok(Arc::new(BTreeMap::from([(
-                self.version.clone(),
-                RegistryVersionInfo {
-                    deps: Default::default(),
-                },
-            )])))
-        }
-
+    impl RegistrySource for TestRegistry {
         fn acquire_source_to(
             &self,
             name: &ModuleName,

--- a/crates/mooncake/src/dependency_source/global.rs
+++ b/crates/mooncake/src/dependency_source/global.rs
@@ -29,7 +29,7 @@ use moonutil::{
     user_log::UserLog,
 };
 
-use crate::registry::Registry;
+use crate::registry::RegistrySource;
 
 use super::DependencySource;
 
@@ -61,7 +61,7 @@ impl<'a> ImmutableDependencySource<'a> {
 
     fn prepare_source(
         &self,
-        registry: &dyn Registry,
+        registry: &dyn RegistrySource,
         module: &ModuleSource,
         checksum: &str,
         directory: &Path,
@@ -131,7 +131,7 @@ impl<'a> ImmutableDependencySource<'a> {
 impl DependencySource for ImmutableDependencySource<'_> {
     fn ensure(
         &self,
-        registry: &dyn Registry,
+        registry: &dyn RegistrySource,
         resolved: &ResolvedEnv,
         frozen: bool,
         user_log: &UserLog,

--- a/crates/mooncake/src/dependency_source/project.rs
+++ b/crates/mooncake/src/dependency_source/project.rs
@@ -35,7 +35,7 @@ use moonutil::{
 };
 use semver::Version;
 
-use crate::{pkg::legacy_postadd, registry::Registry};
+use crate::{pkg::legacy_postadd, registry::RegistrySource};
 
 use super::DependencySource;
 
@@ -105,7 +105,7 @@ impl ProjectDependencySource {
 impl DependencySource for ProjectDependencySource {
     fn ensure(
         &self,
-        registry: &dyn Registry,
+        registry: &dyn RegistrySource,
         resolved: &ResolvedEnv,
         frozen: bool,
         user_log: &UserLog,
@@ -221,7 +221,7 @@ fn diff_dep_dir_state<'a>(
 /// from the current directory, this function will return an error.
 fn sync(
     dep_dir: &ProjectDependencySource,
-    registry: &dyn Registry,
+    registry: &dyn RegistrySource,
     pkg_list: &ResolvedEnv,
     frozen: bool,
     postadd_runner: &ManagedChildRunner,

--- a/crates/mooncake/src/lib.rs
+++ b/crates/mooncake/src/lib.rs
@@ -22,5 +22,5 @@ pub(crate) mod dependency_source;
 pub mod pkg;
 pub mod registry;
 pub(crate) mod resolver;
-pub mod update;
+mod update;
 pub(crate) mod zip_util;

--- a/crates/mooncake/src/pkg/add.rs
+++ b/crates/mooncake/src/pkg/add.rs
@@ -32,7 +32,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::pkg::{install::install_impl, roots_for_selected_module, sync::SyncOutputOptions};
-use crate::registry::{self, Registry};
+use crate::registry::Registry;
 
 /// Add a dependency
 #[derive(Debug, clap::Parser)]
@@ -56,6 +56,7 @@ pub struct AddSubcommand {
 
 #[allow(clippy::too_many_arguments)]
 pub fn add_latest(
+    registry: &impl Registry,
     module_dir: &Path,
     dirs: &PackageDirs,
     pkg_name: &ModuleName,
@@ -70,7 +71,6 @@ pub fn add_latest(
         std::process::exit(0);
     }
 
-    let registry = registry::OnlineRegistry::mooncakes_io();
     let latest_version = registry
         .get_latest_version(pkg_name)
         .ok_or_else(|| {

--- a/crates/mooncake/src/pkg/install.rs
+++ b/crates/mooncake/src/pkg/install.rs
@@ -119,8 +119,9 @@ pub(crate) fn install_impl(
         anyhow::bail!("workspaces that include `moonbitlang/core` are not supported yet");
     }
 
+    let registry = registry::default_registry();
     let resolve_config = ResolveConfig {
-        registry: registry::default_registry(),
+        registry: &registry,
         inject_std: !includes_core && !no_std,
     };
 
@@ -136,12 +137,8 @@ pub(crate) fn install_impl(
         &res,
         output_options.child_output,
     )?;
-    let dependency_paths = dependency_source.ensure(
-        resolve_config.registry.as_ref(),
-        &res,
-        dont_sync,
-        &dependency_user_log,
-    )?;
+    let dependency_paths =
+        dependency_source.ensure(&registry, &res, dont_sync, &dependency_user_log)?;
 
     let managed_child = ManagedChildRunner::new(output_options.child_output, &dependency_user_log);
     install_bin_deps(

--- a/crates/mooncake/src/pkg/remove.rs
+++ b/crates/mooncake/src/pkg/remove.rs
@@ -63,8 +63,9 @@ pub fn remove(
     let m = Arc::new(m);
     let roots = roots_for_selected_module(module_dir, Arc::clone(&m), project_manifest)?;
 
+    let registry = registry::default_registry();
     let resolve_cfg = ResolveConfig {
-        registry: registry::default_registry(),
+        registry: &registry,
         inject_std: false, // no need to inject
     };
     resolve_with_default_env_and_resolver(&resolve_cfg, roots, user_log)?;

--- a/crates/mooncake/src/pkg/tree.rs
+++ b/crates/mooncake/src/pkg/tree.rs
@@ -132,8 +132,9 @@ pub fn tree(
 ) -> anyhow::Result<i32> {
     let module = Arc::new(read_module_desc_file_in_dir(module_dir)?);
     let roots = roots_for_selected_module(module_dir, Arc::clone(&module), project_manifest)?;
+    let registry = registry::default_registry();
     let resolve_cfg = ResolveConfig {
-        registry: registry::default_registry(),
+        registry: &registry,
         inject_std: false,
     };
     let resolved = resolve_with_default_env_and_resolver(&resolve_cfg, roots, user_log)?;

--- a/crates/mooncake/src/pkg/work.rs
+++ b/crates/mooncake/src/pkg/work.rs
@@ -208,8 +208,9 @@ fn resolve_workspace(
         anyhow::bail!("workspaces that include `moonbitlang/core` are not supported yet");
     }
 
+    let registry = registry::default_registry();
     let resolve_config = ResolveConfig {
-        registry: registry::default_registry(),
+        registry: &registry,
         inject_std: !includes_core,
     };
     resolve_with_default_env_and_resolver(&resolve_config, roots, user_log).map_err(Into::into)

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -16,18 +16,18 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+mod client;
 #[cfg(test)]
 pub(crate) mod mock;
-pub(crate) mod online;
 pub mod path;
 
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 
+pub use client::RegistryClient;
 use indexmap::IndexMap;
 use moonutil::dependency::SourceDependencyInfo;
 use moonutil::resolution::ModuleName;
 use moonutil::user_log::UserLog;
-pub use online::*;
 use semver::Version;
 
 #[derive(Debug, Clone, Default)]
@@ -70,7 +70,9 @@ pub trait Registry {
             .last_key_value()
             .map(|(version, _)| version.clone())
     }
+}
 
+pub(crate) trait RegistrySource {
     /// Materialize verified published source without executing package hooks.
     fn materialize_source_to(
         &self,
@@ -118,25 +120,6 @@ where
         (**self).all_versions_of(name)
     }
 
-    fn acquire_source_to(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        expected_checksum: &str,
-        to: &Path,
-        user_log: &UserLog,
-    ) -> anyhow::Result<()> {
-        (**self).acquire_source_to(name, version, expected_checksum, to, user_log)
-    }
-
-    fn source_archive_checksum(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-    ) -> anyhow::Result<String> {
-        (**self).source_archive_checksum(name, version)
-    }
-
     fn get_latest_version(&self, name: &ModuleName) -> Option<Version> {
         (**self).get_latest_version(name)
     }
@@ -157,25 +140,6 @@ where
         (**self).all_versions_of(name)
     }
 
-    fn acquire_source_to(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        expected_checksum: &str,
-        to: &Path,
-        user_log: &UserLog,
-    ) -> anyhow::Result<()> {
-        (**self).acquire_source_to(name, version, expected_checksum, to, user_log)
-    }
-
-    fn source_archive_checksum(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-    ) -> anyhow::Result<String> {
-        (**self).source_archive_checksum(name, version)
-    }
-
     fn get_latest_version(&self, name: &ModuleName) -> Option<Version> {
         (**self).get_latest_version(name)
     }
@@ -185,8 +149,8 @@ where
     }
 }
 
-pub(crate) fn default_registry() -> Box<dyn Registry> {
-    Box::new(OnlineRegistry::mooncakes_io())
+pub(crate) fn default_registry() -> RegistryClient {
+    RegistryClient::configured()
 }
 
 #[allow(clippy::items_after_test_module)]

--- a/crates/mooncake/src/registry/client.rs
+++ b/crates/mooncake/src/registry/client.rs
@@ -31,11 +31,15 @@ use moonutil::{
     dependency::SourceDependencyInfo, locks::FileLock, registry::RegistryConfig,
     resolution::ModuleName, user_log::UserLog,
 };
-use reqwest::header::USER_AGENT;
+use reqwest::{StatusCode, header::USER_AGENT};
 use semver::Version;
 use serde::Deserialize;
 
-use crate::{registry::RegistryVersionInfo, zip_util::extract_zip_to_dir};
+use crate::{
+    registry::RegistryVersionInfo,
+    update::{RegistryIndexRecloneReason, RegistryIndexUpdate, UpdateOutcome},
+    zip_util::extract_zip_to_dir,
+};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -45,22 +49,115 @@ struct RegistryIndexEntry {
     checksum: Option<String>,
 }
 
-pub struct OnlineRegistry {
+struct RegistryEndpoints {
+    packages: String,
+    assets: String,
+}
+
+impl RegistryEndpoints {
+    fn from_config(config: &RegistryConfig) -> Self {
+        let registry = config.registry.trim_end_matches('/');
+        let packages = if registry == "https://mooncakes.io" {
+            "https://download.mooncakes.io/user".to_owned()
+        } else {
+            format!("{registry}/user")
+        };
+        Self {
+            packages,
+            assets: format!("{registry}/assets"),
+        }
+    }
+
+    fn package_archive(&self, name: &ModuleName, version: &Version) -> String {
+        let path = form_urlencoded::Serializer::new(String::new())
+            .append_key_only(&format!("{}/{}/{}", name.username, name.unqual, version))
+            .finish();
+        format!("{}/{}.zip", self.packages, path)
+    }
+
+    fn wasm_asset(&self, name: &ModuleName, version: &Version, package_path: &str) -> String {
+        let artifact_name = wasm_artifact_name(name, package_path);
+        if package_path.is_empty() {
+            format!("{}/{}@{version}/{artifact_name}", self.assets, name)
+        } else {
+            format!(
+                "{}/{}@{version}/{package_path}/{artifact_name}",
+                self.assets, name
+            )
+        }
+    }
+}
+
+/// Access to a configured Mooncakes registry and its local state.
+///
+/// This client owns synchronization of the Git index and symbols archive as
+/// well as verified package and prebuilt wasm downloads. Resolution code can
+/// depend on the narrower [`super::Registry`] interface when it does not need
+/// to synchronize the registry.
+pub struct RegistryClient {
+    config: RegistryConfig,
     index: std::path::PathBuf,
-    url_base: String, // TODO: add download feature to registry interface
+    endpoints: RegistryEndpoints,
     archive_cache: std::path::PathBuf,
     cache: RefCell<HashMap<ModuleName, Arc<BTreeMap<Version, RegistryVersionInfo>>>>,
 }
 
-impl OnlineRegistry {
-    pub fn mooncakes_io() -> Self {
-        let registry = RegistryConfig::load().registry;
-        OnlineRegistry {
-            index: moonutil::registry::index(),
-            url_base: registry_download_base(&registry),
-            archive_cache: moonutil::registry::cache(),
+impl RegistryClient {
+    /// Load registry configuration and use the standard local index and cache.
+    pub fn configured() -> Self {
+        Self::from_config(RegistryConfig::load())
+    }
+
+    fn from_config(config: RegistryConfig) -> Self {
+        Self::with_paths(
+            config,
+            moonutil::registry::index(),
+            moonutil::registry::cache(),
+        )
+    }
+
+    fn with_paths(
+        config: RegistryConfig,
+        index: std::path::PathBuf,
+        archive_cache: std::path::PathBuf,
+    ) -> Self {
+        Self {
+            endpoints: RegistryEndpoints::from_config(&config),
+            config,
+            index,
+            archive_cache,
             cache: RefCell::new(HashMap::new()),
         }
+    }
+
+    /// Return whether a local registry index is available for offline fallback.
+    pub fn has_cached_index(&self) -> bool {
+        self.index.exists()
+    }
+
+    /// Synchronize the Git index and symbols archive with the configured registry.
+    pub fn sync(&self, user_log: &UserLog) -> anyhow::Result<()> {
+        let outcome = crate::update::sync(&self.index, &self.config, user_log)?;
+        self.cache.borrow_mut().clear();
+        log_sync_outcome(outcome, user_log);
+        Ok(())
+    }
+
+    /// Return a verified, locally cached prebuilt wasm asset.
+    pub fn acquire_wasm_asset(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        package_path: &str,
+        user_log: &UserLog,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        let http = reqwest::blocking::Client::builder()
+            .user_agent(format!("mooncake/{}", env!("CARGO_PKG_VERSION")))
+            .build()
+            .context("failed to create registry asset HTTP client")?;
+        self.acquire_wasm_asset_with(name, version, package_path, user_log, |url| {
+            download_registry_asset(&http, url, user_log)
+        })
     }
 
     fn index_file_of(&self, name: &ModuleName) -> std::path::PathBuf {
@@ -76,18 +173,199 @@ impl OnlineRegistry {
             .join(name.unqual.as_str())
             .join(format!("{version}.zip"))
     }
-}
 
-fn registry_download_base(registry: &str) -> String {
-    let registry = registry.trim_end_matches('/');
-    if registry == "https://mooncakes.io" {
-        "https://download.mooncakes.io/user".to_string()
-    } else {
-        format!("{registry}/user")
+    fn wasm_asset_cache_file_of(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        package_path: &str,
+    ) -> std::path::PathBuf {
+        let mut path = self
+            .archive_cache
+            .join("assets")
+            .join(name.username.as_str());
+        for segment in name.unqual.split('/') {
+            path.push(segment);
+        }
+        path.push(version.to_string());
+        for segment in package_path
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+        {
+            path.push(segment);
+        }
+        path.push(wasm_artifact_name(name, package_path));
+        path
+    }
+
+    fn acquire_wasm_asset_with(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        package_path: &str,
+        user_log: &UserLog,
+        mut download: impl FnMut(&str) -> anyhow::Result<Vec<u8>>,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        validate_asset_package_path(name, package_path)?;
+        let url = self.endpoints.wasm_asset(name, version, package_path);
+        let checksum_url = format!("{url}.sha256");
+        let cache_path = self.wasm_asset_cache_file_of(name, version, package_path);
+
+        ensure_cached_wasm(&cache_path, user_log, |staged| {
+            let checksum_bytes = download(&checksum_url)?;
+            let expected_checksum = parse_sha256_checksum(&checksum_bytes)
+                .with_context(|| format!("invalid SHA-256 checksum from {checksum_url}"))?;
+            let bytes = download(&url)?;
+            let actual_checksum = sha256_hex(&bytes);
+            if actual_checksum != expected_checksum {
+                bail!(
+                    "prebuilt wasm checksum mismatch for {url}: expected {expected_checksum}, got {actual_checksum}"
+                );
+            }
+            std::fs::write(staged, bytes)
+                .with_context(|| format!("failed to write cache file {}", staged.display()))?;
+            Ok(())
+        })
     }
 }
 
-impl super::Registry for OnlineRegistry {
+fn log_sync_outcome(outcome: UpdateOutcome, user_log: &UserLog) {
+    match outcome.registry_index {
+        RegistryIndexUpdate::Cloned => user_log.status("Registry index cloned successfully"),
+        RegistryIndexUpdate::Updated => user_log.status("Registry index updated successfully"),
+        RegistryIndexUpdate::Recloned(reason) => {
+            let reason = match reason {
+                RegistryIndexRecloneReason::PullFailed => "Failed to update registry index",
+                RegistryIndexRecloneReason::RemoteMismatch => {
+                    "Registry index remote does not match the configured URL"
+                }
+                RegistryIndexRecloneReason::NotGitRepository => {
+                    "Registry index is not a Git repository"
+                }
+                RegistryIndexRecloneReason::MissingOrigin => "Registry index has no origin remote",
+            };
+            user_log.status(format!("{reason}, re-cloning"));
+            user_log.status("Registry index re-cloned successfully");
+        }
+        RegistryIndexUpdate::ConcurrentUpdateReused => {
+            user_log.status("Registry update already completed by another process");
+            return;
+        }
+    }
+    if outcome.symbols_updated {
+        user_log.status("Symbols updated successfully");
+    }
+}
+
+fn wasm_artifact_name(name: &ModuleName, package_path: &str) -> String {
+    let stem = if package_path.is_empty() {
+        name.last_segment()
+    } else {
+        package_path
+            .rsplit('/')
+            .next()
+            .expect("non-empty package path has a last segment")
+    };
+    format!("{stem}.wasm")
+}
+
+fn validate_asset_package_path(name: &ModuleName, package_path: &str) -> anyhow::Result<()> {
+    let coordinate = if package_path.is_empty() {
+        name.to_string()
+    } else {
+        format!("{name}/{package_path}")
+    };
+    let parsed = super::path::parse_install_style_path(&coordinate)
+        .context("invalid registry asset package path")?;
+    if parsed.module != *name || parsed.package != package_path {
+        bail!("invalid registry asset package path");
+    }
+    Ok(())
+}
+
+fn download_registry_asset(
+    http: &reqwest::blocking::Client,
+    url: &str,
+    user_log: &UserLog,
+) -> anyhow::Result<Vec<u8>> {
+    user_log.info(format!("Downloading {url}"));
+    let response = http
+        .get(url)
+        .send()
+        .with_context(|| format!("failed to download registry asset from {url}"))?;
+    if response.status() == StatusCode::NOT_FOUND {
+        bail!("Prebuilt wasm asset does not exist");
+    }
+    let data = response
+        .error_for_status()
+        .with_context(|| format!("registry asset download returned error status for {url}"))?
+        .bytes()
+        .with_context(|| format!("failed to read registry asset response from {url}"))?;
+    Ok(data.to_vec())
+}
+
+fn ensure_cached_wasm(
+    cache_path: &Path,
+    user_log: &UserLog,
+    produce: impl FnOnce(&Path) -> anyhow::Result<()>,
+) -> anyhow::Result<std::path::PathBuf> {
+    if cache_path.exists() {
+        user_log.info(format!("Using cached {}", cache_path.to_string_lossy()));
+        return Ok(cache_path.to_path_buf());
+    }
+
+    let parent = cache_path
+        .parent()
+        .context("registry cache path has no parent")?;
+    std::fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create registry cache directory {}",
+            parent.display()
+        )
+    })?;
+    let _lock = FileLock::lock(parent)
+        .with_context(|| format!("failed to lock cache directory {}", parent.display()))?;
+
+    if cache_path.exists() {
+        user_log.info(format!("Using cached {}", cache_path.to_string_lossy()));
+        return Ok(cache_path.to_path_buf());
+    }
+
+    let staged = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create cache file in {}", parent.display()))?;
+    produce(staged.path())?;
+    staged
+        .as_file()
+        .sync_all()
+        .with_context(|| format!("failed to sync cache file {}", staged.path().display()))?;
+    staged
+        .persist(cache_path)
+        .with_context(|| format!("failed to publish cached file to {}", cache_path.display()))?;
+    if let Ok(dir) = File::open(parent) {
+        let _ = dir.sync_all();
+    }
+    Ok(cache_path.to_path_buf())
+}
+
+fn parse_sha256_checksum(bytes: &[u8]) -> anyhow::Result<String> {
+    let text = std::str::from_utf8(bytes).context("SHA-256 checksum is not valid UTF-8")?;
+    let checksum = text
+        .split_whitespace()
+        .next()
+        .context("SHA-256 checksum is empty")?;
+    if checksum.len() != 64 || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("SHA-256 checksum must be a 64-character hex digest");
+    }
+    Ok(checksum.to_ascii_lowercase())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+impl super::Registry for RegistryClient {
     fn all_versions_of(
         &self,
         name: &ModuleName,
@@ -131,7 +409,9 @@ impl super::Registry for OnlineRegistry {
 
         Ok(res)
     }
+}
 
+impl super::RegistrySource for RegistryClient {
     fn acquire_source_to(
         &self,
         name: &ModuleName,
@@ -140,7 +420,7 @@ impl super::Registry for OnlineRegistry {
         to: &Path,
         user_log: &UserLog,
     ) -> anyhow::Result<()> {
-        OnlineRegistry::acquire_source_to(self, name, version, expected_checksum, to, user_log)
+        RegistryClient::acquire_source_to(self, name, version, expected_checksum, to, user_log)
     }
 
     fn source_archive_checksum(
@@ -148,7 +428,7 @@ impl super::Registry for OnlineRegistry {
         name: &ModuleName,
         version: &Version,
     ) -> anyhow::Result<String> {
-        self.read_checksum_from_index_file(name, version)
+        RegistryClient::source_archive_checksum(self, name, version)
     }
 }
 
@@ -243,7 +523,7 @@ fn persist_verified_archive(
     Ok(archive)
 }
 
-impl OnlineRegistry {
+impl RegistryClient {
     fn read_checksum_from_index_file(
         &self,
         name: &ModuleName,
@@ -310,10 +590,7 @@ impl OnlineRegistry {
             return Ok(archive);
         }
         user_log.status(format!("Downloading {name}@{version}"));
-        let filepath = form_urlencoded::Serializer::new(String::new())
-            .append_key_only(&format!("{}/{}/{}", name.username, name.unqual, version))
-            .finish();
-        let url = format!("{}/{}.zip", self.url_base, filepath);
+        let url = self.endpoints.package_archive(name, version);
         let client = reqwest::blocking::Client::new();
         let mut response = client
             .get(url)
@@ -325,6 +602,27 @@ impl OnlineRegistry {
             .error_for_status()?;
 
         persist_verified_archive(&mut response, &cache_file, name, version, expected_checksum)
+    }
+
+    /// Return the registry index's SHA-256 checksum for a published source archive.
+    pub fn source_archive_checksum(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+    ) -> anyhow::Result<String> {
+        self.read_checksum_from_index_file(name, version)
+    }
+
+    /// Materialize verified published source without executing package hooks.
+    pub fn materialize_source_to(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        to: &Path,
+        user_log: &UserLog,
+    ) -> anyhow::Result<()> {
+        let checksum = self.source_archive_checksum(name, version)?;
+        self.acquire_source_to(name, version, &checksum, to, user_log)
     }
 
     /// Reuse or download, verify, and extract a registry package without
@@ -371,6 +669,9 @@ mod tests {
         time::{Duration, SystemTime, UNIX_EPOCH},
     };
 
+    use log::LevelFilter;
+    use moonutil::user_log::UserLogEntryLevel;
+
     use super::*;
     use crate::registry::Registry;
 
@@ -379,18 +680,313 @@ mod tests {
     }
 
     #[test]
-    fn official_registry_uses_download_service() {
+    fn registry_update_status_respects_quiet_user_log() {
+        let (user_log, capture) = UserLog::captured(LevelFilter::Error);
+
+        log_sync_outcome(
+            UpdateOutcome {
+                registry_index: RegistryIndexUpdate::Cloned,
+                symbols_updated: true,
+            },
+            &user_log,
+        );
+
+        assert!(capture.take().is_empty());
+    }
+
+    #[test]
+    fn registry_update_status_describes_reclone() {
+        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+
+        log_sync_outcome(
+            UpdateOutcome {
+                registry_index: RegistryIndexUpdate::Recloned(
+                    RegistryIndexRecloneReason::NotGitRepository,
+                ),
+                symbols_updated: true,
+            },
+            &user_log,
+        );
+
+        let entries = capture.take();
+        assert_eq!(entries.len(), 3);
+        assert!(
+            entries
+                .iter()
+                .all(|entry| matches!(entry.level, UserLogEntryLevel::Info))
+        );
         assert_eq!(
-            registry_download_base("https://mooncakes.io/"),
-            "https://download.mooncakes.io/user"
+            entries
+                .into_iter()
+                .map(|entry| entry.message)
+                .collect::<Vec<_>>(),
+            [
+                "Registry index is not a Git repository, re-cloning",
+                "Registry index re-cloned successfully",
+                "Symbols updated successfully",
+            ]
+        );
+    }
+
+    #[test]
+    fn registry_update_status_describes_concurrent_reuse() {
+        let (user_log, capture) = UserLog::captured(LevelFilter::Warn);
+
+        log_sync_outcome(
+            UpdateOutcome {
+                registry_index: RegistryIndexUpdate::ConcurrentUpdateReused,
+                symbols_updated: true,
+            },
+            &user_log,
+        );
+
+        assert_eq!(
+            capture
+                .take()
+                .into_iter()
+                .map(|entry| entry.message)
+                .collect::<Vec<_>>(),
+            ["Registry update already completed by another process"]
+        );
+    }
+
+    #[test]
+    fn official_registry_uses_download_service() {
+        let endpoints = RegistryEndpoints::from_config(&RegistryConfig {
+            registry: "https://mooncakes.io/".to_owned(),
+            index: String::new(),
+            symbols: None,
+        });
+        assert_eq!(
+            endpoints.package_archive(&"test/pkg".into(), &Version::new(1, 2, 3)),
+            "https://download.mooncakes.io/user/test%2Fpkg%2F1.2.3.zip"
         );
     }
 
     #[test]
     fn configured_registry_serves_package_downloads() {
+        let endpoints = RegistryEndpoints::from_config(&RegistryConfig {
+            registry: "https://registry.example.com/".to_owned(),
+            index: String::new(),
+            symbols: None,
+        });
         assert_eq!(
-            registry_download_base("https://registry.example.com/"),
-            "https://registry.example.com/user"
+            endpoints.package_archive(&"test/pkg".into(), &Version::new(1, 2, 3)),
+            "https://registry.example.com/user/test%2Fpkg%2F1.2.3.zip"
+        );
+    }
+
+    fn asset_test_registry(sandbox: &tempfile::TempDir) -> RegistryClient {
+        RegistryClient::with_paths(
+            RegistryConfig {
+                registry: "https://mooncakes.io".to_owned(),
+                index: String::new(),
+                symbols: None,
+            },
+            sandbox.path().join("index"),
+            sandbox.path().join("cache"),
+        )
+    }
+
+    fn parser_module() -> ModuleName {
+        "moonbitlang/parser".into()
+    }
+
+    #[test]
+    fn wasm_asset_urls_are_internal_to_registry_client() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let registry = asset_test_registry(&sandbox);
+        let version = Version::new(0, 3, 3);
+
+        assert_eq!(
+            registry
+                .endpoints
+                .wasm_asset(&parser_module(), &version, "cmd/moonfmt"),
+            "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm"
+        );
+        assert_eq!(
+            registry
+                .endpoints
+                .wasm_asset(&parser_module(), &version, ""),
+            "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/parser.wasm"
+        );
+    }
+
+    #[test]
+    fn parse_wasm_asset_sha256sum_output() {
+        let checksum = "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789";
+        assert_eq!(
+            parse_sha256_checksum(format!("{checksum}  moonfmt.wasm\n").as_bytes()).unwrap(),
+            checksum.to_ascii_lowercase()
+        );
+        assert!(parse_sha256_checksum(b"not-a-checksum").is_err());
+        assert!(parse_sha256_checksum(b"").is_err());
+    }
+
+    #[test]
+    fn wasm_asset_cache_miss_downloads_checksum_and_wasm() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let registry = asset_test_registry(&sandbox);
+        let wasm = b"\0asmtest".to_vec();
+        let checksum = sha256_hex(&wasm);
+        let mut urls = Vec::new();
+        let path = registry
+            .acquire_wasm_asset_with(
+                &parser_module(),
+                &Version::new(0, 3, 3),
+                "cmd/moonfmt",
+                &quiet_user_log(),
+                |url| {
+                    urls.push(url.to_owned());
+                    if url.ends_with(".sha256") {
+                        Ok(format!("{checksum}  moonfmt.wasm\n").into_bytes())
+                    } else {
+                        Ok(wasm.clone())
+                    }
+                },
+            )
+            .unwrap();
+
+        assert_eq!(std::fs::read(path).unwrap(), b"\0asmtest");
+        assert_eq!(
+            urls,
+            [
+                "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm.sha256",
+                "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm",
+            ]
+        );
+    }
+
+    #[test]
+    fn wasm_asset_cache_hit_does_not_download() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let registry = asset_test_registry(&sandbox);
+        let name = parser_module();
+        let version = Version::new(0, 3, 3);
+        let cache_path = registry.wasm_asset_cache_file_of(&name, &version, "cmd/moonfmt");
+        std::fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        std::fs::write(&cache_path, b"\0asmtest").unwrap();
+
+        let path = registry
+            .acquire_wasm_asset_with(&name, &version, "cmd/moonfmt", &quiet_user_log(), |_| {
+                bail!("cache hit should not download")
+            })
+            .unwrap();
+
+        assert_eq!(path, cache_path);
+        assert!(
+            !cache_path
+                .parent()
+                .unwrap()
+                .join(moonutil::constants::MOON_LOCK)
+                .exists()
+        );
+    }
+
+    #[test]
+    fn concurrent_wasm_asset_cache_misses_download_once() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let index = sandbox.path().join("index");
+        let cache = sandbox.path().join("cache");
+        let start = Arc::new(Barrier::new(3));
+        let download_count = Arc::new(AtomicUsize::new(0));
+        let wasm = b"\0asmtest".to_vec();
+        let checksum = sha256_hex(&wasm);
+
+        let threads = (0..2)
+            .map(|_| {
+                let registry = RegistryClient::with_paths(
+                    RegistryConfig {
+                        registry: "https://mooncakes.io".to_owned(),
+                        index: String::new(),
+                        symbols: None,
+                    },
+                    index.clone(),
+                    cache.clone(),
+                );
+                let start = Arc::clone(&start);
+                let download_count = Arc::clone(&download_count);
+                let wasm = wasm.clone();
+                let checksum = checksum.clone();
+                std::thread::spawn(move || {
+                    start.wait();
+                    registry.acquire_wasm_asset_with(
+                        &parser_module(),
+                        &Version::new(0, 3, 3),
+                        "cmd/moonfmt",
+                        &quiet_user_log(),
+                        |url| {
+                            if url.ends_with(".sha256") {
+                                download_count.fetch_add(1, Ordering::SeqCst);
+                                std::thread::sleep(Duration::from_millis(50));
+                                Ok(format!("{checksum}  moonfmt.wasm\n").into_bytes())
+                            } else {
+                                Ok(wasm.clone())
+                            }
+                        },
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        start.wait();
+
+        for thread in threads {
+            assert_eq!(
+                std::fs::read(thread.join().unwrap().unwrap()).unwrap(),
+                b"\0asmtest"
+            );
+        }
+        assert_eq!(download_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn wasm_asset_checksum_mismatch_is_not_cached() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let registry = asset_test_registry(&sandbox);
+        let name = parser_module();
+        let version = Version::new(0, 3, 3);
+        let expected_checksum = sha256_hex(b"expected wasm");
+
+        let error = registry
+            .acquire_wasm_asset_with(&name, &version, "cmd/moonfmt", &quiet_user_log(), |url| {
+                if url.ends_with(".sha256") {
+                    Ok(format!("{expected_checksum}\n").into_bytes())
+                } else {
+                    Ok(b"different wasm".to_vec())
+                }
+            })
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("prebuilt wasm checksum mismatch")
+        );
+        assert!(
+            !registry
+                .wasm_asset_cache_file_of(&name, &version, "cmd/moonfmt")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn wasm_asset_rejects_unvalidated_package_paths() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let registry = asset_test_registry(&sandbox);
+        let error = registry
+            .acquire_wasm_asset_with(
+                &parser_module(),
+                &Version::new(0, 3, 3),
+                "../escape",
+                &quiet_user_log(),
+                |_| bail!("invalid paths must fail before downloading"),
+            )
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("invalid registry asset package path")
         );
     }
 
@@ -405,7 +1001,7 @@ mod tests {
             let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
             let unavailable_address = listener.local_addr().unwrap();
             drop(listener);
-            registry.url_base = format!("http://{unavailable_address}");
+            registry.endpoints.packages = format!("http://{unavailable_address}");
 
             registry
                 .acquire_source_to(
@@ -499,7 +1095,7 @@ mod tests {
         );
     }
 
-    fn test_registry(sandbox: &tempfile::TempDir) -> (OnlineRegistry, ModuleName, Version) {
+    fn test_registry(sandbox: &tempfile::TempDir) -> (RegistryClient, ModuleName, Version) {
         let name: ModuleName = "test/module".into();
         let version = Version::new(1, 2, 3);
         let index = sandbox.path().join("index");
@@ -507,12 +1103,15 @@ mod tests {
         std::fs::create_dir_all(index_file.parent().unwrap()).unwrap();
         std::fs::write(&index_file, "registry entry exists").unwrap();
         (
-            OnlineRegistry {
+            RegistryClient::with_paths(
+                RegistryConfig {
+                    registry: String::new(),
+                    index: String::new(),
+                    symbols: None,
+                },
                 index,
-                url_base: String::new(),
-                archive_cache: sandbox.path().join("archive-cache"),
-                cache: RefCell::new(HashMap::new()),
-            },
+                sandbox.path().join("archive-cache"),
+            ),
             name,
             version,
         )
@@ -662,12 +1261,15 @@ mod tests {
                 let destination = sandbox.path().join(format!("source-{client}"));
                 let barrier = Arc::clone(&barrier);
                 std::thread::spawn(move || {
-                    let registry = OnlineRegistry {
+                    let registry = RegistryClient::with_paths(
+                        RegistryConfig {
+                            registry: url_base,
+                            index: String::new(),
+                            symbols: None,
+                        },
                         index,
-                        url_base,
                         archive_cache,
-                        cache: RefCell::new(HashMap::new()),
-                    };
+                    );
                     barrier.wait();
                     registry.acquire_source_to(
                         &name,
@@ -796,12 +1398,15 @@ mod tests {
         )
         .unwrap();
 
-        let registry = OnlineRegistry {
-            index: index.clone(),
-            url_base: String::new(),
-            archive_cache: index.join("archive-cache"),
-            cache: RefCell::new(HashMap::new()),
-        };
+        let registry = RegistryClient::with_paths(
+            RegistryConfig {
+                registry: String::new(),
+                index: String::new(),
+                symbols: None,
+            },
+            index.clone(),
+            index.join("archive-cache"),
+        );
         let versions = registry
             .all_versions_of(&ModuleName {
                 username: "bobzhang".into(),

--- a/crates/mooncake/src/registry/mock.rs
+++ b/crates/mooncake/src/registry/mock.rs
@@ -169,25 +169,6 @@ impl Registry for MockRegistry {
             .ok_or_else(|| anyhow::anyhow!("module not found in mock registry"))
             .map(Arc::new)
     }
-
-    fn acquire_source_to(
-        &self,
-        _name: &ModuleName,
-        _version: &Version,
-        _expected_checksum: &str,
-        _to: &std::path::Path,
-        _user_log: &moonutil::user_log::UserLog,
-    ) -> anyhow::Result<()> {
-        panic!("Mock registry does not support extracting sources")
-    }
-
-    fn source_archive_checksum(
-        &self,
-        _name: &ModuleName,
-        _version: &Version,
-    ) -> anyhow::Result<String> {
-        panic!("Mock registry does not provide source checksums")
-    }
 }
 
 #[cfg(test)]

--- a/crates/mooncake/src/resolver.rs
+++ b/crates/mooncake/src/resolver.rs
@@ -232,8 +232,8 @@ fn format_resolver_errors(errors: &[ResolverError]) -> String {
         .join("\n")
 }
 
-pub(crate) struct ResolveConfig {
-    pub(crate) registry: Box<dyn Registry>,
+pub(crate) struct ResolveConfig<'a> {
+    pub(crate) registry: &'a dyn Registry,
     pub(crate) inject_std: bool,
 }
 
@@ -243,7 +243,7 @@ pub(crate) fn resolve_with_default_env(
     root: ResolvedRootModules,
     user_log: &UserLog,
 ) -> Result<ResolvedEnv, ResolverErrors> {
-    let mut env = env::ResolverEnv::new(config.registry.as_ref());
+    let mut env = env::ResolverEnv::new(config.registry);
     let mut res = ResolvedEnv::from_root_modules(root);
 
     if config.inject_std {

--- a/crates/mooncake/src/update.rs
+++ b/crates/mooncake/src/update.rs
@@ -70,7 +70,7 @@ impl std::fmt::Display for CommandOutput {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RegistryIndexRecloneReason {
+pub(crate) enum RegistryIndexRecloneReason {
     PullFailed,
     RemoteMismatch,
     NotGitRepository,
@@ -78,7 +78,7 @@ pub enum RegistryIndexRecloneReason {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RegistryIndexUpdate {
+pub(crate) enum RegistryIndexUpdate {
     Cloned,
     Updated,
     Recloned(RegistryIndexRecloneReason),
@@ -86,7 +86,7 @@ pub enum RegistryIndexUpdate {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct UpdateOutcome {
+pub(crate) struct UpdateOutcome {
     pub registry_index: RegistryIndexUpdate,
     /// Whether the best-effort symbols update succeeded.
     ///
@@ -670,7 +670,7 @@ fn run_registry_update_locked(
     Ok(outcome)
 }
 
-pub fn update(
+pub(crate) fn sync(
     target_dir: &Path,
     registry_config: &RegistryConfig,
     user_log: &UserLog,
@@ -681,7 +681,8 @@ pub fn update(
     std::fs::create_dir_all(registry_dir)
         .with_context(|| format!("failed to create `{}`", registry_dir.display()))?;
     let observed = observe_registry_update_state(registry_dir);
-    let registry_identity = format!("{:x}", Sha256::digest(registry_config.index.as_bytes()));
+    let symbols_url = registry_config.symbols.as_deref().unwrap_or(SYMBOLS_URL);
+    let registry_identity = registry_identity(&registry_config.index, symbols_url);
 
     run_registry_update_locked(
         registry_dir,
@@ -691,7 +692,7 @@ pub fn update(
         |previous_etag| {
             let registry_index = update_registry_index(target_dir, registry_config, user_log)?;
             let (symbols_updated, symbols_etag) =
-                match update_symbols_from_url(registry_dir, SYMBOLS_URL, previous_etag) {
+                match update_symbols_from_url(registry_dir, symbols_url, previous_etag) {
                     Ok(etag) => (true, etag),
                     Err(e) => {
                         user_log.warn(format!("failed to update symbols: {e:#}"));
@@ -708,6 +709,14 @@ pub fn update(
             ))
         },
     )
+}
+
+fn registry_identity(index_url: &str, symbols_url: &str) -> String {
+    let mut identity = Sha256::new();
+    identity.update(index_url.as_bytes());
+    identity.update([0]);
+    identity.update(symbols_url.as_bytes());
+    format!("{:x}", identity.finalize())
 }
 
 fn update_registry_index(
@@ -778,6 +787,7 @@ mod tests {
             RegistryConfig {
                 registry: index.clone(),
                 index,
+                symbols: None,
             },
         )
     }
@@ -850,6 +860,7 @@ mod tests {
             RegistryConfig {
                 registry: index.clone(),
                 index,
+                symbols: None,
             },
         )
     }
@@ -859,6 +870,19 @@ mod tests {
             registry_index: RegistryIndexUpdate::Updated,
             symbols_updated: true,
         }
+    }
+
+    #[test]
+    fn registry_update_identity_covers_index_and_symbols() {
+        let identity = registry_identity("https://registry.invalid/index", "https://a/symbols");
+        assert_ne!(
+            identity,
+            registry_identity("https://other.invalid/index", "https://a/symbols")
+        );
+        assert_ne!(
+            identity,
+            registry_identity("https://registry.invalid/index", "https://b/symbols")
+        );
     }
 
     struct TestHttpResponse {

--- a/crates/moonutil/src/mooncakes.rs
+++ b/crates/moonutil/src/mooncakes.rs
@@ -603,6 +603,8 @@ pub struct Credentials {
 pub struct RegistryConfig {
     pub registry: String,
     pub index: String,
+    #[serde(default)]
+    pub symbols: Option<String>,
 }
 
 impl RegistryConfig {
@@ -610,12 +612,14 @@ impl RegistryConfig {
         if let Ok(v) = std::env::var("MOONCAKES_REGISTRY") {
             RegistryConfig {
                 index: format!("{v}/git/index"),
+                symbols: Some(format!("{v}/symbols.zip")),
                 registry: v,
             }
         } else {
             RegistryConfig {
                 registry: "https://mooncakes.io".into(),
                 index: "https://mooncakes.io/git/index".into(),
+                symbols: None,
             }
         }
     }

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -166,8 +166,8 @@ cargo install --path ./crates/moon --debug --offline
   - `src/pkg/{install, sync}`: `moon install`
   - `src/pkg/remove`: `moon remove`
   - `src/pkg/tree`: `moon tree`
-  - `src/registry/online.rs`: downloads packages from
-    mooncakes.io
+  - `src/registry/client.rs`: synchronizes registry metadata and downloads
+    verified packages and prebuilt wasm assets
   - `src/resolver/mvs.rs`: Go-like minimal version selection
     algorithm.
 

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -328,15 +328,23 @@ See details in [Modules and packages][mod-pkg].
 
 Current registry configuration behavior today is:
 
-- `RegistryConfig` currently affects how `moon update` populates the local
-  registry index.
+- `RegistryClient` owns the physical registry lifecycle: synchronizing the Git
+  index and HTTP symbols archive, reading the local index, and downloading and
+  verifying HTTP package archives and prebuilt wasm assets. Resolver code sees
+  only the narrower `Registry` capability.
+- The public `Registry` trait contains only metadata queries used by resolution.
+  Package source acquisition remains on `RegistryClient`; dependency-source
+  tests replace it through a crate-private seam.
+- `RegistryConfig.index` controls how `moon update` populates the local
+  registry index over Git.
+- `RegistryClient` derives the package archive endpoint internally from the
+  loaded registry configuration; callers do not construct or depend on its
+  transport URLs.
+- The optional `RegistryConfig.symbols` URL overrides the default Mooncakes
+  symbols archive used by `moon update`. `MOONCAKES_REGISTRY` derives the
+  index and symbols URLs from the configured registry base.
 - MVS itself resolves against the local on-disk index and does not consume
   `RegistryConfig` directly.
-- Package artifact downloads and symbols download are still tied to the default
-  Mooncakes endpoints.
-
-Future custom/private registry work may configure these pieces together,
-rather than reintroducing unused registry parameters into resolve entry points.
 
 [semver]: https://semver.org/
 [mvs]: https://go.dev/ref/mod#minimal-version-selection

--- a/docs/dev/reference/runwasm.md
+++ b/docs/dev/reference/runwasm.md
@@ -88,9 +88,10 @@ update/retry path.
 
 Version resolution and wasm asset caching are separate.
 
-Once a version is resolved, `runwasm` computes the asset URL and cache path for
-that exact module version and package path. A cache hit runs the cached wasm.
-A cache miss downloads and verifies the wasm asset.
+Once a version is resolved, `runwasm` asks `RegistryClient` to acquire the
+asset for that exact module version and package path. The client owns the
+transport URL, checksum verification, cache path, and atomic cache publication.
+A cache hit runs the cached wasm; a cache miss downloads and verifies it first.
 
 An asset cache miss does not trigger registry update. At that point the version
 has already been resolved.


### PR DESCRIPTION
## Summary

- centralize configured registry endpoints, local index/cache state, Git index and symbols synchronization, package acquisition, and prebuilt wasm acquisition in `RegistryClient`
- keep the public `Registry` trait limited to metadata queries used by dependency resolution, with source acquisition exposed by the concrete client and an internal testing seam
- make registry update reuse account for both the index and symbols endpoints
- exercise the complete registry path with a test registry serving Git smart HTTP, symbols, and package archives

## Why

Registry behavior was split between CLI commands and `mooncake`: callers loaded configuration, selected local paths, invoked update functions, constructed asset URLs, and implemented download/cache behavior independently. This made private-registry behavior incomplete and allowed concurrent update reuse to conflate configurations that shared an index but used different symbols endpoints.

Concentrating those rules in one client gives callers a small interface and keeps endpoint derivation, checksum verification, cache locking, and atomic publication in one implementation.

## Correctness and scope

The existing package and wasm checksum, cache, lock, and publication protocols are preserved behind `RegistryClient`. Successful synchronization invalidates the client's parsed-index cache before subsequent queries. The integration fixture delegates Git requests to `git http-backend`, so the shallow smart-HTTP clone and ordinary HTTP archive paths are exercised together.

The change intentionally leaves resolver policy in the narrower `Registry` trait and keeps `runwasm` execution behavior outside the registry client. Follow-up registry capabilities can deepen the client without reintroducing endpoint or transport knowledge in CLI callers.
