### PR TITLE
Improve moon search output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,6 +1701,7 @@ dependencies = [
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
+ "unicode-width",
  "walkdir",
  "which 6.0.2",
  "windows-sys 0.59.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ tempfile = "3.10.1"
 line-index = "0.1.1"
 libsqlite3-sys = { version = "0.38.2", features = ["bundled"] }
 text-size = "1.1.1"
+unicode-width = "0.1.13"
 log = "0.4.20"
 thiserror = "1.0"
 test-log = "0.2"

--- a/crates/moon/Cargo.toml
+++ b/crates/moon/Cargo.toml
@@ -58,6 +58,7 @@ indexmap.workspace = true
 petgraph.workspace = true
 rand.workspace = true
 tempfile.workspace = true
+unicode-width.workspace = true
 shlex.workspace = true
 derive_builder.workspace = true
 sha2.workspace = true

--- a/crates/moon/src/cli/invocation.rs
+++ b/crates/moon/src/cli/invocation.rs
@@ -169,10 +169,10 @@ pub(crate) fn select(raw_args: Vec<OsString>) -> Result<SelectedInvocation, clap
             DelegatedInvocation::Register { current_dir },
         ),
         command => {
-            let output = if matches!(&command, MoonBuildSubcommands::Check(cmd) if cmd.json) {
-                OutputFormat::Json
-            } else {
-                OutputFormat::Human
+            let output = match &command {
+                MoonBuildSubcommands::Check(command) if command.json => OutputFormat::Json,
+                MoonBuildSubcommands::Search(command) if command.json => OutputFormat::Json,
+                _ => OutputFormat::Human,
             };
             Ok(SelectedInvocation::Moon(Box::new(MoonInvocation {
                 flags,
@@ -352,6 +352,13 @@ mod tests {
             panic!("JSON check should select a Moon invocation")
         };
         assert_eq!(check.output, OutputFormat::Json);
+
+        let SelectedInvocation::Moon(search) =
+            select(args(&["moon", "search", "json", "--json"])).unwrap()
+        else {
+            panic!("JSON search should select a Moon invocation")
+        };
+        assert_eq!(search.output, OutputFormat::Json);
     }
 
     #[test]

--- a/crates/moon/src/cli/runtime.rs
+++ b/crates/moon/src/cli/runtime.rs
@@ -131,7 +131,7 @@ fn run_moon(mut invocation: MoonInvocation) -> i32 {
         && let Err(error) = std::env::set_current_dir(dir)
     {
         let message = format!("failed to change directory to {}: {}", dir.display(), error);
-        return finish_bootstrap_error(&output, capture.as_ref(), message);
+        return finish_bootstrap_error(&output, capture.as_ref(), &invocation.command, message);
     }
 
     let trace_guard = init_tracing(
@@ -148,7 +148,12 @@ fn run_moon(mut invocation: MoonInvocation) -> i32 {
                     format!("{error:?}")
                 };
                 drop(trace_guard);
-                return finish_bootstrap_error(&output, capture.as_ref(), message);
+                return finish_bootstrap_error(
+                    &output,
+                    capture.as_ref(),
+                    &invocation.command,
+                    message,
+                );
             }
         };
     invocation.flags.workspace_env = workspace_env;
@@ -161,18 +166,22 @@ fn run_moon(mut invocation: MoonInvocation) -> i32 {
     }
 
     if invocation.output == OutputFormat::Json {
-        let MoonBuildSubcommands::Check(command) = &invocation.command else {
-            unreachable!("only check currently selects JSON output")
+        let capture = capture
+            .as_ref()
+            .expect("JSON output should have a captured UserLog");
+        return match &invocation.command {
+            MoonBuildSubcommands::Check(command) => {
+                let outcome = super::run_check_json(&invocation.flags, command, &output);
+                drop(trace_guard);
+                finish_check_json(&output, capture, outcome)
+            }
+            MoonBuildSubcommands::Search(command) => {
+                let outcome = super::run_search_json(command, INTERNAL_ERROR_EXIT_CODE);
+                drop(trace_guard);
+                finish_search_json(&output, capture, outcome)
+            }
+            _ => unreachable!("command does not select JSON output"),
         };
-        let outcome = super::run_check_json(&invocation.flags, command, &output);
-        drop(trace_guard);
-        return finish_check_json(
-            &output,
-            capture
-                .as_ref()
-                .expect("JSON output should have a captured UserLog"),
-            outcome,
-        );
     }
 
     let result = dispatch(invocation.flags, invocation.command, &output);
@@ -189,17 +198,39 @@ fn run_moon(mut invocation: MoonInvocation) -> i32 {
 fn finish_bootstrap_error(
     output: &CommandOutput,
     capture: Option<&UserLogCapture>,
+    command: &MoonBuildSubcommands,
     message: String,
 ) -> i32 {
     if let Some(capture) = capture {
-        finish_check_json(
-            output,
-            capture,
-            CheckJsonOutcome::from_error(INTERNAL_ERROR_EXIT_CODE, message),
-        )
+        match command {
+            MoonBuildSubcommands::Check(_) => finish_check_json(
+                output,
+                capture,
+                CheckJsonOutcome::from_error(INTERNAL_ERROR_EXIT_CODE, message),
+            ),
+            MoonBuildSubcommands::Search(_) => finish_search_json(
+                output,
+                capture,
+                super::SearchJsonOutcome::from_error(INTERNAL_ERROR_EXIT_CODE, message),
+            ),
+            _ => unreachable!("command does not select JSON output"),
+        }
     } else {
         output.user_log().error(message);
         INTERNAL_ERROR_EXIT_CODE
+    }
+}
+
+fn finish_search_json(
+    output: &CommandOutput,
+    capture: &UserLogCapture,
+    outcome: super::SearchJsonOutcome,
+) -> i32 {
+    let exit_code = outcome.exit_code();
+    if super::write_search_json(output, capture, outcome).is_err() {
+        INTERNAL_ERROR_EXIT_CODE
+    } else {
+        exit_code
     }
 }
 

--- a/crates/moon/src/cli/search.rs
+++ b/crates/moon/src/cli/search.rs
@@ -19,7 +19,12 @@
 use std::io::Write;
 
 use mooncake::registry::{RegistryClient, RegistrySearchResult};
-use moonutil::command_output::CommandOutput;
+use moonutil::{
+    command_output::CommandOutput,
+    user_log::{UserLogCapture, UserLogEntry, UserLogEntryLevel},
+};
+use serde::Serialize;
+use unicode_width::UnicodeWidthStr;
 
 /// Search for modules in the package registry
 #[derive(Debug, clap::Parser)]
@@ -30,12 +35,85 @@ pub(crate) struct SearchSubcommand {
     /// Limit the number of search results
     #[clap(short, long, default_value_t = 20)]
     pub limit: u32,
+
+    /// Print search results as JSON
+    #[clap(long)]
+    pub json: bool,
 }
 
 pub(crate) fn run_search(cmd: SearchSubcommand, output: &CommandOutput) -> anyhow::Result<i32> {
     let results = RegistryClient::configured().search(&cmd.keyword, cmd.limit)?;
     output.write_result(|writer| render_search_results(writer, &results))?;
     Ok(0)
+}
+
+pub(crate) struct SearchJsonOutcome {
+    exit_code: i32,
+    results: Vec<RegistrySearchResult>,
+    error: Option<String>,
+}
+
+impl SearchJsonOutcome {
+    pub(crate) fn from_error(exit_code: i32, error: impl std::fmt::Display) -> Self {
+        Self {
+            exit_code,
+            results: Vec::new(),
+            error: Some(error.to_string()),
+        }
+    }
+
+    pub(crate) fn exit_code(&self) -> i32 {
+        self.exit_code
+    }
+}
+
+#[derive(Serialize)]
+struct SearchJsonReport {
+    version: u8,
+    status: &'static str,
+    results: Vec<RegistrySearchResult>,
+    messages: Vec<UserLogEntry>,
+}
+
+pub(crate) fn run_search_json(cmd: &SearchSubcommand, error_exit_code: i32) -> SearchJsonOutcome {
+    match RegistryClient::configured().search(&cmd.keyword, cmd.limit) {
+        Ok(results) => SearchJsonOutcome {
+            exit_code: 0,
+            results,
+            error: None,
+        },
+        Err(error) => SearchJsonOutcome::from_error(error_exit_code, format!("{error:#}")),
+    }
+}
+
+pub(crate) fn write_search_json(
+    output: &CommandOutput,
+    capture: &UserLogCapture,
+    outcome: SearchJsonOutcome,
+) -> anyhow::Result<()> {
+    let status = if outcome.exit_code == 0 {
+        "success"
+    } else {
+        "failure"
+    };
+    let mut messages = capture.take();
+    if let Some(error) = outcome.error {
+        messages.push(UserLogEntry {
+            level: UserLogEntryLevel::Error,
+            message: error,
+        });
+    }
+    let report = SearchJsonReport {
+        version: 1,
+        status,
+        results: outcome.results,
+        messages,
+    };
+    output.write_result(|writer| -> anyhow::Result<()> {
+        serde_json::to_writer(&mut *writer, &report)?;
+        writeln!(writer)?;
+        Ok(())
+    })
 }
 
 fn render_search_results(
@@ -54,16 +132,58 @@ fn render_search_results(
         ));
     }
 
-    for result in results {
-        write!(writer, "{}@{}", result.name, result.version)?;
-        if let Some(description) = result.description.as_deref() {
-            let description = sanitize_registry_description(description);
-            if !description.is_empty() {
-                write!(writer, ": {description}")?;
-            }
-        }
-        writeln!(writer)?;
+    if results.is_empty() {
+        writeln!(writer, "No modules found.")?;
+        return Ok(());
     }
+
+    let module_width = results
+        .iter()
+        .map(|result| result.name.width())
+        .max()
+        .unwrap_or_default()
+        .max("MODULE".len());
+    let version_width = results
+        .iter()
+        .map(|result| result.version.to_string().len())
+        .max()
+        .unwrap_or_default()
+        .max("VERSION".len());
+    writeln!(
+        writer,
+        "{} {} found\n",
+        results.len(),
+        if results.len() == 1 {
+            "module"
+        } else {
+            "modules"
+        }
+    )?;
+    writeln!(
+        writer,
+        "{:<module_width$}  {:<version_width$}  DESCRIPTION",
+        "MODULE", "VERSION"
+    )?;
+    for result in results {
+        let module_padding = module_width.saturating_sub(result.name.width());
+        let description = result
+            .description
+            .as_deref()
+            .map(sanitize_registry_description)
+            .filter(|description| !description.is_empty());
+        writeln!(
+            writer,
+            "{}{:module_padding$}  {:<version_width$}  {}",
+            result.name,
+            "",
+            result.version,
+            description.as_deref().unwrap_or("—")
+        )?;
+    }
+    writeln!(
+        writer,
+        "\nRun `moon add <module>@<version>` to add a dependency."
+    )?;
     Ok(())
 }
 
@@ -135,7 +255,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn renders_search_results_as_addable_module_coordinates() {
+    fn renders_search_results_as_a_table() {
         let mut output = Vec::new();
         render_search_results(
             &mut output,
@@ -162,10 +282,71 @@ mod tests {
         )
         .unwrap();
 
+        let output = String::from_utf8(output).unwrap();
+
         expect_test::expect![[r#"
-            mizchi/jq@0.2.2: A jq clone for MoonBit with color and spaces
-            example/no-description@1.0.0
-            example/empty-description@2.0.0
+            3 modules found
+
+            MODULE                     VERSION  DESCRIPTION
+            mizchi/jq                  0.2.2    A jq clone for MoonBit with color and spaces
+            example/no-description     1.0.0    —
+            example/empty-description  2.0.0    —
+
+            Run `moon add <module>@<version>` to add a dependency.
+        "#]]
+        .assert_eq(&output);
+    }
+
+    #[test]
+    fn aligns_unicode_module_names_by_display_width() {
+        let mut output = Vec::new();
+        render_search_results(
+            &mut output,
+            &[
+                RegistrySearchResult {
+                    name: "example/ascii".to_owned(),
+                    version: Version::new(1, 0, 0),
+                    description: None,
+                },
+                RegistrySearchResult {
+                    name: "example/中".to_owned(),
+                    version: Version::new(2, 0, 0),
+                    description: None,
+                },
+                RegistrySearchResult {
+                    name: "example/e\u{301}".to_owned(),
+                    version: Version::new(3, 0, 0),
+                    description: None,
+                },
+            ],
+        )
+        .unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        let version_columns = [
+            ("example/ascii", "1.0.0"),
+            ("example/中", "2.0.0"),
+            ("example/e\u{301}", "3.0.0"),
+        ]
+        .map(|(name, version)| {
+            let row = output
+                .lines()
+                .find(|line| line.starts_with(name))
+                .expect("module row should be present");
+            let version_start = row.find(version).expect("version should be present");
+            unicode_width::UnicodeWidthStr::width(&row[..version_start])
+        });
+
+        assert_eq!(version_columns, [15, 15, 15]);
+    }
+
+    #[test]
+    fn renders_an_explicit_empty_state() {
+        let mut output = Vec::new();
+        render_search_results(&mut output, &[]).unwrap();
+
+        expect_test::expect![[r#"
+            No modules found.
         "#]]
         .assert_eq(&String::from_utf8(output).unwrap());
     }

--- a/crates/moon/tests/test_cases/registry_search.rs
+++ b/crates/moon/tests/test_cases/registry_search.rs
@@ -20,8 +20,15 @@ use std::io::{Read, Write};
 
 use super::*;
 
-#[test]
-fn test_moon_search_uses_configured_registry() {
+const SEARCH_RESULTS: &[u8] = br#"[{"name":"example/json","version":"1.2.3","description":"JSON query\ntools\r\u001b[31mwith color\u001b[0m\tand spaces for MoonBit package development and automation."},{"name":"example/no-description","version":"0.4.0"}]"#;
+
+fn moon_search(
+    args: &[&str],
+    response_status: &'static str,
+    response_body: &'static [u8],
+) -> snapbox::cmd::OutputAssert {
+    // Initialize the shared test dependency before starting the server's timeout.
+    let _ = moonrun_bin();
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     listener.set_nonblocking(true).unwrap();
     let registry = format!("http://{}", listener.local_addr().unwrap());
@@ -40,6 +47,7 @@ fn test_moon_search_uses_configured_registry() {
                 Err(error) => panic!("registry test server failed: {error}"),
             }
         };
+        stream.set_nonblocking(false).unwrap();
 
         let mut request = Vec::new();
         let mut buffer = [0; 1024];
@@ -54,30 +62,123 @@ fn test_moon_search_uses_configured_registry() {
             String::from_utf8_lossy(&request)
         );
 
-        let body = br#"[{"name":"example/json","version":"1.2.3","description":"JSON query\ntools\r\u001b[31mwith color\u001b[0m\tand spaces"},{"name":"example/no-description","version":"0.4.0"}]"#;
         write!(
             stream,
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-            body.len()
+            "HTTP/1.1 {response_status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            response_body.len()
         )
         .unwrap();
-        stream.write_all(body).unwrap();
+        stream.write_all(response_body).unwrap();
     });
 
     let dir = TestDir::new_empty();
     let moon_home = tempfile::TempDir::new().expect("failed to create temp MOON_HOME");
-    moon_cmd(&dir)
+    let assert = moon_cmd(&dir)
         .env("MOON_HOME", moon_home.path())
         .env("MOONCAKES_REGISTRY", registry)
         .env("NO_PROXY", "*")
-        .args(["search", "json query", "--limit", "2"])
-        .assert()
-        .success()
-        .stdout_eq(snapbox::str![[r#"
-example/json@1.2.3: JSON query tools with color and spaces
-example/no-description@0.4.0
+        .args(args)
+        .assert();
+    server.join().unwrap();
+    assert
+}
+
+#[test]
+fn test_moon_search_uses_configured_registry() {
+    moon_search(
+        &["search", "json query", "--limit", "2"],
+        "200 OK",
+        SEARCH_RESULTS,
+    )
+    .success()
+    .stdout_eq(snapbox::str![[r#"
+2 modules found
+
+MODULE                  VERSION  DESCRIPTION
+example/json            1.2.3    JSON query tools with color and spaces for MoonBit package development and automation.
+example/no-description  0.4.0    —
+
+Run `moon add <module>@<version>` to add a dependency.
 
 "#]])
+    .stderr_eq("");
+}
+
+#[test]
+fn test_moon_search_json_is_one_complete_result() {
+    let assert = moon_search(
+        &["search", "json query", "--limit", "2", "--json"],
+        "200 OK",
+        SEARCH_RESULTS,
+    )
+    .success()
+    .stderr_eq("");
+    let report: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)
+        .expect("stdout should contain one complete JSON value");
+
+    assert_eq!(report["version"], 1);
+    assert_eq!(report["status"], "success");
+    assert_eq!(report["messages"], serde_json::json!([]));
+    assert_eq!(
+        report["results"],
+        serde_json::json!([
+            {
+                "name": "example/json",
+                "version": "1.2.3",
+                "description": "JSON query\ntools\r\u{1b}[31mwith color\u{1b}[0m\tand spaces for MoonBit package development and automation."
+            },
+            {
+                "name": "example/no-description",
+                "version": "0.4.0",
+                "description": null
+            }
+        ])
+    );
+}
+
+#[test]
+fn test_moon_search_json_failure_stays_in_json() {
+    let assert = moon_search(
+        &["search", "json query", "--limit", "2", "--json"],
+        "500 Internal Server Error",
+        b"",
+    )
+    .failure()
+    .stderr_eq("");
+    let report: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)
+        .expect("stdout should contain one complete JSON value");
+
+    assert_eq!(report["version"], 1);
+    assert_eq!(report["status"], "failure");
+    assert_eq!(report["results"], serde_json::json!([]));
+    assert_eq!(report["messages"].as_array().unwrap().len(), 1);
+    assert_eq!(report["messages"][0]["level"], "error");
+    assert!(
+        report["messages"][0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("registry search request failed at http://127.0.0.1:")
+    );
+}
+
+#[test]
+fn test_moon_search_json_bootstrap_failure_stays_in_json() {
+    let dir = TestDir::new_empty();
+    let assert = moon_cmd(&dir)
+        .args(["-C", "missing", "search", "json", "--json"])
+        .assert()
+        .failure()
         .stderr_eq("");
-    server.join().unwrap();
+    let report: serde_json::Value = serde_json::from_slice(&assert.get_output().stdout)
+        .expect("stdout should contain one complete JSON value");
+
+    assert_eq!(report["status"], "failure");
+    assert_eq!(report["results"], serde_json::json!([]));
+    assert_eq!(report["messages"][0]["level"], "error");
+    assert!(
+        report["messages"][0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("failed to change directory")
+    );
 }

--- a/crates/mooncake/src/registry/client.rs
+++ b/crates/mooncake/src/registry/client.rs
@@ -37,7 +37,7 @@ use moonutil::{
 };
 use reqwest::{StatusCode, header::USER_AGENT};
 use semver::Version;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     registry::RegistryVersionInfo,
@@ -110,7 +110,7 @@ impl RegistryEndpoints {
 }
 
 /// One module returned by a Mooncakes registry search.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct RegistrySearchResult {
     pub name: String,
     pub version: Version,

--- a/docs/dev/design/cli-execution-lifecycle.md
+++ b/docs/dev/design/cli-execution-lifecycle.md
@@ -85,11 +85,11 @@ enum OutputFormat {
 }
 ```
 
-`check` is currently the only command that selects JSON. The distinction is an
-output contract, not a `JsonCheck` command variant. A future JSON command may
-own a different result schema while reusing the same lifecycle requirement:
-one complete Command Result on stdout and no terminal-only output on stderr.
-No universal JSON payload or generic result trait is required.
+`check` and `search` currently select JSON through command-local `--json`
+flags. The distinction is an output contract, not a JSON-specific command
+variant. Each command owns its result schema while reusing the same lifecycle
+requirement: one complete Command Result on stdout and no terminal-only output
+on stderr. No universal JSON payload or generic result trait is required.
 
 ## Runtime
 
@@ -203,6 +203,8 @@ Public CLI tests cover:
 - trace ownership around the cram delegation point;
 - complete traces before `cram test` and registry `runwasm` delegation;
 - complete JSON stdout and trace files for successful and failed JSON checks;
+- complete JSON stdout with empty stderr for successful and failed registry
+  searches;
 - JSON check capture for successful and failed legacy postadd hooks and nested
   binary-dependency builds; and
 - existing `moon run` trace and temporary-project cleanup invariants.

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -598,6 +598,7 @@ Search for modules in the package registry
 * `-l`, `--limit <LIMIT>` — Limit the number of search results
 
   Default value: `20`
+* `--json` — Print search results as JSON
 
 
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -598,6 +598,7 @@ Search for modules in the package registry
 * `-l`, `--limit <LIMIT>` — Limit the number of search results
 
   Default value: `20`
+* `--json` — Print search results as JSON
 
 
 


### PR DESCRIPTION
## Why

moon search currently returns a sparse line-oriented list and has no structured output for tooling.

## What changed

- render human search results as a plain aligned table with a result count, an explicit empty state, a missing-description marker, and an add-dependency hint
- align Unicode module names by terminal display width, including wide and combining characters
- add moon search --json with a versioned report and structured success and failure messages
- preserve registry data in JSON while sanitizing descriptions in human output
- cover human output plus successful, registry-failure, and bootstrap-failure JSON paths
- document the command flag and JSON lifecycle

## Why this approach

The change keeps presentation at the existing command-output seam and serializes the existing registry result type. It reuses unicode-width, which is already present in the dependency graph, and leaves long descriptions and URLs intact.

The checked-in manual files are generated directly from clap-markdown output so the documentation snapshot remains byte-for-byte authoritative.