### PR TITLE
refactor(moonrun): clarify runtime state ownership

### DIFF
--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -16,8 +16,6 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::ffi::OsString;
-
 use crate::async_host::{AsyncHostError, AsyncHostResult, write_u16};
 use crate::async_sys::fs::dir;
 use crate::async_sys::fs::stub;
@@ -27,14 +25,17 @@ use crate::async_sys::fs::watch_inotify;
 use crate::async_sys::fs::watch_kqueue;
 #[cfg(windows)]
 use crate::async_sys::fs::watch_windows;
-use crate::policy::Policy;
 
 use super::context::ImportContext;
+use super::os_string::encode_guest_units;
 use super::provenance::ported_imports;
 
 ported_imports! {
 pub(super) fn get_tmp_path_len(context: &mut ImportContext<'_, '_>) -> i32 {
-    match tmp_path_utf16_units(context.host.policy())
+    match context
+        .host
+        .temp_dir()
+        .and_then(encode_guest_units)
         .and_then(|units| i32::try_from(units.len()).map_err(|_| AsyncHostError::Fault))
     {
         Ok(len) => len,
@@ -48,7 +49,7 @@ pub(super) fn get_tmp_path_len(context: &mut ImportContext<'_, '_>) -> i32 {
 #[ported(source = "src/fs/stub.c")]
 pub(super) fn get_tmp_path(context: &mut ImportContext<'_, '_>, ptr: u32, len: u32) -> i32 {
     let result = (|| {
-        let units = tmp_path_utf16_units(context.host.policy())?;
+        let units = encode_guest_units(context.host.temp_dir()?)?;
         let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
         if len != units.len() {
             return Err(AsyncHostError::Inval);
@@ -59,10 +60,10 @@ pub(super) fn get_tmp_path(context: &mut ImportContext<'_, '_>, ptr: u32, len: u
 }
 
 pub(super) fn get_tmp_path_buffer(context: &mut ImportContext<'_, '_>) -> AsyncHostResult<u64> {
-    let path = tmp_path(context.host.policy())?;
+    let path = context.host.temp_dir()?;
     Ok(context
         .host
-        .insert_c_buffer(stub::tmp_path_buffer(path.as_os_str())?))
+        .insert_c_buffer(stub::tmp_path_buffer(path)?))
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]
@@ -484,42 +485,6 @@ pub(super) fn watcher_event_dirty_file_id(
     })
 }
 
-fn tmp_path_utf16_units(policy: &Policy) -> AsyncHostResult<Vec<u16>> {
-    os_string_to_utf16_units(tmp_path(policy)?)
-}
-
-fn tmp_path(policy: &Policy) -> AsyncHostResult<OsString> {
-    if !policy.has_env_policy() {
-        return stub::get_tmp_path();
-    }
-    tmp_path_from_policy_env(policy)
-}
-
-#[cfg(unix)]
-fn tmp_path_from_policy_env(policy: &Policy) -> AsyncHostResult<OsString> {
-    stub::get_tmp_path_from_env(policy.env_var_os("TMPDIR"))
-}
-
-#[cfg(windows)]
-fn tmp_path_from_policy_env(policy: &Policy) -> AsyncHostResult<OsString> {
-    stub::get_tmp_path_from_env(policy.env_var_os("TMP"), policy.env_var_os("TEMP"))
-}
-
-#[cfg(unix)]
-fn os_string_to_utf16_units(path: std::ffi::OsString) -> AsyncHostResult<Vec<u16>> {
-    use std::os::unix::ffi::OsStringExt;
-
-    let path = String::from_utf8(path.into_vec()).map_err(|_| AsyncHostError::Inval)?;
-    Ok(path.encode_utf16().collect())
-}
-
-#[cfg(windows)]
-fn os_string_to_utf16_units(path: std::ffi::OsString) -> AsyncHostResult<Vec<u16>> {
-    use std::os::windows::ffi::OsStrExt;
-
-    Ok(path.as_os_str().encode_wide().collect())
-}
-
 #[ported(source = "src/fs/stub.c")]
 pub(super) fn errno_is_lock_violation(_context: &mut ImportContext<'_, '_>, errno: i32) -> i32 {
     if stub::errno_is_lock_violation(errno) {
@@ -549,86 +514,4 @@ fn zero_or_minus_one(context: &ImportContext<'_, '_>, result: AsyncHostResult<()
     }
 }
 
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[cfg(unix)]
-    #[test]
-    fn policy_tmp_path_uses_policy_tmpdir() {
-        use std::os::unix::ffi::OsStrExt;
-
-        let dir = tempfile::tempdir().unwrap();
-        let policy_file = dir.path().join("policy.toml");
-        std::fs::write(&policy_file, "[env.set]\nTMPDIR = \"/policy/tmp\"\n").unwrap();
-        let policy = Policy::from_file(&policy_file).unwrap();
-
-        let path = tmp_path(&policy).unwrap();
-
-        assert_eq!(path.as_os_str().as_bytes(), b"/policy/tmp/");
-    }
-
-    #[cfg(all(unix, not(target_os = "android")))]
-    #[test]
-    fn policy_tmp_path_ignores_denied_host_tmpdir() {
-        use std::os::unix::ffi::OsStrExt;
-
-        let dir = tempfile::tempdir().unwrap();
-        let policy_file = dir.path().join("policy.toml");
-        std::fs::write(&policy_file, "").unwrap();
-        let policy = Policy::from_file(&policy_file).unwrap();
-
-        let path = tmp_path(&policy).unwrap();
-
-        assert_eq!(path.as_os_str().as_bytes(), b"/tmp/");
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn policy_tmp_path_requires_configured_windows_temp_env() {
-        let dir = tempfile::tempdir().unwrap();
-        let policy_file = dir.path().join("policy.toml");
-        std::fs::write(&policy_file, "").unwrap();
-        let policy = Policy::from_file(&policy_file).unwrap();
-
-        assert_eq!(tmp_path(&policy), Err(AsyncHostError::PermissionDenied));
-
-        std::fs::write(&policy_file, "[env.set]\nTEMP = \"C:/Temp\"\n").unwrap();
-        let policy = Policy::from_file(&policy_file).unwrap();
-        let path = tmp_path(&policy).unwrap();
-
-        assert_eq!(path.to_string_lossy(), "C:/Temp\\");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn tmp_path_encodes_unix_path_as_utf16_units() {
-        let path = std::ffi::OsString::from("/tmp/\u{6587}");
-
-        let units = os_string_to_utf16_units(path).unwrap();
-
-        assert_eq!(units, "/tmp/\u{6587}".encode_utf16().collect::<Vec<_>>());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn tmp_path_rejects_non_utf8_unix_os_string() {
-        use std::os::unix::ffi::OsStringExt;
-
-        let path = std::ffi::OsString::from_vec(b"/tmp/\xff".to_vec());
-
-        assert_eq!(os_string_to_utf16_units(path), Err(AsyncHostError::Inval));
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn tmp_path_preserves_windows_wide_units() {
-        let path = std::ffi::OsString::from("A\u{10000}");
-
-        let units = os_string_to_utf16_units(path).unwrap();
-
-        assert_eq!(units, vec![0x0041, 0xd800, 0xdc00]);
-    }
 }

--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -35,7 +35,7 @@ pub(super) fn get_tmp_path_len(context: &mut ImportContext<'_, '_>) -> i32 {
     match context
         .host
         .temp_dir()
-        .and_then(encode_guest_units)
+        .and_then(|path| encode_guest_units(&path))
         .and_then(|units| i32::try_from(units.len()).map_err(|_| AsyncHostError::Fault))
     {
         Ok(len) => len,
@@ -49,7 +49,8 @@ pub(super) fn get_tmp_path_len(context: &mut ImportContext<'_, '_>) -> i32 {
 #[ported(source = "src/fs/stub.c")]
 pub(super) fn get_tmp_path(context: &mut ImportContext<'_, '_>, ptr: u32, len: u32) -> i32 {
     let result = (|| {
-        let units = encode_guest_units(context.host.temp_dir()?)?;
+        let path = context.host.temp_dir()?;
+        let units = encode_guest_units(&path)?;
         let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
         if len != units.len() {
             return Err(AsyncHostError::Inval);
@@ -63,7 +64,7 @@ pub(super) fn get_tmp_path_buffer(context: &mut ImportContext<'_, '_>) -> AsyncH
     let path = context.host.temp_dir()?;
     Ok(context
         .host
-        .insert_c_buffer(stub::tmp_path_buffer(path)?))
+        .insert_c_buffer(stub::tmp_path_buffer(path.as_os_str())?))
 }
 
 #[ported(source = "src/internal/fd_util/stub.c")]

--- a/crates/moonrun/src/async_api/os_string.rs
+++ b/crates/moonrun/src/async_api/os_string.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 
 use crate::async_host::{AsyncHostError, AsyncHostResult, read_u16, write_u16};
 
@@ -34,6 +34,19 @@ pub(super) fn read_guest(
         let units = read_u16(memory, ptr, len)?;
         guest_os_string_from_utf16(&units)
     })
+}
+
+#[cfg(unix)]
+pub(super) fn encode_guest_units(value: &OsStr) -> AsyncHostResult<Vec<u16>> {
+    let value = value.to_str().ok_or(AsyncHostError::Inval)?;
+    Ok(value.encode_utf16().collect())
+}
+
+#[cfg(windows)]
+pub(super) fn encode_guest_units(value: &OsStr) -> AsyncHostResult<Vec<u16>> {
+    use std::os::windows::ffi::OsStrExt;
+
+    Ok(value.encode_wide().collect())
 }
 
 #[cfg(unix)]
@@ -151,6 +164,30 @@ mod tests {
         assert_eq!(
             guest_os_string_from_utf16(&[0xd800]),
             Err(AsyncHostError::Inval)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_guest_encoding_rejects_non_utf8_os_string() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let value = OsString::from_vec(b"/tmp/\xff".to_vec());
+
+        assert_eq!(
+            encode_guest_units(value.as_os_str()),
+            Err(AsyncHostError::Inval)
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_guest_encoding_preserves_wide_units() {
+        let value = OsString::from("A\u{10000}");
+
+        assert_eq!(
+            encode_guest_units(value.as_os_str()).unwrap(),
+            vec![0x0041, 0xd800, 0xdc00]
         );
     }
 

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -32,7 +32,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 #[cfg(unix)]
 use std::collections::HashSet;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 #[cfg(windows)]
@@ -59,6 +59,7 @@ use crate::network::HostNetwork;
 use crate::policy::{Policy, RuntimePathBase};
 use crate::process::HostProcess;
 use crate::resource::{Resource, ResourceClass, ResourcePublication, ResourceRef};
+use crate::temp_dir::TempDir;
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 compile_error!("moonrun async wasm host currently supports only Linux, macOS, and Windows hosts");
@@ -1199,6 +1200,7 @@ pub(crate) struct AsyncHost {
     // that ownership; worker threads own their Jobs and return them through the
     // completion channel instead of sharing the host's tables.
     policy: Arc<Policy>,
+    temp_dir: TempDir,
     network: HostNetwork,
     errno: Cell<i32>,
     addr_infos: RefCell<SecondaryMap<HandleKey, HostAddrInfo>>,
@@ -1235,8 +1237,10 @@ impl AsyncHost {
     pub(crate) fn with_keys(policy: Arc<Policy>, keys: Rc<RefCell<HostKeys>>) -> Self {
         let process = HostProcess::new(Arc::clone(&policy));
         let network = HostNetwork::new(Arc::clone(&policy));
+        let temp_dir = TempDir::new(Arc::clone(&policy));
         Self {
             policy,
+            temp_dir,
             network,
             errno: Cell::new(0),
             addr_infos: RefCell::new(SecondaryMap::new()),
@@ -2631,6 +2635,10 @@ impl AsyncHost {
 
     pub(crate) fn policy(&self) -> &Policy {
         &self.policy
+    }
+
+    pub(crate) fn temp_dir(&self) -> AsyncHostResult<&OsStr> {
+        self.temp_dir.path()
     }
 
     #[cfg(test)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -32,7 +32,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 #[cfg(unix)]
 use std::collections::HashSet;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 #[cfg(windows)]
@@ -2637,7 +2637,7 @@ impl AsyncHost {
         &self.policy
     }
 
-    pub(crate) fn temp_dir(&self) -> AsyncHostResult<&OsStr> {
+    pub(crate) fn temp_dir(&self) -> AsyncHostResult<OsString> {
         self.temp_dir.path()
     }
 

--- a/crates/moonrun/src/async_sys/fs/stub.rs
+++ b/crates/moonrun/src/async_sys/fs/stub.rs
@@ -169,8 +169,8 @@ pub(crate) fn get_tmp_path_from_env(
     tmp: Option<OsString>,
     temp: Option<OsString>,
 ) -> AsyncHostResult<OsString> {
-    tmp.or(temp)
-        .and_then(separator_terminated_windows_path)
+    tmp.and_then(separator_terminated_windows_path)
+        .or_else(|| temp.and_then(separator_terminated_windows_path))
         .ok_or(AsyncHostError::PermissionDenied)
 }
 

--- a/crates/moonrun/src/filesystem/v8/runtime.rs
+++ b/crates/moonrun/src/filesystem/v8/runtime.rs
@@ -21,38 +21,25 @@
 use crate::v8_builder::{ArgsExt, ObjectExt, ScopeExt};
 use crate::{policy::Policy, util::get_ref};
 use std::any::Any;
-use std::io::IsTerminal;
 use std::sync::Arc;
 
-fn construct_args_list<'s>(
-    wasm_file_name: &str,
-    args: &[String],
-    scope: &mut v8::HandleScope<'s>,
-) -> v8::Local<'s, v8::Array> {
-    // argv: [program, ..args]
-    let arr = v8::Array::new(scope, (args.len() + 1) as i32);
+struct RuntimeArgs(Vec<String>);
 
-    let program = scope.string(wasm_file_name);
-    arr.set_index(scope, 0, program.into());
-    for (i, arg) in args.iter().enumerate() {
+fn args_get(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut ret: v8::ReturnValue,
+) {
+    let args = unsafe { get_ref::<RuntimeArgs>(&args) };
+    let result = v8::Array::new(scope, args.0.len() as i32);
+
+    for (index, arg) in args.0.iter().enumerate() {
         let arg = scope.string(arg);
-        arr.set_index(scope, (i + 1) as u32, arg.into());
+        let _ = result.set_index(scope, index as u32, arg.into());
     }
-    arr
+    ret.set(result.into());
 }
 
-fn construct_env_vars<'s>(
-    policy: &Policy,
-    scope: &mut v8::HandleScope<'s>,
-) -> v8::Local<'s, v8::Map> {
-    let map = v8::Map::new(scope);
-    for (k, v) in policy.env_vars() {
-        let key = scope.string(&k);
-        let val = scope.string(&v);
-        map.set(scope, key.into(), val.into());
-    }
-    map
-}
 fn set_env_var(
     scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
@@ -126,25 +113,10 @@ pub(super) fn register<'s>(
     policy: Arc<Policy>,
     dtors: &mut Vec<Box<dyn Any>>,
 ) {
-    let args_list = construct_args_list(wasm_file_name, args, scope);
-    let env_vars = construct_env_vars(&policy, scope);
-    let env_obj = v8::Object::new(scope);
-    let env_vars_key = scope.string("env_vars").into();
-    env_obj.set(scope, env_vars_key, env_vars.into());
-    let args_key = scope.string("args").into();
-    env_obj.set(scope, args_key, args_list.into());
-    let stderr_is_tty_key = scope.string("stderr_is_tty").into();
-    let stderr_is_tty = v8::Boolean::new(scope, std::io::stderr().is_terminal()).into();
-    env_obj.set(scope, stderr_is_tty_key, stderr_is_tty);
-
-    // Expose the run env for the unified JS glue in `template/js_glue.js`.
-    let global_proxy = scope.get_current_context().global(scope);
-    let run_env_key = scope.string("__moonbit_run_env");
-    global_proxy.set(scope, run_env_key.into(), env_obj.into());
-
     let policy_ptr = Arc::as_ptr(&policy);
     dtors.push(Box::new(policy));
 
+    set_policy_func(obj, scope, "env_get_var", get_env_var, policy_ptr);
     set_policy_func(obj, scope, "set_env_var", set_env_var, policy_ptr);
     set_policy_func(obj, scope, "unset_env_var", unset_env_var, policy_ptr);
     set_policy_func(obj, scope, "get_env_vars", get_env_vars, policy_ptr);
@@ -156,6 +128,20 @@ pub(super) fn register<'s>(
         get_env_var_exists,
         policy_ptr,
     );
+
+    let args = Box::new(RuntimeArgs(
+        std::iter::once(wasm_file_name.to_owned())
+            .chain(args.iter().cloned())
+            .collect(),
+    ));
+    let args_ptr = &*args as *const RuntimeArgs;
+    let data = v8::External::new(scope, args_ptr as *mut std::ffi::c_void);
+    let function = v8::Function::builder(args_get)
+        .data(data.into())
+        .build(scope)
+        .unwrap();
+    obj.set_value(scope, "args_get", function.into());
+    dtors.push(args);
 }
 
 fn set_policy_func<'s>(

--- a/crates/moonrun/src/lib.rs
+++ b/crates/moonrun/src/lib.rs
@@ -39,6 +39,7 @@ mod resource;
 mod run_termination;
 mod source_map;
 mod sqlite;
+mod temp_dir;
 mod util;
 mod v8_backend;
 mod v8_builder;

--- a/crates/moonrun/src/temp_dir.rs
+++ b/crates/moonrun/src/temp_dir.rs
@@ -18,36 +18,25 @@
 
 //! Run-owned temporary-directory selection.
 
-use std::ffi::{OsStr, OsString};
-use std::sync::{Arc, OnceLock};
+use std::ffi::OsString;
+use std::sync::Arc;
 
 use crate::async_host::AsyncHostResult;
 use crate::async_sys::fs::stub;
 use crate::policy::Policy;
 
-/// The temporary-directory base observed by one Run.
-///
-/// Cache both success and failure so the length and value imports observe one
-/// stable path even if the guest mutates its environment between those calls.
+/// Selects the temporary-directory base observed by one Run.
 pub(crate) struct TempDir {
     policy: Arc<Policy>,
-    path: OnceLock<AsyncHostResult<OsString>>,
 }
 
 impl TempDir {
     pub(crate) fn new(policy: Arc<Policy>) -> Self {
-        Self {
-            policy,
-            path: OnceLock::new(),
-        }
+        Self { policy }
     }
 
-    pub(crate) fn path(&self) -> AsyncHostResult<&OsStr> {
-        self.path
-            .get_or_init(|| resolve(&self.policy))
-            .as_ref()
-            .map(OsString::as_os_str)
-            .map_err(|error| *error)
+    pub(crate) fn path(&self) -> AsyncHostResult<OsString> {
+        resolve(&self.policy)
     }
 }
 
@@ -74,7 +63,7 @@ mod tests {
     #[cfg(windows)]
     use crate::async_host::AsyncHostError;
 
-    fn policy(contents: &str) -> Arc<Policy> {
+    fn load_policy(contents: &str) -> Arc<Policy> {
         let dir = tempfile::tempdir().unwrap();
         let policy_file = dir.path().join("policy.toml");
         std::fs::write(&policy_file, contents).unwrap();
@@ -86,22 +75,27 @@ mod tests {
     fn policy_tmp_path_uses_policy_tmpdir() {
         use std::os::unix::ffi::OsStrExt;
 
-        let temp_dir = TempDir::new(policy("[env.set]\nTMPDIR = \"/policy/tmp\"\n"));
+        let temp_dir = TempDir::new(load_policy("[env.set]\nTMPDIR = \"/policy/tmp\"\n"));
 
         assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/policy/tmp/");
     }
 
     #[cfg(unix)]
     #[test]
-    fn first_tmp_path_result_is_cached() {
+    fn tmp_path_reflects_policy_env_changes() {
         use std::os::unix::ffi::OsStrExt;
 
-        let policy = policy("[env.set]\nTMPDIR = \"/first\"\n");
+        let policy = load_policy("[env.set]\nTMPDIR = \"/first\"\n");
         let temp_dir = TempDir::new(Arc::clone(&policy));
 
         assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/first/");
         policy.set_env_var("TMPDIR".to_owned(), "/second".to_owned());
-        assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/first/");
+        assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/second/");
+        policy.unset_env_var("TMPDIR");
+        assert_eq!(
+            temp_dir.path().unwrap(),
+            stub::get_tmp_path_from_env(None).unwrap()
+        );
     }
 
     #[cfg(all(unix, not(target_os = "android")))]
@@ -109,7 +103,7 @@ mod tests {
     fn policy_tmp_path_ignores_denied_host_tmpdir() {
         use std::os::unix::ffi::OsStrExt;
 
-        let temp_dir = TempDir::new(policy(""));
+        let temp_dir = TempDir::new(load_policy(""));
 
         assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/tmp/");
     }
@@ -117,21 +111,22 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn policy_tmp_path_requires_configured_windows_temp_env() {
-        let policy = policy("");
+        let policy = load_policy("");
         let temp_dir = TempDir::new(Arc::clone(&policy));
 
         assert_eq!(temp_dir.path(), Err(AsyncHostError::PermissionDenied));
-        policy.set_env_var("TEMP".to_owned(), "C:/TooLate".to_owned());
-        assert_eq!(temp_dir.path(), Err(AsyncHostError::PermissionDenied));
-
-        let temp_dir = TempDir::new(policy("[env.set]\nTEMP = \"C:/Temp\"\n"));
+        policy.set_env_var("TEMP".to_owned(), "C:/Temp".to_owned());
         assert_eq!(temp_dir.path().unwrap().to_string_lossy(), "C:/Temp\\");
+        policy.unset_env_var("TEMP");
+        assert_eq!(temp_dir.path(), Err(AsyncHostError::PermissionDenied));
     }
 
     #[cfg(windows)]
     #[test]
     fn empty_policy_tmp_falls_back_to_temp() {
-        let temp_dir = TempDir::new(policy("[env.set]\nTMP = \"\"\nTEMP = \"C:/Fallback\"\n"));
+        let temp_dir = TempDir::new(load_policy(
+            "[env.set]\nTMP = \"\"\nTEMP = \"C:/Fallback\"\n",
+        ));
 
         assert_eq!(temp_dir.path().unwrap().to_string_lossy(), "C:/Fallback\\");
     }

--- a/crates/moonrun/src/temp_dir.rs
+++ b/crates/moonrun/src/temp_dir.rs
@@ -1,0 +1,138 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Run-owned temporary-directory selection.
+
+use std::ffi::{OsStr, OsString};
+use std::sync::{Arc, OnceLock};
+
+use crate::async_host::AsyncHostResult;
+use crate::async_sys::fs::stub;
+use crate::policy::Policy;
+
+/// The temporary-directory base observed by one Run.
+///
+/// Cache both success and failure so the length and value imports observe one
+/// stable path even if the guest mutates its environment between those calls.
+pub(crate) struct TempDir {
+    policy: Arc<Policy>,
+    path: OnceLock<AsyncHostResult<OsString>>,
+}
+
+impl TempDir {
+    pub(crate) fn new(policy: Arc<Policy>) -> Self {
+        Self {
+            policy,
+            path: OnceLock::new(),
+        }
+    }
+
+    pub(crate) fn path(&self) -> AsyncHostResult<&OsStr> {
+        self.path
+            .get_or_init(|| resolve(&self.policy))
+            .as_ref()
+            .map(OsString::as_os_str)
+            .map_err(|error| *error)
+    }
+}
+
+fn resolve(policy: &Policy) -> AsyncHostResult<OsString> {
+    if !policy.has_env_policy() {
+        return stub::get_tmp_path();
+    }
+    resolve_from_policy_env(policy)
+}
+
+#[cfg(unix)]
+fn resolve_from_policy_env(policy: &Policy) -> AsyncHostResult<OsString> {
+    stub::get_tmp_path_from_env(policy.env_var_os("TMPDIR"))
+}
+
+#[cfg(windows)]
+fn resolve_from_policy_env(policy: &Policy) -> AsyncHostResult<OsString> {
+    stub::get_tmp_path_from_env(policy.env_var_os("TMP"), policy.env_var_os("TEMP"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(windows)]
+    use crate::async_host::AsyncHostError;
+
+    fn policy(contents: &str) -> Arc<Policy> {
+        let dir = tempfile::tempdir().unwrap();
+        let policy_file = dir.path().join("policy.toml");
+        std::fs::write(&policy_file, contents).unwrap();
+        Arc::new(Policy::from_file(&policy_file).unwrap())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn policy_tmp_path_uses_policy_tmpdir() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let temp_dir = TempDir::new(policy("[env.set]\nTMPDIR = \"/policy/tmp\"\n"));
+
+        assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/policy/tmp/");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn first_tmp_path_result_is_cached() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let policy = policy("[env.set]\nTMPDIR = \"/first\"\n");
+        let temp_dir = TempDir::new(Arc::clone(&policy));
+
+        assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/first/");
+        policy.set_env_var("TMPDIR".to_owned(), "/second".to_owned());
+        assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/first/");
+    }
+
+    #[cfg(all(unix, not(target_os = "android")))]
+    #[test]
+    fn policy_tmp_path_ignores_denied_host_tmpdir() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let temp_dir = TempDir::new(policy(""));
+
+        assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/tmp/");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn policy_tmp_path_requires_configured_windows_temp_env() {
+        let policy = policy("");
+        let temp_dir = TempDir::new(Arc::clone(&policy));
+
+        assert_eq!(temp_dir.path(), Err(AsyncHostError::PermissionDenied));
+        policy.set_env_var("TEMP".to_owned(), "C:/TooLate".to_owned());
+        assert_eq!(temp_dir.path(), Err(AsyncHostError::PermissionDenied));
+
+        let temp_dir = TempDir::new(policy("[env.set]\nTEMP = \"C:/Temp\"\n"));
+        assert_eq!(temp_dir.path().unwrap().to_string_lossy(), "C:/Temp\\");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn empty_policy_tmp_falls_back_to_temp() {
+        let temp_dir = TempDir::new(policy("[env.set]\nTMP = \"\"\nTEMP = \"C:/Fallback\"\n"));
+
+        assert_eq!(temp_dir.path().unwrap().to_string_lossy(), "C:/Fallback\\");
+    }
+}

--- a/crates/moonrun/src/template/js_glue.js
+++ b/crates/moonrun/src/template/js_glue.js
@@ -4,12 +4,6 @@
 const __moonbit_fs_unstable =
     globalThis.__moonbit_fs_unstable ||
     (globalThis.__moonbit_fs_unstable = {});
-// Provided by the filesystem adapter; fallback keeps interactive tests safe.
-const __moonbit_run_env = globalThis.__moonbit_run_env || {
-    env_vars: new Map(),
-    args: [],
-    stderr_is_tty: false,
-};
 // JS helper API attached to __moonbit_fs_unstable.
 (function init_js_api(obj) {
     // String ops
@@ -120,30 +114,12 @@ const __moonbit_run_env = globalThis.__moonbit_run_env || {
     obj.jsvalue_is_string = jsvalue_is_string
 })(__moonbit_fs_unstable);
 
-// Sys API wiring (env vars + args).
-(function init_runtime_api(obj, run_env) {
-    // Return the value of the environment variable
-    function env_get_var(name) {
-        return run_env.env_vars.get(name) || ""
-    }
-
-    // Get the list of arguments passed to the program
-    function args_get() {
-        return run_env.args
-    }
-
-    obj.env_get_var = env_get_var
-    obj.args_get = args_get
-})(__moonbit_fs_unstable, __moonbit_run_env);
-
 const __moonbit_wasi_unstable = globalThis.__moonbit_wasi_unstable || {};
 const __moonrun_v8_import = globalThis.__moonrun_v8_import || {};
 const moonbitlang_async = globalThis["moonbitlang/async"] || {};
 const moonbitlang_sqlite = globalThis["moonbitlang/sqlite"] || {};
 const moonbit_ffi_memory_sanitizer =
     globalThis["moonbit:ffi/memory-sanitizer"] || {};
-
-delete globalThis.__moonbit_run_env;
 
 function demangleMangledFunctionName(funcName) {
     if (typeof __moonbit_demangle_mangled_function_name === "function") {

--- a/crates/moonrun/src/v8_backend.rs
+++ b/crates/moonrun/src/v8_backend.rs
@@ -25,6 +25,10 @@ use anyhow::Context;
 use std::sync::{Arc, OnceLock};
 
 const BUILTIN_SCRIPT_ORIGIN_PREFIX: &str = "__$moonrun_v8_builtin_script$__";
+const JS_GLUE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/src/template/js_glue.js"
+));
 
 pub(crate) struct CompiledModule(v8::CompiledWasmModule);
 
@@ -168,11 +172,7 @@ pub(crate) fn run(
     ));
     entrypoint_source.push_str(demangle_js_template::DEMANGLE_JS_TEMPLATE);
     entrypoint_source.push('\n');
-    let js_glue = include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/src/template/js_glue.js"
-    ));
-    entrypoint_source.push_str(js_glue);
+    entrypoint_source.push_str(JS_GLUE);
 
     let code = scope.string(&entrypoint_source);
     let script_origin = create_script_origin(scope, "wasm_mode_entry");
@@ -233,4 +233,16 @@ fn create_script_origin<'s>(scope: &mut v8::HandleScope<'s>, name: &str) -> v8::
 struct TestArgs {
     package: String,
     file_and_index: Vec<(String, Vec<std::ops::Range<u32>>)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JS_GLUE;
+
+    #[test]
+    fn js_glue_does_not_own_runtime_values() {
+        assert!(!JS_GLUE.contains("__moonbit_run_env"));
+        assert!(!JS_GLUE.contains("function env_get_var"));
+        assert!(!JS_GLUE.contains("function args_get"));
+    }
 }

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -986,6 +986,10 @@ OSError("[..]@fs.open()[..]denied/secret.txt[..]Permission denied")
 OSError("[..]@fs.open()[..]denied/secret.txt[..]Access is denied.")
 
 "#]];
+    #[cfg(not(windows))]
+    let env_mutate_stdout = "runtime override\nmissing\n/first/\n/second/\n/tmp/\n";
+    #[cfg(windows)]
+    let env_mutate_stdout = "runtime override\nmissing\nC:/First\\\nC:/Second\\\nmissing\n";
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .current_dir(dir.path())
@@ -1013,7 +1017,7 @@ OSError("[..]@fs.open()[..]denied/secret.txt[..]Access is denied.")
         .arg(&env_mutate_wasm)
         .assert()
         .success()
-        .stdout_eq("runtime override\nmissing\n");
+        .stdout_eq(env_mutate_stdout);
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .current_dir(dir.path())

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -1017,7 +1017,7 @@ OSError("[..]@fs.open()[..]denied/secret.txt[..]Access is denied.")
         .arg(&env_mutate_wasm)
         .assert()
         .success()
-        .stdout_eq(env_mutate_stdout);
+        .stdout_eq(snapbox::Data::text(env_mutate_stdout).raw());
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .current_dir(dir.path())

--- a/crates/moonrun/tests/test_cases/test_policy_workspace.in/env_mutate/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_policy_workspace.in/env_mutate/main.mbt
@@ -17,6 +17,32 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 ///|
+fn get_tmp_path_len() -> Int = "moonbitlang/async" "fs/get_tmp_path_len"
+
+///|
+fn get_tmp_path(dst : Int, len : Int) -> Int = "moonbitlang/async" "fs/get_tmp_path"
+
+///|
+#borrow(str)
+extern "wasm" fn string_to_ptr(str : String) -> Int =
+  #|(func (param i32) (result i32) local.get 0)
+
+///|
+fn print_tmp_path() -> Unit {
+  let len = get_tmp_path_len()
+  if len < 0 {
+    println("missing")
+    return
+  }
+  let path = String::make(len, '\u{0}')
+  if get_tmp_path(string_to_ptr(path), len) == 0 {
+    println(path)
+  } else {
+    println("missing")
+  }
+}
+
+///|
 fn main {
   @env.set_env_var("MOONRUN_POLICY_ENV", "runtime override")
   if @env.get_env_var("MOONRUN_POLICY_ENV") is Some(value) {
@@ -31,4 +57,20 @@ fn main {
   } else {
     println("missing")
   }
+
+  // Prime the temp-path import before mutating the shared Run environment.
+  let _ = get_tmp_path_len()
+  @env.set_env_var("TMPDIR", "/first")
+  @env.set_env_var("TMP", "C:/First")
+  @env.set_env_var("TEMP", "C:/Fallback")
+  print_tmp_path()
+
+  @env.set_env_var("TMPDIR", "/second")
+  @env.set_env_var("TMP", "C:/Second")
+  print_tmp_path()
+
+  @env.unset_env_var("TMPDIR")
+  @env.unset_env_var("TMP")
+  @env.unset_env_var("TEMP")
+  print_tmp_path()
 }


### PR DESCRIPTION
## Why

The V8 JavaScript glue retained an intermediate runtime environment even though environment and argument values belong to the Rust host. Temporary-directory selection also mixed policy, platform fallback, and guest string encoding inside the async adapter, making that behavior harder to reuse from another Wasm runtime.

## Why this is correct

- Rust now exposes environment lookup and argument retrieval directly; JavaScript only forwards the imports.
- A per-Run TempDir host module owns policy-aware platform selection and resolves each lookup against the current Run environment, matching the native helper after environment changes.
- OS-string-to-guest encoding stays in the OS-string adapter instead of the temporary-path domain.
- On Windows, an empty TMP is treated as absent so a configured TEMP remains usable. Unrestricted runs retain the native GetTempPath2W fallback, while policy-restricted runs do not read ambient environment outside policy.

## Scope

The change is a focused runtime-ownership cleanup plus regression coverage for mutable temp-directory environment variables. It does not introduce a parallel policy abstraction; the existing per-Run environment work remains the deeper seam for environment virtualization.