### PR TITLE
fix(moonrun): use run environment for WASI

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -53,11 +53,10 @@ restrict WASI descriptors.
 _Avoid_: WASI sandbox, virtual filesystem
 
 **Env**:
-The environment interface selected for one Run. Moonrun Policy contributes
-only its startup selection; runtime reads and mutations go through Env instead
-of treating Policy as mutable state. The current unrestricted mode retains its
-legacy process-environment write-through behavior; Run-owned isolation is a
-separate behavior change.
+The environment interface selected for one Run and shared by MoonBit
+environment imports, WASI environment calls, temporary-directory resolution,
+and child inheritance. Moonrun Policy contributes only its startup selection;
+unrestricted mode retains its legacy process-environment write-through behavior.
 _Avoid_: Mutable policy, per-import environment map
 
 **WASI Capability Surface**:

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -89,9 +89,12 @@ system and switches supported moonrun-owned host surfaces into sandbox mode.
 The policy is deny-by-default: omitted or empty `fs`, `net`, and `env` objects
 deny that surface, and process spawning is disabled unless explicitly allowed.
 Add entries only for the access the program should have. The policy covers
-`moonbitlang/async` and moonrun's own `__moonbit_*_unstable` FFI surfaces. It
-does not apply to WASI
-(`wasi_snapshot_preview1` / `__moonbit_wasi_unstable`).
+`moonbitlang/async` and moonrun's own non-WASI `__moonbit_*_unstable` FFI
+surfaces. WASI operations generally remain outside Moonrun Policy
+(`wasi_snapshot_preview1` / `__moonbit_wasi_unstable`), with one shared-state
+exception: `environ_get` and `environ_sizes_get` expose the Run environment
+realized from the `env` policy. WASI descriptors, preopens, and other WASI
+operations are still configured separately from Moonrun Policy.
 
 An empty JSON object denies all policy-covered filesystem, network, and
 environment access:
@@ -134,8 +137,9 @@ wildcard `"*"` allows every host path on every platform. List a root in both
 The environment policy constructs the guest environment. Use `from_host` to copy
 selected host variables if present, `required_from_host` to require selected
 host variables, and `env.set` for literal values. `env.set` overrides values
-copied from the host. Do not put secrets directly in the policy file; pass them
-by name through `from_host` or `required_from_host`.
+copied from the host. The realized environment is shared by MoonBit runtime
+environment APIs and WASI environment calls. Do not put secrets directly in the
+policy file; pass them by name through `from_host` or `required_from_host`.
 
 Process spawning is disabled unless the request matches a `process.allow` rule
 or `process.spawn` is `true`. Rules match the requested program exactly and

--- a/crates/moonrun/src/env.rs
+++ b/crates/moonrun/src/env.rs
@@ -156,7 +156,10 @@ impl Env {
                 // `vars_os` preserves native values. On Windows it is backed
                 // by GetEnvironmentStringsW; failure to obtain the process
                 // block is a process-wide condition from which no Run can
-                // usefully recover.
+                // usefully recover. On Unix, Env deliberately models POSIX
+                // `name=value` variables rather than opaque `envp` entries;
+                // malformed raw entries such as `TOKEN` or `=x` are outside
+                // this interface rather than being preserved byte-for-byte.
                 std::env::vars_os().collect()
             }
             EnvBacking::Owned(entries) => entries

--- a/crates/moonrun/src/host_imports.rs
+++ b/crates/moonrun/src/host_imports.rs
@@ -391,8 +391,8 @@ pub(crate) fn install(
             scope,
             wasm_file_name,
             args,
-            Rc::clone(v8_context.memory_binding()),
-            termination_request.clone(),
+            Arc::clone(&environment),
+            &v8_context,
             dtors,
         );
     }

--- a/crates/moonrun/src/wasi_api.rs
+++ b/crates/moonrun/src/wasi_api.rs
@@ -16,9 +16,10 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+use crate::env::Env;
 use crate::run_termination::{RunTermination, TerminationRequest};
 use crate::v8_builder::ScopeExt;
-use crate::v8_import::{V8ImportError, V8MemoryBinding};
+use crate::v8_import::{V8ImportError, V8MemoryBinding, V8RunContext};
 use rand::{RngCore, rngs::OsRng};
 use std::any::Any;
 use std::collections::BTreeMap;
