### PR TITLE
feat(moonrun): port async file watchers

### DIFF
--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -61,6 +61,7 @@ features = [
     "Win32_System_IO",
     "Win32_System_Ioctl",
     "Win32_System_JobObjects",
+    "Win32_System_LibraryLoader",
     "Win32_System_Pipes",
     "Win32_System_SystemServices",
     "Win32_System_Threading",

--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -320,19 +320,12 @@ pub(super) fn kqueue_watcher_add_file(
     file: u64,
     is_dir: i32,
 ) -> i32 {
-    use std::os::fd::AsRawFd;
-
-    let result = (|| {
-        let kqueue_resource = context.host.acquire_resource(kqueue)?;
-        let file_resource = context.host.acquire_resource(file)?;
-        watch_kqueue::add_file(
-            kqueue_resource.as_fd()?.as_raw_fd(),
-            file_resource.as_fd()?.as_raw_fd(),
-            is_dir != 0,
-            file,
-        )
-    })();
-    zero_or_minus_one(context, result)
+    zero_or_minus_one(
+        context,
+        context
+            .host
+            .kqueue_watcher_add_file(kqueue, file, is_dir != 0),
+    )
 }
 
 #[ported(

--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -393,24 +393,17 @@ pub(super) fn kqueue_watcher_event_has_modify(
     })
 }
 
-#[ported(
-    source = "src/fs/watch_windows.c",
-    original = "moonbitlang_async_has_ReadDirectoryChangesExW"
-)]
 #[cfg(windows)]
-pub(super) fn watcher_has_read_directory_changes_ex(
-    _context: &mut ImportContext<'_, '_>,
-) -> i32 {
-    i32::from(watch_windows::has_read_directory_changes_ex())
+pub(super) fn windows_watcher_buffer_new(context: &mut ImportContext<'_, '_>) -> u64 {
+    context.host.insert_windows_watcher_buffer()
 }
 
-#[ported(
-    source = "src/fs/watch_windows.c",
-    original = "moonbitlang_async_watcher_event_buffer_size"
-)]
 #[cfg(windows)]
-pub(super) fn watcher_event_buffer_size(_context: &mut ImportContext<'_, '_>) -> u32 {
-    watch_windows::event_buffer_size()
+pub(super) fn windows_watcher_buffer_free(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+) -> AsyncHostResult<()> {
+    context.host.free_windows_watcher_buffer(buffer)
 }
 
 #[ported(
@@ -425,7 +418,9 @@ pub(super) fn watcher_event_get_size(
 ) -> AsyncHostResult<u32> {
     context
         .host
-        .with_c_buffer(buffer, |buffer| watch_windows::event_get_size(buffer, offset))
+        .with_windows_watcher_buffer(buffer, |buffer| {
+            watch_windows::event_get_size(buffer, offset)
+        })
 }
 
 #[ported(
@@ -438,62 +433,61 @@ pub(super) fn watcher_event_is_modify(
     buffer: u64,
     offset: u32,
 ) -> AsyncHostResult<i32> {
-    context.host.with_c_buffer(buffer, |buffer| {
+    context.host.with_windows_watcher_buffer(buffer, |buffer| {
         watch_windows::event_is_modify(buffer, offset).map(i32::from)
     })
 }
 
-#[ported(
-    source = "src/fs/watch_windows.c",
-    original = "moonbitlang_async_watcher_event_get_path_len"
-)]
 #[cfg(windows)]
-pub(super) fn watcher_event_get_path_len(
+pub(super) fn watcher_event_path_len(
     context: &mut ImportContext<'_, '_>,
     buffer: u64,
     offset: u32,
 ) -> AsyncHostResult<u32> {
     context
         .host
-        .with_c_buffer(buffer, |buffer| watch_windows::event_get_path_len(buffer, offset))
+        .with_windows_watcher_buffer(buffer, |buffer| {
+            watch_windows::event_path_len(buffer, offset)
+        })
 }
 
-#[ported(
-    source = "src/fs/watch_windows.c",
-    original = "moonbitlang_async_watcher_event_get_path_offset"
-)]
 #[cfg(windows)]
-pub(super) fn watcher_event_get_path_offset(_context: &mut ImportContext<'_, '_>) -> u32 {
-    watch_windows::event_get_path_offset()
-}
-
-#[ported(
-    source = "src/fs/watch_windows.c",
-    original = "moonbitlang_async_watcher_event_get_file_id"
-)]
-#[cfg(windows)]
-pub(super) fn watcher_event_get_file_id(
+pub(super) fn watcher_event_path_copy(
     context: &mut ImportContext<'_, '_>,
     buffer: u64,
     offset: u32,
-) -> AsyncHostResult<u64> {
-    context
+    out: u32,
+    out_len: u32,
+) -> AsyncHostResult<()> {
+    let path = context
         .host
-        .with_c_buffer(buffer, |buffer| watch_windows::event_get_file_id(buffer, offset))
+        .with_windows_watcher_buffer(buffer, |buffer| {
+            watch_windows::event_path_units(buffer, offset)
+        })?;
+    if usize::try_from(out_len).map_err(|_| AsyncHostError::Fault)? != path.len() {
+        return Err(AsyncHostError::Inval);
+    }
+    context.with_memory_mut(|memory| write_u16(memory, out, &path))
 }
 
-#[ported(
-    source = "src/fs/watch_windows.c",
-    original = "moonbitlang_async_watcher_event_get_parent_file_id"
-)]
 #[cfg(windows)]
-pub(super) fn watcher_event_get_parent_file_id(
+pub(super) fn watcher_event_has_file_ids(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+) -> AsyncHostResult<i32> {
+    context.host.with_windows_watcher_buffer(buffer, |buffer| {
+        watch_windows::event_has_file_ids(buffer).map(i32::from)
+    })
+}
+
+#[cfg(windows)]
+pub(super) fn watcher_event_dirty_file_id(
     context: &mut ImportContext<'_, '_>,
     buffer: u64,
     offset: u32,
 ) -> AsyncHostResult<u64> {
-    context.host.with_c_buffer(buffer, |buffer| {
-        watch_windows::event_get_parent_file_id(buffer, offset)
+    context.host.with_windows_watcher_buffer(buffer, |buffer| {
+        watch_windows::event_dirty_file_id(buffer, offset)
     })
 }
 

--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -22,6 +22,12 @@ use crate::async_host::{AsyncHostError, AsyncHostResult, write_u16};
 use crate::async_policy::AsyncPolicy;
 use crate::async_sys::fs::dir;
 use crate::async_sys::fs::stub;
+#[cfg(target_os = "linux")]
+use crate::async_sys::fs::watch_inotify;
+#[cfg(target_os = "macos")]
+use crate::async_sys::fs::watch_kqueue;
+#[cfg(windows)]
+use crate::async_sys::fs::watch_windows;
 
 use super::context::ImportContext;
 use super::provenance::ported_imports;
@@ -128,6 +134,367 @@ pub(super) fn dir_entry_file_id(
 ) -> AsyncHostResult<u64> {
     context.host
         .with_c_buffer(buf, |buf| dir::entry_file_id(buf, 0, offset))
+}
+
+#[ported(
+    source = "src/fs/watch_inotify.c",
+    original = "moonbitlang_async_inotify_create"
+)]
+#[cfg(target_os = "linux")]
+pub(super) fn inotify_create(context: &mut ImportContext<'_, '_>) -> u64 {
+    match watch_inotify::create() {
+        Ok(fd) => context.host.insert_file_resource(fd),
+        Err(error) => {
+            context.host.record_error(error);
+            context.host.invalid_fd()
+        }
+    }
+}
+
+#[ported(
+    source = "src/fs/watch_inotify.c",
+    original = "moonbitlang_async_inotify_remove_file"
+)]
+#[cfg(target_os = "linux")]
+pub(super) fn inotify_remove_file(
+    context: &mut ImportContext<'_, '_>,
+    watcher: u64,
+    wd: u64,
+) -> i32 {
+    use std::os::fd::AsRawFd;
+
+    let result = (|| {
+        let wd = i32::try_from(wd).map_err(|_| AsyncHostError::Inval)?;
+        context.host.with_resource(watcher, |watcher| {
+            watch_inotify::remove_file(watcher.as_fd()?.as_raw_fd(), wd)
+        })
+    })();
+    zero_or_minus_one(context, result)
+}
+
+#[ported(
+    source = "src/fs/watch_inotify.c",
+    original = "moonbitlang_async_inotify_event_buffer_size"
+)]
+#[cfg(target_os = "linux")]
+pub(super) fn inotify_event_buffer_size(_context: &mut ImportContext<'_, '_>) -> u32 {
+    watch_inotify::event_buffer_size()
+}
+
+#[ported(
+    source = "src/fs/watch_inotify.c",
+    original = "moonbitlang_async_inotify_fetch_event"
+)]
+#[cfg(target_os = "linux")]
+pub(super) fn inotify_fetch_event(
+    context: &mut ImportContext<'_, '_>,
+    watcher: u64,
+    buffer: u64,
+    len: u32,
+) -> i32 {
+    use std::os::fd::AsRawFd;
+
+    let result = (|| {
+        let watcher = context.host.acquire_resource(watcher)?;
+        context.host.with_c_buffer_mut(buffer, |buffer| {
+            watch_inotify::fetch_event(watcher.as_fd()?.as_raw_fd(), buffer, len)
+        })
+    })();
+    match result {
+        Ok(n) => n,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(
+    source = "src/fs/watch_inotify.c",
+    original = "moonbitlang_async_inotify_event_get_size"
+)]
+#[cfg(target_os = "linux")]
+pub(super) fn inotify_event_get_size(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    offset: u32,
+) -> AsyncHostResult<u32> {
+    context
+        .host
+        .with_c_buffer(buffer, |buffer| watch_inotify::event_get_size(buffer, offset))
+}
+
+#[ported(
+    source = "src/fs/watch_inotify.c",
+    original = "moonbitlang_async_inotify_event_get_wd"
+)]
+#[cfg(target_os = "linux")]
+pub(super) fn inotify_event_get_wd(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    offset: u32,
+) -> AsyncHostResult<u64> {
+    context.host.with_c_buffer(buffer, |buffer| {
+        let wd = watch_inotify::event_get_wd(buffer, offset)?;
+        Ok(i64::from(wd) as u64)
+    })
+}
+
+#[ported(
+    source = "src/fs/watch_inotify.c",
+    original = "moonbitlang_async_inotify_event_has_relevant_event"
+)]
+#[cfg(target_os = "linux")]
+pub(super) fn inotify_event_has_relevant_event(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    offset: u32,
+) -> AsyncHostResult<i32> {
+    context.host.with_c_buffer(buffer, |buffer| {
+        watch_inotify::event_has_relevant_event(buffer, offset).map(i32::from)
+    })
+}
+
+#[ported(
+    source = "src/fs/watch_inotify.c",
+    original = "moonbitlang_async_inotify_event_has_overflow"
+)]
+#[cfg(target_os = "linux")]
+pub(super) fn inotify_event_has_overflow(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    offset: u32,
+) -> AsyncHostResult<i32> {
+    context.host.with_c_buffer(buffer, |buffer| {
+        watch_inotify::event_has_overflow(buffer, offset).map(i32::from)
+    })
+}
+
+#[ported(
+    source = "src/fs/watch_inotify.c",
+    original = "moonbitlang_async_inotify_event_has_ignore"
+)]
+#[cfg(target_os = "linux")]
+pub(super) fn inotify_event_has_ignore(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    offset: u32,
+) -> AsyncHostResult<i32> {
+    context.host.with_c_buffer(buffer, |buffer| {
+        watch_inotify::event_has_ignore(buffer, offset).map(i32::from)
+    })
+}
+
+#[ported(
+    source = "src/fs/watch_kqueue.c",
+    original = "moonbitlang_async_kqueue_watcher_create"
+)]
+#[cfg(target_os = "macos")]
+pub(super) fn kqueue_watcher_create(context: &mut ImportContext<'_, '_>) -> u64 {
+    match watch_kqueue::create() {
+        Ok(fd) => context.host.insert_file_resource(fd),
+        Err(error) => {
+            context.host.record_error(error);
+            context.host.invalid_fd()
+        }
+    }
+}
+
+#[ported(
+    source = "src/fs/watch_kqueue.c",
+    original = "moonbitlang_async_kqueue_watcher_buffer_size"
+)]
+#[cfg(target_os = "macos")]
+pub(super) fn kqueue_watcher_buffer_size(_context: &mut ImportContext<'_, '_>) -> u32 {
+    watch_kqueue::buffer_size()
+}
+
+#[ported(
+    source = "src/fs/watch_kqueue.c",
+    original = "moonbitlang_async_kqueue_watcher_add_file"
+)]
+#[cfg(target_os = "macos")]
+pub(super) fn kqueue_watcher_add_file(
+    context: &mut ImportContext<'_, '_>,
+    kqueue: u64,
+    file: u64,
+    is_dir: i32,
+) -> i32 {
+    use std::os::fd::AsRawFd;
+
+    let result = (|| {
+        let kqueue_resource = context.host.acquire_resource(kqueue)?;
+        let file_resource = context.host.acquire_resource(file)?;
+        watch_kqueue::add_file(
+            kqueue_resource.as_fd()?.as_raw_fd(),
+            file_resource.as_fd()?.as_raw_fd(),
+            is_dir != 0,
+            file,
+        )
+    })();
+    zero_or_minus_one(context, result)
+}
+
+#[ported(
+    source = "src/fs/watch_kqueue.c",
+    original = "moonbitlang_async_kqueue_watcher_fetch_event"
+)]
+#[cfg(target_os = "macos")]
+pub(super) fn kqueue_watcher_fetch_event(
+    context: &mut ImportContext<'_, '_>,
+    kqueue: u64,
+    buffer: u64,
+    len: u32,
+) -> i32 {
+    use std::os::fd::AsRawFd;
+
+    let result = (|| {
+        let kqueue = context.host.acquire_resource(kqueue)?;
+        context.host.with_c_buffer_mut(buffer, |buffer| {
+            watch_kqueue::fetch_event(kqueue.as_fd()?.as_raw_fd(), buffer, len)
+        })
+    })();
+    match result {
+        Ok(n) => n,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(
+    source = "src/fs/watch_kqueue.c",
+    original = "moonbitlang_async_kqueue_watcher_event_get_fd"
+)]
+#[cfg(target_os = "macos")]
+pub(super) fn kqueue_watcher_event_get_fd(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    index: u32,
+) -> AsyncHostResult<u64> {
+    context
+        .host
+        .with_c_buffer(buffer, |buffer| watch_kqueue::event_get_fd(buffer, index))
+}
+
+#[ported(
+    source = "src/fs/watch_kqueue.c",
+    original = "moonbitlang_async_kqueue_watcher_event_has_modify"
+)]
+#[cfg(target_os = "macos")]
+pub(super) fn kqueue_watcher_event_has_modify(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    index: u32,
+) -> AsyncHostResult<i32> {
+    context.host.with_c_buffer(buffer, |buffer| {
+        watch_kqueue::event_has_modify(buffer, index).map(i32::from)
+    })
+}
+
+#[ported(
+    source = "src/fs/watch_windows.c",
+    original = "moonbitlang_async_has_ReadDirectoryChangesExW"
+)]
+#[cfg(windows)]
+pub(super) fn watcher_has_read_directory_changes_ex(
+    _context: &mut ImportContext<'_, '_>,
+) -> i32 {
+    i32::from(watch_windows::has_read_directory_changes_ex())
+}
+
+#[ported(
+    source = "src/fs/watch_windows.c",
+    original = "moonbitlang_async_watcher_event_buffer_size"
+)]
+#[cfg(windows)]
+pub(super) fn watcher_event_buffer_size(_context: &mut ImportContext<'_, '_>) -> u32 {
+    watch_windows::event_buffer_size()
+}
+
+#[ported(
+    source = "src/fs/watch_windows.c",
+    original = "moonbitlang_async_watcher_event_get_size"
+)]
+#[cfg(windows)]
+pub(super) fn watcher_event_get_size(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    offset: u32,
+) -> AsyncHostResult<u32> {
+    context
+        .host
+        .with_c_buffer(buffer, |buffer| watch_windows::event_get_size(buffer, offset))
+}
+
+#[ported(
+    source = "src/fs/watch_windows.c",
+    original = "moonbitlang_async_watcher_event_is_modify_event"
+)]
+#[cfg(windows)]
+pub(super) fn watcher_event_is_modify(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    offset: u32,
+) -> AsyncHostResult<i32> {
+    context.host.with_c_buffer(buffer, |buffer| {
+        watch_windows::event_is_modify(buffer, offset).map(i32::from)
+    })
+}
+
+#[ported(
+    source = "src/fs/watch_windows.c",
+    original = "moonbitlang_async_watcher_event_get_path_len"
+)]
+#[cfg(windows)]
+pub(super) fn watcher_event_get_path_len(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    offset: u32,
+) -> AsyncHostResult<u32> {
+    context
+        .host
+        .with_c_buffer(buffer, |buffer| watch_windows::event_get_path_len(buffer, offset))
+}
+
+#[ported(
+    source = "src/fs/watch_windows.c",
+    original = "moonbitlang_async_watcher_event_get_path_offset"
+)]
+#[cfg(windows)]
+pub(super) fn watcher_event_get_path_offset(_context: &mut ImportContext<'_, '_>) -> u32 {
+    watch_windows::event_get_path_offset()
+}
+
+#[ported(
+    source = "src/fs/watch_windows.c",
+    original = "moonbitlang_async_watcher_event_get_file_id"
+)]
+#[cfg(windows)]
+pub(super) fn watcher_event_get_file_id(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    offset: u32,
+) -> AsyncHostResult<u64> {
+    context
+        .host
+        .with_c_buffer(buffer, |buffer| watch_windows::event_get_file_id(buffer, offset))
+}
+
+#[ported(
+    source = "src/fs/watch_windows.c",
+    original = "moonbitlang_async_watcher_event_get_parent_file_id"
+)]
+#[cfg(windows)]
+pub(super) fn watcher_event_get_parent_file_id(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    offset: u32,
+) -> AsyncHostResult<u64> {
+    context.host.with_c_buffer(buffer, |buffer| {
+        watch_windows::event_get_parent_file_id(buffer, offset)
+    })
 }
 
 fn tmp_path_utf16_units(policy: &AsyncPolicy) -> AsyncHostResult<Vec<u16>> {

--- a/crates/moonrun/src/async_api/io.rs
+++ b/crates/moonrun/src/async_api/io.rs
@@ -191,6 +191,19 @@ pub(super) fn make_accept_io_result(
 
 #[ported(
     source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_make_read_dir_changes_io_result"
+)]
+#[cfg(windows)]
+pub(super) fn make_read_dir_changes_io_result(
+    context: &mut ImportContext<'_, '_>,
+    buffer: u64,
+    len: u32,
+) -> crate::async_host::AsyncHostResult<u64> {
+    context.host.make_read_dir_changes_io_result(buffer, len)
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
     original = "moonbitlang_async_get_accept_peer_addr"
 )]
 #[cfg(windows)]
