### PR TITLE
Reuse the registry HTTP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,7 +1741,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arcstr",
- "bytes",
  "clap",
  "colored",
  "dialoguer",

--- a/crates/mooncake/Cargo.toml
+++ b/crates/mooncake/Cargo.toml
@@ -34,7 +34,6 @@ anyhow.workspace = true
 zip.workspace = true
 colored.workspace = true
 reqwest.workspace = true
-bytes.workspace = true
 semver.workspace = true
 clap.workspace = true
 sha2.workspace = true

--- a/crates/mooncake/src/registry/client.rs
+++ b/crates/mooncake/src/registry/client.rs
@@ -102,6 +102,7 @@ pub struct RegistryClient {
     config: RegistryConfig,
     home: MoonHomeLayout,
     endpoints: RegistryEndpoints,
+    http: reqwest::blocking::Client,
     cache: RefCell<HashMap<ModuleName, Arc<BTreeMap<Version, RegistryVersionInfo>>>>,
 }
 
@@ -120,6 +121,10 @@ impl RegistryClient {
             endpoints: RegistryEndpoints::from_config(&config),
             config,
             home,
+            http: reqwest::blocking::Client::builder()
+                .user_agent(format!("mooncake/{}", env!("CARGO_PKG_VERSION")))
+                .build()
+                .expect("failed to create registry HTTP client"),
             cache: RefCell::new(HashMap::new()),
         }
     }
