### PR TITLE
fix: support standalone mbtx checks

### DIFF
--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -65,6 +65,12 @@ fn test_single_file_mbtx_run() {
 }
 
 #[test]
+fn test_single_file_mbtx_check() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let _ = get_stdout(&dir, ["check", "import_ok.mbtx"]);
+}
+
+#[test]
 fn test_single_file_mbtx_run_does_not_warn_about_supported_targets() {
     let dir = TestDir::new("moon_test_single_file.in");
     let stderr = get_stderr(&dir, ["run", "import_ok.mbtx"]);

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -65,6 +65,17 @@ fn test_single_file_mbtx_run() {
 }
 
 #[test]
+fn test_single_file_mbtx_run_does_not_warn_about_supported_targets() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let stderr = get_stderr(&dir, ["run", "import_ok.mbtx"]);
+
+    assert!(
+        !stderr.contains("Package `moon/test/single` does not declare `supported_targets`"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn test_standalone_mbt_run_rejects_relative_dependency_cache() {
     let dir = TestDir::new("moon_test_single_file.in");
 

--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/check.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/check.rs
@@ -43,6 +43,10 @@ pub(crate) struct MooncCheck<'a> {
     /// Whether to enable single file mode.
     pub single_file: bool,
 
+    /// Whether `moonc check` should accept the inline import declaration of an
+    /// already-resolved `.mbtx` single-file input.
+    pub ignore_import_declaration: bool,
+
     /// Extra flags to append at the end.
     pub extra_flags: &'a [String],
 }
@@ -65,6 +69,10 @@ impl<'a> CmdlineAbstraction for MooncCheck<'a> {
 
         // Doctest-only MBT files
         self.required.add_doctest_only_sources(args);
+
+        if self.ignore_import_declaration {
+            args.push("-ignore-import-declaration".to_string());
+        }
 
         // Include doctests for blackbox
         self.required.add_include_doctests_if_blackbox(args);

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -379,6 +379,7 @@ impl<'a> LoweringContext<'a> {
             defaults: self.set_build_commons(artifacts, package, info, is_main),
             mi_out: mi_output.into(),
             single_file: package.is_single_file(),
+            ignore_import_declaration: package.is_mbtx_single_file(),
             extra_flags: module.compile_flags.as_deref().unwrap_or_default(),
         };
 

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -303,7 +303,8 @@ impl<'a> BuildPlanConstructor<'a> {
         let importer_pkg = self.input.pkg_dirs.get_package(importer_target.package);
         let dependency_pkg = self.input.pkg_dirs.get_package(dep.package);
 
-        if importer_pkg.supported_targets_decl == SupportedTargetsDeclKind::Omitted
+        if importer_pkg.single_file_source_kind.is_none()
+            && importer_pkg.supported_targets_decl == SupportedTargetsDeclKind::Omitted
             && importer_target.package != dep.package
             && dependency_pkg.supported_targets_decl != SupportedTargetsDeclKind::Omitted
             && self

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -28,10 +28,10 @@ There are 4 kinds of source files within each package:
 
 Standalone inputs are represented as synthetic single-file packages. Their
 source format is recorded while resolving the input. In particular, an
-original `.mbtx` input is kept as a regular, unconditional source file, and
-`moonc build-package` receives `-ignore-import-declaration` when lowering that
-synthetic package. This does not make `.mbtx` a source extension discovered in
-ordinary packages.
+original `.mbtx` input is kept as a regular, unconditional source file. Both
+`moonc build-package` and `moonc check` receive `-ignore-import-declaration`
+when lowering that synthetic package. This does not make `.mbtx` a source
+extension discovered in ordinary packages.
 
 ### Build targets
 


### PR DESCRIPTION
## Why

Standalone `.mbtx` inputs were handled inconsistently: running one could emit a misleading `supported_targets` warning, and checking one failed because the inline import declaration reached `moonc check`.

## What changed

- Suppress the missing-`supported_targets` warning for synthetic single-file packages, which have no package manifest.
- Forward `-ignore-import-declaration` to `moonc check` for synthetic `.mbtx` inputs.
- Cover both behaviors with standalone `.mbtx` regressions.

## Why this is correct

The synthetic package already resolves inline imports before compiler lowering. Passing the compiler flag therefore matches the existing `moon run` build path, while real packages retain the existing warning behavior.

## Scope

The change is limited to synthetic single-file packages and does not alter manifest-backed package selection or diagnostics.