### PR TITLE
refactor(moonutil): centralize Moon home layout

### DIFF
--- a/crates/moon/src/cli/deps.rs
+++ b/crates/moon/src/cli/deps.rs
@@ -28,7 +28,6 @@ use moonutil::{
     cli_support::AutoSyncFlags,
     project::{PackageDirs, ProjectContext},
     resolution::ModuleName,
-    toolchain,
     user_log::UserLog,
 };
 use std::path::{Path, PathBuf};
@@ -96,7 +95,7 @@ pub(crate) fn install_cli(
         return Ok(0);
     }
 
-    let install_dir = cmd.bin.unwrap_or_else(toolchain::user_bin);
+    let install_dir = cmd.bin.unwrap_or_else(|| moonutil::MOON_HOME.bin_dir());
     let has_git_ref = cmd.rev.is_some() || cmd.branch.is_some() || cmd.tag.is_some();
 
     // Explicit --path takes priority

--- a/crates/moon/src/cli/new.rs
+++ b/crates/moon/src/cli/new.rs
@@ -20,8 +20,9 @@ use std::{fs::File, io::BufReader, path::PathBuf};
 
 use anyhow::bail;
 use moonutil::{
+    MOON_HOME,
     constants::{is_moon_mod_exist, is_moon_pkg_exist},
-    registry::{Credentials, credentials_json, validate_username},
+    registry::{Credentials, validate_username},
     user_log::UserLog,
 };
 