@@ -303,6 +316,25 @@ pub(super) fn read_io_result(
     result: u64,
 ) -> i32 {
     match context.host.read_io_result(fd, result) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            context.host.record_error(error);
+            -1
+        }
+    }
+}
+
+#[ported(
+    source = "src/internal/event_loop/io_windows.c",
+    original = "moonbitlang_async_read_dir_changes"
+)]
+#[cfg(windows)]
+pub(super) fn read_dir_changes_io_result(
+    context: &mut ImportContext<'_, '_>,
+    fd: u64,
+    result: u64,
+) -> i32 {
+    match context.host.read_dir_changes_io_result(fd, result) {
         Ok(bytes) => bytes,
         Err(error) => {
             context.host.record_error(error);

--- a/crates/moonrun/src/async_api/io.rs
+++ b/crates/moonrun/src/async_api/io.rs
@@ -189,17 +189,12 @@ pub(super) fn make_accept_io_result(
     context.host.make_accept_io_result(addr_len)
 }
 
-#[ported(
-    source = "src/internal/event_loop/io_windows.c",
-    original = "moonbitlang_async_make_read_dir_changes_io_result"
-)]
 #[cfg(windows)]
 pub(super) fn make_read_dir_changes_io_result(
     context: &mut ImportContext<'_, '_>,
     buffer: u64,
-    len: u32,
 ) -> crate::async_host::AsyncHostResult<u64> {
-    context.host.make_read_dir_changes_io_result(buffer, len)
+    context.host.make_read_dir_changes_io_result(buffer)
 }
 
 #[ported(

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -747,16 +747,10 @@ declare_async_imports! {
     fake io::make_accept_io_result(addr_len: u32) -> u64 => "io/make_accept_io_result/windows";
 
     #[cfg(windows)]
-    ported io::make_read_dir_changes_io_result(
-        buffer: u64,
-        len: u32,
-    ) -> u64 => "io/make_read_dir_changes_io_result/windows";
+    helper io::make_read_dir_changes_io_result(buffer: u64) -> u64 => "io/make_read_dir_changes_io_result/windows";
 
     #[cfg(not(windows))]
-    fake io::make_read_dir_changes_io_result(
-        buffer: u64,
-        len: u32,
-    ) -> u64 => "io/make_read_dir_changes_io_result/windows";
+    fake io::make_read_dir_changes_io_result(buffer: u64) -> u64 => "io/make_read_dir_changes_io_result/windows";
 
     #[cfg(windows)]
     ported io::get_accept_peer_addr(result: u64, dst: u32, dst_len: u32) -> void => "io/get_accept_peer_addr/windows";
@@ -807,10 +801,10 @@ declare_async_imports! {
     fake io::read_io_result(fd: u64, result: u64) -> i32 => "io/read/windows";
 
     #[cfg(windows)]
-    ported io::read_dir_changes_io_result(fd: u64, result: u64) -> i32 => "io/read_dir_changes/windows/basic";
+    ported io::read_dir_changes_io_result(fd: u64, result: u64) -> i32 => "io/read_dir_changes/windows";
 
     #[cfg(not(windows))]
-    fake io::read_dir_changes_io_result(fd: u64, result: u64) -> i32 => "io/read_dir_changes/windows/basic";
+    fake io::read_dir_changes_io_result(fd: u64, result: u64) -> i32 => "io/read_dir_changes/windows";
 
     #[cfg(windows)]
     ported io::write_io_result(fd: u64, result: u64) -> i32 => "io/write/windows";
@@ -1064,52 +1058,57 @@ declare_async_imports! {
     fake fs::kqueue_watcher_event_has_modify(buffer: u64, index: u32) -> i32 => "fs/kqueue_watcher/event_has_modify";
 
     #[cfg(windows)]
-    ported fs::watcher_has_read_directory_changes_ex() -> i32 => "fs/watcher/windows/has_ReadDirectoryChangesExW";
+    helper fs::windows_watcher_buffer_new() -> u64 => "fs/watcher/windows/buffer/new";
 
     #[cfg(not(windows))]
-    fake fs::watcher_has_read_directory_changes_ex() -> i32 => "fs/watcher/windows/has_ReadDirectoryChangesExW";
+    fake fs::windows_watcher_buffer_new() -> u64 => "fs/watcher/windows/buffer/new";
 
     #[cfg(windows)]
-    ported fs::watcher_event_buffer_size() -> u32 => "fs/watcher/windows/basic/event_buffer_size";
+    helper fs::windows_watcher_buffer_free(buffer: u64) -> void => "fs/watcher/windows/buffer/free";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_buffer_size() -> u32 => "fs/watcher/windows/basic/event_buffer_size";
+    fake fs::windows_watcher_buffer_free(buffer: u64) -> void => "fs/watcher/windows/buffer/free";
 
     #[cfg(windows)]
-    ported fs::watcher_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/basic/event_get_size";
+    ported fs::watcher_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/event_get_size";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/basic/event_get_size";
+    fake fs::watcher_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/event_get_size";
 
     #[cfg(windows)]
-    ported fs::watcher_event_is_modify(buffer: u64, offset: u32) -> i32 => "fs/watcher/windows/basic/event_is_modify";
+    ported fs::watcher_event_is_modify(buffer: u64, offset: u32) -> i32 => "fs/watcher/windows/event_is_modify";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_is_modify(buffer: u64, offset: u32) -> i32 => "fs/watcher/windows/basic/event_is_modify";
+    fake fs::watcher_event_is_modify(buffer: u64, offset: u32) -> i32 => "fs/watcher/windows/event_is_modify";
 
+    // Returns the number of UTF-16 code units in the event path.
     #[cfg(windows)]
-    ported fs::watcher_event_get_path_len(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/basic/event_get_path_len";
+    helper fs::watcher_event_path_len(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/event_path_len";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_get_path_len(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/basic/event_get_path_len";
+    fake fs::watcher_event_path_len(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/event_path_len";
 
+    // Copies the event's raw UTF-16 code units into guest String storage.
     #[cfg(windows)]
-    ported fs::watcher_event_get_path_offset() -> u32 => "fs/watcher/windows/basic/event_get_path_offset";
+    helper fs::watcher_event_path_copy(buffer: u64, offset: u32, out: u32, out_len: u32) -> void => "fs/watcher/windows/event_path_copy";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_get_path_offset() -> u32 => "fs/watcher/windows/basic/event_get_path_offset";
+    fake fs::watcher_event_path_copy(buffer: u64, offset: u32, out: u32, out_len: u32) -> void => "fs/watcher/windows/event_path_copy";
 
+    // Extended notifications carry file IDs; basic notifications require a
+    // path lookup to recover the same information.
     #[cfg(windows)]
-    ported fs::watcher_event_get_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/windows/extended/event_get_file_id";
+    helper fs::watcher_event_has_file_ids(buffer: u64) -> i32 => "fs/watcher/windows/event_has_file_ids";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_get_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/windows/extended/event_get_file_id";
+    fake fs::watcher_event_has_file_ids(buffer: u64) -> i32 => "fs/watcher/windows/event_has_file_ids";
 
+    // Returns FileId for content changes and ParentFileId for entry changes.
     #[cfg(windows)]
-    ported fs::watcher_event_get_parent_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/windows/extended/event_get_parent_file_id";
+    helper fs::watcher_event_dirty_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/windows/event_dirty_file_id";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_get_parent_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/windows/extended/event_get_parent_file_id";
+    fake fs::watcher_event_dirty_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/windows/event_dirty_file_id";
 
     // thread_pool.c FS jobs. Path-taking jobs use the Guest String Path ABI:
     // MoonBit String pointer plus UTF-16 code-unit length.

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -807,10 +807,10 @@ declare_async_imports! {
     fake io::read_io_result(fd: u64, result: u64) -> i32 => "io/read/windows";
 
     #[cfg(windows)]
-    ported io::read_dir_changes_io_result(fd: u64, result: u64) -> i32 => "io/read_dir_changes/windows";
+    ported io::read_dir_changes_io_result(fd: u64, result: u64) -> i32 => "io/read_dir_changes/windows/basic";
 
     #[cfg(not(windows))]
-    fake io::read_dir_changes_io_result(fd: u64, result: u64) -> i32 => "io/read_dir_changes/windows";
+    fake io::read_dir_changes_io_result(fd: u64, result: u64) -> i32 => "io/read_dir_changes/windows/basic";
 
     #[cfg(windows)]
     ported io::write_io_result(fd: u64, result: u64) -> i32 => "io/write/windows";
@@ -1064,52 +1064,52 @@ declare_async_imports! {
     fake fs::kqueue_watcher_event_has_modify(buffer: u64, index: u32) -> i32 => "fs/kqueue_watcher/event_has_modify";
 
     #[cfg(windows)]
-    ported fs::watcher_has_read_directory_changes_ex() -> i32 => "fs/watcher/has_ReadDirectoryChangesExW/windows";
+    ported fs::watcher_has_read_directory_changes_ex() -> i32 => "fs/watcher/windows/has_ReadDirectoryChangesExW";
 
     #[cfg(not(windows))]
-    fake fs::watcher_has_read_directory_changes_ex() -> i32 => "fs/watcher/has_ReadDirectoryChangesExW/windows";
+    fake fs::watcher_has_read_directory_changes_ex() -> i32 => "fs/watcher/windows/has_ReadDirectoryChangesExW";
 
     #[cfg(windows)]
-    ported fs::watcher_event_buffer_size() -> u32 => "fs/watcher/event_buffer_size/windows";
+    ported fs::watcher_event_buffer_size() -> u32 => "fs/watcher/windows/basic/event_buffer_size";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_buffer_size() -> u32 => "fs/watcher/event_buffer_size/windows";
+    fake fs::watcher_event_buffer_size() -> u32 => "fs/watcher/windows/basic/event_buffer_size";
 
     #[cfg(windows)]
-    ported fs::watcher_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/watcher/event_get_size/windows";
+    ported fs::watcher_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/basic/event_get_size";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/watcher/event_get_size/windows";
+    fake fs::watcher_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/basic/event_get_size";
 
     #[cfg(windows)]
-    ported fs::watcher_event_is_modify(buffer: u64, offset: u32) -> i32 => "fs/watcher/event_is_modify/windows";
+    ported fs::watcher_event_is_modify(buffer: u64, offset: u32) -> i32 => "fs/watcher/windows/basic/event_is_modify";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_is_modify(buffer: u64, offset: u32) -> i32 => "fs/watcher/event_is_modify/windows";
+    fake fs::watcher_event_is_modify(buffer: u64, offset: u32) -> i32 => "fs/watcher/windows/basic/event_is_modify";
 
     #[cfg(windows)]
-    ported fs::watcher_event_get_path_len(buffer: u64, offset: u32) -> u32 => "fs/watcher/event_get_path_len/windows";
+    ported fs::watcher_event_get_path_len(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/basic/event_get_path_len";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_get_path_len(buffer: u64, offset: u32) -> u32 => "fs/watcher/event_get_path_len/windows";
+    fake fs::watcher_event_get_path_len(buffer: u64, offset: u32) -> u32 => "fs/watcher/windows/basic/event_get_path_len";
 
     #[cfg(windows)]
-    ported fs::watcher_event_get_path_offset() -> u32 => "fs/watcher/event_get_path_offset/windows";
+    ported fs::watcher_event_get_path_offset() -> u32 => "fs/watcher/windows/basic/event_get_path_offset";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_get_path_offset() -> u32 => "fs/watcher/event_get_path_offset/windows";
+    fake fs::watcher_event_get_path_offset() -> u32 => "fs/watcher/windows/basic/event_get_path_offset";
 
     #[cfg(windows)]
-    ported fs::watcher_event_get_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/event_get_file_id/windows";
+    ported fs::watcher_event_get_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/windows/extended/event_get_file_id";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_get_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/event_get_file_id/windows";
+    fake fs::watcher_event_get_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/windows/extended/event_get_file_id";
 
     #[cfg(windows)]
-    ported fs::watcher_event_get_parent_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/event_get_parent_file_id/windows";
+    ported fs::watcher_event_get_parent_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/windows/extended/event_get_parent_file_id";
 
     #[cfg(not(windows))]
-    fake fs::watcher_event_get_parent_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/event_get_parent_file_id/windows";
+    fake fs::watcher_event_get_parent_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/windows/extended/event_get_parent_file_id";
 
     // thread_pool.c FS jobs. Path-taking jobs use the Guest String Path ABI:
     // MoonBit String pointer plus UTF-16 code-unit length.

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -747,6 +747,18 @@ declare_async_imports! {
     fake io::make_accept_io_result(addr_len: u32) -> u64 => "io/make_accept_io_result/windows";
 
     #[cfg(windows)]
+    ported io::make_read_dir_changes_io_result(
+        buffer: u64,
+        len: u32,
+    ) -> u64 => "io/make_read_dir_changes_io_result/windows";
+
+    #[cfg(not(windows))]
+    fake io::make_read_dir_changes_io_result(
+        buffer: u64,
+        len: u32,
+    ) -> u64 => "io/make_read_dir_changes_io_result/windows";
+
+    #[cfg(windows)]
     ported io::get_accept_peer_addr(result: u64, dst: u32, dst_len: u32) -> void => "io/get_accept_peer_addr/windows";
 
     #[cfg(not(windows))]
@@ -793,6 +805,12 @@ declare_async_imports! {
 
     #[cfg(not(windows))]
     fake io::read_io_result(fd: u64, result: u64) -> i32 => "io/read/windows";
+
+    #[cfg(windows)]
+    ported io::read_dir_changes_io_result(fd: u64, result: u64) -> i32 => "io/read_dir_changes/windows";
+
+    #[cfg(not(windows))]
+    fake io::read_dir_changes_io_result(fd: u64, result: u64) -> i32 => "io/read_dir_changes/windows";
 
     #[cfg(windows)]
     ported io::write_io_result(fd: u64, result: u64) -> i32 => "io/write/windows";
@@ -955,6 +973,144 @@ declare_async_imports! {
 
     ported fs::dir_entry_file_id(buf: u64, offset: u32) -> u64 => "fs/dir_entry_get_file_id";
 
+    #[cfg(target_os = "linux")]
+    ported fs::inotify_create() -> u64 => "fs/inotify/create";
+
+    #[cfg(not(target_os = "linux"))]
+    fake fs::inotify_create() -> u64 => "fs/inotify/create";
+
+    #[cfg(target_os = "linux")]
+    ported fs::inotify_remove_file(watcher: u64, wd: u64) -> i32 => "fs/inotify/remove_file";
+
+    #[cfg(not(target_os = "linux"))]
+    fake fs::inotify_remove_file(watcher: u64, wd: u64) -> i32 => "fs/inotify/remove_file";
+
+    #[cfg(target_os = "linux")]
+    ported fs::inotify_event_buffer_size() -> u32 => "fs/inotify/event_buffer_size";
+
+    #[cfg(not(target_os = "linux"))]
+    fake fs::inotify_event_buffer_size() -> u32 => "fs/inotify/event_buffer_size";
+
+    #[cfg(target_os = "linux")]
+    ported fs::inotify_fetch_event(watcher: u64, buffer: u64, len: u32) -> i32 => "fs/inotify/fetch_event";
+
+    #[cfg(not(target_os = "linux"))]
+    fake fs::inotify_fetch_event(watcher: u64, buffer: u64, len: u32) -> i32 => "fs/inotify/fetch_event";
+
+    #[cfg(target_os = "linux")]
+    ported fs::inotify_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/inotify/event_get_size";
+
+    #[cfg(not(target_os = "linux"))]
+    fake fs::inotify_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/inotify/event_get_size";
+
+    #[cfg(target_os = "linux")]
+    ported fs::inotify_event_get_wd(buffer: u64, offset: u32) -> u64 => "fs/inotify/event_get_wd";
+
+    #[cfg(not(target_os = "linux"))]
+    fake fs::inotify_event_get_wd(buffer: u64, offset: u32) -> u64 => "fs/inotify/event_get_wd";
+
+    #[cfg(target_os = "linux")]
+    ported fs::inotify_event_has_relevant_event(buffer: u64, offset: u32) -> i32 => "fs/inotify/event_has_relevant_event";
+
+    #[cfg(not(target_os = "linux"))]
+    fake fs::inotify_event_has_relevant_event(buffer: u64, offset: u32) -> i32 => "fs/inotify/event_has_relevant_event";
+
+    #[cfg(target_os = "linux")]
+    ported fs::inotify_event_has_overflow(buffer: u64, offset: u32) -> i32 => "fs/inotify/event_has_overflow";
+
+    #[cfg(not(target_os = "linux"))]
+    fake fs::inotify_event_has_overflow(buffer: u64, offset: u32) -> i32 => "fs/inotify/event_has_overflow";
+
+    #[cfg(target_os = "linux")]
+    ported fs::inotify_event_has_ignore(buffer: u64, offset: u32) -> i32 => "fs/inotify/event_has_ignore";
+
+    #[cfg(not(target_os = "linux"))]
+    fake fs::inotify_event_has_ignore(buffer: u64, offset: u32) -> i32 => "fs/inotify/event_has_ignore";
+
+    #[cfg(target_os = "macos")]
+    ported fs::kqueue_watcher_create() -> u64 => "fs/kqueue_watcher/create";
+
+    #[cfg(not(target_os = "macos"))]
+    fake fs::kqueue_watcher_create() -> u64 => "fs/kqueue_watcher/create";
+
+    #[cfg(target_os = "macos")]
+    ported fs::kqueue_watcher_buffer_size() -> u32 => "fs/kqueue_watcher/buffer_size";
+
+    #[cfg(not(target_os = "macos"))]
+    fake fs::kqueue_watcher_buffer_size() -> u32 => "fs/kqueue_watcher/buffer_size";
+
+    #[cfg(target_os = "macos")]
+    ported fs::kqueue_watcher_add_file(kqueue: u64, file: u64, is_dir: i32) -> i32 => "fs/kqueue_watcher/add_file";
+
+    #[cfg(not(target_os = "macos"))]
+    fake fs::kqueue_watcher_add_file(kqueue: u64, file: u64, is_dir: i32) -> i32 => "fs/kqueue_watcher/add_file";
+
+    #[cfg(target_os = "macos")]
+    ported fs::kqueue_watcher_fetch_event(kqueue: u64, buffer: u64, len: u32) -> i32 => "fs/kqueue_watcher/fetch_event";
+
+    #[cfg(not(target_os = "macos"))]
+    fake fs::kqueue_watcher_fetch_event(kqueue: u64, buffer: u64, len: u32) -> i32 => "fs/kqueue_watcher/fetch_event";
+
+    #[cfg(target_os = "macos")]
+    ported fs::kqueue_watcher_event_get_fd(buffer: u64, index: u32) -> u64 => "fs/kqueue_watcher/event_get_fd";
+
+    #[cfg(not(target_os = "macos"))]
+    fake fs::kqueue_watcher_event_get_fd(buffer: u64, index: u32) -> u64 => "fs/kqueue_watcher/event_get_fd";
+
+    #[cfg(target_os = "macos")]
+    ported fs::kqueue_watcher_event_has_modify(buffer: u64, index: u32) -> i32 => "fs/kqueue_watcher/event_has_modify";
+
+    #[cfg(not(target_os = "macos"))]
+    fake fs::kqueue_watcher_event_has_modify(buffer: u64, index: u32) -> i32 => "fs/kqueue_watcher/event_has_modify";
+
+    #[cfg(windows)]
+    ported fs::watcher_has_read_directory_changes_ex() -> i32 => "fs/watcher/has_ReadDirectoryChangesExW/windows";
+
+    #[cfg(not(windows))]
+    fake fs::watcher_has_read_directory_changes_ex() -> i32 => "fs/watcher/has_ReadDirectoryChangesExW/windows";
+
+    #[cfg(windows)]
+    ported fs::watcher_event_buffer_size() -> u32 => "fs/watcher/event_buffer_size/windows";
+
+    #[cfg(not(windows))]
+    fake fs::watcher_event_buffer_size() -> u32 => "fs/watcher/event_buffer_size/windows";
+
+    #[cfg(windows)]
+    ported fs::watcher_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/watcher/event_get_size/windows";
+
+    #[cfg(not(windows))]
+    fake fs::watcher_event_get_size(buffer: u64, offset: u32) -> u32 => "fs/watcher/event_get_size/windows";
+
+    #[cfg(windows)]
+    ported fs::watcher_event_is_modify(buffer: u64, offset: u32) -> i32 => "fs/watcher/event_is_modify/windows";
+
+    #[cfg(not(windows))]
+    fake fs::watcher_event_is_modify(buffer: u64, offset: u32) -> i32 => "fs/watcher/event_is_modify/windows";
+
+    #[cfg(windows)]
+    ported fs::watcher_event_get_path_len(buffer: u64, offset: u32) -> u32 => "fs/watcher/event_get_path_len/windows";
+
+    #[cfg(not(windows))]
+    fake fs::watcher_event_get_path_len(buffer: u64, offset: u32) -> u32 => "fs/watcher/event_get_path_len/windows";
+
+    #[cfg(windows)]
+    ported fs::watcher_event_get_path_offset() -> u32 => "fs/watcher/event_get_path_offset/windows";
+
+    #[cfg(not(windows))]
+    fake fs::watcher_event_get_path_offset() -> u32 => "fs/watcher/event_get_path_offset/windows";
+
+    #[cfg(windows)]
+    ported fs::watcher_event_get_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/event_get_file_id/windows";
+
+    #[cfg(not(windows))]
+    fake fs::watcher_event_get_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/event_get_file_id/windows";
+
+    #[cfg(windows)]
+    ported fs::watcher_event_get_parent_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/event_get_parent_file_id/windows";
+
+    #[cfg(not(windows))]
+    fake fs::watcher_event_get_parent_file_id(buffer: u64, offset: u32) -> u64 => "fs/watcher/event_get_parent_file_id/windows";
+
     // thread_pool.c FS jobs. Path-taking jobs use the Guest String Path ABI:
     // MoonBit String pointer plus UTF-16 code-unit length.
     compat thread_pool::make_open_job_legacy(
@@ -1062,6 +1218,22 @@ declare_async_imports! {
     ported thread_pool::make_rmdir_job(path_ptr: u32, path_len: u32) -> u64 => "thread_pool/make_rmdir_job";
 
     ported thread_pool::make_readdir_job(dir: u64, buf: u64, len: u32, restart: i32) -> u64 => "thread_pool/make_readdir_job";
+
+    #[cfg(target_os = "linux")]
+    ported thread_pool::make_inotify_add_watch_job(
+        inotify: u64,
+        path_ptr: u32,
+        path_len: u32,
+        is_dir: i32,
+    ) -> u64 => "thread_pool/make_inotify_add_watch_job";
+
+    #[cfg(not(target_os = "linux"))]
+    fake thread_pool::make_inotify_add_watch_job(
+        inotify: u64,
+        path_ptr: u32,
+        path_len: u32,
+        is_dir: i32,
+    ) -> u64 => "thread_pool/make_inotify_add_watch_job";
 
     ported thread_pool::make_bind_job(socket: u64, addr: u32, addr_len: u32) -> u64 => "thread_pool/make_bind_job";
 

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -530,6 +530,31 @@ pub(super) fn make_readdir_job(
         ))
 }
 
+#[cfg(target_os = "linux")]
+#[ported(
+    source = "src/internal/event_loop/fs.c",
+    original = "moonbitlang_async_make_inotify_add_watch_job"
+)]
+pub(super) fn make_inotify_add_watch_job(
+    context: &mut ImportContext<'_, '_>,
+    inotify: u64,
+    path_ptr: u32,
+    path_len: u32,
+    is_dir: i32,
+) -> AsyncHostResult<u64> {
+    let inotify = context
+        .host
+        .acquire_resource_of_class(inotify, ResourceClass::File)?;
+    let path = read_guest_os_string(context, path_ptr, path_len)?;
+    context
+        .host
+        .insert_job(thread_pool::make_inotify_add_watch_job(
+            inotify,
+            path,
+            is_dir != 0,
+        ))
+}
+
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_bind_job(
     context: &mut ImportContext<'_, '_>,

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -530,11 +530,11 @@ pub(super) fn make_readdir_job(
         ))
 }
 
-#[cfg(target_os = "linux")]
 #[ported(
     source = "src/internal/event_loop/fs.c",
     original = "moonbitlang_async_make_inotify_add_watch_job"
 )]
+#[cfg(target_os = "linux")]
 pub(super) fn make_inotify_add_watch_job(
     context: &mut ImportContext<'_, '_>,
     inotify: u64,

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -2573,6 +2573,26 @@ impl AsyncHost {
             .insert_resource(Resource::new(raw_fd))
     }
 
+    #[cfg(target_os = "macos")]
+    pub(crate) fn kqueue_watcher_add_file(
+        &self,
+        kqueue_handle: HostHandle,
+        file_handle: HostHandle,
+        is_dir: bool,
+    ) -> AsyncHostResult<()> {
+        use std::os::fd::AsRawFd;
+
+        let kqueue = self.acquire_resource(kqueue_handle)?;
+        let file = self.acquire_resource(file_handle)?;
+        Self::check_file_metadata_policy(&self.policy, Some(file.as_ref()))?;
+        crate::async_sys::fs::watch_kqueue::add_file(
+            kqueue.as_fd()?.as_raw_fd(),
+            file.as_fd()?.as_raw_fd(),
+            is_dir,
+            file_handle,
+        )
+    }
+
     pub(crate) fn insert_failed_job(&self, error: AsyncHostError) -> AsyncHostResult<u64> {
         self.insert_job(thread_pool::make_failed_job(error.errno()))
     }
@@ -5994,6 +6014,42 @@ mod tests {
         host.free_job(time_job).unwrap();
         host.free_job(size_job).unwrap();
         host.close_fd(fd).unwrap();
+        host.free_job(open_job).unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn kqueue_watcher_registration_requires_read_policy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let writable = tmp.path().join("writable");
+        std::fs::create_dir(&writable).unwrap();
+        let file = writable.join("data.txt");
+        std::fs::write(&file, "secret").unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(&policy_file, "[fs]\nwrite = [\"writable\"]\n").unwrap();
+        let host = host_with_policy(&policy_file);
+        let open_job = host
+            .insert_job(thread_pool::make_open_job(
+                file.as_os_str().to_os_string(),
+                1,
+                0,
+                false,
+                0,
+                0,
+            ))
+            .unwrap();
+        host.run_job(open_job).unwrap();
+        let file_handle = host.open_job_get_fd(open_job).unwrap();
+        let kqueue_handle =
+            host.insert_file_resource(crate::async_sys::fs::watch_kqueue::create().unwrap());
+
+        assert_eq!(
+            host.kqueue_watcher_add_file(kqueue_handle, file_handle, false),
+            Err(AsyncHostError::PermissionDenied)
+        );
+
+        host.close_fd(kqueue_handle).unwrap();
+        host.close_fd(file_handle).unwrap();
         host.free_job(open_job).unwrap();
     }
 

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -104,6 +104,38 @@ impl CBufferLease {
         (self.key, self.buffer)
     }
 }
+
+#[cfg(windows)]
+enum HostWindowsWatcherBuffer {
+    Available(crate::async_sys::fs::watch_windows::EventBuffer),
+    Leased,
+}
+
+#[cfg(windows)]
+#[derive(Debug)]
+pub(crate) struct WindowsWatcherBufferLease {
+    key: HandleKey,
+    buffer: crate::async_sys::fs::watch_windows::EventBuffer,
+}
+
+#[cfg(windows)]
+impl WindowsWatcherBufferLease {
+    fn new(key: HandleKey, buffer: crate::async_sys::fs::watch_windows::EventBuffer) -> Self {
+        Self { key, buffer }
+    }
+
+    fn buffer(&self) -> &crate::async_sys::fs::watch_windows::EventBuffer {
+        &self.buffer
+    }
+
+    fn buffer_mut(&mut self) -> &mut crate::async_sys::fs::watch_windows::EventBuffer {
+        &mut self.buffer
+    }
+
+    fn into_parts(self) -> (HandleKey, crate::async_sys::fs::watch_windows::EventBuffer) {
+        (self.key, self.buffer)
+    }
+}
 #[cfg(unix)]
 type HostProcessArgv = Vec<Option<OsString>>;
 #[cfg(unix)]
@@ -438,6 +470,16 @@ impl HandleTable {
         self.remove(handle, HandleKind::CBuffer)
     }
 
+    #[cfg(windows)]
+    fn windows_watcher_buffer(&self, handle: HostHandle) -> AsyncHostResult<HandleKey> {
+        self.key(handle, HandleKind::WindowsWatcherBuffer)
+    }
+
+    #[cfg(windows)]
+    fn remove_windows_watcher_buffer(&mut self, handle: HostHandle) -> AsyncHostResult<HandleKey> {
+        self.remove(handle, HandleKind::WindowsWatcherBuffer)
+    }
+
     #[cfg(unix)]
     fn process_argv(&self, handle: HostHandle) -> AsyncHostResult<HandleKey> {
         self.key(handle, HandleKind::ProcessArgv)
@@ -765,10 +807,10 @@ struct HostIoResult {
     // read constructors allocate output capacity, and write constructors copy
     // the input payload before any overlapped operation can outlive the import.
     buffer: Vec<u8>,
-    // ReadDirectoryChangesW writes into a stable host C buffer. Lease it
-    // while the OVERLAPPED operation is pending, then return it to the CBuffer
-    // table before the guest parses the completed events.
-    read_dir_changes_buffer: Option<CBufferLease>,
+    // Directory change notification writes into a stable host watcher buffer.
+    // Lease it while the OVERLAPPED operation is pending, then restore the
+    // bytes and selected event layout before the guest parses the batch.
+    read_dir_changes_buffer: Option<WindowsWatcherBufferLease>,
     read_dir_changes_len: usize,
     socket_flags: u32,
     addr_buffer: Vec<u8>,
@@ -933,7 +975,8 @@ impl HostIoResult {
         })
     }
 
-    fn for_read_dir_changes(buffer: CBufferLease, len: usize) -> Self {
+    fn for_read_dir_changes(buffer: WindowsWatcherBufferLease) -> Self {
+        let len = buffer.buffer().capacity();
         Self {
             overlapped: Self::zeroed_overlapped(),
             kind: HostIoKind::ReadDirChanges,
@@ -953,6 +996,10 @@ impl HostIoResult {
 
     fn overlapped_ptr(&mut self) -> *mut windows_sys::Win32::System::IO::OVERLAPPED {
         &mut self.overlapped
+    }
+
+    fn reset_overlapped(&mut self) {
+        self.overlapped = Self::zeroed_overlapped();
     }
 
     fn overlapped_addr(&mut self) -> OverlappedAddr {
@@ -1162,6 +1209,8 @@ pub(crate) struct AsyncHost {
     errno: Cell<i32>,
     addr_infos: RefCell<SecondaryMap<HandleKey, HostAddrInfo>>,
     c_buffers: RefCell<SecondaryMap<HandleKey, HostCBuffer>>,
+    #[cfg(windows)]
+    windows_watcher_buffers: RefCell<SecondaryMap<HandleKey, HostWindowsWatcherBuffer>>,
     #[cfg(unix)]
     process_argvs: RefCell<SecondaryMap<HandleKey, HostProcessArgv>>,
     process_envs: RefCell<SecondaryMap<HandleKey, HostProcessEnv>>,
@@ -1199,6 +1248,8 @@ impl AsyncHost {
             errno: Cell::new(0),
             addr_infos: RefCell::new(SecondaryMap::new()),
             c_buffers: RefCell::new(SecondaryMap::new()),
+            #[cfg(windows)]
+            windows_watcher_buffers: RefCell::new(SecondaryMap::new()),
             #[cfg(unix)]
             process_argvs: RefCell::new(SecondaryMap::new()),
             process_envs: RefCell::new(SecondaryMap::new()),
@@ -1302,6 +1353,16 @@ impl AsyncHost {
         }
     }
 
+    #[cfg(windows)]
+    fn restore_windows_watcher_buffer(&self, buffer: WindowsWatcherBufferLease) {
+        let (key, buffer) = buffer.into_parts();
+        if let Some(entry) = self.windows_watcher_buffers.borrow_mut().get_mut(key)
+            && matches!(entry, HostWindowsWatcherBuffer::Leased)
+        {
+            *entry = HostWindowsWatcherBuffer::Available(buffer);
+        }
+    }
+
     fn revoke_unclaimed_spawn(process_policy_state: Option<&ProcessPolicyState>, job: &Job) {
         let Some(state) = process_policy_state else {
             return;
@@ -1364,6 +1425,13 @@ impl AsyncHost {
                 let c_buffers = self.c_buffers.borrow();
                 if !c_buffers.is_empty() {
                     leaks.push(format!("c_buffers={}", c_buffers.len()));
+                }
+            }
+            #[cfg(windows)]
+            {
+                let buffers = self.windows_watcher_buffers.borrow();
+                if !buffers.is_empty() {
+                    leaks.push(format!("windows_watcher_buffers={}", buffers.len()));
                 }
             }
             {
@@ -1869,6 +1937,73 @@ impl AsyncHost {
             HostCBuffer::Available(buffer) => Ok(CBufferLease::new(key, buffer)),
             HostCBuffer::Leased => {
                 *entry = HostCBuffer::Leased;
+                Err(AsyncHostError::Badf)
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn insert_windows_watcher_buffer(&self) -> u64 {
+        let key = self
+            .handles
+            .borrow_mut()
+            .insert(HandleKind::WindowsWatcherBuffer);
+        self.windows_watcher_buffers.borrow_mut().insert(
+            key,
+            HostWindowsWatcherBuffer::Available(
+                crate::async_sys::fs::watch_windows::EventBuffer::new(),
+            ),
+        );
+        handle_from_key(key)
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn free_windows_watcher_buffer(&self, handle: u64) -> AsyncHostResult<()> {
+        if handle == INVALID_HOST_HANDLE {
+            return Ok(());
+        }
+        let key = self
+            .handles
+            .borrow_mut()
+            .remove_windows_watcher_buffer(handle)?;
+        self.windows_watcher_buffers
+            .borrow_mut()
+            .remove(key)
+            .map(|_| ())
+            .ok_or(AsyncHostError::Badf)
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn with_windows_watcher_buffer<T>(
+        &self,
+        handle: u64,
+        f: impl FnOnce(&crate::async_sys::fs::watch_windows::EventBuffer) -> AsyncHostResult<T>,
+    ) -> AsyncHostResult<T> {
+        let key = self.handles.borrow().windows_watcher_buffer(handle)?;
+        let buffers = self.windows_watcher_buffers.borrow();
+        match buffers.get(key).ok_or(AsyncHostError::Badf)? {
+            HostWindowsWatcherBuffer::Available(buffer) => f(buffer),
+            HostWindowsWatcherBuffer::Leased => Err(AsyncHostError::Badf),
+        }
+    }
+
+    #[cfg(windows)]
+    fn lease_windows_watcher_buffer(
+        &self,
+        handle: u64,
+    ) -> AsyncHostResult<WindowsWatcherBufferLease> {
+        if handle == INVALID_HOST_HANDLE {
+            return Err(AsyncHostError::Badf);
+        }
+        let key = self.handles.borrow().windows_watcher_buffer(handle)?;
+        let mut buffers = self.windows_watcher_buffers.borrow_mut();
+        let entry = buffers.get_mut(key).ok_or(AsyncHostError::Badf)?;
+        match std::mem::replace(entry, HostWindowsWatcherBuffer::Leased) {
+            HostWindowsWatcherBuffer::Available(buffer) => {
+                Ok(WindowsWatcherBufferLease::new(key, buffer))
+            }
+            HostWindowsWatcherBuffer::Leased => {
+                *entry = HostWindowsWatcherBuffer::Leased;
                 Err(AsyncHostError::Badf)
             }
         }
@@ -2828,17 +2963,9 @@ impl AsyncHost {
     pub(crate) fn make_read_dir_changes_io_result(
         &self,
         buffer_handle: u64,
-        len: u32,
     ) -> AsyncHostResult<u64> {
-        let mut buffer = self.lease_c_buffer(buffer_handle)?;
-        let len = match usize::try_from(len) {
-            Ok(len) if len <= buffer.as_mut_slice().len() => len,
-            _ => {
-                self.restore_c_buffer(buffer);
-                return Err(AsyncHostError::Fault);
-            }
-        };
-        self.insert_io_result(HostIoResult::for_read_dir_changes(buffer, len))
+        let buffer = self.lease_windows_watcher_buffer(buffer_handle)?;
+        self.insert_io_result(HostIoResult::for_read_dir_changes(buffer))
     }
 
     #[cfg(windows)]
@@ -2884,7 +3011,7 @@ impl AsyncHost {
         drop(io_results);
         drop(handles);
         if let Some(buffer) = buffer {
-            self.restore_c_buffer(buffer);
+            self.restore_windows_watcher_buffer(buffer);
         }
         Ok(())
     }
@@ -2919,7 +3046,7 @@ impl AsyncHost {
         drop(io_results);
         drop(handles);
         if let Some(buffer) = buffer {
-            self.restore_c_buffer(buffer);
+            self.restore_windows_watcher_buffer(buffer);
         }
         status
     }
@@ -2966,11 +3093,24 @@ impl AsyncHost {
             result.clear_pending();
             i32::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
         };
+        if result.kind == HostIoKind::ReadDirChanges {
+            let completed_len = status
+                .as_ref()
+                .ok()
+                .and_then(|len| usize::try_from(*len).ok())
+                .unwrap_or(0);
+            result
+                .read_dir_changes_buffer
+                .as_mut()
+                .ok_or(AsyncHostError::Inval)?
+                .buffer_mut()
+                .complete_read(completed_len)?;
+        }
         let buffer = result.read_dir_changes_buffer.take();
         drop(io_results);
         drop(handles);
         if let Some(buffer) = buffer {
-            self.restore_c_buffer(buffer);
+            self.restore_windows_watcher_buffer(buffer);
         }
         status
     }
@@ -3113,7 +3253,8 @@ impl AsyncHost {
         fd_handle: HostHandle,
         result_handle: u64,
     ) -> AsyncHostResult<i32> {
-        use windows_sys::Win32::Foundation::ERROR_IO_PENDING;
+        use crate::async_sys::fs::watch_windows::EventLayout;
+        use windows_sys::Win32::Foundation::{ERROR_INVALID_FUNCTION, ERROR_IO_PENDING};
         use windows_sys::Win32::Storage::FileSystem::{
             FILE_NOTIFY_CHANGE_DIR_NAME, FILE_NOTIFY_CHANGE_FILE_NAME,
             FILE_NOTIFY_CHANGE_LAST_WRITE, FILE_NOTIFY_CHANGE_SIZE, ReadDirectoryChangesW,
@@ -3135,31 +3276,81 @@ impl AsyncHost {
             .read_dir_changes_buffer
             .as_mut()
             .ok_or(AsyncHostError::Inval)?
+            .buffer_mut()
             .as_mut_slice()
             .as_mut_ptr();
+        let notify_filter = FILE_NOTIFY_CHANGE_SIZE
+            | FILE_NOTIFY_CHANGE_LAST_WRITE
+            | FILE_NOTIFY_CHANGE_FILE_NAME
+            | FILE_NOTIFY_CHANGE_DIR_NAME;
         let mut bytes_returned = 0;
-        let success = unsafe {
-            ReadDirectoryChangesW(
+        let extended = unsafe {
+            crate::async_sys::fs::watch_windows::read_directory_changes_extended(
                 file.as_file()?.as_raw_handle(),
                 buffer.cast(),
                 len,
                 1,
-                FILE_NOTIFY_CHANGE_SIZE
-                    | FILE_NOTIFY_CHANGE_LAST_WRITE
-                    | FILE_NOTIFY_CHANGE_FILE_NAME
-                    | FILE_NOTIFY_CHANGE_DIR_NAME,
+                notify_filter,
                 &mut bytes_returned,
                 result.overlapped_ptr(),
-                None,
             )
+        };
+        let (success, layout) = match extended {
+            Some(success) if success != 0 => (success, EventLayout::Extended),
+            Some(_) => {
+                let error = last_native_error();
+                if error
+                    != AsyncHostError::Native(
+                        i32::try_from(ERROR_INVALID_FUNCTION).expect("Windows error code fits i32"),
+                    )
+                {
+                    return Err(error);
+                }
+                result.reset_overlapped();
+                bytes_returned = 0;
+                let success = unsafe {
+                    ReadDirectoryChangesW(
+                        file.as_file()?.as_raw_handle(),
+                        buffer.cast(),
+                        len,
+                        1,
+                        notify_filter,
+                        &mut bytes_returned,
+                        result.overlapped_ptr(),
+                        None,
+                    )
+                };
+                (success, EventLayout::Basic)
+            }
+            None => {
+                let success = unsafe {
+                    ReadDirectoryChangesW(
+                        file.as_file()?.as_raw_handle(),
+                        buffer.cast(),
+                        len,
+                        1,
+                        notify_filter,
+                        &mut bytes_returned,
+                        result.overlapped_ptr(),
+                        None,
+                    )
+                };
+                (success, EventLayout::Basic)
+            }
         };
         if success == 0 {
             return Err(last_native_error());
         }
+        result
+            .read_dir_changes_buffer
+            .as_mut()
+            .ok_or(AsyncHostError::Inval)?
+            .buffer_mut()
+            .begin_read(layout);
 
-        // ReadDirectoryChangesW reports that the completion packet was
-        // queued, not synchronous completion. Match native async by exposing
-        // the operation as pending even though the Windows call returned TRUE.
+        // Directory change notification reports that the completion packet
+        // was queued, not synchronous completion. Match native async by
+        // exposing the operation as pending even though the call returned TRUE.
         result.mark_pending(Arc::clone(file))?;
         Err(AsyncHostError::Native(ERROR_IO_PENDING as i32))
     }
@@ -6404,31 +6595,31 @@ mod tests {
     #[test]
     fn read_dir_changes_io_result_leases_buffer_until_free() {
         let host = AsyncHost::default();
-        let buffer = host.insert_c_buffer(vec![1, 2, 3].into_boxed_slice());
-        let result = host.make_read_dir_changes_io_result(buffer, 3).unwrap();
+        let buffer = host.insert_windows_watcher_buffer();
+        let result = host.make_read_dir_changes_io_result(buffer).unwrap();
 
         assert_eq!(
-            host.with_c_buffer(buffer, |_| Ok(())),
+            host.with_windows_watcher_buffer(buffer, |_| Ok(())),
             Err(AsyncHostError::Badf)
         );
 
         host.free_io_result(result).unwrap();
         assert_eq!(
-            host.with_c_buffer(buffer, |bytes| Ok(bytes.to_vec())),
-            Ok(vec![1, 2, 3])
+            host.with_windows_watcher_buffer(buffer, |buffer| Ok(buffer.capacity())),
+            Ok(usize::try_from(crate::async_sys::fs::watch_windows::event_buffer_size()).unwrap())
         );
-        host.free_c_buffer(buffer).unwrap();
+        host.free_windows_watcher_buffer(buffer).unwrap();
     }
 
     #[cfg(windows)]
     #[test]
-    fn rejected_read_dir_changes_length_restores_buffer() {
+    fn read_dir_changes_rejects_a_generic_c_buffer() {
         let host = AsyncHost::default();
         let buffer = host.insert_c_buffer(vec![1, 2, 3].into_boxed_slice());
 
         assert_eq!(
-            host.make_read_dir_changes_io_result(buffer, 4),
-            Err(AsyncHostError::Fault)
+            host.make_read_dir_changes_io_result(buffer),
+            Err(AsyncHostError::Badf)
         );
         assert_eq!(
             host.with_c_buffer(buffer, |bytes| Ok(bytes.to_vec())),

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -765,7 +765,7 @@ struct HostIoResult {
     // read constructors allocate output capacity, and write constructors copy
     // the input payload before any overlapped operation can outlive the import.
     buffer: Vec<u8>,
-    // ReadDirectoryChangesExW writes into a stable host C buffer. Lease it
+    // ReadDirectoryChangesW writes into a stable host C buffer. Lease it
     // while the OVERLAPPED operation is pending, then return it to the CBuffer
     // table before the guest parses the completed events.
     read_dir_changes_buffer: Option<CBufferLease>,
@@ -3116,8 +3116,7 @@ impl AsyncHost {
         use windows_sys::Win32::Foundation::ERROR_IO_PENDING;
         use windows_sys::Win32::Storage::FileSystem::{
             FILE_NOTIFY_CHANGE_DIR_NAME, FILE_NOTIFY_CHANGE_FILE_NAME,
-            FILE_NOTIFY_CHANGE_LAST_WRITE, FILE_NOTIFY_CHANGE_SIZE, ReadDirectoryChangesExW,
-            ReadDirectoryNotifyExtendedInformation,
+            FILE_NOTIFY_CHANGE_LAST_WRITE, FILE_NOTIFY_CHANGE_SIZE, ReadDirectoryChangesW,
         };
 
         let handles = self.handles.borrow();
@@ -3140,7 +3139,7 @@ impl AsyncHost {
             .as_mut_ptr();
         let mut bytes_returned = 0;
         let success = unsafe {
-            ReadDirectoryChangesExW(
+            ReadDirectoryChangesW(
                 file.as_file()?.as_raw_handle(),
                 buffer.cast(),
                 len,
@@ -3152,14 +3151,13 @@ impl AsyncHost {
                 &mut bytes_returned,
                 result.overlapped_ptr(),
                 None,
-                ReadDirectoryNotifyExtendedInformation,
             )
         };
         if success == 0 {
             return Err(last_native_error());
         }
 
-        // ReadDirectoryChangesExW reports that the completion packet was
+        // ReadDirectoryChangesW reports that the completion packet was
         // queued, not synchronous completion. Match native async by exposing
         // the operation as pending even though the Windows call returned TRUE.
         result.mark_pending(Arc::clone(file))?;

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -734,6 +734,7 @@ enum HostIoKind {
     SocketWithAddr,
     Connect,
     Accept,
+    ReadDirChanges,
 }
 
 #[cfg(windows)]
@@ -746,7 +747,7 @@ impl HostIoKind {
         let resource = handles.resource_ref(handle)?;
         let class = resource.resource_class();
         match self {
-            Self::File if class == ResourceClass::File => Ok(resource),
+            Self::File | Self::ReadDirChanges if class == ResourceClass::File => Ok(resource),
             Self::Socket if class.is_socket() => Ok(resource),
             Self::SocketWithAddr if class == ResourceClass::UdpSocket => Ok(resource),
             _ => Err(AsyncHostError::Inval),
@@ -764,6 +765,11 @@ struct HostIoResult {
     // read constructors allocate output capacity, and write constructors copy
     // the input payload before any overlapped operation can outlive the import.
     buffer: Vec<u8>,
+    // ReadDirectoryChangesExW writes into a stable host C buffer. Lease it
+    // while the OVERLAPPED operation is pending, then return it to the CBuffer
+    // table before the guest parses the completed events.
+    read_dir_changes_buffer: Option<CBufferLease>,
+    read_dir_changes_len: usize,
     socket_flags: u32,
     addr_buffer: Vec<u8>,
     // WSARecvFrom may complete asynchronously and write through lpFromlen later.
@@ -804,6 +810,8 @@ impl HostIoResult {
             kind: HostIoKind::File,
             event,
             buffer,
+            read_dir_changes_buffer: None,
+            read_dir_changes_len: 0,
             socket_flags: 0,
             addr_buffer: Vec::new(),
             addr_len: 0,
@@ -829,6 +837,8 @@ impl HostIoResult {
             kind: HostIoKind::Socket,
             event,
             buffer,
+            read_dir_changes_buffer: None,
+            read_dir_changes_len: 0,
             socket_flags: flags as u32,
             addr_buffer: Vec::new(),
             addr_len: 0,
@@ -868,6 +878,8 @@ impl HostIoResult {
             kind: HostIoKind::SocketWithAddr,
             event,
             buffer,
+            read_dir_changes_buffer: None,
+            read_dir_changes_len: 0,
             socket_flags: flags as u32,
             addr_buffer,
             addr_len,
@@ -884,6 +896,8 @@ impl HostIoResult {
             kind: HostIoKind::Connect,
             event: IO_RESULT_WRITE_EVENT,
             buffer: Vec::new(),
+            read_dir_changes_buffer: None,
+            read_dir_changes_len: 0,
             socket_flags: 0,
             addr_buffer,
             addr_len: 0,
@@ -907,6 +921,8 @@ impl HostIoResult {
             kind: HostIoKind::Accept,
             event: IO_RESULT_READ_EVENT,
             buffer: Vec::new(),
+            read_dir_changes_buffer: None,
+            read_dir_changes_len: 0,
             socket_flags: 0,
             addr_buffer: Vec::new(),
             addr_len: i32::try_from(addr_len).map_err(|_| AsyncHostError::Fault)?,
@@ -915,6 +931,24 @@ impl HostIoResult {
             pending_resource: None,
             extra_pending_close_resource: None,
         })
+    }
+
+    fn for_read_dir_changes(buffer: CBufferLease, len: usize) -> Self {
+        Self {
+            overlapped: Self::zeroed_overlapped(),
+            kind: HostIoKind::ReadDirChanges,
+            event: IO_RESULT_READ_EVENT,
+            buffer: Vec::new(),
+            read_dir_changes_buffer: Some(buffer),
+            read_dir_changes_len: len,
+            socket_flags: 0,
+            addr_buffer: Vec::new(),
+            addr_len: 0,
+            accept_buffer: Vec::new(),
+            accept_bytes_received: 0,
+            pending_resource: None,
+            extra_pending_close_resource: None,
+        }
     }
 
     fn overlapped_ptr(&mut self) -> *mut windows_sys::Win32::System::IO::OVERLAPPED {
@@ -960,7 +994,10 @@ impl HostIoResult {
         len: u32,
     ) -> AsyncHostResult<()> {
         self.validate_completed_read()?;
-        if self.kind == HostIoKind::SocketWithAddr {
+        if matches!(
+            self.kind,
+            HostIoKind::SocketWithAddr | HostIoKind::ReadDirChanges
+        ) {
             return Err(AsyncHostError::Inval);
         }
         self.copy_read_payload(memory, dst, offset, len)
@@ -1253,6 +1290,10 @@ impl AsyncHost {
         let Some(buffer) = buffer.take() else {
             return;
         };
+        self.restore_c_buffer(buffer);
+    }
+
+    fn restore_c_buffer(&self, buffer: CBufferLease) {
         let (key, buffer) = buffer.into_parts();
         if let Some(entry) = self.c_buffers.borrow_mut().get_mut(key)
             && matches!(entry, HostCBuffer::Leased)
@@ -2390,6 +2431,13 @@ impl AsyncHost {
         self.handles.borrow_mut().insert_resource(file)
     }
 
+    #[cfg(unix)]
+    pub(crate) fn insert_file_resource(&self, raw_fd: RawFd) -> HostHandle {
+        self.handles
+            .borrow_mut()
+            .insert_resource(Resource::new(raw_fd))
+    }
+
     pub(crate) fn insert_failed_job(&self, error: AsyncHostError) -> AsyncHostResult<u64> {
         self.insert_job(thread_pool::make_failed_job(error.errno()))
     }
@@ -2777,6 +2825,23 @@ impl AsyncHost {
     }
 
     #[cfg(windows)]
+    pub(crate) fn make_read_dir_changes_io_result(
+        &self,
+        buffer_handle: u64,
+        len: u32,
+    ) -> AsyncHostResult<u64> {
+        let mut buffer = self.lease_c_buffer(buffer_handle)?;
+        let len = match usize::try_from(len) {
+            Ok(len) if len <= buffer.as_mut_slice().len() => len,
+            _ => {
+                self.restore_c_buffer(buffer);
+                return Err(AsyncHostError::Fault);
+            }
+        };
+        self.insert_io_result(HostIoResult::for_read_dir_changes(buffer, len))
+    }
+
+    #[cfg(windows)]
     fn insert_io_result(&self, result: HostIoResult) -> AsyncHostResult<u64> {
         let key = self.handles.borrow_mut().insert(HandleKind::IoResult);
         let handle = handle_from_key(key);
@@ -2815,6 +2880,12 @@ impl AsyncHost {
         handles.remove_io_result(handle)?;
         let overlapped = result.overlapped_addr();
         io_results.io_results_by_overlapped.remove(&overlapped);
+        let buffer = result.read_dir_changes_buffer.take();
+        drop(io_results);
+        drop(handles);
+        if let Some(buffer) = buffer {
+            self.restore_c_buffer(buffer);
+        }
         Ok(())
     }
 
@@ -2841,7 +2912,16 @@ impl AsyncHost {
             .get_mut(result_key)
             .ok_or(AsyncHostError::Badf)?;
         result.validate_pending_resource(file)?;
-        result.cancel_pending()
+        let status = result.cancel_pending();
+        let buffer = (!result.is_pending())
+            .then(|| result.read_dir_changes_buffer.take())
+            .flatten();
+        drop(io_results);
+        drop(handles);
+        if let Some(buffer) = buffer {
+            self.restore_c_buffer(buffer);
+        }
+        status
     }
 
     #[cfg(windows)]
@@ -2863,7 +2943,7 @@ impl AsyncHost {
             .ok_or(AsyncHostError::Badf)?;
         result.validate_pending_resource(file)?;
         let mut bytes_transferred = 0;
-        if unsafe {
+        let status = if unsafe {
             GetOverlappedResult(
                 raw_handle,
                 result.overlapped_ptr(),
@@ -2873,17 +2953,26 @@ impl AsyncHost {
         } == 0
         {
             let error = last_native_error();
-            if !matches!(
+            if matches!(
                 error,
                 AsyncHostError::Native(errno)
                     if errno == windows_sys::Win32::Foundation::ERROR_IO_INCOMPLETE as i32
             ) {
-                result.clear_pending();
+                return Err(error);
             }
-            return Err(error);
+            result.clear_pending();
+            Err(error)
+        } else {
+            result.clear_pending();
+            i32::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
+        };
+        let buffer = result.read_dir_changes_buffer.take();
+        drop(io_results);
+        drop(handles);
+        if let Some(buffer) = buffer {
+            self.restore_c_buffer(buffer);
         }
-        result.clear_pending();
-        i32::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
+        status
     }
 
     #[cfg(windows)]
@@ -2997,7 +3086,9 @@ impl AsyncHost {
                     )
                 }
             }
-            HostIoKind::Connect | HostIoKind::Accept => return Err(AsyncHostError::Inval),
+            HostIoKind::Connect | HostIoKind::Accept | HostIoKind::ReadDirChanges => {
+                return Err(AsyncHostError::Inval);
+            }
         };
         if success != 0 {
             return i32::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault);
@@ -3014,6 +3105,65 @@ impl AsyncHost {
         } else {
             Err(AsyncHostError::Native(errno))
         }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn read_dir_changes_io_result(
+        &self,
+        fd_handle: HostHandle,
+        result_handle: u64,
+    ) -> AsyncHostResult<i32> {
+        use windows_sys::Win32::Foundation::ERROR_IO_PENDING;
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_NOTIFY_CHANGE_DIR_NAME, FILE_NOTIFY_CHANGE_FILE_NAME,
+            FILE_NOTIFY_CHANGE_LAST_WRITE, FILE_NOTIFY_CHANGE_SIZE, ReadDirectoryChangesExW,
+            ReadDirectoryNotifyExtendedInformation,
+        };
+
+        let handles = self.handles.borrow();
+        let result_key = handles.io_result(result_handle)?;
+        let mut io_results = self.io_results.borrow_mut();
+        let result = io_results
+            .io_results
+            .get_mut(result_key)
+            .ok_or(AsyncHostError::Badf)?;
+        if result.kind != HostIoKind::ReadDirChanges || result.is_pending() {
+            return Err(AsyncHostError::Inval);
+        }
+        let file = result.kind.resource_ref(&handles, fd_handle)?;
+        let len = u32::try_from(result.read_dir_changes_len).map_err(|_| AsyncHostError::Fault)?;
+        let buffer = result
+            .read_dir_changes_buffer
+            .as_mut()
+            .ok_or(AsyncHostError::Inval)?
+            .as_mut_slice()
+            .as_mut_ptr();
+        let mut bytes_returned = 0;
+        let success = unsafe {
+            ReadDirectoryChangesExW(
+                file.as_file()?.as_raw_handle(),
+                buffer.cast(),
+                len,
+                1,
+                FILE_NOTIFY_CHANGE_SIZE
+                    | FILE_NOTIFY_CHANGE_LAST_WRITE
+                    | FILE_NOTIFY_CHANGE_FILE_NAME
+                    | FILE_NOTIFY_CHANGE_DIR_NAME,
+                &mut bytes_returned,
+                result.overlapped_ptr(),
+                None,
+                ReadDirectoryNotifyExtendedInformation,
+            )
+        };
+        if success == 0 {
+            return Err(last_native_error());
+        }
+
+        // ReadDirectoryChangesExW reports that the completion packet was
+        // queued, not synchronous completion. Match native async by exposing
+        // the operation as pending even though the Windows call returned TRUE.
+        result.mark_pending(Arc::clone(file))?;
+        Err(AsyncHostError::Native(ERROR_IO_PENDING as i32))
     }
 
     #[cfg(windows)]
@@ -3090,7 +3240,9 @@ impl AsyncHost {
                     )
                 }
             }
-            HostIoKind::Connect | HostIoKind::Accept => return Err(AsyncHostError::Inval),
+            HostIoKind::Connect | HostIoKind::Accept | HostIoKind::ReadDirChanges => {
+                return Err(AsyncHostError::Inval);
+            }
         };
         if success != 0 {
             i32::try_from(bytes_transferred).map_err(|_| AsyncHostError::Fault)
@@ -3387,6 +3539,10 @@ impl AsyncHost {
                 *follow_symlink,
             ),
             JobPayload::Realpath { path, .. } => {
+                policy.stat_path(RuntimePathBase::CurrentDirectory, path)
+            }
+            #[cfg(target_os = "linux")]
+            JobPayload::InotifyAddWatch { path, .. } => {
                 policy.stat_path(RuntimePathBase::CurrentDirectory, path)
             }
             JobPayload::Access { path, access } => policy.access_path(path, *access),
@@ -6244,6 +6400,43 @@ mod tests {
         assert_eq!(result.buffer, vec![0; 3]);
         assert_eq!(result.event, IO_RESULT_READ_EVENT);
         assert_eq!(result.pending_resource_identity(), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn read_dir_changes_io_result_leases_buffer_until_free() {
+        let host = AsyncHost::default();
+        let buffer = host.insert_c_buffer(vec![1, 2, 3].into_boxed_slice());
+        let result = host.make_read_dir_changes_io_result(buffer, 3).unwrap();
+
+        assert_eq!(
+            host.with_c_buffer(buffer, |_| Ok(())),
+            Err(AsyncHostError::Badf)
+        );
+
+        host.free_io_result(result).unwrap();
+        assert_eq!(
+            host.with_c_buffer(buffer, |bytes| Ok(bytes.to_vec())),
+            Ok(vec![1, 2, 3])
+        );
+        host.free_c_buffer(buffer).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rejected_read_dir_changes_length_restores_buffer() {
+        let host = AsyncHost::default();
+        let buffer = host.insert_c_buffer(vec![1, 2, 3].into_boxed_slice());
+
+        assert_eq!(
+            host.make_read_dir_changes_io_result(buffer, 4),
+            Err(AsyncHostError::Fault)
+        );
+        assert_eq!(
+            host.with_c_buffer(buffer, |bytes| Ok(bytes.to_vec())),
+            Ok(vec![1, 2, 3])
+        );
+        host.free_c_buffer(buffer).unwrap();
     }
 
     #[cfg(windows)]

--- a/crates/moonrun/src/async_sys/fs/mod.rs
+++ b/crates/moonrun/src/async_sys/fs/mod.rs
@@ -18,3 +18,9 @@
 
 pub(crate) mod dir;
 pub(crate) mod stub;
+#[cfg(target_os = "linux")]
+pub(crate) mod watch_inotify;
+#[cfg(target_os = "macos")]
+pub(crate) mod watch_kqueue;
+#[cfg(windows)]
+pub(crate) mod watch_windows;

--- a/crates/moonrun/src/async_sys/fs/watch_inotify.rs
+++ b/crates/moonrun/src/async_sys/fs/watch_inotify.rs
@@ -1,0 +1,161 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::internal::fd_util::stub::RawFd;
+use crate::async_sys::ported_fns;
+
+const EVENT_HEADER_SIZE: usize = std::mem::size_of::<libc::inotify_event>();
+
+ported_fns! {
+    #[ported(
+        source = "src/fs/watch_inotify.c",
+        original = "moonbitlang_async_inotify_create"
+    )]
+    pub(crate) fn create() -> AsyncHostResult<RawFd> {
+        let fd = unsafe { libc::inotify_init1(libc::IN_NONBLOCK | libc::IN_CLOEXEC) };
+        if fd < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(fd)
+        }
+    }
+
+    #[ported(
+        source = "src/fs/watch_inotify.c",
+        original = "moonbitlang_async_inotify_remove_file"
+    )]
+    pub(crate) fn remove_file(inotify: RawFd, wd: i32) -> AsyncHostResult<()> {
+        if unsafe { libc::inotify_rm_watch(inotify, wd) } < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/fs/watch_inotify.c",
+        original = "moonbitlang_async_inotify_event_buffer_size"
+    )]
+    pub(crate) fn event_buffer_size() -> u32 {
+        let min_size = EVENT_HEADER_SIZE + libc::NAME_MAX as usize + 1;
+        u32::try_from(4096usize.max(min_size)).expect("inotify event buffer size fits u32")
+    }
+
+    #[ported(
+        source = "src/fs/watch_inotify.c",
+        original = "moonbitlang_async_inotify_fetch_event"
+    )]
+    pub(crate) fn fetch_event(
+        inotify: RawFd,
+        buffer: &mut [u8],
+        len: u32,
+    ) -> AsyncHostResult<i32> {
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        let buffer = buffer.get_mut(..len).ok_or(AsyncHostError::Fault)?;
+        let ret = unsafe { libc::read(inotify, buffer.as_mut_ptr().cast(), buffer.len()) };
+        if ret > 0 {
+            i32::try_from(ret).map_err(|_| AsyncHostError::Fault)
+        } else if ret < 0 && last_errno() == libc::EAGAIN {
+            Ok(0)
+        } else if ret < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(0)
+        }
+    }
+
+    #[ported(
+        source = "src/fs/watch_inotify.c",
+        original = "moonbitlang_async_inotify_event_get_size"
+    )]
+    pub(crate) fn event_get_size(buffer: &[u8], offset: u32) -> AsyncHostResult<u32> {
+        let event = event_at(buffer, offset)?;
+        let size = EVENT_HEADER_SIZE
+            .checked_add(event.len as usize)
+            .ok_or(AsyncHostError::Fault)?;
+        let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+        if offset.checked_add(size).ok_or(AsyncHostError::Fault)? > buffer.len() {
+            return Err(AsyncHostError::Fault);
+        }
+        u32::try_from(size).map_err(|_| AsyncHostError::Fault)
+    }
+
+    #[ported(
+        source = "src/fs/watch_inotify.c",
+        original = "moonbitlang_async_inotify_event_get_wd"
+    )]
+    pub(crate) fn event_get_wd(buffer: &[u8], offset: u32) -> AsyncHostResult<i32> {
+        Ok(event_at(buffer, offset)?.wd)
+    }
+
+    #[ported(
+        source = "src/fs/watch_inotify.c",
+        original = "moonbitlang_async_inotify_event_has_relevant_event"
+    )]
+    pub(crate) fn event_has_relevant_event(
+        buffer: &[u8],
+        offset: u32,
+    ) -> AsyncHostResult<bool> {
+        let mask = event_at(buffer, offset)?.mask;
+        Ok(mask
+            & (libc::IN_CREATE
+                | libc::IN_DELETE
+                | libc::IN_MODIFY
+                | libc::IN_MOVED_FROM
+                | libc::IN_MOVED_TO)
+            != 0)
+    }
+
+    #[ported(
+        source = "src/fs/watch_inotify.c",
+        original = "moonbitlang_async_inotify_event_has_overflow"
+    )]
+    pub(crate) fn event_has_overflow(buffer: &[u8], offset: u32) -> AsyncHostResult<bool> {
+        Ok(event_at(buffer, offset)?.mask & libc::IN_Q_OVERFLOW != 0)
+    }
+
+    #[ported(
+        source = "src/fs/watch_inotify.c",
+        original = "moonbitlang_async_inotify_event_has_ignore"
+    )]
+    pub(crate) fn event_has_ignore(buffer: &[u8], offset: u32) -> AsyncHostResult<bool> {
+        Ok(event_at(buffer, offset)?.mask & libc::IN_IGNORED != 0)
+    }
+}
+
+fn event_at(buffer: &[u8], offset: u32) -> AsyncHostResult<libc::inotify_event> {
+    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+    let end = offset
+        .checked_add(EVENT_HEADER_SIZE)
+        .ok_or(AsyncHostError::Fault)?;
+    if end > buffer.len() {
+        return Err(AsyncHostError::Fault);
+    }
+    Ok(unsafe { std::ptr::read_unaligned(buffer.as_ptr().add(offset).cast()) })
+}
+
+fn last_errno() -> i32 {
+    std::io::Error::last_os_error()
+        .raw_os_error()
+        .unwrap_or_else(|| AsyncHostError::Inval.errno())
+}
+
+fn last_native_error() -> AsyncHostError {
+    AsyncHostError::Native(last_errno())
+}

--- a/crates/moonrun/src/async_sys/fs/watch_inotify.rs
+++ b/crates/moonrun/src/async_sys/fs/watch_inotify.rs
@@ -21,6 +21,7 @@ use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::ported_fns;
 
 const EVENT_HEADER_SIZE: usize = std::mem::size_of::<libc::inotify_event>();
+const NAME_MAX: usize = 255;
 
 ported_fns! {
     #[ported(
@@ -53,7 +54,7 @@ ported_fns! {
         original = "moonbitlang_async_inotify_event_buffer_size"
     )]
     pub(crate) fn event_buffer_size() -> u32 {
-        let min_size = EVENT_HEADER_SIZE + libc::NAME_MAX as usize + 1;
+        let min_size = EVENT_HEADER_SIZE + NAME_MAX + 1;
         u32::try_from(4096usize.max(min_size)).expect("inotify event buffer size fits u32")
     }
 

--- a/crates/moonrun/src/async_sys/fs/watch_kqueue.rs
+++ b/crates/moonrun/src/async_sys/fs/watch_kqueue.rs
@@ -1,0 +1,165 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::internal::fd_util::stub::RawFd;
+use crate::async_sys::ported_fns;
+
+const EVENT_COUNT: usize = 1024;
+const EVENT_SIZE: usize = std::mem::size_of::<libc::kevent>();
+
+ported_fns! {
+    #[ported(
+        source = "src/fs/watch_kqueue.c",
+        original = "moonbitlang_async_kqueue_watcher_create"
+    )]
+    pub(crate) fn create() -> AsyncHostResult<RawFd> {
+        let kqueue = unsafe { libc::kqueue() };
+        if kqueue < 0 {
+            return Err(last_native_error());
+        }
+        let flags = unsafe { libc::fcntl(kqueue, libc::F_GETFD) };
+        if flags < 0
+            || (flags & libc::FD_CLOEXEC) == 0
+                && unsafe { libc::fcntl(kqueue, libc::F_SETFD, flags | libc::FD_CLOEXEC) } < 0
+        {
+            unsafe { libc::close(kqueue) };
+            return Err(last_native_error());
+        }
+        Ok(kqueue)
+    }
+
+    #[ported(
+        source = "src/fs/watch_kqueue.c",
+        original = "moonbitlang_async_kqueue_watcher_buffer_size"
+    )]
+    pub(crate) fn buffer_size() -> u32 {
+        u32::try_from(EVENT_COUNT * EVENT_SIZE).expect("kqueue watcher buffer size fits u32")
+    }
+
+    #[ported(
+        source = "src/fs/watch_kqueue.c",
+        original = "moonbitlang_async_kqueue_watcher_add_file"
+    )]
+    pub(crate) fn add_file(
+        kqueue: RawFd,
+        file: RawFd,
+        is_dir: bool,
+        file_handle: u64,
+    ) -> AsyncHostResult<()> {
+        let mut event = empty_kevent();
+        event.ident = file as libc::uintptr_t;
+        event.filter = libc::EVFILT_VNODE;
+        event.flags = libc::EV_ADD | libc::EV_CLEAR;
+        event.fflags = libc::NOTE_WRITE | if is_dir { 0 } else { libc::NOTE_EXTEND };
+        event.udata = usize::try_from(file_handle)
+            .map_err(|_| AsyncHostError::Fault)? as *mut libc::c_void;
+        if unsafe {
+            libc::kevent(
+                kqueue,
+                &event,
+                1,
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null(),
+            )
+        } < 0
+        {
+            Err(last_native_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[ported(
+        source = "src/fs/watch_kqueue.c",
+        original = "moonbitlang_async_kqueue_watcher_fetch_event"
+    )]
+    pub(crate) fn fetch_event(
+        kqueue: RawFd,
+        buffer: &mut [u8],
+        len: u32,
+    ) -> AsyncHostResult<i32> {
+        let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
+        let buffer = buffer.get_mut(..len).ok_or(AsyncHostError::Fault)?;
+        let event_count = buffer.len() / EVENT_SIZE;
+        let event_count = i32::try_from(event_count).map_err(|_| AsyncHostError::Fault)?;
+        let timeout = libc::timespec { tv_sec: 0, tv_nsec: 0 };
+        let ret = unsafe {
+            libc::kevent(
+                kqueue,
+                std::ptr::null(),
+                0,
+                buffer.as_mut_ptr().cast(),
+                event_count,
+                &timeout,
+            )
+        };
+        if ret < 0 {
+            Err(last_native_error())
+        } else {
+            Ok(ret)
+        }
+    }
+
+    #[ported(
+        source = "src/fs/watch_kqueue.c",
+        original = "moonbitlang_async_kqueue_watcher_event_get_fd"
+    )]
+    pub(crate) fn event_get_fd(buffer: &[u8], index: u32) -> AsyncHostResult<u64> {
+        let event = event_at(buffer, index)?;
+        let handle = event.udata as usize;
+        if handle == 0 {
+            Ok(event.ident as u64)
+        } else {
+            Ok(handle as u64)
+        }
+    }
+
+    #[ported(
+        source = "src/fs/watch_kqueue.c",
+        original = "moonbitlang_async_kqueue_watcher_event_has_modify"
+    )]
+    pub(crate) fn event_has_modify(buffer: &[u8], index: u32) -> AsyncHostResult<bool> {
+        Ok(event_at(buffer, index)?.fflags & (libc::NOTE_WRITE | libc::NOTE_EXTEND) != 0)
+    }
+}
+
+fn event_at(buffer: &[u8], index: u32) -> AsyncHostResult<libc::kevent> {
+    let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
+    let offset = index.checked_mul(EVENT_SIZE).ok_or(AsyncHostError::Fault)?;
+    let end = offset
+        .checked_add(EVENT_SIZE)
+        .ok_or(AsyncHostError::Fault)?;
+    if end > buffer.len() {
+        return Err(AsyncHostError::Fault);
+    }
+    Ok(unsafe { std::ptr::read_unaligned(buffer.as_ptr().add(offset).cast()) })
+}
+
+fn empty_kevent() -> libc::kevent {
+    unsafe { std::mem::zeroed() }
+}
+
+fn last_native_error() -> AsyncHostError {
+    AsyncHostError::Native(
+        std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or_else(|| AsyncHostError::Inval.errno()),
+    )
+}

--- a/crates/moonrun/src/async_sys/fs/watch_windows.rs
+++ b/crates/moonrun/src/async_sys/fs/watch_windows.rs
@@ -18,11 +18,9 @@
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::ported_fns;
-use windows_sys::Win32::Storage::FileSystem::{
-    FILE_ACTION_MODIFIED, FILE_NOTIFY_EXTENDED_INFORMATION,
-};
+use windows_sys::Win32::Storage::FileSystem::{FILE_ACTION_MODIFIED, FILE_NOTIFY_INFORMATION};
 
-const EVENT_SIZE: usize = std::mem::size_of::<FILE_NOTIFY_EXTENDED_INFORMATION>();
+const EVENT_SIZE: usize = std::mem::size_of::<FILE_NOTIFY_INFORMATION>();
 
 ported_fns! {
     #[ported(
@@ -30,7 +28,7 @@ ported_fns! {
         original = "moonbitlang_async_has_ReadDirectoryChangesExW"
     )]
     pub(crate) fn has_read_directory_changes_ex() -> bool {
-        true
+        false
     }
 
     #[ported(
@@ -70,7 +68,7 @@ ported_fns! {
         original = "moonbitlang_async_watcher_event_get_path_offset"
     )]
     pub(crate) fn event_get_path_offset() -> u32 {
-        u32::try_from(std::mem::offset_of!(FILE_NOTIFY_EXTENDED_INFORMATION, FileName))
+        u32::try_from(std::mem::offset_of!(FILE_NOTIFY_INFORMATION, FileName))
             .expect("Windows watcher path offset fits u32")
     }
 
@@ -78,8 +76,8 @@ ported_fns! {
         source = "src/fs/watch_windows.c",
         original = "moonbitlang_async_watcher_event_get_file_id"
     )]
-    pub(crate) fn event_get_file_id(buffer: &[u8], offset: u32) -> AsyncHostResult<u64> {
-        Ok(event_at(buffer, offset)?.FileId as u64)
+    pub(crate) fn event_get_file_id(_buffer: &[u8], _offset: u32) -> AsyncHostResult<u64> {
+        Err(AsyncHostError::Inval)
     }
 
     #[ported(
@@ -87,14 +85,14 @@ ported_fns! {
         original = "moonbitlang_async_watcher_event_get_parent_file_id"
     )]
     pub(crate) fn event_get_parent_file_id(
-        buffer: &[u8],
-        offset: u32,
+        _buffer: &[u8],
+        _offset: u32,
     ) -> AsyncHostResult<u64> {
-        Ok(event_at(buffer, offset)?.ParentFileId as u64)
+        Err(AsyncHostError::Inval)
     }
 }
 
-fn event_at(buffer: &[u8], offset: u32) -> AsyncHostResult<FILE_NOTIFY_EXTENDED_INFORMATION> {
+fn event_at(buffer: &[u8], offset: u32) -> AsyncHostResult<FILE_NOTIFY_INFORMATION> {
     let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
     let end = offset
         .checked_add(EVENT_SIZE)
@@ -103,4 +101,48 @@ fn event_at(buffer: &[u8], offset: u32) -> AsyncHostResult<FILE_NOTIFY_EXTENDED_
         return Err(AsyncHostError::Fault);
     }
     Ok(unsafe { std::ptr::read_unaligned(buffer.as_ptr().add(offset).cast()) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_windows_watcher_uses_basic_event_layout() {
+        assert!(!has_read_directory_changes_ex());
+        assert_eq!(
+            event_buffer_size(),
+            u32::try_from(std::mem::size_of::<FILE_NOTIFY_INFORMATION>() * 16384).unwrap()
+        );
+        assert_eq!(
+            event_get_path_offset(),
+            u32::try_from(std::mem::offset_of!(FILE_NOTIFY_INFORMATION, FileName)).unwrap()
+        );
+    }
+
+    #[test]
+    fn basic_event_accessors_read_unaligned_headers() {
+        let offset = 3usize;
+        let mut buffer = vec![0; offset + EVENT_SIZE];
+        let mut event = unsafe { std::mem::zeroed::<FILE_NOTIFY_INFORMATION>() };
+        event.NextEntryOffset = EVENT_SIZE as u32;
+        event.Action = FILE_ACTION_MODIFIED;
+        event.FileNameLength = 4;
+        unsafe {
+            std::ptr::write_unaligned(buffer.as_mut_ptr().add(offset).cast(), event);
+        }
+
+        assert_eq!(
+            event_get_size(&buffer, offset as u32),
+            Ok(EVENT_SIZE as u32)
+        );
+        assert_eq!(event_is_modify(&buffer, offset as u32), Ok(true));
+        assert_eq!(event_get_path_len(&buffer, offset as u32), Ok(4));
+    }
+
+    #[test]
+    fn extended_event_accessors_are_rejected() {
+        assert_eq!(event_get_file_id(&[], 0), Err(AsyncHostError::Inval));
+        assert_eq!(event_get_parent_file_id(&[], 0), Err(AsyncHostError::Inval));
+    }
 }

--- a/crates/moonrun/src/async_sys/fs/watch_windows.rs
+++ b/crates/moonrun/src/async_sys/fs/watch_windows.rs
@@ -18,85 +18,254 @@
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::ported_fns;
-use windows_sys::Win32::Storage::FileSystem::{FILE_ACTION_MODIFIED, FILE_NOTIFY_INFORMATION};
+use std::sync::OnceLock;
+use windows_sys::Win32::Foundation::{BOOL, HANDLE};
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_ACTION_MODIFIED, FILE_NOTIFY_CHANGE, FILE_NOTIFY_EXTENDED_INFORMATION,
+    FILE_NOTIFY_INFORMATION, READ_DIRECTORY_NOTIFY_INFORMATION_CLASS,
+    ReadDirectoryNotifyExtendedInformation,
+};
+use windows_sys::Win32::System::IO::{LPOVERLAPPED_COMPLETION_ROUTINE, OVERLAPPED};
+use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
 
-const EVENT_SIZE: usize = std::mem::size_of::<FILE_NOTIFY_INFORMATION>();
+const BASIC_EVENT_SIZE: usize = std::mem::size_of::<FILE_NOTIFY_INFORMATION>();
+const EXTENDED_EVENT_SIZE: usize = std::mem::size_of::<FILE_NOTIFY_EXTENDED_INFORMATION>();
+// ReadDirectoryChanges{Ex}W rejects buffers larger than 64 KiB for network
+// directories. Use the same capacity everywhere so local and remote watches
+// have identical submission behavior.
+const EVENT_BUFFER_SIZE: usize = 64 * 1024;
+
+type ReadDirectoryChangesExWFn = unsafe extern "system" fn(
+    HANDLE,
+    *mut core::ffi::c_void,
+    u32,
+    BOOL,
+    FILE_NOTIFY_CHANGE,
+    *mut u32,
+    *mut OVERLAPPED,
+    LPOVERLAPPED_COMPLETION_ROUTINE,
+    READ_DIRECTORY_NOTIFY_INFORMATION_CLASS,
+) -> BOOL;
+
+pub(crate) unsafe fn read_directory_changes_extended(
+    directory: HANDLE,
+    buffer: *mut core::ffi::c_void,
+    len: u32,
+    watch_subtree: BOOL,
+    notify_filter: FILE_NOTIFY_CHANGE,
+    bytes_returned: *mut u32,
+    overlapped: *mut OVERLAPPED,
+) -> Option<BOOL> {
+    static FUNCTION: OnceLock<Option<ReadDirectoryChangesExWFn>> = OnceLock::new();
+    let function = FUNCTION
+        .get_or_init(|| unsafe {
+            let kernel32 =
+                GetModuleHandleW("kernel32.dll\0".encode_utf16().collect::<Vec<_>>().as_ptr());
+            if kernel32.is_null() {
+                return None;
+            }
+            GetProcAddress(kernel32, c"ReadDirectoryChangesExW".as_ptr().cast()).map(|function| {
+                // GetProcAddress returned the named Kernel32 export. Windows defines
+                // this exact system-call signature for ReadDirectoryChangesExW.
+                std::mem::transmute::<
+                    unsafe extern "system" fn() -> isize,
+                    ReadDirectoryChangesExWFn,
+                >(function)
+            })
+        })
+        .as_ref()
+        .copied()?;
+    Some(unsafe {
+        function(
+            directory,
+            buffer,
+            len,
+            watch_subtree,
+            notify_filter,
+            bytes_returned,
+            overlapped,
+            None,
+            ReadDirectoryNotifyExtendedInformation,
+        )
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EventLayout {
+    Basic,
+    Extended,
+}
+
+#[derive(Debug)]
+pub(crate) struct EventBuffer {
+    // ReadDirectoryChanges{Ex}W requires a DWORD-aligned output buffer. Keep
+    // the allocation typed as u32; byte slices are only temporary views over
+    // the same initialized storage.
+    words: Box<[u32]>,
+    layout: Option<EventLayout>,
+    completed_len: usize,
+}
+
+impl EventBuffer {
+    pub(crate) fn new() -> Self {
+        let len = usize::try_from(event_buffer_size())
+            .expect("Windows watcher buffer size is nonnegative");
+        assert!(len.is_multiple_of(std::mem::size_of::<u32>()));
+        Self {
+            words: vec![0; len / std::mem::size_of::<u32>()].into_boxed_slice(),
+            layout: None,
+            completed_len: 0,
+        }
+    }
+
+    pub(crate) fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: u32 storage is initialized, and this view covers exactly the
+        // same allocation without outliving the exclusive borrow.
+        unsafe {
+            std::slice::from_raw_parts_mut(
+                self.words.as_mut_ptr().cast(),
+                self.words.len() * std::mem::size_of::<u32>(),
+            )
+        }
+    }
+
+    pub(crate) fn capacity(&self) -> usize {
+        self.words.len() * std::mem::size_of::<u32>()
+    }
+
+    pub(crate) fn begin_read(&mut self, layout: EventLayout) {
+        self.layout = Some(layout);
+        self.completed_len = 0;
+    }
+
+    pub(crate) fn complete_read(&mut self, len: usize) -> AsyncHostResult<()> {
+        if len > self.capacity() {
+            return Err(AsyncHostError::Fault);
+        }
+        self.completed_len = len;
+        Ok(())
+    }
+
+    fn layout(&self) -> AsyncHostResult<EventLayout> {
+        self.layout.ok_or(AsyncHostError::Inval)
+    }
+
+    fn completed_bytes(&self) -> &[u8] {
+        // SAFETY: u32 storage is initialized, and completed_len was checked
+        // against this allocation's byte capacity before it was recorded.
+        unsafe { std::slice::from_raw_parts(self.words.as_ptr().cast(), self.completed_len) }
+    }
+}
+
+pub(crate) fn event_buffer_size() -> u32 {
+    u32::try_from(EVENT_BUFFER_SIZE).expect("Windows watcher buffer size fits u32")
+}
 
 ported_fns! {
     #[ported(
         source = "src/fs/watch_windows.c",
-        original = "moonbitlang_async_has_ReadDirectoryChangesExW"
-    )]
-    pub(crate) fn has_read_directory_changes_ex() -> bool {
-        false
-    }
-
-    #[ported(
-        source = "src/fs/watch_windows.c",
-        original = "moonbitlang_async_watcher_event_buffer_size"
-    )]
-    pub(crate) fn event_buffer_size() -> u32 {
-        u32::try_from(EVENT_SIZE * 16384).expect("Windows watcher buffer size fits u32")
-    }
-
-    #[ported(
-        source = "src/fs/watch_windows.c",
         original = "moonbitlang_async_watcher_event_get_size"
     )]
-    pub(crate) fn event_get_size(buffer: &[u8], offset: u32) -> AsyncHostResult<u32> {
-        Ok(event_at(buffer, offset)?.NextEntryOffset)
+    pub(crate) fn event_get_size(buffer: &EventBuffer, offset: u32) -> AsyncHostResult<u32> {
+        Ok(match buffer.layout()? {
+            EventLayout::Basic => basic_event_at(buffer.completed_bytes(), offset)?.NextEntryOffset,
+            EventLayout::Extended => extended_event_at(buffer.completed_bytes(), offset)?.NextEntryOffset,
+        })
     }
 
     #[ported(
         source = "src/fs/watch_windows.c",
         original = "moonbitlang_async_watcher_event_is_modify_event"
     )]
-    pub(crate) fn event_is_modify(buffer: &[u8], offset: u32) -> AsyncHostResult<bool> {
-        Ok(event_at(buffer, offset)?.Action == FILE_ACTION_MODIFIED)
-    }
-
-    #[ported(
-        source = "src/fs/watch_windows.c",
-        original = "moonbitlang_async_watcher_event_get_path_len"
-    )]
-    pub(crate) fn event_get_path_len(buffer: &[u8], offset: u32) -> AsyncHostResult<u32> {
-        Ok(event_at(buffer, offset)?.FileNameLength)
-    }
-
-    #[ported(
-        source = "src/fs/watch_windows.c",
-        original = "moonbitlang_async_watcher_event_get_path_offset"
-    )]
-    pub(crate) fn event_get_path_offset() -> u32 {
-        u32::try_from(std::mem::offset_of!(FILE_NOTIFY_INFORMATION, FileName))
-            .expect("Windows watcher path offset fits u32")
-    }
-
-    #[ported(
-        source = "src/fs/watch_windows.c",
-        original = "moonbitlang_async_watcher_event_get_file_id"
-    )]
-    pub(crate) fn event_get_file_id(_buffer: &[u8], _offset: u32) -> AsyncHostResult<u64> {
-        Err(AsyncHostError::Inval)
-    }
-
-    #[ported(
-        source = "src/fs/watch_windows.c",
-        original = "moonbitlang_async_watcher_event_get_parent_file_id"
-    )]
-    pub(crate) fn event_get_parent_file_id(
-        _buffer: &[u8],
-        _offset: u32,
-    ) -> AsyncHostResult<u64> {
-        Err(AsyncHostError::Inval)
+    pub(crate) fn event_is_modify(
+        buffer: &EventBuffer,
+        offset: u32,
+    ) -> AsyncHostResult<bool> {
+        let action = match buffer.layout()? {
+            EventLayout::Basic => basic_event_at(buffer.completed_bytes(), offset)?.Action,
+            EventLayout::Extended => extended_event_at(buffer.completed_bytes(), offset)?.Action,
+        };
+        Ok(action == FILE_ACTION_MODIFIED)
     }
 }
 
-fn event_at(buffer: &[u8], offset: u32) -> AsyncHostResult<FILE_NOTIFY_INFORMATION> {
-    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
-    let end = offset
-        .checked_add(EVENT_SIZE)
+pub(crate) fn event_path_len(buffer: &EventBuffer, offset: u32) -> AsyncHostResult<u32> {
+    u32::try_from(event_path_bytes(buffer, offset)?.len() / std::mem::size_of::<u16>())
+        .map_err(|_| AsyncHostError::Fault)
+}
+
+pub(crate) fn event_path_units(buffer: &EventBuffer, offset: u32) -> AsyncHostResult<Vec<u16>> {
+    Ok(event_path_bytes(buffer, offset)?
+        .chunks_exact(std::mem::size_of::<u16>())
+        .map(|unit| u16::from_le_bytes([unit[0], unit[1]]))
+        .collect())
+}
+
+fn event_path_bytes(buffer: &EventBuffer, offset: u32) -> AsyncHostResult<&[u8]> {
+    let (path_offset, path_len) = match buffer.layout()? {
+        EventLayout::Basic => {
+            let event = basic_event_at(buffer.completed_bytes(), offset)?;
+            (
+                std::mem::offset_of!(FILE_NOTIFY_INFORMATION, FileName),
+                event.FileNameLength,
+            )
+        }
+        EventLayout::Extended => {
+            let event = extended_event_at(buffer.completed_bytes(), offset)?;
+            (
+                std::mem::offset_of!(FILE_NOTIFY_EXTENDED_INFORMATION, FileName),
+                event.FileNameLength,
+            )
+        }
+    };
+    let event_offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+    let path_offset = event_offset
+        .checked_add(path_offset)
         .ok_or(AsyncHostError::Fault)?;
+    let path_len = usize::try_from(path_len).map_err(|_| AsyncHostError::Fault)?;
+    let path_end = path_offset
+        .checked_add(path_len)
+        .ok_or(AsyncHostError::Fault)?;
+    let path = buffer
+        .completed_bytes()
+        .get(path_offset..path_end)
+        .ok_or(AsyncHostError::Fault)?;
+    if !path.len().is_multiple_of(std::mem::size_of::<u16>()) {
+        return Err(AsyncHostError::Inval);
+    }
+    Ok(path)
+}
+
+pub(crate) fn event_has_file_ids(buffer: &EventBuffer) -> AsyncHostResult<bool> {
+    Ok(buffer.layout()? == EventLayout::Extended)
+}
+
+pub(crate) fn event_dirty_file_id(buffer: &EventBuffer, offset: u32) -> AsyncHostResult<u64> {
+    if buffer.layout()? != EventLayout::Extended {
+        return Err(AsyncHostError::Inval);
+    }
+    let event = extended_event_at(buffer.completed_bytes(), offset)?;
+    Ok(if event.Action == FILE_ACTION_MODIFIED {
+        event.FileId as u64
+    } else {
+        event.ParentFileId as u64
+    })
+}
+
+fn basic_event_at(buffer: &[u8], offset: u32) -> AsyncHostResult<FILE_NOTIFY_INFORMATION> {
+    event_at(buffer, offset, BASIC_EVENT_SIZE)
+}
+
+fn extended_event_at(
+    buffer: &[u8],
+    offset: u32,
+) -> AsyncHostResult<FILE_NOTIFY_EXTENDED_INFORMATION> {
+    event_at(buffer, offset, EXTENDED_EVENT_SIZE)
+}
+
+fn event_at<T: Copy>(buffer: &[u8], offset: u32, size: usize) -> AsyncHostResult<T> {
+    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+    let end = offset.checked_add(size).ok_or(AsyncHostError::Fault)?;
     if end > buffer.len() {
         return Err(AsyncHostError::Fault);
     }
@@ -108,41 +277,75 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_windows_watcher_uses_basic_event_layout() {
-        assert!(!has_read_directory_changes_ex());
-        assert_eq!(
-            event_buffer_size(),
-            u32::try_from(std::mem::size_of::<FILE_NOTIFY_INFORMATION>() * 16384).unwrap()
-        );
-        assert_eq!(
-            event_get_path_offset(),
-            u32::try_from(std::mem::offset_of!(FILE_NOTIFY_INFORMATION, FileName)).unwrap()
-        );
-    }
-
-    #[test]
-    fn basic_event_accessors_read_unaligned_headers() {
+    fn basic_event_accessors_preserve_raw_utf16_path() {
         let offset = 3usize;
-        let mut buffer = vec![0; offset + EVENT_SIZE];
+        let mut buffer = EventBuffer::new();
+        buffer.begin_read(EventLayout::Basic);
         let mut event = unsafe { std::mem::zeroed::<FILE_NOTIFY_INFORMATION>() };
-        event.NextEntryOffset = EVENT_SIZE as u32;
+        event.NextEntryOffset = BASIC_EVENT_SIZE as u32;
         event.Action = FILE_ACTION_MODIFIED;
         event.FileNameLength = 4;
         unsafe {
-            std::ptr::write_unaligned(buffer.as_mut_ptr().add(offset).cast(), event);
+            std::ptr::write_unaligned(buffer.as_mut_slice().as_mut_ptr().add(offset).cast(), event);
         }
+        let path_offset = offset + std::mem::offset_of!(FILE_NOTIFY_INFORMATION, FileName);
+        buffer.as_mut_slice()[path_offset..path_offset + 4].copy_from_slice(&[0x00, 0xd8, b'b', 0]);
+        buffer.complete_read(path_offset + 4).unwrap();
 
         assert_eq!(
             event_get_size(&buffer, offset as u32),
-            Ok(EVENT_SIZE as u32)
+            Ok(BASIC_EVENT_SIZE as u32)
         );
         assert_eq!(event_is_modify(&buffer, offset as u32), Ok(true));
-        assert_eq!(event_get_path_len(&buffer, offset as u32), Ok(4));
+        assert_eq!(event_path_len(&buffer, offset as u32), Ok(2));
+        assert_eq!(
+            event_path_units(&buffer, offset as u32),
+            Ok(vec![0xd800, u16::from(b'b')])
+        );
+        assert_eq!(event_has_file_ids(&buffer), Ok(false));
+        assert_eq!(
+            event_dirty_file_id(&buffer, offset as u32),
+            Err(AsyncHostError::Inval)
+        );
     }
 
     #[test]
-    fn extended_event_accessors_are_rejected() {
-        assert_eq!(event_get_file_id(&[], 0), Err(AsyncHostError::Inval));
-        assert_eq!(event_get_parent_file_id(&[], 0), Err(AsyncHostError::Inval));
+    fn extended_event_accessors_use_the_extended_layout() {
+        let offset = 5usize;
+        let mut buffer = EventBuffer::new();
+        buffer.begin_read(EventLayout::Extended);
+        let mut event = unsafe { std::mem::zeroed::<FILE_NOTIFY_EXTENDED_INFORMATION>() };
+        event.NextEntryOffset = EXTENDED_EVENT_SIZE as u32;
+        event.Action = FILE_ACTION_MODIFIED;
+        event.FileId = 42;
+        event.ParentFileId = 24;
+        event.FileNameLength = 4;
+        unsafe {
+            std::ptr::write_unaligned(buffer.as_mut_slice().as_mut_ptr().add(offset).cast(), event);
+        }
+        let path_offset = offset + std::mem::offset_of!(FILE_NOTIFY_EXTENDED_INFORMATION, FileName);
+        buffer.as_mut_slice()[path_offset..path_offset + 4].copy_from_slice(&[b'c', 0, b'd', 0]);
+        buffer.complete_read(path_offset + 4).unwrap();
+
+        assert_eq!(
+            event_get_size(&buffer, offset as u32),
+            Ok(EXTENDED_EVENT_SIZE as u32)
+        );
+        assert_eq!(event_is_modify(&buffer, offset as u32), Ok(true));
+        assert_eq!(event_path_len(&buffer, offset as u32), Ok(2));
+        assert_eq!(
+            event_path_units(&buffer, offset as u32),
+            Ok(vec![u16::from(b'c'), u16::from(b'd')])
+        );
+        assert_eq!(event_has_file_ids(&buffer), Ok(true));
+        assert_eq!(event_dirty_file_id(&buffer, offset as u32), Ok(42));
+    }
+
+    #[test]
+    fn event_accessors_reject_an_uninitialized_layout() {
+        let buffer = EventBuffer::new();
+        assert_eq!(event_get_size(&buffer, 0), Err(AsyncHostError::Inval));
+        assert_eq!(event_path_len(&buffer, 0), Err(AsyncHostError::Inval));
+        assert_eq!(event_has_file_ids(&buffer), Err(AsyncHostError::Inval));
     }
 }

--- a/crates/moonrun/src/async_sys/fs/watch_windows.rs
+++ b/crates/moonrun/src/async_sys/fs/watch_windows.rs
@@ -1,0 +1,106 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_sys::ported_fns;
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_ACTION_MODIFIED, FILE_NOTIFY_EXTENDED_INFORMATION,
+};
+
+const EVENT_SIZE: usize = std::mem::size_of::<FILE_NOTIFY_EXTENDED_INFORMATION>();
+
+ported_fns! {
+    #[ported(
+        source = "src/fs/watch_windows.c",
+        original = "moonbitlang_async_has_ReadDirectoryChangesExW"
+    )]
+    pub(crate) fn has_read_directory_changes_ex() -> bool {
+        true
+    }
+
+    #[ported(
+        source = "src/fs/watch_windows.c",
+        original = "moonbitlang_async_watcher_event_buffer_size"
+    )]
+    pub(crate) fn event_buffer_size() -> u32 {
+        u32::try_from(EVENT_SIZE * 16384).expect("Windows watcher buffer size fits u32")
+    }
+
+    #[ported(
+        source = "src/fs/watch_windows.c",
+        original = "moonbitlang_async_watcher_event_get_size"
+    )]
+    pub(crate) fn event_get_size(buffer: &[u8], offset: u32) -> AsyncHostResult<u32> {
+        Ok(event_at(buffer, offset)?.NextEntryOffset)
+    }
+
+    #[ported(
+        source = "src/fs/watch_windows.c",
+        original = "moonbitlang_async_watcher_event_is_modify_event"
+    )]
+    pub(crate) fn event_is_modify(buffer: &[u8], offset: u32) -> AsyncHostResult<bool> {
+        Ok(event_at(buffer, offset)?.Action == FILE_ACTION_MODIFIED)
+    }
+
+    #[ported(
+        source = "src/fs/watch_windows.c",
+        original = "moonbitlang_async_watcher_event_get_path_len"
+    )]
+    pub(crate) fn event_get_path_len(buffer: &[u8], offset: u32) -> AsyncHostResult<u32> {
+        Ok(event_at(buffer, offset)?.FileNameLength)
+    }
+
+    #[ported(
+        source = "src/fs/watch_windows.c",
+        original = "moonbitlang_async_watcher_event_get_path_offset"
+    )]
+    pub(crate) fn event_get_path_offset() -> u32 {
+        u32::try_from(std::mem::offset_of!(FILE_NOTIFY_EXTENDED_INFORMATION, FileName))
+            .expect("Windows watcher path offset fits u32")
+    }
+
+    #[ported(
+        source = "src/fs/watch_windows.c",
+        original = "moonbitlang_async_watcher_event_get_file_id"
+    )]
+    pub(crate) fn event_get_file_id(buffer: &[u8], offset: u32) -> AsyncHostResult<u64> {
+        Ok(event_at(buffer, offset)?.FileId as u64)
+    }
+
+    #[ported(
+        source = "src/fs/watch_windows.c",
+        original = "moonbitlang_async_watcher_event_get_parent_file_id"
+    )]
+    pub(crate) fn event_get_parent_file_id(
+        buffer: &[u8],
+        offset: u32,
+    ) -> AsyncHostResult<u64> {
+        Ok(event_at(buffer, offset)?.ParentFileId as u64)
+    }
+}
+
+fn event_at(buffer: &[u8], offset: u32) -> AsyncHostResult<FILE_NOTIFY_EXTENDED_INFORMATION> {
+    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+    let end = offset
+        .checked_add(EVENT_SIZE)
+        .ok_or(AsyncHostError::Fault)?;
+    if end > buffer.len() {
+        return Err(AsyncHostError::Fault);
+    }
+    Ok(unsafe { std::ptr::read_unaligned(buffer.as_ptr().add(offset).cast()) })
+}

