### PR TITLE
fix: remove test driver template deprecations

### DIFF
--- a/crates/moonbuild/template/test_driver_project/common.mbt
+++ b/crates/moonbuild/template/test_driver_project/common.mbt
@@ -39,7 +39,7 @@ fn MoonBitTestDriverInternalOsString::to_string(
   self : MoonBitTestDriverInternalOsString,
 ) -> String {
   let bytes = self.0
-  let res = @moonbitlang/core/prelude.StringBuilder::new()
+  let res = @moonbitlang/core/prelude.StringBuilder()
   let len = bytes.length()
   let mut i = 0
   while i < len {

--- a/crates/moonbuild/template/test_driver_project/entry.mbt
+++ b/crates/moonbuild/template/test_driver_project/entry.mbt
@@ -27,7 +27,7 @@ fn main {
 
 ///|
 #cfg(target="js")
-extern "js" fn moonbit_test_driver_js_parse_args() -> Array[
+extern "js" fn moonbit_test_driver_js_parse_args() -> FixedArray[
   MoonBitTestDriverInternalTestEntry,
 ] =
   #|() => {
@@ -57,7 +57,7 @@ extern "js" fn moonbit_test_driver_js_parse_args() -> Array[
 /// Executes selected JavaScript tests from parsed test entries.
 #cfg(target="js")
 pub fn moonbit_test_driver_internal_execute(
-  tests : Array[MoonBitTestDriverInternalTestEntry],
+  tests : FixedArray[MoonBitTestDriverInternalTestEntry],
 ) -> Unit {
   let async_tests = []
   for i in 0..<tests.length() {


### PR DESCRIPTION
## Why

The test driver template emitted deprecation warnings with the current MoonBit toolchain.

## What changed

Replace deprecated `StringBuilder` construction and use `FixedArray` for the JavaScript FFI boundary.

## Why this is correct

Both changes follow the toolchain diagnostics directly, and the `FixedArray` type is propagated to its sole JavaScript consumer.

## Scope

The change is limited to the two deprecated template constructs.