@@ -171,6 +172,7 @@ impl TryFrom<i32> for ClockId {
 
 struct WasiContext {
     argv: Vec<Vec<u8>>,
+    environment: Arc<Env>,
     preopen_dir_name: Vec<u8>,
     preopen_dir_host_path: PathBuf,
     preopen_dir_real_path: PathBuf,
@@ -229,8 +231,10 @@ fn build_argv(wasm_file_name: &str, args: &[String]) -> Vec<Vec<u8>> {
     argv
 }
 
-fn collect_environ() -> Vec<Vec<u8>> {
-    std::env::vars_os()
+fn collect_environ(environment: &Env) -> Vec<Vec<u8>> {
+    environment
+        .entries()
+        .into_iter()
         .map(|(key, value)| {
             encode_c_string(format!(
                 "{}={}",
@@ -1578,11 +1582,11 @@ fn environ_sizes_get(
     let result = (|| -> WasiResult<()> {
         let environc_ptr = read_u32_arg(scope, &args, 0)?;
         let environ_buf_size_ptr = read_u32_arg(scope, &args, 1)?;
+        let context = callback_context(&args);
 
-        let environ = collect_environ();
+        let environ = collect_environ(&context.environment);
         let environc = u32::try_from(environ.len()).map_err(|_| WASI_ERRNO_FAULT)?;
         let environ_buf_size = table_bytes_len(&environ)?;
-        let context = callback_context(&args);
 
         with_wasi_memory_mut(scope, context, |memory| {
             write_u32(memory, environc_ptr, environc)?;
@@ -1604,7 +1608,7 @@ fn environ_get(
         let environ_buf_ptr = read_u32_arg(scope, &args, 1)?;
         let context = callback_context(&args);
 
-        let environ = collect_environ();
+        let environ = collect_environ(&context.environment);
         with_wasi_memory_mut(scope, context, |memory| {
             write_c_string_table(memory, &environ, environ_ptr, environ_buf_ptr)
         })
@@ -1794,8 +1798,8 @@ pub(crate) fn init_env<'s>(
     scope: &mut v8::HandleScope<'s>,
     wasm_file_name: &str,
     args: &[String],
-    memory_binding: Rc<V8MemoryBinding>,
-    termination_request: TerminationRequest,
+    environment: Arc<Env>,
+    run_context: &V8RunContext,
     dtors: &mut Vec<Box<dyn Any>>,
 ) {
     let preopen_dir_host_path = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
@@ -1803,12 +1807,13 @@ pub(crate) fn init_env<'s>(
         fs::canonicalize(&preopen_dir_host_path).unwrap_or_else(|_| preopen_dir_host_path.clone());
     let context = Box::new(WasiContext {
         argv: build_argv(wasm_file_name, args),
+        environment,
         preopen_dir_name: preopen_name(),
         preopen_dir_host_path,
         preopen_dir_real_path,
         descriptors: Mutex::new(DescriptorTable::new()),
-        memory_binding,
-        termination_request,
+        memory_binding: Rc::clone(run_context.memory_binding()),
+        termination_request: run_context.termination_request().clone(),
     });
     let context_ptr = &*context as *const WasiContext as *mut std::ffi::c_void;
 
@@ -1841,6 +1846,7 @@ mod tests {
     fn test_context(root: &Path) -> WasiContext {
         WasiContext {
             argv: Vec::new(),
+            environment: Arc::new(Env::owned([]).unwrap()),
             preopen_dir_name: preopen_name(),
             preopen_dir_host_path: root.to_path_buf(),
             preopen_dir_real_path: fs::canonicalize(root).expect("canonicalize preopen root"),
@@ -1848,6 +1854,24 @@ mod tests {
             memory_binding: Rc::new(V8MemoryBinding::new()),
             termination_request: TerminationRequest::default(),
         }
+    }
+
+    #[test]
+    fn wasi_environment_uses_current_run_environment() {
+        let environment = Env::owned([
+            ("MOONRUN_WASI_ADD".into(), "initial".into()),
+            ("MOONRUN_WASI_REMOVE".into(), "removed".into()),
+        ])
+        .unwrap();
+        environment
+            .set("MOONRUN_WASI_ADD".into(), "updated".into())
+            .unwrap();
+        environment.unset("MOONRUN_WASI_REMOVE".as_ref()).unwrap();
+
+        assert_eq!(
+            collect_environ(&environment),
+            vec![b"MOONRUN_WASI_ADD=updated\0".to_vec()]
+        );
     }
 
     #[test]

--- a/crates/moonrun/tests/test_cases/test_policy_workspace.in/env_get/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_policy_workspace.in/env_get/main.mbt
@@ -17,10 +17,32 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 ///|
+#unsafe_skip_stub_check
+#borrow(count, size)
+fn wasi_environ_sizes_get(
+  count : Ref[Int],
+  size : Ref[Int],
+) -> Int = "wasi_snapshot_preview1" "environ_sizes_get"
+
+///|
+fn assert_wasi_environment_count(expected : Int) -> Unit {
+  let count = Ref(-1)
+  let size = Ref(-1)
+  if wasi_environ_sizes_get(count, size) != 0 {
+    abort("WASI environ_sizes_get failed")
+  }
+  if count.val != expected {
+    abort("WASI environment bypassed the Run environment")
+  }
+}
+
+///|
 fn main {
   if @env.get_env_var("MOONRUN_POLICY_ENV") is Some(value) {
     println(value)
+    assert_wasi_environment_count(1)
   } else {
     println("missing")
+    assert_wasi_environment_count(0)
   }
 }


### PR DESCRIPTION
## Why

Policy-backed Runs already expose their selected environment through `Env` to MoonBit imports, temporary-directory resolution, and child inheritance. WASI bypassed that seam with `std::env::vars_os()`, which could leak host variables and make environment views disagree within one Run.

## What

- Retain the Run `Env` in `WasiContext` and read its current entries for WASI environment calls.
- Reuse `V8RunContext` for V8-specific memory and termination state instead of widening the initialization interface further.
- Document that Unix `Env` models POSIX `name=value` variables, not opaque malformed `envp` entries.
- Cover current-value behavior at the `Env` seam and policy isolation end to end.

## Scope

This is the smallest step that closes the WASI bypass. It deliberately does not add strict WASI snapshots, ambient `EnvDelta` isolation, or a public explicit-environment builder; those remain independent follow-ups.