### PR TITLE
feat(moonrun): inherit policy across moonx spawns

### DIFF
--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -74,6 +74,7 @@ pub(crate) struct MoonxInvocation {
     pub(crate) target: MoonxTarget,
     pub(crate) experimental_policy: Option<PathBuf>,
     pub(crate) verbose: bool,
+    inherited_policy: Option<OsString>,
     package: String,
     args: Vec<String>,
 }
@@ -81,14 +82,7 @@ pub(crate) struct MoonxInvocation {
 pub(crate) fn is_moonx_invocation(raw_args: &[OsString]) -> bool {
     raw_args
         .first()
-        .and_then(|arg| std::path::Path::new(arg).file_name())
-        .is_some_and(|name| {
-            if cfg!(windows) {
-                name.eq_ignore_ascii_case("moonx") || name.eq_ignore_ascii_case("moonx.exe")
-            } else {
-                name == "moonx" || name == "moonx.exe"
-            }
-        })
+        .is_some_and(|arg| moonutil::constants::is_moonx_executable(arg))
 }
 
 pub(crate) fn parse_from(raw_args: &[OsString]) -> Result<MoonxInvocation, clap::Error> {
@@ -102,10 +96,20 @@ pub(crate) fn parse_from(raw_args: &[OsString]) -> Result<MoonxInvocation, clap:
         [separator, args @ ..] if separator == "--" => args,
         _ => args,
     };
+    let inherited_policy = std::env::var_os(moonutil::constants::MOONRUN_INHERITED_POLICY);
+    // Moonx is only an intermediary. Remove the reserved value before
+    // registry/cache work can start subprocesses; the prepared moonrun command
+    // receives it explicitly below.
+    if inherited_policy.is_some() {
+        unsafe {
+            std::env::remove_var(moonutil::constants::MOONRUN_INHERITED_POLICY);
+        }
+    }
     Ok(MoonxInvocation {
         target: cli.target,
         experimental_policy: cli.experimental_policy,
         verbose: cli.verbose,
+        inherited_policy,
         package: package.clone(),
         args: args.to_vec(),
     })
@@ -116,14 +120,23 @@ pub(crate) fn prepare(
     user_log: &UserLog,
 ) -> anyhow::Result<std::process::Command> {
     let quiet = !invocation.verbose;
-    let target = match invocation.target {
-        MoonxTarget::Wasm => RegistryRunTarget::Wasm {
-            experimental_policy: invocation.experimental_policy,
+    let target = match (invocation.target, invocation.inherited_policy) {
+        (MoonxTarget::Native, Some(_)) => {
+            anyhow::bail!("a sandboxed moonx invocation cannot use --target native")
+        }
+        (MoonxTarget::Wasm, inherited_policy) => RegistryRunTarget::Wasm {
+            // The parent snapshot is authoritative. A child policy option may
+            // not replace it, but remains valid for ordinary top-level moonx.
+            experimental_policy: inherited_policy
+                .is_none()
+                .then_some(invocation.experimental_policy)
+                .flatten(),
+            inherited_policy,
         },
-        MoonxTarget::Native if invocation.experimental_policy.is_some() => {
+        (MoonxTarget::Native, None) if invocation.experimental_policy.is_some() => {
             anyhow::bail!("--experimental-policy is only valid with `--target wasm`")
         }
-        MoonxTarget::Native => RegistryRunTarget::Native,
+        (MoonxTarget::Native, None) => RegistryRunTarget::Native,
     };
     registry_runner::prepare(
         invocation.package,
@@ -185,5 +198,26 @@ mod tests {
             let MoonxPackage::External(package_and_args) = cli.package;
             assert_eq!(package_and_args, ["user/module", flag]);
         }
+    }
+
+    #[test]
+    fn inherited_policy_rejects_native_execution_before_registry_work() {
+        let error = prepare(
+            MoonxInvocation {
+                target: MoonxTarget::Native,
+                experimental_policy: None,
+                verbose: false,
+                inherited_policy: Some(OsString::from("opaque-token")),
+                package: "user/module".to_owned(),
+                args: Vec::new(),
+            },
+            &UserLog::new(log::LevelFilter::Warn),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "a sandboxed moonx invocation cannot use --target native"
+        );
     }
 }

--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -16,6 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
@@ -27,6 +28,7 @@ use crate::rr_build;
 pub(crate) enum RegistryRunTarget {
     Wasm {
         experimental_policy: Option<PathBuf>,
+        inherited_policy: Option<OsString>,
     },
     Native,
 }
@@ -86,12 +88,14 @@ pub(crate) fn prepare(
     match target {
         RegistryRunTarget::Wasm {
             experimental_policy,
+            inherited_policy,
         } => {
             let wasm_path = registry.acquire_executable_wasm(&package, user_log)?;
             prepare_artifact(
                 crate::run::ExecutionMode::MoonRun,
                 &wasm_path,
                 experimental_policy.as_deref(),
+                inherited_policy.as_deref(),
                 &args,
                 user_log,
             )
@@ -102,6 +106,7 @@ pub(crate) fn prepare(
             prepare_artifact(
                 crate::run::ExecutionMode::Native,
                 &executable,
+                None,
                 None,
                 &args,
                 user_log,
@@ -140,6 +145,7 @@ fn prepare_artifact(
     mode: crate::run::ExecutionMode<'_>,
     artifact: &Path,
     experimental_policy: Option<&Path>,
+    inherited_policy: Option<&std::ffi::OsStr>,
     args: &[String],
     user_log: &UserLog,
 ) -> anyhow::Result<std::process::Command> {
@@ -151,11 +157,18 @@ fn prepare_artifact(
         user_log.info(rr_build::format_dry_run_command(&run_cmd, Path::new(".")));
     }
 
+    if let Some(token) = inherited_policy {
+        run_cmd.env(moonutil::constants::MOONRUN_INHERITED_POLICY, token);
+    } else {
+        run_cmd.env_remove(moonutil::constants::MOONRUN_INHERITED_POLICY);
+    }
+
     Ok(run_cmd)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsStr;
     use std::sync::{
         Arc, Barrier,
         atomic::{AtomicUsize, Ordering},
@@ -164,6 +177,25 @@ mod tests {
     use anyhow::bail;
 
     use super::*;
+
+    #[test]
+    fn inherited_policy_is_attached_only_to_the_final_moonrun_command() {
+        let command = prepare_artifact(
+            crate::run::ExecutionMode::MoonRun,
+            Path::new("program.wasm"),
+            None,
+            Some(OsStr::new("策略-🌙")),
+            &[],
+            &UserLog::new(log::LevelFilter::Warn),
+        )
+        .unwrap();
+
+        let inherited = command
+            .get_envs()
+            .find(|(name, _)| *name == moonutil::constants::MOONRUN_INHERITED_POLICY)
+            .and_then(|(_, value)| value);
+        assert_eq!(inherited, Some(OsStr::new("策略-🌙")));
+    }
 
     #[test]
     fn failed_production_does_not_publish_a_cache_entry() {

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -86,6 +86,7 @@ pub(crate) fn run_runwasm(
         cmd.package,
         super::registry_runner::RegistryRunTarget::Wasm {
             experimental_policy: cmd.experimental_policy,
+            inherited_policy: None,
         },
         cmd.args,
         cli.quiet,

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -52,6 +52,25 @@ operations before moonrun performs them. It does not implicitly configure or
 restrict WASI descriptors.
 _Avoid_: WASI sandbox, virtual filesystem
 
+**Policy Snapshot**:
+A host-owned, temporary serialization of the effective Moonrun Policy for a
+future child Run. It stores canonical filesystem roots, already materialized
+environment values, and resolved network authority instead of referring back
+to the user policy file. Its format is an internal process-boundary protocol,
+not a user policy format.
+_Avoid_: Policy source copy, inherited policy path, public policy format
+
+**Snapshot Transport**:
+The internal ownership seam that publishes a Policy Snapshot, supplies an
+opaque token at the trusted spawn boundary, and consumes that token before the
+child runs untrusted code. The current backend uses a protected, read-only
+temporary file outside the WASI preopen: the originating Policy retains a
+cleanup lease, while the child opens and unlinks the file immediately after a
+successful handoff. Callers do not interpret the token, so another transport
+can replace this backend without changing policy serialization or process
+dispatch.
+_Avoid_: Snapshot path ABI, fixed snapshot descriptor
+
 **WASI Capability Surface**:
 The files and directories reachable through WASI descriptors and preopens.
 WASI access is configured separately from Moonrun Policy, even when both

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -31,6 +31,7 @@ serde_json.workspace = true
 serde_json_lenient.workspace = true
 libsqlite3-sys.workspace = true
 slotmap.workspace = true
+tempfile.workspace = true
 toml = { workspace = true, features = ["parse", "serde", "std"] }
 moonutil.workspace = true
 rand = "0.8.5"
@@ -77,7 +78,6 @@ chrono.workspace = true
 escargot.workspace = true
 moon-test-util = { path = "../moon-test-util" }
 snapbox.workspace = true
-tempfile.workspace = true
 tokio = { workspace = true, features = ["io-util", "net", "time"] }
 
 [[bin]]

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -172,6 +172,19 @@ access. The `fs` and `net` objects do not sandbox child processes. PID-based
 process operations are restricted to children spawned by the current moonrun
 instance while policy mode is active.
 
+A `moonx` request is handled specially. After the logical spawn request passes
+the process policy, moonrun snapshots the current policy. Moonx relays the
+opaque transport token to the child moonrun that executes the registry Wasm,
+and that child applies the snapshot to its Run.
+The snapshot contains current environment values and resolved network authority;
+it does not reopen the original policy file. Moonrun passes the snapshot through
+an internal transport whose current backend is a protected, read-only temporary
+file outside the WASI preopen. The child opens and unlinks the file immediately;
+the transport token is opaque to policy, moonx, and process-dispatch callers so
+the backend can be replaced independently. A sandboxed `moonx --target native` request is rejected because
+native code cannot inherit Moonrun Policy. The inherited snapshot is
+authoritative; a nested `--experimental-policy` cannot replace it.
+
 ```json
 {
   "env": {

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -3636,7 +3636,7 @@ impl AsyncHost {
     }
 
     fn run_policy_checked_job(policy: &Policy, process: &HostProcess, job: &mut Job) {
-        if let Err(error) = Self::check_job_policy(policy, process, job) {
+        if let Err(error) = Self::check_and_prepare_job_policy(policy, process, job) {
             job.set_err(error.errno());
             return;
         }
@@ -3646,12 +3646,20 @@ impl AsyncHost {
         }
     }
 
-    fn check_job_policy(policy: &Policy, process: &HostProcess, job: &Job) -> AsyncHostResult<()> {
+    fn check_and_prepare_job_policy(
+        policy: &Policy,
+        process: &HostProcess,
+        job: &mut Job,
+    ) -> AsyncHostResult<()> {
         match job.payload() {
             JobPayload::Filesystem(job) => job.check_policy(policy),
             JobPayload::Process(job) => process.check_job(job),
             _ => Ok(()),
+        }?;
+        if let Ok(job) = job.process_mut() {
+            process.prepare_job(job)?;
         }
+        Ok(())
     }
 
     fn finish_process_job(process: &HostProcess, job: &Job) -> AsyncHostResult<()> {

--- a/crates/moonrun/src/async_sys/process.rs
+++ b/crates/moonrun/src/async_sys/process.rs
@@ -95,6 +95,66 @@ fn unix_process_env_entry(key: OsString, value: OsString) -> Option<OsString> {
     Some(OsString::from_vec(entry))
 }
 
+#[cfg(unix)]
+pub(crate) fn set_process_env_var(
+    env: &mut Vec<OsString>,
+    key: &std::ffi::OsStr,
+    value: Option<&std::ffi::OsStr>,
+) {
+    use std::os::unix::ffi::OsStrExt;
+
+    let key_bytes = key.as_bytes();
+    env.retain(|entry| {
+        let entry = entry.as_os_str().as_bytes();
+        entry
+            .iter()
+            .position(|byte| *byte == b'=')
+            .is_none_or(|separator| &entry[..separator] != key_bytes)
+    });
+    if let Some(value) = value
+        && let Some(entry) = unix_process_env_entry(key.to_owned(), value.to_owned())
+    {
+        env.push(entry);
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn set_process_env_var(
+    env: &mut Vec<u16>,
+    key: &std::ffi::OsStr,
+    value: Option<&std::ffi::OsStr>,
+) {
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+    use windows_sys::Win32::Globalization::{CSTR_EQUAL, CompareStringOrdinal};
+
+    let key = key.encode_wide().collect::<Vec<_>>();
+    let inherited = env
+        .split(|unit| *unit == 0)
+        .filter(|entry| !entry.is_empty())
+        .filter(|entry| {
+            let Some(separator) = entry.iter().position(|unit| *unit == b'=' as u16) else {
+                return false;
+            };
+            separator != key.len()
+                || unsafe {
+                    CompareStringOrdinal(
+                        entry.as_ptr(),
+                        separator as i32,
+                        key.as_ptr(),
+                        key.len() as i32,
+                        1,
+                    )
+                } != CSTR_EQUAL
+        })
+        .map(OsString::from_wide)
+        .collect();
+    let mut builder = ProcessEnvBuilder::new(inherited);
+    if let Some(value) = value {
+        process_env_builder_add_entry(&mut builder, OsString::from_wide(&key), value.to_owned());
+    }
+    *env = finish_process_env_builder(builder);
+}
+
 ported_fns! {
     #[ported(
         source = "src/process/unix.c",
@@ -503,6 +563,28 @@ mod tests {
     }
 
     #[test]
+    fn unix_host_env_override_replaces_guest_value_without_losing_unicode() {
+        let mut env = vec![
+            OsString::from("MOONRUN_INHERITED_POLICY=guest"),
+            OsString::from("UNICODE=策略-🌙"),
+        ];
+
+        set_process_env_var(
+            &mut env,
+            std::ffi::OsStr::new("MOONRUN_INHERITED_POLICY"),
+            Some(std::ffi::OsStr::new("/tmp/策略-🌙")),
+        );
+
+        assert_eq!(
+            env,
+            [
+                OsString::from("UNICODE=策略-🌙"),
+                OsString::from("MOONRUN_INHERITED_POLICY=/tmp/策略-🌙"),
+            ]
+        );
+    }
+
+    #[test]
     fn unix_wait_status_distinguishes_exit_from_signal() {
         assert_eq!(unix_wait_status_exit_code(7 << 8), 7);
         assert_eq!(unix_wait_status_exit_code(libc::SIGTERM), -libc::SIGTERM);
@@ -553,6 +635,24 @@ mod windows_tests {
         assert_eq!(
             finish_process_env_builder(builder),
             "GOOD=before\0\0".encode_utf16().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn windows_host_env_override_is_case_insensitive_and_preserves_unicode() {
+        let mut env = "moonrun_inherited_policy=guest\0UNICODE=策略-🌙\0\0"
+            .encode_utf16()
+            .collect();
+
+        set_process_env_var(
+            &mut env,
+            std::ffi::OsStr::new("MOONRUN_INHERITED_POLICY"),
+            Some(std::ffi::OsStr::new(r"C:\策略-🌙")),
+        );
+
+        assert_eq!(
+            String::from_utf16(&env).unwrap(),
+            "UNICODE=策略-🌙\0MOONRUN_INHERITED_POLICY=C:\\策略-🌙\0\0"
         );
     }
 

--- a/crates/moonrun/src/engine.rs
+++ b/crates/moonrun/src/engine.rs
@@ -45,6 +45,7 @@ pub struct RunOptions {
     pub(crate) no_stack_trace: bool,
     pub(crate) test_args: Option<String>,
     pub(crate) policy_file: Option<PathBuf>,
+    pub(crate) inherited_policy: Option<Arc<policy::Policy>>,
 }
 
 impl RunOptions {
@@ -70,6 +71,13 @@ impl RunOptions {
     pub fn with_policy_file(mut self, policy_file: impl Into<PathBuf>) -> Self {
         self.policy_file = Some(policy_file.into());
         self
+    }
+
+    /// Consume a host-authenticated policy snapshot received from another moonrun process.
+    #[doc(hidden)]
+    pub fn with_inherited_policy(mut self, token: std::ffi::OsString) -> anyhow::Result<Self> {
+        self.inherited_policy = Some(Arc::new(policy::Policy::from_inherited_snapshot(token)?));
+        Ok(self)
     }
 }
 
@@ -173,13 +181,18 @@ impl Engine {
     }
 
     /// Execute one isolated run synchronously on the calling thread.
-    pub fn run(&self, module: &Module, options: RunOptions) -> anyhow::Result<RunOutcome> {
-        let policy = Arc::new(match options.policy_file.as_ref() {
-            Some(path) => policy::Policy::from_file(path).context(
+    pub fn run(&self, module: &Module, mut options: RunOptions) -> anyhow::Result<RunOutcome> {
+        let inherited_policy = options.inherited_policy.take();
+        let policy = match (&options.policy_file, inherited_policy) {
+            (Some(path), None) => Arc::new(policy::Policy::from_file(path).context(
                 "failed to load sandbox policy (experimental); run `moonrun --help` for policy format notes",
-            )?,
-            None => policy::Policy::allow_all(),
-        });
+            )?),
+            (None, Some(policy)) => policy,
+            (None, None) => Arc::new(policy::Policy::allow_all()),
+            (Some(_), Some(_)) => {
+                anyhow::bail!("a policy file and inherited policy snapshot are mutually exclusive")
+            }
+        };
         v8_backend::run(
             &self.config,
             module.name(),

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -98,6 +98,12 @@ fn main() -> anyhow::Result<()> {
     if let Some(test_args) = matches.test_args {
         options = options.with_test_args(test_args);
     }
+    if let Some(token) = std::env::var_os(moonutil::constants::MOONRUN_INHERITED_POLICY) {
+        unsafe {
+            std::env::remove_var(moonutil::constants::MOONRUN_INHERITED_POLICY);
+        }
+        options = options.with_inherited_policy(token)?;
+    }
     if let Some(policy) = matches.policy {
         options = options.with_policy_file(policy);
     }

--- a/crates/moonrun/src/policy/config.rs
+++ b/crates/moonrun/src/policy/config.rs
@@ -20,7 +20,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Default, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -31,7 +31,7 @@ pub(super) struct PolicyConfig {
     pub(super) process: Option<ProcessConfig>,
 }
 
-#[derive(Default, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct FsConfig {
     #[serde(default)]
@@ -40,7 +40,7 @@ pub(super) struct FsConfig {
     pub(super) write: Vec<PathBuf>,
 }
 
-#[derive(Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct NetConfig {
     #[serde(default)]
@@ -51,7 +51,7 @@ pub(super) struct NetConfig {
     pub(super) bind: Vec<String>,
 }
 
-#[derive(Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct EnvConfig {
     #[serde(default)]
@@ -62,7 +62,7 @@ pub(super) struct EnvConfig {
     pub(super) set: BTreeMap<String, String>,
 }
 
-#[derive(Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct ProcessConfig {
     #[serde(default)]
@@ -71,7 +71,7 @@ pub(super) struct ProcessConfig {
     pub(super) allow: Vec<ProcessRuleConfig>,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct ProcessRuleConfig {
     pub(super) program: String,

--- a/crates/moonrun/src/policy/fs.rs
+++ b/crates/moonrun/src/policy/fs.rs
@@ -16,8 +16,10 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
 
@@ -34,6 +36,7 @@ use super::{config::FsConfig, sandbox_denied};
 pub(super) struct FsPolicy {
     read_roots: Vec<FsRoot>,
     write_roots: Vec<FsRoot>,
+    protected_paths: Arc<Mutex<HashSet<PathBuf>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -60,7 +63,27 @@ impl FsPolicy {
         Ok(Self {
             read_roots: resolve_roots(config.read, config_dir)?,
             write_roots: resolve_roots(config.write, config_dir)?,
+            protected_paths: Arc::default(),
         })
+    }
+
+    /// Protect host-owned runtime state from Moonrun Policy filesystem imports.
+    ///
+    /// Ancestors are protected from writes as well because directory rename or
+    /// recursive removal would otherwise mutate a protected descendant.
+    pub(super) fn protect_path(&self, path: PathBuf) {
+        self.protected_paths.lock().unwrap().insert(path);
+    }
+
+    pub(super) fn unprotect_path(&self, path: &Path) {
+        self.protected_paths.lock().unwrap().remove(path);
+    }
+
+    pub(super) fn config_for_snapshot(&self) -> FsConfig {
+        FsConfig {
+            read: roots_for_snapshot(&self.read_roots),
+            write: roots_for_snapshot(&self.write_roots),
+        }
     }
 
     pub(super) fn allows(
@@ -111,6 +134,15 @@ impl FsPolicy {
         intents: FsIntents,
         target: &str,
     ) -> AsyncHostResult<()> {
+        let protected_paths = self.protected_paths.lock().unwrap();
+        if protected_paths.contains(path)
+            || (intents.write
+                && protected_paths
+                    .iter()
+                    .any(|protected| protected.starts_with(path)))
+        {
+            return sandbox_denied(intents.sandbox_action(), Some(target));
+        }
         if intents.read && !self.allows_read(path) {
             return sandbox_denied("file read", Some(target));
         }
@@ -209,6 +241,16 @@ fn resolve_roots(roots: Vec<PathBuf>, config_dir: &Path) -> anyhow::Result<Vec<F
                 )
             })?;
             Ok(FsRoot::Path(path))
+        })
+        .collect()
+}
+
+fn roots_for_snapshot(roots: &[FsRoot]) -> Vec<PathBuf> {
+    roots
+        .iter()
+        .map(|root| match root {
+            FsRoot::Any => PathBuf::from("*"),
+            FsRoot::Path(path) => path.clone(),
         })
         .collect()
 }

--- a/crates/moonrun/src/policy/mod.rs
+++ b/crates/moonrun/src/policy/mod.rs
@@ -26,9 +26,11 @@ mod env;
 mod fs;
 mod net;
 mod process;
+mod snapshot;
 
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
+use std::sync::Mutex;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 
@@ -38,13 +40,17 @@ pub(crate) use self::fs::RuntimePathBase;
 use self::fs::{FsIntents, FsPolicy};
 use self::net::{NetOperation, NetPolicy};
 use self::process::ProcessPolicy;
+pub(crate) use self::snapshot::PolicySnapshot;
+use self::snapshot::SnapshotTemplate;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct Policy {
     fs: Option<FsPolicy>,
     net: Option<NetPolicy>,
     env: Option<EnvPolicy>,
     process: Option<ProcessPolicy>,
+    snapshot_template: Option<SnapshotTemplate>,
+    snapshot_leases: Mutex<Vec<PolicySnapshot>>,
 }
 
 fn sandbox_denied(action: &str, target: Option<&str>) -> AsyncHostResult<()> {
@@ -63,6 +69,8 @@ impl Policy {
             net: None,
             env: None,
             process: None,
+            snapshot_template: None,
+            snapshot_leases: Mutex::default(),
         }
     }
 
@@ -73,17 +81,48 @@ impl Policy {
     }
 
     fn from_config(config: PolicyConfig, config_dir: &Path) -> anyhow::Result<Self> {
+        let fs_config = config.fs.unwrap_or_default();
+        let net_config = config.net.unwrap_or_default();
+        let env_config = config.env.unwrap_or_default();
+        let process_config = config.process.unwrap_or_default();
+        let fs = FsPolicy::from_config(fs_config, config_dir)?;
+        let snapshot_template = SnapshotTemplate::new(
+            fs.config_for_snapshot(),
+            net_config.clone(),
+            process_config.clone(),
+        );
         Ok(Self {
-            fs: Some(FsPolicy::from_config(
-                config.fs.unwrap_or_default(),
-                config_dir,
-            )?),
-            net: Some(NetPolicy::from_config(config.net.unwrap_or_default())?),
-            env: Some(EnvPolicy::from_config(config.env.unwrap_or_default())?),
-            process: Some(ProcessPolicy::from_config(
-                config.process.unwrap_or_default(),
-            )?),
+            fs: Some(fs),
+            net: Some(NetPolicy::from_config(net_config)?),
+            env: Some(EnvPolicy::from_config(env_config)?),
+            process: Some(ProcessPolicy::from_config(process_config)?),
+            snapshot_template: Some(snapshot_template),
+            snapshot_leases: Mutex::default(),
         })
+    }
+
+    pub(crate) fn from_inherited_snapshot(token: OsString) -> anyhow::Result<Self> {
+        Self::from_config(PolicySnapshot::consume(token)?, Path::new("."))
+    }
+
+    pub(crate) fn snapshot_for_child(&self) -> anyhow::Result<Option<snapshot::PolicySnapshot>> {
+        let Some(template) = self.snapshot_template.as_ref() else {
+            return Ok(None);
+        };
+        let net = self
+            .net_policy()
+            .expect("policy-bearing runs always have a network policy");
+        let env = self
+            .env_policy()
+            .expect("policy-bearing runs always have an environment policy");
+        let fs = self
+            .fs_policy()
+            .expect("policy-bearing runs always have a filesystem policy");
+        let snapshot = template.write(fs, net, env)?;
+        let mut leases = self.snapshot_leases.lock().unwrap();
+        leases.retain(|snapshot| !snapshot.is_consumed());
+        leases.push(snapshot.clone());
+        Ok(Some(snapshot))
     }
 
     pub(crate) fn open_path(
@@ -526,6 +565,173 @@ mod tests {
         #[cfg(windows)]
         policy
             .spawn_process_windows(OsStr::new("program.exe"))
+            .unwrap();
+    }
+
+    #[test]
+    fn snapshot_captures_effective_policy_without_reusing_the_source_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let allowed = tmp.path().join("allowed");
+        std::fs::create_dir(&allowed).unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(
+            &policy_file,
+            r#"
+[fs]
+read = ["allowed"]
+write = ["allowed"]
+
+[env.set]
+INITIAL = "value"
+MOONRUN_INHERITED_POLICY = "guest value"
+
+[process]
+spawn = true
+"#,
+        )
+        .unwrap();
+        let policy = Policy::from_file(&policy_file).unwrap();
+        policy.unset_env_var("INITIAL");
+        policy.set_env_var("CURRENT".to_owned(), "策略-🌙".to_owned());
+
+        let snapshot = policy.snapshot_for_child().unwrap().unwrap();
+        std::fs::write(&policy_file, "").unwrap();
+        let snapshot_path = PathBuf::from(snapshot.transport_token());
+        let inherited =
+            Policy::from_inherited_snapshot(snapshot.transport_token().to_owned()).unwrap();
+        assert!(!snapshot_path.exists());
+        snapshot.handoff();
+
+        assert_eq!(inherited.get_env_var("CURRENT").as_deref(), Some("策略-🌙"));
+        assert!(!inherited.env_var_exists("INITIAL"));
+        assert!(!inherited.env_var_exists(moonutil::constants::MOONRUN_INHERITED_POLICY));
+        inherited
+            .write_path(
+                RuntimePathBase::CurrentDirectory,
+                allowed.join("child.txt").as_os_str(),
+            )
+            .unwrap();
+        #[cfg(unix)]
+        inherited
+            .spawn_process_unix(OsStr::new("program"), &[OsString::from("program")])
+            .unwrap();
+        #[cfg(windows)]
+        inherited
+            .spawn_process_windows(OsStr::new("program.exe"))
+            .unwrap();
+    }
+
+    #[test]
+    fn snapshot_transport_is_read_only_and_protected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let policy = Policy::from_config(
+            PolicyConfig {
+                fs: Some(config::FsConfig {
+                    read: vec![PathBuf::from("*")],
+                    write: vec![PathBuf::from("*")],
+                }),
+                ..PolicyConfig::default()
+            },
+            tmp.path(),
+        )
+        .unwrap();
+        let snapshot = policy.snapshot_for_child().unwrap().unwrap();
+        let path = PathBuf::from(snapshot.transport_token());
+        assert!(std::fs::OpenOptions::new().write(true).open(&path).is_err());
+        assert_eq!(
+            policy.read_path(RuntimePathBase::CurrentDirectory, path.as_os_str()),
+            Err(AsyncHostError::PermissionDenied)
+        );
+        assert_eq!(
+            policy.write_path(RuntimePathBase::CurrentDirectory, path.as_os_str()),
+            Err(AsyncHostError::PermissionDenied)
+        );
+        assert_eq!(
+            policy.remove_path(path.parent().unwrap().as_os_str()),
+            Err(AsyncHostError::PermissionDenied)
+        );
+    }
+
+    #[test]
+    fn unrestricted_runs_do_not_create_policy_snapshots() {
+        assert!(Policy::allow_all().snapshot_for_child().unwrap().is_none());
+    }
+
+    #[test]
+    fn originating_policy_keeps_cleanup_lease_until_run_teardown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let policy = Policy::from_config(PolicyConfig::default(), tmp.path()).unwrap();
+        let snapshot = policy.snapshot_for_child().unwrap().unwrap();
+        let path = PathBuf::from(snapshot.transport_token());
+
+        drop(snapshot);
+        assert!(path.exists());
+        drop(policy);
+        assert!(!path.exists());
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn snapshot_preserves_non_utf8_filesystem_roots() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp
+            .path()
+            .join(std::ffi::OsString::from_vec(b"allowed-\xff".to_vec()));
+        std::fs::create_dir(&root).unwrap();
+        let policy = Policy::from_config(
+            PolicyConfig {
+                fs: Some(config::FsConfig {
+                    read: vec![root.clone()],
+                    write: vec![root.clone()],
+                }),
+                ..PolicyConfig::default()
+            },
+            tmp.path(),
+        )
+        .unwrap();
+
+        let snapshot = policy.snapshot_for_child().unwrap().unwrap();
+        let inherited =
+            Policy::from_inherited_snapshot(snapshot.transport_token().to_owned()).unwrap();
+        snapshot.handoff();
+
+        inherited
+            .write_path(
+                RuntimePathBase::CurrentDirectory,
+                root.join("child.txt").as_os_str(),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn snapshot_preserves_resolved_network_authority() {
+        let tmp = tempfile::tempdir().unwrap();
+        let policy = Policy::from_config(
+            PolicyConfig {
+                net: Some(config::NetConfig {
+                    dns: Vec::new(),
+                    connect: vec!["api.example.com:443".to_owned()],
+                    bind: Vec::new(),
+                }),
+                ..PolicyConfig::default()
+            },
+            tmp.path(),
+        )
+        .unwrap();
+        let resolved = ipv4_addr(Ipv4Addr::LOCALHOST, 0);
+        policy
+            .register_dns_result(OsStr::new("api.example.com"), &[resolved])
+            .unwrap();
+
+        let snapshot = policy.snapshot_for_child().unwrap().unwrap();
+        let inherited =
+            Policy::from_inherited_snapshot(snapshot.transport_token().to_owned()).unwrap();
+        snapshot.handoff();
+
+        inherited
+            .check_connect(&ipv4_addr(Ipv4Addr::LOCALHOST, 443))
             .unwrap();
     }
 

--- a/crates/moonrun/src/policy/net.rs
+++ b/crates/moonrun/src/policy/net.rs
@@ -162,6 +162,15 @@ impl NetPolicy {
             sandbox_denied(operation.sandbox_action(), Some(&target))
         }
     }
+
+    pub(super) fn resolved_connect_for_snapshot(&self) -> Vec<String> {
+        self.resolved_connect
+            .lock()
+            .unwrap()
+            .iter()
+            .map(SocketRule::describe)
+            .collect()
+    }
 }
 
 impl NetOperation {
@@ -254,6 +263,21 @@ impl SocketRule {
             SocketPortRule::Any => true,
             SocketPortRule::Exact(port) => port == addr.port,
         }
+    }
+
+    fn describe(&self) -> String {
+        let host = match &self.host {
+            SocketHostRule::Ip(IpAddr::V4(ip)) => ip.to_string(),
+            SocketHostRule::Ip(IpAddr::V6(ip)) => format!("[{ip}]"),
+            SocketHostRule::Any | SocketHostRule::Name(_) => {
+                unreachable!("resolved connect rules always contain an IP address")
+            }
+        };
+        let port = match self.port {
+            SocketPortRule::Any => "*".to_owned(),
+            SocketPortRule::Exact(port) => port.to_string(),
+        };
+        format!("{host}:{port}")
     }
 }
 

--- a/crates/moonrun/src/policy/snapshot.rs
+++ b/crates/moonrun/src/policy/snapshot.rs
@@ -1,0 +1,220 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+use super::config::{EnvConfig, FsConfig, NetConfig, PolicyConfig, ProcessConfig};
+use super::env::EnvPolicy;
+use super::fs::FsPolicy;
+use super::net::NetPolicy;
+
+mod transport;
+
+const SNAPSHOT_VERSION: u32 = 1;
+
+#[derive(Debug)]
+pub(super) struct SnapshotTemplate {
+    fs: FsConfig,
+    net: NetConfig,
+    process: ProcessConfig,
+}
+
+impl SnapshotTemplate {
+    pub(super) fn new(fs: FsConfig, net: NetConfig, process: ProcessConfig) -> Self {
+        Self { fs, net, process }
+    }
+
+    pub(super) fn write(
+        &self,
+        fs_policy: &FsPolicy,
+        net_policy: &NetPolicy,
+        env_policy: &EnvPolicy,
+    ) -> anyhow::Result<PolicySnapshot> {
+        let mut net = self.net.clone();
+        net.connect
+            .extend(net_policy.resolved_connect_for_snapshot());
+        let mut env = env_policy
+            .vars()
+            .into_iter()
+            .collect::<std::collections::BTreeMap<_, _>>();
+        env.retain(|name, _| {
+            if cfg!(windows) {
+                !name.eq_ignore_ascii_case(moonutil::constants::MOONRUN_INHERITED_POLICY)
+            } else {
+                name != moonutil::constants::MOONRUN_INHERITED_POLICY
+            }
+        });
+        let document = SnapshotDocument {
+            version: SNAPSHOT_VERSION,
+            fs: SnapshotFsConfig::from_config(&self.fs),
+            net,
+            env: EnvConfig {
+                set: env,
+                ..EnvConfig::default()
+            },
+            process: self.process.clone(),
+        };
+        let contents =
+            serde_json::to_vec(&document).context("failed to serialize policy snapshot")?;
+        Ok(PolicySnapshot {
+            transport: Arc::new(transport::SnapshotTransport::publish(&contents, fs_policy)?),
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PolicySnapshot {
+    transport: Arc<transport::SnapshotTransport>,
+}
+
+impl PolicySnapshot {
+    /// Return the opaque token that the spawn boundary must authenticate.
+    pub(crate) fn transport_token(&self) -> &OsStr {
+        self.transport.token()
+    }
+
+    /// Release the spawn Job's lease after a successful handoff.
+    ///
+    /// The originating Policy keeps a cleanup lease until the child consumes
+    /// the token or the parent Run ends.
+    pub(crate) fn handoff(self) {}
+
+    pub(super) fn is_consumed(&self) -> bool {
+        self.transport.is_consumed()
+    }
+
+    pub(super) fn consume(token: OsString) -> anyhow::Result<PolicyConfig> {
+        let contents = transport::SnapshotTransport::consume(token)?;
+        read(&contents)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotDocument {
+    version: u32,
+    fs: SnapshotFsConfig,
+    net: NetConfig,
+    env: EnvConfig,
+    process: ProcessConfig,
+}
+
+impl SnapshotDocument {
+    fn into_config(self) -> anyhow::Result<PolicyConfig> {
+        anyhow::ensure!(
+            self.version == SNAPSHOT_VERSION,
+            "unsupported policy snapshot version {}",
+            self.version
+        );
+        Ok(PolicyConfig {
+            fs: Some(self.fs.into_config()),
+            net: Some(self.net),
+            env: Some(self.env),
+            process: Some(self.process),
+        })
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotFsConfig {
+    read: Vec<SnapshotPath>,
+    write: Vec<SnapshotPath>,
+}
+
+impl SnapshotFsConfig {
+    fn from_config(config: &FsConfig) -> Self {
+        Self {
+            read: config
+                .read
+                .iter()
+                .map(|path| SnapshotPath::from_path(path.as_path()))
+                .collect(),
+            write: config
+                .write
+                .iter()
+                .map(|path| SnapshotPath::from_path(path.as_path()))
+                .collect(),
+        }
+    }
+
+    fn into_config(self) -> FsConfig {
+        FsConfig {
+            read: self.read.into_iter().map(SnapshotPath::into_path).collect(),
+            write: self
+                .write
+                .into_iter()
+                .map(SnapshotPath::into_path)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+enum SnapshotPath {
+    #[cfg(unix)]
+    Unix(Vec<u8>),
+    #[cfg(windows)]
+    Windows(Vec<u16>),
+}
+
+impl SnapshotPath {
+    fn from_path(path: &Path) -> Self {
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+
+            Self::Unix(path.as_os_str().as_bytes().to_vec())
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::ffi::OsStrExt;
+
+            Self::Windows(path.as_os_str().encode_wide().collect())
+        }
+    }
+
+    fn into_path(self) -> PathBuf {
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+
+            let Self::Unix(path) = self;
+            PathBuf::from(std::ffi::OsString::from_vec(path))
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::ffi::OsStringExt;
+
+            let Self::Windows(path) = self;
+            PathBuf::from(std::ffi::OsString::from_wide(&path))
+        }
+    }
+}
+
+pub(super) fn read(contents: &[u8]) -> anyhow::Result<PolicyConfig> {
+    let document = serde_json::from_slice::<SnapshotDocument>(contents)
+        .context("failed to parse policy snapshot")?;
+    document.into_config()
+}

--- a/crates/moonrun/src/policy/snapshot/transport.rs
+++ b/crates/moonrun/src/policy/snapshot/transport.rs
@@ -1,0 +1,198 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Process-boundary transport for policy snapshots.
+//!
+//! Snapshot serialization and process spawning depend only on this ownership
+//! protocol, not on the current temporary-file-path backend. A replacement
+//! transport must preserve three operations: publish an opaque token, retain a
+//! cleanup lease across intermediary processes, and consume the token exactly
+//! once before the child runs untrusted code.
+
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+use anyhow::Context;
+
+use super::super::fs::FsPolicy;
+
+#[derive(Debug)]
+pub(super) struct SnapshotTransport {
+    path: PathBuf,
+    fs_policy: FsPolicy,
+}
+
+impl SnapshotTransport {
+    pub(super) fn publish(contents: &[u8], fs_policy: &FsPolicy) -> anyhow::Result<Self> {
+        let mut builder = tempfile::Builder::new();
+        builder.prefix("moonrun-policy-").suffix(".json");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            // Create the file read-only from its first filesystem-visible
+            // instant. The creator's already-open handle remains writable.
+            builder.permissions(std::fs::Permissions::from_mode(0o400));
+        }
+        let mut snapshot = builder
+            .tempfile()
+            .context("failed to create temporary policy snapshot")?;
+        let snapshot_path = std::fs::canonicalize(snapshot.path())
+            .context("failed to resolve temporary policy snapshot")?;
+        let wasi_preopen = std::fs::canonicalize(
+            std::env::current_dir().context("failed to resolve the current directory")?,
+        )
+        .context("failed to resolve the WASI preopen directory")?;
+        anyhow::ensure!(
+            !snapshot_path.starts_with(&wasi_preopen),
+            "temporary policy snapshot would be reachable through the WASI preopen"
+        );
+        snapshot
+            .as_file_mut()
+            .write_all(contents)
+            .context("failed to write temporary policy snapshot")?;
+        snapshot
+            .as_file_mut()
+            .flush()
+            .context("failed to flush temporary policy snapshot")?;
+        snapshot
+            .as_file()
+            .sync_all()
+            .context("failed to sync temporary policy snapshot")?;
+
+        #[cfg(windows)]
+        {
+            let mut permissions = snapshot
+                .as_file()
+                .metadata()
+                .context("failed to inspect temporary policy snapshot")?
+                .permissions();
+            permissions.set_readonly(true);
+            snapshot
+                .as_file()
+                .set_permissions(permissions)
+                .context("failed to make temporary policy snapshot read-only")?;
+        }
+
+        let (file, _) = snapshot
+            .keep()
+            .context("failed to publish temporary policy snapshot")?;
+        drop(file);
+        fs_policy.protect_path(snapshot_path.clone());
+        Ok(Self {
+            path: snapshot_path,
+            fs_policy: fs_policy.clone(),
+        })
+    }
+
+    pub(super) fn token(&self) -> &OsStr {
+        self.path.as_os_str()
+    }
+
+    pub(super) fn is_consumed(&self) -> bool {
+        !self.path.exists()
+    }
+
+    pub(super) fn consume(token: OsString) -> anyhow::Result<Vec<u8>> {
+        let path = PathBuf::from(token);
+        let mut file = File::open(&path).context("failed to open inherited policy snapshot")?;
+        remove_snapshot(&path).context("failed to consume inherited policy snapshot")?;
+        let mut contents = Vec::new();
+        file.read_to_end(&mut contents)
+            .context("failed to read inherited policy snapshot")?;
+        Ok(contents)
+    }
+}
+
+impl Drop for SnapshotTransport {
+    fn drop(&mut self) {
+        let _ = remove_snapshot(&self.path);
+        self.fs_policy.unprotect_path(&self.path);
+    }
+}
+
+#[cfg_attr(windows, allow(clippy::permissions_set_readonly_false))]
+fn remove_snapshot(path: &std::path::Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        // Windows refuses to delete a file carrying its read-only attribute.
+        // The snapshot remains protected by Moonrun Policy while this trusted
+        // cleanup code clears the attribute and immediately removes the name.
+        let mut permissions = std::fs::metadata(path)?.permissions();
+        permissions.set_readonly(false);
+        std::fs::set_permissions(path, permissions)?;
+    }
+    std::fs::remove_file(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy() -> FsPolicy {
+        FsPolicy::from_config(
+            super::super::super::config::FsConfig {
+                read: vec![PathBuf::from("*")],
+                write: vec![PathBuf::from("*")],
+            },
+            std::path::Path::new("."),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn publisher_removes_snapshot_when_its_last_lease_is_dropped() {
+        let policy = policy();
+        let transport = SnapshotTransport::publish(b"snapshot", &policy).unwrap();
+        let path = PathBuf::from(transport.token());
+        assert!(
+            policy
+                .allows(
+                    super::super::super::fs::RuntimePathBase::CurrentDirectory,
+                    path.as_os_str(),
+                    super::super::super::fs::FsIntents::write(),
+                )
+                .is_err()
+        );
+
+        drop(transport);
+
+        assert!(!path.exists());
+        policy
+            .allows(
+                super::super::super::fs::RuntimePathBase::CurrentDirectory,
+                path.as_os_str(),
+                super::super::super::fs::FsIntents::write(),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn consumer_unlinks_snapshot() {
+        let transport = SnapshotTransport::publish(b"snapshot", &policy()).unwrap();
+        let path = PathBuf::from(transport.token());
+
+        assert_eq!(
+            SnapshotTransport::consume(path.into_os_string()).unwrap(),
+            b"snapshot"
+        );
+        assert!(transport.is_consumed());
+    }
+}

--- a/crates/moonrun/src/process/job/mod.rs
+++ b/crates/moonrun/src/process/job/mod.rs
@@ -57,6 +57,7 @@ enum Kind {
         options: SpawnOptions,
         stdio: [Option<ResourceRef>; 3],
         cwd: Option<OsString>,
+        inherited_policy: Option<crate::policy::PolicySnapshot>,
         result: Option<ResourcePublication>,
     },
     #[cfg(windows)]
@@ -66,6 +67,7 @@ enum Kind {
         options: SpawnOptions,
         stdio: [Option<ResourceRef>; 3],
         cwd: Option<OsString>,
+        inherited_policy: Option<crate::policy::PolicySnapshot>,
         result: Option<ResourcePublication>,
     },
     WaitForProcess {
@@ -101,6 +103,7 @@ impl Job {
                 options,
                 stdio: [stdin, stdout, stderr],
                 cwd,
+                inherited_policy: None,
                 result: None,
             },
         }
@@ -124,6 +127,7 @@ impl Job {
                 options,
                 stdio: [stdin, stdout, stderr],
                 cwd,
+                inherited_policy: None,
                 result: None,
             },
         }
@@ -244,6 +248,7 @@ impl Job {
                 options,
                 stdio,
                 cwd,
+                inherited_policy,
                 result,
             } => runner::run_spawn_job_unix(
                 std::mem::take(path),
@@ -251,6 +256,7 @@ impl Job {
                 std::mem::take(env),
                 std::mem::take(stdio),
                 cwd.take(),
+                inherited_policy.take(),
                 *options,
                 result,
             ),
@@ -261,12 +267,14 @@ impl Job {
                 options,
                 stdio,
                 cwd,
+                inherited_policy,
                 result,
             } => runner::run_spawn_job_windows(
                 std::mem::take(command_line),
                 std::mem::take(env),
                 std::mem::take(stdio),
                 cwd.take(),
+                inherited_policy.take(),
                 *options,
                 result,
             ),
@@ -303,6 +311,69 @@ impl Job {
                 pid,
                 ..
             } => process.check_wait(handle.is_some(), *tracked_pid, *pid),
+        }
+    }
+
+    pub(super) fn prepare_inherited_moonx(
+        &mut self,
+        policy: &crate::policy::Policy,
+    ) -> AsyncHostResult<()> {
+        match &mut self.kind {
+            #[cfg(unix)]
+            Kind::SpawnUnix {
+                args,
+                env,
+                inherited_policy,
+                ..
+            } => {
+                crate::async_sys::process::set_process_env_var(
+                    env,
+                    std::ffi::OsStr::new(moonutil::constants::MOONRUN_INHERITED_POLICY),
+                    None,
+                );
+                if !args
+                    .first()
+                    .is_some_and(|arg| moonutil::constants::is_moonx_executable(arg))
+                {
+                    return Ok(());
+                }
+                let Some(snapshot) = policy.snapshot_for_child().map_err(|error| {
+                    eprintln!("failed to snapshot sandbox policy: {error:#}");
+                    AsyncHostError::Io
+                })?
+                else {
+                    return Ok(());
+                };
+                *inherited_policy = Some(snapshot);
+                Ok(())
+            }
+            #[cfg(windows)]
+            Kind::SpawnWindows {
+                command_line,
+                env,
+                inherited_policy,
+                ..
+            } => {
+                crate::async_sys::process::set_process_env_var(
+                    env,
+                    std::ffi::OsStr::new(moonutil::constants::MOONRUN_INHERITED_POLICY),
+                    None,
+                );
+                let argv0 = moonutil::shlex::get_argv0_windows(&command_line.to_string_lossy());
+                if !moonutil::constants::is_moonx_executable(std::ffi::OsStr::new(&argv0)) {
+                    return Ok(());
+                }
+                let Some(snapshot) = policy.snapshot_for_child().map_err(|error| {
+                    eprintln!("failed to snapshot sandbox policy: {error:#}");
+                    AsyncHostError::Io
+                })?
+                else {
+                    return Ok(());
+                };
+                *inherited_policy = Some(snapshot);
+                Ok(())
+            }
+            Kind::WaitForProcess { .. } => Ok(()),
         }
     }
 
@@ -391,5 +462,82 @@ mod tests {
                 symbol.rust_symbol
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn policy_bearing_moonx_spawn_receives_a_snapshot_without_rewriting_the_command() {
+        let tmp = tempfile::tempdir().unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(
+            &policy_file,
+            r#"
+[env.set]
+UNICODE = "策略-🌙"
+
+[process]
+spawn = true
+"#,
+        )
+        .unwrap();
+        let policy = crate::policy::Policy::from_file(&policy_file).unwrap();
+        let mut job = Job::spawn_unix(
+            OsString::from("moon"),
+            vec![
+                OsString::from("moonx"),
+                OsString::from("user/module"),
+                OsString::from("参数-🌙"),
+            ],
+            vec![OsString::from("MOONRUN_INHERITED_POLICY=guest")],
+            None,
+            None,
+            None,
+            None,
+            SpawnOptions {
+                child_signal_mask: unsafe { std::mem::zeroed() },
+            },
+        );
+
+        job.prepare_inherited_moonx(&policy).unwrap();
+
+        let Kind::SpawnUnix {
+            path,
+            args,
+            env,
+            inherited_policy,
+            ..
+        } = &job.kind
+        else {
+            unreachable!()
+        };
+        assert_eq!(path, "moon");
+        assert_eq!(args, &["moonx", "user/module", "参数-🌙"]);
+        assert!(env.is_empty());
+        assert!(inherited_policy.is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ordinary_spawn_cannot_supply_inherited_policy_capability() {
+        let mut job = Job::spawn_unix(
+            OsString::from("program"),
+            vec![OsString::from("program")],
+            vec![OsString::from("MOONRUN_INHERITED_POLICY=guest")],
+            None,
+            None,
+            None,
+            None,
+            SpawnOptions {
+                child_signal_mask: unsafe { std::mem::zeroed() },
+            },
+        );
+
+        job.prepare_inherited_moonx(&crate::policy::Policy::allow_all())
+            .unwrap();
+
+        let Kind::SpawnUnix { env, .. } = &job.kind else {
+            unreachable!()
+        };
+        assert!(env.is_empty());
     }
 }

--- a/crates/moonrun/src/process/job/runner.rs
+++ b/crates/moonrun/src/process/job/runner.rs
@@ -54,6 +54,7 @@ ported_fns! {
         env: Vec<OsString>,
         stdio: [Option<ResourceRef>; 3],
         cwd: Option<OsString>,
+        inherited_policy: Option<crate::policy::PolicySnapshot>,
         options: SpawnOptions,
         result: &mut Option<ResourcePublication>,
     ) -> AsyncHostResult<i64> {
@@ -63,6 +64,7 @@ ported_fns! {
             env,
             stdio,
             cwd,
+            inherited_policy,
             options,
             result,
         )
@@ -79,6 +81,7 @@ ported_fns! {
         env: Vec<u16>,
         stdio: [Option<ResourceRef>; 3],
         cwd: Option<OsString>,
+        inherited_policy: Option<crate::policy::PolicySnapshot>,
         options: SpawnOptions,
         result: &mut Option<ResourcePublication>,
     ) -> AsyncHostResult<i64> {
@@ -87,6 +90,7 @@ ported_fns! {
             env,
             stdio,
             cwd,
+            inherited_policy,
             options,
             result,
         )
@@ -121,11 +125,21 @@ fn spawn_process_unix(
     env: Vec<OsString>,
     stdio: [Option<ResourceRef>; 3],
     cwd: Option<OsString>,
+    inherited_policy: Option<crate::policy::PolicySnapshot>,
     options: SpawnOptions,
     result: &mut Option<ResourcePublication>,
 ) -> AsyncHostResult<i64> {
     #[cfg(not(target_os = "linux"))]
     let _ = result;
+
+    let mut env = env;
+    crate::async_sys::process::set_process_env_var(
+        &mut env,
+        std::ffi::OsStr::new(moonutil::constants::MOONRUN_INHERITED_POLICY),
+        inherited_policy
+            .as_ref()
+            .map(crate::policy::PolicySnapshot::transport_token),
+    );
 
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     let posix_spawn_addchdir = match cwd.as_ref() {
@@ -147,6 +161,9 @@ fn spawn_process_unix(
             std::env::var_os("PATH"),
         )
         .map_err(AsyncHostError::Native)?;
+        if let Some(snapshot) = inherited_policy {
+            snapshot.handoff();
+        }
         if let Ok(pidfd) = crate::async_sys::process::open_pid_handle(pid) {
             *result = Some(ResourcePublication::Unpublished(Resource::new(pidfd)));
         }
@@ -263,6 +280,9 @@ fn spawn_process_unix(
 
     match spawn_result {
         Ok(pid) => {
+            if let Some(snapshot) = inherited_policy {
+                snapshot.handoff();
+            }
             #[cfg(target_os = "linux")]
             if let Ok(pidfd) = crate::async_sys::process::open_pid_handle(pid) {
                 *result = Some(ResourcePublication::Unpublished(Resource::new(pidfd)));
@@ -411,9 +431,10 @@ fn add_chdir_file_action(
 #[allow(clippy::too_many_arguments)]
 fn spawn_process_windows(
     command_line: OsString,
-    env_block: Vec<u16>,
+    mut env_block: Vec<u16>,
     stdio: [Option<ResourceRef>; 3],
     cwd: Option<OsString>,
+    inherited_policy: Option<crate::policy::PolicySnapshot>,
     options: SpawnOptions,
     result: &mut Option<ResourcePublication>,
 ) -> AsyncHostResult<i64> {
@@ -430,8 +451,6 @@ fn spawn_process_windows(
         STARTUPINFOEXW, TerminateProcess, UpdateProcThreadAttribute,
     };
 
-    let mut command_line = command_line.encode_wide().collect::<Vec<_>>();
-    command_line.push(0);
     let cwd = cwd.map(|cwd| {
         let mut cwd = cwd.encode_wide().collect::<Vec<_>>();
         cwd.push(0);
@@ -471,6 +490,15 @@ fn spawn_process_windows(
             }
         }
     }
+    crate::async_sys::process::set_process_env_var(
+        &mut env_block,
+        std::ffi::OsStr::new(moonutil::constants::MOONRUN_INHERITED_POLICY),
+        inherited_policy
+            .as_ref()
+            .map(crate::policy::PolicySnapshot::transport_token),
+    );
+    let mut command_line = command_line.encode_wide().collect::<Vec<_>>();
+    command_line.push(0);
 
     let mut startup_info = unsafe { std::mem::zeroed::<STARTUPINFOEXW>() };
     startup_info.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
@@ -606,6 +634,9 @@ fn spawn_process_windows(
     *result = Some(ResourcePublication::Unpublished(Resource::new(
         process_info.hProcess,
     )));
+    if let Some(snapshot) = inherited_policy {
+        snapshot.handoff();
+    }
     Ok(i64::from(process_info.dwProcessId))
 }
 
@@ -905,6 +936,12 @@ fn last_native_errno() -> i32 {
 mod tests {
     use super::*;
 
+    fn empty_signal_mask() -> libc::sigset_t {
+        let mut mask = unsafe { std::mem::zeroed() };
+        assert_eq!(unsafe { libc::sigemptyset(&mut mask) }, 0);
+        mask
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn missing_addchdir_api_reports_enosys() {
@@ -939,6 +976,52 @@ mod tests {
             run_wait_for_process_job(None, pid, false),
             Ok(-i64::from(libc::SIGTERM))
         );
+    }
+
+    #[test]
+    fn inherited_policy_token_overrides_guest_env_and_is_readable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(
+            &policy_file,
+            r#"
+[env.set]
+SECRET = "策略-🌙"
+
+[process]
+spawn = true
+"#,
+        )
+        .unwrap();
+        let policy = crate::policy::Policy::from_file(&policy_file).unwrap();
+        let snapshot = policy.snapshot_for_child().unwrap().unwrap();
+        let mut result = None;
+
+        let pid = run_spawn_job_unix(
+            OsString::from("/bin/sh"),
+            vec![
+                OsString::from("sh"),
+                OsString::from("-c"),
+                OsString::from(concat!(
+                    "test \"$MOONRUN_INHERITED_POLICY\" != guest && ",
+                    "test -r \"$MOONRUN_INHERITED_POLICY\" && ",
+                    "{ IFS= read -r first < \"$MOONRUN_INHERITED_POLICY\" || ",
+                    "test -n \"$first\"; } && ",
+                    "rm -f \"$MOONRUN_INHERITED_POLICY\""
+                )),
+            ],
+            vec![OsString::from("MOONRUN_INHERITED_POLICY=guest")],
+            [None, None, None],
+            None,
+            Some(snapshot),
+            SpawnOptions {
+                child_signal_mask: empty_signal_mask(),
+            },
+            &mut result,
+        )
+        .unwrap();
+
+        assert_eq!(run_wait_for_process_job(None, pid as i32, false), Ok(0));
     }
 }
 

--- a/crates/moonrun/src/process/mod.rs
+++ b/crates/moonrun/src/process/mod.rs
@@ -63,6 +63,10 @@ impl HostProcess {
         job.check_policy(self)
     }
 
+    pub(crate) fn prepare_job(&self, job: &mut Job) -> AsyncHostResult<()> {
+        job.prepare_inherited_moonx(&self.policy)
+    }
+
     pub(crate) fn finish_job(&self, job: &Job, ret: i64, err: i32) -> AsyncHostResult<()> {
         job.finish(self, ret, err)
     }

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -969,12 +969,33 @@ fn test_moon_run_policy_with_workspace_async_fs() {
     let env_mutate_wasm = wasm_file("env_mutate");
     let listen_implicit_bind_wasm = wasm_file("listen_implicit_bind");
     let process_env_wasm = wasm_file("process_env");
+    let spawn_moonx_wasm = wasm_file("spawn_moonx");
     let policy_file = std::fs::canonicalize(dir.path().join("policy.toml")).unwrap();
     let deny_all_policy_file = std::fs::canonicalize(dir.path().join("deny-all.toml")).unwrap();
     let process_any_args_policy_file =
         std::fs::canonicalize(dir.path().join("process-any-args.toml")).unwrap();
     let process_prefix_deny_policy_file =
         std::fs::canonicalize(dir.path().join("process-prefix-deny.toml")).unwrap();
+    let moonx_policy_file = std::fs::canonicalize(dir.path().join("moonx-policy.toml")).unwrap();
+
+    let moon_home = tempfile::tempdir().unwrap();
+    let moonx_bin_dir = tempfile::tempdir().unwrap();
+    let moonx_bin = moonx_bin_dir
+        .path()
+        .join(if cfg!(windows) { "moonx.exe" } else { "moonx" });
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(moon_bin(), &moonx_bin).unwrap();
+    #[cfg(windows)]
+    std::fs::copy(moon_bin(), &moonx_bin).unwrap();
+    let moonx_path = std::env::join_paths(std::iter::once(moonx_bin_dir.path().to_owned()).chain(
+        std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()),
+    ))
+    .unwrap();
+    let cached_moonx_wasm = moon_home
+        .path()
+        .join("registry/cache/assets/moonrun/policy-test/1.0.0/cmd/env/env.wasm");
+    std::fs::create_dir_all(cached_moonx_wasm.parent().unwrap()).unwrap();
+    std::fs::copy(&env_get_wasm, cached_moonx_wasm).unwrap();
 
     #[cfg(not(windows))]
     let fs_deny_read_stdout = snapbox::str![[r#"
@@ -1062,6 +1083,34 @@ OSError("[..]@fs.open()[..]denied/secret.txt[..]Access is denied.")
         .success()
         .stdout_eq("spawn denied\n")
         .stderr_eq("Sandbox policy blocked process spawn\n");
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .current_dir(dir.path())
+        .env("MOON_HOME", moon_home.path())
+        .env("MOONRUN_OVERRIDE", snapbox::cmd::cargo_bin!("moonrun"))
+        .env("PATH", &moonx_path)
+        .arg("--policy")
+        .arg(&moonx_policy_file)
+        .arg(&spawn_moonx_wasm)
+        .assert()
+        .success()
+        .stdout_eq("inherited policy 🌙\n")
+        .stderr_eq("");
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .current_dir(dir.path())
+        .env("MOON_HOME", moon_home.path())
+        .env("MOONRUN_OVERRIDE", snapbox::cmd::cargo_bin!("moonrun"))
+        .env("PATH", &moonx_path)
+        .arg("--policy")
+        .arg(&moonx_policy_file)
+        .arg(&spawn_moonx_wasm)
+        .arg("--")
+        .arg("native")
+        .assert()
+        .success()
+        .stdout_eq("nested moonx exited with code 255\n")
+        .stderr_eq("Error: a sandboxed moonx invocation cannot use --target native\n");
 
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
         .current_dir(dir.path())

--- a/crates/moonrun/tests/test_cases/test_policy_workspace.in/moonx-policy.toml
+++ b/crates/moonrun/tests/test_cases/test_policy_workspace.in/moonx-policy.toml
@@ -1,0 +1,32 @@
+# moon: The build system and package manager for MoonBit.
+# Copyright (C) 2024 International Digital Economy Academy
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+[env]
+from_host = ["MOON_HOME", "MOONRUN_OVERRIDE", "PATH"]
+
+[env.set]
+MOONRUN_POLICY_ENV = "inherited policy 🌙"
+MOONRUN_INHERITED_POLICY = "guest forgery"
+
+[[process.allow]]
+program = "moonx"
+args_prefix = ["moonrun/policy-test/cmd/env@1.0.0"]
+
+[[process.allow]]
+program = "moonx"
+args_prefix = ["--target", "native", "moonrun/policy-test/cmd/env@1.0.0"]

--- a/crates/moonrun/tests/test_cases/test_policy_workspace.in/spawn_moonx/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_policy_workspace.in/spawn_moonx/main.mbt
@@ -1,0 +1,33 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+///|
+async fn main {
+  let args = @env.args()
+  let moonx_args = if args.length() > 1 && args[1] == "native" {
+    ["--target", "native", "moonrun/policy-test/cmd/env@1.0.0"]
+  } else {
+    ["moonrun/policy-test/cmd/env@1.0.0"]
+  }
+  let (code, output) = @process.collect_stdout("moonx", moonx_args)
+  if code != 0 {
+    println("nested moonx exited with code \{code}")
+    return
+  }
+  println(output.text().trim(char_set="\n\r "))
+}

--- a/crates/moonrun/tests/test_cases/test_policy_workspace.in/spawn_moonx/moon.pkg
+++ b/crates/moonrun/tests/test_cases/test_policy_workspace.in/spawn_moonx/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/io",
+  "moonbitlang/async/process",
+  "moonbitlang/core/env",
+}
+
+options(
+  "is-main": true,
+)

--- a/crates/moonutil/src/constants.rs
+++ b/crates/moonutil/src/constants.rs
@@ -26,6 +26,18 @@ pub const MOON_PKG_JSON: &str = "moon.pkg.json";
 pub const MOON_WORK: &str = "moon.work";
 pub const MOON_WORK_ENV: &str = "MOON_WORK";
 pub const MOON_NO_WORKSPACE: &str = "MOON_NO_WORKSPACE";
+/// Host-only token used to hand an effective policy snapshot to a moonrun child.
+pub const MOONRUN_INHERITED_POLICY: &str = "MOONRUN_INHERITED_POLICY";
+
+pub fn is_moonx_executable(path: &std::ffi::OsStr) -> bool {
+    std::path::Path::new(path).file_name().is_some_and(|name| {
+        if cfg!(windows) {
+            name.eq_ignore_ascii_case("moonx") || name.eq_ignore_ascii_case("moonx.exe")
+        } else {
+            name == "moonx" || name == "moonx.exe"
+        }
+    })
+}
 pub const MOON_PKG: &str = "moon.pkg";
 pub const MBTI_GENERATED: &str = "pkg.generated.mbti";
 pub const MBTI_USER_WRITTEN: &str = "pkg.mbti";

--- a/crates/moonutil/src/shlex.rs
+++ b/crates/moonutil/src/shlex.rs
@@ -99,20 +99,18 @@ pub fn split_argv0_windows(args: &str) -> (String, &str) {
 }
 
 fn parse_windows_argv0(args: &str) -> (String, &str) {
-    let (quoted, rest) = if let Some(rest) = args.strip_prefix('"') {
-        (true, rest)
-    } else {
-        (false, args)
-    };
-    for (i, c) in rest.char_indices() {
-        // Exit condition
-        if quoted && c == '"' {
-            return (rest[..i].to_string(), &rest[i + 1..]);
-        } else if !quoted && c.is_whitespace() {
-            return (rest[..i].to_string(), &rest[i..]);
+    let mut argv0 = String::new();
+    let mut in_quotes = false;
+    for (index, c) in args.char_indices() {
+        if c == '"' {
+            in_quotes = !in_quotes;
+        } else if !in_quotes && c.is_whitespace() {
+            return (argv0, &args[index..]);
+        } else {
+            argv0.push(c);
         }
     }
-    (rest.to_string(), "")
+    (argv0, "")
 }
 
 fn next_windows_arg(mut args: &str) -> Option<(String, &str)> {

--- a/crates/moonutil/src/shlex/tests.rs
+++ b/crates/moonutil/src/shlex/tests.rs
@@ -79,6 +79,10 @@ fn argv0_parsing() {
     let (argv0, rest) = parse_windows_argv0(r#"C:\app.exe"#);
     assert_eq!(argv0, r#"C:\app.exe"#);
     assert_eq!(rest, "");
+
+    let (argv0, rest) = parse_windows_argv0(r#""moon"x user/module"#);
+    assert_eq!(argv0, "moonx");
+    assert_eq!(rest, " user/module");
 }
 
 #[test]


### PR DESCRIPTION
## Why

A policy-bearing Moonrun guest can invoke moonx, whose registry Wasm is then executed by a new moonrun process. Without an authoritative handoff, that nested Run would not be governed by the policy currently applied to its parent. Reusing the source policy file would also rematerialize environment and network state and could observe later file changes.

## What

- Serialize the effective Moonrun Policy, including canonical filesystem roots, materialized environment values, resolved network authority, and process rules.
- Publish it through an opaque snapshot transport backed by a protected, read-only temporary file outside the WASI preopen.
- Detect approved moonx process Jobs after policy checking and inject the reserved transport value at the final host spawn boundary, overriding any guest-provided value without lossy environment conversion.
- Have moonx remove the internal value before registry work, relay it only to the final nested moonrun, reject inherited native execution, and keep the parent snapshot authoritative.
- Retain cleanup ownership in the originating Policy while the child consumes and unlinks the snapshot.

## Why this is correct

The snapshot captures the policy already governing the parent rather than reopening its source. Policy authorization still precedes the special handling, ordinary child processes cannot supply the reserved value, and the transport token remains opaque outside the transport module. The temporary backend can therefore be replaced independently later.

## Scope

This PR intentionally keeps the existing moonrun to moonx to moonrun process topology. A separate follow-up will make moonrun execute inherited moonx requests directly and remove the intermediate relay.