### PR TITLE
refactor(mooncake): own executable package resolution

### DIFF
--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -18,10 +18,9 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, bail};
-use mooncake::registry::{Registry, RegistryClient, path as registry_path};
-use moonutil::{locks::lock_directory, resolution::ModuleName, user_log::UserLog};
-use semver::Version;
+use anyhow::Context;
+use mooncake::registry::{RegistryClient, ResolvedExecutablePackage};
+use moonutil::{MOON_HOME, locks::lock_directory, user_log::UserLog};
 
 use crate::rr_build;
 
@@ -30,200 +29,6 @@ pub(crate) enum RegistryRunTarget {
         experimental_policy: Option<PathBuf>,
     },
     Native,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct ResolvedExecutablePackage {
-    pub module_name: ModuleName,
-    pub package_path: String,
-    pub version: Version,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum LatestVersionLookup {
-    Found(Version),
-    NoVersionInformation,
-    NotFound,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum ExecutablePackageVersionSelector {
-    Exact(Version),
-    LocallyKnownLatest,
-    RefreshLatest,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LatestVersionResolutionPolicy {
-    PreferLocal,
-    Refresh,
-}
-
-impl ResolvedExecutablePackage {
-    pub(super) fn artifact_name(&self, suffix: &str) -> String {
-        let stem = if self.package_path.is_empty() {
-            self.module_name.last_segment()
-        } else {
-            self.package_path
-                .rsplit('/')
-                .next()
-                .expect("non-empty package path must have a last segment")
-        };
-        format!("{stem}{suffix}")
-    }
-
-    pub(super) fn cache_path(&self, suffix: &str) -> PathBuf {
-        moonutil::MOON_HOME.registry_executable_artifact_path(
-            &self.module_name,
-            &self.version,
-            &self.package_path,
-            &self.artifact_name(suffix),
-        )
-    }
-}
-
-fn resolve_registry_package(
-    package: &str,
-    user_log: &UserLog,
-) -> anyhow::Result<ResolvedExecutablePackage> {
-    let (module_name, package_path, requested_version) =
-        parse_executable_package_coordinate(package)?;
-    let version = match requested_version {
-        ExecutablePackageVersionSelector::Exact(version) => version,
-        ExecutablePackageVersionSelector::LocallyKnownLatest => resolve_latest_version(
-            &module_name,
-            LatestVersionResolutionPolicy::PreferLocal,
-            user_log,
-        )?,
-        ExecutablePackageVersionSelector::RefreshLatest => resolve_latest_version(
-            &module_name,
-            LatestVersionResolutionPolicy::Refresh,
-            user_log,
-        )?,
-    };
-    Ok(ResolvedExecutablePackage {
-        module_name,
-        package_path,
-        version,
-    })
-}
-
-fn resolve_latest_version(
-    module_name: &ModuleName,
-    policy: LatestVersionResolutionPolicy,
-    user_log: &UserLog,
-) -> anyhow::Result<Version> {
-    let registry = RegistryClient::configured();
-    let had_index = registry.has_cached_index();
-
-    resolve_latest_version_with(
-        module_name,
-        user_log,
-        had_index,
-        policy,
-        || latest_version_from_registry(&registry, module_name),
-        || registry.sync(user_log),
-    )
-}
-
-fn latest_version_from_registry(
-    registry: &impl Registry,
-    module_name: &ModuleName,
-) -> LatestVersionLookup {
-    let versions = match registry.all_versions_of(module_name) {
-        Ok(versions) => versions,
-        Err(_) => return LatestVersionLookup::NotFound,
-    };
-    versions
-        .last_key_value()
-        .map(|(version, _)| LatestVersionLookup::Found(version.clone()))
-        .unwrap_or(LatestVersionLookup::NoVersionInformation)
-}
-
-fn resolve_latest_version_with(
-    module_name: &ModuleName,
-    user_log: &UserLog,
-    had_index: bool,
-    policy: LatestVersionResolutionPolicy,
-    mut lookup_latest_version: impl FnMut() -> LatestVersionLookup,
-    mut update_registry: impl FnMut() -> anyhow::Result<()>,
-) -> anyhow::Result<Version> {
-    if policy == LatestVersionResolutionPolicy::PreferLocal
-        && let LatestVersionLookup::Found(version) = lookup_latest_version()
-    {
-        user_log.info(format!(
-            "Resolved {module_name} latest version to {version}"
-        ));
-        return Ok(version);
-    }
-
-    match update_registry() {
-        Ok(()) => {}
-        Err(e) if policy == LatestVersionResolutionPolicy::Refresh => {
-            return Err(e).context("Failed to update registry index");
-        }
-        Err(e) => {
-            if had_index {
-                user_log.warn(format!(
-                    "Failed to update registry index, using cached index: {}",
-                    e
-                ));
-            } else {
-                return Err(e).context("Failed to update registry index");
-            }
-        }
-    }
-
-    let version = match lookup_latest_version() {
-        LatestVersionLookup::Found(version) => version,
-        LatestVersionLookup::NoVersionInformation => {
-            bail!("Module `{module_name}` has no version information")
-        }
-        LatestVersionLookup::NotFound if had_index => {
-            bail!("Module `{module_name}` not found in registry")
-        }
-        LatestVersionLookup::NotFound => {
-            bail!("Module `{module_name}` not found in registry after updating the index")
-        }
-    };
-    user_log.info(format!(
-        "Resolved {module_name} latest version to {version}"
-    ));
-    Ok(version)
-}
-
-fn parse_executable_package_coordinate(
-    input: &str,
-) -> anyhow::Result<(ModuleName, String, ExecutablePackageVersionSelector)> {
-    if input.ends_with("...") {
-        bail!("Invalid package coordinate `{input}`: wildcard package paths are not supported");
-    }
-
-    if input.contains('@') {
-        let parsed = if let Ok(parsed) = registry_path::parse_module_at_version_path(input) {
-            parsed
-        } else if let Ok(parsed) = registry_path::parse_package_at_version_path(input) {
-            parsed
-        } else {
-            bail!("Invalid package coordinate `{input}`");
-        };
-        let version = if parsed.version == "latest" {
-            ExecutablePackageVersionSelector::RefreshLatest
-        } else {
-            ExecutablePackageVersionSelector::Exact(Version::parse(&parsed.version).with_context(
-                || format!("Invalid version `{}` in package coordinate", parsed.version),
-            )?)
-        };
-        return Ok((parsed.module, parsed.package, version));
-    }
-
-    let parsed = registry_path::parse_install_style_path(input)
-        .with_context(|| format!("Invalid package coordinate `{input}`"))?;
-    Ok((
-        parsed.module,
-        parsed.package,
-        ExecutablePackageVersionSelector::LocallyKnownLatest,
-    ))
 }
 
 pub(super) fn ensure_cached_file(
@@ -277,12 +82,12 @@ pub(crate) fn prepare(
     verbose: bool,
     user_log: &UserLog,
 ) -> anyhow::Result<std::process::Command> {
-    let package = resolve_registry_package(&package, user_log)?;
+    let registry = RegistryClient::configured();
     match target {
         RegistryRunTarget::Wasm {
             experimental_policy,
         } => {
-            let wasm_path = super::runwasm::cached_wasm_path(&package, user_log)?;
+            let wasm_path = registry.acquire_executable_wasm(&package, user_log)?;
             prepare_artifact(
                 crate::run::ExecutionMode::MoonRun,
                 &wasm_path,
@@ -292,6 +97,7 @@ pub(crate) fn prepare(
             )
         }
         RegistryRunTarget::Native => {
+            let package = registry.resolve_executable_package(&package, user_log)?;
             let executable = cached_native_executable(&package, user_log, quiet, verbose)?;
             prepare_artifact(
                 crate::run::ExecutionMode::Native,
@@ -310,7 +116,12 @@ fn cached_native_executable(
     quiet: bool,
     verbose: bool,
 ) -> anyhow::Result<PathBuf> {
-    let cache_path = package.cache_path(".exe");
+    let cache_path = MOON_HOME.registry_executable_artifact_path(
+        &package.module_name,
+        &package.version,
+        &package.package_path,
+        &package.artifact_name(".exe"),
+    );
 
     ensure_cached_file(&cache_path, user_log, |staged| {
         super::install_binary::build_registry_native_executable_to(
@@ -345,224 +156,14 @@ fn prepare_artifact(
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        cell::Cell,
-        sync::{
-            Arc, Barrier,
-            atomic::{AtomicUsize, Ordering},
-        },
+    use std::sync::{
+        Arc, Barrier,
+        atomic::{AtomicUsize, Ordering},
     };
 
+    use anyhow::bail;
+
     use super::*;
-
-    fn parse(input: &str) -> (ModuleName, String, ExecutablePackageVersionSelector) {
-        parse_executable_package_coordinate(input).unwrap()
-    }
-
-    #[test]
-    fn parse_install_style_version() {
-        let (module_name, package_path, version) = parse("moonbitlang/parser/cmd/moonfmt@0.3.3");
-        assert_eq!(module_name.to_string(), "moonbitlang/parser");
-        assert_eq!(package_path, "cmd/moonfmt");
-        assert_eq!(
-            version,
-            ExecutablePackageVersionSelector::Exact("0.3.3".parse().unwrap())
-        );
-    }
-
-    #[test]
-    fn parse_module_version_alias() {
-        let (module_name, package_path, version) = parse("moonbitlang/parser@0.3.3/cmd/moonfmt");
-        assert_eq!(module_name.to_string(), "moonbitlang/parser");
-        assert_eq!(package_path, "cmd/moonfmt");
-        assert_eq!(
-            version,
-            ExecutablePackageVersionSelector::Exact("0.3.3".parse().unwrap())
-        );
-    }
-
-    #[test]
-    fn parse_unpinned_coordinate() {
-        let (module_name, package_path, version) = parse("moonbitlang/parser/cmd/moonfmt");
-        assert_eq!(module_name.to_string(), "moonbitlang/parser");
-        assert_eq!(package_path, "cmd/moonfmt");
-        assert_eq!(
-            version,
-            ExecutablePackageVersionSelector::LocallyKnownLatest
-        );
-    }
-
-    #[test]
-    fn parse_explicit_latest_coordinates() {
-        let (module_name, package_path, version) = parse("moonbitlang/parser/cmd/moonfmt@latest");
-        assert_eq!(module_name.to_string(), "moonbitlang/parser");
-        assert_eq!(package_path, "cmd/moonfmt");
-        assert_eq!(version, ExecutablePackageVersionSelector::RefreshLatest);
-
-        let (module_name, package_path, version) = parse("moonbitlang/parser@latest/cmd/moonfmt");
-        assert_eq!(module_name.to_string(), "moonbitlang/parser");
-        assert_eq!(package_path, "cmd/moonfmt");
-        assert_eq!(version, ExecutablePackageVersionSelector::RefreshLatest);
-    }
-
-    #[test]
-    fn latest_resolution_uses_local_registry_before_updating() {
-        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
-        let mut update_called = false;
-
-        let version = resolve_latest_version_with(
-            &module_name,
-            &UserLog::new(log::LevelFilter::Warn),
-            true,
-            LatestVersionResolutionPolicy::PreferLocal,
-            || LatestVersionLookup::Found("0.3.3".parse().unwrap()),
-            || {
-                update_called = true;
-                Ok(())
-            },
-        )
-        .unwrap();
-
-        assert_eq!(version.to_string(), "0.3.3");
-        assert!(!update_called);
-    }
-
-    #[test]
-    fn latest_resolution_updates_after_local_registry_miss() {
-        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
-        let mut lookup_count = 0;
-        let mut update_called = false;
-
-        let version = resolve_latest_version_with(
-            &module_name,
-            &UserLog::new(log::LevelFilter::Warn),
-            true,
-            LatestVersionResolutionPolicy::PreferLocal,
-            || {
-                lookup_count += 1;
-                if lookup_count > 1 {
-                    LatestVersionLookup::Found("0.3.3".parse().unwrap())
-                } else {
-                    LatestVersionLookup::NotFound
-                }
-            },
-            || {
-                update_called = true;
-                Ok(())
-            },
-        )
-        .unwrap();
-
-        assert_eq!(version.to_string(), "0.3.3");
-        assert_eq!(lookup_count, 2);
-        assert!(update_called);
-    }
-
-    #[test]
-    fn explicit_latest_refreshes_before_resolving() {
-        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
-        let registry_updated = Cell::new(false);
-        let lookup_count = Cell::new(0);
-
-        let version = resolve_latest_version_with(
-            &module_name,
-            &UserLog::new(log::LevelFilter::Warn),
-            true,
-            LatestVersionResolutionPolicy::Refresh,
-            || {
-                lookup_count.set(lookup_count.get() + 1);
-                LatestVersionLookup::Found(
-                    if registry_updated.get() {
-                        "0.4.0"
-                    } else {
-                        "0.3.3"
-                    }
-                    .parse()
-                    .unwrap(),
-                )
-            },
-            || {
-                registry_updated.set(true);
-                Ok(())
-            },
-        )
-        .unwrap();
-
-        assert_eq!(version.to_string(), "0.4.0");
-        assert!(registry_updated.get());
-        assert_eq!(lookup_count.get(), 1);
-    }
-
-    #[test]
-    fn explicit_latest_fails_when_refresh_fails() {
-        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
-        let lookup_called = Cell::new(false);
-
-        let err = resolve_latest_version_with(
-            &module_name,
-            &UserLog::new(log::LevelFilter::Warn),
-            true,
-            LatestVersionResolutionPolicy::Refresh,
-            || {
-                lookup_called.set(true);
-                LatestVersionLookup::Found("0.3.3".parse().unwrap())
-            },
-            || Err(anyhow::anyhow!("offline")),
-        )
-        .unwrap_err();
-
-        assert_eq!(err.to_string(), "Failed to update registry index");
-        assert_eq!(err.source().unwrap().to_string(), "offline");
-        assert!(!lookup_called.get());
-    }
-
-    #[test]
-    fn latest_resolution_preserves_no_version_information_after_update() {
-        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
-        let mut update_called = false;
-
-        let err = resolve_latest_version_with(
-            &module_name,
-            &UserLog::new(log::LevelFilter::Warn),
-            true,
-            LatestVersionResolutionPolicy::PreferLocal,
-            || LatestVersionLookup::NoVersionInformation,
-            || {
-                update_called = true;
-                Ok(())
-            },
-        )
-        .unwrap_err();
-
-        assert_eq!(
-            err.to_string(),
-            "Module `moonbitlang/parser` has no version information"
-        );
-        assert!(update_called);
-    }
-
-    #[test]
-    fn root_package_uses_module_last_segment_for_artifact_name() {
-        let package = ResolvedExecutablePackage {
-            module_name: "moonbitlang/parser".parse().unwrap(),
-            package_path: String::new(),
-            version: "0.3.3".parse().unwrap(),
-        };
-        assert_eq!(package.artifact_name(".exe"), "parser.exe");
-    }
-
-    #[test]
-    fn reject_invalid_coordinates() {
-        assert!(parse_executable_package_coordinate("moonbitlang/parser@bad/cmd/moonfmt").is_err());
-        assert!(parse_executable_package_coordinate("moonbitlang/parser/cmd/moonfmt@bad").is_err());
-        assert!(parse_executable_package_coordinate("moonbitlang/parser@0.3.3/cmd@0.4.0").is_err());
-        assert!(parse_executable_package_coordinate("moonbitlang/parser/0.3.3@0.4.0/cmd").is_err());
-        assert!(parse_executable_package_coordinate("moonbitlang/parser/...").is_err());
-        assert!(parse_executable_package_coordinate("moonbitlang/parser//cmd").is_err());
-        assert!(parse_executable_package_coordinate("./moonbitlang/parser").is_err());
-        assert!(parse_executable_package_coordinate("C:/moonbitlang/parser").is_err());
-        assert!(parse_executable_package_coordinate("https://mooncakes.io/x").is_err());
-    }
 
     #[test]
     fn failed_production_does_not_publish_a_cache_entry() {

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -19,14 +19,13 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::bail;
-use mooncake::registry::RegistryClient;
 use moonutil::{
     cli_support::AutoSyncFlags, cli_support::UniversalFlags, command_output::CommandOutput,
-    constants::is_moon_pkg_exist, target::SurfaceTarget, user_log::UserLog,
+    constants::is_moon_pkg_exist, target::SurfaceTarget,
 };
 use tracing::instrument;
 
-use super::{BuildFlags, RunSubcommand, registry_runner::ResolvedExecutablePackage};
+use super::{BuildFlags, RunSubcommand};
 use crate::cli::process::ProcessAction;
 
 /// Run a local package as WebAssembly or a prebuilt WebAssembly binary
@@ -94,18 +93,6 @@ pub(crate) fn run_runwasm(
         output.user_log(),
     )
     .map(ProcessAction::Delegate)
-}
-
-pub(super) fn cached_wasm_path(
-    package: &ResolvedExecutablePackage,
-    user_log: &UserLog,
-) -> anyhow::Result<PathBuf> {
-    RegistryClient::configured().acquire_wasm_asset(
-        &package.module_name,
-        &package.version,
-        &package.package_path,
-        user_log,
-    )
 }
 
 fn should_run_as_local_package(input: &str) -> anyhow::Result<bool> {

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -17,6 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 mod client;
+mod executable;
 #[cfg(test)]
 pub(crate) mod mock;
 pub mod path;
@@ -24,6 +25,7 @@ pub mod path;
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 pub use client::RegistryClient;
+pub use executable::ResolvedExecutablePackage;
 use indexmap::IndexMap;
 use moonutil::dependency::SourceDependencyInfo;
 use moonutil::resolution::ModuleName;

--- a/crates/mooncake/src/registry/executable.rs
+++ b/crates/mooncake/src/registry/executable.rs
@@ -1,0 +1,443 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use anyhow::{Context, bail};
+use moonutil::{resolution::ModuleName, user_log::UserLog};
+use semver::Version;
+
+use super::{Registry, RegistryClient, path as registry_path};
+
+/// One exact main package selected by an Executable Package Coordinate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedExecutablePackage {
+    pub module_name: ModuleName,
+    pub package_path: String,
+    pub version: Version,
+}
+
+impl ResolvedExecutablePackage {
+    pub fn artifact_name(&self, suffix: &str) -> String {
+        let stem = if self.package_path.is_empty() {
+            self.module_name.last_segment()
+        } else {
+            self.package_path
+                .rsplit('/')
+                .next()
+                .expect("non-empty package path must have a last segment")
+        };
+        format!("{stem}{suffix}")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LatestVersionLookup {
+    Found(Version),
+    NoVersionInformation,
+    NotFound,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExecutablePackageVersionSelector {
+    Exact(Version),
+    LocallyKnownLatest,
+    RefreshLatest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LatestVersionResolutionPolicy {
+    PreferLocal,
+    Refresh,
+}
+
+impl RegistryClient {
+    /// Resolve an Executable Package Coordinate to one exact main package.
+    pub fn resolve_executable_package(
+        &self,
+        coordinate: &str,
+        user_log: &UserLog,
+    ) -> anyhow::Result<ResolvedExecutablePackage> {
+        let (module_name, package_path, requested_version) =
+            parse_executable_package_coordinate(coordinate)?;
+        let version = match requested_version {
+            ExecutablePackageVersionSelector::Exact(version) => version,
+            ExecutablePackageVersionSelector::LocallyKnownLatest => self
+                .resolve_latest_executable_version(
+                    &module_name,
+                    LatestVersionResolutionPolicy::PreferLocal,
+                    user_log,
+                )?,
+            ExecutablePackageVersionSelector::RefreshLatest => self
+                .resolve_latest_executable_version(
+                    &module_name,
+                    LatestVersionResolutionPolicy::Refresh,
+                    user_log,
+                )?,
+        };
+        Ok(ResolvedExecutablePackage {
+            module_name,
+            package_path,
+            version,
+        })
+    }
+
+    /// Resolve an Executable Package Coordinate and acquire its cached Wasm artifact.
+    pub fn acquire_executable_wasm(
+        &self,
+        coordinate: &str,
+        user_log: &UserLog,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        let package = self.resolve_executable_package(coordinate, user_log)?;
+        self.acquire_wasm_asset(
+            &package.module_name,
+            &package.version,
+            &package.package_path,
+            user_log,
+        )
+    }
+
+    fn resolve_latest_executable_version(
+        &self,
+        module_name: &ModuleName,
+        policy: LatestVersionResolutionPolicy,
+        user_log: &UserLog,
+    ) -> anyhow::Result<Version> {
+        resolve_latest_version_with(
+            module_name,
+            user_log,
+            self.has_cached_index(),
+            policy,
+            || latest_version_from_registry(self, module_name),
+            || self.sync(user_log),
+        )
+    }
+}
+
+fn latest_version_from_registry(
+    registry: &impl Registry,
+    module_name: &ModuleName,
+) -> LatestVersionLookup {
+    let versions = match registry.all_versions_of(module_name) {
+        Ok(versions) => versions,
+        Err(_) => return LatestVersionLookup::NotFound,
+    };
+    versions
+        .last_key_value()
+        .map(|(version, _)| LatestVersionLookup::Found(version.clone()))
+        .unwrap_or(LatestVersionLookup::NoVersionInformation)
+}
+
+fn resolve_latest_version_with(
+    module_name: &ModuleName,
+    user_log: &UserLog,
+    had_index: bool,
+    policy: LatestVersionResolutionPolicy,
+    mut lookup_latest_version: impl FnMut() -> LatestVersionLookup,
+    mut update_registry: impl FnMut() -> anyhow::Result<()>,
+) -> anyhow::Result<Version> {
+    if policy == LatestVersionResolutionPolicy::PreferLocal
+        && let LatestVersionLookup::Found(version) = lookup_latest_version()
+    {
+        user_log.info(format!(
+            "Resolved {module_name} latest version to {version}"
+        ));
+        return Ok(version);
+    }
+
+    match update_registry() {
+        Ok(()) => {}
+        Err(error) if policy == LatestVersionResolutionPolicy::Refresh => {
+            return Err(error).context("Failed to update registry index");
+        }
+        Err(error) => {
+            if had_index {
+                user_log.warn(format!(
+                    "Failed to update registry index, using cached index: {error}"
+                ));
+            } else {
+                return Err(error).context("Failed to update registry index");
+            }
+        }
+    }
+
+    let version = match lookup_latest_version() {
+        LatestVersionLookup::Found(version) => version,
+        LatestVersionLookup::NoVersionInformation => {
+            bail!("Module `{module_name}` has no version information")
+        }
+        LatestVersionLookup::NotFound if had_index => {
+            bail!("Module `{module_name}` not found in registry")
+        }
+        LatestVersionLookup::NotFound => {
+            bail!("Module `{module_name}` not found in registry after updating the index")
+        }
+    };
+    user_log.info(format!(
+        "Resolved {module_name} latest version to {version}"
+    ));
+    Ok(version)
+}
+
+fn parse_executable_package_coordinate(
+    input: &str,
+) -> anyhow::Result<(ModuleName, String, ExecutablePackageVersionSelector)> {
+    if input.ends_with("...") {
+        bail!("Invalid package coordinate `{input}`: wildcard package paths are not supported");
+    }
+
+    if input.contains('@') {
+        let parsed = if let Ok(parsed) = registry_path::parse_module_at_version_path(input) {
+            parsed
+        } else if let Ok(parsed) = registry_path::parse_package_at_version_path(input) {
+            parsed
+        } else {
+            bail!("Invalid package coordinate `{input}`");
+        };
+        let version = if parsed.version == "latest" {
+            ExecutablePackageVersionSelector::RefreshLatest
+        } else {
+            ExecutablePackageVersionSelector::Exact(Version::parse(&parsed.version).with_context(
+                || format!("Invalid version `{}` in package coordinate", parsed.version),
+            )?)
+        };
+        return Ok((parsed.module, parsed.package, version));
+    }
+
+    let parsed = registry_path::parse_install_style_path(input)
+        .with_context(|| format!("Invalid package coordinate `{input}`"))?;
+    Ok((
+        parsed.module,
+        parsed.package,
+        ExecutablePackageVersionSelector::LocallyKnownLatest,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    fn parse(input: &str) -> (ModuleName, String, ExecutablePackageVersionSelector) {
+        parse_executable_package_coordinate(input).unwrap()
+    }
+
+    #[test]
+    fn parse_install_style_version() {
+        let (module_name, package_path, version) = parse("moonbitlang/parser/cmd/moonfmt@0.3.3");
+        assert_eq!(module_name.to_string(), "moonbitlang/parser");
+        assert_eq!(package_path, "cmd/moonfmt");
+        assert_eq!(
+            version,
+            ExecutablePackageVersionSelector::Exact("0.3.3".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn parse_module_version_alias() {
+        let (module_name, package_path, version) = parse("moonbitlang/parser@0.3.3/cmd/moonfmt");
+        assert_eq!(module_name.to_string(), "moonbitlang/parser");
+        assert_eq!(package_path, "cmd/moonfmt");
+        assert_eq!(
+            version,
+            ExecutablePackageVersionSelector::Exact("0.3.3".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn parse_unpinned_coordinate() {
+        let (module_name, package_path, version) = parse("moonbitlang/parser/cmd/moonfmt");
+        assert_eq!(module_name.to_string(), "moonbitlang/parser");
+        assert_eq!(package_path, "cmd/moonfmt");
+        assert_eq!(
+            version,
+            ExecutablePackageVersionSelector::LocallyKnownLatest
+        );
+    }
+
+    #[test]
+    fn parse_explicit_latest_coordinates() {
+        let (module_name, package_path, version) = parse("moonbitlang/parser/cmd/moonfmt@latest");
+        assert_eq!(module_name.to_string(), "moonbitlang/parser");
+        assert_eq!(package_path, "cmd/moonfmt");
+        assert_eq!(version, ExecutablePackageVersionSelector::RefreshLatest);
+
+        let (module_name, package_path, version) = parse("moonbitlang/parser@latest/cmd/moonfmt");
+        assert_eq!(module_name.to_string(), "moonbitlang/parser");
+        assert_eq!(package_path, "cmd/moonfmt");
+        assert_eq!(version, ExecutablePackageVersionSelector::RefreshLatest);
+    }
+
+    #[test]
+    fn latest_resolution_uses_local_registry_before_updating() {
+        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
+        let mut update_called = false;
+
+        let version = resolve_latest_version_with(
+            &module_name,
+            &UserLog::new(log::LevelFilter::Warn),
+            true,
+            LatestVersionResolutionPolicy::PreferLocal,
+            || LatestVersionLookup::Found("0.3.3".parse().unwrap()),
+            || {
+                update_called = true;
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(version.to_string(), "0.3.3");
+        assert!(!update_called);
+    }
+
+    #[test]
+    fn latest_resolution_updates_after_local_registry_miss() {
+        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
+        let mut lookup_count = 0;
+        let mut update_called = false;
+
+        let version = resolve_latest_version_with(
+            &module_name,
+            &UserLog::new(log::LevelFilter::Warn),
+            true,
+            LatestVersionResolutionPolicy::PreferLocal,
+            || {
+                lookup_count += 1;
+                if lookup_count > 1 {
+                    LatestVersionLookup::Found("0.3.3".parse().unwrap())
+                } else {
+                    LatestVersionLookup::NotFound
+                }
+            },
+            || {
+                update_called = true;
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(version.to_string(), "0.3.3");
+        assert_eq!(lookup_count, 2);
+        assert!(update_called);
+    }
+
+    #[test]
+    fn explicit_latest_refreshes_before_resolving() {
+        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
+        let registry_updated = Cell::new(false);
+        let lookup_count = Cell::new(0);
+
+        let version = resolve_latest_version_with(
+            &module_name,
+            &UserLog::new(log::LevelFilter::Warn),
+            true,
+            LatestVersionResolutionPolicy::Refresh,
+            || {
+                lookup_count.set(lookup_count.get() + 1);
+                LatestVersionLookup::Found(
+                    if registry_updated.get() {
+                        "0.4.0"
+                    } else {
+                        "0.3.3"
+                    }
+                    .parse()
+                    .unwrap(),
+                )
+            },
+            || {
+                registry_updated.set(true);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(version.to_string(), "0.4.0");
+        assert!(registry_updated.get());
+        assert_eq!(lookup_count.get(), 1);
+    }
+
+    #[test]
+    fn explicit_latest_fails_when_refresh_fails() {
+        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
+        let lookup_called = Cell::new(false);
+
+        let error = resolve_latest_version_with(
+            &module_name,
+            &UserLog::new(log::LevelFilter::Warn),
+            true,
+            LatestVersionResolutionPolicy::Refresh,
+            || {
+                lookup_called.set(true);
+                LatestVersionLookup::Found("0.3.3".parse().unwrap())
+            },
+            || Err(anyhow::anyhow!("offline")),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "Failed to update registry index");
+        assert_eq!(error.source().unwrap().to_string(), "offline");
+        assert!(!lookup_called.get());
+    }
+
+    #[test]
+    fn latest_resolution_preserves_no_version_information_after_update() {
+        let module_name = "moonbitlang/parser".parse::<ModuleName>().unwrap();
+        let mut update_called = false;
+
+        let error = resolve_latest_version_with(
+            &module_name,
+            &UserLog::new(log::LevelFilter::Warn),
+            true,
+            LatestVersionResolutionPolicy::PreferLocal,
+            || LatestVersionLookup::NoVersionInformation,
+            || {
+                update_called = true;
+                Ok(())
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Module `moonbitlang/parser` has no version information"
+        );
+        assert!(update_called);
+    }
+
+    #[test]
+    fn root_package_uses_module_last_segment_for_artifact_name() {
+        let package = ResolvedExecutablePackage {
+            module_name: "moonbitlang/parser".parse().unwrap(),
+            package_path: String::new(),
+            version: "0.3.3".parse().unwrap(),
+        };
+        assert_eq!(package.artifact_name(".exe"), "parser.exe");
+    }
+
+    #[test]
+    fn reject_invalid_coordinates() {
+        assert!(parse_executable_package_coordinate("moonbitlang/parser@bad/cmd/moonfmt").is_err());
+        assert!(parse_executable_package_coordinate("moonbitlang/parser/cmd/moonfmt@bad").is_err());
+        assert!(parse_executable_package_coordinate("moonbitlang/parser@0.3.3/cmd@0.4.0").is_err());
+        assert!(parse_executable_package_coordinate("moonbitlang/parser/0.3.3@0.4.0/cmd").is_err());
+        assert!(parse_executable_package_coordinate("moonbitlang/parser/...").is_err());
+        assert!(parse_executable_package_coordinate("moonbitlang/parser//cmd").is_err());
+        assert!(parse_executable_package_coordinate("./moonbitlang/parser").is_err());
+        assert!(parse_executable_package_coordinate("C:/moonbitlang/parser").is_err());
+        assert!(parse_executable_package_coordinate("https://mooncakes.io/x").is_err());
+    }
+}


### PR DESCRIPTION
## Why

Executable Package Coordinate parsing, latest-version selection, and Wasm artifact acquisition are registry concerns, but their coordination lived in the moon CLI. Keeping these rules behind RegistryClient gives moonx and runwasm one registry-owned interface and allows another executable runner to reuse the same behavior without depending on the moon CLI.

## Correctness

RegistryClient now resolves pinned, explicit-latest, and locally-known-latest coordinates with the existing refresh and fallback rules, then acquires the exact Wasm artifact through its existing verified cache path. The existing coordinate and version-selection tests move with the implementation. Native moonx continues to use the same resolved package while retaining native artifact production in moon.

## Scope

This is an ownership refactor only. It removes the duplicate coordination from moon and does not change command-line behavior, cache layout, registry update policy, or native build behavior.