### PR TITLE
feat(moonrun): add memory-only SQLite core imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,6 +1435,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-index"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1775,7 @@ dependencies = [
  "clap",
  "escargot",
  "libc",
+ "libsqlite3-sys",
  "moon-test-util",
  "moonutil",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ dialoguer = { version = "0.11.0", features = [
 self-replace = "1.3.7"
 tempfile = "3.10.1"
 line-index = "0.1.1"
+libsqlite3-sys = { version = "0.38.2", features = ["bundled"] }
 text-size = "1.1.1"
 log = "0.4.20"
 thiserror = "1.0"

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -64,15 +64,16 @@ imports. WASI does not pass through the Host Filesystem.
 _Avoid_: WASI filesystem, V8 filesystem
 
 **Handle**:
-An opaque value held by MoonBit code that names a moonrun-owned object, such as a Resource, Job, Worker, poll instance, Host Buffer, address-info result, or Completion Source.
+An opaque value held by MoonBit code that names a moonrun-owned object, such as a Resource, Job, Worker, poll instance, Host Buffer, address-info result, Completion Source, SQLite Database, or SQLite Statement.
 _Avoid_: Host Handle, Guest Handle, raw fd, pointer, id
 
 **Host**:
-The per-run composition root for moonrun-owned import state. It creates one Host Key namespace, wires it into domain states such as the Async Host, and performs leak checking only when the complete run is torn down. Domain operations and payload accounting remain on their owning state or API module.
+The per-run composition root for moonrun-owned import state. It creates one Host Key namespace, wires it into domain modules such as the Async Host and SQLite Host, and performs leak checking only when the complete run is torn down. Domain operations and payload accounting remain on their owning Host module.
 _Avoid_: giant host API, async-only host
 
 **Host Key**:
 The internal generational key behind a Handle. One primary Host Key table records only liveness and resource kind; domain payloads live in secondary maps keyed by Host Key.
+All Handle kinds share the slotmap null Host Key. An ABI that needs to create or compare a null Handle obtains its encoded value from the running Host rather than hard-coding the slotmap representation.
 _Avoid_: resource payload, raw pointer, per-API key
 
 **V8 Memory Binding**:
@@ -121,8 +122,16 @@ The V8-facing `moonbitlang/async` adapter that registers imports, decodes wasm A
 _Avoid_: Runtime state, native-stub implementation
 
 **Async Host**:
-Moonrun-owned async runtime state for one `moonbitlang/async` host instance: Resources, host workers, completion queues, Jobs, and opaque host poll instances. It uses the Host's shared Host Key namespace.
+Moonrun-owned async runtime state for one `moonbitlang/async` host instance: Resources, host workers, completion queues, Jobs, and opaque host poll instances. It uses the Host's shared Host Key namespace and contains no SQLite state.
 _Avoid_: `moonbitlang/async` source mirror
+
+**SQLite API**:
+The V8-facing `moonbitlang/sqlite` adapter that lowers SQLite-shaped calls into the portable wasm ABI, borrows Guest Memory for synchronous native calls, and reports ABI contract violations as traps. Native SQLite pointers never cross this interface: SQLite objects and the reserved VFS parameter use opaque `u64` Handles with one runtime-discovered null Host Key. UTF-8 filenames use a NUL-terminated backing Bytes value plus its byte length; the adapter bounds the read by that length and validates the terminator and encoding. UTF-16 SQL uses a backing String plus code-unit offset and length; `pzTail` is returned as an absolute code-unit offset in that same String so a StringView can contain multiple statements. Borrowed strings such as `sqlite3_errmsg16` are copied into caller-provided Guest Memory.
+_Avoid_: SQLite Host, SQLite wrapper SDK
+
+**SQLite Host**:
+The engine-neutral SQLite implementation for one run. It owns SQLite policy and operations, uses the Host's shared Host Key namespace, and contains the Database and Statement pointer maps, teardown, and leak accounting. Runtime adapters lower their own memory and scalar representations before crossing its interface.
+_Avoid_: SQLite API, Async Host, V8 SQLite
 
 **Async Sys**:
 The V8-free native-stub port layer. Implemented files follow the `moonbitlang/async` source layout and carry provenance for the native source path and symbol they track. Poller files are direct ports behind the wasm `poll/*` imports.

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -29,6 +29,7 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true
+libsqlite3-sys.workspace = true
 slotmap.workspace = true
 toml = { workspace = true, features = ["parse", "serde", "std"] }
 moonutil.workspace = true

--- a/crates/moonrun/docs/adr/0009-use-one-handle-namespace.md
+++ b/crates/moonrun/docs/adr/0009-use-one-handle-namespace.md
@@ -1,6 +1,6 @@
 # Use One Handle Namespace
 
-Moonrun will use a single Handle namespace created by the per-run Host and shared by its domain states. Guest-visible Handles for Resources, Jobs, Workers, poll instances, Host Buffers, address-info results, and similar moonrun objects are allocated from one primary `SlotMap<HostKey, HostResourceKind>`, so a Resource Handle cannot accidentally also be a Job or poll handle.
+Moonrun will use a single Handle namespace created by the per-run Host and shared by its domain states. Guest-visible Handles for Resources, Jobs, Workers, poll instances, Host Buffers, address-info results, SQLite Databases, SQLite Statements, and similar moonrun objects are allocated from one primary `SlotMap<HostKey, HostResourceKind>`, so a Resource Handle cannot accidentally also be a Job, poll, or SQLite handle.
 
 Payload storage should not mint identity. Family-specific state lives in `SecondaryMap<HostKey, Payload>` tables, and lookup-only structures such as Windows overlapped-pointer maps are secondary indexes back to Handles. The Host Key table validates the expected `HostResourceKind` before any payload map is touched; generation bits on `HostKey` still reject stale Handles after removal. Import registries declare ABI and register callbacks; they do not own keys or payloads.
 

--- a/crates/moonrun/src/host.rs
+++ b/crates/moonrun/src/host.rs
@@ -22,15 +22,20 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
-#[cfg(test)]
 use slotmap::Key;
 use slotmap::{KeyData, SlotMap, new_key_type};
 
 use crate::async_host::AsyncHost;
 use crate::async_policy::AsyncPolicy;
+use crate::sqlite::SqliteHost;
 
 new_key_type! {
     pub(crate) struct HostKey;
+}
+
+/// The one null Handle value shared by every Host resource kind.
+pub(crate) fn null_handle() -> u64 {
+    HostKey::null().data().as_ffi()
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -50,6 +55,8 @@ pub(crate) enum HostResourceKind {
     TlsConnection,
     #[cfg(windows)]
     IoResult,
+    SqliteDatabase,
+    SqliteStatement,
 }
 
 /// The only identity mint for moonrun-owned opaque guest handles.
@@ -87,18 +94,28 @@ impl HostKeys {
 /// namespace and performs teardown with the complete per-run Host.
 pub(crate) struct Host {
     async_state: AsyncHost,
+    sqlite: SqliteHost,
 }
 
 impl Host {
     pub(crate) fn new(policy: Arc<AsyncPolicy>) -> Self {
         let keys = Rc::new(RefCell::new(HostKeys::default()));
         Self {
-            async_state: AsyncHost::with_keys(policy, keys),
+            async_state: AsyncHost::with_keys(policy, Rc::clone(&keys)),
+            sqlite: SqliteHost::with_keys(keys),
         }
     }
 
     pub(crate) fn async_state(&self) -> &AsyncHost {
         &self.async_state
+    }
+
+    pub(crate) fn null_handle(&self) -> u64 {
+        null_handle()
+    }
+
+    pub(crate) fn sqlite(&self) -> &SqliteHost {
+        &self.sqlite
     }
 }
 
@@ -110,8 +127,15 @@ impl Drop for Host {
             return;
         }
 
+        let mut leaks = Vec::new();
         if let Some(summary) = self.async_state.leak_summary() {
-            panic!("moonrun host leaked resources: async({summary})");
+            leaks.push(format!("async({summary})"));
+        }
+        if let Some(summary) = self.sqlite.leak_summary() {
+            leaks.push(format!("sqlite({summary})"));
+        }
+        if !leaks.is_empty() {
+            panic!("moonrun Host leaked state: {}", leaks.join(", "));
         }
     }
 }
@@ -128,6 +152,12 @@ mod tests {
         let job_handle = job.data().as_ffi();
         let poll_handle = poll.data().as_ffi();
 
+        assert_eq!(
+            HostKey::from(KeyData::from_ffi(null_handle())),
+            HostKey::null()
+        );
+        assert_ne!(job_handle, null_handle());
+        assert_eq!(keys.key(null_handle(), HostResourceKind::Job), None);
         assert_ne!(job_handle, poll_handle);
         assert_eq!(keys.key(job_handle, HostResourceKind::Job), Some(job));
         assert_eq!(keys.key(job_handle, HostResourceKind::Poll), None);

--- a/crates/moonrun/src/host_imports.rs
+++ b/crates/moonrun/src/host_imports.rs
@@ -20,7 +20,8 @@
 
 use crate::v8_builder::{ArgsExt, ObjectExt, ScopeExt};
 use crate::{
-    async_api, async_policy, backtrace_api, fs_api_temp, run_termination, sys_api, util, wasi_api,
+    async_api, async_policy, backtrace_api, fs_api_temp, run_termination, sqlite, sys_api, util,
+    wasi_api,
 };
 use rand::Rng;
 use rand::SeedableRng;
@@ -400,6 +401,12 @@ pub(crate) fn install(
         let async_runtime = global_proxy.child(scope, async_api::MOONBIT_ASYNC_MODULE);
         // SAFETY: the same lifetime invariant as the memory binding above.
         unsafe { async_api::init_env(async_runtime, scope, v8_context_ptr) };
+    }
+
+    {
+        let sqlite = global_proxy.child(scope, sqlite::v8::MOONBIT_SQLITE_MODULE);
+        // SAFETY: the same lifetime invariant as the memory binding above.
+        unsafe { sqlite::v8::init_env(sqlite, scope, v8_context_ptr) };
     }
 
     {

--- a/crates/moonrun/src/sqlite/connection.rs
+++ b/crates/moonrun/src/sqlite/connection.rs
@@ -1,0 +1,265 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::ffi::{CStr, c_void};
+use std::ptr::{self, NonNull};
+
+use libsqlite3_sys as ffi;
+use slotmap::Key;
+
+use super::policy::{ensure_open_flags, ensure_valid_database, install_authorizer};
+use super::{SqliteHost, SqliteHostError, SqliteHostResult};
+use crate::host::{HostResourceKind, null_handle};
+
+// `libsqlite3-sys` intentionally omits SQLite's UTF-16 convenience APIs from
+// its generated bindings. The bundled SQLite library still exports them.
+unsafe extern "C" {
+    fn sqlite3_errmsg16(database: *mut ffi::sqlite3) -> *const c_void;
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum Database {
+    /// The connection opened and the Host policy was installed.
+    Ready(NonNull<ffi::sqlite3>),
+    /// SQLite returned a connection together with an error. It remains valid
+    /// only for reading the error and closing the connection.
+    Failed(NonNull<ffi::sqlite3>),
+}
+
+impl Database {
+    pub(super) fn pointer(self) -> NonNull<ffi::sqlite3> {
+        match self {
+            Self::Ready(pointer) | Self::Failed(pointer) => pointer,
+        }
+    }
+
+    pub(super) fn is_ready(self) -> bool {
+        matches!(self, Self::Ready(_))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct OpenOutcome {
+    pub(crate) code: i32,
+    /// Like `sqlite3_open_v2`, most failures still return a connection so the
+    /// caller can retrieve its error message and close it.
+    pub(crate) database: Option<u64>,
+}
+
+impl SqliteHost {
+    pub(crate) fn open_v2(&self, filename: &CStr, flags: i32, vfs: u64) -> OpenOutcome {
+        if let Err(code) = ensure_valid_database(filename, vfs) {
+            return OpenOutcome {
+                code,
+                database: None,
+            };
+        }
+        let flags = ensure_open_flags(flags);
+
+        let mut database = ptr::null_mut();
+        let code =
+            unsafe { ffi::sqlite3_open_v2(filename.as_ptr(), &mut database, flags, ptr::null()) };
+        let Some(database) = NonNull::new(database) else {
+            return OpenOutcome {
+                code,
+                database: None,
+            };
+        };
+
+        let code = if code == ffi::SQLITE_OK {
+            install_authorizer(database)
+        } else {
+            code
+        };
+
+        let database = if code == ffi::SQLITE_OK {
+            Database::Ready(database)
+        } else {
+            Database::Failed(database)
+        };
+        OpenOutcome {
+            code,
+            database: Some(self.insert_database(database)),
+        }
+    }
+
+    /// Return the current connection error length in UTF-16 code units,
+    /// excluding its trailing NUL.
+    pub(crate) fn errmsg16_length(&self, database: u64) -> SqliteHostResult<u32> {
+        let database = self.database(database)?;
+        let message = unsafe { sqlite3_errmsg16(database.pointer().as_ptr()) };
+        // No other thread can access this run-local connection, and the scan
+        // finishes before another SQLite call can invalidate the pointer.
+        unsafe { utf16_message_length(message) }
+    }
+
+    /// Copy SQLite's current connection error while its pointer is valid.
+    ///
+    /// The returned length is measured in UTF-16 code units and excludes the
+    /// trailing NUL. If `output` cannot hold the complete message and its NUL,
+    /// it is left unchanged and the returned length tells the caller how much
+    /// content the current message contains.
+    pub(crate) fn copy_errmsg16(&self, database: u64, output: &mut [u16]) -> SqliteHostResult<u32> {
+        let database = self.database(database)?;
+        let message = unsafe { sqlite3_errmsg16(database.pointer().as_ptr()) };
+        // No other thread can access this run-local connection, and copying
+        // finishes before another SQLite call can invalidate the pointer.
+        unsafe { copy_utf16_message(message, output) }
+    }
+
+    pub(crate) fn close(&self, database: u64) -> SqliteHostResult<i32> {
+        if database == null_handle() {
+            return Ok(ffi::SQLITE_OK);
+        }
+        let database_handle = database;
+        let database = self.database(database_handle)?;
+        let pointer = database.pointer();
+        let code = unsafe { ffi::sqlite3_close(pointer.as_ptr()) };
+        if code == ffi::SQLITE_OK {
+            let removed = self.remove_database(database_handle)?;
+            debug_assert_eq!(removed.pointer(), pointer);
+        }
+        Ok(code)
+    }
+
+    fn insert_database(&self, database: Database) -> u64 {
+        let key = self
+            .keys
+            .borrow_mut()
+            .insert(HostResourceKind::SqliteDatabase);
+        let replaced = self.databases.borrow_mut().insert(key, database);
+        debug_assert!(replaced.is_none());
+        key.data().as_ffi()
+    }
+
+    pub(super) fn database(&self, handle: u64) -> SqliteHostResult<Database> {
+        let key = self
+            .keys
+            .borrow()
+            .key(handle, HostResourceKind::SqliteDatabase)
+            .ok_or(SqliteHostError::InvalidHandle)?;
+        self.databases
+            .borrow()
+            .get(key)
+            .copied()
+            .ok_or(SqliteHostError::InvalidHandle)
+    }
+
+    fn remove_database(&self, handle: u64) -> SqliteHostResult<Database> {
+        let key = self
+            .keys
+            .borrow()
+            .key(handle, HostResourceKind::SqliteDatabase)
+            .ok_or(SqliteHostError::InvalidHandle)?;
+        let database = self
+            .databases
+            .borrow_mut()
+            .remove(key)
+            .ok_or(SqliteHostError::InvalidHandle)?;
+        let removed = self.keys.borrow_mut().remove(key);
+        debug_assert_eq!(removed, Some(HostResourceKind::SqliteDatabase));
+        Ok(database)
+    }
+}
+
+/// Measure a native-endian, NUL-terminated SQLite UTF-16 string, excluding NUL.
+///
+/// # Safety
+///
+/// A non-NULL `message` must point to a valid SQLite-owned UTF-16 string whose
+/// lifetime covers this call.
+unsafe fn utf16_message_length(message: *const c_void) -> SqliteHostResult<u32> {
+    if message.is_null() {
+        return Ok(0);
+    }
+
+    let message = message.cast::<u16>();
+    let mut length = 0_usize;
+    // SAFETY: SQLite guarantees a NUL-terminated UTF-16 string for every
+    // non-NULL result, and the caller guarantees its lifetime for this scan.
+    while unsafe { *message.add(length) } != 0 {
+        length += 1;
+    }
+    u32::try_from(length).map_err(|_| SqliteHostError::Overflow)
+}
+
+/// Copy a native-endian, NUL-terminated SQLite UTF-16 string.
+///
+/// # Safety
+///
+/// A non-NULL `message` must point to a valid SQLite-owned UTF-16 string whose
+/// lifetime covers this call.
+unsafe fn copy_utf16_message(message: *const c_void, output: &mut [u16]) -> SqliteHostResult<u32> {
+    if message.is_null() {
+        if let Some(first) = output.first_mut() {
+            *first = 0;
+        }
+        return Ok(0);
+    }
+
+    // SAFETY: upheld by this function's caller.
+    let length = unsafe { utf16_message_length(message) }?;
+    let required = length as usize + 1;
+    if output.len() >= required {
+        // SAFETY: the scan above proved that the slice contains `length`
+        // content code units followed by its NUL terminator.
+        let message = unsafe { std::slice::from_raw_parts(message.cast::<u16>(), required) };
+        output[..required].copy_from_slice(message);
+    }
+    Ok(length)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sqlite::tests::{host, open_memory, utf16le};
+
+    #[test]
+    fn error_messages_report_content_length_and_copy_with_termination() {
+        let host = host();
+        let database = open_memory(&host);
+        let sql = utf16le("SELECT 不存在");
+        let outcome = host.prepare16_v2(database, &sql).unwrap();
+        assert_eq!(outcome.code, ffi::SQLITE_ERROR);
+
+        let length = host.errmsg16_length(database).unwrap();
+        let mut complete = vec![0; length as usize + 1];
+        assert_eq!(host.copy_errmsg16(database, &mut complete), Ok(length));
+        assert_eq!(complete.last(), Some(&0));
+        let message = String::from_utf16(&complete[..length as usize]).unwrap();
+        assert!(message.starts_with("no such column"));
+        assert!(message.ends_with("不存在"));
+
+        let mut short = [0xffff; 5];
+        assert_eq!(host.copy_errmsg16(database, &mut short), Ok(length));
+        assert_eq!(short, [0xffff; 5]);
+        assert_eq!(host.close(database), Ok(ffi::SQLITE_OK));
+    }
+
+    #[test]
+    fn unavailable_utf16_error_preserves_sqlite_null() {
+        let mut output = [0xffff];
+
+        assert_eq!(unsafe { utf16_message_length(ptr::null()) }, Ok(0));
+        assert_eq!(
+            unsafe { copy_utf16_message(ptr::null(), &mut output) },
+            Ok(0)
+        );
+        assert_eq!(output, [0]);
+    }
+}

--- a/crates/moonrun/src/sqlite/mod.rs
+++ b/crates/moonrun/src/sqlite/mod.rs
@@ -1,0 +1,153 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! SQLite behavior, lifetime state, policy, and runtime adapters.
+
+pub(crate) mod v8;
+
+mod connection;
+mod policy;
+mod statement;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use libsqlite3_sys as ffi;
+use slotmap::SecondaryMap;
+
+use crate::host::{HostKey, HostKeys};
+
+use connection::Database;
+use statement::Statement;
+
+#[cfg(not(target_endian = "little"))]
+compile_error!("moonrun SQLite imports require a little-endian host");
+
+/// Failures of the Host interface itself, distinct from SQLite result codes.
+///
+/// SQLite result codes are returned inside successful Host calls. These errors
+/// mean the caller violated the portable Host contract and become wasm traps
+/// in a runtime adapter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SqliteHostError {
+    InvalidHandle,
+    InvalidInput,
+    Overflow,
+}
+
+pub(crate) type SqliteHostResult<T> = Result<T, SqliteHostError>;
+
+/// Per-run SQLite policy, operations, identity, and payload storage.
+///
+/// Runtime adapters lower their own memory and scalar representations before
+/// crossing this interface. The shared Host Key table supplies identity, while
+/// SQLite-owned pointers remain private payloads of this module.
+pub(crate) struct SqliteHost {
+    keys: Rc<RefCell<HostKeys>>,
+    databases: RefCell<SecondaryMap<HostKey, Database>>,
+    statements: RefCell<SecondaryMap<HostKey, Statement>>,
+}
+
+impl SqliteHost {
+    pub(crate) fn with_keys(keys: Rc<RefCell<HostKeys>>) -> Self {
+        Self {
+            keys,
+            databases: RefCell::new(SecondaryMap::new()),
+            statements: RefCell::new(SecondaryMap::new()),
+        }
+    }
+
+    /// Describe live SQLite payloads without inspecting another domain's keys.
+    pub(crate) fn leak_summary(&self) -> Option<String> {
+        let databases = self.databases.borrow().len();
+        let statements = self.statements.borrow().len();
+        let mut leaks = Vec::new();
+        if databases != 0 {
+            leaks.push(format!("databases={databases}"));
+        }
+        if statements != 0 {
+            leaks.push(format!("statements={statements}"));
+        }
+        (!leaks.is_empty()).then(|| leaks.join(", "))
+    }
+}
+
+impl Drop for SqliteHost {
+    fn drop(&mut self) {
+        // Statements hold their connections open, so destroy them first.
+        for statement in self.statements.get_mut().values() {
+            unsafe { ffi::sqlite3_finalize(statement.pointer.as_ptr()) };
+        }
+        for database in self.databases.get_mut().values() {
+            unsafe { ffi::sqlite3_close(database.pointer().as_ptr()) };
+        }
+    }
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    use super::*;
+
+    pub(super) fn host() -> SqliteHost {
+        SqliteHost::with_keys(Rc::new(RefCell::new(HostKeys::default())))
+    }
+
+    pub(super) fn open_memory(host: &SqliteHost) -> u64 {
+        let outcome = host.open_v2(
+            c":memory:",
+            ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE,
+            crate::host::null_handle(),
+        );
+        assert_eq!(outcome.code, ffi::SQLITE_OK);
+        outcome.database.unwrap()
+    }
+
+    pub(super) fn utf16le(text: &str) -> Vec<u16> {
+        text.encode_utf16().collect()
+    }
+
+    #[test]
+    fn encoding_is_the_only_guest_pragma() {
+        let host = host();
+        let database = open_memory(&host);
+        let encoding = utf16le("PRAGMA encoding='UTF-16le'");
+        let outcome = host.prepare16_v2(database, &encoding).unwrap();
+        assert_eq!(outcome.code, ffi::SQLITE_OK);
+        let statement = outcome.statement.unwrap();
+        assert_eq!(host.step(statement), Ok(ffi::SQLITE_DONE));
+        assert_eq!(host.finalize(statement), Ok(ffi::SQLITE_OK));
+
+        let temp_store = utf16le("PRAGMA temp_store=MEMORY");
+        let outcome = host.prepare16_v2(database, &temp_store).unwrap();
+        assert_eq!(outcome.code, ffi::SQLITE_AUTH);
+        assert_eq!(outcome.statement, None);
+        assert_eq!(host.close(database), Ok(ffi::SQLITE_OK));
+    }
+
+    #[test]
+    fn guest_pragmas_cannot_change_process_global_configuration() {
+        let host = host();
+        let database = open_memory(&host);
+        let sql = utf16le("PRAGMA hard_heap_limit=1");
+        let outcome = host.prepare16_v2(database, &sql).unwrap();
+
+        assert_eq!(outcome.code, ffi::SQLITE_AUTH);
+        assert_eq!(outcome.statement, None);
+        assert_eq!(host.close(database), Ok(ffi::SQLITE_OK));
+    }
+}

--- a/crates/moonrun/src/sqlite/policy.rs
+++ b/crates/moonrun/src/sqlite/policy.rs
@@ -1,0 +1,111 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::ffi::{CStr, c_char, c_int, c_void};
+use std::ptr::{self, NonNull};
+
+use libsqlite3_sys as ffi;
+
+use crate::host::null_handle;
+
+/// Ensure the requested database and VFS are available in the MVP.
+pub(super) fn ensure_valid_database(filename: &CStr, vfs: u64) -> Result<(), i32> {
+    if filename.to_bytes() != b":memory:" || vfs != null_handle() {
+        return Err(ffi::SQLITE_CANTOPEN);
+    }
+    Ok(())
+}
+
+/// Preserve SQLite's access-mode bits and remove every extension flag.
+pub(super) fn ensure_open_flags(flags: i32) -> i32 {
+    flags & (ffi::SQLITE_OPEN_READONLY | ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE)
+}
+
+/// Install the complete MVP SQL policy before guest SQL can be prepared.
+///
+/// The authorizer rejects database attachment and every guest PRAGMA except
+/// the encoding selection a caller may perform before schema initialization.
+pub(super) fn install_authorizer(database: NonNull<ffi::sqlite3>) -> i32 {
+    unsafe {
+        ffi::sqlite3_set_authorizer(
+            database.as_ptr(),
+            Some(untrusted_authorizer),
+            ptr::null_mut(),
+        )
+    }
+}
+
+unsafe extern "C" fn untrusted_authorizer(
+    _context: *mut c_void,
+    action: c_int,
+    argument1: *const c_char,
+    _argument2: *const c_char,
+    _database: *const c_char,
+    _trigger: *const c_char,
+) -> c_int {
+    // SAFETY: SQLite owns the callback arguments and keeps their
+    // NUL-terminated strings valid for the duration of this call.
+    match action {
+        ffi::SQLITE_PRAGMA
+            if !argument1.is_null()
+                && unsafe { CStr::from_ptr(argument1) }
+                    .to_bytes()
+                    .eq_ignore_ascii_case(b"encoding") =>
+        {
+            ffi::SQLITE_OK
+        }
+        ffi::SQLITE_ATTACH | ffi::SQLITE_DETACH | ffi::SQLITE_PRAGMA => ffi::SQLITE_DENY,
+        _ => ffi::SQLITE_OK,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_flags_preserve_only_access_modes() {
+        for flags in [
+            ffi::SQLITE_OPEN_READONLY,
+            ffi::SQLITE_OPEN_READWRITE,
+            ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE,
+            ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE | 0x4000_0000,
+        ] {
+            assert_eq!(
+                ensure_open_flags(flags),
+                flags
+                    & (ffi::SQLITE_OPEN_READONLY
+                        | ffi::SQLITE_OPEN_READWRITE
+                        | ffi::SQLITE_OPEN_CREATE)
+            );
+        }
+    }
+
+    #[test]
+    fn database_policy_accepts_only_private_memory_and_the_default_vfs() {
+        assert_eq!(ensure_valid_database(c":memory:", null_handle()), Ok(()));
+        assert_eq!(
+            ensure_valid_database(c"database.sqlite", null_handle()),
+            Err(ffi::SQLITE_CANTOPEN)
+        );
+        assert_eq!(
+            ensure_valid_database(c":memory:", u64::MAX),
+            Err(ffi::SQLITE_CANTOPEN)
+        );
+    }
+}

--- a/crates/moonrun/src/sqlite/statement.rs
+++ b/crates/moonrun/src/sqlite/statement.rs
@@ -1,0 +1,239 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::ffi::{c_int, c_void};
+use std::ptr::{self, NonNull};
+
+use libsqlite3_sys as ffi;
+use slotmap::Key;
+
+use super::{SqliteHost, SqliteHostError, SqliteHostResult};
+use crate::host::{HostResourceKind, null_handle};
+
+// `libsqlite3-sys` intentionally omits SQLite's UTF-16 convenience APIs from
+// its generated bindings. The bundled SQLite library still exports them.
+unsafe extern "C" {
+    fn sqlite3_prepare16_v2(
+        database: *mut ffi::sqlite3,
+        sql: *const c_void,
+        sql_length: c_int,
+        statement_out: *mut *mut ffi::sqlite3_stmt,
+        tail_out: *mut *const c_void,
+    ) -> c_int;
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct Statement {
+    pub(super) pointer: NonNull<ffi::sqlite3_stmt>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PrepareOutcome {
+    pub(crate) code: i32,
+    pub(crate) statement: Option<u64>,
+    /// UTF-16 code units consumed from the supplied SQL view.
+    pub(crate) tail_offset: u32,
+}
+
+impl SqliteHost {
+    /// Prepare the first statement in a native-endian UTF-16 view.
+    ///
+    /// `tail_offset` is measured in UTF-16 code units from the start of `sql`.
+    /// The runtime adapter combines it with the view's backing-string offset.
+    pub(crate) fn prepare16_v2(
+        &self,
+        database: u64,
+        sql: &[u16],
+    ) -> SqliteHostResult<PrepareOutcome> {
+        let byte_length = sql
+            .len()
+            .checked_mul(size_of::<u16>())
+            .ok_or(SqliteHostError::Overflow)?;
+        let native_length = i32::try_from(byte_length).map_err(|_| SqliteHostError::Overflow)?;
+        let database = self.database(database)?;
+        if !database.is_ready() {
+            return Ok(PrepareOutcome {
+                code: ffi::SQLITE_MISUSE,
+                statement: None,
+                tail_offset: 0,
+            });
+        }
+
+        let native_start = sql.as_ptr().cast::<c_void>();
+        let mut statement = ptr::null_mut();
+        let mut native_tail = ptr::null();
+        let code = unsafe {
+            sqlite3_prepare16_v2(
+                database.pointer().as_ptr(),
+                native_start,
+                native_length,
+                &mut statement,
+                &mut native_tail,
+            )
+        };
+        // SAFETY: SQLite guarantees that `pzTail` points into the supplied SQL
+        // and UTF-16 input keeps both pointers aligned to code units.
+        let tail_offset = unsafe { native_tail.cast::<u16>().offset_from(sql.as_ptr()) };
+        let tail_offset = u32::try_from(tail_offset).map_err(|_| SqliteHostError::Overflow)?;
+        let statement =
+            NonNull::new(statement).map(|pointer| self.insert_statement(Statement { pointer }));
+
+        Ok(PrepareOutcome {
+            code,
+            statement,
+            tail_offset,
+        })
+    }
+
+    pub(crate) fn step(&self, statement: u64) -> SqliteHostResult<i32> {
+        let statement = self.statement(statement)?;
+        Ok(unsafe { ffi::sqlite3_step(statement.pointer.as_ptr()) })
+    }
+
+    pub(crate) fn finalize(&self, statement: u64) -> SqliteHostResult<i32> {
+        if statement == null_handle() {
+            return Ok(ffi::SQLITE_OK);
+        }
+        let statement = self.remove_statement(statement)?;
+        // `sqlite3_finalize` always destroys the statement, even when it
+        // reports an earlier execution error. Remove the guest handle before
+        // transferring ownership to SQLite so no stale pointer can remain.
+        Ok(unsafe { ffi::sqlite3_finalize(statement.pointer.as_ptr()) })
+    }
+
+    pub(crate) fn column_int64(&self, statement: u64, column: i32) -> SqliteHostResult<i64> {
+        let statement = self.statement(statement)?;
+        let columns = unsafe { ffi::sqlite3_data_count(statement.pointer.as_ptr()) };
+        if !(0..columns).contains(&column) {
+            return Err(SqliteHostError::InvalidInput);
+        }
+        Ok(unsafe { ffi::sqlite3_column_int64(statement.pointer.as_ptr(), column) })
+    }
+
+    fn insert_statement(&self, statement: Statement) -> u64 {
+        let key = self
+            .keys
+            .borrow_mut()
+            .insert(HostResourceKind::SqliteStatement);
+        let replaced = self.statements.borrow_mut().insert(key, statement);
+        debug_assert!(replaced.is_none());
+        key.data().as_ffi()
+    }
+
+    fn statement(&self, handle: u64) -> SqliteHostResult<Statement> {
+        let key = self
+            .keys
+            .borrow()
+            .key(handle, HostResourceKind::SqliteStatement)
+            .ok_or(SqliteHostError::InvalidHandle)?;
+        self.statements
+            .borrow()
+            .get(key)
+            .copied()
+            .ok_or(SqliteHostError::InvalidHandle)
+    }
+
+    fn remove_statement(&self, handle: u64) -> SqliteHostResult<Statement> {
+        let key = self
+            .keys
+            .borrow()
+            .key(handle, HostResourceKind::SqliteStatement)
+            .ok_or(SqliteHostError::InvalidHandle)?;
+        let statement = self
+            .statements
+            .borrow_mut()
+            .remove(key)
+            .ok_or(SqliteHostError::InvalidHandle)?;
+        let removed = self.keys.borrow_mut().remove(key);
+        debug_assert_eq!(removed, Some(HostResourceKind::SqliteStatement));
+        Ok(statement)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sqlite::tests::{host, open_memory, utf16le};
+
+    #[test]
+    fn prepare_reports_the_first_statement_tail_in_code_units() {
+        let host = host();
+        let database = open_memory(&host);
+        let first = "SELECT 1;";
+        let sql = utf16le(&format!("{first} SELECT 2"));
+
+        let outcome = host.prepare16_v2(database, &sql).unwrap();
+
+        assert_eq!(outcome.code, ffi::SQLITE_OK);
+        assert_eq!(outcome.tail_offset, first.encode_utf16().count() as u32);
+        assert_eq!(
+            host.finalize(outcome.statement.unwrap()),
+            Ok(ffi::SQLITE_OK)
+        );
+        assert_eq!(host.close(database), Ok(ffi::SQLITE_OK));
+    }
+
+    #[test]
+    fn complete_memory_lifecycle_crosses_only_the_host_interface() {
+        let host = host();
+        let database = open_memory(&host);
+        let sql = utf16le("CREATE TABLE 数据(value INTEGER)");
+        let outcome = host.prepare16_v2(database, &sql).unwrap();
+
+        assert_eq!(outcome.code, ffi::SQLITE_OK);
+        assert_eq!(outcome.tail_offset, sql.len() as u32);
+        let statement = outcome.statement.unwrap();
+        assert_eq!(host.step(statement), Ok(ffi::SQLITE_DONE));
+        assert_eq!(host.finalize(statement), Ok(ffi::SQLITE_OK));
+        assert_eq!(host.close(database), Ok(ffi::SQLITE_OK));
+    }
+
+    #[test]
+    fn column_access_requires_a_current_row_and_valid_index() {
+        let host = host();
+        let database = open_memory(&host);
+        let sql = utf16le("SELECT 42");
+        let statement = host
+            .prepare16_v2(database, &sql)
+            .unwrap()
+            .statement
+            .unwrap();
+
+        assert_eq!(
+            host.column_int64(statement, 0),
+            Err(SqliteHostError::InvalidInput)
+        );
+        assert_eq!(host.step(statement), Ok(ffi::SQLITE_ROW));
+        assert_eq!(
+            host.column_int64(statement, -1),
+            Err(SqliteHostError::InvalidInput)
+        );
+        assert_eq!(
+            host.column_int64(statement, 1),
+            Err(SqliteHostError::InvalidInput)
+        );
+        assert_eq!(host.column_int64(statement, 0), Ok(42));
+        assert_eq!(host.step(statement), Ok(ffi::SQLITE_DONE));
+        assert_eq!(
+            host.column_int64(statement, 0),
+            Err(SqliteHostError::InvalidInput)
+        );
+        assert_eq!(host.finalize(statement), Ok(ffi::SQLITE_OK));
+        assert_eq!(host.close(database), Ok(ffi::SQLITE_OK));
+    }
+}

--- a/crates/moonrun/src/sqlite/v8/connection.rs
+++ b/crates/moonrun/src/sqlite/v8/connection.rs
@@ -1,0 +1,68 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use super::context::{ImportContext, SqliteError, SqliteResult};
+use crate::guest_memory::GuestMemory;
+use crate::host::null_handle;
+
+pub(super) fn open_v2(
+    context: &mut ImportContext,
+    filename: u32,
+    filename_length: i32,
+    database_out: u32,
+    flags: i32,
+    vfs: u64,
+) -> SqliteResult<i32> {
+    let filename_length = u32::try_from(filename_length).map_err(|_| SqliteError::Fault)?;
+    context.validate_write(database_out, size_of::<u64>())?;
+    context.write_u64(database_out, null_handle())?;
+
+    let filename = context.read_utf8_c_string(filename, filename_length)?;
+    let outcome = context.host.open_v2(filename, flags, vfs);
+    context.write_u64(database_out, outcome.database.unwrap_or_else(null_handle))?;
+    Ok(outcome.code)
+}
+
+/// Copy the current connection error into Guest Memory as UTF-16LE.
+///
+/// Capacity and the return value are UTF-16 code units; the returned content
+/// length excludes NUL. Call `sqlite3_errmsg16_length` first and allocate one
+/// additional code unit for the terminator. If the current message does not
+/// fit, the output is left unchanged and its current content length is
+/// returned so the caller can retry.
+pub(super) fn errmsg16(
+    context: &mut ImportContext,
+    database: u64,
+    output: u32,
+    capacity: u32,
+) -> SqliteResult<u32> {
+    if output == 0 || capacity == 0 {
+        return Err(SqliteError::Fault);
+    }
+    let byte_capacity = capacity.checked_mul(2).ok_or(SqliteError::Overflow)?;
+    let (host, memory) = context.host_and_memory();
+    let bytes = memory.read_exact_mut(output, byte_capacity)?;
+    // SAFETY: every bit pattern is a valid `u16`. The prefix/suffix check
+    // rejects a runtime memory backing that does not satisfy this ABI's
+    // alignment requirement.
+    let (prefix, output, suffix) = unsafe { bytes.align_to_mut::<u16>() };
+    if !prefix.is_empty() || !suffix.is_empty() {
+        return Err(SqliteError::Fault);
+    }
+    Ok(host.copy_errmsg16(database, output)?)
+}

--- a/crates/moonrun/src/sqlite/v8/context.rs
+++ b/crates/moonrun/src/sqlite/v8/context.rs
@@ -1,0 +1,195 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::ffi::CStr;
+
+use crate::guest_memory::{GuestMemory, GuestMemoryError};
+use crate::sqlite::{SqliteHost, SqliteHostError};
+use crate::v8_import::{V8ImportError, V8RunContext};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum SqliteError {
+    Fault,
+    InvalidHandle,
+    Overflow,
+}
+
+pub(super) type SqliteResult<T> = Result<T, SqliteError>;
+
+pub(super) fn with_memory_context<T>(
+    scope: &mut v8::HandleScope,
+    context: &V8RunContext,
+    f: impl FnOnce(&mut ImportContext<'_>) -> SqliteResult<T>,
+) -> SqliteResult<T> {
+    context.memory_binding().with_memory_mut(scope, |memory| {
+        f(&mut ImportContext {
+            host: context.host().sqlite(),
+            memory,
+        })
+    })
+}
+
+pub(super) struct ImportContext<'a> {
+    pub(super) host: &'a SqliteHost,
+    memory: &'a mut [u8],
+}
+
+impl ImportContext<'_> {
+    pub(super) fn host_and_memory(&mut self) -> (&SqliteHost, &mut [u8]) {
+        (self.host, self.memory)
+    }
+
+    /// Borrow one UTF-16 view from a MoonBit backing String.
+    ///
+    /// Offset and length are UTF-16 code units, not bytes. The caller lowers
+    /// signed ABI values first; unaligned backing pointers, overflow, and
+    /// out-of-bounds views violate the wasm ABI contract.
+    pub(super) fn read_utf16_view(
+        &self,
+        pointer: u32,
+        offset: u32,
+        length: u32,
+    ) -> SqliteResult<&[u16]> {
+        if pointer == 0 || !pointer.is_multiple_of(2) {
+            return Err(SqliteError::Fault);
+        }
+        let byte_offset = offset.checked_mul(2).ok_or(SqliteError::Overflow)?;
+        let byte_length = length.checked_mul(2).ok_or(SqliteError::Overflow)?;
+        let pointer = pointer
+            .checked_add(byte_offset)
+            .ok_or(SqliteError::Overflow)?;
+        let bytes = self.memory.read_exact(pointer, byte_length)?;
+        // SAFETY: every bit pattern is a valid `u16`. The prefix/suffix check
+        // below rejects a runtime memory backing that does not provide the
+        // alignment promised by this UTF-16 ABI.
+        let (prefix, units, suffix) = unsafe { bytes.align_to::<u16>() };
+        if !prefix.is_empty() || !suffix.is_empty() {
+            return Err(SqliteError::Fault);
+        }
+        Ok(units)
+    }
+
+    /// Borrow one NUL-terminated UTF-8 string from a MoonBit Bytes value.
+    ///
+    /// Length includes the terminator. The explicit length bounds the Guest
+    /// Memory read; the remaining checks enforce SQLite's filename contract.
+    pub(super) fn read_utf8_c_string(&self, pointer: u32, length: u32) -> SqliteResult<&CStr> {
+        if pointer == 0 || length == 0 {
+            return Err(SqliteError::Fault);
+        }
+        let bytes = self.memory.read_exact(pointer, length)?;
+        let value = CStr::from_bytes_with_nul(bytes).map_err(|_| SqliteError::Fault)?;
+        value.to_str().map_err(|_| SqliteError::Fault)?;
+        Ok(value)
+    }
+
+    pub(super) fn validate_write(&self, pointer: u32, length: usize) -> SqliteResult<()> {
+        if pointer == 0 {
+            return Err(SqliteError::Fault);
+        }
+        let length = u32::try_from(length).map_err(|_| SqliteError::Overflow)?;
+        self.memory.read_exact(pointer, length)?;
+        Ok(())
+    }
+
+    pub(super) fn write_u32(&mut self, pointer: u32, value: u32) -> SqliteResult<()> {
+        self.write_exact(pointer, &value.to_le_bytes())
+    }
+
+    pub(super) fn write_u64(&mut self, pointer: u32, value: u64) -> SqliteResult<()> {
+        self.write_exact(pointer, &value.to_le_bytes())
+    }
+
+    fn write_exact(&mut self, pointer: u32, value: &[u8]) -> SqliteResult<()> {
+        if pointer == 0 {
+            return Err(SqliteError::Fault);
+        }
+        self.memory.write_exact(pointer, value)?;
+        Ok(())
+    }
+}
+
+impl From<GuestMemoryError> for SqliteError {
+    fn from(_error: GuestMemoryError) -> Self {
+        Self::Fault
+    }
+}
+
+impl From<V8ImportError> for SqliteError {
+    fn from(_error: V8ImportError) -> Self {
+        Self::Fault
+    }
+}
+
+impl From<SqliteHostError> for SqliteError {
+    fn from(error: SqliteHostError) -> Self {
+        match error {
+            SqliteHostError::InvalidHandle => Self::InvalidHandle,
+            SqliteHostError::InvalidInput => Self::Fault,
+            SqliteHostError::Overflow => Self::Overflow,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use crate::host::HostKeys;
+
+    #[test]
+    fn utf16_view_uses_code_unit_offsets_and_lengths() {
+        let host = SqliteHost::with_keys(Rc::new(RefCell::new(HostKeys::default())));
+        let mut memory = (0_u8..16).collect::<Vec<_>>();
+        let context = ImportContext {
+            host: &host,
+            memory: &mut memory,
+        };
+
+        assert_eq!(
+            context.read_utf16_view(2, 2, 2),
+            Ok(&[u16::from_le_bytes([6, 7]), u16::from_le_bytes([8, 9])][..])
+        );
+        assert_eq!(context.read_utf16_view(3, 0, 1), Err(SqliteError::Fault));
+        assert_eq!(
+            context.read_utf16_view(2, u32::MAX, 1),
+            Err(SqliteError::Overflow)
+        );
+    }
+
+    #[test]
+    fn utf8_c_string_checks_its_explicit_length() {
+        let host = SqliteHost::with_keys(Rc::new(RefCell::new(HostKeys::default())));
+        let mut memory = b"x:memory:\0trailing".to_vec();
+        let context = ImportContext {
+            host: &host,
+            memory: &mut memory,
+        };
+
+        assert_eq!(
+            context
+                .read_utf8_c_string(1, 9)
+                .map(|value| value.to_bytes()),
+            Ok(&b":memory:"[..])
+        );
+        assert_eq!(context.read_utf8_c_string(1, 8), Err(SqliteError::Fault));
+        assert_eq!(context.read_utf8_c_string(1, 10), Err(SqliteError::Fault));
+    }
+}

--- a/crates/moonrun/src/sqlite/v8/mod.rs
+++ b/crates/moonrun/src/sqlite/v8/mod.rs
@@ -1,0 +1,60 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! V8-facing, synchronous adapter for the SQLite Host interface.
+//!
+//! The `sqlite3_*` imports keep SQLite-shaped operations while adapting native
+//! pointers to a portable wasm ABI. Guest-memory pointers are unsigned wasm
+//! `i32` offsets, while SQLite-owned objects and the reserved VFS parameter are
+//! opaque `u64` Handles. The guest obtains their shared null value at runtime
+//! through `sqlite3_null_handle`.
+//!
+//! UTF-16 inputs and outputs use the little-endian code units stored by wasm.
+//! `sqlite3_prepare16_v2` receives a backing String plus a code-unit offset and
+//! length, and returns `pzTail` as an absolute code-unit offset in that same
+//! String. This preserves multiple-statement and `StringView` semantics without
+//! exposing a runtime-specific address. `sqlite3_errmsg16_length` measures the
+//! current error and `sqlite3_errmsg16` copies it into a caller-provided Guest
+//! Memory buffer instead of exposing SQLite's borrowed native pointer. SQLite
+//! behavior and policy belong to the parent `sqlite` module; this adapter only
+//! lowers V8 values and Guest Memory.
+//! Callback-bearing extension APIs, varargs, process-global configuration,
+//! custom VFSes, and file-backed databases are outside the MVP.
+
+mod connection;
+mod context;
+mod registry;
+mod registry_macros;
+mod statement;
+
+use crate::v8_import::V8RunContext;
+
+pub(crate) use registry::MOONBIT_SQLITE_MODULE;
+
+/// # Safety
+///
+/// `context` must remain valid whenever a registered callback can be invoked.
+pub(crate) unsafe fn init_env<'s>(
+    obj: v8::Local<'s, v8::Object>,
+    scope: &mut v8::HandleScope<'s>,
+    context: *const V8RunContext,
+) {
+    // SAFETY: the caller retains the per-run V8 context throughout guest
+    // execution and does not re-enter V8 after dropping it.
+    unsafe { registry::register_imports(obj, scope, context) };
+}

--- a/crates/moonrun/src/sqlite/v8/registry.rs
+++ b/crates/moonrun/src/sqlite/v8/registry.rs
@@ -1,0 +1,61 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use super::context::{SqliteError, with_memory_context};
+use super::registry_macros::declare_sqlite_imports;
+use super::{connection, statement};
+use crate::v8_import::{ImportArgs, V8ImportError, V8RunContext};
+
+pub(crate) const MOONBIT_SQLITE_MODULE: &str = "moonbitlang/sqlite";
+
+// This is the complete `moonbitlang/sqlite` ABI surface. The declaration
+// generates both the V8 callbacks and their registration, so adding a symbol
+// cannot update one without the other. Each entry names its implementation
+// target; the registry does not expose how the macro reaches that target.
+declare_sqlite_imports! {
+    Host::null_handle() -> u64 => "sqlite3_null_handle";
+
+    connection::open_v2(
+        filename: u32,
+        filename_length: i32,
+        database_out: u32,
+        flags: i32,
+        vfs: u64,
+    ) -> i32 => "sqlite3_open_v2";
+    SqliteHost::errmsg16_length(database: u64)
+        -> u32 => "sqlite3_errmsg16_length";
+    connection::errmsg16(
+        database: u64,
+        output: u32,
+        capacity: u32,
+    ) -> u32 => "sqlite3_errmsg16";
+    SqliteHost::close(database: u64) -> i32 => "sqlite3_close";
+
+    statement::prepare16_v2(
+        database: u64,
+        sql: u32,
+        sql_offset: i32,
+        sql_length: i32,
+        statement_out: u32,
+        tail_out: u32,
+    ) -> i32 => "sqlite3_prepare16_v2";
+    SqliteHost::step(statement: u64) -> i32 => "sqlite3_step";
+    SqliteHost::finalize(statement: u64) -> i32 => "sqlite3_finalize";
+    SqliteHost::column_int64(statement: u64, column: i32)
+        -> i64 => "sqlite3_column_int64";
+}

--- a/crates/moonrun/src/sqlite/v8/registry_macros.rs
+++ b/crates/moonrun/src/sqlite/v8/registry_macros.rs
@@ -1,0 +1,230 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+macro_rules! decode_wasm_arg {
+    ($args:ident, i32) => {
+        $args.next_i32()
+    };
+    ($args:ident, u32) => {
+        $args.next_u32()
+    };
+    ($args:ident, u64) => {
+        $args.next_u64()
+    };
+}
+
+macro_rules! wasm_arg_count {
+    () => {
+        0_i32
+    };
+    ($head:ident $(, $tail:ident)*) => {
+        1_i32 + $crate::sqlite::v8::registry_macros::wasm_arg_count!($($tail),*)
+    };
+}
+
+macro_rules! decode_sqlite_args {
+    ($scope:ident, $args:ident,) => {
+        Ok::<(), V8ImportError>(())
+    };
+    ($scope:ident, $args:ident, $($arg:ident : $arg_ty:ident),+ $(,)?) => {{
+        let mut import_args = ImportArgs::new($scope, &$args);
+        (|| -> Result<_, V8ImportError> {
+            $(
+                let $arg = $crate::sqlite::v8::registry_macros::decode_wasm_arg!(
+                    import_args,
+                    $arg_ty
+                )?;
+            )+
+            Ok(($($arg,)+))
+        })()
+    }};
+}
+
+macro_rules! finish_sqlite_import {
+    ($scope:ident, $ret:ident, $name:expr, i32, $result:expr) => {
+        match $result {
+            Ok(value) => $ret.set_int32(value),
+            Err(error) => {
+                crate::v8_import::throw_import_error($scope, MOONBIT_SQLITE_MODULE, $name, error)
+            }
+        }
+    };
+    ($scope:ident, $ret:ident, $name:expr, u32, $result:expr) => {
+        match $result {
+            Ok(value) => $ret.set_int32(value as i32),
+            Err(error) => {
+                crate::v8_import::throw_import_error($scope, MOONBIT_SQLITE_MODULE, $name, error)
+            }
+        }
+    };
+    ($scope:ident, $ret:ident, $name:expr, i64, $result:expr) => {
+        match $result {
+            Ok(value) => $ret.set(v8::BigInt::new_from_i64($scope, value).into()),
+            Err(error) => {
+                crate::v8_import::throw_import_error($scope, MOONBIT_SQLITE_MODULE, $name, error)
+            }
+        }
+    };
+    ($scope:ident, $ret:ident, $name:expr, u64, $result:expr) => {
+        match $result {
+            Ok(value) => $ret.set(v8::BigInt::new_from_u64($scope, value).into()),
+            Err(error) => {
+                crate::v8_import::throw_import_error($scope, MOONBIT_SQLITE_MODULE, $name, error)
+            }
+        }
+    };
+}
+
+macro_rules! invoke_sqlite_import {
+    (
+        $scope:ident,
+        $args:ident,
+        Host::$callback:ident,
+        ($($arg:ident),*)
+    ) => {{
+        // SAFETY: `register_imports` installs the retained `V8RunContext`
+        // pointer with this callback.
+        let context: &crate::v8_import::V8RunContext =
+            unsafe { crate::v8_import::callback_context(&$args) };
+        Ok::<_, SqliteError>(context.host().$callback($($arg),*))
+    }};
+    (
+        $scope:ident,
+        $args:ident,
+        SqliteHost::$callback:ident,
+        ($($arg:ident),*)
+    ) => {{
+        // SAFETY: `register_imports` installs the retained `V8RunContext`
+        // pointer with this callback.
+        let context: &crate::v8_import::V8RunContext =
+            unsafe { crate::v8_import::callback_context(&$args) };
+        context
+            .host()
+            .sqlite()
+            .$callback($($arg),*)
+            .map_err(SqliteError::from)
+    }};
+    (
+        $scope:ident,
+        $args:ident,
+        $module:ident::$callback:ident,
+        ($($arg:ident),*)
+    ) => {{
+        // SAFETY: `register_imports` installs the retained `V8RunContext`
+        // pointer with this callback.
+        let context: &crate::v8_import::V8RunContext =
+            unsafe { crate::v8_import::callback_context(&$args) };
+        with_memory_context($scope, context, |context| {
+            $module::$callback(context, $($arg),*)
+        })
+    }};
+}
+
+macro_rules! register_sqlite_import {
+    (
+        $obj:ident,
+        $registration_scope:ident,
+        $context_ptr:ident,
+        $module:ident::$callback:ident(
+            $($arg:ident : $arg_ty:ident),* $(,)?
+        ) -> $ret_ty:ident => $wasm_symbol:literal
+    ) => {{
+        fn callback(
+            scope: &mut v8::HandleScope,
+            args: v8::FunctionCallbackArguments,
+            mut ret: v8::ReturnValue,
+        ) {
+            let result = if args.length()
+                != $crate::sqlite::v8::registry_macros::wasm_arg_count!($($arg_ty),*)
+            {
+                Err(SqliteError::from(V8ImportError::InvalidArgument))
+            } else {
+                let decoded = $crate::sqlite::v8::registry_macros::decode_sqlite_args!(
+                    scope,
+                    args,
+                    $($arg : $arg_ty),*
+                );
+
+                match decoded {
+                    Ok(($($arg,)*)) => {
+                        $crate::sqlite::v8::registry_macros::invoke_sqlite_import!(
+                            scope,
+                            args,
+                            $module::$callback,
+                            ($($arg),*)
+                        )
+                    }
+                    Err(error) => Err(SqliteError::from(error)),
+                }
+            };
+
+            $crate::sqlite::v8::registry_macros::finish_sqlite_import!(
+                scope,
+                ret,
+                $wasm_symbol,
+                $ret_ty,
+                result
+            );
+        }
+
+        crate::v8_import::register_func(
+            $obj,
+            $registration_scope,
+            $wasm_symbol,
+            callback,
+            $context_ptr,
+        );
+    }};
+}
+
+macro_rules! declare_sqlite_imports {
+    ($(
+        $(#[$meta:meta])*
+        $module:ident::$callback:ident(
+            $($arg:ident : $arg_ty:ident),* $(,)?
+        ) -> $ret_ty:ident => $wasm_symbol:literal;
+    )*) => {
+        /// Register every SQLite import against one retained V8 run context.
+        ///
+        /// # Safety
+        ///
+        /// `context_ptr` must remain valid whenever a registered callback can
+        /// be invoked.
+        pub(super) unsafe fn register_imports<'s>(
+            obj: v8::Local<'s, v8::Object>,
+            scope: &mut v8::HandleScope<'s>,
+            context_ptr: *const V8RunContext,
+        ) {
+            $(
+                $(#[$meta])*
+                $crate::sqlite::v8::registry_macros::register_sqlite_import!(
+                    obj,
+                    scope,
+                    context_ptr,
+                    $module::$callback($($arg : $arg_ty),*)
+                        -> $ret_ty => $wasm_symbol
+                );
+            )*
+        }
+    };
+}
+
+pub(super) use {
+    declare_sqlite_imports, decode_sqlite_args, decode_wasm_arg, finish_sqlite_import,
+    invoke_sqlite_import, register_sqlite_import, wasm_arg_count,
+};

--- a/crates/moonrun/src/sqlite/v8/statement.rs
+++ b/crates/moonrun/src/sqlite/v8/statement.rs
@@ -1,0 +1,56 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use super::context::{ImportContext, SqliteError, SqliteResult};
+use crate::host::null_handle;
+
+pub(super) fn prepare16_v2(
+    context: &mut ImportContext,
+    database: u64,
+    sql_pointer: u32,
+    sql_offset: i32,
+    sql_length: i32,
+    statement_out: u32,
+    tail_out: u32,
+) -> SqliteResult<i32> {
+    let sql_offset = u32::try_from(sql_offset).map_err(|_| SqliteError::Fault)?;
+    let sql_length = u32::try_from(sql_length).map_err(|_| SqliteError::Fault)?;
+    context.validate_write(statement_out, size_of::<u64>())?;
+    if tail_out != 0 {
+        context.validate_write(tail_out, size_of::<u32>())?;
+    }
+    context.write_u64(statement_out, null_handle())?;
+    if tail_out != 0 {
+        context.write_u32(tail_out, sql_offset)?;
+    }
+
+    let sql = context.read_utf16_view(sql_pointer, sql_offset, sql_length)?;
+
+    // No guest callback can grow memory while the synchronous Host call
+    // borrows these SQL bytes from Guest Memory.
+    let outcome = context.host.prepare16_v2(database, sql)?;
+
+    if tail_out != 0 {
+        let guest_tail = sql_offset
+            .checked_add(outcome.tail_offset)
+            .ok_or(SqliteError::Overflow)?;
+        context.write_u32(tail_out, guest_tail)?;
+    }
+    context.write_u64(statement_out, outcome.statement.unwrap_or_else(null_handle))?;
+    Ok(outcome.code)
+}

--- a/crates/moonrun/src/template/js_glue.js
+++ b/crates/moonrun/src/template/js_glue.js
@@ -145,6 +145,7 @@ const __moonbit_backtrace_runtime = globalThis.__moonbit_backtrace_runtime || {
 const __moonbit_wasi_unstable = globalThis.__moonbit_wasi_unstable || {};
 const __moonrun_v8_import = globalThis.__moonrun_v8_import || {};
 const moonbitlang_async = globalThis["moonbitlang/async"] || {};
+const moonbitlang_sqlite = globalThis["moonbitlang/sqlite"] || {};
 const moonbit_ffi_memory_sanitizer =
     globalThis["moonbit:ffi/memory-sanitizer"] || {};
 
@@ -426,6 +427,7 @@ const spectest = {
     __moonbit_sys_unstable: __moonbit_sys_unstable,
     __moonbit_time_unstable: __moonbit_time_unstable,
     "moonbitlang/async": moonbitlang_async,
+    "moonbitlang/sqlite": moonbitlang_sqlite,
     "moonbit:ffi/memory-sanitizer": moonbit_ffi_memory_sanitizer,
     wasi_snapshot_preview1: wasi_snapshot_preview1,
     moonbit: {

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -628,6 +628,56 @@ fn test_moon_run_with_async_host_imports() {
 }
 
 #[test]
+fn test_moon_run_with_sqlite_ffi_imports() {
+    let dir = TestDir::new("test_sqlite_ffi.in");
+
+    moon_cmd()
+        .current_dir(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success();
+
+    let wasm_file = dir.join("_build/wasm/debug/build/main/main.wasm");
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .current_dir(&dir)
+        .env(MOONBIT_ASYNC_CHECK_FD_LEAK, "1")
+        .arg(&wasm_file)
+        .assert()
+        .success()
+        .stdout_eq("ok\n")
+        .stderr_eq("");
+
+    assert!(!dir.join("not-a-memory-database").exists());
+
+    let leaked_wasm = dir.join("_build/wasm/debug/build/leak/leak.wasm");
+    let assert = snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .current_dir(&dir)
+        .env(MOONBIT_ASYNC_CHECK_FD_LEAK, "1")
+        .env("RUST_BACKTRACE", "0")
+        .arg(&leaked_wasm)
+        .assert()
+        .failure()
+        .stdout_eq("leaked\n");
+    let stderr = std::str::from_utf8(&assert.get_output().stderr).unwrap();
+    assert!(
+        stderr.contains("moonrun Host leaked state: sqlite(databases=1)"),
+        "expected SQLite leak assertion in stderr, got:\n{stderr}"
+    );
+
+    let invalid_handle_wasm =
+        dir.join("_build/wasm/debug/build/invalid_handle/invalid_handle.wasm");
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(&invalid_handle_wasm)
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: moonbitlang/sqlite.sqlite3_close failed: InvalidHandle
+[..]
+"#]]);
+}
+
+#[test]
 fn test_moon_run_with_async_stdio_imports() {
     let dir = TestDir::new("test_async_stdio.in");
 
@@ -915,7 +965,7 @@ fn test_moon_run_async_host_leak_check_env() {
         .stdout_eq("leaked\n");
     let stderr = std::str::from_utf8(&assert.get_output().stderr).unwrap();
     assert!(
-        stderr.contains("moonrun host leaked resources: async(polls=1"),
+        stderr.contains("moonrun Host leaked state: async(polls=1"),
         "expected async host leak assertion in stderr, got:\n{stderr}"
     );
 }

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/invalid_handle/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/invalid_handle/main.mbt
@@ -16,32 +16,14 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Embeddable execution support for MoonBit Wasm programs.
-//!
-//! The interface is experimental. It currently separates guest termination
-//! from host-process termination, while retaining Moonrun's existing V8 and
-//! process-scoped host integrations.
+///|
+fn event_bus_create() -> UInt64 = "moonbitlang/async" "event_bus/create"
 
-mod async_api;
-mod async_host;
-mod async_policy;
-mod async_sys;
-mod backtrace_api;
-mod demangle_js_template;
-mod fs_api_temp;
-mod guest_memory;
-mod host;
-mod host_fs;
-mod host_imports;
-mod memory_sanitizer_api;
-mod run_termination;
-mod runtime;
-mod sqlite;
-mod sys_api;
-mod util;
-mod v8_backend;
-mod v8_builder;
-mod v8_import;
-mod wasi_api;
+///|
+fn sqlite3_close(database : UInt64) -> Int = "moonbitlang/sqlite" "sqlite3_close"
 
-pub use runtime::{RunOptions, RunOutcome, Runtime, RuntimeConfig};
+///|
+fn main {
+  let event_bus = event_bus_create()
+  ignore(sqlite3_close(event_bus))
+}

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/invalid_handle/moon.pkg
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/invalid_handle/moon.pkg
@@ -1,0 +1,1 @@
+options("is-main": true)

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/leak/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/leak/main.mbt
@@ -1,0 +1,59 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+///|
+const SQLITE_OK = 0
+
+///|
+const SQLITE_OPEN_READWRITE = 0x00000002
+
+///|
+const SQLITE_OPEN_CREATE = 0x00000004
+
+///|
+/// Returns the shared null value for database, statement, and VFS Handles.
+fn sqlite3_null_handle() -> UInt64 = "moonbitlang/sqlite" "sqlite3_null_handle"
+
+///|
+#unsafe_skip_stub_check
+#borrow(filename, database)
+fn sqlite3_open_v2(
+  filename : Bytes,
+  filename_length : Int,
+  database : Ref[UInt64],
+  flags : Int,
+  vfs : UInt64,
+) -> Int = "moonbitlang/sqlite" "sqlite3_open_v2"
+
+///|
+fn main {
+  let null_handle = sqlite3_null_handle()
+  let database = Ref(null_handle)
+  let filename = b":memory:\x00"
+  if sqlite3_open_v2(
+      filename,
+      filename.length(),
+      database,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+      null_handle,
+    ) !=
+    SQLITE_OK {
+    abort("memory database open failed")
+  }
+  println("leaked")
+}

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/leak/moon.pkg
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/leak/moon.pkg
@@ -1,0 +1,1 @@
+options("is-main": true)

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/main.mbt
@@ -1,0 +1,403 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+///|
+const SQLITE_OK = 0
+
+///|
+const SQLITE_ERROR = 1
+
+///|
+const SQLITE_BUSY = 5
+
+///|
+const SQLITE_CANTOPEN = 14
+
+///|
+const SQLITE_AUTH = 23
+
+///|
+const SQLITE_ROW = 100
+
+///|
+const SQLITE_DONE = 101
+
+///|
+const SQLITE_OPEN_READWRITE = 0x00000002
+
+///|
+const SQLITE_OPEN_CREATE = 0x00000004
+
+///|
+/// Returns the shared null value for database, statement, and VFS Handles.
+fn sqlite3_null_handle() -> UInt64 = "moonbitlang/sqlite" "sqlite3_null_handle"
+
+///|
+#unsafe_skip_stub_check
+#borrow(filename, database)
+fn sqlite3_open_v2(
+  filename : Bytes,
+  filename_length : Int,
+  database : Ref[UInt64],
+  flags : Int,
+  vfs : UInt64,
+) -> Int = "moonbitlang/sqlite" "sqlite3_open_v2"
+
+///|
+/// Returns the current UTF-16 error length in code units, excluding NUL.
+fn sqlite3_errmsg16_length(database : UInt64) -> Int = "moonbitlang/sqlite" "sqlite3_errmsg16_length"
+
+///|
+/// Copies the current UTF-16 error and returns its content length, excluding
+/// NUL. The output is unchanged if it cannot also hold the terminator.
+#unsafe_skip_stub_check
+#borrow(output)
+fn sqlite3_errmsg16(
+  database : UInt64,
+  output : FixedArray[UInt16],
+  capacity : Int,
+) -> Int = "moonbitlang/sqlite" "sqlite3_errmsg16"
+
+///|
+fn sqlite3_close(database : UInt64) -> Int = "moonbitlang/sqlite" "sqlite3_close"
+
+///|
+#unsafe_skip_stub_check
+#borrow(sql, statement, tail)
+fn sqlite3_prepare16_v2(
+  database : UInt64,
+  sql : String,
+  sql_offset : Int,
+  sql_length : Int,
+  statement : Ref[UInt64],
+  tail : Ref[Int],
+) -> Int = "moonbitlang/sqlite" "sqlite3_prepare16_v2"
+
+///|
+fn sqlite3_step(statement : UInt64) -> Int = "moonbitlang/sqlite" "sqlite3_step"
+
+///|
+fn sqlite3_finalize(statement : UInt64) -> Int = "moonbitlang/sqlite" "sqlite3_finalize"
+
+///|
+fn sqlite3_column_int64(statement : UInt64, column : Int) -> Int64 = "moonbitlang/sqlite" "sqlite3_column_int64"
+
+///|
+extern "wasm" fn grow_memory_for_test(pages : Int) -> Int =
+  #|(func (param i32) (result i32)
+  #|  local.get 0
+  #|  memory.grow)
+
+///|
+fn prepare(
+  database : UInt64,
+  sql : StringView,
+  null_handle : UInt64,
+) -> UInt64 raise {
+  let statement = Ref(null_handle)
+  let tail = Ref(sql.start_offset())
+  assert_true(
+    sqlite3_prepare16_v2(
+      database,
+      sql.data(),
+      sql.start_offset(),
+      sql.length(),
+      statement,
+      tail,
+    ) ==
+    SQLITE_OK,
+    msg="sqlite3_prepare16_v2 failed",
+  )
+  assert_true(
+    statement.val != null_handle,
+    msg="sqlite3_prepare16_v2 returned null",
+  )
+  assert_true(
+    tail.val == sql.start_offset() + sql.length(),
+    msg="sqlite3_prepare16_v2 returned the wrong tail",
+  )
+  statement.val
+}
+
+///|
+fn execute(
+  database : UInt64,
+  sql : StringView,
+  null_handle : UInt64,
+) -> Unit raise {
+  let statement = prepare(database, sql, null_handle)
+  assert_true(sqlite3_step(statement) == SQLITE_DONE, msg="sqlite3_step failed")
+  assert_true(
+    sqlite3_finalize(statement) == SQLITE_OK,
+    msg="sqlite3_finalize failed",
+  )
+}
+
+///|
+fn main raise {
+  let null_handle = sqlite3_null_handle()
+  assert_true(
+    sqlite3_close(null_handle) == SQLITE_OK,
+    msg="sqlite3_close(NULL) failed",
+  )
+  assert_true(
+    sqlite3_finalize(null_handle) == SQLITE_OK,
+    msg="sqlite3_finalize(NULL) failed",
+  )
+
+  let rejected = Ref(null_handle)
+  let rejected_filename = b"not-a-memory-database\x00"
+  assert_true(
+    sqlite3_open_v2(
+      rejected_filename,
+      rejected_filename.length(),
+      rejected,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+      null_handle,
+    ) ==
+    SQLITE_CANTOPEN,
+    msg="file-backed database was not rejected",
+  )
+  assert_true(
+    rejected.val == null_handle,
+    msg="rejected database returned a handle",
+  )
+
+  let custom_vfs = Ref(null_handle)
+  let memory_filename = b":memory:\x00"
+  assert_true(
+    sqlite3_open_v2(
+      memory_filename,
+      memory_filename.length(),
+      custom_vfs,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+      1UL,
+    ) ==
+    SQLITE_CANTOPEN,
+    msg="custom VFS handle was not rejected",
+  )
+  assert_true(
+    custom_vfs.val == null_handle,
+    msg="custom VFS returned a database",
+  )
+
+  let database = Ref(null_handle)
+  assert_true(
+    sqlite3_open_v2(
+      memory_filename,
+      memory_filename.length(),
+      database,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+      null_handle,
+    ) ==
+    SQLITE_OK,
+    msg="memory database open failed",
+  )
+  let database = database.val
+  assert_true(
+    database != null_handle,
+    msg="memory database returned a null handle",
+  )
+
+  execute(database, "PRAGMA encoding='UTF-16le'", null_handle)
+
+  // SQLite imports must reacquire the current memory backing after growth.
+  assert_true(grow_memory_for_test(1) >= 0, msg="failed to grow wasm memory")
+
+  execute(database, "CREATE TABLE 项目(value INTEGER)", null_handle)
+  execute(database, "INSERT INTO 项目 VALUES (5000000000)", null_handle)
+
+  let invalid_statement = Ref(null_handle)
+  let invalid_tail = Ref(0)
+  let invalid_sql = "SELECT 不存在"
+  assert_true(
+    sqlite3_prepare16_v2(
+      database,
+      invalid_sql,
+      0,
+      invalid_sql.length(),
+      invalid_statement,
+      invalid_tail,
+    ) ==
+    SQLITE_ERROR,
+    msg="invalid SQL did not fail",
+  )
+  let short_error : FixedArray[UInt16] = FixedArray::make(5, 0xFFFF)
+  let error_length = sqlite3_errmsg16_length(database)
+  let copied_error_length = sqlite3_errmsg16(
+    database,
+    short_error,
+    short_error.length(),
+  )
+  assert_true(
+    copied_error_length == error_length,
+    msg="error length changed while copying",
+  )
+  assert_true(
+    error_length > short_error.length(),
+    msg="short buffer unexpectedly held the error",
+  )
+  assert_true(
+    short_error[0] == 0xFFFF &&
+    short_error[1] == 0xFFFF &&
+    short_error[2] == 0xFFFF &&
+    short_error[3] == 0xFFFF &&
+    short_error[4] == 0xFFFF,
+    msg="short output was partially overwritten",
+  )
+  let complete_error : FixedArray[UInt16] = FixedArray::make(
+    error_length + 1, 0xFFFF,
+  )
+  assert_true(
+    sqlite3_errmsg16(database, complete_error, complete_error.length()) ==
+    error_length,
+    msg="error length changed while copying",
+  )
+  assert_true(
+    complete_error[error_length] == 0,
+    msg="complete error was not NUL-terminated",
+  )
+  assert_true(
+    complete_error[error_length - 3] == 0x4E0D &&
+    complete_error[error_length - 2] == 0x5B58 &&
+    complete_error[error_length - 1] == 0x5728,
+    msg="complete error was not copied as UTF-16",
+  )
+
+  let query = prepare(database, "SELECT value FROM 项目", null_handle)
+  assert_true(sqlite3_step(query) == SQLITE_ROW, msg="query returned no row")
+  assert_true(
+    sqlite3_column_int64(query, 0) == 5000000000L,
+    msg="query returned wrong value",
+  )
+  assert_true(
+    sqlite3_step(query) == SQLITE_DONE,
+    msg="query returned an extra row",
+  )
+  assert_true(sqlite3_finalize(query) == SQLITE_OK, msg="query finalize failed")
+
+  let batch = "ignored SELECT 42; SELECT 7 ignored"
+  let batch_start = "ignored ".length()
+  let batch_end = batch.length() - " ignored".length()
+  let first_view = batch.view(start_offset=batch_start, end_offset=batch_end)
+  let first_statement = Ref(null_handle)
+  let first_tail = Ref(batch_start)
+  assert_true(
+    sqlite3_prepare16_v2(
+      database,
+      first_view.data(),
+      first_view.start_offset(),
+      first_view.length(),
+      first_statement,
+      first_tail,
+    ) ==
+    SQLITE_OK,
+    msg="first batch prepare failed",
+  )
+  assert_true(
+    first_tail.val == batch_start + "SELECT 42;".length(),
+    msg="first batch prepare returned the wrong backing-string tail",
+  )
+  assert_true(
+    sqlite3_step(first_statement.val) == SQLITE_ROW,
+    msg="first batch query returned no row",
+  )
+  assert_true(
+    sqlite3_column_int64(first_statement.val, 0) == 42L,
+    msg="first batch query returned wrong value",
+  )
+  assert_true(
+    sqlite3_finalize(first_statement.val) == SQLITE_OK,
+    msg="first batch query finalize failed",
+  )
+
+  let second_view = batch.view(
+    start_offset=first_tail.val,
+    end_offset=batch_end,
+  )
+  let second_statement = prepare(database, second_view, null_handle)
+  assert_true(
+    sqlite3_step(second_statement) == SQLITE_ROW,
+    msg="second batch query returned no row",
+  )
+  assert_true(
+    sqlite3_column_int64(second_statement, 0) == 7L,
+    msg="second batch query returned wrong value",
+  )
+  assert_true(
+    sqlite3_finalize(second_statement) == SQLITE_OK,
+    msg="second batch query finalize failed",
+  )
+
+  let comment_backing = "xx-- no statement"
+  let comment = comment_backing.view(start_offset=2)
+  let comment_statement = Ref(null_handle)
+  let comment_tail = Ref(comment.start_offset())
+  assert_true(
+    sqlite3_prepare16_v2(
+      database,
+      comment.data(),
+      comment.start_offset(),
+      comment.length(),
+      comment_statement,
+      comment_tail,
+    ) ==
+    SQLITE_OK,
+    msg="comment-only prepare failed",
+  )
+  assert_true(
+    comment_statement.val == null_handle,
+    msg="comment-only prepare returned a statement",
+  )
+  assert_true(
+    comment_tail.val == comment.start_offset() + comment.length(),
+    msg="comment-only prepare returned the wrong tail",
+  )
+
+  let denied_statement = Ref(null_handle)
+  let denied_tail = Ref(0)
+  let attach = "ATTACH DATABASE ':memory:' AS other"
+  assert_true(
+    sqlite3_prepare16_v2(
+      database,
+      attach,
+      0,
+      attach.length(),
+      denied_statement,
+      denied_tail,
+    ) ==
+    SQLITE_AUTH,
+    msg="ATTACH was not denied",
+  )
+  assert_true(
+    denied_statement.val == null_handle,
+    msg="denied ATTACH returned a statement",
+  )
+
+  let outstanding = prepare(database, "SELECT 1", null_handle)
+  assert_true(
+    sqlite3_close(database) == SQLITE_BUSY,
+    msg="sqlite3_close did not preserve the busy database handle",
+  )
+  assert_true(
+    sqlite3_finalize(outstanding) == SQLITE_OK,
+    msg="outstanding statement finalize failed",
+  )
+  assert_true(sqlite3_close(database) == SQLITE_OK, msg="sqlite3_close failed")
+  println("ok")
+}

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/moon.pkg
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/moon.pkg
@@ -1,0 +1,1 @@
+options("is-main": true)

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/moon.mod
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/moon.mod
@@ -1,0 +1,1 @@
+name = "username/sqlite-ffi"


### PR DESCRIPTION
## Why

Moonrun needs a small embedded relational database path, but SQLite lifetime rules, error strings, native pointers, and SQL policy need an explicit portable wasm ABI. This PR keeps that work separate from the runtime and Guest Memory infrastructure merged in #2053.

## What changed

- Bundle SQLite with `libsqlite3-sys`.
- Register nine synchronous `moonbitlang/sqlite` imports: the shared null Handle, open, error-message length and copying, close, prepare, step, finalize, and integer-column access.
- Declare the complete import surface once; a SQLite-specific registry macro generates both V8 callbacks and registration.
- Organize the implementation as one `sqlite` module tree: connection and statement behavior, identity and payload storage, and policy live at the root, while V8 and Guest Memory lowering live under `sqlite::v8`.
- Represent SQLite objects as typed generational `u64` Handles in the per-run Host namespace. `SqliteHost` uses the shared Host key registry for identity and keeps database and statement payloads in explicit domain maps. Database, statement, and reserved VFS Handles share the slotmap null Host Key, whose encoded value is discovered at runtime rather than hard-coded by Wasm.
- Keep `sqlite3_open_v2` filenames in UTF-8 so MoonBit owns filename encoding, while SQL and error messages use SQLite's UTF-16 interfaces to match MoonBit `String` storage.
- Model SQL input as a backing String plus UTF-16 code-unit offset and length. Return `pzTail` as an absolute code-unit offset in the same backing String, preserving `StringView` and multiple-statement use without exposing a guest or native pointer.
- Preserve the `open_v2` flags slot for long-lived Wasm compatibility, mask it to `READONLY | READWRITE | CREATE`, and leave validation of those remaining bits to SQLite.
- Keep the complete open policy local to `sqlite::policy`: the initial surface accepts only exact `:memory:` databases and the null VFS Handle. The same policy module owns the authorizer that rejects `ATTACH`, `DETACH`, and guest PRAGMAs other than `encoding`.

## Why this is correct

Runtime adapters lower their own memory and scalar representations before entering the runtime-independent SQLite implementation; no V8 object or native SQLite pointer crosses that seam. Each memory-consuming synchronous import acquires a fresh Guest Memory borrow, while error-length lookup, `close`, `step`, `finalize`, and `column_int64` do not acquire memory at all.

`sqlite3_prepare16_v2` borrows exactly one typed UTF-16 String view on supported little-endian hosts. Negative offsets or lengths, misalignment, and invalid guest ranges trap as ABI violations. SQLite returns `pzTail` inside that view; the implementation subtracts the UTF-16 pointers and the adapter combines the resulting code-unit offset with the view start. Tests prepare two statements successively from one nonzero-offset `StringView` and cover comment-only input, where the tail advances but the statement is null.

SQLite result codes remain ordinary return values, including `SQLITE_AUTH`, `SQLITE_BUSY`, and prepare errors. The separate Rust `Result` represents only Host interface violations such as a stale Handle or invalid guest range, which runtime adapters report as traps.

SQLite's borrowed native error pointer never crosses the ABI. `sqlite3_errmsg16_length` returns the current content length in UTF-16 code units, excluding NUL, so MoonBit can allocate one additional code unit for the terminator. `sqlite3_errmsg16` measures again and returns that current content length: it copies the complete message and NUL only when they fit, otherwise leaves the output unchanged so the caller can resize and retry.

SQLite pointers stay behind typed generational Handles. Following SQLite's native contract, most failed opens still return a non-null Handle for error retrieval and close; the explicit failed state prevents SQL preparation. Statements are removed from both the Host key registry and statement payload map before `sqlite3_finalize`, databases remain registered when `sqlite3_close` returns `SQLITE_BUSY`, and column reads are accepted only while SQLite exposes a current row and the index is valid. Teardown finalizes statements before closing databases.

## Scope

This MVP intentionally omits file-backed databases, non-null VFS Handles, `open16`, SQLite-to-guest callbacks, text/blob pointer returns, resource quotas, progress interruption, a MoonBit SDK, and asynchronous SQLite execution. It also leaves SQLite temporary-storage behavior unchanged. Later runtimes can reuse the same `sqlite` implementation while supplying their own runtime adapter and import registration alongside `sqlite::v8`.
