### PR TITLE
refactor(moonrun): separate guest memory from V8 binding

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -71,9 +71,17 @@ _Avoid_: giant host API, async-only host
 The internal generational key behind a Handle. One primary Host Key table records only liveness and resource kind; domain payloads live in secondary maps keyed by Host Key.
 _Avoid_: resource payload, raw pointer, per-API key
 
-**V8 Import Runtime**:
-The shared V8 adapter state used by all memory-consuming host imports, including WASI. After instantiation, the JavaScript runner binds the instance's exact `memory` export through one explicit setter, independent of which import families are present. The runtime reacquires that memory's backing buffer for every import call, decodes ABI arguments, registers callbacks, and constructs traps.
-_Avoid_: Async API, SQLite API, domain state
+**Guest Memory**:
+A short-lived, runtime-neutral view of wasm linear memory during one host call. It provides checked access using unsigned wasm addresses and never reserves address zero; an individual ABI decides whether zero represents null. The view must not survive a guest re-entry or memory growth.
+_Avoid_: V8 Memory Binding, retained memory pointer, C null policy
+
+**V8 Memory Binding**:
+The V8 adapter's retained handle to the instance's exact exported memory. The JavaScript runner binds it once after instantiation, and every memory-consuming import reacquires the current backing buffer before constructing a Guest Memory view. Imports invoked by a wasm start function cannot use this post-instantiation binding.
+_Avoid_: Guest Memory, Host memory, generic runtime memory
+
+**V8 Run Context**:
+The V8-private per-run composition object that retains the Host, V8 Memory Binding, and termination request for current V8 adapters. Other wasm runtimes carry the same engine-neutral Host state through their own adapter mechanisms rather than implementing a universal runtime context.
+_Avoid_: Host, import family, universal runtime context
 
 **Resource**:
 A moonrun-owned OS or runtime object that can be acquired by a Job, such as a file, socket, or directory cursor.

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -21,8 +21,12 @@ A host-owned queue of completed job identifiers that the guest event loop drains
 _Avoid_: Notify pipe, callback queue
 
 **Guest Memory**:
-The wasm linear memory owned by the guest program.
-_Avoid_: Wasm buffer, V8 memory
+The wasm linear memory owned by the guest program. A runtime adapter exposes it
+to a host operation only through a fresh, checked borrow for one host call.
+That borrow uses unsigned wasm addresses, does not reserve address zero, and
+must not survive guest re-entry or memory growth; an individual ABI decides
+whether zero represents null.
+_Avoid_: Wasm buffer, V8 Memory Binding, retained memory pointer, C null policy
 
 **Untrusted Guest**:
 A wasm program that may call the async boundary outside the sequencing and ownership discipline expected from MoonBit async code.
@@ -71,12 +75,8 @@ _Avoid_: giant host API, async-only host
 The internal generational key behind a Handle. One primary Host Key table records only liveness and resource kind; domain payloads live in secondary maps keyed by Host Key.
 _Avoid_: resource payload, raw pointer, per-API key
 
-**Guest Memory**:
-A short-lived, runtime-neutral view of wasm linear memory during one host call. It provides checked access using unsigned wasm addresses and never reserves address zero; an individual ABI decides whether zero represents null. The view must not survive a guest re-entry or memory growth.
-_Avoid_: V8 Memory Binding, retained memory pointer, C null policy
-
 **V8 Memory Binding**:
-The V8 adapter's retained handle to the instance's exact exported memory. The JavaScript runner binds it once after instantiation, and every memory-consuming import reacquires the current backing buffer before constructing a Guest Memory view. Imports invoked by a wasm start function cannot use this post-instantiation binding.
+The V8 adapter's retained handle to the instance's exact exported memory. The JavaScript runner binds it once after instantiation, and every memory-consuming import reacquires the current backing buffer before borrowing Guest Memory. Imports invoked by a wasm start function cannot use this post-instantiation binding.
 _Avoid_: Guest Memory, Host memory, generic runtime memory
 
 **V8 Run Context**:

--- a/crates/moonrun/src/async_api/c_buffer.rs
+++ b/crates/moonrun/src/async_api/c_buffer.rs
@@ -16,8 +16,9 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory};
+use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::c_buffer::stub;
+use crate::guest_memory::GuestMemory;
 
 use super::context::ImportContext;
 use super::provenance::ported_imports;

--- a/crates/moonrun/src/async_api/context.rs
+++ b/crates/moonrun/src/async_api/context.rs
@@ -16,55 +16,32 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::rc::Rc;
-
 use crate::async_host::{AsyncHost, AsyncHostError, AsyncHostResult};
-use crate::host::Host;
 use crate::run_termination::{RunTermination, TerminationRequest};
-use crate::v8_import::{V8ImportError, V8ImportState};
+use crate::v8_import::{V8ImportError, V8MemoryBinding, V8RunContext};
 
 pub(super) use crate::v8_import::ImportArgs;
 
