### PR TITLE
test: reuse host artifacts in integration tests

### DIFF
--- a/crates/moon/tests/support/util.rs
+++ b/crates/moon/tests/support/util.rs
@@ -41,13 +41,14 @@ pub(crate) fn moon_bin() -> PathBuf {
 pub(crate) fn moonrun_bin() -> PathBuf {
     MOONRUN_BIN
         .get_or_init(|| {
+            // `moonrun` is a host tool. Keep Cargo's default target layout so
+            // it can reuse artifacts from the outer Cargo invocation.
             escargot::CargoBuild::new()
                 .manifest_path(
                     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../moonrun/Cargo.toml"),
                 )
                 .bin("moonrun")
                 .current_release()
-                .current_target()
                 .run()
                 .expect("failed to build moonrun")
                 .path()

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -31,11 +31,12 @@ fn moon_bin() -> &'static PathBuf {
     static MOON_BIN: OnceLock<PathBuf> = OnceLock::new();
     MOON_BIN.get_or_init(|| {
         let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../moon/Cargo.toml");
+        // `moon` is a host tool. Keep Cargo's default target layout so it can
+        // reuse artifacts from the outer Cargo invocation.
         escargot::CargoBuild::new()
             .manifest_path(manifest_path)
             .bin("moon")
             .current_release()
-            .current_target()
             .run()
             .expect("failed to build moon")
             .path()


### PR DESCRIPTION
## Why

The Moon and Moonrun integration suites build each other through Escargot. Calling current_target passes an explicit host target, which puts those builds under target/<triple>/debug while the outer workspace build uses target/debug. A cache miss therefore compiles the same dependency graph into a second artifact layout, and CI may rebuild changed workspace binaries twice.

## Why this is correct

Both helper binaries are host tools. Letting Cargo use its default target selection keeps them in the same artifact layout as the outer build while retaining the selected profile and Escargot fallback build behavior.

## Scope

This only removes the redundant explicit target from the two test helpers and documents the artifact-reuse invariant. Production behavior is unchanged.