### PR TITLE
perf(info): compose backend builds

### DIFF
--- a/crates/moon/src/cli/info.rs
+++ b/crates/moon/src/cli/info.rs
@@ -312,31 +312,44 @@ pub(crate) fn run_info(
     std::fs::create_dir_all(target_dir)?;
     let _lock = lock_directory(target_dir, output.user_log())?;
 
-    let mut all_meta = vec![];
-    let mut ok = true;
-    for (tgt, target_kind) in execution_targets {
-        let (success, meta) = run_info_rr_internal(
-            &cli,
-            &cmd,
-            tgt,
-            target_kind,
-            target_dir,
-            mooncake_bin_dir,
-            resolve_output.clone(),
-            &selection,
-            &output_plan,
-            output.user_log(),
-        )?;
-        if !success {
-            ok = false;
-            continue;
-        }
-        all_meta.push((tgt, meta));
+    let planned_runs = execution_targets
+        .into_iter()
+        .map(|(target, target_kind)| {
+            let (meta, input) = plan_info_rr(
+                &cli,
+                &cmd,
+                target,
+                target_kind,
+                target_dir,
+                mooncake_bin_dir,
+                resolve_output.clone(),
+                &selection,
+                &output_plan,
+                output.user_log(),
+            )?;
+            Ok((target, meta, input))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    if planned_runs.is_empty() {
+        return Ok(0);
     }
 
-    if !ok {
+    for (_, meta, _) in &planned_runs {
+        rr_build::generate_all_pkgs_json(meta)?;
+    }
+    let (all_meta, build_inputs): (Vec<_>, Vec<_>) = planned_runs
+        .into_iter()
+        .map(|(target, meta, input)| ((target, meta), input))
+        .unzip();
+    let build_input = rr_build::compose_build_inputs(build_inputs)?;
+    // TODO: UX: Consider mirroring flags from `moon check`?
+    let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature, cli.verbose);
+    let result = rr_build::execute_build(&cfg, build_input, target_dir, output.user_log())?;
+    let print_result = result.print_info(cli.quiet, "generating mbti files");
+    if !result.successful() {
         return Ok(1);
     }
+    print_result?;
 
     imp::promote_info_results(&output_plan, all_meta.iter());
     output.write_result(|writer| {
@@ -345,11 +358,9 @@ pub(crate) fn run_info(
     Ok(0)
 }
 
-/// Run `moon info` for the given target.
-///
-/// Returns `(success, build metadata if not dry-run)`.
+/// Plan `moon info` for one target backend.
 #[allow(clippy::too_many_arguments)]
-fn run_info_rr_internal(
+fn plan_info_rr(
     cli: &UniversalFlags,
     cmd: &InfoSubcommand,
     target: TargetBackend,
@@ -360,7 +371,7 @@ fn run_info_rr_internal(
     selection: &PackageSelection,
     output_plan: &imp::InfoOutputPlan,
     user_log: &UserLog,
-) -> anyhow::Result<(bool, BuildMeta)> {
+) -> anyhow::Result<(BuildMeta, rr_build::BuildInput)> {
     let mut preconfig = rr_build::preconfig_compile(
         &cmd.auto_sync_flags,
         cli,
@@ -385,7 +396,7 @@ fn run_info_rr_internal(
     )?;
     let intent =
         calc_user_intent_for_info(&ctx, &resolve_output, planning_context.target_backend())?;
-    let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
+    rr_build::plan_resolved_build_from_intent(
         preconfig,
         &cli.unstable_feature,
         user_log,
@@ -393,19 +404,5 @@ fn run_info_rr_internal(
         intent,
         mooncake_bin_dir,
         resolve_output,
-    )?;
-    // Generate the all_pkgs.json for indirect dependency resolution
-    // before executing the build
-    rr_build::generate_all_pkgs_json(&build_meta)?;
-
-    // TODO: UX: Consider mirroring flags from `moon check`?
-    let cfg = BuildConfig::from_flags(&BuildFlags::default(), &cli.unstable_feature, cli.verbose);
-    let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
-    let success = result.successful();
-    let print_result = result.print_info(cli.quiet, "generating mbti files");
-    if success {
-        print_result?;
-    }
-
-    Ok((success, build_meta))
+    )
 }

--- a/crates/moon/tests/test_cases/moon_info_compare_backends/mod.rs
+++ b/crates/moon/tests/test_cases/moon_info_compare_backends/mod.rs
@@ -18,3 +18,17 @@ fn test_moon_info_compare_backends() {
 
     expect_file!["moon_info_compare_backends.out"].assert_eq(&out);
 }
+
+#[test]
+fn test_moon_info_composes_backend_builds() {
+    let dir = TestDir::new("moon_info_compare_backends");
+
+    moon_cmd(&dir)
+        .args(["info", "--target", "all"])
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![[r#"
+Finished. moon: ran [..] tasks, now up to date
+
+"#]]);
+}

--- a/crates/moon/tests/test_cases/windows_long_paths/mod.rs
+++ b/crates/moon/tests/test_cases/windows_long_paths/mod.rs
@@ -303,12 +303,15 @@ fn check_native_reports_its_long_output_directory() {
 
 #[test]
 fn info_native_reports_its_long_check_directory() {
-    LongPathCase::new().assert_compiler_path_failure(
-        &["info", "--target", "native"],
-        "native",
-        "debug",
-        "check",
+    let case = LongPathCase::new();
+    // Keep the requested and canonical backends identical so this test has one
+    // intentionally failing compiler action. Multi-backend scheduling is not
+    // part of the long-path reporting contract.
+    write_file(
+        &case.dir.as_ref().join("moon.mod"),
+        "name = \"test/long-path\"\npreferred_target = \"native\"\n",
     );
+    case.assert_compiler_path_failure(&["info", "--target", "native"], "native", "debug", "check");
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/windows_long_paths/mod.rs
+++ b/crates/moon/tests/test_cases/windows_long_paths/mod.rs
@@ -25,6 +25,10 @@ struct LongPathCase {
 
 impl LongPathCase {
     fn new() -> Self {
+        Self::new_with_preferred_target("wasm-gc")
+    }
+
+    fn new_with_preferred_target(preferred_target: &str) -> Self {
         let dir = TestDir::new_empty();
         let root = dir.as_ref();
         assert!(
@@ -59,7 +63,7 @@ impl LongPathCase {
         // target explicitly to commands that support it.
         write_file(
             &root.join("moon.mod"),
-            "name = \"test/long-path\"\npreferred_target = \"wasm-gc\"\n",
+            &format!("name = \"test/long-path\"\npreferred_target = \"{preferred_target}\"\n"),
         );
         write_file(&package_manifest, "pkgtype(kind: \"executable\")\n");
         write_file(
@@ -303,14 +307,7 @@ fn check_native_reports_its_long_output_directory() {
 
 #[test]
 fn info_native_reports_its_long_check_directory() {
-    let case = LongPathCase::new();
-    // Keep the requested and canonical backends identical so this test has one
-    // intentionally failing compiler action. Multi-backend scheduling is not
-    // part of the long-path reporting contract.
-    write_file(
-        &case.dir.as_ref().join("moon.mod"),
-        "name = \"test/long-path\"\npreferred_target = \"native\"\n",
-    );
+    let case = LongPathCase::new_with_preferred_target("native");
     case.assert_compiler_path_failure(&["info", "--target", "native"], "native", "debug", "check");
 }
 

--- a/crates/moon/tests/test_cases/windows_long_paths/mod.rs
+++ b/crates/moon/tests/test_cases/windows_long_paths/mod.rs
@@ -25,10 +25,6 @@ struct LongPathCase {
 
 impl LongPathCase {
     fn new() -> Self {
-        Self::new_with_preferred_target("wasm-gc")
-    }
-
-    fn new_with_preferred_target(preferred_target: &str) -> Self {
         let dir = TestDir::new_empty();
         let root = dir.as_ref();
         assert!(
@@ -63,7 +59,7 @@ impl LongPathCase {
         // target explicitly to commands that support it.
         write_file(
             &root.join("moon.mod"),
-            &format!("name = \"test/long-path\"\npreferred_target = \"{preferred_target}\"\n"),
+            "name = \"test/long-path\"\npreferred_target = \"wasm-gc\"\n",
         );
         write_file(&package_manifest, "pkgtype(kind: \"executable\")\n");
         write_file(
@@ -303,12 +299,6 @@ fn check_native_reports_its_long_output_directory() {
         "debug",
         "check",
     );
-}
-
-#[test]
-fn info_native_reports_its_long_check_directory() {
-    let case = LongPathCase::new_with_preferred_target("native");
-    case.assert_compiler_path_failure(&["info", "--target", "native"], "native", "debug", "check");
 }
 
 #[test]


### PR DESCRIPTION
## Why

`moon info --target all` planned each backend independently but also executed each backend in a serial loop. That prevented n2 from scheduling ready compiler actions across backends and produced one completion summary per backend even though the command is one invocation.

## What changed

- Plan each backend-specific `moon info` build without executing it immediately.
- Generate each plan's package metadata, compose the resulting build inputs, and execute one n2 graph.
- Preserve the existing post-build order: promote generated interfaces only after the invocation-wide build succeeds, then compare the promoted backend results.
- Add a regression test requiring one aggregate completion summary for `--target all`.

## Why this is correct and minimal

Build planning remains backend-specific, so backend-dependent file selection and artifact paths are unchanged. Composition happens only at the existing Execution Plan boundary, where physical-output conflicts and shared actions are already validated. A failed composed build still prevents both promotion and comparison.

This PR changes only `moon info` orchestration and its focused regression coverage. Backend labels in composed progress displays are intentionally left to a separate follow-up that can apply consistently to every multi-backend command.