-pub(super) struct AsyncContext {
-    host: Rc<Host>,
-    v8_import: Rc<V8ImportState>,
-    termination_request: TerminationRequest,
-}
-
-impl AsyncContext {
-    pub(super) fn new(
-        host: Rc<Host>,
-        v8_import: Rc<V8ImportState>,
-        termination_request: TerminationRequest,
-    ) -> Self {
-        Self {
-            host,
-            v8_import,
-            termination_request,
-        }
-    }
-}
-
-pub(super) fn callback_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s AsyncContext {
-    // SAFETY: every async callback is registered with the pointer to the
-    // `AsyncContext` retained by `async_api::init_env` for the V8 run.
+pub(super) fn callback_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s V8RunContext {
+    // SAFETY: every async callback is registered with the pointer to the V8
+    // run context retained by `host_imports` for the complete run.
     unsafe { crate::v8_import::callback_context(args) }
 }
 
 pub(super) struct ImportContext<'a, 'scope> {
     pub(super) scope: &'a mut v8::HandleScope<'scope>,
     pub(super) host: &'a AsyncHost,
-    v8_import: &'a V8ImportState,
+    memory_binding: &'a V8MemoryBinding,
     termination_request: &'a TerminationRequest,
 }
 
 impl<'a, 'scope> ImportContext<'a, 'scope> {
-    pub(super) fn new(scope: &'a mut v8::HandleScope<'scope>, context: &'a AsyncContext) -> Self {
+    pub(super) fn new(scope: &'a mut v8::HandleScope<'scope>, context: &'a V8RunContext) -> Self {
         Self {
             scope,
-            host: context.host.async_state(),
-            v8_import: &context.v8_import,
-            termination_request: &context.termination_request,
+            host: context.host().async_state(),
+            memory_binding: context.memory_binding(),
+            termination_request: context.termination_request(),
         }
     }
 
@@ -80,7 +57,7 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
         f: impl FnOnce(&AsyncHost, &mut [u8]) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
         let host = self.host;
-        self.v8_import
+        self.memory_binding
             .with_memory_mut(self.scope, |memory| f(host, memory))
     }
 

--- a/crates/moonrun/src/async_api/fd_util.rs
+++ b/crates/moonrun/src/async_api/fd_util.rs
@@ -16,7 +16,8 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory};
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::guest_memory::GuestMemory;
 
 use super::context::ImportContext;
 use super::provenance::ported_imports;
@@ -96,12 +97,13 @@ pub(super) fn pipe(
         if len < 2 {
             return Err(AsyncHostError::Fault);
         }
-        context.with_memory_mut(|memory| memory.read_exact_mut(dst, 16).map(|_| ()))?;
+        context.with_memory_mut(|memory| Ok(memory.read_exact_mut(dst, 16).map(|_| ())?))?;
         let fds = context.host
             .pipe(read_end_is_async != 0, write_end_is_async != 0)?;
         context.with_memory_mut(|memory| {
             memory.write_u64_le(dst, fds[0])?;
-            memory.write_u64_le(dst.checked_add(8).ok_or(AsyncHostError::Fault)?, fds[1])
+            memory.write_u64_le(dst.checked_add(8).ok_or(AsyncHostError::Fault)?, fds[1])?;
+            Ok(())
         })
     })();
     match result {

--- a/crates/moonrun/src/async_api/mod.rs
+++ b/crates/moonrun/src/async_api/mod.rs
@@ -16,12 +16,12 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Runtime-facing `moonbitlang/async` import adapter.
+//! V8-facing `moonbitlang/async` import adapter.
 //!
 //! This layer owns the canonical wasm import list, decodes wasm ABI values from
 //! callback arguments, acquires guest memory, sets return values, and reports
 //! traps. Callback implementations are written against `ImportContext` so the
-//! host behavior stays separate from runtime-specific memory access.
+//! engine-neutral Host behavior stays separate from V8-specific memory access.
 //! Ported native-stub behavior belongs in `async_sys`; shared runtime state
 //! belongs in `async_host`.
 
@@ -47,30 +47,17 @@ mod thread_pool;
 mod time;
 mod tls;
 
-use std::any::Any;
-use std::rc::Rc;
-
-use crate::host::Host;
-use crate::run_termination::TerminationRequest;
-use crate::v8_import::V8ImportState;
+use crate::v8_import::V8RunContext;
 
 pub(crate) use registry::MOONBIT_ASYNC_MODULE;
 
-pub(crate) fn init_env<'s>(
+/// # Safety
+///
+/// `context` must remain valid whenever a registered callback can be invoked.
+pub(crate) unsafe fn init_env<'s>(
     obj: v8::Local<'s, v8::Object>,
     scope: &mut v8::HandleScope<'s>,
-    dtors: &mut Vec<Box<dyn Any>>,
-    host: Rc<Host>,
-    v8_import: Rc<V8ImportState>,
-    termination_request: TerminationRequest,
+    context: *const V8RunContext,
 ) {
-    let context = Box::new(context::AsyncContext::new(
-        host,
-        v8_import,
-        termination_request,
-    ));
-    let context_ptr = &*context as *const context::AsyncContext;
-    dtors.push(context);
-
-    registry::register_imports(obj, scope, context_ptr);
+    registry::register_imports(obj, scope, context);
 }

