### PR TITLE
fix(moon): update nightly warning index

### DIFF
--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -38,7 +38,7 @@ Warning name: `{mnemonic}`
     }
 }
 
-// Snapshot generated from `moonc check -warn-help` on 2026-08-10.
+// Snapshot generated from `moonc check -warn-help` on 2026-08-14.
 // Update this file manually when the compiler's warning table changes.
 const WARNING_ENTRIES: &[WarningEntry] = &[
     WarningEntry {
@@ -455,6 +455,11 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
         mnemonic: "unused_lexcase",
         description: "`lexmatch`/`lexscan` branch that can never be selected because other branches takes precedence or its pattern matches nothing.",
         id: 90,
+    },
+    WarningEntry {
+        mnemonic: "unused_errdefer",
+        description: "unused `errdefer` statement",
+        id: 91,
     },
 ];
 

--- a/crates/moon/src/cli/snapshots/explain_warning_index.txt
+++ b/crates/moon/src/cli/snapshots/explain_warning_index.txt
@@ -81,3 +81,4 @@
 0088	guard_redundant_bang	Redundant `!` on an exhaustive `guard`.
 0089	guard_redundant_else	Redundant `else` on an exhaustive `guard`.
 0090	unused_lexcase	`lexmatch`/`lexscan` branch that can never be selected because other branches takes precedence or its pattern matches nothing.
+0091	unused_errdefer	unused `errdefer` statement

--- a/crates/moon/tests/test_cases/diag_loc_map.in/moon.mod.json
+++ b/crates/moon/tests/test_cases/diag_loc_map.in/moon.mod.json
@@ -1,4 +1,4 @@
 {
   "name": "dummy",
-  "warn-list": "-27"
+  "warn-list": "-27-79"
 }


### PR DESCRIPTION
## Why

The 2026-08-14 MoonBit nightly added warning 0091, `unused_errdefer`. Moon's checked-in warning index still reflected the previous compiler table, so its nightly consistency check failed.

## What changed

- add warning 0091 to the warning index used by `moon explain`
- update the corresponding checked-in warning snapshot
- record the nightly date that generated the table
- suppress unrelated warning 0079 in the source-map diagnostic fixture so that test remains focused on location remapping

## Why this is minimal

This PR only synchronizes Moon's warning metadata with the new compiler output and isolates one diagnostic fixture from newly enabled deprecation noise. Runtime and command behavior are otherwise unchanged.
