### PR TITLE
fix(build): distinguish backend and prebuild actions

### DIFF
--- a/crates/moon/tests/test_cases/targets/mod.rs
+++ b/crates/moon/tests/test_cases/targets/mod.rs
@@ -84,6 +84,41 @@ Finished. moon: no work to do
 }
 
 #[test]
+fn progress_identifies_backend_and_prebuild_plan_kinds() {
+    for (target, backend_plan_kinds) in [("wasm", &["wasm"][..]), ("wasm,js", &["wasm", "js"][..])]
+    {
+        let dir = TestDir::new("targets/shared_n2_db");
+
+        moon_cmd(&dir)
+            .args(["check", "--target", target, "-j1", "--trace", "--quiet"])
+            .assert()
+            .success();
+
+        let trace = std::fs::read_to_string(dir.join("trace.json")).unwrap();
+        let events: serde_json::Value = serde_json::from_str(&trace).unwrap();
+        let descriptions = events
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|event| event["name"] == "n2.task" && event["ph"] == "B")
+            .filter_map(|event| event["args"]["desc"].as_str())
+            .map(|description| description.trim_matches('"'))
+            .collect::<Vec<_>>();
+
+        for plan_kind in backend_plan_kinds {
+            assert!(descriptions.iter().any(|description| {
+                description.starts_with("check ")
+                    && description.ends_with(&format!("({plan_kind})"))
+            }));
+        }
+        assert!(descriptions.iter().any(|description| {
+            description.starts_with("run script ")
+                && description.ends_with("generated.txt (prebuild)")
+        }));
+    }
+}
+
+#[test]
 fn multi_target_tests_wait_for_every_backend_to_build() {
     let dir = TestDir::new("targets/build_barrier");
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -31,7 +31,8 @@ use super::{BuildOptions, CExecutableRealization, CStubLibraryRealization, Lower
 use crate::{
     ResolveOutput,
     build_plan::{
-        ArtifactKey, BuildAction, BuildPlan, PackagePrebuildAction, is_package_prebuild_node,
+        ArtifactKey, BuildAction, BuildPlan, BuildPlanActionKey, PackagePrebuildAction,
+        PackagePrebuildKey, package_file_key,
     },
     discover::{DiscoverResult, DiscoveredPackage},
     execution_plan::{ActionId, ExecutionAction, ExecutionPlanBuilder, ExternalInput},
@@ -68,7 +69,7 @@ pub(super) struct RealizedArtifact {
 }
 
 impl ActionArtifacts {
-    fn new(ctx: &LoweringContext<'_>, action: BuildPlanNode) -> Self {
+    fn new(ctx: &LoweringContext<'_>, action: &BuildPlanActionKey) -> Self {
         let outputs = ctx
             .plan
             .provided_artifacts(action)
@@ -77,7 +78,7 @@ impl ActionArtifacts {
         let dependencies = ctx
             .plan
             .artifact_dependencies(action)
-            .map(|(dependency_action, artifact)| Self::realize(ctx, dependency_action, artifact))
+            .map(|(dependency_action, artifact)| Self::realize(ctx, &dependency_action, artifact))
             .collect();
         Self {
             outputs,
@@ -87,7 +88,7 @@ impl ActionArtifacts {
 
     fn realize(
         ctx: &LoweringContext<'_>,
-        provider_action: BuildPlanNode,
+        provider_action: &BuildPlanActionKey,
         artifact: ArtifactKey,
     ) -> RealizedArtifact {
         let paths = ctx.artifact_paths.paths_for_artifact(
@@ -221,7 +222,45 @@ impl<'a> LoweringContext<'a> {
         self.packages.get_package(target.package)
     }
 
-    fn action(&self, node: BuildPlanNode) -> BuildAction<'a> {
+    fn action(&self, action: &BuildPlanActionKey) -> BuildAction<'a> {
+        let node = match action {
+            BuildPlanActionKey::Backend(node) => *node,
+            BuildPlanActionKey::PackagePrebuild(key) => {
+                let action = self
+                    .plan
+                    .package_prebuild_plan()
+                    .action(key)
+                    .expect("package prebuild key should name a planned action");
+                return match (key, action) {
+                    (PackagePrebuildKey::Custom { .. }, PackagePrebuildAction::Custom { info }) => {
+                        BuildAction::RunPrebuild { info }
+                    }
+                    (
+                        PackagePrebuildKey::MoonLex {
+                            package,
+                            input: key_input,
+                        },
+                        PackagePrebuildAction::MoonLex { input, output },
+                    ) if key_input == input => BuildAction::RunMoonLexPrebuild {
+                        package: *package,
+                        input,
+                        output,
+                    },
+                    (
+                        PackagePrebuildKey::MoonYacc {
+                            package,
+                            input: key_input,
+                        },
+                        PackagePrebuildAction::MoonYacc { input, output },
+                    ) if key_input == input => BuildAction::RunMoonYaccPrebuild {
+                        package: *package,
+                        input,
+                        output,
+                    },
+                    _ => unreachable!("package prebuild key and action kind must agree"),
+                };
+            }
+        };
         match node {
             BuildPlanNode::Check(target) => BuildAction::Check {
                 target,
@@ -325,42 +364,10 @@ impl<'a> LoweringContext<'a> {
                     .expect("Runtime info should be present for BuildRuntimeLib nodes"),
             },
             BuildPlanNode::BuildDocs(module) => BuildAction::BuildDocs { module },
-            BuildPlanNode::RunPrebuild(_, _) => {
-                let Some(PackagePrebuildAction::Custom { info, .. }) =
-                    self.plan.package_prebuild_plan().action(node)
-                else {
-                    unreachable!("complete package prebuild actions contain their prebuild info");
-                };
-                BuildAction::RunPrebuild { info }
-            }
-            BuildPlanNode::RunMoonLexPrebuild(package, _) => {
-                let Some(PackagePrebuildAction::MoonLex { input, output, .. }) =
-                    self.plan.package_prebuild_plan().action(node)
-                else {
-                    unreachable!("moonlex actions contain their input and output paths");
-                };
-                BuildAction::RunMoonLexPrebuild {
-                    package,
-                    input,
-                    output,
-                }
-            }
-            BuildPlanNode::RunMoonYaccPrebuild(package, _) => {
-                let Some(PackagePrebuildAction::MoonYacc { input, output, .. }) =
-                    self.plan.package_prebuild_plan().action(node)
-                else {
-                    unreachable!("moonyacc actions contain their input and output paths");
-                };
-                BuildAction::RunMoonYaccPrebuild {
-                    package,
-                    input,
-                    output,
-                }
-            }
         }
     }
 
-    fn human_desc(&self, node: BuildPlanNode, action: BuildAction<'_>) -> String {
+    fn human_desc(&self, action_key: &BuildPlanActionKey, action: BuildAction<'_>) -> String {
         let generator_desc = |tool: &str, package, input: &Path| {
             let input_name = input.file_name().map_or_else(
                 || input.display().to_string(),
@@ -368,36 +375,80 @@ impl<'a> LoweringContext<'a> {
             );
             format!("run {tool} {} {input_name}", self.packages.fqn(package))
         };
-        let plan_kind = if is_package_prebuild_node(node) {
-            "prebuild"
-        } else {
-            self.opt.target_backend().to_flag()
+        let description = match (action_key, action) {
+            (BuildPlanActionKey::Backend(node), _) => {
+                return node.human_desc(
+                    self.modules,
+                    self.packages,
+                    self.opt.target_backend().to_flag(),
+                );
+            }
+            (BuildPlanActionKey::PackagePrebuild(key), BuildAction::RunPrebuild { info }) => {
+                let outputs = info
+                    .resolved_outputs
+                    .iter()
+                    .map(|output| {
+                        output.file_name().map_or_else(
+                            || output.display().to_string(),
+                            |name| name.to_string_lossy().into_owned(),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let outputs = if outputs.is_empty() {
+                    "(no outputs)".to_string()
+                } else {
+                    outputs.join(", ")
+                };
+                format!("run script {} {outputs}", self.packages.fqn(key.package()))
+            }
+            (
+                BuildPlanActionKey::PackagePrebuild(_),
+                BuildAction::RunMoonLexPrebuild { package, input, .. },
+            ) => generator_desc("moonlex", package, input),
+            (
+                BuildPlanActionKey::PackagePrebuild(_),
+                BuildAction::RunMoonYaccPrebuild { package, input, .. },
+            ) => generator_desc("moonyacc", package, input),
+            _ => unreachable!("Build Plan action kind must agree with its hydrated action"),
         };
+        format!("{description} (prebuild)")
+    }
+
+    fn string_id(&self, action: &BuildPlanActionKey) -> String {
         match action {
-            BuildAction::RunMoonLexPrebuild { package, input, .. } => {
-                format!(
-                    "{} ({plan_kind})",
-                    generator_desc("moonlex", package, input)
-                )
+            BuildPlanActionKey::Backend(node) => node.string_id(self.modules, self.packages),
+            BuildPlanActionKey::PackagePrebuild(PackagePrebuildKey::Custom {
+                package,
+                declaration_index,
+            }) => format!(
+                "{}@RunPrebuild_{}",
+                self.packages.fqn(*package),
+                declaration_index
+            ),
+            BuildPlanActionKey::PackagePrebuild(PackagePrebuildKey::MoonLex { package, input }) => {
+                let package = self.packages.get_package(*package);
+                let input = package_file_key(&package.root_path, input);
+                format!("{}@RunMoonLexPrebuild_{}", package.fqn, input.display())
             }
-            BuildAction::RunMoonYaccPrebuild { package, input, .. } => {
-                format!(
-                    "{} ({plan_kind})",
-                    generator_desc("moonyacc", package, input)
-                )
+            BuildPlanActionKey::PackagePrebuild(PackagePrebuildKey::MoonYacc {
+                package,
+                input,
+            }) => {
+                let package = self.packages.get_package(*package);
+                let input = package_file_key(&package.root_path, input);
+                format!("{}@RunMoonYaccPrebuild_{}", package.fqn, input.display())
             }
-            _ => node.human_desc(self.modules, self.packages, plan_kind),
         }
     }
 
     #[instrument(level = Level::DEBUG, skip(self, execution))]
     pub(super) fn lower_action(
         &mut self,
-        node: BuildPlanNode,
+        action_key: &BuildPlanActionKey,
         execution: &mut ExecutionPlanBuilder,
     ) -> Result<ActionId, LoweringError> {
-        let action = self.action(node);
-        let action_artifacts = ActionArtifacts::new(self, node);
+        let action = self.action(action_key);
+        let action_artifacts = ActionArtifacts::new(self, action_key);
 
         // Lower the action to its command and tool-specific execution transport.
         let cmd = match action {
@@ -518,10 +569,12 @@ impl<'a> LoweringContext<'a> {
         external_inputs.sort();
         external_inputs.dedup();
 
-        let error_package = node
-            .extract_target()
-            .map(|target| self.get_package(target).fqn.clone())
-            .into();
+        let error_package = match action_key {
+            BuildPlanActionKey::Backend(node) => node.extract_target(),
+            BuildPlanActionKey::PackagePrebuild(_) => None,
+        }
+        .map(|target| self.get_package(target).fqn.clone())
+        .into();
         // Keep this exhaustive: adding an action must require an explicit
         // decision that lowering describes every filesystem observation.
         let cache_eligible = match action {
@@ -625,14 +678,16 @@ impl<'a> LoweringContext<'a> {
             inputs,
             outputs,
             command,
-            node.string_id(self.modules, self.packages),
-            self.human_desc(node, action),
+            self.string_id(action_key),
+            self.human_desc(action_key, action),
         )
         .with_external_inputs(external_inputs)
         .with_cache_eligible(cache_eligible)
         .with_can_dirty_on_output(matches!(
-            node,
-            BuildPlanNode::Check(_) | BuildPlanNode::EmitProof(_) | BuildPlanNode::Prove(_)
+            action_key,
+            BuildPlanActionKey::Backend(
+                BuildPlanNode::Check(_) | BuildPlanNode::EmitProof(_) | BuildPlanNode::Prove(_)
+            )
         ))
         .with_error_package(error_package);
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -30,7 +30,9 @@ use walkdir::WalkDir;
 use super::{BuildOptions, CExecutableRealization, CStubLibraryRealization, LoweringError};
 use crate::{
     ResolveOutput,
-    build_plan::{ArtifactKey, BuildAction, BuildPlan, PackagePrebuildAction},
+    build_plan::{
+        ArtifactKey, BuildAction, BuildPlan, PackagePrebuildAction, is_package_prebuild_node,
+    },
     discover::{DiscoverResult, DiscoveredPackage},
     execution_plan::{ActionId, ExecutionAction, ExecutionPlanBuilder, ExternalInput},
     model::{BackendConfig, BuildPlanNode, BuildTarget},
@@ -366,14 +368,25 @@ impl<'a> LoweringContext<'a> {
             );
             format!("run {tool} {} {input_name}", self.packages.fqn(package))
         };
+        let plan_kind = if is_package_prebuild_node(node) {
+            "prebuild"
+        } else {
+            self.opt.target_backend().to_flag()
+        };
         match action {
             BuildAction::RunMoonLexPrebuild { package, input, .. } => {
-                generator_desc("moonlex", package, input)
+                format!(
+                    "{} ({plan_kind})",
+                    generator_desc("moonlex", package, input)
+                )
             }
             BuildAction::RunMoonYaccPrebuild { package, input, .. } => {
-                generator_desc("moonyacc", package, input)
+                format!(
+                    "{} ({plan_kind})",
+                    generator_desc("moonyacc", package, input)
+                )
             }
-            _ => node.human_desc(self.modules, self.packages),
+            _ => node.human_desc(self.modules, self.packages, plan_kind),
         }
     }
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -34,7 +34,7 @@ use tracing::instrument;
 
 use crate::{
     ResolveOutput,
-    build_plan::BuildPlan,
+    build_plan::{BuildPlan, BuildPlanActionKey},
     execution_plan::{ActionId, ExecutionPlan, ExecutionPlanBuilder},
     model::{BackendConfig, BuildPlanNode, OperatingSystem, PackageId},
     target_layout::{
@@ -263,15 +263,15 @@ fn lower_actions(
     resolve_output: &ResolveOutput,
     plan: &BuildPlan,
     opt: &BuildOptions,
-) -> Result<(ExecutionPlan, HashMap<BuildPlanNode, ActionId>), LoweringError> {
+) -> Result<(ExecutionPlan, HashMap<BuildPlanActionKey, ActionId>), LoweringError> {
     let mut ctx = LoweringContext::new(opt.artifact_paths.clone(), resolve_output, plan, opt);
     let mut execution = ExecutionPlanBuilder::default();
     let mut action_ids = HashMap::new();
 
-    for node in plan.all_nodes() {
-        debug!("Lowering action: {:?}", node);
-        let action = ctx.lower_action(node, &mut execution)?;
-        action_ids.insert(node, action);
+    for action_key in plan.all_actions() {
+        debug!("Lowering action: {:?}", action_key);
+        let action = ctx.lower_action(&action_key, &mut execution)?;
+        action_ids.insert(action_key, action);
     }
 
     Ok((
@@ -285,53 +285,53 @@ fn lower_actions(
 fn partition_standalone_actions(
     plan: &BuildPlan,
     script_package: PackageId,
-) -> (Vec<BuildPlanNode>, Vec<BuildPlanNode>) {
-    let action_package = |node| match node {
-        BuildPlanNode::Check(target)
-        | BuildPlanNode::EmitProof(target)
-        | BuildPlanNode::Prove(target)
-        | BuildPlanNode::BuildCore(target)
-        | BuildPlanNode::LinkCore(target)
-        | BuildPlanNode::MakeExecutable(target)
-        | BuildPlanNode::GenerateDsym(target)
-        | BuildPlanNode::GenerateTestInfo(target)
-        | BuildPlanNode::GenerateMbti(target) => Some(target.package),
-        BuildPlanNode::BuildCStub(package, _)
-        | BuildPlanNode::ArchiveOrLinkCStubs(package)
-        | BuildPlanNode::BuildVirtual(package)
-        | BuildPlanNode::RunPrebuild(package, _)
-        | BuildPlanNode::RunMoonLexPrebuild(package, _)
-        | BuildPlanNode::RunMoonYaccPrebuild(package, _) => Some(package),
-        BuildPlanNode::Bundle(_)
-        | BuildPlanNode::BuildRuntimeObject(_)
-        | BuildPlanNode::BuildRuntimeLib
-        | BuildPlanNode::BuildDocs(_) => None,
+) -> (Vec<BuildPlanActionKey>, Vec<BuildPlanActionKey>) {
+    let action_package = |action: &BuildPlanActionKey| match action {
+        BuildPlanActionKey::Backend(node) => match node {
+            BuildPlanNode::Check(target)
+            | BuildPlanNode::EmitProof(target)
+            | BuildPlanNode::Prove(target)
+            | BuildPlanNode::BuildCore(target)
+            | BuildPlanNode::LinkCore(target)
+            | BuildPlanNode::MakeExecutable(target)
+            | BuildPlanNode::GenerateDsym(target)
+            | BuildPlanNode::GenerateTestInfo(target)
+            | BuildPlanNode::GenerateMbti(target) => Some(target.package),
+            BuildPlanNode::BuildCStub(package, _)
+            | BuildPlanNode::ArchiveOrLinkCStubs(package)
+            | BuildPlanNode::BuildVirtual(package) => Some(*package),
+            BuildPlanNode::Bundle(_)
+            | BuildPlanNode::BuildRuntimeObject(_)
+            | BuildPlanNode::BuildRuntimeLib
+            | BuildPlanNode::BuildDocs(_) => None,
+        },
+        BuildPlanActionKey::PackagePrebuild(key) => Some(key.package()),
     };
-    let nodes = plan.all_nodes().collect::<Vec<_>>();
-    let script_owned_actions = nodes
+    let actions = plan.all_actions().collect::<Vec<_>>();
+    let script_owned_actions = actions
         .iter()
-        .copied()
-        .filter(|&node| action_package(node) == Some(script_package))
+        .filter(|action| action_package(action) == Some(script_package))
+        .cloned()
         .collect::<HashSet<_>>();
     assert!(
         !script_owned_actions.is_empty(),
         "standalone action plan should contain work for the synthesized script package"
     );
 
-    let mut dependency_actions = nodes
+    let mut dependency_actions = actions
         .iter()
-        .copied()
-        .filter(|&node| action_package(node).is_some_and(|package| package != script_package))
+        .filter(|action| action_package(action).is_some_and(|package| package != script_package))
+        .cloned()
         .collect::<HashSet<_>>();
-    let mut pending = dependency_actions.iter().copied().collect::<Vec<_>>();
+    let mut pending = dependency_actions.iter().cloned().collect::<Vec<_>>();
     while let Some(action) = pending.pop() {
-        for dependency in plan.dependency_nodes(action) {
+        for dependency in plan.dependency_actions(&action) {
             assert!(
                 !script_owned_actions.contains(&dependency),
                 "standalone dependency preparation action {action:?} depends on \
                  script action {dependency:?}"
             );
-            if dependency_actions.insert(dependency) {
+            if dependency_actions.insert(dependency.clone()) {
                 pending.push(dependency);
             }
         }
@@ -343,12 +343,12 @@ fn partition_standalone_actions(
         "standalone root action should remain in the script execution phase"
     );
 
-    let dependencies = nodes
+    let dependencies = actions
         .iter()
-        .copied()
         .filter(|action| dependency_actions.contains(action))
+        .cloned()
         .collect();
-    let script = nodes
+    let script = actions
         .into_iter()
         .filter(|action| !dependency_actions.contains(action))
         .collect();
@@ -653,27 +653,25 @@ mod tests {
     fn lowered_generator_actions_track_host_and_payload_executables() {
         let (resolve_output, target) = single_package_resolve_output();
         let mut plan = BuildPlan::default();
-        plan.test_insert_moonlex_prebuild(
+        let moonlex = plan.test_insert_moonlex_prebuild(
             target.package,
-            0,
             PathBuf::from("main/lexer.mbl"),
             PathBuf::from("main/lexer.mbt"),
         );
-        plan.test_insert_moonyacc_prebuild(
+        let moonyacc = plan.test_insert_moonyacc_prebuild(
             target.package,
-            0,
             PathBuf::from("main/parser.mby"),
             PathBuf::from("main/parser.mbt"),
         );
-        plan.test_provide_artifact(
-            BuildPlanNode::RunMoonLexPrebuild(target.package, 0),
+        plan.test_provide_prebuild_artifact(
+            moonlex,
             ArtifactKey::PrebuildOutput {
                 package: target.package,
                 path: PathBuf::from("lexer.mbt"),
             },
         );
-        plan.test_provide_artifact(
-            BuildPlanNode::RunMoonYaccPrebuild(target.package, 0),
+        plan.test_provide_prebuild_artifact(
+            moonyacc,
             ArtifactKey::PrebuildOutput {
                 package: target.package,
                 path: PathBuf::from("parser.mbt"),
@@ -789,8 +787,9 @@ mod tests {
         let actions = nodes
             .into_iter()
             .map(|node| {
+                let action = BuildPlanActionKey::Backend(node);
                 context
-                    .lower_action(node, &mut execution)
+                    .lower_action(&action, &mut execution)
                     .expect("lowering should succeed")
             })
             .collect::<Vec<_>>();
@@ -858,9 +857,15 @@ mod tests {
 
         assert_eq!(
             dependency_nodes,
-            HashSet::from([dependency_node, runtime_node])
+            HashSet::from([
+                BuildPlanActionKey::Backend(dependency_node),
+                BuildPlanActionKey::Backend(runtime_node),
+            ])
         );
-        assert_eq!(script_nodes, HashSet::from([script_node]));
+        assert_eq!(
+            script_nodes,
+            HashSet::from([BuildPlanActionKey::Backend(script_node)])
+        );
     }
 
     #[test]
@@ -891,7 +896,13 @@ mod tests {
         let script_nodes = script_nodes.into_iter().collect::<HashSet<_>>();
 
         assert!(dependency_actions.is_empty());
-        assert_eq!(script_nodes, HashSet::from([script_node, runtime_node]));
+        assert_eq!(
+            script_nodes,
+            HashSet::from([
+                BuildPlanActionKey::Backend(script_node),
+                BuildPlanActionKey::Backend(runtime_node),
+            ])
+        );
     }
 
     #[test]
@@ -1070,7 +1081,9 @@ mod tests {
             lower_actions(&resolve_output, &plan, &options).expect("lowering should succeed");
         for node in nodes {
             assert!(
-                !execution.action(actions[&node]).is_cache_eligible(),
+                !execution
+                    .action(actions[&BuildPlanActionKey::Backend(node)])
+                    .is_cache_eligible(),
                 "{node:?} with opaque flags should be ineligible"
             );
         }

--- a/crates/moonbuild-rupes-recta/src/build_plan/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/artifact.rs
@@ -24,7 +24,9 @@ use std::{
 use indexmap::IndexSet;
 use moonutil::resolution::ModuleId;
 
-use crate::model::{BuildPlanNode, BuildTarget, PackageId, TargetKind};
+use crate::model::{BuildTarget, PackageId, TargetKind};
+
+use super::BuildPlanActionKey;
 
 /// Normalize a package file declaration without retaining the package's
 /// physical root. Explicit paths outside the package remain absolute because
@@ -196,32 +198,41 @@ impl ArtifactKey {
 
 /// Artifact providers and the artifact requirements of each action.
 ///
-/// The existing high-level [`BuildPlanNode`] identifies an action. Multiple
-/// artifacts may name the same provider without introducing a positional or
-/// arena ID.
+/// [`BuildPlanActionKey`] distinguishes backend actions from package prebuild
+/// actions without introducing a positional or arena ID. Multiple artifacts
+/// may name the same provider.
 #[derive(Debug, Default)]
 pub(super) struct ArtifactPlan {
-    providers: HashMap<ArtifactKey, BuildPlanNode>,
-    artifacts_by_provider: HashMap<BuildPlanNode, IndexSet<ArtifactKey>>,
-    requirements_by_consumer: HashMap<BuildPlanNode, IndexSet<ArtifactKey>>,
+    providers: HashMap<ArtifactKey, BuildPlanActionKey>,
+    artifacts_by_provider: HashMap<BuildPlanActionKey, IndexSet<ArtifactKey>>,
+    requirements_by_consumer: HashMap<BuildPlanActionKey, IndexSet<ArtifactKey>>,
 }
 
 impl ArtifactPlan {
-    pub(super) fn require(&mut self, consumer: BuildPlanNode, artifact: ArtifactKey) {
+    pub(super) fn require(
+        &mut self,
+        consumer: impl Into<BuildPlanActionKey>,
+        artifact: ArtifactKey,
+    ) {
         self.requirements_by_consumer
-            .entry(consumer)
+            .entry(consumer.into())
             .or_default()
             .insert(artifact);
     }
 
-    pub(super) fn provide(&mut self, provider: BuildPlanNode, artifact: ArtifactKey) {
-        if let Some(&existing) = self.providers.get(&artifact) {
+    pub(super) fn provide(
+        &mut self,
+        provider: impl Into<BuildPlanActionKey>,
+        artifact: ArtifactKey,
+    ) {
+        let provider = provider.into();
+        if let Some(existing) = self.providers.get(&artifact) {
             assert_eq!(
-                existing, provider,
+                existing, &provider,
                 "artifact {artifact:?} has conflicting providers {existing:?} and {provider:?}"
             );
         } else {
-            self.providers.insert(artifact.clone(), provider);
+            self.providers.insert(artifact.clone(), provider.clone());
         }
         self.artifacts_by_provider
             .entry(provider)
@@ -229,27 +240,29 @@ impl ArtifactPlan {
             .insert(artifact);
     }
 
-    pub(super) fn provider(&self, artifact: &ArtifactKey) -> Option<BuildPlanNode> {
-        self.providers.get(artifact).copied()
+    pub(super) fn provider(&self, artifact: &ArtifactKey) -> Option<BuildPlanActionKey> {
+        self.providers.get(artifact).cloned()
     }
 
-    pub(super) fn requirements(&self) -> impl Iterator<Item = (BuildPlanNode, ArtifactKey)> + '_ {
+    pub(super) fn requirements(
+        &self,
+    ) -> impl Iterator<Item = (BuildPlanActionKey, ArtifactKey)> + '_ {
         self.requirements_by_consumer
             .iter()
-            .flat_map(|(&consumer, requirements)| {
+            .flat_map(|(consumer, requirements)| {
                 requirements
                     .iter()
                     .cloned()
-                    .map(move |artifact| (consumer, artifact))
+                    .map(move |artifact| (consumer.clone(), artifact))
             })
     }
 
-    pub(super) fn provided_by(
-        &self,
-        provider: BuildPlanNode,
-    ) -> impl Iterator<Item = &ArtifactKey> {
+    pub(super) fn provided_by<'a>(
+        &'a self,
+        provider: &BuildPlanActionKey,
+    ) -> impl Iterator<Item = &'a ArtifactKey> + 'a {
         self.artifacts_by_provider
-            .get(&provider)
+            .get(provider)
             .into_iter()
             .flat_map(IndexSet::iter)
     }
@@ -265,14 +278,14 @@ impl ArtifactPlan {
 
     pub(super) fn dependencies(
         &self,
-        consumer: BuildPlanNode,
-    ) -> impl Iterator<Item = (BuildPlanNode, ArtifactKey)> + '_ {
+        consumer: &BuildPlanActionKey,
+    ) -> impl Iterator<Item = (BuildPlanActionKey, ArtifactKey)> + '_ {
         self.requirements_by_consumer
-            .get(&consumer)
+            .get(consumer)
             .into_iter()
             .flat_map(|requirements| requirements.iter().cloned())
             .map(|artifact| {
-                let provider = self.providers[&artifact];
+                let provider = self.providers[&artifact].clone();
                 (provider, artifact)
             })
     }
@@ -285,13 +298,14 @@ mod tests {
     use slotmap::SlotMap;
 
     use super::*;
+    use crate::model::BuildPlanNode;
 
     #[test]
     fn multiple_artifacts_can_share_one_provider() {
         let mut packages = SlotMap::<PackageId, ()>::with_key();
         let package = packages.insert(());
         let target = package.build_target(TargetKind::Source);
-        let provider = BuildPlanNode::BuildCore(target);
+        let provider = BuildPlanActionKey::Backend(BuildPlanNode::BuildCore(target));
         let build_mi = ArtifactKey::BuildMi {
             package,
             target_kind: TargetKind::Source,
@@ -302,10 +316,10 @@ mod tests {
         };
 
         let mut plan = ArtifactPlan::default();
-        plan.provide(provider, build_mi.clone());
-        plan.provide(provider, core_ir.clone());
+        plan.provide(provider.clone(), build_mi.clone());
+        plan.provide(provider.clone(), core_ir.clone());
 
-        assert_eq!(plan.provider(&build_mi), Some(provider));
+        assert_eq!(plan.provider(&build_mi), Some(provider.clone()));
         assert_eq!(plan.provider(&core_ir), Some(provider));
         assert_eq!(plan.providers.len(), 2);
     }
@@ -315,7 +329,7 @@ mod tests {
         let mut packages = SlotMap::<PackageId, ()>::with_key();
         let dependency = packages.insert(());
         let consumer = packages.insert(());
-        let consumer = BuildPlanNode::BuildVirtual(consumer);
+        let consumer = BuildPlanActionKey::Backend(BuildPlanNode::BuildVirtual(consumer));
         let check_mi = ArtifactKey::CheckMi {
             package: dependency,
             target_kind: TargetKind::Source,
@@ -326,7 +340,7 @@ mod tests {
         };
 
         let mut plan = ArtifactPlan::default();
-        plan.require(consumer, build_mi.clone());
+        plan.require(consumer.clone(), build_mi.clone());
 
         assert_eq!(
             plan.requirements().collect::<HashSet<_>>(),

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -57,8 +57,8 @@ use crate::{
 };
 
 use super::{
-    BuildCStubsInfo, BuildPlanConstructError, BuildRuntimeInfo, BuildTargetInfo, LinkCoreInfo,
-    MakeExecutableInfo,
+    BuildCStubsInfo, BuildPlanActionKey, BuildPlanConstructError, BuildRuntimeInfo,
+    BuildTargetInfo, LinkCoreInfo, MakeExecutableInfo, PackagePrebuildKey,
     artifact::{ArtifactKey, package_file_key, runtime_source_key},
     c_stub_archive_fingerprint,
     constructor::{BuildPlanConstructor, PackageFileSet},
@@ -216,10 +216,11 @@ impl<'a> BuildPlanConstructor<'a> {
                 .iter()
                 .enumerate()
                 .filter(|(index, _)| {
-                    !self
-                        .res
-                        .package_prebuild
-                        .contains_node(BuildPlanNode::RunPrebuild(pkg_id, *index as u32))
+                    let key = PackagePrebuildKey::Custom {
+                        package: pkg_id,
+                        declaration_index: *index as u32,
+                    };
+                    !self.res.package_prebuild.contains_key(&key)
                 })
                 .map(|(index, command)| {
                     self.resolve_custom_prebuild(pkg_id, command)
@@ -267,17 +268,17 @@ impl<'a> BuildPlanConstructor<'a> {
             }
         }
 
-        for (index, input) in moonlex_inputs.into_iter().enumerate() {
+        for input in moonlex_inputs {
             let output = input.with_extension("mbt");
             self.res
                 .package_prebuild
-                .insert_moonlex(pkg_id, index as u32, input, output);
+                .insert_moonlex(pkg_id, input, output);
         }
-        for (index, input) in moonyacc_inputs.into_iter().enumerate() {
+        for input in moonyacc_inputs {
             let output = input.with_extension("mbt");
             self.res
                 .package_prebuild
-                .insert_moonyacc(pkg_id, index as u32, input, output);
+                .insert_moonyacc(pkg_id, input, output);
         }
         self.register_package_prebuild_artifacts(pkg_id);
         Ok(())
@@ -289,9 +290,9 @@ impl<'a> BuildPlanConstructor<'a> {
             .res
             .package_prebuild
             .actions_for_package(package)
-            .map(|action| {
+            .map(|(key, action)| {
                 (
-                    action.node(),
+                    key.clone(),
                     action.input_paths().to_vec(),
                     action.output_paths().to_vec(),
                 )
@@ -300,11 +301,11 @@ impl<'a> BuildPlanConstructor<'a> {
 
         let providers = actions
             .iter()
-            .flat_map(|(node, _, outputs)| {
+            .flat_map(|(key, _, outputs)| {
                 outputs.iter().map(|output| {
                     (
                         output.clone(),
-                        *node,
+                        BuildPlanActionKey::PackagePrebuild(key.clone()),
                         ArtifactKey::PrebuildOutput {
                             package,
                             path: package_file_key(&pkg.root_path, output),
@@ -315,14 +316,19 @@ impl<'a> BuildPlanConstructor<'a> {
             .collect::<Vec<_>>();
 
         for (_, provider, artifact) in &providers {
-            self.res.artifacts.provide(*provider, artifact.clone());
+            self.res
+                .artifacts
+                .provide(provider.clone(), artifact.clone());
         }
         for (consumer, inputs, _) in actions {
             for input in inputs {
                 if let Some((_, _, artifact)) =
                     providers.iter().find(|(output, _, _)| *output == input)
                 {
-                    self.res.artifacts.require(consumer, artifact.clone());
+                    self.res.artifacts.require(
+                        BuildPlanActionKey::PackagePrebuild(consumer.clone()),
+                        artifact.clone(),
+                    );
                 }
             }
         }

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -33,9 +33,8 @@ use moonutil::user_log::UserLog;
 use tracing::{Level, instrument};
 
 use super::{
-    BuildEnvironment, BuildPlan, BuildPlanConstructError,
+    BuildEnvironment, BuildPlan, BuildPlanActionKey, BuildPlanConstructError,
     artifact::{ArtifactKey, package_file_key, runtime_source_key},
-    package_prebuild::is_package_prebuild_node,
 };
 
 /// The struct responsible for holding the states and dependencies used during
@@ -169,10 +168,6 @@ impl<'a> BuildPlanConstructor<'a> {
     #[cfg_attr(debug_assertions, track_caller)]
     #[instrument(level = Level::DEBUG, skip(self))]
     pub(super) fn need_node(&mut self, node: BuildPlanNode) -> BuildPlanNode {
-        assert!(
-            !is_package_prebuild_node(node),
-            "package prebuild actions must be planned through PackagePrebuildPlan"
-        );
         #[cfg(debug_assertions)]
         {
             // Record the call-site that scheduled this node for later diagnostics.
@@ -389,11 +384,6 @@ impl<'a> BuildPlanConstructor<'a> {
                     .artifacts
                     .provide(node, ArtifactKey::DocsDir { module });
             }
-            BuildPlanNode::RunPrebuild(..)
-            | BuildPlanNode::RunMoonLexPrebuild(..)
-            | BuildPlanNode::RunMoonYaccPrebuild(..) => {
-                unreachable!("package prebuild actions are registered while planning prebuild")
-            }
         }
     }
 
@@ -554,7 +544,7 @@ impl<'a> BuildPlanConstructor<'a> {
                     .artifacts
                     .provider(artifact)
                     .expect("prebuild artifact should name a planned output");
-                debug_assert!(is_package_prebuild_node(provider));
+                debug_assert!(matches!(provider, BuildPlanActionKey::PackagePrebuild(_)));
                 return;
             }
         };
@@ -643,11 +633,6 @@ impl<'a> BuildPlanConstructor<'a> {
                 );
             }
             BuildPlanNode::BuildDocs(_) => (),
-            BuildPlanNode::RunPrebuild(_, _)
-            | BuildPlanNode::RunMoonLexPrebuild(_, _)
-            | BuildPlanNode::RunMoonYaccPrebuild(_, _) => {
-                unreachable!("package prebuild actions are stored in PackagePrebuildPlan")
-            }
             BuildPlanNode::BuildVirtual(_build_target) => (),
         }
     }
@@ -713,11 +698,6 @@ impl<'a> BuildPlanConstructor<'a> {
             BuildPlanNode::BuildRuntimeLib => self.build_runtime_lib(node),
             BuildPlanNode::GenerateMbti(target) => self.build_generate_mbti(node, target),
             BuildPlanNode::BuildDocs(module_id) => self.build_build_docs(node, module_id),
-            BuildPlanNode::RunPrebuild(_, _)
-            | BuildPlanNode::RunMoonLexPrebuild(_, _)
-            | BuildPlanNode::RunMoonYaccPrebuild(_, _) => {
-                unreachable!("package prebuild actions are planned separately")
-            }
             BuildPlanNode::BuildVirtual(target) => self.build_parse_mbti(node, target),
         }
     }

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -87,9 +87,23 @@ use artifact::ArtifactPlan;
 pub(crate) use artifact::package_file_key;
 use constructor::BuildPlanConstructor;
 pub use package_prebuild::PrebuildInfo;
-pub(crate) use package_prebuild::{
-    PackagePrebuildAction, PackagePrebuildPlan, is_package_prebuild_node,
-};
+pub(crate) use package_prebuild::{PackagePrebuildAction, PackagePrebuildKey, PackagePrebuildPlan};
+
+/// Identity of one semantic action in a Build Plan.
+///
+/// Backend work and package-level prebuild are peer action kinds. Target kind
+/// remains nested inside the backend actions for which it is meaningful.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum BuildPlanActionKey {
+    Backend(BuildPlanNode),
+    PackagePrebuild(PackagePrebuildKey),
+}
+
+impl From<BuildPlanNode> for BuildPlanActionKey {
+    fn from(node: BuildPlanNode) -> Self {
+        Self::Backend(node)
+    }
+}
 
 /// A build plan of actions and the artifacts that connect them.
 ///
@@ -142,32 +156,32 @@ pub struct BuildPlan {
 }
 
 impl BuildPlan {
-    /// Get the list of nodes that **the given node depends on**.
-    pub fn dependency_nodes(
+    /// Get the semantic actions that **the given action depends on**.
+    pub(crate) fn dependency_actions(
         &self,
-        node: BuildPlanNode,
-    ) -> impl Iterator<Item = BuildPlanNode> + '_ {
+        action: &BuildPlanActionKey,
+    ) -> impl Iterator<Item = BuildPlanActionKey> + '_ {
         let mut seen = HashSet::new();
-        self.artifact_dependencies(node)
+        self.artifact_dependencies(action)
             .map(|(provider, _)| provider)
-            .filter(move |dependency| seen.insert(*dependency))
+            .filter(move |dependency| seen.insert(dependency.clone()))
     }
 
     pub(crate) fn artifact_dependencies(
         &self,
-        node: BuildPlanNode,
-    ) -> impl Iterator<Item = (BuildPlanNode, ArtifactKey)> + '_ {
-        self.artifacts.dependencies(node)
+        action: &BuildPlanActionKey,
+    ) -> impl Iterator<Item = (BuildPlanActionKey, ArtifactKey)> + '_ {
+        self.artifacts.dependencies(action)
     }
 
     pub(crate) fn provided_artifacts(
         &self,
-        node: BuildPlanNode,
+        action: &BuildPlanActionKey,
     ) -> impl Iterator<Item = ArtifactKey> + '_ {
-        self.artifacts.provided_by(node).cloned()
+        self.artifacts.provided_by(action).cloned()
     }
 
-    pub(crate) fn artifact_provider(&self, artifact: &ArtifactKey) -> BuildPlanNode {
+    pub(crate) fn artifact_provider(&self, artifact: &ArtifactKey) -> BuildPlanActionKey {
         self.artifacts
             .provider(artifact)
             .expect("requested artifact should have a provider")
@@ -222,14 +236,19 @@ impl BuildPlan {
         self.bundle_info.get(&module_id)
     }
 
-    pub fn all_nodes(&self) -> impl Iterator<Item = BuildPlanNode> + '_ {
+    pub(crate) fn all_actions(&self) -> impl Iterator<Item = BuildPlanActionKey> + '_ {
         self.actions
             .iter()
             .copied()
-            .chain(self.package_prebuild.nodes())
+            .map(BuildPlanActionKey::Backend)
+            .chain(
+                self.package_prebuild
+                    .actions()
+                    .map(|(key, _)| BuildPlanActionKey::PackagePrebuild(key.clone())),
+            )
     }
 
-    pub fn node_count(&self) -> usize {
+    pub fn action_count(&self) -> usize {
         self.actions.len() + self.package_prebuild.action_count()
     }
 }
@@ -237,7 +256,6 @@ impl BuildPlan {
 #[cfg(test)]
 impl BuildPlan {
     pub(crate) fn test_add_node(&mut self, node: BuildPlanNode) {
-        assert!(!package_prebuild::is_package_prebuild_node(node));
         self.actions.insert(node);
     }
 
@@ -251,10 +269,18 @@ impl BuildPlan {
     }
 
     pub(crate) fn test_provide_artifact(&mut self, provider: BuildPlanNode, artifact: ArtifactKey) {
-        if !package_prebuild::is_package_prebuild_node(provider) {
-            self.actions.insert(provider);
-        }
+        self.actions.insert(provider);
         self.artifacts.provide(provider, artifact);
+    }
+
+    pub(crate) fn test_provide_prebuild_artifact(
+        &mut self,
+        provider: PackagePrebuildKey,
+        artifact: ArtifactKey,
+    ) {
+        assert!(self.package_prebuild.contains_key(&provider));
+        self.artifacts
+            .provide(BuildPlanActionKey::PackagePrebuild(provider), artifact);
     }
 
     pub(crate) fn test_insert_build_target_info(
@@ -268,23 +294,30 @@ impl BuildPlan {
     pub(crate) fn test_insert_moonlex_prebuild(
         &mut self,
         package: PackageId,
-        index: u32,
         input: PathBuf,
         output: PathBuf,
-    ) {
-        self.package_prebuild
-            .insert_moonlex(package, index, input, output);
+    ) -> PackagePrebuildKey {
+        let key = PackagePrebuildKey::MoonLex {
+            package,
+            input: input.clone(),
+        };
+        self.package_prebuild.insert_moonlex(package, input, output);
+        key
     }
 
     pub(crate) fn test_insert_moonyacc_prebuild(
         &mut self,
         package: PackageId,
-        index: u32,
         input: PathBuf,
         output: PathBuf,
-    ) {
+    ) -> PackagePrebuildKey {
+        let key = PackagePrebuildKey::MoonYacc {
+            package,
+            input: input.clone(),
+        };
         self.package_prebuild
-            .insert_moonyacc(package, index, input, output);
+            .insert_moonyacc(package, input, output);
+        key
     }
 
     pub(crate) fn test_insert_link_core_info(&mut self, target: BuildTarget, info: LinkCoreInfo) {
@@ -720,8 +753,8 @@ pub fn build_plan(
     let result = constructor.finish();
 
     info!(
-        "Build plan construction completed with {} total nodes",
-        result.node_count()
+        "Build plan construction completed with {} total actions",
+        result.action_count()
     );
     Ok(result)
 }

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -87,7 +87,9 @@ use artifact::ArtifactPlan;
 pub(crate) use artifact::package_file_key;
 use constructor::BuildPlanConstructor;
 pub use package_prebuild::PrebuildInfo;
-pub(crate) use package_prebuild::{PackagePrebuildAction, PackagePrebuildPlan};
+pub(crate) use package_prebuild::{
+    PackagePrebuildAction, PackagePrebuildPlan, is_package_prebuild_node,
+};
 
 /// A build plan of actions and the artifacts that connect them.
 ///

--- a/crates/moonbuild-rupes-recta/src/build_plan/package_prebuild.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/package_prebuild.rs
@@ -18,7 +18,40 @@
 
 use std::path::PathBuf;
 
-use crate::model::{BuildPlanNode, PackageId};
+use indexmap::IndexMap;
+
+use crate::model::PackageId;
+
+/// Identity of one package-level file-generation action.
+///
+/// Custom commands have no declared name and may intentionally have no output,
+/// so their manifest position is their only lossless declaration coordinate.
+/// Built-in generators are instead identified by their concrete input path.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PackagePrebuildKey {
+    Custom {
+        package: PackageId,
+        declaration_index: u32,
+    },
+    MoonLex {
+        package: PackageId,
+        input: PathBuf,
+    },
+    MoonYacc {
+        package: PackageId,
+        input: PathBuf,
+    },
+}
+
+impl PackagePrebuildKey {
+    pub(crate) fn package(&self) -> PackageId {
+        match self {
+            Self::Custom { package, .. }
+            | Self::MoonLex { package, .. }
+            | Self::MoonYacc { package, .. } => *package,
+        }
+    }
+}
 
 /// Resolved information about a custom package prebuild command.
 #[derive(Debug)]
@@ -33,46 +66,12 @@ pub struct PrebuildInfo {
 
 #[derive(Debug)]
 pub(crate) enum PackagePrebuildAction {
-    Custom {
-        package: PackageId,
-        index: u32,
-        info: PrebuildInfo,
-    },
-    MoonLex {
-        package: PackageId,
-        index: u32,
-        input: PathBuf,
-        output: PathBuf,
-    },
-    MoonYacc {
-        package: PackageId,
-        index: u32,
-        input: PathBuf,
-        output: PathBuf,
-    },
+    Custom { info: PrebuildInfo },
+    MoonLex { input: PathBuf, output: PathBuf },
+    MoonYacc { input: PathBuf, output: PathBuf },
 }
 
 impl PackagePrebuildAction {
-    pub(crate) fn node(&self) -> BuildPlanNode {
-        match self {
-            Self::Custom { package, index, .. } => BuildPlanNode::RunPrebuild(*package, *index),
-            Self::MoonLex { package, index, .. } => {
-                BuildPlanNode::RunMoonLexPrebuild(*package, *index)
-            }
-            Self::MoonYacc { package, index, .. } => {
-                BuildPlanNode::RunMoonYaccPrebuild(*package, *index)
-            }
-        }
-    }
-
-    pub(crate) fn package(&self) -> PackageId {
-        match self {
-            Self::Custom { package, .. }
-            | Self::MoonLex { package, .. }
-            | Self::MoonYacc { package, .. } => *package,
-        }
-    }
-
     pub(crate) fn output_paths(&self) -> &[PathBuf] {
         match self {
             Self::Custom { info, .. } => &info.resolved_outputs,
@@ -84,7 +83,7 @@ impl PackagePrebuildAction {
 
     pub(crate) fn input_paths(&self) -> &[PathBuf] {
         match self {
-            Self::Custom { info, .. } => &info.resolved_inputs,
+            Self::Custom { info } => &info.resolved_inputs,
             Self::MoonLex { input, .. } | Self::MoonYacc { input, .. } => {
                 std::slice::from_ref(input)
             }
@@ -95,13 +94,11 @@ impl PackagePrebuildAction {
 /// Backend-independent package prebuild actions within one Build Plan.
 ///
 /// Actions are stored separately from backend actions, but use the same
-/// artifact provider/requirement registry. Each action is complete: its command
-/// and physical inputs/outputs travel together. The existing `(package,
-/// index)` node is only a compatibility address used by Build Action
-/// Projection.
+/// artifact provider/requirement registry. Each key names exactly one action;
+/// command data and physical outputs remain stored with that action.
 #[derive(Default)]
 pub(crate) struct PackagePrebuildPlan {
-    actions: Vec<PackagePrebuildAction>,
+    actions: IndexMap<PackagePrebuildKey, PackagePrebuildAction>,
 }
 
 impl PackagePrebuildPlan {
@@ -109,115 +106,99 @@ impl PackagePrebuildPlan {
         self.actions.len()
     }
 
-    pub(crate) fn nodes(&self) -> impl Iterator<Item = BuildPlanNode> + '_ {
-        self.actions.iter().map(PackagePrebuildAction::node)
+    pub(crate) fn actions(
+        &self,
+    ) -> impl Iterator<Item = (&PackagePrebuildKey, &PackagePrebuildAction)> {
+        self.actions.iter()
     }
 
-    pub(crate) fn contains_node(&self, node: BuildPlanNode) -> bool {
-        self.actions.iter().any(|action| action.node() == node)
+    pub(crate) fn contains_key(&self, key: &PackagePrebuildKey) -> bool {
+        self.actions.contains_key(key)
     }
 
-    pub(crate) fn action(&self, node: BuildPlanNode) -> Option<&PackagePrebuildAction> {
-        self.actions.iter().find(|action| action.node() == node)
+    pub(crate) fn action(&self, key: &PackagePrebuildKey) -> Option<&PackagePrebuildAction> {
+        self.actions.get(key)
     }
 
     pub(crate) fn actions_for_package(
         &self,
         package: PackageId,
-    ) -> impl Iterator<Item = &PackagePrebuildAction> {
+    ) -> impl Iterator<Item = (&PackagePrebuildKey, &PackagePrebuildAction)> {
         self.actions
             .iter()
-            .filter(move |action| action.package() == package)
+            .filter(move |(key, _)| key.package() == package)
     }
 
     pub(crate) fn insert_custom(&mut self, package: PackageId, index: u32, info: PrebuildInfo) {
-        let node = BuildPlanNode::RunPrebuild(package, index);
+        let key = PackagePrebuildKey::Custom {
+            package,
+            declaration_index: index,
+        };
+        let previous = self
+            .actions
+            .insert(key, PackagePrebuildAction::Custom { info });
         debug_assert!(
-            !self.contains_node(node),
+            previous.is_none(),
             "custom prebuild should only be planned once"
         );
-        self.actions.push(PackagePrebuildAction::Custom {
-            package,
-            index,
-            info,
-        });
     }
 
-    pub(crate) fn insert_moonlex(
-        &mut self,
-        package: PackageId,
-        index: u32,
-        input: PathBuf,
-        output: PathBuf,
-    ) {
-        let node = BuildPlanNode::RunMoonLexPrebuild(package, index);
-        if self.contains_node(node) {
+    pub(crate) fn insert_moonlex(&mut self, package: PackageId, input: PathBuf, output: PathBuf) {
+        let key = PackagePrebuildKey::MoonLex {
+            package,
+            input: input.clone(),
+        };
+        if self.contains_key(&key) {
             return;
         }
-        self.actions.push(PackagePrebuildAction::MoonLex {
-            package,
-            index,
-            input,
-            output,
-        });
+        self.actions
+            .insert(key, PackagePrebuildAction::MoonLex { input, output });
     }
 
-    pub(crate) fn insert_moonyacc(
-        &mut self,
-        package: PackageId,
-        index: u32,
-        input: PathBuf,
-        output: PathBuf,
-    ) {
-        let node = BuildPlanNode::RunMoonYaccPrebuild(package, index);
-        if self.contains_node(node) {
+    pub(crate) fn insert_moonyacc(&mut self, package: PackageId, input: PathBuf, output: PathBuf) {
+        let key = PackagePrebuildKey::MoonYacc {
+            package,
+            input: input.clone(),
+        };
+        if self.contains_key(&key) {
             return;
         }
-        self.actions.push(PackagePrebuildAction::MoonYacc {
-            package,
-            index,
-            input,
-            output,
-        });
+        self.actions
+            .insert(key, PackagePrebuildAction::MoonYacc { input, output });
     }
 
     /// All concrete outputs produced for one package, in planning order.
     pub(crate) fn output_paths(&self, package: PackageId) -> impl Iterator<Item = &PathBuf> {
         self.actions
             .iter()
-            .filter(move |action| action.package() == package)
-            .flat_map(PackagePrebuildAction::output_paths)
+            .filter(move |(key, _)| key.package() == package)
+            .flat_map(|(_, action)| action.output_paths())
     }
 
     pub(crate) fn custom_output_paths(&self, package: PackageId) -> impl Iterator<Item = &PathBuf> {
-        self.actions.iter().flat_map(move |action| match action {
-            PackagePrebuildAction::Custom {
-                package: action_package,
-                info,
-                ..
-            } if *action_package == package => info.resolved_outputs.as_slice(),
-            _ => &[],
-        })
+        self.actions
+            .iter()
+            .flat_map(move |(key, action)| match (key, action) {
+                (
+                    PackagePrebuildKey::Custom {
+                        package: action_package,
+                        ..
+                    },
+                    PackagePrebuildAction::Custom { info },
+                ) if *action_package == package => info.resolved_outputs.as_slice(),
+                _ => &[],
+            })
     }
-}
-
-pub(crate) fn is_package_prebuild_node(node: BuildPlanNode) -> bool {
-    matches!(
-        node,
-        BuildPlanNode::RunPrebuild(..)
-            | BuildPlanNode::RunMoonLexPrebuild(..)
-            | BuildPlanNode::RunMoonYaccPrebuild(..)
-    )
 }
 
 #[cfg(test)]
 mod tests {
     use slotmap::KeyData;
 
-    use crate::model::TargetKind;
+    use crate::model::{BuildPlanNode, TargetKind};
 
     use super::*;
-    use crate::build_plan::BuildPlan;
+    use crate::build_plan::{BuildPlan, BuildPlanActionKey};
 
     fn package_id(raw: u64) -> PackageId {
         PackageId::from(KeyData::from_ffi(raw))
@@ -227,7 +208,10 @@ mod tests {
     fn package_prebuild_provider_is_separate_from_backend_graph() {
         let package = package_id(1);
         let backend_node = BuildPlanNode::Check(package.build_target(TargetKind::Source));
-        let prebuild_node = BuildPlanNode::RunPrebuild(package, 0);
+        let prebuild_key = PackagePrebuildKey::Custom {
+            package,
+            declaration_index: 0,
+        };
         let mut plan = BuildPlan::default();
         plan.actions.insert(backend_node);
         plan.package_prebuild.insert_custom(
@@ -242,12 +226,16 @@ mod tests {
         );
 
         assert!(plan.actions.contains(&backend_node));
-        assert!(!plan.actions.contains(&prebuild_node));
         assert_eq!(plan.package_prebuild_plan().action_count(), 1);
+        assert!(plan.package_prebuild.contains_key(&prebuild_key));
+        let backend = BuildPlanActionKey::Backend(backend_node);
         assert_eq!(
-            plan.all_nodes().collect::<Vec<_>>(),
-            [backend_node, prebuild_node]
+            plan.all_actions().collect::<Vec<_>>(),
+            [
+                backend.clone(),
+                BuildPlanActionKey::PackagePrebuild(prebuild_key),
+            ]
         );
-        assert_eq!(plan.dependency_nodes(backend_node).count(), 0);
+        assert_eq!(plan.dependency_actions(&backend).count(), 0);
     }
 }

--- a/crates/moonbuild-rupes-recta/src/compile/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/compile/mod.rs
@@ -131,7 +131,7 @@ pub fn compile(
     )?;
 
     info!("Build plan created successfully");
-    debug!("Build plan contains {} nodes", plan.node_count());
+    debug!("Build plan contains {} actions", plan.action_count());
 
     lower_plan(cx, resolve_output, plan)
 }
@@ -166,7 +166,10 @@ pub fn compile_standalone(
     )?;
 
     info!("Standalone build plan created successfully");
-    debug!("Standalone build plan contains {} nodes", plan.node_count());
+    debug!(
+        "Standalone build plan contains {} actions",
+        plan.action_count()
+    );
 
     let lower_env = lowering_options(cx);
     let lowered = build_lower::lower_standalone_build_plan(
@@ -488,22 +491,22 @@ mod tests {
             .build_plan
             .as_deref()
             .expect("standalone should retain one logical plan for debug export");
-        assert_eq!(plan.node_count(), 3);
+        assert_eq!(plan.action_count(), 3);
         assert!(
             !plan
-                .all_nodes()
-                .any(|node| node == BuildPlanNode::MakeExecutable(script_target))
+                .all_actions()
+                .any(|action| action == BuildPlanNode::MakeExecutable(script_target).into())
         );
         assert_eq!(
             plan.artifact_provider(&ArtifactKey::Executable {
                 package: script_target.package,
                 target_kind: script_target.kind,
             }),
-            BuildPlanNode::LinkCore(script_target)
+            BuildPlanNode::LinkCore(script_target).into()
         );
         assert!(
-            plan.dependency_nodes(BuildPlanNode::BuildCore(script_target))
-                .any(|node| node == BuildPlanNode::BuildCore(dependency_target))
+            plan.dependency_actions(&BuildPlanNode::BuildCore(script_target).into())
+                .any(|action| action == BuildPlanNode::BuildCore(dependency_target).into())
         );
 
         let dependency_outputs = output

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -270,9 +270,8 @@ impl PackageId {
 ///
 /// Note: You may recognize that some nodes are keyed by [`BuildTarget`] while
 /// others are keyed by just [`PackageId`] or even [`ModuleId`]. This is because
-/// some artifacts (like C stubs and prebuild scripts) are shared by every
-/// target within the package/module, so they don't need to be duplicated for
-/// each target.
+/// some backend artifacts, such as C stubs, are shared by every target within
+/// the package/module and do not need to be duplicated for each target.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum BuildPlanNode {
     /// Check the given build target
@@ -344,14 +343,6 @@ pub enum BuildPlanNode {
     /// Build the virtual package's `.mbti` interface file to get an `.mi` file.
     BuildVirtual(PackageId),
 
-    /// Run the i-th prebuild script in the prebuild script list.
-    RunPrebuild(PackageId, u32),
-
-    /// Run the i-th prebuild rule for `moonlex` predefined prebuild.
-    RunMoonLexPrebuild(PackageId, u32),
-    /// Run the i-th prebuild rule for `moonyacc` predefined prebuild.
-    RunMoonYaccPrebuild(PackageId, u32),
-
     /// Docs build for a single selected module.
     ///
     /// The legacy layout does not have a separate folder for different kinds
@@ -379,21 +370,18 @@ impl BuildPlanNode {
             | BuildPlanNode::Bundle(_)
             | BuildPlanNode::BuildRuntimeLib
             | BuildPlanNode::BuildDocs(_)
-            | BuildPlanNode::BuildVirtual(_)
-            | BuildPlanNode::RunPrebuild(_, _)
-            | BuildPlanNode::RunMoonLexPrebuild(_, _)
-            | BuildPlanNode::RunMoonYaccPrebuild(_, _) => None,
+            | BuildPlanNode::BuildVirtual(_) => None,
         }
     }
 
     /// Return a human-readable description for this build plan node, resolving
-    /// PackageId/ModuleId to names and rendering its plan and target kinds as
+    /// PackageId/ModuleId to names and rendering its backend and target kind as
     /// one qualifier.
     pub(crate) fn human_desc(
         &self,
         env: &ResolvedEnv,
         packages: &DiscoverResult,
-        plan_kind: &str,
+        backend: &str,
     ) -> String {
         let file_basename = |path: &std::path::Path| {
             path.file_name()
@@ -403,11 +391,11 @@ impl BuildPlanNode {
         };
 
         let qualifier = |kind: TargetKind| match kind {
-            TargetKind::Source => format!(" ({plan_kind})"),
-            TargetKind::WhiteboxTest => format!(" ({plan_kind}, whitebox test)"),
-            TargetKind::BlackboxTest => format!(" ({plan_kind}, blackbox test)"),
-            TargetKind::InlineTest => format!(" ({plan_kind}, inline test)"),
-            TargetKind::SubPackage => format!(" ({plan_kind}, subpackage)"),
+            TargetKind::Source => format!(" ({backend})"),
+            TargetKind::WhiteboxTest => format!(" ({backend}, whitebox test)"),
+            TargetKind::BlackboxTest => format!(" ({backend}, blackbox test)"),
+            TargetKind::InlineTest => format!(" ({backend}, inline test)"),
+            TargetKind::SubPackage => format!(" ({backend}, subpackage)"),
         };
 
         let description = match self {
@@ -474,39 +462,6 @@ impl BuildPlanNode {
             BuildPlanNode::BuildVirtual(package_id) => {
                 format!("build virtual {}", packages.fqn(*package_id))
             }
-            BuildPlanNode::RunPrebuild(package_id, index) => {
-                let pkg = packages.get_package(*package_id);
-                let cmd = &pkg.raw.pre_build.as_ref().expect("prebuild exists")[*index as usize];
-                let outputs: Vec<String> = cmd
-                    .output()
-                    .iter()
-                    .map(|path| {
-                        std::path::Path::new(path)
-                            .file_name()
-                            .and_then(|name| name.to_str())
-                            .map(|s| s.to_string())
-                            .unwrap_or_else(|| path.clone())
-                    })
-                    .collect();
-                let joined = if outputs.is_empty() {
-                    "(no outputs)".to_string()
-                } else {
-                    outputs.join(", ")
-                };
-                format!("run script {} {}", packages.fqn(*package_id), joined)
-            }
-            BuildPlanNode::RunMoonLexPrebuild(package_id, index) => {
-                let pkg = packages.get_package(*package_id);
-                let input = &pkg.mbt_lex_files[*index as usize];
-                let input_name = file_basename(input.as_path());
-                format!("run moonlex {} {}", packages.fqn(*package_id), input_name)
-            }
-            BuildPlanNode::RunMoonYaccPrebuild(package_id, index) => {
-                let pkg = packages.get_package(*package_id);
-                let input = &pkg.mbt_yacc_files[*index as usize];
-                let input_name = file_basename(input.as_path());
-                format!("run moonyacc {} {}", packages.fqn(*package_id), input_name)
-            }
             BuildPlanNode::BuildDocs(module_id) => {
                 let src = env.module_source(*module_id);
                 format!("build docs {}", src)
@@ -516,7 +471,7 @@ impl BuildPlanNode {
         if self.extract_target().is_some() {
             description
         } else {
-            format!("{description} ({plan_kind})")
+            format!("{description} ({backend})")
         }
     }
 
@@ -579,18 +534,6 @@ impl BuildPlanNode {
             BuildPlanNode::BuildVirtual(pkg) => {
                 let fqn = packages.fqn(*pkg);
                 format!("{}@BuildVirtual", fqn)
-            }
-            BuildPlanNode::RunPrebuild(pkg, idx) => {
-                let fqn = packages.fqn(*pkg);
-                format!("{}@RunPrebuild_{}", fqn, idx)
-            }
-            BuildPlanNode::RunMoonLexPrebuild(pkg, idx) => {
-                let fqn = packages.fqn(*pkg);
-                format!("{}@RunMoonLexPrebuild_{}", fqn, idx)
-            }
-            BuildPlanNode::RunMoonYaccPrebuild(pkg, idx) => {
-                let fqn = packages.fqn(*pkg);
-                format!("{}@RunMoonYaccPrebuild_{}", fqn, idx)
             }
             BuildPlanNode::BuildDocs(module_id) => {
                 let src = env.module_source(*module_id);

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -387,8 +387,14 @@ impl BuildPlanNode {
     }
 
     /// Return a human-readable description for this build plan node, resolving
-    /// PackageId/ModuleId to names.
-    pub fn human_desc(&self, env: &ResolvedEnv, packages: &DiscoverResult) -> String {
+    /// PackageId/ModuleId to names and rendering its plan and target kinds as
+    /// one qualifier.
+    pub(crate) fn human_desc(
+        &self,
+        env: &ResolvedEnv,
+        packages: &DiscoverResult,
+        plan_kind: &str,
+    ) -> String {
         let file_basename = |path: &std::path::Path| {
             path.file_name()
                 .and_then(|name| name.to_str())
@@ -396,30 +402,30 @@ impl BuildPlanNode {
                 .unwrap_or_else(|| path.display().to_string())
         };
 
-        let kind_suffix = |kind: TargetKind| match kind {
-            TargetKind::Source => "",
-            TargetKind::WhiteboxTest => " (whitebox test)",
-            TargetKind::BlackboxTest => " (blackbox test)",
-            TargetKind::InlineTest => " (inline test)",
-            TargetKind::SubPackage => " (subpackage)",
+        let qualifier = |kind: TargetKind| match kind {
+            TargetKind::Source => format!(" ({plan_kind})"),
+            TargetKind::WhiteboxTest => format!(" ({plan_kind}, whitebox test)"),
+            TargetKind::BlackboxTest => format!(" ({plan_kind}, blackbox test)"),
+            TargetKind::InlineTest => format!(" ({plan_kind}, inline test)"),
+            TargetKind::SubPackage => format!(" ({plan_kind}, subpackage)"),
         };
 
-        match self {
+        let description = match self {
             BuildPlanNode::Check(build_target) => {
                 let fqn = packages.fqn(build_target.package);
-                format!("check {}{}", fqn, kind_suffix(build_target.kind))
+                format!("check {}{}", fqn, qualifier(build_target.kind))
             }
             BuildPlanNode::EmitProof(build_target) => {
                 let fqn = packages.fqn(build_target.package);
-                format!("emit proof {}{}", fqn, kind_suffix(build_target.kind))
+                format!("emit proof {}{}", fqn, qualifier(build_target.kind))
             }
             BuildPlanNode::Prove(build_target) => {
                 let fqn = packages.fqn(build_target.package);
-                format!("prove {}{}", fqn, kind_suffix(build_target.kind))
+                format!("prove {}{}", fqn, qualifier(build_target.kind))
             }
             BuildPlanNode::BuildCore(build_target) => {
                 let fqn = packages.fqn(build_target.package);
-                format!("build {}{}", fqn, kind_suffix(build_target.kind))
+                format!("build {}{}", fqn, qualifier(build_target.kind))
             }
             BuildPlanNode::BuildCStub(package_id, index) => {
                 let pkg = packages.get_package(*package_id);
@@ -431,31 +437,27 @@ impl BuildPlanNode {
             }
             BuildPlanNode::LinkCore(build_target) => {
                 let fqn = packages.fqn(build_target.package);
-                format!("link {}{}", fqn, kind_suffix(build_target.kind))
+                format!("link {}{}", fqn, qualifier(build_target.kind))
             }
             BuildPlanNode::MakeExecutable(build_target) => {
                 let fqn = packages.fqn(build_target.package);
-                format!("make executable {}{}", fqn, kind_suffix(build_target.kind))
+                format!("make executable {}{}", fqn, qualifier(build_target.kind))
             }
             BuildPlanNode::GenerateDsym(build_target) => {
                 let fqn = packages.fqn(build_target.package);
-                format!("generate dSYM {}{}", fqn, kind_suffix(build_target.kind))
+                format!("generate dSYM {}{}", fqn, qualifier(build_target.kind))
             }
             BuildPlanNode::GenerateTestInfo(build_target) => {
                 let fqn = packages.fqn(build_target.package);
                 format!(
                     "generate test driver for {}{}",
                     fqn,
-                    kind_suffix(build_target.kind)
+                    qualifier(build_target.kind)
                 )
             }
             BuildPlanNode::GenerateMbti(build_target) => {
                 let fqn = packages.fqn(build_target.package);
-                format!(
-                    "generate mbti for {}{}",
-                    fqn,
-                    kind_suffix(build_target.kind)
-                )
+                format!("generate mbti for {}{}", fqn, qualifier(build_target.kind))
             }
             BuildPlanNode::Bundle(module_id) => {
                 let module_src = env.module_source(*module_id);
@@ -491,7 +493,7 @@ impl BuildPlanNode {
                 } else {
                     outputs.join(", ")
                 };
-                format!("prebuild script {} {}", packages.fqn(*package_id), joined)
+                format!("run script {} {}", packages.fqn(*package_id), joined)
             }
             BuildPlanNode::RunMoonLexPrebuild(package_id, index) => {
                 let pkg = packages.get_package(*package_id);
@@ -509,6 +511,12 @@ impl BuildPlanNode {
                 let src = env.module_source(*module_id);
                 format!("build docs {}", src)
             }
+        };
+
+        if self.extract_target().is_some() {
+            description
+        } else {
+            format!("{description} ({plan_kind})")
         }
     }
 

--- a/crates/moonbuild-rupes-recta/src/util.rs
+++ b/crates/moonbuild-rupes-recta/src/util.rs
@@ -20,7 +20,10 @@
 
 use crate::discover::DiscoverResult;
 use crate::pkg_solve::DepRelationship;
-use crate::{build_plan::BuildPlan, model::BuildPlanNode};
+use crate::{
+    build_plan::{BuildPlan, BuildPlanActionKey, PackagePrebuildKey, package_file_key},
+    model::BuildPlanNode,
+};
 use moonutil::resolution::ResolvedEnv;
 use petgraph::Direction;
 use std::io::{self, Write};
@@ -192,21 +195,12 @@ impl BuildPlanNode {
             BuildPlanNode::GenerateTestInfo(target) => format!("{:?}@GenerateTestInfo", target),
             BuildPlanNode::Bundle(module_id) => format!("{:?}@Bundle", module_id),
             BuildPlanNode::GenerateMbti(target) => format!("{:?}@GenerateMbti", target),
-            BuildPlanNode::RunPrebuild(target, index) => {
-                format!("{:?}@RunPrebuild_{}", target, index)
-            }
             BuildPlanNode::BuildRuntimeObject(index) => {
                 format!("BuildRuntimeObject_{index}")
             }
             BuildPlanNode::BuildRuntimeLib => "BuildRuntimeLib".to_string(),
             BuildPlanNode::BuildDocs(module_id) => format!("{:?}@BuildDocs", module_id),
             BuildPlanNode::BuildVirtual(target) => format!("{:?}@BuildVirtual", target),
-            BuildPlanNode::RunMoonLexPrebuild(package_id, index) => {
-                format!("{:?}@RunMoonLexPrebuild_{}", package_id, index)
-            }
-            BuildPlanNode::RunMoonYaccPrebuild(package_id, index) => {
-                format!("{:?}@RunMoonYaccPrebuild_{}", package_id, index)
-            }
         }
     }
 
@@ -260,10 +254,6 @@ impl BuildPlanNode {
                 let fqn = packages.fqn(build_target.package);
                 format!("{}\\nGenerateMbti", fqn)
             }
-            BuildPlanNode::RunPrebuild(target, index) => {
-                let fqn = packages.fqn(*target);
-                format!("{}\\nRunPrebuild_{}", fqn, index)
-            }
             BuildPlanNode::BuildRuntimeObject(index) => {
                 format!("BuildRuntimeObject_{index}")
             }
@@ -275,14 +265,6 @@ impl BuildPlanNode {
             BuildPlanNode::BuildVirtual(package) => {
                 let fqn = packages.fqn(*package);
                 format!("{}\\nBuildVirtual", fqn)
-            }
-            BuildPlanNode::RunMoonLexPrebuild(package_id, index) => {
-                let fqn = packages.fqn(*package_id);
-                format!("{}\\nRunMoonLexPrebuild_{}", fqn, index)
-            }
-            BuildPlanNode::RunMoonYaccPrebuild(package_id, index) => {
-                let fqn = packages.fqn(*package_id);
-                format!("{}\\nRunMoonYaccPrebuild_{}", fqn, index)
             }
         }
     }
@@ -301,13 +283,74 @@ impl BuildPlanNode {
             BuildPlanNode::GenerateTestInfo(_) => "lightgray",
             BuildPlanNode::Bundle(_) => "wheat",
             BuildPlanNode::GenerateMbti(_) => "lightcyan",
-            BuildPlanNode::RunPrebuild(_, _) => "khaki",
             BuildPlanNode::BuildRuntimeObject(_) => "orange",
             BuildPlanNode::BuildRuntimeLib => "orange",
             BuildPlanNode::BuildDocs(_) => "lavender",
             BuildPlanNode::BuildVirtual(_) => "lightsteelblue",
-            BuildPlanNode::RunMoonLexPrebuild(..) => "plum",
-            BuildPlanNode::RunMoonYaccPrebuild(..) => "thistle",
+        }
+    }
+}
+
+impl BuildPlanActionKey {
+    fn gen_node_id(&self, packages: &DiscoverResult) -> String {
+        match self {
+            Self::Backend(node) => node.gen_node_id(),
+            Self::PackagePrebuild(PackagePrebuildKey::Custom {
+                package,
+                declaration_index,
+            }) => format!("{package:?}@RunPrebuild_{declaration_index}"),
+            Self::PackagePrebuild(PackagePrebuildKey::MoonLex { package, input }) => {
+                let package_root = &packages.get_package(*package).root_path;
+                let input = package_file_key(package_root, input);
+                format!("{package:?}@RunMoonLexPrebuild_{}", input.display())
+            }
+            Self::PackagePrebuild(PackagePrebuildKey::MoonYacc { package, input }) => {
+                let package_root = &packages.get_package(*package).root_path;
+                let input = package_file_key(package_root, input);
+                format!("{package:?}@RunMoonYaccPrebuild_{}", input.display())
+            }
+        }
+    }
+
+    fn gen_label(&self, env: &ResolvedEnv, packages: &DiscoverResult) -> String {
+        let file_name = |path: &Path| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.display().to_string())
+        };
+        match self {
+            Self::Backend(node) => node.gen_label(env, packages),
+            Self::PackagePrebuild(PackagePrebuildKey::Custom {
+                package,
+                declaration_index,
+            }) => format!(
+                "{}\\nRunPrebuild_{}",
+                packages.fqn(*package),
+                declaration_index
+            ),
+            Self::PackagePrebuild(PackagePrebuildKey::MoonLex { package, input }) => {
+                format!(
+                    "{}\\nRunMoonLexPrebuild_{}",
+                    packages.fqn(*package),
+                    file_name(input)
+                )
+            }
+            Self::PackagePrebuild(PackagePrebuildKey::MoonYacc { package, input }) => {
+                format!(
+                    "{}\\nRunMoonYaccPrebuild_{}",
+                    packages.fqn(*package),
+                    file_name(input)
+                )
+            }
+        }
+    }
+
+    fn gen_color(&self) -> &'static str {
+        match self {
+            Self::Backend(node) => node.gen_color(),
+            Self::PackagePrebuild(PackagePrebuildKey::Custom { .. }) => "khaki",
+            Self::PackagePrebuild(PackagePrebuildKey::MoonLex { .. }) => "plum",
+            Self::PackagePrebuild(PackagePrebuildKey::MoonYacc { .. }) => "thistle",
         }
     }
 }
@@ -323,11 +366,11 @@ pub fn print_build_plan_dot(
     writeln!(writer, "    rankdir=TB;")?;
     writeln!(writer, "    node [shape=box];")?;
 
-    // Nodes: use BuildPlanNode debug as ID, label with package FQN, target kind, and action
-    for node in build_plan.all_nodes() {
-        let node_id = node.gen_node_id();
-        let label = node.gen_label(env, packages);
-        let color = node.gen_color();
+    // Nodes: label both backend and package-prebuild actions.
+    for action in build_plan.all_actions() {
+        let node_id = action.gen_node_id(packages);
+        let label = action.gen_label(env, packages);
+        let color = action.gen_color();
 
         writeln!(
             writer,
@@ -336,11 +379,11 @@ pub fn print_build_plan_dot(
         )?;
     }
 
-    // Edges: dependencies between build plan nodes
-    for node in build_plan.all_nodes() {
-        for dep in build_plan.dependency_nodes(node) {
-            let node_id = node.gen_node_id();
-            let dep_id = dep.gen_node_id();
+    // Edges: artifact requirements between Build Plan actions.
+    for action in build_plan.all_actions() {
+        for dep in build_plan.dependency_actions(&action) {
+            let node_id = action.gen_node_id(packages);
+            let dep_id = dep.gen_node_id(packages);
             writeln!(writer, "    \"{}\" -> \"{}\";\n", node_id, dep_id)?;
         }
     }

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -59,10 +59,11 @@ We will use these terms in the document:
   [Modules and Packages](./modules-packages.md).
 
 - The **build plan** is a logical representation of requested artifacts and
-  the actions that produce them. It contains **build plan nodes** that
-  represent build operations (e.g. "compile package X", "check package Y"),
-  but not the actual command line to execute. Nodes require logical artifacts;
-  the plan records the action that provides each artifact.
+  the actions that produce them. Its actions are either backend build-plan
+  nodes (for example, "compile package X" or "check package Y") or package
+  prebuild actions. It does not contain the actual command line to execute.
+  Actions require logical artifacts; the plan records the action that provides
+  each artifact.
 
 - The **execution plan** is the executor-neutral concrete graph. It contains
   commands, input paths, external file observations, and declared physical
@@ -96,9 +97,10 @@ In a broad sense, `moon` subcommands follows this order when executing project-b
      Execution Plans into one executor graph, sharing compatible physical
      providers such as package prebuild actions. JSON-formatted checks retain
      each diagnostic's backend through the originating n2 Build ID, so they use
-     the same composed graph. Lowering completes each progress description with
-     its plan kind and optional target kind, such as `(wasm, blackbox test)` or
-     `(prebuild)`, before the executor receives it.
+     the same composed graph. Backend actions render their backend together
+     with any applicable target kind, such as `(wasm, blackbox test)`;
+     package-prebuild actions independently render `(prebuild)` before the
+     executor receives either description.
    - Execute the concrete build graph in its executor ([n2][]).
      The executor ensures the graph is executed incrementally, rebuilding only the changed parts.
 4. Perform other operations required after build
@@ -365,7 +367,7 @@ The compilation of a package is controlled by a number of axes:
   The rest are tests: _whitebox test_, _blackbox test_, _inline test_.
   A **build target** is the package combined with its build target kind
   ("package X's blackbox test").
-- The action, or **build plan node** to execute on the package:
+- The backend action, or **build plan node**, to execute on the package:
   build, check, link, etc.
 - The properties of the package itself.
   For example, a package can optionally be _virtual_ to be overridable.
@@ -441,7 +443,19 @@ blackbox check/test artifacts for `is-main` packages.
 The details of how a user intent is mapped to requested artifacts
 is described in [its module](/crates/moonbuild-rupes-recta/src/intent.rs).
 
-## Build plan node
+## Build Plan actions
+
+`BuildPlanActionKey` makes the two top-level action kinds explicit:
+
+- `Backend(BuildPlanNode)` identifies backend-specific semantic work.
+- `PackagePrebuild(PackagePrebuildKey)` identifies package-level file
+  generation independent of backend target kind.
+
+`TargetKind` is nested only in backend nodes whose meaning varies across
+source, whitebox, blackbox, or inline-test targets. It is not an optional field
+on a generic action and does not apply to package prebuild.
+
+### Backend build-plan nodes
 
 **Build plan nodes** are logical representation of the command to be executed.
 Many build plan nodes operate on build targets,
@@ -453,18 +467,20 @@ Here are some examples:
 - `LinkCore(BuildTarget)` links all dependencies of a build target into the compiled form.
 - `BuildVirtual(PackageId)` builds the virtual package interface of the given package
   (build targets don't make sense on virtual packages).
-- `RunPrebuild(PackageId, u32)` runs the prebuild command of a package with the given index.
 - `BuildRuntimeObject(u32)` compiles one shipped runtime C translation unit.
 - `BuildRuntimeLib` collects the runtime objects into the single runtime
   library used globally by all consumers in the project. TCC-run lowers this
   node directly from all runtime sources instead.
 
-The full list of build plan nodes are available in [its module](/crates/moonbuild-rupes-recta/src/model.rs).
+The full list of backend build-plan nodes is available in
+[its module](/crates/moonbuild-rupes-recta/src/model.rs). Package prebuild keys
+and actions are defined in
+[`package_prebuild.rs`](/crates/moonbuild-rupes-recta/src/build_plan/package_prebuild.rs).
 
-### Node dependency
+### Action dependency
 
-Build plan nodes require artifacts to form a directed acyclic graph called the
-**build plan**. The artifact registry selects the provider node for each
+Build Plan actions require artifacts to form a directed acyclic graph. The
+artifact registry selects the provider action for each
 requirement.
 
 For example, if build target A depends on build target B,

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -96,7 +96,9 @@ In a broad sense, `moon` subcommands follows this order when executing project-b
      Execution Plans into one executor graph, sharing compatible physical
      providers such as package prebuild actions. JSON-formatted checks retain
      each diagnostic's backend through the originating n2 Build ID, so they use
-     the same composed graph.
+     the same composed graph. Lowering completes each progress description with
+     its plan kind and optional target kind, such as `(wasm, blackbox test)` or
+     `(prebuild)`, before the executor receives it.
    - Execute the concrete build graph in its executor ([n2][]).
      The executor ensures the graph is executed incrementally, rebuilding only the changed parts.
 4. Perform other operations required after build

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -116,14 +116,20 @@ registry:
 ```rust
 pub struct BuildPlan {
     actions: IndexSet<BuildPlanNode>,
+    package_prebuild: PackagePrebuildPlan,
     artifacts: ArtifactPlan,
     // hydrated planning metadata
 }
 
+enum BuildPlanActionKey {
+    Backend(BuildPlanNode),
+    PackagePrebuild(PackagePrebuildKey),
+}
+
 struct ArtifactPlan {
-    providers: HashMap<ArtifactKey, BuildPlanNode>,
-    artifacts_by_provider: HashMap<BuildPlanNode, IndexSet<ArtifactKey>>,
-    requirements_by_consumer: HashMap<BuildPlanNode, IndexSet<ArtifactKey>>,
+    providers: HashMap<ArtifactKey, BuildPlanActionKey>,
+    artifacts_by_provider: HashMap<BuildPlanActionKey, IndexSet<ArtifactKey>>,
+    requirements_by_consumer: HashMap<BuildPlanActionKey, IndexSet<ArtifactKey>>,
 }
 ```
 
@@ -131,6 +137,13 @@ There is no weighted action-edge graph and no `FileDependencyKind`. A provider
 may expose multiple artifacts, but each artifact has at most one provider in a
 plan. At the end of planning, validation requires every requested artifact and
 every Artifact Requirement to have a provider.
+
+`BuildPlanActionKey` is the sole union of semantic action kinds. Backend nodes
+retain `BuildTarget` and therefore `TargetKind` only where those concepts
+apply. Package prebuild actions are a peer branch keyed by their declaration
+coordinate: custom commands use the manifest declaration index, while moonlex
+and moonyacc use their concrete input paths. No package prebuild action is
+projected through a synthetic `BuildPlanNode`.
 
 Builders name only what they consume:
 
@@ -253,10 +266,10 @@ identity or cache digest. Concrete output paths likewise are not cache digests.
 
 ## Action lowering and n2 adaptation
 
-`build_lower` walks semantic `BuildPlanNode` values, hydrates the metadata for
-one node on demand, and resolves every `ArtifactKey` through
+`build_lower` walks semantic `BuildPlanActionKey` values, hydrates the metadata
+for one action on demand, and resolves every `ArtifactKey` through
 `ArtifactPathResolver`. `ActionArtifacts` realizes outputs with the current
-node as provider context and requirements with the selected provider node as
+action as provider context and requirements with the selected provider action as
 context:
 
 ```rust

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -330,9 +330,10 @@ and then generate a test driver and related metadata.
 Both files are generated per-build-target via `moon generate-test-driver` (`GenerateTestInfo`).
 The driver is used in `BuildPackage` like a regular source file.
 
-## Glossary of major build plan nodes
+## Glossary of major Build Plan actions
 
-The following is a table
+Backend build-plan nodes and package prebuild actions are peer action kinds.
+`TargetKind` appears only inside backend nodes for which it has meaning.
 
 | Build plan node                 | Command                     | Outputs               | Dependencies                               | Note                                           |
 | ------------------------------- | --------------------------- | --------------------- | ------------------------------------------ | ---------------------------------------------- |
@@ -348,7 +349,11 @@ The following is a table
 | `GenerateMbti(BuildTarget)`     | `mooninfo`                  | `.mbti`               | `.mi`                                      | Get text repr of `.mi`                         |
 | `GenerateTestInfo(BuildTarget)` | `moon generate-test-driver` | test driver, metadata | source files                               | Generate the test driver and metadata          |
 | `BuildVirtual(PackageId)`       | `moonc build-interface`     | `.mi`                 | `.mbti`                                    | Get interface from `.mbti`                     |
-| `RunPrebuild(PackageId, int)`   | User-defined                | user-defined          | user-defined                               | Run a user-defined prebuild task               |
+
+`PackagePrebuildKey` separately identifies custom, moonlex, and moonyacc
+actions. Custom commands use their manifest declaration position because a
+valid command may have no output or the same outputs as another command;
+built-in generators use their input path.
 
 ## Solving import loops
 

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -38,7 +38,7 @@ Notes:
 - When arrays are used, placeholders expand to space-separated lists in declaration order.
 - During ordinary input-module builds that plan package prebuild, each planned
   action's declared outputs are tracked as build outputs. Bin-dep compatibility
-  builds do not create package-level prebuild nodes; they consume existing
+  builds do not create package-level prebuild actions; they consume existing
   `.mbt` and `.mbt.md` outputs as package sources.
 - Outputs of actions in the current `PackagePrebuildPlan` go through the same
   File Interpretation as paths in the Package File Set. `.mbt` becomes a
@@ -128,6 +128,10 @@ Behavior:
 - `PackagePrebuildPlan` is an action-storage seam, not a separate dependency
   model. Each declared output is registered as a `PrebuildOutput` artifact in
   the Build Plan's common artifact registry.
+- The common registry keys providers and consumers by `BuildPlanActionKey`,
+  whose `Backend` and `PackagePrebuild` variants are peer action kinds.
+  Package prebuild is therefore never represented as a backend node with an
+  inapplicable target kind.
 - There is no explicit edge between two prebuild tasks solely because one is
   written earlier in `pre-build`. If one task consumes another task's declared
   output, it records an Artifact Requirement on that `PrebuildOutput`.


### PR DESCRIPTION
## Why

Composed executions need progress to distinguish backend work from package prebuild work. The previous implementation could render that distinction, but Build Plan still represented real package prebuild actions through synthetic `BuildPlanNode::Run*Prebuild` variants and then recovered their actual data from `PackagePrebuildPlan`. That made prebuild look like a backend action and forced artifact planning, lowering, standalone projection, and debug output to special-case it.

## What changed

- Complete backend progress descriptions during lowering with backend and applicable target kind, such as `(wasm, blackbox test)`.
- Complete package prebuild descriptions independently as `(prebuild)` for both single- and multi-backend executions.
- Add one `BuildPlanActionKey` boundary with peer `Backend` and `PackagePrebuild` variants, and use it throughout the common artifact registry and lowering traversal.
- Give custom prebuild commands an explicit manifest declaration coordinate, while moonlex and moonyacc actions use their input path instead of an enumerated action index.
- Remove the three synthetic prebuild `BuildPlanNode` variants and `is_package_prebuild_node` compatibility test.
- Synchronize the Build Plan and prebuild architecture references.

## Why this is correct and minimal

The change replaces the compatibility projection rather than adding another graph or adapter. `BuildPlan` still owns backend actions and `PackagePrebuildPlan` still owns complete package prebuild actions; `BuildPlanActionKey` is only their shared semantic identity at the artifact and lowering boundary. Target kind remains nested in backend actions where it applies and is absent from package prebuild identity.

Action insertion order, requested artifacts, commands, physical inputs and outputs, Execution Plan construction, and n2 composition are unchanged. Package prebuild providers therefore continue to merge by identical physical execution behavior across backend plans.