### PR TITLE
feat(native/windows): auto-select C toolchain (MSVC, Clang, MinGW)

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -87,7 +87,8 @@ impl<'a> BuildPlanConstructor<'a> {
     fn new_native_linker_context(&self, err: anyhow::Error) -> anyhow::Error {
         if self.build_env.direct_native_target() == Some(NativeTarget::X86_64PcWindowsMsvc) {
             err.context(
-                "Windows MSVC direct object native target requires an MSVC compiler/linker driver such as cl.exe or clang-cl.exe",
+                "Windows direct-object native backend requires MSVC (cl.exe or clang-cl.exe); \
+                 MinGW/GCC is supported via the generated-C backend (unset MOONBIT_NEW_NATIVE)",
             )
         } else if self.build_env.direct_native_target().is_some() {
             err.context(
@@ -107,7 +108,10 @@ impl<'a> BuildPlanConstructor<'a> {
 
         self.warned_incompatible_windows_msvc_env_override = true;
         self.user_log.warn(
-            "MOON_CC is ignored for Windows MSVC direct object native target because it is not a cl-compatible driver; set MOON_CC to cl.exe or clang-cl.exe to override MSVC discovery.",
+            "MOON_CC is ignored for Windows direct-object native target because it is not a \
+             cl-compatible driver; set MOON_CC to cl.exe or clang-cl.exe to override MSVC \
+             discovery, or unset MOONBIT_NEW_NATIVE to use the generated-C backend which \
+             supports MinGW/GCC.",
         );
     }
 

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -77,6 +77,16 @@ pub enum DirectNativeMode {
 impl NativeTarget {
     pub fn from_env_for_host() -> Option<Self> {
         let env_value = std::env::var(ENV_MOONBIT_NEW_NATIVE).ok();
+        // On Windows, the direct-object backend requires MSVC (ABI compatibility).
+        // When MOONBIT_NEW_NATIVE=1 but MSVC is absent, fall back to GeneratedC so
+        // that MinGW/GCC can be used transparently via the generated-C path.
+        #[cfg(windows)]
+        if env_value.as_deref() == Some("1") {
+            if moonutil::compiler_flags::is_windows_msvc_discoverable() {
+                return Some(Self::X86_64PcWindowsMsvc);
+            }
+            return None;
+        }
         Self::from_host_with_new_native_env(
             std::env::consts::ARCH,
             std::env::consts::OS,

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -289,6 +289,19 @@ pub fn resolve_windows_msvc_toolchain() -> anyhow::Result<Toolchain> {
     resolve_native_toolchain_executables(discovered_windows_msvc_toolchain()?)
 }
 
+/// Returns true if an MSVC toolchain can be discovered on the current Windows host.
+/// Always returns false on non-Windows platforms.
+pub fn is_windows_msvc_discoverable() -> bool {
+    #[cfg(windows)]
+    {
+        resolve_windows_msvc_toolchain().is_ok()
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
 fn ensure_windows_msvc_compatible(cc: &CC) -> anyhow::Result<()> {
     if cc.is_msvc() {
         Ok(())
@@ -763,6 +776,12 @@ impl CC {
             .is_some_and(|target| target.contains("apple-darwin"))
     }
 
+    pub fn targets_mingw(&self) -> bool {
+        self.target_triple
+            .as_deref()
+            .is_some_and(|t| t.contains("mingw") || t.contains("w64-windows-gnu"))
+    }
+
     pub fn should_link_libm(&self) -> bool {
         self.is_full_featured_gcc_like() && !self.targets_msvc()
     }
@@ -883,6 +902,14 @@ fn detected_default_native_toolchain() -> anyhow::Result<Toolchain> {
     {
         if let Ok(toolchain) = discovered_windows_msvc_toolchain() {
             return Ok(toolchain);
+        }
+        // MSVC not found; try MinGW before the generic system cc probe.
+        // x86_64-w64-mingw32-gcc is the canonical MinGW cross-compiler name.
+        for name in ["x86_64-w64-mingw32-gcc", "i686-w64-mingw32-gcc"] {
+            let Ok(path) = which::which(name) else { continue };
+            if let Ok(cc) = CC::try_from_detected_path(&path, CCKind::Gcc) {
+                return Ok(Toolchain::from_path_probe(cc));
+            }
         }
     }
 


### PR DESCRIPTION
On Windows, native backend currently only supports MSVC (cl.exe / clang-cl.exe). Users with MinGW or a standalone Clang have to set MOON_CC manually. This changes the detection order to MSVC > MinGW > system cc so all three work out of the box.

Three changes:

`detected_default_native_toolchain` on Windows - after MSVC probe fails, explicitly try `x86_64-w64-mingw32-gcc` and `i686-w64-mingw32-gcc` before falling through to the generic system-cc probe. Canonical MinGW names get priority over a bare `gcc` that may point to something else.

`NativeTarget::from_env_for_host` - when `MOONBIT_NEW_NATIVE=1` on Windows but MSVC is absent, return `None` instead of `X86_64PcWindowsMsvc`. The build falls back to generated-C mode, which then picks up MinGW/GCC through the detection above. The direct-object path cannot support MinGW because it emits MSVC-ABI objects; the generated-C path works with any C compiler.

Error and warning messages in `builders.rs` updated to mention that MinGW/GCC is supported via generated-C mode and how to reach it.

Existing Linux/macOS behaviour is unaffected (`#[cfg(windows)]` guards). The `from_host_with_new_native_env` tests cover the original behaviour and still pass without modification. Windows + MinGW integration testing requires a real MSYS2 environment not available in CI.