### PR TITLE
Allow policy-checked SQLite file databases

### DIFF
--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -173,10 +173,12 @@ Moonrun Policy authorizes operations performed by supported moonrun-owned host
 interfaces. It is not an operating-system syscall sandbox or a complete
 resource-isolation mechanism. In particular:
 
-- SQLite currently exposes only private in-memory databases. File-backed
-  database access is planned, but its exact VFS and temporary-file integration
-  is not yet part of the interface contract. Guest-selected database paths will
-  be subject to Moonrun Policy when that support is added.
+- SQLite supports private in-memory databases and file-backed databases through
+  the default native VFS. Guest-selected database paths are authorized by
+  Moonrun Policy when the connection is opened. Connections require read
+  access to the database path and its parent directory; writable connections
+  also require write access to that directory, where SQLite may use journal,
+  WAL, and shared-memory files.
 - SQLite may use its native VFS to create internal temporary files in the
   operating system's default temporary directory, even when the main database
   is in memory. These internal paths are not selected by the guest and do not

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -167,6 +167,28 @@ connections to the IP addresses returned by that lookup on the configured port.
 Use `dns` only when a program needs standalone DNS lookup permission without
 also granting outbound connects.
 
+## Security Model and Known Limitations
+
+Moonrun Policy authorizes operations performed by supported moonrun-owned host
+interfaces. It is not an operating-system syscall sandbox or a complete
+resource-isolation mechanism. In particular:
+
+- SQLite currently exposes only private in-memory databases. File-backed
+  database access is planned, but its exact VFS and temporary-file integration
+  is not yet part of the interface contract. Guest-selected database paths will
+  be subject to Moonrun Policy when that support is added.
+- SQLite may use its native VFS to create internal temporary files in the
+  operating system's default temporary directory, even when the main database
+  is in memory. These internal paths are not selected by the guest and do not
+  currently pass through the filesystem policy.
+- Native SQLite CPU time, heap usage, database size, and temporary-disk usage
+  do not currently have per-run quotas.
+
+Deployments that require strict isolation for untrusted workloads should also
+use operating-system process isolation and resource limits. Security defects
+that violate the documented policy should be reported privately rather than
+added to this list with a public reproducer.
+
 # Contribution
 
 To contribute, please read the contribution guidelines at [docs/dev](./docs/dev/README.md).

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -179,6 +179,11 @@ resource-isolation mechanism. In particular:
   access to the database path and its parent directory; writable connections
   also require write access to that directory, where SQLite may use journal,
   WAL, and shared-memory files.
+- File-backed SQLite authorization is currently a pathname check performed
+  before the native VFS opens the database. If another guest filesystem
+  operation or external actor replaces that path or one of its parent symlinks
+  between those steps, SQLite can resolve a file outside the checked roots.
+  Moonrun does not yet bind this authorization to a stable filesystem identity.
 - SQLite may use its native VFS to create internal temporary files in the
   operating system's default temporary directory, even when the main database
   is in memory. These internal paths are not selected by the guest and do not

