### PR TITLE
Omit NUL terminators from SQLite string copies

### DIFF
--- a/crates/moonrun/src/sqlite/column.rs
+++ b/crates/moonrun/src/sqlite/column.rs
@@ -62,11 +62,12 @@ impl SqliteHost {
         u32::try_from(length).map_err(|_| SqliteHostError::Overflow)
     }
 
-    /// Copy a UTF-16 column including its NUL terminator when it fits.
+    /// Copy a UTF-16 column when it fits.
     ///
-    /// The returned content length excludes NUL. A short output and a NULL or
-    /// failed conversion leave the output unchanged; `sqlite3_errcode` lets
-    /// the caller distinguish SQL NULL from a conversion allocation failure.
+    /// The returned content length excludes SQLite's trailing NUL. A short
+    /// output and a NULL or failed conversion leave the output unchanged;
+    /// `sqlite3_errcode` lets the caller distinguish SQL NULL from a conversion
+    /// allocation failure.
     pub(crate) fn copy_column_text16(
         &self,
         statement: u64,
@@ -76,13 +77,12 @@ impl SqliteHost {
         let Some((pointer, length)) = self.text16_column(statement, column)? else {
             return Ok(0);
         };
-        let required = length.checked_add(1).ok_or(SqliteHostError::Overflow)?;
-        if output.len() >= required {
-            // SAFETY: SQLite returned a UTF-16 string with `length` content
-            // units followed by a NUL, and no SQLite call can invalidate it
-            // before this synchronous copy completes.
-            let value = unsafe { std::slice::from_raw_parts(pointer, required) };
-            output[..required].copy_from_slice(value);
+        if output.len() >= length && length != 0 {
+            // SAFETY: SQLite reported `length` content units for this pointer,
+            // and no SQLite call can invalidate it before this synchronous
+            // copy completes.
+            let value = unsafe { std::slice::from_raw_parts(pointer, length) };
+            output[..length].copy_from_slice(value);
         }
         u32::try_from(length).map_err(|_| SqliteHostError::Overflow)
     }
@@ -210,13 +210,12 @@ mod tests {
             Ok(text.len() as u32)
         );
         assert_eq!(short_text, [0xffff; 2]);
-        let mut output_text = vec![0xffff; text.len() + 1];
+        let mut output_text = vec![0xffff; text.len()];
         assert_eq!(
             host.copy_column_text16(statement, 2, &mut output_text),
             Ok(text.len() as u32)
         );
-        assert_eq!(&output_text[..text.len()], text);
-        assert_eq!(output_text[text.len()], 0);
+        assert_eq!(output_text, text);
 
         assert_eq!(host.column_blob_length(statement, 3), Ok(blob.len() as u32));
         let mut short_blob = [0xaa; 2];

--- a/crates/moonrun/src/sqlite/connection.rs
+++ b/crates/moonrun/src/sqlite/connection.rs
@@ -120,10 +120,10 @@ impl SqliteHost {
 
     /// Copy SQLite's current connection error while its pointer is valid.
     ///
-    /// The returned length is measured in UTF-16 code units and excludes the
-    /// trailing NUL. If `output` cannot hold the complete message and its NUL,
-    /// it is left unchanged and the returned length tells the caller how much
-    /// content the current message contains.
+    /// The returned length and `output` are measured in UTF-16 content code
+    /// units; SQLite's trailing NUL is not copied. If `output` cannot hold the
+    /// complete message, it is left unchanged and the returned length tells
+    /// the caller how much space to allocate.
     pub(crate) fn copy_errmsg16(&self, database: u64, output: &mut [u16]) -> SqliteHostResult<u32> {
         let database = self.database(database)?;
         let message = unsafe { sqlite3_errmsg16(database.pointer().as_ptr()) };
@@ -216,20 +216,17 @@ unsafe fn utf16_message_length(message: *const c_void) -> SqliteHostResult<u32> 
 /// lifetime covers this call.
 unsafe fn copy_utf16_message(message: *const c_void, output: &mut [u16]) -> SqliteHostResult<u32> {
     if message.is_null() {
-        if let Some(first) = output.first_mut() {
-            *first = 0;
-        }
         return Ok(0);
     }
 
     // SAFETY: upheld by this function's caller.
     let length = unsafe { utf16_message_length(message) }?;
-    let required = length as usize + 1;
-    if output.len() >= required {
-        // SAFETY: the scan above proved that the slice contains `length`
-        // content code units followed by its NUL terminator.
-        let message = unsafe { std::slice::from_raw_parts(message.cast::<u16>(), required) };
-        output[..required].copy_from_slice(message);
+    let content_length = length as usize;
+    if output.len() >= content_length && content_length != 0 {
+        // SAFETY: the scan above proved that the slice contains at least
+        // `content_length` code units before its NUL terminator.
+        let message = unsafe { std::slice::from_raw_parts(message.cast::<u16>(), content_length) };
+        output[..content_length].copy_from_slice(message);
     }
     Ok(length)
 }
@@ -240,7 +237,7 @@ mod tests {
     use crate::sqlite::tests::{host, open_memory, utf16le};
 
     #[test]
-    fn error_messages_report_content_length_and_copy_with_termination() {
+    fn error_messages_report_and_copy_content_length() {
         let host = host();
         let database = open_memory(&host);
         let sql = utf16le("SELECT 不存在");
@@ -250,10 +247,9 @@ mod tests {
         assert_eq!(host.extended_errcode(database), Ok(ffi::SQLITE_ERROR));
 
         let length = host.errmsg16_length(database).unwrap();
-        let mut complete = vec![0; length as usize + 1];
+        let mut complete = vec![0xffff; length as usize];
         assert_eq!(host.copy_errmsg16(database, &mut complete), Ok(length));
-        assert_eq!(complete.last(), Some(&0));
-        let message = String::from_utf16(&complete[..length as usize]).unwrap();
+        let message = String::from_utf16(&complete).unwrap();
         assert!(message.starts_with("no such column"));
         assert!(message.ends_with("不存在"));
 
@@ -272,6 +268,6 @@ mod tests {
             unsafe { copy_utf16_message(ptr::null(), &mut output) },
             Ok(0)
         );
-        assert_eq!(output, [0]);
+        assert_eq!(output, [0xffff]);
     }
 }

--- a/crates/moonrun/src/sqlite/v8/column.rs
+++ b/crates/moonrun/src/sqlite/v8/column.rs
@@ -26,12 +26,16 @@ pub(super) fn column_text16(
     output: u32,
     capacity: u32,
 ) -> SqliteResult<u32> {
-    if output == 0 || capacity == 0 {
-        return Err(SqliteError::Fault);
-    }
     let byte_capacity = capacity.checked_mul(2).ok_or(SqliteError::Overflow)?;
     let (host, memory) = context.host_and_memory();
-    let bytes = memory.read_exact_mut(output, byte_capacity)?;
+    let bytes = if capacity == 0 {
+        &mut []
+    } else {
+        if output == 0 {
+            return Err(SqliteError::Fault);
+        }
+        memory.read_exact_mut(output, byte_capacity)?
+    };
     // SAFETY: every bit pattern is a valid `u16`; the alignment check rejects
     // a Guest Memory range that does not satisfy this ABI's promise.
     let (prefix, output, suffix) = unsafe { bytes.align_to_mut::<u16>() };

--- a/crates/moonrun/src/sqlite/v8/connection.rs
+++ b/crates/moonrun/src/sqlite/v8/connection.rs
@@ -40,23 +40,26 @@ pub(super) fn open_v2(
 
 /// Copy the current connection error into Guest Memory as UTF-16LE.
 ///
-/// Capacity and the return value are UTF-16 code units; the returned content
-/// length excludes NUL. Call `sqlite3_errmsg16_length` first and allocate one
-/// additional code unit for the terminator. If the current message does not
-/// fit, the output is left unchanged and its current content length is
-/// returned so the caller can retry.
+/// Capacity and the return value are UTF-16 content code units. SQLite's
+/// trailing NUL is not copied. If the current message does not fit, the output
+/// is left unchanged and its current content length is returned so the caller
+/// can retry.
 pub(super) fn errmsg16(
     context: &mut ImportContext,
     database: u64,
     output: u32,
     capacity: u32,
 ) -> SqliteResult<u32> {
-    if output == 0 || capacity == 0 {
-        return Err(SqliteError::Fault);
-    }
     let byte_capacity = capacity.checked_mul(2).ok_or(SqliteError::Overflow)?;
     let (host, memory) = context.host_and_memory();
-    let bytes = memory.read_exact_mut(output, byte_capacity)?;
+    let bytes = if capacity == 0 {
+        &mut []
+    } else {
+        if output == 0 {
+            return Err(SqliteError::Fault);
+        }
+        memory.read_exact_mut(output, byte_capacity)?
+    };
     // SAFETY: every bit pattern is a valid `u16`. The prefix/suffix check
     // rejects a runtime memory backing that does not satisfy this ABI's
     // alignment requirement.

--- a/crates/moonrun/src/sqlite/v8/context.rs
+++ b/crates/moonrun/src/sqlite/v8/context.rs
@@ -100,13 +100,15 @@ impl ImportContext<'_> {
 
     /// Borrow one NUL-terminated UTF-8 string from a MoonBit Bytes value.
     ///
-    /// Length includes the terminator. The explicit length bounds the Guest
-    /// Memory read; the remaining checks enforce SQLite's filename contract.
+    /// Length counts content bytes and excludes the terminator supplied by the
+    /// Bytes representation. The remaining checks enforce SQLite's filename
+    /// contract.
     pub(super) fn read_utf8_c_string(&self, pointer: u32, length: u32) -> SqliteResult<&CStr> {
-        if pointer == 0 || length == 0 {
+        if pointer == 0 {
             return Err(SqliteError::Fault);
         }
-        let bytes = self.memory.read_exact(pointer, length)?;
+        let terminated_length = length.checked_add(1).ok_or(SqliteError::Overflow)?;
+        let bytes = self.memory.read_exact(pointer, terminated_length)?;
         let value = CStr::from_bytes_with_nul(bytes).map_err(|_| SqliteError::Fault)?;
         value.to_str().map_err(|_| SqliteError::Fault)?;
         Ok(value)
@@ -208,12 +210,18 @@ mod tests {
 
         assert_eq!(
             context
-                .read_utf8_c_string(1, 9)
+                .read_utf8_c_string(1, 8)
                 .map(|value| value.to_bytes()),
             Ok(&b":memory:"[..])
         );
-        assert_eq!(context.read_utf8_c_string(1, 8), Err(SqliteError::Fault));
-        assert_eq!(context.read_utf8_c_string(1, 10), Err(SqliteError::Fault));
+        assert_eq!(
+            context
+                .read_utf8_c_string(9, 0)
+                .map(|value| value.to_bytes()),
+            Ok(&b""[..])
+        );
+        assert_eq!(context.read_utf8_c_string(1, 7), Err(SqliteError::Fault));
+        assert_eq!(context.read_utf8_c_string(1, 9), Err(SqliteError::Fault));
     }
 
     #[test]

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/leak/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/leak/main.mbt
@@ -44,7 +44,7 @@ fn sqlite3_open_v2(
 fn main {
   let null_handle = sqlite3_null_handle()
   let database = Ref(null_handle)
-  let filename = b":memory:\x00"
+  let filename = b":memory:"
   if sqlite3_open_v2(
       filename,
       filename.length(),

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/main.mbt
@@ -91,7 +91,7 @@ fn sqlite3_errmsg16_length(database : UInt64) -> Int = "moonbitlang/sqlite" "sql
 
 ///|
 /// Copies the current UTF-16 error and returns its content length, excluding
-/// NUL. The output is unchanged if it cannot also hold the terminator.
+/// NUL. The output is unchanged if it cannot hold the complete content.
 #unsafe_skip_stub_check
 #borrow(output)
 fn sqlite3_errmsg16(
@@ -260,7 +260,7 @@ fn main raise {
   )
 
   let denied = Ref(null_handle)
-  let denied_filename = b"denied/database.sqlite\x00"
+  let denied_filename = b"denied/database.sqlite"
   assert_true(
     sqlite3_open_v2(
       denied_filename,
@@ -278,7 +278,7 @@ fn main raise {
   )
 
   let file_database = Ref(null_handle)
-  let file_database_filename = b"allowed/database.sqlite\x00"
+  let file_database_filename = b"allowed/database.sqlite"
   assert_true(
     sqlite3_open_v2(
       file_database_filename,
@@ -330,7 +330,7 @@ fn main raise {
   )
 
   let custom_vfs = Ref(null_handle)
-  let memory_filename = b":memory:\x00"
+  let memory_filename = b":memory:"
   assert_true(
     sqlite3_open_v2(
       memory_filename,
@@ -420,17 +420,13 @@ fn main raise {
     msg="short output was partially overwritten",
   )
   let complete_error : FixedArray[UInt16] = FixedArray::make(
-    error_length + 1,
+    error_length,
     0xFFFF,
   )
   assert_true(
     sqlite3_errmsg16(database, complete_error, complete_error.length()) ==
     error_length,
     msg="error length changed while copying",
-  )
-  assert_true(
-    complete_error[error_length] == 0,
-    msg="complete error was not NUL-terminated",
   )
   assert_true(
     complete_error[error_length - 3] == 0x4E0D &&
@@ -531,10 +527,7 @@ fn main raise {
     short_text[0] == 0xFFFF && short_text[1] == 0xFFFF,
     msg="short UTF-16 output was partially overwritten",
   )
-  let text_output : FixedArray[UInt16] = FixedArray::make(
-    text_length + 1,
-    0xFFFF,
-  )
+  let text_output : FixedArray[UInt16] = FixedArray::make(text_length, 0xFFFF)
   assert_true(
     sqlite3_column_text16(bound, 2, text_output, text_output.length()) ==
     text_length,
@@ -543,8 +536,7 @@ fn main raise {
   assert_true(
     text_output[0] == 0x503C &&
     text_output[1] == 0xD83D &&
-    text_output[2] == 0xDE00 &&
-    text_output[3] == 0,
+    text_output[2] == 0xDE00,
     msg="UTF-16 column did not round-trip",
   )
 


### PR DESCRIPTION
## Why

MoonBit strings are length-counted, while the SQLite copy imports already expose an explicit content length. Copying SQLite's native trailing NUL therefore required callers to allocate an extra unused code unit and made capacity differ from the reported length.

## What changed

- Copy exactly the reported UTF-16 content for error messages and text columns, without a trailing NUL.
- Accept zero-capacity output for empty string results.
- Keep short output buffers unchanged and return the required content length.
- Treat `sqlite3_open_v2`'s explicit filename length as content bytes, excluding
  the NUL supplied by MoonBit `Bytes`.
- Update the SQLite FFI coverage to allocate exactly the reported length.

`sqlite3_open_v2` still passes a valid C string to SQLite: the adapter validates
the explicit content plus the following `Bytes` terminator, but the terminator
is not part of the ABI length.

This is the one-commit follow-up originally stacked on #2070. That PR merged
while this PR was being created, so GitHub now shows `main` as the base.