@@ -29,7 +30,7 @@ use super::UniversalFlags;
 
 /// Read the existing username from the credentials file
 fn get_existing_username(user_log: &UserLog) -> Option<String> {
-    let credentials_path = credentials_json();
+    let credentials_path = MOON_HOME.credentials_path();
     if !credentials_path.exists() {
         user_log.warn(
             "Using default username. You may login with `moon login` to store your username, or provide one with `--user <username>`.",

--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -73,22 +73,12 @@ impl ResolvedExecutablePackage {
     }
 
     pub(super) fn cache_path(&self, suffix: &str) -> PathBuf {
-        let mut cache_path = moonutil::registry::cache()
-            .join("assets")
-            .join(self.module_name.username.as_str());
-        for segment in self.module_name.unqual.split('/') {
-            cache_path.push(segment);
-        }
-        cache_path.push(self.version.to_string());
-        for segment in self
-            .package_path
-            .split('/')
-            .filter(|segment| !segment.is_empty())
-        {
-            cache_path.push(segment);
-        }
-        cache_path.push(self.artifact_name(suffix));
-        cache_path
+        moonutil::MOON_HOME.registry_executable_artifact_path(
+            &self.module_name,
+            &self.version,
+            &self.package_path,
+            &self.artifact_name(suffix),
+        )
     }
 }
 

--- a/crates/moon/src/cli/whoami.rs
+++ b/crates/moon/src/cli/whoami.rs
@@ -19,17 +19,14 @@
 use std::{fs::File, io::BufReader};
 
 use anyhow::Context;
-use moonutil::{
-    cli_support::UniversalFlags,
-    registry::{Credentials, credentials_json},
-};
+use moonutil::{MOON_HOME, cli_support::UniversalFlags, registry::Credentials};
 
 /// Show login status and username
 #[derive(Debug, clap::Parser)]
 pub(crate) struct WhoamiSubcommand {}
 
 pub(crate) fn run_whoami(_cli: &UniversalFlags, _cmd: WhoamiSubcommand) -> anyhow::Result<i32> {
-    let credentials_path = credentials_json();
+    let credentials_path = MOON_HOME.credentials_path();
     if !credentials_path.exists() {
         println!("Not logged in");
         return Ok(0);

--- a/crates/moon/tests/add_upgrade_existing_dependency.rs
+++ b/crates/moon/tests/add_upgrade_existing_dependency.rs
@@ -30,8 +30,8 @@ fn run_moon(dir: &Path, moon_home: &Path) -> snapbox::cmd::Command {
 }
 
 fn write_registry_index(moon_home: &Path) {
-    let index_dir = moon_home.join("registry").join("index");
-    let index = index_dir.join("user").join("example").join("dep.index");
+    let layout = moonutil::MoonHomeLayout::new(moon_home.to_path_buf());
+    let index = layout.registry_index_file(&"example/dep".into());
     std::fs::create_dir_all(index.parent().unwrap()).unwrap();
     std::fs::write(
         index,

--- a/crates/moon/tests/support/util.rs
+++ b/crates/moon/tests/support/util.rs
@@ -174,10 +174,10 @@ pub(crate) fn replace_dir(s: &str, dir: impl AsRef<std::path::Path>) -> String {
     let s = s.replace(&path_str1, "$ROOT");
     let s = s.replace(&path_str2, "$ROOT");
     let toolchain_root = toolchain_root_for_tests();
-    let moon_home = moonutil::toolchain::home();
+    let moon_home = moonutil::MOON_HOME.root();
     let show_toolchain_root = match (
         dunce::canonicalize(&toolchain_root),
-        dunce::canonicalize(&moon_home),
+        dunce::canonicalize(moon_home),
     ) {
         (Ok(toolchain_root), Ok(moon_home)) => toolchain_root != moon_home,
         _ => toolchain_root != moon_home,
@@ -301,7 +301,10 @@ pub(crate) fn collapse_core_import_args(s: &str, backend: TargetBackend) -> Stri
     let expected_imports = core_import_specs(backend);
     let bundle = core_bundle_for_tests(backend);
     let mut bundle_prefixes = vec![format!("{}/", bundle.to_string_lossy().replace('\\', "/"))];
-    for root in [moonutil::toolchain::home(), toolchain_root_for_tests()] {
+    for root in [
+        moonutil::MOON_HOME.root().to_path_buf(),
+        toolchain_root_for_tests(),
+    ] {
         if let Ok(relative) = bundle.strip_prefix(root) {
             bundle_prefixes.push(format!(
                 "$MOON_HOME/{}/",
@@ -376,19 +379,14 @@ pub(crate) fn cache_registry_package(
     }
     let zip = archive.finish().unwrap().into_inner();
 
-    let (username, package) = name.split_once('/').unwrap();
-    let zip_path = moon_home
-        .join("registry/cache")
-        .join(username)
-        .join(package)
-        .join(format!("{version}.zip"));
+    let layout = moonutil::MoonHomeLayout::new(moon_home.to_path_buf());
+    let module_name: moonutil::resolution::ModuleName = name.into();
+    let version = version.parse().unwrap();
+    let zip_path = layout.registry_source_archive_path(&module_name, &version);
     std::fs::create_dir_all(zip_path.parent().unwrap()).unwrap();
     std::fs::write(&zip_path, &zip).unwrap();
 
-    let index_path = moon_home
-        .join("registry/index/user")
-        .join(username)
-        .join(format!("{package}.index"));
+    let index_path = layout.registry_index_file(&module_name);
     std::fs::create_dir_all(index_path.parent().unwrap()).unwrap();
     std::fs::write(
         &index_path,

--- a/crates/moon/tests/test_cases/indirect_dep/mod.rs
+++ b/crates/moon/tests/test_cases/indirect_dep/mod.rs
@@ -43,7 +43,8 @@ fn normalize_all_pkgs_json(dir: &impl AsRef<std::path::Path>, json_path: &Path) 
 
     // Replace the MOON_HOME path with $MOON_HOME
     normalized_json.replace(
-        &moonutil::toolchain::home()
+        &moonutil::MOON_HOME
+            .root()
             .to_str()
             .unwrap()
             .replace('\\', "/"),

--- a/crates/moon/tests/test_cases/package_management.rs
+++ b/crates/moon/tests/test_cases/package_management.rs
@@ -138,10 +138,11 @@ fn test_moon_update_reclones_for_different_registry_url() {
         .stdout_eq("")
         .stderr_eq("Registry index cloned successfully\nSymbols updated successfully\n");
 
+    let registry_index = moonutil::MoonHomeLayout::new(dir.to_path_buf()).registry_index_dir();
     let _ = std::process::Command::new("git")
         .args([
             "-C",
-            dir.join("registry").join("index").to_str().unwrap(),
+            registry_index.to_str().unwrap(),
             "remote",
             "set-url",
             "origin",
@@ -361,7 +362,8 @@ fn test_fetch_and_binary_install_run_legacy_postadd() {
         "failed to initialize local registry index:\n{}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let local_index = moon_home.path().join("registry/index");
+    let local_index =
+        moonutil::MoonHomeLayout::new(moon_home.path().to_path_buf()).registry_index_dir();
     std::fs::create_dir_all(local_index.parent().unwrap()).unwrap();
     let output = std::process::Command::new("git")
         .arg("clone")

--- a/crates/moon/tests/test_cases/whitespace_test/mod.rs
+++ b/crates/moon/tests/test_cases/whitespace_test/mod.rs
@@ -81,7 +81,8 @@ fn test_whitespace_parent_space() -> anyhow::Result<()> {
     );
     let out = out.replace(&prefix, ".");
     let out = out.replace(
-        &moonutil::toolchain::home()
+        &moonutil::MOON_HOME
+            .root()
             .to_str()
             .unwrap()
             .replace('\\', "/"),

--- a/crates/moonbuild/src/upgrade.rs
+++ b/crates/moonbuild/src/upgrade.rs
@@ -19,6 +19,7 @@
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use dialoguer::Confirm;
+use moonutil::MOON_HOME;
 use moonutil::toolchain;
 use moonutil::version::{VersionItems, get_moon_version, get_moonc_version, get_moonrun_version};
 use reqwest;
@@ -136,12 +137,12 @@ fn should_upgrade(latest_version_info: &VersionItems) -> Option<bool> {
 }
 
 fn upgrade_home() -> Result<PathBuf> {
-    let home = toolchain::home();
+    let home = MOON_HOME.root();
     let toolchain_root = toolchain::toolchain_root();
     let canonicalize =
         |path: &Path| dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
 
-    if canonicalize(&home) != canonicalize(&toolchain_root) {
+    if canonicalize(home) != canonicalize(&toolchain_root) {
         bail!(
             "moon upgrade only supports toolchains installed under MOON_HOME. Active toolchain root is `{}`, but MOON_HOME is `{}`. Please upgrade this installation with the package manager or installer that owns the toolchain.",
             toolchain_root.display(),
@@ -149,7 +150,7 @@ fn upgrade_home() -> Result<PathBuf> {
         );
     }
 
-    Ok(home)
+    Ok(home.to_path_buf())
 }
 
 pub fn upgrade(cmd: UpgradeSubcommand) -> Result<i32> {
@@ -285,7 +286,7 @@ mod windows {
         let _ = MOON_EXE_PATH.set(current_exe.clone());
         let _ = TEMP_EXE_PATH.set(temp_exe);
 
-        if current_exe.starts_with(toolchain::home()) {
+        if current_exe.starts_with(MOON_HOME.root()) {
             self_replace::self_delete().context("failed to delete current moon.exe")?;
         }
 

--- a/crates/mooncake/src/registry/client.rs
+++ b/crates/mooncake/src/registry/client.rs
@@ -28,8 +28,8 @@ use std::{
 use anyhow::{Context, bail};
 use indexmap::map::IndexMap;
 use moonutil::{
-    dependency::SourceDependencyInfo, locks::FileLock, registry::RegistryConfig,
-    resolution::ModuleName, user_log::UserLog,
+    MOON_HOME, MoonHomeLayout, dependency::SourceDependencyInfo, locks::FileLock,
+    registry::RegistryConfig, resolution::ModuleName, user_log::UserLog,
 };
 use reqwest::{StatusCode, header::USER_AGENT};
 use semver::Version;
@@ -96,9 +96,8 @@ impl RegistryEndpoints {
 /// to synchronize the registry.
 pub struct RegistryClient {
     config: RegistryConfig,
-    index: std::path::PathBuf,
+    home: MoonHomeLayout,
     endpoints: RegistryEndpoints,
-    archive_cache: std::path::PathBuf,
     cache: RefCell<HashMap<ModuleName, Arc<BTreeMap<Version, RegistryVersionInfo>>>>,
 }
 
@@ -109,35 +108,26 @@ impl RegistryClient {
     }
 
     fn from_config(config: RegistryConfig) -> Self {
-        Self::with_paths(
-            config,
-            moonutil::registry::index(),
-            moonutil::registry::cache(),
-        )
+        Self::with_home(config, MOON_HOME.clone())
     }
 
-    fn with_paths(
-        config: RegistryConfig,
-        index: std::path::PathBuf,
-        archive_cache: std::path::PathBuf,
-    ) -> Self {
+    fn with_home(config: RegistryConfig, home: MoonHomeLayout) -> Self {
         Self {
             endpoints: RegistryEndpoints::from_config(&config),
             config,
-            index,
-            archive_cache,
+            home,
             cache: RefCell::new(HashMap::new()),
         }
     }
 
     /// Return whether a local registry index is available for offline fallback.
     pub fn has_cached_index(&self) -> bool {
-        self.index.exists()
+        self.home.registry_index_dir().exists()
     }
 
     /// Synchronize the Git index and symbols archive with the configured registry.
     pub fn sync(&self, user_log: &UserLog) -> anyhow::Result<()> {
-        let outcome = crate::update::sync(&self.index, &self.config, user_log)?;
+        let outcome = crate::update::sync(&self.home, &self.config, user_log)?;
         self.cache.borrow_mut().clear();
         log_sync_outcome(outcome, user_log);
         Ok(())
@@ -160,44 +150,6 @@ impl RegistryClient {
         })
     }
 
-    fn index_file_of(&self, name: &ModuleName) -> std::path::PathBuf {
-        self.index
-            .join("user")
-            .join(name.username.as_str())
-            .join(format!("{}.index", name.unqual))
-    }
-
-    fn archive_cache_file_of(&self, name: &ModuleName, version: &Version) -> std::path::PathBuf {
-        self.archive_cache
-            .join(name.username.as_str())
-            .join(name.unqual.as_str())
-            .join(format!("{version}.zip"))
-    }
-
-    fn wasm_asset_cache_file_of(
-        &self,
-        name: &ModuleName,
-        version: &Version,
-        package_path: &str,
-    ) -> std::path::PathBuf {
-        let mut path = self
-            .archive_cache
-            .join("assets")
-            .join(name.username.as_str());
-        for segment in name.unqual.split('/') {
-            path.push(segment);
-        }
-        path.push(version.to_string());
-        for segment in package_path
-            .split('/')
-            .filter(|segment| !segment.is_empty())
-        {
-            path.push(segment);
-        }
-        path.push(wasm_artifact_name(name, package_path));
-        path
-    }
-
     fn acquire_wasm_asset_with(
         &self,
         name: &ModuleName,
@@ -209,7 +161,12 @@ impl RegistryClient {
         validate_asset_package_path(name, package_path)?;
         let url = self.endpoints.wasm_asset(name, version, package_path);
         let checksum_url = format!("{url}.sha256");
-        let cache_path = self.wasm_asset_cache_file_of(name, version, package_path);
+        let cache_path = self.home.registry_executable_artifact_path(
+            name,
+            version,
+            package_path,
+            &wasm_artifact_name(name, package_path),
+        );
 
         ensure_cached_wasm(&cache_path, user_log, |staged| {
             let checksum_bytes = download(&checksum_url)?;
@@ -375,7 +332,7 @@ impl super::Registry for RegistryClient {
             return Ok(Arc::clone(v));
         }
 
-        let index_file = self.index_file_of(name);
+        let index_file = self.home.registry_index_file(name);
         log::debug!("Reading versions of {} from {}", name, index_file.display());
         let file = std::fs::File::open(index_file)?;
         let reader = std::io::BufReader::new(file);
@@ -529,7 +486,7 @@ impl RegistryClient {
         name: &ModuleName,
         version: &Version,
     ) -> anyhow::Result<String> {
-        let p = self.index_file_of(name);
+        let p = self.home.registry_index_file(name);
         let file = std::fs::File::open(&p)?;
         let reader = std::io::BufReader::new(file);
 
@@ -563,11 +520,11 @@ impl RegistryClient {
         expected_checksum: &str,
         user_log: &UserLog,
     ) -> anyhow::Result<File> {
-        let pkg_index = self.index_file_of(name);
+        let pkg_index = self.home.registry_index_file(name);
         if !pkg_index.exists() {
             anyhow::bail!("Module {}@{} not found", name, version);
         }
-        let cache_file = self.archive_cache_file_of(name, version);
+        let cache_file = self.home.registry_source_archive_path(name, version);
         if let Some(archive) = open_cached_archive(&cache_file, expected_checksum)? {
             user_log.status(format!("Using cached {name}@{version}"));
             return Ok(archive);
@@ -577,7 +534,7 @@ impl RegistryClient {
             .parent()
             .expect("registry cache file has a parent");
         std::fs::create_dir_all(cache_dir)?;
-        let cache_lock_file = cache_file.with_extension("zip.lock");
+        let cache_lock_file = self.home.registry_source_archive_lock_path(name, version);
         let _cache_lock = FileLock::lock_file_with_user_log(&cache_lock_file, user_log)
             .with_context(|| {
                 format!(
@@ -777,14 +734,13 @@ mod tests {
     }
 
     fn asset_test_registry(sandbox: &tempfile::TempDir) -> RegistryClient {
-        RegistryClient::with_paths(
+        RegistryClient::with_home(
             RegistryConfig {
                 registry: "https://mooncakes.io".to_owned(),
                 index: String::new(),
                 symbols: None,
             },
-            sandbox.path().join("index"),
-            sandbox.path().join("cache"),
+            MoonHomeLayout::new(sandbox.path().to_path_buf()),
         )
     }
 
@@ -863,7 +819,12 @@ mod tests {
         let registry = asset_test_registry(&sandbox);
         let name = parser_module();
         let version = Version::new(0, 3, 3);
-        let cache_path = registry.wasm_asset_cache_file_of(&name, &version, "cmd/moonfmt");
+        let cache_path = registry.home.registry_executable_artifact_path(
+            &name,
+            &version,
+            "cmd/moonfmt",
+            "moonfmt.wasm",
+        );
         std::fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
         std::fs::write(&cache_path, b"\0asmtest").unwrap();
 
@@ -875,10 +836,9 @@ mod tests {
 
         assert_eq!(path, cache_path);
         assert!(
-            !cache_path
-                .parent()
-                .unwrap()
-                .join(moonutil::constants::MOON_LOCK)
+            !registry
+                .home
+                .registry_package_assets_lock_path(&name, &version, "cmd/moonfmt")
                 .exists()
         );
     }
@@ -886,8 +846,7 @@ mod tests {
     #[test]
     fn concurrent_wasm_asset_cache_misses_download_once() {
         let sandbox = tempfile::TempDir::new().unwrap();
-        let index = sandbox.path().join("index");
-        let cache = sandbox.path().join("cache");
+        let home = MoonHomeLayout::new(sandbox.path().to_path_buf());
         let start = Arc::new(Barrier::new(3));
         let download_count = Arc::new(AtomicUsize::new(0));
         let wasm = b"\0asmtest".to_vec();
@@ -895,14 +854,13 @@ mod tests {
 
         let threads = (0..2)
             .map(|_| {
-                let registry = RegistryClient::with_paths(
+                let registry = RegistryClient::with_home(
                     RegistryConfig {
                         registry: "https://mooncakes.io".to_owned(),
                         index: String::new(),
                         symbols: None,
                     },
-                    index.clone(),
-                    cache.clone(),
+                    home.clone(),
                 );
                 let start = Arc::clone(&start);
                 let download_count = Arc::clone(&download_count);
@@ -964,7 +922,8 @@ mod tests {
         );
         assert!(
             !registry
-                .wasm_asset_cache_file_of(&name, &version, "cmd/moonfmt")
+                .home
+                .registry_executable_artifact_path(&name, &version, "cmd/moonfmt", "moonfmt.wasm")
                 .exists()
         );
     }
@@ -1098,19 +1057,18 @@ mod tests {
     fn test_registry(sandbox: &tempfile::TempDir) -> (RegistryClient, ModuleName, Version) {
         let name: ModuleName = "test/module".into();
         let version = Version::new(1, 2, 3);
-        let index = sandbox.path().join("index");
-        let index_file = index.join("user/test/module.index");
+        let home = MoonHomeLayout::new(sandbox.path().to_path_buf());
+        let index_file = home.registry_index_file(&name);
         std::fs::create_dir_all(index_file.parent().unwrap()).unwrap();
         std::fs::write(&index_file, "registry entry exists").unwrap();
         (
-            RegistryClient::with_paths(
+            RegistryClient::with_home(
                 RegistryConfig {
                     registry: String::new(),
                     index: String::new(),
                     symbols: None,
                 },
-                index,
-                sandbox.path().join("archive-cache"),
+                home,
             ),
             name,
             version,
@@ -1134,7 +1092,7 @@ mod tests {
         let (registry, name, version) = test_registry(&sandbox);
         let archive = test_archive();
         let checksum = calc_sha2(&mut Cursor::new(&archive)).unwrap();
-        let archive_path = registry.archive_cache_file_of(&name, &version);
+        let archive_path = registry.home.registry_source_archive_path(&name, &version);
         std::fs::create_dir_all(archive_path.parent().unwrap()).unwrap();
         std::fs::write(archive_path, archive).unwrap();
         let destination = sandbox.path().join("source");
@@ -1155,7 +1113,7 @@ mod tests {
         let (registry, name, version) = test_registry(&sandbox);
         let archive = test_archive();
         let checksum = calc_sha2(&mut Cursor::new(&archive)).unwrap();
-        let archive_path = registry.archive_cache_file_of(&name, &version);
+        let archive_path = registry.home.registry_source_archive_path(&name, &version);
         std::fs::create_dir_all(archive_path.parent().unwrap()).unwrap();
         std::fs::write(&archive_path, archive).unwrap();
 
@@ -1176,7 +1134,11 @@ mod tests {
                 .unwrap()
                 .join(moonutil::constants::MOON_LOCK),
         );
-        let version_lock = open_lock(&archive_path.with_extension("zip.lock"));
+        let version_lock = open_lock(
+            &registry
+                .home
+                .registry_source_archive_lock_path(&name, &version),
+        );
 
         let destination = sandbox.path().join("source");
         let (result_sender, result_receiver) = std::sync::mpsc::channel();
@@ -1252,8 +1214,7 @@ mod tests {
         let barrier = Arc::new(Barrier::new(2));
         let clients = (0..2)
             .map(|client| {
-                let index = registry.index.clone();
-                let archive_cache = registry.archive_cache.clone();
+                let home = registry.home.clone();
                 let url_base = url_base.clone();
                 let name = name.clone();
                 let version = version.clone();
@@ -1261,14 +1222,13 @@ mod tests {
                 let destination = sandbox.path().join(format!("source-{client}"));
                 let barrier = Arc::clone(&barrier);
                 std::thread::spawn(move || {
-                    let registry = RegistryClient::with_paths(
+                    let registry = RegistryClient::with_home(
                         RegistryConfig {
                             registry: url_base,
                             index: String::new(),
                             symbols: None,
                         },
-                        index,
-                        archive_cache,
+                        home,
                     );
                     barrier.wait();
                     registry.acquire_source_to(
@@ -1299,8 +1259,8 @@ mod tests {
         assert_eq!(request_count.load(Ordering::Relaxed), 1);
         assert!(
             registry
-                .archive_cache_file_of(&name, &version)
-                .with_extension("zip.lock")
+                .home
+                .registry_source_archive_lock_path(&name, &version)
                 .is_file()
         );
     }
@@ -1354,7 +1314,7 @@ mod tests {
     fn acquire_source_to_reports_cached_archive_io_errors() {
         let sandbox = tempfile::TempDir::new().unwrap();
         let (registry, name, version) = test_registry(&sandbox);
-        let archive_path = registry.archive_cache_file_of(&name, &version);
+        let archive_path = registry.home.registry_source_archive_path(&name, &version);
         std::fs::create_dir_all(&archive_path).unwrap();
         let destination = sandbox.path().join("source");
 
@@ -1388,8 +1348,9 @@ mod tests {
 
     #[test]
     fn all_versions_accepts_single_rule_object_from_index_jsonl() {
-        let index = temp_index_dir();
-        let index_file = index.join("user").join("bobzhang").join("openseek.index");
+        let home = MoonHomeLayout::new(temp_index_dir());
+        let module: ModuleName = "bobzhang/openseek".into();
+        let index_file = home.registry_index_file(&module);
         std::fs::create_dir_all(index_file.parent().unwrap()).unwrap();
         std::fs::write(
             &index_file,
@@ -1398,14 +1359,13 @@ mod tests {
         )
         .unwrap();
 
-        let registry = RegistryClient::with_paths(
+        let registry = RegistryClient::with_home(
             RegistryConfig {
                 registry: String::new(),
                 index: String::new(),
                 symbols: None,
             },
-            index.clone(),
-            index.join("archive-cache"),
+            home.clone(),
         );
         let versions = registry
             .all_versions_of(&ModuleName {
@@ -1429,6 +1389,6 @@ mod tests {
             "abc123"
         );
 
-        let _ = std::fs::remove_dir_all(index);
+        let _ = std::fs::remove_dir_all(home.root());
     }
 }

--- a/crates/mooncake/src/update.rs
+++ b/crates/mooncake/src/update.rs
@@ -21,6 +21,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
 use moonutil::{
+    MoonHomeLayout,
     git::{GitCommandError, Stdios},
     locks::FileLock,
     registry::RegistryConfig,
@@ -36,7 +37,6 @@ use sha2::{Digest, Sha256};
 use crate::zip_util::extract_zip_to_dir;
 
 const SYMBOLS_URL: &str = "https://download.mooncakes.io/symbols.zip";
-const REGISTRY_UPDATE_STATE: &str = ".registry-update-state.json";
 
 #[derive(Debug)]
 struct CommandOutput {
@@ -495,13 +495,13 @@ fn download_symbols_zip(
 
 fn update_symbols_from_url(
     registry_dir: &Path,
+    target_dir: &Path,
     symbols_url: &str,
     previous_etag: Option<&SymbolsEtag>,
 ) -> anyhow::Result<Option<SymbolsEtag>> {
     std::fs::create_dir_all(registry_dir)
         .with_context(|| format!("failed to create `{}`", registry_dir.display()))?;
 
-    let target_dir = registry_dir.join("symbols");
     let previous_etag = target_dir.is_dir().then_some(previous_etag).flatten();
     let download = download_symbols_zip(symbols_url, previous_etag)?;
     let (data, etag) = match download {
@@ -527,11 +527,11 @@ fn update_symbols_from_url(
     if target_dir.exists() {
         let backup_dir = unique_sibling_dir(registry_dir, ".symbols.old")
             .context("failed to create backup dir")?;
-        std::fs::rename(&target_dir, &backup_dir)
+        std::fs::rename(target_dir, &backup_dir)
             .context("failed to move existing symbols dir to backup")?;
 
-        if let Err(e) = std::fs::rename(&tmp_dir, &target_dir) {
-            let _ = std::fs::rename(&backup_dir, &target_dir);
+        if let Err(e) = std::fs::rename(&tmp_dir, target_dir) {
+            let _ = std::fs::rename(&backup_dir, target_dir);
             let _ = std::fs::remove_dir_all(&tmp_dir);
             return Err(anyhow::Error::from(e).context("failed to replace symbols directory"));
         }
@@ -543,7 +543,7 @@ fn update_symbols_from_url(
             )
         })?;
     } else {
-        std::fs::rename(&tmp_dir, &target_dir)
+        std::fs::rename(&tmp_dir, target_dir)
             .context("failed to move symbols directory into place")?;
     }
 
@@ -564,9 +564,8 @@ enum RegistryUpdateObservation {
     Unavailable,
 }
 
-fn observe_registry_update_state(registry_dir: &Path) -> RegistryUpdateObservation {
-    let path = registry_dir.join(REGISTRY_UPDATE_STATE);
-    match std::fs::read(&path) {
+fn observe_registry_update_state(path: &Path) -> RegistryUpdateObservation {
+    match std::fs::read(path) {
         Ok(data) => match serde_json::from_slice(&data) {
             Ok(state) => RegistryUpdateObservation::Observed(Some(state)),
             Err(error) => {
@@ -594,6 +593,7 @@ fn observe_registry_update_state(registry_dir: &Path) -> RegistryUpdateObservati
 
 fn write_registry_update_state(
     registry_dir: &Path,
+    state_path: &Path,
     registry_identity: &str,
     symbols_etag: Option<SymbolsEtag>,
 ) -> anyhow::Result<()> {
@@ -608,15 +608,13 @@ fn write_registry_update_state(
     };
     let mut staged = tempfile::NamedTempFile::new_in(registry_dir)?;
     serde_json::to_writer(staged.as_file_mut(), &state)?;
-    staged
-        .persist(registry_dir.join(REGISTRY_UPDATE_STATE))
-        .map_err(|error| error.error)?;
+    staged.persist(state_path).map_err(|error| error.error)?;
     Ok(())
 }
 
 #[tracing::instrument(level = "debug", skip_all)]
 fn run_registry_update_locked(
-    registry_dir: &Path,
+    home: &MoonHomeLayout,
     registry_identity: &str,
     observed: RegistryUpdateObservation,
     user_log: &UserLog,
@@ -624,16 +622,18 @@ fn run_registry_update_locked(
         Option<&SymbolsEtag>,
     ) -> anyhow::Result<(UpdateOutcome, Option<SymbolsEtag>)>,
 ) -> anyhow::Result<UpdateOutcome> {
+    let registry_dir = home.registry_dir();
+    let state_path = home.registry_update_state_path();
     let _lock = {
         let _span = tracing::debug_span!("acquire_registry_update_lock").entered();
-        FileLock::lock_with_user_log(registry_dir, user_log)
+        FileLock::lock_file_with_user_log(&home.registry_update_lock_path(), user_log)
             .context("failed to lock registry update directory")?
     };
 
     // The observation was captured before waiting for the lock. A changed
     // generation therefore represents work completed by a concurrent caller,
     // not a freshness window for a later update.
-    let current = observe_registry_update_state(registry_dir);
+    let current = observe_registry_update_state(&state_path);
     let reuse = match (&observed, &current) {
         (
             RegistryUpdateObservation::Observed(observed),
@@ -657,7 +657,7 @@ fn run_registry_update_locked(
     let (outcome, symbols_etag) = perform_update(previous_etag)?;
     if outcome.symbols_updated
         && let Err(error) =
-            write_registry_update_state(registry_dir, registry_identity, symbols_etag)
+            write_registry_update_state(&registry_dir, &state_path, registry_identity, symbols_etag)
     {
         user_log.warn(format!(
             "failed to record completed registry update: {error:#}"
@@ -671,34 +671,38 @@ fn run_registry_update_locked(
 }
 
 pub(crate) fn sync(
-    target_dir: &Path,
+    home: &MoonHomeLayout,
     registry_config: &RegistryConfig,
     user_log: &UserLog,
 ) -> anyhow::Result<UpdateOutcome> {
-    let registry_dir = target_dir
-        .parent()
-        .context("registry index directory has no parent")?;
-    std::fs::create_dir_all(registry_dir)
+    let registry_dir = home.registry_dir();
+    let target_dir = home.registry_index_dir();
+    let symbols_dir = home.registry_symbols_dir();
+    std::fs::create_dir_all(&registry_dir)
         .with_context(|| format!("failed to create `{}`", registry_dir.display()))?;
-    let observed = observe_registry_update_state(registry_dir);
+    let observed = observe_registry_update_state(&home.registry_update_state_path());
     let symbols_url = registry_config.symbols.as_deref().unwrap_or(SYMBOLS_URL);
     let registry_identity = registry_identity(&registry_config.index, symbols_url);
 
     run_registry_update_locked(
-        registry_dir,
+        home,
         &registry_identity,
         observed,
         user_log,
         |previous_etag| {
-            let registry_index = update_registry_index(target_dir, registry_config, user_log)?;
-            let (symbols_updated, symbols_etag) =
-                match update_symbols_from_url(registry_dir, symbols_url, previous_etag) {
-                    Ok(etag) => (true, etag),
-                    Err(e) => {
-                        user_log.warn(format!("failed to update symbols: {e:#}"));
-                        (false, None)
-                    }
-                };
+            let registry_index = update_registry_index(&target_dir, registry_config, user_log)?;
+            let (symbols_updated, symbols_etag) = match update_symbols_from_url(
+                &registry_dir,
+                &symbols_dir,
+                symbols_url,
+                previous_etag,
+            ) {
+                Ok(etag) => (true, etag),
+                Err(e) => {
+                    user_log.warn(format!("failed to update symbols: {e:#}"));
+                    (false, None)
+                }
+            };
 
             Ok((
                 UpdateOutcome {
@@ -794,6 +798,12 @@ mod tests {
 
     fn quiet_user_log() -> UserLog {
         UserLog::new(log::LevelFilter::Off)
+    }
+
+    fn test_moon_home(root: &tempfile::TempDir) -> MoonHomeLayout {
+        let home = MoonHomeLayout::new(root.path().to_path_buf());
+        std::fs::create_dir_all(home.registry_dir()).unwrap();
+        home
     }
 
     fn registry_with_history() -> (tempfile::TempDir, RegistryConfig) {
@@ -937,7 +947,8 @@ mod tests {
 
     #[test]
     fn symbols_update_reuses_an_etag_on_not_modified() {
-        let registry = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let home = test_moon_home(&root);
         let (url, server) = serve_http(vec![
             TestHttpResponse {
                 status: "200 OK",
@@ -951,20 +962,30 @@ mod tests {
             },
         ]);
 
-        let etag = update_symbols_from_url(registry.path(), &url, None)
-            .unwrap()
-            .unwrap();
+        let etag = update_symbols_from_url(
+            &home.registry_dir(),
+            &home.registry_symbols_dir(),
+            &url,
+            None,
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(etag.url, url);
         assert_eq!(etag.value, "\"symbols-v1\"");
-        std::fs::write(registry.path().join("symbols/symbol.txt"), "local").unwrap();
+        std::fs::write(home.registry_symbols_dir().join("symbol.txt"), "local").unwrap();
 
-        let reused = update_symbols_from_url(registry.path(), &url, Some(&etag))
-            .unwrap()
-            .unwrap();
+        let reused = update_symbols_from_url(
+            &home.registry_dir(),
+            &home.registry_symbols_dir(),
+            &url,
+            Some(&etag),
+        )
+        .unwrap()
+        .unwrap();
 
         assert_eq!(reused, etag);
         assert_eq!(
-            std::fs::read_to_string(registry.path().join("symbols/symbol.txt")).unwrap(),
+            std::fs::read_to_string(home.registry_symbols_dir().join("symbol.txt")).unwrap(),
             "local"
         );
         let requests = server.join().unwrap();
@@ -978,7 +999,8 @@ mod tests {
 
     #[test]
     fn symbols_update_ignores_an_etag_when_local_symbols_are_missing() {
-        let registry = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let home = test_moon_home(&root);
         let (url, server) = serve_http(vec![TestHttpResponse {
             status: "200 OK",
             headers: vec![("ETag", "\"symbols-v2\"")],
@@ -989,13 +1011,18 @@ mod tests {
             value: "\"symbols-v1\"".to_owned(),
         };
 
-        let updated = update_symbols_from_url(registry.path(), &url, Some(&etag))
-            .unwrap()
-            .unwrap();
+        let updated = update_symbols_from_url(
+            &home.registry_dir(),
+            &home.registry_symbols_dir(),
+            &url,
+            Some(&etag),
+        )
+        .unwrap()
+        .unwrap();
 
         assert_eq!(updated.value, "\"symbols-v2\"");
         assert_eq!(
-            std::fs::read_to_string(registry.path().join("symbols/symbol.txt")).unwrap(),
+            std::fs::read_to_string(home.registry_symbols_dir().join("symbol.txt")).unwrap(),
             "restored"
         );
         let requests = server.join().unwrap();
@@ -1004,8 +1031,9 @@ mod tests {
 
     #[test]
     fn symbols_update_ignores_an_invalid_etag() {
-        let registry = tempfile::tempdir().unwrap();
-        std::fs::create_dir(registry.path().join("symbols")).unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let home = test_moon_home(&root);
+        std::fs::create_dir(home.registry_symbols_dir()).unwrap();
         let (url, server) = serve_http(vec![TestHttpResponse {
             status: "200 OK",
             headers: Vec::new(),
@@ -1016,7 +1044,13 @@ mod tests {
             value: "invalid\netag".to_owned(),
         };
 
-        let updated = update_symbols_from_url(registry.path(), &url, Some(&etag)).unwrap();
+        let updated = update_symbols_from_url(
+            &home.registry_dir(),
+            &home.registry_symbols_dir(),
+            &url,
+            Some(&etag),
+        )
+        .unwrap();
 
         assert_eq!(updated, None);
         let requests = server.join().unwrap();
@@ -1057,30 +1091,25 @@ mod tests {
 
     #[test]
     fn concurrent_registry_updates_are_coalesced() {
-        let registry_dir = Arc::new(tempfile::tempdir().unwrap());
+        let root = tempfile::tempdir().unwrap();
+        let home = Arc::new(test_moon_home(&root));
         let barrier = Arc::new(Barrier::new(2));
         let performed = Arc::new(AtomicUsize::new(0));
-        let observed = observe_registry_update_state(registry_dir.path());
+        let observed = observe_registry_update_state(&home.registry_update_state_path());
         let mut threads = Vec::new();
 
         for _ in 0..2 {
-            let registry_dir = Arc::clone(&registry_dir);
+            let home = Arc::clone(&home);
             let barrier = Arc::clone(&barrier);
             let performed = Arc::clone(&performed);
             let observed = observed.clone();
             threads.push(std::thread::spawn(move || {
                 barrier.wait();
-                run_registry_update_locked(
-                    registry_dir.path(),
-                    "registry-a",
-                    observed,
-                    &quiet_user_log(),
-                    |_| {
-                        performed.fetch_add(1, Ordering::SeqCst);
-                        std::thread::sleep(std::time::Duration::from_millis(50));
-                        Ok((successful_update(), None))
-                    },
-                )
+                run_registry_update_locked(&home, "registry-a", observed, &quiet_user_log(), |_| {
+                    performed.fetch_add(1, Ordering::SeqCst);
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    Ok((successful_update(), None))
+                })
                 .unwrap()
             }));
         }
@@ -1103,7 +1132,8 @@ mod tests {
 
     #[test]
     fn completed_registry_update_is_not_a_ttl() {
-        let registry_dir = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let home = test_moon_home(&root);
         let performed = AtomicUsize::new(0);
         let etag = SymbolsEtag {
             url: "https://example.invalid/symbols.zip".to_owned(),
@@ -1120,26 +1150,20 @@ mod tests {
         };
 
         run_registry_update_locked(
-            registry_dir.path(),
+            &home,
             "registry-a",
-            observe_registry_update_state(registry_dir.path()),
+            observe_registry_update_state(&home.registry_update_state_path()),
             &quiet_user_log(),
             perform,
         )
         .unwrap();
-        let observed = observe_registry_update_state(registry_dir.path());
-        run_registry_update_locked(
-            registry_dir.path(),
-            "registry-a",
-            observed,
-            &quiet_user_log(),
-            perform,
-        )
-        .unwrap();
+        let observed = observe_registry_update_state(&home.registry_update_state_path());
+        run_registry_update_locked(&home, "registry-a", observed, &quiet_user_log(), perform)
+            .unwrap();
 
         assert_eq!(performed.load(Ordering::SeqCst), 2);
         let RegistryUpdateObservation::Observed(Some(state)) =
-            observe_registry_update_state(registry_dir.path())
+            observe_registry_update_state(&home.registry_update_state_path())
         else {
             panic!("registry update state was not written");
         };
@@ -1148,11 +1172,12 @@ mod tests {
 
     #[test]
     fn concurrent_update_for_a_different_registry_is_not_reused() {
-        let registry_dir = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let home = test_moon_home(&root);
         let performed = AtomicUsize::new(0);
         for registry_identity in ["registry-a", "registry-b"] {
             run_registry_update_locked(
-                registry_dir.path(),
+                &home,
                 registry_identity,
                 RegistryUpdateObservation::Observed(None),
                 &quiet_user_log(),
@@ -1169,11 +1194,12 @@ mod tests {
 
     #[test]
     fn update_with_failed_symbols_is_not_reused() {
-        let registry_dir = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let home = test_moon_home(&root);
         let performed = AtomicUsize::new(0);
         for _ in 0..2 {
             run_registry_update_locked(
-                registry_dir.path(),
+                &home,
                 "registry-a",
                 RegistryUpdateObservation::Observed(None),
                 &quiet_user_log(),

--- a/crates/moonutil/src/cache.rs
+++ b/crates/moonutil/src/cache.rs
@@ -44,13 +44,6 @@ impl CacheKind {
         }
     }
 
-    const fn default_directory(self) -> &'static str {
-        match self {
-            Self::DependencySources => "deps",
-            Self::BuildArtifacts => "build",
-        }
-    }
-
     const fn ownership(self) -> &'static [u8] {
         match self {
             Self::DependencySources => b"dependency-sources\n",
@@ -113,9 +106,10 @@ pub fn resolve_cache_root(kind: CacheKind) -> anyhow::Result<CacheRoot> {
         }
         None => Ok(CacheRoot::Path {
             kind,
-            path: crate::moon_dir::home()
-                .join("cache")
-                .join(kind.default_directory()),
+            path: match kind {
+                CacheKind::DependencySources => crate::MOON_HOME.dependency_cache_dir(),
+                CacheKind::BuildArtifacts => crate::MOON_HOME.build_cache_dir(),
+            },
         }),
     }
 }

--- a/crates/moonutil/src/lib.rs
+++ b/crates/moonutil/src/lib.rs
@@ -62,4 +62,6 @@ pub mod text;
 pub mod toolchain;
 pub mod user_log;
 pub mod version;
+
+pub use moon_dir::{MOON_HOME, MoonHomeLayout};
 pub mod workspace;

--- a/crates/moonutil/src/moon_dir.rs
+++ b/crates/moonutil/src/moon_dir.rs
@@ -16,34 +16,188 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+//! Moon home and selected toolchain layouts.
+
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
+use semver::Version;
+
 use crate::{
-    constants::{BUILD_DIR, PRELUDE_PROOF_DIR},
+    constants::{BUILD_DIR, MOON_LOCK, PRELUDE_PROOF_DIR},
+    resolution::ModuleName,
     target::TargetBackend,
 };
 
+/// Paths owned by one Moon home directory.
+#[derive(Clone, Debug)]
+pub struct MoonHomeLayout {
+    root: PathBuf,
+}
+
+impl MoonHomeLayout {
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// User-installed executables.
+    ///
+    /// In the default self-contained installation this is also the selected
+    /// toolchain's `bin` directory. Package-managed toolchains may live under
+    /// a separate root.
+    pub fn bin_dir(&self) -> PathBuf {
+        self.root.join("bin")
+    }
+
+    /// Default cache of resolved dependency source trees.
+    pub fn dependency_cache_dir(&self) -> PathBuf {
+        self.cache_dir().join("deps")
+    }
+
+    /// Default cache of build artifacts.
+    pub fn build_cache_dir(&self) -> PathBuf {
+        self.cache_dir().join("build")
+    }
+
+    /// Registry metadata and downloaded content.
+    pub fn registry_dir(&self) -> PathBuf {
+        self.root.join("registry")
+    }
+
+    /// Local Git checkout of the registry index.
+    pub fn registry_index_dir(&self) -> PathBuf {
+        self.registry_dir().join("index")
+    }
+
+    /// One module's JSON-lines entry in the local registry index checkout.
+    pub fn registry_index_file(&self, name: &ModuleName) -> PathBuf {
+        self.registry_index_dir()
+            .join("user")
+            .join(name.username.as_str())
+            .join(format!("{}.index", name.unqual))
+    }
+
+    /// Verified registry downloads, including package and executable archives.
+    pub fn registry_cache_dir(&self) -> PathBuf {
+        self.registry_dir().join("cache")
+    }
+
+    /// One verified module source archive.
+    pub fn registry_source_archive_path(&self, name: &ModuleName, version: &Version) -> PathBuf {
+        self.registry_cache_dir()
+            .join(name.username.as_str())
+            .join(name.unqual.as_str())
+            .join(format!("{version}.zip"))
+    }
+
+    /// Lock serializing publication of one source archive version.
+    pub fn registry_source_archive_lock_path(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+    ) -> PathBuf {
+        self.registry_source_archive_path(name, version)
+            .with_extension("zip.lock")
+    }
+
+    /// Directory containing cached executable artifacts.
+    pub fn registry_assets_dir(&self) -> PathBuf {
+        self.registry_cache_dir().join("assets")
+    }
+
+    /// Directory for one registry package's cached executable artifacts.
+    pub fn registry_package_assets_dir(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        package_path: &str,
+    ) -> PathBuf {
+        let mut path = self.registry_assets_dir().join(name.username.as_str());
+        path.extend(name.unqual.split('/'));
+        path.push(version.to_string());
+        path.extend(
+            package_path
+                .split('/')
+                .filter(|segment| !segment.is_empty()),
+        );
+        path
+    }
+
+    /// One cached executable artifact published for a registry package.
+    pub fn registry_executable_artifact_path(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        package_path: &str,
+        artifact_name: &str,
+    ) -> PathBuf {
+        self.registry_package_assets_dir(name, version, package_path)
+            .join(artifact_name)
+    }
+
+    /// Lock serializing publication within one registry package asset directory.
+    pub fn registry_package_assets_lock_path(
+        &self,
+        name: &ModuleName,
+        version: &Version,
+        package_path: &str,
+    ) -> PathBuf {
+        self.registry_package_assets_dir(name, version, package_path)
+            .join(MOON_LOCK)
+    }
+
+    /// Materialized symbol metadata downloaded during registry sync.
+    pub fn registry_symbols_dir(&self) -> PathBuf {
+        self.registry_dir().join("symbols")
+    }
+
+    /// Lock serializing updates to the registry index and symbols.
+    pub fn registry_update_lock_path(&self) -> PathBuf {
+        self.registry_dir().join(MOON_LOCK)
+    }
+
+    /// State used to coalesce concurrent registry updates.
+    pub fn registry_update_state_path(&self) -> PathBuf {
+        self.registry_dir().join(".registry-update-state.json")
+    }
+
+    /// Moon-owned global caches selected by `MOON_DEP_CACHE` and
+    /// `MOON_BUILD_CACHE` when those variables are unset.
+    pub fn cache_dir(&self) -> PathBuf {
+        self.root.join("cache")
+    }
+
+    pub fn credentials_path(&self) -> PathBuf {
+        self.root.join("credentials.json")
+    }
+
+    pub fn config_path(&self) -> PathBuf {
+        self.root.join("config.json")
+    }
+}
+
 pub struct MoonDirs {
-    pub moon_home: PathBuf,
     pub moon_include_path: PathBuf,
     pub moon_lib_path: PathBuf,
     pub moon_bin_path: PathBuf,
     pub internal_tcc_path: PathBuf,
 }
 
-static MOON_HOME: LazyLock<PathBuf> = LazyLock::new(resolve_home);
+pub static MOON_HOME: LazyLock<MoonHomeLayout> =
+    LazyLock::new(|| MoonHomeLayout::new(resolve_moon_home()));
 static TOOLCHAIN_ROOT: LazyLock<PathBuf> = LazyLock::new(resolve_toolchain_root);
 
 pub static MOON_DIRS: LazyLock<MoonDirs> = LazyLock::new(|| {
-    let moon_home = home();
     let toolchain_root = toolchain_root();
     let moon_include_path = toolchain_root.join("include");
     let moon_lib_path = toolchain_root.join("lib");
     let moon_bin_path = toolchain_root.join("bin");
     let internal_tcc_path = moon_bin_path.join("internal").join("tcc");
     MoonDirs {
-        moon_home,
         moon_include_path,
         moon_lib_path,
         moon_bin_path,
@@ -74,6 +228,18 @@ fn infer_toolchain_root_from_exe(current_exe: &Path) -> Option<PathBuf> {
     Some(root.to_path_buf())
 }
 
+fn resolve_moon_home() -> PathBuf {
+    std::env::var_os("MOON_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let Some(home) = home::home_dir() else {
+                eprintln!("Failed to get home directory");
+                std::process::exit(1);
+            };
+            home.join(".moon")
+        })
+}
+
 fn resolve_toolchain_root() -> PathBuf {
     if let Some(path) = std::env::var_os("MOON_TOOLCHAIN_ROOT") {
         return PathBuf::from(path);
@@ -85,35 +251,15 @@ fn resolve_toolchain_root() -> PathBuf {
         return root;
     }
 
-    home()
-}
-
-fn resolve_home() -> PathBuf {
-    if let Some(moon_home) = std::env::var_os("MOON_HOME") {
-        PathBuf::from(moon_home)
-    } else {
-        let Some(h) = home::home_dir() else {
-            eprintln!("Failed to get home directory");
-            std::process::exit(1);
-        };
-        h.join(".moon")
-    }
+    MOON_HOME.root().to_path_buf()
 }
 
 pub fn toolchain_root() -> PathBuf {
     TOOLCHAIN_ROOT.clone()
 }
 
-pub fn home() -> PathBuf {
-    MOON_HOME.clone()
-}
-
 pub fn bin() -> PathBuf {
     toolchain_root().join("bin")
-}
-
-pub fn user_bin() -> PathBuf {
-    home().join("bin")
 }
 
 pub fn include() -> PathBuf {
@@ -189,72 +335,75 @@ pub fn core_core(backend: TargetBackend) -> Vec<String> {
     ]
 }
 
-pub fn cache() -> PathBuf {
-    home().join("registry").join("cache")
-}
+#[test]
+fn derives_paths_from_one_home_root() {
+    let layout = MoonHomeLayout::new(PathBuf::from("moon-home"));
 
-/// Reserved binary names that cannot be overwritten by user-installed packages.
-pub const RESERVED_BIN_NAMES: &[&str] = &[
-    "moon",
-    "moonc",
-    "mooncake",
-    "moondoc",
-    "moonfmt",
-    "mooninfo",
-    "moonrun",
-    "moon_cove_report",
-    "moon-ide",
-    "moon-lsp",
-    "moon-wasm-opt",
-    "moonbit-lsp",
-];
-
-pub fn index() -> PathBuf {
-    home().join("registry").join("index")
-}
-
-pub fn credentials_json() -> PathBuf {
-    home().join("credentials.json")
-}
-
-pub fn config_json() -> PathBuf {
-    home().join("config.json")
+    assert_eq!(layout.root(), Path::new("moon-home"));
+    assert_eq!(layout.bin_dir(), Path::new("moon-home/bin"));
+    assert_eq!(
+        layout.dependency_cache_dir(),
+        Path::new("moon-home/cache/deps")
+    );
+    assert_eq!(layout.build_cache_dir(), Path::new("moon-home/cache/build"));
+    assert_eq!(layout.registry_dir(), Path::new("moon-home/registry"));
+    assert_eq!(
+        layout.registry_index_dir(),
+        Path::new("moon-home/registry/index")
+    );
+    assert_eq!(
+        layout.registry_cache_dir(),
+        Path::new("moon-home/registry/cache")
+    );
+    let name: ModuleName = "moonbitlang/parser".parse().unwrap();
+    let version = Version::new(0, 3, 3);
+    assert_eq!(
+        layout.registry_index_file(&name),
+        Path::new("moon-home/registry/index/user/moonbitlang/parser.index")
+    );
+    assert_eq!(
+        layout.registry_source_archive_path(&name, &version),
+        Path::new("moon-home/registry/cache/moonbitlang/parser/0.3.3.zip")
+    );
+    assert_eq!(
+        layout.registry_source_archive_lock_path(&name, &version),
+        Path::new("moon-home/registry/cache/moonbitlang/parser/0.3.3.zip.lock")
+    );
+    assert_eq!(
+        layout.registry_executable_artifact_path(&name, &version, "cmd/moonfmt", "moonfmt.wasm"),
+        Path::new(
+            "moon-home/registry/cache/assets/moonbitlang/parser/0.3.3/cmd/moonfmt/moonfmt.wasm"
+        )
+    );
+    assert_eq!(
+        layout.registry_package_assets_lock_path(&name, &version, "cmd/moonfmt"),
+        Path::new(
+            "moon-home/registry/cache/assets/moonbitlang/parser/0.3.3/cmd/moonfmt/.moon-lock"
+        )
+    );
+    assert_eq!(
+        layout.registry_symbols_dir(),
+        Path::new("moon-home/registry/symbols")
+    );
+    assert_eq!(
+        layout.registry_update_lock_path(),
+        Path::new("moon-home/registry/.moon-lock")
+    );
+    assert_eq!(
+        layout.registry_update_state_path(),
+        Path::new("moon-home/registry/.registry-update-state.json")
+    );
+    assert_eq!(layout.cache_dir(), Path::new("moon-home/cache"));
+    assert_eq!(
+        layout.credentials_path(),
+        Path::new("moon-home/credentials.json")
+    );
+    assert_eq!(layout.config_path(), Path::new("moon-home/config.json"));
 }
 
 #[test]
 fn test_moon_dir() {
     use expect_test::expect;
-
-    let home_dirs = [
-        home(),
-        user_bin(),
-        cache(),
-        index(),
-        credentials_json(),
-        config_json(),
-    ];
-    dbg!(&home_dirs);
-    let home_dirs = home_dirs
-        .iter()
-        .map(|p| {
-            p.strip_prefix(home())
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .replace(['\\', '/'], "|")
-        })
-        .collect::<Vec<_>>();
-    expect![[r#"
-        [
-            "",
-            "bin",
-            "registry|cache",
-            "registry|index",
-            "credentials.json",
-            "config.json",
-        ]
-    "#]]
-    .assert_debug_eq(&home_dirs);
 
     let toolchain_dirs = [
         bin(),

--- a/crates/moonutil/src/mooncakes.rs
+++ b/crates/moonutil/src/mooncakes.rs
@@ -625,7 +625,7 @@ impl RegistryConfig {
     }
 
     pub fn load() -> Self {
-        let config_path = crate::moon_dir::config_json();
+        let config_path = crate::MOON_HOME.config_path();
         if !config_path.exists() {
             return Self::new();
         }

--- a/crates/moonutil/src/path_normalizer.rs
+++ b/crates/moonutil/src/path_normalizer.rs
@@ -18,10 +18,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::{
-    binaries::configured_binary_overrides,
-    moon_dir::{home, toolchain_root},
-};
+use crate::{MOON_HOME, binaries::configured_binary_overrides, moon_dir::toolchain_root};
 
 /// Best-effort privacy and stability normalization for dry-run paths.
 pub struct PathNormalizer {
@@ -51,7 +48,7 @@ impl PathNormalizer {
         Self::from_paths(
             source_dir,
             toolchain_root(),
-            home(),
+            MOON_HOME.root().to_path_buf(),
             override_aliases,
             current_program_alias,
         )

--- a/crates/moonutil/src/registry.rs
+++ b/crates/moonutil/src/registry.rs
@@ -16,7 +16,6 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Registry account, configuration, and cache paths.
+//! Registry account and configuration types.
 
-pub use crate::moon_dir::{cache, config_json, credentials_json, index};
 pub use crate::mooncakes::{Credentials, RegistryConfig, validate_username};

--- a/crates/moonutil/src/toolchain.rs
+++ b/crates/moonutil/src/toolchain.rs
@@ -32,10 +32,26 @@ use std::{
 
 pub use crate::binaries::{BINARIES, CachedBinaries, moon_cram_in, mooncake_in};
 pub use crate::moon_dir::{
-    MOON_DIRS, MoonDirs, RESERVED_BIN_NAMES, abort_core_in, bin, core, core_bundle, core_bundle_in,
-    core_core, core_core_in, core_package_mi_in, home, include, is_toolchain_root, lib,
-    prelude_proof, toolchain_root, user_bin, why3_datadir, why3_libdir,
+    MOON_DIRS, MoonDirs, abort_core_in, bin, core, core_bundle, core_bundle_in, core_core,
+    core_core_in, core_package_mi_in, include, is_toolchain_root, lib, prelude_proof,
+    toolchain_root, why3_datadir, why3_libdir,
 };
+
+/// Reserved binary names that cannot be overwritten by user-installed packages.
+pub const RESERVED_BIN_NAMES: &[&str] = &[
+    "moon",
+    "moonc",
+    "mooncake",
+    "moondoc",
+    "moonfmt",
+    "mooninfo",
+    "moonrun",
+    "moon_cove_report",
+    "moon-ide",
+    "moon-lsp",
+    "moon-wasm-opt",
+    "moonbit-lsp",
+];
 
 /// Return the runtime C translation units shipped by the selected toolchain.
 ///

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -34,7 +34,7 @@ behavior.
 | `moon test`, test-driver events, test filtering, snapshots, or choosing a test level | [Test suite strategy](reference/testing-strategy.md) and [`moon test` execution flow](reference/tests.md); use the repository-local [`snapbox-testing` skill](../../.agents/skills/snapbox-testing/SKILL.md) for snapbox assertions |
 | Command stdout/stderr, logs, progress, child output, tracing lifecycle, delegation, or dry-run output | The glossary's [Command Communication](../../CONTEXT.md#command-communication), [command-results ADR](../adr/0004-separate-command-results-from-user-logs.md), [command output migration](command-output-migration.md), [CLI execution lifecycle](design/cli-execution-lifecycle.md), and [dry-run behavior](reference/dry-run.md) |
 | `moon run` process launch, stdin, signals, temporary cleanup, or Windows Job Objects | [`moon run` process lifecycle](design/moon-run-process-lifecycle.md). This is the `moon` CLI process layer, not the wasm runtime implementation. |
-| Global build cache, artifact identity, cleaning, or cross-compilation cache constraints | [Global build state and cache design](design/global-build-cache.md) and [build plan artifact dependencies](reference/build-plan-artifact-dependencies.md) |
+| Moon home paths, global build cache, artifact identity, cleaning, or cross-compilation cache constraints | [Moon home layout](reference/moon-home-layout.md), [global build state and cache design](design/global-build-cache.md), and [build plan artifact dependencies](reference/build-plan-artifact-dependencies.md) |
 | `moonx`, `moon runwasm`, executable package coordinates, binary installation, or binary discovery | [moonx dispatch ADR](../adr/0003-dispatch-moonx-by-executable-name.md), [`moonx`](reference/moonx.md), [`moon runwasm`](reference/runwasm.md), [`moon install`](reference/moon-install-binary.md), and [binary discovery](reference/binaries.md) as applicable |
 | Prebuild tasks, bundle, indirect dependencies, or toolchain packaging | [Prebuild tasks](reference/prebuild.md), [`moon bundle`](reference/bundle.md), [indirect dependencies](reference/indirect-dep.md), or [toolchain layout](reference/toolchain-layout.md) as applicable |
 | Wasm runtime imports, Handles, async host behavior, V8, or Wasmtime | Repository [async wasm host boundary ADR](../adr/0001-async-wasm-host-boundary.md), then the [`moonrun` developer documentation](../../crates/moonrun/docs/dev/README.md) |
@@ -175,8 +175,8 @@ cargo install --path ./crates/moon --debug --offline
   - `src/common.rs`: common definitions shared by other crates
   - `src/scan.rs`: scans the project directory to gather all
     structural information
-  - `src/moon_dir.rs`: gets the `.moon`, `core`, etc. directory
-    paths and handles related environment variables
+  - `src/moon_dir.rs`: owns paths and environment selection for mutable
+    `MOON_HOME` state and the installed toolchain
   - `src/features.rs`: unstable feature flags (`rr_*`)
   - `src/build.rs`: for `moon version`
 

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -309,8 +309,9 @@ There are two types of dependencies in a module.
 There are two kinds of sources that dependencies come from:
 
 - A **registry dependency** is resolved from the local registry index under
-  `~/.moon/registry/index`, which is typically populated from `mooncakes.io`
-  by `moon update`.
+  `$MOON_HOME/registry/index`, which is typically populated from
+  `mooncakes.io` by `moon update`. See the
+  [Moon home layout](./moon-home-layout.md) for its physical structure.
   It is declared with a version range (written as a version number)
   and later resolved to a concrete version.
 - A **local dependency** is fetched from a local path.

--- a/docs/dev/reference/moon-home-layout.md
+++ b/docs/dev/reference/moon-home-layout.md
@@ -1,0 +1,105 @@
+# Moon home layout
+
+`MOON_HOME` is the root of mutable per-user state. It is logically distinct
+from the selected MoonBit toolchain root, which owns immutable installed files
+such as `bin`, `lib`, `include`, and `share`. The default self-contained
+installation currently selects `MOON_HOME` as its toolchain root, so the two
+trees overlap unless `MOON_TOOLCHAIN_ROOT` or executable discovery selects a
+different installation.
+
+When `MOON_HOME` is unset, Moon uses `.moon` under the operating system's user
+home directory. When it is set, its value is used directly.
+
+## Implemented layout
+
+The complete persistent tree that production code currently creates is:
+
+```text
+$MOON_HOME/
+  bin/
+  cache/
+    build/
+      .moon-cache
+    deps/
+      .moon-cache
+      .moon-lock
+      v1/sources/<username>/<encoded-module>/<version>/
+        .moon-source-archive-checksum
+        ...
+  registry/
+    .moon-lock
+    .registry-update-state.json
+    index/
+      .git/
+      user/<username>/<module>.index
+      ...
+    symbols/
+      ...
+    cache/
+      <username>/<module>/<version>.zip
+      <username>/<module>/<version>.zip.lock
+      assets/<username>/<module>/<version>/<package...>/
+        .moon-lock
+        <artifact>
+  config.json
+  credentials.json
+```
+
+- `bin` contains executables installed for the user. In the default
+  self-contained installation, the selected toolchain root is also
+  `MOON_HOME`, so this directory additionally contains toolchain executables.
+  Package-managed toolchains separate those roles by selecting another
+  toolchain root.
+- `cache/build` and `cache/deps` are the default Moon-owned global cache roots.
+  `MOON_BUILD_CACHE` and `MOON_DEP_CACHE` may replace or disable those roots.
+  Each initialized root contains a `.moon-cache` ownership marker. The build
+  cache has no artifact layout yet. The dependency cache uses one root lock
+  and stores immutable source trees below `v1/sources`; `/` in a module's
+  unqualified name is encoded as `+` there.
+- `registry/index` is the local Git checkout of the registry index.
+- Module metadata is read from
+  `registry/index/user/<username>/<module>.index`.
+- `registry/symbols` is the symbols archive materialized by registry sync.
+- Verified source archives use
+  `registry/cache/<username>/<module>/<version>.zip`. The adjacent
+  `.zip.lock` serializes publication of one module version.
+- Cached executable artifacts use a separate `assets` namespace. Module,
+  version, and package segments form directories below it; `.moon-lock`
+  serializes publication within one package directory.
+- `registry/.moon-lock` serializes index and symbols updates.
+  `.registry-update-state.json` lets callers that waited for that lock reuse a
+  concurrent update. Lock files remain in place after unlocking so all
+  processes continue to lock the same filesystem object.
+- `config.json` stores registry configuration.
+- `credentials.json` stores Mooncakes login credentials.
+
+The layout deliberately records current behavior rather than claiming every
+choice is ideal. In particular, it makes three asymmetries visible for future
+design work:
+
+- registry source archives and executable artifacts use different nesting and
+  lock scopes;
+- the dependency source cache encodes nested module names with `+`, while the
+  registry cache represents them as path segments; and
+- registry downloads, locally built native executables, and downloaded wasm
+  executables share one `registry/cache` tree.
+
+This refactor does not change those paths. Changes to them require a migration
+and compatibility decision rather than an incidental `PathBuf::join` edit.
+
+## Code ownership
+
+`moonutil::MoonHomeLayout` owns paths relative to one Moon home root.
+`moonutil::MOON_HOME` is the process-wide layout selected from the environment.
+
+`MoonHomeLayout` owns every fixed path rooted directly in `MOON_HOME`,
+including registry entries, archives, executable artifacts, locks, and update
+state. Configurable cache implementations own their versioned contents below
+the selected cache root. Behavioral owners remain separate:
+
+- `RegistryClient` owns registry synchronization, validation, downloads, and
+  cache publication.
+- `moonutil::cache` owns cache-root selection, ownership validation, and
+  lifecycle rules.
+- `moonutil::toolchain` owns installed toolchain paths and must not be used to
+  locate mutable Moon home state.

--- a/docs/dev/reference/moonx.md
+++ b/docs/dev/reference/moonx.md
@@ -105,7 +105,8 @@ build directories are temporary and are not retained.
 Wasm and native artifacts share the coordinate-shaped registry asset cache:
 `registry/cache/assets/<module>/<version>/<package>/<binary>`. Their file
 suffixes distinguish `.wasm` and `.exe`; cached native artifacts use `.exe` on
-every platform, including Unix.
+every platform, including Unix. The physical path and lock scope are defined by
+the [Moon home layout](./moon-home-layout.md).
 The existing Mooncakes download cache may retain the verified source archive;
 `moonx` does not retain an extracted source tree or build workspace alongside
 the Cached Executable Artifact.

--- a/docs/dev/reference/readme.md
+++ b/docs/dev/reference/readme.md
@@ -12,6 +12,7 @@ This is a reference documentation of the current MoonBuild behavior.
 * [How binaries are found](./binaries.md)
 * [Native C toolchain resolution](./native-c-toolchain-resolution.md)
 * [Toolchain packaging layouts and discovery](./toolchain-layout.md)
+* [Moon home layout](./moon-home-layout.md)
 * [Indirect dependency support for compiler](./indirect-dep.md)
 * [Debugging utilities](./debugging.md)
 

--- a/docs/dev/reference/toolchain-layout.md
+++ b/docs/dev/reference/toolchain-layout.md
@@ -45,6 +45,12 @@ Project-local layout remains outside this module. For example, `.mooncakes`,
 `_build`, resolved package roots, and workspace discovery are project facts,
 not toolchain facts.
 
+Mutable per-user state is likewise outside this module. Paths rooted at
+`MOON_HOME` are owned by `moonutil::MoonHomeLayout`; see the
+[Moon home layout](./moon-home-layout.md) reference. In particular,
+`moonutil::toolchain` must not be used to locate user-installed binaries,
+registry state, caches, configuration, or credentials.
+
 RR should not decide whether a build uses the installed stdlib by calling
 `moonutil::toolchain::core()` in lowering or metadata code. The command
 orchestration layer selects `stdlib_path` first, then passes that value through


### PR DESCRIPTION
## Why

Moon home paths were split between `moon_dir`, registry update and download code, cache configuration, and CLI callers. This made the persistent layout implicit and allowed native and WebAssembly registry artifact paths to evolve independently.

## What changed

- introduce `MoonHomeLayout` as the single owner of fixed paths rooted at `MOON_HOME`
- keep installed toolchain layout under `moonutil::toolchain` while routing user binaries, caches, registry state, configuration, and credentials through `MoonHomeLayout`
- make `RegistryClient` carry the layout and use it for index entries, archives, executable artifacts, locks, symbols, and update state
- document the complete implemented layout and its existing hierarchy and lock asymmetries

## Why this is correct

All path methods reproduce the existing on-disk paths, and callers now derive them from one explicit root. Registry update and download behavior, lock lifetimes, cache formats, and install destinations are unchanged.

## Scope

This is a path-ownership refactor only. It records the existing directory and lock structure but deliberately does not migrate cache formats or change lock granularity; those can be reviewed separately.
