### PR TITLE
fix(moonrun): distinguish unavailable column names

### DIFF
--- a/crates/moonrun/src/sqlite/column.rs
+++ b/crates/moonrun/src/sqlite/column.rs
@@ -38,33 +38,36 @@ impl SqliteHost {
         Ok(unsafe { ffi::sqlite3_column_count(statement.pointer.as_ptr()) })
     }
 
+    /// Return the UTF-16 column-name length, or `-1` when SQLite could not
+    /// allocate the converted name.
     pub(crate) fn column_name16_length(
         &self,
         statement: u64,
         column: i32,
-    ) -> SqliteHostResult<u32> {
+    ) -> SqliteHostResult<i32> {
         let statement = self.result_column(statement, column)?;
         let name = unsafe { sqlite3_column_name16(statement.pointer.as_ptr(), column) };
         // The scan completes before another SQLite call can invalidate the
         // statement-owned pointer.
-        unsafe { utf16_string_length(name) }
+        column_name_length(unsafe { utf16_string_length(name) }?)
     }
 
     /// Copy a UTF-16 column name when it fits.
     ///
     /// The returned content length excludes SQLite's trailing NUL. A short
-    /// output leaves the output unchanged.
+    /// output leaves the output unchanged. `-1` reports that SQLite could not
+    /// allocate the UTF-16 column name.
     pub(crate) fn copy_column_name16(
         &self,
         statement: u64,
         column: i32,
         output: &mut [u16],
-    ) -> SqliteHostResult<u32> {
+    ) -> SqliteHostResult<i32> {
         let statement = self.result_column(statement, column)?;
         let name = unsafe { sqlite3_column_name16(statement.pointer.as_ptr(), column) };
         // The copy completes before another SQLite call can invalidate the
         // statement-owned pointer.
-        unsafe { copy_utf16_string(name, output) }
+        column_name_length(unsafe { copy_utf16_string(name, output) }?)
     }
 
     pub(crate) fn column_type(&self, statement: u64, column: i32) -> SqliteHostResult<i32> {
@@ -203,6 +206,15 @@ impl SqliteHost {
     }
 }
 