--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -24,8 +24,9 @@ use std::os::windows::io::AsRawHandle;
 
 #[cfg(windows)]
 use crate::async_host::read_u16;
-use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory, INVALID_HOST_HANDLE};
+use crate::async_host::{AsyncHostError, AsyncHostResult, INVALID_HOST_HANDLE};
 use crate::async_sys::process;
+use crate::guest_memory::GuestMemory;
 
 use super::context::ImportContext;
 use super::os_string::read_guest as read_guest_os_string;
@@ -366,7 +367,7 @@ pub(super) fn get_process_result(
                 process::get_process_result(Some(raw_handle), pid)
             })?
         };
-        context.with_memory_mut(|memory| memory.write_exact(out, &code.to_le_bytes()))
+        context.with_memory_mut(|memory| Ok(memory.write_exact(out, &code.to_le_bytes())?))
     })();
     match result {
         Ok(()) => 0,

--- a/crates/moonrun/src/async_api/random.rs
+++ b/crates/moonrun/src/async_api/random.rs
@@ -18,7 +18,8 @@
 
 use rand::{RngCore, rngs::OsRng};
 
-use crate::async_host::{AsyncHostError, GuestMemory};
+use crate::async_host::AsyncHostError;
+use crate::guest_memory::GuestMemory;
 
 use super::context::ImportContext;
 

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -17,7 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use super::context::{
-    AsyncContext, FinishI32, FinishI64, FinishVoid, ImportArgs, ImportContext, callback_context,
+    FinishI32, FinishI64, FinishVoid, ImportArgs, ImportContext, callback_context,
     throw_import_error,
 };
 #[cfg(test)]
@@ -184,7 +184,7 @@ macro_rules! declare_async_imports {
         pub(super) fn register_imports<'s>(
             obj: v8::Local<'s, v8::Object>,
             scope: &mut v8::HandleScope<'s>,
-            context_ptr: *const AsyncContext,
+            context_ptr: *const crate::v8_import::V8RunContext,
         ) {
             $(
                 $(#[$meta])*

--- a/crates/moonrun/src/async_api/signal.rs
+++ b/crates/moonrun/src/async_api/signal.rs
@@ -17,8 +17,8 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::async_host::AsyncHostError;
-use crate::async_host::GuestMemory;
 use crate::async_sys::signal;
+use crate::guest_memory::GuestMemory;
 
 use super::context::ImportContext;
 use super::provenance::ported_imports;

--- a/crates/moonrun/src/async_api/socket.rs
+++ b/crates/moonrun/src/async_api/socket.rs
@@ -21,10 +21,11 @@ use std::os::fd::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
 
-use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory, read_u16};
+use crate::async_host::{AsyncHostError, AsyncHostResult, read_u16};
 use crate::async_policy::AsyncPolicy;
 use crate::async_sys::internal::event_loop::thread_pool::{Resource, ResourceClass};
 use crate::async_sys::socket as sys;
+use crate::guest_memory::GuestMemory;
 
 use super::context::ImportContext;
 use super::provenance::ported_imports;

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -16,8 +16,9 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory};
+use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::event_loop::thread_pool::{self, ResourceClass, ResourceRef};
+use crate::guest_memory::GuestMemory;
 
 use super::context::ImportContext;
 use super::os_string::read_guest as read_guest_os_string;

--- a/crates/moonrun/src/async_api/tls.rs
+++ b/crates/moonrun/src/async_api/tls.rs
@@ -19,9 +19,10 @@
 use std::path::PathBuf;
 
 use crate::async_host::{
-    AsyncHostError, AsyncHostResult, GuestMemory, read_u16,
+    AsyncHostError, AsyncHostResult, read_u16,
     tls::{TlsFileType, TlsTrust},
 };
+use crate::guest_memory::GuestMemory;
 
 use super::context::ImportContext;
 use super::provenance::ported_imports;

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -985,7 +985,8 @@ impl HostIoResult {
             .addr_buffer
             .get(..actual_addr_len)
             .ok_or(AsyncHostError::Fault)?;
-        memory.write_with_capacity(addr, addr_len, addr_data)
+        memory.write_with_capacity(addr, addr_len, addr_data)?;
+        Ok(())
     }
 
     #[cfg(test)]
@@ -3255,7 +3256,8 @@ impl AsyncHost {
             .accept_buffer
             .get(offset..end)
             .ok_or(AsyncHostError::Fault)?;
-        memory.write_with_capacity(dst, dst_len, addr)
+        memory.write_with_capacity(dst, dst_len, addr)?;
+        Ok(())
     }
 
     #[cfg(windows)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -51,6 +51,7 @@ use crate::async_sys::internal::event_loop::{
 };
 use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::socket::RawSocket;
+use crate::guest_memory::{GuestMemory, GuestMemoryError};
 pub(crate) use crate::host::HostKey as HandleKey;
 use crate::host::{HostKeys, HostResourceKind as HandleKind};
 
@@ -159,55 +160,10 @@ impl AsyncHostError {
     }
 }
 
