### PR TITLE
refactor(moonrun): move filesystem jobs into filesystem

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -5,7 +5,11 @@ Moonrun executes MoonBit wasm programs and provides host services that wasm code
 ## Language
 
 **Job**:
-A host operation requested by guest code whose result is observed later by the guest coroutine.
+A host operation requested by guest code whose result is observed later by the
+guest coroutine. Its `err` field carries host or system errors handled uniformly
+by the MoonBit worker loop. When `err` is zero, its `ret` field is defined by the
+operation and may be a value, a success sentinel, or a domain-specific status;
+structured results and domain-specific diagnostics remain in its payload.
 _Avoid_: Task, request
 
 **Worker**:
@@ -57,10 +61,12 @@ other.
 _Avoid_: Moonrun Policy, FFI permissions
 
 **Host Filesystem**:
-The runtime-engine-neutral implementation of moonrun's permission-backed
-filesystem imports. It owns authorization, host filesystem operations, and
-guest-visible error semantics; runtime adapters only convert values and expose
-imports. WASI does not pass through the Host Filesystem.
+The per-Run, runtime-engine-neutral implementation of moonrun's
+permission-backed filesystem operations. It owns filesystem authorization,
+Filesystem Job payloads, execution, and result interpretation. Runtime adapters
+only convert values and expose imports; the thread pool only schedules
+Filesystem Jobs and delivers their Completions. WASI does not pass through the
+Host Filesystem.
 _Avoid_: WASI filesystem, V8 filesystem
 
 **Host Network**:
@@ -162,8 +168,18 @@ The engine-neutral SQLite implementation for one run. It owns SQLite policy and 
 _Avoid_: SQLite API, Async Host, V8 SQLite
 
 **Async Sys**:
-The V8-free native-stub port layer. Implemented files follow the `moonbitlang/async` source layout and carry provenance for the native source path and symbol they track. Poller files are direct ports behind the wasm `poll/*` imports.
+The V8-free native-stub port layer. Ports carry provenance for the native source
+path and symbol they track. Reusable operating-system operations remain here;
+Job implementations live with their owning domain. Poller files are direct
+ports behind the wasm `poll/*` imports.
 _Avoid_: V8 adapter, placeholder unsupported imports
+
+**Thread Pool**:
+The shared host facility that schedules Jobs outside the guest coroutine loop.
+It owns the common Job result envelope, Workers, and Completion delivery. It
+does not interpret Filesystem or Network Job semantics, which remain in their
+owning domain modules.
+_Avoid_: Filesystem executor, Network executor, SQLite executor
 
 **Host Poller**:
 The `async_sys::internal::event_loop::poll` port of native epoll, kqueue, or IOCP. The wasm event loop owns opaque `Instance` handles and calls `poll/wait`, `poll/event_fd`, and `poll/event_events`. Resource registrations store their Resource Handle directly in the poller's opaque user-data field. The event accessor returns the native field unchanged, including platform-specific non-Resource values; later Resource operations—not the accessor—validate any returned Handle.

--- a/crates/moonrun/docs/dev/async-upstream-porting.md
+++ b/crates/moonrun/docs/dev/async-upstream-porting.md
@@ -110,6 +110,15 @@ currently pinned wasm wrapper still calls it during a staged migration.
 The annotations must continue to expose unported upstream work. A passing
 substring check is not proof that two symbols are equivalent.
 
+Do not record a thread-pool adapter as a ported implementation merely because
+upstream submits an operation to its thread pool. Job construction and domain
+payload and result adapters are not separate implementations to track. Record
+provenance on the domain implementation that performs the operation, retaining
+its actual upstream source path even when upstream currently places that worker
+in `thread_pool.c`. Within the thread-pool module, record implementation
+provenance only for the thread pool itself, such as worker scheduling,
+cancellation, and completion delivery.
+
 ## Wasm ABI discipline
 
 Treat every wasm import as an exact typed interface. The current V8 adapter

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -18,12 +18,18 @@
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::event_loop::thread_pool;
+use crate::filesystem::Job as FilesystemJob;
 use crate::guest_memory::GuestMemory;
 use crate::resource::{ResourceClass, ResourceRef};
 
 use super::context::ImportContext;
 use super::os_string::read_guest as read_guest_os_string;
 use super::provenance::ported_imports;
