### PR TITLE
feat(moonrun): isolate run environments

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -94,6 +94,32 @@ _Avoid_: Host Handle, Guest Handle, raw fd, pointer, id
 The per-run composition root for moonrun-owned import state. It creates one Host Key namespace, wires it into domain modules such as the Async Host and SQLite Host, and performs leak checking only when the complete run is torn down. Domain operations and payload accounting remain on their owning Host module.
 _Avoid_: giant host API, async-only host
 
+**Env**:
+The mutable environment owned by one Run's Host. Its constructor applies the
+startup-only Moonrun Policy to a read-only environment source, then owns only a
+per-Run delta of set and unset operations. The source is either explicit Run
+input or the ambient process environment; an ambient source is read lazily and
+the embedding process must treat it as immutable while the Run is active.
+Env is the only environment interface used by moonrun-owned imports, WASI
+environment reads, Temp Dir selection, and child inheritance. A spawn that
+requests inheritance materializes and snapshots Env when its environment
+builder is created; the resulting child does not retain a live reference. Env
+stores native `OsString` names and values so child inheritance is not forced
+through Unicode.
+String-only guest APIs expose entries representable by their string ABI.
+WASI preserves one Env snapshot across a matching environment size/get pair.
+Platform-specific child-block encoding belongs to the process Adapter after
+inherited and override entries have been merged, not to Env.
+_Avoid_: mutable policy, direct process-environment access, per-import environment map
+
+**Temp Dir**:
+The temporary-directory base resolved from the current Env by one Run's Host.
+An unrestricted Windows Run may use the native OS fallback when its Env omits
+`TMP` and `TEMP`; sandbox mode does not consult that process-global fallback.
+The platform Adapter owns path selection and normalization below the Temp Dir
+interface.
+_Avoid_: environment policy, per-import temp lookup, process-global temp mutation
+
 **Host Key**:
 The internal generational key behind a Handle. One primary Host Key table records only liveness and resource kind; domain payloads live in secondary maps keyed by Host Key.
 All Handle kinds share the slotmap null Host Key. An ABI that needs to create or compare a null Handle obtains its encoded value from the running Host rather than hard-coding the slotmap representation.

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -37,7 +37,9 @@ use moonrun::{Engine, RunOptions, RunOutcome};
 let outcome = Engine::default()
     .run_file(
         "path/to/file.wasm",
-        RunOptions::default().with_args(["arg"]),
+        RunOptions::default()
+            .with_args(["arg"])
+            .environment([("APP_ENV", "test")]),
     )
     .unwrap();
 