-pub(crate) trait GuestMemory {
-    fn bytes(&self) -> &[u8];
-
-    fn bytes_mut(&mut self) -> &mut [u8];
-
-    fn read_exact(&self, offset: u32, len: u32) -> AsyncHostResult<&[u8]> {
-        let (offset, end) = guest_bounds(offset, len)?;
-        self.bytes().get(offset..end).ok_or(AsyncHostError::Fault)
+impl From<GuestMemoryError> for AsyncHostError {
+    fn from(_error: GuestMemoryError) -> Self {
+        Self::Fault
     }
-
-    fn read_exact_mut(&mut self, offset: u32, len: u32) -> AsyncHostResult<&mut [u8]> {
-        let (offset, end) = guest_bounds(offset, len)?;
-        self.bytes_mut()
-            .get_mut(offset..end)
-            .ok_or(AsyncHostError::Fault)
-    }
-
-    fn write_exact(&mut self, offset: u32, data: &[u8]) -> AsyncHostResult<()> {
-        let len = u32::try_from(data.len()).map_err(|_| AsyncHostError::Fault)?;
-        let dst = self.read_exact_mut(offset, len)?;
-        dst.copy_from_slice(data);
-        Ok(())
-    }
-
-    fn write_with_capacity(
-        &mut self,
-        offset: u32,
-        capacity: u32,
-        data: &[u8],
-    ) -> AsyncHostResult<()> {
-        let data_len = u32::try_from(data.len()).map_err(|_| AsyncHostError::Fault)?;
-        if data_len > capacity {
-            return Err(AsyncHostError::Fault);
-        }
-        let dst = self.read_exact_mut(offset, capacity)?;
-        dst[..data.len()].copy_from_slice(data);
-        Ok(())
-    }
-
-    fn write_u64_le(&mut self, offset: u32, value: u64) -> AsyncHostResult<()> {
-        self.write_exact(offset, &value.to_le_bytes())
-    }
-}
-
-fn guest_bounds(offset: u32, len: u32) -> AsyncHostResult<(usize, usize)> {
-    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
-    let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
-    let end = offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
-    Ok((offset, end))
 }
 
 pub(crate) fn read_u16(memory: &[u8], offset: u32, len: u32) -> AsyncHostResult<Vec<u16>> {
@@ -243,26 +199,6 @@ fn u16_bounds(memory_len: usize, offset: u32, len: usize) -> AsyncHostResult<(us
         return Err(AsyncHostError::Fault);
     }
     Ok((offset, end))
-}
-
-impl GuestMemory for [u8] {
-    fn bytes(&self) -> &[u8] {
-        self
-    }
-
-    fn bytes_mut(&mut self) -> &mut [u8] {
-        self
-    }
-}
-
-impl<const N: usize> GuestMemory for [u8; N] {
-    fn bytes(&self) -> &[u8] {
-        self.as_slice()
-    }
-
-    fn bytes_mut(&mut self) -> &mut [u8] {
-        self.as_mut_slice()
-    }
 }
 
 #[derive(Debug)]
@@ -4903,44 +4839,6 @@ mod tests {
     }
 
     #[test]
-    fn guest_memory_read_exact_accepts_in_bounds_access() {
-        let memory = [1, 2, 3, 4];
-
-        assert_eq!(memory.read_exact(1, 2).unwrap(), &[2, 3]);
-        assert!(memory.read_exact(4, 0).unwrap().is_empty());
-    }
-
-    #[test]
-    fn guest_memory_read_exact_rejects_out_of_bounds_access() {
-        let memory = [0; 4];
-
-        for (offset, len) in [(3, 2), (u32::MAX, 1), (2, u32::MAX)] {
-            assert_eq!(memory.read_exact(offset, len), Err(AsyncHostError::Fault));
-        }
-    }
-
-    #[test]
-    fn guest_memory_read_exact_mut_accepts_in_bounds_access() {
-        let mut memory = [1, 2, 3, 4];
-
-        memory.read_exact_mut(1, 2).unwrap().fill(9);
-
-        assert_eq!(memory, [1, 9, 9, 4]);
-    }
-
-    #[test]
-    fn guest_memory_read_exact_mut_rejects_out_of_bounds_access() {
-        let mut memory = [0; 4];
-
-        for (offset, len) in [(3, 2), (u32::MAX, 1), (2, u32::MAX)] {
-            assert_eq!(
-                memory.read_exact_mut(offset, len),
-                Err(AsyncHostError::Fault)
-            );
-        }
-    }
-
-    #[test]
     fn guest_memory_helpers_read_and_write_u16_units() {
         let mut memory = AlignedBytes([0; 8]);
 
@@ -4969,19 +4867,6 @@ mod tests {
 
         assert!(read_u16(&memory, 0, 0).unwrap().is_empty());
         write_u16(&mut memory, 0, &[]).unwrap();
-    }
-
-    #[test]
-    fn guest_memory_writes_fixed_little_endian_words() {
-        let mut memory = [0; 16];
-
-        memory.write_u64_le(2, 0x1020_3040_5060_7080).unwrap();
-
-        assert_eq!(
-            &memory[2..10],
-            &[0x80, 0x70, 0x60, 0x50, 0x40, 0x30, 0x20, 0x10]
-        );
-        assert_eq!(memory.write_u64_le(10, 1), Err(AsyncHostError::Fault));
     }
 
     #[test]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -16,8 +16,9 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::async_host::{AsyncHostError, AsyncHostResult, GuestMemory};
+use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util;
+use crate::guest_memory::GuestMemory;
 
 use super::fs::{
     run_access_job, run_chmod_job, run_file_kind_by_path_job, run_file_size_job,
@@ -246,7 +247,7 @@ pub(crate) fn get_read_result(
         return Err(AsyncHostError::Badf);
     };
     let dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
-    memory.write_with_capacity(dst, len, result)
+    Ok(memory.write_with_capacity(dst, len, result)?)
 }
 
 pub(crate) fn get_file_time_result(
@@ -277,7 +278,7 @@ pub(crate) fn get_file_time_result(
     record[24..28].copy_from_slice(&fd_util::stub::get_mtime_nsec(file_time).to_le_bytes());
     record[32..40].copy_from_slice(&fd_util::stub::get_ctime_sec(file_time).to_le_bytes());
     record[40..44].copy_from_slice(&fd_util::stub::get_ctime_nsec(file_time).to_le_bytes());
-    memory.write_exact(dst, &record)
+    Ok(memory.write_exact(dst, &record)?)
 }
 
 pub(crate) fn get_stat_result(
@@ -290,5 +291,5 @@ pub(crate) fn get_stat_result(
         return Ok(());
     }
     let result = super::jobs::stat_job_result(job)?;
-    memory.write_with_capacity(dst, dst_len, result.as_bytes())
+    Ok(memory.write_with_capacity(dst, dst_len, result.as_bytes())?)
 }

--- a/crates/moonrun/src/guest_memory.rs
+++ b/crates/moonrun/src/guest_memory.rs
@@ -1,0 +1,158 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Runtime-neutral access to one short-lived view of wasm linear memory.
+//!
+//! Runtime adapters are responsible for acquiring a fresh view for every host
+//! call. This interface only defines checked access after that acquisition; it
+//! does not retain a runtime memory object or make address zero mean null.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GuestMemoryError {
+    OutOfBounds,
+}
+
+pub(crate) type GuestMemoryResult<T> = Result<T, GuestMemoryError>;
+
+pub(crate) trait GuestMemory {
+    fn bytes(&self) -> &[u8];
+
+    fn bytes_mut(&mut self) -> &mut [u8];
+
+    fn read_exact(&self, offset: u32, len: u32) -> GuestMemoryResult<&[u8]> {
+        let (offset, end) = guest_bounds(offset, len)?;
+        self.bytes()
+            .get(offset..end)
+            .ok_or(GuestMemoryError::OutOfBounds)
+    }
+
+    fn read_exact_mut(&mut self, offset: u32, len: u32) -> GuestMemoryResult<&mut [u8]> {
+        let (offset, end) = guest_bounds(offset, len)?;
+        self.bytes_mut()
+            .get_mut(offset..end)
+            .ok_or(GuestMemoryError::OutOfBounds)
+    }
+
+    fn write_exact(&mut self, offset: u32, data: &[u8]) -> GuestMemoryResult<()> {
+        let len = u32::try_from(data.len()).map_err(|_| GuestMemoryError::OutOfBounds)?;
+        let dst = self.read_exact_mut(offset, len)?;
+        dst.copy_from_slice(data);
+        Ok(())
+    }
+
+    fn write_with_capacity(
+        &mut self,
+        offset: u32,
+        capacity: u32,
+        data: &[u8],
+    ) -> GuestMemoryResult<()> {
+        let data_len = u32::try_from(data.len()).map_err(|_| GuestMemoryError::OutOfBounds)?;
+        if data_len > capacity {
+            return Err(GuestMemoryError::OutOfBounds);
+        }
+        let dst = self.read_exact_mut(offset, capacity)?;
+        dst[..data.len()].copy_from_slice(data);
+        Ok(())
+    }
+
+    fn write_u64_le(&mut self, offset: u32, value: u64) -> GuestMemoryResult<()> {
+        self.write_exact(offset, &value.to_le_bytes())
+    }
+}
+
+fn guest_bounds(offset: u32, len: u32) -> GuestMemoryResult<(usize, usize)> {
+    let offset = usize::try_from(offset).map_err(|_| GuestMemoryError::OutOfBounds)?;
+    let len = usize::try_from(len).map_err(|_| GuestMemoryError::OutOfBounds)?;
+    let end = offset
+        .checked_add(len)
+        .ok_or(GuestMemoryError::OutOfBounds)?;
+    Ok((offset, end))
+}
+
+impl GuestMemory for [u8] {
+    fn bytes(&self) -> &[u8] {
+        self
+    }
+
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        self
+    }
+}
+
+impl<const N: usize> GuestMemory for [u8; N] {
+    fn bytes(&self) -> &[u8] {
+        self.as_slice()
+    }
+
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        self.as_mut_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn access_checks_ranges_without_reserving_address_zero() {
+        let mut memory = [0_u8; 8];
+
+        memory.write_exact(0, &[1, 2]).unwrap();
+        memory.read_exact_mut(2, 2).unwrap().fill(3);
+
+        assert_eq!(memory.read_exact(0, 2).unwrap(), &[1, 2]);
+        assert_eq!(memory.read_exact(2, 2).unwrap(), &[3, 3]);
+        assert_eq!(
+            memory.read_exact(u32::MAX, 1),
+            Err(GuestMemoryError::OutOfBounds)
+        );
+        assert_eq!(
+            memory.write_exact(7, &[1, 2]),
+            Err(GuestMemoryError::OutOfBounds)
+        );
+    }
+
+    #[test]
+    fn capacity_write_validates_the_whole_output_range() {
+        let mut memory = [0_u8; 8];
+
+        memory.write_with_capacity(2, 4, &[1, 2]).unwrap();
+
+        assert_eq!(&memory, &[0, 0, 1, 2, 0, 0, 0, 0]);
+        assert_eq!(
+            memory.write_with_capacity(6, 4, &[1, 2]),
+            Err(GuestMemoryError::OutOfBounds)
+        );
+    }
+
+    #[test]
+    fn fixed_width_writes_use_little_endian() {
+        let mut memory = [0_u8; 16];
+
+        memory.write_u64_le(2, 0x1020_3040_5060_7080).unwrap();
+
+        assert_eq!(
+            &memory[2..10],
+            &[0x80, 0x70, 0x60, 0x50, 0x40, 0x30, 0x20, 0x10]
+        );
+        assert_eq!(
+            memory.write_u64_le(10, 1),
+            Err(GuestMemoryError::OutOfBounds)
+        );
+    }
+}

--- a/crates/moonrun/src/host.rs
+++ b/crates/moonrun/src/host.rs
@@ -82,7 +82,7 @@ impl HostKeys {
 /// Composition root for host-owned state.
 ///
 /// Behavior remains on each domain state. `Host` wires those states to one key
-/// namespace and performs teardown only after every import context is gone.
+/// namespace and performs teardown with the complete per-run Host.
 pub(crate) struct Host {
     async_state: AsyncHost,
 }

--- a/crates/moonrun/src/host_imports.rs
+++ b/crates/moonrun/src/host_imports.rs
@@ -353,10 +353,21 @@ pub(crate) fn install(
 ) -> run_termination::TerminationRequest {
     let global_proxy = scope.get_current_context().global(scope);
     let termination_request = run_termination::TerminationRequest::default();
-    let host = Rc::new(crate::host::Host::new(Arc::clone(&async_policy)));
-    let v8_import = Rc::new(crate::v8_import::V8ImportState::new());
+    let v8_context = Box::new(crate::v8_import::V8RunContext::new(
+        crate::host::Host::new(Arc::clone(&async_policy)),
+        termination_request.clone(),
+    ));
+    let v8_context_ptr = &*v8_context as *const crate::v8_import::V8RunContext;
     let v8_import_runtime = global_proxy.child(scope, "__moonrun_v8_import");
-    crate::v8_import::register_memory_setter(v8_import_runtime, scope, Rc::as_ptr(&v8_import));
+    // SAFETY: `dtors` retains `v8_context` throughout guest execution. The
+    // single-shot runner does not re-enter V8 after dropping `dtors`.
+    unsafe {
+        crate::v8_import::register_memory_binder(
+            v8_import_runtime,
+            scope,
+            Rc::as_ptr(v8_context.memory_binding()),
+        )
+    };
 
     let print_env_box = Box::<PrintEnv>::default();
     let identifier = scope.string("print");
@@ -387,14 +398,8 @@ pub(crate) fn install(
 
     {
         let async_runtime = global_proxy.child(scope, async_api::MOONBIT_ASYNC_MODULE);
-        async_api::init_env(
-            async_runtime,
-            scope,
-            dtors,
-            Rc::clone(&host),
-            Rc::clone(&v8_import),
-            termination_request.clone(),
-        );
+        // SAFETY: the same lifetime invariant as the memory binding above.
+        unsafe { async_api::init_env(async_runtime, scope, v8_context_ptr) };
     }
 
     {
@@ -404,11 +409,15 @@ pub(crate) fn install(
             scope,
             wasm_file_name,
             args,
-            Rc::clone(&v8_import),
+            Rc::clone(v8_context.memory_binding()),
             termination_request.clone(),
             dtors,
         );
     }
+
+    // All V8 callbacks are unreachable after the single-shot run returns, so
+    // retaining this one box in `dtors` covers every pointer registered above.
+    dtors.push(v8_context);
 
     // API for the fs module
     {

--- a/crates/moonrun/src/lib.rs
+++ b/crates/moonrun/src/lib.rs
@@ -29,6 +29,7 @@ mod async_sys;
 mod backtrace_api;
 mod demangle_js_template;
 mod fs_api_temp;
+mod guest_memory;
 mod host;
 mod host_fs;
 mod host_imports;

--- a/crates/moonrun/src/template/js_glue.js
+++ b/crates/moonrun/src/template/js_glue.js
@@ -467,7 +467,7 @@ try {
     let instance = new WebAssembly.Instance(module, spectest);
     const memory = instance.exports.memory;
     if (memory instanceof WebAssembly.Memory) {
-        __moonrun_v8_import.set_memory(memory);
+        __moonrun_v8_import.bind_memory(memory);
     }
     if (test_mode) {
         for (param of testParams) {

--- a/crates/moonrun/src/v8_import.rs
+++ b/crates/moonrun/src/v8_import.rs
@@ -16,12 +16,15 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Shared V8 adapter mechanics for memory-consuming wasm host imports.
+//! Per-run context and shared mechanics for the current V8 host adapters.
 
 use std::fmt::Debug;
 use std::ptr::NonNull;
+use std::rc::Rc;
 use std::sync::OnceLock;
 
+use crate::host::Host;
+use crate::run_termination::TerminationRequest;
 use crate::v8_builder::ObjectExt;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -34,18 +37,18 @@ pub(crate) enum V8ImportError {
 ///
 /// The `WebAssembly.Memory` object is stable. Its backing buffer is not, so an
 /// import must reacquire the buffer on every guest-to-host call.
-pub(crate) struct V8ImportState {
+pub(crate) struct V8MemoryBinding {
     memory: OnceLock<v8::Global<v8::WasmMemoryObject>>,
 }
 
-impl V8ImportState {
+impl V8MemoryBinding {
     pub(crate) fn new() -> Self {
         Self {
             memory: OnceLock::new(),
         }
     }
 
-    fn set_memory(
+    fn bind(
         &self,
         scope: &mut v8::HandleScope,
         memory: v8::Local<v8::WasmMemoryObject>,
@@ -86,6 +89,38 @@ impl V8ImportState {
     }
 }
 
+/// Per-run state needed by V8 adapters for engine-neutral Host operations.
+///
+/// This is deliberately V8-private. Other wasm runtimes acquire Guest Memory
+/// and carry Host state through their own adapter mechanisms.
+pub(crate) struct V8RunContext {
+    host: Host,
+    memory_binding: Rc<V8MemoryBinding>,
+    termination_request: TerminationRequest,
+}
+
+impl V8RunContext {
+    pub(crate) fn new(host: Host, termination_request: TerminationRequest) -> Self {
+        Self {
+            host,
+            memory_binding: Rc::new(V8MemoryBinding::new()),
+            termination_request,
+        }
+    }
+
+    pub(crate) fn host(&self) -> &Host {
+        &self.host
+    }
+
+    pub(crate) fn memory_binding(&self) -> &Rc<V8MemoryBinding> {
+        &self.memory_binding
+    }
+
+    pub(crate) fn termination_request(&self) -> &TerminationRequest {
+        &self.termination_request
+    }
+}
+
 /// Recover the concrete context pointer installed with `register_func`.
 ///
 /// # Safety
@@ -100,13 +135,13 @@ pub(crate) unsafe fn callback_context<'s, T>(args: &v8::FunctionCallbackArgument
     unsafe { &*(pointer as *const T) }
 }
 
-fn memory_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s V8ImportState {
-    // SAFETY: `register_memory_setter` installs only a `V8ImportState` pointer
-    // and its owner retains that state for the complete V8 run.
+fn memory_binding<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s V8MemoryBinding {
+    // SAFETY: `register_memory_binder` installs only a `V8MemoryBinding`
+    // pointer and its owner retains that binding for the complete V8 run.
     unsafe { callback_context(args) }
 }
 
-fn set_memory(
+fn bind_memory(
     scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
     _ret: v8::ReturnValue,
@@ -117,19 +152,27 @@ fn set_memory(
         }
         let memory = v8::Local::<v8::WasmMemoryObject>::try_from(args.get(0))
             .map_err(|_| V8ImportError::InvalidArgument)?;
-        memory_context(&args).set_memory(scope, memory)
+        memory_binding(&args).bind(scope, memory)
     })();
     if let Err(error) = result {
-        throw_import_error(scope, "__moonrun_v8_import", "set_memory", error);
+        throw_import_error(scope, "__moonrun_v8_import", "bind_memory", error);
     }
 }
 
-pub(crate) fn register_memory_setter<'s>(
+/// Register the bootstrap hook that binds the instance's exported memory.
+///
+/// The JS runner can obtain an exported memory only after instantiation. Until
+/// it calls this hook, memory-consuming imports fail with `Fault`.
+/// # Safety
+///
+/// `binding` must remain valid whenever the registered callback can be
+/// invoked.
+pub(crate) unsafe fn register_memory_binder<'s>(
     obj: v8::Local<'s, v8::Object>,
     scope: &mut v8::HandleScope<'s>,
-    state: *const V8ImportState,
+    binding: *const V8MemoryBinding,
 ) {
-    register_func(obj, scope, "set_memory", set_memory, state);
+    register_func(obj, scope, "bind_memory", bind_memory, binding);
 }
 
 pub(crate) struct ImportArgs<'a, 'scope, 'args> {

--- a/crates/moonrun/src/wasi_api.rs
+++ b/crates/moonrun/src/wasi_api.rs
@@ -18,7 +18,7 @@
 
 use crate::run_termination::{RunTermination, TerminationRequest};
 use crate::v8_builder::ScopeExt;
-use crate::v8_import::{V8ImportError, V8ImportState};
+use crate::v8_import::{V8ImportError, V8MemoryBinding};
 use rand::{RngCore, rngs::OsRng};
 use std::any::Any;
 use std::collections::BTreeMap;
@@ -175,7 +175,7 @@ struct WasiContext {
     preopen_dir_host_path: PathBuf,
     preopen_dir_real_path: PathBuf,
     descriptors: Mutex<DescriptorTable>,
-    v8_import: Rc<V8ImportState>,
+    memory_binding: Rc<V8MemoryBinding>,
     termination_request: TerminationRequest,
 }
 
@@ -713,7 +713,7 @@ fn with_wasi_memory_mut<T>(
     f: impl FnOnce(&mut [u8]) -> WasiResult<T>,
 ) -> WasiResult<T> {
     context
-        .v8_import
+        .memory_binding
         .with_memory_mut(scope, |memory| {
             Ok::<WasiResult<T>, V8ImportError>(f(memory))
         })
@@ -1794,7 +1794,7 @@ pub(crate) fn init_env<'s>(
     scope: &mut v8::HandleScope<'s>,
     wasm_file_name: &str,
     args: &[String],
-    v8_import: Rc<V8ImportState>,
+    memory_binding: Rc<V8MemoryBinding>,
     termination_request: TerminationRequest,
     dtors: &mut Vec<Box<dyn Any>>,
 ) {
@@ -1807,7 +1807,7 @@ pub(crate) fn init_env<'s>(
         preopen_dir_host_path,
         preopen_dir_real_path,
         descriptors: Mutex::new(DescriptorTable::new()),
-        v8_import,
+        memory_binding,
         termination_request,
     });
     let context_ptr = &*context as *const WasiContext as *mut std::ffi::c_void;
@@ -1845,7 +1845,7 @@ mod tests {
             preopen_dir_host_path: root.to_path_buf(),
             preopen_dir_real_path: fs::canonicalize(root).expect("canonicalize preopen root"),
             descriptors: Mutex::new(DescriptorTable::new()),
-            v8_import: Rc::new(V8ImportState::new()),
+            memory_binding: Rc::new(V8MemoryBinding::new()),
             termination_request: TerminationRequest::default(),
         }
     }


### PR DESCRIPTION
## Why

Moonrun's checked Guest Memory operations were coupled to the Async implementation, while the retained memory object and callback context were V8-specific. That made the ownership and lifetime model unclear and would force future Wasm runtimes to depend on V8 concepts or duplicate memory-access rules.

## What changed

- Add a runtime-neutral `GuestMemory` interface for one short-lived, checked view of Wasm linear memory.
- Treat Wasm `i32` addresses as unsigned `u32` offsets; address zero remains valid at this layer.
- Rename the retained V8 memory state to `V8MemoryBinding` and reacquire the current backing buffer on every host call.
- Add one V8-private `V8RunContext` that owns the engine-neutral Host, memory binding, and termination state.
- Move existing Async and WASI adapters onto those seams without changing their public import ABIs.
- Rename the JavaScript bootstrap hook to `bind_memory` to describe its actual role.

## Why this is correct

The design separates two different lifetimes: a runtime adapter retains its engine-specific memory binding for the run, while Host code receives only a fresh borrowed `GuestMemory` view for the duration of a call. Reacquiring the backing buffer avoids retaining a stale slice after `memory.grow`.

Only the V8 adapter interprets V8 `External` data and owns V8 handles. The Host and checked Guest Memory operations contain no V8 types, so another runtime can provide its own binding/acquisition mechanism without changing Host logic.

## Scope

This PR intentionally provides infrastructure only. It adds no SQLite functionality and no universal callback, import-output, registry, or trampoline abstraction. Those abstractions should be introduced only when a second concrete runtime or execution mode demonstrates the shared contract. SQLite is split into a stacked follow-up PR so its API and safety policy can be reviewed independently.