### PR TITLE
perf(check): compose multi-backend JSON builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "n2"
 version = "0.1.5"
-source = "git+https://github.com/moonbitlang/n2.git?rev=e070bc9758d39dd37e045be25351e6a256fa98c1#e070bc9758d39dd37e045be25351e6a256fa98c1"
+source = "git+https://github.com/moonbitlang/n2.git?rev=601d553ef78c09918baa086a07f05b4ba2d0f238#601d553ef78c09918baa086a07f05b4ba2d0f238"
 dependencies = [
  "anyhow",
  "argh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.95"
 edition = "2024"
 
 [workspace.dependencies]
-n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "e070bc9758d39dd37e045be25351e6a256fa98c1" }
+n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "601d553ef78c09918baa086a07f05b4ba2d0f238" }
 arcstr = { version = "1.2", features = ["serde"] }
 moonbuild = { path = "./crates/moonbuild", version = "*" }
 moonbuild-rupes-recta = { path = "./crates/moonbuild-rupes-recta", version = "*" }

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -92,6 +92,10 @@ struct CheckJsonSummary {
     moon_warnings: usize,
     diagnostic_errors: usize,
     diagnostic_warnings: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hidden_diagnostic_errors: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hidden_diagnostic_warnings: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -111,28 +115,31 @@ struct CheckJsonAccumulator {
     build_failed: bool,
     diagnostic_errors: usize,
     diagnostic_warnings: usize,
+    hidden_diagnostic_errors: usize,
+    hidden_diagnostic_warnings: usize,
 }
 
 impl CheckJsonAccumulator {
-    fn append_build(
-        &mut self,
-        target_backend: TargetBackend,
-        mut result: rr_build::JsonBuildOutput,
-        user_log: &UserLog,
-    ) {
+    fn append_build(&mut self, result: rr_build::JsonBuildOutput, user_log: &UserLog) {
         let successful = result.successful();
-        for diagnostic in &mut result.diagnostics {
-            diagnostic
-                .as_object_mut()
-                .expect("Moonc diagnostic should be a JSON object")
-                .insert(
-                    "target_backend".to_string(),
-                    serde_json::Value::String(target_backend.to_flag().to_string()),
-                );
-        }
-        self.diagnostics.extend(result.diagnostics);
+        self.diagnostics
+            .extend(result.diagnostics.into_iter().map(|diagnostic| {
+                let mut value = diagnostic.value;
+                if let Some(target_backend) = diagnostic.target_backend {
+                    value
+                        .as_object_mut()
+                        .expect("Moonc diagnostic should be a JSON object")
+                        .insert(
+                            "target_backend".to_string(),
+                            serde_json::Value::String(target_backend.to_flag().to_string()),
+                        );
+                }
+                value
+            }));
         self.diagnostic_errors += result.n_errors;
         self.diagnostic_warnings += result.n_warnings;
+        self.hidden_diagnostic_errors += result.hidden_errors;
+        self.hidden_diagnostic_warnings += result.hidden_warnings;
         self.tasks_executed = if successful && !self.build_failed {
             Some(self.tasks_executed.unwrap_or_default() + result.n_tasks_executed.unwrap())
         } else {
@@ -286,6 +293,10 @@ pub(crate) fn write_check_json(
             moon_warnings,
             diagnostic_errors: outcome.accumulator.diagnostic_errors,
             diagnostic_warnings: outcome.accumulator.diagnostic_warnings,
+            hidden_diagnostic_errors: (outcome.accumulator.hidden_diagnostic_errors != 0)
+                .then_some(outcome.accumulator.hidden_diagnostic_errors),
+            hidden_diagnostic_warnings: (outcome.accumulator.hidden_diagnostic_warnings != 0)
+                .then_some(outcome.accumulator.hidden_diagnostic_warnings),
         },
     };
     output.write_result(|writer| -> anyhow::Result<()> {
@@ -617,14 +628,13 @@ fn run_check_for_single_file_rr(
     cfg.explain_errors |= cmd.explain;
 
     if let Some(json) = json {
-        let target_backend = build_meta.target_backend();
         let result = rr_build::execute_build_json(
             &cfg.with_suppressed_progress(true),
             build_graph,
             target_dir,
         )?;
         let successful = result.successful();
-        json.append_build(target_backend, result, user_log);
+        json.append_build(result, user_log);
         return Ok(if successful { 0 } else { 1 });
     }
 
@@ -830,25 +840,18 @@ fn run_check_normal_rr_from_resolved(
             }
         }
 
+        let build_inputs = planned_runs.into_iter().map(|(_, input)| input).collect();
+        let build_input = rr_build::compose_build_inputs(build_inputs)?;
         if let Some(json) = json {
-            // FIXME: Compose JSON checks after n2 exposes BuildId on its final
-            // output callback, so diagnostics can retain their backend tag.
-            let mut ok = true;
-            for (build_meta, build_graph) in planned_runs {
-                let target_backend = build_meta.target_backend();
-                let result = rr_build::execute_build_json(
-                    &cfg.clone().with_suppressed_progress(true),
-                    build_graph,
-                    target_dir,
-                )?;
-                let successful = result.successful();
-                json.append_build(target_backend, result, user_log);
-                ok &= successful;
-            }
-            ok
+            let result = rr_build::execute_build_json(
+                &cfg.with_suppressed_progress(true),
+                build_input,
+                target_dir,
+            )?;
+            let successful = result.successful();
+            json.append_build(result, user_log);
+            successful
         } else {
-            let build_inputs = planned_runs.into_iter().map(|(_, input)| input).collect();
-            let build_input = rr_build::compose_build_inputs(build_inputs)?;
             let result = rr_build::execute_build(&cfg, build_input, target_dir, user_log)?;
             result.print_info(cli.quiet, "checking")?;
             result.successful()

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -30,7 +30,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::{Arc, mpsc},
 };
 
 use anyhow::Context;
@@ -1487,12 +1487,24 @@ fn execute_n2_graph_capturing(
         .or_else(|| std::thread::available_parallelism().ok().map(|x| x.into()))
         .unwrap();
 
-    let action_outputs = Arc::new(Mutex::new(Vec::new()));
+    let (captured_output_sender, captured_output_receiver) = mpsc::channel();
     let mut prog_console: Box<dyn n2::progress::Progress> = create_progress_console(
-        Some(Box::new(capture_diagnostics_callback(
-            backend_by_build,
-            Arc::clone(&action_outputs),
-        ))),
+        Some(Box::new(move |build_id, output: &str| {
+            let target_backend = backend_by_build
+                .get(&build_id)
+                .copied()
+                .expect("every n2 build should retain its action backend");
+            let mut captured = ResultCatcher::default();
+            for line in output.split('\n').filter(|line| !line.is_empty()) {
+                captured.append_content(line, None);
+            }
+            captured_output_sender
+                .send(CapturedActionOutput {
+                    target_backend,
+                    content: captured,
+                })
+                .expect("captured output receiver should outlive n2 progress");
+        })),
         cfg.verbose,
         cfg.suppress_progress,
     );
@@ -1517,10 +1529,7 @@ fn execute_n2_graph_capturing(
     drop(work);
     drop(prog_console); // Ensure the progress bar won't mess with diagnostic output
     let res = res?;
-    let action_outputs = {
-        let mut outputs = action_outputs.lock().unwrap();
-        std::mem::take(&mut *outputs)
-    };
+    let action_outputs = captured_output_receiver.into_iter().collect();
 
     Ok(CapturedBuildExecution {
         n_tasks_executed: res,
@@ -1541,27 +1550,6 @@ fn finish_captured_build(
         n_tasks_executed: execution.n_tasks_executed,
         n_errors: processed.n_errors,
         n_warnings: processed.n_warnings,
-    }
-}
-
-/// Capture each n2 action's output together with its backend provenance.
-fn capture_diagnostics_callback(
-    backend_by_build: HashMap<n2::graph::BuildId, Option<TargetBackend>>,
-    action_outputs: Arc<Mutex<Vec<CapturedActionOutput>>>,
-) -> impl Fn(n2::graph::BuildId, &str) {
-    move |build_id, output: &str| {
-        let target_backend = backend_by_build
-            .get(&build_id)
-            .copied()
-            .expect("every n2 build should retain its action backend");
-        let mut captured = ResultCatcher::default();
-        for line in output.split('\n').filter(|line| !line.is_empty()) {
-            captured.append_content(line, None);
-        }
-        action_outputs.lock().unwrap().push(CapturedActionOutput {
-            target_backend,
-            content: captured,
-        });
     }
 }
 

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -30,7 +30,8 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     path::{Path, PathBuf},
-    sync::{Arc, mpsc},
+    rc::Rc,
+    sync::mpsc,
 };
 
 use anyhow::Context;
@@ -707,7 +708,7 @@ pub(crate) fn plan_resolved_build_from_intent(
         .copied()
         .map(|id| (id, Some(cx.backend.target_backend())))
         .collect();
-    let execution_plan = Arc::new(compile_output.execution_plan);
+    let execution_plan = Rc::new(compile_output.execution_plan);
     let build_meta = BuildMeta {
         resolve_output,
         artifacts,
@@ -805,7 +806,7 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
     let layout = cx.artifact_paths.target_layout();
     let dependency_actions = compile_output.dependency_actions;
     let script_actions = compile_output.script_actions;
-    let execution_plan = Arc::new(compile_output.execution_plan);
+    let execution_plan = Rc::new(compile_output.execution_plan);
     let action_backends = execution_plan
         .action_ids()
         .map(|id| (id, Some(backend)))
@@ -814,7 +815,7 @@ pub(crate) fn plan_resolved_standalone_build_from_intent(
         None
     } else {
         Some(BuildInput {
-            execution_plan: Arc::clone(&execution_plan),
+            execution_plan: Rc::clone(&execution_plan),
             action_ids: dependency_actions,
             action_backends: action_backends.clone(),
             db_path: layout.n2_db_path(),
@@ -842,7 +843,7 @@ pub fn plan_fmt(
     project_manifest: &ProjectManifest,
     user_log: &UserLog,
 ) -> anyhow::Result<BuildInput> {
-    let execution_plan = Arc::new(moonbuild_rupes_recta::fmt::build_execution_plan_for_fmt(
+    let execution_plan = Rc::new(moonbuild_rupes_recta::fmt::build_execution_plan_for_fmt(
         resolved,
         cfg,
         target_dir,
@@ -1059,7 +1060,7 @@ impl Default for BuildConfig {
 #[derive(Debug, Clone)]
 pub struct BuildInput {
     /// Executor-neutral actions shared by execution and its projections.
-    execution_plan: Arc<ExecutionPlan>,
+    execution_plan: Rc<ExecutionPlan>,
 
     /// The portion of the Execution Plan owned by this execution phase.
     action_ids: Vec<ActionId>,
@@ -1139,7 +1140,7 @@ impl BuildInput {
         }
 
         Ok(Self {
-            execution_plan: Arc::new(execution_plan),
+            execution_plan: Rc::new(execution_plan),
             action_ids,
             action_backends,
             db_path,

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -1177,12 +1177,47 @@ pub(crate) fn compose_build_inputs(inputs: Vec<BuildInput>) -> anyhow::Result<Bu
 
 struct CapturedBuildExecution {
     n_tasks_executed: Option<usize>,
-    diagnostics: ResultCatcher,
+    action_outputs: Vec<CapturedActionOutput>,
+}
+
+struct CapturedActionOutput {
+    target_backend: Option<TargetBackend>,
+    content: ResultCatcher,
 }
 
 impl CapturedBuildExecution {
     fn successful(&self) -> bool {
         self.n_tasks_executed.is_some()
+    }
+
+    fn diagnostic_sources<'a>(
+        &'a self,
+        build_metas: impl IntoIterator<Item = &'a BuildMeta>,
+    ) -> Vec<CapturedDiagnosticSource<'a>> {
+        let build_metas = build_metas.into_iter().collect::<Vec<_>>();
+        let sole_build_meta = match build_metas.as_slice() {
+            [build_meta] => Some(*build_meta),
+            _ => None,
+        };
+        self.action_outputs
+            .iter()
+            .map(|output| {
+                let build_meta = output
+                    .target_backend
+                    .and_then(|backend| {
+                        build_metas
+                            .iter()
+                            .find(|meta| meta.target_backend() == backend)
+                            .copied()
+                    })
+                    .or(sole_build_meta);
+                CapturedDiagnosticSource {
+                    diagnostics: &output.content,
+                    build_succeeded: self.successful(),
+                    build_meta,
+                }
+            })
+            .collect()
     }
 }
 
@@ -1213,8 +1248,16 @@ pub struct JsonBuildOutput {
     pub n_warnings: usize,
     pub hidden_errors: usize,
     pub hidden_warnings: usize,
-    pub diagnostics: Vec<serde_json::Value>,
+    pub diagnostics: Vec<JsonBuildDiagnostic>,
     pub non_diagnostic_output: Vec<String>,
+}
+
+/// One compiler diagnostic and the backend of the n2 action that emitted it.
+/// The command layer remains responsible for projecting this into its JSON
+/// schema.
+pub struct JsonBuildDiagnostic {
+    pub target_backend: Option<TargetBackend>,
+    pub value: serde_json::Value,
 }
 
 impl JsonBuildOutput {
@@ -1230,26 +1273,51 @@ pub fn execute_build_json(
     target_dir: &Path,
 ) -> anyhow::Result<JsonBuildOutput> {
     let execution = execute_build_capturing(cfg, input, target_dir)?;
-    let collected = collect_json_diagnostics(
-        &[CapturedDiagnosticSource::new(&execution, None)],
-        cfg,
-        true,
-    );
+    // Keep the existing per-backend diagnostic-limit semantics while all
+    // backends execute in one n2 graph. Shared actions have no backend and are
+    // collected in their own group.
+    let mut sources_by_backend = BTreeMap::new();
+    for output in &execution.action_outputs {
+        sources_by_backend
+            .entry(output.target_backend)
+            .or_insert_with(Vec::new)
+            .push(CapturedDiagnosticSource {
+                diagnostics: &output.content,
+                build_succeeded: execution.successful(),
+                build_meta: None,
+            });
+    }
+
+    let mut n_errors = 0;
+    let mut n_warnings = 0;
+    let mut hidden_errors = 0;
+    let mut hidden_warnings = 0;
+    let mut diagnostics = Vec::new();
+    let mut non_diagnostic_output = Vec::new();
+    for (target_backend, sources) in sources_by_backend {
+        let collected = collect_json_diagnostics(&sources, cfg, true);
+        n_errors += collected.processed.n_errors;
+        n_warnings += collected.processed.n_warnings;
+        hidden_errors += collected.processed.hidden_errors;
+        hidden_warnings += collected.processed.hidden_warnings;
+        diagnostics.extend(collected.diagnostics.into_iter().map(|content| {
+            JsonBuildDiagnostic {
+                target_backend,
+                value: serde_json::from_str(&content)
+                    .expect("collected Moonc diagnostic should remain valid JSON"),
+            }
+        }));
+        non_diagnostic_output.extend(collected.non_diagnostic_output);
+    }
+
     Ok(JsonBuildOutput {
         n_tasks_executed: execution.n_tasks_executed,
-        n_errors: collected.processed.n_errors,
-        n_warnings: collected.processed.n_warnings,
-        hidden_errors: collected.processed.hidden_errors,
-        hidden_warnings: collected.processed.hidden_warnings,
-        diagnostics: collected
-            .diagnostics
-            .into_iter()
-            .map(|content| {
-                serde_json::from_str(&content)
-                    .expect("collected Moonc diagnostic should remain valid JSON")
-            })
-            .collect(),
-        non_diagnostic_output: collected.non_diagnostic_output,
+        n_errors,
+        n_warnings,
+        hidden_errors,
+        hidden_warnings,
+        diagnostics,
+        non_diagnostic_output,
     })
 }
 
@@ -1284,13 +1352,9 @@ pub fn execute_standalone_build(
             return Err(error);
         }
     };
-    let processed = process_captured_diagnostics(
-        &[
-            CapturedDiagnosticSource::new(&dependency_execution, None),
-            CapturedDiagnosticSource::new(&script_execution, None),
-        ],
-        cfg,
-    );
+    let mut diagnostic_sources = dependency_execution.diagnostic_sources([]);
+    diagnostic_sources.extend(script_execution.diagnostic_sources([]));
+    let processed = process_captured_diagnostics(&diagnostic_sources, cfg);
     processed.warn_if_limited(user_log);
 
     Ok(N2RunStats {
@@ -1316,14 +1380,14 @@ pub fn execute_test_build(
     user_log: &UserLog,
 ) -> anyhow::Result<N2RunStats> {
     let execution = execute_build_capturing(cfg, input, target_dir)?;
-    // Generated-driver diagnostics can be projected back to source paths only
-    // when one Target Layout owns every captured line. Multi-backend builds
-    // keep the raw path until diagnostic capture retains BuildId provenance.
-    let build_meta = match build_metas {
-        [build_meta] => Some(*build_meta),
-        _ => None,
-    };
-    Ok(finish_captured_build(cfg, &execution, build_meta, user_log))
+    let sources = execution.diagnostic_sources(build_metas.iter().copied());
+    let processed = process_captured_diagnostics(&sources, cfg);
+    processed.warn_if_limited(user_log);
+    Ok(N2RunStats {
+        n_tasks_executed: execution.n_tasks_executed,
+        n_errors: processed.n_errors,
+        n_warnings: processed.n_warnings,
+    })
 }
 
 /// Callback on the [`n2::work::Work`] to be done for target artifacts.
@@ -1423,15 +1487,12 @@ fn execute_n2_graph_capturing(
         .or_else(|| std::thread::available_parallelism().ok().map(|x| x.into()))
         .unwrap();
 
-    // FIXME: Preserve `backend_by_build` through diagnostic capture once n2's
-    // final-output callback exposes its BuildId. The n2 projection deliberately
-    // retains BuildId -> ActionId today; the current console callback erases it.
-    let _backend_by_build = backend_by_build;
-    let result_catcher = Arc::new(Mutex::new(ResultCatcher::default()));
+    let action_outputs = Arc::new(Mutex::new(Vec::new()));
     let mut prog_console: Box<dyn n2::progress::Progress> = create_progress_console(
-        Some(Box::new(capture_diagnostics_callback(Arc::clone(
-            &result_catcher,
-        )))),
+        Some(Box::new(capture_diagnostics_callback(
+            backend_by_build,
+            Arc::clone(&action_outputs),
+        ))),
         cfg.verbose,
         cfg.suppress_progress,
     );
@@ -1456,14 +1517,14 @@ fn execute_n2_graph_capturing(
     drop(work);
     drop(prog_console); // Ensure the progress bar won't mess with diagnostic output
     let res = res?;
-    let diagnostics = {
-        let mut result_catcher = result_catcher.lock().unwrap();
-        std::mem::take(&mut *result_catcher)
+    let action_outputs = {
+        let mut outputs = action_outputs.lock().unwrap();
+        std::mem::take(&mut *outputs)
     };
 
     Ok(CapturedBuildExecution {
         n_tasks_executed: res,
-        diagnostics,
+        action_outputs,
     })
 }
 
@@ -1473,8 +1534,8 @@ fn finish_captured_build(
     build_meta: Option<&BuildMeta>,
     user_log: &UserLog,
 ) -> N2RunStats {
-    let processed =
-        process_captured_diagnostics(&[CapturedDiagnosticSource::new(execution, build_meta)], cfg);
+    let sources = execution.diagnostic_sources(build_meta);
+    let processed = process_captured_diagnostics(&sources, cfg);
     processed.warn_if_limited(user_log);
     N2RunStats {
         n_tasks_executed: execution.n_tasks_executed,
@@ -1483,16 +1544,24 @@ fn finish_captured_build(
     }
 }
 
-/// Capture compiler output from n2 so it can be processed after the build.
-fn capture_diagnostics_callback(catcher: Arc<Mutex<ResultCatcher>>) -> impl Fn(&str) {
-    move |output: &str| {
-        let mut catcher = catcher.lock().unwrap();
-        output
-            .split('\n')
-            .filter(|it| !it.is_empty())
-            .for_each(|content| {
-                catcher.append_content(content, None);
-            });
+/// Capture each n2 action's output together with its backend provenance.
+fn capture_diagnostics_callback(
+    backend_by_build: HashMap<n2::graph::BuildId, Option<TargetBackend>>,
+    action_outputs: Arc<Mutex<Vec<CapturedActionOutput>>>,
+) -> impl Fn(n2::graph::BuildId, &str) {
+    move |build_id, output: &str| {
+        let target_backend = backend_by_build
+            .get(&build_id)
+            .copied()
+            .expect("every n2 build should retain its action backend");
+        let mut captured = ResultCatcher::default();
+        for line in output.split('\n').filter(|line| !line.is_empty()) {
+            captured.append_content(line, None);
+        }
+        action_outputs.lock().unwrap().push(CapturedActionOutput {
+            target_backend,
+            content: captured,
+        });
     }
 }
 
@@ -1504,16 +1573,6 @@ struct CapturedDiagnosticSource<'a> {
     diagnostics: &'a ResultCatcher,
     build_succeeded: bool,
     build_meta: Option<&'a BuildMeta>,
-}
-
-impl<'a> CapturedDiagnosticSource<'a> {
-    fn new(execution: &'a CapturedBuildExecution, build_meta: Option<&'a BuildMeta>) -> Self {
-        Self {
-            diagnostics: &execution.diagnostics,
-            build_succeeded: execution.successful(),
-            build_meta,
-        }
-    }
 }
 
 struct ProcessedDiagnostics {

--- a/crates/moon/tests/test_cases/diagnostics_format/check.rs
+++ b/crates/moon/tests/test_cases/diagnostics_format/check.rs
@@ -187,6 +187,30 @@ fn test_moon_check_complete_json_collects_every_planned_backend() {
 }
 
 #[test]
+fn test_moon_check_complete_json_target_all_preserves_backend_provenance() {
+    let dir = TestDir::new("dedup_diag_error_limit.in");
+
+    moon_cmd(&dir)
+        .args([
+            "check",
+            "--json",
+            "--target",
+            "all",
+            "--diagnostic-limit",
+            "1",
+            "--sort-input",
+            "-j1",
+        ])
+        .assert()
+        .failure()
+        .stderr_eq("")
+        .stdout_eq(snapbox::str![[r#"
+{"version":1,"status":"failure","diagnostics":[[..]"target_backend":"wasm"[..]"target_backend":"wasm-gc"[..]"target_backend":"js"[..]"target_backend":"native"[..]],"messages":[{"$message_type":"moon","level":"warning","message":"diagnostic output limited by --diagnostic-limit: 0 errors and 12 warnings were not displayed."}],"summary":{"tasks_executed":null,"moon_errors":0,"moon_warnings":1,"diagnostic_errors":4,"diagnostic_warnings":12,"hidden_diagnostic_warnings":12}}
+
+"#]]);
+}
+
+#[test]
 fn test_moon_check_complete_json_quiet_filters_moon_warnings() {
     let dir = TestDir::new("dedup_diag_error_limit.in");
     let report = parse_complete_json(

--- a/crates/moonbuild/src/entry.rs
+++ b/crates/moonbuild/src/entry.rs
@@ -18,23 +18,26 @@
 
 use ariadne::ReportKind;
 use colored::Colorize;
-use n2::progress::{DumbConsoleProgress, FancyConsoleProgress, Progress};
+use n2::progress::{BuildOutputCallback, DumbConsoleProgress, FancyConsoleProgress, Progress};
 use n2::terminal;
 use std::io::Write;
 
 use crate::runtest::TestStatistics;
 use moonutil::test_metadata::MbtTestInfo;
 
-#[allow(clippy::type_complexity)]
 pub fn create_progress_console(
-    callback: Option<Box<dyn Fn(&str) + Send>>,
+    callback: Option<Box<BuildOutputCallback>>,
     verbose: bool,
     suppress_progress: bool,
 ) -> Box<dyn Progress> {
     if !suppress_progress && terminal::use_fancy() {
-        Box::new(FancyConsoleProgress::new(verbose, callback))
+        Box::new(FancyConsoleProgress::new_with_build_output(
+            verbose, callback,
+        ))
     } else {
-        Box::new(DumbConsoleProgress::new(verbose, callback))
+        Box::new(DumbConsoleProgress::new_with_build_output(
+            verbose, callback,
+        ))
     }
 }
 

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -92,10 +92,11 @@ In a broad sense, `moon` subcommands follows this order when executing project-b
 3. Execute the build graph
    - Generate metadata files required by compiler actions. Full project checks
      also publish `packages.json` for tooling compatibility during migration.
-   - For an ordinary multi-backend invocation, compose the independently
-     lowered Execution Plans into one executor graph, sharing compatible
-     physical providers such as package prebuild actions. JSON-formatted
-     checks remain per-backend until diagnostic capture retains Build IDs.
+   - For a multi-backend invocation, compose the independently lowered
+     Execution Plans into one executor graph, sharing compatible physical
+     providers such as package prebuild actions. JSON-formatted checks retain
+     each diagnostic's backend through the originating n2 Build ID, so they use
+     the same composed graph.
    - Execute the concrete build graph in its executor ([n2][]).
      The executor ensures the graph is executed incrementally, rebuilding only the changed parts.
 4. Perform other operations required after build

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -324,10 +324,16 @@ duplicating the provider.
 Ordinary project and workspace commands execute one n2 graph per invocation.
 A single-backend invocation projects one Execution Plan directly; a
 multi-backend invocation first composes its independently lowered Execution
-Plans as described above. JSON-formatted `moon check` is temporarily an
-exception: until n2's final-output callback exposes the originating Build ID,
-it executes one graph per backend so each diagnostic can retain its backend
-tag.
+Plans as described above. The n2 adapter preserves each Build ID's originating
+Action ID, which execution projects through the composed plan's action-backend
+map. n2 reports completed action output with that Build ID. This lets
+JSON-formatted `moon check` execute the same composed graph while the command
+layer still annotates each compiler diagnostic with its backend.
+
+The n2 failure budget applies to the composed invocation-wide graph rather
+than restarting for each backend. JSON output reports every diagnostic that
+completed before that executor boundary; diagnostic-limit summaries include
+machine-readable hidden error and warning counts when output was truncated.
 
 ## Results above lowering
 


### PR DESCRIPTION
## Why

`moon check --target all --json` still executed one n2 graph per backend because captured action output lost its originating n2 Build ID. That made JSON mode miss the invocation-wide backend composition used by human output, repeating n2 startup and preventing cross-backend scheduling and shared prebuild execution.

## What changed

- update n2 to the revision that reports `(BuildId, output)` after the unsafe database compaction was reverted
- preserve each composed action's backend through `BuildId -> ActionId -> TargetBackend`
- execute JSON checks through the same composed `BuildInput` as human checks
- group captured diagnostics by backend before applying the existing diagnostic limit and attach `target_backend` at the command JSON seam
- expose non-zero hidden diagnostic counts as optional JSON summary metadata

## Why this is correct

The n2 adapter already owns the authoritative Build ID to Action ID projection, and composition already records each action's backend. The callback now forwards that existing identity instead of inferring provenance from paths or output text. Backend-specific compiler actions retain their tag, while a physically shared action deliberately has no backend owner. Single-backend, standalone, test-build, and ordinary human-output paths continue through the same capture implementation.

The n2 failure budget now applies once to the invocation-wide graph, matching the execution boundary. Diagnostic-limit warnings are summarized once for the complete JSON result, with machine-readable hidden counts in `summary`.

## Scope

This removes the JSON-only per-backend execution loop and its temporary FIXME. It does not add a planning or execution representation, change Build Plan lowering, or change the JSON command-result ownership boundary.