### PR TITLE
refactor(moonrun): canonicalize policy before loading

### DIFF
--- a/crates/moonrun/src/policy/fs.rs
+++ b/crates/moonrun/src/policy/fs.rs
@@ -19,8 +19,6 @@
 use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
 
-use anyhow::Context;
-
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 
 use super::{config::FsConfig, sandbox_denied};
@@ -56,11 +54,12 @@ pub(crate) enum RuntimePathBase<'a> {
 }
 
 impl FsPolicy {
-    pub(super) fn from_config(config: FsConfig, config_dir: &Path) -> anyhow::Result<Self> {
-        Ok(Self {
-            read_roots: resolve_roots(config.read, config_dir)?,
-            write_roots: resolve_roots(config.write, config_dir)?,
-        })
+    /// Construct runtime enforcement from roots canonicalized by `policy`.
+    pub(super) fn from_canonical_config(config: FsConfig) -> Self {
+        Self {
+            read_roots: roots_from_config(config.read),
+            write_roots: roots_from_config(config.write),
+        }
     }
 
     pub(super) fn allows(
@@ -190,25 +189,15 @@ impl FsIntents {
     }
 }
 
-fn resolve_roots(roots: Vec<PathBuf>, config_dir: &Path) -> anyhow::Result<Vec<FsRoot>> {
+fn roots_from_config(roots: Vec<PathBuf>) -> Vec<FsRoot> {
     roots
         .into_iter()
         .map(|root| {
             if root.as_os_str() == OsStr::new("*") {
-                return Ok(FsRoot::Any);
-            }
-            let path = if root.is_absolute() {
-                root
+                FsRoot::Any
             } else {
-                config_dir.join(root)
-            };
-            let path = std::fs::canonicalize(&path).with_context(|| {
-                format!(
-                    "failed to resolve sandbox filesystem root {}",
-                    path.display()
-                )
-            })?;
-            Ok(FsRoot::Path(path))
+                FsRoot::Path(root)
+            }
         })
         .collect()
 }
@@ -284,7 +273,15 @@ mod tests {
     use super::*;
 
     fn policy(read: Vec<PathBuf>, write: Vec<PathBuf>, config_dir: &Path) -> FsPolicy {
-        FsPolicy::from_config(FsConfig { read, write }, config_dir).unwrap()
+        let config = crate::policy::canonicalize(
+            super::super::config::PolicyConfig {
+                fs: Some(FsConfig { read, write }),
+                ..Default::default()
+            },
+            config_dir,
+        )
+        .unwrap();
+        FsPolicy::from_canonical_config(config.fs.unwrap())
     }
 
     #[test]

--- a/crates/moonrun/src/policy/mod.rs
+++ b/crates/moonrun/src/policy/mod.rs
@@ -28,7 +28,9 @@ mod net;
 mod process;
 
 use std::ffi::{OsStr, OsString};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 
@@ -73,11 +75,11 @@ impl Policy {
     }
 
     fn from_config(config: PolicyConfig, config_dir: &Path) -> anyhow::Result<Self> {
+        let config = canonicalize(config, config_dir)?;
         Ok(Self {
-            fs: Some(FsPolicy::from_config(
+            fs: Some(FsPolicy::from_canonical_config(
                 config.fs.unwrap_or_default(),
-                config_dir,
-            )?),
+            )),
             net: Some(NetPolicy::from_config(config.net.unwrap_or_default())?),
             env: Some(EnvPolicy::from_config(config.env.unwrap_or_default())?),
             process: Some(ProcessPolicy::from_config(
@@ -321,6 +323,41 @@ impl Policy {
     }
 }
 
+/// Resolve source-relative policy values into a transport-independent form.
+///
+/// Environment materialization and runtime rule validation deliberately remain
+/// part of Policy construction; only filesystem roots depend on the policy
+/// source directory.
+fn canonicalize(mut config: PolicyConfig, config_dir: &Path) -> anyhow::Result<PolicyConfig> {
+    if let Some(fs) = config.fs.as_mut() {
+        fs.read = canonicalize_roots(std::mem::take(&mut fs.read), config_dir)?;
+        fs.write = canonicalize_roots(std::mem::take(&mut fs.write), config_dir)?;
+    }
+    Ok(config)
+}
+
+fn canonicalize_roots(roots: Vec<PathBuf>, config_dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    roots
+        .into_iter()
+        .map(|root| {
+            if root.as_os_str() == OsStr::new("*") {
+                return Ok(root);
+            }
+            let path = if root.is_absolute() {
+                root
+            } else {
+                config_dir.join(root)
+            };
+            std::fs::canonicalize(&path).with_context(|| {
+                format!(
+                    "failed to resolve sandbox filesystem root {}",
+                    path.display()
+                )
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::ffi::OsStr;
@@ -330,6 +367,121 @@ mod tests {
     use crate::async_host::AsyncHostError;
 
     use super::*;
+
+    fn config_with_fs_roots(read: Vec<PathBuf>, write: Vec<PathBuf>) -> PolicyConfig {
+        PolicyConfig {
+            fs: Some(config::FsConfig { read, write }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn canonicalize_resolves_filesystem_roots_and_preserves_wildcards() {
+        let tmp = tempfile::tempdir().unwrap();
+        let read = tmp.path().join("read");
+        let write = tmp.path().join("write");
+        std::fs::create_dir(&read).unwrap();
+        std::fs::create_dir(&write).unwrap();
+        let canonical_read = std::fs::canonicalize(&read).unwrap();
+        let canonical_write = std::fs::canonicalize(&write).unwrap();
+
+        let config = canonicalize(
+            PolicyConfig {
+                fs: Some(config::FsConfig {
+                    read: vec![PathBuf::from("read"), PathBuf::from("*")],
+                    write: vec![write.clone()],
+                }),
+                net: Some(config::NetConfig {
+                    dns: vec!["example.com".to_owned()],
+                    ..Default::default()
+                }),
+                env: Some(config::EnvConfig {
+                    from_host: vec!["PATH".to_owned()],
+                    ..Default::default()
+                }),
+                process: Some(config::ProcessConfig {
+                    spawn: true,
+                    ..Default::default()
+                }),
+            },
+            tmp.path(),
+        )
+        .unwrap();
+
+        let fs = config.fs.unwrap();
+        assert_eq!(fs.read, [canonical_read, PathBuf::from("*")]);
+        assert_eq!(fs.write, [canonical_write]);
+        assert_eq!(config.net.unwrap().dns, ["example.com"]);
+        assert_eq!(config.env.unwrap().from_host, ["PATH"]);
+        assert!(config.process.unwrap().spawn);
+    }
+
+    #[test]
+    fn canonicalize_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        let canonical_target = std::fs::canonicalize(&target).unwrap();
+
+        let first = canonicalize(
+            config_with_fs_roots(vec![PathBuf::from("target")], Vec::new()),
+            tmp.path(),
+        )
+        .unwrap();
+        let second = canonicalize(first, Path::new("unrelated-source-directory")).unwrap();
+
+        assert_eq!(second.fs.unwrap().read, [canonical_target]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonicalize_resolves_symlinks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        let alias = tmp.path().join("alias");
+        std::fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &alias).unwrap();
+        let canonical_target = std::fs::canonicalize(&target).unwrap();
+
+        let config =
+            canonicalize(config_with_fs_roots(vec![alias], Vec::new()), tmp.path()).unwrap();
+
+        assert_eq!(config.fs.unwrap().read, [canonical_target]);
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn canonicalize_preserves_non_utf8_paths() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let name = std::ffi::OsString::from_vec(b"allowed-\xff".to_vec());
+        let root = tmp.path().join(&name);
+        std::fs::create_dir(&root).unwrap();
+
+        let config = canonicalize(
+            config_with_fs_roots(vec![PathBuf::from(name)], Vec::new()),
+            tmp.path(),
+        )
+        .unwrap();
+
+        assert_eq!(config.fs.unwrap().read, [root]);
+    }
+
+    #[test]
+    fn canonicalize_reports_the_resolved_missing_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("missing");
+        let error = match canonicalize(
+            config_with_fs_roots(vec![PathBuf::from("missing")], Vec::new()),
+            tmp.path(),
+        ) {
+            Ok(_) => panic!("expected a missing root to fail canonicalization"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains(&missing.display().to_string()));
+    }
 
     #[test]
     fn no_policy_leaves_fs_unrestricted() {


### PR DESCRIPTION
## Why

Policy filesystem roots are currently resolved while constructing `FsPolicy`, coupling runtime enforcement to the policy source directory. A policy copy or another future transport would otherwise need to reproduce that path-resolution behavior.

## What

- canonicalize source-relative filesystem roots at the `Policy` boundary
- preserve wildcard roots while resolving absolute, relative, and symlinked paths
- make `FsPolicy` consume only canonicalized configuration
- keep environment materialization and network/process validation in their existing runtime policy constructors

## Why this split

This PR establishes the transport-independent policy representation as a single, focused seam. It intentionally contains no policy transport, environment forwarding, or moonx inheritance behavior; those can be reviewed separately on top of this change.