--- a/crates/moonrun/src/async_policy.rs
+++ b/crates/moonrun/src/async_policy.rs
@@ -88,10 +88,25 @@ impl AsyncPolicy {
     }
 
     pub(crate) fn stat_path(&self, base: RuntimePathBase<'_>, path: &OsStr) -> AsyncHostResult<()> {
+        self.read_path(base, path)
+    }
+
+    pub(crate) fn read_path(&self, base: RuntimePathBase<'_>, path: &OsStr) -> AsyncHostResult<()> {
         let Some(fs) = self.fs_policy() else {
             return Ok(());
         };
         fs.allows(base, path, FsIntents::read())
+    }
+
+    pub(crate) fn write_path(
+        &self,
+        base: RuntimePathBase<'_>,
+        path: &OsStr,
+    ) -> AsyncHostResult<()> {
+        let Some(fs) = self.fs_policy() else {
+            return Ok(());
+        };
+        fs.allows(base, path, FsIntents::write())
     }
 
     pub(crate) fn stat_entry_path(
@@ -117,10 +132,7 @@ impl AsyncPolicy {
     }
 
     pub(crate) fn chmod_path(&self, path: &OsStr) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows(RuntimePathBase::CurrentDirectory, path, FsIntents::write())
+        self.write_path(RuntimePathBase::CurrentDirectory, path)
     }
 
     pub(crate) fn remove_path(&self, path: &OsStr) -> AsyncHostResult<()> {

--- a/crates/moonrun/src/host.rs
+++ b/crates/moonrun/src/host.rs
@@ -101,8 +101,8 @@ impl Host {
     pub(crate) fn new(policy: Arc<AsyncPolicy>) -> Self {
         let keys = Rc::new(RefCell::new(HostKeys::default()));
         Self {
-            async_state: AsyncHost::with_keys(policy, Rc::clone(&keys)),
-            sqlite: SqliteHost::with_keys(keys),
+            async_state: AsyncHost::with_keys(Arc::clone(&policy), Rc::clone(&keys)),
+            sqlite: SqliteHost::with_keys(policy, keys),
         }
     }
 

--- a/crates/moonrun/src/sqlite/connection.rs
+++ b/crates/moonrun/src/sqlite/connection.rs
@@ -63,13 +63,13 @@ pub(crate) struct OpenOutcome {
 
 impl SqliteHost {
     pub(crate) fn open_v2(&self, filename: &CStr, flags: i32, vfs: u64) -> OpenOutcome {
-        if let Err(code) = ensure_valid_database(filename, vfs) {
+        let flags = ensure_open_flags(flags);
+        if let Err(code) = ensure_valid_database(&self.policy, filename, flags, vfs) {
             return OpenOutcome {
                 code,
                 database: None,
             };
         }
-        let flags = ensure_open_flags(flags);
 
         let mut database = ptr::null_mut();
         let code =

--- a/crates/moonrun/src/sqlite/mod.rs
+++ b/crates/moonrun/src/sqlite/mod.rs
@@ -28,10 +28,12 @@ mod statement;
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use libsqlite3_sys as ffi;
 use slotmap::SecondaryMap;
 
+use crate::async_policy::AsyncPolicy;
 use crate::host::{HostKey, HostKeys};
 
 use connection::Database;
@@ -60,14 +62,16 @@ pub(crate) type SqliteHostResult<T> = Result<T, SqliteHostError>;
 /// crossing this interface. The shared Host Key table supplies identity, while
 /// SQLite-owned pointers remain private payloads of this module.
 pub(crate) struct SqliteHost {
+    policy: Arc<AsyncPolicy>,
     keys: Rc<RefCell<HostKeys>>,
     databases: RefCell<SecondaryMap<HostKey, Database>>,
     statements: RefCell<SecondaryMap<HostKey, Statement>>,
 }
 
 impl SqliteHost {
-    pub(crate) fn with_keys(keys: Rc<RefCell<HostKeys>>) -> Self {
+    pub(crate) fn with_keys(policy: Arc<AsyncPolicy>, keys: Rc<RefCell<HostKeys>>) -> Self {
         Self {
+            policy,
             keys,
             databases: RefCell::new(SecondaryMap::new()),
             statements: RefCell::new(SecondaryMap::new()),
@@ -106,7 +110,10 @@ pub(super) mod tests {
     use super::*;
 
     pub(super) fn host() -> SqliteHost {
-        SqliteHost::with_keys(Rc::new(RefCell::new(HostKeys::default())))
+        SqliteHost::with_keys(
+            Arc::new(AsyncPolicy::allow_all()),
+            Rc::new(RefCell::new(HostKeys::default())),
+        )
     }
 
     pub(super) fn open_memory(host: &SqliteHost) -> u64 {

--- a/crates/moonrun/src/sqlite/policy.rs
+++ b/crates/moonrun/src/sqlite/policy.rs
@@ -17,16 +17,53 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use std::ffi::{CStr, c_char, c_int, c_void};
+use std::path::Path;
 use std::ptr::{self, NonNull};
 
 use libsqlite3_sys as ffi;
 
+use crate::async_policy::{AsyncPolicy, RuntimePathBase};
 use crate::host::null_handle;
 
 /// Ensure the requested database and VFS are available in the MVP.
-pub(super) fn ensure_valid_database(filename: &CStr, vfs: u64) -> Result<(), i32> {
-    if filename.to_bytes() != b":memory:" || vfs != null_handle() {
+///
+/// File-backed connections use SQLite's default VFS. The main database is
+/// authorized for reading together with its parent directory because SQLite
+/// may read journal, WAL, and shared-memory files beside it. Writable
+/// connections also require write access to that directory.
+pub(super) fn ensure_valid_database(
+    policy: &AsyncPolicy,
+    filename: &CStr,
+    flags: i32,
+    vfs: u64,
+) -> Result<(), i32> {
+    if vfs != null_handle() {
         return Err(ffi::SQLITE_CANTOPEN);
+    }
+    if filename.to_bytes() == b":memory:" {
+        return Ok(());
+    }
+
+    let filename = filename.to_str().map_err(|_| ffi::SQLITE_CANTOPEN)?;
+    if filename.is_empty() {
+        return Err(ffi::SQLITE_CANTOPEN);
+    }
+    let database = Path::new(filename);
+    policy
+        .read_path(RuntimePathBase::CurrentDirectory, database.as_os_str())
+        .map_err(|_| ffi::SQLITE_CANTOPEN)?;
+    let parent = database
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty());
+    let parent = parent.unwrap_or_else(|| Path::new("."));
+    policy
+        .read_path(RuntimePathBase::CurrentDirectory, parent.as_os_str())
+        .map_err(|_| ffi::SQLITE_CANTOPEN)?;
+
+    if flags & (ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE) != 0 {
+        policy
+            .write_path(RuntimePathBase::CurrentDirectory, parent.as_os_str())
+            .map_err(|_| ffi::SQLITE_CANTOPEN)?;
     }
     Ok(())
 }
@@ -77,6 +114,11 @@ unsafe extern "C" fn untrusted_authorizer(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CString;
+
+    fn c_path(path: &Path) -> CString {
+        CString::new(path.to_str().unwrap()).unwrap()
+    }
 
     #[test]
     fn open_flags_preserve_only_access_modes() {
@@ -97,14 +139,98 @@ mod tests {
     }
 
     #[test]
-    fn database_policy_accepts_only_private_memory_and_the_default_vfs() {
-        assert_eq!(ensure_valid_database(c":memory:", null_handle()), Ok(()));
+    fn database_policy_accepts_memory_and_files_with_the_default_vfs() {
+        let policy = AsyncPolicy::allow_all();
         assert_eq!(
-            ensure_valid_database(c"database.sqlite", null_handle()),
+            ensure_valid_database(
+                &policy,
+                c":memory:",
+                ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE,
+                null_handle()
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            ensure_valid_database(
+                &policy,
+                c"database.sqlite",
+                ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE,
+                null_handle()
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            ensure_valid_database(&policy, c":memory:", ffi::SQLITE_OPEN_READWRITE, u64::MAX),
             Err(ffi::SQLITE_CANTOPEN)
         );
         assert_eq!(
-            ensure_valid_database(c":memory:", u64::MAX),
+            ensure_valid_database(&policy, c"", ffi::SQLITE_OPEN_READWRITE, null_handle()),
+            Err(ffi::SQLITE_CANTOPEN)
+        );
+    }
+
+    #[test]
+    fn database_policy_requires_read_access_and_parent_write_access() {
+        let temp = tempfile::tempdir().unwrap();
+        let allowed = temp.path().join("allowed");
+        let denied = temp.path().join("denied");
+        std::fs::create_dir(&allowed).unwrap();
+        std::fs::create_dir(&denied).unwrap();
+        let policy_file = temp.path().join("policy.toml");
+        std::fs::write(
+            &policy_file,
+            "[fs]\nread = [\"allowed\"]\nwrite = [\"allowed\"]\n",
+        )
+        .unwrap();
+        let policy = AsyncPolicy::from_file(&policy_file).unwrap();
+        let allowed_database = c_path(&allowed.join("database.sqlite"));
+        let denied_database = c_path(&denied.join("database.sqlite"));
+
+        assert_eq!(
+            ensure_valid_database(
+                &policy,
+                &allowed_database,
+                ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE,
+                null_handle()
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            ensure_valid_database(
+                &policy,
+                &denied_database,
+                ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE,
+                null_handle()
+            ),
+            Err(ffi::SQLITE_CANTOPEN)
+        );
+    }
+
+    #[test]
+    fn database_requires_its_directory_not_just_the_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let database = temp.path().join("database.sqlite");
+        std::fs::write(&database, []).unwrap();
+        let policy_file = temp.path().join("policy.toml");
+        std::fs::write(
+            &policy_file,
+            "[fs]\nread = [\"database.sqlite\"]\nwrite = [\"database.sqlite\"]\n",
+        )
+        .unwrap();
+        let policy = AsyncPolicy::from_file(&policy_file).unwrap();
+        let database = c_path(&database);
+
+        assert_eq!(
+            ensure_valid_database(&policy, &database, ffi::SQLITE_OPEN_READONLY, null_handle()),
+            Err(ffi::SQLITE_CANTOPEN)
+        );
+        assert_eq!(
+            ensure_valid_database(
+                &policy,
+                &database,
+                ffi::SQLITE_OPEN_READWRITE,
+                null_handle()
+            ),
             Err(ffi::SQLITE_CANTOPEN)
         );
     }

--- a/crates/moonrun/src/sqlite/v8/context.rs
+++ b/crates/moonrun/src/sqlite/v8/context.rs
@@ -165,12 +165,21 @@ mod tests {
     use super::*;
     use std::cell::RefCell;
     use std::rc::Rc;
+    use std::sync::Arc;
 
+    use crate::async_policy::AsyncPolicy;
     use crate::host::HostKeys;
+
+    fn host() -> SqliteHost {
+        SqliteHost::with_keys(
+            Arc::new(AsyncPolicy::allow_all()),
+            Rc::new(RefCell::new(HostKeys::default())),
+        )
+    }
 
     #[test]
     fn utf16_view_uses_code_unit_offsets_and_lengths() {
-        let host = SqliteHost::with_keys(Rc::new(RefCell::new(HostKeys::default())));
+        let host = host();
         let mut memory = (0_u8..16).collect::<Vec<_>>();
         let context = ImportContext {
             host: &host,
@@ -190,7 +199,7 @@ mod tests {
 
     #[test]
     fn utf8_c_string_checks_its_explicit_length() {
-        let host = SqliteHost::with_keys(Rc::new(RefCell::new(HostKeys::default())));
+        let host = host();
         let mut memory = b"x:memory:\0trailing".to_vec();
         let context = ImportContext {
             host: &host,
@@ -209,7 +218,7 @@ mod tests {
 
     #[test]
     fn byte_view_uses_byte_offsets_and_lengths() {
-        let host = SqliteHost::with_keys(Rc::new(RefCell::new(HostKeys::default())));
+        let host = host();
         let mut memory = (0_u8..8).collect::<Vec<_>>();
         let context = ImportContext {
             host: &host,

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -638,17 +638,26 @@ fn test_moon_run_with_sqlite_ffi_imports() {
         .success();
 
     let wasm_file = dir.join("_build/wasm/debug/build/main/main.wasm");
+    std::fs::create_dir(dir.join("allowed")).unwrap();
+    std::fs::create_dir(dir.join("denied")).unwrap();
+    let policy_file = dir.join("policy.toml");
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .current_dir(&dir)
         .env(MOONBIT_ASYNC_CHECK_FD_LEAK, "1")
+        .arg("--policy")
+        .arg(&policy_file)
         .arg(&wasm_file)
         .assert()
         .success()
         .stdout_eq("ok\n")
-        .stderr_eq("");
+        .stderr_eq(snapbox::str![[r#"
+Sandbox policy blocked file read: "denied/database.sqlite"
 
-    assert!(!dir.join("not-a-memory-database").exists());
+"#]]);
+
+    assert!(dir.join("allowed/database.sqlite").exists());
+    assert!(!dir.join("denied/database.sqlite").exists());
 
     let leaked_wasm = dir.join("_build/wasm/debug/build/leak/leak.wasm");
     let assert = snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/main.mbt
@@ -62,6 +62,9 @@ const SQLITE_BLOB = 4
 const SQLITE_NULL = 5
 
 ///|
+const SQLITE_OPEN_READONLY = 0x00000001
+
+///|
 const SQLITE_OPEN_READWRITE = 0x00000002
 
 ///|
@@ -256,22 +259,74 @@ fn main raise {
     msg="sqlite3_finalize(NULL) failed",
   )
 
-  let rejected = Ref(null_handle)
-  let rejected_filename = b"not-a-memory-database\x00"
+  let denied = Ref(null_handle)
+  let denied_filename = b"denied/database.sqlite\x00"
   assert_true(
     sqlite3_open_v2(
-      rejected_filename,
-      rejected_filename.length(),
-      rejected,
+      denied_filename,
+      denied_filename.length(),
+      denied,
       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
       null_handle,
     ) ==
     SQLITE_CANTOPEN,
-    msg="file-backed database was not rejected",
+    msg="database outside the filesystem policy was not rejected",
   )
   assert_true(
-    rejected.val == null_handle,
-    msg="rejected database returned a handle",
+    denied.val == null_handle,
+    msg="denied database returned a handle",
+  )
+
+  let file_database = Ref(null_handle)
+  let file_database_filename = b"allowed/database.sqlite\x00"
+  assert_true(
+    sqlite3_open_v2(
+      file_database_filename,
+      file_database_filename.length(),
+      file_database,
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+      null_handle,
+    ) ==
+    SQLITE_OK,
+    msg="file-backed database open failed",
+  )
+  let file_database = file_database.val
+  execute(file_database, "CREATE TABLE persisted(value INTEGER)", null_handle)
+  execute(file_database, "INSERT INTO persisted VALUES (42)", null_handle)
+  assert_true(
+    sqlite3_close(file_database) == SQLITE_OK,
+    msg="file-backed database close failed",
+  )
+
+  let reopened = Ref(null_handle)
+  assert_true(
+    sqlite3_open_v2(
+      file_database_filename,
+      file_database_filename.length(),
+      reopened,
+      SQLITE_OPEN_READONLY,
+      null_handle,
+    ) ==
+    SQLITE_OK,
+    msg="file-backed database reopen failed",
+  )
+  let reopened = reopened.val
+  let persisted = prepare(reopened, "SELECT value FROM persisted", null_handle)
+  assert_true(
+    sqlite3_step(persisted) == SQLITE_ROW,
+    msg="file-backed database returned no row",
+  )
+  assert_true(
+    sqlite3_column_int64(persisted, 0) == 42L,
+    msg="file-backed value did not persist",
+  )
+  assert_true(
+    sqlite3_finalize(persisted) == SQLITE_OK,
+    msg="file-backed query finalize failed",
+  )
+  assert_true(
+    sqlite3_close(reopened) == SQLITE_OK,
+    msg="file-backed database reopen close failed",
   )
 
   let custom_vfs = Ref(null_handle)

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/policy.toml
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/policy.toml
@@ -1,0 +1,21 @@
+# moon: The build system and package manager for MoonBit.
+# Copyright (C) 2024 International Digital Economy Academy
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+[fs]
+read = ["allowed"]
+write = ["allowed"]


### PR DESCRIPTION
## Summary

- allow SQLite imports to open ordinary file-backed databases through the default native VFS
- authorize the database path and its parent directory through Moonrun Policy while preserving `:memory:`, null-VFS, and access-flag behavior
- document the remaining native-VFS temporary-file and resource-isolation limitations

## Why

The initial SQLite MVP only accepted private in-memory databases. That prevents normal persistence even when a Moonrun filesystem policy already grants the guest access to a directory.

## Design

The open boundary masks flags to SQLite's three access-mode bits, rejects custom VFS handles, and checks the effective file access before calling SQLite. File-backed connections require read access to the database and its parent directory; writable connections also require parent-directory write access because SQLite may use journal, WAL, and shared-memory sidecars there.

The change deliberately keeps the default SQLite VFS. A custom policy VFS, native resource quotas, and mediation of SQLite's internal temporary files remain follow-up work.