### PR TITLE
Add moon search for registry modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
 name = "moon"
 version = "0.1.0"
 dependencies = [
+ "anstream",
  "anstyle",
  "anyhow",
  "blake3",

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -27,6 +27,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anstream.workspace = true
 anstyle.workspace = true
 moonbuild.workspace = true
 mooncake.workspace = true

--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -44,6 +44,7 @@ pub(crate) mod registry_runner;
 pub(crate) mod run;
 pub(crate) mod runtime;
 pub(crate) mod runwasm;
+pub(crate) mod search;
 pub(crate) mod shell_completion;
 pub(crate) mod test;
 pub(crate) mod tool;
@@ -79,6 +80,7 @@ pub(crate) use new::*;
 pub(crate) use prove::*;
 pub(crate) use run::*;
 pub(crate) use runwasm::*;
+pub(crate) use search::*;
 pub(crate) use shell_completion::*;
 pub(crate) use test::*;
 pub(crate) use tool::*;
@@ -136,6 +138,7 @@ pub(crate) enum MoonBuildSubcommands {
     Install(InstallSubcommand),
     Tree(TreeSubcommand),
     Fetch(FetchSubcommand),
+    Search(SearchSubcommand),
     Work(WorkSubcommand),
 
     // Mooncake

--- a/crates/moon/src/cli/runtime.rs
+++ b/crates/moon/src/cli/runtime.rs
@@ -246,6 +246,7 @@ fn dispatch(
         Remove(command) => super::remove_cli(flags, command, output.user_log()).map(Into::into),
         Run(command) => super::run_run(&flags, command, output).map(Into::into),
         RunWasm(command) => super::run_runwasm(&flags, command, output),
+        Search(command) => super::run_search(command, output).map(Into::into),
         Test(command) => super::run_test(flags, command, output).map(Into::into),
         Tree(command) => super::tree_cli(flags, command, output.user_log()).map(Into::into),
         Update(command) => super::update_cli(flags, command, output.user_log()).map(Into::into),

--- a/crates/moon/src/cli/search.rs
+++ b/crates/moon/src/cli/search.rs
@@ -73,10 +73,25 @@ fn is_safe_registry_module_name(name: &str) -> bool {
             && component != "."
             && component != ".."
             && !component.contains(['@', ':', '\\'])
-            && component
-                .chars()
-                .all(|character| !character.is_whitespace() && !character.is_control())
+            && component.chars().all(|character| {
+                !character.is_whitespace()
+                    && !character.is_control()
+                    && !is_bidirectional_format_control(character)
+            })
     })
+}
+
+fn is_bidirectional_format_control(character: char) -> bool {
+    // These Unicode formatting controls can reorder surrounding text without
+    // occupying a visible cell, making a coordinate appear to say something else.
+    matches!(
+        character,
+        '\u{061c}'
+            | '\u{200e}'
+            | '\u{200f}'
+            | '\u{202a}'..='\u{202e}'
+            | '\u{2066}'..='\u{206f}'
+    )
 }
 
 fn sanitize_registry_description(description: &str) -> String {
@@ -97,7 +112,10 @@ fn sanitize_registry_description(description: &str) -> String {
     let mut sanitized = String::with_capacity(printable.len());
     let mut pending_space = false;
     for character in printable.chars() {
-        if character.is_whitespace() || character.is_control() {
+        if character.is_whitespace()
+            || character.is_control()
+            || is_bidirectional_format_control(character)
+        {
             pending_space = !sanitized.is_empty();
         } else {
             if pending_space {
@@ -126,7 +144,8 @@ mod tests {
                     name: "mizchi/jq".to_owned(),
                     version: Version::new(0, 2, 2),
                     description: Some(
-                        "A jq clone\nfor MoonBit\r\x1b[31mwith color\x1b[0m\tand spaces".to_owned(),
+                        "A jq clone\nfor MoonBit\r\x1b[31mwith color\x1b[0m\tand\u{202e}spaces"
+                            .to_owned(),
                     ),
                 },
                 RegistrySearchResult {
@@ -157,6 +176,8 @@ mod tests {
             "example/module\nforged/coordinate",
             "example/module\roverwrite",
             "example/\x1b[2Jmodule",
+            "example/\u{202e}module",
+            "example/\u{2066}module",
             "example/module name",
             "example/module@9.9.9",
         ] {

--- a/crates/moon/src/cli/search.rs
+++ b/crates/moon/src/cli/search.rs
@@ -42,6 +42,18 @@ fn render_search_results(
     writer: &mut dyn Write,
     results: &[RegistrySearchResult],
 ) -> std::io::Result<()> {
+    // Validate every name before writing anything so one malformed registry
+    // result cannot leave a partial, trusted-looking list of coordinates.
+    if results
+        .iter()
+        .any(|result| !is_safe_registry_module_name(&result.name))
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "registry search response contains an invalid module name",
+        ));
+    }
+
     for result in results {
         write!(writer, "{}@{}", result.name, result.version)?;
         if let Some(description) = result.description.as_deref() {
@@ -53,6 +65,18 @@ fn render_search_results(
         writeln!(writer)?;
     }
     Ok(())
+}
+
+fn is_safe_registry_module_name(name: &str) -> bool {
+    name.split('/').all(|component| {
+        !component.is_empty()
+            && component != "."
+            && component != ".."
+            && !component.contains(['@', ':', '\\'])
+            && component
+                .chars()
+                .all(|character| !character.is_whitespace() && !character.is_control())
+    })
 }
 
 fn sanitize_registry_description(description: &str) -> String {
@@ -125,5 +149,41 @@ mod tests {
             example/empty-description@2.0.0
         "#]]
         .assert_eq(&String::from_utf8(output).unwrap());
+    }
+
+    #[test]
+    fn rejects_unsafe_module_names_before_rendering() {
+        for name in [
+            "example/module\nforged/coordinate",
+            "example/module\roverwrite",
+            "example/\x1b[2Jmodule",
+            "example/module name",
+            "example/module@9.9.9",
+        ] {
+            let mut output = Vec::new();
+            let error = render_search_results(
+                &mut output,
+                &[
+                    RegistrySearchResult {
+                        name: "example/valid".to_owned(),
+                        version: Version::new(1, 0, 0),
+                        description: None,
+                    },
+                    RegistrySearchResult {
+                        name: name.to_owned(),
+                        version: Version::new(2, 0, 0),
+                        description: None,
+                    },
+                ],
+            )
+            .unwrap_err();
+
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+            assert_eq!(
+                error.to_string(),
+                "registry search response contains an invalid module name"
+            );
+            assert!(output.is_empty());
+        }
     }
 }

--- a/crates/moon/src/cli/search.rs
+++ b/crates/moon/src/cli/search.rs
@@ -44,16 +44,46 @@ fn render_search_results(
 ) -> std::io::Result<()> {
     for result in results {
         write!(writer, "{}@{}", result.name, result.version)?;
-        if let Some(description) = result
-            .description
-            .as_deref()
-            .filter(|value| !value.is_empty())
-        {
-            write!(writer, ": {description}")?;
+        if let Some(description) = result.description.as_deref() {
+            let description = sanitize_registry_description(description);
+            if !description.is_empty() {
+                write!(writer, ": {description}")?;
+            }
         }
         writeln!(writer)?;
     }
     Ok(())
+}
+
+fn sanitize_registry_description(description: &str) -> String {
+    // Preserve word boundaries across lines before stripping terminal escape
+    // sequences, which would otherwise discard newlines along with controls.
+    let single_line = description
+        .chars()
+        .map(|character| {
+            if character.is_whitespace() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    let printable = anstream::adapter::strip_str(&single_line).to_string();
+
+    let mut sanitized = String::with_capacity(printable.len());
+    let mut pending_space = false;
+    for character in printable.chars() {
+        if character.is_whitespace() || character.is_control() {
+            pending_space = !sanitized.is_empty();
+        } else {
+            if pending_space {
+                sanitized.push(' ');
+                pending_space = false;
+            }
+            sanitized.push(character);
+        }
+    }
+    sanitized
 }
 
 #[cfg(test)]
@@ -71,20 +101,28 @@ mod tests {
                 RegistrySearchResult {
                     name: "mizchi/jq".to_owned(),
                     version: Version::new(0, 2, 2),
-                    description: Some("A jq clone implemented in MoonBit".to_owned()),
+                    description: Some(
+                        "A jq clone\nfor MoonBit\r\x1b[31mwith color\x1b[0m\tand spaces".to_owned(),
+                    ),
                 },
                 RegistrySearchResult {
                     name: "example/no-description".to_owned(),
                     version: Version::new(1, 0, 0),
                     description: None,
                 },
+                RegistrySearchResult {
+                    name: "example/empty-description".to_owned(),
+                    version: Version::new(2, 0, 0),
+                    description: Some("\x1b[2J\r\n".to_owned()),
+                },
             ],
         )
         .unwrap();
 
         expect_test::expect![[r#"
-            mizchi/jq@0.2.2: A jq clone implemented in MoonBit
+            mizchi/jq@0.2.2: A jq clone for MoonBit with color and spaces
             example/no-description@1.0.0
+            example/empty-description@2.0.0
         "#]]
         .assert_eq(&String::from_utf8(output).unwrap());
     }

--- a/crates/moon/src/cli/search.rs
+++ b/crates/moon/src/cli/search.rs
@@ -1,0 +1,91 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::io::Write;
+
+use mooncake::registry::{RegistryClient, RegistrySearchResult};
+use moonutil::command_output::CommandOutput;
+
+/// Search for modules in the package registry
+#[derive(Debug, clap::Parser)]
+pub(crate) struct SearchSubcommand {
+    /// The keyword to search for
+    pub keyword: String,
+
+    /// Limit the number of search results
+    #[clap(short, long, default_value_t = 20)]
+    pub limit: u32,
+}
+
+pub(crate) fn run_search(cmd: SearchSubcommand, output: &CommandOutput) -> anyhow::Result<i32> {
+    let results = RegistryClient::configured().search(&cmd.keyword, cmd.limit)?;
+    output.write_result(|writer| render_search_results(writer, &results))?;
+    Ok(0)
+}
+
+fn render_search_results(
+    writer: &mut dyn Write,
+    results: &[RegistrySearchResult],
+) -> std::io::Result<()> {
+    for result in results {
+        write!(writer, "{}@{}", result.name, result.version)?;
+        if let Some(description) = result
+            .description
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            write!(writer, ": {description}")?;
+        }
+        writeln!(writer)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use semver::Version;
+
+    use super::*;
+
+    #[test]
+    fn renders_search_results_as_addable_module_coordinates() {
+        let mut output = Vec::new();
+        render_search_results(
+            &mut output,
+            &[
+                RegistrySearchResult {
+                    name: "mizchi/jq".to_owned(),
+                    version: Version::new(0, 2, 2),
+                    description: Some("A jq clone implemented in MoonBit".to_owned()),
+                },
+                RegistrySearchResult {
+                    name: "example/no-description".to_owned(),
+                    version: Version::new(1, 0, 0),
+                    description: None,
+                },
+            ],
+        )
+        .unwrap();
+
+        expect_test::expect![[r#"
+            mizchi/jq@0.2.2: A jq clone implemented in MoonBit
+            example/no-description@1.0.0
+        "#]]
+        .assert_eq(&String::from_utf8(output).unwrap());
+    }
+}

--- a/crates/moon/tests/test_cases/mod.rs
+++ b/crates/moon/tests/test_cases/mod.rs
@@ -98,6 +98,7 @@ mod prebuild;
 mod prebuild_config_script;
 mod prebuild_link_config_self;
 mod query_symbol;
+mod registry_search;
 mod run_command;
 mod run_doc_test;
 mod run_md_test;

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use std::io::{Read, Write};
+
 fn moonx_bin(bin_dir: &tempfile::TempDir) -> std::path::PathBuf {
     let moonx = bin_dir
         .path()
@@ -66,6 +68,7 @@ fn test_moon_help() {
               install                Install a binary package globally or install project dependencies (deprecated without args)
               tree                   Display the dependency tree
               fetch                  Download a package to .repos directory (unstable)
+              search                 Search for modules in the package registry
               work                   Workspace maintenance commands
               login                  Log in to your account
               whoami                 Show login status and username
@@ -101,6 +104,62 @@ fn test_moon_help() {
                       Unstable flags to MoonBuild [env: MOON_UNSTABLE=] [default: ]
         "#]],
     );
+}
+
+#[test]
+fn test_moon_search_uses_configured_registry() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let registry = format!("http://{}", listener.local_addr().unwrap());
+    let server = std::thread::spawn(move || {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(connection) => break connection,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "moon search did not contact the configured registry"
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                Err(error) => panic!("registry test server failed: {error}"),
+            }
+        };
+
+        let mut request = Vec::new();
+        let mut buffer = [0; 1024];
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let read = stream.read(&mut buffer).unwrap();
+            assert_ne!(read, 0, "request ended before its headers");
+            request.extend_from_slice(&buffer[..read]);
+        }
+        assert!(
+            request.starts_with(b"GET /api/v0/search?kw=json+query&limit=2 HTTP/1.1\r\n"),
+            "unexpected registry request: {}",
+            String::from_utf8_lossy(&request)
+        );
+
+        let body = br#"[{"name":"example/json","version":"1.2.3","description":"JSON query tools"},{"name":"example/no-description","version":"0.4.0"}]"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        )
+        .unwrap();
+        stream.write_all(body).unwrap();
+    });
+
+    let dir = TestDir::new_empty();
+    moon_cmd(&dir)
+        .env("MOONCAKES_REGISTRY", registry)
+        .env("NO_PROXY", "*")
+        .args(["search", "json query", "--limit", "2"])
+        .assert()
+        .success()
+        .stdout_eq("example/json@1.2.3: JSON query tools\nexample/no-description@0.4.0\n")
+        .stderr_eq("");
+    server.join().unwrap();
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-use std::io::{Read, Write};
-
 fn moonx_bin(bin_dir: &tempfile::TempDir) -> std::path::PathBuf {
     let moonx = bin_dir
         .path()
@@ -104,64 +102,6 @@ fn test_moon_help() {
                       Unstable flags to MoonBuild [env: MOON_UNSTABLE=] [default: ]
         "#]],
     );
-}
-
-#[test]
-fn test_moon_search_uses_configured_registry() {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    listener.set_nonblocking(true).unwrap();
-    let registry = format!("http://{}", listener.local_addr().unwrap());
-    let server = std::thread::spawn(move || {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        let (mut stream, _) = loop {
-            match listener.accept() {
-                Ok(connection) => break connection,
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                    assert!(
-                        std::time::Instant::now() < deadline,
-                        "moon search did not contact the configured registry"
-                    );
-                    std::thread::sleep(std::time::Duration::from_millis(5));
-                }
-                Err(error) => panic!("registry test server failed: {error}"),
-            }
-        };
-
-        let mut request = Vec::new();
-        let mut buffer = [0; 1024];
-        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
-            let read = stream.read(&mut buffer).unwrap();
-            assert_ne!(read, 0, "request ended before its headers");
-            request.extend_from_slice(&buffer[..read]);
-        }
-        assert!(
-            request.starts_with(b"GET /api/v0/search?kw=json+query&limit=2 HTTP/1.1\r\n"),
-            "unexpected registry request: {}",
-            String::from_utf8_lossy(&request)
-        );
-
-        let body = br#"[{"name":"example/json","version":"1.2.3","description":"JSON query\ntools\r\u001b[31mwith color\u001b[0m\tand spaces"},{"name":"example/no-description","version":"0.4.0"}]"#;
-        write!(
-            stream,
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-            body.len()
-        )
-        .unwrap();
-        stream.write_all(body).unwrap();
-    });
-
-    let dir = TestDir::new_empty();
-    moon_cmd(&dir)
-        .env("MOONCAKES_REGISTRY", registry)
-        .env("NO_PROXY", "*")
-        .args(["search", "json query", "--limit", "2"])
-        .assert()
-        .success()
-        .stdout_eq(
-            "example/json@1.2.3: JSON query tools with color and spaces\nexample/no-description@0.4.0\n",
-        )
-        .stderr_eq("");
-    server.join().unwrap();
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -140,7 +140,7 @@ fn test_moon_search_uses_configured_registry() {
             String::from_utf8_lossy(&request)
         );
 
-        let body = br#"[{"name":"example/json","version":"1.2.3","description":"JSON query tools"},{"name":"example/no-description","version":"0.4.0"}]"#;
+        let body = br#"[{"name":"example/json","version":"1.2.3","description":"JSON query\ntools\r\u001b[31mwith color\u001b[0m\tand spaces"},{"name":"example/no-description","version":"0.4.0"}]"#;
         write!(
             stream,
             "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -157,7 +157,9 @@ fn test_moon_search_uses_configured_registry() {
         .args(["search", "json query", "--limit", "2"])
         .assert()
         .success()
-        .stdout_eq("example/json@1.2.3: JSON query tools\nexample/no-description@0.4.0\n")
+        .stdout_eq(
+            "example/json@1.2.3: JSON query tools with color and spaces\nexample/no-description@0.4.0\n",
+        )
         .stderr_eq("");
     server.join().unwrap();
 }

--- a/crates/moon/tests/test_cases/registry_search.rs
+++ b/crates/moon/tests/test_cases/registry_search.rs
@@ -1,0 +1,83 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::io::{Read, Write};
+
+use super::*;
+
+#[test]
+fn test_moon_search_uses_configured_registry() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let registry = format!("http://{}", listener.local_addr().unwrap());
+    let server = std::thread::spawn(move || {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(connection) => break connection,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "moon search did not contact the configured registry"
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                Err(error) => panic!("registry test server failed: {error}"),
+            }
+        };
+
+        let mut request = Vec::new();
+        let mut buffer = [0; 1024];
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let read = stream.read(&mut buffer).unwrap();
+            assert_ne!(read, 0, "request ended before its headers");
+            request.extend_from_slice(&buffer[..read]);
+        }
+        assert!(
+            request.starts_with(b"GET /api/v0/search?kw=json+query&limit=2 HTTP/1.1\r\n"),
+            "unexpected registry request: {}",
+            String::from_utf8_lossy(&request)
+        );
+
+        let body = br#"[{"name":"example/json","version":"1.2.3","description":"JSON query\ntools\r\u001b[31mwith color\u001b[0m\tand spaces"},{"name":"example/no-description","version":"0.4.0"}]"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        )
+        .unwrap();
+        stream.write_all(body).unwrap();
+    });
+
+    let dir = TestDir::new_empty();
+    let moon_home = tempfile::TempDir::new().expect("failed to create temp MOON_HOME");
+    moon_cmd(&dir)
+        .env("MOON_HOME", moon_home.path())
+        .env("MOONCAKES_REGISTRY", registry)
+        .env("NO_PROXY", "*")
+        .args(["search", "json query", "--limit", "2"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+example/json@1.2.3: JSON query tools with color and spaces
+example/no-description@0.4.0
+
+"#]])
+        .stderr_eq("");
+    server.join().unwrap();
+}

--- a/crates/mooncake/src/registry.rs
+++ b/crates/mooncake/src/registry.rs
@@ -24,7 +24,7 @@ pub mod path;
 
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 
-pub use client::RegistryClient;
+pub use client::{RegistryClient, RegistrySearchResult};
 pub use executable::ResolvedExecutablePackage;
 use indexmap::IndexMap;
 use moonutil::dependency::SourceDependencyInfo;

--- a/crates/mooncake/src/registry/client.rs
+++ b/crates/mooncake/src/registry/client.rs
@@ -54,8 +54,16 @@ struct RegistryIndexEntry {
 }
 
 struct RegistryEndpoints {
+    registry: String,
     packages: String,
     assets: String,
+}
+
+fn registry_http_client() -> anyhow::Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .user_agent(format!("mooncake/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("failed to create registry HTTP client")
 }
 
 impl RegistryEndpoints {
@@ -67,9 +75,18 @@ impl RegistryEndpoints {
             format!("{registry}/user")
         };
         Self {
+            registry: registry.to_owned(),
             packages,
             assets: format!("{registry}/assets"),
         }
+    }
+
+    fn search(&self, keyword: &str, limit: u32) -> String {
+        let query = form_urlencoded::Serializer::new(String::new())
+            .append_pair("kw", keyword)
+            .append_pair("limit", &limit.to_string())
+            .finish();
+        format!("{}/api/v0/search?{query}", self.registry)
     }
 
     fn package_archive(&self, name: &ModuleName, version: &Version) -> String {
@@ -92,12 +109,21 @@ impl RegistryEndpoints {
     }
 }
 
+/// One module returned by a Mooncakes registry search.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct RegistrySearchResult {
+    pub name: String,
+    pub version: Version,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
 /// Access to a configured Mooncakes registry and its local state.
 ///
-/// This client owns synchronization of the Git index and symbols archive as
-/// well as verified package and prebuilt wasm downloads. Resolution code can
-/// depend on the narrower [`super::Registry`] interface when it does not need
-/// to synchronize the registry.
+/// This client owns remote search, synchronization of the Git index and symbols
+/// archive, and verified package and prebuilt wasm downloads. Resolution code
+/// can depend on the narrower [`super::Registry`] interface when it only needs
+/// local registry metadata.
 pub struct RegistryClient {
     config: RegistryConfig,
     home: MoonHomeLayout,
@@ -137,6 +163,22 @@ impl RegistryClient {
         Ok(())
     }
 
+    /// Search the configured registry for published modules.
+    #[tracing::instrument(skip(self), fields(registry = %self.config.registry))]
+    pub fn search(&self, keyword: &str, limit: u32) -> anyhow::Result<Vec<RegistrySearchResult>> {
+        let url = self.endpoints.search(keyword, limit);
+        let response = registry_http_client()?
+            .get(&url)
+            .send()
+            .with_context(|| format!("failed to search registry at {url}"))?
+            .error_for_status()
+            .with_context(|| format!("registry search request failed at {url}"))?;
+
+        response
+            .json()
+            .with_context(|| format!("failed to parse registry search response from {url}"))
+    }
+
     /// Return a verified, locally cached prebuilt wasm asset.
     pub fn acquire_wasm_asset(
         &self,
@@ -145,10 +187,7 @@ impl RegistryClient {
         package_path: &str,
         user_log: &UserLog,
     ) -> anyhow::Result<std::path::PathBuf> {
-        let http = reqwest::blocking::Client::builder()
-            .user_agent(format!("mooncake/{}", env!("CARGO_PKG_VERSION")))
-            .build()
-            .context("failed to create registry asset HTTP client")?;
+        let http = registry_http_client()?;
         self.acquire_wasm_asset_with(name, version, package_path, user_log, |url| {
             download_registry_asset(&http, url, user_log)
         })
@@ -732,6 +771,36 @@ mod tests {
         assert_eq!(
             endpoints.package_archive(&"test/pkg".into(), &Version::new(1, 2, 3)),
             "https://registry.example.com/user/test%2Fpkg%2F1.2.3.zip"
+        );
+    }
+
+    #[test]
+    fn registry_search_url_uses_configured_registry_and_encodes_query() {
+        let endpoints = RegistryEndpoints::from_config(&RegistryConfig {
+            registry: "https://registry.example.com/".to_owned(),
+            index: String::new(),
+            symbols: None,
+        });
+        assert_eq!(
+            endpoints.search("json query", 7),
+            "https://registry.example.com/api/v0/search?kw=json+query&limit=7"
+        );
+    }
+
+    #[test]
+    fn registry_search_result_ignores_unneeded_response_fields() {
+        let results: Vec<RegistrySearchResult> = serde_json::from_str(
+            r#"[{"name":"mizchi/jq","version":"0.2.2","license":"Apache-2.0","description":"A jq clone","is_new":false}]"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            results,
+            [RegistrySearchResult {
+                name: "mizchi/jq".to_owned(),
+                version: Version::new(0, 2, 2),
+                description: Some("A jq clone".to_owned()),
+            }]
         );
     }
 

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -361,18 +361,19 @@ See details in [Modules and packages][mod-pkg].
 
 Current registry configuration behavior today is:
 
-- `RegistryClient` owns the physical registry lifecycle: synchronizing the Git
-  index and HTTP symbols archive, reading the local index, and downloading and
-  verifying HTTP package archives and prebuilt wasm assets. Resolver code sees
-  only the narrower `Registry` capability.
+- `RegistryClient` owns the physical registry lifecycle: searching the remote
+  service, synchronizing the Git index and HTTP symbols archive, reading the
+  local index, and downloading and verifying HTTP package archives and
+  prebuilt wasm assets. Resolver code sees only the narrower `Registry`
+  capability.
 - The public `Registry` trait contains only metadata queries used by resolution.
   Package source acquisition remains on `RegistryClient`; dependency-source
   tests replace it through a crate-private seam.
 - `RegistryConfig.index` controls how `moon update` populates the local
   registry index over Git.
-- `RegistryClient` derives the package archive endpoint internally from the
-  loaded registry configuration; callers do not construct or depend on its
-  transport URLs.
+- `RegistryClient` derives the search and package archive endpoints internally
+  from the loaded registry configuration; callers do not construct or depend
+  on its transport URLs.
 - The optional `RegistryConfig.symbols` URL overrides the default Mooncakes
   symbols archive used by `moon update`. `MOONCAKES_REGISTRY` derives the
   index and symbols URLs from the configured registry base.

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -23,6 +23,7 @@ This document contains the help content for the `moon` command-line program.
 * [`moon install`↴](#moon-install)
 * [`moon tree`↴](#moon-tree)
 * [`moon fetch`↴](#moon-fetch)
+* [`moon search`↴](#moon-search)
 * [`moon work`↴](#moon-work)
 * [`moon work init`↴](#moon-work-init)
 * [`moon work use`↴](#moon-work-use)
@@ -66,6 +67,7 @@ This document contains the help content for the `moon` command-line program.
 * `install` — Install a binary package globally or install project dependencies (deprecated without args)
 * `tree` — Display the dependency tree
 * `fetch` — Download a package to .repos directory (unstable)
+* `search` — Search for modules in the package registry
 * `work` — Workspace maintenance commands
 * `login` — Log in to your account
 * `whoami` — Show login status and username
@@ -578,6 +580,24 @@ Note: This is an unstable command and may change or be removed in future version
 ###### **Options:**
 
 * `--no-update` — Do not update the registry index before fetching
+
+
+
+## `moon search`
+
+Search for modules in the package registry
+
+**Usage:** `moon search [OPTIONS] <KEYWORD>`
+
+###### **Arguments:**
+
+* `<KEYWORD>` — The keyword to search for
+
+###### **Options:**
+
+* `-l`, `--limit <LIMIT>` — Limit the number of search results
+
+  Default value: `20`
 
 
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -23,6 +23,7 @@ This document contains the help content for the `moon` command-line program.
 * [`moon install`↴](#moon-install)
 * [`moon tree`↴](#moon-tree)
 * [`moon fetch`↴](#moon-fetch)
+* [`moon search`↴](#moon-search)
 * [`moon work`↴](#moon-work)
 * [`moon work init`↴](#moon-work-init)
 * [`moon work use`↴](#moon-work-use)
@@ -66,6 +67,7 @@ This document contains the help content for the `moon` command-line program.
 * `install` — Install a binary package globally or install project dependencies (deprecated without args)
 * `tree` — Display the dependency tree
 * `fetch` — Download a package to .repos directory (unstable)
+* `search` — Search for modules in the package registry
 * `work` — Workspace maintenance commands
 * `login` — Log in to your account
 * `whoami` — Show login status and username
@@ -578,6 +580,24 @@ Note: This is an unstable command and may change or be removed in future version
 ###### **Options:**
 
 * `--no-update` — Do not update the registry index before fetching
+
+
+
+## `moon search`
+
+Search for modules in the package registry
+
+**Usage:** `moon search [OPTIONS] <KEYWORD>`
+
+###### **Arguments:**
+
+* `<KEYWORD>` — The keyword to search for
+
+###### **Options:**
+
+* `-l`, `--limit <LIMIT>` — Limit the number of search results
+
+  Default value: `20`
 
 
 


### PR DESCRIPTION
## Why
Moon can add and install registry modules, but it has no lightweight way to discover them. Users currently need to call the Mooncakes search API directly.

## What
- add moon search <keyword> with a configurable result limit
- put remote search and endpoint construction on RegistryClient
- render addable module@version coordinates with descriptions
- update command help and registry architecture documentation

## Correctness
RegistryClient derives the search endpoint from the configured registry and URL-encodes all query parameters. The CLI preserves the registry response order and writes the result through the command-result stdout channel.

## Scope
This is intentionally a thin registry-backed search. It does not add a local index or reinterpret the service ranking, so ranking improvements can remain an independent registry concern.