### PR TITLE
refactor(build): clarify BuildPlan subplan ownership

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,23 @@ _Avoid_: Using entity names for operations, adding containers only to mirror voc
 
 ## Build Planning
 
+**Build Plan**:
+A self-contained semantic plan for one Target Backend, composed from a Backend
+Plan, a Package Prebuild Plan, and the Build Artifact relationships between
+their actions.
+_Avoid_: Execution Plan, treating either subplan as the complete build
+
+**Backend Plan**:
+The backend-specific subplan that owns its semantic action membership and the
+shared planning information required to lower those actions.
+_Avoid_: Package Prebuild Plan, bare action set
+
+**Package Prebuild Plan**:
+The subplan that owns package-level file-generation actions whose meaning is
+independent of Target Backend. It participates in the enclosing Build Plan's
+artifact relationships rather than defining a separate dependency model.
+_Avoid_: Backend Plan, prebuild action graph
+
 **Build Artifact**:
 A logical build result identified independently of its physical output root and provider derivation. Artifact identity includes the semantic output kind: check, build, proof, and virtual-contract `.mi` files are distinct. Identity is scoped to one backend-specific Build Plan.
 _Avoid_: Output path, action ID, build product

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -228,8 +228,7 @@ impl<'a> LoweringContext<'a> {
             BuildPlanActionKey::PackagePrebuild(key) => {
                 let action = self
                     .plan
-                    .package_prebuild_plan()
-                    .action(key)
+                    .package_prebuild_action(key)
                     .expect("package prebuild key should name a planned action");
                 return match (key, action) {
                     (PackagePrebuildKey::Custom { .. }, PackagePrebuildAction::Custom { info }) => {

--- a/crates/moonbuild-rupes-recta/src/build_plan/artifact.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/artifact.rs
@@ -198,17 +198,17 @@ impl ArtifactKey {
 
 /// Artifact providers and the artifact requirements of each action.
 ///
-/// [`BuildPlanActionKey`] distinguishes backend actions from package prebuild
-/// actions without introducing a positional or arena ID. Multiple artifacts
-/// may name the same provider.
+/// [`BuildPlanActionKey`] qualifies references to actions owned by the backend
+/// and package-prebuild subplans without introducing a positional or arena ID.
+/// Multiple artifacts may name the same provider.
 #[derive(Debug, Default)]
-pub(super) struct ArtifactPlan {
+pub(super) struct ArtifactRegistry {
     providers: HashMap<ArtifactKey, BuildPlanActionKey>,
     artifacts_by_provider: HashMap<BuildPlanActionKey, IndexSet<ArtifactKey>>,
     requirements_by_consumer: HashMap<BuildPlanActionKey, IndexSet<ArtifactKey>>,
 }
 
-impl ArtifactPlan {
+impl ArtifactRegistry {
     pub(super) fn require(
         &mut self,
         consumer: impl Into<BuildPlanActionKey>,
@@ -315,7 +315,7 @@ mod tests {
             target_kind: TargetKind::Source,
         };
 
-        let mut plan = ArtifactPlan::default();
+        let mut plan = ArtifactRegistry::default();
         plan.provide(provider.clone(), build_mi.clone());
         plan.provide(provider.clone(), core_ir.clone());
 
@@ -339,7 +339,7 @@ mod tests {
             target_kind: TargetKind::Source,
         };
 
-        let mut plan = ArtifactPlan::default();
+        let mut plan = ArtifactRegistry::default();
         plan.require(consumer.clone(), build_mi.clone());
 
         assert_eq!(
@@ -361,7 +361,7 @@ mod tests {
             target_kind: TargetKind::Source,
         };
 
-        let mut plan = ArtifactPlan::default();
+        let mut plan = ArtifactRegistry::default();
         plan.provide(BuildPlanNode::BuildCore(target), artifact.clone());
         plan.provide(BuildPlanNode::Check(target), artifact);
     }

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -134,14 +134,25 @@ impl<'a> BuildPlanConstructor<'a> {
                 continue;
             };
             let cc_overridden = native.cc.is_some()
-                && self.res.make_executable_info.iter().any(|(target, info)| {
-                    target.package == package
-                        && info.effective_native_toolchain.source() == ToolchainSource::EnvOverride
-                });
+                && self
+                    .res
+                    .backend
+                    .make_executable_info
+                    .iter()
+                    .any(|(target, info)| {
+                        target.package == package
+                            && info.effective_native_toolchain.source()
+                                == ToolchainSource::EnvOverride
+                    });
             let stub_cc_overridden = native.stub_cc.is_some()
-                && self.res.c_stubs_info.get(&package).is_some_and(|info| {
-                    info.effective_native_toolchain.source() == ToolchainSource::EnvOverride
-                });
+                && self
+                    .res
+                    .backend
+                    .c_stubs_info
+                    .get(&package)
+                    .is_some_and(|info| {
+                        info.effective_native_toolchain.source() == ToolchainSource::EnvOverride
+                    });
             let fields = [
                 cc_overridden.then_some("`link.native.cc`"),
                 stub_cc_overridden.then_some("`link.native.stub-cc`"),
@@ -1044,7 +1055,7 @@ impl<'a> BuildPlanConstructor<'a> {
             link_flags,
             static_archive_fingerprint,
         };
-        self.res.c_stubs_info.insert(target, c_info);
+        self.res.backend.c_stubs_info.insert(target, c_info);
         self.resolved_node(node);
 
         Ok(())
@@ -1095,7 +1106,10 @@ impl<'a> BuildPlanConstructor<'a> {
             abort_overridden,
             // std: self.build_env.std, // Can move std/nostd to per-package info
         };
-        self.res.link_core_info.insert(target, link_core_info);
+        self.res
+            .backend
+            .link_core_info
+            .insert(target, link_core_info);
         self.resolved_node(node);
 
         Ok(())
@@ -1197,12 +1211,12 @@ impl<'a> BuildPlanConstructor<'a> {
                 unreachable!("non-native executable planning returns before toolchain planning")
             }
         };
-        if generate_dsym && self.res.dsymutil.is_none() {
-            self.res.dsymutil = Some(moonutil::toolchain::resolve_executable("dsymutil").map_err(
-                |error| {
+        if generate_dsym && self.res.backend.dsymutil.is_none() {
+            self.res.backend.dsymutil = Some(
+                moonutil::toolchain::resolve_executable("dsymutil").map_err(|error| {
                     BuildPlanConstructError::FailedToResolveDsymutil(error, pkg.fqn.clone().into())
-                },
-            )?);
+                })?,
+            );
         }
 
         let v = MakeExecutableInfo {
@@ -1211,7 +1225,7 @@ impl<'a> BuildPlanConstructor<'a> {
             c_flags,
             link_flags,
         };
-        self.res.make_executable_info.insert(target, v);
+        self.res.backend.make_executable_info.insert(target, v);
 
         self.require_artifact(node, ArtifactKey::RuntimeLibrary);
 
@@ -1491,6 +1505,7 @@ impl<'a> BuildPlanConstructor<'a> {
             "recording bundle targets"
         );
         self.res
+            .backend
             .bundle_info
             .insert(module_id, BuildBundleInfo { bundle_targets });
         self.resolved_node(node);
@@ -1610,7 +1625,7 @@ impl<'a> BuildPlanConstructor<'a> {
                 .cc()
                 .archiver_updates_existing_archive())
         .then(|| runtime_archive_fingerprint(&source_files, &simdutf_objects));
-        self.res.runtime_info = Some(BuildRuntimeInfo {
+        self.res.backend.runtime_info = Some(BuildRuntimeInfo {
             effective_native_toolchain,
             source_files,
             simdutf_objects,
@@ -1620,6 +1635,7 @@ impl<'a> BuildPlanConstructor<'a> {
         if builds_static_archive {
             let source_count = self
                 .res
+                .backend
                 .runtime_info
                 .as_ref()
                 .expect("runtime info was just populated")
@@ -1628,6 +1644,7 @@ impl<'a> BuildPlanConstructor<'a> {
             for index in 0..source_count {
                 let source = &self
                     .res
+                    .backend
                     .runtime_info
                     .as_ref()
                     .expect("runtime info was just populated")
@@ -1702,7 +1719,10 @@ impl<'a> BuildPlanConstructor<'a> {
                 MBTI_USER_WRITTEN
             ));
         }
-        self.res.virtual_contract_inputs.insert(target, selected);
+        self.res
+            .backend
+            .virtual_contract_inputs
+            .insert(target, selected);
 
         for dep in self.input.pkg_rel.dep_graph.neighbors_directed(
             target.build_target(TargetKind::Source),

--- a/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/constructor.rs
@@ -188,7 +188,7 @@ impl<'a> BuildPlanConstructor<'a> {
 
         if !self.resolved.contains(&node) {
             self.pending.push(node);
-            self.res.actions.insert(node);
+            self.res.backend.insert(node);
         }
         node
     }
@@ -202,7 +202,7 @@ impl<'a> BuildPlanConstructor<'a> {
             node
         );
         debug_assert!(
-            self.res.actions.contains(&node),
+            self.res.backend.contains(&node),
             "Node {:?} should be in the plan before resolving",
             node
         );
@@ -355,6 +355,7 @@ impl<'a> BuildPlanConstructor<'a> {
             BuildPlanNode::BuildRuntimeObject(index) => {
                 let info = self
                     .res
+                    .backend
                     .runtime_info
                     .as_ref()
                     .expect("runtime info should be present for runtime object nodes");
@@ -395,7 +396,7 @@ impl<'a> BuildPlanConstructor<'a> {
             | BuildPlanNode::BuildCore(target)
             | BuildPlanNode::GenerateTestInfo(target) => target,
             BuildPlanNode::BuildVirtual(package) => {
-                let Some(input) = self.res.virtual_contract_inputs.get(&package) else {
+                let Some(input) = self.res.backend.virtual_contract_inputs.get(&package) else {
                     return;
                 };
                 let pkg = self.input.pkg_dirs.get_package(package);
@@ -522,6 +523,7 @@ impl<'a> BuildPlanConstructor<'a> {
             ArtifactKey::RuntimeObject { source } => {
                 let info = self
                     .res
+                    .backend
                     .runtime_info
                     .as_ref()
                     .expect("runtime info should be planned before its object requirements");
@@ -562,7 +564,10 @@ impl<'a> BuildPlanConstructor<'a> {
                 let pkg = self.input.pkg_dirs.get_package(build_target.package);
                 if pkg.has_implementation() {
                     assert!(
-                        self.res.build_target_infos.contains_key(&build_target),
+                        self.res
+                            .backend
+                            .build_target_infos
+                            .contains_key(&build_target),
                         "Build target info for {:?} should be present when resolving node {:?}",
                         build_target,
                         node
@@ -572,7 +577,7 @@ impl<'a> BuildPlanConstructor<'a> {
             BuildPlanNode::BuildCStub(build_target, _)
             | BuildPlanNode::ArchiveOrLinkCStubs(build_target) => {
                 assert!(
-                    self.res.c_stubs_info.contains_key(&build_target),
+                    self.res.backend.c_stubs_info.contains_key(&build_target),
                     "C stubs info for {:?} should be present when resolving node {:?}",
                     build_target,
                     node
@@ -580,7 +585,7 @@ impl<'a> BuildPlanConstructor<'a> {
             }
             BuildPlanNode::LinkCore(build_target) => {
                 assert!(
-                    self.res.link_core_info.contains_key(&build_target),
+                    self.res.backend.link_core_info.contains_key(&build_target),
                     "Link core info for {:?} should be present when resolving node {:?}",
                     build_target,
                     node
@@ -589,14 +594,17 @@ impl<'a> BuildPlanConstructor<'a> {
             BuildPlanNode::MakeExecutable(build_target)
             | BuildPlanNode::GenerateDsym(build_target) => {
                 assert!(
-                    self.res.make_executable_info.contains_key(&build_target),
+                    self.res
+                        .backend
+                        .make_executable_info
+                        .contains_key(&build_target),
                     "Make executable info for {:?} should be present when resolving node {:?}",
                     build_target,
                     node
                 );
                 if matches!(node, BuildPlanNode::GenerateDsym(_)) {
                     assert!(
-                        self.res.dsymutil.is_some(),
+                        self.res.backend.dsymutil.is_some(),
                         "dSYM info for {:?} should be present when resolving node {:?}",
                         build_target,
                         node
@@ -606,7 +614,7 @@ impl<'a> BuildPlanConstructor<'a> {
             BuildPlanNode::GenerateMbti(_build_target) => (),
             BuildPlanNode::Bundle(module_id) => {
                 assert!(
-                    self.res.bundle_info.contains_key(&module_id),
+                    self.res.backend.bundle_info.contains_key(&module_id),
                     "Bundle info for module {:?} should be present when resolving node {:?}",
                     module_id,
                     node
@@ -615,6 +623,7 @@ impl<'a> BuildPlanConstructor<'a> {
             BuildPlanNode::BuildRuntimeObject(index) => {
                 let info = self
                     .res
+                    .backend
                     .runtime_info
                     .as_ref()
                     .expect("Runtime info should be present for runtime object nodes");
@@ -627,7 +636,7 @@ impl<'a> BuildPlanConstructor<'a> {
             }
             BuildPlanNode::BuildRuntimeLib => {
                 assert!(
-                    self.res.runtime_info.is_some(),
+                    self.res.backend.runtime_info.is_some(),
                     "Runtime info should be present when resolving node {:?}",
                     node
                 );
@@ -704,7 +713,7 @@ impl<'a> BuildPlanConstructor<'a> {
 
     /// Populate the target info for the given target, if not already present.
     pub(super) fn populate_target_info(&mut self, target: BuildTarget) {
-        if self.res.build_target_infos.contains_key(&target) {
+        if self.res.backend.build_target_infos.contains_key(&target) {
             // Already populated
             return;
         }
@@ -715,6 +724,6 @@ impl<'a> BuildPlanConstructor<'a> {
             let pkg = self.input.pkg_dirs.get_package(target.package);
             self.warn_if_main_package_uses_blackbox_inputs(pkg, &info.regular_files);
         }
-        self.res.build_target_infos.insert(target, info);
+        self.res.backend.build_target_infos.insert(target, info);
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -83,16 +83,16 @@ mod package_prebuild;
 
 pub(crate) use action::BuildAction;
 pub use artifact::ArtifactKey;
-use artifact::ArtifactPlan;
+use artifact::ArtifactRegistry;
 pub(crate) use artifact::package_file_key;
 use constructor::BuildPlanConstructor;
 pub use package_prebuild::PrebuildInfo;
 pub(crate) use package_prebuild::{PackagePrebuildAction, PackagePrebuildKey, PackagePrebuildPlan};
 
-/// Identity of one semantic action in a Build Plan.
+/// A qualified reference to one semantic action in a Build Plan.
 ///
-/// Backend work and package-level prebuild are peer action kinds. Target kind
-/// remains nested inside the backend actions for which it is meaningful.
+/// The referenced action remains owned by its backend or package-prebuild
+/// subplan; this enum does not define a third action identity.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum BuildPlanActionKey {
     Backend(BuildPlanNode),
@@ -105,26 +105,23 @@ impl From<BuildPlanNode> for BuildPlanActionKey {
     }
 }
 
-/// A build plan of actions and the artifacts that connect them.
+/// Backend-specific actions and the shared metadata required to lower them.
 ///
-/// Build-plan nodes identify actions. Every dependency names a logical artifact
-/// and is resolved through that artifact's unique provider. The plan also
-/// stores the metadata required to lower each action.
+/// A completed Backend Plan contains the metadata required to lower every
+/// planned action. Keeping both here makes that invariant local to backend
+/// planning.
 #[derive(Default)]
-pub struct BuildPlan {
+struct BackendPlan {
     /// Planned backend actions, in stable insertion order.
     actions: IndexSet<BuildPlanNode>,
 
-    /// Logical artifacts provided and required by planned actions.
-    artifacts: ArtifactPlan,
-
     /// The map of build target to its files and metadata.
-    /// Used by nodes that require access to the raw MoonBit source files, like
+    /// Used by actions that require access to the raw MoonBit source files, like
     /// `Check`, `BuildCore`, `GenerateTestInfo` and `Format`.
     ///
-    /// The following maps contain metadata needed for different types of build
-    /// nodes. For each node present in the final graph, its metadata must
-    /// already be present in the map.
+    /// The following maps contain metadata needed for different backend action
+    /// kinds. Every action in the completed subplan must be lowerable from
+    /// these maps.
     build_target_infos: HashMap<BuildTarget, BuildTargetInfo>,
 
     /// The map of build target to the metadata it needs when linking core
@@ -142,14 +139,46 @@ pub struct BuildPlan {
     /// The information needed to build the native runtime library.
     runtime_info: Option<BuildRuntimeInfo>,
 
-    /// Backend-independent package file-generation actions.
-    package_prebuild: PackagePrebuildPlan,
-
     /// The concrete `.mbti` input selected for each planned virtual contract.
     virtual_contract_inputs: HashMap<PackageId, PathBuf>,
 
     /// The map of build target to its bundle information
     bundle_info: HashMap<ModuleId, BuildBundleInfo>,
+}
+
+impl BackendPlan {
+    fn actions(&self) -> impl Iterator<Item = BuildPlanNode> + '_ {
+        self.actions.iter().copied()
+    }
+
+    fn contains(&self, action: &BuildPlanNode) -> bool {
+        self.actions.contains(action)
+    }
+
+    fn insert(&mut self, action: BuildPlanNode) {
+        self.actions.insert(action);
+    }
+
+    fn action_count(&self) -> usize {
+        self.actions.len()
+    }
+}
+
+/// A build plan composed from backend work, package prebuild, and the
+/// artifacts that connect the two subplans.
+///
+/// Each subplan owns its action membership and lowering metadata. The artifact
+/// registry records provider and consumer relationships across the two
+/// subplans through [`BuildPlanActionKey`].
+#[derive(Default)]
+pub struct BuildPlan {
+    backend: BackendPlan,
+
+    /// Backend-independent package file-generation actions.
+    package_prebuild: PackagePrebuildPlan,
+
+    /// Logical artifacts provided and required by planned actions.
+    artifacts: ArtifactRegistry,
 
     /// Logical results requested by the caller, in request order.
     requested_artifacts: IndexSet<ArtifactKey>,
@@ -193,53 +222,56 @@ impl BuildPlan {
 
     /// Get build target information for the given target.
     pub fn get_build_target_info(&self, target: &BuildTarget) -> Option<&BuildTargetInfo> {
-        self.build_target_infos.get(target)
+        self.backend.build_target_infos.get(target)
     }
 
     /// Get link core information for the given target.
     pub fn get_link_core_info(&self, target: &BuildTarget) -> Option<&LinkCoreInfo> {
-        self.link_core_info.get(target)
+        self.backend.link_core_info.get(target)
     }
 
     /// Get C stubs information for the given target.
     pub fn get_c_stubs_info(&self, target: PackageId) -> Option<&BuildCStubsInfo> {
-        self.c_stubs_info.get(&target)
+        self.backend.c_stubs_info.get(&target)
     }
 
     /// Get make executable information for the given target.
     pub fn get_make_executable_info(&self, target: &BuildTarget) -> Option<&MakeExecutableInfo> {
-        self.make_executable_info.get(target)
+        self.backend.make_executable_info.get(target)
     }
 
     /// Get the resolved dsymutil executable.
     pub fn get_dsymutil(&self) -> Option<&Path> {
-        self.dsymutil.as_deref()
+        self.backend.dsymutil.as_deref()
     }
 
     /// Get runtime library build information.
     pub fn get_runtime_info(&self) -> Option<&BuildRuntimeInfo> {
-        self.runtime_info.as_ref()
+        self.backend.runtime_info.as_ref()
     }
 
-    pub(crate) fn package_prebuild_plan(&self) -> &PackagePrebuildPlan {
-        &self.package_prebuild
+    pub(crate) fn package_prebuild_action(
+        &self,
+        key: &PackagePrebuildKey,
+    ) -> Option<&PackagePrebuildAction> {
+        self.package_prebuild.action(key)
     }
 
     pub(crate) fn virtual_contract_input(&self, package: PackageId) -> Option<&Path> {
-        self.virtual_contract_inputs
+        self.backend
+            .virtual_contract_inputs
             .get(&package)
             .map(PathBuf::as_path)
     }
 
     /// Get bundle information for the given module.
     pub fn bundle_info(&self, module_id: ModuleId) -> Option<&BuildBundleInfo> {
-        self.bundle_info.get(&module_id)
+        self.backend.bundle_info.get(&module_id)
     }
 
     pub(crate) fn all_actions(&self) -> impl Iterator<Item = BuildPlanActionKey> + '_ {
-        self.actions
-            .iter()
-            .copied()
+        self.backend
+            .actions()
             .map(BuildPlanActionKey::Backend)
             .chain(
                 self.package_prebuild
@@ -249,14 +281,14 @@ impl BuildPlan {
     }
 
     pub fn action_count(&self) -> usize {
-        self.actions.len() + self.package_prebuild.action_count()
+        self.backend.action_count() + self.package_prebuild.action_count()
     }
 }
 
 #[cfg(test)]
 impl BuildPlan {
     pub(crate) fn test_add_node(&mut self, node: BuildPlanNode) {
-        self.actions.insert(node);
+        self.backend.insert(node);
     }
 
     pub(crate) fn test_request_artifact(&mut self, artifact: ArtifactKey) {
@@ -264,12 +296,12 @@ impl BuildPlan {
     }
 
     pub(crate) fn test_require_artifact(&mut self, consumer: BuildPlanNode, artifact: ArtifactKey) {
-        self.actions.insert(consumer);
+        self.backend.insert(consumer);
         self.artifacts.require(consumer, artifact);
     }
 
     pub(crate) fn test_provide_artifact(&mut self, provider: BuildPlanNode, artifact: ArtifactKey) {
-        self.actions.insert(provider);
+        self.backend.insert(provider);
         self.artifacts.provide(provider, artifact);
     }
 
@@ -288,7 +320,7 @@ impl BuildPlan {
         target: BuildTarget,
         info: BuildTargetInfo,
     ) {
-        self.build_target_infos.insert(target, info);
+        self.backend.build_target_infos.insert(target, info);
     }
 
     pub(crate) fn test_insert_moonlex_prebuild(
@@ -321,11 +353,11 @@ impl BuildPlan {
     }
 
     pub(crate) fn test_insert_link_core_info(&mut self, target: BuildTarget, info: LinkCoreInfo) {
-        self.link_core_info.insert(target, info);
+        self.backend.link_core_info.insert(target, info);
     }
 
     pub(crate) fn test_insert_c_stubs_info(&mut self, package: PackageId, info: BuildCStubsInfo) {
-        self.c_stubs_info.insert(package, info);
+        self.backend.c_stubs_info.insert(package, info);
     }
 
     pub(crate) fn test_insert_make_executable_info(
@@ -333,15 +365,15 @@ impl BuildPlan {
         target: BuildTarget,
         info: MakeExecutableInfo,
     ) {
-        self.make_executable_info.insert(target, info);
+        self.backend.make_executable_info.insert(target, info);
     }
 
     pub(crate) fn test_insert_dsymutil(&mut self, dsymutil: PathBuf) {
-        self.dsymutil = Some(dsymutil);
+        self.backend.dsymutil = Some(dsymutil);
     }
 
     pub(crate) fn test_insert_runtime_info(&mut self, info: BuildRuntimeInfo) {
-        self.runtime_info = Some(info);
+        self.backend.runtime_info = Some(info);
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/build_plan/package_prebuild.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/package_prebuild.rs
@@ -91,11 +91,11 @@ impl PackagePrebuildAction {
     }
 }
 
-/// Backend-independent package prebuild actions within one Build Plan.
+/// The backend-independent package-prebuild subplan within one Build Plan.
 ///
-/// Actions are stored separately from backend actions, but use the same
-/// artifact provider/requirement registry. Each key names exactly one action;
-/// command data and physical outputs remain stored with that action.
+/// Each key names exactly one action. Command data and physical outputs remain
+/// with that action, while cross-subplan dependencies use the enclosing Build
+/// Plan's artifact registry.
 #[derive(Default)]
 pub(crate) struct PackagePrebuildPlan {
     actions: IndexMap<PackagePrebuildKey, PackagePrebuildAction>,
@@ -205,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    fn package_prebuild_provider_is_separate_from_backend_graph() {
+    fn package_prebuild_provider_is_separate_from_backend_plan() {
         let package = package_id(1);
         let backend_node = BuildPlanNode::Check(package.build_target(TargetKind::Source));
         let prebuild_key = PackagePrebuildKey::Custom {
@@ -213,7 +213,7 @@ mod tests {
             declaration_index: 0,
         };
         let mut plan = BuildPlan::default();
-        plan.actions.insert(backend_node);
+        plan.backend.insert(backend_node);
         plan.package_prebuild.insert_custom(
             package,
             0,
@@ -225,8 +225,8 @@ mod tests {
             },
         );
 
-        assert!(plan.actions.contains(&backend_node));
-        assert_eq!(plan.package_prebuild_plan().action_count(), 1);
+        assert!(plan.backend.contains(&backend_node));
+        assert_eq!(plan.package_prebuild.action_count(), 1);
         assert!(plan.package_prebuild.contains_key(&prebuild_key));
         let backend = BuildPlanActionKey::Backend(backend_node);
         assert_eq!(

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -445,6 +445,7 @@ is described in [its module](/crates/moonbuild-rupes-recta/src/intent.rs).
 
 ## Build Plan actions
 
+`BuildPlan` composes a backend subplan and a package-prebuild subplan.
 `BuildPlanActionKey` makes the two top-level action kinds explicit:
 
 - `Backend(BuildPlanNode)` identifies backend-specific semantic work.

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -110,15 +110,23 @@ consumers track it without exposing it as a caller-requested Build Artifact.
 
 ## Planning IR
 
-`BuildPlan` stores planned actions in stable insertion order and one artifact
-registry:
+`BuildPlan` composes two action-owning subplans with one artifact registry:
 
 ```rust
 pub struct BuildPlan {
-    actions: IndexSet<BuildPlanNode>,
+    backend: BackendPlan,
     package_prebuild: PackagePrebuildPlan,
-    artifacts: ArtifactPlan,
-    // hydrated planning metadata
+    artifacts: ArtifactRegistry,
+    requested_artifacts: IndexSet<ArtifactKey>,
+}
+
+struct BackendPlan {
+    actions: IndexSet<BuildPlanNode>,
+    // metadata required to lower backend actions
+}
+
+struct PackagePrebuildPlan {
+    actions: IndexMap<PackagePrebuildKey, PackagePrebuildAction>,
 }
 
 enum BuildPlanActionKey {
@@ -126,7 +134,7 @@ enum BuildPlanActionKey {
     PackagePrebuild(PackagePrebuildKey),
 }
 
-struct ArtifactPlan {
+struct ArtifactRegistry {
     providers: HashMap<ArtifactKey, BuildPlanActionKey>,
     artifacts_by_provider: HashMap<BuildPlanActionKey, IndexSet<ArtifactKey>>,
     requirements_by_consumer: HashMap<BuildPlanActionKey, IndexSet<ArtifactKey>>,
@@ -138,12 +146,12 @@ may expose multiple artifacts, but each artifact has at most one provider in a
 plan. At the end of planning, validation requires every requested artifact and
 every Artifact Requirement to have a provider.
 
-`BuildPlanActionKey` is the sole union of semantic action kinds. Backend nodes
-retain `BuildTarget` and therefore `TargetKind` only where those concepts
-apply. Package prebuild actions are a peer branch keyed by their declaration
-coordinate: custom commands use the manifest declaration index, while moonlex
-and moonyacc use their concrete input paths. No package prebuild action is
-projected through a synthetic `BuildPlanNode`.
+`BuildPlanActionKey` is the union used by the common artifact registry to
+connect providers and consumers from either subplan. Backend nodes retain
+`BuildTarget` and therefore `TargetKind` only where those concepts apply.
+Package prebuild actions are keyed by their declaration coordinate: custom
+commands use the manifest declaration index, while moonlex and moonyacc use
+their concrete input paths.
 
 Builders name only what they consume:
 
@@ -193,12 +201,12 @@ providers and cannot substitute for one another.
 
 ## Package prebuild actions
 
-Each backend-specific `BuildPlan` owns a `PackagePrebuildPlan` containing
-complete custom prebuild, moonlex, and moonyacc actions. This is an action
-storage boundary, not a second dependency model.
+Each backend-specific `BuildPlan` composes a `BackendPlan` and a
+`PackagePrebuildPlan`. The package-prebuild subplan owns complete custom
+prebuild, moonlex, and moonyacc actions; it is not a second dependency model.
 
 Every generated file is registered as `PrebuildOutput { package, path }` in the
-same `ArtifactPlan` used by backend actions. A prebuild action consuming an
+same `ArtifactRegistry` used by backend actions. A prebuild action consuming an
 earlier generated file records an Artifact Requirement, so custom-to-moonlex
 and custom-to-moonyacc pipelines are explicit before n2 adaptation. Backend
 actions likewise require the generated `.mbt`, `.mbt.md`, `.mbtp`, or `.mbti`

--- a/docs/dev/reference/prebuild.md
+++ b/docs/dev/reference/prebuild.md
@@ -125,11 +125,13 @@ Behavior:
 - During ordinary input-module builds, each backend-specific Build Plan owns a
   separate `PackagePrebuildPlan` containing the requested custom, moonlex, and
   moonyacc actions. Bin-dep compatibility builds create none.
-- `PackagePrebuildPlan` is an action-storage seam, not a separate dependency
-  model. Each declared output is registered as a `PrebuildOutput` artifact in
-  the Build Plan's common artifact registry.
+- `PackagePrebuildPlan` owns package file-generation actions as a peer of the
+  `BackendPlan`; it is not a separate dependency model. Each declared output
+  is registered as a `PrebuildOutput` artifact in the Build Plan's common
+  artifact registry.
 - The common registry keys providers and consumers by `BuildPlanActionKey`,
-  whose `Backend` and `PackagePrebuild` variants are peer action kinds.
+  whose variants qualify references into the peer backend and package-prebuild
+  subplans.
   Package prebuild is therefore never represented as a backend node with an
   inapplicable target kind.
 - There is no explicit edge between two prebuild tasks solely because one is


### PR DESCRIPTION
## Why

`BuildPlan` stored backend action membership and lowering metadata directly, while package prebuild already had its own subplan. That made the two peer kinds look structurally unrelated and made the artifact relationship table look like another plan.

## What changed

- Introduce `BackendPlan` as the owner of backend actions and their lowering metadata.
- Keep `BuildPlan` as the composition root for `BackendPlan`, `PackagePrebuildPlan`, requested artifacts, and their shared relationships.
- Rename the relationship-only `ArtifactPlan` to `ArtifactRegistry` and narrow prebuild lookup at the lowering boundary.
- Synchronize the MoonBuild glossary and implemented-behavior references.

## Why this is correct

The action set, metadata maps, artifact provider/requirement relationships, and lowering behavior are unchanged; the existing state is only moved under its semantic owner. Both subplans continue to connect through the same artifact registry.

## Scope

This deliberately avoids renaming existing node/key types, adding another action representation, or changing build behavior. It is a structural ownership cleanup that prepares later work without introducing a compatibility layer.