### PR TITLE
feat(run): add wasm policy option

### DIFF
--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -284,7 +284,7 @@ pub(crate) fn prepare(
         } => {
             let wasm_path = super::runwasm::cached_wasm_path(&package, user_log)?;
             prepare_artifact(
-                crate::run::ExecutionMode::MoonRun,
+                crate::run::ExecutionMode::Wasm,
                 &wasm_path,
                 experimental_policy.as_deref(),
                 &args,

--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -284,7 +284,7 @@ pub(crate) fn prepare(
         } => {
             let wasm_path = super::runwasm::cached_wasm_path(&package, user_log)?;
             prepare_artifact(
-                crate::run::ExecutionMode::Wasm,
+                crate::run::ExecutionMode::MoonRun,
                 &wasm_path,
                 experimental_policy.as_deref(),
                 &args,

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -107,7 +107,8 @@ pub(crate) struct RunSubcommand {
     #[clap(trailing_var_arg = true, num_args = 0.., allow_hyphen_values = true)]
     pub args: Vec<String>,
 
-    #[clap(skip)]
+    /// Pass a moonrun JSON policy file to the Wasm backend; ignored by other backends
+    #[clap(long = "wasm-policy", value_name = "PATH")]
     pub(crate) moonrun_policy: Option<PathBuf>,
 
     #[clap(flatten)]
@@ -350,7 +351,7 @@ fn build_wasm_file_executable_from_arg(
     let print_dir = std::env::current_dir().context("failed to get current directory")?;
     if cli.dry_run {
         let mut run_cmd = crate::run::command_for_with_moonrun_policy(
-            crate::run::ExecutionMode::MoonRun,
+            crate::run::ExecutionMode::Wasm,
             &wasm_path,
             None,
             cmd.moonrun_policy.as_deref(),

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -107,7 +107,7 @@ pub(crate) struct RunSubcommand {
     #[clap(trailing_var_arg = true, num_args = 0.., allow_hyphen_values = true)]
     pub args: Vec<String>,
 
-    /// Pass a moonrun JSON policy file to the Wasm backend; ignored by other backends
+    /// Pass a moonrun JSON policy file to Wasm backends; ignored by other backends
     #[clap(long = "wasm-policy", value_name = "PATH")]
     pub(crate) moonrun_policy: Option<PathBuf>,
 
@@ -351,7 +351,7 @@ fn build_wasm_file_executable_from_arg(
     let print_dir = std::env::current_dir().context("failed to get current directory")?;
     if cli.dry_run {
         let mut run_cmd = crate::run::command_for_with_moonrun_policy(
-            crate::run::ExecutionMode::Wasm,
+            crate::run::ExecutionMode::MoonRun,
             &wasm_path,
             None,
             cmd.moonrun_policy.as_deref(),

--- a/crates/moon/src/run/runtime.rs
+++ b/crates/moon/src/run/runtime.rs
@@ -24,10 +24,11 @@ use std::process::Command;
 use moonbuild::entry::TestArgs;
 use moonbuild_rupes_recta::model::{BackendConfig, NativeBackendMode, TccRunConfig};
 
-/// The concrete process used to execute one built artifact.
+/// The runtime mode used to execute one built artifact.
 #[derive(Clone, Copy)]
 pub(crate) enum ExecutionMode<'a> {
-    MoonRun,
+    Wasm,
+    WasmGc,
     Node,
     Native,
     TccRun(&'a TccRunConfig),
@@ -36,7 +37,8 @@ pub(crate) enum ExecutionMode<'a> {
 impl<'a> From<&'a BackendConfig> for ExecutionMode<'a> {
     fn from(backend: &'a BackendConfig) -> Self {
         match backend {
-            BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } => Self::MoonRun,
+            BackendConfig::Wasm { .. } => Self::Wasm,
+            BackendConfig::WasmGc { .. } => Self::WasmGc,
             BackendConfig::Js => Self::Node,
             BackendConfig::Native(NativeBackendMode::TccRun(config)) => Self::TccRun(config),
             BackendConfig::Native(
@@ -76,13 +78,15 @@ pub(crate) fn command_for_with_moonrun_policy(
     moonrun_policy: Option<&Path>,
 ) -> Command {
     match mode {
-        ExecutionMode::MoonRun => {
+        mode @ (ExecutionMode::Wasm | ExecutionMode::WasmGc) => {
             let mut cmd = Command::new(&*moonutil::toolchain::BINARIES.moonrun);
             if let Some(t) = test {
                 cmd.arg("--test-args");
                 cmd.arg(serde_json::to_string(t).unwrap());
             }
-            if let Some(policy) = moonrun_policy {
+            if matches!(mode, ExecutionMode::Wasm)
+                && let Some(policy) = moonrun_policy
+            {
                 cmd.arg("--policy");
                 cmd.arg(policy);
             }

--- a/crates/moon/src/run/runtime.rs
+++ b/crates/moon/src/run/runtime.rs
@@ -27,8 +27,7 @@ use moonbuild_rupes_recta::model::{BackendConfig, NativeBackendMode, TccRunConfi
 /// The runtime mode used to execute one built artifact.
 #[derive(Clone, Copy)]
 pub(crate) enum ExecutionMode<'a> {
-    Wasm,
-    WasmGc,
+    MoonRun,
     Node,
     Native,
     TccRun(&'a TccRunConfig),
@@ -37,8 +36,7 @@ pub(crate) enum ExecutionMode<'a> {
 impl<'a> From<&'a BackendConfig> for ExecutionMode<'a> {
     fn from(backend: &'a BackendConfig) -> Self {
         match backend {
-            BackendConfig::Wasm { .. } => Self::Wasm,
-            BackendConfig::WasmGc { .. } => Self::WasmGc,
+            BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } => Self::MoonRun,
             BackendConfig::Js => Self::Node,
             BackendConfig::Native(NativeBackendMode::TccRun(config)) => Self::TccRun(config),
             BackendConfig::Native(
@@ -78,15 +76,13 @@ pub(crate) fn command_for_with_moonrun_policy(
     moonrun_policy: Option<&Path>,
 ) -> Command {
     match mode {
-        mode @ (ExecutionMode::Wasm | ExecutionMode::WasmGc) => {
+        ExecutionMode::MoonRun => {
             let mut cmd = Command::new(&*moonutil::toolchain::BINARIES.moonrun);
             if let Some(t) = test {
                 cmd.arg("--test-args");
                 cmd.arg(serde_json::to_string(t).unwrap());
             }
-            if matches!(mode, ExecutionMode::Wasm)
-                && let Some(policy) = moonrun_policy
-            {
+            if let Some(policy) = moonrun_policy {
                 cmd.arg("--policy");
                 cmd.arg(policy);
             }

--- a/crates/moon/src/tests/planner/cli_to_planner.rs
+++ b/crates/moon/src/tests/planner/cli_to_planner.rs
@@ -113,6 +113,22 @@ fn run_diagnostic_limit_parses() {
 }
 
 #[test]
+fn run_wasm_policy_parses() {
+    let (_, cmd) = parse_run_command(&[
+        "run",
+        "--wasm-policy",
+        "moonrun-policy.json",
+        "-e",
+        r#"fn main { println("hello") }"#,
+    ]);
+
+    assert_eq!(
+        cmd.moonrun_policy.as_deref(),
+        Some(std::path::Path::new("moonrun-policy.json"))
+    );
+}
+
+#[test]
 fn native_target_dry_run_test_command_parses_as_expected() {
     let (cli, cmd) =
         parse_test_command(&["test", "--target", "native", "--dry-run", "--sort-input"]);

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -461,6 +461,30 @@ fn test_runwasm_local_package_forwards_experimental_policy() {
 }
 
 #[test]
+fn test_run_direct_wasm_forwards_policy() {
+    let dir = TestDir::new("moon_run_with_cli_args.in");
+    moon_cmd(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success();
+
+    let stderr = get_err_stderr_with_envs(
+        &dir,
+        [
+            "run",
+            "_build/wasm/debug/build/main/main.wasm",
+            "--wasm-policy",
+            "missing-policy.json",
+        ],
+        [("MOONRUN_OVERRIDE", moonrun_bin())],
+    );
+    assert!(
+        stderr.contains("failed to load sandbox policy"),
+        "expected direct Wasm execution to forward the policy:\n{stderr}"
+    );
+}
+
+#[test]
 fn test_run_with_explicit_target_exits_with_guest_exit_code() {
     let dir = TestDir::new("moon_run_with_cli_args.in");
     moon_cmd(&dir)

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -140,7 +140,7 @@ fn test_moon_run_single_file_dry_run() {
 }
 
 #[test]
-fn test_moon_run_wasm_policy_is_only_forwarded_to_wasm_backend() {
+fn test_moon_run_wasm_policy_is_only_forwarded_to_wasm_backends() {
     let dir = TestDir::new("run_single_mbt_file.in");
 
     let wasm_output = get_stdout(
@@ -171,7 +171,7 @@ fn test_moon_run_wasm_policy_is_only_forwarded_to_wasm_backend() {
             "--target",
             "wasm-gc",
             "--wasm-policy",
-            "missing-wasm-gc-policy.json",
+            "wasm-gc-policy.json",
             "--dry-run",
         ],
     );
@@ -183,8 +183,11 @@ fn test_moon_run_wasm_policy_is_only_forwarded_to_wasm_backend() {
         "expected the WasmGC run command to use moonrun:\n{wasm_gc_output}"
     );
     assert!(
-        !wasm_gc_output.contains("missing-wasm-gc-policy.json"),
-        "expected the WasmGC backend to ignore the policy:\n{wasm_gc_output}"
+        wasm_gc_output
+            .lines()
+            .last()
+            .is_some_and(|line| line.contains("--policy wasm-gc-policy.json")),
+        "expected the WasmGC run command to forward the policy:\n{wasm_gc_output}"
     );
 
     let js_output = get_stdout(

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -140,6 +140,79 @@ fn test_moon_run_single_file_dry_run() {
 }
 
 #[test]
+fn test_moon_run_wasm_policy_is_only_forwarded_to_wasm_backend() {
+    let dir = TestDir::new("run_single_mbt_file.in");
+
+    let wasm_output = get_stdout(
+        &dir,
+        [
+            "run",
+            "a/b/single.mbt",
+            "--target",
+            "wasm",
+            "--wasm-policy",
+            "moonrun-policy.json",
+            "--dry-run",
+        ],
+    );
+    assert!(
+        wasm_output
+            .lines()
+            .last()
+            .is_some_and(|line| line.contains("--policy moonrun-policy.json")),
+        "expected Wasm run command to forward the policy:\n{wasm_output}"
+    );
+
+    let wasm_gc_output = get_stdout(
+        &dir,
+        [
+            "run",
+            "a/b/single.mbt",
+            "--target",
+            "wasm-gc",
+            "--wasm-policy",
+            "missing-wasm-gc-policy.json",
+            "--dry-run",
+        ],
+    );
+    assert!(
+        wasm_gc_output
+            .lines()
+            .last()
+            .is_some_and(|line| line.contains("single.wasm")),
+        "expected the WasmGC run command to use moonrun:\n{wasm_gc_output}"
+    );
+    assert!(
+        !wasm_gc_output.contains("missing-wasm-gc-policy.json"),
+        "expected the WasmGC backend to ignore the policy:\n{wasm_gc_output}"
+    );
+
+    let js_output = get_stdout(
+        &dir,
+        [
+            "run",
+            "a/b/single.mbt",
+            "--target",
+            "js",
+            "--wasm-policy",
+            "missing-policy.json",
+            "--dry-run",
+        ],
+    );
+    assert!(
+        js_output
+            .lines()
+            .last()
+            .is_some_and(|line| line.contains("single.js")),
+        "expected the JavaScript run command to remain unchanged:\n{js_output}"
+    );
+    assert!(
+        !js_output.contains("missing-policy.json"),
+        "expected the JavaScript backend to ignore the policy:\n{js_output}"
+    );
+}
+
+#[test]
 fn test_moon_run_single_mbt_file() {
     let dir = TestDir::new("run_single_mbt_file.in");
 

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -250,7 +250,7 @@ Run a main package
   Possible values: `info`, `warn`, `error`
 
 * `--diagnostic-limit <N>` — Limit the number of rendered diagnostics
-* `--wasm-policy <PATH>` — Pass a moonrun JSON policy file to the Wasm backend; ignored by other backends
+* `--wasm-policy <PATH>` — Pass a moonrun JSON policy file to Wasm backends; ignored by other backends
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not run the code
 * `--profile` — Profile the native executable using Time Profiler on macOS or perf on Linux

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -250,6 +250,7 @@ Run a main package
   Possible values: `info`, `warn`, `error`
 
 * `--diagnostic-limit <N>` — Limit the number of rendered diagnostics
+* `--wasm-policy <PATH>` — Pass a moonrun JSON policy file to the Wasm backend; ignored by other backends
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not run the code
 * `--profile` — Profile the native executable using Time Profiler on macOS or perf on Linux

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -250,7 +250,7 @@ Run a main package
   Possible values: `info`, `warn`, `error`
 
 * `--diagnostic-limit <N>` — Limit the number of rendered diagnostics
-* `--wasm-policy <PATH>` — Pass a moonrun JSON policy file to the Wasm backend; ignored by other backends
+* `--wasm-policy <PATH>` — Pass a moonrun JSON policy file to Wasm backends; ignored by other backends
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not run the code
 * `--profile` — Profile the native executable using Time Profiler on macOS or perf on Linux

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -250,6 +250,7 @@ Run a main package
   Possible values: `info`, `warn`, `error`
 
 * `--diagnostic-limit <N>` — Limit the number of rendered diagnostics
+* `--wasm-policy <PATH>` — Pass a moonrun JSON policy file to the Wasm backend; ignored by other backends
 * `--frozen` — Do not sync dependencies, assuming local dependencies are up-to-date
 * `--build-only` — Only build, do not run the code
 * `--profile` — Profile the native executable using Time Profiler on macOS or perf on Linux


### PR DESCRIPTION
## Why

Moonrun supports JSON policy files, but `moon run` could not configure that policy directly. Users otherwise had to invoke moonrun themselves instead of using the normal project execution flow.

## What changed

- Add `moon run --wasm-policy <PATH>`.
- Forward the file as `moonrun --policy <PATH>` for both Wasm target backends.
- Accept but ignore the option for backends that do not use moonrun.
- Document the option and cover CLI parsing and runtime command construction.

## Why this is correct

Wasm and WasmGC artifacts share one moonrun execution mode, so policy forwarding follows the runtime that enforces it instead of duplicating compiler-backend distinctions in command construction. The same path covers direct `.wasm` execution and `moon runwasm`.

## Scope

The change reuses the existing moonrun policy argument path. It does not change moonrun policy semantics or the policy file format.
