### PR TITLE
chore: sync async and nightly fixtures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,3 @@
 [submodule "third_party/moonbitlang_async"]
 	path = third_party/moonbitlang_async
 	url = https://github.com/moonbitlang/async.git
-	branch = codex/async-process

--- a/crates/moon/tests/test_cases/bench2.in/bench2.mbt
+++ b/crates/moon/tests/test_cases/bench2.in/bench2.mbt
@@ -14,7 +14,7 @@ pub fn sum(data~ : Array[Int], start? : Int = 0, length? : Int) -> Int {
   let end = if length is Some(length) { start + length } else { data.length() }
   for i = start, sum = 0; i < end; i = i + 1, sum = sum + data[i] {
 
-  } else {
+  } nobreak {
     sum
   }
 }

--- a/crates/moon/tests/test_cases/check_fmt.in/check_fmt.mbt
+++ b/crates/moon/tests/test_cases/check_fmt.in/check_fmt.mbt
@@ -15,7 +15,7 @@ pub fn sum(data~ : Array[Int], start? : Int = 0, length? : Int) -> Int {
   let end = if length is Some(length) { start + length } else { data.length() }
   for i = start, sum = 0; i < end; i = i + 1, sum = sum + data[i] {
 
-  } else {
+  } nobreak {
     sum
   }
 }

--- a/crates/moon/tests/test_cases/clean/clean.in/clean.mbt
+++ b/crates/moon/tests/test_cases/clean/clean.in/clean.mbt
@@ -14,7 +14,7 @@ pub fn sum(data~ : Array[Int], start? : Int = 0, length? : Int) -> Int {
   let end = if length is Some(length) { start + length } else { data.length() }
   for i = start, sum = 0; i < end; i = i + 1, sum = sum + data[i] {
 
-  } else {
+  } nobreak {
     sum
   }
 }

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -78,7 +78,7 @@ fn test_moonrun_against_upstream_async() {
         .args(["test", "--target", "wasm"])
         .assert()
         .success()
-        .stdout_eq("Total tests: 446, passed: 446, failed: 0.\n");
+        .stdout_eq("Total tests: 452, passed: 452, failed: 0.\n");
 }
 
 struct TestDir(moon_test_util::test_dir::TestDir);


### PR DESCRIPTION
## Why

The latest MoonBit nightly no longer accepts `else` as the exit block of a functional `for` loop, causing the bench, formatting-check, and clean integration fixtures to fail before reaching their intended assertions.

The async wasm integration also still points at the temporary `codex/async-process` branch even though its watcher work has landed upstream. Keeping that override prevents the submodule from following canonical async `main` and omits subsequent upstream compatibility fixes.

## Correctness

The affected fixtures now use the current `nobreak` spelling without changing their loop behavior or test intent.

The async gitlink points at the latest `moonbitlang/async` main commit. The watcher changes from the temporary branch are present upstream, Moonrun's port provenance remains aligned, and the upstream wasm test expectation reflects the new total of 452 tests.

## Scope

This updates only the three affected MoonBit fixtures, removes the stale submodule branch override, advances the async gitlink, and updates the exact upstream test count. No Moonrun host behavior changes are included.