--- a/crates/moonrun/src/async_sys/internal/event_loop/io.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/io.rs
@@ -136,6 +136,10 @@ pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
                 "make_accept_io_result",
                 "moonbitlang_async_make_accept_io_result",
             ),
+            ported_windows_symbol(
+                "make_read_dir_changes_io_result",
+                "moonbitlang_async_make_read_dir_changes_io_result",
+            ),
             ported_windows_symbol("free_io_result", "moonbitlang_async_free_io_result"),
             ported_windows_symbol(
                 "io_result_get_event",
@@ -147,6 +151,10 @@ pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
                 "moonbitlang_async_io_result_get_status",
             ),
             ported_windows_symbol("read_io_result", "moonbitlang_async_read"),
+            ported_windows_symbol(
+                "read_dir_changes_io_result",
+                "moonbitlang_async_read_dir_changes",
+            ),
             ported_windows_symbol("write_io_result", "moonbitlang_async_write"),
             ported_windows_symbol("connect_io_result", "moonbitlang_async_connect"),
             ported_windows_symbol(

--- a/crates/moonrun/src/async_sys/internal/event_loop/io.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/io.rs
@@ -136,10 +136,6 @@ pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
                 "make_accept_io_result",
                 "moonbitlang_async_make_accept_io_result",
             ),
