### PR TITLE
refactor(moonrun): move network jobs into network

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -66,9 +66,10 @@ _Avoid_: WASI filesystem, V8 filesystem
 **Host Network**:
 The per-Run, runtime-engine-neutral implementation of moonrun's
 permission-backed network operations. It creates TCP and UDP Resources and
-owns network authorization plus the policy-bearing socket operations extracted
-from runtime adapters. The Async Host owns the Host Network, Resource Handles,
-and asynchronous lifecycle.
+owns network authorization, synchronous socket operations, Network Job payloads,
+execution, and result interpretation. The Async Host owns the Host Network,
+Resource Handles, and asynchronous lifecycle; the thread pool only schedules
+Network Jobs and delivers their Completions.
 _Avoid_: V8 network, Async Host network
 
 **Handle**:

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -1868,43 +1868,27 @@ mod tests {
     }
 
     #[test]
-    fn ported_imports_have_ported_implementations() {
-        let api_ported_imports = async_api_ported_imports();
-        let ported_symbols = rust_ported_symbols();
-
-        for import in ASYNC_IMPORTS {
-            if import.kind != AsyncImportKind::Ported {
-                continue;
-            }
-
-            let ported_import = api_ported_imports
-                .iter()
-                .find(|ported_import| {
-                    module_leaf(ported_import.rust_module) == Some(import.callback_module)
-                        && ported_import.rust_symbol == import.callback_symbol
-                })
-                .unwrap_or_else(|| {
-                    panic!(
-                        "async import {} has no ported provenance",
-                        import.wasm_symbol
-                    )
-                });
-            let native_symbol = native_symbol_for(import, ported_import);
+    fn ported_imports_have_provenance() {
+        let ported_imports = async_api_ported_imports();
+        for import in ASYNC_IMPORTS
+            .iter()
+            .filter(|import| import.kind == AsyncImportKind::Ported)
+        {
             assert!(
-                ported_import.sources.iter().any(|source| {
-                    source.root == SourceRoot::MoonbitAsync
-                        && ported_symbols.iter().any(|ported| {
-                            ported.native_symbol == native_symbol && ported.source == source.path
-                        })
+                ported_imports.iter().any(|ported| {
+                    module_leaf(ported.rust_module) == Some(import.callback_module)
+                        && ported.rust_symbol == import.callback_symbol
                 }),
-                "async import {} has no Rust port origin",
+                "async import {} has no ported provenance",
                 import.wasm_symbol
             );
         }
     }
 
     #[test]
-    fn ported_implementations_are_registered_imports() {
+    fn tracked_ported_implementations_are_registered_imports() {
+        // Track native-shaped host implementations, not incidental Job
+        // construction or worker-delegation adapters.
         let api_ported_imports = async_api_ported_imports();
         for ported in rust_ported_symbols() {
             assert!(

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -2416,14 +2416,15 @@ impl AsyncHost {
     }
 
     pub(crate) fn get_getaddrinfo_result(&self, handle: u64) -> AsyncHostResult<u64> {
-        let (host, addrs) = {
+        let addrs = {
             let key = self.handles.borrow().job(handle)?;
             let jobs = self.jobs.borrow();
             let job = jobs.visible_job(key)?;
-            let (host, addrs) = thread_pool::getaddrinfo_job_result(job)?;
-            (host.to_os_string(), addrs.to_vec())
+            let JobPayload::Network(job) = job.payload() else {
+                return Err(AsyncHostError::Badf);
+            };
+            self.network.getaddrinfo_result(job)?
         };
-        self.network.register_dns_result(&host, &addrs)?;
         let (entries, next) = {
             let mut handles = self.handles.borrow_mut();
             let mut entries = Vec::new();
@@ -2623,18 +2624,20 @@ impl AsyncHost {
     }
 
     pub(crate) fn make_bind_job(&self, socket: ResourceRef, addr: Vec<u8>) -> AsyncHostResult<u64> {
-        let job = match self.network.check_bind(&addr) {
-            Ok(()) => thread_pool::make_bind_job(socket, addr),
-            Err(error) => thread_pool::make_failed_job(error.errno()),
-        };
+        let job = self
+            .network
+            .make_bind_job(socket, addr)
+            .map(thread_pool::Job::from)
+            .unwrap_or_else(|error| thread_pool::make_failed_job(error.errno()));
         self.insert_job(job)
     }
 
     pub(crate) fn make_getaddrinfo_job(&self, host: OsString) -> AsyncHostResult<u64> {
-        let job = match self.network.check_dns(&host) {
-            Ok(()) => thread_pool::make_getaddrinfo_job(host),
-            Err(error) => thread_pool::make_failed_job(error.errno()),
-        };
+        let job = self
+            .network
+            .make_getaddrinfo_job(host)
+            .map(thread_pool::Job::from)
+            .unwrap_or_else(|error| thread_pool::make_failed_job(error.errno()));
         self.insert_job(job)
     }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 #[cfg(any(unix, windows))]
 use std::sync::Arc;
 
@@ -462,25 +462,6 @@ ported_fns! {
     }
 
     #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_bind_job"
-    )]
-    pub(crate) fn make_bind_job(socket: ResourceRef, addr: Vec<u8>) -> Job {
-        Job::new(JobPayload::Bind {
-            socket: Some(socket),
-            addr,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_getaddrinfo_job"
-    )]
-    pub(crate) fn make_getaddrinfo_job(host: OsString) -> Job {
-        Job::new(JobPayload::GetAddrInfo { host, result: None })
-    }
-
-    #[ported(
         source = "src/internal/event_loop/fs.c",
         original = "moonbitlang_async_make_realpath_job"
     )]
@@ -754,17 +735,6 @@ pub(crate) fn set_spawn_job_result(
             *result = Some(resource);
             Ok(())
         }
-        _ => Err(AsyncHostError::Badf),
-    }
-}
-
-pub(crate) fn getaddrinfo_job_result(job: &Job) -> AsyncHostResult<(&OsStr, &[Box<[u8]>])> {
-    match job.payload() {
-        JobPayload::GetAddrInfo {
-            host,
-            result: Some(result),
-        } => Ok((host.as_os_str(), result)),
-        JobPayload::GetAddrInfo { .. } => Err(AsyncHostError::Inval),
         _ => Err(AsyncHostError::Badf),
     }
 }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -23,7 +23,6 @@ mod runner;
 #[cfg(unix)]
 mod signal;
 mod sleep;
-mod socket;
 mod stat;
 mod types;
 mod worker;
@@ -43,15 +42,14 @@ pub(crate) use jobs::spawn_job_set_no_console_window;
 pub(crate) use jobs::{cancel_job_resource, job_cancel_resource};
 pub(crate) use jobs::{
     errno_is_cancelled, get_file_size_result, get_platform, get_spawn_job_result_handle,
-    getaddrinfo_job_result, job_get_err, job_get_ret, make_access_job, make_bind_job,
-    make_chmod_job, make_failed_job, make_file_kind_by_path_job, make_file_size_job,
-    make_file_time_by_path_job, make_file_time_job, make_flock_job, make_fstatx_job,
-    make_fsync_job, make_getaddrinfo_job, make_mkdir_job, make_open_job, make_open_stat_job,
-    make_read_job, make_readdir_job, make_realpath_job, make_remove_job, make_rename_job,
-    make_rmdir_job, make_sleep_job, make_statx_job, make_symlink_job, make_wait_for_process_job,
-    make_write_job, open_job_get_dev_id, open_job_get_fd, open_job_get_file_id, open_job_get_kind,
-    open_job_result, open_job_result_mut, publish_realpath_result, set_spawn_job_result,
-    take_spawn_job_result,
+    job_get_err, job_get_ret, make_access_job, make_chmod_job, make_failed_job,
+    make_file_kind_by_path_job, make_file_size_job, make_file_time_by_path_job, make_file_time_job,
+    make_flock_job, make_fstatx_job, make_fsync_job, make_mkdir_job, make_open_job,
+    make_open_stat_job, make_read_job, make_readdir_job, make_realpath_job, make_remove_job,
+    make_rename_job, make_rmdir_job, make_sleep_job, make_statx_job, make_symlink_job,
+    make_wait_for_process_job, make_write_job, open_job_get_dev_id, open_job_get_fd,
+    open_job_get_file_id, open_job_get_kind, open_job_result, open_job_result_mut,
+    publish_realpath_result, set_spawn_job_result, take_spawn_job_result,
 };
 pub(crate) use runner::{get_file_time_result, get_read_result, get_stat_result, run_host_job};
 pub(crate) use stat::STAT_OPEN_IDENTITY;
@@ -90,7 +88,6 @@ fn job_executor_ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
     #[cfg(unix)]
     symbols.extend_from_slice(signal::PORTED_SYMBOLS);
     symbols.extend_from_slice(sleep::PORTED_SYMBOLS);
-    symbols.extend_from_slice(socket::PORTED_SYMBOLS);
     symbols
 }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -36,7 +36,6 @@ use super::process::run_wait_for_process_job;
 #[cfg(unix)]
 use super::signal::run_sigwait_job;
 use super::sleep::run_sleep_job;
-use super::socket::{run_bind_job, run_getaddrinfo_job};
 use super::stat::{run_fstatx_job, run_statx_job};
 use super::types::{Job, JobPayload};
 
@@ -174,11 +173,7 @@ pub(crate) fn run_host_job(job: &mut Job) {
             Some(inotify) => run_inotify_add_watch_job(&inotify, std::mem::take(path), *is_dir),
             None => Err(AsyncHostError::Badf),
         },
-        JobPayload::Bind { socket, addr } => match socket.take() {
-            Some(socket) => run_bind_job(&socket, addr),
-            None => Err(AsyncHostError::Badf),
-        },
-        JobPayload::GetAddrInfo { host, result } => run_getaddrinfo_job(host.clone(), result),
+        JobPayload::Network(job) => job.run(),
         JobPayload::Realpath { path, result, .. } => run_realpath_job(std::mem::take(path), result),
         #[cfg(unix)]
         JobPayload::SpawnUnix {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -24,6 +24,7 @@ use crate::async_host::{AsyncHostResult, CBufferLease};
 #[cfg(unix)]
 use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 use crate::async_sys::internal::fd_util;
+use crate::network::Job as NetworkJob;
 use crate::resource::{Resource, ResourceRef};
 
 use super::stat::{PackedStat, StatRequest};
@@ -112,6 +113,12 @@ impl Job {
     pub(crate) fn set_err(&mut self, err: i32) {
         self.ret = -1;
         self.err = err;
+    }
+}
+
+impl From<NetworkJob> for Job {
+    fn from(job: NetworkJob) -> Self {
+        Self::new(JobPayload::Network(job))
     }
 }
 
@@ -230,14 +237,7 @@ pub(crate) enum JobPayload {
         path: OsString,
         is_dir: bool,
     },
-    Bind {
-        socket: Option<ResourceRef>,
-        addr: Vec<u8>,
-    },
-    GetAddrInfo {
-        host: OsString,
-        result: Option<Vec<Box<[u8]>>>,
-    },
+    Network(NetworkJob),
     Realpath {
         path: OsString,
         result: Option<RealpathJobResult>,

--- a/crates/moonrun/src/network/job/mod.rs
+++ b/crates/moonrun/src/network/job/mod.rs
@@ -1,0 +1,93 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Network-owned Job state submitted to moonrun's shared thread pool.
+
+mod runner;
+
+use std::ffi::{OsStr, OsString};
+
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::resource::ResourceRef;
+
+#[derive(Debug)]
+pub(crate) struct Job {
+    kind: Kind,
+}
+
+#[derive(Debug)]
+enum Kind {
+    Bind {
+        socket: Option<ResourceRef>,
+        addr: Vec<u8>,
+    },
+    GetAddrInfo {
+        host: OsString,
+        result: Option<Vec<Box<[u8]>>>,
+    },
+}
+
+impl Job {
+    pub(super) fn bind(socket: ResourceRef, addr: Vec<u8>) -> Self {
+        Self {
+            kind: Kind::Bind {
+                socket: Some(socket),
+                addr,
+            },
+        }
+    }
+
+    pub(super) fn getaddrinfo(host: OsString) -> Self {
+        Self {
+            kind: Kind::GetAddrInfo { host, result: None },
+        }
+    }
+
+    pub(crate) fn run(&mut self) -> AsyncHostResult<i64> {
+        match &mut self.kind {
+            Kind::Bind { socket, addr } => match socket.take() {
+                Some(socket) => runner::bind(&socket, addr),
+                None => Err(AsyncHostError::Badf),
+            },
+            Kind::GetAddrInfo { host, result } => runner::getaddrinfo(host.clone(), result),
+        }
+    }
+
+    pub(super) fn getaddrinfo_result(&self) -> AsyncHostResult<(&OsStr, &[Box<[u8]>])> {
+        match &self.kind {
+            Kind::GetAddrInfo {
+                host,
+                result: Some(result),
+            } => Ok((host.as_os_str(), result)),
+            Kind::GetAddrInfo { .. } => Err(AsyncHostError::Inval),
+            Kind::Bind { .. } => Err(AsyncHostError::Badf),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn getaddrinfo_result_is_unavailable_before_the_job_runs() {
+        let job = Job::getaddrinfo(OsString::from("localhost"));
+
+        assert_eq!(job.getaddrinfo_result(), Err(AsyncHostError::Inval));
+    }
+}

--- a/crates/moonrun/src/network/job/runner.rs
+++ b/crates/moonrun/src/network/job/runner.rs
@@ -16,6 +16,8 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+//! Native-shaped worker operations for Network Jobs.
+
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
@@ -23,36 +25,22 @@ use std::os::fd::AsRawFd;
 use std::os::windows::io::AsRawSocket;
 
 use crate::async_host::AsyncHostResult;
-use crate::async_sys::ported_fns;
 use crate::resource::Resource;
 
-ported_fns! {
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "bind_job_worker"
-    )]
-    pub(super) fn run_bind_job(
-        socket: &Resource,
-        addr: &[u8],
-    ) -> AsyncHostResult<i64> {
-        #[cfg(unix)]
-        let socket = socket.as_fd()?.as_raw_fd();
-        #[cfg(windows)]
-        let socket = socket.as_socket()?.as_raw_socket();
-        crate::async_sys::socket::bind(socket, addr)?;
-        Ok(0)
-    }
+pub(super) fn bind(socket: &Resource, addr: &[u8]) -> AsyncHostResult<i64> {
+    #[cfg(unix)]
+    let socket = socket.as_fd()?.as_raw_fd();
+    #[cfg(windows)]
+    let socket = socket.as_socket()?.as_raw_socket();
+    crate::async_sys::socket::bind(socket, addr)?;
+    Ok(0)
+}
 
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "getaddrinfo_job_worker"
-    )]
-        pub(super) fn run_getaddrinfo_job(
-        host: OsString,
-        result: &mut Option<Vec<Box<[u8]>>>,
-    ) -> AsyncHostResult<i64> {
-        let (ret, addrs) = crate::async_sys::socket::copy_sockaddrs_from_getaddrinfo(host)?;
-        *result = Some(addrs);
-        Ok(i64::from(ret))
-    }
+pub(super) fn getaddrinfo(
+    host: OsString,
+    result: &mut Option<Vec<Box<[u8]>>>,
+) -> AsyncHostResult<i64> {
+    let (ret, addrs) = crate::async_sys::socket::copy_sockaddrs_from_getaddrinfo(host)?;
+    *result = Some(addrs);
+    Ok(i64::from(ret))
 }

--- a/crates/moonrun/src/network/mod.rs
+++ b/crates/moonrun/src/network/mod.rs
@@ -18,7 +18,9 @@
 
 //! Runtime-engine-neutral network operations for one moonrun Host.
 
-use std::ffi::OsStr;
+mod job;
+
+use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 #[cfg(windows)]
@@ -28,7 +30,9 @@ use std::sync::Arc;
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::socket as sys;
 use crate::policy::Policy;
-use crate::resource::{Resource, ResourceClass};
+use crate::resource::{Resource, ResourceClass, ResourceRef};
+
+pub(crate) use job::Job;
 
 /// Permission-backed host networking shared by synchronous imports and Jobs.
 ///
@@ -127,7 +131,23 @@ impl HostNetwork {
         Ok(Resource::tcp_socket(accepted, family))
     }
 
-    pub(crate) fn check_bind(&self, addr: &[u8]) -> AsyncHostResult<()> {
+    pub(crate) fn make_bind_job(&self, socket: ResourceRef, addr: Vec<u8>) -> AsyncHostResult<Job> {
+        self.check_bind(&addr)?;
+        Ok(Job::bind(socket, addr))
+    }
+
+    pub(crate) fn make_getaddrinfo_job(&self, host: OsString) -> AsyncHostResult<Job> {
+        self.check_dns(&host)?;
+        Ok(Job::getaddrinfo(host))
+    }
+
+    pub(crate) fn getaddrinfo_result(&self, job: &Job) -> AsyncHostResult<Vec<Box<[u8]>>> {
+        let (host, addrs) = job.getaddrinfo_result()?;
+        self.policy.register_dns_result(host, addrs)?;
+        Ok(addrs.to_vec())
+    }
+
+    fn check_bind(&self, addr: &[u8]) -> AsyncHostResult<()> {
         self.policy.check_bind(addr)
     }
 
@@ -135,16 +155,8 @@ impl HostNetwork {
         self.policy.check_connect(addr)
     }
 
-    pub(crate) fn check_dns(&self, host: &OsStr) -> AsyncHostResult<()> {
+    fn check_dns(&self, host: &OsStr) -> AsyncHostResult<()> {
         self.policy.check_dns(host)
-    }
-
-    pub(crate) fn register_dns_result(
-        &self,
-        host: &OsStr,
-        addrs: &[Box<[u8]>],
-    ) -> AsyncHostResult<()> {
-        self.policy.register_dns_result(host, addrs)
     }
 }
 
@@ -340,5 +352,28 @@ mod tests {
         drop(socket);
         #[cfg(windows)]
         assert_eq!(crate::async_sys::internal::event_loop::io::cleanup_wsa(), 0);
+    }
+
+    #[test]
+    fn job_preparation_checks_network_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy_file = dir.path().join("deny-all.toml");
+        std::fs::write(&policy_file, "").unwrap();
+        let network = HostNetwork::new(Arc::new(Policy::from_file(&policy_file).unwrap()));
+        let mut addr = vec![0; usize::try_from(sys::ipv4_addr_size()).unwrap()];
+        sys::init_ip_addr(&mut addr, 0x7f000001, 1234).unwrap();
+
+        assert_eq!(
+            network
+                .make_bind_job(Arc::new(Resource::invalid()), addr)
+                .unwrap_err(),
+            AsyncHostError::PermissionDenied
+        );
+        assert_eq!(
+            network
+                .make_getaddrinfo_job(OsString::from("localhost"))
+                .unwrap_err(),
+            AsyncHostError::PermissionDenied
+        );
     }
 }


### PR DESCRIPTION
## Why

Network Job state and execution currently live inside the shared thread-pool implementation. That makes the scheduler responsible for network semantics and obscures the intended split: domain modules own operations, while the thread pool owns worker organization and completion delivery.

## What changed

- add an opaque `network::Job` for bind and address-resolution payloads, execution, and results
- make Host Network perform policy-aware Job preparation and DNS-result registration
- reduce the thread pool to wrapping and delegating Network Jobs through its existing Job envelope
- keep import provenance separate from opt-in tracking of native-shaped host implementations, so Job constructors and thin worker adapters do not require implementation symbols

## Why this is correct

Network Jobs still execute the same socket bind and address-resolution implementations. Policy denial still becomes a failed asynchronous Job, acquired socket ownership is unchanged, and DNS results are registered before being exposed as address-info Handles.

## Why this is minimal

This moves only the two existing Network Jobs. It does not change guest ABI, worker scheduling, completion delivery, cancellation, filesystem Jobs, SQLite execution, or any runtime execution strategy.
