### PR TITLE
ci: update GitHub Actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,11 +40,13 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.95.0
 
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
@@ -81,12 +83,13 @@ jobs:
       LINUX_GLIBC_VERSION: ${{ inputs.glibc-version || '2.23' }}
       LINUX_TARGET: x86_64-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: 1.95.0
           targets: ${{ env.LINUX_TARGET }}
 
       - uses: mlugg/setup-zig@v2

--- a/.github/workflows/check-merge-commit.yml
+++ b/.github/workflows/check-merge-commit.yml
@@ -28,11 +28,11 @@ jobs:
 
     steps:
     - name: Check out the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
   
     - name: Get all commit messages
       id: get-commit-messages
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           // If this commit is not part of a PR (e.g. in merge queue check),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,7 +420,6 @@ jobs:
         run: |
           cargo run --bin moon -- -C ~/.moon/lib/core test --target all
           cargo run --bin moon -- -C ~/.moon/lib/core test --release --target all
-          cargo run --bin moon -- -C ~/.moon/lib/core test --doc
       - name: Test core (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         env:
@@ -428,7 +427,6 @@ jobs:
         run: |
           cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target all
           cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target all
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --doc
 
   # coverage:
   #   needs: bleeding-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       CCAA-signed: ${{ steps.CCAA-check-step.outputs.CCAA-signed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: CCAA check
         id: CCAA-check-step
         env:
@@ -80,7 +80,7 @@ jobs:
     env:
       HAWKEYE_VERSION: v5.6.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download HawkEye
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/korandoru/hawkeye/releases/download/$HAWKEYE_VERSION/hawkeye-installer.sh | sh
       - name: License Header Check
@@ -97,7 +97,7 @@ jobs:
       - name: download typos
         run: curl -LsSf https://github.com/crate-ci/typos/releases/download/$TYPOS_VERSION/typos-$TYPOS_VERSION-x86_64-unknown-linux-musl.tar.gz | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: check for typos
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v2
@@ -134,12 +134,13 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: 1.95.0
           components: rustfmt, clippy
 
       - name: Cargo cache
@@ -202,14 +203,8 @@ jobs:
         env:
           MOONRUN_OVERRIDE: ${{ github.workspace }}/target/debug/moonrun
         run: |
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target wasm-gc
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target js
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target wasm
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target native
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target wasm-gc
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target js
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target wasm
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target native
+          cargo run --bin moon -- -C ~/.moon/lib/core test --target all
+          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target all
 
       # LLVM is currently disabled because it doesn't exist on non-bleeding channels.
       # TODO: Add this back when we add LLVM to nightly
@@ -226,12 +221,13 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: 1.95.0
           components: rustfmt, clippy
 
       - name: Cargo cache
@@ -260,14 +256,8 @@ jobs:
         env:
           MOONRUN_OVERRIDE: ${{ github.workspace }}\target\debug\moonrun.exe
         run: |
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target wasm-gc
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target js
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target wasm
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target native
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm-gc
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target js
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target native
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target all
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target all
 
       # LLVM is currently disabled because it doesn't exist on non-bleeding channels.
       # TODO: Add this back when we add LLVM to nightly
@@ -289,12 +279,13 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: 1.95.0
           components: rustfmt, clippy
 
       - name: Cargo cache
@@ -365,12 +356,13 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: 1.95.0
           components: rustfmt, clippy
 
       - name: Cargo cache
@@ -426,28 +418,16 @@ jobs:
         env:
           MOONRUN_OVERRIDE: ${{ github.workspace }}/target/debug/moonrun
         run: |
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target wasm-gc
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target js
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target wasm
-          cargo run --bin moon -- -C ~/.moon/lib/core test --target native
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target wasm-gc
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target js
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target wasm
-          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target native
+          cargo run --bin moon -- -C ~/.moon/lib/core test --target all
+          cargo run --bin moon -- -C ~/.moon/lib/core test --release --target all
           cargo run --bin moon -- -C ~/.moon/lib/core test --doc
       - name: Test core (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         env:
           MOONRUN_OVERRIDE: ${{ github.workspace }}\target\debug\moonrun.exe
         run: |
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target wasm-gc
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target js
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target wasm
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target native
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm-gc
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target js
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target wasm
-          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target native
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --target all
+          cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --release --target all
           cargo run --bin moon -- -C "$env:USERPROFILE\.moon\lib\core" test --doc
 
   # coverage:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/moonrun-conformance.yml
+++ b/.github/workflows/moonrun-conformance.yml
@@ -56,11 +56,13 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.95.0
 
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

Update active GitHub Actions to their latest action releases while retaining the Rust 1.95.0 toolchain. Consolidate repeated core backend test commands to `--target all`, and remove the deprecated `test --doc` invocations because regular test runs already include doc tests.

## Why

Keep CI on supported action runtimes and reduce duplicated test orchestration without changing backend or doc-test coverage.

## Validation

Validated the updated workflow YAML and checked the diff for whitespace errors.