### PR TITLE
fix(moonrun): use unsigned guest memory values

### DIFF
--- a/crates/moonrun/src/async_api/c_buffer.rs
+++ b/crates/moonrun/src/async_api/c_buffer.rs
@@ -31,12 +31,12 @@ pub(super) fn is_null(_context: &mut ImportContext<'_, '_>, ptr: u64) -> i32 {
 pub(super) fn blit_to_c(
     context: &mut ImportContext<'_, '_>,
     dst: u64,
-    dst_offset: i32,
-    src: i32,
-    src_offset: i32,
-    len: i32,
+    dst_offset: u32,
+    src: u32,
+    src_offset: u32,
+    len: u32,
 ) -> AsyncHostResult<()> {
-    let src_len = checked_add_i32(src_offset, len)?;
+    let src_len = src_offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
     context.with_host_and_memory_mut(|host, memory| {
         let src = memory.read_exact(src, src_len)?;
         host.with_c_buffer_mut(dst, |dst| {
@@ -49,12 +49,12 @@ pub(super) fn blit_to_c(
 pub(super) fn blit_from_c(
     context: &mut ImportContext<'_, '_>,
     src: u64,
-    src_offset: i32,
-    dst: i32,
-    dst_offset: i32,
-    len: i32,
+    src_offset: u32,
+    dst: u32,
+    dst_offset: u32,
+    len: u32,
 ) -> AsyncHostResult<()> {
-    let dst_len = checked_add_i32(dst_offset, len)?;
+    let dst_len = dst_offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
     context.with_host_and_memory_mut(|host, memory| {
         let dst = memory.read_exact_mut(dst, dst_len)?;
         host.with_c_buffer(src, |src| {
@@ -67,21 +67,21 @@ pub(super) fn blit_from_c(
 pub(super) fn c_buffer_get(
     context: &mut ImportContext<'_, '_>,
     buf: u64,
-    index: i32,
+    index: u32,
 ) -> AsyncHostResult<i32> {
     context.host
         .with_c_buffer(buf, |buf| stub::c_buffer_get(buf, index).map(i32::from))
 }
 
 #[ported(source = "src/internal/c_buffer/stub.c")]
-pub(super) fn strlen(context: &mut ImportContext<'_, '_>, buf: u64) -> AsyncHostResult<i32> {
+pub(super) fn strlen(context: &mut ImportContext<'_, '_>, buf: u64) -> AsyncHostResult<u32> {
     context.host.with_c_buffer(buf, stub::strlen)
 }
 
-pub(super) fn length(context: &mut ImportContext<'_, '_>, buf: u64) -> AsyncHostResult<i32> {
+pub(super) fn length(context: &mut ImportContext<'_, '_>, buf: u64) -> AsyncHostResult<u32> {
     context
         .host
-        .with_c_buffer(buf, |buf| i32::try_from(buf.len()).map_err(|_| AsyncHostError::Fault))
+        .with_c_buffer(buf, |buf| u32::try_from(buf.len()).map_err(|_| AsyncHostError::Fault))
 }
 
 pub(super) fn free(context: &mut ImportContext<'_, '_>, ptr: u64) -> AsyncHostResult<()> {
@@ -92,11 +92,8 @@ pub(super) fn free(context: &mut ImportContext<'_, '_>, ptr: u64) -> AsyncHostRe
     source = "src/internal/c_buffer/stub.c",
     original = "moonbitlang_async_make_c_buffer"
 )]
-pub(super) fn new(context: &mut ImportContext<'_, '_>, size: i32) -> AsyncHostResult<u64> {
+pub(super) fn new(context: &mut ImportContext<'_, '_>, size: u32) -> AsyncHostResult<u64> {
     Ok(context.host.insert_c_buffer(stub::make_c_buffer(size)?))
 }
 
-fn checked_add_i32(lhs: i32, rhs: i32) -> AsyncHostResult<i32> {
-    lhs.checked_add(rhs).ok_or(AsyncHostError::Fault)
-}
 }

--- a/crates/moonrun/src/async_api/context.rs
+++ b/crates/moonrun/src/async_api/context.rs
@@ -153,10 +153,30 @@ impl FinishI32 for i32 {
     }
 }
 
+impl FinishI32 for u32 {
+    fn finish_i32(
+        self,
+        _scope: &mut v8::HandleScope,
+        ret: &mut v8::ReturnValue,
+        _import_name: &str,
+    ) {
+        ret.set_uint32(self);
+    }
+}
+
 impl FinishI32 for AsyncHostResult<i32> {
     fn finish_i32(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str) {
         match self {
             Ok(value) => ret.set_int32(value),
+            Err(error) => throw_import_error(scope, import_name, error),
+        }
+    }
+}
+
+impl FinishI32 for AsyncHostResult<u32> {
+    fn finish_i32(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str) {
+        match self {
+            Ok(value) => ret.set_uint32(value),
             Err(error) => throw_import_error(scope, import_name, error),
         }
     }

--- a/crates/moonrun/src/async_api/event_bus.rs
+++ b/crates/moonrun/src/async_api/event_bus.rs
@@ -195,7 +195,7 @@ pub(super) fn wait(context: &mut ImportContext<'_, '_>, bus: u64, timeout_ms: i3
 pub(super) fn get_event(
     context: &mut ImportContext<'_, '_>,
     bus: u64,
-    index: i32,
+    index: u32,
 ) -> AsyncHostResult<u64> {
     context.host.poll_get_event(bus, index)
 }
@@ -229,6 +229,6 @@ pub(super) fn event_io_result(
 pub(super) fn event_bytes_transferred(
     context: &mut ImportContext<'_, '_>,
     event: u64,
-) -> AsyncHostResult<i32> {
+) -> AsyncHostResult<u32> {
     context.host.poll_event_bytes_transferred(event)
 }

--- a/crates/moonrun/src/async_api/fd_util.rs
+++ b/crates/moonrun/src/async_api/fd_util.rs
@@ -22,13 +22,13 @@ use super::context::ImportContext;
 use super::provenance::ported_imports;
 
 ported_imports! {
-const FILE_TIME_RECORD_LEN: i32 = 48;
-const ATIME_SEC_OFFSET: i32 = 0;
-const ATIME_NSEC_OFFSET: i32 = 8;
-const MTIME_SEC_OFFSET: i32 = 16;
-const MTIME_NSEC_OFFSET: i32 = 24;
-const CTIME_SEC_OFFSET: i32 = 32;
-const CTIME_NSEC_OFFSET: i32 = 40;
+const FILE_TIME_RECORD_LEN: u32 = 48;
+const ATIME_SEC_OFFSET: u32 = 0;
+const ATIME_NSEC_OFFSET: u32 = 8;
+const MTIME_SEC_OFFSET: u32 = 16;
+const MTIME_NSEC_OFFSET: u32 = 24;
+const CTIME_SEC_OFFSET: u32 = 32;
+const CTIME_NSEC_OFFSET: u32 = 40;
 
 pub(super) fn invalid_fd(context: &mut ImportContext<'_, '_>) -> u64 {
     context.host.invalid_fd()
@@ -50,45 +50,45 @@ pub(super) fn kind_of_fd(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
     }
 }
 
-pub(super) fn sizeof_file_time(_context: &mut ImportContext<'_, '_>) -> i32 {
+pub(super) fn sizeof_file_time(_context: &mut ImportContext<'_, '_>) -> u32 {
     FILE_TIME_RECORD_LEN
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_atime_sec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i64> {
+pub(super) fn get_atime_sec(context: &mut ImportContext<'_, '_>, ptr: u32) -> AsyncHostResult<i64> {
     file_time_i64(context, ptr, ATIME_SEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_atime_nsec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i32> {
+pub(super) fn get_atime_nsec(context: &mut ImportContext<'_, '_>, ptr: u32) -> AsyncHostResult<i32> {
     file_time_i32(context, ptr, ATIME_NSEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_mtime_sec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i64> {
+pub(super) fn get_mtime_sec(context: &mut ImportContext<'_, '_>, ptr: u32) -> AsyncHostResult<i64> {
     file_time_i64(context, ptr, MTIME_SEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_mtime_nsec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i32> {
+pub(super) fn get_mtime_nsec(context: &mut ImportContext<'_, '_>, ptr: u32) -> AsyncHostResult<i32> {
     file_time_i32(context, ptr, MTIME_NSEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_ctime_sec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i64> {
+pub(super) fn get_ctime_sec(context: &mut ImportContext<'_, '_>, ptr: u32) -> AsyncHostResult<i64> {
     file_time_i64(context, ptr, CTIME_SEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
-pub(super) fn get_ctime_nsec(context: &mut ImportContext<'_, '_>, ptr: i32) -> AsyncHostResult<i32> {
+pub(super) fn get_ctime_nsec(context: &mut ImportContext<'_, '_>, ptr: u32) -> AsyncHostResult<i32> {
     file_time_i32(context, ptr, CTIME_NSEC_OFFSET)
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
 pub(super) fn pipe(
     context: &mut ImportContext<'_, '_>,
-    dst: i32,
-    len: i32,
+    dst: u32,
+    len: u32,
     read_end_is_async: i32,
     write_end_is_async: i32,
 ) -> i32 {
@@ -128,23 +128,25 @@ pub(super) fn set_cloexec(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
     }
 }
 
-fn file_time_i64(context: &mut ImportContext<'_, '_>, ptr: i32, field_offset: i32) -> AsyncHostResult<i64> {
+fn file_time_i64(context: &mut ImportContext<'_, '_>, ptr: u32, field_offset: u32) -> AsyncHostResult<i64> {
     read_field(context, ptr, field_offset, 8)
         .map(|bytes| i64::from_le_bytes(bytes.as_slice().try_into().unwrap()))
 }
 
-fn file_time_i32(context: &mut ImportContext<'_, '_>, ptr: i32, field_offset: i32) -> AsyncHostResult<i32> {
+fn file_time_i32(context: &mut ImportContext<'_, '_>, ptr: u32, field_offset: u32) -> AsyncHostResult<i32> {
     read_field(context, ptr, field_offset, 4)
         .map(|bytes| i32::from_le_bytes(bytes.as_slice().try_into().unwrap()))
 }
 
 fn read_field(
     context: &mut ImportContext<'_, '_>,
-    ptr: i32,
-    field_offset: i32,
-    len: i32,
+    ptr: u32,
+    field_offset: u32,
+    len: u32,
 ) -> AsyncHostResult<Vec<u8>> {
-    let offset = ptr.checked_add(field_offset).ok_or(AsyncHostError::Fault)?;
-    context.with_memory_mut(|memory| Ok(memory.read_exact(offset, len)?.to_vec()))
+    let ptr = ptr
+        .checked_add(field_offset)
+        .ok_or(AsyncHostError::Fault)?;
+    context.with_memory_mut(|memory| Ok(memory.read_exact(ptr, len)?.to_vec()))
 }
 }

--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -40,7 +40,7 @@ pub(super) fn get_tmp_path_len(context: &mut ImportContext<'_, '_>) -> i32 {
 }
 
 #[ported(source = "src/fs/stub.c")]
-pub(super) fn get_tmp_path(context: &mut ImportContext<'_, '_>, ptr: i32, len: i32) -> i32 {
+pub(super) fn get_tmp_path(context: &mut ImportContext<'_, '_>, ptr: u32, len: u32) -> i32 {
     let result = (|| {
         let units = tmp_path_utf16_units(context.host.policy())?;
         let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
@@ -65,7 +65,7 @@ pub(super) fn close_fd(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
 }
 
 #[ported(source = "src/fs/dir.c")]
-pub(super) fn dir_buffer_min_size(_context: &mut ImportContext<'_, '_>) -> i32 {
+pub(super) fn dir_buffer_min_size(_context: &mut ImportContext<'_, '_>) -> u32 {
     dir::buffer_min_size()
 }
 
@@ -73,8 +73,8 @@ pub(super) fn dir_buffer_min_size(_context: &mut ImportContext<'_, '_>) -> i32 {
 pub(super) fn dir_entry_length(
     context: &mut ImportContext<'_, '_>,
     buf: u64,
-    offset: i32,
-) -> AsyncHostResult<i32> {
+    offset: u32,
+) -> AsyncHostResult<u32> {
     context.host
         .with_c_buffer(buf, |buf| dir::entry_length(buf, 0, offset))
 }
@@ -83,8 +83,8 @@ pub(super) fn dir_entry_length(
 pub(super) fn dir_entry_name_len(
     context: &mut ImportContext<'_, '_>,
     buf: u64,
-    offset: i32,
-) -> AsyncHostResult<i32> {
+    offset: u32,
+) -> AsyncHostResult<u32> {
     context.host
         .with_c_buffer(buf, |buf| dir::entry_name_len(buf, 0, offset))
 }
@@ -93,8 +93,8 @@ pub(super) fn dir_entry_name_len(
 pub(super) fn dir_entry_name_offset(
     context: &mut ImportContext<'_, '_>,
     buf: u64,
-    offset: i32,
-) -> AsyncHostResult<i32> {
+    offset: u32,
+) -> AsyncHostResult<u32> {
     context.host
         .with_c_buffer(buf, |buf| dir::entry_name_offset(buf, 0, offset))
 }
@@ -103,7 +103,7 @@ pub(super) fn dir_entry_name_offset(
 pub(super) fn dir_entry_is_dir(
     context: &mut ImportContext<'_, '_>,
     buf: u64,
-    offset: i32,
+    offset: u32,
 ) -> AsyncHostResult<i32> {
     context.host
         .with_c_buffer(buf, |buf| dir::entry_is_dir(buf, 0, offset))
@@ -113,7 +113,7 @@ pub(super) fn dir_entry_is_dir(
 pub(super) fn dir_entry_is_hidden(
     context: &mut ImportContext<'_, '_>,
     buf: u64,
-    offset: i32,
+    offset: u32,
 ) -> AsyncHostResult<i32> {
     context.host
         .with_c_buffer(buf, |buf| dir::entry_is_hidden(buf, 0, offset))
@@ -124,7 +124,7 @@ pub(super) fn dir_entry_is_hidden(
 pub(super) fn dir_entry_file_id(
     context: &mut ImportContext<'_, '_>,
     buf: u64,
-    offset: i32,
+    offset: u32,
 ) -> AsyncHostResult<u64> {
     context.host
         .with_c_buffer(buf, |buf| dir::entry_file_id(buf, 0, offset))

--- a/crates/moonrun/src/async_api/io.rs
+++ b/crates/moonrun/src/async_api/io.rs
@@ -25,9 +25,9 @@ ported_imports! {
 pub(super) fn read(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
-    dst: i32,
-    offset: i32,
-    len: i32,
+    dst: u32,
+    offset: u32,
+    len: u32,
 ) -> i32 {
     // Unix io/read is the pollable nonblocking path. Regular files are routed
     // through worker jobs, so this borrowed guest slice must not outlive the syscall.
@@ -47,9 +47,9 @@ pub(super) fn read(
 pub(super) fn write(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
-    src: i32,
-    offset: i32,
-    len: i32,
+    src: u32,
+    offset: u32,
+    len: u32,
 ) -> i32 {
     // See io/read: this import is for pollable nonblocking handles, not
     // regular files, and the borrowed guest slice is used only for the syscall.
@@ -71,7 +71,7 @@ pub(super) fn write(
 #[cfg(windows)]
 pub(super) fn make_file_read_io_result(
     context: &mut ImportContext<'_, '_>,
-    len: i32,
+    len: u32,
     position: i64,
 ) -> crate::async_host::AsyncHostResult<u64> {
     context.host.make_file_read_io_result(len, position)
@@ -84,9 +84,9 @@ pub(super) fn make_file_read_io_result(
 #[cfg(windows)]
 pub(super) fn make_file_write_io_result(
     context: &mut ImportContext<'_, '_>,
-    src: i32,
-    offset: i32,
-    len: i32,
+    src: u32,
+    offset: u32,
+    len: u32,
     position: i64,
 ) -> crate::async_host::AsyncHostResult<u64> {
     context.with_host_and_memory_mut(|host, memory| {
@@ -101,7 +101,7 @@ pub(super) fn make_file_write_io_result(
 #[cfg(windows)]
 pub(super) fn make_socket_read_io_result(
     context: &mut ImportContext<'_, '_>,
-    len: i32,
+    len: u32,
     flags: i32,
 ) -> crate::async_host::AsyncHostResult<u64> {
     context.host.make_socket_read_io_result(len, flags)
@@ -114,9 +114,9 @@ pub(super) fn make_socket_read_io_result(
 #[cfg(windows)]
 pub(super) fn make_socket_write_io_result(
     context: &mut ImportContext<'_, '_>,
-    src: i32,
-    offset: i32,
-    len: i32,
+    src: u32,
+    offset: u32,
+    len: u32,
     flags: i32,
 ) -> crate::async_host::AsyncHostResult<u64> {
     context.with_host_and_memory_mut(|host, memory| {
@@ -132,10 +132,10 @@ pub(super) fn make_socket_write_io_result(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_socket_with_addr_read_io_result(
     context: &mut ImportContext<'_, '_>,
-    len: i32,
+    len: u32,
     flags: i32,
-    addr: i32,
-    addr_len: i32,
+    addr: u32,
+    addr_len: u32,
 ) -> crate::async_host::AsyncHostResult<u64> {
     context.with_host_and_memory_mut(|host, memory| {
         host.make_socket_with_addr_read_io_result(memory, len, flags, addr, addr_len)
@@ -150,12 +150,12 @@ pub(super) fn make_socket_with_addr_read_io_result(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_socket_with_addr_write_io_result(
     context: &mut ImportContext<'_, '_>,
-    src: i32,
-    offset: i32,
-    len: i32,
+    src: u32,
+    offset: u32,
+    len: u32,
     flags: i32,
-    addr: i32,
-    addr_len: i32,
+    addr: u32,
+    addr_len: u32,
 ) -> crate::async_host::AsyncHostResult<u64> {
     context.with_host_and_memory_mut(|host, memory| {
         host.make_socket_with_addr_write_io_result(memory, src, offset, len, flags, addr, addr_len)
@@ -169,8 +169,8 @@ pub(super) fn make_socket_with_addr_write_io_result(
 #[cfg(windows)]
 pub(super) fn make_connect_io_result(
     context: &mut ImportContext<'_, '_>,
-    addr: i32,
-    addr_len: i32,
+    addr: u32,
+    addr_len: u32,
 ) -> crate::async_host::AsyncHostResult<u64> {
     context.with_host_and_memory_mut(|host, memory| {
         host.make_connect_io_result(memory, addr, addr_len)
@@ -184,7 +184,7 @@ pub(super) fn make_connect_io_result(
 #[cfg(windows)]
 pub(super) fn make_accept_io_result(
     context: &mut ImportContext<'_, '_>,
-    addr_len: i32,
+    addr_len: u32,
 ) -> crate::async_host::AsyncHostResult<u64> {
     context.host.make_accept_io_result(addr_len)
 }
@@ -197,8 +197,8 @@ pub(super) fn make_accept_io_result(
 pub(super) fn get_accept_peer_addr(
     context: &mut ImportContext<'_, '_>,
     result: u64,
-    dst: i32,
-    dst_len: i32,
+    dst: u32,
+    dst_len: u32,
 ) -> crate::async_host::AsyncHostResult<()> {
     context.with_host_and_memory_mut(|host, memory| {
         host.get_accept_peer_addr(memory, result, dst, dst_len)
@@ -267,9 +267,9 @@ pub(super) fn io_result_get_status(
 pub(super) fn io_result_copy_read(
     context: &mut ImportContext<'_, '_>,
     result: u64,
-    dst: i32,
-    offset: i32,
-    len: i32,
+    dst: u32,
+    offset: u32,
+    len: u32,
 ) -> crate::async_host::AsyncHostResult<()> {
     context.with_host_and_memory_mut(|host, memory| {
         host.io_result_copy_read(memory, result, dst, offset, len)
@@ -281,11 +281,11 @@ pub(super) fn io_result_copy_read(
 pub(super) fn io_result_copy_read_with_addr(
     context: &mut ImportContext<'_, '_>,
     result: u64,
-    dst: i32,
-    offset: i32,
-    len: i32,
-    addr: i32,
-    addr_len: i32,
+    dst: u32,
+    offset: u32,
+    len: u32,
+    addr: u32,
+    addr_len: u32,
 ) -> crate::async_host::AsyncHostResult<()> {
     context.with_host_and_memory_mut(|host, memory| {
         host.io_result_copy_read_with_addr(memory, result, dst, offset, len, addr, addr_len)

--- a/crates/moonrun/src/async_api/os_string.rs
+++ b/crates/moonrun/src/async_api/os_string.rs
@@ -27,8 +27,8 @@ use super::context::ImportContext;
 // Windows OsString preserves the original UTF-16 code units.
 pub(super) fn read_guest(
     context: &mut ImportContext<'_, '_>,
-    ptr: i32,
-    len: i32,
+    ptr: u32,
+    len: u32,
 ) -> AsyncHostResult<OsString> {
     context.with_memory_mut(|memory| {
         let units = read_u16(memory, ptr, len)?;
@@ -56,9 +56,9 @@ fn guest_os_string_from_utf16(units: &[u16]) -> AsyncHostResult<OsString> {
 pub(super) fn decode_len(
     context: &mut ImportContext<'_, '_>,
     ptr: u64,
-    offset: i32,
+    offset: u32,
     len: i32,
-) -> AsyncHostResult<i32> {
+) -> AsyncHostResult<u32> {
     let string = context
         .host
         .with_c_buffer(ptr, |buffer| decode_native_string(buffer, offset, len))?;
@@ -68,27 +68,27 @@ pub(super) fn decode_len(
 pub(super) fn decode(
     context: &mut ImportContext<'_, '_>,
     ptr: u64,
-    offset: i32,
+    offset: u32,
     len: i32,
-    out: i32,
-    out_len: i32,
+    out: u32,
+    out_len: u32,
 ) -> AsyncHostResult<()> {
     let string = context
         .host
         .with_c_buffer(ptr, |buffer| decode_native_string(buffer, offset, len))?;
     let units = string.encode_utf16().collect::<Vec<_>>();
-    let actual_len = i32::try_from(units.len()).map_err(|_| AsyncHostError::Fault)?;
+    let actual_len = u32::try_from(units.len()).map_err(|_| AsyncHostError::Fault)?;
     if actual_len != out_len {
         return Err(AsyncHostError::Inval);
     }
     context.with_memory_mut(|memory| write_u16(memory, out, &units))
 }
 
-fn utf16_len(string: &str) -> AsyncHostResult<i32> {
-    i32::try_from(string.encode_utf16().count()).map_err(|_| AsyncHostError::Fault)
+fn utf16_len(string: &str) -> AsyncHostResult<u32> {
+    u32::try_from(string.encode_utf16().count()).map_err(|_| AsyncHostError::Fault)
 }
 
-fn decode_native_string(bytes: &[u8], offset: i32, len: i32) -> AsyncHostResult<String> {
+fn decode_native_string(bytes: &[u8], offset: u32, len: i32) -> AsyncHostResult<String> {
     let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
     let bytes = bytes.get(offset..).ok_or(AsyncHostError::Fault)?;
     let bytes = native_string_bytes(bytes, len)?;

--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -51,7 +51,7 @@ pub(super) fn get_curr_env(context: &mut ImportContext<'_, '_>) -> AsyncHostResu
 pub(super) fn env_block_length(
     context: &mut ImportContext<'_, '_>,
     env: u64,
-) -> AsyncHostResult<i32> {
+) -> AsyncHostResult<u32> {
     context.host.process_env_length(env)
 }
 
@@ -60,7 +60,7 @@ pub(super) fn env_block_length(
 pub(super) fn env_block_length(
     context: &mut ImportContext<'_, '_>,
     env: u64,
-) -> AsyncHostResult<i32> {
+) -> AsyncHostResult<u32> {
     context.host.process_env_length(env)
 }
 
@@ -68,7 +68,7 @@ pub(super) fn env_block_length(
 #[cfg(unix)]
 pub(super) fn allocate_env_block(
     context: &mut ImportContext<'_, '_>,
-    size: i32,
+    size: u32,
 ) -> AsyncHostResult<u64> {
     let size = usize::try_from(size).map_err(|_| AsyncHostError::Fault)?;
     Ok(context.host.insert_process_env(vec![None; size]))
@@ -78,7 +78,7 @@ pub(super) fn allocate_env_block(
 #[cfg(windows)]
 pub(super) fn allocate_env_block(
     context: &mut ImportContext<'_, '_>,
-    size: i32,
+    size: u32,
 ) -> AsyncHostResult<u64> {
     let size = usize::try_from(size).map_err(|_| AsyncHostError::Fault)?;
     let size = size.checked_add(1).ok_or(AsyncHostError::Fault)?;
@@ -133,11 +133,11 @@ pub(super) fn write_env_block(
 pub(super) fn env_block_add_entry(
     context: &mut ImportContext<'_, '_>,
     env: u64,
-    index: i32,
-    key: i32,
-    key_len: i32,
-    value: i32,
-    value_len: i32,
+    index: u32,
+    key: u32,
+    key_len: u32,
+    value: u32,
+    value_len: u32,
 ) -> AsyncHostResult<()> {
     let key = read_guest_os_string(context, key, key_len)?;
     let value = read_guest_os_string(context, value, value_len)?;
@@ -149,11 +149,11 @@ pub(super) fn env_block_add_entry(
 pub(super) fn env_block_add_entry(
     context: &mut ImportContext<'_, '_>,
     env: u64,
-    offset: i32,
-    key: i32,
-    key_len: i32,
-    value: i32,
-    value_len: i32,
+    offset: u32,
+    key: u32,
+    key_len: u32,
+    value: u32,
+    value_len: u32,
 ) -> AsyncHostResult<()> {
     let key = read_guest_u16(context, key, key_len)?;
     let value = read_guest_u16(context, value, value_len)?;
@@ -198,10 +198,10 @@ pub(super) fn make_env(
 pub(super) fn env_add_entry(
     context: &mut ImportContext<'_, '_>,
     env: u64,
-    key: i32,
-    key_len: i32,
-    value: i32,
-    value_len: i32,
+    key: u32,
+    key_len: u32,
+    value: u32,
+    value_len: u32,
 ) -> AsyncHostResult<()> {
     let key = read_guest_os_string(context, key, key_len)?;
     let value = read_guest_os_string(context, value, value_len)?;
@@ -216,10 +216,10 @@ pub(super) fn env_add_entry(
 pub(super) fn env_add_entry(
     context: &mut ImportContext<'_, '_>,
     env: u64,
-    key: i32,
-    key_len: i32,
-    value: i32,
-    value_len: i32,
+    key: u32,
+    key_len: u32,
+    value: u32,
+    value_len: u32,
 ) -> AsyncHostResult<()> {
     let key = read_guest_os_string(context, key, key_len)?;
     let value = read_guest_os_string(context, value, value_len)?;
@@ -232,7 +232,7 @@ pub(super) fn env_add_entry(
 #[cfg(unix)]
 pub(super) fn make_argv_array_unix(
     context: &mut ImportContext<'_, '_>,
-    len: i32,
+    len: u32,
 ) -> AsyncHostResult<u64> {
     context.host.insert_process_argv(len)
 }
@@ -245,9 +245,9 @@ pub(super) fn make_argv_array_unix(
 pub(super) fn argv_array_add_encoded_entry_unix(
     context: &mut ImportContext<'_, '_>,
     argv: u64,
-    index: i32,
-    arg: i32,
-    arg_len: i32,
+    index: u32,
+    arg: u32,
+    arg_len: u32,
 ) -> AsyncHostResult<()> {
     let arg = read_guest_os_string(context, arg, arg_len)?;
     context.host.process_argv_add_entry(argv, index, arg)
@@ -258,9 +258,9 @@ pub(super) fn argv_array_add_encoded_entry_unix(
 pub(super) fn argv_array_add_entry_unix(
     context: &mut ImportContext<'_, '_>,
     argv: u64,
-    index: i32,
-    arg: i32,
-    arg_len: i32,
+    index: u32,
+    arg: u32,
+    arg_len: u32,
 ) -> AsyncHostResult<()> {
     let arg = read_guest_os_string(context, arg, arg_len)?;
     context.host.process_argv_add_entry(argv, index, arg)
@@ -325,7 +325,7 @@ pub(super) fn get_process_result(
     context: &mut ImportContext<'_, '_>,
     handle: u64,
     pid: i32,
-    out: i32,
+    out: u32,
 ) -> i32 {
     let result = (|| {
         let handle_id = if handle == INVALID_HOST_HANDLE || handle == context.host.invalid_fd() {
@@ -543,8 +543,8 @@ fn windows_env_block(entries: Vec<OsString>) -> Vec<u16> {
 #[cfg(windows)]
 fn read_guest_u16(
     context: &mut ImportContext<'_, '_>,
-    ptr: i32,
-    len: i32,
+    ptr: u32,
+    len: u32,
 ) -> AsyncHostResult<Vec<u16>> {
     context.with_memory_mut(|memory| read_u16(memory, ptr, len))
 }

--- a/crates/moonrun/src/async_api/random.rs
+++ b/crates/moonrun/src/async_api/random.rs
@@ -22,7 +22,7 @@ use crate::async_host::{AsyncHostError, GuestMemory};
 
 use super::context::ImportContext;
 
-pub(super) fn fill(context: &mut ImportContext<'_, '_>, buffer: i32, length: i32) -> i32 {
+pub(super) fn fill(context: &mut ImportContext<'_, '_>, buffer: u32, length: u32) -> i32 {
     let result = context.with_memory_mut(|memory| {
         let destination = memory.read_exact_mut(buffer, length)?;
         OsRng.try_fill_bytes(destination).map_err(|error| {

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -76,7 +76,11 @@ macro_rules! import_kind {
 
 #[cfg(test)]
 macro_rules! wasm_type {
+    // Wasm integer types are signless, so both Rust types map to the same ABI.
     (i32) => {
+        WasmType::I32
+    };
+    (u32) => {
         WasmType::I32
     };
     (i64) => {
@@ -100,6 +104,9 @@ macro_rules! wasm_result {
 macro_rules! decode_wasm_arg {
     ($args:ident, i32) => {
         $args.next_i32()
+    };
+    ($args:ident, u32) => {
+        $args.next_u32()
     };
     ($args:ident, i64) => {
         $args.next_i64()
@@ -139,6 +146,9 @@ macro_rules! finish_wasm_import {
         $result.finish_void($scope, &mut $ret, $name)
     };
     ($scope:ident, $ret:ident, $name:expr, i32, $result:expr) => {
+        $result.finish_i32($scope, &mut $ret, $name)
+    };
+    ($scope:ident, $ret:ident, $name:expr, u32, $result:expr) => {
         $result.finish_i32($scope, &mut $ret, $name)
     };
     ($scope:ident, $ret:ident, $name:expr, i64, $result:expr) => {
@@ -331,7 +341,7 @@ declare_async_imports! {
 
     ported event_bus::wait(bus: u64, timeout_ms: i32) -> i32 => "event_bus/wait";
 
-    ported event_bus::get_event(bus: u64, index: i32) -> u64 => "event_bus/get_event";
+    ported event_bus::get_event(bus: u64, index: u32) -> u64 => "event_bus/get_event";
 
     ported event_bus::event_fd(event: u64) -> u64 => "event_bus/event_fd";
 
@@ -354,10 +364,10 @@ declare_async_imports! {
     fake event_bus::event_io_result(event: u64) -> u64 => "event_bus/event_io_result/windows";
 
     #[cfg(windows)]
-    ported event_bus::event_bytes_transferred(event: u64) -> i32 => "event_bus/event_bytes_transferred/windows";
+    ported event_bus::event_bytes_transferred(event: u64) -> u32 => "event_bus/event_bytes_transferred/windows";
 
     #[cfg(not(windows))]
-    fake event_bus::event_bytes_transferred(event: u64) -> i32 => "event_bus/event_bytes_transferred/windows";
+    fake event_bus::event_bytes_transferred(event: u64) -> u32 => "event_bus/event_bytes_transferred/windows";
 
     ported event_loop::errno_is_cancelled(errno: i32) -> i32 => "thread_pool/errno_is_cancelled";
 
@@ -384,10 +394,10 @@ declare_async_imports! {
     helper thread_pool::destroy_thread_pool() -> void => "thread_pool/destroy_thread_pool";
 
     #[cfg(unix)]
-    helper thread_pool::fetch_completion(source_fd: u64, dst: i32, max_jobs: i32) -> i32 => "thread_pool/fetch_completion/unix";
+    helper thread_pool::fetch_completion(source_fd: u64, dst: u32, max_jobs: u32) -> i32 => "thread_pool/fetch_completion/unix";
 
     #[cfg(windows)]
-    fake thread_pool::fetch_completion(source_fd: u64, dst: i32, max_jobs: i32) -> i32 => "thread_pool/fetch_completion/unix";
+    fake thread_pool::fetch_completion(source_fd: u64, dst: u32, max_jobs: u32) -> i32 => "thread_pool/fetch_completion/unix";
 
     ported thread_pool::make_sleep_job(duration_ms: i32) -> u64 => "thread_pool/make_sleep_job";
 
@@ -396,7 +406,7 @@ declare_async_imports! {
 
     // Cryptographically secure random bytes. Like the other native-style
     // helpers, this returns 0 on success and -1 after recording errno.
-    helper random::fill(buffer: i32, length: i32) -> i32 => "random/fill";
+    helper random::fill(buffer: u32, length: u32) -> i32 => "random/fill";
 
     // os_error/stub.c predicates, errno accessors, and string formatting.
     ported os_error::get_errno() -> i32 => "os_error/get_errno";
@@ -424,9 +434,9 @@ declare_async_imports! {
     helper os_error::free_errno_str(ptr: u64) -> void => "os_error/free_errno_str";
 
     // Decode host-native strings into guest-owned MoonBit String storage.
-    helper os_string::decode_len(ptr: u64, offset: i32, len: i32) -> i32 => "os_string/decode_len";
+    helper os_string::decode_len(ptr: u64, offset: u32, len: i32) -> u32 => "os_string/decode_len";
 
-    helper os_string::decode(ptr: u64, offset: i32, len: i32, out: i32, out_len: i32) -> void => "os_string/decode";
+    helper os_string::decode(ptr: u64, offset: u32, len: i32, out: u32, out_len: u32) -> void => "os_string/decode";
 
     helper fs::close_fd(fd: u64) -> i32 => "fd_util/close_fd";
 
@@ -434,13 +444,13 @@ declare_async_imports! {
 
     helper stdio::get_stdio_handle(id: i32) -> u64 => "stdio/get_stdio_handle";
 
-    helper signal::get_signal_by_index(index: i32) -> i32 => "signal/get_signal_by_index";
+    helper signal::get_signal_by_index(index: u32) -> i32 => "signal/get_signal_by_index";
 
     ported signal::set_global_cancellation_signals(
-        all_signals: i32,
-        all_signals_len: i32,
-        signals: i32,
-        signals_len: i32,
+        all_signals: u32,
+        all_signals_len: u32,
+        signals: u32,
+        signals_len: u32,
     ) -> void => "signal/set_global_cancellation_signals";
 
     #[cfg(windows)]
@@ -453,16 +463,16 @@ declare_async_imports! {
 
     #[cfg(unix)]
     ported fd_util::pipe(
-        dst: i32,
-        len: i32,
+        dst: u32,
+        len: u32,
         read_end_is_async: i32,
         write_end_is_async: i32,
     ) -> i32 => "fd_util/pipe";
 
     #[cfg(windows)]
     helper fd_util::pipe(
-        dst: i32,
-        len: i32,
+        dst: u32,
+        len: u32,
         read_end_is_async: i32,
         write_end_is_async: i32,
     ) -> i32 => "fd_util/pipe";
@@ -471,42 +481,42 @@ declare_async_imports! {
 
     helper fd_util::set_cloexec(fd: u64) -> i32 => "fd_util/set_cloexec";
 
-    helper fd_util::sizeof_file_time() -> i32 => "fd_util/sizeof_file_time";
+    helper fd_util::sizeof_file_time() -> u32 => "fd_util/sizeof_file_time";
 
-    ported fd_util::get_atime_sec(ptr: i32) -> i64 => "fd_util/get_atime_sec";
+    ported fd_util::get_atime_sec(ptr: u32) -> i64 => "fd_util/get_atime_sec";
 
-    ported fd_util::get_atime_nsec(ptr: i32) -> i32 => "fd_util/get_atime_nsec";
+    ported fd_util::get_atime_nsec(ptr: u32) -> i32 => "fd_util/get_atime_nsec";
 
-    ported fd_util::get_mtime_sec(ptr: i32) -> i64 => "fd_util/get_mtime_sec";
+    ported fd_util::get_mtime_sec(ptr: u32) -> i64 => "fd_util/get_mtime_sec";
 
-    ported fd_util::get_mtime_nsec(ptr: i32) -> i32 => "fd_util/get_mtime_nsec";
+    ported fd_util::get_mtime_nsec(ptr: u32) -> i32 => "fd_util/get_mtime_nsec";
 
-    ported fd_util::get_ctime_sec(ptr: i32) -> i64 => "fd_util/get_ctime_sec";
+    ported fd_util::get_ctime_sec(ptr: u32) -> i64 => "fd_util/get_ctime_sec";
 
-    ported fd_util::get_ctime_nsec(ptr: i32) -> i32 => "fd_util/get_ctime_nsec";
+    ported fd_util::get_ctime_nsec(ptr: u32) -> i32 => "fd_util/get_ctime_nsec";
 
     // Small internal utility stubs.
     ported env_util::getpid() -> i32 => "env_util/getpid";
 
     #[cfg(unix)]
-    ported io::read(fd: u64, dst: i32, offset: i32, len: i32) -> i32 => "io/read/unix";
+    ported io::read(fd: u64, dst: u32, offset: u32, len: u32) -> i32 => "io/read/unix";
 
     #[cfg(windows)]
-    fake io::read(fd: u64, dst: i32, offset: i32, len: i32) -> i32 => "io/read/unix";
+    fake io::read(fd: u64, dst: u32, offset: u32, len: u32) -> i32 => "io/read/unix";
 
     #[cfg(unix)]
-    ported io::write(fd: u64, src: i32, offset: i32, len: i32) -> i32 => "io/write/unix";
+    ported io::write(fd: u64, src: u32, offset: u32, len: u32) -> i32 => "io/write/unix";
 
     #[cfg(windows)]
-    fake io::write(fd: u64, src: i32, offset: i32, len: i32) -> i32 => "io/write/unix";
+    fake io::write(fd: u64, src: u32, offset: u32, len: u32) -> i32 => "io/write/unix";
 
-    ported socket::ipv4_addr_size() -> i32 => "socket/ipv4_addr_size";
+    ported socket::ipv4_addr_size() -> u32 => "socket/ipv4_addr_size";
 
-    ported socket::ipv6_addr_size() -> i32 => "socket/ipv6_addr_size";
+    ported socket::ipv6_addr_size() -> u32 => "socket/ipv6_addr_size";
 
-    ported socket::init_ip_addr(addr: i32, ip: i32, port: i32) -> void => "socket/init_ip_addr";
+    ported socket::init_ip_addr(addr: u32, ip: u32, port: u32) -> void => "socket/init_ip_addr";
 
-    ported socket::init_ipv6_addr(addr: i32, ip: i32, port: i32, scope_id: i32) -> void => "socket/init_ipv6_addr";
+    ported socket::init_ipv6_addr(addr: u32, ip: u32, port: u32, scope_id: u32) -> void => "socket/init_ipv6_addr";
 
     #[cfg(unix)]
     ported socket::gai_strerror(code: i32) -> u64 => "socket/gai_strerror";
@@ -514,29 +524,29 @@ declare_async_imports! {
     #[cfg(windows)]
     fake socket::gai_strerror(code: i32) -> u64 => "socket/gai_strerror";
 
-    ported socket::ip_addr_get_ip(addr: i32, addr_len: i32) -> i32 => "socket/ip_addr_get_ip";
+    ported socket::ip_addr_get_ip(addr: u32, addr_len: u32) -> u32 => "socket/ip_addr_get_ip";
 
-    ported socket::ip_addr_get_port(addr: i32, addr_len: i32) -> i32 => "socket/ip_addr_get_port";
+    ported socket::ip_addr_get_port(addr: u32, addr_len: u32) -> u32 => "socket/ip_addr_get_port";
 
-    ported socket::addr_is_ipv6(addr: i32, addr_len: i32) -> i32 => "socket/addr_is_ipv6";
+    ported socket::addr_is_ipv6(addr: u32, addr_len: u32) -> i32 => "socket/addr_is_ipv6";
 
-    ported socket::addr_is_multicast(addr: i32, addr_len: i32) -> i32 => "socket/addr_is_multicast";
+    ported socket::addr_is_multicast(addr: u32, addr_len: u32) -> i32 => "socket/addr_is_multicast";
 
-    ported socket::addr_get_ipv6_bytes_offset() -> i32 => "socket/addr_get_ipv6_bytes_offset";
+    ported socket::addr_get_ipv6_bytes_offset() -> u32 => "socket/addr_get_ipv6_bytes_offset";
 
-    helper socket::addr_copy_ipv6_bytes(addr: i32, out: i32, addr_len: i32, len: i32) -> void => "socket/addr_copy_ipv6_bytes";
+    helper socket::addr_copy_ipv6_bytes(addr: u32, out: u32, addr_len: u32, len: u32) -> void => "socket/addr_copy_ipv6_bytes";
 
-    ported socket::addr_get_ipv6_scope_id(addr: i32, addr_len: i32) -> i32 => "socket/addr_get_ipv6_scope_id";
+    ported socket::addr_get_ipv6_scope_id(addr: u32, addr_len: u32) -> u32 => "socket/addr_get_ipv6_scope_id";
 
-    ported socket::addr_is_ipv6_wildcard(addr: i32, addr_len: i32) -> i32 => "socket/addr_is_ipv6_wildcard";
+    ported socket::addr_is_ipv6_wildcard(addr: u32, addr_len: u32) -> i32 => "socket/addr_is_ipv6_wildcard";
 
     helper socket::addrinfo_is_null(addrinfo: u64) -> i32 => "socket/addrinfo_is_null";
 
     helper socket::addrinfo_get_next(addrinfo: u64) -> u64 => "socket/addrinfo_get_next";
 
-    ported socket::addrinfo_addr_size(addrinfo: u64) -> i32 => "socket/addrinfo_addr_size";
+    ported socket::addrinfo_addr_size(addrinfo: u64) -> u32 => "socket/addrinfo_addr_size";
 
-    ported socket::addrinfo_fill_addr(addrinfo: u64, out: i32, port: i32, out_len: i32) -> void => "socket/addrinfo_fill_addr";
+    ported socket::addrinfo_fill_addr(addrinfo: u64, out: u32, port: u32, out_len: u32) -> void => "socket/addrinfo_fill_addr";
 
     helper socket::addrinfo_free(addrinfo: u64) -> void => "socket/addrinfo_free";
 
@@ -544,13 +554,13 @@ declare_async_imports! {
 
     ported socket::make_udp_socket(family: i32, multicast: i32) -> u64 => "socket/make_udp_socket";
 
-    ported socket::join_multicast_group(fd: u64, multi_addr: i32, local_addr: i32, multi_addr_len: i32, local_addr_len: i32) -> i32 => "socket/join_multicast_group";
+    ported socket::join_multicast_group(fd: u64, multi_addr: u32, local_addr: u32, multi_addr_len: u32, local_addr_len: u32) -> i32 => "socket/join_multicast_group";
 
-    ported socket::join_multicast_group_v6(fd: u64, multi_addr: i32, interface_index: i32, multi_addr_len: i32) -> i32 => "socket/join_multicast_group_v6";
+    ported socket::join_multicast_group_v6(fd: u64, multi_addr: u32, interface_index: u32, multi_addr_len: u32) -> i32 => "socket/join_multicast_group_v6";
 
-    ported socket::set_multicast_interface(fd: u64, local_addr: i32, local_addr_len: i32) -> i32 => "socket/set_multicast_interface";
+    ported socket::set_multicast_interface(fd: u64, local_addr: u32, local_addr_len: u32) -> i32 => "socket/set_multicast_interface";
 
-    ported socket::set_multicast_interface_v6(fd: u64, interface_index: i32) -> i32 => "socket/set_multicast_interface_v6";
+    ported socket::set_multicast_interface_v6(fd: u64, interface_index: u32) -> i32 => "socket/set_multicast_interface_v6";
 
     ported socket::set_multicast_ttl(fd: u64, ttl: i32, family: i32) -> i32 => "socket/set_multicast_ttl";
 
@@ -566,35 +576,35 @@ declare_async_imports! {
 
     ported socket::enable_keepalive(fd: u64, keep_idle: i32, keep_count: i32, keep_intvl: i32) -> i32 => "socket/enable_keepalive";
 
-    ported socket::getsockname(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/getsockname";
+    ported socket::getsockname(fd: u64, addr: u32, addr_len: u32) -> i32 => "socket/getsockname";
 
-    ported socket::if_nametoindex(name: i32, name_len: i32) -> i32 => "socket/if_nametoindex";
+    ported socket::if_nametoindex(name: u32, name_len: u32) -> u32 => "socket/if_nametoindex";
 
-    ported socket::if_indextoname(index: i32) -> u64 => "socket/if_indextoname";
+    ported socket::if_indextoname(index: u32) -> u64 => "socket/if_indextoname";
 
-    ported socket::find_ipv6_test_interface() -> i32 => "socket/find_ipv6_test_interface";
+    ported socket::find_ipv6_test_interface() -> u32 => "socket/find_ipv6_test_interface";
 
-    ported socket::udp_client_connect(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/udp_client_connect";
+    ported socket::udp_client_connect(fd: u64, addr: u32, addr_len: u32) -> i32 => "socket/udp_client_connect";
 
-    helper socket::bind(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/bind";
-
-    #[cfg(unix)]
-    ported socket::recvfrom(fd: u64, buf: i32, offset: i32, len: i32, addr: i32, addr_len: i32) -> i32 => "socket/recvfrom/unix";
-
-    #[cfg(windows)]
-    fake socket::recvfrom(fd: u64, buf: i32, offset: i32, len: i32, addr: i32, addr_len: i32) -> i32 => "socket/recvfrom/unix";
+    helper socket::bind(fd: u64, addr: u32, addr_len: u32) -> i32 => "socket/bind";
 
     #[cfg(unix)]
-    ported socket::sendto(fd: u64, buf: i32, offset: i32, len: i32, addr: i32, addr_len: i32) -> i32 => "socket/sendto/unix";
+    ported socket::recvfrom(fd: u64, buf: u32, offset: u32, len: u32, addr: u32, addr_len: u32) -> i32 => "socket/recvfrom/unix";
 
     #[cfg(windows)]
-    fake socket::sendto(fd: u64, buf: i32, offset: i32, len: i32, addr: i32, addr_len: i32) -> i32 => "socket/sendto/unix";
+    fake socket::recvfrom(fd: u64, buf: u32, offset: u32, len: u32, addr: u32, addr_len: u32) -> i32 => "socket/recvfrom/unix";
 
     #[cfg(unix)]
-    ported socket::connect(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/connect/unix";
+    ported socket::sendto(fd: u64, buf: u32, offset: u32, len: u32, addr: u32, addr_len: u32) -> i32 => "socket/sendto/unix";
 
     #[cfg(windows)]
-    fake socket::connect(fd: u64, addr: i32, addr_len: i32) -> i32 => "socket/connect/unix";
+    fake socket::sendto(fd: u64, buf: u32, offset: u32, len: u32, addr: u32, addr_len: u32) -> i32 => "socket/sendto/unix";
+
+    #[cfg(unix)]
+    ported socket::connect(fd: u64, addr: u32, addr_len: u32) -> i32 => "socket/connect/unix";
+
+    #[cfg(windows)]
+    fake socket::connect(fd: u64, addr: u32, addr_len: u32) -> i32 => "socket/connect/unix";
 
     #[cfg(unix)]
     ported socket::getsockerr(fd: u64) -> i32 => "socket/getsockerr/unix";
@@ -603,10 +613,10 @@ declare_async_imports! {
     fake socket::getsockerr(fd: u64) -> i32 => "socket/getsockerr/unix";
 
     #[cfg(unix)]
-    ported socket::accept(fd: u64, addr: i32, addr_len: i32) -> u64 => "socket/accept/unix";
+    ported socket::accept(fd: u64, addr: u32, addr_len: u32) -> u64 => "socket/accept/unix";
 
     #[cfg(windows)]
-    fake socket::accept(fd: u64, addr: i32, addr_len: i32) -> u64 => "socket/accept/unix";
+    fake socket::accept(fd: u64, addr: u32, addr_len: u32) -> u64 => "socket/accept/unix";
 
     #[cfg(windows)]
     ported socket::connect_io_result(fd: u64, result: u64) -> i32 => "socket/connect/windows";
@@ -634,113 +644,113 @@ declare_async_imports! {
 
     #[cfg(windows)]
     ported io::make_file_read_io_result(
-        len: i32,
+        len: u32,
         position: i64,
     ) -> u64 => "io/make_file_read_io_result/windows";
 
     #[cfg(not(windows))]
     fake io::make_file_read_io_result(
-        len: i32,
+        len: u32,
         position: i64,
     ) -> u64 => "io/make_file_read_io_result/windows";
 
     #[cfg(windows)]
     ported io::make_file_write_io_result(
-        src: i32,
-        offset: i32,
-        len: i32,
+        src: u32,
+        offset: u32,
+        len: u32,
         position: i64,
     ) -> u64 => "io/make_file_write_io_result/windows";
 
     #[cfg(not(windows))]
     fake io::make_file_write_io_result(
-        src: i32,
-        offset: i32,
-        len: i32,
+        src: u32,
+        offset: u32,
+        len: u32,
         position: i64,
     ) -> u64 => "io/make_file_write_io_result/windows";
 
     #[cfg(windows)]
     ported io::make_socket_read_io_result(
-        len: i32,
+        len: u32,
         flags: i32,
     ) -> u64 => "io/make_socket_read_io_result/windows";
 
     #[cfg(not(windows))]
     fake io::make_socket_read_io_result(
-        len: i32,
+        len: u32,
         flags: i32,
     ) -> u64 => "io/make_socket_read_io_result/windows";
 
     #[cfg(windows)]
     ported io::make_socket_write_io_result(
-        src: i32,
-        offset: i32,
-        len: i32,
+        src: u32,
+        offset: u32,
+        len: u32,
         flags: i32,
     ) -> u64 => "io/make_socket_write_io_result/windows";
 
     #[cfg(not(windows))]
     fake io::make_socket_write_io_result(
-        src: i32,
-        offset: i32,
-        len: i32,
+        src: u32,
+        offset: u32,
+        len: u32,
         flags: i32,
     ) -> u64 => "io/make_socket_write_io_result/windows";
 
     #[cfg(windows)]
     ported io::make_socket_with_addr_read_io_result(
-        len: i32,
+        len: u32,
         flags: i32,
-        addr: i32,
-        addr_len: i32,
+        addr: u32,
+        addr_len: u32,
     ) -> u64 => "io/make_socket_with_addr_read_io_result/windows";
 
     #[cfg(not(windows))]
     fake io::make_socket_with_addr_read_io_result(
-        len: i32,
+        len: u32,
         flags: i32,
-        addr: i32,
-        addr_len: i32,
+        addr: u32,
+        addr_len: u32,
     ) -> u64 => "io/make_socket_with_addr_read_io_result/windows";
 
     #[cfg(windows)]
     ported io::make_socket_with_addr_write_io_result(
-        src: i32,
-        offset: i32,
-        len: i32,
+        src: u32,
+        offset: u32,
+        len: u32,
         flags: i32,
-        addr: i32,
-        addr_len: i32,
+        addr: u32,
+        addr_len: u32,
     ) -> u64 => "io/make_socket_with_addr_write_io_result/windows";
 
     #[cfg(not(windows))]
     fake io::make_socket_with_addr_write_io_result(
-        src: i32,
-        offset: i32,
-        len: i32,
+        src: u32,
+        offset: u32,
+        len: u32,
         flags: i32,
-        addr: i32,
-        addr_len: i32,
+        addr: u32,
+        addr_len: u32,
     ) -> u64 => "io/make_socket_with_addr_write_io_result/windows";
 
     #[cfg(windows)]
-    ported io::make_connect_io_result(addr: i32, addr_len: i32) -> u64 => "io/make_connect_io_result/windows";
+    ported io::make_connect_io_result(addr: u32, addr_len: u32) -> u64 => "io/make_connect_io_result/windows";
 
     #[cfg(not(windows))]
-    fake io::make_connect_io_result(addr: i32, addr_len: i32) -> u64 => "io/make_connect_io_result/windows";
+    fake io::make_connect_io_result(addr: u32, addr_len: u32) -> u64 => "io/make_connect_io_result/windows";
 
     #[cfg(windows)]
-    ported io::make_accept_io_result(addr_len: i32) -> u64 => "io/make_accept_io_result/windows";
+    ported io::make_accept_io_result(addr_len: u32) -> u64 => "io/make_accept_io_result/windows";
 
     #[cfg(not(windows))]
-    fake io::make_accept_io_result(addr_len: i32) -> u64 => "io/make_accept_io_result/windows";
+    fake io::make_accept_io_result(addr_len: u32) -> u64 => "io/make_accept_io_result/windows";
 
     #[cfg(windows)]
-    ported io::get_accept_peer_addr(result: u64, dst: i32, dst_len: i32) -> void => "io/get_accept_peer_addr/windows";
+    ported io::get_accept_peer_addr(result: u64, dst: u32, dst_len: u32) -> void => "io/get_accept_peer_addr/windows";
 
     #[cfg(not(windows))]
-    fake io::get_accept_peer_addr(result: u64, dst: i32, dst_len: i32) -> void => "io/get_accept_peer_addr/windows";
+    fake io::get_accept_peer_addr(result: u64, dst: u32, dst_len: u32) -> void => "io/get_accept_peer_addr/windows";
 
     #[cfg(windows)]
     ported io::free_io_result(result: u64) -> void => "io/free_io_result/windows";
@@ -767,16 +777,16 @@ declare_async_imports! {
     fake io::io_result_get_status(result: u64, fd: u64) -> i32 => "io/io_result_get_status/windows";
 
     #[cfg(windows)]
-    helper io::io_result_copy_read(result: u64, dst: i32, offset: i32, len: i32) -> void => "io/io_result_copy_read/windows";
+    helper io::io_result_copy_read(result: u64, dst: u32, offset: u32, len: u32) -> void => "io/io_result_copy_read/windows";
 
     #[cfg(not(windows))]
-    fake io::io_result_copy_read(result: u64, dst: i32, offset: i32, len: i32) -> void => "io/io_result_copy_read/windows";
+    fake io::io_result_copy_read(result: u64, dst: u32, offset: u32, len: u32) -> void => "io/io_result_copy_read/windows";
 
     #[cfg(windows)]
-    helper io::io_result_copy_read_with_addr(result: u64, dst: i32, offset: i32, len: i32, addr: i32, addr_len: i32) -> void => "io/io_result_copy_read_with_addr/windows";
+    helper io::io_result_copy_read_with_addr(result: u64, dst: u32, offset: u32, len: u32, addr: u32, addr_len: u32) -> void => "io/io_result_copy_read_with_addr/windows";
 
     #[cfg(not(windows))]
-    fake io::io_result_copy_read_with_addr(result: u64, dst: i32, offset: i32, len: i32, addr: i32, addr_len: i32) -> void => "io/io_result_copy_read_with_addr/windows";
+    fake io::io_result_copy_read_with_addr(result: u64, dst: u32, offset: u32, len: u32, addr: u32, addr_len: u32) -> void => "io/io_result_copy_read_with_addr/windows";
 
     #[cfg(windows)]
     ported io::read_io_result(fd: u64, result: u64) -> i32 => "io/read/windows";
@@ -798,17 +808,17 @@ declare_async_imports! {
 
     helper c_buffer::is_null(ptr: u64) -> i32 => "c_buffer/is_null";
 
-    ported c_buffer::blit_to_c(dst: u64, dst_offset: i32, src: i32, src_offset: i32, len: i32) -> void => "c_buffer/blit_to_c";
+    ported c_buffer::blit_to_c(dst: u64, dst_offset: u32, src: u32, src_offset: u32, len: u32) -> void => "c_buffer/blit_to_c";
 
-    ported c_buffer::blit_from_c(src: u64, src_offset: i32, dst: i32, dst_offset: i32, len: i32) -> void => "c_buffer/blit_from_c";
+    ported c_buffer::blit_from_c(src: u64, src_offset: u32, dst: u32, dst_offset: u32, len: u32) -> void => "c_buffer/blit_from_c";
 
-    ported c_buffer::c_buffer_get(buf: u64, index: i32) -> i32 => "c_buffer/c_buffer_get";
+    ported c_buffer::c_buffer_get(buf: u64, index: u32) -> i32 => "c_buffer/c_buffer_get";
 
-    ported c_buffer::strlen(buf: u64) -> i32 => "c_buffer/strlen";
+    ported c_buffer::strlen(buf: u64) -> u32 => "c_buffer/strlen";
 
-    helper c_buffer::length(buf: u64) -> i32 => "c_buffer/length";
+    helper c_buffer::length(buf: u64) -> u32 => "c_buffer/length";
 
-    ported c_buffer::new(size: i32) -> u64 => "c_buffer/new";
+    ported c_buffer::new(size: u32) -> u64 => "c_buffer/new";
 
     helper c_buffer::free(ptr: u64) -> void => "c_buffer/free";
 
@@ -818,32 +828,32 @@ declare_async_imports! {
 
     ported tls::set_client(
         tls: u64,
-        host: i32,
-        host_len: i32,
+        host: u32,
+        host_len: u32,
         sni: i32,
         trust: i32,
     ) -> i32 => "tls/connection/set_client";
 
     ported tls::add_root_certificate(
         tls: u64,
-        root: i32,
-        root_len: i32,
+        root: u32,
+        root_len: u32,
     ) -> i32 => "tls/connection/add_root_certificate";
 
     ported tls::set_server_files(
         tls: u64,
-        private_key_file: i32,
-        private_key_file_len: i32,
+        private_key_file: u32,
+        private_key_file_len: u32,
         private_key_type_abi: i32,
-        certificate_file: i32,
-        certificate_file_len: i32,
+        certificate_file: u32,
+        certificate_file_len: u32,
         certificate_type_abi: i32,
     ) -> i32 => "tls/connection/set_server_files";
 
     ported tls::set_server_pfx(
         tls: u64,
-        pfx_content: i32,
-        pfx_content_len: i32,
+        pfx_content: u32,
+        pfx_content_len: u32,
     ) -> i32 => "tls/connection/set_server_pfx";
 
     ported tls::free(tls: u64) -> void => "tls/connection/free";
@@ -854,53 +864,53 @@ declare_async_imports! {
 
     ported tls::read_plain(
         tls: u64,
-        in_buffer: i32,
-        in_buffer_offset: i32,
-        in_buffer_len: i32,
-        out_buffer: i32,
-        out_buffer_offset: i32,
-        out_buffer_len: i32,
-        plain_buffer: i32,
-        plain_buffer_offset: i32,
-        plain_buffer_len: i32,
+        in_buffer: u32,
+        in_buffer_offset: u32,
+        in_buffer_len: u32,
+        out_buffer: u32,
+        out_buffer_offset: u32,
+        out_buffer_len: u32,
+        plain_buffer: u32,
+        plain_buffer_offset: u32,
+        plain_buffer_len: u32,
     ) -> i32 => "tls/connection/read_plain";
 
     ported tls::write_plain(
         tls: u64,
-        in_buffer: i32,
-        in_buffer_offset: i32,
-        in_buffer_len: i32,
-        out_buffer: i32,
-        out_buffer_offset: i32,
-        out_buffer_len: i32,
-        plain_buffer: i32,
-        plain_buffer_offset: i32,
-        plain_buffer_len: i32,
+        in_buffer: u32,
+        in_buffer_offset: u32,
+        in_buffer_len: u32,
+        out_buffer: u32,
+        out_buffer_offset: u32,
+        out_buffer_len: u32,
+        plain_buffer: u32,
+        plain_buffer_offset: u32,
+        plain_buffer_len: u32,
     ) -> i32 => "tls/connection/write_plain";
 
     ported tls::connect(
         tls: u64,
-        in_buffer: i32,
-        in_buffer_offset: i32,
-        in_buffer_len: i32,
-        out_buffer: i32,
-        out_buffer_offset: i32,
-        out_buffer_len: i32,
+        in_buffer: u32,
+        in_buffer_offset: u32,
+        in_buffer_len: u32,
+        out_buffer: u32,
+        out_buffer_offset: u32,
+        out_buffer_len: u32,
     ) -> i32 => "tls/connection/connect";
 
     ported tls::accept(
         tls: u64,
-        in_buffer: i32,
-        in_buffer_offset: i32,
-        in_buffer_len: i32,
-        out_buffer: i32,
-        out_buffer_offset: i32,
-        out_buffer_len: i32,
+        in_buffer: u32,
+        in_buffer_offset: u32,
+        in_buffer_len: u32,
+        out_buffer: u32,
+        out_buffer_offset: u32,
+        out_buffer_len: u32,
     ) -> i32 => "tls/connection/accept";
 
-    ported tls::bytes_read(tls: u64) -> i32 => "tls/connection/bytes_read";
+    ported tls::bytes_read(tls: u64) -> u32 => "tls/connection/bytes_read";
 
-    ported tls::bytes_to_write(tls: u64) -> i32 => "tls/connection/bytes_to_write";
+    ported tls::bytes_to_write(tls: u64) -> u32 => "tls/connection/bytes_to_write";
 
     ported tls::wants_read(tls: u64) -> i32 => "tls/connection/wants_read";
 
@@ -927,29 +937,29 @@ declare_async_imports! {
 
     // Writes the native temporary directory as UTF-16 code units into a
     // guest-allocated MoonBit String.
-    ported fs::get_tmp_path(ptr: i32, len: i32) -> i32 => "fs/get_tmp_path";
+    ported fs::get_tmp_path(ptr: u32, len: u32) -> i32 => "fs/get_tmp_path";
 
     helper fs::get_tmp_path_buffer() -> u64 => "fs/get_tmp_path_buffer";
 
-    ported fs::dir_buffer_min_size() -> i32 => "fs/dir_buffer_min_size";
+    ported fs::dir_buffer_min_size() -> u32 => "fs/dir_buffer_min_size";
 
-    ported fs::dir_entry_length(buf: u64, offset: i32) -> i32 => "fs/dir_entry_length";
+    ported fs::dir_entry_length(buf: u64, offset: u32) -> u32 => "fs/dir_entry_length";
 
-    ported fs::dir_entry_name_len(buf: u64, offset: i32) -> i32 => "fs/dir_entry_get_name_len";
+    ported fs::dir_entry_name_len(buf: u64, offset: u32) -> u32 => "fs/dir_entry_get_name_len";
 
-    ported fs::dir_entry_name_offset(buf: u64, offset: i32) -> i32 => "fs/dir_entry_get_name_offset";
+    ported fs::dir_entry_name_offset(buf: u64, offset: u32) -> u32 => "fs/dir_entry_get_name_offset";
 
-    ported fs::dir_entry_is_dir(buf: u64, offset: i32) -> i32 => "fs/dir_entry_is_dir";
+    ported fs::dir_entry_is_dir(buf: u64, offset: u32) -> i32 => "fs/dir_entry_is_dir";
 
-    ported fs::dir_entry_is_hidden(buf: u64, offset: i32) -> i32 => "fs/dir_entry_is_hidden";
+    ported fs::dir_entry_is_hidden(buf: u64, offset: u32) -> i32 => "fs/dir_entry_is_hidden";
 
-    ported fs::dir_entry_file_id(buf: u64, offset: i32) -> u64 => "fs/dir_entry_get_file_id";
+    ported fs::dir_entry_file_id(buf: u64, offset: u32) -> u64 => "fs/dir_entry_get_file_id";
 
     // thread_pool.c FS jobs. Path-taking jobs use the Guest String Path ABI:
     // MoonBit String pointer plus UTF-16 code-unit length.
     compat thread_pool::make_open_job_legacy(
-        path_ptr: i32,
-        path_len: i32,
+        path_ptr: u32,
+        path_len: u32,
         access: i32,
         create_mode: i32,
         append: i32,
@@ -958,33 +968,33 @@ declare_async_imports! {
     ) -> u64 => "thread_pool/make_open_job";
 
     ported thread_pool::make_open_stat_job(
-        path_ptr: i32,
-        path_len: i32,
+        path_ptr: u32,
+        path_len: u32,
         access: i32,
         create_mode: i32,
         append: i32,
         sync: i32,
         mode: i32,
         stat_request: i32,
-        stat_result_len: i32,
+        stat_result_len: u32,
     ) -> u64 => "thread_pool/make_open_stat_job";
 
     ported thread_pool::make_fstatx_job(
         fd: u64,
         stat_request: i32,
-        stat_result_len: i32,
+        stat_result_len: u32,
     ) -> u64 => "thread_pool/make_fstatx_job";
 
     ported thread_pool::make_statx_job(
-        path_ptr: i32,
-        path_len: i32,
+        path_ptr: u32,
+        path_len: u32,
         stat_request: i32,
-        stat_result_len: i32,
+        stat_result_len: u32,
         parent: u64,
         follow_symlink: i32,
     ) -> u64 => "thread_pool/make_statx_job";
 
-    helper thread_pool::get_stat_result(job: u64, dst: i32, dst_len: i32) -> void => "thread_pool/get_stat_result";
+    helper thread_pool::get_stat_result(job: u64, dst: u32, dst_len: u32) -> void => "thread_pool/get_stat_result";
 
     ported thread_pool::open_job_get_fd(job: u64) -> u64 => "thread_pool/open_job_get_fd";
 
@@ -994,16 +1004,16 @@ declare_async_imports! {
 
     compat thread_pool::open_job_get_file_id(job: u64) -> u64 => "thread_pool/open_job_get_file_id";
 
-    ported thread_pool::make_read_job(fd: u64, len: i32, position: i64) -> u64 => "thread_pool/make_read_job";
+    ported thread_pool::make_read_job(fd: u64, len: u32, position: i64) -> u64 => "thread_pool/make_read_job";
 
-    ported thread_pool::make_write_job(fd: u64, ptr: i32, offset: i32, len: i32, position: i64) -> u64 => "thread_pool/make_write_job";
+    ported thread_pool::make_write_job(fd: u64, ptr: u32, offset: u32, len: u32, position: i64) -> u64 => "thread_pool/make_write_job";
 
-    helper thread_pool::get_read_result(job: u64, dst: i32, offset: i32, len: i32) -> void => "thread_pool/get_read_result";
+    helper thread_pool::get_read_result(job: u64, dst: u32, offset: u32, len: u32) -> void => "thread_pool/get_read_result";
 
     compat thread_pool::make_file_kind_by_path_job(
         parent: u64,
-        path_ptr: i32,
-        path_len: i32,
+        path_ptr: u32,
+        path_len: u32,
         follow_symlink: i32,
     ) -> u64 => "thread_pool/make_file_kind_by_path_job";
 
@@ -1014,89 +1024,89 @@ declare_async_imports! {
     compat thread_pool::make_file_time_job(fd: u64) -> u64 => "thread_pool/make_file_time_job";
 
     compat thread_pool::make_file_time_by_path_job(
-        path_ptr: i32,
-        path_len: i32,
+        path_ptr: u32,
+        path_len: u32,
         follow_symlink: i32,
     ) -> u64 => "thread_pool/make_file_time_by_path_job";
 
-    helper thread_pool::get_file_time_result(job: u64, out: i32) -> void => "thread_pool/get_file_time_result";
+    helper thread_pool::get_file_time_result(job: u64, out: u32) -> void => "thread_pool/get_file_time_result";
 
-    ported thread_pool::make_access_job(path_ptr: i32, path_len: i32, access: i32) -> u64 => "thread_pool/make_access_job";
+    ported thread_pool::make_access_job(path_ptr: u32, path_len: u32, access: i32) -> u64 => "thread_pool/make_access_job";
 
-    ported thread_pool::make_chmod_job(path_ptr: i32, path_len: i32, mode: i32) -> u64 => "thread_pool/make_chmod_job";
+    ported thread_pool::make_chmod_job(path_ptr: u32, path_len: u32, mode: i32) -> u64 => "thread_pool/make_chmod_job";
 
     ported thread_pool::make_fsync_job(fd: u64, only_data: i32) -> u64 => "thread_pool/make_fsync_job";
 
     ported thread_pool::make_flock_job(fd: u64, exclusive: i32) -> u64 => "thread_pool/make_flock_job";
 
-    ported thread_pool::make_remove_job(path_ptr: i32, path_len: i32) -> u64 => "thread_pool/make_remove_job";
+    ported thread_pool::make_remove_job(path_ptr: u32, path_len: u32) -> u64 => "thread_pool/make_remove_job";
 
     ported thread_pool::make_rename_job(
-        old_path_ptr: i32,
-        old_path_len: i32,
-        new_path_ptr: i32,
-        new_path_len: i32,
+        old_path_ptr: u32,
+        old_path_len: u32,
+        new_path_ptr: u32,
+        new_path_len: u32,
         replace: i32,
     ) -> u64 => "thread_pool/make_rename_job";
 
     ported thread_pool::make_symlink_job(
-        target_ptr: i32,
-        target_len: i32,
-        path_ptr: i32,
-        path_len: i32,
+        target_ptr: u32,
+        target_len: u32,
+        path_ptr: u32,
+        path_len: u32,
         force_symlink: i32,
     ) -> u64 => "thread_pool/make_symlink_job";
 
-    ported thread_pool::make_mkdir_job(path_ptr: i32, path_len: i32, mode: i32) -> u64 => "thread_pool/make_mkdir_job";
+    ported thread_pool::make_mkdir_job(path_ptr: u32, path_len: u32, mode: i32) -> u64 => "thread_pool/make_mkdir_job";
 
-    ported thread_pool::make_rmdir_job(path_ptr: i32, path_len: i32) -> u64 => "thread_pool/make_rmdir_job";
+    ported thread_pool::make_rmdir_job(path_ptr: u32, path_len: u32) -> u64 => "thread_pool/make_rmdir_job";
 
-    ported thread_pool::make_readdir_job(dir: u64, buf: u64, len: i32, restart: i32) -> u64 => "thread_pool/make_readdir_job";
+    ported thread_pool::make_readdir_job(dir: u64, buf: u64, len: u32, restart: i32) -> u64 => "thread_pool/make_readdir_job";
 
-    ported thread_pool::make_bind_job(socket: u64, addr: i32, addr_len: i32) -> u64 => "thread_pool/make_bind_job";
+    ported thread_pool::make_bind_job(socket: u64, addr: u32, addr_len: u32) -> u64 => "thread_pool/make_bind_job";
 
-    ported thread_pool::make_getaddrinfo_job(host: i32, host_len: i32) -> u64 => "thread_pool/make_getaddrinfo_job";
+    ported thread_pool::make_getaddrinfo_job(host: u32, host_len: u32) -> u64 => "thread_pool/make_getaddrinfo_job";
 
     helper thread_pool::get_getaddrinfo_result(job: u64) -> u64 => "thread_pool/get_getaddrinfo_result";
 
-    ported thread_pool::make_realpath_job(path_ptr: i32, path_len: i32) -> u64 => "thread_pool/make_realpath_job";
+    ported thread_pool::make_realpath_job(path_ptr: u32, path_len: u32) -> u64 => "thread_pool/make_realpath_job";
 
     ported thread_pool::get_realpath_result(job: u64) -> u64 => "thread_pool/get_realpath_result";
 
     #[cfg(unix)]
     compat thread_pool::make_spawn_job_unix(
-        path: i32,
-        path_len: i32,
+        path: u32,
+        path_len: u32,
         args: u64,
         env: u64,
-        inherited_env_entry_count: i32,
+        inherited_env_entry_count: u32,
         stdin: u64,
         stdout: u64,
         stderr: u64,
-        cwd: i32,
-        cwd_len: i32,
+        cwd: u32,
+        cwd_len: u32,
         has_cwd: i32,
     ) -> u64 => "thread_pool/make_spawn_job/unix";
 
     #[cfg(windows)]
     fake thread_pool::make_spawn_job_unix(
-        path: i32,
-        path_len: i32,
+        path: u32,
+        path_len: u32,
         args: u64,
         env: u64,
-        inherited_env_entry_count: i32,
+        inherited_env_entry_count: u32,
         stdin: u64,
         stdout: u64,
         stderr: u64,
-        cwd: i32,
-        cwd_len: i32,
+        cwd: u32,
+        cwd_len: u32,
         has_cwd: i32,
     ) -> u64 => "thread_pool/make_spawn_job/unix";
 
     #[cfg(unix)]
     ported thread_pool::spawn_job_unix(
-        path: i32,
-        path_len: i32,
+        path: u32,
+        path_len: u32,
         args: u64,
         env: u64,
         stdin: u64,
@@ -1106,8 +1116,8 @@ declare_async_imports! {
 
     #[cfg(windows)]
     fake thread_pool::spawn_job_unix(
-        path: i32,
-        path_len: i32,
+        path: u32,
+        path_len: u32,
         args: u64,
         env: u64,
         stdin: u64,
@@ -1117,14 +1127,14 @@ declare_async_imports! {
 
     #[cfg(windows)]
     compat thread_pool::make_spawn_job_windows(
-        command_line: i32,
-        command_line_len: i32,
+        command_line: u32,
+        command_line_len: u32,
         env: u64,
         stdin: u64,
         stdout: u64,
         stderr: u64,
-        cwd: i32,
-        cwd_len: i32,
+        cwd: u32,
+        cwd_len: u32,
         has_cwd: i32,
         no_console_window: i32,
         is_orphan: i32,
@@ -1132,14 +1142,14 @@ declare_async_imports! {
 
     #[cfg(unix)]
     fake thread_pool::make_spawn_job_windows(
-        command_line: i32,
-        command_line_len: i32,
+        command_line: u32,
+        command_line_len: u32,
         env: u64,
         stdin: u64,
         stdout: u64,
         stderr: u64,
-        cwd: i32,
-        cwd_len: i32,
+        cwd: u32,
+        cwd_len: u32,
         has_cwd: i32,
         no_console_window: i32,
         is_orphan: i32,
@@ -1147,8 +1157,8 @@ declare_async_imports! {
 
     #[cfg(windows)]
     ported thread_pool::spawn_job_windows(
-        command_line: i32,
-        command_line_len: i32,
+        command_line: u32,
+        command_line_len: u32,
         env: u64,
         stdin: u64,
         stdout: u64,
@@ -1158,8 +1168,8 @@ declare_async_imports! {
 
     #[cfg(unix)]
     fake thread_pool::spawn_job_windows(
-        command_line: i32,
-        command_line_len: i32,
+        command_line: u32,
+        command_line_len: u32,
         env: u64,
         stdin: u64,
         stdout: u64,
@@ -1169,8 +1179,8 @@ declare_async_imports! {
 
     ported thread_pool::spawn_job_set_cwd(
         job: u64,
-        cwd: i32,
-        cwd_len: i32,
+        cwd: u32,
+        cwd_len: u32,
     ) -> void => "thread_pool/spawn_job/set_cwd";
 
     #[cfg(windows)]
@@ -1190,16 +1200,16 @@ declare_async_imports! {
     ported thread_pool::make_wait_for_process_job(handle: u64, pid: i32) -> u64 => "thread_pool/make_wait_for_process_job";
 
     #[cfg(unix)]
-    ported thread_pool::make_sigwait_job(signals: i32, signals_len: i32) -> u64 => "thread_pool/make_sigwait_job";
+    ported thread_pool::make_sigwait_job(signals: u32, signals_len: u32) -> u64 => "thread_pool/make_sigwait_job";
 
     #[cfg(windows)]
-    fake thread_pool::make_sigwait_job(signals: i32, signals_len: i32) -> u64 => "thread_pool/make_sigwait_job";
+    fake thread_pool::make_sigwait_job(signals: u32, signals_len: u32) -> u64 => "thread_pool/make_sigwait_job";
 
     helper process::get_curr_env() -> u64 => "process/get_curr_env";
 
-    helper process::env_block_length(env: u64) -> i32 => "process/env_block_length";
+    helper process::env_block_length(env: u64) -> u32 => "process/env_block_length";
 
-    helper process::allocate_env_block(size: i32) -> u64 => "process/allocate_env_block";
+    helper process::allocate_env_block(size: u32) -> u64 => "process/allocate_env_block";
 
     compat process::free_env(env: u64) -> void => "process/free_env";
 
@@ -1207,28 +1217,28 @@ declare_async_imports! {
 
     helper process::env_block_add_entry(
         env: u64,
-        index_or_offset: i32,
-        key: i32,
-        key_len: i32,
-        value: i32,
-        value_len: i32,
+        index_or_offset: u32,
+        key: u32,
+        key_len: u32,
+        value: u32,
+        value_len: u32,
     ) -> void => "process/env_block_add_entry";
 
     helper process::make_env(inherit_env: i32) -> u64 => "process/make_env";
 
     ported process::env_add_entry(
         env: u64,
-        key: i32,
-        key_len: i32,
-        value: i32,
-        value_len: i32,
+        key: u32,
+        key_len: u32,
+        value: u32,
+        value_len: u32,
     ) -> void => "process/env_add_entry";
 
     #[cfg(unix)]
-    helper process::make_argv_array_unix(len: i32) -> u64 => "process/make_argv_array/unix";
+    helper process::make_argv_array_unix(len: u32) -> u64 => "process/make_argv_array/unix";
 
     #[cfg(windows)]
-    fake process::make_argv_array_unix(len: i32) -> u64 => "process/make_argv_array/unix";
+    fake process::make_argv_array_unix(len: u32) -> u64 => "process/make_argv_array/unix";
 
     #[cfg(unix)]
     compat process::free_argv(argv: u64) -> void => "process/free_argv";
@@ -1239,38 +1249,38 @@ declare_async_imports! {
     #[cfg(unix)]
     helper process::argv_array_add_encoded_entry_unix(
         argv: u64,
-        index: i32,
-        arg: i32,
-        arg_len: i32,
+        index: u32,
+        arg: u32,
+        arg_len: u32,
     ) -> void => "process/argv_array_add_encoded_entry/unix";
 
     #[cfg(windows)]
     fake process::argv_array_add_encoded_entry_unix(
         argv: u64,
-        index: i32,
-        arg: i32,
-        arg_len: i32,
+        index: u32,
+        arg: u32,
+        arg_len: u32,
     ) -> void => "process/argv_array_add_encoded_entry/unix";
 
     #[cfg(unix)]
     helper process::argv_array_add_entry_unix(
         argv: u64,
-        index: i32,
-        arg: i32,
-        arg_len: i32,
+        index: u32,
+        arg: u32,
+        arg_len: u32,
     ) -> void => "process/argv_array_add_entry/unix";
 
     #[cfg(windows)]
     fake process::argv_array_add_entry_unix(
         argv: u64,
-        index: i32,
-        arg: i32,
-        arg_len: i32,
+        index: u32,
+        arg: u32,
+        arg_len: u32,
     ) -> void => "process/argv_array_add_entry/unix";
 
     helper process::open_pid_handle(pid: i32) -> u64 => "process/open_pid_handle";
 
-    ported process::get_process_result(handle: u64, pid: i32, out: i32) -> i32 => "process/get_process_result";
+    ported process::get_process_result(handle: u64, pid: i32, out: u32) -> i32 => "process/get_process_result";
 
     ported process::terminate(pid: i32, signal: i32) -> void => "process/terminate";
 

--- a/crates/moonrun/src/async_api/signal.rs
+++ b/crates/moonrun/src/async_api/signal.rs
@@ -26,7 +26,7 @@ use super::provenance::ported_imports;
 ported_imports! {
 pub(super) fn get_signal_by_index(
     _context: &mut ImportContext<'_, '_>,
-    index: i32,
+    index: u32,
 ) -> i32 {
     signal::get_signal_by_index(index)
 }
@@ -35,10 +35,10 @@ pub(super) fn get_signal_by_index(
 #[cfg(any(unix, windows))]
 pub(super) fn set_global_cancellation_signals(
     context: &mut ImportContext<'_, '_>,
-    all_signals: i32,
-    all_signals_len: i32,
-    signals: i32,
-    signals_len: i32,
+    all_signals: u32,
+    all_signals_len: u32,
+    signals: u32,
+    signals_len: u32,
 ) -> crate::async_host::AsyncHostResult<()> {
     let all_signals = context.with_memory_mut(|memory| read_i32_array(memory, all_signals, all_signals_len))?;
     let signals = context.with_memory_mut(|memory| read_i32_array(memory, signals, signals_len))?;
@@ -63,8 +63,8 @@ pub(super) fn set_console_control_handler(
 #[cfg(any(unix, windows))]
 fn read_i32_array(
     memory: &(impl GuestMemory + ?Sized),
-    offset: i32,
-    len: i32,
+    offset: u32,
+    len: u32,
 ) -> crate::async_host::AsyncHostResult<Vec<i32>> {
     let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
     let byte_len = len
@@ -72,7 +72,7 @@ fn read_i32_array(
         .ok_or(AsyncHostError::Fault)?;
     let bytes = memory.read_exact(
         offset,
-        i32::try_from(byte_len).map_err(|_| AsyncHostError::Fault)?,
+        u32::try_from(byte_len).map_err(|_| AsyncHostError::Fault)?,
     )?;
     Ok(bytes
         .chunks_exact(std::mem::size_of::<i32>())

--- a/crates/moonrun/src/async_api/socket.rs
+++ b/crates/moonrun/src/async_api/socket.rs
@@ -31,21 +31,21 @@ use super::provenance::ported_imports;
 
 ported_imports! {
 #[ported(source = "src/socket/socket.c")]
-pub(super) fn ipv4_addr_size(_context: &mut ImportContext<'_, '_>) -> i32 {
+pub(super) fn ipv4_addr_size(_context: &mut ImportContext<'_, '_>) -> u32 {
     sys::ipv4_addr_size()
 }
 
 #[ported(source = "src/socket/socket.c")]
-pub(super) fn ipv6_addr_size(_context: &mut ImportContext<'_, '_>) -> i32 {
+pub(super) fn ipv6_addr_size(_context: &mut ImportContext<'_, '_>) -> u32 {
     sys::ipv6_addr_size()
 }
 
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn init_ip_addr(
     context: &mut ImportContext<'_, '_>,
-    addr: i32,
-    ip: i32,
-    port: i32,
+    addr: u32,
+    ip: u32,
+    port: u32,
 ) -> AsyncHostResult<()> {
     context.with_memory_mut(|memory| {
         let addr_len = sys::ipv4_addr_size();
@@ -57,10 +57,10 @@ pub(super) fn init_ip_addr(
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn init_ipv6_addr(
     context: &mut ImportContext<'_, '_>,
-    addr: i32,
-    ip: i32,
-    port: i32,
-    scope_id: i32,
+    addr: u32,
+    ip: u32,
+    port: u32,
+    scope_id: u32,
 ) -> AsyncHostResult<()> {
     context.with_memory_mut(|memory| {
         let ip = memory.read_exact(ip, 16)?.to_vec();
@@ -79,9 +79,9 @@ pub(super) fn gai_strerror(context: &mut ImportContext<'_, '_>, code: i32) -> u6
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn ip_addr_get_ip(
     context: &mut ImportContext<'_, '_>,
-    addr: i32,
-    addr_len: i32,
-) -> AsyncHostResult<i32> {
+    addr: u32,
+    addr_len: u32,
+) -> AsyncHostResult<u32> {
     context.with_memory_mut(|memory| {
         let addr = memory.read_exact(addr, addr_len)?;
         sys::ip_addr_get_ip(addr)
@@ -91,9 +91,9 @@ pub(super) fn ip_addr_get_ip(
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn ip_addr_get_port(
     context: &mut ImportContext<'_, '_>,
-    addr: i32,
-    addr_len: i32,
-) -> AsyncHostResult<i32> {
+    addr: u32,
+    addr_len: u32,
+) -> AsyncHostResult<u32> {
     context.with_memory_mut(|memory| {
         let addr = memory.read_exact(addr, addr_len)?;
         sys::ip_addr_get_port(addr)
@@ -103,8 +103,8 @@ pub(super) fn ip_addr_get_port(
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn addr_is_ipv6(
     context: &mut ImportContext<'_, '_>,
-    addr: i32,
-    addr_len: i32,
+    addr: u32,
+    addr_len: u32,
 ) -> AsyncHostResult<i32> {
     context
         .with_memory_mut(|memory| {
@@ -117,8 +117,8 @@ pub(super) fn addr_is_ipv6(
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn addr_is_multicast(
     context: &mut ImportContext<'_, '_>,
-    addr: i32,
-    addr_len: i32,
+    addr: u32,
+    addr_len: u32,
 ) -> AsyncHostResult<i32> {
     context
         .with_memory_mut(|memory| {
@@ -129,16 +129,16 @@ pub(super) fn addr_is_multicast(
 }
 
 #[ported(source = "src/socket/socket.c")]
-pub(super) fn addr_get_ipv6_bytes_offset(_context: &mut ImportContext<'_, '_>) -> i32 {
+pub(super) fn addr_get_ipv6_bytes_offset(_context: &mut ImportContext<'_, '_>) -> u32 {
     sys::addr_get_ipv6_bytes_offset()
 }
 
 pub(super) fn addr_copy_ipv6_bytes(
     context: &mut ImportContext<'_, '_>,
-    addr: i32,
-    out: i32,
-    addr_len: i32,
-    len: i32,
+    addr: u32,
+    out: u32,
+    addr_len: u32,
+    len: u32,
 ) -> AsyncHostResult<()> {
     context.with_memory_mut(|memory| {
         let addr = memory.read_exact(addr, addr_len)?;
@@ -160,9 +160,9 @@ pub(super) fn addr_copy_ipv6_bytes(
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn addr_get_ipv6_scope_id(
     context: &mut ImportContext<'_, '_>,
-    addr: i32,
-    addr_len: i32,
-) -> AsyncHostResult<i32> {
+    addr: u32,
+    addr_len: u32,
+) -> AsyncHostResult<u32> {
     context.with_memory_mut(|memory| {
         let addr = memory.read_exact(addr, addr_len)?;
         sys::addr_get_ipv6_scope_id(addr)
@@ -172,8 +172,8 @@ pub(super) fn addr_get_ipv6_scope_id(
 #[ported(source = "src/socket/socket.c")]
 pub(super) fn addr_is_ipv6_wildcard(
     context: &mut ImportContext<'_, '_>,
-    addr: i32,
-    addr_len: i32,
+    addr: u32,
+    addr_len: u32,
 ) -> AsyncHostResult<i32> {
     context
         .with_memory_mut(|memory| {
@@ -198,7 +198,7 @@ pub(super) fn addrinfo_get_next(
 pub(super) fn addrinfo_addr_size(
     context: &mut ImportContext<'_, '_>,
     addrinfo: u64,
-) -> AsyncHostResult<i32> {
+) -> AsyncHostResult<u32> {
     if addrinfo == crate::async_host::INVALID_HOST_HANDLE {
         return Ok(0);
     }
@@ -210,9 +210,9 @@ pub(super) fn addrinfo_addr_size(
 pub(super) fn addrinfo_fill_addr(
     context: &mut ImportContext<'_, '_>,
     addrinfo: u64,
-    out: i32,
-    port: i32,
-    out_len: i32,
+    out: u32,
+    port: u32,
+    out_len: u32,
 ) -> AsyncHostResult<()> {
     if addrinfo == crate::async_host::INVALID_HOST_HANDLE {
         return Ok(());
@@ -258,10 +258,10 @@ pub(super) fn make_udp_socket(context: &mut ImportContext<'_, '_>, family: i32, 
 pub(super) fn join_multicast_group(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
-    multi_addr: i32,
-    local_addr: i32,
-    multi_addr_len: i32,
-    local_addr_len: i32,
+    multi_addr: u32,
+    local_addr: u32,
+    multi_addr_len: u32,
+    local_addr_len: u32,
 ) -> i32 {
     let host = context.host;
     let result = context.with_memory_mut(|memory| {
@@ -278,9 +278,9 @@ pub(super) fn join_multicast_group(
 pub(super) fn join_multicast_group_v6(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
-    multi_addr: i32,
-    interface_index: i32,
-    multi_addr_len: i32,
+    multi_addr: u32,
+    interface_index: u32,
+    multi_addr_len: u32,
 ) -> i32 {
     let host = context.host;
     let result = context.with_memory_mut(|memory| {
@@ -296,8 +296,8 @@ pub(super) fn join_multicast_group_v6(
 pub(super) fn set_multicast_interface(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
-    local_addr: i32,
-    local_addr_len: i32,
+    local_addr: u32,
+    local_addr_len: u32,
 ) -> i32 {
     let host = context.host;
     let result = context.with_memory_mut(|memory| {
@@ -313,7 +313,7 @@ pub(super) fn set_multicast_interface(
 pub(super) fn set_multicast_interface_v6(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
-    interface_index: i32,
+    interface_index: u32,
 ) -> i32 {
     let host = context.host;
     zero_or_minus_one(
@@ -408,7 +408,7 @@ pub(super) fn enable_keepalive(
 }
 
 #[ported(source = "src/socket/socket.c")]
-pub(super) fn getsockname(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, addr_len: i32) -> i32 {
+pub(super) fn getsockname(context: &mut ImportContext<'_, '_>, fd: u64, addr: u32, addr_len: u32) -> i32 {
     let host = context.host;
     let result = context.with_memory_mut(|memory| {
         let addr = memory.read_exact_mut(addr, addr_len)?;
@@ -418,7 +418,7 @@ pub(super) fn getsockname(context: &mut ImportContext<'_, '_>, fd: u64, addr: i3
 }
 
 #[ported(source = "src/socket/socket.c")]
-pub(super) fn if_nametoindex(context: &mut ImportContext<'_, '_>, name: i32, name_len: i32) -> i32 {
+pub(super) fn if_nametoindex(context: &mut ImportContext<'_, '_>, name: u32, name_len: u32) -> u32 {
     let result = context.with_memory_mut(|memory| {
         let name = read_u16(memory, name, name_len)?;
         sys::if_nametoindex(&name)
@@ -433,7 +433,7 @@ pub(super) fn if_nametoindex(context: &mut ImportContext<'_, '_>, name: i32, nam
 }
 
 #[ported(source = "src/socket/socket.c")]
-pub(super) fn if_indextoname(context: &mut ImportContext<'_, '_>, index: i32) -> u64 {
+pub(super) fn if_indextoname(context: &mut ImportContext<'_, '_>, index: u32) -> u64 {
     match sys::if_indextoname(index) {
         Ok(name) => context.host.insert_c_buffer(name.into_boxed_slice()),
         Err(error) => {
@@ -444,7 +444,7 @@ pub(super) fn if_indextoname(context: &mut ImportContext<'_, '_>, index: i32) ->
 }
 
 #[ported(source = "src/socket/socket.c")]
-pub(super) fn find_ipv6_test_interface(_context: &mut ImportContext<'_, '_>) -> i32 {
+pub(super) fn find_ipv6_test_interface(_context: &mut ImportContext<'_, '_>) -> u32 {
     sys::find_ipv6_test_interface()
 }
 
@@ -452,8 +452,8 @@ pub(super) fn find_ipv6_test_interface(_context: &mut ImportContext<'_, '_>) -> 
 pub(super) fn udp_client_connect(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
-    addr: i32,
-    addr_len: i32,
+    addr: u32,
+    addr_len: u32,
 ) -> i32 {
     let host = context.host;
     let result = context.with_memory_mut(|memory| {
@@ -466,7 +466,7 @@ pub(super) fn udp_client_connect(
     zero_or_minus_one(context, result)
 }
 
-pub(super) fn bind(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, addr_len: i32) -> i32 {
+pub(super) fn bind(context: &mut ImportContext<'_, '_>, fd: u64, addr: u32, addr_len: u32) -> i32 {
     let host = context.host;
     let result = context.with_memory_mut(|memory| {
         let addr = memory.read_exact(addr, addr_len)?;
@@ -481,28 +481,22 @@ pub(super) fn bind(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, addr
 pub(super) fn recvfrom(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
-    buf: i32,
-    offset: i32,
-    len: i32,
-    addr: i32,
-    addr_len: i32,
+    buf: u32,
+    offset: u32,
+    len: u32,
+    addr: u32,
+    addr_len: u32,
 ) -> i32 {
-    let offset_buf = match checked_add_i32(buf, offset) {
-        Ok(offset_buf) => offset_buf,
-        Err(error) => {
-            context.host.record_error(error);
-            return -1;
-        }
-    };
     let host = context.host;
     let result = context.with_memory_mut(|memory| {
-        memory.read_exact(offset_buf, len)?;
+        let buf = buf.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        memory.read_exact(buf, len)?;
         let mut data = vec![0; usize::try_from(len).map_err(|_| AsyncHostError::Fault)?];
         let mut addr_data = memory.read_exact(addr, addr_len)?.to_vec();
         let n = host.with_raw_resource_class(fd, ResourceClass::UdpSocket, |fd| {
             sys::recvfrom(fd, &mut data, &mut addr_data)
         })?;
-        memory.write_exact(offset_buf, &data[..n])?;
+        memory.write_exact(buf, &data[..n])?;
         memory.write_exact(addr, &addr_data)?;
         i32::try_from(n).map_err(|_| AsyncHostError::Fault)
     });
@@ -520,22 +514,16 @@ pub(super) fn recvfrom(
 pub(super) fn sendto(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
-    buf: i32,
-    offset: i32,
-    len: i32,
-    addr: i32,
-    addr_len: i32,
+    buf: u32,
+    offset: u32,
+    len: u32,
+    addr: u32,
+    addr_len: u32,
 ) -> i32 {
-    let offset_buf = match checked_add_i32(buf, offset) {
-        Ok(offset_buf) => offset_buf,
-        Err(error) => {
-            context.host.record_error(error);
-            return -1;
-        }
-    };
     let host = context.host;
     let result = context.with_memory_mut(|memory| {
-        let data = memory.read_exact(offset_buf, len)?;
+        let buf = buf.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        let data = memory.read_exact(buf, len)?;
         let addr = memory.read_exact(addr, addr_len)?;
         host.policy().connect_socket(addr)?;
         host.with_raw_resource_class(fd, ResourceClass::UdpSocket, |fd| {
@@ -554,7 +542,7 @@ pub(super) fn sendto(
 
 #[ported(source = "src/internal/event_loop/io_unix.c")]
 #[cfg(unix)]
-pub(super) fn connect(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, addr_len: i32) -> i32 {
+pub(super) fn connect(context: &mut ImportContext<'_, '_>, fd: u64, addr: u32, addr_len: u32) -> i32 {
     let host = context.host;
     let result = context.with_memory_mut(|memory| {
         let addr = memory.read_exact(addr, addr_len)?;
@@ -579,7 +567,7 @@ pub(super) fn getsockerr(context: &mut ImportContext<'_, '_>, fd: u64) -> i32 {
 
 #[ported(source = "src/internal/event_loop/io_unix.c")]
 #[cfg(unix)]
-pub(super) fn accept(context: &mut ImportContext<'_, '_>, fd: u64, addr: i32, addr_len: i32) -> u64 {
+pub(super) fn accept(context: &mut ImportContext<'_, '_>, fd: u64, addr: u32, addr_len: u32) -> u64 {
     let host = context.host;
     let result = context.with_memory_mut(|memory| {
         let addr = memory.read_exact_mut(addr, addr_len)?;
@@ -786,11 +774,6 @@ fn socket_addr_port(addr: &[u8]) -> AsyncHostResult<u16> {
         }
         _ => Err(AsyncHostError::Inval),
     }
-}
-
-#[cfg(unix)]
-fn checked_add_i32(lhs: i32, rhs: i32) -> AsyncHostResult<i32> {
-    lhs.checked_add(rhs).ok_or(AsyncHostError::Fault)
 }
 
 #[cfg(test)]

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -89,8 +89,8 @@ pub(super) fn cancel_worker(context: &mut ImportContext<'_, '_>, worker: u64) ->
 pub(super) fn fetch_completion(
     context: &mut ImportContext<'_, '_>,
     source_fd: u64,
-    dst: i32,
-    max_jobs: i32,
+    dst: u32,
+    max_jobs: u32,
 ) -> i32 {
     match context.with_host_and_memory_mut(|host, memory| {
         host.fetch_completion(memory, source_fd, dst, max_jobs)
@@ -122,8 +122,8 @@ pub(super) fn make_sleep_job(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_open_job_legacy(
     context: &mut ImportContext<'_, '_>,
-    path_ptr: i32,
-    path_len: i32,
+    path_ptr: u32,
+    path_len: u32,
     access: i32,
     create_mode: i32,
     append: i32,
@@ -152,15 +152,15 @@ pub(super) fn make_open_job_legacy(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_open_stat_job(
     context: &mut ImportContext<'_, '_>,
-    path_ptr: i32,
-    path_len: i32,
+    path_ptr: u32,
+    path_len: u32,
     access: i32,
     create_mode: i32,
     append: i32,
     sync: i32,
     mode: i32,
     stat_request: i32,
-    stat_result_len: i32,
+    stat_result_len: u32,
 ) -> AsyncHostResult<u64> {
     let filename = read_guest_os_string(context, path_ptr, path_len)?;
     context.host.insert_job(thread_pool::make_open_stat_job(
@@ -183,7 +183,7 @@ pub(super) fn make_fstatx_job(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
     stat_request: i32,
-    stat_result_len: i32,
+    stat_result_len: u32,
 ) -> AsyncHostResult<u64> {
     let file = context.host.acquire_resource(fd)?;
     context.host.insert_job(thread_pool::make_fstatx_job(
@@ -200,10 +200,10 @@ pub(super) fn make_fstatx_job(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_statx_job(
     context: &mut ImportContext<'_, '_>,
-    path_ptr: i32,
-    path_len: i32,
+    path_ptr: u32,
+    path_len: u32,
     stat_request: i32,
-    stat_result_len: i32,
+    stat_result_len: u32,
     parent: u64,
     follow_symlink: i32,
 ) -> AsyncHostResult<u64> {
@@ -229,8 +229,8 @@ pub(super) fn make_statx_job(
 pub(super) fn get_stat_result(
     context: &mut ImportContext<'_, '_>,
     job: u64,
-    dst: i32,
-    dst_len: i32,
+    dst: u32,
+    dst_len: u32,
 ) -> AsyncHostResult<()> {
     context.with_host_and_memory_mut(|host, memory| {
         host.get_stat_result(memory, job, dst, dst_len)
@@ -241,7 +241,7 @@ pub(super) fn get_stat_result(
 pub(super) fn make_read_job(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
-    len: i32,
+    len: u32,
     position: i64,
 ) -> AsyncHostResult<u64> {
     let file = context
@@ -255,17 +255,16 @@ pub(super) fn make_read_job(
 pub(super) fn make_write_job(
     context: &mut ImportContext<'_, '_>,
     fd: u64,
-    ptr: i32,
-    offset: i32,
-    len: i32,
+    ptr: u32,
+    offset: u32,
+    len: u32,
     position: i64,
 ) -> AsyncHostResult<u64> {
     let file = context
         .host
         .acquire_resource_of_class(fd, ResourceClass::File)?;
-    let offset_ptr = ptr.checked_add(offset).ok_or(AsyncHostError::Fault)?;
-    let data =
-        context.with_memory_mut(|memory| Ok(memory.read_exact(offset_ptr, len)?.to_vec()))?;
+    let ptr = ptr.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+    let data = context.with_memory_mut(|memory| Ok(memory.read_exact(ptr, len)?.to_vec()))?;
 
     context.host
         .insert_job(thread_pool::make_write_job(file, data, position))
@@ -274,9 +273,9 @@ pub(super) fn make_write_job(
 pub(super) fn get_read_result(
     context: &mut ImportContext<'_, '_>,
     job: u64,
-    dst: i32,
-    offset: i32,
-    len: i32,
+    dst: u32,
+    offset: u32,
+    len: u32,
 ) -> AsyncHostResult<()> {
     context.with_host_and_memory_mut(|host, memory| {
         host.get_read_result(memory, job, dst, offset, len)
@@ -292,8 +291,8 @@ pub(super) fn get_read_result(
 pub(super) fn make_file_kind_by_path_job(
     context: &mut ImportContext<'_, '_>,
     parent: u64,
-    path_ptr: i32,
-    path_len: i32,
+    path_ptr: u32,
+    path_len: u32,
     follow_symlink: i32,
 ) -> AsyncHostResult<u64> {
     let parent = if parent == context.host.invalid_fd() {
@@ -363,8 +362,8 @@ pub(super) fn make_file_time_job(
 )]
 pub(super) fn make_file_time_by_path_job(
     context: &mut ImportContext<'_, '_>,
-    path_ptr: i32,
-    path_len: i32,
+    path_ptr: u32,
+    path_len: u32,
     follow_symlink: i32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
@@ -379,7 +378,7 @@ pub(super) fn make_file_time_by_path_job(
 pub(super) fn get_file_time_result(
     context: &mut ImportContext<'_, '_>,
     job: u64,
-    out: i32,
+    out: u32,
 ) -> AsyncHostResult<()> {
     context.with_host_and_memory_mut(|host, memory| {
         host.get_file_time_result(memory, job, out)
@@ -389,8 +388,8 @@ pub(super) fn get_file_time_result(
 #[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_access_job(
     context: &mut ImportContext<'_, '_>,
-    path_ptr: i32,
-    path_len: i32,
+    path_ptr: u32,
+    path_len: u32,
     access: i32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
@@ -402,8 +401,8 @@ pub(super) fn make_access_job(
 #[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_chmod_job(
     context: &mut ImportContext<'_, '_>,
-    path_ptr: i32,
-    path_len: i32,
+    path_ptr: u32,
+    path_len: u32,
     mode: i32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
@@ -441,8 +440,8 @@ pub(super) fn make_flock_job(
 #[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_remove_job(
     context: &mut ImportContext<'_, '_>,
-    path_ptr: i32,
-    path_len: i32,
+    path_ptr: u32,
+    path_len: u32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
     context.host.insert_job(thread_pool::make_remove_job(path))
@@ -451,10 +450,10 @@ pub(super) fn make_remove_job(
 #[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_rename_job(
     context: &mut ImportContext<'_, '_>,
-    old_path_ptr: i32,
-    old_path_len: i32,
-    new_path_ptr: i32,
-    new_path_len: i32,
+    old_path_ptr: u32,
+    old_path_len: u32,
+    new_path_ptr: u32,
+    new_path_len: u32,
     replace: i32,
 ) -> AsyncHostResult<u64> {
     let old_path = read_guest_os_string(context, old_path_ptr, old_path_len)?;
@@ -470,10 +469,10 @@ pub(super) fn make_rename_job(
 #[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_symlink_job(
     context: &mut ImportContext<'_, '_>,
-    target_ptr: i32,
-    target_len: i32,
-    path_ptr: i32,
-    path_len: i32,
+    target_ptr: u32,
+    target_len: u32,
+    path_ptr: u32,
+    path_len: u32,
     force_symlink: i32,
 ) -> AsyncHostResult<u64> {
     let target = read_guest_os_string(context, target_ptr, target_len)?;
@@ -489,8 +488,8 @@ pub(super) fn make_symlink_job(
 #[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_mkdir_job(
     context: &mut ImportContext<'_, '_>,
-    path_ptr: i32,
-    path_len: i32,
+    path_ptr: u32,
+    path_len: u32,
     mode: i32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
@@ -502,8 +501,8 @@ pub(super) fn make_mkdir_job(
 #[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_rmdir_job(
     context: &mut ImportContext<'_, '_>,
-    path_ptr: i32,
-    path_len: i32,
+    path_ptr: u32,
+    path_len: u32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
     context.host.insert_job(thread_pool::make_rmdir_job(path))
@@ -514,7 +513,7 @@ pub(super) fn make_readdir_job(
     context: &mut ImportContext<'_, '_>,
     dir: u64,
     buf: u64,
-    len: i32,
+    len: u32,
     restart: i32,
 ) -> AsyncHostResult<u64> {
     let dir = context
@@ -534,8 +533,8 @@ pub(super) fn make_readdir_job(
 pub(super) fn make_bind_job(
     context: &mut ImportContext<'_, '_>,
     socket: u64,
-    addr: i32,
-    addr_len: i32,
+    addr: u32,
+    addr_len: u32,
 ) -> AsyncHostResult<u64> {
     let socket = context.host.acquire_socket_resource(socket)?;
     let addr = context.with_memory_mut(|memory| Ok(memory.read_exact(addr, addr_len)?.to_vec()))?;
@@ -548,8 +547,8 @@ pub(super) fn make_bind_job(
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
 pub(super) fn make_getaddrinfo_job(
     context: &mut ImportContext<'_, '_>,
-    host: i32,
-    host_len: i32,
+    host: u32,
+    host_len: u32,
 ) -> AsyncHostResult<u64> {
     let host = read_guest_os_string(context, host, host_len)?;
     match context.host.policy().resolve_dns(&host) {
@@ -569,16 +568,16 @@ pub(super) fn make_getaddrinfo_job(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_spawn_job_unix(
     context: &mut ImportContext<'_, '_>,
-    path: i32,
-    path_len: i32,
+    path: u32,
+    path_len: u32,
     args: u64,
     env: u64,
-    inherited_env_entry_count: i32,
+    inherited_env_entry_count: u32,
     stdin: u64,
     stdout: u64,
     stderr: u64,
-    cwd: i32,
-    cwd_len: i32,
+    cwd: u32,
+    cwd_len: u32,
     has_cwd: i32,
 ) -> AsyncHostResult<u64> {
     let (args, env) = context.host.take_legacy_process_spawn_inputs(
@@ -613,8 +612,8 @@ pub(super) fn make_spawn_job_unix(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn spawn_job_unix(
     context: &mut ImportContext<'_, '_>,
-    path: i32,
-    path_len: i32,
+    path: u32,
+    path_len: u32,
     args: u64,
     env: u64,
     stdin: u64,
@@ -645,8 +644,8 @@ pub(super) fn spawn_job_unix(
 pub(super) fn spawn_job_set_cwd(
     context: &mut ImportContext<'_, '_>,
     job: u64,
-    cwd: i32,
-    cwd_len: i32,
+    cwd: u32,
+    cwd_len: u32,
 ) -> AsyncHostResult<()> {
     let cwd = read_guest_os_string(context, cwd, cwd_len)?;
     context.host.spawn_job_set_cwd(job, cwd)
@@ -663,14 +662,14 @@ pub(super) fn spawn_job_set_cwd(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_spawn_job_windows(
     context: &mut ImportContext<'_, '_>,
-    command_line: i32,
-    command_line_len: i32,
+    command_line: u32,
+    command_line_len: u32,
     env: u64,
     stdin: u64,
     stdout: u64,
     stderr: u64,
-    cwd: i32,
-    cwd_len: i32,
+    cwd: u32,
+    cwd_len: u32,
     has_cwd: i32,
     no_console_window: i32,
     is_orphan: i32,
@@ -710,8 +709,8 @@ pub(super) fn make_spawn_job_windows(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn spawn_job_windows(
     context: &mut ImportContext<'_, '_>,
-    command_line: i32,
-    command_line_len: i32,
+    command_line: u32,
+    command_line_len: u32,
     env: u64,
     stdin: u64,
     stdout: u64,
@@ -803,8 +802,8 @@ pub(super) fn make_wait_for_process_job(
 #[cfg(unix)]
 pub(super) fn make_sigwait_job(
     context: &mut ImportContext<'_, '_>,
-    signals: i32,
-    signals_len: i32,
+    signals: u32,
+    signals_len: u32,
 ) -> AsyncHostResult<u64> {
     let signals =
         context.with_memory_mut(|memory| read_i32_array(memory, signals, signals_len))?;
@@ -835,8 +834,8 @@ pub(super) fn get_getaddrinfo_result(
 #[cfg(unix)]
 fn read_i32_array(
     memory: &(impl GuestMemory + ?Sized),
-    offset: i32,
-    len: i32,
+    offset: u32,
+    len: u32,
 ) -> AsyncHostResult<Vec<i32>> {
     let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
     let byte_len = len
@@ -844,7 +843,7 @@ fn read_i32_array(
         .ok_or(AsyncHostError::Fault)?;
     let bytes = memory.read_exact(
         offset,
-        i32::try_from(byte_len).map_err(|_| AsyncHostError::Fault)?,
+        u32::try_from(byte_len).map_err(|_| AsyncHostError::Fault)?,
     )?;
     Ok(bytes
         .chunks_exact(std::mem::size_of::<i32>())
@@ -855,8 +854,8 @@ fn read_i32_array(
 #[ported(source = "src/internal/event_loop/fs.c")]
 pub(super) fn make_realpath_job(
     context: &mut ImportContext<'_, '_>,
-    path_ptr: i32,
-    path_len: i32,
+    path_ptr: u32,
+    path_len: u32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
     context

--- a/crates/moonrun/src/async_api/tls.rs
+++ b/crates/moonrun/src/async_api/tls.rs
@@ -36,8 +36,8 @@ pub(super) fn new(context: &mut ImportContext<'_, '_>) -> u64 {
 pub(super) fn set_client(
     context: &mut ImportContext<'_, '_>,
     tls: u64,
-    host: i32,
-    host_len: i32,
+    host: u32,
+    host_len: u32,
     sni: i32,
     trust_abi: i32,
 ) -> AsyncHostResult<i32> {
@@ -52,8 +52,8 @@ pub(super) fn set_client(
 pub(super) fn add_root_certificate(
     context: &mut ImportContext<'_, '_>,
     tls: u64,
-    root: i32,
-    root_len: i32,
+    root: u32,
+    root_len: u32,
 ) -> AsyncHostResult<i32> {
     context.with_host_and_memory_mut(|host, memory| {
         let root = memory.read_exact(root, root_len)?;
@@ -66,11 +66,11 @@ pub(super) fn add_root_certificate(
 pub(super) fn set_server_files(
     context: &mut ImportContext<'_, '_>,
     tls: u64,
-    private_key_file: i32,
-    private_key_file_len: i32,
+    private_key_file: u32,
+    private_key_file_len: u32,
     private_key_type_abi: i32,
-    certificate_file: i32,
-    certificate_file_len: i32,
+    certificate_file: u32,
+    certificate_file_len: u32,
     certificate_type_abi: i32,
 ) -> AsyncHostResult<i32> {
     context.with_host_and_memory_mut(|host, memory| {
@@ -90,8 +90,8 @@ pub(super) fn set_server_files(
 pub(super) fn set_server_pfx(
     context: &mut ImportContext<'_, '_>,
     tls: u64,
-    pfx_content: i32,
-    pfx_content_len: i32,
+    pfx_content: u32,
+    pfx_content_len: u32,
 ) -> AsyncHostResult<i32> {
     context.with_host_and_memory_mut(|host, memory| {
         host.tls_set_server_pfx(
@@ -121,15 +121,15 @@ pub(super) fn take_global_error(context: &mut ImportContext<'_, '_>) -> u64 {
 pub(super) fn read_plain(
     context: &mut ImportContext<'_, '_>,
     tls: u64,
-    in_buffer: i32,
-    in_buffer_offset: i32,
-    in_buffer_len: i32,
-    out_buffer: i32,
-    out_buffer_offset: i32,
-    out_buffer_len: i32,
-    plain_buffer: i32,
-    plain_buffer_offset: i32,
-    plain_buffer_len: i32,
+    in_buffer: u32,
+    in_buffer_offset: u32,
+    in_buffer_len: u32,
+    out_buffer: u32,
+    out_buffer_offset: u32,
+    out_buffer_len: u32,
+    plain_buffer: u32,
+    plain_buffer_offset: u32,
+    plain_buffer_len: u32,
 ) -> AsyncHostResult<i32> {
     context.with_host_and_memory_mut(|host, memory| {
         let (input, output, plain) = read_guest_buffers3_mut(
@@ -150,15 +150,15 @@ pub(super) fn read_plain(
 pub(super) fn write_plain(
     context: &mut ImportContext<'_, '_>,
     tls: u64,
-    in_buffer: i32,
-    in_buffer_offset: i32,
-    in_buffer_len: i32,
-    out_buffer: i32,
-    out_buffer_offset: i32,
-    out_buffer_len: i32,
-    plain_buffer: i32,
-    plain_buffer_offset: i32,
-    plain_buffer_len: i32,
+    in_buffer: u32,
+    in_buffer_offset: u32,
+    in_buffer_len: u32,
+    out_buffer: u32,
+    out_buffer_offset: u32,
+    out_buffer_len: u32,
+    plain_buffer: u32,
+    plain_buffer_offset: u32,
+    plain_buffer_len: u32,
 ) -> AsyncHostResult<i32> {
     context.with_host_and_memory_mut(|host, memory| {
         let (input, output, plain) = read_guest_buffers3_mut(
@@ -179,12 +179,12 @@ pub(super) fn write_plain(
 pub(super) fn connect(
     context: &mut ImportContext<'_, '_>,
     tls: u64,
-    in_buffer: i32,
-    in_buffer_offset: i32,
-    in_buffer_len: i32,
-    out_buffer: i32,
-    out_buffer_offset: i32,
-    out_buffer_len: i32,
+    in_buffer: u32,
+    in_buffer_offset: u32,
+    in_buffer_len: u32,
+    out_buffer: u32,
+    out_buffer_offset: u32,
+    out_buffer_len: u32,
 ) -> AsyncHostResult<i32> {
     context.with_host_and_memory_mut(|host, memory| {
         let (input, output) = read_guest_input_output_mut(
@@ -203,12 +203,12 @@ pub(super) fn connect(
 pub(super) fn accept(
     context: &mut ImportContext<'_, '_>,
     tls: u64,
-    in_buffer: i32,
-    in_buffer_offset: i32,
-    in_buffer_len: i32,
-    out_buffer: i32,
-    out_buffer_offset: i32,
-    out_buffer_len: i32,
+    in_buffer: u32,
+    in_buffer_offset: u32,
+    in_buffer_len: u32,
+    out_buffer: u32,
+    out_buffer_offset: u32,
+    out_buffer_len: u32,
 ) -> AsyncHostResult<i32> {
     context.with_host_and_memory_mut(|host, memory| {
         let (input, output) = read_guest_input_output_mut(
@@ -223,7 +223,7 @@ pub(super) fn accept(
 }
 
 #[ported(source = "src/tls/tls.wasm.mbt", original = "tls/connection/bytes_read")]
-pub(super) fn bytes_read(context: &mut ImportContext<'_, '_>, tls: u64) -> AsyncHostResult<i32> {
+pub(super) fn bytes_read(context: &mut ImportContext<'_, '_>, tls: u64) -> AsyncHostResult<u32> {
     context.host.tls_bytes_read(tls)
 }
 
@@ -231,7 +231,7 @@ pub(super) fn bytes_read(context: &mut ImportContext<'_, '_>, tls: u64) -> Async
 pub(super) fn bytes_to_write(
     context: &mut ImportContext<'_, '_>,
     tls: u64,
-) -> AsyncHostResult<i32> {
+) -> AsyncHostResult<u32> {
     context.host.tls_bytes_to_write(tls)
 }
 
@@ -278,19 +278,18 @@ pub(super) fn server_endpoint_channel_binding(
 }
 }
 
-fn guest_offset(ptr: i32, offset: i32) -> AsyncHostResult<i32> {
-    if offset < 0 {
-        return Err(AsyncHostError::Fault);
-    }
+fn guest_offset(ptr: u32, offset: u32) -> AsyncHostResult<usize> {
+    let ptr = usize::try_from(ptr).map_err(|_| AsyncHostError::Fault)?;
+    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
     ptr.checked_add(offset).ok_or(AsyncHostError::Fault)
 }
 
 fn read_guest_input_output_mut(
     memory: &mut (impl GuestMemory + ?Sized),
-    input_offset: i32,
-    input_len: i32,
-    output_offset: i32,
-    output_len: i32,
+    input_offset: usize,
+    input_len: u32,
+    output_offset: usize,
+    output_len: u32,
 ) -> AsyncHostResult<(&mut [u8], &mut [u8])> {
     let input = guest_range(memory.bytes().len(), input_offset, input_len)?;
     let output = guest_range(memory.bytes().len(), output_offset, output_len)?;
@@ -313,12 +312,12 @@ fn read_guest_input_output_mut(
 
 fn read_guest_buffers3_mut(
     memory: &mut (impl GuestMemory + ?Sized),
-    first_offset: i32,
-    first_len: i32,
-    second_offset: i32,
-    second_len: i32,
-    third_offset: i32,
-    third_len: i32,
+    first_offset: usize,
+    first_len: u32,
+    second_offset: usize,
+    second_len: u32,
+    third_offset: usize,
+    third_len: u32,
 ) -> AsyncHostResult<(&mut [u8], &mut [u8], &mut [u8])> {
     let memory_len = memory.bytes().len();
     let first = guest_range(memory_len, first_offset, first_len)?;
@@ -351,10 +350,9 @@ fn ranges_overlap(first: &std::ops::Range<usize>, second: &std::ops::Range<usize
 
 fn guest_range(
     memory_len: usize,
-    offset: i32,
-    len: i32,
+    offset: usize,
+    len: u32,
 ) -> AsyncHostResult<std::ops::Range<usize>> {
-    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
     let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
     let end = offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
     if end > memory_len {
@@ -363,14 +361,14 @@ fn guest_range(
     Ok(offset..end)
 }
 
-fn read_guest_string(memory: &[u8], ptr: i32, len: i32) -> AsyncHostResult<String> {
+fn read_guest_string(memory: &[u8], ptr: u32, len: u32) -> AsyncHostResult<String> {
     let units = read_u16(memory, ptr, len)?;
     Ok(std::char::decode_utf16(units)
         .map(|unit| unit.unwrap_or(std::char::REPLACEMENT_CHARACTER))
         .collect())
 }
 
-fn read_guest_os_path(memory: &[u8], ptr: i32, len: i32) -> AsyncHostResult<PathBuf> {
+fn read_guest_os_path(memory: &[u8], ptr: u32, len: u32) -> AsyncHostResult<PathBuf> {
     let units = read_u16(memory, ptr, len)?;
 
     #[cfg(unix)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -164,20 +164,20 @@ pub(crate) trait GuestMemory {
 
     fn bytes_mut(&mut self) -> &mut [u8];
 
-    fn read_exact(&self, offset: i32, len: i32) -> AsyncHostResult<&[u8]> {
+    fn read_exact(&self, offset: u32, len: u32) -> AsyncHostResult<&[u8]> {
         let (offset, end) = guest_bounds(offset, len)?;
         self.bytes().get(offset..end).ok_or(AsyncHostError::Fault)
     }
 
-    fn read_exact_mut(&mut self, offset: i32, len: i32) -> AsyncHostResult<&mut [u8]> {
+    fn read_exact_mut(&mut self, offset: u32, len: u32) -> AsyncHostResult<&mut [u8]> {
         let (offset, end) = guest_bounds(offset, len)?;
         self.bytes_mut()
             .get_mut(offset..end)
             .ok_or(AsyncHostError::Fault)
     }
 
-    fn write_exact(&mut self, offset: i32, data: &[u8]) -> AsyncHostResult<()> {
-        let len = i32::try_from(data.len()).map_err(|_| AsyncHostError::Fault)?;
+    fn write_exact(&mut self, offset: u32, data: &[u8]) -> AsyncHostResult<()> {
+        let len = u32::try_from(data.len()).map_err(|_| AsyncHostError::Fault)?;
         let dst = self.read_exact_mut(offset, len)?;
         dst.copy_from_slice(data);
         Ok(())
@@ -185,11 +185,11 @@ pub(crate) trait GuestMemory {
 
     fn write_with_capacity(
         &mut self,
-        offset: i32,
-        capacity: i32,
+        offset: u32,
+        capacity: u32,
         data: &[u8],
     ) -> AsyncHostResult<()> {
-        let data_len = i32::try_from(data.len()).map_err(|_| AsyncHostError::Fault)?;
+        let data_len = u32::try_from(data.len()).map_err(|_| AsyncHostError::Fault)?;
         if data_len > capacity {
             return Err(AsyncHostError::Fault);
         }
@@ -198,19 +198,19 @@ pub(crate) trait GuestMemory {
         Ok(())
     }
 
-    fn write_u64_le(&mut self, offset: i32, value: u64) -> AsyncHostResult<()> {
+    fn write_u64_le(&mut self, offset: u32, value: u64) -> AsyncHostResult<()> {
         self.write_exact(offset, &value.to_le_bytes())
     }
 }
 
-fn guest_bounds(offset: i32, len: i32) -> AsyncHostResult<(usize, usize)> {
+fn guest_bounds(offset: u32, len: u32) -> AsyncHostResult<(usize, usize)> {
     let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
     let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
     let end = offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
     Ok((offset, end))
 }
 
-pub(crate) fn read_u16(memory: &[u8], offset: i32, len: i32) -> AsyncHostResult<Vec<u16>> {
+pub(crate) fn read_u16(memory: &[u8], offset: u32, len: u32) -> AsyncHostResult<Vec<u16>> {
     let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
     let (offset, end) = u16_bounds(memory.len(), offset, len)?;
     Ok(memory[offset..end]
@@ -219,7 +219,7 @@ pub(crate) fn read_u16(memory: &[u8], offset: i32, len: i32) -> AsyncHostResult<
         .collect())
 }
 
-pub(crate) fn write_u16(memory: &mut [u8], offset: i32, data: &[u16]) -> AsyncHostResult<()> {
+pub(crate) fn write_u16(memory: &mut [u8], offset: u32, data: &[u16]) -> AsyncHostResult<()> {
     let (offset, end) = u16_bounds(memory.len(), offset, data.len())?;
     for (dst, value) in memory[offset..end]
         .chunks_exact_mut(std::mem::size_of::<u16>())
@@ -230,7 +230,7 @@ pub(crate) fn write_u16(memory: &mut [u8], offset: i32, data: &[u16]) -> AsyncHo
     Ok(())
 }
 
-fn u16_bounds(memory_len: usize, offset: i32, len: usize) -> AsyncHostResult<(usize, usize)> {
+fn u16_bounds(memory_len: usize, offset: u32, len: usize) -> AsyncHostResult<(usize, usize)> {
     let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
     if len != 0 && offset % std::mem::align_of::<u16>() != 0 {
         return Err(AsyncHostError::Fault);
@@ -850,7 +850,7 @@ impl HostIoResult {
         unsafe { overlapped.assume_init() }
     }
 
-    fn for_file_read(len: i32, position: i64) -> AsyncHostResult<Self> {
+    fn for_file_read(len: u32, position: i64) -> AsyncHostResult<Self> {
         let buffer = vec![0; usize::try_from(len).map_err(|_| AsyncHostError::Fault)?];
         Ok(Self::for_file(IO_RESULT_READ_EVENT, buffer, position))
     }
@@ -878,7 +878,7 @@ impl HostIoResult {
         }
     }
 
-    fn for_socket_read(len: i32, flags: i32) -> AsyncHostResult<Self> {
+    fn for_socket_read(len: u32, flags: i32) -> AsyncHostResult<Self> {
         let buffer = vec![0; usize::try_from(len).map_err(|_| AsyncHostError::Fault)?];
         Ok(Self::for_socket(IO_RESULT_READ_EVENT, buffer, flags))
     }
@@ -904,7 +904,7 @@ impl HostIoResult {
     }
 
     fn for_socket_with_addr_read(
-        len: i32,
+        len: u32,
         flags: i32,
         addr_buffer: Vec<u8>,
     ) -> AsyncHostResult<Self> {
@@ -958,7 +958,7 @@ impl HostIoResult {
         }
     }
 
-    fn for_accept(addr_len: i32) -> AsyncHostResult<Self> {
+    fn for_accept(addr_len: u32) -> AsyncHostResult<Self> {
         let addr_len_usize = usize::try_from(addr_len).map_err(|_| AsyncHostError::Fault)?;
         let accept_addr_len = addr_len_usize
             .checked_add(16)
@@ -973,7 +973,7 @@ impl HostIoResult {
             buffer: Vec::new(),
             socket_flags: 0,
             addr_buffer: Vec::new(),
-            addr_len,
+            addr_len: i32::try_from(addr_len).map_err(|_| AsyncHostError::Fault)?,
             accept_buffer: vec![0; accept_buffer_len],
             accept_bytes_received: 0,
             pending_resource: None,
@@ -1002,26 +1002,26 @@ impl HostIoResult {
     fn copy_read_payload(
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
-        dst: i32,
-        offset: i32,
-        len: i32,
+        dst: u32,
+        offset: u32,
+        len: u32,
     ) -> AsyncHostResult<()> {
-        let dst_offset = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
         let bytes_transferred = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
         let data = self
             .buffer
             .get(..bytes_transferred)
             .ok_or(AsyncHostError::Fault)?;
-        memory.write_exact(dst_offset, data)?;
+        let dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        memory.write_exact(dst, data)?;
         Ok(())
     }
 
     fn copy_read_result(
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
-        dst: i32,
-        offset: i32,
-        len: i32,
+        dst: u32,
+        offset: u32,
+        len: u32,
     ) -> AsyncHostResult<()> {
         self.validate_completed_read()?;
         if self.kind == HostIoKind::SocketWithAddr {
@@ -1033,11 +1033,11 @@ impl HostIoResult {
     fn copy_read_result_with_addr(
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
-        dst: i32,
-        offset: i32,
-        len: i32,
-        addr: i32,
-        addr_len: i32,
+        dst: u32,
+        offset: u32,
+        len: u32,
+        addr: u32,
+        addr_len: u32,
     ) -> AsyncHostResult<()> {
         self.validate_completed_read()?;
         if self.kind != HostIoKind::SocketWithAddr {
@@ -1658,7 +1658,7 @@ impl AsyncHost {
         Ok(result)
     }
 
-    pub(crate) fn poll_get_event(&self, poll_handle: u64, index: i32) -> AsyncHostResult<u64> {
+    pub(crate) fn poll_get_event(&self, poll_handle: u64, index: u32) -> AsyncHostResult<u64> {
         let poll_key = self.handles.borrow().poll(poll_handle)?;
         let polls = self.polls.borrow();
         if polls.current_event_poll != Some(poll_key) {
@@ -1666,7 +1666,7 @@ impl AsyncHost {
         }
         let poll = polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?;
         poll::event_list_get(&poll.instance, index)?;
-        u64::try_from(index).map_err(|_| AsyncHostError::Fault)
+        Ok(u64::from(index))
     }
 
     fn with_event<T>(
@@ -1674,7 +1674,7 @@ impl AsyncHost {
         event_handle: u64,
         f: impl FnOnce(&poll::PollEvent) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
-        let index = event_index(event_handle)?;
+        let index = u32::try_from(event_handle).map_err(|_| AsyncHostError::Fault)?;
         let polls = self.polls.borrow();
         let poll_key = polls.current_event_poll.ok_or(AsyncHostError::Badf)?;
         let poll = polls.polls.get(poll_key).ok_or(AsyncHostError::Badf)?;
@@ -1720,7 +1720,7 @@ impl AsyncHost {
     }
 
     #[cfg(windows)]
-    pub(crate) fn poll_event_bytes_transferred(&self, event_handle: u64) -> AsyncHostResult<i32> {
+    pub(crate) fn poll_event_bytes_transferred(&self, event_handle: u64) -> AsyncHostResult<u32> {
         self.with_event(event_handle, |event| {
             Ok(poll::event_get_bytes_transferred(event))
         })
@@ -1897,7 +1897,7 @@ impl AsyncHost {
     }
 
     #[cfg(unix)]
-    pub(crate) fn insert_process_argv(&self, len: i32) -> AsyncHostResult<u64> {
+    pub(crate) fn insert_process_argv(&self, len: u32) -> AsyncHostResult<u64> {
         let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
         let key = self.handles.borrow_mut().insert(HandleKind::ProcessArgv);
         self.process_argvs.borrow_mut().insert(key, vec![None; len]);
@@ -1908,7 +1908,7 @@ impl AsyncHost {
     pub(crate) fn process_argv_add_entry(
         &self,
         handle: u64,
-        index: i32,
+        index: u32,
         value: OsString,
     ) -> AsyncHostResult<()> {
         let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
@@ -1925,7 +1925,7 @@ impl AsyncHost {
         &self,
         argv_handle: u64,
         env_handle: u64,
-        inherited_env_entry_count: i32,
+        inherited_env_entry_count: u32,
     ) -> AsyncHostResult<(Vec<OsString>, Vec<OsString>)> {
         if argv_handle == INVALID_HOST_HANDLE || env_handle == INVALID_HOST_HANDLE {
             return Err(AsyncHostError::Badf);
@@ -2053,20 +2053,20 @@ impl AsyncHost {
     }
 
     #[cfg(unix)]
-    pub(crate) fn process_env_length(&self, handle: u64) -> AsyncHostResult<i32> {
+    pub(crate) fn process_env_length(&self, handle: u64) -> AsyncHostResult<u32> {
         let key = self.process_env(handle)?;
         let process_envs = self.process_envs.borrow();
         let env = process_envs.get(key).ok_or(AsyncHostError::Badf)?;
-        i32::try_from(env.len()).map_err(|_| AsyncHostError::Fault)
+        u32::try_from(env.len()).map_err(|_| AsyncHostError::Fault)
     }
 
     #[cfg(windows)]
-    pub(crate) fn process_env_length(&self, handle: u64) -> AsyncHostResult<i32> {
+    pub(crate) fn process_env_length(&self, handle: u64) -> AsyncHostResult<u32> {
         let key = self.process_env(handle)?;
         let process_envs = self.process_envs.borrow();
         let env = process_envs.get(key).ok_or(AsyncHostError::Badf)?;
         let len = env.len().checked_sub(1).ok_or(AsyncHostError::Fault)?;
-        i32::try_from(len).map_err(|_| AsyncHostError::Fault)
+        u32::try_from(len).map_err(|_| AsyncHostError::Fault)
     }
 
     #[cfg(unix)]
@@ -2126,7 +2126,7 @@ impl AsyncHost {
     pub(crate) fn process_env_add_entry(
         &self,
         handle: u64,
-        index: i32,
+        index: u32,
         key: OsString,
         value: OsString,
     ) -> AsyncHostResult<()> {
@@ -2143,7 +2143,7 @@ impl AsyncHost {
     pub(crate) fn process_env_add_entry(
         &self,
         handle: u64,
-        offset: i32,
+        offset: u32,
         key: &[u16],
         value: &[u16],
     ) -> AsyncHostResult<()> {
@@ -2709,12 +2709,12 @@ impl AsyncHost {
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
         handle: HostHandle,
-        dst: i32,
-        offset: i32,
-        len: i32,
+        dst: u32,
+        offset: u32,
+        len: u32,
     ) -> AsyncHostResult<i32> {
-        let offset_dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
-        let dst = memory.read_exact_mut(offset_dst, len)?;
+        let dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        let dst = memory.read_exact_mut(dst, len)?;
         self.with_resource(handle, |file| {
             crate::async_sys::internal::event_loop::io::read(file.as_file()?.as_raw_fd(), dst)
                 .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
@@ -2726,12 +2726,12 @@ impl AsyncHost {
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
         handle: HostHandle,
-        src: i32,
-        offset: i32,
-        len: i32,
+        src: u32,
+        offset: u32,
+        len: u32,
     ) -> AsyncHostResult<i32> {
-        let offset_src = src.checked_add(offset).ok_or(AsyncHostError::Fault)?;
-        let src = memory.read_exact(offset_src, len)?;
+        let src = src.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        let src = memory.read_exact(src, len)?;
         self.with_resource(handle, |file| {
             crate::async_sys::internal::event_loop::io::write(file.as_file()?.as_raw_fd(), src)
                 .and_then(|ret| i32::try_from(ret).map_err(|_| AsyncHostError::Fault))
@@ -2741,16 +2741,16 @@ impl AsyncHost {
     #[cfg(windows)]
     fn read_guest_slice(
         memory: &mut (impl GuestMemory + ?Sized),
-        ptr: i32,
-        offset: i32,
-        len: i32,
+        ptr: u32,
+        offset: u32,
+        len: u32,
     ) -> AsyncHostResult<Vec<u8>> {
-        let start = ptr.checked_add(offset).ok_or(AsyncHostError::Fault)?;
-        Ok(memory.read_exact(start, len)?.to_vec())
+        let ptr = ptr.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        Ok(memory.read_exact(ptr, len)?.to_vec())
     }
 
     #[cfg(windows)]
-    pub(crate) fn make_file_read_io_result(&self, len: i32, position: i64) -> AsyncHostResult<u64> {
+    pub(crate) fn make_file_read_io_result(&self, len: u32, position: i64) -> AsyncHostResult<u64> {
         self.insert_io_result(HostIoResult::for_file_read(len, position)?)
     }
 
@@ -2758,9 +2758,9 @@ impl AsyncHost {
     pub(crate) fn make_file_write_io_result(
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
-        src: i32,
-        offset: i32,
-        len: i32,
+        src: u32,
+        offset: u32,
+        len: u32,
         position: i64,
     ) -> AsyncHostResult<u64> {
         let buffer = Self::read_guest_slice(memory, src, offset, len)?;
@@ -2768,7 +2768,7 @@ impl AsyncHost {
     }
 
     #[cfg(windows)]
-    pub(crate) fn make_socket_read_io_result(&self, len: i32, flags: i32) -> AsyncHostResult<u64> {
+    pub(crate) fn make_socket_read_io_result(&self, len: u32, flags: i32) -> AsyncHostResult<u64> {
         self.insert_io_result(HostIoResult::for_socket_read(len, flags)?)
     }
 
@@ -2776,9 +2776,9 @@ impl AsyncHost {
     pub(crate) fn make_socket_write_io_result(
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
-        src: i32,
-        offset: i32,
-        len: i32,
+        src: u32,
+        offset: u32,
+        len: u32,
         flags: i32,
     ) -> AsyncHostResult<u64> {
         let buffer = Self::read_guest_slice(memory, src, offset, len)?;
@@ -2789,10 +2789,10 @@ impl AsyncHost {
     pub(crate) fn make_socket_with_addr_read_io_result(
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
-        len: i32,
+        len: u32,
         flags: i32,
-        addr: i32,
-        addr_len: i32,
+        addr: u32,
+        addr_len: u32,
     ) -> AsyncHostResult<u64> {
         let addr_buffer = memory.read_exact(addr, addr_len)?.to_vec();
         self.insert_io_result(HostIoResult::for_socket_with_addr_read(
@@ -2807,12 +2807,12 @@ impl AsyncHost {
     pub(crate) fn make_socket_with_addr_write_io_result(
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
-        src: i32,
-        offset: i32,
-        len: i32,
+        src: u32,
+        offset: u32,
+        len: u32,
         flags: i32,
-        addr: i32,
-        addr_len: i32,
+        addr: u32,
+        addr_len: u32,
     ) -> AsyncHostResult<u64> {
         let buffer = Self::read_guest_slice(memory, src, offset, len)?;
         let addr_buffer = memory.read_exact(addr, addr_len)?.to_vec();
@@ -2827,15 +2827,15 @@ impl AsyncHost {
     pub(crate) fn make_connect_io_result(
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
-        addr: i32,
-        addr_len: i32,
+        addr: u32,
+        addr_len: u32,
     ) -> AsyncHostResult<u64> {
         let addr_buffer = memory.read_exact(addr, addr_len)?.to_vec();
         self.insert_io_result(HostIoResult::for_connect(addr_buffer))
     }
 
     #[cfg(windows)]
-    pub(crate) fn make_accept_io_result(&self, addr_len: i32) -> AsyncHostResult<u64> {
+    pub(crate) fn make_accept_io_result(&self, addr_len: u32) -> AsyncHostResult<u64> {
         self.insert_io_result(HostIoResult::for_accept(addr_len)?)
     }
 
@@ -2955,9 +2955,9 @@ impl AsyncHost {
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
         result_handle: u64,
-        dst: i32,
-        offset: i32,
-        len: i32,
+        dst: u32,
+        offset: u32,
+        len: u32,
     ) -> AsyncHostResult<()> {
         let key = self.handles.borrow().io_result(result_handle)?;
         let io_results = self.io_results.borrow();
@@ -2971,11 +2971,11 @@ impl AsyncHost {
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
         result_handle: u64,
-        dst: i32,
-        offset: i32,
-        len: i32,
-        addr: i32,
-        addr_len: i32,
+        dst: u32,
+        offset: u32,
+        len: u32,
+        addr: u32,
+        addr_len: u32,
     ) -> AsyncHostResult<()> {
         let key = self.handles.borrow().io_result(result_handle)?;
         let io_results = self.io_results.borrow();
@@ -3303,8 +3303,8 @@ impl AsyncHost {
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
         result_handle: u64,
-        dst: i32,
-        dst_len: i32,
+        dst: u32,
+        dst_len: u32,
     ) -> AsyncHostResult<()> {
         let key = self.handles.borrow().io_result(result_handle)?;
         let io_results = self.io_results.borrow();
@@ -3718,9 +3718,9 @@ impl AsyncHost {
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
         handle: u64,
-        dst: i32,
-        offset: i32,
-        len: i32,
+        dst: u32,
+        offset: u32,
+        len: u32,
     ) -> AsyncHostResult<()> {
         let key = self.handles.borrow().job(handle)?;
         let jobs = self.jobs.borrow();
@@ -3732,7 +3732,7 @@ impl AsyncHost {
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
         handle: u64,
-        dst: i32,
+        dst: u32,
     ) -> AsyncHostResult<()> {
         let key = self.handles.borrow().job(handle)?;
         let jobs = self.jobs.borrow();
@@ -3744,8 +3744,8 @@ impl AsyncHost {
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
         handle: u64,
-        dst: i32,
-        dst_len: i32,
+        dst: u32,
+        dst_len: u32,
     ) -> AsyncHostResult<()> {
         let key = self.handles.borrow().job(handle)?;
         let jobs = self.jobs.borrow();
@@ -3784,8 +3784,8 @@ impl AsyncHost {
         &self,
         memory: &mut (impl GuestMemory + ?Sized),
         source_fd: HostHandle,
-        dst: i32,
-        max_jobs: i32,
+        dst: u32,
+        max_jobs: u32,
     ) -> AsyncHostResult<i32> {
         let (completion_notifier, completion_source) = {
             let completions = self.thread_pool_completions.borrow();
@@ -3805,8 +3805,8 @@ impl AsyncHost {
         let max_bytes = max_jobs
             .checked_mul(std::mem::size_of::<i32>())
             .ok_or(AsyncHostError::Fault)?;
-        let max_bytes_i32 = i32::try_from(max_bytes).map_err(|_| AsyncHostError::Fault)?;
-        let completions = memory.read_exact_mut(dst, max_bytes_i32)?;
+        let max_bytes_u32 = u32::try_from(max_bytes).map_err(|_| AsyncHostError::Fault)?;
+        let completions = memory.read_exact_mut(dst, max_bytes_u32)?;
         let bytes = completion_notifier.fetch(completions)?;
         self.restore_completed_worker_jobs();
         debug_assert_eq!(bytes % std::mem::size_of::<i32>(), 0);
@@ -4008,12 +4008,14 @@ impl AsyncHost {
         })
     }
 
-    pub(crate) fn tls_bytes_read(&self, handle: HostHandle) -> AsyncHostResult<i32> {
-        self.with_tls_connection_mut(handle, 0, |tls| tls.bytes_read())
+    pub(crate) fn tls_bytes_read(&self, handle: HostHandle) -> AsyncHostResult<u32> {
+        let bytes = self.with_tls_connection_mut(handle, 0, |tls| tls.bytes_read())?;
+        u32::try_from(bytes).map_err(|_| AsyncHostError::Fault)
     }
 
-    pub(crate) fn tls_bytes_to_write(&self, handle: HostHandle) -> AsyncHostResult<i32> {
-        self.with_tls_connection_mut(handle, 0, |tls| tls.bytes_to_write())
+    pub(crate) fn tls_bytes_to_write(&self, handle: HostHandle) -> AsyncHostResult<u32> {
+        let bytes = self.with_tls_connection_mut(handle, 0, |tls| tls.bytes_to_write())?;
+        u32::try_from(bytes).map_err(|_| AsyncHostError::Fault)
     }
 
     pub(crate) fn tls_wants_read(&self, handle: HostHandle) -> AsyncHostResult<i32> {
@@ -4277,10 +4279,6 @@ fn raw_overlapped_handle(file: &Resource) -> AsyncHostResult<RawHandle> {
 #[cfg(windows)]
 fn raw_fd_to_guest(fd: RawFd) -> AsyncHostResult<HostHandle> {
     Ok(fd as usize as u64)
-}
-
-fn event_index(event: u64) -> AsyncHostResult<i32> {
-    i32::try_from(event).map_err(|_| AsyncHostError::Fault)
 }
 
 #[cfg(test)]
@@ -4916,7 +4914,7 @@ mod tests {
     fn guest_memory_read_exact_rejects_out_of_bounds_access() {
         let memory = [0; 4];
 
-        for (offset, len) in [(-1, 1), (0, -1), (3, 2), (i32::MAX, 1), (2, i32::MAX)] {
+        for (offset, len) in [(3, 2), (u32::MAX, 1), (2, u32::MAX)] {
             assert_eq!(memory.read_exact(offset, len), Err(AsyncHostError::Fault));
         }
     }
@@ -4934,7 +4932,7 @@ mod tests {
     fn guest_memory_read_exact_mut_rejects_out_of_bounds_access() {
         let mut memory = [0; 4];
 
-        for (offset, len) in [(-1, 1), (0, -1), (3, 2), (i32::MAX, 1), (2, i32::MAX)] {
+        for (offset, len) in [(3, 2), (u32::MAX, 1), (2, u32::MAX)] {
             assert_eq!(
                 memory.read_exact_mut(offset, len),
                 Err(AsyncHostError::Fault)

--- a/crates/moonrun/src/async_host/tls/openssl.rs
+++ b/crates/moonrun/src/async_host/tls/openssl.rs
@@ -254,12 +254,12 @@ impl TlsConnection {
         self.advance_state(input, output)
     }
 
-    pub(crate) fn bytes_read(&self) -> i32 {
-        self.last_bytes_read as i32
+    pub(crate) fn bytes_read(&self) -> usize {
+        self.last_bytes_read
     }
 
-    pub(crate) fn bytes_to_write(&self) -> i32 {
-        self.last_bytes_to_write as i32
+    pub(crate) fn bytes_to_write(&self) -> usize {
+        self.last_bytes_to_write
     }
 
     fn advance_state(&mut self, input: &mut [u8], output: &mut [u8]) -> i32 {

--- a/crates/moonrun/src/async_host/tls/schannel.rs
+++ b/crates/moonrun/src/async_host/tls/schannel.rs
@@ -358,12 +358,12 @@ impl TlsConnection {
         self.advance_state(input, output)
     }
 
-    pub(crate) fn bytes_read(&self) -> i32 {
-        self.schannel.bytes_read as i32
+    pub(crate) fn bytes_read(&self) -> usize {
+        self.schannel.bytes_read
     }
 
-    pub(crate) fn bytes_to_write(&self) -> i32 {
-        self.schannel.bytes_to_write as i32
+    pub(crate) fn bytes_to_write(&self) -> usize {
+        self.schannel.bytes_to_write
     }
 
     pub(crate) fn peer_certificate(&mut self) -> Result<Option<Vec<u8>>, ()> {

--- a/crates/moonrun/src/async_policy.rs
+++ b/crates/moonrun/src/async_policy.rs
@@ -468,8 +468,7 @@ mod tests {
 
     fn ipv4_addr(ip: Ipv4Addr, port: u16) -> Box<[u8]> {
         let mut addr = vec![0; crate::async_sys::socket::ipv4_addr_size() as usize];
-        crate::async_sys::socket::init_ip_addr(&mut addr, u32::from(ip) as i32, i32::from(port))
-            .unwrap();
+        crate::async_sys::socket::init_ip_addr(&mut addr, u32::from(ip), u32::from(port)).unwrap();
         addr.into_boxed_slice()
     }
 }

--- a/crates/moonrun/src/async_policy/net.rs
+++ b/crates/moonrun/src/async_policy/net.rs
@@ -531,8 +531,7 @@ mod tests {
 
     fn ipv4_addr(ip: Ipv4Addr, port: u16) -> Box<[u8]> {
         let mut addr = vec![0; crate::async_sys::socket::ipv4_addr_size() as usize];
-        crate::async_sys::socket::init_ip_addr(&mut addr, u32::from(ip) as i32, i32::from(port))
-            .unwrap();
+        crate::async_sys::socket::init_ip_addr(&mut addr, u32::from(ip), u32::from(port)).unwrap();
         addr.into_boxed_slice()
     }
 }

--- a/crates/moonrun/src/async_sys/fs/dir.rs
+++ b/crates/moonrun/src/async_sys/fs/dir.rs
@@ -53,24 +53,26 @@ ported_fns! {
         source = "src/fs/dir.c",
         original = "moonbitlang_async_dir_buffer_min_size"
     )]
-    pub(crate) fn buffer_min_size() -> i32 {
+    pub(crate) fn buffer_min_size() -> u32 {
         #[cfg(windows)]
         {
             use windows_sys::Win32::Foundation::MAX_PATH;
             use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
 
-            (std::mem::size_of::<FILE_ID_BOTH_DIR_INFO>()
-                + MAX_PATH as usize * std::mem::size_of::<u16>()) as i32
+            let size = std::mem::size_of::<FILE_ID_BOTH_DIR_INFO>()
+                + usize::try_from(MAX_PATH).expect("MAX_PATH fits usize")
+                    * std::mem::size_of::<u16>();
+            u32::try_from(size).expect("directory buffer size fits u32")
         }
 
         #[cfg(target_os = "macos")]
         {
-            (MAC_DIRENT_SIZE + NAME_MAX) as i32
+            u32::try_from(MAC_DIRENT_SIZE + NAME_MAX).expect("directory buffer size fits u32")
         }
 
         #[cfg(target_os = "linux")]
         {
-            (LINUX_DIRENT_SIZE + NAME_MAX) as i32
+            u32::try_from(LINUX_DIRENT_SIZE + NAME_MAX).expect("directory buffer size fits u32")
         }
     }
 
@@ -78,24 +80,23 @@ ported_fns! {
         source = "src/fs/dir.c",
         original = "moonbitlang_async_dir_entry_length"
     )]
-    pub(crate) fn entry_length(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<i32> {
+    pub(crate) fn entry_length(buf: &[u8], buf_ptr: u32, offset: u32) -> AsyncHostResult<u32> {
         #[cfg(windows)]
         {
             let entry = windows_entry(buf, buf_ptr, offset)?;
-            i32::try_from(entry.NextEntryOffset).map_err(|_| AsyncHostError::Fault)
+            Ok(entry.NextEntryOffset)
         }
 
         #[cfg(target_os = "macos")]
         {
             let entry = entry_offset(buf_ptr, offset)?;
-            i32::try_from(read_u32_ne(buf, entry + MAC_D_RECLEN_OFFSET)?)
-                .map_err(|_| AsyncHostError::Fault)
+            read_u32_ne(buf, entry + MAC_D_RECLEN_OFFSET)
         }
 
         #[cfg(target_os = "linux")]
         {
             let entry = entry_offset(buf_ptr, offset)?;
-            Ok(i32::from(read_u16_ne(buf, entry + LINUX_D_RECLEN_OFFSET)?))
+            Ok(u32::from(read_u16_ne(buf, entry + LINUX_D_RECLEN_OFFSET)?))
         }
     }
 
@@ -103,23 +104,23 @@ ported_fns! {
         source = "src/fs/dir.c",
         original = "moonbitlang_async_dir_entry_get_name_len"
     )]
-    pub(crate) fn entry_name_len(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<i32> {
+    pub(crate) fn entry_name_len(buf: &[u8], buf_ptr: u32, offset: u32) -> AsyncHostResult<u32> {
         #[cfg(windows)]
         {
             let entry = windows_entry(buf, buf_ptr, offset)?;
-            i32::try_from(entry.FileNameLength).map_err(|_| AsyncHostError::Fault)
+            Ok(entry.FileNameLength)
         }
 
         #[cfg(target_os = "macos")]
         {
             let (_, len) = mac_name_range(buf, buf_ptr, offset)?;
-            i32::try_from(len).map_err(|_| AsyncHostError::Fault)
+            u32::try_from(len).map_err(|_| AsyncHostError::Fault)
         }
 
         #[cfg(target_os = "linux")]
         {
             let (_, len) = linux_name_range(buf, buf_ptr, offset)?;
-            i32::try_from(len).map_err(|_| AsyncHostError::Fault)
+            u32::try_from(len).map_err(|_| AsyncHostError::Fault)
         }
     }
 
@@ -129,22 +130,22 @@ ported_fns! {
     )]
     pub(crate) fn entry_name_offset(
         buf: &[u8],
-        buf_ptr: i32,
-        offset: i32,
-    ) -> AsyncHostResult<i32> {
+        buf_ptr: u32,
+        offset: u32,
+    ) -> AsyncHostResult<u32> {
         #[cfg(windows)]
         {
             use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
 
             windows_name_range(buf, buf_ptr, offset)?;
-            i32::try_from(std::mem::offset_of!(FILE_ID_BOTH_DIR_INFO, FileName))
+            u32::try_from(std::mem::offset_of!(FILE_ID_BOTH_DIR_INFO, FileName))
                 .map_err(|_| AsyncHostError::Fault)
         }
 
         #[cfg(target_os = "macos")]
         {
             let name_offset = mac_name_offset(buf, buf_ptr, offset)?;
-            i32::try_from(
+            u32::try_from(
                 MAC_D_NAME_OFFSET
                     .checked_add(name_offset)
                     .ok_or(AsyncHostError::Fault)?,
@@ -155,7 +156,7 @@ ported_fns! {
         #[cfg(target_os = "linux")]
         {
             linux_name_range(buf, buf_ptr, offset)?;
-            i32::try_from(LINUX_D_NAME_OFFSET).map_err(|_| AsyncHostError::Fault)
+            u32::try_from(LINUX_D_NAME_OFFSET).map_err(|_| AsyncHostError::Fault)
         }
     }
 
@@ -163,7 +164,7 @@ ported_fns! {
         source = "src/fs/dir.c",
         original = "moonbitlang_async_dir_entry_is_dir"
     )]
-    pub(crate) fn entry_is_dir(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<i32> {
+    pub(crate) fn entry_is_dir(buf: &[u8], buf_ptr: u32, offset: u32) -> AsyncHostResult<i32> {
         #[cfg(windows)]
         {
             use windows_sys::Win32::Storage::FileSystem::{
@@ -207,7 +208,7 @@ ported_fns! {
         source = "src/fs/dir.c",
         original = "moonbitlang_async_dir_entry_is_hidden"
     )]
-    pub(crate) fn entry_is_hidden(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<bool> {
+    pub(crate) fn entry_is_hidden(buf: &[u8], buf_ptr: u32, offset: u32) -> AsyncHostResult<bool> {
         #[cfg(windows)]
         {
             use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_HIDDEN;
@@ -233,7 +234,7 @@ ported_fns! {
         source = "src/fs/dir.c",
         original = "moonbitlang_async_dir_entry_get_file_id"
     )]
-    pub(crate) fn entry_file_id(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<u64> {
+    pub(crate) fn entry_file_id(buf: &[u8], buf_ptr: u32, offset: u32) -> AsyncHostResult<u64> {
         #[cfg(windows)]
         {
             let entry = windows_entry(buf, buf_ptr, offset)?;
@@ -254,9 +255,10 @@ ported_fns! {
     }
 }
 
-fn entry_offset(buf_ptr: i32, offset: i32) -> AsyncHostResult<usize> {
-    let ptr = buf_ptr.checked_add(offset).ok_or(AsyncHostError::Fault)?;
-    usize::try_from(ptr).map_err(|_| AsyncHostError::Fault)
+fn entry_offset(buf_ptr: u32, offset: u32) -> AsyncHostResult<usize> {
+    let buf_ptr = usize::try_from(buf_ptr).map_err(|_| AsyncHostError::Fault)?;
+    let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
+    buf_ptr.checked_add(offset).ok_or(AsyncHostError::Fault)
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -294,7 +296,7 @@ fn read_u64_ne(buf: &[u8], offset: usize) -> AsyncHostResult<u64> {
 }
 
 #[cfg(target_os = "linux")]
-fn linux_name_range(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<(usize, usize)> {
+fn linux_name_range(buf: &[u8], buf_ptr: u32, offset: u32) -> AsyncHostResult<(usize, usize)> {
     let entry = entry_offset(buf_ptr, offset)?;
     let reclen = usize::from(read_u16_ne(buf, entry + LINUX_D_RECLEN_OFFSET)?);
     let name_start = entry
@@ -312,7 +314,7 @@ fn linux_name_range(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<(u
 }
 
 #[cfg(target_os = "macos")]
-fn mac_name_range(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<(usize, usize)> {
+fn mac_name_range(buf: &[u8], buf_ptr: u32, offset: u32) -> AsyncHostResult<(usize, usize)> {
     let entry = entry_offset(buf_ptr, offset)?;
     let reclen = usize::try_from(read_u32_ne(buf, entry + MAC_D_RECLEN_OFFSET)?)
         .map_err(|_| AsyncHostError::Fault)?;
@@ -335,7 +337,7 @@ fn mac_name_range(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<(usi
 }
 
 #[cfg(target_os = "macos")]
-fn mac_name_offset(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<usize> {
+fn mac_name_offset(buf: &[u8], buf_ptr: u32, offset: u32) -> AsyncHostResult<usize> {
     let entry = entry_offset(buf_ptr, offset)?;
     usize::try_from(read_i32_ne(buf, entry + MAC_D_NAME_OFFSET)?).map_err(|_| AsyncHostError::Fault)
 }
@@ -343,8 +345,8 @@ fn mac_name_offset(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<usi
 #[cfg(windows)]
 fn windows_entry(
     buf: &[u8],
-    buf_ptr: i32,
-    offset: i32,
+    buf_ptr: u32,
+    offset: u32,
 ) -> AsyncHostResult<windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO> {
     use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
 
@@ -359,7 +361,7 @@ fn windows_entry(
 }
 
 #[cfg(windows)]
-fn windows_name_range(buf: &[u8], buf_ptr: i32, offset: i32) -> AsyncHostResult<(usize, usize)> {
+fn windows_name_range(buf: &[u8], buf_ptr: u32, offset: u32) -> AsyncHostResult<(usize, usize)> {
     use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
 
     let entry = windows_entry(buf, buf_ptr, offset)?;

--- a/crates/moonrun/src/async_sys/internal/c_buffer/stub.rs
+++ b/crates/moonrun/src/async_sys/internal/c_buffer/stub.rs
@@ -26,10 +26,10 @@ ported_fns! {
     )]
     pub(crate) fn blit_to_c(
         dst: &mut [u8],
-        dst_offset: i32,
+        dst_offset: u32,
         src: &[u8],
-        src_offset: i32,
-        len: i32,
+        src_offset: u32,
+        len: u32,
     ) -> AsyncHostResult<()> {
         let src = checked_range(src, src_offset, len)?;
         let dst = checked_range_mut(dst, dst_offset, len)?;
@@ -43,10 +43,10 @@ ported_fns! {
     )]
     pub(crate) fn blit_from_c(
         src: &[u8],
-        src_offset: i32,
+        src_offset: u32,
         dst: &mut [u8],
-        dst_offset: i32,
-        len: i32,
+        dst_offset: u32,
+        len: u32,
     ) -> AsyncHostResult<()> {
         let src = checked_range(src, src_offset, len)?;
         let dst = checked_range_mut(dst, dst_offset, len)?;
@@ -58,7 +58,7 @@ ported_fns! {
         source = "src/internal/c_buffer/stub.c",
         original = "moonbitlang_async_c_buffer_get"
     )]
-    pub(crate) fn c_buffer_get(buf: &[u8], index: i32) -> AsyncHostResult<u8> {
+    pub(crate) fn c_buffer_get(buf: &[u8], index: u32) -> AsyncHostResult<u8> {
         let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
         buf.get(index).copied().ok_or(AsyncHostError::Fault)
     }
@@ -67,33 +67,33 @@ ported_fns! {
         source = "src/internal/c_buffer/stub.c",
         original = "moonbitlang_async_strlen"
     )]
-    pub(crate) fn strlen(buf: &[u8]) -> AsyncHostResult<i32> {
+    pub(crate) fn strlen(buf: &[u8]) -> AsyncHostResult<u32> {
         let len = buf
             .iter()
             .position(|byte| *byte == 0)
             .ok_or(AsyncHostError::Fault)?;
-        i32::try_from(len).map_err(|_| AsyncHostError::Fault)
+        u32::try_from(len).map_err(|_| AsyncHostError::Fault)
     }
 
     #[ported(
         source = "src/internal/c_buffer/stub.c",
         original = "moonbitlang_async_make_c_buffer"
     )]
-    pub(crate) fn make_c_buffer(size: i32) -> AsyncHostResult<Box<[u8]>> {
+    pub(crate) fn make_c_buffer(size: u32) -> AsyncHostResult<Box<[u8]>> {
         let size = usize::try_from(size).map_err(|_| AsyncHostError::Fault)?;
         Ok(vec![0; size].into_boxed_slice())
     }
 
 }
 
-fn checked_range(src: &[u8], offset: i32, len: i32) -> AsyncHostResult<&[u8]> {
+fn checked_range(src: &[u8], offset: u32, len: u32) -> AsyncHostResult<&[u8]> {
     let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
     let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
     let end = offset.checked_add(len).ok_or(AsyncHostError::Fault)?;
     src.get(offset..end).ok_or(AsyncHostError::Fault)
 }
 
-fn checked_range_mut(src: &mut [u8], offset: i32, len: i32) -> AsyncHostResult<&mut [u8]> {
+fn checked_range_mut(src: &mut [u8], offset: u32, len: u32) -> AsyncHostResult<&mut [u8]> {
     let offset = usize::try_from(offset).map_err(|_| AsyncHostError::Fault)?;
     let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
     let end = offset.checked_add(len).ok_or(AsyncHostError::Fault)?;

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/epoll.rs
@@ -145,7 +145,7 @@ ported_fns! {
         source = "src/internal/event_loop/epoll.c",
         original = "moonbitlang_async_event_list_get"
     )]
-    pub(crate) fn event_list_get(instance: &PollInstance, index: i32) -> AsyncHostResult<&PollEvent> {
+    pub(crate) fn event_list_get(instance: &PollInstance, index: u32) -> AsyncHostResult<&PollEvent> {
         let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
         if index >= instance.event_count {
             return Err(AsyncHostError::Fault);

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/iocp.rs
@@ -132,7 +132,7 @@ ported_fns! {
         source = "src/internal/event_loop/iocp.c",
         original = "moonbitlang_async_event_list_get"
     )]
-    pub(crate) fn event_list_get(instance: &PollInstance, index: i32) -> AsyncHostResult<&PollEvent> {
+    pub(crate) fn event_list_get(instance: &PollInstance, index: u32) -> AsyncHostResult<&PollEvent> {
         let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
         if index >= instance.event_count {
             return Err(AsyncHostError::Fault);
@@ -165,8 +165,8 @@ ported_fns! {
         source = "src/internal/event_loop/iocp.c",
         original = "moonbitlang_async_event_get_bytes_transferred"
     )]
-    pub(crate) fn event_get_bytes_transferred(event: &PollEvent) -> i32 {
-        event.dwNumberOfBytesTransferred as i32
+    pub(crate) fn event_get_bytes_transferred(event: &PollEvent) -> u32 {
+        event.dwNumberOfBytesTransferred
     }
 }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/kqueue.rs
@@ -236,7 +236,7 @@ ported_fns! {
         source = "src/internal/event_loop/kqueue.c",
         original = "moonbitlang_async_event_list_get"
     )]
-    pub(crate) fn event_list_get(instance: &PollInstance, index: i32) -> AsyncHostResult<&PollEvent> {
+    pub(crate) fn event_list_get(instance: &PollInstance, index: u32) -> AsyncHostResult<&PollEvent> {
         let index = usize::try_from(index).map_err(|_| AsyncHostError::Fault)?;
         if index >= instance.event_count {
             return Err(AsyncHostError::Fault);

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/fs.rs
@@ -78,7 +78,7 @@ ported_fns! {
     )]
     pub(super) fn run_read_job(
         file: &Resource,
-        len: i32,
+        len: u32,
         position: i64,
         result: &mut Option<Vec<u8>>,
     ) -> AsyncHostResult<i64> {
@@ -264,7 +264,7 @@ ported_fns! {
     pub(super) fn run_readdir_job(
         dir: &Resource,
         buffer: &mut [u8],
-        len: i32,
+        len: u32,
         restart: bool,
     ) -> AsyncHostResult<i64> {
         let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -90,7 +90,7 @@ ported_fns! {
     )]
     pub(crate) fn make_read_job(
         file: ResourceRef,
-        len: i32,
+        len: u32,
         position: i64,
     ) -> Job {
         Job::new(JobPayload::Read {
@@ -152,7 +152,7 @@ ported_fns! {
         sync: i32,
         mode: i32,
         stat_request: u32,
-        stat_result_len: i32,
+        stat_result_len: u32,
     ) -> Job {
         let request = match StatRequest::new(stat_request, stat_result_len) {
             Ok(request) => request,
@@ -177,7 +177,7 @@ ported_fns! {
     pub(crate) fn make_fstatx_job(
         file: ResourceRef,
         stat_request: u32,
-        stat_result_len: i32,
+        stat_result_len: u32,
     ) -> Job {
         let request = match StatRequest::new(stat_request, stat_result_len) {
             Ok(request) => request,
@@ -198,7 +198,7 @@ ported_fns! {
         parent: Option<ResourceRef>,
         path: OsString,
         stat_request: u32,
-        stat_result_len: i32,
+        stat_result_len: u32,
         follow_symlink: bool,
     ) -> Job {
         let request = match StatRequest::new(stat_request, stat_result_len) {
@@ -432,7 +432,7 @@ ported_fns! {
     pub(crate) fn make_readdir_job(
         dir: ResourceRef,
         buffer: crate::async_host::CBufferLease,
-        len: i32,
+        len: u32,
         restart: bool,
     ) -> Job {
         Job::new(JobPayload::Readdir {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -231,9 +231,9 @@ pub(crate) fn run_host_job(job: &mut Job) {
 pub(crate) fn get_read_result(
     job: &Job,
     memory: &mut (impl GuestMemory + ?Sized),
-    dst: i32,
-    offset: i32,
-    len: i32,
+    dst: u32,
+    offset: u32,
+    len: u32,
 ) -> AsyncHostResult<()> {
     if job.err() != 0 {
         return Ok(());
@@ -245,14 +245,14 @@ pub(crate) fn get_read_result(
     else {
         return Err(AsyncHostError::Badf);
     };
-    let dst_offset = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
-    memory.write_with_capacity(dst_offset, len, result)
+    let dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+    memory.write_with_capacity(dst, len, result)
 }
 
 pub(crate) fn get_file_time_result(
     job: &Job,
     memory: &mut (impl GuestMemory + ?Sized),
-    dst: i32,
+    dst: u32,
 ) -> AsyncHostResult<()> {
     if job.err() != 0 {
         return Ok(());
@@ -283,8 +283,8 @@ pub(crate) fn get_file_time_result(
 pub(crate) fn get_stat_result(
     job: &Job,
     memory: &mut (impl GuestMemory + ?Sized),
-    dst: i32,
-    dst_len: i32,
+    dst: u32,
+    dst_len: u32,
 ) -> AsyncHostResult<()> {
     if job.err() != 0 {
         return Ok(());

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/stat.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/stat.rs
@@ -57,8 +57,9 @@ impl StatRequest {
         }
     }
 
-    pub(super) fn new(mask: u32, capacity: i32) -> AsyncHostResult<Self> {
-        if mask & !STAT_SUPPORTED_PROPERTY_MASK != 0 || capacity < STAT_HEADER_LEN as i32 {
+    pub(super) fn new(mask: u32, capacity: u32) -> AsyncHostResult<Self> {
+        let header_len = u32::try_from(STAT_HEADER_LEN).map_err(|_| AsyncHostError::Fault)?;
+        if mask & !STAT_SUPPORTED_PROPERTY_MASK != 0 || capacity < header_len {
             return Err(AsyncHostError::Inval);
         }
         let property_words = (0..8)
@@ -1012,7 +1013,7 @@ mod tests {
                 .sum::<usize>();
             let expected_len = STAT_HEADER_LEN + expected_words * 8;
 
-            let request = StatRequest::new(mask, expected_len as i32).unwrap();
+            let request = StatRequest::new(mask, u32::try_from(expected_len).unwrap()).unwrap();
 
             assert_eq!(request.mask(), mask);
             assert_eq!(request.encoded_len(), expected_len);
@@ -1076,7 +1077,7 @@ mod tests {
         let mut job = make_fstatx_job(
             std::sync::Arc::new(Resource::new(raw)),
             request,
-            StatRequest::new(request, 40).unwrap().encoded_len() as i32,
+            u32::try_from(StatRequest::new(request, 40).unwrap().encoded_len()).unwrap(),
         );
 
         run_host_job(&mut job);

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -417,7 +417,7 @@ pub(crate) enum JobPayload {
     },
     Read {
         file: Option<ResourceRef>,
-        len: i32,
+        len: u32,
         position: i64,
         result: Option<Vec<u8>>,
     },
@@ -505,7 +505,7 @@ pub(crate) enum JobPayload {
     Readdir {
         dir: Option<ResourceRef>,
         buffer: Option<CBufferLease>,
-        len: i32,
+        len: u32,
         restart: bool,
     },
     Bind {

--- a/crates/moonrun/src/async_sys/signal.rs
+++ b/crates/moonrun/src/async_sys/signal.rs
@@ -102,7 +102,7 @@ ported_fns! {
     }
 }
 
-pub(crate) fn get_signal_by_index(index: i32) -> i32 {
+pub(crate) fn get_signal_by_index(index: u32) -> i32 {
     match index {
         0 => signal_int(),
         1 => signal_term(),

--- a/crates/moonrun/src/async_sys/socket.rs
+++ b/crates/moonrun/src/async_sys/socket.rs
@@ -297,27 +297,28 @@ mod win {
         Ok((0, addrs))
     }
 
-    pub(super) fn ipv4_addr_size() -> i32 {
-        std::mem::size_of::<ws::SOCKADDR_IN>() as i32
+    pub(super) fn ipv4_addr_size() -> u32 {
+        u32::try_from(std::mem::size_of::<ws::SOCKADDR_IN>()).expect("socket address size fits u32")
     }
 
-    pub(super) fn ipv6_addr_size() -> i32 {
-        std::mem::size_of::<ws::SOCKADDR_IN6>() as i32
+    pub(super) fn ipv6_addr_size() -> u32 {
+        u32::try_from(std::mem::size_of::<ws::SOCKADDR_IN6>())
+            .expect("socket address size fits u32")
     }
 
-    pub(super) fn init_ip_addr(addr: &mut [u8], ip: i32, port: i32) -> AsyncHostResult<()> {
+    pub(super) fn init_ip_addr(addr: &mut [u8], ip: u32, port: u32) -> AsyncHostResult<()> {
         let mut sockaddr = unsafe { std::mem::zeroed::<ws::SOCKADDR_IN>() };
         sockaddr.sin_family = ws::AF_INET;
         sockaddr.sin_port = (port as u16).to_be();
-        sockaddr.sin_addr.S_un.S_addr = (ip as u32).to_be();
+        sockaddr.sin_addr.S_un.S_addr = ip.to_be();
         write_struct(addr, &sockaddr)
     }
 
     pub(super) fn init_ipv6_addr(
         addr: &mut [u8],
         ip: &[u8],
-        port: i32,
-        scope_id: i32,
+        port: u32,
+        scope_id: u32,
     ) -> AsyncHostResult<()> {
         let ip: [u8; 16] = ip
             .get(..16)
@@ -328,16 +329,18 @@ mod win {
         sockaddr.sin6_family = ws::AF_INET6;
         sockaddr.sin6_port = (port as u16).to_be();
         sockaddr.sin6_addr.u.Byte = ip;
-        sockaddr.Anonymous.sin6_scope_id = scope_id as u32;
+        sockaddr.Anonymous.sin6_scope_id = scope_id;
         write_struct(addr, &sockaddr)
     }
 
-    pub(super) fn ip_addr_get_ip(addr: &[u8]) -> AsyncHostResult<i32> {
-        Ok(u32::from_be(unsafe { read_sockaddr_in(addr)?.sin_addr.S_un.S_addr }) as i32)
+    pub(super) fn ip_addr_get_ip(addr: &[u8]) -> AsyncHostResult<u32> {
+        Ok(u32::from_be(unsafe {
+            read_sockaddr_in(addr)?.sin_addr.S_un.S_addr
+        }))
     }
 
-    pub(super) fn ip_addr_get_port(addr: &[u8]) -> AsyncHostResult<i32> {
-        Ok(i32::from(u16::from_be(read_sockaddr_in(addr)?.sin_port)))
+    pub(super) fn ip_addr_get_port(addr: &[u8]) -> AsyncHostResult<u32> {
+        Ok(u32::from(u16::from_be(read_sockaddr_in(addr)?.sin_port)))
     }
 
     pub(super) fn addr_is_ipv6(addr: &[u8]) -> AsyncHostResult<bool> {
@@ -356,8 +359,8 @@ mod win {
         }
     }
 
-    pub(super) fn addr_get_ipv6_scope_id(addr: &[u8]) -> AsyncHostResult<i32> {
-        Ok(unsafe { read_sockaddr_in6(addr)?.Anonymous.sin6_scope_id } as i32)
+    pub(super) fn addr_get_ipv6_scope_id(addr: &[u8]) -> AsyncHostResult<u32> {
+        Ok(unsafe { read_sockaddr_in6(addr)?.Anonymous.sin6_scope_id })
     }
 
     pub(super) fn addr_is_ipv6_wildcard(addr: &[u8]) -> AsyncHostResult<bool> {
@@ -455,12 +458,12 @@ mod win {
     pub(super) fn join_multicast_group_v6(
         fd: RawSocket,
         multi_addr: &[u8],
-        interface_index: i32,
+        interface_index: u32,
     ) -> AsyncHostResult<()> {
         let multi_addr = read_sockaddr_in6(multi_addr)?;
         let mreq = ws::IPV6_MREQ {
             ipv6mr_multiaddr: multi_addr.sin6_addr,
-            ipv6mr_interface: interface_index as u32,
+            ipv6mr_interface: interface_index,
         };
         socket_error(unsafe {
             ws::setsockopt(
@@ -488,9 +491,8 @@ mod win {
 
     pub(super) fn set_multicast_interface_v6(
         fd: RawSocket,
-        interface_index: i32,
+        interface_index: u32,
     ) -> AsyncHostResult<()> {
-        let interface_index = interface_index as u32;
         socket_error(unsafe {
             ws::setsockopt(
                 socket(fd),
@@ -570,7 +572,7 @@ mod win {
         })
     }
 
-    pub(super) fn if_nametoindex(name: &[u16]) -> AsyncHostResult<i32> {
+    pub(super) fn if_nametoindex(name: &[u16]) -> AsyncHostResult<u32> {
         let name: Vec<u16> = name.iter().copied().chain(std::iter::once(0)).collect();
         let mut luid = unsafe { std::mem::zeroed::<NET_LUID_LH>() };
         let mut errno = unsafe { ConvertInterfaceAliasToLuid(name.as_ptr(), &mut luid) };
@@ -582,12 +584,12 @@ mod win {
         if errno != NO_ERROR {
             return Err(win32_error(errno));
         }
-        i32::try_from(index).map_err(|_| AsyncHostError::Fault)
+        Ok(index)
     }
 
-    pub(super) fn if_indextoname(index: i32) -> AsyncHostResult<Vec<u8>> {
+    pub(super) fn if_indextoname(index: u32) -> AsyncHostResult<Vec<u8>> {
         let mut luid = unsafe { std::mem::zeroed::<NET_LUID_LH>() };
-        let mut errno = unsafe { ConvertInterfaceIndexToLuid(index as u32, &mut luid) };
+        let mut errno = unsafe { ConvertInterfaceIndexToLuid(index, &mut luid) };
         if errno != NO_ERROR {
             return Err(win32_error(errno));
         }
@@ -607,7 +609,7 @@ mod win {
         Ok(bytes)
     }
 
-    pub(super) fn find_ipv6_test_interface() -> i32 {
+    pub(super) fn find_ipv6_test_interface() -> u32 {
         let flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER;
         let mut buf_len = 16 * 1024u32;
         for _ in 0..3 {
@@ -650,7 +652,7 @@ mod win {
                                 unsafe { &*(address.lpSockaddr.cast::<ws::SOCKADDR_IN6>()) };
                             let bytes = unsafe { sockaddr.sin6_addr.u.Byte };
                             if bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80 {
-                                return adapter_ref.Ipv6IfIndex as i32;
+                                return adapter_ref.Ipv6IfIndex;
                             }
                         }
                         unicast = unsafe { (*unicast).Next };
@@ -677,17 +679,17 @@ mod win {
         socket_error(unsafe { ws::connect(socket(fd), addr.as_ptr().cast::<ws::SOCKADDR>(), len) })
     }
 
-    pub(super) fn addrinfo_addr_size(addr: &[u8]) -> i32 {
+    pub(super) fn addrinfo_addr_size(addr: &[u8]) -> u32 {
         if addr.is_empty() {
             return 0;
         }
-        i32::try_from(addr.len()).unwrap_or(0)
+        u32::try_from(addr.len()).unwrap_or(0)
     }
 
     pub(super) fn addrinfo_fill_addr(
         addr: &[u8],
         out: &mut [u8],
-        port: i32,
+        port: u32,
     ) -> AsyncHostResult<()> {
         match sockaddr_family(addr)? as u16 {
             ws::AF_INET => {
@@ -719,8 +721,9 @@ ported_fns! {
         original = "moonbitlang_async_ipv4_addr_size"
     )]
     #[cfg(unix)]
-    pub(crate) fn ipv4_addr_size() -> i32 {
-        std::mem::size_of::<libc::sockaddr_in>() as i32
+    pub(crate) fn ipv4_addr_size() -> u32 {
+        u32::try_from(std::mem::size_of::<libc::sockaddr_in>())
+            .expect("socket address size fits u32")
     }
 
     #[ported(
@@ -728,7 +731,7 @@ ported_fns! {
         original = "moonbitlang_async_ipv4_addr_size"
     )]
     #[cfg(windows)]
-    pub(crate) fn ipv4_addr_size() -> i32 {
+    pub(crate) fn ipv4_addr_size() -> u32 {
         win::ipv4_addr_size()
     }
 
@@ -737,8 +740,9 @@ ported_fns! {
         original = "moonbitlang_async_ipv6_addr_size"
     )]
     #[cfg(unix)]
-    pub(crate) fn ipv6_addr_size() -> i32 {
-        std::mem::size_of::<libc::sockaddr_in6>() as i32
+    pub(crate) fn ipv6_addr_size() -> u32 {
+        u32::try_from(std::mem::size_of::<libc::sockaddr_in6>())
+            .expect("socket address size fits u32")
     }
 
     #[ported(
@@ -746,7 +750,7 @@ ported_fns! {
         original = "moonbitlang_async_ipv6_addr_size"
     )]
     #[cfg(windows)]
-    pub(crate) fn ipv6_addr_size() -> i32 {
+    pub(crate) fn ipv6_addr_size() -> u32 {
         win::ipv6_addr_size()
     }
 
@@ -755,12 +759,12 @@ ported_fns! {
         original = "moonbitlang_async_init_ip_addr"
     )]
     #[cfg(unix)]
-    pub(crate) fn init_ip_addr(addr: &mut [u8], ip: i32, port: i32) -> AsyncHostResult<()> {
+    pub(crate) fn init_ip_addr(addr: &mut [u8], ip: u32, port: u32) -> AsyncHostResult<()> {
         let sockaddr = libc::sockaddr_in {
             sin_family: libc::AF_INET as libc::sa_family_t,
             sin_port: (port as u16).to_be(),
             sin_addr: libc::in_addr {
-                s_addr: (ip as u32).to_be(),
+                s_addr: ip.to_be(),
             },
             ..unsafe { std::mem::zeroed() }
         };
@@ -772,7 +776,7 @@ ported_fns! {
         original = "moonbitlang_async_init_ip_addr"
     )]
     #[cfg(windows)]
-    pub(crate) fn init_ip_addr(addr: &mut [u8], ip: i32, port: i32) -> AsyncHostResult<()> {
+    pub(crate) fn init_ip_addr(addr: &mut [u8], ip: u32, port: u32) -> AsyncHostResult<()> {
         win::init_ip_addr(addr, ip, port)
     }
 
@@ -784,8 +788,8 @@ ported_fns! {
     pub(crate) fn init_ipv6_addr(
         addr: &mut [u8],
         ip: &[u8],
-        port: i32,
-        scope_id: i32,
+        port: u32,
+        scope_id: u32,
     ) -> AsyncHostResult<()> {
         let ip: [u8; 16] = ip
             .get(..16)
@@ -796,7 +800,7 @@ ported_fns! {
             sin6_family: libc::AF_INET6 as libc::sa_family_t,
             sin6_port: (port as u16).to_be(),
             sin6_addr: libc::in6_addr { s6_addr: ip },
-            sin6_scope_id: scope_id as u32,
+            sin6_scope_id: scope_id,
             ..unsafe { std::mem::zeroed() }
         };
         write_struct(addr, &sockaddr)
@@ -810,8 +814,8 @@ ported_fns! {
     pub(crate) fn init_ipv6_addr(
         addr: &mut [u8],
         ip: &[u8],
-        port: i32,
-        scope_id: i32,
+        port: u32,
+        scope_id: u32,
     ) -> AsyncHostResult<()> {
         win::init_ipv6_addr(addr, ip, port, scope_id)
     }
@@ -831,8 +835,8 @@ ported_fns! {
         original = "moonbitlang_async_ip_addr_get_ip"
     )]
     #[cfg(unix)]
-    pub(crate) fn ip_addr_get_ip(addr: &[u8]) -> AsyncHostResult<i32> {
-        Ok(u32::from_be(read_sockaddr_in(addr)?.sin_addr.s_addr) as i32)
+    pub(crate) fn ip_addr_get_ip(addr: &[u8]) -> AsyncHostResult<u32> {
+        Ok(u32::from_be(read_sockaddr_in(addr)?.sin_addr.s_addr))
     }
 
     #[ported(
@@ -840,7 +844,7 @@ ported_fns! {
         original = "moonbitlang_async_ip_addr_get_ip"
     )]
     #[cfg(windows)]
-    pub(crate) fn ip_addr_get_ip(addr: &[u8]) -> AsyncHostResult<i32> {
+    pub(crate) fn ip_addr_get_ip(addr: &[u8]) -> AsyncHostResult<u32> {
         win::ip_addr_get_ip(addr)
     }
 
@@ -849,8 +853,8 @@ ported_fns! {
         original = "moonbitlang_async_ip_addr_get_port"
     )]
     #[cfg(unix)]
-    pub(crate) fn ip_addr_get_port(addr: &[u8]) -> AsyncHostResult<i32> {
-        Ok(i32::from(u16::from_be(read_sockaddr_in(addr)?.sin_port)))
+    pub(crate) fn ip_addr_get_port(addr: &[u8]) -> AsyncHostResult<u32> {
+        Ok(u32::from(u16::from_be(read_sockaddr_in(addr)?.sin_port)))
     }
 
     #[ported(
@@ -858,7 +862,7 @@ ported_fns! {
         original = "moonbitlang_async_ip_addr_get_port"
     )]
     #[cfg(windows)]
-    pub(crate) fn ip_addr_get_port(addr: &[u8]) -> AsyncHostResult<i32> {
+    pub(crate) fn ip_addr_get_port(addr: &[u8]) -> AsyncHostResult<u32> {
         win::ip_addr_get_port(addr)
     }
 
@@ -910,8 +914,9 @@ ported_fns! {
         original = "moonbitlang_async_addr_get_ipv6_bytes_offset"
     )]
     #[cfg(unix)]
-    pub(crate) fn addr_get_ipv6_bytes_offset() -> i32 {
-        std::mem::offset_of!(libc::sockaddr_in6, sin6_addr) as i32
+    pub(crate) fn addr_get_ipv6_bytes_offset() -> u32 {
+        u32::try_from(std::mem::offset_of!(libc::sockaddr_in6, sin6_addr))
+            .expect("socket address offset fits u32")
     }
 
     #[ported(
@@ -919,8 +924,9 @@ ported_fns! {
         original = "moonbitlang_async_addr_get_ipv6_bytes_offset"
     )]
     #[cfg(windows)]
-    pub(crate) fn addr_get_ipv6_bytes_offset() -> i32 {
-        std::mem::offset_of!(ws::SOCKADDR_IN6, sin6_addr) as i32
+    pub(crate) fn addr_get_ipv6_bytes_offset() -> u32 {
+        u32::try_from(std::mem::offset_of!(ws::SOCKADDR_IN6, sin6_addr))
+            .expect("socket address offset fits u32")
     }
 
     #[ported(
@@ -928,8 +934,8 @@ ported_fns! {
         original = "moonbitlang_async_addr_get_ipv6_scope_id"
     )]
     #[cfg(unix)]
-    pub(crate) fn addr_get_ipv6_scope_id(addr: &[u8]) -> AsyncHostResult<i32> {
-        Ok(read_sockaddr_in6(addr)?.sin6_scope_id as i32)
+    pub(crate) fn addr_get_ipv6_scope_id(addr: &[u8]) -> AsyncHostResult<u32> {
+        Ok(read_sockaddr_in6(addr)?.sin6_scope_id)
     }
 
     #[ported(
@@ -937,7 +943,7 @@ ported_fns! {
         original = "moonbitlang_async_addr_get_ipv6_scope_id"
     )]
     #[cfg(windows)]
-    pub(crate) fn addr_get_ipv6_scope_id(addr: &[u8]) -> AsyncHostResult<i32> {
+    pub(crate) fn addr_get_ipv6_scope_id(addr: &[u8]) -> AsyncHostResult<u32> {
         win::addr_get_ipv6_scope_id(addr)
     }
 
@@ -1089,7 +1095,7 @@ ported_fns! {
     pub(crate) fn join_multicast_group_v6(
         fd: RawSocket,
         multi_addr: &[u8],
-        interface_index: i32,
+        interface_index: u32,
     ) -> AsyncHostResult<()> {
         let multi_addr = read_sockaddr_in6(multi_addr)?;
         let mreq = libc::ipv6_mreq {
@@ -1124,7 +1130,7 @@ ported_fns! {
     pub(crate) fn join_multicast_group_v6(
         fd: RawSocket,
         multi_addr: &[u8],
-        interface_index: i32,
+        interface_index: u32,
     ) -> AsyncHostResult<()> {
         win::join_multicast_group_v6(fd, multi_addr, interface_index)
     }
@@ -1168,7 +1174,7 @@ ported_fns! {
     #[cfg(unix)]
     pub(crate) fn set_multicast_interface_v6(
         fd: RawSocket,
-        interface_index: i32,
+        interface_index: u32,
     ) -> AsyncHostResult<()> {
         let interface_index = interface_index as libc::c_uint;
         if unsafe {
@@ -1194,7 +1200,7 @@ ported_fns! {
     #[cfg(windows)]
     pub(crate) fn set_multicast_interface_v6(
         fd: RawSocket,
-        interface_index: i32,
+        interface_index: u32,
     ) -> AsyncHostResult<()> {
         win::set_multicast_interface_v6(fd, interface_index)
     }
@@ -1493,7 +1499,7 @@ ported_fns! {
         original = "moonbitlang_async_if_nametoindex"
     )]
     #[cfg(unix)]
-    pub(crate) fn if_nametoindex(name: &[u16]) -> AsyncHostResult<i32> {
+    pub(crate) fn if_nametoindex(name: &[u16]) -> AsyncHostResult<u32> {
         let name = char::decode_utf16(name.iter().copied())
             .collect::<Result<String, _>>()
             .map_err(|_| AsyncHostError::Inval)?;
@@ -1502,7 +1508,7 @@ ported_fns! {
         if index == 0 {
             Err(last_native_error())
         } else {
-            Ok(index as i32)
+            Ok(index)
         }
     }
 
@@ -1511,7 +1517,7 @@ ported_fns! {
         original = "moonbitlang_async_if_nametoindex"
     )]
     #[cfg(windows)]
-    pub(crate) fn if_nametoindex(name: &[u16]) -> AsyncHostResult<i32> {
+    pub(crate) fn if_nametoindex(name: &[u16]) -> AsyncHostResult<u32> {
         win::if_nametoindex(name)
     }
 
@@ -1520,9 +1526,9 @@ ported_fns! {
         original = "moonbitlang_async_if_indextoname"
     )]
     #[cfg(unix)]
-    pub(crate) fn if_indextoname(index: i32) -> AsyncHostResult<Vec<u8>> {
+    pub(crate) fn if_indextoname(index: u32) -> AsyncHostResult<Vec<u8>> {
         let mut name = vec![0; libc::IF_NAMESIZE + 1];
-        let ptr = unsafe { libc::if_indextoname(index as u32, name.as_mut_ptr().cast()) };
+        let ptr = unsafe { libc::if_indextoname(index, name.as_mut_ptr().cast()) };
         if ptr.is_null() {
             return Err(last_native_error());
         }
@@ -1536,7 +1542,7 @@ ported_fns! {
         original = "moonbitlang_async_if_indextoname"
     )]
     #[cfg(windows)]
-    pub(crate) fn if_indextoname(index: i32) -> AsyncHostResult<Vec<u8>> {
+    pub(crate) fn if_indextoname(index: u32) -> AsyncHostResult<Vec<u8>> {
         win::if_indextoname(index)
     }
 
@@ -1545,7 +1551,7 @@ ported_fns! {
         original = "moonbitlang_async_find_ipv6_test_interface"
     )]
     #[cfg(unix)]
-    pub(crate) fn find_ipv6_test_interface() -> i32 {
+    pub(crate) fn find_ipv6_test_interface() -> u32 {
         let mut ifaddrs = std::ptr::null_mut();
         if unsafe { libc::getifaddrs(&mut ifaddrs) } < 0 {
             return 0;
@@ -1574,7 +1580,7 @@ ported_fns! {
                     if is_link_local {
                         let index = unsafe { libc::if_nametoindex(ifaddr.ifa_name) };
                         if index != 0 {
-                            result = index as i32;
+                            result = index;
                             break;
                         }
                     }
@@ -1593,7 +1599,7 @@ ported_fns! {
         original = "moonbitlang_async_find_ipv6_test_interface"
     )]
     #[cfg(windows)]
-    pub(crate) fn find_ipv6_test_interface() -> i32 {
+    pub(crate) fn find_ipv6_test_interface() -> u32 {
         win::find_ipv6_test_interface()
     }
 
@@ -1738,11 +1744,11 @@ ported_fns! {
         original = "moonbitlang_async_addrinfo_addr_size"
     )]
     #[cfg(unix)]
-    pub(crate) fn addrinfo_addr_size(addr: &[u8]) -> i32 {
+    pub(crate) fn addrinfo_addr_size(addr: &[u8]) -> u32 {
         if addr.is_empty() {
             return 0;
         }
-        i32::try_from(addr.len()).unwrap_or(0)
+        u32::try_from(addr.len()).unwrap_or(0)
     }
 
     #[ported(
@@ -1750,7 +1756,7 @@ ported_fns! {
         original = "moonbitlang_async_addrinfo_addr_size"
     )]
     #[cfg(windows)]
-    pub(crate) fn addrinfo_addr_size(addr: &[u8]) -> i32 {
+    pub(crate) fn addrinfo_addr_size(addr: &[u8]) -> u32 {
         win::addrinfo_addr_size(addr)
     }
 
@@ -1759,7 +1765,7 @@ ported_fns! {
         original = "moonbitlang_async_addrinfo_fill_addr"
     )]
     #[cfg(unix)]
-    pub(crate) fn addrinfo_fill_addr(addr: &[u8], out: &mut [u8], port: i32) -> AsyncHostResult<()> {
+    pub(crate) fn addrinfo_fill_addr(addr: &[u8], out: &mut [u8], port: u32) -> AsyncHostResult<()> {
         match sockaddr_family(addr)? {
             libc::AF_INET => {
                 let mut sockaddr = read_sockaddr_in(addr)?;
@@ -1781,7 +1787,7 @@ ported_fns! {
         original = "moonbitlang_async_addrinfo_fill_addr"
     )]
     #[cfg(windows)]
-    pub(crate) fn addrinfo_fill_addr(addr: &[u8], out: &mut [u8], port: i32) -> AsyncHostResult<()> {
+    pub(crate) fn addrinfo_fill_addr(addr: &[u8], out: &mut [u8], port: u32) -> AsyncHostResult<()> {
         win::addrinfo_fill_addr(addr, out, port)
     }
 }
@@ -1827,7 +1833,7 @@ mod tests {
         init_ipv6_addr(&mut addr, &ip, 443, 0).unwrap();
 
         let offset = std::mem::offset_of!(libc::sockaddr_in6, sin6_addr);
-        assert_eq!(addr_get_ipv6_bytes_offset(), offset as i32);
+        assert_eq!(addr_get_ipv6_bytes_offset(), u32::try_from(offset).unwrap());
         let len = std::mem::size_of::<libc::in6_addr>();
         assert_eq!(&addr[offset..offset + len], &ip);
     }

--- a/crates/moonrun/src/v8_import.rs
+++ b/crates/moonrun/src/v8_import.rs
@@ -158,6 +158,15 @@ impl<'a, 'scope, 'args> ImportArgs<'a, 'scope, 'args> {
             .ok_or(V8ImportError::InvalidArgument)
     }
 
+    /// Decode the same Wasm `i32` value with unsigned Rust semantics.
+    pub(crate) fn next_u32(&mut self) -> Result<u32, V8ImportError> {
+        let value = self.args.get(self.next_index);
+        self.next_index += 1;
+        value
+            .uint32_value(self.scope)
+            .ok_or(V8ImportError::InvalidArgument)
+    }
+
     pub(crate) fn next_i64(&mut self) -> Result<i64, V8ImportError> {
         let value = self.args.get(self.next_index);
         self.next_index += 1;
@@ -177,16 +186,18 @@ impl<'a, 'scope, 'args> ImportArgs<'a, 'scope, 'args> {
     pub(crate) fn next_u64(&mut self) -> Result<u64, V8ImportError> {
         let value = self.args.get(self.next_index);
         self.next_index += 1;
-        if !value.is_big_int() {
-            return Err(V8ImportError::InvalidArgument);
-        }
-        let bigint =
-            v8::Local::<v8::BigInt>::try_from(value).map_err(|_| V8ImportError::InvalidArgument)?;
-        let (result, lossless) = bigint.u64_value();
-        lossless
-            .then_some(result)
-            .ok_or(V8ImportError::InvalidArgument)
+        decode_wasm_u64(value).ok_or(V8ImportError::InvalidArgument)
     }
+}
+
+pub(crate) fn decode_wasm_u64(value: v8::Local<v8::Value>) -> Option<u64> {
+    let bigint = v8::Local::<v8::BigInt>::try_from(value).ok()?;
+    let (signed, signed_lossless) = bigint.i64_value();
+    if signed_lossless {
+        return Some(u64::from_ne_bytes(signed.to_ne_bytes()));
+    }
+    let (unsigned, unsigned_lossless) = bigint.u64_value();
+    unsigned_lossless.then_some(unsigned)
 }
 
 pub(crate) fn register_func<'s, T>(
@@ -214,4 +225,24 @@ pub(crate) fn throw_import_error(
     let message = v8::String::new(scope, &message).unwrap_or_else(|| v8::String::empty(scope));
     let exception = v8::Exception::error(scope, message);
     scope.throw_exception(exception);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wasm_u64_decoder_preserves_all_i64_bit_patterns() {
+        crate::v8_backend::initialize(&crate::runtime::RuntimeConfig::default()).unwrap();
+        let isolate = &mut v8::Isolate::new(Default::default());
+        let scope = &mut v8::HandleScope::new(isolate);
+        let context = v8::Context::new(scope, Default::default());
+        let scope = &mut v8::ContextScope::new(scope, context);
+
+        let signed = v8::BigInt::new_from_i64(scope, -1);
+        assert_eq!(decode_wasm_u64(signed.into()), Some(u64::MAX));
+
+        let unsigned = v8::BigInt::new_from_u64(scope, u64::MAX);
+        assert_eq!(decode_wasm_u64(unsigned.into()), Some(u64::MAX));
+    }
 }

--- a/crates/moonrun/src/wasi_api.rs
+++ b/crates/moonrun/src/wasi_api.rs
@@ -249,6 +249,14 @@ fn read_i32_arg(
     args.get(index).int32_value(scope).ok_or(WASI_ERRNO_INVAL)
 }
 
+fn read_u32_arg(
+    scope: &mut v8::HandleScope,
+    args: &v8::FunctionCallbackArguments,
+    index: i32,
+) -> WasiResult<u32> {
+    args.get(index).uint32_value(scope).ok_or(WASI_ERRNO_INVAL)
+}
+
 fn read_u64_arg(
     scope: &mut v8::HandleScope,
     args: &v8::FunctionCallbackArguments,
@@ -256,20 +264,14 @@ fn read_u64_arg(
 ) -> WasiResult<u64> {
     let value = args.get(index);
     if value.is_big_int() {
-        let bigint = v8::Local::<v8::BigInt>::try_from(value).map_err(|_| WASI_ERRNO_INVAL)?;
-        let (result, lossless) = bigint.u64_value();
-        if lossless {
-            Ok(result)
-        } else {
-            Err(WASI_ERRNO_INVAL)
-        }
+        crate::v8_import::decode_wasm_u64(value).ok_or(WASI_ERRNO_INVAL)
     } else {
         let value = value.integer_value(scope).ok_or(WASI_ERRNO_INVAL)?;
         u64::try_from(value).map_err(|_| WASI_ERRNO_INVAL)
     }
 }
 
-fn ptr_to_offset(ptr: i32) -> WasiResult<usize> {
+fn ptr_to_offset(ptr: u32) -> WasiResult<usize> {
     usize::try_from(ptr).map_err(|_| WASI_ERRNO_FAULT)
 }
 
@@ -301,7 +303,7 @@ fn write_u32_at(memory: &mut [u8], offset: usize, value: u32) -> WasiResult<()> 
     Ok(())
 }
 
-fn write_u32(memory: &mut [u8], ptr: i32, value: u32) -> WasiResult<()> {
+fn write_u32(memory: &mut [u8], ptr: u32, value: u32) -> WasiResult<()> {
     write_u32_at(memory, ptr_to_offset(ptr)?, value)
 }
 
@@ -336,8 +338,8 @@ fn table_bytes_len(values: &[Vec<u8>]) -> WasiResult<u32> {
 fn write_c_string_table(
     memory: &mut [u8],
     values: &[Vec<u8>],
-    pointers_ptr: i32,
-    bytes_ptr: i32,
+    pointers_ptr: u32,
+    bytes_ptr: u32,
 ) -> WasiResult<()> {
     let pointers_base = ptr_to_offset(pointers_ptr)?;
     let mut cursor = ptr_to_offset(bytes_ptr)?;
@@ -357,7 +359,7 @@ fn write_c_string_table(
     Ok(())
 }
 
-fn iovec(memory: &[u8], iovs_ptr: i32, index: u32) -> WasiResult<(usize, usize)> {
+fn iovec(memory: &[u8], iovs_ptr: u32, index: u32) -> WasiResult<(usize, usize)> {
     let base = ptr_to_offset(iovs_ptr)?;
     let index_offset = usize::try_from(index).map_err(|_| WASI_ERRNO_FAULT)?;
     let iov_offset = base
@@ -503,7 +505,7 @@ fn guest_path_from_bytes(path: &[u8]) -> WasiResult<PathBuf> {
     Ok(PathBuf::from(path))
 }
 
-fn read_path_from_memory(memory: &[u8], path_ptr: i32, path_len: usize) -> WasiResult<PathBuf> {
+fn read_path_from_memory(memory: &[u8], path_ptr: u32, path_len: usize) -> WasiResult<PathBuf> {
     let path = checked_range(memory, ptr_to_offset(path_ptr)?, path_len)?;
     if path.contains(&0) {
         return Err(WASI_ERRNO_INVAL);
@@ -735,8 +737,8 @@ fn random_get(
     mut ret: v8::ReturnValue,
 ) {
     let result = (|| -> WasiResult<()> {
-        let buffer = read_i32_arg(scope, &args, 0)?;
-        let length = read_i32_arg(scope, &args, 1)?;
+        let buffer = read_u32_arg(scope, &args, 0)?;
+        let length = read_u32_arg(scope, &args, 1)?;
         let context = callback_context(&args);
         with_wasi_memory_mut(scope, context, |memory| {
             let offset = ptr_to_offset(buffer)?;
@@ -780,14 +782,14 @@ fn path_open(
     let result = (|| -> WasiResult<()> {
         let dirfd = read_i32_arg(scope, &args, 0)?;
         let dirflags = read_i32_arg(scope, &args, 1)?;
-        let path_ptr = read_i32_arg(scope, &args, 2)?;
+        let path_ptr = read_u32_arg(scope, &args, 2)?;
         let path_len =
-            usize::try_from(read_i32_arg(scope, &args, 3)?).map_err(|_| WASI_ERRNO_INVAL)?;
+            usize::try_from(read_u32_arg(scope, &args, 3)?).map_err(|_| WASI_ERRNO_INVAL)?;
         let oflags = read_i32_arg(scope, &args, 4)?;
         let rights_base = read_u64_arg(scope, &args, 5)?;
         let rights_inheriting = read_u64_arg(scope, &args, 6)?;
         let fdflags = read_i32_arg(scope, &args, 7)?;
-        let opened_fd_ptr = read_i32_arg(scope, &args, 8)?;
+        let opened_fd_ptr = read_u32_arg(scope, &args, 8)?;
         let context = callback_context(&args);
 
         validate_known_flag_bits(dirflags, WASI_KNOWN_LOOKUPFLAGS_MASK)?;
@@ -883,13 +885,13 @@ fn path_readlink(
 ) {
     let result = (|| -> WasiResult<()> {
         let dirfd = read_i32_arg(scope, &args, 0)?;
-        let path_ptr = read_i32_arg(scope, &args, 1)?;
+        let path_ptr = read_u32_arg(scope, &args, 1)?;
         let path_len =
-            usize::try_from(read_i32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
-        let buf_ptr = read_i32_arg(scope, &args, 3)?;
+            usize::try_from(read_u32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
+        let buf_ptr = read_u32_arg(scope, &args, 3)?;
         let buf_len =
-            usize::try_from(read_i32_arg(scope, &args, 4)?).map_err(|_| WASI_ERRNO_INVAL)?;
-        let buf_used_ptr = read_i32_arg(scope, &args, 5)?;
+            usize::try_from(read_u32_arg(scope, &args, 4)?).map_err(|_| WASI_ERRNO_INVAL)?;
+        let buf_used_ptr = read_u32_arg(scope, &args, 5)?;
         let context = callback_context(&args);
         require_fd_right(context, dirfd, WASI_RIGHT_PATH_READLINK)?;
 
@@ -936,9 +938,9 @@ fn path_create_directory(
 ) {
     let result = (|| -> WasiResult<()> {
         let dirfd = read_i32_arg(scope, &args, 0)?;
-        let path_ptr = read_i32_arg(scope, &args, 1)?;
+        let path_ptr = read_u32_arg(scope, &args, 1)?;
         let path_len =
-            usize::try_from(read_i32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
+            usize::try_from(read_u32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
         let context = callback_context(&args);
         require_fd_right(context, dirfd, WASI_RIGHT_PATH_CREATE_DIRECTORY)?;
 
@@ -965,13 +967,13 @@ fn path_rename(
 ) {
     let result = (|| -> WasiResult<()> {
         let old_fd = read_i32_arg(scope, &args, 0)?;
-        let old_path_ptr = read_i32_arg(scope, &args, 1)?;
+        let old_path_ptr = read_u32_arg(scope, &args, 1)?;
         let old_path_len =
-            usize::try_from(read_i32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
+            usize::try_from(read_u32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
         let new_fd = read_i32_arg(scope, &args, 3)?;
-        let new_path_ptr = read_i32_arg(scope, &args, 4)?;
+        let new_path_ptr = read_u32_arg(scope, &args, 4)?;
         let new_path_len =
-            usize::try_from(read_i32_arg(scope, &args, 5)?).map_err(|_| WASI_ERRNO_INVAL)?;
+            usize::try_from(read_u32_arg(scope, &args, 5)?).map_err(|_| WASI_ERRNO_INVAL)?;
         let context = callback_context(&args);
         require_fd_right(context, old_fd, WASI_RIGHT_PATH_RENAME_SOURCE)?;
         require_fd_right(context, new_fd, WASI_RIGHT_PATH_RENAME_TARGET)?;
@@ -1011,9 +1013,9 @@ fn path_remove_directory(
 ) {
     let result = (|| -> WasiResult<()> {
         let dirfd = read_i32_arg(scope, &args, 0)?;
-        let path_ptr = read_i32_arg(scope, &args, 1)?;
+        let path_ptr = read_u32_arg(scope, &args, 1)?;
         let path_len =
-            usize::try_from(read_i32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
+            usize::try_from(read_u32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
         let context = callback_context(&args);
         require_fd_right(context, dirfd, WASI_RIGHT_PATH_REMOVE_DIRECTORY)?;
 
@@ -1040,9 +1042,9 @@ fn path_unlink_file(
 ) {
     let result = (|| -> WasiResult<()> {
         let dirfd = read_i32_arg(scope, &args, 0)?;
-        let path_ptr = read_i32_arg(scope, &args, 1)?;
+        let path_ptr = read_u32_arg(scope, &args, 1)?;
         let path_len =
-            usize::try_from(read_i32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
+            usize::try_from(read_u32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
         let context = callback_context(&args);
         require_fd_right(context, dirfd, WASI_RIGHT_PATH_UNLINK_FILE)?;
 
@@ -1064,7 +1066,7 @@ fn path_unlink_file(
 
 fn parse_poll_subscriptions(
     memory: &[u8],
-    in_ptr: i32,
+    in_ptr: u32,
     nsubscriptions: usize,
 ) -> WasiResult<Vec<PollSubscription>> {
     let base = ptr_to_offset(in_ptr)?;
@@ -1368,14 +1370,14 @@ fn poll_oneoff_impl(
     mut ret: v8::ReturnValue,
 ) {
     let result = (|| -> WasiResult<()> {
-        let in_ptr = read_i32_arg(scope, &args, 0)?;
-        let out_ptr = read_i32_arg(scope, &args, 1)?;
-        let nsubscriptions_i32 = read_i32_arg(scope, &args, 2)?;
-        let nevents_ptr = read_i32_arg(scope, &args, 3)?;
-        if nsubscriptions_i32 <= 0 {
+        let in_ptr = read_u32_arg(scope, &args, 0)?;
+        let out_ptr = read_u32_arg(scope, &args, 1)?;
+        let nsubscriptions_u32 = read_u32_arg(scope, &args, 2)?;
+        let nevents_ptr = read_u32_arg(scope, &args, 3)?;
+        if nsubscriptions_u32 == 0 {
             return Err(WASI_ERRNO_INVAL);
         }
-        let nsubscriptions = usize::try_from(nsubscriptions_i32).map_err(|_| WASI_ERRNO_INVAL)?;
+        let nsubscriptions = usize::try_from(nsubscriptions_u32).map_err(|_| WASI_ERRNO_INVAL)?;
         let context = callback_context(&args);
 
         let mut subscriptions = with_wasi_memory_mut(scope, context, |memory| {
@@ -1431,7 +1433,7 @@ fn fd_prestat_get(
 ) {
     let result = (|| -> WasiResult<()> {
         let fd = read_i32_arg(scope, &args, 0)?;
-        let prestat_ptr = read_i32_arg(scope, &args, 1)?;
+        let prestat_ptr = read_u32_arg(scope, &args, 1)?;
         let context = callback_context(&args);
         if !preopen_matches(context, fd) {
             return Err(WASI_ERRNO_BADF);
@@ -1458,9 +1460,9 @@ fn fd_prestat_dir_name(
 ) {
     let result = (|| -> WasiResult<()> {
         let fd = read_i32_arg(scope, &args, 0)?;
-        let path_ptr = read_i32_arg(scope, &args, 1)?;
+        let path_ptr = read_u32_arg(scope, &args, 1)?;
         let path_len =
-            usize::try_from(read_i32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
+            usize::try_from(read_u32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
         let context = callback_context(&args);
         if !preopen_matches(context, fd) {
             return Err(WASI_ERRNO_BADF);
@@ -1488,11 +1490,11 @@ fn fd_readdir(
 ) {
     let result = (|| -> WasiResult<()> {
         let fd = read_i32_arg(scope, &args, 0)?;
-        let buf_ptr = read_i32_arg(scope, &args, 1)?;
+        let buf_ptr = read_u32_arg(scope, &args, 1)?;
         let buf_len =
-            usize::try_from(read_i32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
+            usize::try_from(read_u32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
         let cookie = read_u64_arg(scope, &args, 3)?;
-        let buf_used_ptr = read_i32_arg(scope, &args, 4)?;
+        let buf_used_ptr = read_u32_arg(scope, &args, 4)?;
         let context = callback_context(&args);
         require_fd_right(context, fd, WASI_RIGHT_FD_READDIR)?;
         let dir_path = dir_path_for_fd(context, fd)?;
@@ -1533,8 +1535,8 @@ fn args_sizes_get(
     mut ret: v8::ReturnValue,
 ) {
     let result = (|| -> WasiResult<()> {
-        let argc_ptr = read_i32_arg(scope, &args, 0)?;
-        let argv_buf_size_ptr = read_i32_arg(scope, &args, 1)?;
+        let argc_ptr = read_u32_arg(scope, &args, 0)?;
+        let argv_buf_size_ptr = read_u32_arg(scope, &args, 1)?;
 
         let context = callback_context(&args);
         let argc = u32::try_from(context.argv.len()).map_err(|_| WASI_ERRNO_FAULT)?;
@@ -1556,8 +1558,8 @@ fn args_get(
     mut ret: v8::ReturnValue,
 ) {
     let result = (|| -> WasiResult<()> {
-        let argv_ptr = read_i32_arg(scope, &args, 0)?;
-        let argv_buf_ptr = read_i32_arg(scope, &args, 1)?;
+        let argv_ptr = read_u32_arg(scope, &args, 0)?;
+        let argv_buf_ptr = read_u32_arg(scope, &args, 1)?;
         let context = callback_context(&args);
 
         with_wasi_memory_mut(scope, context, |memory| {
@@ -1574,8 +1576,8 @@ fn environ_sizes_get(
     mut ret: v8::ReturnValue,
 ) {
     let result = (|| -> WasiResult<()> {
-        let environc_ptr = read_i32_arg(scope, &args, 0)?;
-        let environ_buf_size_ptr = read_i32_arg(scope, &args, 1)?;
+        let environc_ptr = read_u32_arg(scope, &args, 0)?;
+        let environ_buf_size_ptr = read_u32_arg(scope, &args, 1)?;
 
         let environ = collect_environ();
         let environc = u32::try_from(environ.len()).map_err(|_| WASI_ERRNO_FAULT)?;
@@ -1598,8 +1600,8 @@ fn environ_get(
     mut ret: v8::ReturnValue,
 ) {
     let result = (|| -> WasiResult<()> {
-        let environ_ptr = read_i32_arg(scope, &args, 0)?;
-        let environ_buf_ptr = read_i32_arg(scope, &args, 1)?;
+        let environ_ptr = read_u32_arg(scope, &args, 0)?;
+        let environ_buf_ptr = read_u32_arg(scope, &args, 1)?;
         let context = callback_context(&args);
 
         let environ = collect_environ();
@@ -1631,10 +1633,9 @@ fn fd_write(
 ) {
     let result = (|| -> WasiResult<()> {
         let fd = read_i32_arg(scope, &args, 0)?;
-        let iovs_ptr = read_i32_arg(scope, &args, 1)?;
-        let iovs_len =
-            u32::try_from(read_i32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
-        let nwritten_ptr = read_i32_arg(scope, &args, 3)?;
+        let iovs_ptr = read_u32_arg(scope, &args, 1)?;
+        let iovs_len = read_u32_arg(scope, &args, 2)?;
+        let nwritten_ptr = read_u32_arg(scope, &args, 3)?;
         let context = callback_context(&args);
         require_fd_right(context, fd, WASI_RIGHT_FD_WRITE)?;
         let descriptor = if fd > WASI_FD_STDERR {
@@ -1699,10 +1700,9 @@ fn fd_read(
 ) {
     let result = (|| -> WasiResult<()> {
         let fd = read_i32_arg(scope, &args, 0)?;
-        let iovs_ptr = read_i32_arg(scope, &args, 1)?;
-        let iovs_len =
-            u32::try_from(read_i32_arg(scope, &args, 2)?).map_err(|_| WASI_ERRNO_INVAL)?;
-        let nread_ptr = read_i32_arg(scope, &args, 3)?;
+        let iovs_ptr = read_u32_arg(scope, &args, 1)?;
+        let iovs_len = read_u32_arg(scope, &args, 2)?;
+        let nread_ptr = read_u32_arg(scope, &args, 3)?;
         let context = callback_context(&args);
         require_fd_right(context, fd, WASI_RIGHT_FD_READ)?;
         let descriptor = if fd > WASI_FD_STDERR {


### PR DESCRIPTION
## Summary

- model guest memory addresses, offsets, lengths, capacities, and indices as Rust `u32` values while preserving the Wasm `i32` ABI
- add explicit unsigned argument/result handling in the async import registry and propagate it through moonrun APIs
- use checked arithmetic and narrowing conversions at memory and host-resource boundaries
- preserve every Wasm `i64` bit pattern when decoding Rust `u64` values from V8 BigInts

## Rationale

The registry historically treated Wasm `i32` as Rust `i32`. That conflated the Wasm value type, which only specifies a 32-bit representation, with the signedness of address-like values in Rust. As a result, valid guest addresses with the high bit set could be rejected before normal bounds checking.

This change makes the Rust-side semantics explicit: address-like values use `u32`, while genuinely signed values such as statuses, error codes, flags, process IDs, signals, and sentinel-bearing results remain `i32`. Boundary calculations use checked operations so invalid ranges fail instead of wrapping or truncating.

The change is limited to moonrun's runtime and import plumbing and does not add parameter-name or string-based semantic checks.
