### PR TITLE
Upgrade n2 with record compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,13 +1823,14 @@ dependencies = [
 [[package]]
 name = "n2"
 version = "0.1.5"
-source = "git+https://github.com/moonbitlang/n2.git?rev=601d553ef78c09918baa086a07f05b4ba2d0f238#601d553ef78c09918baa086a07f05b4ba2d0f238"
+source = "git+https://github.com/moonbitlang/n2.git?rev=79d275ef051cf0d4864ae3b4f4947e3f3f035899#79d275ef051cf0d4864ae3b4f4947e3f3f035899"
 dependencies = [
  "anyhow",
  "argh",
  "colored",
  "libc",
  "rustc-hash 1.1.0",
+ "tempfile",
  "tracing",
  "windows-sys 0.48.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.95"
 edition = "2024"
 
 [workspace.dependencies]
-n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "601d553ef78c09918baa086a07f05b4ba2d0f238" }
+n2 = { git = "https://github.com/moonbitlang/n2.git", rev = "79d275ef051cf0d4864ae3b4f4947e3f3f035899" }
 arcstr = { version = "1.2", features = ["serde"] }
 moonbuild = { path = "./crates/moonbuild", version = "*" }
 moonbuild-rupes-recta = { path = "./crates/moonbuild-rupes-recta", version = "*" }

--- a/crates/moon/tests/test_cases/targets/mod.rs
+++ b/crates/moon/tests/test_cases/targets/mod.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod n2_compaction;
+
 #[test]
 fn test_many_targets() {
     let dir = TestDir::new("targets/many_targets");

--- a/crates/moon/tests/test_cases/targets/n2_compaction.rs
+++ b/crates/moon/tests/test_cases/targets/n2_compaction.rs
@@ -1,0 +1,223 @@
+use super::*;
+
+use std::path::Path;
+
+const N2_BUILD_RECORD_MARK: u16 = 0x8000;
+const N2_COMPACTION_MIN_SIZE: u64 = 2 * 1024 * 1024;
+
+// n2's database model is intentionally private. These helpers append valid
+// version-1 records so an end-to-end test can cross the compaction threshold
+// without invoking Moon tens of thousands of times.
+struct EncodedBuildRecord {
+    outputs: Vec<u32>,
+}
+
+fn n2_build_records(database: &[u8]) -> (u32, Vec<EncodedBuildRecord>) {
+    assert!(database.len() >= 8, "n2 database should contain a header");
+    assert_eq!(&database[..8], b"n2db\x01\0\0\0");
+
+    let mut records = Vec::new();
+    let mut path_count = 0;
+    let mut offset = 8;
+    while offset < database.len() {
+        let header = u16::from_le_bytes(database[offset..offset + 2].try_into().unwrap());
+        offset += 2;
+        if header & N2_BUILD_RECORD_MARK == 0 {
+            offset += usize::from(header);
+            assert!(offset <= database.len(), "truncated n2 path record");
+            path_count += 1;
+            continue;
+        }
+
+        let output_count = usize::from(header & !N2_BUILD_RECORD_MARK);
+        let mut outputs = Vec::with_capacity(output_count);
+        for _ in 0..output_count {
+            outputs.push(u32::from_le_bytes([
+                database[offset],
+                database[offset + 1],
+                database[offset + 2],
+                0,
+            ]));
+            offset += 3;
+        }
+        let dependency_count = usize::from(u16::from_le_bytes(
+            database[offset..offset + 2].try_into().unwrap(),
+        ));
+        offset += 2 + dependency_count * 3 + 8;
+        assert!(offset <= database.len(), "truncated n2 build record");
+        records.push(EncodedBuildRecord { outputs });
+    }
+    (path_count, records)
+}
+
+fn append_record_until_compaction_threshold(path: &Path, prefix: &[u8], record: &[u8]) -> u64 {
+    let mut size = std::fs::metadata(path).unwrap().len();
+    let prefix_len = u64::try_from(prefix.len()).unwrap();
+    let record_len = u64::try_from(record.len()).unwrap();
+    let mut database =
+        std::io::BufWriter::new(std::fs::OpenOptions::new().append(true).open(path).unwrap());
+    database.write_all(prefix).unwrap();
+    size += prefix_len;
+    while size < N2_COMPACTION_MIN_SIZE {
+        database.write_all(record).unwrap();
+        size += record_len;
+    }
+    database.flush().unwrap();
+    size
+}
+
+fn append_superseded_records(path: &Path) -> u64 {
+    let database = std::fs::read(path).unwrap();
+    let (path_count, _) = n2_build_records(&database);
+    assert!(
+        path_count <= 0x00ff_ffff,
+        "n2 path ID should fit in 24 bits"
+    );
+    let encoded_id = path_count.to_le_bytes();
+
+    let name = b"__moon_compaction_probe__";
+    let mut path_record = Vec::with_capacity(2 + name.len());
+    path_record.extend_from_slice(&(name.len() as u16).to_le_bytes());
+    path_record.extend_from_slice(name);
+
+    // A few large records keep this e2e test fast while remaining valid n2
+    // records. Their dummy output has no producer in Moon's current graph, so
+    // neither replay nor the retained final record affects dirty checking.
+    let dependency_count = u16::MAX;
+    let mut record = Vec::with_capacity(15 + usize::from(dependency_count) * 3);
+    record.extend_from_slice(&(N2_BUILD_RECORD_MARK | 1).to_le_bytes());
+    record.extend_from_slice(&encoded_id[..3]);
+    record.extend_from_slice(&dependency_count.to_le_bytes());
+    for _ in 0..dependency_count {
+        record.extend_from_slice(&encoded_id[..3]);
+    }
+    record.extend_from_slice(&0u64.to_le_bytes());
+    append_record_until_compaction_threshold(path, &path_record, &record)
+}
+
+fn append_incompatible_output_records(path: &Path) -> u64 {
+    let database = std::fs::read(path).unwrap();
+    let (_, records) = n2_build_records(&database);
+    let multi_output = records
+        .iter()
+        .rev()
+        .find(|record| record.outputs.len() >= 2)
+        .expect("build should write a multi-output n2 record");
+    let unrelated_output = records
+        .iter()
+        .rev()
+        .flat_map(|record| record.outputs.iter())
+        .copied()
+        .find(|output| !multi_output.outputs.contains(output))
+        .expect("build should write another n2 record");
+
+    // Simulate output ownership changing from {a, b} to {a, c}. The current
+    // graph still maps a/b and c to different execution actions, so replay
+    // ignores this incompatible record before compaction.
+    let dependency_count = u16::MAX;
+    let mut record = Vec::with_capacity(18 + usize::from(dependency_count) * 3);
+    record.extend_from_slice(&(N2_BUILD_RECORD_MARK | 2).to_le_bytes());
+    record.extend_from_slice(&multi_output.outputs[0].to_le_bytes()[..3]);
+    record.extend_from_slice(&unrelated_output.to_le_bytes()[..3]);
+    record.extend_from_slice(&dependency_count.to_le_bytes());
+    for _ in 0..dependency_count {
+        record.extend_from_slice(&multi_output.outputs[0].to_le_bytes()[..3]);
+    }
+    record.extend_from_slice(&0u64.to_le_bytes());
+    append_record_until_compaction_threshold(path, &[], &record)
+}
+
+#[test]
+fn preserves_partial_target_history() {
+    let dir = TestDir::new("targets/shared_n2_db");
+
+    moon_cmd(&dir)
+        .args(["check", "--target", "all"])
+        .assert()
+        .success();
+
+    let database = dir.join("_build/.moon_db");
+    let bloated_size = append_superseded_records(&database);
+
+    moon_cmd(&dir)
+        .args(["check", "--target", "js"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![""])
+        .stderr_eq(snapbox::str![[r#"
+Finished. moon: no work to do
+
+"#]]);
+
+    let compacted_size = std::fs::metadata(&database).unwrap().len();
+    assert!(
+        compacted_size < bloated_size / 3,
+        "n2 database should be compacted: {bloated_size} -> {compacted_size}"
+    );
+
+    moon_cmd(&dir)
+        .args(["check", "--target", "all"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![""])
+        .stderr_eq(snapbox::str![[r#"
+Finished. moon: no work to do
+
+"#]]);
+}
+
+#[test]
+fn accepts_conservative_rebuild_after_output_set_change() {
+    let dir = TestDir::new("targets/shared_n2_db");
+
+    moon_cmd(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success();
+
+    let database = dir.join("_build/.moon_db");
+    let bloated_size = append_incompatible_output_records(&database);
+
+    // This invocation replays the complete log before compacting it, so the
+    // compatible older records still make the graph up to date.
+    moon_cmd(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![""])
+        .stderr_eq(snapbox::str![[r#"
+Finished. moon: no work to do
+
+"#]]);
+    let compacted_size = std::fs::metadata(&database).unwrap().len();
+    assert!(
+        compacted_size < bloated_size / 3,
+        "n2 database should be compacted: {bloated_size} -> {compacted_size}"
+    );
+
+    // Known and accepted n2 trade-off: compaction treats any shared output as
+    // superseding the complete older record. If multi-output ownership changes
+    // and later changes back, Moon may conservatively rebuild once. This loses
+    // only a cache hit; it cannot reuse stale work or produce an incorrect build.
+    // Reconsider this decision if normal Moon target selection starts changing
+    // overlapping output sets across invocations.
+    moon_cmd(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![""])
+        .stderr_eq(snapbox::str![[r#"
+Finished. moon: ran 2 tasks, now up to date
+
+"#]]);
+
+    moon_cmd(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![""])
+        .stderr_eq(snapbox::str![[r#"
+Finished. moon: no work to do
+
+"#]]);
+}

--- a/crates/moon/tests/test_cases/targets/n2_compaction.rs
+++ b/crates/moon/tests/test_cases/targets/n2_compaction.rs
@@ -179,7 +179,9 @@ fn accepts_conservative_rebuild_after_output_set_change() {
     let bloated_size = append_incompatible_output_records(&database);
 
     // This invocation replays the complete log before compacting it, so the
-    // compatible older records still make the graph up to date.
+    // compatible older records still make the graph up to date. The synthetic
+    // record does not execute an intervening producer or alter output metadata;
+    // this test covers compaction's cache behavior, not output provenance.
     moon_cmd(&dir)
         .args(["build", "--target", "wasm"])
         .assert()
@@ -195,12 +197,13 @@ Finished. moon: no work to do
         "n2 database should be compacted: {bloated_size} -> {compacted_size}"
     );
 
-    // Known and accepted n2 trade-off: compaction treats any shared output as
-    // superseding the complete older record. If multi-output ownership changes
-    // and later changes back, Moon may conservatively rebuild once. This loses
-    // only a cache hit; it cannot reuse stale work or produce an incorrect build.
-    // Reconsider this decision if normal Moon target selection starts changing
-    // overlapping output sets across invocations.
+    // Known and accepted n2 compaction trade-off: treating any shared output as
+    // superseding the complete older record can cause one conservative rebuild.
+    // This assertion accepts that cache-hit loss for unchanged outputs. It does
+    // not assert provenance safety under arbitrary ownership changes: n2 replay
+    // can reuse stale output if an intervening producer preserves old output
+    // metadata. Normal Moon target selection does not create overlapping output
+    // ownership changes; reconsider this decision if that invariant changes.
     moon_cmd(&dir)
         .args(["build", "--target", "wasm"])
         .assert()

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -139,6 +139,27 @@ database for each execution; sharing persistent state does not compose the
 graphs or reuse one open database handle. The dependency and script graphs of a
 standalone build execute sequentially against this database.
 
+n2 records completed builds in an append-only log. When the database is at
+least 2 MiB, opening it compacts the log if all path records and live build
+records fit in one third of its current size. Compaction scans the complete
+database after replay, independently of the partial graph that opened it, and
+preserves every path record so persistent path IDs remain stable. Moon holds
+the target-directory lock across database use because compaction replaces the
+database file before returning its append handle.
+
+A later complete build record supersedes an entire older record when they
+share any declared output. This whole-record rule is intentionally
+conservative for histories whose multi-output ownership changes. For example,
+after records for outputs `{a, b}` and then `{a, c}`, compaction may discard
+the older `{a, b}` record. If the graph later returns to `{a, b}`, the
+invocation that performed compaction may still use the older state replayed
+before rewriting, while a subsequent invocation rebuilds once and records
+fresh state. Moon accepts this cache-hit loss because it cannot reuse stale
+work or produce an incorrect build. Normal `--target all` and single-target
+alternation does not create this case: multi-backend composition shares a
+provider only when its complete Execution Action and output set agree, while
+backend-specific outputs use distinct paths.
+
 ### Directory and environment facts
 
 Directory discovery is intentionally front-loaded. Command entry points should

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -154,11 +154,17 @@ after records for outputs `{a, b}` and then `{a, c}`, compaction may discard
 the older `{a, b}` record. If the graph later returns to `{a, b}`, the
 invocation that performed compaction may still use the older state replayed
 before rewriting, while a subsequent invocation rebuilds once and records
-fresh state. Moon accepts this cache-hit loss because it cannot reuse stale
-work or produce an incorrect build. Normal `--target all` and single-target
-alternation does not create this case: multi-backend composition shares a
-provider only when its complete Execution Action and output set agree, while
-backend-specific outputs use distinct paths.
+fresh state.
+
+Known n2 limitation: replay validates cached work from command, input, and
+output metadata rather than output-producer provenance. If overlapping output
+ownership changes and an intervening producer preserves the old output
+timestamps, the invocation that opens and compacts the complete history can
+reuse an older compatible record and observe stale output. Compaction removes
+that older record, so a subsequent invocation rebuilds. Normal `--target all`
+and single-target alternation does not create this ownership history:
+multi-backend composition shares a provider only when its complete Execution
+Action and output set agree, while backend-specific outputs use distinct paths.
 
 ### Directory and environment facts
 


### PR DESCRIPTION
## Why

The n2 build database is append-only and can grow indefinitely as completed build records are superseded. Upstream n2 now compacts large databases, but Moon shares one database across partial target graphs, so the upgrade needs coverage that history outside the graph performing maintenance remains usable.

## What changed

- Upgrade n2 to the revision that compacts superseded build records.
- Add an end-to-end regression that crosses the compaction threshold with valid database records, verifies that compaction occurs, and confirms both a single-target graph and `--target all` remain up to date.
- Document and cover the accepted cache-only trade-off for incompatible multi-output record histories: compaction may cause one conservative rebuild, followed by normal incremental behavior.

## Why this is correct

n2 scans the complete database when selecting live records, independently of the partial graph that opened it. The regression checks both the physical size reduction and replay through a different target projection after compaction.

The incompatible-output case is intentionally treated as a cache hit loss rather than a correctness issue: Moon rebuilds instead of reusing stale work. The test records this decision and its reconsideration condition.

## Scope

This PR only updates the n2 dependency and adds focused target/database tests; it does not change Moon's production build-planning or execution logic.