+
+fn filesystem_job_or_failed(job: AsyncHostResult<FilesystemJob>) -> thread_pool::Job {
+    job.map(Into::into)
+        .unwrap_or_else(|error| thread_pool::make_failed_job(error.errno()))
+}
 
 ported_imports! {
 pub(super) fn free_job(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<()> {
@@ -119,7 +125,8 @@ pub(super) fn make_sleep_job(
     source = "src/internal/event_loop/thread_pool.c",
     original = "moonbitlang_async_make_open_job",
     upstream_pr = 527,
-    replacement = "thread_pool/make_open_stat_job"
+    replacement = "thread_pool/make_open_stat_job",
+    api_only = true
 )]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn make_open_job_legacy(
@@ -134,14 +141,9 @@ pub(super) fn make_open_job_legacy(
 ) -> AsyncHostResult<u64> {
     let filename = read_guest_os_string(context, path_ptr, path_len)?;
 
-    context.host.insert_job(thread_pool::make_open_job(
-        filename,
-        access,
-        create_mode,
-        append != 0,
-        sync,
-        mode,
-    ))
+    context.host.insert_job(
+        FilesystemJob::open_legacy(filename, access, create_mode, append != 0, sync, mode),
+    )
 }
 
 // Unlike the native ABI, the wasm maker does not receive the eventual output
@@ -165,7 +167,7 @@ pub(super) fn make_open_stat_job(
     stat_result_len: u32,
 ) -> AsyncHostResult<u64> {
     let filename = read_guest_os_string(context, path_ptr, path_len)?;
-    context.host.insert_job(thread_pool::make_open_stat_job(
+    context.host.insert_job(filesystem_job_or_failed(FilesystemJob::open(
         filename,
         access,
         create_mode,
@@ -174,7 +176,7 @@ pub(super) fn make_open_stat_job(
         mode,
         stat_request as u32,
         stat_result_len,
-    ))
+    )))
 }
 
 #[ported(
@@ -188,11 +190,13 @@ pub(super) fn make_fstatx_job(
     stat_result_len: u32,
 ) -> AsyncHostResult<u64> {
     let file = context.host.acquire_resource(fd)?;
-    context.host.insert_job(thread_pool::make_fstatx_job(
-        file,
-        stat_request as u32,
-        stat_result_len,
-    ))
+    context
+        .host
+        .insert_job(filesystem_job_or_failed(FilesystemJob::fstatx(
+            file,
+            stat_request as u32,
+            stat_result_len,
+        )))
 }
 
 #[ported(
@@ -219,13 +223,15 @@ pub(super) fn make_statx_job(
         )
     };
     let path = read_guest_os_string(context, path_ptr, path_len)?;
-    context.host.insert_job(thread_pool::make_statx_job(
-        parent,
-        path,
-        stat_request as u32,
-        stat_result_len,
-        follow_symlink != 0,
-    ))
+    context
+        .host
+        .insert_job(filesystem_job_or_failed(FilesystemJob::statx(
+            parent,
+            path,
+            stat_request as u32,
+            stat_result_len,
+            follow_symlink != 0,
+        )))
 }
 
 pub(super) fn get_stat_result(
@@ -249,8 +255,9 @@ pub(super) fn make_read_job(
     let file = context
         .host
         .acquire_resource_of_class(fd, ResourceClass::File)?;
-    context.host
-        .insert_job(thread_pool::make_read_job(file, len, position))
+    context
+        .host
+        .insert_job(FilesystemJob::read(file, len, position))
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
@@ -268,8 +275,9 @@ pub(super) fn make_write_job(
     let ptr = ptr.checked_add(offset).ok_or(AsyncHostError::Fault)?;
     let data = context.with_memory_mut(|memory| Ok(memory.read_exact(ptr, len)?.to_vec()))?;
 
-    context.host
-        .insert_job(thread_pool::make_write_job(file, data, position))
+    context
+        .host
+        .insert_job(FilesystemJob::write(file, data, position))
 }
 
 pub(super) fn get_read_result(
@@ -288,7 +296,8 @@ pub(super) fn get_read_result(
     source = "src/internal/event_loop/thread_pool.c",
     original = "moonbitlang_async_make_file_kind_by_path_job",
     upstream_pr = 527,
-    replacement = "thread_pool/make_statx_job with STAT_FILE_KIND"
+    replacement = "thread_pool/make_statx_job with STAT_FILE_KIND",
+    api_only = true
 )]
 pub(super) fn make_file_kind_by_path_job(
     context: &mut ImportContext<'_, '_>,
@@ -308,32 +317,31 @@ pub(super) fn make_file_kind_by_path_job(
     };
     let path = read_guest_os_string(context, path_ptr, path_len)?;
 
-    context.host
-        .insert_job(thread_pool::make_file_kind_by_path_job(
-            parent,
-            path,
-            follow_symlink != 0,
-        ))
+    context.host.insert_job(
+        FilesystemJob::file_kind_by_path(parent, path, follow_symlink != 0),
+    )
 }
 
 #[compat(
     source = "src/internal/event_loop/thread_pool.c",
     original = "moonbitlang_async_make_file_size_job",
     upstream_pr = 527,
-    replacement = "thread_pool/make_fstatx_job with STAT_FILE_SIZE"
+    replacement = "thread_pool/make_fstatx_job with STAT_FILE_SIZE",
+    api_only = true
 )]
 pub(super) fn make_file_size_job(context: &mut ImportContext<'_, '_>, fd: u64) -> AsyncHostResult<u64> {
     let file = context
         .host
         .acquire_resource_of_class(fd, ResourceClass::File)?;
-    context.host.insert_job(thread_pool::make_file_size_job(file))
+    context.host.insert_job(FilesystemJob::file_size(file))
 }
 
 #[compat(
     source = "src/internal/event_loop/thread_pool.c",
     original = "moonbitlang_async_get_file_size_result",
     upstream_pr = 527,
-    replacement = "thread_pool/get_stat_result"
+    replacement = "thread_pool/get_stat_result",
+    api_only = true
 )]
 pub(super) fn get_file_size_result(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<i64> {
     context.host.get_file_size_result(job)
@@ -343,7 +351,8 @@ pub(super) fn get_file_size_result(context: &mut ImportContext<'_, '_>, job: u64
     source = "src/internal/event_loop/thread_pool.c",
     original = "moonbitlang_async_make_file_time_job",
     upstream_pr = 527,
-    replacement = "thread_pool/make_fstatx_job with timestamp properties"
+    replacement = "thread_pool/make_fstatx_job with timestamp properties",
+    api_only = true
 )]
 pub(super) fn make_file_time_job(
     context: &mut ImportContext<'_, '_>,
@@ -352,15 +361,15 @@ pub(super) fn make_file_time_job(
     let file = context
         .host
         .acquire_resource_of_class(fd, ResourceClass::File)?;
-    context.host
-        .insert_job(thread_pool::make_file_time_job(file))
+    context.host.insert_job(FilesystemJob::file_time(file))
 }
 
 #[compat(
     source = "src/internal/event_loop/thread_pool.c",
     original = "moonbitlang_async_make_file_time_by_path_job",
     upstream_pr = 527,
-    replacement = "thread_pool/make_statx_job with timestamp properties"
+    replacement = "thread_pool/make_statx_job with timestamp properties",
+    api_only = true
 )]
 pub(super) fn make_file_time_by_path_job(
     context: &mut ImportContext<'_, '_>,
@@ -370,11 +379,9 @@ pub(super) fn make_file_time_by_path_job(
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
 
-    context.host
-        .insert_job(thread_pool::make_file_time_by_path_job(
-            path,
-            follow_symlink != 0,
-        ))
+    context.host.insert_job(
+        FilesystemJob::file_time_by_path(path, follow_symlink != 0),
+    )
 }
 
 pub(super) fn get_file_time_result(
@@ -396,8 +403,9 @@ pub(super) fn make_access_job(
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
 
-    context.host
-        .insert_job(thread_pool::make_access_job(path, access))
+    context
+        .host
+        .insert_job(FilesystemJob::access(path, access))
 }
 
 #[ported(source = "src/internal/event_loop/fs.c")]
@@ -409,8 +417,9 @@ pub(super) fn make_chmod_job(
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
 
-    context.host
-        .insert_job(thread_pool::make_chmod_job(path, mode))
+    context
+        .host
+        .insert_job(FilesystemJob::chmod(path, mode))
 }
 
 #[ported(source = "src/internal/event_loop/fs.c")]
@@ -422,8 +431,9 @@ pub(super) fn make_fsync_job(
     let file = context
         .host
         .acquire_resource_of_class(fd, ResourceClass::File)?;
-    context.host
-        .insert_job(thread_pool::make_fsync_job(file, only_data != 0))
+    context
+        .host
+        .insert_job(FilesystemJob::fsync(file, only_data != 0))
 }
 
 #[ported(source = "src/internal/event_loop/fs.c")]
@@ -435,8 +445,9 @@ pub(super) fn make_flock_job(
     let file = context
         .host
         .acquire_resource_of_class(fd, ResourceClass::File)?;
-    context.host
-        .insert_job(thread_pool::make_flock_job(file, exclusive != 0))
+    context
+        .host
+        .insert_job(FilesystemJob::flock(file, exclusive != 0))
 }
 
 #[ported(source = "src/internal/event_loop/fs.c")]
@@ -446,7 +457,7 @@ pub(super) fn make_remove_job(
     path_len: u32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
-    context.host.insert_job(thread_pool::make_remove_job(path))
+    context.host.insert_job(FilesystemJob::remove(path))
 }
 
 #[ported(source = "src/internal/event_loop/fs.c")]
@@ -461,11 +472,9 @@ pub(super) fn make_rename_job(
     let old_path = read_guest_os_string(context, old_path_ptr, old_path_len)?;
     let new_path = read_guest_os_string(context, new_path_ptr, new_path_len)?;
 
-    context.host.insert_job(thread_pool::make_rename_job(
-        old_path,
-        new_path,
-        replace != 0,
-    ))
+    context
+        .host
+        .insert_job(FilesystemJob::rename(old_path, new_path, replace != 0))
 }
 
 #[ported(source = "src/internal/event_loop/fs.c")]
@@ -480,11 +489,9 @@ pub(super) fn make_symlink_job(
     let target = read_guest_os_string(context, target_ptr, target_len)?;
     let path = read_guest_os_string(context, path_ptr, path_len)?;
 
-    context.host.insert_job(thread_pool::make_symlink_job(
-        target,
-        path,
-        force_symlink != 0,
-    ))
+    context.host.insert_job(
+        FilesystemJob::symlink(target, path, force_symlink != 0),
+    )
 }
 
 #[ported(source = "src/internal/event_loop/fs.c")]
@@ -496,8 +503,9 @@ pub(super) fn make_mkdir_job(
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
 
-    context.host
-        .insert_job(thread_pool::make_mkdir_job(path, mode))
+    context
+        .host
+        .insert_job(FilesystemJob::mkdir(path, mode))
 }
 
 #[ported(source = "src/internal/event_loop/fs.c")]
@@ -507,7 +515,7 @@ pub(super) fn make_rmdir_job(
     path_len: u32,
 ) -> AsyncHostResult<u64> {
     let path = read_guest_os_string(context, path_ptr, path_len)?;
-    context.host.insert_job(thread_pool::make_rmdir_job(path))
+    context.host.insert_job(FilesystemJob::rmdir(path))
 }
 
 #[ported(source = "src/internal/event_loop/fs.c")]
@@ -522,13 +530,9 @@ pub(super) fn make_readdir_job(
         .host
         .acquire_resource_of_class(dir, ResourceClass::File)?;
     let buffer = context.host.lease_c_buffer(buf)?;
-    context.host
-        .insert_job(thread_pool::make_readdir_job(
-            dir,
-            buffer,
-            len,
-            restart != 0,
-        ))
+    context.host.insert_job(
+        FilesystemJob::readdir(dir, buffer, len, restart != 0),
+    )
 }
 
 #[ported(
@@ -547,13 +551,9 @@ pub(super) fn make_inotify_add_watch_job(
         .host
         .acquire_resource_of_class(inotify, ResourceClass::File)?;
     let path = read_guest_os_string(context, path_ptr, path_len)?;
-    context
-        .host
-        .insert_job(thread_pool::make_inotify_add_watch_job(
-            inotify,
-            path,
-            is_dir != 0,
-        ))
+    context.host.insert_job(
+        FilesystemJob::inotify_add_watch(inotify, path, is_dir != 0),
+    )
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]
@@ -881,7 +881,7 @@ pub(super) fn make_realpath_job(
     let path = read_guest_os_string(context, path_ptr, path_len)?;
     context
         .host
-        .insert_job(thread_pool::make_realpath_job(path))
+        .insert_job(FilesystemJob::realpath(path))
 }
 
 #[ported(source = "src/internal/event_loop/fs.c")]
@@ -901,7 +901,8 @@ pub(super) fn open_job_get_fd(context: &mut ImportContext<'_, '_>, job: u64) -> 
     source = "src/internal/event_loop/thread_pool.c",
     original = "moonbitlang_async_open_job_get_kind",
     upstream_pr = 527,
-    replacement = "thread_pool/get_stat_result with STAT_FILE_KIND"
+    replacement = "thread_pool/get_stat_result with STAT_FILE_KIND",
+    api_only = true
 )]
 pub(super) fn open_job_get_kind(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<i32> {
     context.host.open_job_get_kind(job)
@@ -911,7 +912,8 @@ pub(super) fn open_job_get_kind(context: &mut ImportContext<'_, '_>, job: u64) -
     source = "src/internal/event_loop/thread_pool.c",
     original = "moonbitlang_async_open_job_get_dev_id",
     upstream_pr = 527,
-    replacement = "thread_pool/get_stat_result with STAT_DEVICE_ID"
+    replacement = "thread_pool/get_stat_result with STAT_DEVICE_ID",
+    api_only = true
 )]
 pub(super) fn open_job_get_dev_id(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_dev_id(job)
@@ -921,7 +923,8 @@ pub(super) fn open_job_get_dev_id(context: &mut ImportContext<'_, '_>, job: u64)
     source = "src/internal/event_loop/thread_pool.c",
     original = "moonbitlang_async_open_job_get_file_id",
     upstream_pr = 527,
-    replacement = "thread_pool/get_stat_result with STAT_FILE_ID"
+    replacement = "thread_pool/get_stat_result with STAT_FILE_ID",
+    api_only = true
 )]
 pub(super) fn open_job_get_file_id(context: &mut ImportContext<'_, '_>, job: u64) -> AsyncHostResult<u64> {
     context.host.open_job_get_file_id(job)

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -4023,8 +4023,12 @@ impl AsyncHost {
         let key = self.handles.borrow().job(handle)?;
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
+        let job_error = job.err();
+        if job_error != 0 {
+            return Ok(());
+        }
         let filesystem_job = job.filesystem()?;
-        filesystem_job.copy_stat_result(job.err(), memory, dst, dst_len)
+        filesystem_job.copy_stat_result(job_error, memory, dst, dst_len)
     }
 
     pub(crate) fn get_realpath_result(&self, handle: u64) -> AsyncHostResult<u64> {
@@ -5365,6 +5369,23 @@ mod tests {
             .unwrap();
 
         assert_eq!(&memory[8..11], b"abc");
+    }
+
+    #[test]
+    fn failed_stat_job_does_not_require_a_filesystem_payload() {
+        let host = AsyncHost::default();
+        let error = AsyncHostError::Inval.errno();
+        let job = host
+            .insert_job(thread_pool::make_failed_job(error))
+            .unwrap();
+        let mut memory = [0xaa; 8];
+
+        host.run_job(job).unwrap();
+        assert_eq!(host.job_get_err(job).unwrap(), error);
+        host.get_stat_result(memory.as_mut_slice(), job, 0, 8)
+            .unwrap();
+
+        assert_eq!(memory, [0xaa; 8]);
     }
 
     #[test]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -44,8 +44,7 @@ use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 use crate::async_sys::internal::event_loop::{
     poll::{self, PollInstance},
     thread_pool::{
-        self, HostHandle, HostWorkerJob, Job, JobPayload, OpenJobResource, ResourceTable,
-        WorkerCompletionId,
+        self, HostHandle, HostWorkerJob, Job, JobPayload, ResourceTable, WorkerCompletionId,
     },
 };
 use crate::async_sys::internal::fd_util::stub::RawFd;
@@ -55,7 +54,7 @@ pub(crate) use crate::host::HostKey as HandleKey;
 use crate::host::{HostKeys, HostResourceKind as HandleKind};
 use crate::network::HostNetwork;
 use crate::policy::{Policy, RuntimePathBase};
-use crate::resource::{Resource, ResourceClass, ResourceRef};
+use crate::resource::{Resource, ResourceClass, ResourcePublication, ResourceRef};
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 compile_error!("moonrun async wasm host currently supports only Linux, macOS, and Windows hosts");
@@ -1340,10 +1339,10 @@ impl AsyncHost {
     }
 
     fn restore_c_buffer_lease(&self, job: &mut Job) {
-        let JobPayload::Readdir { buffer, .. } = job.payload_mut() else {
+        let Ok(job) = job.filesystem_mut() else {
             return;
         };
-        let Some(buffer) = buffer.take() else {
+        let Some(buffer) = job.take_c_buffer_lease() else {
             return;
         };
         self.restore_c_buffer(buffer);
@@ -1378,11 +1377,11 @@ impl AsyncHost {
         let unclaimed = match job.payload() {
             #[cfg(unix)]
             JobPayload::SpawnUnix { result, .. } => {
-                !matches!(result, Some(OpenJobResource::Published(_)))
+                !matches!(result, Some(ResourcePublication::Published(_)))
             }
             #[cfg(windows)]
             JobPayload::SpawnWindows { result, .. } => {
-                !matches!(result, Some(OpenJobResource::Published(_)))
+                !matches!(result, Some(ResourcePublication::Published(_)))
             }
             _ => false,
         };
@@ -1401,24 +1400,24 @@ impl AsyncHost {
 
     fn publish_open_job_result(&self, key: HandleKey) -> AsyncHostResult<HostHandle> {
         let mut jobs = self.jobs.borrow_mut();
-        let placeholder = OpenJobResource::Published(self.invalid_fd());
+        let placeholder = ResourcePublication::Published(self.invalid_fd());
         let file = {
             let job = jobs.visible_job_mut(key)?;
-            let result = thread_pool::open_job_result_mut(job)?;
+            let result = job.filesystem_mut()?.open_result_mut()?;
             match std::mem::replace(&mut result.resource, placeholder) {
-                OpenJobResource::Published(fd) => {
-                    result.resource = OpenJobResource::Published(fd);
+                ResourcePublication::Published(fd) => {
+                    result.resource = ResourcePublication::Published(fd);
                     return Ok(fd);
                 }
-                OpenJobResource::Unpublished(file) => file,
+                ResourcePublication::Unpublished(file) => file,
             }
         };
 
         let fd = self.handles.borrow_mut().insert_resource(file);
         let job = jobs.visible_job_mut(key)?;
-        let result = thread_pool::open_job_result_mut(job)?;
-        result.resource = OpenJobResource::Published(fd);
-        thread_pool::open_job_get_fd(result)
+        let result = job.filesystem_mut()?.open_result_mut()?;
+        result.resource = ResourcePublication::Published(fd);
+        result.published_resource_handle()
     }
 
     /// Describe live async payloads without inspecting another domain's keys.
@@ -2334,9 +2333,9 @@ impl AsyncHost {
         self.handles.borrow().process_env(handle)
     }
 
-    pub(crate) fn insert_job(&self, job: Job) -> AsyncHostResult<u64> {
+    pub(crate) fn insert_job(&self, job: impl Into<Job>) -> AsyncHostResult<u64> {
         let key = self.handles.borrow_mut().insert(HandleKind::Job);
-        self.jobs.borrow_mut().insert_job(key, job);
+        self.jobs.borrow_mut().insert_job(key, job.into());
         Ok(handle_from_key(key))
     }
 
@@ -2355,12 +2354,10 @@ impl AsyncHost {
         // Native realpath frees its resolved path from the job finalizer.
         // After get_realpath_result exposes that path as a host c_buffer,
         // freeing the job must also release the c_buffer slot.
-        if let thread_pool::JobPayload::Realpath {
-            result: Some(thread_pool::RealpathJobResult::Published(buffer_handle)),
-            ..
-        } = job.payload()
+        if let Ok(job) = job.filesystem()
+            && let Some(buffer_handle) = job.published_realpath_handle()
         {
-            let _ = self.free_c_buffer(*buffer_handle);
+            let _ = self.free_c_buffer(buffer_handle);
         }
         Ok(())
     }
@@ -2388,31 +2385,28 @@ impl AsyncHost {
         let key = self.handles.borrow().job(handle)?;
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
-        let result = thread_pool::open_job_result(job)?;
-        thread_pool::open_job_get_kind(result)
+        job.filesystem()?.open_result()?.file_kind()
     }
 
     pub(crate) fn open_job_get_dev_id(&self, handle: u64) -> AsyncHostResult<u64> {
         let key = self.handles.borrow().job(handle)?;
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
-        let result = thread_pool::open_job_result(job)?;
-        thread_pool::open_job_get_dev_id(result)
+        job.filesystem()?.open_result()?.device_id()
     }
 
     pub(crate) fn open_job_get_file_id(&self, handle: u64) -> AsyncHostResult<u64> {
         let key = self.handles.borrow().job(handle)?;
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
-        let result = thread_pool::open_job_result(job)?;
-        thread_pool::open_job_get_file_id(result)
+        job.filesystem()?.open_result()?.file_id()
     }
 
     pub(crate) fn get_file_size_result(&self, handle: u64) -> AsyncHostResult<i64> {
         let key = self.handles.borrow().job(handle)?;
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
-        crate::async_sys::internal::event_loop::thread_pool::get_file_size_result(job)
+        job.filesystem()?.file_size_result()
     }
 
     pub(crate) fn get_getaddrinfo_result(&self, handle: u64) -> AsyncHostResult<u64> {
@@ -2450,22 +2444,22 @@ impl AsyncHost {
         let job = jobs.visible_job_mut(key)?;
         let Some(result) = thread_pool::take_spawn_job_result(job)? else {
             let fd = self.invalid_fd();
-            thread_pool::set_spawn_job_result(job, OpenJobResource::Published(fd))?;
+            thread_pool::set_spawn_job_result(job, ResourcePublication::Published(fd))?;
             return Ok(fd);
         };
         let resource = match result {
-            OpenJobResource::Published(fd) => {
-                thread_pool::set_spawn_job_result(job, OpenJobResource::Published(fd))?;
+            ResourcePublication::Published(fd) => {
+                thread_pool::set_spawn_job_result(job, ResourcePublication::Published(fd))?;
                 return Ok(fd);
             }
-            OpenJobResource::Unpublished(resource) => resource,
+            ResourcePublication::Unpublished(resource) => resource,
         };
         let process_pid = self.process_policy_state.as_ref().map(|_| job.ret() as i32);
         let fd = self.handles.borrow_mut().insert_resource(resource);
         if let Some(pid) = process_pid {
             self.track_process_handle(fd, pid);
         }
-        thread_pool::set_spawn_job_result(job, OpenJobResource::Published(fd))?;
+        thread_pool::set_spawn_job_result(job, ResourcePublication::Published(fd))?;
         thread_pool::get_spawn_job_result_handle(job)
     }
 
@@ -3761,82 +3755,7 @@ impl AsyncHost {
         job: &Job,
     ) -> AsyncHostResult<()> {
         match job.payload() {
-            JobPayload::Open {
-                filename,
-                access,
-                create_mode,
-                append,
-                request,
-                ..
-            } => {
-                policy.open_path(
-                    RuntimePathBase::CurrentDirectory,
-                    filename,
-                    *access,
-                    *create_mode,
-                    *append,
-                )?;
-                if request.mask() & !thread_pool::STAT_OPEN_IDENTITY != 0 {
-                    policy.stat_path(RuntimePathBase::CurrentDirectory, filename)?;
-                }
-                Ok(())
-            }
-            JobPayload::Fstatx { file, .. } => {
-                Self::check_file_metadata_policy(policy, file.as_deref())
-            }
-            JobPayload::Statx {
-                parent,
-                path,
-                follow_symlink,
-                ..
-            } => Self::check_path_metadata_policy(
-                policy,
-                Self::resource_path_base(parent.as_deref()),
-                path,
-                *follow_symlink,
-            ),
-            JobPayload::FileKindByPath {
-                parent,
-                path,
-                follow_symlink,
-            } => Self::check_path_metadata_policy(
-                policy,
-                Self::resource_path_base(parent.as_deref()),
-                path,
-                *follow_symlink,
-            ),
-            JobPayload::FileSize { file, .. } | JobPayload::FileTime { file, .. } => {
-                Self::check_file_metadata_policy(policy, file.as_deref())
-            }
-            JobPayload::FileTimeByPath {
-                path,
-                follow_symlink,
-                ..
-            } => Self::check_path_metadata_policy(
-                policy,
-                RuntimePathBase::CurrentDirectory,
-                path,
-                *follow_symlink,
-            ),
-            JobPayload::Realpath { path, .. } => {
-                policy.stat_path(RuntimePathBase::CurrentDirectory, path)
-            }
-            #[cfg(target_os = "linux")]
-            JobPayload::InotifyAddWatch { path, .. } => {
-                policy.stat_path(RuntimePathBase::CurrentDirectory, path)
-            }
-            JobPayload::Access { path, access } => policy.access_path(path, *access),
-            JobPayload::Chmod { path, .. } => policy.chmod_path(path),
-            JobPayload::Flock { file, exclusive } => {
-                Self::check_file_lock_policy(policy, file.as_deref(), *exclusive)
-            }
-            JobPayload::Remove { path } => policy.remove_path(path),
-            JobPayload::Rename {
-                old_path, new_path, ..
-            } => policy.rename_path(old_path, new_path),
-            JobPayload::Symlink { path, .. } => policy.symlink_path(path),
-            JobPayload::Mkdir { path, .. } => policy.mkdir_path(path),
-            JobPayload::Rmdir { path } => policy.rmdir_path(path),
+            JobPayload::Filesystem(job) => job.check_policy(policy),
             #[cfg(unix)]
             JobPayload::SpawnUnix { path, args, .. } => {
                 policy.spawn_process_unix(path.as_os_str(), args)
@@ -3946,19 +3865,6 @@ impl AsyncHost {
         }
     }
 
-    fn check_path_metadata_policy(
-        policy: &Policy,
-        base: RuntimePathBase<'_>,
-        path: &std::ffi::OsStr,
-        follow_symlink: bool,
-    ) -> AsyncHostResult<()> {
-        if follow_symlink {
-            policy.stat_path(base, path)
-        } else {
-            policy.stat_entry_path(base, path)
-        }
-    }
-
     fn check_file_lock_policy(
         policy: &Policy,
         file: Option<&Resource>,
@@ -3976,16 +3882,6 @@ impl AsyncHost {
                 std::ffi::OsStr::new(""),
                 exclusive,
             ),
-        }
-    }
-
-    fn resource_path_base(parent: Option<&Resource>) -> RuntimePathBase<'_> {
-        match parent {
-            None => RuntimePathBase::CurrentDirectory,
-            Some(parent) => parent
-                .policy_path()
-                .map(RuntimePathBase::PolicyPath)
-                .unwrap_or(RuntimePathBase::Untracked),
         }
     }
 
@@ -4100,7 +3996,8 @@ impl AsyncHost {
         let key = self.handles.borrow().job(handle)?;
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
-        thread_pool::get_read_result(job, memory, dst, offset, len)
+        let filesystem_job = job.filesystem()?;
+        filesystem_job.copy_read_result(job.err(), memory, dst, offset, len)
     }
 
     pub(crate) fn get_file_time_result(
@@ -4112,7 +4009,8 @@ impl AsyncHost {
         let key = self.handles.borrow().job(handle)?;
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
-        thread_pool::get_file_time_result(job, memory, dst)
+        let filesystem_job = job.filesystem()?;
+        filesystem_job.copy_file_time_result(job.err(), memory, dst)
     }
 
     pub(crate) fn get_stat_result(
@@ -4125,7 +4023,8 @@ impl AsyncHost {
         let key = self.handles.borrow().job(handle)?;
         let jobs = self.jobs.borrow();
         let job = jobs.visible_job(key)?;
-        thread_pool::get_stat_result(job, memory, dst, dst_len)
+        let filesystem_job = job.filesystem()?;
+        filesystem_job.copy_stat_result(job.err(), memory, dst, dst_len)
     }
 
     pub(crate) fn get_realpath_result(&self, handle: u64) -> AsyncHostResult<u64> {
@@ -4134,7 +4033,8 @@ impl AsyncHost {
         let job = jobs.visible_job_mut(key)?;
         // Keep the mutable job borrow through publication so its ownership of
         // the resulting c_buffer changes atomically on the V8 thread.
-        thread_pool::publish_realpath_result(job, |buffer| {
+        let job = job.filesystem_mut()?;
+        job.publish_realpath_result(|buffer| {
             let buffer_key = self.handles.borrow_mut().insert(HandleKind::CBuffer);
             self.c_buffers
                 .borrow_mut()
@@ -4661,6 +4561,7 @@ mod tests {
     use std::ffi::OsString;
 
     use super::*;
+    use crate::filesystem::Job as FilesystemJob;
 
     #[repr(align(2))]
     struct AlignedBytes<const N: usize>([u8; N]);
@@ -5435,15 +5336,13 @@ mod tests {
         let host = AsyncHost::default();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
-        let job = thread_pool::make_read_job(Arc::new(Resource::invalid()), 3, -1);
+        let job = FilesystemJob::read(Arc::new(Resource::invalid()), 3, -1);
         let job_handle = host.insert_job(job).unwrap();
         {
             let mut jobs = host.jobs.borrow_mut();
             let job = jobs.visible_job_mut(job_key(&host, job_handle)).unwrap();
-            let thread_pool::JobPayload::Read { result, .. } = job.payload_mut() else {
-                panic!("expected read job");
-            };
-            *result = Some(b"abc".to_vec());
+            let job = job.filesystem_mut().unwrap();
+            job.set_read_result(b"abc".to_vec()).unwrap();
             host.thread_pool_completions
                 .borrow()
                 .notifier
@@ -5515,7 +5414,7 @@ mod tests {
             AsyncHostError::Badf
         );
 
-        let job = thread_pool::make_readdir_job(Arc::new(Resource::invalid()), lease, 4, false);
+        let job = FilesystemJob::readdir(Arc::new(Resource::invalid()), lease, 4, false);
         let job = host.insert_job(job).unwrap();
         host.run_job(job).unwrap();
 
@@ -5535,7 +5434,7 @@ mod tests {
         let host = AsyncHost::default();
         let handle = host.insert_c_buffer(b"abcd".to_vec().into_boxed_slice());
         let lease = host.lease_c_buffer(handle).unwrap();
-        let job = thread_pool::make_readdir_job(Arc::new(Resource::invalid()), lease, 4, false);
+        let job = FilesystemJob::readdir(Arc::new(Resource::invalid()), lease, 4, false);
         let job = host.insert_job(job).unwrap();
 
         host.free_job(job).unwrap();
@@ -5552,7 +5451,7 @@ mod tests {
         let host = AsyncHost::default();
         let handle = host.insert_c_buffer(b"abcd".to_vec().into_boxed_slice());
         let lease = host.lease_c_buffer(handle).unwrap();
-        let job = thread_pool::make_readdir_job(Arc::new(Resource::invalid()), lease, 4, false);
+        let job = FilesystemJob::readdir(Arc::new(Resource::invalid()), lease, 4, false);
         let job = host.insert_job(job).unwrap();
         let worker_job = host
             .take_worker_job(WorkerCompletionId::from_abi(1), job_key(&host, job))
@@ -5577,7 +5476,7 @@ mod tests {
         let host = AsyncHost::default();
         let handle = host.insert_c_buffer(b"old".to_vec().into_boxed_slice());
         let lease = host.lease_c_buffer(handle).unwrap();
-        let job = thread_pool::make_readdir_job(Arc::new(Resource::invalid()), lease, 3, false);
+        let job = FilesystemJob::readdir(Arc::new(Resource::invalid()), lease, 3, false);
         let job = host.insert_job(job).unwrap();
 
         host.free_c_buffer(handle).unwrap();
@@ -5600,19 +5499,16 @@ mod tests {
     fn realpath_result_is_registered_c_buffer_cleaned_up_with_job() {
         let host = AsyncHost::default();
         let job_handle = host
-            .insert_job(thread_pool::make_realpath_job(std::ffi::OsString::from(
+            .insert_job(FilesystemJob::realpath(std::ffi::OsString::from(
                 "/tmp/example",
             )))
             .unwrap();
         {
             let mut jobs = host.jobs.borrow_mut();
             let job = jobs.visible_job_mut(job_key(&host, job_handle)).unwrap();
-            let thread_pool::JobPayload::Realpath { result, .. } = job.payload_mut() else {
-                panic!("expected realpath job");
-            };
-            *result = Some(thread_pool::RealpathJobResult::Unpublished(
-                b"/tmp/example\0".to_vec().into_boxed_slice(),
-            ));
+            let job = job.filesystem_mut().unwrap();
+            job.set_realpath_result(b"/tmp/example\0".to_vec().into_boxed_slice())
+                .unwrap();
         }
 
         let buffer_handle = host.get_realpath_result(job_handle).unwrap();
@@ -5680,7 +5576,7 @@ mod tests {
         let path =
             std::env::temp_dir().join(format!("moonrun-published-open-job-{}", std::process::id()));
         let job = host
-            .insert_job(thread_pool::make_open_job(
+            .insert_job(FilesystemJob::open_legacy(
                 path.as_os_str().to_os_string(),
                 2,
                 3,
@@ -5720,7 +5616,7 @@ mod tests {
         std::fs::write(&policy_file, "[fs]\nread = [\"allowed\"]\n").unwrap();
         let host = host_with_policy(&policy_file);
         let job = host
-            .insert_job(thread_pool::make_open_job(
+            .insert_job(FilesystemJob::open_legacy(
                 denied_file.as_os_str().to_os_string(),
                 0,
                 0,
@@ -5753,7 +5649,7 @@ mod tests {
         std::fs::write(&policy_file, "[fs]\nread = [\"allowed\"]\n").unwrap();
         let host = host_with_policy(&policy_file);
         let job = host
-            .insert_job(thread_pool::make_realpath_job(
+            .insert_job(FilesystemJob::realpath(
                 denied_file.as_os_str().to_os_string(),
             ))
             .unwrap();
@@ -5783,7 +5679,7 @@ mod tests {
         let poll = host.poll_create().unwrap();
         let completion_source = host.init_thread_pool(poll).unwrap();
         let job = host
-            .insert_job(thread_pool::make_open_job(
+            .insert_job(FilesystemJob::open_legacy(
                 denied_file.as_os_str().to_os_string(),
                 0,
                 0,
@@ -5847,7 +5743,7 @@ mod tests {
             )
             .unwrap();
         let job = host
-            .insert_job(thread_pool::make_open_job(
+            .insert_job(FilesystemJob::open_legacy(
                 link.as_os_str().to_os_string(),
                 0,
                 0,
@@ -5887,12 +5783,12 @@ mod tests {
         std::fs::write(&policy_file, "[fs]\nwrite = [\"allowed\"]\n").unwrap();
         let host = host_with_policy(&policy_file);
         let remove_job = host
-            .insert_job(thread_pool::make_remove_job(
+            .insert_job(FilesystemJob::remove(
                 denied_link.as_os_str().to_os_string(),
             ))
             .unwrap();
         let rename_job = host
-            .insert_job(thread_pool::make_rename_job(
+            .insert_job(FilesystemJob::rename(
                 allowed_source.as_os_str().to_os_string(),
                 denied_link.as_os_str().to_os_string(),
                 true,
@@ -5938,14 +5834,14 @@ mod tests {
         std::fs::write(&policy_file, "[fs]\nread = [\"allowed\"]\n").unwrap();
         let host = host_with_policy(&policy_file);
         let kind_job = host
-            .insert_job(thread_pool::make_file_kind_by_path_job(
+            .insert_job(FilesystemJob::file_kind_by_path(
                 None,
                 denied_link.as_os_str().to_os_string(),
                 false,
             ))
             .unwrap();
         let time_job = host
-            .insert_job(thread_pool::make_file_time_by_path_job(
+            .insert_job(FilesystemJob::file_time_by_path(
                 denied_link.as_os_str().to_os_string(),
                 false,
             ))
@@ -5988,7 +5884,7 @@ mod tests {
         std::fs::write(&policy_file, "[fs]\nread = [\"allowed\"]\n").unwrap();
         let host = host_with_policy(&policy_file);
         let parent_open_job = host
-            .insert_job(thread_pool::make_open_job(
+            .insert_job(FilesystemJob::open_legacy(
                 allowed.as_os_str().to_os_string(),
                 0,
                 0,
@@ -6002,14 +5898,14 @@ mod tests {
         let parent_fd = host.open_job_get_fd(parent_open_job).unwrap();
         let parent = host.acquire_resource(parent_fd).unwrap();
         let allowed_link_job = host
-            .insert_job(thread_pool::make_file_kind_by_path_job(
+            .insert_job(FilesystemJob::file_kind_by_path(
                 Some(Arc::clone(&parent)),
                 std::ffi::OsString::from("link.txt"),
                 false,
             ))
             .unwrap();
         let denied_link_job = host
-            .insert_job(thread_pool::make_file_kind_by_path_job(
+            .insert_job(FilesystemJob::file_kind_by_path(
                 None,
                 denied_link.as_os_str().to_os_string(),
                 false,
@@ -6042,7 +5938,7 @@ mod tests {
         std::fs::write(&policy_file, "[fs]\nwrite = [\"writable\"]\n").unwrap();
         let host = host_with_policy(&policy_file);
         let open_job = host
-            .insert_job(thread_pool::make_open_job(
+            .insert_job(FilesystemJob::open_legacy(
                 file.as_os_str().to_os_string(),
                 1,
                 0,
@@ -6056,10 +5952,10 @@ mod tests {
         let fd = host.open_job_get_fd(open_job).unwrap();
         let resource = host.acquire_resource(fd).unwrap();
         let size_job = host
-            .insert_job(thread_pool::make_file_size_job(Arc::clone(&resource)))
+            .insert_job(FilesystemJob::file_size(Arc::clone(&resource)))
             .unwrap();
         let time_job = host
-            .insert_job(thread_pool::make_file_time_job(Arc::clone(&resource)))
+            .insert_job(FilesystemJob::file_time(Arc::clone(&resource)))
             .unwrap();
 
         host.run_job(size_job).unwrap();
@@ -6093,7 +5989,7 @@ mod tests {
         std::fs::write(&policy_file, "[fs]\nwrite = [\"writable\"]\n").unwrap();
         let host = host_with_policy(&policy_file);
         let open_job = host
-            .insert_job(thread_pool::make_open_job(
+            .insert_job(FilesystemJob::open_legacy(
                 file.as_os_str().to_os_string(),
                 1,
                 0,
@@ -6128,28 +6024,34 @@ mod tests {
         std::fs::write(&policy_file, "[fs]\nwrite = [\"writable\"]\n").unwrap();
         let host = host_with_policy(&policy_file);
         let identity_job = host
-            .insert_job(thread_pool::make_open_stat_job(
-                file.as_os_str().to_os_string(),
-                1,
-                0,
-                false,
-                0,
-                0,
-                thread_pool::STAT_OPEN_IDENTITY,
-                32,
-            ))
+            .insert_job(
+                FilesystemJob::open(
+                    file.as_os_str().to_os_string(),
+                    1,
+                    0,
+                    false,
+                    0,
+                    0,
+                    crate::filesystem::STAT_OPEN_IDENTITY,
+                    32,
+                )
+                .unwrap(),
+            )
             .unwrap();
         let metadata_job = host
-            .insert_job(thread_pool::make_open_stat_job(
-                file.as_os_str().to_os_string(),
-                1,
-                0,
-                false,
-                0,
-                0,
-                thread_pool::STAT_OPEN_IDENTITY | 0x0002,
-                40,
-            ))
+            .insert_job(
+                FilesystemJob::open(
+                    file.as_os_str().to_os_string(),
+                    1,
+                    0,
+                    false,
+                    0,
+                    0,
+                    crate::filesystem::STAT_OPEN_IDENTITY | 0x0002,
+                    40,
+                )
+                .unwrap(),
+            )
             .unwrap();
 
         host.run_job(identity_job).unwrap();
@@ -6177,7 +6079,7 @@ mod tests {
         std::fs::write(&policy_file, "[fs]\nread = [\"readable\"]\n").unwrap();
         let host = host_with_policy(&policy_file);
         let open_job = host
-            .insert_job(thread_pool::make_open_job(
+            .insert_job(FilesystemJob::open_legacy(
                 file.as_os_str().to_os_string(),
                 0,
                 0,
@@ -6210,7 +6112,7 @@ mod tests {
         std::fs::write(&policy_file, "[fs]\nread = [\"readable\"]\n").unwrap();
         let host = host_with_policy(&policy_file);
         let open_job = host
-            .insert_job(thread_pool::make_open_job(
+            .insert_job(FilesystemJob::open_legacy(
                 file.as_os_str().to_os_string(),
                 0,
                 0,
@@ -6224,7 +6126,7 @@ mod tests {
         let fd = host.open_job_get_fd(open_job).unwrap();
         let resource = host.acquire_resource(fd).unwrap();
         let flock_job = host
-            .insert_job(thread_pool::make_flock_job(Arc::clone(&resource), true))
+            .insert_job(FilesystemJob::flock(Arc::clone(&resource), true))
             .unwrap();
 
         host.run_job(flock_job).unwrap();
@@ -6285,7 +6187,7 @@ mod tests {
         let path =
             std::env::temp_dir().join(format!("moonrun-discarded-open-job-{}", std::process::id()));
         let job_handle = host
-            .insert_job(thread_pool::make_open_job(
+            .insert_job(FilesystemJob::open_legacy(
                 path.as_os_str().to_os_string(),
                 2,
                 3,
@@ -6301,8 +6203,8 @@ mod tests {
 
         assert_eq!(job.err(), 0);
         assert!(matches!(
-            thread_pool::open_job_result(&job).unwrap().resource,
-            OpenJobResource::Unpublished(_)
+            job.filesystem().unwrap().open_result().unwrap().resource,
+            ResourcePublication::Unpublished(_)
         ));
         assert_eq!(resource_count(&host), 0);
         host.jobs.borrow_mut().jobs.remove(key);
@@ -6460,7 +6362,7 @@ mod tests {
         ));
         std::fs::write(&displaced_path, b"displaced").unwrap();
         let displaced_job = host
-            .insert_job(thread_pool::make_remove_job(
+            .insert_job(FilesystemJob::remove(
                 displaced_path.as_os_str().to_os_string(),
             ))
             .unwrap();
@@ -6470,7 +6372,7 @@ mod tests {
         ));
         std::fs::write(&queued_path, b"queued").unwrap();
         let queued_job = host
-            .insert_job(thread_pool::make_remove_job(
+            .insert_job(FilesystemJob::remove(
                 queued_path.as_os_str().to_os_string(),
             ))
             .unwrap();
@@ -6512,11 +6414,7 @@ mod tests {
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let first_job = host
-            .insert_job(thread_pool::make_read_job(
-                Arc::new(Resource::invalid()),
-                1,
-                -1,
-            ))
+            .insert_job(FilesystemJob::read(Arc::new(Resource::invalid()), 1, -1))
             .unwrap();
         let old_worker = host.spawn_worker(42, first_job).unwrap();
         host.poll_wait(poll, 1000).unwrap();
@@ -6537,11 +6435,7 @@ mod tests {
 
         host.init_thread_pool(poll).unwrap();
         let second_job = host
-            .insert_job(thread_pool::make_read_job(
-                Arc::new(Resource::invalid()),
-                1,
-                -1,
-            ))
+            .insert_job(FilesystemJob::read(Arc::new(Resource::invalid()), 1, -1))
             .unwrap();
         let new_worker = host.spawn_worker(43, second_job).unwrap();
         let wake_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
@@ -6601,11 +6495,7 @@ mod tests {
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let job = host
-            .insert_job(thread_pool::make_read_job(
-                Arc::new(Resource::invalid()),
-                1,
-                -1,
-            ))
+            .insert_job(FilesystemJob::read(Arc::new(Resource::invalid()), 1, -1))
             .unwrap();
         let worker = host.spawn_worker(42, job).unwrap();
         host.poll_wait(poll, 1000).unwrap();
@@ -6660,7 +6550,7 @@ mod tests {
         let [read, write] = host.pipe(true, true).unwrap();
         host.poll_register(poll, read, true).unwrap();
         let job = host
-            .insert_job(thread_pool::make_read_job(
+            .insert_job(FilesystemJob::read(
                 host.acquire_resource(read).unwrap(),
                 1,
                 -1,

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -3857,6 +3857,7 @@ impl AsyncHost {
         Ok(())
     }
 
+    #[cfg(target_os = "macos")]
     fn check_file_metadata_policy(policy: &Policy, file: Option<&Resource>) -> AsyncHostResult<()> {
         let file = file.ok_or(AsyncHostError::Badf)?;
         match file.policy_path() {

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/jobs.rs
@@ -24,27 +24,19 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 #[cfg(unix)]
 use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 use crate::async_sys::ported_fns;
-use crate::resource::ResourceRef;
+use crate::resource::{ResourcePublication, ResourceRef};
 
-use super::stat::{PackedStat, STAT_DEVICE_ID, STAT_FILE_ID, STAT_FILE_KIND, StatRequest};
-use super::types::{
-    HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult, RealpathJobResult, SpawnOptions,
-    platform,
-};
+use super::types::{HostHandle, Job, JobPayload, SpawnOptions, platform};
 
 pub(crate) fn make_failed_job(errno: i32) -> Job {
     Job::new(JobPayload::Failed { errno })
 }
 
-ported_fns! {
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_get_platform"
-    )]
-    pub(crate) fn get_platform() -> i32 {
-        platform()
-    }
+pub(crate) fn get_platform() -> i32 {
+    platform()
+}
 
+ported_fns! {
     #[ported(
         source = "src/internal/event_loop/thread_pool.c",
         original = "moonbitlang_async_job_get_ret"
@@ -76,579 +68,136 @@ ported_fns! {
             errno == libc::EINTR
         }
     }
+}
 
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_sleep_job"
-    )]
-    pub(crate) fn make_sleep_job(ms: i32) -> Job {
-        Job::new(JobPayload::Sleep { duration_ms: ms })
-    }
+pub(crate) fn make_sleep_job(ms: i32) -> Job {
+    Job::new(JobPayload::Sleep { duration_ms: ms })
+}
 
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_read_job"
-    )]
-    pub(crate) fn make_read_job(
-        file: ResourceRef,
-        len: u32,
-        position: i64,
-    ) -> Job {
-        Job::new(JobPayload::Read {
-            file: Some(file),
-            len,
-            position,
-            result: None,
-        })
-    }
+#[allow(clippy::too_many_arguments)]
+#[cfg(unix)]
+pub(crate) fn make_spawn_job_unix(
+    path: OsString,
+    args: Vec<OsString>,
+    env: Vec<OsString>,
+    stdin: Option<ResourceRef>,
+    stdout: Option<ResourceRef>,
+    stderr: Option<ResourceRef>,
+    cwd: Option<OsString>,
+    options: SpawnOptions,
+) -> Job {
+    Job::new(JobPayload::SpawnUnix {
+        path,
+        args,
+        env,
+        options,
+        stdio: [stdin, stdout, stderr],
+        cwd,
+        result: None,
+    })
+}
 
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_write_job"
-    )]
-    pub(crate) fn make_write_job(file: ResourceRef, data: Vec<u8>, position: i64) -> Job {
-        Job::new(JobPayload::Write {
-            file: Some(file),
-            data,
-            position,
-        })
-    }
+#[allow(clippy::too_many_arguments)]
+#[cfg(windows)]
+pub(crate) fn make_spawn_job_windows(
+    command_line: OsString,
+    env: Vec<u16>,
+    stdin: Option<ResourceRef>,
+    stdout: Option<ResourceRef>,
+    stderr: Option<ResourceRef>,
+    cwd: Option<OsString>,
+    options: SpawnOptions,
+) -> Job {
+    Job::new(JobPayload::SpawnWindows {
+        command_line,
+        env,
+        options,
+        stdio: [stdin, stdout, stderr],
+        cwd,
+        result: None,
+    })
+}
 
-    #[compat(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_open_job",
-        upstream_pr = 527,
-        replacement = "make_open_stat_job"
-    )]
-    pub(crate) fn make_open_job(
-        filename: OsString,
-        access: i32,
-        create_mode: i32,
-        append: bool,
-        sync: i32,
-        mode: i32,
-    ) -> Job {
-        Job::new(JobPayload::Open {
-            filename,
-            access,
-            create_mode,
-            append,
-            sync,
-            mode,
-            request: StatRequest::open_identity(),
-            result: None,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_open_job"
-    )]
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn make_open_stat_job(
-        filename: OsString,
-        access: i32,
-        create_mode: i32,
-        append: bool,
-        sync: i32,
-        mode: i32,
-        stat_request: u32,
-        stat_result_len: u32,
-    ) -> Job {
-        let request = match StatRequest::new(stat_request, stat_result_len) {
-            Ok(request) => request,
-            Err(error) => return make_failed_job(error.errno()),
-        };
-        Job::new(JobPayload::Open {
-            filename,
-            access,
-            create_mode,
-            append,
-            sync,
-            mode,
-            request,
-            result: None,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_fstatx_job"
-    )]
-    pub(crate) fn make_fstatx_job(
-        file: ResourceRef,
-        stat_request: u32,
-        stat_result_len: u32,
-    ) -> Job {
-        let request = match StatRequest::new(stat_request, stat_result_len) {
-            Ok(request) => request,
-            Err(error) => return make_failed_job(error.errno()),
-        };
-        Job::new(JobPayload::Fstatx {
-            file: Some(file),
-            request,
-            result: None,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_statx_job"
-    )]
-    pub(crate) fn make_statx_job(
-        parent: Option<ResourceRef>,
-        path: OsString,
-        stat_request: u32,
-        stat_result_len: u32,
-        follow_symlink: bool,
-    ) -> Job {
-        let request = match StatRequest::new(stat_request, stat_result_len) {
-            Ok(request) => request,
-            Err(error) => return make_failed_job(error.errno()),
-        };
-        Job::new(JobPayload::Statx {
-            parent,
-            path,
-            request,
-            follow_symlink,
-            result: None,
-        })
-    }
-
-    #[compat(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_file_kind_by_path_job",
-        upstream_pr = 527,
-        replacement = "make_statx_job with STAT_FILE_KIND"
-    )]
-    pub(crate) fn make_file_kind_by_path_job(
-        parent: Option<ResourceRef>,
-        path: OsString,
-        follow_symlink: bool,
-    ) -> Job {
-        Job::new(JobPayload::FileKindByPath {
-            parent,
-            path,
-            follow_symlink,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_open_job_get_fd"
-    )]
-    pub(crate) fn open_job_get_fd(result: &OpenJobResult) -> AsyncHostResult<HostHandle> {
-        match &result.resource {
-            OpenJobResource::Published(fd) => Ok(*fd),
-            OpenJobResource::Unpublished(_) => Err(AsyncHostError::Inval),
+pub(crate) fn spawn_job_set_cwd(job: &mut Job, cwd: OsString) -> AsyncHostResult<()> {
+    match job.payload_mut() {
+        #[cfg(unix)]
+        JobPayload::SpawnUnix { cwd: job_cwd, .. } => {
+            *job_cwd = Some(cwd);
+            Ok(())
         }
-    }
-
-    #[compat(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_open_job_get_kind",
-        upstream_pr = 527,
-        replacement = "get_stat_result with STAT_FILE_KIND"
-    )]
-    pub(crate) fn open_job_get_kind(result: &OpenJobResult) -> AsyncHostResult<i32> {
-        result
-            .stat
-            .scalar(STAT_FILE_KIND)
-            .map(|value| value as i32)
-            .ok_or(AsyncHostError::Inval)
-    }
-
-    #[compat(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_open_job_get_dev_id",
-        upstream_pr = 527,
-        replacement = "get_stat_result with STAT_DEVICE_ID"
-    )]
-    pub(crate) fn open_job_get_dev_id(result: &OpenJobResult) -> AsyncHostResult<u64> {
-        result
-            .stat
-            .scalar(STAT_DEVICE_ID)
-            .ok_or(AsyncHostError::Inval)
-    }
-
-    #[compat(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_open_job_get_file_id",
-        upstream_pr = 527,
-        replacement = "get_stat_result with STAT_FILE_ID"
-    )]
-    pub(crate) fn open_job_get_file_id(result: &OpenJobResult) -> AsyncHostResult<u64> {
-        result
-            .stat
-            .scalar(STAT_FILE_ID)
-            .ok_or(AsyncHostError::Inval)
-    }
-
-    #[compat(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_file_size_job",
-        upstream_pr = 527,
-        replacement = "make_fstatx_job with STAT_FILE_SIZE"
-    )]
-    pub(crate) fn make_file_size_job(file: ResourceRef) -> Job {
-        Job::new(JobPayload::FileSize {
-            file: Some(file),
-            result: 0,
-        })
-    }
-
-    #[compat(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_file_time_job",
-        upstream_pr = 527,
-        replacement = "make_fstatx_job with timestamp properties"
-    )]
-    pub(crate) fn make_file_time_job(file: ResourceRef) -> Job {
-        Job::new(JobPayload::FileTime {
-            file: Some(file),
-            result: None,
-        })
-    }
-
-    #[compat(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_file_time_by_path_job",
-        upstream_pr = 527,
-        replacement = "make_statx_job with timestamp properties"
-    )]
-    pub(crate) fn make_file_time_by_path_job(
-        path: OsString,
-        follow_symlink: bool,
-    ) -> Job {
-        Job::new(JobPayload::FileTimeByPath {
-            path,
-            follow_symlink,
-            result: None,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_access_job"
-    )]
-    pub(crate) fn make_access_job(path: OsString, access: i32) -> Job {
-        Job::new(JobPayload::Access { path, access })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_chmod_job"
-    )]
-    pub(crate) fn make_chmod_job(path: OsString, mode: i32) -> Job {
-        Job::new(JobPayload::Chmod { path, mode })
-    }
-
-    #[compat(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_get_file_size_result",
-        upstream_pr = 527,
-        replacement = "get_stat_result"
-    )]
-    pub(crate) fn get_file_size_result(job: &Job) -> AsyncHostResult<i64> {
-        match job.payload() {
-            JobPayload::FileSize { result, .. } => Ok(*result),
-            _ => Err(AsyncHostError::Badf),
+        #[cfg(windows)]
+        JobPayload::SpawnWindows { cwd: job_cwd, .. } => {
+            *job_cwd = Some(cwd);
+            Ok(())
         }
+        _ => Err(AsyncHostError::Badf),
     }
+}
 
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_fsync_job"
-    )]
-    pub(crate) fn make_fsync_job(file: ResourceRef, only_data: bool) -> Job {
-        Job::new(JobPayload::Fsync {
-            file: Some(file),
-            only_data,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_flock_job"
-    )]
-    pub(crate) fn make_flock_job(file: ResourceRef, exclusive: bool) -> Job {
-        Job::new(JobPayload::Flock {
-            file: Some(file),
-            exclusive,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_remove_job"
-    )]
-    pub(crate) fn make_remove_job(path: OsString) -> Job {
-        Job::new(JobPayload::Remove { path })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_rename_job"
-    )]
-    pub(crate) fn make_rename_job(old_path: OsString, new_path: OsString, replace: bool) -> Job {
-        Job::new(JobPayload::Rename {
-            old_path,
-            new_path,
-            replace,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_symlink_job"
-    )]
-    pub(crate) fn make_symlink_job(target: OsString, path: OsString, force_symlink: bool) -> Job {
-        Job::new(JobPayload::Symlink {
-            target,
-            path,
-            force_symlink,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_mkdir_job"
-    )]
-    pub(crate) fn make_mkdir_job(path: OsString, mode: i32) -> Job {
-        Job::new(JobPayload::Mkdir { path, mode })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_rmdir_job"
-    )]
-    pub(crate) fn make_rmdir_job(path: OsString) -> Job {
-        Job::new(JobPayload::Rmdir { path })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_readdir_job"
-    )]
-    pub(crate) fn make_readdir_job(
-        dir: ResourceRef,
-        buffer: crate::async_host::CBufferLease,
-        len: u32,
-        restart: bool,
-    ) -> Job {
-        Job::new(JobPayload::Readdir {
-            dir: Some(dir),
-            buffer: Some(buffer),
-            len,
-            restart,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_inotify_add_watch_job"
-    )]
-    #[cfg(target_os = "linux")]
-    pub(crate) fn make_inotify_add_watch_job(
-        inotify: ResourceRef,
-        path: OsString,
-        is_dir: bool,
-    ) -> Job {
-        Job::new(JobPayload::InotifyAddWatch {
-            inotify: Some(inotify),
-            path,
-            is_dir,
-        })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_make_realpath_job"
-    )]
-    pub(crate) fn make_realpath_job(path: OsString) -> Job {
-        Job::new(JobPayload::Realpath { path, result: None })
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/fs.c",
-        original = "moonbitlang_async_get_realpath_result"
-    )]
-    pub(crate) fn publish_realpath_result(
-        job: &mut Job,
-        publish: impl FnOnce(Box<[u8]>) -> HostHandle,
-    ) -> AsyncHostResult<HostHandle> {
-        match job.payload_mut() {
-            JobPayload::Realpath {
-                result: Some(RealpathJobResult::Published(handle)),
-                ..
-            } => Ok(*handle),
-            JobPayload::Realpath { result, .. } => {
-                let Some(RealpathJobResult::Unpublished(buffer)) = result.take() else {
-                    return Err(AsyncHostError::Inval);
-                };
-                let handle = publish(buffer);
-                *result = Some(RealpathJobResult::Published(handle));
-                Ok(handle)
-            }
-            _ => Err(AsyncHostError::Badf),
+#[cfg(windows)]
+pub(crate) fn spawn_job_set_no_console_window(job: &mut Job) -> AsyncHostResult<()> {
+    match job.payload_mut() {
+        JobPayload::SpawnWindows { options, .. } => {
+            options.no_console_window = true;
+            Ok(())
         }
+        _ => Err(AsyncHostError::Badf),
     }
+}
 
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_spawn_job"
-    )]
-    #[allow(clippy::too_many_arguments)]
-    #[cfg(unix)]
-    pub(crate) fn make_spawn_job_unix(
-        path: OsString,
-        args: Vec<OsString>,
-        env: Vec<OsString>,
-        stdin: Option<ResourceRef>,
-        stdout: Option<ResourceRef>,
-        stderr: Option<ResourceRef>,
-        cwd: Option<OsString>,
-        options: SpawnOptions,
-    ) -> Job {
-        Job::new(JobPayload::SpawnUnix {
-            path,
-            args,
-            env,
-            options,
-            stdio: [stdin, stdout, stderr],
-            cwd,
-            result: None,
-        })
+pub(crate) fn get_spawn_job_result_handle(job: &Job) -> AsyncHostResult<HostHandle> {
+    match job.payload() {
+        #[cfg(unix)]
+        JobPayload::SpawnUnix {
+            result: Some(ResourcePublication::Published(handle)),
+            ..
+        } => Ok(*handle),
+        #[cfg(windows)]
+        JobPayload::SpawnWindows {
+            result: Some(ResourcePublication::Published(handle)),
+            ..
+        } => Ok(*handle),
+        #[cfg(unix)]
+        JobPayload::SpawnUnix {
+            result: Some(ResourcePublication::Unpublished(_)),
+            ..
+        } => Err(AsyncHostError::Inval),
+        #[cfg(windows)]
+        JobPayload::SpawnWindows {
+            result: Some(ResourcePublication::Unpublished(_)),
+            ..
+        } => Err(AsyncHostError::Inval),
+        #[cfg(unix)]
+        JobPayload::SpawnUnix { result: None, .. } => Ok(crate::async_host::INVALID_HOST_HANDLE),
+        #[cfg(windows)]
+        JobPayload::SpawnWindows { result: None, .. } => Ok(crate::async_host::INVALID_HOST_HANDLE),
+        _ => Err(AsyncHostError::Badf),
     }
+}
 
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_spawn_job"
-    )]
-    #[allow(clippy::too_many_arguments)]
-    #[cfg(windows)]
-    pub(crate) fn make_spawn_job_windows(
-        command_line: OsString,
-        env: Vec<u16>,
-        stdin: Option<ResourceRef>,
-        stdout: Option<ResourceRef>,
-        stderr: Option<ResourceRef>,
-        cwd: Option<OsString>,
-        options: SpawnOptions,
-    ) -> Job {
-        Job::new(JobPayload::SpawnWindows {
-            command_line,
-            env,
-            options,
-            stdio: [stdin, stdout, stderr],
-            cwd,
-            result: None,
-        })
-    }
+pub(crate) fn make_wait_for_process_job(
+    handle: Option<ResourceRef>,
+    tracked_pid: Option<i32>,
+    pid: i32,
+    #[cfg(unix)] defer_reap: bool,
+) -> AsyncHostResult<Job> {
+    Ok(Job::new(JobPayload::WaitForProcess {
+        handle,
+        tracked_pid,
+        pid,
+        #[cfg(unix)]
+        defer_reap,
+        #[cfg(windows)]
+        cancel: Some(Arc::new(super::process::make_wait_for_process_cancel()?)),
+    }))
+}
 
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_spawn_job_set_cwd"
-    )]
-    pub(crate) fn spawn_job_set_cwd(job: &mut Job, cwd: OsString) -> AsyncHostResult<()> {
-        match job.payload_mut() {
-            #[cfg(unix)]
-            JobPayload::SpawnUnix { cwd: job_cwd, .. } => {
-                *job_cwd = Some(cwd);
-                Ok(())
-            }
-            #[cfg(windows)]
-            JobPayload::SpawnWindows { cwd: job_cwd, .. } => {
-                *job_cwd = Some(cwd);
-                Ok(())
-            }
-            _ => Err(AsyncHostError::Badf),
-        }
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_spawn_job_set_no_console_window"
-    )]
-    #[cfg(windows)]
-    pub(crate) fn spawn_job_set_no_console_window(job: &mut Job) -> AsyncHostResult<()> {
-        match job.payload_mut() {
-            JobPayload::SpawnWindows { options, .. } => {
-                options.no_console_window = true;
-                Ok(())
-            }
-            _ => Err(AsyncHostError::Badf),
-        }
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_get_spawn_job_result_handle"
-    )]
-    pub(crate) fn get_spawn_job_result_handle(job: &Job) -> AsyncHostResult<HostHandle> {
-        match job.payload() {
-            #[cfg(unix)]
-            JobPayload::SpawnUnix {
-                result: Some(OpenJobResource::Published(handle)),
-                ..
-            } => Ok(*handle),
-            #[cfg(windows)]
-            JobPayload::SpawnWindows {
-                result: Some(OpenJobResource::Published(handle)),
-                ..
-            } => Ok(*handle),
-            #[cfg(unix)]
-            JobPayload::SpawnUnix {
-                result: Some(OpenJobResource::Unpublished(_)),
-                ..
-            } => Err(AsyncHostError::Inval),
-            #[cfg(windows)]
-            JobPayload::SpawnWindows {
-                result: Some(OpenJobResource::Unpublished(_)),
-                ..
-            } => Err(AsyncHostError::Inval),
-            #[cfg(unix)]
-            JobPayload::SpawnUnix { result: None, .. } => Ok(crate::async_host::INVALID_HOST_HANDLE),
-            #[cfg(windows)]
-            JobPayload::SpawnWindows { result: None, .. } => {
-                Ok(crate::async_host::INVALID_HOST_HANDLE)
-            }
-            _ => Err(AsyncHostError::Badf),
-        }
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_wait_for_process_job"
-    )]
-    pub(crate) fn make_wait_for_process_job(
-        handle: Option<ResourceRef>,
-        tracked_pid: Option<i32>,
-        pid: i32,
-        #[cfg(unix)] defer_reap: bool,
-    ) -> AsyncHostResult<Job> {
-        Ok(Job::new(JobPayload::WaitForProcess {
-            handle,
-            tracked_pid,
-            pid,
-            #[cfg(unix)]
-            defer_reap,
-            #[cfg(windows)]
-            cancel: Some(Arc::new(super::process::make_wait_for_process_cancel()?)),
-        }))
-    }
-
-    #[ported(
-        source = "src/internal/event_loop/thread_pool.c",
-        original = "moonbitlang_async_make_sigwait_job"
-    )]
-    #[cfg(unix)]
-    pub(crate) fn make_sigwait_job(
-        signals: Vec<i32>,
-        notifier: Arc<ThreadPoolCompletionNotifier>,
-    ) -> Job {
-        Job::new(JobPayload::Sigwait { signals, notifier })
-    }
+#[cfg(unix)]
+pub(crate) fn make_sigwait_job(
+    signals: Vec<i32>,
+    notifier: Arc<ThreadPoolCompletionNotifier>,
+) -> Job {
+    Job::new(JobPayload::Sigwait { signals, notifier })
 }
 
 #[cfg(windows)]
@@ -667,50 +216,7 @@ pub(crate) fn cancel_job_resource(cancel: &ResourceRef) -> AsyncHostResult<()> {
     super::process::cancel_wait_for_process(cancel)
 }
 
-pub(crate) fn open_job_result(job: &Job) -> AsyncHostResult<&OpenJobResult> {
-    match job.payload() {
-        JobPayload::Open {
-            result: Some(result),
-            ..
-        } => Ok(result),
-        JobPayload::Open { .. } => Err(AsyncHostError::Inval),
-        _ => Err(AsyncHostError::Badf),
-    }
-}
-
-pub(crate) fn open_job_result_mut(job: &mut Job) -> AsyncHostResult<&mut OpenJobResult> {
-    match job.payload_mut() {
-        JobPayload::Open {
-            result: Some(result),
-            ..
-        } => Ok(result),
-        JobPayload::Open { .. } => Err(AsyncHostError::Inval),
-        _ => Err(AsyncHostError::Badf),
-    }
-}
-
-pub(crate) fn stat_job_result(job: &Job) -> AsyncHostResult<&PackedStat> {
-    match job.payload() {
-        JobPayload::Open {
-            result: Some(OpenJobResult { stat: result, .. }),
-            ..
-        }
-        | JobPayload::Fstatx {
-            result: Some(result),
-            ..
-        }
-        | JobPayload::Statx {
-            result: Some(result),
-            ..
-        } => Ok(result),
-        JobPayload::Open { .. } | JobPayload::Fstatx { .. } | JobPayload::Statx { .. } => {
-            Err(AsyncHostError::Inval)
-        }
-        _ => Err(AsyncHostError::Badf),
-    }
-}
-
-pub(crate) fn take_spawn_job_result(job: &mut Job) -> AsyncHostResult<Option<OpenJobResource>> {
+pub(crate) fn take_spawn_job_result(job: &mut Job) -> AsyncHostResult<Option<ResourcePublication>> {
     match job.payload_mut() {
         #[cfg(unix)]
         JobPayload::SpawnUnix { result, .. } => Ok(result.take()),
@@ -722,7 +228,7 @@ pub(crate) fn take_spawn_job_result(job: &mut Job) -> AsyncHostResult<Option<Ope
 
 pub(crate) fn set_spawn_job_result(
     job: &mut Job,
-    resource: OpenJobResource,
+    resource: ResourcePublication,
 ) -> AsyncHostResult<()> {
     match job.payload_mut() {
         #[cfg(unix)]
@@ -743,8 +249,6 @@ pub(crate) fn set_spawn_job_result(
 mod tests {
     use super::*;
     use crate::async_sys::internal::event_loop::thread_pool::run_host_job;
-    use crate::resource::Resource;
-    use std::sync::Arc;
 
     #[test]
     fn sleep_job_initial_result_matches_native_job_header() {
@@ -755,118 +259,6 @@ mod tests {
     }
 
     #[test]
-    fn read_job_carries_resource_and_length_payload() {
-        let file = Arc::new(Resource::invalid());
-        let job = make_read_job(Arc::clone(&file), 8, -1);
-
-        match job.payload() {
-            JobPayload::Read {
-                file: Some(actual_file),
-                len,
-                position,
-                result: None,
-            } => {
-                assert!(Arc::ptr_eq(actual_file, &file));
-                assert_eq!(*len, 8);
-                assert_eq!(*position, -1);
-            }
-            other => panic!("unexpected payload: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn open_job_carries_owned_path_and_open_flags() {
-        let job = make_open_job(OsString::from("/tmp/example"), 2, 3, true, 1, 0o644);
-
-        match job.payload() {
-            JobPayload::Open {
-                filename,
-                access,
-                create_mode,
-                append,
-                sync,
-                mode,
-                request,
-                result: None,
-            } => {
-                assert_eq!(filename, &OsString::from("/tmp/example"));
-                assert_eq!(*access, 2);
-                assert_eq!(*create_mode, 3);
-                assert!(*append);
-                assert_eq!(*sync, 1);
-                assert_eq!(*mode, 0o644);
-                assert_eq!(request.mask(), super::super::stat::STAT_OPEN_IDENTITY);
-            }
-            other => panic!("unexpected payload: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn realpath_job_carries_owned_path() {
-        let job = make_realpath_job(OsString::from("/tmp/example"));
-
-        match job.payload() {
-            JobPayload::Realpath { path, result: None } => {
-                assert_eq!(path, &OsString::from("/tmp/example"));
-            }
-            other => panic!("unexpected payload: {other:?}"),
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn realpath_job_resolves_to_nul_terminated_c_buffer() {
-        use std::os::unix::ffi::OsStrExt;
-
-        let tmp = tempfile::tempdir().unwrap();
-        let target = tmp.path().join("target");
-        let link = tmp.path().join("link");
-        std::fs::create_dir(&target).unwrap();
-        std::os::unix::fs::symlink(&target, &link).unwrap();
-
-        let mut job = make_realpath_job(link.into_os_string());
-
-        run_host_job(&mut job);
-
-        assert_eq!(job_get_ret(&job), 0);
-        assert_eq!(job_get_err(&job), 0);
-        let JobPayload::Realpath {
-            result: Some(RealpathJobResult::Unpublished(buffer)),
-            ..
-        } = job.payload()
-        else {
-            panic!("expected completed realpath job");
-        };
-        let realpath = std::ffi::CStr::from_bytes_with_nul(buffer.as_ref()).unwrap();
-        let expected = std::fs::canonicalize(target).unwrap();
-        assert_eq!(realpath.to_bytes(), expected.as_os_str().as_bytes());
-    }
-
-    #[test]
-    fn realpath_result_is_published_once() {
-        let mut job = make_realpath_job(OsString::from("unused"));
-        let JobPayload::Realpath { result, .. } = job.payload_mut() else {
-            unreachable!();
-        };
-        *result = Some(RealpathJobResult::Unpublished(
-            b"resolved\0".to_vec().into_boxed_slice(),
-        ));
-
-        let handle = publish_realpath_result(&mut job, |buffer| {
-            assert_eq!(&*buffer, b"resolved\0");
-            42
-        })
-        .unwrap();
-        let same_handle = publish_realpath_result(&mut job, |_| {
-            panic!("a published realpath result must not be published again")
-        })
-        .unwrap();
-
-        assert_eq!(handle, 42);
-        assert_eq!(same_handle, handle);
-    }
-
-    #[test]
     fn sleep_job_runs_without_error() {
         let mut job = make_sleep_job(0);
 
@@ -874,18 +266,6 @@ mod tests {
 
         assert_eq!(job_get_ret(&job), 0);
         assert_eq!(job_get_err(&job), 0);
-    }
-
-    #[test]
-    fn resource_job_releases_file_when_worker_finishes() {
-        let file = Arc::new(Resource::invalid());
-        let file_ref = Arc::downgrade(&file);
-        let mut job = make_flock_job(Arc::clone(&file), true);
-        drop(file);
-
-        run_host_job(&mut job);
-
-        assert!(file_ref.upgrade().is_none());
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -16,19 +16,15 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-mod fs;
 mod jobs;
 mod process;
 mod runner;
 #[cfg(unix)]
 mod signal;
 mod sleep;
-mod stat;
 mod types;
 mod worker;
 
-#[cfg(target_os = "linux")]
-pub(crate) use jobs::make_inotify_add_watch_job;
 #[cfg(unix)]
 pub(crate) use jobs::make_sigwait_job;
 #[cfg(unix)]
@@ -41,22 +37,12 @@ pub(crate) use jobs::spawn_job_set_no_console_window;
 #[cfg(windows)]
 pub(crate) use jobs::{cancel_job_resource, job_cancel_resource};
 pub(crate) use jobs::{
-    errno_is_cancelled, get_file_size_result, get_platform, get_spawn_job_result_handle,
-    job_get_err, job_get_ret, make_access_job, make_chmod_job, make_failed_job,
-    make_file_kind_by_path_job, make_file_size_job, make_file_time_by_path_job, make_file_time_job,
-    make_flock_job, make_fstatx_job, make_fsync_job, make_mkdir_job, make_open_job,
-    make_open_stat_job, make_read_job, make_readdir_job, make_realpath_job, make_remove_job,
-    make_rename_job, make_rmdir_job, make_sleep_job, make_statx_job, make_symlink_job,
-    make_wait_for_process_job, make_write_job, open_job_get_dev_id, open_job_get_fd,
-    open_job_get_file_id, open_job_get_kind, open_job_result, open_job_result_mut,
-    publish_realpath_result, set_spawn_job_result, take_spawn_job_result,
+    errno_is_cancelled, get_platform, get_spawn_job_result_handle, job_get_err, job_get_ret,
+    make_failed_job, make_sleep_job, make_wait_for_process_job, set_spawn_job_result,
+    take_spawn_job_result,
 };
-pub(crate) use runner::{get_file_time_result, get_read_result, get_stat_result, run_host_job};
-pub(crate) use stat::STAT_OPEN_IDENTITY;
-pub(crate) use types::{
-    FileTimeResult, HostHandle, Job, JobPayload, OpenJobResource, OpenJobResult, RealpathJobResult,
-    ResourceTable, SpawnOptions,
-};
+pub(crate) use runner::run_host_job;
+pub(crate) use types::{HostHandle, Job, JobPayload, ResourceTable, SpawnOptions};
 pub(crate) use worker::{
     HostWorkerHandle, HostWorkerJob, HostWorkerJobResult, WorkerCompletionId, cancel_worker,
     free_worker, spawn_worker, wake_worker, worker_enter_idle,
@@ -66,24 +52,14 @@ pub(crate) use worker::{WorkerCancellationTarget, worker_cancellation_target};
 
 #[cfg(test)]
 pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
-    let mut symbols = Vec::new();
-    symbols.extend_from_slice(jobs::PORTED_SYMBOLS);
+    let mut symbols = jobs::PORTED_SYMBOLS.to_vec();
     symbols.extend_from_slice(worker::PORTED_SYMBOLS);
-    symbols
-}
-
-#[cfg(test)]
-pub(crate) fn compat_symbols() -> Vec<crate::async_sys::CompatSymbol> {
-    let mut symbols = Vec::new();
-    symbols.extend_from_slice(jobs::COMPAT_SYMBOLS);
-    symbols.extend_from_slice(fs::COMPAT_SYMBOLS);
     symbols
 }
 
 #[cfg(test)]
 fn job_executor_ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
     let mut symbols = Vec::new();
-    symbols.extend_from_slice(fs::PORTED_SYMBOLS);
     symbols.extend_from_slice(process::PORTED_SYMBOLS);
     #[cfg(unix)]
     symbols.extend_from_slice(signal::PORTED_SYMBOLS);

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/process.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/process.rs
@@ -33,7 +33,8 @@ use crate::async_sys::ported_fns;
 use crate::resource::Resource;
 use crate::resource::ResourceRef;
 
-use super::{OpenJobResource, SpawnOptions};
+use super::SpawnOptions;
+use crate::resource::ResourcePublication;
 
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 mod glibc_compat;
@@ -54,7 +55,7 @@ ported_fns! {
         stdio: [Option<ResourceRef>; 3],
         cwd: Option<OsString>,
         options: SpawnOptions,
-        result: &mut Option<OpenJobResource>,
+        result: &mut Option<ResourcePublication>,
     ) -> AsyncHostResult<i64> {
         spawn_process_unix(
             path,
@@ -79,7 +80,7 @@ ported_fns! {
         stdio: [Option<ResourceRef>; 3],
         cwd: Option<OsString>,
         options: SpawnOptions,
-        result: &mut Option<OpenJobResource>,
+        result: &mut Option<ResourcePublication>,
     ) -> AsyncHostResult<i64> {
         spawn_process_windows(
             command_line,
@@ -121,7 +122,7 @@ fn spawn_process_unix(
     stdio: [Option<ResourceRef>; 3],
     cwd: Option<OsString>,
     options: SpawnOptions,
-    result: &mut Option<OpenJobResource>,
+    result: &mut Option<ResourcePublication>,
 ) -> AsyncHostResult<i64> {
     #[cfg(not(target_os = "linux"))]
     let _ = result;
@@ -147,7 +148,7 @@ fn spawn_process_unix(
         )
         .map_err(AsyncHostError::Native)?;
         if let Ok(pidfd) = crate::async_sys::process::open_pid_handle(pid) {
-            *result = Some(OpenJobResource::Unpublished(Resource::new(pidfd)));
+            *result = Some(ResourcePublication::Unpublished(Resource::new(pidfd)));
         }
         return Ok(i64::from(pid));
     }
@@ -264,7 +265,7 @@ fn spawn_process_unix(
         Ok(pid) => {
             #[cfg(target_os = "linux")]
             if let Ok(pidfd) = crate::async_sys::process::open_pid_handle(pid) {
-                *result = Some(OpenJobResource::Unpublished(Resource::new(pidfd)));
+                *result = Some(ResourcePublication::Unpublished(Resource::new(pidfd)));
             }
             Ok(i64::from(pid))
         }
@@ -414,7 +415,7 @@ fn spawn_process_windows(
     stdio: [Option<ResourceRef>; 3],
     cwd: Option<OsString>,
     options: SpawnOptions,
-    result: &mut Option<OpenJobResource>,
+    result: &mut Option<ResourcePublication>,
 ) -> AsyncHostResult<i64> {
     use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
@@ -602,7 +603,7 @@ fn spawn_process_windows(
     unsafe {
         CloseHandle(process_info.hThread);
     }
-    *result = Some(OpenJobResource::Unpublished(Resource::new(
+    *result = Some(ResourcePublication::Unpublished(Resource::new(
         process_info.hProcess,
     )));
     Ok(i64::from(process_info.dwProcessId))

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/runner.rs
@@ -16,18 +16,6 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::async_host::{AsyncHostError, AsyncHostResult};
-use crate::async_sys::internal::fd_util;
-use crate::guest_memory::GuestMemory;
-
-#[cfg(target_os = "linux")]
-use super::fs::run_inotify_add_watch_job;
-use super::fs::{
-    run_access_job, run_chmod_job, run_file_kind_by_path_job, run_file_size_job,
-    run_file_time_by_path_job, run_file_time_job, run_flock_job, run_fsync_job, run_mkdir_job,
-    run_open_job, run_read_job, run_readdir_job, run_realpath_job, run_remove_job, run_rename_job,
-    run_rmdir_job, run_symlink_job, run_write_job,
-};
 #[cfg(unix)]
 use super::process::run_spawn_job_unix;
 #[cfg(windows)]
@@ -36,8 +24,8 @@ use super::process::run_wait_for_process_job;
 #[cfg(unix)]
 use super::signal::run_sigwait_job;
 use super::sleep::run_sleep_job;
-use super::stat::{run_fstatx_job, run_statx_job};
 use super::types::{Job, JobPayload};
+use crate::async_host::AsyncHostError;
 
 pub(crate) fn run_host_job(job: &mut Job) {
     job.set_ret(0);
@@ -48,133 +36,8 @@ pub(crate) fn run_host_job(job: &mut Job) {
             run_sleep_job(*duration_ms);
             Ok(0)
         }
-        JobPayload::Open {
-            filename,
-            access,
-            create_mode,
-            append,
-            sync,
-            mode,
-            request,
-            result,
-        } => run_open_job(
-            result,
-            std::mem::take(filename),
-            *access,
-            *create_mode,
-            *append,
-            *sync,
-            *mode,
-            *request,
-        ),
-        JobPayload::Fstatx {
-            file,
-            request,
-            result,
-        } => match file.take() {
-            Some(file) => run_fstatx_job(&file, *request, result),
-            None => Err(AsyncHostError::Badf),
-        },
-        JobPayload::Statx {
-            parent,
-            path,
-            request,
-            follow_symlink,
-            result,
-        } => {
-            let parent = parent.take();
-            run_statx_job(
-                parent.as_deref(),
-                std::mem::take(path),
-                *request,
-                *follow_symlink,
-                result,
-            )
-        }
-        JobPayload::Read {
-            file,
-            len,
-            position,
-            result,
-        } => match file.take() {
-            Some(file) => run_read_job(&file, *len, *position, result),
-            None => Err(AsyncHostError::Badf),
-        },
-        JobPayload::Write {
-            file,
-            data,
-            position,
-        } => match file.take() {
-            Some(file) => run_write_job(&file, data, *position),
-            None => Err(AsyncHostError::Badf),
-        },
-        JobPayload::FileKindByPath {
-            parent,
-            path,
-            follow_symlink,
-        } => {
-            let parent = parent.take();
-            run_file_kind_by_path_job(parent.as_deref(), std::mem::take(path), *follow_symlink)
-        }
-        JobPayload::FileSize { file, result } => match file.take() {
-            Some(file) => run_file_size_job(&file, result),
-            None => Err(AsyncHostError::Badf),
-        },
-        JobPayload::FileTime { file, result, .. } => match file.take() {
-            Some(file) => run_file_time_job(&file, result),
-            None => Err(AsyncHostError::Badf),
-        },
-        JobPayload::FileTimeByPath {
-            path,
-            follow_symlink,
-            result,
-            ..
-        } => run_file_time_by_path_job(std::mem::take(path), *follow_symlink, result),
-        JobPayload::Access { path, access } => run_access_job(std::mem::take(path), *access),
-        JobPayload::Chmod { path, mode } => run_chmod_job(std::mem::take(path), *mode),
-        JobPayload::Fsync { file, only_data } => match file.take() {
-            Some(file) => run_fsync_job(&file, *only_data),
-            None => Err(AsyncHostError::Badf),
-        },
-        JobPayload::Flock { file, exclusive } => match file.take() {
-            Some(file) => run_flock_job(&file, *exclusive),
-            None => Err(AsyncHostError::Badf),
-        },
-        JobPayload::Remove { path } => run_remove_job(std::mem::take(path)),
-        JobPayload::Rename {
-            old_path,
-            new_path,
-            replace,
-        } => run_rename_job(std::mem::take(old_path), std::mem::take(new_path), *replace),
-        JobPayload::Symlink {
-            target,
-            path,
-            force_symlink,
-        } => run_symlink_job(std::mem::take(target), std::mem::take(path), *force_symlink),
-        JobPayload::Mkdir { path, mode } => run_mkdir_job(std::mem::take(path), *mode),
-        JobPayload::Rmdir { path } => run_rmdir_job(std::mem::take(path)),
-        JobPayload::Readdir {
-            dir,
-            buffer,
-            len,
-            restart,
-        } => match (dir.take(), buffer.as_mut()) {
-            (Some(dir), Some(buffer)) => {
-                run_readdir_job(&dir, buffer.as_mut_slice(), *len, *restart)
-            }
-            _ => Err(AsyncHostError::Badf),
-        },
-        #[cfg(target_os = "linux")]
-        JobPayload::InotifyAddWatch {
-            inotify,
-            path,
-            is_dir,
-        } => match inotify.take() {
-            Some(inotify) => run_inotify_add_watch_job(&inotify, std::mem::take(path), *is_dir),
-            None => Err(AsyncHostError::Badf),
-        },
+        JobPayload::Filesystem(job) => job.run(),
         JobPayload::Network(job) => job.run(),
-        JobPayload::Realpath { path, result, .. } => run_realpath_job(std::mem::take(path), result),
         #[cfg(unix)]
         JobPayload::SpawnUnix {
             path,
@@ -229,73 +92,10 @@ pub(crate) fn run_host_job(job: &mut Job) {
         JobPayload::Sigwait { signals, notifier } => run_sigwait_job(signals, notifier),
     };
 
+    // A normal host call can still return a domain-specific status in `ret`.
+    // For example, getaddrinfo returns nonzero EAI_* values with `err == 0`.
     match result {
         Ok(ret) => job.set_ret(ret),
         Err(error) => job.set_err(error.errno()),
     }
-}
-
-pub(crate) fn get_read_result(
-    job: &Job,
-    memory: &mut (impl GuestMemory + ?Sized),
-    dst: u32,
-    offset: u32,
-    len: u32,
-) -> AsyncHostResult<()> {
-    if job.err() != 0 {
-        return Ok(());
-    }
-    let JobPayload::Read {
-        result: Some(result),
-        ..
-    } = job.payload()
-    else {
-        return Err(AsyncHostError::Badf);
-    };
-    let dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
-    Ok(memory.write_with_capacity(dst, len, result)?)
-}
-
-pub(crate) fn get_file_time_result(
-    job: &Job,
-    memory: &mut (impl GuestMemory + ?Sized),
-    dst: u32,
-) -> AsyncHostResult<()> {
-    if job.err() != 0 {
-        return Ok(());
-    }
-    let result = match job.payload() {
-        JobPayload::FileTime {
-            result: Some(result),
-            ..
-        }
-        | JobPayload::FileTimeByPath {
-            result: Some(result),
-            ..
-        } => result,
-        _ => return Err(AsyncHostError::Badf),
-    };
-
-    let file_time = result.as_native();
-    let mut record = [0; 48];
-    record[0..8].copy_from_slice(&fd_util::stub::get_atime_sec(file_time).to_le_bytes());
-    record[8..12].copy_from_slice(&fd_util::stub::get_atime_nsec(file_time).to_le_bytes());
-    record[16..24].copy_from_slice(&fd_util::stub::get_mtime_sec(file_time).to_le_bytes());
-    record[24..28].copy_from_slice(&fd_util::stub::get_mtime_nsec(file_time).to_le_bytes());
-    record[32..40].copy_from_slice(&fd_util::stub::get_ctime_sec(file_time).to_le_bytes());
-    record[40..44].copy_from_slice(&fd_util::stub::get_ctime_nsec(file_time).to_le_bytes());
-    Ok(memory.write_exact(dst, &record)?)
-}
-
-pub(crate) fn get_stat_result(
-    job: &Job,
-    memory: &mut (impl GuestMemory + ?Sized),
-    dst: u32,
-    dst_len: u32,
-) -> AsyncHostResult<()> {
-    if job.err() != 0 {
-        return Ok(());
-    }
-    let result = super::jobs::stat_job_result(job)?;
-    Ok(memory.write_with_capacity(dst, dst_len, result.as_bytes())?)
 }

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/types.rs
@@ -20,14 +20,13 @@ use std::ffi::OsString;
 #[cfg(unix)]
 use std::sync::Arc;
 
-use crate::async_host::{AsyncHostResult, CBufferLease};
+use crate::async_host::{AsyncHostError, AsyncHostResult};
 #[cfg(unix)]
 use crate::async_sys::internal::event_loop::ThreadPoolCompletionNotifier;
 use crate::async_sys::internal::fd_util;
+use crate::filesystem::Job as FilesystemJob;
 use crate::network::Job as NetworkJob;
-use crate::resource::{Resource, ResourceRef};
-
-use super::stat::{PackedStat, StatRequest};
+use crate::resource::{ResourcePublication, ResourceRef};
 
 pub(crate) type ResourceHandle = u64;
 pub(crate) type HostHandle = ResourceHandle;
@@ -42,37 +41,12 @@ pub(crate) struct SpawnOptions {
     pub(crate) is_orphan: bool,
 }
 
-#[derive(Debug)]
-pub(crate) struct OpenJobResult {
-    pub(crate) resource: OpenJobResource,
-    pub(super) stat: PackedStat,
-}
-
-#[derive(Debug)]
-pub(crate) enum OpenJobResource {
-    Unpublished(Resource),
-    Published(HostHandle),
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct FileTimeResult(fd_util::stub::FileTime);
-
-impl FileTimeResult {
-    pub(crate) fn new(file_time: fd_util::stub::FileTime) -> Self {
-        Self(file_time)
-    }
-
-    pub(crate) fn as_native(&self) -> &fd_util::stub::FileTime {
-        &self.0
-    }
-}
-
-impl std::fmt::Debug for FileTimeResult {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("FileTimeResult").finish_non_exhaustive()
-    }
-}
-
+/// A host operation following the `moonbitlang/async` native Job contract.
+///
+/// `err` is reserved for host and system errors handled uniformly by the
+/// MoonBit worker loop. When `err` is zero, `ret` is defined by the payload: it
+/// may be a value, a success sentinel, or a domain-specific status code.
+/// Structured results and domain-specific diagnostics remain in the payload.
 #[derive(Debug)]
 pub(crate) struct Job {
     ret: i64,
@@ -95,6 +69,20 @@ impl Job {
 
     pub(crate) fn payload_mut(&mut self) -> &mut JobPayload {
         &mut self.payload
+    }
+
+    pub(crate) fn filesystem(&self) -> AsyncHostResult<&FilesystemJob> {
+        match &self.payload {
+            JobPayload::Filesystem(job) => Ok(job),
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    pub(crate) fn filesystem_mut(&mut self) -> AsyncHostResult<&mut FilesystemJob> {
+        match &mut self.payload {
+            JobPayload::Filesystem(job) => Ok(job),
+            _ => Err(AsyncHostError::Badf),
+        }
     }
 
     pub(crate) fn ret(&self) -> i64 {
@@ -122,12 +110,10 @@ impl From<NetworkJob> for Job {
     }
 }
 
-#[derive(Debug)]
-pub(crate) enum RealpathJobResult {
-    // The completed job owns the native path until the guest requests it.
-    Unpublished(Box<[u8]>),
-    // The host c_buffer table owns the path and the job finalizer releases it.
-    Published(HostHandle),
+impl From<FilesystemJob> for Job {
+    fn from(job: FilesystemJob) -> Self {
+        Self::new(JobPayload::Filesystem(job))
+    }
 }
 
 #[derive(Debug)]
@@ -138,110 +124,8 @@ pub(crate) enum JobPayload {
     Sleep {
         duration_ms: i32,
     },
-    Read {
-        file: Option<ResourceRef>,
-        len: u32,
-        position: i64,
-        result: Option<Vec<u8>>,
-    },
-    Write {
-        file: Option<ResourceRef>,
-        data: Vec<u8>,
-        position: i64,
-    },
-    Open {
-        filename: OsString,
-        access: i32,
-        create_mode: i32,
-        append: bool,
-        sync: i32,
-        mode: i32,
-        request: StatRequest,
-        result: Option<OpenJobResult>,
-    },
-    Fstatx {
-        file: Option<ResourceRef>,
-        request: StatRequest,
-        result: Option<PackedStat>,
-    },
-    Statx {
-        parent: Option<ResourceRef>,
-        path: OsString,
-        request: StatRequest,
-        follow_symlink: bool,
-        result: Option<PackedStat>,
-    },
-    FileKindByPath {
-        parent: Option<ResourceRef>,
-        path: OsString,
-        follow_symlink: bool,
-    },
-    FileSize {
-        file: Option<ResourceRef>,
-        result: i64,
-    },
-    FileTime {
-        file: Option<ResourceRef>,
-        result: Option<FileTimeResult>,
-    },
-    FileTimeByPath {
-        path: OsString,
-        follow_symlink: bool,
-        result: Option<FileTimeResult>,
-    },
-    Access {
-        path: OsString,
-        access: i32,
-    },
-    Chmod {
-        path: OsString,
-        mode: i32,
-    },
-    Fsync {
-        file: Option<ResourceRef>,
-        only_data: bool,
-    },
-    Flock {
-        file: Option<ResourceRef>,
-        exclusive: bool,
-    },
-    Remove {
-        path: OsString,
-    },
-    Rename {
-        old_path: OsString,
-        new_path: OsString,
-        replace: bool,
-    },
-    Symlink {
-        target: OsString,
-        path: OsString,
-        force_symlink: bool,
-    },
-    Mkdir {
-        path: OsString,
-        mode: i32,
-    },
-    Rmdir {
-        path: OsString,
-    },
-    Readdir {
-        dir: Option<ResourceRef>,
-        buffer: Option<CBufferLease>,
-        len: u32,
-        restart: bool,
-    },
-    #[cfg(target_os = "linux")]
-    InotifyAddWatch {
-        inotify: Option<ResourceRef>,
-        path: OsString,
-        is_dir: bool,
-    },
+    Filesystem(FilesystemJob),
     Network(NetworkJob),
-    Realpath {
-        path: OsString,
-        result: Option<RealpathJobResult>,
-    },
     #[cfg(unix)]
     SpawnUnix {
         path: OsString,
@@ -250,7 +134,7 @@ pub(crate) enum JobPayload {
         options: SpawnOptions,
         stdio: [Option<ResourceRef>; 3],
         cwd: Option<OsString>,
-        result: Option<OpenJobResource>,
+        result: Option<ResourcePublication>,
     },
     #[cfg(windows)]
     SpawnWindows {
@@ -259,7 +143,7 @@ pub(crate) enum JobPayload {
         options: SpawnOptions,
         stdio: [Option<ResourceRef>; 3],
         cwd: Option<OsString>,
-        result: Option<OpenJobResource>,
+        result: Option<ResourcePublication>,
     },
     WaitForProcess {
         handle: Option<ResourceRef>,

--- a/crates/moonrun/src/async_sys/mod.rs
+++ b/crates/moonrun/src/async_sys/mod.rs
@@ -185,7 +185,7 @@ pub(crate) fn ported_symbols() -> Vec<PortedSymbol> {
 #[cfg(test)]
 pub(crate) fn compat_symbols() -> Vec<CompatSymbol> {
     let mut symbols = Vec::new();
+    symbols.extend(crate::filesystem::compat_symbols());
     symbols.extend_from_slice(internal::fd_util::stub::COMPAT_SYMBOLS);
-    symbols.extend(internal::event_loop::thread_pool::compat_symbols());
     symbols
 }

--- a/crates/moonrun/src/filesystem/job/mod.rs
+++ b/crates/moonrun/src/filesystem/job/mod.rs
@@ -1,0 +1,1053 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Filesystem-owned Job state submitted to moonrun's shared thread pool.
+
+mod runner;
+mod stat;
+
+use std::ffi::{OsStr, OsString};
+
+use crate::async_host::{AsyncHostError, AsyncHostResult, CBufferLease};
+use crate::async_sys::internal::fd_util;
+use crate::guest_memory::GuestMemory;
+use crate::policy::{Policy, RuntimePathBase};
+use crate::resource::{Resource, ResourcePublication, ResourceRef};
+
+use stat::{PackedStat, STAT_DEVICE_ID, STAT_FILE_ID, STAT_FILE_KIND, StatRequest};
+
+pub(crate) const STAT_OPEN_IDENTITY: u32 = stat::STAT_OPEN_IDENTITY;
+
+#[derive(Debug)]
+pub(crate) struct OpenJobResult {
+    pub(crate) resource: ResourcePublication,
+    stat: PackedStat,
+}
+
+#[derive(Clone, Copy)]
+struct FileTimeResult(fd_util::stub::FileTime);
+
+impl FileTimeResult {
+    fn new(file_time: fd_util::stub::FileTime) -> Self {
+        Self(file_time)
+    }
+
+    fn as_native(&self) -> &fd_util::stub::FileTime {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for FileTimeResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("FileTimeResult").finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
+enum RealpathJobResult {
+    // The completed Job owns the native path until the guest requests it.
+    Unpublished(Box<[u8]>),
+    // The host c_buffer table owns the path and the Job finalizer releases it.
+    Published(u64),
+}
+
+#[derive(Debug)]
+pub(crate) struct Job {
+    kind: Kind,
+}
+
+#[derive(Debug)]
+enum Kind {
+    Open {
+        filename: OsString,
+        access: i32,
+        create_mode: i32,
+        append: bool,
+        sync: i32,
+        mode: i32,
+        request: StatRequest,
+        result: Option<OpenJobResult>,
+    },
+    Fstatx {
+        file: Option<ResourceRef>,
+        request: StatRequest,
+        result: Option<PackedStat>,
+    },
+    Statx {
+        parent: Option<ResourceRef>,
+        path: OsString,
+        request: StatRequest,
+        follow_symlink: bool,
+        result: Option<PackedStat>,
+    },
+    Read {
+        file: Option<ResourceRef>,
+        len: u32,
+        position: i64,
+        result: Option<Vec<u8>>,
+    },
+    Write {
+        file: Option<ResourceRef>,
+        data: Vec<u8>,
+        position: i64,
+    },
+    FileKindByPath {
+        parent: Option<ResourceRef>,
+        path: OsString,
+        follow_symlink: bool,
+    },
+    FileSize {
+        file: Option<ResourceRef>,
+        result: i64,
+    },
+    FileTime {
+        file: Option<ResourceRef>,
+        result: Option<FileTimeResult>,
+    },
+    FileTimeByPath {
+        path: OsString,
+        follow_symlink: bool,
+        result: Option<FileTimeResult>,
+    },
+    Access {
+        path: OsString,
+        access: i32,
+    },
+    Chmod {
+        path: OsString,
+        mode: i32,
+    },
+    Fsync {
+        file: Option<ResourceRef>,
+        only_data: bool,
+    },
+    Flock {
+        file: Option<ResourceRef>,
+        exclusive: bool,
+    },
+    Remove {
+        path: OsString,
+    },
+    Rename {
+        old_path: OsString,
+        new_path: OsString,
+        replace: bool,
+    },
+    Symlink {
+        target: OsString,
+        path: OsString,
+        force_symlink: bool,
+    },
+    Mkdir {
+        path: OsString,
+        mode: i32,
+    },
+    Rmdir {
+        path: OsString,
+    },
+    Readdir {
+        dir: Option<ResourceRef>,
+        buffer: Option<CBufferLease>,
+        len: u32,
+        restart: bool,
+    },
+    #[cfg(target_os = "linux")]
+    InotifyAddWatch {
+        inotify: Option<ResourceRef>,
+        path: OsString,
+        is_dir: bool,
+    },
+    Realpath {
+        path: OsString,
+        result: Option<RealpathJobResult>,
+    },
+}
+
+impl Job {
+    // Generic-stat validation belongs to the Filesystem Job so every adapter
+    // constructs the same valid payload. The outer adapter converts rejection
+    // into the native failed-Job representation.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn open(
+        filename: OsString,
+        access: i32,
+        create_mode: i32,
+        append: bool,
+        sync: i32,
+        mode: i32,
+        stat_request: u32,
+        stat_result_len: u32,
+    ) -> AsyncHostResult<Self> {
+        Ok(Self {
+            kind: Kind::Open {
+                filename,
+                access,
+                create_mode,
+                append,
+                sync,
+                mode,
+                request: StatRequest::new(stat_request, stat_result_len)?,
+                result: None,
+            },
+        })
+    }
+
+    pub(crate) fn open_legacy(
+        filename: OsString,
+        access: i32,
+        create_mode: i32,
+        append: bool,
+        sync: i32,
+        mode: i32,
+    ) -> Self {
+        Self {
+            kind: Kind::Open {
+                filename,
+                access,
+                create_mode,
+                append,
+                sync,
+                mode,
+                request: StatRequest::open_identity(),
+                result: None,
+            },
+        }
+    }
+
+    pub(crate) fn fstatx(
+        file: ResourceRef,
+        stat_request: u32,
+        stat_result_len: u32,
+    ) -> AsyncHostResult<Self> {
+        Ok(Self {
+            kind: Kind::Fstatx {
+                file: Some(file),
+                request: StatRequest::new(stat_request, stat_result_len)?,
+                result: None,
+            },
+        })
+    }
+
+    pub(crate) fn statx(
+        parent: Option<ResourceRef>,
+        path: OsString,
+        stat_request: u32,
+        stat_result_len: u32,
+        follow_symlink: bool,
+    ) -> AsyncHostResult<Self> {
+        Ok(Self {
+            kind: Kind::Statx {
+                parent,
+                path,
+                request: StatRequest::new(stat_request, stat_result_len)?,
+                follow_symlink,
+                result: None,
+            },
+        })
+    }
+
+    pub(crate) fn read(file: ResourceRef, len: u32, position: i64) -> Self {
+        Self {
+            kind: Kind::Read {
+                file: Some(file),
+                len,
+                position,
+                result: None,
+            },
+        }
+    }
+
+    pub(crate) fn write(file: ResourceRef, data: Vec<u8>, position: i64) -> Self {
+        Self {
+            kind: Kind::Write {
+                file: Some(file),
+                data,
+                position,
+            },
+        }
+    }
+
+    pub(crate) fn file_kind_by_path(
+        parent: Option<ResourceRef>,
+        path: OsString,
+        follow_symlink: bool,
+    ) -> Self {
+        Self {
+            kind: Kind::FileKindByPath {
+                parent,
+                path,
+                follow_symlink,
+            },
+        }
+    }
+
+    pub(crate) fn file_size(file: ResourceRef) -> Self {
+        Self {
+            kind: Kind::FileSize {
+                file: Some(file),
+                result: 0,
+            },
+        }
+    }
+
+    pub(crate) fn file_time(file: ResourceRef) -> Self {
+        Self {
+            kind: Kind::FileTime {
+                file: Some(file),
+                result: None,
+            },
+        }
+    }
+
+    pub(crate) fn file_time_by_path(path: OsString, follow_symlink: bool) -> Self {
+        Self {
+            kind: Kind::FileTimeByPath {
+                path,
+                follow_symlink,
+                result: None,
+            },
+        }
+    }
+
+    pub(crate) fn access(path: OsString, access: i32) -> Self {
+        Self {
+            kind: Kind::Access { path, access },
+        }
+    }
+
+    pub(crate) fn chmod(path: OsString, mode: i32) -> Self {
+        Self {
+            kind: Kind::Chmod { path, mode },
+        }
+    }
+
+    pub(crate) fn fsync(file: ResourceRef, only_data: bool) -> Self {
+        Self {
+            kind: Kind::Fsync {
+                file: Some(file),
+                only_data,
+            },
+        }
+    }
+
+    pub(crate) fn flock(file: ResourceRef, exclusive: bool) -> Self {
+        Self {
+            kind: Kind::Flock {
+                file: Some(file),
+                exclusive,
+            },
+        }
+    }
+
+    pub(crate) fn remove(path: OsString) -> Self {
+        Self {
+            kind: Kind::Remove { path },
+        }
+    }
+
+    pub(crate) fn rename(old_path: OsString, new_path: OsString, replace: bool) -> Self {
+        Self {
+            kind: Kind::Rename {
+                old_path,
+                new_path,
+                replace,
+            },
+        }
+    }
+
+    pub(crate) fn symlink(target: OsString, path: OsString, force_symlink: bool) -> Self {
+        Self {
+            kind: Kind::Symlink {
+                target,
+                path,
+                force_symlink,
+            },
+        }
+    }
+
+    pub(crate) fn mkdir(path: OsString, mode: i32) -> Self {
+        Self {
+            kind: Kind::Mkdir { path, mode },
+        }
+    }
+
+    pub(crate) fn rmdir(path: OsString) -> Self {
+        Self {
+            kind: Kind::Rmdir { path },
+        }
+    }
+
+    pub(crate) fn readdir(dir: ResourceRef, buffer: CBufferLease, len: u32, restart: bool) -> Self {
+        Self {
+            kind: Kind::Readdir {
+                dir: Some(dir),
+                buffer: Some(buffer),
+                len,
+                restart,
+            },
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn inotify_add_watch(inotify: ResourceRef, path: OsString, is_dir: bool) -> Self {
+        Self {
+            kind: Kind::InotifyAddWatch {
+                inotify: Some(inotify),
+                path,
+                is_dir,
+            },
+        }
+    }
+
+    pub(crate) fn realpath(path: OsString) -> Self {
+        Self {
+            kind: Kind::Realpath { path, result: None },
+        }
+    }
+
+    pub(crate) fn check_policy(&self, policy: &Policy) -> AsyncHostResult<()> {
+        match &self.kind {
+            Kind::Open {
+                filename,
+                access,
+                create_mode,
+                append,
+                request,
+                ..
+            } => {
+                policy.open_path(
+                    RuntimePathBase::CurrentDirectory,
+                    filename,
+                    *access,
+                    *create_mode,
+                    *append,
+                )?;
+                if request.mask() & !STAT_OPEN_IDENTITY != 0 {
+                    policy.stat_path(RuntimePathBase::CurrentDirectory, filename)?;
+                }
+                Ok(())
+            }
+            Kind::Fstatx { file, .. } => check_file_metadata_policy(policy, file.as_deref()),
+            Kind::Statx {
+                parent,
+                path,
+                follow_symlink,
+                ..
+            }
+            | Kind::FileKindByPath {
+                parent,
+                path,
+                follow_symlink,
+            } => check_path_metadata_policy(
+                policy,
+                resource_path_base(parent.as_deref()),
+                path,
+                *follow_symlink,
+            ),
+            Kind::FileSize { file, .. } | Kind::FileTime { file, .. } => {
+                check_file_metadata_policy(policy, file.as_deref())
+            }
+            Kind::FileTimeByPath {
+                path,
+                follow_symlink,
+                ..
+            } => check_path_metadata_policy(
+                policy,
+                RuntimePathBase::CurrentDirectory,
+                path,
+                *follow_symlink,
+            ),
+            Kind::Realpath { path, .. } => {
+                policy.stat_path(RuntimePathBase::CurrentDirectory, path)
+            }
+            #[cfg(target_os = "linux")]
+            Kind::InotifyAddWatch { path, .. } => {
+                policy.stat_path(RuntimePathBase::CurrentDirectory, path)
+            }
+            Kind::Access { path, access } => policy.access_path(path, *access),
+            Kind::Chmod { path, .. } => policy.chmod_path(path),
+            Kind::Flock { file, exclusive } => {
+                check_file_lock_policy(policy, file.as_deref(), *exclusive)
+            }
+            Kind::Remove { path } => policy.remove_path(path),
+            Kind::Rename {
+                old_path, new_path, ..
+            } => policy.rename_path(old_path, new_path),
+            Kind::Symlink { path, .. } => policy.symlink_path(path),
+            Kind::Mkdir { path, .. } => policy.mkdir_path(path),
+            Kind::Rmdir { path } => policy.rmdir_path(path),
+            Kind::Read { .. } | Kind::Write { .. } | Kind::Fsync { .. } | Kind::Readdir { .. } => {
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn run(&mut self) -> AsyncHostResult<i64> {
+        match &mut self.kind {
+            Kind::Open {
+                filename,
+                access,
+                create_mode,
+                append,
+                sync,
+                mode,
+                request,
+                result,
+            } => runner::run_open_job(
+                result,
+                std::mem::take(filename),
+                *access,
+                *create_mode,
+                *append,
+                *sync,
+                *mode,
+                *request,
+            ),
+            Kind::Fstatx {
+                file,
+                request,
+                result,
+            } => match file.take() {
+                Some(file) => stat::run_fstatx_job(&file, *request, result),
+                None => Err(AsyncHostError::Badf),
+            },
+            Kind::Statx {
+                parent,
+                path,
+                request,
+                follow_symlink,
+                result,
+            } => {
+                let parent = parent.take();
+                stat::run_statx_job(
+                    parent.as_deref(),
+                    std::mem::take(path),
+                    *request,
+                    *follow_symlink,
+                    result,
+                )
+            }
+            Kind::Read {
+                file,
+                len,
+                position,
+                result,
+            } => match file.take() {
+                Some(file) => runner::run_read_job(&file, *len, *position, result),
+                None => Err(AsyncHostError::Badf),
+            },
+            Kind::Write {
+                file,
+                data,
+                position,
+            } => match file.take() {
+                Some(file) => runner::run_write_job(&file, data, *position),
+                None => Err(AsyncHostError::Badf),
+            },
+            Kind::FileKindByPath {
+                parent,
+                path,
+                follow_symlink,
+            } => {
+                let parent = parent.take();
+                runner::run_file_kind_by_path_job(
+                    parent.as_deref(),
+                    std::mem::take(path),
+                    *follow_symlink,
+                )
+            }
+            Kind::FileSize { file, result } => match file.take() {
+                Some(file) => runner::run_file_size_job(&file, result),
+                None => Err(AsyncHostError::Badf),
+            },
+            Kind::FileTime { file, result } => match file.take() {
+                Some(file) => runner::run_file_time_job(&file, result),
+                None => Err(AsyncHostError::Badf),
+            },
+            Kind::FileTimeByPath {
+                path,
+                follow_symlink,
+                result,
+            } => runner::run_file_time_by_path_job(std::mem::take(path), *follow_symlink, result),
+            Kind::Access { path, access } => runner::run_access_job(std::mem::take(path), *access),
+            Kind::Chmod { path, mode } => runner::run_chmod_job(std::mem::take(path), *mode),
+            Kind::Fsync { file, only_data } => match file.take() {
+                Some(file) => runner::run_fsync_job(&file, *only_data),
+                None => Err(AsyncHostError::Badf),
+            },
+            Kind::Flock { file, exclusive } => match file.take() {
+                Some(file) => runner::run_flock_job(&file, *exclusive),
+                None => Err(AsyncHostError::Badf),
+            },
+            Kind::Remove { path } => runner::run_remove_job(std::mem::take(path)),
+            Kind::Rename {
+                old_path,
+                new_path,
+                replace,
+            } => {
+                runner::run_rename_job(std::mem::take(old_path), std::mem::take(new_path), *replace)
+            }
+            Kind::Symlink {
+                target,
+                path,
+                force_symlink,
+            } => runner::run_symlink_job(
+                std::mem::take(target),
+                std::mem::take(path),
+                *force_symlink,
+            ),
+            Kind::Mkdir { path, mode } => runner::run_mkdir_job(std::mem::take(path), *mode),
+            Kind::Rmdir { path } => runner::run_rmdir_job(std::mem::take(path)),
+            Kind::Readdir {
+                dir,
+                buffer,
+                len,
+                restart,
+            } => match (dir.take(), buffer.as_mut()) {
+                (Some(dir), Some(buffer)) => {
+                    runner::run_readdir_job(&dir, buffer.as_mut_slice(), *len, *restart)
+                }
+                _ => Err(AsyncHostError::Badf),
+            },
+            #[cfg(target_os = "linux")]
+            Kind::InotifyAddWatch {
+                inotify,
+                path,
+                is_dir,
+            } => match inotify.take() {
+                Some(inotify) => {
+                    runner::run_inotify_add_watch_job(&inotify, std::mem::take(path), *is_dir)
+                }
+                None => Err(AsyncHostError::Badf),
+            },
+            Kind::Realpath { path, result } => {
+                runner::run_realpath_job(std::mem::take(path), result)
+            }
+        }
+    }
+
+    pub(crate) fn take_c_buffer_lease(&mut self) -> Option<CBufferLease> {
+        match &mut self.kind {
+            Kind::Readdir { buffer, .. } => buffer.take(),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn published_realpath_handle(&self) -> Option<u64> {
+        match &self.kind {
+            Kind::Realpath {
+                result: Some(RealpathJobResult::Published(handle)),
+                ..
+            } => Some(*handle),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn open_result(&self) -> AsyncHostResult<&OpenJobResult> {
+        match &self.kind {
+            Kind::Open {
+                result: Some(result),
+                ..
+            } => Ok(result),
+            Kind::Open { .. } => Err(AsyncHostError::Inval),
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    pub(crate) fn open_result_mut(&mut self) -> AsyncHostResult<&mut OpenJobResult> {
+        match &mut self.kind {
+            Kind::Open {
+                result: Some(result),
+                ..
+            } => Ok(result),
+            Kind::Open { .. } => Err(AsyncHostError::Inval),
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    pub(crate) fn stat_result(&self) -> AsyncHostResult<&PackedStat> {
+        match &self.kind {
+            Kind::Open {
+                result: Some(OpenJobResult { stat: result, .. }),
+                ..
+            }
+            | Kind::Fstatx {
+                result: Some(result),
+                ..
+            }
+            | Kind::Statx {
+                result: Some(result),
+                ..
+            } => Ok(result),
+            Kind::Open { .. } | Kind::Fstatx { .. } | Kind::Statx { .. } => {
+                Err(AsyncHostError::Inval)
+            }
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    pub(crate) fn file_size_result(&self) -> AsyncHostResult<i64> {
+        match &self.kind {
+            Kind::FileSize { result, .. } => Ok(*result),
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    pub(crate) fn publish_realpath_result(
+        &mut self,
+        publish: impl FnOnce(Box<[u8]>) -> u64,
+    ) -> AsyncHostResult<u64> {
+        match &mut self.kind {
+            Kind::Realpath {
+                result: Some(RealpathJobResult::Published(handle)),
+                ..
+            } => Ok(*handle),
+            Kind::Realpath { result, .. } => {
+                let Some(RealpathJobResult::Unpublished(buffer)) = result.take() else {
+                    return Err(AsyncHostError::Inval);
+                };
+                let handle = publish(buffer);
+                *result = Some(RealpathJobResult::Published(handle));
+                Ok(handle)
+            }
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    pub(crate) fn copy_read_result(
+        &self,
+        job_error: i32,
+        memory: &mut (impl GuestMemory + ?Sized),
+        dst: u32,
+        offset: u32,
+        len: u32,
+    ) -> AsyncHostResult<()> {
+        if job_error != 0 {
+            return Ok(());
+        }
+        let Kind::Read {
+            result: Some(result),
+            ..
+        } = &self.kind
+        else {
+            return Err(AsyncHostError::Badf);
+        };
+        let dst = dst.checked_add(offset).ok_or(AsyncHostError::Fault)?;
+        memory.write_with_capacity(dst, len, result)?;
+        Ok(())
+    }
+
+    pub(crate) fn copy_file_time_result(
+        &self,
+        job_error: i32,
+        memory: &mut (impl GuestMemory + ?Sized),
+        dst: u32,
+    ) -> AsyncHostResult<()> {
+        if job_error != 0 {
+            return Ok(());
+        }
+        let result = match &self.kind {
+            Kind::FileTime {
+                result: Some(result),
+                ..
+            }
+            | Kind::FileTimeByPath {
+                result: Some(result),
+                ..
+            } => result,
+            _ => return Err(AsyncHostError::Badf),
+        };
+
+        let file_time = result.as_native();
+        let mut record = [0; 48];
+        record[0..8].copy_from_slice(&fd_util::stub::get_atime_sec(file_time).to_le_bytes());
+        record[8..12].copy_from_slice(&fd_util::stub::get_atime_nsec(file_time).to_le_bytes());
+        record[16..24].copy_from_slice(&fd_util::stub::get_mtime_sec(file_time).to_le_bytes());
+        record[24..28].copy_from_slice(&fd_util::stub::get_mtime_nsec(file_time).to_le_bytes());
+        record[32..40].copy_from_slice(&fd_util::stub::get_ctime_sec(file_time).to_le_bytes());
+        record[40..44].copy_from_slice(&fd_util::stub::get_ctime_nsec(file_time).to_le_bytes());
+        memory.write_exact(dst, &record)?;
+        Ok(())
+    }
+
+    pub(crate) fn copy_stat_result(
+        &self,
+        job_error: i32,
+        memory: &mut (impl GuestMemory + ?Sized),
+        dst: u32,
+        dst_len: u32,
+    ) -> AsyncHostResult<()> {
+        if job_error != 0 {
+            return Ok(());
+        }
+        memory.write_with_capacity(dst, dst_len, self.stat_result()?.as_bytes())?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_read_result(&mut self, bytes: Vec<u8>) -> AsyncHostResult<()> {
+        match &mut self.kind {
+            Kind::Read { result, .. } => {
+                *result = Some(bytes);
+                Ok(())
+            }
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_realpath_result(&mut self, path: Box<[u8]>) -> AsyncHostResult<()> {
+        match &mut self.kind {
+            Kind::Realpath { result, .. } => {
+                *result = Some(RealpathJobResult::Unpublished(path));
+                Ok(())
+            }
+            _ => Err(AsyncHostError::Badf),
+        }
+    }
+}
+
+impl OpenJobResult {
+    pub(crate) fn published_resource_handle(&self) -> AsyncHostResult<u64> {
+        match &self.resource {
+            ResourcePublication::Published(handle) => Ok(*handle),
+            ResourcePublication::Unpublished(_) => Err(AsyncHostError::Inval),
+        }
+    }
+
+    pub(crate) fn file_kind(&self) -> AsyncHostResult<i32> {
+        self.stat
+            .scalar(STAT_FILE_KIND)
+            .map(|value| value as i32)
+            .ok_or(AsyncHostError::Inval)
+    }
+
+    pub(crate) fn device_id(&self) -> AsyncHostResult<u64> {
+        self.stat
+            .scalar(STAT_DEVICE_ID)
+            .ok_or(AsyncHostError::Inval)
+    }
+
+    pub(crate) fn file_id(&self) -> AsyncHostResult<u64> {
+        self.stat.scalar(STAT_FILE_ID).ok_or(AsyncHostError::Inval)
+    }
+}
+
+fn check_file_metadata_policy(policy: &Policy, file: Option<&Resource>) -> AsyncHostResult<()> {
+    let file = file.ok_or(AsyncHostError::Badf)?;
+    match file.policy_path() {
+        Some(path) => policy.stat_path(RuntimePathBase::CurrentDirectory, path.as_os_str()),
+        None => policy.stat_path(RuntimePathBase::Untracked, OsStr::new("")),
+    }
+}
+
+fn check_path_metadata_policy(
+    policy: &Policy,
+    base: RuntimePathBase<'_>,
+    path: &OsStr,
+    follow_symlink: bool,
+) -> AsyncHostResult<()> {
+    if follow_symlink {
+        policy.stat_path(base, path)
+    } else {
+        policy.stat_entry_path(base, path)
+    }
+}
+
+fn check_file_lock_policy(
+    policy: &Policy,
+    file: Option<&Resource>,
+    exclusive: bool,
+) -> AsyncHostResult<()> {
+    let file = file.ok_or(AsyncHostError::Badf)?;
+    match file.policy_path() {
+        Some(path) => policy.lock_path(
+            RuntimePathBase::CurrentDirectory,
+            path.as_os_str(),
+            exclusive,
+        ),
+        None => policy.lock_path(RuntimePathBase::Untracked, OsStr::new(""), exclusive),
+    }
+}
+
+fn resource_path_base(parent: Option<&Resource>) -> RuntimePathBase<'_> {
+    match parent {
+        None => RuntimePathBase::CurrentDirectory,
+        Some(parent) => parent
+            .policy_path()
+            .map(RuntimePathBase::PolicyPath)
+            .unwrap_or(RuntimePathBase::Untracked),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
+    runner::PORTED_SYMBOLS.to_vec()
+}
+
+#[cfg(test)]
+pub(crate) fn compat_symbols() -> Vec<crate::async_sys::CompatSymbol> {
+    runner::COMPAT_SYMBOLS.to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn job_executors_reference_native_worker_symbols() {
+        let async_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../third_party/moonbitlang_async");
+        for symbol in ported_symbols() {
+            let source_path = async_root.join(symbol.source);
+            let contents = std::fs::read_to_string(&source_path)
+                .unwrap_or_else(|error| panic!("failed to read {:?}: {error}", source_path));
+            assert!(
+                contents.contains(symbol.native_symbol),
+                "{:?} does not contain native worker symbol {} for {}::{}",
+                source_path,
+                symbol.native_symbol,
+                symbol.rust_module,
+                symbol.rust_symbol
+            );
+        }
+    }
+
+    #[test]
+    fn read_job_carries_resource_and_length_payload() {
+        let file = std::sync::Arc::new(Resource::invalid());
+        let job = Job::read(std::sync::Arc::clone(&file), 8, -1);
+
+        match &job.kind {
+            Kind::Read {
+                file: Some(actual_file),
+                len,
+                position,
+                result: None,
+            } => {
+                assert!(std::sync::Arc::ptr_eq(actual_file, &file));
+                assert_eq!(*len, 8);
+                assert_eq!(*position, -1);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_job_carries_owned_path_and_open_flags() {
+        let job = Job::open_legacy(OsString::from("/tmp/example"), 2, 3, true, 1, 0o644);
+
+        match &job.kind {
+            Kind::Open {
+                filename,
+                access,
+                create_mode,
+                append,
+                sync,
+                mode,
+                request,
+                result: None,
+            } => {
+                assert_eq!(filename, &OsString::from("/tmp/example"));
+                assert_eq!(*access, 2);
+                assert_eq!(*create_mode, 3);
+                assert!(*append);
+                assert_eq!(*sync, 1);
+                assert_eq!(*mode, 0o644);
+                assert_eq!(request.mask(), STAT_OPEN_IDENTITY);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn realpath_job_carries_owned_path() {
+        let job = Job::realpath(OsString::from("/tmp/example"));
+
+        match &job.kind {
+            Kind::Realpath { path, result: None } => {
+                assert_eq!(path, &OsString::from("/tmp/example"));
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn realpath_job_resolves_to_nul_terminated_c_buffer() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        let link = tmp.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let mut job = Job::realpath(link.into_os_string());
+
+        assert_eq!(job.run(), Ok(0));
+        let Kind::Realpath {
+            result: Some(RealpathJobResult::Unpublished(buffer)),
+            ..
+        } = &job.kind
+        else {
+            panic!("expected completed realpath Job");
+        };
+        let realpath = std::ffi::CStr::from_bytes_with_nul(buffer.as_ref()).unwrap();
+        let expected = std::fs::canonicalize(target).unwrap();
+        assert_eq!(realpath.to_bytes(), expected.as_os_str().as_bytes());
+    }
+
+    #[test]
+    fn realpath_result_is_published_once() {
+        let mut job = Job::realpath(OsString::from("unused"));
+        let Kind::Realpath { result, .. } = &mut job.kind else {
+            unreachable!();
+        };
+        *result = Some(RealpathJobResult::Unpublished(
+            b"resolved\0".to_vec().into_boxed_slice(),
+        ));
+
+        let handle = job
+            .publish_realpath_result(|buffer| {
+                assert_eq!(&*buffer, b"resolved\0");
+                42
+            })
+            .unwrap();
+        let same_handle = job
+            .publish_realpath_result(|_| {
+                panic!("a published realpath result must not be published again")
+            })
+            .unwrap();
+
+        assert_eq!(handle, 42);
+        assert_eq!(same_handle, handle);
+    }
+
+    #[test]
+    fn resource_job_releases_file_when_worker_finishes() {
+        let file = std::sync::Arc::new(Resource::invalid());
+        let file_ref = std::sync::Arc::downgrade(&file);
+        let mut job = Job::flock(std::sync::Arc::clone(&file), true);
+        drop(file);
+
+        let _ = job.run();
+
+        assert!(file_ref.upgrade().is_none());
+    }
+}

--- a/crates/moonrun/src/filesystem/job/mod.rs
+++ b/crates/moonrun/src/filesystem/job/mod.rs
@@ -799,7 +799,7 @@ impl Job {
         Ok(())
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     pub(crate) fn set_read_result(&mut self, bytes: Vec<u8>) -> AsyncHostResult<()> {
         match &mut self.kind {
             Kind::Read { result, .. } => {
@@ -810,7 +810,7 @@ impl Job {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     pub(crate) fn set_realpath_result(&mut self, path: Box<[u8]>) -> AsyncHostResult<()> {
         match &mut self.kind {
             Kind::Realpath { result, .. } => {

--- a/crates/moonrun/src/filesystem/job/runner.rs
+++ b/crates/moonrun/src/filesystem/job/runner.rs
@@ -16,8 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Concrete filesystem job executors ported from
-//! `moonbitlang/async/src/internal/event_loop/thread_pool.c`.
+//! Blocking filesystem operations executed by Filesystem Jobs.
 
 use std::ffi::OsString;
 #[cfg(unix)]
@@ -28,10 +27,10 @@ use std::os::windows::io::AsRawHandle;
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util;
 use crate::async_sys::ported_fns;
-use crate::resource::Resource;
+use crate::resource::{Resource, ResourcePublication};
 
 use super::stat::{StatRequest, run_fstatx_job};
-use super::{FileTimeResult, OpenJobResource, OpenJobResult, RealpathJobResult};
+use super::{FileTimeResult, OpenJobResult, RealpathJobResult};
 
 type RawFile = fd_util::stub::RawFd;
 
@@ -67,7 +66,7 @@ ported_fns! {
         let mut stat = None;
         run_fstatx_job(&resource, request, &mut stat)?;
         *result = Some(OpenJobResult {
-            resource: OpenJobResource::Unpublished(resource),
+            resource: ResourcePublication::Unpublished(resource),
             stat: stat.ok_or(AsyncHostError::Io)?,
         });
         Ok(0)

--- a/crates/moonrun/src/filesystem/job/stat.rs
+++ b/crates/moonrun/src/filesystem/job/stat.rs
@@ -761,7 +761,7 @@ mod platform {
         INVALID_FILE_SIZE, OPEN_EXISTING,
     };
 
-    use super::super::fs::{handle_is_socket, resolve_windows_path_for_parent};
+    use super::super::runner::{handle_is_socket, resolve_windows_path_for_parent};
     use super::*;
 
     #[derive(Default)]
@@ -998,11 +998,6 @@ mod platform {
 mod tests {
     use super::*;
     #[cfg(unix)]
-    use crate::async_sys::internal::event_loop::thread_pool::{
-        JobPayload, get_stat_result, make_fstatx_job,
-    };
-    use crate::async_sys::internal::event_loop::thread_pool::{make_open_stat_job, run_host_job};
-    #[cfg(unix)]
     use crate::resource::Resource;
 
     #[test]
@@ -1075,26 +1070,20 @@ mod tests {
         let raw = unsafe { libc::dup(temp.as_file().as_raw_fd()) };
         assert!(raw >= 0);
         let request = STAT_FILE_KIND | STAT_FILE_SIZE | STAT_DEVICE_ID | STAT_FILE_ID;
-        let mut job = make_fstatx_job(
+        let mut job = crate::filesystem::Job::fstatx(
             std::sync::Arc::new(Resource::new(raw)),
             request,
             u32::try_from(StatRequest::new(request, 40).unwrap().encoded_len()).unwrap(),
-        );
+        )
+        .unwrap();
 
-        run_host_job(&mut job);
+        assert_eq!(job.run(), Ok(0));
 
-        assert_eq!(job.err(), 0);
-        let JobPayload::Fstatx {
-            result: Some(result),
-            ..
-        } = job.payload()
-        else {
-            panic!("expected a host-owned packed result");
-        };
+        let result = job.stat_result().unwrap();
         assert_eq!(result.as_bytes()[0..4], 40_u32.to_le_bytes());
 
         let mut guest = [0_u8; 48];
-        get_stat_result(&job, &mut guest[..], 4, 40).unwrap();
+        job.copy_stat_result(0, &mut guest[..], 4, 40).unwrap();
         assert_eq!(guest[0..4], [0; 4]);
         assert_eq!(guest[4..8], 40_u32.to_le_bytes());
         assert_eq!(guest[8..12], request.to_le_bytes());
@@ -1102,10 +1091,10 @@ mod tests {
     }
 
     #[test]
-    fn invalid_open_stat_request_fails_before_opening_the_path() {
+    fn invalid_open_stat_request_is_rejected_before_opening_the_path() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("must-not-be-created");
-        let mut job = make_open_stat_job(
+        let error = crate::filesystem::Job::open(
             path.clone().into_os_string(),
             1,
             3,
@@ -1114,12 +1103,10 @@ mod tests {
             0o600,
             0x0100,
             8,
-        );
+        )
+        .unwrap_err();
 
-        run_host_job(&mut job);
-
-        assert_eq!(job.ret(), -1);
-        assert_eq!(job.err(), AsyncHostError::Inval.errno());
+        assert_eq!(error, AsyncHostError::Inval);
         assert!(!path.exists());
     }
 

--- a/crates/moonrun/src/filesystem/mod.rs
+++ b/crates/moonrun/src/filesystem/mod.rs
@@ -25,6 +25,13 @@
 
 pub(crate) mod v8;
 
+mod job;
+
+pub(crate) use job::Job;
+
+#[cfg(test)]
+pub(crate) use job::{STAT_OPEN_IDENTITY, compat_symbols};
+
 use std::ffi::OsStr;
 use std::fmt;
 use std::path::Path;

--- a/crates/moonrun/src/resource.rs
+++ b/crates/moonrun/src/resource.rs
@@ -36,6 +36,13 @@ use std::os::windows::io::{
 
 pub(crate) type ResourceRef = Arc<Resource>;
 
+/// A Resource returned by a Job before or after it is exposed through a Handle.
+#[derive(Debug)]
+pub(crate) enum ResourcePublication {
+    Unpublished(Resource),
+    Published(u64),
+}
+
 #[cfg(unix)]
 type OwnedRawFile = OwnedFd;
 #[cfg(windows)]


### PR DESCRIPTION
## Summary

- move filesystem Job state, policy checks, blocking execution, and result handling into the filesystem module
- keep the shared Job envelope and thread-pool scheduling, cancellation, and completion lifecycle in the thread-pool module
- keep guest ABI provenance at the import layer and implementation provenance on the operations that perform the work

## Why

Filesystem operation semantics were spread across Async Host and thread-pool internals. That made the thread pool responsible for domain behavior and obscured the common Job contract. This change gives filesystem work one cohesive owner while preserving the existing execution strategy.

## Correctness

The guest ABI and observable Job `ret`/`err` behavior are unchanged. Filesystem Jobs still pass through the same worker scheduling and completion path; only ownership of their state and result interpretation moves. Compatibility imports remain explicit API-only adapters, while blocking implementations retain their exact upstream provenance.

## Scope

This is a focused ownership refactor. It does not introduce type erasure, a generic Job trait, or new asynchronous operations. Other domains can migrate independently in later changes.