### PR TITLE
Update warning index and error docs

### DIFF
--- a/crates/moon/src/cli/explain_warning_index.rs
+++ b/crates/moon/src/cli/explain_warning_index.rs
@@ -461,6 +461,11 @@ const WARNING_ENTRIES: &[WarningEntry] = &[
         description: "unused `errdefer` statement",
         id: 91,
     },
+    WarningEntry {
+        mnemonic: "fragile_catch_all",
+        description: "fragile `catch` handler that can be converted to `defer` or `errdefer`",
+        id: 92,
+    },
 ];
 
 pub(crate) fn get_warning_entry(id: u16) -> Option<&'static WarningEntry> {

--- a/crates/moon/src/cli/snapshots/explain_warning_index.txt
+++ b/crates/moon/src/cli/snapshots/explain_warning_index.txt
@@ -82,3 +82,4 @@
 0089	guard_redundant_else	Redundant `else` on an exhaustive `guard`.
 0090	unused_lexcase	`lexmatch`/`lexscan` branch that can never be selected because other branches takes precedence or its pattern matches nothing.
 0091	unused_errdefer	unused `errdefer` statement
+0092	fragile_catch_all	fragile `catch` handler that can be converted to `defer` or `errdefer`


### PR DESCRIPTION
## Summary

- Refresh the CLI warning index for `fragile_catch_all`.
- Advance the error-code documentation submodule on its existing `markdown-build` branch.

## Why

Moon should expose the compiler’s current warning metadata and reference the corresponding generated error documentation.

## Correctness

The warning entry matches the compiler-provided warning table, and the submodule remains on its configured branch with only its pinned revision advanced.

## Scope

This is a minimal metadata and documentation-reference update.