+// Column indexes are validated before SQLite is called, so an unavailable
+// column name is specifically the allocation failure documented by SQLite.
+fn column_name_length(length: Option<u32>) -> SqliteHostResult<i32> {
+    let Some(length) = length else {
+        return Ok(-1);
+    };
+    i32::try_from(length).map_err(|_| SqliteHostError::Overflow)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,6 +351,30 @@ mod tests {
             Err(SqliteHostError::InvalidInput)
         );
         assert_eq!(output, [0xffff; 5]);
+
+        assert_eq!(host.finalize(statement), Ok(ffi::SQLITE_OK));
+        assert_eq!(host.close(database), Ok(ffi::SQLITE_OK));
+    }
+
+    #[test]
+    fn column_names_distinguish_empty_strings_from_unavailable_names() {
+        let host = host();
+        let database = open_memory(&host);
+        let sql = utf16le("SELECT 42 AS \"\"");
+        let statement = host
+            .prepare16_v2(database, &sql)
+            .unwrap()
+            .statement
+            .unwrap();
+
+        assert_eq!(host.column_name16_length(statement, 0), Ok(0));
+        let mut output = [0xffff];
+        assert_eq!(host.copy_column_name16(statement, 0, &mut output), Ok(0));
+        assert_eq!(output, [0xffff]);
+        assert_eq!(
+            unsafe { utf16_string_length(std::ptr::null()) }.and_then(column_name_length),
+            Ok(-1)
+        );
 
         assert_eq!(host.finalize(statement), Ok(ffi::SQLITE_OK));
         assert_eq!(host.close(database), Ok(ffi::SQLITE_OK));

--- a/crates/moonrun/src/sqlite/connection.rs
+++ b/crates/moonrun/src/sqlite/connection.rs
@@ -105,7 +105,7 @@ impl SqliteHost {
         let message = unsafe { sqlite3_errmsg16(database.pointer().as_ptr()) };
         // No other thread can access this run-local connection, and the scan
         // finishes before another SQLite call can invalidate the pointer.
-        unsafe { utf16_string_length(message) }
+        Ok(unsafe { utf16_string_length(message) }?.unwrap_or(0))
     }
 
     pub(crate) fn errcode(&self, database: u64) -> SqliteHostResult<i32> {
@@ -137,7 +137,7 @@ impl SqliteHost {
         let message = unsafe { sqlite3_errmsg16(database.pointer().as_ptr()) };
         // No other thread can access this run-local connection, and copying
         // finishes before another SQLite call can invalidate the pointer.
-        unsafe { copy_utf16_string(message, output) }
+        Ok(unsafe { copy_utf16_string(message, output) }?.unwrap_or(0))
     }
 
     pub(crate) fn close(&self, database: u64) -> SqliteHostResult<i32> {
@@ -196,14 +196,15 @@ impl SqliteHost {
 }
 
 /// Measure a native-endian, NUL-terminated SQLite UTF-16 string, excluding NUL.
+/// Return `None` when SQLite supplied a NULL pointer.
 ///
 /// # Safety
 ///
 /// A non-NULL `value` must point to a valid SQLite-owned UTF-16 string whose
 /// lifetime covers this call.
-pub(super) unsafe fn utf16_string_length(value: *const c_void) -> SqliteHostResult<u32> {
+pub(super) unsafe fn utf16_string_length(value: *const c_void) -> SqliteHostResult<Option<u32>> {
     if value.is_null() {
-        return Ok(0);
+        return Ok(None);
     }
 
     let value = value.cast::<u16>();
@@ -213,10 +214,13 @@ pub(super) unsafe fn utf16_string_length(value: *const c_void) -> SqliteHostResu
     while unsafe { *value.add(length) } != 0 {
         length += 1;
     }
-    u32::try_from(length).map_err(|_| SqliteHostError::Overflow)
+    u32::try_from(length)
+        .map(Some)
+        .map_err(|_| SqliteHostError::Overflow)
 }
 
 /// Copy a native-endian, NUL-terminated SQLite UTF-16 string.
+/// Return `None` when SQLite supplied a NULL pointer.
 ///
 /// # Safety
 ///
@@ -225,13 +229,15 @@ pub(super) unsafe fn utf16_string_length(value: *const c_void) -> SqliteHostResu
 pub(super) unsafe fn copy_utf16_string(
     value: *const c_void,
     output: &mut [u16],
-) -> SqliteHostResult<u32> {
+) -> SqliteHostResult<Option<u32>> {
     if value.is_null() {
-        return Ok(0);
+        return Ok(None);
     }
 
     // SAFETY: upheld by this function's caller.
-    let length = unsafe { utf16_string_length(value) }?;
+    let Some(length) = unsafe { utf16_string_length(value) }? else {
+        return Ok(None);
+    };
     let content_length = length as usize;
     if output.len() >= content_length && content_length != 0 {
         // SAFETY: the scan above proved that the slice contains at least
@@ -239,7 +245,7 @@ pub(super) unsafe fn copy_utf16_string(
         let value = unsafe { std::slice::from_raw_parts(value.cast::<u16>(), content_length) };
         output[..content_length].copy_from_slice(value);
     }
-    Ok(length)
+    Ok(Some(length))
 }
 
 #[cfg(test)]
@@ -271,13 +277,22 @@ mod tests {
     }
 
     #[test]
-    fn unavailable_utf16_error_preserves_sqlite_null() {
+    fn utf16_helpers_distinguish_unavailable_and_empty_strings() {
+        let empty = [0_u16];
         let mut output = [0xffff];
 
-        assert_eq!(unsafe { utf16_string_length(ptr::null()) }, Ok(0));
+        assert_eq!(unsafe { utf16_string_length(ptr::null()) }, Ok(None));
+        assert_eq!(
+            unsafe { utf16_string_length(empty.as_ptr().cast()) },
+            Ok(Some(0))
+        );
         assert_eq!(
             unsafe { copy_utf16_string(ptr::null(), &mut output) },
-            Ok(0)
+            Ok(None)
+        );
+        assert_eq!(
+            unsafe { copy_utf16_string(empty.as_ptr().cast(), &mut output) },
+            Ok(Some(0))
         );
         assert_eq!(output, [0xffff]);
     }

--- a/crates/moonrun/src/sqlite/v8/column.rs
+++ b/crates/moonrun/src/sqlite/v8/column.rs
@@ -25,7 +25,7 @@ pub(super) fn column_name16(
     column: i32,
     output: u32,
     capacity: u32,
-) -> SqliteResult<u32> {
+) -> SqliteResult<i32> {
     context.with_utf16_output(output, capacity, |host, output| {
         Ok(host.copy_column_name16(statement, column, output)?)
     })

--- a/crates/moonrun/src/sqlite/v8/registry.rs
+++ b/crates/moonrun/src/sqlite/v8/registry.rs
@@ -85,13 +85,13 @@ declare_sqlite_imports! {
     SqliteHost::finalize(statement: u64) -> i32 => "sqlite3_finalize";
     SqliteHost::column_count(statement: u64) -> i32 => "sqlite3_column_count";
     SqliteHost::column_name16_length(statement: u64, column: i32)
-        -> u32 => "sqlite3_column_name16_length";
+        -> i32 => "sqlite3_column_name16_length";
     column::column_name16(
         statement: u64,
         column: i32,
         output: u32,
         capacity: u32,
-    ) -> u32 => "sqlite3_column_name16";
+    ) -> i32 => "sqlite3_column_name16";
     SqliteHost::column_type(statement: u64, column: i32)
         -> i32 => "sqlite3_column_type";
     SqliteHost::column_int64(statement: u64, column: i32)

--- a/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_sqlite_ffi.in/main/main.mbt
@@ -549,6 +549,30 @@ fn main raise {
     name_output[2] == 0xDE00,
     msg="UTF-16 column name was not copied",
   )
+  let empty_name = prepare(database, "SELECT 1 AS \"\"", null_handle)
+  assert_true(
+    sqlite3_column_name16_length(empty_name, 0) == 0,
+    msg="empty UTF-16 column name did not report zero length",
+  )
+  let empty_name_output : FixedArray[UInt16] = FixedArray::make(1, 0xFFFF)
+  assert_true(
+    sqlite3_column_name16(
+      empty_name,
+      0,
+      empty_name_output,
+      empty_name_output.length(),
+    ) ==
+    0,
+    msg="empty UTF-16 column-name copy did not report zero length",
+  )
+  assert_true(
+    empty_name_output[0] == 0xFFFF,
+    msg="empty UTF-16 column name overwrote the output",
+  )
+  assert_true(
+    sqlite3_finalize(empty_name) == SQLITE_OK,
+    msg="empty column-name query finalize failed",
+  )
   assert_true(
     sqlite3_column_type(bound, 0) == SQLITE_INTEGER &&
     sqlite3_column_type(bound, 1) == SQLITE_FLOAT &&


### PR DESCRIPTION
## Why
sqlite3_column_name16 can return either a valid empty UTF-16 string or a null pointer when SQLite cannot allocate the converted name. Mapping both cases to length 0 prevents guest code from distinguishing allocation failure from an empty alias.

## What
- preserve the distinction between a null UTF-16 pointer and an empty string in the host helpers
- return -1 when a column name is unavailable and 0 for a valid empty name
- expose the column-name length and copy results as signed 32-bit values
- cover the empty-name behavior at both the host-helper and SQLite FFI boundaries

## Why this is correct
The valid column index is checked before reading the name, so a null name reflects SQLite's documented conversion-allocation failure case. Valid byte lengths remain nonnegative, while checked conversion prevents an oversized length from colliding with the -1 sentinel.

## Scope
The change only adjusts the existing UTF-16 column-name path and its regression coverage. The statement and metadata APIs remain part of the already merged PR #2076.