@@ -131,7 +136,7 @@ impl RegistryClient {
 
     /// Synchronize the Git index and symbols archive with the configured registry.
     pub fn sync(&self, user_log: &UserLog) -> anyhow::Result<()> {
-        let outcome = crate::update::sync(&self.home, &self.config, user_log)?;
+        let outcome = crate::update::sync(&self.home, &self.config, &self.http, user_log)?;
         self.cache.borrow_mut().clear();
         log_sync_outcome(outcome, user_log);
         Ok(())
@@ -145,12 +150,8 @@ impl RegistryClient {
         package_path: &str,
         user_log: &UserLog,
     ) -> anyhow::Result<std::path::PathBuf> {
-        let http = reqwest::blocking::Client::builder()
-            .user_agent(format!("mooncake/{}", env!("CARGO_PKG_VERSION")))
-            .build()
-            .context("failed to create registry asset HTTP client")?;
         self.acquire_wasm_asset_with(name, version, package_path, user_log, |url| {
-            download_registry_asset(&http, url, user_log)
+            download_registry_asset(&self.http, url, user_log)
         })
     }
 
@@ -550,8 +551,8 @@ impl RegistryClient {
         }
         user_log.status(format!("Downloading {name}@{version}"));
         let url = self.endpoints.package_archive(name, version);
-        let client = reqwest::blocking::Client::new();
-        let mut response = client
+        let mut response = self
+            .http
             .get(url)
             .header(
                 USER_AGENT,
@@ -1235,6 +1236,89 @@ mod tests {
             result.unwrap();
         }
         assert_eq!(request_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn sequential_archive_downloads_reuse_http_connection() {
+        let sandbox = tempfile::TempDir::new().unwrap();
+        let (mut registry, name, first_version) = test_registry(&sandbox);
+        let second_version = Version::new(1, 2, 4);
+        let archive = test_archive();
+        let checksum = calc_sha2(&mut Cursor::new(&archive)).unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        registry.endpoints.packages = format!("http://{}", listener.local_addr().unwrap());
+
+        let server = std::thread::spawn(move || {
+            let mut connections = 0;
+            let mut requests = 0;
+            while requests < 2 {
+                let (mut stream, _) = listener.accept().unwrap();
+                connections += 1;
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(1)))
+                    .unwrap();
+                while requests < 2 {
+                    let mut request = Vec::new();
+                    let mut buffer = [0_u8; 1024];
+                    loop {
+                        match stream.read(&mut buffer) {
+                            Ok(0) => break,
+                            Ok(read) => request.extend_from_slice(&buffer[..read]),
+                            Err(error)
+                                if matches!(
+                                    error.kind(),
+                                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                                ) =>
+                            {
+                                break;
+                            }
+                            Err(error) => panic!("registry test server failed: {error}"),
+                        }
+                        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    if request.is_empty() {
+                        break;
+                    }
+
+                    requests += 1;
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n",
+                        archive.len()
+                    )
+                    .unwrap();
+                    stream.write_all(&archive).unwrap();
+                }
+            }
+            connections
+        });
+
+        registry
+            .acquire_source_to(
+                &name,
+                &first_version,
+                &checksum,
+                &sandbox.path().join("source-first"),
+                &quiet_user_log(),
+            )
+            .unwrap();
+        registry
+            .acquire_source_to(
+                &name,
+                &second_version,
+                &checksum,
+                &sandbox.path().join("source-second"),
+                &quiet_user_log(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            server.join().unwrap(),
+            1,
+            "sequential registry downloads should share one HTTP connection"
+        );
     }
 
     #[test]

--- a/crates/mooncake/src/registry/client.rs
+++ b/crates/mooncake/src/registry/client.rs
@@ -46,9 +46,10 @@ use crate::{
     zip_util::extract_zip_to_dir,
 };
 
-// Preserve a bounded connection setup while allowing slow or large response
-// bodies to finish without reqwest's blocking-client total request deadline.
+// Bound connection setup separately from stalled reads. Blocking response
+// bodies are streamed so the read timeout resets whenever data arrives.
 const REGISTRY_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const REGISTRY_READ_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -128,7 +129,7 @@ impl RegistryClient {
             home,
             http: reqwest::blocking::Client::builder()
                 .user_agent(format!("mooncake/{}", env!("CARGO_PKG_VERSION")))
-                .timeout(None)
+                .timeout(REGISTRY_READ_TIMEOUT)
                 .connect_timeout(REGISTRY_CONNECT_TIMEOUT)
                 .build()
                 .expect("failed to create registry HTTP client"),
@@ -265,12 +266,14 @@ fn download_registry_asset(
     if response.status() == StatusCode::NOT_FOUND {
         bail!("Prebuilt wasm asset does not exist");
     }
-    let data = response
+    let mut response = response
         .error_for_status()
-        .with_context(|| format!("registry asset download returned error status for {url}"))?
-        .bytes()
+        .with_context(|| format!("registry asset download returned error status for {url}"))?;
+    let mut data = Vec::new();
+    response
+        .read_to_end(&mut data)
         .with_context(|| format!("failed to read registry asset response from {url}"))?;
-    Ok(data.to_vec())
+    Ok(data)
 }
 
 fn ensure_cached_wasm(

--- a/crates/mooncake/src/registry/client.rs
+++ b/crates/mooncake/src/registry/client.rs
@@ -23,6 +23,7 @@ use std::{
     io::{BufRead, Read, Seek, Write},
     path::Path,
     sync::Arc,
+    time::Duration,
 };
 
 use anyhow::{Context, bail};
@@ -44,6 +45,10 @@ use crate::{
     update::{RegistryIndexRecloneReason, RegistryIndexUpdate, UpdateOutcome},
     zip_util::extract_zip_to_dir,
 };
+
+// Preserve a bounded connection setup while allowing slow or large response
+// bodies to finish without reqwest's blocking-client total request deadline.
+const REGISTRY_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -123,6 +128,8 @@ impl RegistryClient {
             home,
             http: reqwest::blocking::Client::builder()
                 .user_agent(format!("mooncake/{}", env!("CARGO_PKG_VERSION")))
+                .timeout(None)
+                .connect_timeout(REGISTRY_CONNECT_TIMEOUT)
                 .build()
                 .expect("failed to create registry HTTP client"),
             cache: RefCell::new(HashMap::new()),
@@ -1240,6 +1247,31 @@ mod tests {
 
     #[test]
     fn sequential_archive_downloads_reuse_http_connection() {
+        fn serve_requests(mut stream: std::net::TcpStream, archive: &[u8], count: usize) {
+            for _ in 0..count {
+                let mut request = Vec::new();
+                let mut buffer = [0_u8; 1024];
+                loop {
+                    let read = stream.read(&mut buffer).unwrap();
+                    if read == 0 {
+                        return;
+                    }
+                    request.extend_from_slice(&buffer[..read]);
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n",
+                    archive.len()
+                )
+                .unwrap();
+                stream.write_all(archive).unwrap();
+            }
+        }
+
         let sandbox = tempfile::TempDir::new().unwrap();
         let (mut registry, name, first_version) = test_registry(&sandbox);
         let second_version = Version::new(1, 2, 4);
@@ -1249,49 +1281,42 @@ mod tests {
         registry.endpoints.packages = format!("http://{}", listener.local_addr().unwrap());
 
         let server = std::thread::spawn(move || {
-            let mut connections = 0;
-            let mut requests = 0;
-            while requests < 2 {
-                let (mut stream, _) = listener.accept().unwrap();
-                connections += 1;
-                stream
-                    .set_read_timeout(Some(Duration::from_secs(1)))
-                    .unwrap();
-                while requests < 2 {
-                    let mut request = Vec::new();
-                    let mut buffer = [0_u8; 1024];
-                    loop {
-                        match stream.read(&mut buffer) {
-                            Ok(0) => break,
-                            Ok(read) => request.extend_from_slice(&buffer[..read]),
-                            Err(error)
-                                if matches!(
-                                    error.kind(),
-                                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
-                                ) =>
-                            {
-                                break;
-                            }
-                            Err(error) => panic!("registry test server failed: {error}"),
-                        }
-                        if request.windows(4).any(|window| window == b"\r\n\r\n") {
-                            break;
-                        }
-                    }
-                    if request.is_empty() {
-                        break;
-                    }
+            let (first_stream, _) = listener.accept().unwrap();
+            let first_control = first_stream.try_clone().unwrap();
+            let archive = Arc::new(archive);
+            let (first_done_tx, first_done_rx) = std::sync::mpsc::channel();
+            let first_connection = {
+                let archive = Arc::clone(&archive);
+                std::thread::spawn(move || {
+                    serve_requests(first_stream, &archive, 2);
+                    let _ = first_done_tx.send(());
+                })
+            };
 
-                    requests += 1;
-                    write!(
-                        stream,
-                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n",
-                        archive.len()
-                    )
-                    .unwrap();
-                    stream.write_all(&archive).unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let connections = loop {
+                match first_done_rx.try_recv() {
+                    Ok(()) => break 1,
+                    Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        panic!("first registry test connection failed")
+                    }
                 }
+                match listener.accept() {
+                    Ok((second_stream, _)) => {
+                        serve_requests(second_stream, &archive, 1);
+                        break 2;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+                    Err(error) => panic!("registry test server failed: {error}"),
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            };
+
+            if connections != 1 {
+                let _ = first_control.shutdown(std::net::Shutdown::Both);
             }
+            first_connection.join().unwrap();
             connections
         });
 

--- a/crates/mooncake/src/update.rs
+++ b/crates/mooncake/src/update.rs
@@ -16,6 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -423,7 +424,7 @@ struct SymbolsEtag {
 #[derive(Debug)]
 enum SymbolsDownload {
     Modified {
-        data: bytes::Bytes,
+        data: Vec<u8>,
         etag: Option<SymbolsEtag>,
     },
     NotModified {
@@ -482,10 +483,12 @@ fn download_symbols_zip(
         return Ok(SymbolsDownload::NotModified { etag });
     }
 
-    let data = response
+    let mut response = response
         .error_for_status()
-        .context("symbols.zip download returned error status")?
-        .bytes()
+        .context("symbols.zip download returned error status")?;
+    let mut data = Vec::new();
+    response
+        .read_to_end(&mut data)
         .context("failed to read symbols.zip response body")?;
     Ok(SymbolsDownload::Modified {
         data,

--- a/crates/mooncake/src/update.rs
+++ b/crates/mooncake/src/update.rs
@@ -437,10 +437,10 @@ enum SymbolsDownload {
     fields(has_previous_etag = previous_etag.is_some())
 )]
 fn download_symbols_zip(
+    client: &reqwest::blocking::Client,
     symbols_url: &str,
     previous_etag: Option<&SymbolsEtag>,
 ) -> anyhow::Result<SymbolsDownload> {
-    let client = reqwest::blocking::Client::new();
     let conditional_etag = previous_etag.and_then(|etag| {
         (etag.url == symbols_url)
             .then(|| {
@@ -494,6 +494,7 @@ fn download_symbols_zip(
 }
 
 fn update_symbols_from_url(
+    client: &reqwest::blocking::Client,
     registry_dir: &Path,
     target_dir: &Path,
     symbols_url: &str,
@@ -503,16 +504,18 @@ fn update_symbols_from_url(
         .with_context(|| format!("failed to create `{}`", registry_dir.display()))?;
 
     let previous_etag = target_dir.is_dir().then_some(previous_etag).flatten();
-    let download = download_symbols_zip(symbols_url, previous_etag)?;
+    let download = download_symbols_zip(client, symbols_url, previous_etag)?;
     let (data, etag) = match download {
         SymbolsDownload::Modified { data, etag } => (data, etag),
         SymbolsDownload::NotModified { etag } if target_dir.is_dir() => return Ok(Some(etag)),
-        SymbolsDownload::NotModified { .. } => match download_symbols_zip(symbols_url, None)? {
-            SymbolsDownload::Modified { data, etag } => (data, etag),
-            SymbolsDownload::NotModified { .. } => {
-                anyhow::bail!("symbols.zip returned 304 but local symbols are missing")
+        SymbolsDownload::NotModified { .. } => {
+            match download_symbols_zip(client, symbols_url, None)? {
+                SymbolsDownload::Modified { data, etag } => (data, etag),
+                SymbolsDownload::NotModified { .. } => {
+                    anyhow::bail!("symbols.zip returned 304 but local symbols are missing")
+                }
             }
-        },
+        }
     };
 
     let tmp_dir = unique_sibling_dir(registry_dir, ".symbols.tmp")
@@ -673,6 +676,7 @@ fn run_registry_update_locked(
 pub(crate) fn sync(
     home: &MoonHomeLayout,
     registry_config: &RegistryConfig,
+    client: &reqwest::blocking::Client,
     user_log: &UserLog,
 ) -> anyhow::Result<UpdateOutcome> {
     let registry_dir = home.registry_dir();
@@ -692,6 +696,7 @@ pub(crate) fn sync(
         |previous_etag| {
             let registry_index = update_registry_index(&target_dir, registry_config, user_log)?;
             let (symbols_updated, symbols_etag) = match update_symbols_from_url(
+                client,
                 &registry_dir,
                 &symbols_dir,
                 symbols_url,
@@ -949,6 +954,7 @@ mod tests {
     fn symbols_update_reuses_an_etag_on_not_modified() {
         let root = tempfile::tempdir().unwrap();
         let home = test_moon_home(&root);
+        let client = reqwest::blocking::Client::new();
         let (url, server) = serve_http(vec![
             TestHttpResponse {
                 status: "200 OK",
@@ -963,6 +969,7 @@ mod tests {
         ]);
 
         let etag = update_symbols_from_url(
+            &client,
             &home.registry_dir(),
             &home.registry_symbols_dir(),
             &url,
@@ -975,6 +982,7 @@ mod tests {
         std::fs::write(home.registry_symbols_dir().join("symbol.txt"), "local").unwrap();
 
         let reused = update_symbols_from_url(
+            &client,
             &home.registry_dir(),
             &home.registry_symbols_dir(),
             &url,
@@ -1001,6 +1009,7 @@ mod tests {
     fn symbols_update_ignores_an_etag_when_local_symbols_are_missing() {
         let root = tempfile::tempdir().unwrap();
         let home = test_moon_home(&root);
+        let client = reqwest::blocking::Client::new();
         let (url, server) = serve_http(vec![TestHttpResponse {
             status: "200 OK",
             headers: vec![("ETag", "\"symbols-v2\"")],
@@ -1012,6 +1021,7 @@ mod tests {
         };
 
         let updated = update_symbols_from_url(
+            &client,
             &home.registry_dir(),
             &home.registry_symbols_dir(),
             &url,
@@ -1033,6 +1043,7 @@ mod tests {
     fn symbols_update_ignores_an_invalid_etag() {
         let root = tempfile::tempdir().unwrap();
         let home = test_moon_home(&root);
+        let client = reqwest::blocking::Client::new();
         std::fs::create_dir(home.registry_symbols_dir()).unwrap();
         let (url, server) = serve_http(vec![TestHttpResponse {
             status: "200 OK",
@@ -1045,6 +1056,7 @@ mod tests {
         };
 
         let updated = update_symbols_from_url(
+            &client,
             &home.registry_dir(),
             &home.registry_symbols_dir(),
             &url,

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -366,7 +366,8 @@ Current registry configuration behavior today is:
   verifying HTTP package archives and prebuilt wasm assets. Resolver code sees
   only the narrower `Registry` capability.
 - One `RegistryClient` reuses one blocking HTTP client and its connection pool
-  across symbols, package archive, and prebuilt wasm downloads.
+  across symbols, package archive, and prebuilt wasm downloads. Connection
+  setup has a 30-second timeout, while response bodies have no total deadline.
 - The public `Registry` trait contains only metadata queries used by resolution.
   Package source acquisition remains on `RegistryClient`; dependency-source
   tests replace it through a crate-private seam.

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -365,6 +365,8 @@ Current registry configuration behavior today is:
   index and HTTP symbols archive, reading the local index, and downloading and
   verifying HTTP package archives and prebuilt wasm assets. Resolver code sees
   only the narrower `Registry` capability.
+- One `RegistryClient` reuses one blocking HTTP client and its connection pool
+  across symbols, package archive, and prebuilt wasm downloads.
 - The public `Registry` trait contains only metadata queries used by resolution.
   Package source acquisition remains on `RegistryClient`; dependency-source
   tests replace it through a crate-private seam.

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -367,7 +367,9 @@ Current registry configuration behavior today is:
   only the narrower `Registry` capability.
 - One `RegistryClient` reuses one blocking HTTP client and its connection pool
   across symbols, package archive, and prebuilt wasm downloads. Connection
-  setup has a 30-second timeout, while response bodies have no total deadline.
+  setup has a 30-second timeout. Once connected, two minutes without response
+  headers or body progress times out, while active downloads have no total
+  deadline.
 - The public `Registry` trait contains only metadata queries used by resolution.
   Package source acquisition remains on `RegistryClient`; dependency-source
   tests replace it through a crate-private seam.


### PR DESCRIPTION
## Summary

- reuse one blocking HTTP client for registry symbols, package archives, and prebuilt wasm assets
- keep a 30-second connection-setup timeout without imposing a total deadline on response-body downloads
- add a deterministic regression test that verifies sequential archive downloads reuse one HTTP connection
- document the shared connection-pool and timeout ownership

## Why

`RegistryClient` previously created HTTP clients independently for symbols and package archive downloads. Dropping those clients also discarded their connection pools, so repeated registry operations could not reuse established connections. In addition, reqwest's blocking client applies a 30-second total request deadline by default, which can abort a download after the connection has already been established.

## Correctness and scope

The client is now owned by `RegistryClient`, which already owns the physical registry lifecycle. Connection setup remains bounded at 30 seconds, while slow or large response bodies can finish without a total deadline. Existing synchronous control flow, cache locks, checksum verification, and atomic publication remain unchanged. This PR intentionally does not add async execution, concurrent downloads, or registry-lock changes.