-            ported_windows_symbol(
-                "make_read_dir_changes_io_result",
-                "moonbitlang_async_make_read_dir_changes_io_result",
-            ),
             ported_windows_symbol("free_io_result", "moonbitlang_async_free_io_result"),
             ported_windows_symbol(
                 "io_result_get_event",

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -273,11 +273,11 @@ ported_fns! {
         read_native_dir(dir, buffer, restart)
     }
 
-    #[cfg(target_os = "linux")]
     #[ported(
         source = "src/internal/event_loop/fs.c",
         original = "inotify_add_watch_job_worker"
     )]
+    #[cfg(target_os = "linux")]
     pub(super) fn run_inotify_add_watch_job(
         inotify: &Resource,
         path: OsString,
@@ -296,7 +296,7 @@ ported_fns! {
             libc::inotify_add_watch(inotify.as_file()?.as_raw_fd(), path.as_ptr(), flags)
         };
         if watch < 0 {
-            return Err(AsyncHostError::last_native_error());
+            return Err(last_native_error());
         }
         Ok(i64::from(watch))
     }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -273,6 +273,34 @@ ported_fns! {
         read_native_dir(dir, buffer, restart)
     }
 
+    #[cfg(target_os = "linux")]
+    #[ported(
+        source = "src/internal/event_loop/fs.c",
+        original = "inotify_add_watch_job_worker"
+    )]
+    pub(super) fn run_inotify_add_watch_job(
+        inotify: &Resource,
+        path: OsString,
+        is_dir: bool,
+    ) -> AsyncHostResult<i64> {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = CString::new(path.into_vec()).map_err(|_| AsyncHostError::Inval)?;
+        let flags = if is_dir {
+            libc::IN_CREATE | libc::IN_MOVED_FROM | libc::IN_MOVED_TO | libc::IN_DELETE
+        } else {
+            libc::IN_MODIFY
+        };
+        let watch = unsafe {
+            libc::inotify_add_watch(inotify.as_file()?.as_raw_fd(), path.as_ptr(), flags)
+        };
+        if watch < 0 {
+            return Err(AsyncHostError::last_native_error());
+        }
+        Ok(i64::from(watch))
+    }
+
     #[ported(
         source = "src/internal/event_loop/fs.c",
         original = "realpath_job_worker"

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -443,6 +443,23 @@ ported_fns! {
         })
     }
 