@@ -65,13 +67,18 @@ the stable program name used for guest arguments and diagnostics:
 let module = engine.compile("server.wasm", wasm_bytes).unwrap();
 ```
 
-The current implementation remains V8-backed and still inherits process stdio,
-environment, working directory, and signal compatibility behavior. These are
-shared process dependencies rather than isolated embedding inputs. Compiled
-modules reuse their prepared representation while each run creates fresh guest
+The current implementation remains V8-backed. Each run owns a private mutable
+environment delta. When `environment` is omitted, the process environment is
+its read-only backing source; Env reads it lazily as native `OsString` values.
+The embedding process must not mutate that environment while any Run backed by
+it is active. Full enumeration and inherited native spawn materialize the
+source plus the Run's delta. Process stdio, working directory, and signal
+compatibility behavior remain shared process dependencies. Compiled modules
+reuse their prepared representation while each run creates fresh guest
 execution state. Thread placement and lifecycle tracking remain the caller's
 responsibility. Moonrun does not yet expose an interruption mechanism for a
-running guest.
+running guest, and broader concurrent-run behavior is not yet part of the
+interface contract.
 
 ## Memory Leak Reporting
 
@@ -89,9 +96,10 @@ system and switches supported moonrun-owned host surfaces into sandbox mode.
 The policy is deny-by-default: omitted or empty `fs`, `net`, and `env` objects
 deny that surface, and process spawning is disabled unless explicitly allowed.
 Add entries only for the access the program should have. The policy covers
-`moonbitlang/async` and moonrun's own `__moonbit_*_unstable` FFI surfaces. It
-does not apply to WASI
-(`wasi_snapshot_preview1` / `__moonbit_wasi_unstable`).
+`moonbitlang/async` and moonrun's own `__moonbit_*_unstable` FFI surfaces. WASI
+environment reads share the same per-Run environment and therefore observe the
+`env` policy. WASI descriptors and preopens remain a separate capability
+surface not controlled by the filesystem policy.
 
 An empty JSON object denies all policy-covered filesystem, network, and
 environment access:
@@ -131,11 +139,28 @@ syntax; Windows policies may use normal Windows paths such as `C:\work` or
 wildcard `"*"` allows every host path on every platform. List a root in both
 `read` and `write` to allow read-write filesystem access.
 
-The environment policy constructs the guest environment. Use `from_host` to copy
-selected host variables if present, `required_from_host` to require selected
-host variables, and `env.set` for literal values. `env.set` overrides values
-copied from the host. Do not put secrets directly in the policy file; pass them
-by name through `from_host` or `required_from_host`.
+The Run chooses its environment source; Moonrun Policy only selects and
+overrides values from that source. Use `from_host` to select source variables
+if present, `required_from_host` to require selected source variables, and
+`env.set` for literal values. The CLI uses the host process environment;
+library callers may provide a fixed source with `RunOptions::environment`.
+`env.set` overrides selected values. Do not put secrets directly in the policy
+file; pass them by name through `from_host` or `required_from_host`. Runtime
+`set` and `unset` operations are immediately visible to subsequent moonrun-owned
+and WASI environment reads without mutating the source. WASI preserves one
+environment snapshot between a matching `environ_sizes_get` and `environ_get`
+so the reported table size remains valid.
+
+The temporary-directory base is resolved from the current Run environment. On
+Windows, an unrestricted Run whose environment omits `TMP` and `TEMP` preserves
+the native `GetTempPath2W` fallback; sandbox mode requires the temporary base to
+be present in the selected environment and does not consult process-global
+fallback variables.
+
+A child that requests inheritance snapshots the current per-Run environment
+when moonrun creates the spawn environment builder. Later parent `set` or
+`unset` operations do not change that builder; the next spawn observes the
+newer state.
 
 Process spawning is disabled unless the request matches a `process.allow` rule
 or `process.spawn` is `true`. Rules match the requested program exactly and
@@ -167,10 +192,12 @@ MoonBit appends `.exe` unless the requested program already ends in `.exe` or
 Allowing a shell, interpreter, package runner, or extensible tool can permit much
 more than the visible argument prefix suggests.
 
-A native child receives the host user's ambient filesystem, network, and process
-access. The `fs` and `net` objects do not sandbox child processes. PID-based
-process operations are restricted to children spawned by the current moonrun
-instance while policy mode is active.
+A native child receives the Run environment snapshot but still has the host
+user's ambient filesystem, network, and process access. The `fs` and `net`
+objects do not sandbox child processes. PID-based process operations are
+restricted to children spawned by the current moonrun instance while policy
+mode is active. Native executable lookup also retains host-platform
+compatibility semantics; it is not yet virtualized through the child Env.
 
 ```json
 {

--- a/crates/moonrun/docs/dev/README.md
+++ b/crates/moonrun/docs/dev/README.md
@@ -7,6 +7,19 @@
   deliver one upstream port at a time, and mark the originating async pull
   request completed after the Moon change lands.
 
+## Proposed designs and research
+
+- [Operating-system support for moonrun virtualization](os-virtualization-research.md):
+  identify which isolation and lifecycle primitives can be delegated to Linux,
+  macOS, and Windows and which semantics must remain inside moonrun.
+- [Scheduler control-flow models for moonrun](scheduler-control-flow-research.md):
+  compare Kubernetes, k0s, Nomad, and Wrangler ownership to separate
+  declarative workload reconciliation from imperative virtual children.
+- [Multi-service Runs and virtual child processes](multi-service-virtual-child-design.md):
+  deepen moonrun around Engine with Deployment Controller, Execution
+  Supervisor, and Host Process for transparent in-process Moonx children
+  through incremental MVP slices.
+
 ## How to Build and Test
 
 ```bash

--- a/crates/moonrun/docs/dev/multi-service-virtual-child-design.md
+++ b/crates/moonrun/docs/dev/multi-service-virtual-child-design.md
@@ -1,0 +1,722 @@
+# Multi-Service Runs and Virtual Child Processes
+
+## Status
+
+Proposed.
+
+This design covers moonrun-owned host imports and the shared per-Run
+environment observed by WASI. The WASI descriptor/preopen Capability Surface
+is explicitly out of scope for the first implementation. The end state
+requires Moonrun Policy to describe and authorize the complete moonrun-owned
+guest world, but the work is deliberately split into independently useful
+increments.
+
+The supporting research is recorded in
+[Operating-System Support for Moonrun Virtualization](os-virtualization-research.md)
+and
+[Scheduler Control-Flow Models for Moonrun](scheduler-control-flow-research.md).
+
+## Executive summary
+
+The existing Engine work is the execution kernel, not a competing design. It
+already supplies reusable compiled Modules and fresh state for synchronous
+Runs. This proposal deepens the system around it in four places:
+
+1. Make every process-scoped dependency used by moonrun-owned imports an
+   explicit per-Run input: environment, working directory, standard streams,
+   Policy, and Run control.
+2. Add an Execution Supervisor above Engine to own concrete attempts, threads,
+   retained outcomes, wait, termination, and cleanup.
+3. Add a Deployment Controller above the supervisor to own declarative
+   multi-service desired state, reconciliation, and restart/replacement policy.
+4. Deepen the existing Host Process so it can route a spawn through the
+   supervisor and maintain the guest-visible child identity, authority, and
+   reap state.
+
+Operating systems provide excellent primitives for real processes and useful
+low-level wakeup primitives for virtual Runs. They do not provide per-thread
+environments, working directories, PIDs, process tables, or safe hard
+termination. Those semantics must remain inside moonrun when multiple Runs
+share one native process.
+
+The first useful release is not the virtual process table. It is isolated
+per-Run environment, working directory, standard streams, and control. An
+Execution Supervisor then turns that shared trunk into retained, controllable
+attempts. Deployment reconciliation and virtual child mapping are separate
+callers of the supervisor rather than two modes inside one Interface.
+
+## Goals
+
+The design supports two use cases.
+
+### Multi-service deployment
+
+An external Deployment specification declares several named workloads. A
+Deployment Controller compares desired and observed state and asks an
+Execution Supervisor to start or stop concrete Run attempts. Workloads have
+independent environment, working directory, standard streams, Policy, and
+lifecycle. Logical workload identity remains stable when a later policy
+replaces an attempt.
+
+This follows the Kubernetes controller direction and the Nomad
+client/task-driver split. It does not follow Wrangler Service Bindings:
+Wrangler injects a callable capability into a runtime-invoked worker, whereas
+moonrun needs an external owner for workload lifecycle. Service discovery and
+request transport are downstream of lifecycle and remain separate.
+
+### Virtual Moonx child
+
+When a guest requests an allowed `moonx` child, moonrun may resolve the target
+to a Module and execute it as another Run in the same native process. To the
+parent guest, the child still has process-shaped spawn, wait, exit, standard
+stream, and termination behavior. Moonrun must never pass its virtual process
+identifier or handle to an operating-system process API.
+
+The first MVP handles an exact, explicitly configured Moonx route for a Wasm
+target. Native-target fallback, shells, detached children, orphan adoption, and
+arbitrary command emulation are not required.
+
+## Non-goals for the first implementation
+
+- Virtualizing WASI descriptors or preopens.
+- Claiming a security boundary equivalent to a container or separate OS
+  process.
+- Transparent hard CPU or memory isolation between in-process Runs.
+- Emulating every platform-specific process operation in the first Moonx MVP.
+- Defining a distributed scheduler, cluster consensus, or remote node protocol.
+- Running `setenv`, `unsetenv`, or `chdir` around a Run and restoring them
+  afterward. That is racy in a concurrent embedding process.
+
+## Research conclusions
+
+The research tested four hypotheses. The evidence supports the following
+answers.
+
+| Question | Conclusion | Design consequence |
+|---|---|---|
+| Can the OS isolate a real child? | Yes. POSIX spawn/exec and Windows process creation accept child environment and standard streams; Windows also accepts a child current directory. Native PID/handle, wait, signaling, Job Objects, pidfds, and kqueue all operate on real processes. | Keep a native child Adapter and delegate native lifecycle to the OS. |
+| Can the OS make an Engine Run look like a process? | No. Process IDs, process tables, environment, current directory, process signals, Job Objects, pidfds, and cgroups name real processes or process-wide state. | Virtual identity, inheritance, wait, exit, and termination live in Host Process and per-Run host Modules. |
+| Can the OS help wake the parent when a virtual Run changes state? | Yes. Linux eventfd, Darwin user events or an equivalent wakeup descriptor, and Windows IO completion packets integrate synthetic completions with native polling. | Reuse the existing Completion Queue/Thread-Pool Completion Source instead of adding periodic polling. |
+| Should Linux namespaces be the portable foundation? | No. They are Linux-only, capability-sensitive, mostly process/thread-group oriented, and unsafe as a semantic dependency after an embedding process has started worker threads. cgroup resource domains also primarily account processes. | Treat namespaces/cgroups as an optional worker-process isolation Adapter, not as in-process semantics or an MVP dependency. |
+
+The orchestration comparison adds four control-flow conclusions:
+
+| Reference | What to borrow | What not to borrow |
+|---|---|---|
+| Kubernetes | external desired/observed state, reconciliation, stable workload identity distinct from replaceable attempts, owner-dependent cleanup | API server, distributed consensus, container-only runtime assumptions, Linux-centric node implementation |
+| k0s | single-binary packaging and supervision of runtime processes | no separate lifecycle model; it preserves Kubernetes scheduling and controller semantics |
+| Nomad | node-local execution ownership, retained task status, distinct start/wait/stop/destroy operations, execution-driver capabilities | out-of-process plugin protocol and the assumption that all OS adapters provide equal isolation |
+| Wrangler | only a possible future request/RPC transport Adapter | runtime-injected Service Binding as the owner of deployment or child lifecycle |
+
+A single-process MVP has one deterministic local placement, so it does not yet
+need a Scheduler Seam. Placement becomes a real Seam only when a second
+execution pool or remote node exists. Desired-state reconciliation and
+imperative child creation are already distinct and must not be merged.
+
+Two qualifications matter:
+
+- Linux `openat2` can strengthen host-backed path confinement for individual
+  filesystem operations, but it does not give a Run a process-independent
+  current directory. Other platforms need equivalent handle-relative Host
+  Filesystem implementations rather than a process `chdir`.
+- OS process termination is safe because the target owns a separate address
+  space. Forcefully terminating an arbitrary thread in the embedding process
+  is unsafe. Virtual child termination must use the existing Run termination
+  and V8 interruption path, followed by normal Host teardown.
+
+## Existing foundation
+
+This proposal preserves the responsibilities already established by moonrun:
+
+- **Engine** compiles immutable Modules and executes one Run synchronously on
+  the calling thread. It does not schedule Runs or retain lifecycle state.
+- **Module** is an immutable, reusable prepared representation.
+- **Host** is the per-Run composition root and owns one Handle namespace.
+- **Async Host** already keeps Resources, Jobs, Workers, pollers, and the
+  Completion Queue per Run.
+- **Host Process** already owns Process Job payloads, authorization, native
+  child ownership, and process-handle provenance. It is the correct Module to
+  deepen; a parallel universal `ProcessTree` would split the same invariants.
+- **Run Termination** already records exit or signal termination without
+  terminating the embedding process.
+- The existing per-instance signal channel already provides a thread-safe Run
+  control path and integrates with V8 interruption and host poll wakeup.
+
+The implementation may have to integrate these changes from separate lines of
+work before the slices below start. That integration changes sequencing, not
+the design.
+
+## Target model
+
+### Engine and per-Run inputs
+
+`Engine::run` remains synchronous:
+
+```text
+Engine::run(Module, RunOptions) -> RunOutcome
+```
+
+`RunOptions` becomes a fully realized description of one Run rather than a set
+of paths that Engine must interpret. It carries, directly or through owned
+handles:
+
+```text
+RunOptions
+  arguments
+  initial environment
+  initial working directory
+  standard input, output, and error
+  immutable Moonrun Policy
+  Run control receiver
+```
+
+Policy-file parsing, inheritance from the embedding process, and Deployment
+configuration are outer Adapter responsibilities. This keeps Engine independent
+of CLI files and makes concurrent tests deterministic.
+
+The current command-line Adapter preserves legacy behavior by providing the
+ambient environment as a read-only source, snapshotting the current directory,
+and borrowing the process standard streams before calling Engine. Env is the
+only Module allowed to read that environment source, and moonrun never mutates
+it. The embedding process must keep it immutable while any Run backed by it is
+active.
+
+### Policy describes; host Modules own mutable state
+
+Moonrun Policy is the source of truth for the moonrun-owned guest world and its
+permissions. It is immutable once a Run starts. It does not become a mutable
+container for runtime state.
+
+At Run construction, Policy and explicit embedding inputs materialize separate
+per-Run host Modules:
+
+| Guest-visible surface | State owner | Policy responsibility |
+|---|---|---|
+| arguments | Run adapter | supply or constrain initial values |
+| environment | Env | select inherited entries, set initial entries, and constrain mutation/visibility |
+| working directory and paths | Host Filesystem | define initial guest cwd, mounts/path mappings, and permitted operations |
+| stdin/stdout/stderr | Host Stdio | select inherited, piped, captured, null, or supervisor-owned streams |
+| files, sockets, Jobs, Workers, pollers | existing Host domains | authorize creation/use and any quotas |
+| DNS/connect/bind | Host Network/Resource state | authorize endpoints and later resolve declared service names |
+| child processes | Host Process | authorize a route, child inheritance, native escape, wait, and termination |
+| signals and exit | Run Termination and Run control | constrain which controls may be sent or observed |
+| time and randomness | dedicated host adapters where exposed by moonrun-owned imports | choose ambient, fixed/seeded, or future quota-aware providers |
+
+The split gives Policy complete coverage without turning it into a giant stateful
+Module. A child receives a snapshot of inheritable parent state plus an
+attenuated Policy. Child authority must never exceed parent authority.
+
+### Control-flow ownership
+
+The two use cases share concrete execution but not intent or lifetime policy:
+
+| Flow | Request owner | Lifecycle owner | Guest-visible owner |
+|---|---|---|---|
+| declared workload | outer Deployment submitter | Deployment Controller owns desired state; Execution Supervisor owns each concrete attempt | none |
+| virtual child | parent guest initiates one imperative spawn | Execution Supervisor owns the accepted attempt; restart is `Never` | Host Process owns child identity, authority, wait, and reap semantics |
+| service request | caller guest initiates an ordinary request | caller owns request/cancellation; Deployment Controller continues to own target workload lifetime | Host Network or later discovery Adapter owns name resolution only |
+
+Inputs flow downward before execution. Status and Completion flow upward. No
+runtime-injected callable object owns deployment topology or child lifetime.
+
+### Execution Supervisor
+
+Execution Supervisor is a deep Module above Engine and below both callers. It
+owns concrete execution attempts, not declarative workload topology:
+
+```text
+start(owner, execution_spec) -> execution_ref
+observe(execution_ref) -> execution_status
+wait(execution_ref) -> outcome
+terminate(execution_ref, deadline, reason)
+destroy(execution_ref)
+```
+
+It retains the outcome after exit so wait-after-exit is reliable. `terminate`
+requests graceful control and may escalate according to Adapter capability;
+`destroy` removes retained state only after callers no longer need it. Engine
+remains synchronous. The Engine Run Adapter places `Engine::run` on a
+supervisor-owned thread and reports the outcome upward.
+
+One concrete attempt has a distinct identity and lifecycle:
+
+```text
+pending -> starting -> running -> stopping -> exited -> destroyed
+                         └──────────────────> exited
+```
+
+Workload identity, child identity, attempt identity, thread identity, and OS
+PID are different concepts. A service replacement creates a new attempt. The
+first virtual-child MVP maps one child identity to exactly one attempt.
+
+The execution Seam becomes public inside moonrun only when two Adapters are
+present:
+
+- Engine Run Adapter: synchronous Engine on a supervisor-owned thread, virtual
+  control, retained Run outcome;
+- Native Process Adapter: OS spawn, wait, signal/terminate, and native process
+  resources.
+
+The useful Interface semantics follow Nomad's task drivers—start, wait, stop,
+and destroy remain distinct—without copying its plugin protocol.
+
+### Deployment Controller
+
+Deployment Controller owns declarative desired state and reconciliation:
+
+```text
+DeploymentSpec
+  workloads: WorkloadName -> Module + Run template + lifecycle policy
+
+Deployment Controller
+  apply(spec) -> revision
+  observe(deployment) -> desired/observed status
+  delete(deployment) -> revision
+```
+
+On each reconciliation, the controller compares desired workload instances
+with observed Execution Supervisor records and starts, stops, or later replaces
+attempts. The first MVP has one local placement, one instance per workload,
+and restart policy `Never`. A Scheduler Seam is deferred until there is a
+second placement target such as another process, execution pool, or remote
+node.
+
+This separation follows Kubernetes controller versus kubelet ownership and
+Nomad server versus client/driver ownership. The controller never calls Engine
+directly and the supervisor never interprets Deployment topology.
+
+### Service discovery
+
+Discovery observes running workloads and publishes stable names to current
+endpoints; it does not create or keep workloads alive. The caller Run retains
+normal request control flow:
+
+```text
+caller guest -> Host Network/discovery -> endpoint -> target workload
+```
+
+The first multi-service MVP does not require discovery. A later discovery Seam
+is justified when native endpoint routing and direct in-process request routing
+both exist. Either Adapter must preserve the same request, cancellation, and
+failure semantics without taking ownership of target lifecycle.
+
+### Process routing Seam
+
+Host Process owns one normalized spawn request. After authorization it asks
+Execution Supervisor to start the selected execution kind:
+
+```text
+Spawn request
+  -> Policy authorization and route selection
+     -> Execution Supervisor
+        -> Native Process Adapter -> OS process
+        -> Engine Run Adapter     -> Engine Run
+```
+
+Routing is explicit and deny-by-default when Policy is active. An allowed
+virtual route must not silently fall back to a native executable if resolution
+fails. Native escape has a separate explicit rule because it grants ambient OS
+authority that cannot be attenuated by moonrun's in-process host Modules.
+
+The normalized route result distinguishes at least:
+
+```text
+NativeExecution(program, argv)
+EngineExecution(target, argv, child_policy)
+Deny(reason)
+```
+
+The initial rule matches only the intended Moonx executable spelling and Wasm
+target form. Shell syntax, PATH-dependent aliases, and package-runner expansion
+are excluded until their semantics are individually designed.
+
+### Host Process child table
+
+Host Process keeps a per-parent child table. Internally, a child is tagged; a
+virtual child is never represented as a raw OS process:
+
+```text
+Child
+  Native
+    guest-visible native PID projection
+    ExecutionRef
+  Virtual
+    guest-visible virtual child identifier
+    ExecutionRef
+```
+
+The guest-visible ABI may still be PID-shaped. Host Process therefore owns a
+mapping from each guest-visible child identifier and process Handle to the
+tagged Child. Native children may preserve the OS PID for compatibility.
+Virtual identifiers are allocated by Host Process, collision-checked against
+all live entries, and resolved before any OS call. The exact encoding is an ABI
+decision and must not leak into domain logic.
+
+A virtual child has a parent-facing lifecycle distinct from the supervisor's
+attempt lifecycle:
+
+```text
+starting -> running -> exited -> reaped
+```
+
+- `spawn` allocates and publishes the entry before the background Run can
+  complete.
+- Execution Supervisor asks Engine Run Adapter to start one
+  supervisor-owned thread that invokes `Engine::run`.
+- Moonx argument or target errors that would occur after a real Moonx process
+  started are written to the child's stderr and become its exit result; they
+  do not retroactively turn a successful spawn into an OS spawn error.
+- Execution Supervisor atomically retains one exit result. Host Process
+  translates its notification into the existing Completion Queue path so
+  parent wait uses no polling.
+- Wait and process-handle operations resolve the child table first. Native
+  and virtual entries then delegate to Execution Supervisor, whose selected
+  Adapter owns OS or Engine mechanics.
+- Termination asks Execution Supervisor to stop the attempt. Engine Run
+  Adapter sends through Run control. Completion is published only after the
+  child Host has torn down, so the parent never observes an exited child whose
+  Resources or Workers are still live.
+- Reaping removes guest reachability according to existing platform-shaped
+  semantics. Dropping the last handle never passes a virtual identifier to an
+  OS close or wait function.
+
+Detached virtual children and orphan adoption are deferred. In the MVP, parent
+teardown asks Execution Supervisor to terminate and destroy every owned child;
+the supervisor joins their Engine threads.
+
+## Complete moonrun-owned virtualization inventory
+
+The table is both a scope checklist and an ordering constraint. “Already
+per-Run” means no new namespace is required, though Policy coverage may still
+need strengthening.
+
+| Surface | Current/likely coupling | End state | Earliest slice |
+|---|---|---|---|
+| Guest arguments | Run input | explicit per-Run immutable values | 1 |
+| Environment get/set/unset and child inheritance | ambient process unless Policy supplies a map | mutable Env created for every Run, including legacy allow-all | 1 |
+| Working directory and relative path base | process cwd | Host Filesystem cwd; never process `chdir` | 2 |
+| Host-backed filesystem namespace | host paths plus permission checks | Policy-defined guest paths/mounts with handle-relative enforcement | 2 for cwd, 9 for portable namespace |
+| Standard streams | process stdio | per-Run Host Stdio resources | 3 |
+| Resources, Handles, Jobs, Workers, completions, pollers | Host/Async Host | remain per-Run | already |
+| Run exit | former process exit risk | Run Termination outcome | already |
+| Signal delivery and interruption | process signal compatibility | per-Run control channel; outer Adapter owns OS handlers | 3 |
+| Execution attempts/status/wait/stop/destroy | direct synchronous Run calls | retained Execution Supervisor records | 4 |
+| Declarative workload desired/observed state | none | Deployment Controller reconciliation | 5 |
+| DNS, connect, bind | real OS network with Policy checks | per-Run authorization plus optional workload-name discovery | existing checks; discovery later |
+| Process spawn/wait/handles/termination | native OS children | tagged native/virtual children in Host Process backed by Execution Supervisor | 7–8 |
+| PID/parent-child identity | native process table | Host Process mapping for virtual children | 8 |
+| Child env/cwd/stdio/Policy inheritance | native ambient behavior | explicit snapshot and attenuation from parent Run | 7–8 |
+| Time | ambient OS clock | explicit ambient or virtual clock provider when required | 9 |
+| Randomness | ambient OS RNG | explicit ambient or deterministic provider when required | 9 |
+
+WASI descriptors remain outside this inventory for the first implementation.
+WASI environment reads consume the current Env; runtime `set` and
+`unset` operations are therefore visible on subsequent reads. A later WASI
+filesystem design must either consume the same realized filesystem inputs or
+state its intentionally different semantics.
+
+## Agile delivery plan
+
+Each slice is independently reviewable, keeps the compatibility Adapter, and
+has an executable acceptance scenario. A slice should not introduce a general
+interface until its second Adapter is present.
+
+### Slice 0: integrate and characterize Engine
+
+Deliverable:
+
+- one Engine can compile a reusable Module and run it more than once;
+- concurrent Runs have fresh Host, Guest Memory, and Run Termination state;
+- Engine remains synchronous and caller-scheduled.
+
+Acceptance:
+
+- two concurrent executions of one Module cannot observe each other's Handles,
+  Jobs, completion identifiers, or exit result.
+
+### Slice 1: per-Run environment
+
+Deliverable:
+
+- split immutable Policy configuration from mutable Env;
+- construct Env in legacy allow-all mode without eagerly enumerating the
+  ambient environment;
+- route every moonrun-owned environment get/set/unset and child environment
+  builder through it;
+- leave the process environment unchanged.
+
+Acceptance:
+
+- two concurrent Runs start with different values for the same variable;
+- each mutates and unsets its value without affecting the other Run or the
+  embedding process.
+
+This is the first production-useful increment for embedders.
+
+### Slice 2: per-Run working directory
+
+Deliverable:
+
+- Host Filesystem owns the Run's current directory and resolves every relative
+  moonrun-owned path against it;
+- no Run calls process `chdir`;
+- the legacy Adapter snapshots the process cwd once.
+
+Acceptance:
+
+- two concurrent Runs open the same relative guest path under different host
+  roots and receive different files;
+- symlink and rename tests anchor authorization before a portable mount
+  namespace is attempted.
+
+### Slice 3: per-Run stdio and control
+
+Deliverable:
+
+- inject stdin/stdout/stderr resources into Host Stdio;
+- integrate the existing per-instance signal/control channel with Engine;
+- preserve inherited interactive streams through the CLI Adapter.
+
+Acceptance:
+
+- two concurrent Runs have separately captured output;
+- terminating one Run wakes and tears it down without changing the other Run's
+  output or outcome.
+
+### Slice 4: Execution Supervisor MVP
+
+Deliverable:
+
+- start one Engine attempt from fully realized Run inputs;
+- own its execution thread and control sender;
+- retain observed state and terminal outcome independently from wait;
+- keep terminate, wait, and destroy as distinct operations;
+- disable automatic restart.
+
+Acceptance:
+
+- wait called after a fast Run has exited still receives the exact outcome;
+- terminate stops one attempt by deadline without affecting another;
+- destroy removes the retained record only after the attempt is terminal.
+
+### Slice 5: Deployment Controller MVP
+
+Deliverable:
+
+- apply a declarative DeploymentSpec with at least two named workloads;
+- converge each workload to one local Engine attempt through Execution
+  Supervisor;
+- report desired and observed state separately;
+- delete the Deployment and deterministically stop/destroy all attempts;
+- keep placement local and restart policy `Never`.
+
+Acceptance:
+
+- one command starts two workloads with conflicting env names and relative
+  paths and observes both as running;
+- externally changing desired state from present to absent removes one workload
+  without terminating the native process or the other workload;
+- a completed workload is observed as completed rather than silently restarted.
+
+This is MVP A. It has the correct controller ownership without a Scheduler,
+cluster protocol, discovery system, or runtime-injected binding.
+
+### Slice 6: normalized process routing and execution Seam
+
+Deliverable:
+
+- move spawn authorization and route selection into Host Process;
+- move the existing native execution mechanics behind Native Process Adapter;
+- use Engine Run Adapter from Slice 4 as the second Adapter at the same Seam;
+- add a Moonx route that can resolve a Module and child Run inputs without yet
+  exposing it as a PID-shaped child;
+- make both Adapters satisfy start, wait, stop, and destroy semantics.
+
+Acceptance:
+
+- a configured Moonx request selects the virtual Adapter;
+- a denied request cannot fall back to PATH/native execution;
+- existing native process tests remain unchanged through Native Process
+  Adapter;
+- wait-after-exit and stop-before-destroy hold for both Adapters.
+
+### Slice 7: child inheritance and virtual execution
+
+Deliverable:
+
+- snapshot parent Env, working directory, and stdio routing when spawn is
+  accepted;
+- attenuate the parent Policy for the child;
+- ask Execution Supervisor to start an Engine attempt with owner `parent child`;
+- publish the supervisor's completion through the existing host completion
+  mechanism;
+- keep child restart policy `Never`.
+
+Acceptance:
+
+- a parent guest starts a child Module which observes the intended inherited
+  environment/cwd, produces captured output, and exits independently;
+- module resolution and execution errors have Moonx-shaped stderr and exit
+  results.
+
+### Slice 8: virtual child table MVP
+
+Deliverable:
+
+- add tagged native/virtual entries and guest identifier/Handle mappings to
+  Host Process;
+- implement spawn, wait, exit-status observation, one termination path, and
+  parent teardown by delegating actual execution control to Execution
+  Supervisor;
+- keep all virtual identifiers out of OS process APIs.
+
+Acceptance:
+
+- an unmodified guest path that spawns the supported Moonx form can wait for a
+  virtual child and receive its exit result;
+- a virtual child may itself start a supported virtual child;
+- concurrent parents cannot wait on or terminate each other's children;
+- parent teardown leaves no running virtual-child thread.
+
+This is MVP B.
+
+### Slice 9: completeness and hardening
+
+Possible follow-ups, selected by demonstrated need:
+
+- portable guest filesystem paths and mount tables;
+- stable workload discovery with native endpoint and direct in-process request
+  Adapters, while preserving caller-owned request control flow;
+- a Scheduler Seam only after a second placement target exists;
+- virtual clocks and deterministic random providers;
+- quotas, recursion/invocation limits, and cycle detection;
+- `OnFailure`/`Always` workload restart, attempt history, health, and shutdown
+  ordering in Deployment Controller;
+- mixed native/virtual trees, detach, orphan, and repeated-wait semantics;
+- optional worker-process isolation using Linux namespaces/cgroups, macOS
+  sandbox facilities, or Windows restricted tokens/Job Objects;
+- WASI descriptor and preopen integration as its own decision.
+
+## Policy compatibility and required decisions
+
+The target model changes two documented semantics and therefore requires an ADR
+before implementation:
+
+1. Moonrun Policy is currently defined as permission configuration rather than
+   a virtual filesystem. The target design makes it the declaration of the
+   complete moonrun-owned guest world while keeping mutable state in domain
+   Modules.
+2. Native process spawn is currently a coarse escape into ambient host
+   authority. The target design makes native escape and virtual routing
+   separate, explicit choices and attenuates authority for virtual children.
+
+Compatibility is provided by an explicit legacy Adapter, not by direct ambient
+reads throughout host Modules. With no Policy file, that Adapter provides the
+embedding process environment as Env's lazy, read-only source, snapshots cwd,
+borrows standard streams, and authorizes the same native operations as today.
+With a Policy, the realized per-Run world is deny-by-default for omitted
+moonrun-owned surfaces.
+
+A future Policy schema should express the normalized model, not expose Engine
+or OS implementation details. At minimum it needs independent declarations for
+initial environment, guest cwd/path mappings, stdio modes, workload-name
+network routes, process routes, native escape, child Policy attenuation, and
+limits. The JSON spelling should be decided only after Slice 1 proves the
+realization flow.
+
+## Invariants
+
+- Engine remains synchronous and owns no execution thread, retained status,
+  desired state, or lifecycle policy.
+- Deployment Controller owns desired workload state and reconciliation; it
+  never calls Engine directly.
+- Execution Supervisor owns concrete attempt threads, retained outcomes, wait,
+  termination, and destruction; it does not interpret Deployment topology.
+- Host Process owns guest-visible child identity, authority, wait eligibility,
+  and reap semantics; it delegates actual execution lifecycle to Execution
+  Supervisor.
+- No moonrun-owned import mutates process environment or cwd. Guest environment
+  reads occur only through Env's read-only source; cwd is snapshotted before
+  Host construction. The current native escape Adapter may still use
+  host-platform executable-lookup semantics until process routing is
+  virtualized.
+- Policy is immutable during a Run; mutable values live in their owning host
+  Module.
+- Child Policy is no more permissive than parent Policy.
+- A route authorized as virtual never silently falls back to native execution.
+- A virtual child identifier or process Handle is resolved by Host Process and
+  never passed to an OS process API.
+- Completion is event-driven; virtual child wait does not periodically poll.
+- A virtual child is reported exited only after its Host teardown is complete.
+- One parent Run cannot observe, wait for, signal, or reap another Run's child.
+- A virtual child is never automatically restarted.
+- Service discovery never creates, restarts, or keeps a workload alive.
+- The compatibility Adapter is the only place that supplies ambient process
+  state to host Modules.
+- The goal is not to eliminate `cfg`; platform conditionals stay below OS
+  Adapter seams, while shared Modules express platform-neutral semantics.
+
+## Rejected alternatives
+
+### Replace Engine with a process supervisor
+
+Engine already has the correct deep responsibility: reusable compilation and
+fresh synchronous Runs. Giving it service topology, threads, and child tables
+would mix execution with lifecycle policy and make embedding harder.
+
+### Change process globals around each Run
+
+Temporarily changing environment or cwd cannot be made correct with concurrent
+Runs or unrelated embedding threads. A global lock would serialize only callers
+that cooperate with moonrun and would not protect other libraries.
+
+### Use Linux namespaces for every Run
+
+They are not portable, many operations require privileges, and their useful
+filesystem/PID/resource semantics are tied to real tasks. They also conflict
+with a V8 process that already owns threads. They remain valuable for an
+optional worker-process Adapter.
+
+### Create a second universal process tree Module
+
+Host Process already owns native child authorization, Process Jobs, child PID
+ownership, and process-handle provenance. A second table would create two
+owners for wait/reap and authorization invariants.
+
+### Fabricate an OS PID, fd, or HANDLE for a virtual child
+
+Synthetic OS-looking values become dangerous as soon as one reaches a native
+API. Moonrun should preserve the guest ABI through an internal mapping, not
+pretend the operating system owns the object.
+
+### Use Wrangler Service Bindings as the lifecycle model
+
+Wrangler's runtime invokes a Worker and injects a callable binding into its
+environment. That model is appropriate for an awaited request/RPC capability,
+but it gives neither an external desired-state controller nor process-shaped
+spawn/wait/reap ownership. Moonrun may later borrow its transport shape behind
+discovery; it must not use it to own workloads or children.
+
+### Put reconciliation and imperative child spawn in one mode-switched Module
+
+A Deployment converges durable desired state, while a child spawn creates one
+parent-scoped attempt with restart `Never`. Merging both into an
+`apply_or_spawn` Interface hides incompatible lifetime rules. They remain
+separate callers of Execution Supervisor.
+
+## Open decisions
+
+The following are intentionally deferred until their preceding slice provides
+evidence:
+
+- the exact guest-visible virtual child identifier allocation and reuse rule;
+- the Moonx command forms and exit-code/stderr compatibility contract;
+- whether a virtual child may outlive its parent;
+- the workload discovery and request transport contract;
+- the condition that justifies introducing a Scheduler Seam and Allocation
+  identity;
+- the portable guest path syntax and mount schema;
+- which time, randomness, and resource-limit controls must be in the first
+  complete Policy version;
+- whether security requirements eventually require selected services or
+  children to use a worker-process Adapter rather than an in-process Run.

--- a/crates/moonrun/docs/dev/os-virtualization-research.md
+++ b/crates/moonrun/docs/dev/os-virtualization-research.md
@@ -1,0 +1,596 @@
+# OS support for Moonrun execution virtualization
+
+Status: research note, 2026-08-24
+
+## Executive answer
+
+Moonrun has two target scenarios:
+
+1. reconcile several declared workloads under one reusable
+   `Engine`/compiled-`Module` execution substrate; and
+2. intercept a guest `moonx` spawn and represent another in-process Engine run
+   as a child process.
+
+The operating system boundary is decisive:
+
+- **For a real child process, the OS already supplies most of the desired
+  virtualization.** POSIX `posix_spawn()` accepts a child environment and can
+  control file descriptors, working directory, process group, and signals;
+  Windows `CreateProcess()` accepts a child environment and working directory
+  and controls inherited handles. Linux adds mount/network/PID namespaces,
+  pidfds, Landlock, and cgroup v2. Windows adds AppContainer and Job Objects.
+  macOS supplies strong spawn, `kqueue`, process-group, and `rlimit` primitives,
+  but the reviewed public APIs do not expose Linux-style mount/network/PID
+  namespaces or a Windows Job Object equivalent.
+- **For an in-process Engine run, the OS does not create a second process
+  world.** Environment, address space, security context, process identity, and
+  hard memory limits remain properties of the enclosing process. cwd and file
+  descriptor state are also process-wide in portable POSIX and Windows APIs.
+  Therefore the Moonrun Policy/Host boundary must own the guest-visible env,
+  cwd/path resolution, stdio, process identity, wait state, cancellation,
+  process tree, service routing, networking permissions, and per-run quotas.
+- **The useful OS reuse inside one process is at the backing-mechanism layer.**
+  Pipes and sockets can back virtual stdio; `eventfd`/a pipe, `EVFILT_USER`, or
+  `PostQueuedCompletionStatus()` can wake the existing poller; real sockets can
+  back explicitly authorized network Resources. V8's
+  `Isolate::TerminateExecution()` can interrupt a virtual child without
+  terminating Moonrun.
+- **Linux per-thread facilities are partial, not a portable semantic base.**
+  `unshare(CLONE_FS)` can give one thread private cwd/root/umask and
+  `CLONE_FILES` a private descriptor table. Mount and network namespaces can
+  also be task-associated. These mechanisms stop matching the Engine once host
+  Jobs execute on shared Workers or V8 performs background work. Creating an
+  unprivileged user namespace additionally requires the caller not to be
+  threaded. cgroup v2 thread mode can account/limit CPU for a dedicated runtime
+  thread, but not memory, and cannot kill only one thread-group member.
+
+The design implication is to deepen the existing per-run Host and process
+domain, not to emulate an OS beside them. Both scenarios should first share
+explicit per-Run inputs and owning host domains for Policy, environment,
+virtual cwd/root, stdio, and cancellation. Deployment reconciliation and
+service discovery sit above that substrate with their own control flow. Only
+the child-process scenario needs the later, special mapping from a virtual
+process ID/Handle to an Engine run.
+
+## Scope and method
+
+This is hypothesis-driven research. It separates evidence from recommendations
+and uses the following MECE issue tree:
+
+```text
+Can the OS supply the execution boundary?
+├── A. Per-run visible state
+│   ├── A1. environment
+│   ├── A2. cwd and filesystem namespace
+│   └── A3. stdin/stdout/stderr
+├── B. Process-shaped lifecycle
+│   ├── B1. identity and stable handles
+│   ├── B2. wait/completion/poll
+│   ├── B3. signals and cancellation
+│   └── B4. groups, descendants, and cleanup
+└── C. External resources
+    ├── C1. networking and service-to-service calls
+    └── C2. resource accounting and limits
+```
+
+The hypotheses tested were:
+
+- **H1:** real child processes can delegate most of A, B, and C to the OS;
+- **H2:** in-process Engine runs can delegate notification and I/O backing to
+  the OS, but not their identity or policy-visible world;
+- **H3:** Linux per-thread APIs are useful enough to replace explicit per-run
+  state; and
+- **H4:** the common part of the two use cases ends before process identity.
+
+H1, H2, and H4 are supported. H3 is rejected as a cross-platform design and is
+only partially supported as an optional Linux optimization.
+
+This note concerns Moonrun-owned imports and the Moonrun Policy. It does not
+claim equivalent WASI descriptor isolation.
+
+## Decision matrix
+
+Legend:
+
+- **OS process**: the kernel supplies the semantics for a real child;
+- **OS backing**: an OS object is useful, but Moonrun still owns guest semantics;
+- **Moonrun**: there is no suitable per-Engine OS object; virtualize explicitly.
+
+| Capability | Real child process | In-process Engine run | Primary owner for the proposed design |
+| --- | --- | --- | --- |
+| Environment | **OS process**: `envp` / `lpEnvironment` | **Moonrun**: host environment is process-wide | mutable per-run env map initialized before execution |
+| cwd | **OS process**: spawn-time cwd | **Moonrun**; Linux `CLONE_FS` is partial | virtual cwd plus dir-relative path operations |
+| Filesystem view | Linux namespace/Landlock; Windows AppContainer; otherwise child credentials/path setup | **Moonrun**; Linux mount namespace is partial and non-portable | Host Filesystem namespace/mount table |
+| stdio | **OS process**: descriptor/handle inheritance and redirection | **OS backing** plus **Moonrun** routing | injected stdin/stdout/stderr Resources |
+| Process identity | PID or Windows process object/handle | **Moonrun** | virtual process ID plus existing Handle namespace |
+| Wait and exit | `waitpid`, pidfd, `EVFILT_PROC`, waitable Windows process handle | **OS backing** for wakeup; status is **Moonrun** state | virtual child state machine and Completion Queue |
+| Signal/cancel | Unix signals/process groups; Windows console control/termination | **Moonrun**, with V8 interruption | cancellation/termination channel per run |
+| Tree cleanup | Linux process groups/cgroups/PID namespaces; Windows Job Objects; macOS process groups | **Moonrun** | virtual parent/child tree and teardown policy |
+| Networking | Linux net namespace/Landlock; Windows AppContainer; real sockets elsewhere | **OS backing** plus **Moonrun** authorization/routing | socket Resources and workload-name discovery/routing |
+| Resource limits | Linux rlimit/cgroup; macOS rlimit; Windows Job Object | mostly **Moonrun**; Linux thread CPU control is partial | concurrency, memory, time, and operation quotas |
+
+## Evidence
+
+### A1. Environment
+
+For real children, POSIX `posix_spawn()` takes an explicit `envp`. The current
+POSIX specification says the child is constructed with the supplied argument
+and environment lists; its rationale treats environment, file descriptors,
+cwd, process group, and signals as spawn inheritance controls
+([The Open Group: `posix_spawn`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_spawn.html)).
+Windows documents that every process has an environment block and that a
+different block can be supplied to `CreateProcess()`
+([Microsoft: Environment Variables](https://learn.microsoft.com/en-us/windows/win32/procthread/environment-variables),
+[Microsoft: `CreateProcess`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa)).
+
+For in-process runs, POSIX exposes the environment through the process-global
+`environ`. POSIX explicitly forbids concurrent environment access while another
+thread modifies it and does not require `setenv()`/`unsetenv()` to be
+thread-safe
+([The Open Group: general thread-safety rules](https://pubs.opengroup.org/onlinepubs/9799919799/functions/V2_chap02.html),
+[The Open Group: `exec` and `environ`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/exec.html)).
+Windows likewise defines one environment block per process
+([Microsoft: About Processes and Threads](https://learn.microsoft.com/en-us/windows/win32/procthread/about-processes-and-threads)).
+No reviewed API supplies an environment block attached to a V8 Isolate or an
+arbitrary logical run.
+
+**Finding:** an explicit env map is both portable and shared by multi-service
+runs and virtual children. Temporarily swapping the host environment is not a
+valid concurrent implementation.
+
+### A2. cwd and filesystem namespace
+
+For real children, POSIX.1-2024 spawn file actions track a child working
+directory without requiring the multi-threaded parent to change its own cwd
+([The Open Group: `posix_spawn`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_spawn.html)).
+Apple documents `posix_spawn()` as constructing a distinct process with
+controlled file actions and inherited process attributes
+([Apple: `posix_spawn(2)`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/posix_spawn.2.html)).
+Windows `CreateProcess()` accepts `lpCurrentDirectory`; Microsoft warns that
+`SetCurrentDirectory()` changes the single cwd shared by every thread
+([Microsoft: `CreateProcess`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa),
+[Microsoft: `SetCurrentDirectory`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setcurrentdirectory)).
+Apple's Foundation documentation likewise calls cwd a process property and
+warns it may be changed by any thread
+([Apple: `URL.currentDirectory()`](https://developer.apple.com/documentation/foundation/url/currentdirectory%28%29?language=occ)).
+
+Portable POSIX `*at` operations provide the important in-process building
+block: `openat()` resolves a relative path from a directory descriptor instead
+of process cwd. The POSIX rationale explicitly names a virtual per-thread cwd
+as a motivation
+([The Open Group: `open`/`openat`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/open.html),
+[The Open Group portability rationale](https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_port.html)).
+Linux `openat2()` goes further: `RESOLVE_BENEATH` prevents escape above a
+dirfd, and `RESOLVE_IN_ROOT` treats the dirfd as a temporary root for one path
+resolution
+([Linux man-pages: `openat2(2)`](https://man7.org/linux/man-pages/man2/openat2.2.html)).
+This is path-resolution help, not a complete filesystem namespace; every
+Moonrun filesystem operation must still use the same root/cwd discipline.
+
+Linux offers two stronger families:
+
+- `unshare(CLONE_FS)` detaches the calling thread's root, cwd, and umask, while
+  `CLONE_FILES` detaches its descriptor table. `CLONE_NEWNS` creates a private
+  mount namespace and implies `CLONE_FS`; `CLONE_NEWNET` moves the caller into
+  a new network namespace. These operations normally require `CAP_SYS_ADMIN`
+  ([Linux man-pages: `unshare(2)`](https://man7.org/linux/man-pages/man2/unshare.2.html)).
+- A mount namespace isolates the list of mounts visible to its member
+  processes
+  ([Linux man-pages: mount namespaces](https://man7.org/linux/man-pages/man7/mount_namespaces.7.html)).
+  Landlock can restrict filesystem and network ambient rights for the current
+  thread and its descendants without privilege, but the restriction can only
+  become tighter and cannot be removed
+  ([Linux kernel: Landlock userspace API](https://www.kernel.org/doc/html/latest/userspace-api/landlock.html)).
+
+The Linux options do not form a safe general in-process Engine boundary:
+
+- an Engine run's host Jobs may execute on shared Workers that did not enter
+  the runtime thread's namespace or detached fd table;
+- newly created V8/background threads inherit from the creating thread rather
+  than from a logical Engine identifier;
+- `CLONE_NEWUSER`, the usual way for an unprivileged caller to acquire
+  capabilities for other new namespaces, requires the calling process not to
+  be threaded
+  ([Linux man-pages: `unshare(2)`](https://man7.org/linux/man-pages/man2/unshare.2.html)); and
+- Landlock is intentionally irreversible, making worker reuse across
+  differently privileged runs unsuitable.
+
+Windows AppContainer can isolate a real process's files, network, credentials,
+and process access, but it is a process launch/security-token facility, not an
+Isolate facility
+([Microsoft: AppContainer isolation](https://learn.microsoft.com/en-us/windows/win32/secauthz/appcontainer-isolation),
+[Microsoft: launching an AppContainer](https://learn.microsoft.com/en-us/windows/win32/secauthz/implementing-an-appcontainer)).
+
+**Finding:** use OS cwd/namespaces for real native children where available.
+For Engine runs, resolve all Moonrun-owned paths through explicit virtual
+cwd/root state. On Linux, use `openat2()` as a hardening implementation detail,
+not as the portable policy model.
+
+### A3. stdin, stdout, and stderr
+
+POSIX spawn file actions can close, open, and `dup2` descriptors in the child;
+unchanged descriptors otherwise remain inherited
+([The Open Group: `posix_spawn`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_spawn.html)).
+Windows uses `STARTF_USESTDHANDLES` for standard handles and can restrict child
+inheritance with `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`
+([Microsoft: process inheritance](https://learn.microsoft.com/en-us/windows/win32/procthread/inheritance)).
+
+Those operations change a real child's descriptor/handle table. They cannot
+give two Engine runs different meanings for process fd 0/1/2. Pipes, sockets,
+files, and memory buffers can still back per-run streams. On Windows,
+overlapped named-pipe I/O can deliver completion through an IOCP
+([Microsoft: overlapped pipe I/O](https://learn.microsoft.com/en-us/windows/win32/ipc/synchronous-and-overlapped-input-and-output)).
+On Unix, pipe/socket fds are pollable; on macOS `EVFILT_READ` and
+`EVFILT_WRITE` cover fd readiness
+([Apple: `kqueue(2)`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html)).
+
+**Finding:** stdio should be three injected Resource-like endpoints. OS pipes
+are an implementation option, not their guest identity. This state is shared
+by both target scenarios.
+
+### B1. Process identity and stable handles
+
+A real POSIX child receives a kernel PID and is waitable by its parent. Linux
+pidfds provide a stable fd reference to a process, are observable by
+`poll`/`epoll`, can be waited on with `waitid(P_PIDFD)`, and avoid PID-reuse
+races when signaling
+([Linux man-pages: `pidfd_open(2)`](https://man7.org/linux/man-pages/man2/pidfd_open.2.html),
+[Linux man-pages: `pidfd_send_signal(2)`](https://man7.org/linux/man-pages/man2/pidfd_send_signal.2.html)).
+macOS `EVFILT_PROC` takes a PID and can report `NOTE_EXIT`, `NOTE_FORK`,
+`NOTE_EXEC`, and `NOTE_REAP`
+([Apple: `kqueue(2)`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html)).
+Windows returns a PID and process Handle. The process object becomes signaled
+at termination and can be passed to the wait functions
+([Microsoft: terminating a process](https://learn.microsoft.com/en-us/windows/win32/procthread/terminating-a-process),
+[Microsoft: `WaitForSingleObject`](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject)).
+
+Linux PID namespaces only assign different PID mappings to actual processes;
+the first actual process is PID 1, and subsequent `fork`/`clone` children
+receive namespace PIDs
+([Linux man-pages: PID namespaces](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html)).
+They cannot assign a second PID to a logical run inside an existing process.
+The same is true of macOS PIDs and Windows process objects.
+
+**Finding:** a virtual child requires a Moonrun-allocated ID and an entry in a
+virtual process table. It must never pass that ID to `kill`, `waitpid`,
+`OpenProcess`, or other native APIs. The current process-policy state is built
+around OS PIDs and process handles
+([`async_host/mod.rs`](../../src/async_host/mod.rs)); this is the special seam
+that appears only after the shared per-run context exists.
+
+### B2. wait, completion, and poll integration
+
+Real child exit already fits every target OS event mechanism:
+
+- Linux pidfds become readable on process exit and can be registered with
+  `epoll`
+  ([Linux man-pages: `pidfd_open(2)`](https://man7.org/linux/man-pages/man2/pidfd_open.2.html));
+- macOS provides `EVFILT_PROC/NOTE_EXIT`, with `waitpid()` still retrieving and
+  reaping child status
+  ([Apple: `kqueue(2)`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html),
+  [Apple: `wait(2)`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/wait.2.html)); and
+- Windows process handles are waitable; Job Object events can also be
+  associated with an IOCP
+  ([Microsoft: Job Objects](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects),
+  [Microsoft: Nested Jobs](https://learn.microsoft.com/en-us/windows/win32/procthread/nested-jobs)).
+
+A virtual child's completion is a user-space state transition, but it can wake
+the same poller:
+
+- Linux `eventfd()` creates a pollable event-notification fd
+  ([Linux man-pages: `eventfd(2)`](https://man7.org/linux/man-pages/man2/eventfd.2.html));
+- Darwin exposes `EVFILT_USER` and `NOTE_TRIGGER`
+  ([Apple XNU `event.h`](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/sys/event.h)); and
+- Windows explicitly permits application-generated IOCP packets through
+  `PostQueuedCompletionStatus()`
+  ([Microsoft: `PostQueuedCompletionStatus`](https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-postqueuedcompletionstatus)).
+
+Moonrun already has epoll, kqueue, and IOCP Host Poller adapters
+([`poll/mod.rs`](../../src/async_sys/internal/event_loop/poll/mod.rs)) and a
+Completion Queue abstraction. Therefore no new public wait mechanism is
+required for virtual children.
+
+**Finding:** translate Engine completion into the existing host Completion
+Queue and wake its existing completion source. `eventfd`/`EVFILT_USER`/IOCP are
+optional backing choices; they are not virtual process handles.
+
+### B3. Signals and cancellation
+
+Unix signals and process groups control real processes. POSIX process groups
+exist to signal related processes; macOS exposes `killpg()`
+([The Open Group: process-group definition](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html),
+[Apple: `killpg(2)`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/killpg.2.html)).
+Linux pidfd signaling avoids PID reuse. Windows console process groups can
+receive `CTRL+BREAK`, subject to console attachment rules, and
+`TerminateProcess()` terminates a real process
+([Microsoft: `GenerateConsoleCtrlEvent`](https://learn.microsoft.com/en-us/windows/console/generateconsolectrlevent),
+[Microsoft: terminating a process](https://learn.microsoft.com/en-us/windows/win32/procthread/terminating-a-process)).
+
+These mechanisms cannot terminate one Engine run without terminating or
+signaling threads that share the Moonrun process. POSIX asynchronous thread
+cancellation is especially unsuitable as a general substitute: only three
+functions are required to be async-cancel-safe, and cancellation during any
+other function has undefined behavior
+([The Open Group: thread cancellation](https://pubs.opengroup.org/onlinepubs/9799919799/functions/V2_chap02.html)).
+
+V8 does provide an embedder-level primitive: `Isolate::TerminateExecution()`
+may be called from another thread and forcefully terminates JavaScript
+execution in that Isolate
+([V8 public API: `v8-isolate.h`](https://chromium.googlesource.com/v8/v8.git/%2B/HEAD/include/v8-isolate.h)).
+Host Jobs that are already blocking still need their own cooperative
+cancellation or resource close/abort path.
+
+**Finding:** represent guest signals as virtual termination requests. The
+outer CLI may translate Ctrl-C/OS signals into the selected run's cancellation
+channel; only a native child adapter should invoke native signal APIs.
+
+### B4. Process grouping and cleanup
+
+The OS can group real descendants, with different strength on each platform:
+
+- POSIX process groups support group signaling, but membership can change and
+  they do not provide resource accounting. macOS supplies this level directly
+  through `setpgid()`/`killpg()`
+  ([Apple: `setpgid(2)`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/setpgid.2.html)).
+- Linux PID namespaces give a namespace an init/reaper; if that init exits,
+  the kernel kills the namespace's remaining processes
+  ([Linux man-pages: PID namespaces](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html)).
+  cgroup v2's `cgroup.kill` kills all processes in a cgroup subtree and handles
+  concurrent forks/migration
+  ([Linux kernel: cgroup v2](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html)).
+- Windows Job Objects manage a group of processes as a unit, normally include
+  descendants, can terminate the group, and support
+  `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Nested jobs model process trees on
+  Windows 8+
+  ([Microsoft: Job Objects](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects)).
+
+None of these kernels sees relationships between two Engine runs in one
+process. Closing a thread Handle does not terminate the thread, and terminating
+the Moonrun process would terminate every run.
+
+**Finding:** keep the virtual parent/child relation in Moonrun. It should own
+whether non-detached descendants are cancelled during parent/Host teardown.
+Real-child adapters may additionally use cgroups, process groups, or Job
+Objects for kernel-enforced cleanup.
+
+### C1. Networking and multi-service routing
+
+Linux network namespaces isolate devices, protocol stacks, routing tables,
+firewall rules, port numbers, and abstract Unix sockets
+([Linux man-pages: network namespaces](https://man7.org/linux/man-pages/man7/network_namespaces.7.html)).
+Landlock can restrict selected network actions/ports for a thread and its
+descendants. Windows AppContainer can deny network access unless appropriate
+capabilities are granted. These mechanisms are valuable for real sandboxed
+processes but have the same task/process association problems described above
+for an in-process Engine.
+
+Networking does not determine workload lifecycle ownership. Kubernetes and
+Nomad publish stable logical service names over changing workload endpoints;
+the consumer still initiates an ordinary network or request flow. Wrangler's
+callable Service Binding instead injects an invocation capability into a
+runtime-invoked Worker. The control-flow comparison is developed separately in
+[Scheduler Control-Flow Models for Moonrun](scheduler-control-flow-research.md).
+
+**Finding:** keep deployment reconciliation, service discovery, and request
+transport as separate Modules. Host Network may later resolve a declared name
+to a native endpoint or direct in-process request route, but discovery must not
+create, restart, or keep a workload alive. OS sockets remain appropriate for
+external ingress/egress and compatibility surfaces.
+
+### C2. Resource accounting and limits
+
+Real process limits are mature:
+
+- Unix `rlimit` values are process attributes inherited by children and shared
+  by all threads; Linux `prlimit()` can change another process's limits
+  ([Linux man-pages: `getrlimit(2)`](https://man7.org/linux/man-pages/man2/getrlimit.2.html)).
+  macOS documents `RLIMIT_CPU`, file-size, data, and other limits for the
+  current process and processes it creates
+  ([Apple: `getrlimit(2)`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getrlimit.2.html)).
+- Linux cgroup v2 accounts and controls groups of processes, including CPU,
+  memory, and PID controllers. `memory.max` is a hard memory limit and
+  `cgroup.kill` operates on the process subtree
+  ([Linux kernel: cgroup v2](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html)).
+- Windows Job Objects enforce and account for process/job memory, CPU rate,
+  process count, and other limits
+  ([Microsoft: Job Objects](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects),
+  [Microsoft: extended Job limits](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_extended_limit_information),
+  [Microsoft: Job CPU rate control](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_cpu_rate_control_information)).
+
+Those limits cannot generally distinguish Engine runs in one address space.
+Linux cgroup v2 is a narrow exception: thread mode permits thread-granularity
+control for the `cpu`, `cpuset`, `perf_event`, and `pids` controllers. Domain
+consumption such as shared process memory remains at the common threaded
+domain, and `cgroup.kill` is rejected for a threaded cgroup because killing is
+process-directed
+([Linux kernel: cgroup v2 thread mode](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html)).
+It can only account Engine CPU correctly if all execution attributable to that
+Engine, including relevant helpers, is pinned into the same threaded cgroup.
+
+**Finding:** cross-platform per-run limits must be enforced above the OS:
+admission/concurrency limits, Wasm/Isolate memory configuration, wall-clock
+deadline, operation/byte quotas, and cooperative cancellation. Linux threaded
+cgroup CPU control can be an opt-in enhancement after attribution is proven;
+it cannot be the documented Moonrun guarantee.
+
+## Recommendations derived from the evidence
+
+The statements in this section are design recommendations, not claims about OS
+behavior.
+
+### 1. Make the shared per-Run inputs explicit first
+
+Deepen the existing execution path with explicit inputs and separate owning
+host domains:
+
+```text
+RunOptions
+├── immutable Policy
+├── initial env -> mutable Env
+├── initial cwd/root -> Host Filesystem
+├── stdin / stdout / stderr -> Host Stdio
+├── control receiver -> Run Termination
+├── resource budget -> owning Host domains
+└── network namespace inputs -> Host Network
+```
+
+Every Moonrun-owned import should resolve these values from the current Host.
+No import should fall back to host `std::env`, process cwd, or process-global
+stdio after Host construction. Policy describes the world and its authority;
+mutable runtime state remains with the owning domain. This is the common
+implementation for both multi-service and virtual-child use cases.
+
+### 2. Keep OS adapters below Execution Supervisor
+
+The execution Seam should eventually distinguish:
+
+```text
+Execution Adapter
+├── Native Process Adapter (OS PID/Handle, native wait/signal/cleanup)
+└── Engine Run Adapter     (Engine completion and virtual cancellation)
+```
+
+Execution Supervisor retains status and outcomes above both Adapters. Host
+Process maps guest-visible child IDs and Handles to an `ExecutionRef` before
+any platform call. This prevents a virtual ID from reaching `kill(2)`,
+`waitpid()`, or `OpenProcess()` and gives both Adapters one place to implement
+start, wait, stop, and destroy mechanics.
+
+Do not start with this mapping. It is the most special part of the second use
+case and depends on the shared per-Run inputs, completion, and termination
+model.
+
+### 3. Keep discovery downstream of execution ownership
+
+Use one discovery registry populated from observed executions:
+
+```text
+workload name -> current healthy endpoints or request routes
+```
+
+The Deployment Controller owns desired workload state. Execution Supervisor
+owns concrete attempts. Discovery only reflects current endpoints. A future
+direct in-process request Adapter may optimize transport while preserving
+caller-owned request, cancellation, and failure semantics.
+
+### 4. Reuse the existing Completion Queue
+
+Both a request response and an Engine child exit can be host completions.
+Publish their Job identifiers to the existing Completion Queue and wake the
+existing platform completion source. Do not add a second future/event-loop API
+or expose `eventfd`, kqueue identifiers, or Windows Handles to guest code.
+
+### 5. Treat native OS isolation as adapter-specific hardening
+
+For intentionally real children:
+
+- Linux may use pidfds for stable identity, cgroup v2 for cleanup/limits,
+  Landlock for unprivileged restriction, and namespaces when deployment
+  privileges permit;
+- Windows should use an explicit inherited-handle list and may use a Job Object
+  and AppContainer when native sandboxing is required; and
+- macOS should use spawn file actions, kqueue process events, process groups,
+  and rlimits, without claiming namespace-equivalent containment.
+
+These mechanisms strengthen native children but must not change the portable
+observable semantics of Engine children.
+
+## Agile delivery sequence
+
+Each increment has a usable done condition and proceeds from shared mechanisms
+to the special process-table mapping.
+
+### Increment 1: explicit env
+
+Done when two concurrent Engine runs can observe different environments and no
+Moonrun-owned env import reads or mutates the host process environment.
+
+Why first: it is entirely in-memory, shared by both use cases, and exposes the
+required per-run plumbing with little OS surface.
+
+### Increment 2: virtual cwd and Host Filesystem path base
+
+Done when two concurrent runs resolve the same relative guest path under
+different virtual cwd/root values without calling process `chdir`.
+
+Use portable dir-relative operations; optionally harden Linux opens with
+`openat2()`. Do not broaden this increment into a complete WASI redesign.
+
+### Increment 3: injected stdio and cancellation
+
+Done when concurrent runs can independently inherit, pipe, or capture all three
+streams and one run can be terminated without terminating the other or the
+embedding process.
+
+This produces the first generally useful concurrent Engine-run substrate.
+
+### Increment 4: Execution Supervisor and Deployment Controller MVP
+
+Done when Execution Supervisor owns threads and retained attempt outcomes, and
+an external Deployment Controller converges at least two named workloads to
+one local Run each with independent env/cwd/stdio/Policy. Changing desired
+state stops one workload without terminating the embedding process or another
+workload.
+
+Defer distributed placement, service discovery, callable bindings, and hard
+per-workload OS resource limits. They do not establish the core ownership
+model.
+
+### Increment 5: virtual `moonx` child MVP
+
+Done when an allowlisted Wasm-target `moonx` spawn:
+
+- returns immediately with a virtual child ID and process Handle;
+- runs on a separate Engine execution unit with derived per-Run inputs;
+- supports stdin/stdout/stderr, wait, exit status, and terminate;
+- completes waits through the existing Completion Queue; and
+- never passes its virtual ID to an OS process API.
+
+Limit the MVP to direct, non-detached children and no silent fallback from a
+denied/unsupported virtual `moonx` command to ambient OS execution.
+
+### Increment 6: lifecycle depth and resource controls
+
+Add virtual process groups, descendant cleanup, orphan/detach rules, deadlines,
+memory/concurrency quotas, and mixed native/Engine child tests. Evaluate Linux
+threaded cgroup CPU control only after all Engine-attributable threads can be
+identified; add native cgroup/Job Object/AppContainer hardening independently.
+
+## Risks and unanswered questions
+
+- Whether all host filesystem calls have a dir-relative form or need a common
+  safe path resolver, especially on Windows and macOS.
+- Whether Engine execution and all per-run Host Jobs can be attributed to a
+  stable set of threads; this determines whether Linux threaded cgroups can
+  provide meaningful CPU accounting.
+- The exact child-policy derivation rule. The safe invariant is
+  `child policy <= parent policy`; Deployment-owned Policy composition needs an
+  explicit, separate rule.
+- Stdio backpressure and close ordering when a parent exits before a virtual
+  child or service call.
+- Which native-shaped process ABI observations beyond spawn/wait/terminate are
+  required by MoonBit programs, especially process groups, signal numbers,
+  detached execution, and handle-close/reap ordering.
+- Whether a later direct in-process request route targets a warm Run or creates
+  a fresh Run. This affects state isolation and performance but not the OS
+  boundary found by this research.
+
+## Conclusion
+
+The OS should remain the implementation of **native child processes**, and its
+notification/I/O primitives should remain useful backing objects. It cannot be
+the implementation of **in-process virtual processes or services**. The
+portable contract must therefore live in Moonrun's per-run Host state.
+
+The highest-leverage order is:
+
+```text
+env -> cwd/filesystem base -> stdio/cancellation
+    -> Execution Supervisor -> Deployment Controller
+    -> virtual child ID/Handle table
+    -> discovery and transport
+    -> deep tree semantics and hard limits
+```
+
+That order delivers the shared execution substrate before the least reusable
+part: mapping an Engine child into the native-shaped process table.

--- a/crates/moonrun/docs/dev/scheduler-control-flow-research.md
+++ b/crates/moonrun/docs/dev/scheduler-control-flow-research.md
@@ -1,0 +1,468 @@
+# Scheduler Control-Flow Models for Moonrun
+
+Status: research note, 2026-08-24.
+
+## Executive answer
+
+The earlier Wrangler analogy was wrong at the most important level: control-flow
+ownership.
+
+Wrangler's Service Binding model is runtime-injected and invocation-shaped. The
+runtime invokes a Worker's handler for an incoming event and injects a callable
+binding into the caller's `env`; calling another Worker is an awaited HTTP or
+RPC invocation. Cloudflare explicitly says that an unawaited downstream Worker
+may be terminated early. That is a useful precedent for an in-process request
+binding, but not for a workload supervisor or a process tree
+([Cloudflare Service Bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/),
+[Cloudflare handler model](https://developers.cloudflare.com/workers/runtime-apis/handlers/)).
+
+Kubernetes and Nomad have the control direction Moonrun needs:
+
+- a caller declares intended work;
+- an orchestrator owns desired and observed state;
+- a node-local agent decides when actual execution must start, stop, or restart;
+- an execution Adapter performs the runtime-specific operation and reports
+  status upward; and
+- workloads do not receive the orchestrator's lifecycle authority as an
+  injected callable binding.
+
+Kubernetes is the stronger precedent for `spec`/`status`, reconciliation,
+owner-dependent cleanup, and separating a logical workload from a replaceable
+execution attempt. Nomad is the closer implementation precedent for moonrun:
+it is a single binary, treats an Allocation as the mapping of a task group to a
+client, and gives task drivers explicit `StartTask`, `WaitTask`, `StopTask`,
+`DestroyTask`, and recovery operations
+([Kubernetes controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
+[Nomad scheduling](https://developer.hashicorp.com/nomad/docs/concepts/scheduling/how-scheduling-works),
+[Nomad task-driver lifecycle](https://developer.hashicorp.com/nomad/plugins/author/task-driver)).
+
+k0s does not supply a different scheduling or lifecycle model. It packages and
+supervises certified upstream Kubernetes components in a single binary. Its
+useful lesson for moonrun is packaging and local process supervision, not new
+orchestration semantics
+([k0s overview](https://docs.k0sproject.io/stable/),
+[k0s architecture](https://docs.k0sproject.io/stable/architecture/)).
+
+The resulting recommendation is:
+
+1. Put multi-service desired state and reconciliation in a Deployment
+   Controller above an Execution Supervisor. The controller owns convergence
+   and restart policy; the supervisor owns concrete attempts, observed state,
+   threads, and teardown.
+2. Keep Engine synchronous. Place an execution Seam below the supervisor with
+   at least an in-process Engine Adapter and a native-process Adapter. The
+   supervisor calls this Interface; an Adapter reports completion back.
+3. Represent a declared workload and a virtual child as two different lifetime
+   policies over shared execution records. A workload is reconciled toward
+   desired state. A child spawn is an imperative, parent-scoped request and
+   defaults to no restart.
+4. Keep the guest-visible child Handle/provenance in Host Process, but keep the
+   authoritative execution record and attempt lifecycle in the supervisor.
+   Host Process asks the supervisor to start, wait, signal, or terminate; it
+   does not call Engine itself.
+5. Treat service discovery as a separate name-to-endpoint Module. An eventual
+   direct in-process request Adapter may optimize transport behind that Seam,
+   but it must not invert lifecycle ownership.
+
+## Question tree and hypotheses
+
+The research used this MECE issue tree:
+
+```text
+Which reference model has the control ownership Moonrun needs?
+├── A. Intent and convergence
+│   ├── A1. Who records desired state?
+│   ├── A2. Who observes actual state?
+│   └── A3. Who decides to start, replace, restart, or stop?
+├── B. Execution lifecycle
+│   ├── B1. What is the scheduling/lifecycle unit?
+│   ├── B2. Who invokes the runtime?
+│   ├── B3. How are wait, exit, and recovery represented?
+│   └── B4. How are termination and ownership cleanup represented?
+├── C. Connectivity
+│   ├── C1. How is a logical service named?
+│   ├── C2. How is the current endpoint resolved?
+│   └── C3. Is the workload called by injected capability or network endpoint?
+└── D. Portability
+    ├── D1. Is the control model OS-independent?
+    ├── D2. Which worker platforms are implemented?
+    └── D3. Which isolation features remain OS-specific?
+```
+
+The tested hypotheses were:
+
+- **H1:** Wrangler is a suitable model for multi-service lifecycle ownership.
+  **Rejected.** It is suitable for an injected request-binding contract, not
+  for desired-state reconciliation or process-shaped execution.
+- **H2:** Kubernetes supplies the correct external-control model, even if its
+  distributed machinery is excessive for moonrun. **Supported.** Controllers
+  reconcile resources, while kubelet reconciles node-local Pods through CRI.
+- **H3:** k0s materially changes Kubernetes control flow and offers a separate
+  model. **Rejected.** k0s preserves upstream Kubernetes and mainly changes
+  packaging, bootstrap, defaults, and process supervision.
+- **H4:** Nomad's client and task-driver model is a closer implementation shape
+  for a cross-platform, single-binary moonrun. **Supported with caveats.** The
+  lifecycle Interface is close, but driver isolation and networking vary by OS.
+- **H5:** multi-service Runs and virtual children can use one identical
+  reconciliation policy. **Rejected.** They can share execution records and
+  Adapters, but a declared service is desired-state work whereas a child spawn
+  is an imperative, parent-scoped lifetime with process-compatible wait and
+  termination semantics.
+
+## Evidence matrix
+
+| Concern | Kubernetes | k0s | Nomad | Wrangler | Moonrun implication |
+| --- | --- | --- | --- | --- | --- |
+| Source of intent | Objects carry a desired `spec`; controllers move current state toward it. | Uses upstream Kubernetes objects and controllers. | A Job is declarative desired state; an Evaluation reconciles desired and emergent state. | Caller configuration declares a binding, but invocation starts from a runtime-delivered event or another Worker call. | Persist desired and observed service state outside Engine. Do not make injected bindings the topology owner. |
+| Reconciliation owner | Control-plane controllers create/remove resources; kubelet has a node-local sync loop for assigned Pods. | k0s supervises the same API server, controller manager, scheduler, kubelet, and runtime roles. | Servers evaluate and place; clients watch Allocations and execute tasks. | Workers execute handlers when the runtime invokes them. | A Deployment Controller owns convergence; an Execution Supervisor owns concrete local attempts; Engine is below both. |
+| Placement versus execution | Scheduler binds an unbound Pod to a Node; kubelet asks a CRI runtime to launch it. | Same Kubernetes division. | Server scheduler creates an Allocation mapping a task group to a client; the client uses a task driver. | No comparable node-agent lifecycle Interface is exposed by Service Bindings. | Preserve a placement/execution split even if MVP has one local placement. |
+| Lifecycle unit | Pod is the smallest deployable object and groups co-scheduled containers. | Same Pod model. | Task Group is the scheduling unit; Allocation maps it to one client. A Task is the driver-executed unit. | An event/RPC invocation is the operative unit for bindings. | Use a logical workload/child record distinct from a concrete Run attempt. Do not identify a workload by a V8 isolate or thread. |
+| Start | Kubelet reconciles a PodSpec and calls CRI to create/start the sandbox and containers. | Same, with bundled/default runtime wiring. | Client calls the task driver's `StartTask` with a stable task ID and receives a recoverable handle. | Runtime calls the Worker handler; one Worker calls another through injected `env` binding. | Supervisor starts an Adapter; Host Process and guests never call `Engine::run` directly. |
+| Wait and status | Pod/container state is reported in object status; observers wait for status conditions. | Same. | `WaitTask` reports `ExitResult`; calling it after exit must return the recorded result immediately. | Downstream invocation is awaited as a call result; this is not a durable process status object. | Store terminal outcome in the Run record and make wait observe it through notification. Native `waitpid` stays inside its Adapter. |
+| Stop and kill | Deletion expresses desired removal; kubelet requests graceful stop and force-kills after the grace period. | Same. | `StopTask` signals, waits for a timeout, then force-kills; `DestroyTask` removes retained task state. | A downstream invocation not kept alive by its caller may be terminated early. | Termination is a supervisor transition with a deadline. Engine Adapter maps it to Run termination/V8 interruption; native Adapter maps it to OS control. |
+| Restart and replacement | Kubelet may restart containers in a Pod; higher controllers replace failed disposable Pods. A Pod is scheduled once and replacements have new UIDs. | Same. | Restarts occur on the client; exhausted local attempts can fail the Allocation and cause scheduler rescheduling. | Service Binding docs specify invocation lifetime, not long-lived desired-state restart policy. | Keep restart policy outside Engine. Give every attempt a distinct identity. Virtual children default to `Never`; services may opt into reconciliation. |
+| Ownership cleanup | Owner references and garbage collection model dependent deletion. | Same. | Allocation and task-group lifecycle orders main, sidecar, prestart, and poststop tasks. | Binding declaration grants call access; it is not a process ownership tree. | Record parent-child ownership separately from service names and routing. Define parent exit, orphan, and cascade policy explicitly. |
+| Service discovery | A Service is a stable logical network endpoint over changing Pods; clients discover it through DNS or environment variables. | Bundles Kubernetes networking and CoreDNS defaults. | Registers services with native discovery or Consul; consumers use addresses, templates, DNS, or a mesh. | Runtime injects a callable RPC/HTTP object into `env`; both Workers commonly execute on the same thread. | Start with stable names resolved to endpoint records. A later in-process call Adapter can preserve request/RPC semantics without owning Runs. |
+| Platform story | Linux control plane; supported Linux and Windows workers. No native macOS worker is documented. | Upstream model; Windows worker support is experimental and requires Linux control plane plus a Linux worker. No macOS host support is listed. | Product docs state macOS, Windows, and Linux support; task-driver and isolation capabilities still vary by OS. | Cloudflare owns the production runtime; local tools abstract its host implementation. | Nomad is the better portability precedent, but moonrun still needs its own OS-neutral Interface and per-OS Adapters. |
+
+Primary evidence:
+
+- Kubernetes controller loops and the Job controller's explicit separation from
+  Pod execution:
+  [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/).
+- Kubernetes node execution ownership and CRI:
+  [Cluster architecture](https://kubernetes.io/docs/concepts/architecture/),
+  [Kubelet sync loop](https://kubernetes.io/docs/reference/node/kubelet-sync-loop/),
+  and [CRI](https://kubernetes.io/docs/concepts/containers/cri/).
+- Kubernetes workload identity, restart, and termination:
+  [Pods](https://kubernetes.io/docs/concepts/workloads/pods/),
+  [Pod lifecycle](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/),
+  [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/), and
+  [owners and dependents](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/).
+- Kubernetes logical service discovery:
+  [Service](https://kubernetes.io/docs/concepts/services-networking/service/).
+- Kubernetes platform limits:
+  [Windows containers in Kubernetes](https://kubernetes.io/docs/concepts/windows/intro/)
+  and
+  [Windows resource management](https://kubernetes.io/docs/concepts/configuration/windows-resource-management/).
+- k0s upstream status, architecture, runtime, and platform limits:
+  [k0s overview](https://docs.k0sproject.io/stable/),
+  [architecture](https://docs.k0sproject.io/stable/architecture/),
+  [runtime](https://docs.k0sproject.io/stable/runtime/),
+  [system requirements](https://docs.k0sproject.io/stable/system-requirements/),
+  and
+  [experimental Windows workers](https://docs.k0sproject.io/stable/experimental-windows/).
+- Nomad desired-state scheduling and control-plane/client split:
+  [architecture](https://developer.hashicorp.com/nomad/docs/architecture),
+  [scheduling](https://developer.hashicorp.com/nomad/docs/concepts/scheduling/how-scheduling-works),
+  and [glossary](https://developer.hashicorp.com/nomad/docs/glossary).
+- Nomad execution and restart ownership:
+  [task-driver authoring](https://developer.hashicorp.com/nomad/plugins/author/task-driver),
+  [restart policy](https://developer.hashicorp.com/nomad/docs/job-specification/restart),
+  and [task-group lifecycle](https://developer.hashicorp.com/nomad/docs/job-specification/lifecycle).
+- Nomad service discovery and portability:
+  [service discovery](https://developer.hashicorp.com/nomad/docs/networking/service-discovery),
+  [task drivers](https://developer.hashicorp.com/nomad/docs/deploy/task-driver),
+  [supported platforms](https://developer.hashicorp.com/nomad/docs/what-is-nomad),
+  [raw-exec limitations](https://developer.hashicorp.com/nomad/docs/deploy/task-driver/raw_exec),
+  and
+  [Consul service-mesh platform limit](https://developer.hashicorp.com/nomad/docs/networking/consul/service-mesh).
+- Wrangler's injected call model and local multi-Worker topology:
+  [Service Bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/)
+  and
+  [multi-Worker development](https://developers.cloudflare.com/workers/local-development/multi-workers/).
+
+## Findings
+
+### 1. The decisive split is controller ownership versus runtime injection
+
+Kubernetes controllers are non-terminating loops. They read declared resources,
+act to move current state toward desired state, and report status. The Job
+controller does not run containers; it creates Pods. Once a Pod is assigned to
+a Node, kubelet becomes the node-local reconciliation owner and acts as the CRI
+client
+([Kubernetes controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
+[Kubelet sync loop](https://kubernetes.io/docs/reference/node/kubelet-sync-loop/)).
+
+Nomad has the same direction with fewer layers. Users submit a Job. Servers
+create Evaluations and Allocations. A client watches for assigned Allocations
+and uses a task driver to run the tasks. The task cannot decide that it should
+exist merely by holding an injected object
+([Nomad architecture](https://developer.hashicorp.com/nomad/docs/architecture),
+[Nomad scheduling](https://developer.hashicorp.com/nomad/docs/concepts/scheduling/how-scheduling-works)).
+
+Wrangler Service Bindings point the other way for invocation. The caller gets a
+binding on `env` and invokes the target with RPC or HTTP. The target's work is
+tied to that awaited invocation; Cloudflare warns that failing to await it can
+terminate it early. This is a capability-bearing call path, not an external
+desired-state controller
+([Cloudflare Service Bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/)).
+
+**Finding:** moonrun's multi-service topology needs an external Deployment
+Controller. Wrangler remains relevant only if moonrun later injects a
+request/RPC binding after the controller and Execution Supervisor have already
+established the target's lifecycle and route.
+
+### 2. Nomad's execution Seam is closer than CRI to a virtual Engine Run
+
+CRI establishes the correct separation: kubelet is the client and the runtime
+is an Adapter. It is nevertheless container-specific. Nomad's task-driver
+Interface is closer to the operations moonrun must expose:
+
+- `StartTask` accepts all launch configuration, assigns a stable ID, and
+  returns state usable for recovery;
+- `WaitTask` reports exit and must still report a retained exit after the task
+  has already finished;
+- `StopTask` performs graceful control followed by forced termination after a
+  timeout;
+- `DestroyTask` removes retained task state independently from stop; and
+- `InspectTask` reports current status
+  ([Nomad task-driver lifecycle](https://developer.hashicorp.com/nomad/plugins/author/task-driver)).
+
+This separation prevents three common ownership errors:
+
+1. execution completion does not erase state before a waiter observes it;
+2. stop is not conflated with resource destruction; and
+3. a restarted client or driver can recover an already-running task rather
+   than treating the supervising process as the task's lifetime.
+
+Moonrun does not need to copy the plugin protocol. It should borrow the
+Interface semantics at an internal Seam. The Engine Adapter can implement
+`start` by placing synchronous `Engine::run` on a supervisor-owned thread and
+can implement `wait` from the stored Run outcome. A native-process Adapter can
+use OS spawn, wait, and termination internally.
+
+**Finding:** Engine remains an execution kernel. The Execution Supervisor owns
+the execution thread, handle registry, status retention, and control requests.
+
+### 3. Logical identity and execution-attempt identity must differ
+
+A Kubernetes Pod has a UID, is scheduled once, and is not moved to another
+Node. If a higher-level workload needs recovery, its controller creates a
+replacement Pod with a new identity. Kubelet may separately restart a
+container within the same Pod according to policy
+([Kubernetes Pod lifecycle](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/)).
+
+Nomad similarly distinguishes a Job, a Task Group, an Allocation that maps the
+group to one client, and the task execution controlled by a driver. Local task
+restart and scheduler rescheduling are different operations
+([Nomad glossary](https://developer.hashicorp.com/nomad/docs/glossary),
+[Nomad restart policy](https://developer.hashicorp.com/nomad/docs/job-specification/restart)).
+
+**Finding:** moonrun needs at least two identities in the model:
+
+- a stable workload or child identity that callers observe; and
+- a Run-attempt identity for one concrete Engine invocation.
+
+For a virtual child, the first MVP should have exactly one attempt and restart
+policy `Never`, preserving child-process expectations. For a declared service,
+later restart or replacement creates a new attempt while the service identity
+stays stable. A V8 isolate, thread ID, native PID, or virtual PID must not serve
+as both identities.
+
+### 4. Service discovery is downstream of lifecycle, not its owner
+
+Kubernetes Service provides a stable network identity while controllers update
+EndpointSlices as Pods change. Consumers use DNS or environment variables.
+Nomad registers addresses with its native catalog or Consul and exposes them
+through queries, templates, DNS, or a mesh. In both systems, discovery observes
+the currently realized workloads; it does not own their execution
+([Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/),
+[Nomad service discovery](https://developer.hashicorp.com/nomad/docs/networking/service-discovery)).
+
+Wrangler combines discovery, authorization, and transport in a callable object
+injected into `env`. That can be attractive for in-process Runs, but importing
+the binding before the scheduler model would invert ownership again.
+
+**Finding:** discovery should resolve a logical name to current healthy
+endpoints or a request route, populated from observed workload state. Introduce
+its Seam only when native endpoint routing and in-process dispatch are both
+real Adapters. Until then, keep discovery out of the execution Interface.
+
+### 5. Kubernetes semantics are portable; its implementation is not
+
+Kubernetes supports Linux or Windows worker nodes, but its control plane runs
+on Linux. The Windows worker implementation has feature differences, and its
+resource control uses Windows Job Objects where Linux uses cgroups. The
+reviewed upstream documentation does not define a native macOS worker
+([Kubernetes Windows overview](https://kubernetes.io/docs/concepts/windows/intro/),
+[Windows resource management](https://kubernetes.io/docs/concepts/configuration/windows-resource-management/)).
+
+k0s preserves these constraints. Its Windows worker support is explicitly
+experimental, requires a Linux control plane and at least one Linux worker, and
+supervises `kubelet.exe` and `kube-proxy.exe`. Its published system requirements
+list Linux and Windows, not macOS
+([k0s experimental Windows](https://docs.k0sproject.io/stable/experimental-windows/),
+[k0s system requirements](https://docs.k0sproject.io/stable/system-requirements/)).
+
+Nomad explicitly supports macOS, Windows, and Linux and exposes driver
+capabilities so placement can account for installed drivers. That does not make
+isolation uniform. Its `raw_exec` driver runs on supported operating systems
+but provides no filesystem isolation; Linux can add cgroups, while Nomad's
+Consul service mesh requires Linux network namespaces and does not run on
+Windows or macOS
+([Nomad supported platforms](https://developer.hashicorp.com/nomad/docs/what-is-nomad),
+[Nomad raw exec](https://developer.hashicorp.com/nomad/docs/deploy/task-driver/raw_exec),
+[Nomad Consul service mesh](https://developer.hashicorp.com/nomad/docs/networking/consul/service-mesh)).
+
+**Finding:** borrow Kubernetes' OS-neutral desired/observed model and Nomad's
+capability-reporting execution Seam. Do not claim Kubernetes, k0s, or Nomad can
+provide portable isolation for in-process Runs. Moonrun still needs its own
+Linux, macOS, and Windows backing implementations.
+
+## Recommended Moonrun control model
+
+The following names are descriptive for this research note, not accepted
+Moonrun glossary entries.
+
+```text
+Deployment Spec ──desired state──▶ Deployment Controller
+                                           │
+                                           ├─ reconcile managed workloads
+                                           ├─ own restart/replacement policy
+                                           └─ publish workload status
+                                                       │
+Guest spawn Job ─▶ Host Process ───────────────┐        │
+Guest wait/kill ─▶ Host Process ───────────────┤        │
+                                              ▼        ▼
+                                         Execution Supervisor
+                                           ├─ retain observed status/outcome
+                                           └─ own attempts, threads, deadlines,
+                                              wait, termination, and teardown
+                                                       │
+                                             execution Interface
+                                                ┌──────┴──────┐
+                                                ▼             ▼
+                                      Engine Run Adapter  Native Process Adapter
+                                                │             │
+                                                ▼             ▼
+                                          Engine::run    OS spawn/wait/kill
+```
+
+This puts the Seams at places where at least two Adapters genuinely vary:
+
+- the execution Seam has Engine and native-process Adapters;
+- the discovery Seam can have native endpoint and future in-process request
+  Adapters; and
+- the platform backing below each Adapter differs across Linux, macOS, and
+  Windows without leaking those differences into Policy or guest Handles.
+
+Deployment Controller and Execution Supervisor have different Interfaces
+because desired-state reconciliation and imperative execution are different
+control flows:
+
+```text
+Deployment Controller
+  apply(deployment_spec) -> revision
+  observe(deployment_ref) -> deployment_status
+  delete(deployment_ref) -> revision
+
+Execution Supervisor
+  start(owner, execution_spec) -> execution_ref
+  observe(execution_ref) -> execution_status
+  wait(execution_ref) -> outcome
+  terminate(execution_ref, deadline, reason)
+  destroy(execution_ref)
+```
+
+The controller calls the supervisor while reconciling a Deployment. Host
+Process calls the same supervisor after authorizing an imperative child
+request. The supervisor does not need a mode-switched `apply_or_spawn`
+operation and does not own service topology.
+
+The execution Interface can mirror the useful parts of Nomad without exposing
+driver implementation details:
+
+```text
+start(run_attempt_spec) -> attempt_handle
+wait(attempt_handle) -> outcome
+stop(attempt_handle, deadline, reason)
+destroy(attempt_handle)
+```
+
+`destroy` is intentionally distinct from `stop` and `wait`: waiters must still
+observe an outcome after execution ends, and Handle cleanup must be explicit.
+
+### Managed service path
+
+A declared workload has desired and observed state. Deployment Controller
+compares the two and asks Execution Supervisor to start, stop, or later replace
+attempts. Workload identity remains stable across attempts. The first
+implementation can have one local placement, one replica per declaration, no
+health-based restart, and restart policy `Never`; that still establishes
+correct ownership without implementing a distributed scheduler.
+
+### Virtual child path
+
+A virtual child is not a miniature Deployment and should not be silently
+restarted. The guest's spawn Job is an imperative request. Host Process checks
+Policy and guest Handle provenance, then asks Execution Supervisor to
+materialize one execution record and one attempt. The supervisor owns the
+execution; Host Process owns the parent guest's reference to it.
+
+The child outcome remains queryable until all guest-visible Handles and pending
+waits are released. Termination changes the record to a stopping state and asks
+the execution Adapter to stop. A virtual process identifier is never sent to
+an OS process operation.
+
+Parent-child ownership and service discovery are independent relations:
+
+- ownership determines cascading termination, orphan behavior, wait
+  eligibility, and Policy attenuation;
+- service identity determines request routing; and
+- attempt identity determines which concrete execution produced a status or
+  consumed resources.
+
+## Agile implications
+
+The research changes the order and acceptance criteria, not the goal of
+starting with shared virtualization:
+
+1. **Per-Run inputs:** explicit environment, cwd, stdio, Policy, and control
+   remain the shared first slice. They are required by every execution Adapter.
+2. **Execution Supervisor skeleton:** add one local observed-state registry and
+   one Engine Adapter. It owns threads and retains terminal outcomes; restart
+   is disabled.
+3. **Multi-service MVP:** add Deployment Controller, apply a declarative
+   specification with several named workloads, converge each to one local Run,
+   observe status, and stop all Runs deterministically. No distributed
+   placement or callable binding is needed.
+4. **Execution Seam:** add the native-process Adapter or a test Adapter before
+   generalizing the Interface further. Two concrete Adapters justify the Seam.
+5. **Virtual-child MVP:** route one authorized Moonx spawn through Host Process
+   to the supervisor; implement spawn, wait-after-exit, terminate with deadline,
+   and explicit cleanup; keep restart `Never`.
+6. **Reconciliation hardening:** add health, `OnFailure`/`Always` service restart,
+   attempt history, and shutdown ordering.
+7. **Discovery and transport:** publish stable logical service endpoints, then
+   add direct in-process request dispatch only behind the same routing
+   Interface.
+8. **Platform hardening:** let execution Adapters report supported isolation and
+   control capabilities; use platform-specific mechanisms without changing the
+   supervisor model.
+
+## Explicit caveats
+
+- This research recommends Kubernetes' control model, not its API-server,
+  distributed consensus, admission, container networking, or cluster scale.
+  A single-process MVP does not need to imitate those mechanisms.
+- Nomad's task-driver Interface is an analogy, not a mandate to introduce an
+  out-of-process plugin protocol or copy its exact types.
+- Neither Kubernetes nor Nomad models a POSIX parent-child tree for ordinary
+  application code. Virtual child inheritance, wait ownership, orphaning, and
+  signal behavior still require Moonrun-specific design and native-behavior
+  tests.
+- `spec`/`status` is useful for managed services. Treating `spawn` as durable
+  desired state would incorrectly permit automatic child recreation; virtual
+  children need imperative creation plus retained observed state.
+- Nomad's statement that it supports macOS, Windows, and Linux does not imply
+  equal isolation on those platforms. The documented raw-exec and service-mesh
+  limitations are counterexamples.
+- k0s marketing language about a single package or broad infrastructure support
+  must not be read as symmetric host support. Its dedicated Windows document is
+  explicitly experimental and Linux-dependent.
+- Wrangler remains a valid precedent for a declared, capability-bearing,
+  in-process request Interface. It is rejected only as the owner of deployment
+  and process lifecycle.
+- The provisional terms in this note need a glossary/ADR decision before they
+  become public Moonrun vocabulary or implementation types.

--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -43,7 +43,7 @@ pub(super) fn get_curr_env(context: &mut ImportContext<'_, '_>) -> u64 {
 #[ported(source = "src/process/windows.c", original = "moonbitlang_async_get_curr_env")]
 #[cfg(windows)]
 pub(super) fn get_curr_env(context: &mut ImportContext<'_, '_>) -> AsyncHostResult<u64> {
-    let env = windows_env_block(inherited_windows_env(context)?);
+    let env = windows_env_block(inherited_windows_env(context));
     Ok(context.host.insert_process_env(env))
 }
 
@@ -186,7 +186,7 @@ pub(super) fn make_env(
     let inherited = if inherit_env == 0 {
         Vec::new()
     } else {
-        inherited_windows_env(context)?
+        inherited_windows_env(context)
     };
     Ok(context.host.insert_process_env_builder(inherited))
 }
@@ -437,92 +437,22 @@ pub(super) fn kill(context: &mut ImportContext<'_, '_>, pid: i32) -> AsyncHostRe
 
 #[cfg(unix)]
 fn inherited_unix_env(context: &ImportContext<'_, '_>) -> Vec<OsString> {
-    if context.host.policy().has_env_policy() {
-        context
-            .host
-            .policy()
-            .env_vars()
-            .into_iter()
-            .map(|(key, value)| OsString::from(format!("{key}={value}")))
-            .collect()
-    } else {
-        current_unix_env()
-    }
-}
-
-#[cfg(unix)]
-fn current_unix_env() -> Vec<OsString> {
-    use std::ffi::CStr;
-    use std::os::unix::ffi::OsStringExt;
-
-    unsafe extern "C" {
-        static mut environ: *mut *mut libc::c_char;
-    }
-
-    let mut entries = Vec::new();
-    let mut cursor = unsafe { environ };
-    while !cursor.is_null() {
-        let entry = unsafe { *cursor };
-        if entry.is_null() {
-            break;
-        }
-        entries.push(OsString::from_vec(
-            unsafe { CStr::from_ptr(entry) }.to_bytes().to_vec(),
-        ));
-        cursor = unsafe { cursor.add(1) };
-    }
-    entries
+    context.host.environment().process_entries()
 }
 
 #[cfg(windows)]
-fn inherited_windows_env(context: &ImportContext<'_, '_>) -> AsyncHostResult<Vec<OsString>> {
-    if context.host.policy().has_env_policy() {
-        Ok(context
-            .host
-            .policy()
-            .env_vars()
-            .into_iter()
-            .map(|(key, value)| OsString::from(format!("{key}={value}")))
-            .collect())
-    } else {
-        current_windows_env()
-    }
-}
+fn inherited_windows_env(context: &ImportContext<'_, '_>) -> Vec<OsString> {
+    use std::os::windows::ffi::OsStrExt;
 
-#[cfg(windows)]
-fn current_windows_env() -> AsyncHostResult<Vec<OsString>> {
-    use std::os::windows::ffi::OsStringExt;
-    use windows_sys::Win32::Foundation::GetLastError;
-    use windows_sys::Win32::System::Environment::{
-        FreeEnvironmentStringsW, GetEnvironmentStringsW,
-    };
-
-    let block = unsafe { GetEnvironmentStringsW() };
-    if block.is_null() {
-        return Err(AsyncHostError::Native(unsafe { GetLastError() } as i32));
-    }
-
-    let mut entries = Vec::new();
-    let mut cursor = block;
-    loop {
-        let mut len = 0usize;
-        while unsafe { *cursor.add(len) } != 0 {
-            len += 1;
-        }
-        if len == 0 {
-            break;
-        }
-        if unsafe { *cursor } != b'=' as u16 {
-            let entry = unsafe { std::slice::from_raw_parts(cursor, len) };
-            entries.push(OsString::from_wide(entry));
-        }
-        cursor = unsafe { cursor.add(len + 1) };
-    }
-    unsafe {
-        FreeEnvironmentStringsW(block);
-    }
-
-    Ok(entries)
+    context
+        .host
+        .environment()
+        .process_entries()
+        .into_iter()
+        // Preserve the previous adapter behavior: drive-current pseudo
+        // variables are not exposed through Moonrun's process environment.
+        .filter(|entry| entry.encode_wide().next() != Some(b'=' as u16))
+        .collect()
 }
 
 #[cfg(windows)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -56,7 +56,9 @@ use crate::guest_memory::{GuestMemory, GuestMemoryError};
 pub(crate) use crate::host::HostKey as HandleKey;
 use crate::host::{HostKeys, HostResourceKind as HandleKind};
 use crate::network::HostNetwork;
-use crate::policy::{Policy, RuntimePathBase};
+#[cfg(test)]
+use crate::policy::InitialEnv;
+use crate::policy::{Env, Policy, RuntimePathBase};
 use crate::process::HostProcess;
 use crate::resource::{Resource, ResourceClass, ResourcePublication, ResourceRef};
 use crate::temp_dir::TempDir;
@@ -1200,6 +1202,7 @@ pub(crate) struct AsyncHost {
     // that ownership; worker threads own their Jobs and return them through the
     // completion channel instead of sharing the host's tables.
     policy: Arc<Policy>,
+    environment: Arc<Env>,
     temp_dir: TempDir,
     network: HostNetwork,
     errno: Cell<i32>,
@@ -1223,6 +1226,7 @@ pub(crate) struct AsyncHost {
     tls_error: RefCell<Option<String>>,
 }
 
+#[cfg(test)]
 impl Default for AsyncHost {
     fn default() -> Self {
         Self::new(Arc::new(Policy::allow_all()))
@@ -1230,16 +1234,31 @@ impl Default for AsyncHost {
 }
 
 impl AsyncHost {
+    #[cfg(test)]
     pub(crate) fn new(policy: Arc<Policy>) -> Self {
-        Self::with_keys(policy, Rc::new(RefCell::new(HostKeys::default())))
+        let environment = Arc::new(
+            policy
+                .realize_env(InitialEnv::Explicit(Vec::new()))
+                .expect("construct test Host environment"),
+        );
+        Self::with_keys(
+            policy,
+            environment,
+            Rc::new(RefCell::new(HostKeys::default())),
+        )
     }
 
-    pub(crate) fn with_keys(policy: Arc<Policy>, keys: Rc<RefCell<HostKeys>>) -> Self {
+    pub(crate) fn with_keys(
+        policy: Arc<Policy>,
+        environment: Arc<Env>,
+        keys: Rc<RefCell<HostKeys>>,
+    ) -> Self {
         let process = HostProcess::new(Arc::clone(&policy));
         let network = HostNetwork::new(Arc::clone(&policy));
-        let temp_dir = TempDir::new(Arc::clone(&policy));
+        let temp_dir = TempDir::new(Arc::clone(&environment), &policy);
         Self {
             policy,
+            environment,
             temp_dir,
             network,
             errno: Cell::new(0),
@@ -2635,6 +2654,10 @@ impl AsyncHost {
 
     pub(crate) fn policy(&self) -> &Policy {
         &self.policy
+    }
+
+    pub(crate) fn environment(&self) -> &Env {
+        &self.environment
     }
 
     pub(crate) fn temp_dir(&self) -> AsyncHostResult<OsString> {

--- a/crates/moonrun/src/async_sys/fs/stub.rs
+++ b/crates/moonrun/src/async_sys/fs/stub.rs
@@ -53,15 +53,9 @@ ported_fns! {
         source = "src/fs/stub.c",
         original = "moonbitlang_async_get_tmp_path"
     )]
+    #[cfg(windows)]
     pub(crate) fn get_tmp_path() -> AsyncHostResult<OsString> {
-        #[cfg(unix)]
-        {
-            Ok(tmp_path_from_native_stub())
-        }
-        #[cfg(windows)]
-        {
-            tmp_path_from_native_stub()
-        }
+        tmp_path_from_native_stub()
     }
 
     #[ported(
@@ -199,11 +193,6 @@ fn last_native_error() -> AsyncHostError {
 }
 
 #[cfg(unix)]
-fn tmp_path_from_native_stub() -> OsString {
-    tmp_path_from_env(std::env::var_os("TMPDIR"))
-}
-
-#[cfg(unix)]
 fn tmp_path_from_env(tmpdir: Option<OsString>) -> OsString {
     // POSIX reserves TMPDIR for temporary-file placement. The async tmpdir
     // layer concatenates this base path with a generated name, so the host
@@ -308,6 +297,9 @@ mod tests {
 
     #[test]
     fn tmp_path_is_non_empty_and_separator_terminated() {
+        #[cfg(unix)]
+        let path = get_tmp_path_from_env(Some(OsString::from("/moonrun/tmp"))).unwrap();
+        #[cfg(windows)]
         let path = get_tmp_path().unwrap();
 
         assert!(!path.as_os_str().is_empty());
@@ -317,6 +309,9 @@ mod tests {
 
     #[test]
     fn tmp_path_buffer_is_non_empty() {
+        #[cfg(unix)]
+        let path = get_tmp_path_from_env(Some(OsString::from("/moonrun/tmp"))).unwrap();
+        #[cfg(windows)]
         let path = get_tmp_path().unwrap();
         let buffer = tmp_path_buffer(path.as_os_str()).unwrap();
 

--- a/crates/moonrun/src/engine.rs
+++ b/crates/moonrun/src/engine.rs
@@ -18,6 +18,7 @@
 
 use crate::{policy, source_map, v8_backend};
 use anyhow::Context;
+use std::ffi::OsString;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -45,6 +46,7 @@ pub struct RunOptions {
     pub(crate) no_stack_trace: bool,
     pub(crate) test_args: Option<String>,
     pub(crate) policy_file: Option<PathBuf>,
+    pub(crate) initial_environment: Option<Vec<(OsString, OsString)>>,
 }
 
 impl RunOptions {
@@ -69,6 +71,27 @@ impl RunOptions {
 
     pub fn with_policy_file(mut self, policy_file: impl Into<PathBuf>) -> Self {
         self.policy_file = Some(policy_file.into());
+        self
+    }
+
+    /// Use a fixed initial environment instead of the ambient process environment.
+    ///
+    /// Moonrun Policy selects and overrides values from whichever source this
+    /// Run chooses; it does not choose the source. When this option is omitted,
+    /// the embedding process environment is used as a read-only, lazy source
+    /// and must not be mutated while the Run is active.
+    pub fn environment<I, K, V>(mut self, environment: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<OsString>,
+        V: Into<OsString>,
+    {
+        self.initial_environment = Some(
+            environment
+                .into_iter()
+                .map(|(name, value)| (name.into(), value.into()))
+                .collect(),
+        );
         self
     }
 }
@@ -123,9 +146,11 @@ impl fmt::Debug for Module {
 /// on the calling thread. It does not create threads or retain run lifecycle
 /// state; callers choose execution placement and manage lifecycle.
 ///
-/// The current implementation still uses process stdio, environment, working
-/// directory, and signal compatibility behavior. Those remain shared,
-/// process-scoped dependencies to extract in later changes.
+/// The guest environment is owned by each Run. The current implementation
+/// still uses process stdio, working directory, and signal compatibility
+/// behavior. Those remain shared, process-scoped dependencies to extract in
+/// later changes. Concurrent run semantics beyond environment isolation are
+/// not yet part of this experimental interface.
 #[derive(Clone, Debug)]
 pub struct Engine {
     config: EngineConfig,
@@ -173,13 +198,22 @@ impl Engine {
     }
 
     /// Execute one isolated run synchronously on the calling thread.
-    pub fn run(&self, module: &Module, options: RunOptions) -> anyhow::Result<RunOutcome> {
+    pub fn run(&self, module: &Module, mut options: RunOptions) -> anyhow::Result<RunOutcome> {
         let policy = Arc::new(match options.policy_file.as_ref() {
             Some(path) => policy::Policy::from_file(path).context(
                 "failed to load sandbox policy (experimental); run `moonrun --help` for policy format notes",
             )?,
             None => policy::Policy::allow_all(),
         });
+        let initial_environment = match options.initial_environment.take() {
+            Some(entries) => policy::InitialEnv::Explicit(entries),
+            None => policy::InitialEnv::Ambient,
+        };
+        let environment = Arc::new(
+            policy
+                .realize_env(initial_environment)
+                .context("failed to construct the Run environment")?,
+        );
         v8_backend::run(
             &self.config,
             module.name(),
@@ -187,6 +221,7 @@ impl Engine {
             module.source_map(),
             options,
             policy,
+            environment,
         )
     }
 

--- a/crates/moonrun/src/filesystem/v8/runtime.rs
+++ b/crates/moonrun/src/filesystem/v8/runtime.rs
@@ -18,8 +18,9 @@
 
 //! V8 adapter for runtime values exposed through the unstable filesystem object.
 
+use crate::policy::Env;
+use crate::util::get_ref;
 use crate::v8_builder::{ArgsExt, ObjectExt, ScopeExt};
-use crate::{policy::Policy, util::get_ref};
 use std::any::Any;
 use std::sync::Arc;
 
@@ -45,11 +46,11 @@ fn set_env_var(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let policy = unsafe { get_ref::<Policy>(&args) };
+    let environment = environment(&args);
     let key = args.string_lossy(scope, 0);
     let value = args.string_lossy(scope, 1);
 
-    policy.set_env_var(key, value);
+    environment.set(key, value);
 
     ret.set_undefined()
 }
@@ -59,9 +60,9 @@ fn unset_env_var(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let policy = unsafe { get_ref::<Policy>(&args) };
+    let environment = environment(&args);
     let key = args.string_lossy(scope, 0);
-    policy.unset_env_var(&key);
+    environment.unset(&key);
     ret.set_undefined()
 }
 
@@ -70,9 +71,9 @@ fn get_env_var(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let policy = unsafe { get_ref::<Policy>(&args) };
+    let environment = environment(&args);
     let key = args.string_lossy(scope, 0);
-    let value = policy.get_env_var(&key).unwrap_or_default();
+    let value = environment.get(&key).unwrap_or_default();
     let value = scope.string(&value);
     ret.set(value.into());
 }
@@ -82,9 +83,9 @@ fn get_env_var_exists(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let policy = unsafe { get_ref::<Policy>(&args) };
+    let environment = environment(&args);
     let key = args.string_lossy(scope, 0);
-    ret.set_bool(policy.env_var_exists(&key));
+    ret.set_bool(environment.contains(&key));
 }
 
 fn get_env_vars(
@@ -92,14 +93,14 @@ fn get_env_vars(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let policy = unsafe { get_ref::<Policy>(&args) };
+    let environment = environment(&args);
     let result = v8::Array::new(scope, 0);
     let mut index = 0;
-    for (k, v) in policy.env_vars() {
+    for (k, v) in environment.utf8_vars() {
         let key = scope.string(&k);
         let val = scope.string(&v);
-        result.set_index(scope, index, key.into()).unwrap();
-        result.set_index(scope, index + 1, val.into()).unwrap();
+        let _ = result.set_index(scope, index, key.into());
+        let _ = result.set_index(scope, index + 1, val.into());
         index += 2;
     }
     ret.set(result.into());
@@ -110,23 +111,23 @@ pub(super) fn register<'s>(
     scope: &mut v8::HandleScope<'s>,
     wasm_file_name: &str,
     args: &[String],
-    policy: Arc<Policy>,
+    environment: Arc<Env>,
     dtors: &mut Vec<Box<dyn Any>>,
 ) {
-    let policy_ptr = Arc::as_ptr(&policy);
-    dtors.push(Box::new(policy));
+    let environment_ptr = Arc::as_ptr(&environment);
+    dtors.push(Box::new(environment));
 
-    set_policy_func(obj, scope, "env_get_var", get_env_var, policy_ptr);
-    set_policy_func(obj, scope, "set_env_var", set_env_var, policy_ptr);
-    set_policy_func(obj, scope, "unset_env_var", unset_env_var, policy_ptr);
-    set_policy_func(obj, scope, "get_env_vars", get_env_vars, policy_ptr);
-    set_policy_func(obj, scope, "get_env_var", get_env_var, policy_ptr);
-    set_policy_func(
+    set_environment_func(obj, scope, "env_get_var", get_env_var, environment_ptr);
+    set_environment_func(obj, scope, "set_env_var", set_env_var, environment_ptr);
+    set_environment_func(obj, scope, "unset_env_var", unset_env_var, environment_ptr);
+    set_environment_func(obj, scope, "get_env_vars", get_env_vars, environment_ptr);
+    set_environment_func(obj, scope, "get_env_var", get_env_var, environment_ptr);
+    set_environment_func(
         obj,
         scope,
         "get_env_var_exists",
         get_env_var_exists,
-        policy_ptr,
+        environment_ptr,
     );
 
     let args = Box::new(RuntimeArgs(
@@ -144,14 +145,19 @@ pub(super) fn register<'s>(
     dtors.push(args);
 }
 
-fn set_policy_func<'s>(
+fn environment<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s Env {
+    // SAFETY: `register` retains the Arc for the complete guest execution.
+    unsafe { get_ref::<Env>(args) }
+}
+
+fn set_environment_func<'s>(
     obj: v8::Local<'s, v8::Object>,
     scope: &mut v8::HandleScope<'s>,
     name: &str,
     callback: impl v8::MapFnTo<v8::FunctionCallback>,
-    policy_ptr: *const Policy,
+    environment: *const Env,
 ) {
-    let data = v8::External::new(scope, policy_ptr as *mut std::ffi::c_void);
+    let data = v8::External::new(scope, environment as *mut std::ffi::c_void);
     let function = v8::Function::builder(callback)
         .data(data.into())
         .build(scope)

--- a/crates/moonrun/src/host.rs
+++ b/crates/moonrun/src/host.rs
@@ -26,7 +26,7 @@ use slotmap::Key;
 use slotmap::{KeyData, SlotMap, new_key_type};
 
 use crate::async_host::AsyncHost;
-use crate::policy::Policy;
+use crate::policy::{Env, Policy};
 use crate::sqlite::SqliteHost;
 
 new_key_type! {
@@ -98,10 +98,10 @@ pub(crate) struct Host {
 }
 
 impl Host {
-    pub(crate) fn new(policy: Arc<Policy>) -> Self {
+    pub(crate) fn new(policy: Arc<Policy>, environment: Arc<Env>) -> Self {
         let keys = Rc::new(RefCell::new(HostKeys::default()));
         Self {
-            async_state: AsyncHost::with_keys(Arc::clone(&policy), Rc::clone(&keys)),
+            async_state: AsyncHost::with_keys(Arc::clone(&policy), environment, Rc::clone(&keys)),
             sqlite: SqliteHost::with_keys(policy, keys),
         }
     }
@@ -122,7 +122,8 @@ impl Host {
 impl Drop for Host {
     fn drop(&mut self) {
         // Keep the historical opt-in name for compatibility even though the
-        // check now runs at the lifetime of the complete per-run Host.
+        // check now runs at the lifetime of the complete per-run Host. This is
+        // embedding-process diagnostics configuration, not a guest Env read.
         if std::thread::panicking() || std::env::var_os("MOONBIT_ASYNC_CHECK_FD_LEAK").is_none() {
             return;
         }

--- a/crates/moonrun/src/host_imports.rs
+++ b/crates/moonrun/src/host_imports.rs
@@ -325,11 +325,12 @@ pub(crate) fn install(
     wasm_file_name: &str,
     args: &[String],
     policy: Arc<policy::Policy>,
+    environment: Arc<policy::Env>,
 ) -> run_termination::TerminationRequest {
     let global_proxy = scope.get_current_context().global(scope);
     let termination_request = run_termination::TerminationRequest::default();
     let v8_context = Box::new(crate::v8_import::V8RunContext::new(
-        crate::host::Host::new(Arc::clone(&policy)),
+        crate::host::Host::new(Arc::clone(&policy), Arc::clone(&environment)),
         termination_request.clone(),
     ));
     let v8_context_ptr = &*v8_context as *const crate::v8_import::V8RunContext;
@@ -390,8 +391,11 @@ pub(crate) fn install(
             scope,
             wasm_file_name,
             args,
-            Rc::clone(v8_context.memory_binding()),
-            termination_request.clone(),
+            wasi_api::WasiRunResources::new(
+                Arc::clone(&environment),
+                Rc::clone(v8_context.memory_binding()),
+                termination_request.clone(),
+            ),
             dtors,
         );
     }
@@ -403,7 +407,15 @@ pub(crate) fn install(
     // API for the fs module
     {
         let obj = global_proxy.child(scope, "__moonbit_fs_unstable");
-        filesystem::v8::init_env(obj, scope, wasm_file_name, args, Arc::clone(&policy), dtors);
+        filesystem::v8::init_env(
+            obj,
+            scope,
+            wasm_file_name,
+            args,
+            Arc::clone(&policy),
+            environment,
+            dtors,
+        );
     }
     {
         let io = global_proxy.child(scope, "__moonbit_io_unstable");

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -44,7 +44,7 @@ struct Commandline {
     #[clap(
         long,
         value_name = "PATH",
-        long_help = r#"Experimental: Sandbox wasm runtime host access using a JSON policy file. WASI is not covered.
+        long_help = r#"Experimental: Sandbox wasm runtime host access using a JSON policy file. WASI descriptors and preopens are not covered; WASI environment reads use the same per-Run environment as moonrun-owned imports.
 
 Supplying --policy enables deny-by-default mode: omitted or empty fs, net, and env objects deny that surface, and process spawning is disabled unless explicitly allowed.
 

--- a/crates/moonrun/src/policy/env.rs
+++ b/crates/moonrun/src/policy/env.rs
@@ -16,117 +16,644 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::sync::{Arc, Mutex};
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::sync::{Arc, RwLock};
 
 use super::config::EnvConfig;
 
+/// The mutable environment visible to one Run.
+///
+/// Construction applies the startup-only policy once. Per-Run mutations stay
+/// in `delta`; unmodified values are read lazily from the immutable source.
+#[derive(Debug)]
+pub(crate) struct Env {
+    source: Arc<dyn EnvironmentSource>,
+    delta: RwLock<EnvDelta>,
+}
+
+pub(crate) enum InitialEnv {
+    Ambient,
+    Explicit(Vec<(OsString, OsString)>),
+}
+
 #[derive(Clone, Debug)]
 pub(super) struct EnvPolicy {
-    vars: Arc<Mutex<BTreeMap<String, String>>>,
+    from_host: Vec<String>,
+    required_from_host: Vec<String>,
+    set: BTreeMap<String, String>,
 }
 
 impl EnvPolicy {
     pub(super) fn from_config(config: EnvConfig) -> anyhow::Result<Self> {
-        let mut vars = BTreeMap::new();
-
-        let copy_all = config.from_host.iter().any(|name| name == "*");
-        if copy_all {
-            vars.extend(std::env::vars());
+        for (name, value) in &config.set {
+            validate_environment_entry(OsStr::new(name), OsStr::new(value))?;
         }
-
-        copy_host_names(&mut vars, &config.from_host, false)?;
-        copy_host_names(&mut vars, &config.required_from_host, true)?;
-
-        for (name, value) in config.set {
-            vars.insert(name, value);
-        }
-
         Ok(Self {
-            vars: Arc::new(Mutex::new(vars)),
+            from_host: validate_host_names(config.from_host)?,
+            required_from_host: validate_host_names(config.required_from_host)?,
+            set: config.set,
         })
     }
 
-    pub(super) fn vars(&self) -> Vec<(String, String)> {
-        self.vars
-            .lock()
-            .unwrap()
+    fn selected_names(&self) -> Option<Vec<OsString>> {
+        if self.from_host.iter().any(|name| name == "*") {
+            return None;
+        }
+
+        let mut names: Vec<OsString> = Vec::new();
+        for name in self
+            .from_host
             .iter()
-            .map(|(name, value)| (name.clone(), value.clone()))
-            .collect()
+            .chain(&self.required_from_host)
+            .filter(|name| name.as_str() != "*")
+        {
+            if !names
+                .iter()
+                .any(|selected| names_equal(selected, OsStr::new(name)))
+            {
+                names.push(name.into());
+            }
+        }
+        Some(names)
     }
 
-    pub(super) fn get(&self, name: &str) -> Option<String> {
-        self.vars.lock().unwrap().get(name).cloned()
-    }
+    fn realize(&self, source: Arc<dyn EnvironmentSource>) -> anyhow::Result<Env> {
+        for name in self
+            .required_from_host
+            .iter()
+            .filter(|name| name.as_str() != "*")
+        {
+            if source.get(OsStr::new(name)).is_none() {
+                anyhow::bail!("required host environment variable {name:?} is not set");
+            }
+        }
 
-    pub(super) fn contains(&self, name: &str) -> bool {
-        self.vars.lock().unwrap().contains_key(name)
-    }
-
-    pub(super) fn set(&self, name: String, value: String) {
-        self.vars.lock().unwrap().insert(name, value);
-    }
-
-    pub(super) fn unset(&self, name: &str) {
-        self.vars.lock().unwrap().remove(name);
+        let source: Arc<dyn EnvironmentSource> = match self.selected_names() {
+            Some(names) => Arc::new(SelectedEnvironment { source, names }),
+            None => source,
+        };
+        let mut delta = EnvDelta::default();
+        for (name, value) in &self.set {
+            delta.set(name.into(), value.into());
+        }
+        Ok(Env::new(source, delta))
     }
 }
 
-fn copy_host_names(
-    vars: &mut BTreeMap<String, String>,
-    names: &[String],
-    required: bool,
-) -> anyhow::Result<()> {
-    let mut seen = BTreeSet::new();
-    for name in names {
-        if name == "*" {
-            continue;
-        }
-        if !seen.insert(name) {
-            anyhow::bail!("duplicate environment policy entry {name:?}");
-        }
-        match std::env::var(name) {
-            Ok(value) => {
-                vars.insert(name.clone(), value);
-            }
-            Err(_) if required => {
-                anyhow::bail!("required host environment variable {name:?} is not set");
-            }
-            Err(_) => {}
+impl Env {
+    pub(super) fn realize(initial: InitialEnv, policy: Option<&EnvPolicy>) -> anyhow::Result<Self> {
+        let source: Arc<dyn EnvironmentSource> = match initial {
+            InitialEnv::Ambient => Arc::new(AmbientEnvironment),
+            InitialEnv::Explicit(entries) => Arc::new(ExplicitEnvironment::new(entries)?),
+        };
+        Self::from_source(source, policy)
+    }
+
+    fn from_source(
+        source: Arc<dyn EnvironmentSource>,
+        policy: Option<&EnvPolicy>,
+    ) -> anyhow::Result<Self> {
+        match policy {
+            Some(policy) => policy.realize(source),
+            None => Ok(Self::new(source, EnvDelta::default())),
         }
     }
+
+    fn new(source: Arc<dyn EnvironmentSource>, delta: EnvDelta) -> Self {
+        Self {
+            source,
+            delta: RwLock::new(delta),
+        }
+    }
+
+    /// Return the subset representable by MoonBit and WASI string APIs.
+    ///
+    /// Native process inheritance uses [`Self::process_entries`] instead, so
+    /// an entry that is not Unicode is not lost from a child environment.
+    pub(crate) fn utf8_vars(&self) -> Vec<(String, String)> {
+        self.vars_os()
+            .into_iter()
+            .filter_map(|(name, value)| {
+                Some((name.to_str()?.to_owned(), value.to_str()?.to_owned()))
+            })
+            .collect()
+    }
+
+    pub(crate) fn process_entries(&self) -> Vec<OsString> {
+        self.vars_os()
+            .into_iter()
+            .map(|(name, value)| {
+                let mut entry = name;
+                entry.push("=");
+                entry.push(&value);
+                entry
+            })
+            .collect()
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Option<String> {
+        self.get_os(name)?.into_string().ok()
+    }
+
+    pub(crate) fn get_os(&self, name: &str) -> Option<OsString> {
+        let change = self
+            .delta
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(OsStr::new(name))
+            .cloned();
+        match change {
+            Some(EnvChange::Set(value)) => Some(value),
+            Some(EnvChange::Unset) => None,
+            None => self.source.get(OsStr::new(name)).map(|(_, value)| value),
+        }
+    }
+
+    pub(crate) fn contains(&self, name: &str) -> bool {
+        self.get_os(name).is_some()
+    }
+
+    pub(crate) fn set(&self, name: String, value: String) {
+        // Guest mutation imports cannot report configuration errors. Keep the
+        // Env invariant without allowing an invalid update to panic the Run.
+        if !valid_environment_name(OsStr::new(&name)) || contains_nul(OsStr::new(&value)) {
+            return;
+        }
+        self.delta
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .set(name.into(), value.into());
+    }
+
+    pub(crate) fn unset(&self, name: &str) {
+        if !valid_environment_name(OsStr::new(name)) {
+            return;
+        }
+        self.delta
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .unset(name.into());
+    }
+
+    fn vars_os(&self) -> Vec<(OsString, OsString)> {
+        let mut vars = self.source.vars();
+        normalize(&mut vars);
+
+        let delta = self
+            .delta
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for (name, change) in &delta.changes {
+            match change {
+                EnvChange::Set(value) => insert(&mut vars, name.clone(), value.clone()),
+                EnvChange::Unset => remove(&mut vars, name),
+            }
+        }
+        vars
+    }
+}
+
+trait EnvironmentSource: std::fmt::Debug + Send + Sync {
+    fn get(&self, name: &OsStr) -> Option<(OsString, OsString)>;
+    fn vars(&self) -> Vec<(OsString, OsString)>;
+}
+
+#[derive(Debug)]
+struct AmbientEnvironment;
+
+impl EnvironmentSource for AmbientEnvironment {
+    fn get(&self, name: &OsStr) -> Option<(OsString, OsString)> {
+        // `var_os` panics for invalid names; guest-provided lookup keys are
+        // untrusted and one Run must not be able to unwind another.
+        valid_environment_name(name)
+            .then(|| std::env::var_os(name))
+            .flatten()
+            .map(|value| (name.to_os_string(), value))
+    }
+
+    fn vars(&self) -> Vec<(OsString, OsString)> {
+        // `vars_os` preserves native OsString values and is backed by
+        // GetEnvironmentStringsW on Windows. That implementation panics only
+        // if the OS cannot return any environment block, a process-wide
+        // failure from which no Run can usefully recover.
+        std::env::vars_os().collect()
+    }
+}
+
+#[cfg(unix)]
+fn valid_environment_name(name: &OsStr) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+
+    let name = name.as_bytes();
+    !name.is_empty() && !name.contains(&b'=') && !name.contains(&0)
+}
+
+#[cfg(windows)]
+fn valid_environment_name(name: &OsStr) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+
+    let mut name = name.encode_wide().peekable();
+    name.peek().is_some() && name.all(|unit| unit != b'=' as u16 && unit != 0)
+}
+
+#[derive(Debug)]
+struct ExplicitEnvironment {
+    vars: Vec<(OsString, OsString)>,
+}
+
+impl ExplicitEnvironment {
+    fn new(mut vars: Vec<(OsString, OsString)>) -> anyhow::Result<Self> {
+        for (name, value) in &vars {
+            validate_environment_entry(name, value)?;
+        }
+        normalize(&mut vars);
+        Ok(Self { vars })
+    }
+}
+
+impl EnvironmentSource for ExplicitEnvironment {
+    fn get(&self, name: &OsStr) -> Option<(OsString, OsString)> {
+        self.vars
+            .iter()
+            .find(|(stored, _)| names_equal(stored, name))
+            .cloned()
+    }
+
+    fn vars(&self) -> Vec<(OsString, OsString)> {
+        self.vars.clone()
+    }
+}
+
+#[derive(Debug)]
+struct SelectedEnvironment {
+    source: Arc<dyn EnvironmentSource>,
+    names: Vec<OsString>,
+}
+
+impl EnvironmentSource for SelectedEnvironment {
+    fn get(&self, name: &OsStr) -> Option<(OsString, OsString)> {
+        self.names
+            .iter()
+            .any(|selected| names_equal(selected, name))
+            .then(|| self.source.get(name))
+            .flatten()
+    }
+
+    fn vars(&self) -> Vec<(OsString, OsString)> {
+        self.names
+            .iter()
+            .filter_map(|name| self.source.get(name))
+            .collect()
+    }
+}
+
+#[derive(Debug, Default)]
+struct EnvDelta {
+    changes: Vec<(OsString, EnvChange)>,
+}
+
+impl EnvDelta {
+    fn get(&self, name: &OsStr) -> Option<&EnvChange> {
+        self.changes
+            .iter()
+            .find(|(stored, _)| names_equal(stored, name))
+            .map(|(_, change)| change)
+    }
+
+    fn set(&mut self, name: OsString, value: OsString) {
+        self.insert(name, EnvChange::Set(value));
+    }
+
+    fn unset(&mut self, name: OsString) {
+        self.insert(name, EnvChange::Unset);
+    }
+
+    fn insert(&mut self, name: OsString, change: EnvChange) {
+        if let Some((_, stored)) = self
+            .changes
+            .iter_mut()
+            .find(|(stored, _)| names_equal(stored, &name))
+        {
+            *stored = change;
+        } else {
+            self.changes.push((name, change));
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum EnvChange {
+    Set(OsString),
+    Unset,
+}
+
+fn validate_host_names(names: Vec<String>) -> anyhow::Result<Vec<String>> {
+    let mut seen: Vec<&str> = Vec::new();
+    for name in &names {
+        if name != "*" && !valid_environment_name(OsStr::new(name)) {
+            anyhow::bail!("invalid environment variable name {name:?}");
+        }
+        if name != "*"
+            && seen
+                .iter()
+                .any(|seen| names_equal(OsStr::new(seen), OsStr::new(name)))
+        {
+            anyhow::bail!("duplicate environment policy entry {name:?}");
+        }
+        seen.push(name);
+    }
+    Ok(names)
+}
+
+fn validate_environment_entry(name: &OsStr, value: &OsStr) -> anyhow::Result<()> {
+    if !valid_environment_name(name) {
+        anyhow::bail!("invalid environment variable name {name:?}");
+    }
+    if contains_nul(value) {
+        anyhow::bail!("environment variable {name:?} contains a NUL in its value");
+    }
     Ok(())
+}
+
+#[cfg(unix)]
+fn contains_nul(value: &OsStr) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+
+    value.as_bytes().contains(&0)
+}
+
+#[cfg(windows)]
+fn contains_nul(value: &OsStr) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+
+    value.encode_wide().any(|unit| unit == 0)
+}
+
+fn normalize(vars: &mut Vec<(OsString, OsString)>) {
+    let mut normalized = Vec::with_capacity(vars.len());
+    for (name, value) in vars.drain(..) {
+        insert(&mut normalized, name, value);
+    }
+    *vars = normalized;
+}
+
+fn insert(vars: &mut Vec<(OsString, OsString)>, name: OsString, value: OsString) {
+    if let Some((_, stored_value)) = vars
+        .iter_mut()
+        .find(|(stored, _)| names_equal(stored, &name))
+    {
+        *stored_value = value;
+    } else {
+        vars.push((name, value));
+    }
+}
+
+fn remove(vars: &mut Vec<(OsString, OsString)>, name: &OsStr) {
+    if let Some(index) = vars
+        .iter()
+        .position(|(stored, _)| names_equal(stored, name))
+    {
+        vars.remove(index);
+    }
+}
+
+#[cfg(not(windows))]
+fn names_equal(left: &OsStr, right: &OsStr) -> bool {
+    left == right
+}
+
+#[cfg(windows)]
+fn names_equal(left: &OsStr, right: &OsStr) -> bool {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Globalization::{CSTR_EQUAL, CompareStringOrdinal};
+
+    let left = left.encode_wide().collect::<Vec<_>>();
+    let right = right.encode_wide().collect::<Vec<_>>();
+    let (Ok(left_len), Ok(right_len)) = (i32::try_from(left.len()), i32::try_from(right.len()))
+    else {
+        return left == right;
+    };
+    (unsafe { CompareStringOrdinal(left.as_ptr(), left_len, right.as_ptr(), right_len, 1) })
+        == CSTR_EQUAL
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug)]
+    struct CountingEnvironment {
+        vars: Vec<(OsString, OsString)>,
+        gets: Arc<AtomicUsize>,
+        enumerations: Arc<AtomicUsize>,
+    }
+
+    impl EnvironmentSource for CountingEnvironment {
+        fn get(&self, name: &OsStr) -> Option<(OsString, OsString)> {
+            self.gets.fetch_add(1, Ordering::Relaxed);
+            self.vars
+                .iter()
+                .find(|(stored, _)| names_equal(stored, name))
+                .cloned()
+        }
+
+        fn vars(&self) -> Vec<(OsString, OsString)> {
+            self.enumerations.fetch_add(1, Ordering::Relaxed);
+            self.vars.clone()
+        }
+    }
+
+    fn counting_environment(
+        policy: Option<&EnvPolicy>,
+    ) -> (Env, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+        let gets = Arc::new(AtomicUsize::new(0));
+        let enumerations = Arc::new(AtomicUsize::new(0));
+        let source = CountingEnvironment {
+            vars: vec![("SOURCE".into(), "value".into())],
+            gets: Arc::clone(&gets),
+            enumerations: Arc::clone(&enumerations),
+        };
+        (
+            Env::from_source(Arc::new(source), policy).unwrap(),
+            gets,
+            enumerations,
+        )
+    }
+
+    #[test]
+    fn single_key_reads_and_delta_updates_do_not_enumerate_the_source() {
+        let (environment, gets, enumerations) = counting_environment(None);
+
+        assert_eq!(environment.get("SOURCE").as_deref(), Some("value"));
+        environment.set("LOCAL".to_owned(), "set".to_owned());
+        assert_eq!(environment.get("LOCAL").as_deref(), Some("set"));
+        environment.unset("SOURCE");
+        assert_eq!(environment.get("SOURCE"), None);
+
+        assert_eq!(gets.load(Ordering::Relaxed), 1);
+        assert_eq!(enumerations.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn materializing_all_vars_enumerates_the_source_once() {
+        let (environment, _, enumerations) = counting_environment(None);
+
+        assert_eq!(
+            environment.utf8_vars(),
+            vec![("SOURCE".to_owned(), "value".to_owned())]
+        );
+
+        assert_eq!(enumerations.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn invalid_ambient_names_do_not_panic() {
+        let environment = Env::realize(InitialEnv::Ambient, None).unwrap();
+
+        assert_eq!(environment.get(""), None);
+        assert_eq!(environment.get("INVALID=NAME"), None);
+        assert_eq!(environment.get("INVALID\0NAME"), None);
+    }
+
+    #[test]
+    fn invalid_explicit_entries_are_rejected_at_run_construction() {
+        for (name, value) in [("", "value"), ("BAD=NAME", "value"), ("NAME", "bad\0value")] {
+            let result = Env::realize(
+                InitialEnv::Explicit(vec![(name.into(), value.into())]),
+                None,
+            );
+            assert!(result.is_err(), "accepted {name:?}={value:?}");
+        }
+    }
+
+    #[test]
+    fn invalid_policy_and_runtime_entries_are_not_installed() {
+        assert!(
+            EnvPolicy::from_config(EnvConfig {
+                set: BTreeMap::from([("BAD=NAME".to_owned(), "value".to_owned())]),
+                ..EnvConfig::default()
+            })
+            .is_err()
+        );
+
+        let environment = Env::realize(InitialEnv::Explicit(Vec::new()), None).unwrap();
+        environment.set("BAD=NAME".to_owned(), "value".to_owned());
+        environment.set("NAME".to_owned(), "bad\0value".to_owned());
+        environment.unset("BAD=NAME");
+
+        assert!(environment.utf8_vars().is_empty());
+    }
+
+    #[test]
+    fn empty_policy_does_not_read_the_source_even_when_enumerated() {
+        let policy = EnvPolicy::from_config(EnvConfig::default()).unwrap();
+        let (environment, gets, enumerations) = counting_environment(Some(&policy));
+
+        assert!(environment.utf8_vars().is_empty());
+
+        assert_eq!(gets.load(Ordering::Relaxed), 0);
+        assert_eq!(enumerations.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn selected_policy_materializes_only_selected_names() {
+        let policy = EnvPolicy::from_config(EnvConfig {
+            from_host: vec!["SOURCE".to_owned()],
+            ..EnvConfig::default()
+        })
+        .unwrap();
+        let (environment, gets, enumerations) = counting_environment(Some(&policy));
+
+        assert_eq!(
+            environment.utf8_vars(),
+            vec![("SOURCE".to_owned(), "value".to_owned())]
+        );
+
+        assert_eq!(gets.load(Ordering::Relaxed), 1);
+        assert_eq!(enumerations.load(Ordering::Relaxed), 0);
+    }
 
     #[test]
     fn empty_env_config_starts_empty() {
         let policy = EnvPolicy::from_config(EnvConfig::default()).unwrap();
 
-        assert!(policy.vars().is_empty());
+        assert!(
+            Env::realize(InitialEnv::Explicit(Vec::new()), Some(&policy))
+                .unwrap()
+                .utf8_vars()
+                .is_empty()
+        );
     }
 
     #[test]
-    fn set_values_are_available_and_mutable() {
+    fn set_values_override_selected_inputs() {
         let policy = EnvPolicy::from_config(EnvConfig {
             set: BTreeMap::from([("APP_ENV".to_owned(), "test".to_owned())]),
             ..EnvConfig::default()
         })
         .unwrap();
 
-        assert_eq!(policy.get("APP_ENV").as_deref(), Some("test"));
-        policy.set("APP_ENV".to_owned(), "dev".to_owned());
-        assert_eq!(policy.get("APP_ENV").as_deref(), Some("dev"));
-        policy.unset("APP_ENV");
-        assert!(!policy.contains("APP_ENV"));
+        assert_eq!(
+            Env::realize(
+                InitialEnv::Explicit(vec![("APP_ENV".into(), "production".into())]),
+                Some(&policy),
+            )
+            .unwrap()
+            .get("APP_ENV")
+            .as_deref(),
+            Some("test")
+        );
     }
 
     #[test]
-    fn vars_are_returned_in_stable_name_order() {
+    fn host_selection_reads_only_the_supplied_initial_environment() {
+        let policy = EnvPolicy::from_config(EnvConfig {
+            from_host: vec!["OPTIONAL".to_owned()],
+            required_from_host: vec!["REQUIRED".to_owned()],
+            ..EnvConfig::default()
+        })
+        .unwrap();
+        let initial = vec![
+            ("OPTIONAL".into(), "one".into()),
+            ("REQUIRED".into(), "two".into()),
+            ("HIDDEN".into(), "secret".into()),
+        ];
+
+        assert_eq!(
+            Env::realize(InitialEnv::Explicit(initial), Some(&policy))
+                .unwrap()
+                .utf8_vars(),
+            vec![
+                ("OPTIONAL".to_owned(), "one".to_owned()),
+                ("REQUIRED".to_owned(), "two".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn wildcard_copies_the_supplied_initial_environment() {
+        let policy = EnvPolicy::from_config(EnvConfig {
+            from_host: vec!["*".to_owned()],
+            ..EnvConfig::default()
+        })
+        .unwrap();
+        let initial = vec![("A".into(), "1".into()), ("B".into(), "2".into())];
+
+        assert_eq!(
+            Env::realize(InitialEnv::Explicit(initial), Some(&policy))
+                .unwrap()
+                .utf8_vars(),
+            vec![
+                ("A".to_owned(), "1".to_owned()),
+                ("B".to_owned(), "2".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn selected_vars_are_returned_in_stable_name_order() {
         let policy = EnvPolicy::from_config(EnvConfig {
             set: BTreeMap::from([
                 ("B".to_owned(), "2".to_owned()),
@@ -137,10 +664,12 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            policy.vars(),
+            Env::realize(InitialEnv::Explicit(Vec::new()), Some(&policy))
+                .unwrap()
+                .utf8_vars(),
             vec![
                 ("A".to_owned(), "1".to_owned()),
-                ("B".to_owned(), "2".to_owned())
+                ("B".to_owned(), "2".to_owned()),
             ]
         );
     }
@@ -162,16 +691,99 @@ mod tests {
 
     #[test]
     fn missing_required_host_value_is_an_error() {
-        let error = EnvPolicy::from_config(EnvConfig {
+        let policy = EnvPolicy::from_config(EnvConfig {
             required_from_host: vec!["MOONRUN_ENV_POLICY_TEST_MISSING".to_owned()],
             ..EnvConfig::default()
         })
-        .unwrap_err();
+        .unwrap();
+        let error = Env::realize(InitialEnv::Explicit(Vec::new()), Some(&policy)).unwrap_err();
 
         assert!(
             error
                 .to_string()
                 .contains("MOONRUN_ENV_POLICY_TEST_MISSING")
         );
+    }
+
+    #[test]
+    fn run_environments_are_independent_after_policy_construction() {
+        let policy = EnvPolicy::from_config(EnvConfig {
+            from_host: vec!["SHARED".to_owned()],
+            ..EnvConfig::default()
+        })
+        .unwrap();
+        let initial = vec![("SHARED".into(), "initial".into())];
+        let left = Env::realize(InitialEnv::Explicit(initial.clone()), Some(&policy)).unwrap();
+        let right = Env::realize(InitialEnv::Explicit(initial), Some(&policy)).unwrap();
+
+        left.set("SHARED".to_owned(), "left".to_owned());
+        right.unset("SHARED");
+
+        assert_eq!(left.get("SHARED").as_deref(), Some("left"));
+        assert!(!right.contains("SHARED"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_environment_names_are_case_insensitive() {
+        let environment = Env::realize(
+            InitialEnv::Explicit(vec![("Path".into(), "initial".into())]),
+            None,
+        )
+        .unwrap();
+
+        environment.set("PATH".to_owned(), "updated".to_owned());
+
+        assert_eq!(environment.get("path").as_deref(), Some("updated"));
+        assert_eq!(environment.utf8_vars().len(), 1);
+        environment.unset("pAtH");
+        assert!(!environment.contains("PATH"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_process_entries_preserve_non_unicode_values_and_order() {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let environment = Env::realize(
+            InitialEnv::Explicit(vec![
+                ("SECOND".into(), OsString::from_vec(vec![b'v', 0xff])),
+                ("FIRST".into(), "one".into()),
+            ]),
+            None,
+        )
+        .unwrap();
+
+        assert!(environment.contains("SECOND"));
+        assert_eq!(environment.get("SECOND"), None);
+        assert_eq!(
+            environment.utf8_vars(),
+            vec![("FIRST".to_owned(), "one".to_owned())]
+        );
+        assert_eq!(
+            environment
+                .process_entries()
+                .into_iter()
+                .map(|entry| entry.as_os_str().as_bytes().to_vec())
+                .collect::<Vec<_>>(),
+            vec![b"SECOND=v\xff".to_vec(), b"FIRST=one".to_vec()]
+        );
+    }
+
+    #[test]
+    fn poisoned_lock_does_not_make_the_environment_panic() {
+        let environment = Env::realize(
+            InitialEnv::Explicit(vec![("KEY".into(), "before".into())]),
+            None,
+        )
+        .unwrap();
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = environment.delta.write().unwrap();
+            panic!("poison the test lock");
+        });
+
+        environment.set("KEY".to_owned(), "after".to_owned());
+
+        assert_eq!(environment.get("KEY").as_deref(), Some("after"));
     }
 }

--- a/crates/moonrun/src/policy/mod.rs
+++ b/crates/moonrun/src/policy/mod.rs
@@ -27,13 +27,16 @@ mod fs;
 mod net;
 mod process;
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
+#[cfg(unix)]
+use std::ffi::OsString;
 use std::path::Path;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 
 use self::config::PolicyConfig;
 use self::env::EnvPolicy;
+pub(crate) use self::env::{Env, InitialEnv};
 pub(crate) use self::fs::RuntimePathBase;
 use self::fs::{FsIntents, FsPolicy};
 use self::net::{NetOperation, NetPolicy};
@@ -239,26 +242,8 @@ impl Policy {
         net.check_socket(NetOperation::Bind, addr)
     }
 
-    pub(crate) fn env_vars(&self) -> Vec<(String, String)> {
-        self.env_policy()
-            .map_or_else(|| std::env::vars().collect(), EnvPolicy::vars)
-    }
-
-    pub(crate) fn get_env_var(&self, name: &str) -> Option<String> {
-        self.env_policy()
-            .map_or_else(|| std::env::var(name).ok(), |env| env.get(name))
-    }
-
-    pub(crate) fn env_var_exists(&self, name: &str) -> bool {
-        self.env_policy()
-            .map_or_else(|| std::env::var(name).is_ok(), |env| env.contains(name))
-    }
-
-    pub(crate) fn env_var_os(&self, name: &str) -> Option<OsString> {
-        self.env_policy().map_or_else(
-            || std::env::var_os(name),
-            |env| env.get(name).map(OsString::from),
-        )
+    pub(crate) fn realize_env(&self, initial: InitialEnv) -> anyhow::Result<Env> {
+        Env::realize(initial, self.env_policy())
     }
 
     pub(crate) fn has_env_policy(&self) -> bool {
@@ -285,24 +270,6 @@ impl Policy {
 
     pub(crate) fn has_process_policy(&self) -> bool {
         self.process.is_some()
-    }
-
-    pub(crate) fn set_env_var(&self, name: String, value: String) {
-        if let Some(env) = self.env_policy() {
-            env.set(name, value);
-        } else {
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::set_var(name, value) };
-        }
-    }
-
-    pub(crate) fn unset_env_var(&self, name: &str) {
-        if let Some(env) = self.env_policy() {
-            env.unset(name);
-        } else {
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::remove_var(name) };
-        }
     }
 
     #[inline]
@@ -467,8 +434,14 @@ mod tests {
         )
         .unwrap();
 
-        assert!(policy.env_vars().is_empty());
-        assert!(!policy.env_var_exists("PATH"));
+        let environment = policy
+            .realize_env(InitialEnv::Explicit(vec![(
+                "PATH".into(),
+                "host path".into(),
+            )]))
+            .unwrap();
+        assert!(environment.utf8_vars().is_empty());
+        assert!(!environment.contains("PATH"));
     }
 
     #[test]

--- a/crates/moonrun/src/temp_dir.rs
+++ b/crates/moonrun/src/temp_dir.rs
@@ -22,39 +22,49 @@ use std::ffi::OsString;
 use std::sync::Arc;
 
 use crate::async_host::AsyncHostResult;
-use crate::async_sys::fs::stub;
-use crate::policy::Policy;
+use crate::policy::{Env, Policy};
 
 /// Selects the temporary-directory base observed by one Run.
 pub(crate) struct TempDir {
-    policy: Arc<Policy>,
+    environment: Arc<Env>,
+    sandboxed: bool,
 }
 
 impl TempDir {
-    pub(crate) fn new(policy: Arc<Policy>) -> Self {
-        Self { policy }
+    pub(crate) fn new(environment: Arc<Env>, policy: &Policy) -> Self {
+        Self {
+            environment,
+            sandboxed: policy.has_env_policy(),
+        }
     }
 
     pub(crate) fn path(&self) -> AsyncHostResult<OsString> {
-        resolve(&self.policy)
+        platform::resolve(&self.environment, self.sandboxed)
     }
-}
-
-fn resolve(policy: &Policy) -> AsyncHostResult<OsString> {
-    if !policy.has_env_policy() {
-        return stub::get_tmp_path();
-    }
-    resolve_from_policy_env(policy)
 }
 
 #[cfg(unix)]
-fn resolve_from_policy_env(policy: &Policy) -> AsyncHostResult<OsString> {
-    stub::get_tmp_path_from_env(policy.env_var_os("TMPDIR"))
+mod platform {
+    use super::*;
+    use crate::async_sys::fs::stub;
+
+    pub(super) fn resolve(environment: &Env, _sandboxed: bool) -> AsyncHostResult<OsString> {
+        stub::get_tmp_path_from_env(environment.get_os("TMPDIR"))
+    }
 }
 
 #[cfg(windows)]
-fn resolve_from_policy_env(policy: &Policy) -> AsyncHostResult<OsString> {
-    stub::get_tmp_path_from_env(policy.env_var_os("TMP"), policy.env_var_os("TEMP"))
+mod platform {
+    use super::*;
+    use crate::async_host::AsyncHostError;
+    use crate::async_sys::fs::stub;
+
+    pub(super) fn resolve(environment: &Env, sandboxed: bool) -> AsyncHostResult<OsString> {
+        match stub::get_tmp_path_from_env(environment.get_os("TMP"), environment.get_os("TEMP")) {
+            Err(AsyncHostError::PermissionDenied) if !sandboxed => stub::get_tmp_path(),
+            result => result,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -62,72 +72,90 @@ mod tests {
     use super::*;
     #[cfg(windows)]
     use crate::async_host::AsyncHostError;
+    use crate::policy::InitialEnv;
 
-    fn load_policy(contents: &str) -> Arc<Policy> {
-        let dir = tempfile::tempdir().unwrap();
-        let policy_file = dir.path().join("policy.toml");
-        std::fs::write(&policy_file, contents).unwrap();
-        Arc::new(Policy::from_file(&policy_file).unwrap())
+    fn environment(
+        policy: &Policy,
+        entries: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) -> Arc<Env> {
+        Arc::new(
+            policy
+                .realize_env(InitialEnv::Explicit(
+                    entries
+                        .into_iter()
+                        .map(|(name, value)| (name.into(), value.into()))
+                        .collect(),
+                ))
+                .unwrap(),
+        )
+    }
+
+    fn sandboxed_policy() -> Policy {
+        let directory = tempfile::tempdir().unwrap();
+        let policy_file = directory.path().join("policy.toml");
+        std::fs::write(&policy_file, "").unwrap();
+        Policy::from_file(&policy_file).unwrap()
     }
 
     #[cfg(unix)]
     #[test]
-    fn policy_tmp_path_uses_policy_tmpdir() {
+    fn temp_directory_reflects_run_environment_changes() {
         use std::os::unix::ffi::OsStrExt;
 
-        let temp_dir = TempDir::new(load_policy("[env.set]\nTMPDIR = \"/policy/tmp\"\n"));
-
-        assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/policy/tmp/");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn tmp_path_reflects_policy_env_changes() {
-        use std::os::unix::ffi::OsStrExt;
-
-        let policy = load_policy("[env.set]\nTMPDIR = \"/first\"\n");
-        let temp_dir = TempDir::new(Arc::clone(&policy));
+        let policy = Policy::allow_all();
+        let environment = environment(&policy, [("TMPDIR", "/first")]);
+        let temp_dir = TempDir::new(Arc::clone(&environment), &policy);
 
         assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/first/");
-        policy.set_env_var("TMPDIR".to_owned(), "/second".to_owned());
+        environment.set("TMPDIR".into(), "/second".into());
         assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/second/");
-        policy.unset_env_var("TMPDIR");
-        assert_eq!(
-            temp_dir.path().unwrap(),
-            stub::get_tmp_path_from_env(None).unwrap()
-        );
+        environment.unset("TMPDIR");
+        assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/tmp/");
     }
 
     #[cfg(all(unix, not(target_os = "android")))]
     #[test]
-    fn policy_tmp_path_ignores_denied_host_tmpdir() {
+    fn sandboxed_unix_run_uses_constant_fallback_without_host_env() {
         use std::os::unix::ffi::OsStrExt;
 
-        let temp_dir = TempDir::new(load_policy(""));
+        let policy = sandboxed_policy();
+        let temp_dir = TempDir::new(environment(&policy, []), &policy);
 
         assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/tmp/");
     }
 
     #[cfg(windows)]
     #[test]
-    fn policy_tmp_path_requires_configured_windows_temp_env() {
-        let policy = load_policy("");
-        let temp_dir = TempDir::new(Arc::clone(&policy));
+    fn empty_tmp_falls_back_to_current_run_temp() {
+        let policy = Policy::allow_all();
+        let temp_dir = TempDir::new(
+            environment(&policy, [("TMP", ""), ("TEMP", "C:/Fallback")]),
+            &policy,
+        );
 
-        assert_eq!(temp_dir.path(), Err(AsyncHostError::PermissionDenied));
-        policy.set_env_var("TEMP".to_owned(), "C:/Temp".to_owned());
-        assert_eq!(temp_dir.path().unwrap().to_string_lossy(), "C:/Temp\\");
-        policy.unset_env_var("TEMP");
-        assert_eq!(temp_dir.path(), Err(AsyncHostError::PermissionDenied));
+        assert_eq!(temp_dir.path().unwrap().to_string_lossy(), "C:/Fallback\\");
     }
 
     #[cfg(windows)]
     #[test]
-    fn empty_policy_tmp_falls_back_to_temp() {
-        let temp_dir = TempDir::new(load_policy(
-            "[env.set]\nTMP = \"\"\nTEMP = \"C:/Fallback\"\n",
-        ));
+    fn unrestricted_windows_run_uses_native_fallback() {
+        let policy = Policy::allow_all();
+        let temp_dir = TempDir::new(environment(&policy, [("APP_ENV", "test")]), &policy);
 
-        assert_eq!(temp_dir.path().unwrap().to_string_lossy(), "C:/Fallback\\");
+        assert!(!temp_dir.path().unwrap().is_empty());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn sandboxed_windows_run_observes_current_environment_without_native_fallback() {
+        let policy = sandboxed_policy();
+        let environment = environment(&policy, []);
+        let temp_dir = TempDir::new(Arc::clone(&environment), &policy);
+
+        assert_eq!(temp_dir.path(), Err(AsyncHostError::PermissionDenied));
+        environment.set("TEMP".into(), "C:/Temp".into());
+        assert_eq!(temp_dir.path().unwrap().to_string_lossy(), "C:/Temp\\");
+        environment.unset("TEMP");
+        assert_eq!(temp_dir.path(), Err(AsyncHostError::PermissionDenied));
     }
 }

--- a/crates/moonrun/src/v8_backend.rs
+++ b/crates/moonrun/src/v8_backend.rs
@@ -17,7 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::engine::{EngineConfig, RunOptions, RunOutcome};
-use crate::policy::Policy;
+use crate::policy::{Env, Policy};
 use crate::run_termination::RunTermination;
 use crate::v8_builder::{ObjectExt, ScopeExt};
 use crate::{demangle_js_template, host_imports, memory_sanitizer_api};
@@ -122,6 +122,7 @@ pub(crate) fn run(
     source_map: Option<&str>,
     options: RunOptions,
     policy: Arc<Policy>,
+    environment: Arc<Env>,
 ) -> anyhow::Result<RunOutcome> {
     initialize(config)?;
 
@@ -139,8 +140,14 @@ pub(crate) fn run(
     let memory_sanitizer = memory_sanitizer_api::MemorySanitizer::default();
 
     let mut dtors = Vec::new();
-    let termination_request =
-        host_imports::install(&mut dtors, scope, module_name, &options.args, policy);
+    let termination_request = host_imports::install(
+        &mut dtors,
+        scope,
+        module_name,
+        &options.args,
+        policy,
+        environment,
+    );
 
     let memory_sanitizer_imports =
         global_proxy.child(scope, memory_sanitizer_api::MEMORY_SANITIZER_MODULE);

--- a/crates/moonrun/src/wasi_api.rs
+++ b/crates/moonrun/src/wasi_api.rs
@@ -16,11 +16,13 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use crate::policy::Env;
 use crate::run_termination::{RunTermination, TerminationRequest};
 use crate::v8_builder::ScopeExt;
 use crate::v8_import::{V8ImportError, V8MemoryBinding};
 use rand::{RngCore, rngs::OsRng};
 use std::any::Any;
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::{ErrorKind, Read, Seek, Write};
@@ -171,12 +173,56 @@ impl TryFrom<i32> for ClockId {
 
 struct WasiContext {
     argv: Vec<Vec<u8>>,
+    environment: Arc<Env>,
+    environment_snapshot: RefCell<Option<Vec<Vec<u8>>>>,
     preopen_dir_name: Vec<u8>,
     preopen_dir_host_path: PathBuf,
     preopen_dir_real_path: PathBuf,
     descriptors: Mutex<DescriptorTable>,
     memory_binding: Rc<V8MemoryBinding>,
     termination_request: TerminationRequest,
+}
+
+impl WasiContext {
+    fn snapshot_environ(&self) -> WasiResult<(u32, u32)> {
+        let environ = collect_environ(&self.environment);
+        let count = u32::try_from(environ.len()).map_err(|_| WASI_ERRNO_FAULT)?;
+        let bytes = table_bytes_len(&environ)?;
+        *self
+            .environment_snapshot
+            .try_borrow_mut()
+            .map_err(|_| WASI_ERRNO_FAULT)? = Some(environ);
+        Ok((count, bytes))
+    }
+
+    fn take_environ_snapshot(&self) -> WasiResult<Vec<Vec<u8>>> {
+        Ok(self
+            .environment_snapshot
+            .try_borrow_mut()
+            .map_err(|_| WASI_ERRNO_FAULT)?
+            .take()
+            .unwrap_or_else(|| collect_environ(&self.environment)))
+    }
+}
+
+pub(crate) struct WasiRunResources {
+    environment: Arc<Env>,
+    memory_binding: Rc<V8MemoryBinding>,
+    termination_request: TerminationRequest,
+}
+
+impl WasiRunResources {
+    pub(crate) fn new(
+        environment: Arc<Env>,
+        memory_binding: Rc<V8MemoryBinding>,
+        termination_request: TerminationRequest,
+    ) -> Self {
+        Self {
+            environment,
+            memory_binding,
+            termination_request,
+        }
+    }
 }
 
 struct DirectoryEntry {
@@ -229,15 +275,11 @@ fn build_argv(wasm_file_name: &str, args: &[String]) -> Vec<Vec<u8>> {
     argv
 }
 
-fn collect_environ() -> Vec<Vec<u8>> {
-    std::env::vars_os()
-        .map(|(key, value)| {
-            encode_c_string(format!(
-                "{}={}",
-                key.to_string_lossy(),
-                value.to_string_lossy()
-            ))
-        })
+fn collect_environ(environment: &Env) -> Vec<Vec<u8>> {
+    environment
+        .utf8_vars()
+        .into_iter()
+        .map(|(key, value)| encode_c_string(format!("{key}={value}")))
         .collect()
 }
 
@@ -1579,10 +1621,8 @@ fn environ_sizes_get(
         let environc_ptr = read_u32_arg(scope, &args, 0)?;
         let environ_buf_size_ptr = read_u32_arg(scope, &args, 1)?;
 
-        let environ = collect_environ();
-        let environc = u32::try_from(environ.len()).map_err(|_| WASI_ERRNO_FAULT)?;
-        let environ_buf_size = table_bytes_len(&environ)?;
         let context = callback_context(&args);
+        let (environc, environ_buf_size) = context.snapshot_environ()?;
 
         with_wasi_memory_mut(scope, context, |memory| {
             write_u32(memory, environc_ptr, environc)?;
@@ -1604,7 +1644,7 @@ fn environ_get(
         let environ_buf_ptr = read_u32_arg(scope, &args, 1)?;
         let context = callback_context(&args);
 
-        let environ = collect_environ();
+        let environ = context.take_environ_snapshot()?;
         with_wasi_memory_mut(scope, context, |memory| {
             write_c_string_table(memory, &environ, environ_ptr, environ_buf_ptr)
         })
@@ -1794,15 +1834,21 @@ pub(crate) fn init_env<'s>(
     scope: &mut v8::HandleScope<'s>,
     wasm_file_name: &str,
     args: &[String],
-    memory_binding: Rc<V8MemoryBinding>,
-    termination_request: TerminationRequest,
+    resources: WasiRunResources,
     dtors: &mut Vec<Box<dyn Any>>,
 ) {
+    let WasiRunResources {
+        environment,
+        memory_binding,
+        termination_request,
+    } = resources;
     let preopen_dir_host_path = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let preopen_dir_real_path =
         fs::canonicalize(&preopen_dir_host_path).unwrap_or_else(|_| preopen_dir_host_path.clone());
     let context = Box::new(WasiContext {
         argv: build_argv(wasm_file_name, args),
+        environment,
+        environment_snapshot: RefCell::new(None),
         preopen_dir_name: preopen_name(),
         preopen_dir_host_path,
         preopen_dir_real_path,
@@ -1837,10 +1883,17 @@ pub(crate) fn init_env<'s>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::policy::Policy;
 
     fn test_context(root: &Path) -> WasiContext {
         WasiContext {
             argv: Vec::new(),
+            environment: Arc::new(
+                Policy::allow_all()
+                    .realize_env(crate::policy::InitialEnv::Explicit(Vec::new()))
+                    .unwrap(),
+            ),
+            environment_snapshot: RefCell::new(None),
             preopen_dir_name: preopen_name(),
             preopen_dir_host_path: root.to_path_buf(),
             preopen_dir_real_path: fs::canonicalize(root).expect("canonicalize preopen root"),
@@ -1848,6 +1901,52 @@ mod tests {
             memory_binding: Rc::new(V8MemoryBinding::new()),
             termination_request: TerminationRequest::default(),
         }
+    }
+
+    #[test]
+    fn wasi_environment_reads_the_current_run_environment() {
+        let environment = Policy::allow_all()
+            .realize_env(crate::policy::InitialEnv::Explicit(vec![
+                ("KEEP".into(), "initial".into()),
+                ("REMOVE".into(), "old".into()),
+            ]))
+            .unwrap();
+
+        environment.set("KEEP".to_owned(), "updated".to_owned());
+        environment.set("ADD".to_owned(), "new".to_owned());
+        environment.unset("REMOVE");
+
+        assert_eq!(
+            collect_environ(&environment),
+            vec![b"KEEP=updated\0".to_vec(), b"ADD=new\0".to_vec()]
+        );
+    }
+
+    #[test]
+    fn wasi_environment_get_uses_the_snapshot_reported_by_sizes_get() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = test_context(directory.path());
+        context
+            .environment
+            .set("VALUE".to_owned(), "before".to_owned());
+        let expected = collect_environ(&context.environment);
+
+        assert_eq!(
+            context.snapshot_environ().unwrap(),
+            (
+                u32::try_from(expected.len()).unwrap(),
+                table_bytes_len(&expected).unwrap(),
+            )
+        );
+        context
+            .environment
+            .set("VALUE".to_owned(), "after sizes".to_owned());
+
+        assert_eq!(context.take_environ_snapshot().unwrap(), expected);
+        assert_eq!(
+            context.take_environ_snapshot().unwrap(),
+            collect_environ(&context.environment)
+        );
     }
 
     #[test]

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -397,6 +397,62 @@ fn moonrun_library_returns_guest_exit_without_terminating_embedder() {
 }
 
 #[test]
+fn moonrun_run_environments_are_isolated_from_each_other_and_the_host() {
+    const MUTABLE_NAME: &str = "MOONRUN_RUN_ENV_ISOLATION_MUTABLE";
+
+    let dir = TestDir::new("test_run_environment.in");
+    moon_cmd()
+        .current_dir(&dir)
+        .args(["build", "--target", "wasm"])
+        .assert()
+        .success();
+
+    let wasm = dir.join("_build/wasm/debug/build/main/main.wasm");
+    let engine = moonrun::Engine::default();
+    let module = engine.load_file(wasm).unwrap();
+    let error = engine
+        .run(
+            &module,
+            moonrun::RunOptions::default().environment([("BAD=NAME", "value")]),
+        )
+        .unwrap_err();
+    assert!(
+        format!("{error:#}").contains("invalid environment variable name"),
+        "{error:#}"
+    );
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let host_value_before = std::env::var_os(MUTABLE_NAME);
+
+    std::thread::scope(|scope| {
+        let threads = ["left", "right"].map(|value| {
+            let barrier = std::sync::Arc::clone(&barrier);
+            let engine = engine.clone();
+            let module = module.clone();
+            scope.spawn(move || {
+                barrier.wait();
+                engine.run(
+                    &module,
+                    moonrun::RunOptions::default()
+                        .environment([("MOONRUN_RUN_ENV_ISOLATION_INPUT", value)]),
+                )
+            })
+        });
+        let [left, right] = threads;
+
+        assert_eq!(
+            left.join().unwrap().unwrap(),
+            moonrun::RunOutcome::Completed
+        );
+        assert_eq!(
+            right.join().unwrap().unwrap(),
+            moonrun::RunOutcome::Completed
+        );
+    });
+
+    assert_eq!(std::env::var_os(MUTABLE_NAME), host_value_before);
+}
+
+#[test]
 fn moonrun_library_compiles_modules_when_loading() {
     let wasm = tempfile::Builder::new()
         .prefix("invalid.")
@@ -1028,9 +1084,9 @@ OSError("[..]@fs.open()[..]denied/secret.txt[..]Access is denied.")
         .assert()
         .success()
         .stdout_eq(if cfg!(windows) {
-            "MOONRUN_POLICY_ENV=configured by policy\n"
+            "MOONRUN_POLICY_ENV=runtime override inherited\n"
         } else {
-            "configured by policy|\n"
+            "runtime override inherited|\n"
         });
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
@@ -1042,9 +1098,9 @@ OSError("[..]@fs.open()[..]denied/secret.txt[..]Access is denied.")
         .assert()
         .success()
         .stdout_eq(if cfg!(windows) {
-            "MOONRUN_POLICY_ENV=configured by policy\n"
+            "MOONRUN_POLICY_ENV=runtime override inherited\n"
         } else {
-            "configured by policy|\n"
+            "runtime override inherited|\n"
         });
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))

--- a/crates/moonrun/tests/test_cases/test_policy_workspace.in/process_env/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_policy_workspace.in/process_env/main.mbt
@@ -29,6 +29,9 @@ fn host_platform() -> HostPlatform = "moonbitlang/async" "runtime/get_platform"
 
 ///|
 async fn main {
+  @env.set_env_var("MOONRUN_POLICY_ENV", "runtime override inherited")
+  @env.set_env_var("MOONRUN_REMOVED_ENV", "not inherited")
+  @env.unset_env_var("MOONRUN_REMOVED_ENV")
   let (command, args) = if host_platform() is Windows {
     (
       "cmd.exe",

--- a/crates/moonrun/tests/test_cases/test_policy_workspace.in/process_env/moon.pkg
+++ b/crates/moonrun/tests/test_cases/test_policy_workspace.in/process_env/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbitlang/async/io",
   "moonbitlang/async/os_error",
   "moonbitlang/async/process",
+  "moonbitlang/core/env",
 }
 
 options(

--- a/crates/moonrun/tests/test_cases/test_run_environment.in/main/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_run_environment.in/main/main.mbt
@@ -16,25 +16,27 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! V8 adapter for MoonBit's unstable filesystem import object.
+///|
+fn runtime_exit(code : Int) = "moonbitlang/async" "runtime/exit"
 
-mod runtime;
-mod whole_file;
-
-use std::any::Any;
-use std::sync::Arc;
-
-use crate::policy::{Env, Policy};
-
-pub(crate) fn init_env<'s>(
-    obj: v8::Local<'s, v8::Object>,
-    scope: &mut v8::HandleScope<'s>,
-    wasm_file_name: &str,
-    args: &[String],
-    policy: Arc<Policy>,
-    environment: Arc<Env>,
-    dtors: &mut Vec<Box<dyn Any>>,
-) {
-    runtime::register(obj, scope, wasm_file_name, args, environment, dtors);
-    whole_file::register(obj, scope, policy, dtors);
+///|
+fn main {
+  let expected = match @env.get_env_var("MOONRUN_RUN_ENV_ISOLATION_INPUT") {
+    Some(value) => value
+    None => {
+      runtime_exit(70)
+      return
+    }
+  }
+  @env.set_env_var("MOONRUN_RUN_ENV_ISOLATION_MUTABLE", expected)
+  for _ in 0..<100_000 {
+    if @env.get_env_var("MOONRUN_RUN_ENV_ISOLATION_MUTABLE") != Some(expected) {
+      runtime_exit(71)
+      return
+    }
+  }
+  @env.unset_env_var("MOONRUN_RUN_ENV_ISOLATION_MUTABLE")
+  if @env.get_env_var("MOONRUN_RUN_ENV_ISOLATION_MUTABLE") is Some(_) {
+    runtime_exit(72)
+  }
 }

--- a/crates/moonrun/tests/test_cases/test_run_environment.in/main/moon.pkg
+++ b/crates/moonrun/tests/test_cases/test_run_environment.in/main/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "moonbitlang/core/env",
+}
+
+options(
+  "is-main": true,
+)

--- a/crates/moonrun/tests/test_cases/test_run_environment.in/moon.mod
+++ b/crates/moonrun/tests/test_cases/test_run_environment.in/moon.mod
@@ -1,0 +1,7 @@
+name = "moon/run_environment"
+
+version = "0.1.0"
+
+options(
+  source: ".",
+)


### PR DESCRIPTION
## Why

Moonrun needs a per-Run environment before one Engine can safely host multiple services or virtual children. Previously Policy also held mutable environment state, allow-all runs mutated the embedding process environment, WASI read a separate process-global view, and inherited children could not be defined against one Run-owned environment.

## What changed

- Add a per-Run `Env` backed by a lazy native `OsString` source plus an `EnvDelta` for set and unset operations.
- Keep `EnvPolicy` startup-only: it selects, requires, and overrides values from the Run-selected source.
- Add `RunOptions::environment` as the value-builder API for an explicit fixed source; the default remains the ambient process environment as a read-only backing source.
- Route MoonBit environment APIs, WASI environment reads, temporary-directory selection, and native child inheritance through the same `Env`.
- Preserve one WASI environment snapshot across a matching `environ_sizes_get` / `environ_get` pair.
- Snapshot inherited child environments when their spawn environment builder is created, while avoiding source enumeration when inheritance is disabled.
- Preserve native non-Unicode values, Windows case-insensitive names, and the existing platform-specific child-block construction below the OS Adapter seam.
- Preserve the native `GetTempPath2W` fallback for unrestricted Windows Runs whose environment omits `TMP` and `TEMP`; policy mode still denies that process-global fallback.
- Reject invalid explicit and policy environment entries during Run construction and safely ignore invalid runtime mutations instead of panicking.
- Record the multi-service and virtual-child control model plus the operating-system virtualization research.

## Why this is correct

Policy construction no longer owns mutable runtime values. Every execution realizes a fresh `Env`, and runtime mutations affect only its delta rather than process-global state. Keyed reads stay lazy; full enumeration happens only for APIs that require it, including WASI tables and inherited child environments.

Child inheritance materializes the current `Env` when the guest creates its spawn environment builder, so later parent mutations cannot change that child snapshot. WASI retains the table measured by `environ_sizes_get` until the matching `environ_get`, preventing mutations between the two calls from invalidating guest allocation sizes.

Temporary-directory selection reads the current Run environment. On Windows, only an unrestricted Run may fall back to `GetTempPath2W` when `TMP` and `TEMP` are absent, preserving the native `USERPROFILE` and Windows-directory search without exposing process-global fallback in policy mode.

## Why this remains minimal

PR #2094 owns the Run-state, V8 callback-lifetime, and temporary-directory seams. This PR adapts those seams from mutable Policy/process-global reads to `Env`; it does not add another ownership layer. The existing native process builder and platform environment-block encoding remain unchanged.

## Scope

This is the shared Env MVP. Process stdio, working directory, executable lookup, virtual PID mapping, and the broader WASI capability surface remain follow-up virtualization seams.
