### PR TITLE
fix(moonrun): report blocked process spawns

### DIFF
--- a/crates/moonrun/src/policy/fs.rs
+++ b/crates/moonrun/src/policy/fs.rs
@@ -23,7 +23,7 @@ use anyhow::Context;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 
-use super::config::FsConfig;
+use super::{config::FsConfig, sandbox_denied};
 
 /// Restricts async filesystem operations to native host roots.
 ///
@@ -76,7 +76,7 @@ impl FsPolicy {
         {
             Ok(path) => path,
             Err(AsyncHostError::PermissionDenied) => {
-                return sandbox_denied(intents.sandbox_action(), &target);
+                return sandbox_denied(intents.sandbox_action(), Some(&target));
             }
             Err(error) => return Err(error),
         };
@@ -97,7 +97,7 @@ impl FsPolicy {
         {
             Ok(path) => path,
             Err(AsyncHostError::PermissionDenied) => {
-                return sandbox_denied(intents.sandbox_action(), &target);
+                return sandbox_denied(intents.sandbox_action(), Some(&target));
             }
             Err(error) => return Err(error),
         };
@@ -112,10 +112,10 @@ impl FsPolicy {
         target: &str,
     ) -> AsyncHostResult<()> {
         if intents.read && !self.allows_read(path) {
-            return sandbox_denied("file read", target);
+            return sandbox_denied("file read", Some(target));
         }
         if intents.write && !self.allows_write(path) {
-            return sandbox_denied("file write", target);
+            return sandbox_denied("file write", Some(target));
         }
         Ok(())
     }
@@ -261,11 +261,6 @@ fn normalize_path(path: PathBuf) -> PathBuf {
         }
     }
     normalized
-}
-
-fn sandbox_denied(action: &str, target: &str) -> AsyncHostResult<()> {
-    eprintln!("Sandbox policy blocked {action}: {target}");
-    Err(AsyncHostError::PermissionDenied)
 }
 
 fn sandbox_path_target(base: RuntimePathBase<'_>, path: &OsStr) -> String {

--- a/crates/moonrun/src/policy/mod.rs
+++ b/crates/moonrun/src/policy/mod.rs
@@ -30,7 +30,7 @@ mod process;
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
 
-use crate::async_host::AsyncHostResult;
+use crate::async_host::{AsyncHostError, AsyncHostResult};
 
 use self::config::PolicyConfig;
 use self::env::EnvPolicy;
@@ -45,6 +45,15 @@ pub(crate) struct Policy {
     net: Option<NetPolicy>,
     env: Option<EnvPolicy>,
     process: Option<ProcessPolicy>,
+}
+
+fn sandbox_denied(action: &str, target: Option<&str>) -> AsyncHostResult<()> {
+    if let Some(target) = target {
+        eprintln!("Sandbox policy blocked {action}: {target}");
+    } else {
+        eprintln!("Sandbox policy blocked {action}");
+    }
+    Err(AsyncHostError::PermissionDenied)
 }
 
 impl Policy {

--- a/crates/moonrun/src/policy/net.rs
+++ b/crates/moonrun/src/policy/net.rs
@@ -24,7 +24,7 @@ use anyhow::Context;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 
-use super::config::NetConfig;
+use super::{config::NetConfig, sandbox_denied};
 
 #[derive(Clone, Debug)]
 pub(super) struct NetPolicy {
@@ -112,7 +112,7 @@ impl NetPolicy {
         {
             Ok(())
         } else {
-            sandbox_denied("DNS lookup", &target)
+            sandbox_denied("DNS lookup", Some(&target))
         }
     }
 
@@ -159,7 +159,7 @@ impl NetPolicy {
         {
             Ok(())
         } else {
-            sandbox_denied(operation.sandbox_action(), &target)
+            sandbox_denied(operation.sandbox_action(), Some(&target))
         }
     }
 }
@@ -288,11 +288,6 @@ fn split_host_port(value: &str) -> anyhow::Result<(&str, &str)> {
 
 fn normalize_dns_name(name: &str) -> String {
     name.trim().trim_end_matches('.').to_ascii_lowercase()
-}
-
-fn sandbox_denied(action: &str, target: &str) -> AsyncHostResult<()> {
-    eprintln!("Sandbox policy blocked {action}: {target}");
-    Err(AsyncHostError::PermissionDenied)
 }
 
 fn quote_os_str(value: &OsStr) -> String {

--- a/crates/moonrun/src/policy/process.rs
+++ b/crates/moonrun/src/policy/process.rs
@@ -22,9 +22,12 @@ use std::ffi::OsString;
 
 use anyhow::{bail, ensure};
 
-use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::async_host::AsyncHostResult;
 
-use super::config::{ProcessConfig, ProcessRuleConfig};
+use super::{
+    config::{ProcessConfig, ProcessRuleConfig},
+    sandbox_denied,
+};
 
 #[derive(Clone, Debug)]
 pub(super) enum ProcessPolicy {
@@ -70,7 +73,7 @@ impl ProcessPolicy {
             Self::Scoped(rules) if rules.iter().any(|rule| rule.matches_unix(program, argv)) => {
                 Ok(())
             }
-            Self::Scoped(_) => Err(AsyncHostError::PermissionDenied),
+            Self::Scoped(_) => sandbox_denied("process spawn", None),
         }
     }
 
@@ -90,7 +93,7 @@ impl ProcessPolicy {
                 }) {
                     Ok(())
                 } else {
-                    Err(AsyncHostError::PermissionDenied)
+                    sandbox_denied("process spawn", None)
                 }
             }
         }
@@ -205,6 +208,8 @@ fn matches_windows_command_line_prefix(command_line: &[u16], prefix: &[u16]) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use crate::async_host::AsyncHostError;
 
     #[cfg(unix)]
     fn scoped_rule(program: &str, args_prefix: &[&str]) -> ProcessPolicy {

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -1060,7 +1060,8 @@ OSError("[..]@fs.open()[..]denied/secret.txt[..]Access is denied.")
         .arg(&process_env_wasm)
         .assert()
         .success()
-        .stdout_eq("spawn denied\n");
+        .stdout_eq("spawn denied\n")
+        .stderr_eq("Sandbox policy blocked process spawn\n");
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .current_dir(dir.path())
@@ -1083,7 +1084,8 @@ Sandbox policy blocked network bind: "0.0.0.0:0"
         .arg(&process_env_wasm)
         .assert()
         .success()
-        .stdout_eq("spawn denied\n");
+        .stdout_eq("spawn denied\n")
+        .stderr_eq("Sandbox policy blocked process spawn\n");
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .current_dir(dir.path())


### PR DESCRIPTION
## Why

Moonrun reports filesystem and network policy denials to stderr, but a rejected process spawn surfaced only as `EACCES`. That made it difficult to distinguish a Moonrun Policy decision from an operating-system spawn failure.

## What changed

- Report `Sandbox policy blocked process spawn` when process policy rejects a spawn on Unix or Windows.
- Keep command arguments out of the diagnostic so rejected commands do not leak potentially sensitive values.
- Consolidate filesystem, network, and process denial reporting in the policy module.
- Cover both scoped-rule mismatches and deny-by-default process policy.

## Why this is correct and minimal

The diagnostic is emitted only from the process policy rejection branches. The guest-visible `PermissionDenied` result is unchanged, and native spawn failures remain untouched. The shared reporter preserves the existing filesystem and network messages while avoiding a third copy of the reporting logic.