+    #[cfg(target_os = "linux")]
+    #[ported(
+        source = "src/internal/event_loop/fs.c",
+        original = "moonbitlang_async_make_inotify_add_watch_job"
+    )]
+    pub(crate) fn make_inotify_add_watch_job(
+        inotify: ResourceRef,
+        path: OsString,
+        is_dir: bool,
+    ) -> Job {
+        Job::new(JobPayload::InotifyAddWatch {
+            inotify: Some(inotify),
+            path,
+            is_dir,
+        })
+    }
+
     #[ported(
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_make_bind_job"

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -443,11 +443,11 @@ ported_fns! {
         })
     }
 
-    #[cfg(target_os = "linux")]
     #[ported(
         source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_inotify_add_watch_job"
     )]
+    #[cfg(target_os = "linux")]
     pub(crate) fn make_inotify_add_watch_job(
         inotify: ResourceRef,
         path: OsString,

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -28,6 +28,8 @@ mod stat;
 mod types;
 mod worker;
 
+#[cfg(target_os = "linux")]
+pub(crate) use jobs::make_inotify_add_watch_job;
 #[cfg(unix)]
 pub(crate) use jobs::make_sigwait_job;
 #[cfg(unix)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -20,6 +20,8 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util;
 use crate::guest_memory::GuestMemory;
 
+#[cfg(target_os = "linux")]
+use super::fs::run_inotify_add_watch_job;
 use super::fs::{
     run_access_job, run_chmod_job, run_file_kind_by_path_job, run_file_size_job,
     run_file_time_by_path_job, run_file_time_job, run_flock_job, run_fsync_job, run_mkdir_job,
@@ -162,6 +164,15 @@ pub(crate) fn run_host_job(job: &mut Job) {
                 run_readdir_job(&dir, buffer.as_mut_slice(), *len, *restart)
             }
             _ => Err(AsyncHostError::Badf),
+        },
+        #[cfg(target_os = "linux")]
+        JobPayload::InotifyAddWatch {
+            inotify,
+            path,
+            is_dir,
+        } => match inotify.take() {
+            Some(inotify) => run_inotify_add_watch_job(&inotify, std::mem::take(path), *is_dir),
+            None => Err(AsyncHostError::Badf),
         },
         JobPayload::Bind { socket, addr } => match socket.take() {
             Some(socket) => run_bind_job(&socket, addr),

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -508,6 +508,12 @@ pub(crate) enum JobPayload {
         len: u32,
         restart: bool,
     },
+    #[cfg(target_os = "linux")]
+    InotifyAddWatch {
+        inotify: Option<ResourceRef>,
+        path: OsString,
+        is_dir: bool,
+    },
     Bind {
         socket: Option<ResourceRef>,
         addr: Vec<u8>,

--- a/crates/moonrun/src/async_sys/mod.rs
+++ b/crates/moonrun/src/async_sys/mod.rs
@@ -169,6 +169,12 @@ pub(crate) fn ported_symbols() -> Vec<PortedSymbol> {
     symbols.extend(internal::event_loop::thread_pool::ported_symbols());
     symbols.extend_from_slice(fs::dir::PORTED_SYMBOLS);
     symbols.extend_from_slice(fs::stub::PORTED_SYMBOLS);
+    #[cfg(target_os = "linux")]
+    symbols.extend_from_slice(fs::watch_inotify::PORTED_SYMBOLS);
+    #[cfg(target_os = "macos")]
+    symbols.extend_from_slice(fs::watch_kqueue::PORTED_SYMBOLS);
+    #[cfg(windows)]
+    symbols.extend_from_slice(fs::watch_windows::PORTED_SYMBOLS);
     symbols.extend_from_slice(os_error::stub::PORTED_SYMBOLS);
     symbols.extend_from_slice(process::PORTED_SYMBOLS);
     symbols.extend_from_slice(signal::PORTED_SYMBOLS);

--- a/crates/moonrun/src/host.rs
+++ b/crates/moonrun/src/host.rs
@@ -40,6 +40,8 @@ pub(crate) enum HostResourceKind {
     Poll,
     Worker,
     CBuffer,
+    #[cfg(windows)]
+    WindowsWatcherBuffer,
     #[cfg(unix)]
     ProcessArgv,
     ProcessEnv,

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -78,7 +78,7 @@ fn test_moonrun_against_upstream_async() {
         .args(["test", "--target", "wasm"])
         .assert()
         .success()
-        .stdout_eq("Total tests: 435, passed: 435, failed: 0.\n");
+        .stdout_eq("Total tests: 446, passed: 446, failed: 0.\n");
 }
 
 struct TestDir(moon_test_util::test_dir::TestDir);


### PR DESCRIPTION
## Why

The async Wasm artifact could not use its native file watcher implementations under moonrun. The missing host boundary covered inotify on Linux, kqueue on macOS, and overlapped directory notifications on Windows, so the upstream watcher tests remained native-only.

A kqueue vnode watch is a handle-based metadata observation. Without a host-side read-policy check, a write-only Resource could be registered to observe changes outside configured read roots.

Windows also cannot assume that ReadDirectoryChangesExW is usable: the export is version-dependent and the extended operation is unsupported by some filesystems. Wasm must not observe or guess which native event layout the host selected. Windows network directories additionally reject notification buffers larger than 64 KiB.

## What changed

- Port the native watcher syscalls and event accessors as namespaced async imports.
- Keep OS resources behind Moonrun Resource Handles while preserving native watcher descriptors and event-loop behavior.
- Add the Linux inotify add-watch worker Job, including execution-time filesystem policy checks.
- Enforce acquired-resource read policy immediately before registering macOS kqueue vnode watches.
- Give Windows watcher notifications a dedicated, DWORD-aligned host buffer resource that remains leased for the full overlapped operation.
- Resolve ReadDirectoryChangesExW dynamically, use it when available, and fall back to ReadDirectoryChangesW when the extended operation reports ERROR_INVALID_FUNCTION.
- Cap the Windows directory-change buffer at 64 KiB so local and network-directory watches use the same valid submission size.
- Keep the selected Windows event layout inside the host. Copy event paths to the guest as raw UTF-16 code units and expose file-ID availability plus the dirty file ID without misrepresenting it as a complete FileIdentity.
- Bump the async submodule to moonbitlang/async#549 and enable the 11 watcher tests in the upstream e2e suite.

## Why this is correct

The watcher state machines remain in moonbitlang/async. Moonrun exposes the same platform operations and completion model as the native boundary, with strict Wasm signatures and runtime platform selection. The macOS registration path uses the Resource policy path and checks read authority before any EV_ADD side effect, matching the policy applied to Linux add-watch jobs and other handle-based metadata operations.

On Windows, each completed buffer records the layout actually submitted, access is bounded by the completed byte count, and the guest never depends on FILE_NOTIFY_INFORMATION or FILE_NOTIFY_EXTENDED_INFORMATION offsets. Event paths preserve the exact UTF-16 code units produced by Windows, matching the native memcpy path without a lossy Unicode round trip. The 64 KiB capacity is valid for both local and network directories and remains entirely host-private, so it does not change the Wasm ABI or event layout.

The same Wasm artifact therefore instantiates on Linux, macOS, and Windows while calling only the backend selected by event_loop.platform.

## Split and merge order

The runtime and companion backend are split at the existing repository boundary. Merge this Moon PR first, then merge moonbitlang/async#549. The companion PR intentionally has no wasm-runtime-port-required label because that label is only for upstream work still requiring a Moon backport.
