### PR TITLE
refactor(moonrun): separate runtime environment state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,7 @@ dependencies = [
  "slotmap",
  "snapbox",
  "tempfile",
+ "thiserror 1.0.63",
  "tokio",
  "toml",
  "v8",

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -52,6 +52,14 @@ operations before moonrun performs them. It does not implicitly configure or
 restrict WASI descriptors.
 _Avoid_: WASI sandbox, virtual filesystem
 
+**Env**:
+The environment interface selected for one Run. Moonrun Policy contributes
+only its startup selection; runtime reads and mutations go through Env instead
+of treating Policy as mutable state. The current unrestricted mode retains its
+legacy process-environment write-through behavior; Run-owned isolation is a
+separate behavior change.
+_Avoid_: Mutable policy, per-import environment map
+
 **WASI Capability Surface**:
 The files and directories reachable through WASI descriptors and preopens.
 WASI access is configured separately from Moonrun Policy, even when both

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -29,6 +29,7 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true
+thiserror.workspace = true
 libsqlite3-sys.workspace = true
 slotmap.workspace = true
 toml = { workspace = true, features = ["parse", "serde", "std"] }

--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -43,7 +43,7 @@ pub(super) fn get_curr_env(context: &mut ImportContext<'_, '_>) -> u64 {
 #[ported(source = "src/process/windows.c", original = "moonbitlang_async_get_curr_env")]
 #[cfg(windows)]
 pub(super) fn get_curr_env(context: &mut ImportContext<'_, '_>) -> AsyncHostResult<u64> {
-    let env = windows_env_block(inherited_windows_env(context)?);
+    let env = windows_env_block(inherited_windows_env(context));
     Ok(context.host.insert_process_env(env))
 }
 
@@ -186,7 +186,7 @@ pub(super) fn make_env(
     let inherited = if inherit_env == 0 {
         Vec::new()
     } else {
-        inherited_windows_env(context)?
+        inherited_windows_env(context)
     };
     Ok(context.host.insert_process_env_builder(inherited))
 }
@@ -437,92 +437,32 @@ pub(super) fn kill(context: &mut ImportContext<'_, '_>, pid: i32) -> AsyncHostRe
 
 #[cfg(unix)]
 fn inherited_unix_env(context: &ImportContext<'_, '_>) -> Vec<OsString> {
-    if context.host.policy().has_env_policy() {
-        context
-            .host
-            .policy()
-            .env_vars()
-            .into_iter()
-            .map(|(key, value)| OsString::from(format!("{key}={value}")))
-            .collect()
-    } else {
-        current_unix_env()
-    }
-}
-
-#[cfg(unix)]
-fn current_unix_env() -> Vec<OsString> {
-    use std::ffi::CStr;
-    use std::os::unix::ffi::OsStringExt;
-
-    unsafe extern "C" {
-        static mut environ: *mut *mut libc::c_char;
-    }
-
-    let mut entries = Vec::new();
-    let mut cursor = unsafe { environ };
-    while !cursor.is_null() {
-        let entry = unsafe { *cursor };
-        if entry.is_null() {
-            break;
-        }
-        entries.push(OsString::from_vec(
-            unsafe { CStr::from_ptr(entry) }.to_bytes().to_vec(),
-        ));
-        cursor = unsafe { cursor.add(1) };
-    }
-    entries
+    context
+        .host
+        .environment()
+        .inherited_entries()
+        .into_iter()
+        .map(|(mut name, value)| {
+            name.push("=");
+            name.push(value);
+            name
+        })
+        .collect()
 }
 
 #[cfg(windows)]
-fn inherited_windows_env(context: &ImportContext<'_, '_>) -> AsyncHostResult<Vec<OsString>> {
-    if context.host.policy().has_env_policy() {
-        Ok(context
-            .host
-            .policy()
-            .env_vars()
-            .into_iter()
-            .map(|(key, value)| OsString::from(format!("{key}={value}")))
-            .collect())
-    } else {
-        current_windows_env()
-    }
-}
-
-#[cfg(windows)]
-fn current_windows_env() -> AsyncHostResult<Vec<OsString>> {
-    use std::os::windows::ffi::OsStringExt;
-    use windows_sys::Win32::Foundation::GetLastError;
-    use windows_sys::Win32::System::Environment::{
-        FreeEnvironmentStringsW, GetEnvironmentStringsW,
-    };
-
-    let block = unsafe { GetEnvironmentStringsW() };
-    if block.is_null() {
-        return Err(AsyncHostError::Native(unsafe { GetLastError() } as i32));
-    }
-
-    let mut entries = Vec::new();
-    let mut cursor = block;
-    loop {
-        let mut len = 0usize;
-        while unsafe { *cursor.add(len) } != 0 {
-            len += 1;
-        }
-        if len == 0 {
-            break;
-        }
-        if unsafe { *cursor } != b'=' as u16 {
-            let entry = unsafe { std::slice::from_raw_parts(cursor, len) };
-            entries.push(OsString::from_wide(entry));
-        }
-        cursor = unsafe { cursor.add(len + 1) };
-    }
-    unsafe {
-        FreeEnvironmentStringsW(block);
-    }
-
-    Ok(entries)
+fn inherited_windows_env(context: &ImportContext<'_, '_>) -> Vec<OsString> {
+    context
+        .host
+        .environment()
+        .inherited_entries()
+        .into_iter()
+        .map(|(mut name, value)| {
+            name.push("=");
+            name.push(value);
+            name
+        })
+        .collect()
 }
 
 #[cfg(windows)]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -52,6 +52,7 @@ use crate::async_sys::internal::event_loop::{
 };
 use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::socket::RawSocket;
+use crate::env::Env;
 use crate::guest_memory::{GuestMemory, GuestMemoryError};
 pub(crate) use crate::host::HostKey as HandleKey;
 use crate::host::{HostKeys, HostResourceKind as HandleKind};
@@ -1200,6 +1201,7 @@ pub(crate) struct AsyncHost {
     // that ownership; worker threads own their Jobs and return them through the
     // completion channel instead of sharing the host's tables.
     policy: Arc<Policy>,
+    environment: Arc<Env>,
     temp_dir: TempDir,
     network: HostNetwork,
     errno: Cell<i32>,
@@ -1223,6 +1225,7 @@ pub(crate) struct AsyncHost {
     tls_error: RefCell<Option<String>>,
 }
 
+#[cfg(test)]
 impl Default for AsyncHost {
     fn default() -> Self {
         Self::new(Arc::new(Policy::allow_all()))
@@ -1230,16 +1233,31 @@ impl Default for AsyncHost {
 }
 
 impl AsyncHost {
+    #[cfg(test)]
     pub(crate) fn new(policy: Arc<Policy>) -> Self {
-        Self::with_keys(policy, Rc::new(RefCell::new(HostKeys::default())))
+        let environment = Arc::new(
+            policy
+                .realize_env()
+                .expect("construct test Host environment"),
+        );
+        Self::with_keys(
+            policy,
+            environment,
+            Rc::new(RefCell::new(HostKeys::default())),
+        )
     }
 
-    pub(crate) fn with_keys(policy: Arc<Policy>, keys: Rc<RefCell<HostKeys>>) -> Self {
+    pub(crate) fn with_keys(
+        policy: Arc<Policy>,
+        environment: Arc<Env>,
+        keys: Rc<RefCell<HostKeys>>,
+    ) -> Self {
         let process = HostProcess::new(Arc::clone(&policy));
         let network = HostNetwork::new(Arc::clone(&policy));
-        let temp_dir = TempDir::new(Arc::clone(&policy));
+        let temp_dir = TempDir::new(Arc::clone(&environment), &policy);
         Self {
             policy,
+            environment,
             temp_dir,
             network,
             errno: Cell::new(0),
@@ -2635,6 +2653,10 @@ impl AsyncHost {
 
     pub(crate) fn policy(&self) -> &Policy {
         &self.policy
+    }
+
+    pub(crate) fn environment(&self) -> &Env {
+        &self.environment
     }
 
     pub(crate) fn temp_dir(&self) -> AsyncHostResult<OsString> {

--- a/crates/moonrun/src/engine.rs
+++ b/crates/moonrun/src/engine.rs
@@ -125,7 +125,9 @@ impl fmt::Debug for Module {
 ///
 /// The current implementation still uses process stdio, environment, working
 /// directory, and signal compatibility behavior. Those remain shared,
-/// process-scoped dependencies to extract in later changes.
+/// process-scoped dependencies to extract in later changes. In particular,
+/// unrestricted guest environment mutations write through to the process and
+/// must not race other process-environment access.
 #[derive(Clone, Debug)]
 pub struct Engine {
     config: EngineConfig,
@@ -180,6 +182,11 @@ impl Engine {
             )?,
             None => policy::Policy::allow_all(),
         });
+        let environment = Arc::new(
+            policy
+                .realize_env()
+                .context("failed to construct the Run environment")?,
+        );
         v8_backend::run(
             &self.config,
             module.name(),
@@ -187,6 +194,7 @@ impl Engine {
             module.source_map(),
             options,
             policy,
+            environment,
         )
     }
 

--- a/crates/moonrun/src/env.rs
+++ b/crates/moonrun/src/env.rs
@@ -1,0 +1,466 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Runtime environment state behind moonrun's environment seam.
+//!
+//! Callers use one native-string interface regardless of whether the Run uses
+//! moonrun's legacy ambient environment or an owned environment realized from
+//! policy. The ambient backing deliberately preserves the existing write-
+//! through contract: the embedder must serialize process-environment access.
+//! A later isolation change can replace that backing without changing callers.
+
+use std::ffi::{OsStr, OsString};
+use std::io;
+use std::sync::RwLock;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum EnvError {
+    #[error("invalid environment variable name {0:?}")]
+    InvalidName(OsString),
+    #[error("environment variable {0:?} contains a NUL in its value")]
+    ValueContainsNul(OsString),
+    #[error("failed to set environment variable {name:?}")]
+    Set {
+        name: OsString,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to unset environment variable {name:?}")]
+    Unset {
+        name: OsString,
+        #[source]
+        source: io::Error,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) struct Env {
+    backing: EnvBacking,
+}
+
+#[derive(Debug)]
+enum EnvBacking {
+    Ambient,
+    Owned(RwLock<Vec<(OsString, OsString)>>),
+}
+
+impl Env {
+    pub(crate) fn ambient() -> Self {
+        Self {
+            backing: EnvBacking::Ambient,
+        }
+    }
+
+    pub(crate) fn owned(
+        entries: impl IntoIterator<Item = (OsString, OsString)>,
+    ) -> Result<Self, EnvError> {
+        let mut entries = entries.into_iter().collect::<Vec<_>>();
+        for (name, value) in &entries {
+            validate_initial_entry(name, value)?;
+        }
+        let mut normalized = Vec::with_capacity(entries.len());
+        for (name, value) in entries.drain(..) {
+            insert(&mut normalized, name, value);
+        }
+        Ok(Self {
+            backing: EnvBacking::Owned(RwLock::new(normalized)),
+        })
+    }
+
+    pub(crate) fn get(&self, name: &OsStr) -> Option<OsString> {
+        if !os::valid_initial_name(name) {
+            return None;
+        }
+        match &self.backing {
+            EnvBacking::Ambient => std::env::var_os(name),
+            EnvBacking::Owned(entries) => entries
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .iter()
+                .find(|(stored, _)| os::names_equal(stored, name))
+                .map(|(_, value)| value.clone()),
+        }
+    }
+
+    pub(crate) fn set(&self, name: OsString, value: OsString) -> Result<(), EnvError> {
+        validate_mutation(&name, &value)?;
+        match &self.backing {
+            EnvBacking::Ambient => {
+                // This preserves moonrun's existing unrestricted behavior. A
+                // later isolation change can replace this backing without
+                // changing Env's interface or its consumers.
+                // SAFETY: the legacy ambient contract requires the embedder to
+                // serialize all process-environment access while a Run mutates it.
+                unsafe { os::set(&name, &value) }.map_err(|source| EnvError::Set {
+                    name: name.clone(),
+                    source,
+                })?;
+            }
+            EnvBacking::Owned(entries) => insert(
+                &mut entries
+                    .write()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()),
+                name,
+                value,
+            ),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn unset(&self, name: &OsStr) -> Result<(), EnvError> {
+        validate_name(name)?;
+        match &self.backing {
+            EnvBacking::Ambient => {
+                // See the compatibility note in `set`.
+                // SAFETY: the same legacy serialization contract applies here.
+                unsafe { os::unset(name) }.map_err(|source| EnvError::Unset {
+                    name: name.to_owned(),
+                    source,
+                })?;
+            }
+            EnvBacking::Owned(entries) => {
+                let mut entries = entries
+                    .write()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if let Some(index) = entries
+                    .iter()
+                    .position(|(stored, _)| os::names_equal(stored, name))
+                {
+                    entries.remove(index);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn entries(&self) -> Vec<(OsString, OsString)> {
+        match &self.backing {
+            EnvBacking::Ambient => {
+                // `vars_os` preserves native values. On Windows it is backed
+                // by GetEnvironmentStringsW; failure to obtain the process
+                // block is a process-wide condition from which no Run can
+                // usefully recover.
+                std::env::vars_os().collect()
+            }
+            EnvBacking::Owned(entries) => entries
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone(),
+        }
+    }
+
+    /// Entries inherited by a child created from this environment.
+    ///
+    /// This retains moonrun's existing Windows behavior: ambient drive-current
+    /// pseudo entries are omitted, while an owned policy environment keeps the
+    /// entries selected at startup. Process-block encoding stays in the process
+    /// adapter.
+    pub(crate) fn inherited_entries(&self) -> Vec<(OsString, OsString)> {
+        match &self.backing {
+            EnvBacking::Ambient => os::inherited_entries(),
+            EnvBacking::Owned(_) => self.entries(),
+        }
+    }
+}
+
+fn insert(entries: &mut Vec<(OsString, OsString)>, name: OsString, value: OsString) {
+    if let Some((stored_name, stored_value)) = entries
+        .iter_mut()
+        .find(|(stored, _)| os::names_equal(stored, &name))
+    {
+        *stored_name = name;
+        *stored_value = value;
+    } else {
+        entries.push((name, value));
+    }
+    entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+}
+
+fn validate_initial_entry(name: &OsStr, value: &OsStr) -> Result<(), EnvError> {
+    if !os::valid_initial_name(name) {
+        return Err(EnvError::InvalidName(name.to_owned()));
+    }
+    if os::contains_nul(value) {
+        return Err(EnvError::ValueContainsNul(name.to_owned()));
+    }
+    Ok(())
+}
+
+fn validate_mutation(name: &OsStr, value: &OsStr) -> Result<(), EnvError> {
+    validate_name(name)?;
+    if os::contains_nul(value) {
+        return Err(EnvError::ValueContainsNul(name.to_owned()));
+    }
+    Ok(())
+}
+
+fn validate_name(name: &OsStr) -> Result<(), EnvError> {
+    if !os::valid_name(name) {
+        return Err(EnvError::InvalidName(name.to_owned()));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+mod os {
+    use super::*;
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    pub(super) fn valid_initial_name(name: &OsStr) -> bool {
+        if valid_name(name) {
+            return true;
+        }
+        let name = name.as_bytes();
+        name.first() == Some(&b'=') && name[1..].iter().all(|&byte| byte != b'=' && byte != 0)
+    }
+
+    pub(super) fn valid_name(name: &OsStr) -> bool {
+        let name = name.as_bytes();
+        !name.is_empty() && !name.contains(&b'=') && !name.contains(&0)
+    }
+
+    pub(super) fn contains_nul(value: &OsStr) -> bool {
+        value.as_bytes().contains(&0)
+    }
+
+    pub(super) fn names_equal(left: &OsStr, right: &OsStr) -> bool {
+        left == right
+    }
+
+    pub(super) fn inherited_entries() -> Vec<(OsString, OsString)> {
+        std::env::vars_os().collect()
+    }
+
+    pub(super) unsafe fn set(name: &OsStr, value: &OsStr) -> io::Result<()> {
+        let name = CString::new(name.as_bytes()).map_err(invalid_input)?;
+        let value = CString::new(value.as_bytes()).map_err(invalid_input)?;
+        if unsafe { libc::setenv(name.as_ptr(), value.as_ptr(), 1) } == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    pub(super) unsafe fn unset(name: &OsStr) -> io::Result<()> {
+        let name = CString::new(name.as_bytes()).map_err(invalid_input)?;
+        if unsafe { libc::unsetenv(name.as_ptr()) } == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn invalid_input(error: std::ffi::NulError) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidInput, error)
+    }
+}
+
+#[cfg(windows)]
+mod os {
+    use super::*;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Globalization::{CSTR_EQUAL, CompareStringOrdinal};
+    use windows_sys::Win32::System::Environment::SetEnvironmentVariableW;
+
+    pub(super) fn valid_initial_name(name: &OsStr) -> bool {
+        let mut name = name.encode_wide();
+        match name.next() {
+            Some(first) if first == b'=' as u16 => {
+                name.all(|unit| unit != b'=' as u16 && unit != 0)
+            }
+            Some(first) if first != 0 => name.all(|unit| unit != b'=' as u16 && unit != 0),
+            _ => false,
+        }
+    }
+
+    pub(super) fn valid_name(name: &OsStr) -> bool {
+        let mut name = name.encode_wide();
+        match name.next() {
+            Some(first) if first != b'=' as u16 && first != 0 => {
+                name.all(|unit| unit != b'=' as u16 && unit != 0)
+            }
+            _ => false,
+        }
+    }
+
+    pub(super) fn contains_nul(value: &OsStr) -> bool {
+        value.encode_wide().any(|unit| unit == 0)
+    }
+
+    pub(super) fn names_equal(left: &OsStr, right: &OsStr) -> bool {
+        let left = left.encode_wide().collect::<Vec<_>>();
+        let right = right.encode_wide().collect::<Vec<_>>();
+        let (Ok(left_len), Ok(right_len)) = (i32::try_from(left.len()), i32::try_from(right.len()))
+        else {
+            return left == right;
+        };
+        (unsafe { CompareStringOrdinal(left.as_ptr(), left_len, right.as_ptr(), right_len, 1) })
+            == CSTR_EQUAL
+    }
+
+    pub(super) fn inherited_entries() -> Vec<(OsString, OsString)> {
+        std::env::vars_os()
+            .filter(|(name, _)| name.encode_wide().next() != Some(b'=' as u16))
+            .collect()
+    }
+
+    pub(super) unsafe fn set(name: &OsStr, value: &OsStr) -> io::Result<()> {
+        let name = wide_null(name);
+        let value = wide_null(value);
+        if unsafe { SetEnvironmentVariableW(name.as_ptr(), value.as_ptr()) } != 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    pub(super) unsafe fn unset(name: &OsStr) -> io::Result<()> {
+        let name = wide_null(name);
+        if unsafe { SetEnvironmentVariableW(name.as_ptr(), std::ptr::null()) } != 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn wide_null(value: &OsStr) -> Vec<u16> {
+        value.encode_wide().chain(std::iter::once(0)).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owned_environment_applies_mutations_over_initial_values() {
+        let environment = Env::owned([
+            ("KEEP".into(), "initial".into()),
+            ("REMOVE".into(), "initial".into()),
+        ])
+        .unwrap();
+
+        environment.set("KEEP".into(), "updated".into()).unwrap();
+        environment.unset("REMOVE".as_ref()).unwrap();
+        environment.set("ADD".into(), "new".into()).unwrap();
+
+        assert_eq!(environment.get("KEEP".as_ref()), Some("updated".into()));
+        assert_eq!(environment.get("REMOVE".as_ref()), None);
+        assert_eq!(environment.get("ADD".as_ref()), Some("new".into()));
+    }
+
+    #[test]
+    fn owned_environment_enumerates_its_current_values() {
+        let environment =
+            Env::owned([("B".into(), "initial".into()), ("A".into(), "one".into())]).unwrap();
+
+        environment.set("B".into(), "two".into()).unwrap();
+        environment.set("C".into(), "three".into()).unwrap();
+
+        assert_eq!(
+            environment.entries(),
+            vec![
+                ("A".into(), "one".into()),
+                ("B".into(), "two".into()),
+                ("C".into(), "three".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_environment_entries_are_rejected_without_panicking() {
+        assert!(Env::owned([("BAD=NAME".into(), "value".into())]).is_err());
+        assert!(Env::owned([("NAME".into(), "bad\0value".into())]).is_err());
+
+        let environment = Env::owned([("KEEP".into(), "value".into())]).unwrap();
+        assert!(environment.set("BAD=NAME".into(), "value".into()).is_err());
+        assert!(environment.set("NAME".into(), "bad\0value".into()).is_err());
+        assert!(environment.unset("BAD=NAME".as_ref()).is_err());
+        assert_eq!(environment.get("BAD=NAME".as_ref()), None);
+        assert_eq!(environment.entries(), vec![("KEEP".into(), "value".into())]);
+    }
+
+    #[test]
+    fn owned_environment_normalizes_duplicate_initial_names() {
+        let environment = Env::owned([
+            ("DUPLICATE".into(), "old".into()),
+            ("DUPLICATE".into(), "new".into()),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            environment.entries(),
+            vec![("DUPLICATE".into(), "new".into())]
+        );
+    }
+
+    #[test]
+    fn ambient_environment_rejects_invalid_mutations_before_calling_the_os() {
+        let environment = Env::ambient();
+
+        assert!(environment.set("BAD=NAME".into(), "value".into()).is_err());
+        assert!(environment.set("NAME".into(), "bad\0value".into()).is_err());
+        assert!(environment.unset("BAD=NAME".as_ref()).is_err());
+        assert_eq!(environment.get("BAD=NAME".as_ref()), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_environment_names_are_case_sensitive() {
+        let environment = Env::owned([("Path".into(), "mixed".into())]).unwrap();
+
+        assert_eq!(environment.get("Path".as_ref()), Some("mixed".into()));
+        assert_eq!(environment.get("PATH".as_ref()), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_environment_names_are_case_insensitive() {
+        let environment = Env::owned([("Path".into(), "old".into())]).unwrap();
+
+        environment.set("PATH".into(), "new".into()).unwrap();
+
+        assert_eq!(environment.get("path".as_ref()), Some("new".into()));
+        assert_eq!(environment.entries(), vec![("PATH".into(), "new".into())]);
+    }
+
+    #[test]
+    fn owned_environment_accepts_native_leading_equals_entries() {
+        let environment = Env::owned([("=C:".into(), "native".into())]).unwrap();
+
+        assert_eq!(environment.get("=C:".as_ref()), Some("native".into()));
+        assert_eq!(environment.inherited_entries(), environment.entries());
+        assert!(environment.set("=C:".into(), "changed".into()).is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn ambient_os_failures_are_reported_instead_of_panicking() {
+        let environment = Env::ambient();
+        let oversized_name = "A".repeat(32_767);
+
+        assert!(
+            environment
+                .set(oversized_name.into(), "value".into())
+                .is_err()
+        );
+    }
+}

--- a/crates/moonrun/src/env.rs
+++ b/crates/moonrun/src/env.rs
@@ -453,14 +453,9 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn ambient_os_failures_are_reported_instead_of_panicking() {
-        let environment = Env::ambient();
-        let oversized_name = "A".repeat(32_767);
+    fn windows_environment_adapter_reports_os_errors() {
+        let result = unsafe { os::set("BAD=NAME".as_ref(), "value".as_ref()) };
 
-        assert!(
-            environment
-                .set(oversized_name.into(), "value".into())
-                .is_err()
-        );
+        assert!(result.is_err());
     }
 }

--- a/crates/moonrun/src/filesystem/v8/mod.rs
+++ b/crates/moonrun/src/filesystem/v8/mod.rs
@@ -24,6 +24,7 @@ mod whole_file;
 use std::any::Any;
 use std::sync::Arc;
 
+use crate::env::Env;
 use crate::policy::Policy;
 
 pub(crate) fn init_env<'s>(
@@ -32,8 +33,9 @@ pub(crate) fn init_env<'s>(
     wasm_file_name: &str,
     args: &[String],
     policy: Arc<Policy>,
+    environment: Arc<Env>,
     dtors: &mut Vec<Box<dyn Any>>,
 ) {
-    runtime::register(obj, scope, wasm_file_name, args, Arc::clone(&policy), dtors);
+    runtime::register(obj, scope, wasm_file_name, args, environment, dtors);
     whole_file::register(obj, scope, policy, dtors);
 }

--- a/crates/moonrun/src/filesystem/v8/runtime.rs
+++ b/crates/moonrun/src/filesystem/v8/runtime.rs
@@ -18,8 +18,9 @@
 
 //! V8 adapter for runtime values exposed through the unstable filesystem object.
 
+use crate::env::Env;
+use crate::util::get_ref;
 use crate::v8_builder::{ArgsExt, ObjectExt, ScopeExt};
-use crate::{policy::Policy, util::get_ref};
 use std::any::Any;
 use std::sync::Arc;
 
@@ -45,11 +46,12 @@ fn set_env_var(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let policy = unsafe { get_ref::<Policy>(&args) };
+    let environment = unsafe { get_ref::<Env>(&args) };
     let key = args.string_lossy(scope, 0);
     let value = args.string_lossy(scope, 1);
 
-    policy.set_env_var(key, value);
+    // The legacy guest ABI has no error channel for environment mutations.
+    let _ = environment.set(key.into(), value.into());
 
     ret.set_undefined()
 }
@@ -59,9 +61,10 @@ fn unset_env_var(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let policy = unsafe { get_ref::<Policy>(&args) };
+    let environment = unsafe { get_ref::<Env>(&args) };
     let key = args.string_lossy(scope, 0);
-    policy.unset_env_var(&key);
+    // The legacy guest ABI has no error channel for environment mutations.
+    let _ = environment.unset(key.as_ref());
     ret.set_undefined()
 }
 
@@ -70,9 +73,12 @@ fn get_env_var(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let policy = unsafe { get_ref::<Policy>(&args) };
+    let environment = unsafe { get_ref::<Env>(&args) };
     let key = args.string_lossy(scope, 0);
-    let value = policy.get_env_var(&key).unwrap_or_default();
+    let value = environment
+        .get(key.as_ref())
+        .and_then(|value| value.into_string().ok())
+        .unwrap_or_default();
     let value = scope.string(&value);
     ret.set(value.into());
 }
@@ -82,9 +88,9 @@ fn get_env_var_exists(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let policy = unsafe { get_ref::<Policy>(&args) };
+    let environment = unsafe { get_ref::<Env>(&args) };
     let key = args.string_lossy(scope, 0);
-    ret.set_bool(policy.env_var_exists(&key));
+    ret.set_bool(environment.get(key.as_ref()).is_some());
 }
 
 fn get_env_vars(
@@ -92,12 +98,15 @@ fn get_env_vars(
     args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let policy = unsafe { get_ref::<Policy>(&args) };
+    let environment = unsafe { get_ref::<Env>(&args) };
     let result = v8::Array::new(scope, 0);
     let mut index = 0;
-    for (k, v) in policy.env_vars() {
-        let key = scope.string(&k);
-        let val = scope.string(&v);
+    for (name, value) in environment.entries() {
+        let (Some(name), Some(value)) = (name.to_str(), value.to_str()) else {
+            continue;
+        };
+        let key = scope.string(name);
+        let val = scope.string(value);
         result.set_index(scope, index, key.into()).unwrap();
         result.set_index(scope, index + 1, val.into()).unwrap();
         index += 2;
@@ -110,23 +119,23 @@ pub(super) fn register<'s>(
     scope: &mut v8::HandleScope<'s>,
     wasm_file_name: &str,
     args: &[String],
-    policy: Arc<Policy>,
+    environment: Arc<Env>,
     dtors: &mut Vec<Box<dyn Any>>,
 ) {
-    let policy_ptr = Arc::as_ptr(&policy);
-    dtors.push(Box::new(policy));
+    let environment_ptr = Arc::as_ptr(&environment);
+    dtors.push(Box::new(environment));
 
-    set_policy_func(obj, scope, "env_get_var", get_env_var, policy_ptr);
-    set_policy_func(obj, scope, "set_env_var", set_env_var, policy_ptr);
-    set_policy_func(obj, scope, "unset_env_var", unset_env_var, policy_ptr);
-    set_policy_func(obj, scope, "get_env_vars", get_env_vars, policy_ptr);
-    set_policy_func(obj, scope, "get_env_var", get_env_var, policy_ptr);
-    set_policy_func(
+    set_env_func(obj, scope, "env_get_var", get_env_var, environment_ptr);
+    set_env_func(obj, scope, "set_env_var", set_env_var, environment_ptr);
+    set_env_func(obj, scope, "unset_env_var", unset_env_var, environment_ptr);
+    set_env_func(obj, scope, "get_env_vars", get_env_vars, environment_ptr);
+    set_env_func(obj, scope, "get_env_var", get_env_var, environment_ptr);
+    set_env_func(
         obj,
         scope,
         "get_env_var_exists",
         get_env_var_exists,
-        policy_ptr,
+        environment_ptr,
     );
 
     let args = Box::new(RuntimeArgs(
@@ -144,14 +153,14 @@ pub(super) fn register<'s>(
     dtors.push(args);
 }
 
-fn set_policy_func<'s>(
+fn set_env_func<'s>(
     obj: v8::Local<'s, v8::Object>,
     scope: &mut v8::HandleScope<'s>,
     name: &str,
     callback: impl v8::MapFnTo<v8::FunctionCallback>,
-    policy_ptr: *const Policy,
+    environment: *const Env,
 ) {
-    let data = v8::External::new(scope, policy_ptr as *mut std::ffi::c_void);
+    let data = v8::External::new(scope, environment as *mut std::ffi::c_void);
     let function = v8::Function::builder(callback)
         .data(data.into())
         .build(scope)

--- a/crates/moonrun/src/host.rs
+++ b/crates/moonrun/src/host.rs
@@ -26,6 +26,7 @@ use slotmap::Key;
 use slotmap::{KeyData, SlotMap, new_key_type};
 
 use crate::async_host::AsyncHost;
+use crate::env::Env;
 use crate::policy::Policy;
 use crate::sqlite::SqliteHost;
 
@@ -98,10 +99,10 @@ pub(crate) struct Host {
 }
 
 impl Host {
-    pub(crate) fn new(policy: Arc<Policy>) -> Self {
+    pub(crate) fn new(policy: Arc<Policy>, environment: Arc<Env>) -> Self {
         let keys = Rc::new(RefCell::new(HostKeys::default()));
         Self {
-            async_state: AsyncHost::with_keys(Arc::clone(&policy), Rc::clone(&keys)),
+            async_state: AsyncHost::with_keys(Arc::clone(&policy), environment, Rc::clone(&keys)),
             sqlite: SqliteHost::with_keys(policy, keys),
         }
     }

--- a/crates/moonrun/src/host_imports.rs
+++ b/crates/moonrun/src/host_imports.rs
@@ -325,11 +325,12 @@ pub(crate) fn install(
     wasm_file_name: &str,
     args: &[String],
     policy: Arc<policy::Policy>,
+    environment: Arc<crate::env::Env>,
 ) -> run_termination::TerminationRequest {
     let global_proxy = scope.get_current_context().global(scope);
     let termination_request = run_termination::TerminationRequest::default();
     let v8_context = Box::new(crate::v8_import::V8RunContext::new(
-        crate::host::Host::new(Arc::clone(&policy)),
+        crate::host::Host::new(Arc::clone(&policy), Arc::clone(&environment)),
         termination_request.clone(),
     ));
     let v8_context_ptr = &*v8_context as *const crate::v8_import::V8RunContext;
@@ -403,7 +404,15 @@ pub(crate) fn install(
     // API for the fs module
     {
         let obj = global_proxy.child(scope, "__moonbit_fs_unstable");
-        filesystem::v8::init_env(obj, scope, wasm_file_name, args, Arc::clone(&policy), dtors);
+        filesystem::v8::init_env(
+            obj,
+            scope,
+            wasm_file_name,
+            args,
+            Arc::clone(&policy),
+            environment,
+            dtors,
+        );
     }
     {
         let io = global_proxy.child(scope, "__moonbit_io_unstable");

--- a/crates/moonrun/src/lib.rs
+++ b/crates/moonrun/src/lib.rs
@@ -27,6 +27,7 @@ mod async_host;
 mod async_sys;
 mod demangle_js_template;
 mod engine;
+mod env;
 mod filesystem;
 mod guest_memory;
 mod host;

--- a/crates/moonrun/src/policy/env.rs
+++ b/crates/moonrun/src/policy/env.rs
@@ -16,65 +16,46 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::sync::{Arc, Mutex};
+use std::collections::BTreeSet;
+use std::ffi::OsString;
 
 use super::config::EnvConfig;
+use crate::env::Env;
 
 #[derive(Clone, Debug)]
 pub(super) struct EnvPolicy {
-    vars: Arc<Mutex<BTreeMap<String, String>>>,
+    initial: Vec<(OsString, OsString)>,
 }
 
 impl EnvPolicy {
     pub(super) fn from_config(config: EnvConfig) -> anyhow::Result<Self> {
-        let mut vars = BTreeMap::new();
+        let mut vars = Vec::new();
 
         let copy_all = config.from_host.iter().any(|name| name == "*");
         if copy_all {
-            vars.extend(std::env::vars());
+            vars.extend(std::env::vars_os());
         }
 
         copy_host_names(&mut vars, &config.from_host, false)?;
         copy_host_names(&mut vars, &config.required_from_host, true)?;
 
         for (name, value) in config.set {
-            vars.insert(name, value);
+            vars.push((name.into(), value.into()));
         }
 
+        let environment = Env::owned(vars)?;
         Ok(Self {
-            vars: Arc::new(Mutex::new(vars)),
+            initial: environment.entries(),
         })
     }
 
-    pub(super) fn vars(&self) -> Vec<(String, String)> {
-        self.vars
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(name, value)| (name.clone(), value.clone()))
-            .collect()
-    }
-
-    pub(super) fn get(&self, name: &str) -> Option<String> {
-        self.vars.lock().unwrap().get(name).cloned()
-    }
-
-    pub(super) fn contains(&self, name: &str) -> bool {
-        self.vars.lock().unwrap().contains_key(name)
-    }
-
-    pub(super) fn set(&self, name: String, value: String) {
-        self.vars.lock().unwrap().insert(name, value);
-    }
-
-    pub(super) fn unset(&self, name: &str) {
-        self.vars.lock().unwrap().remove(name);
+    pub(super) fn realize(&self) -> anyhow::Result<Env> {
+        Ok(Env::owned(self.initial.clone())?)
     }
 }
 
 fn copy_host_names(
-    vars: &mut BTreeMap<String, String>,
+    vars: &mut Vec<(OsString, OsString)>,
     names: &[String],
     required: bool,
 ) -> anyhow::Result<()> {
@@ -86,14 +67,14 @@ fn copy_host_names(
         if !seen.insert(name) {
             anyhow::bail!("duplicate environment policy entry {name:?}");
         }
-        match std::env::var(name) {
-            Ok(value) => {
-                vars.insert(name.clone(), value);
+        match std::env::var_os(name) {
+            Some(value) => {
+                vars.push((name.into(), value));
             }
-            Err(_) if required => {
+            None if required => {
                 anyhow::bail!("required host environment variable {name:?} is not set");
             }
-            Err(_) => {}
+            None => {}
         }
     }
     Ok(())
@@ -102,27 +83,45 @@ fn copy_host_names(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     #[test]
     fn empty_env_config_starts_empty() {
         let policy = EnvPolicy::from_config(EnvConfig::default()).unwrap();
 
-        assert!(policy.vars().is_empty());
+        assert!(policy.realize().unwrap().entries().is_empty());
     }
 
     #[test]
-    fn set_values_are_available_and_mutable() {
+    fn set_values_are_applied_to_the_realized_environment() {
+        let policy = EnvPolicy::from_config(EnvConfig {
+            set: BTreeMap::from([("APP_ENV".to_owned(), "test".to_owned())]),
+            ..EnvConfig::default()
+        })
+        .unwrap();
+        let environment = policy.realize().unwrap();
+
+        assert_eq!(environment.get("APP_ENV".as_ref()), Some("test".into()));
+        environment.set("APP_ENV".into(), "dev".into()).unwrap();
+        assert_eq!(environment.get("APP_ENV".as_ref()), Some("dev".into()));
+        environment.unset("APP_ENV".as_ref()).unwrap();
+        assert_eq!(environment.get("APP_ENV".as_ref()), None);
+    }
+
+    #[test]
+    fn startup_policy_realizes_independent_environments() {
         let policy = EnvPolicy::from_config(EnvConfig {
             set: BTreeMap::from([("APP_ENV".to_owned(), "test".to_owned())]),
             ..EnvConfig::default()
         })
         .unwrap();
 
-        assert_eq!(policy.get("APP_ENV").as_deref(), Some("test"));
-        policy.set("APP_ENV".to_owned(), "dev".to_owned());
-        assert_eq!(policy.get("APP_ENV").as_deref(), Some("dev"));
-        policy.unset("APP_ENV");
-        assert!(!policy.contains("APP_ENV"));
+        let left = policy.realize().unwrap();
+        let right = policy.realize().unwrap();
+        left.set("APP_ENV".into(), "left".into()).unwrap();
+
+        assert_eq!(left.get("APP_ENV".as_ref()), Some("left".into()));
+        assert_eq!(right.get("APP_ENV".as_ref()), Some("test".into()));
     }
 
     #[test]
@@ -137,11 +136,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            policy.vars(),
-            vec![
-                ("A".to_owned(), "1".to_owned()),
-                ("B".to_owned(), "2".to_owned())
-            ]
+            policy.realize().unwrap().entries(),
+            vec![("A".into(), "1".into()), ("B".into(), "2".into())]
         );
     }
 

--- a/crates/moonrun/src/policy/mod.rs
+++ b/crates/moonrun/src/policy/mod.rs
@@ -27,7 +27,9 @@ mod fs;
 mod net;
 mod process;
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
+#[cfg(unix)]
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;

--- a/crates/moonrun/src/policy/mod.rs
+++ b/crates/moonrun/src/policy/mod.rs
@@ -33,6 +33,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::env::Env;
 
 use self::config::PolicyConfig;
 use self::env::EnvPolicy;
@@ -241,26 +242,9 @@ impl Policy {
         net.check_socket(NetOperation::Bind, addr)
     }
 
-    pub(crate) fn env_vars(&self) -> Vec<(String, String)> {
+    pub(crate) fn realize_env(&self) -> anyhow::Result<Env> {
         self.env_policy()
-            .map_or_else(|| std::env::vars().collect(), EnvPolicy::vars)
-    }
-
-    pub(crate) fn get_env_var(&self, name: &str) -> Option<String> {
-        self.env_policy()
-            .map_or_else(|| std::env::var(name).ok(), |env| env.get(name))
-    }
-
-    pub(crate) fn env_var_exists(&self, name: &str) -> bool {
-        self.env_policy()
-            .map_or_else(|| std::env::var(name).is_ok(), |env| env.contains(name))
-    }
-
-    pub(crate) fn env_var_os(&self, name: &str) -> Option<OsString> {
-        self.env_policy().map_or_else(
-            || std::env::var_os(name),
-            |env| env.get(name).map(OsString::from),
-        )
+            .map_or_else(|| Ok(Env::ambient()), EnvPolicy::realize)
     }
 
     pub(crate) fn has_env_policy(&self) -> bool {
@@ -287,24 +271,6 @@ impl Policy {
 
     pub(crate) fn has_process_policy(&self) -> bool {
         self.process.is_some()
-    }
-
-    pub(crate) fn set_env_var(&self, name: String, value: String) {
-        if let Some(env) = self.env_policy() {
-            env.set(name, value);
-        } else {
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::set_var(name, value) };
-        }
-    }
-
-    pub(crate) fn unset_env_var(&self, name: &str) {
-        if let Some(env) = self.env_policy() {
-            env.unset(name);
-        } else {
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::remove_var(name) };
-        }
     }
 
     #[inline]
@@ -619,8 +585,9 @@ mod tests {
         )
         .unwrap();
 
-        assert!(policy.env_vars().is_empty());
-        assert!(!policy.env_var_exists("PATH"));
+        let environment = policy.realize_env().unwrap();
+        assert!(environment.entries().is_empty());
+        assert!(environment.get("PATH".as_ref()).is_none());
     }
 
     #[test]

--- a/crates/moonrun/src/temp_dir.rs
+++ b/crates/moonrun/src/temp_dir.rs
@@ -22,39 +22,52 @@ use std::ffi::OsString;
 use std::sync::Arc;
 
 use crate::async_host::AsyncHostResult;
-use crate::async_sys::fs::stub;
+use crate::env::Env;
 use crate::policy::Policy;
 
 /// Selects the temporary-directory base observed by one Run.
 pub(crate) struct TempDir {
-    policy: Arc<Policy>,
+    environment: Arc<Env>,
+    source: TempDirSource,
+}
+
+#[derive(Clone, Copy)]
+enum TempDirSource {
+    Native,
+    RunEnvironment,
 }
 
 impl TempDir {
-    pub(crate) fn new(policy: Arc<Policy>) -> Self {
-        Self { policy }
+    pub(crate) fn new(environment: Arc<Env>, policy: &Policy) -> Self {
+        Self {
+            environment,
+            source: if policy.has_env_policy() {
+                TempDirSource::RunEnvironment
+            } else {
+                TempDirSource::Native
+            },
+        }
     }
 
     pub(crate) fn path(&self) -> AsyncHostResult<OsString> {
-        resolve(&self.policy)
+        match self.source {
+            TempDirSource::Native => crate::async_sys::fs::stub::get_tmp_path(),
+            TempDirSource::RunEnvironment => resolve_from_run_environment(&self.environment),
+        }
     }
-}
-
-fn resolve(policy: &Policy) -> AsyncHostResult<OsString> {
-    if !policy.has_env_policy() {
-        return stub::get_tmp_path();
-    }
-    resolve_from_policy_env(policy)
 }
 
 #[cfg(unix)]
-fn resolve_from_policy_env(policy: &Policy) -> AsyncHostResult<OsString> {
-    stub::get_tmp_path_from_env(policy.env_var_os("TMPDIR"))
+fn resolve_from_run_environment(environment: &Env) -> AsyncHostResult<OsString> {
+    crate::async_sys::fs::stub::get_tmp_path_from_env(environment.get("TMPDIR".as_ref()))
 }
 
 #[cfg(windows)]
-fn resolve_from_policy_env(policy: &Policy) -> AsyncHostResult<OsString> {
-    stub::get_tmp_path_from_env(policy.env_var_os("TMP"), policy.env_var_os("TEMP"))
+fn resolve_from_run_environment(environment: &Env) -> AsyncHostResult<OsString> {
+    crate::async_sys::fs::stub::get_tmp_path_from_env(
+        environment.get("TMP".as_ref()),
+        environment.get("TEMP".as_ref()),
+    )
 }
 
 #[cfg(test)]
@@ -62,12 +75,17 @@ mod tests {
     use super::*;
     #[cfg(windows)]
     use crate::async_host::AsyncHostError;
+    #[cfg(unix)]
+    use crate::async_sys::fs::stub;
 
-    fn load_policy(contents: &str) -> Arc<Policy> {
+    fn load_temp_dir(contents: &str) -> (Arc<Env>, TempDir) {
         let dir = tempfile::tempdir().unwrap();
         let policy_file = dir.path().join("policy.toml");
         std::fs::write(&policy_file, contents).unwrap();
-        Arc::new(Policy::from_file(&policy_file).unwrap())
+        let policy = Policy::from_file(&policy_file).unwrap();
+        let environment = Arc::new(policy.realize_env().unwrap());
+        let temp_dir = TempDir::new(Arc::clone(&environment), &policy);
+        (environment, temp_dir)
     }
 
     #[cfg(unix)]
@@ -75,7 +93,7 @@ mod tests {
     fn policy_tmp_path_uses_policy_tmpdir() {
         use std::os::unix::ffi::OsStrExt;
 
-        let temp_dir = TempDir::new(load_policy("[env.set]\nTMPDIR = \"/policy/tmp\"\n"));
+        let (_, temp_dir) = load_temp_dir("[env.set]\nTMPDIR = \"/policy/tmp\"\n");
 
         assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/policy/tmp/");
     }
@@ -85,13 +103,12 @@ mod tests {
     fn tmp_path_reflects_policy_env_changes() {
         use std::os::unix::ffi::OsStrExt;
 
-        let policy = load_policy("[env.set]\nTMPDIR = \"/first\"\n");
-        let temp_dir = TempDir::new(Arc::clone(&policy));
+        let (environment, temp_dir) = load_temp_dir("[env.set]\nTMPDIR = \"/first\"\n");
 
         assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/first/");
-        policy.set_env_var("TMPDIR".to_owned(), "/second".to_owned());
+        environment.set("TMPDIR".into(), "/second".into()).unwrap();
         assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/second/");
-        policy.unset_env_var("TMPDIR");
+        environment.unset("TMPDIR".as_ref()).unwrap();
         assert_eq!(
             temp_dir.path().unwrap(),
             stub::get_tmp_path_from_env(None).unwrap()
@@ -103,7 +120,7 @@ mod tests {
     fn policy_tmp_path_ignores_denied_host_tmpdir() {
         use std::os::unix::ffi::OsStrExt;
 
-        let temp_dir = TempDir::new(load_policy(""));
+        let (_, temp_dir) = load_temp_dir("");
 
         assert_eq!(temp_dir.path().unwrap().as_bytes(), b"/tmp/");
     }
@@ -111,22 +128,19 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn policy_tmp_path_requires_configured_windows_temp_env() {
-        let policy = load_policy("");
-        let temp_dir = TempDir::new(Arc::clone(&policy));
+        let (environment, temp_dir) = load_temp_dir("");
 
         assert_eq!(temp_dir.path(), Err(AsyncHostError::PermissionDenied));
-        policy.set_env_var("TEMP".to_owned(), "C:/Temp".to_owned());
+        environment.set("TEMP".into(), "C:/Temp".into()).unwrap();
         assert_eq!(temp_dir.path().unwrap().to_string_lossy(), "C:/Temp\\");
-        policy.unset_env_var("TEMP");
+        environment.unset("TEMP".as_ref()).unwrap();
         assert_eq!(temp_dir.path(), Err(AsyncHostError::PermissionDenied));
     }
 
     #[cfg(windows)]
     #[test]
     fn empty_policy_tmp_falls_back_to_temp() {
-        let temp_dir = TempDir::new(load_policy(
-            "[env.set]\nTMP = \"\"\nTEMP = \"C:/Fallback\"\n",
-        ));
+        let (_, temp_dir) = load_temp_dir("[env.set]\nTMP = \"\"\nTEMP = \"C:/Fallback\"\n");
 
         assert_eq!(temp_dir.path().unwrap().to_string_lossy(), "C:/Fallback\\");
     }

--- a/crates/moonrun/src/v8_backend.rs
+++ b/crates/moonrun/src/v8_backend.rs
@@ -17,6 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::engine::{EngineConfig, RunOptions, RunOutcome};
+use crate::env::Env;
 use crate::policy::Policy;
 use crate::run_termination::RunTermination;
 use crate::v8_builder::{ObjectExt, ScopeExt};
@@ -122,6 +123,7 @@ pub(crate) fn run(
     source_map: Option<&str>,
     options: RunOptions,
     policy: Arc<Policy>,
+    environment: Arc<Env>,
 ) -> anyhow::Result<RunOutcome> {
     initialize(config)?;
 
@@ -139,8 +141,14 @@ pub(crate) fn run(
     let memory_sanitizer = memory_sanitizer_api::MemorySanitizer::default();
 
     let mut dtors = Vec::new();
-    let termination_request =
-        host_imports::install(&mut dtors, scope, module_name, &options.args, policy);
+    let termination_request = host_imports::install(
+        &mut dtors,
+        scope,
+        module_name,
+        &options.args,
+        policy,
+        environment,
+    );
 
     let memory_sanitizer_imports =
         global_proxy.child(scope, memory_sanitizer_api::MEMORY_SANITIZER_MODULE);


### PR DESCRIPTION
## Why

PR #2093 shows the broader environment-virtualization target, but it combines the runtime seam with isolation, public configuration, and WASI behavior. That makes the change difficult to review and merge incrementally.

This PR establishes the first independently useful boundary: Policy selects the startup environment, while runtime environment state lives behind a dedicated `Env` module.

## What changes

- add a native-string `Env` interface for get, set, unset, enumeration, and child inheritance
- realize one environment per Run from the startup Policy
- route MoonBit runtime access, temporary-directory lookup, and child inheritance through that environment
- keep platform-specific name comparison and mutation APIs below the OS adapter seam
- return environment validation and OS mutation failures instead of panicking

## Compatibility and scope

Allow-all mode retains its existing process-environment write-through behavior. Windows allow-all temporary paths still use the native fallback introduced by #2094, and Policy mode remains deny-by-default.

The PR intentionally does not add environment injection, Run isolation, WASI environment changes, snapshots, or virtual-child behavior. Those remain follow-up steps toward #2093.
