### PR TITLE
feat(check): publish package metadata backend index

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -419,7 +419,7 @@ fn run_check_impl(
                 .collect()
         };
         let mut ret_value = 0;
-        let mut target_backends = Vec::with_capacity(targets.len());
+        let mut build_metas = Vec::with_capacity(targets.len());
         for t in targets {
             let result = run_check_for_single_file_rr(
                 cli,
@@ -430,12 +430,12 @@ fn run_check_impl(
                 output,
                 json.as_deref_mut(),
             );
-            let (x, target_backend) = match t {
+            let (x, build_meta) = match t {
                 Some(t) => result.context(format!("failed to run check for target {t:?}"))?,
                 None => result?,
             };
             ret_value = ret_value.max(x);
-            target_backends.push(target_backend);
+            build_metas.push(build_meta);
         }
         if !cli.dry_run {
             let _lock = lock_directory(&dirs.target_dir, user_log).with_context(|| {
@@ -444,7 +444,7 @@ fn run_check_impl(
                     dirs.target_dir.display()
                 )
             })?;
-            rr_build::generate_metadata_index(&dirs.target_dir, target_backends)?;
+            rr_build::generate_metadata_index(&build_metas)?;
         }
         return Ok(ret_value);
     }
@@ -520,7 +520,7 @@ fn run_check_for_single_file_rr(
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
     json: Option<&mut CheckJsonAccumulator>,
-) -> anyhow::Result<(i32, TargetBackend)> {
+) -> anyhow::Result<(i32, rr_build::BuildMeta)> {
     let user_log = output.user_log();
     let PackageDirs {
         source_dir,
@@ -588,8 +588,6 @@ fn run_check_for_single_file_rr(
         resolved,
     )
     .context("Failed to calculate build plan")?;
-    let target_backend = build_meta.target_backend();
-
     if cli.dry_run {
         output.write_result(|writer| {
             rr_build::write_dry_run(
@@ -600,7 +598,7 @@ fn run_check_for_single_file_rr(
                 target_dir,
             )
         })?;
-        return Ok((0, target_backend));
+        return Ok((0, build_meta));
     }
 
     let _lock = lock_directory(target_dir, user_log).with_context(|| {
@@ -635,13 +633,13 @@ fn run_check_for_single_file_rr(
         )?;
         let successful = result.successful();
         json.append_build(result, user_log);
-        return Ok((if successful { 0 } else { 1 }, target_backend));
+        return Ok((if successful { 0 } else { 1 }, build_meta));
     }
 
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
     result.print_info(cli.quiet, "checking")?;
 
-    Ok((if result.successful() { 0 } else { 1 }, target_backend))
+    Ok((if result.successful() { 0 } else { 1 }, build_meta))
 }
 
 fn get_user_intents_single_file(
@@ -849,10 +847,7 @@ fn run_check_normal_rr_from_resolved(
                 .0;
             rr_build::generate_metadata_selector(selected, None)?;
             rr_build::generate_metadata_index(
-                target_dir,
-                planned_runs
-                    .iter()
-                    .map(|(build_meta, _)| build_meta.target_backend()),
+                planned_runs.iter().map(|(build_meta, _)| build_meta),
             )?;
         }
 

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -27,8 +27,8 @@
 //!    ordered list of single-backend RR plans.
 //! 4. `plan_check_rr_from_resolved` still plans exactly one backend group.
 //! 5. The command layer composes those plans into one executor graph. Project
-//!    checks without a selector publish `packages.json`; focused checks leave
-//!    it untouched.
+//!    checks without a selector publish `packages.json` and `index.json`;
+//!    focused checks leave them untouched.
 //!
 use anyhow::Context;
 use log::LevelFilter;
@@ -613,6 +613,7 @@ fn run_check_for_single_file_rr(
         .map(String::from);
     rr_build::generate_metadata(source_dir, &build_meta, &build_graph, filename.as_deref())?;
     rr_build::generate_metadata_selector(&build_meta, filename.as_deref())?;
+    rr_build::generate_metadata_index(std::iter::once(&build_meta))?;
 
     let mut cfg = BuildConfig::from_flags(
         &cmd.build_flags,
@@ -843,6 +844,9 @@ fn run_check_normal_rr_from_resolved(
                 .expect("non-empty planned runs were checked above")
                 .0;
             rr_build::generate_metadata_selector(selected, None)?;
+            rr_build::generate_metadata_index(
+                planned_runs.iter().map(|(build_meta, _)| build_meta),
+            )?;
         }
 
         let build_inputs = planned_runs.into_iter().map(|(_, input)| input).collect();

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -409,13 +409,52 @@ fn run_check_impl(
         dirs.mooncake_bin_dir = dirs.target_dir.join(moonutil::constants::MOON_BIN_DIR);
     }
 
+    if let Some(single_file_path) = single_file.as_deref() {
+        let targets = if cmd.build_flags.target.is_empty() {
+            vec![None]
+        } else {
+            lower_surface_targets(&cmd.build_flags.target)
+                .into_iter()
+                .map(Some)
+                .collect()
+        };
+        let mut ret_value = 0;
+        let mut target_backends = Vec::with_capacity(targets.len());
+        for t in targets {
+            let result = run_check_for_single_file_rr(
+                cli,
+                cmd,
+                single_file_path,
+                &dirs,
+                t,
+                output,
+                json.as_deref_mut(),
+            );
+            let (x, target_backend) = match t {
+                Some(t) => result.context(format!("failed to run check for target {t:?}"))?,
+                None => result?,
+            };
+            ret_value = ret_value.max(x);
+            target_backends.push(target_backend);
+        }
+        if !cli.dry_run {
+            let _lock = lock_directory(&dirs.target_dir, user_log).with_context(|| {
+                format!(
+                    "failed to acquire build lock in target directory `{}`",
+                    dirs.target_dir.display()
+                )
+            })?;
+            rr_build::generate_metadata_index(&dirs.target_dir, target_backends)?;
+        }
+        return Ok(ret_value);
+    }
+
     if cmd.build_flags.target.is_empty() {
-        return run_check_internal(
+        return run_check_normal_internal(
             cli,
             cmd,
             &dirs,
             &watch_ignored_subtree,
-            single_file.as_deref(),
             None,
             output,
             json,
@@ -425,15 +464,14 @@ fn run_check_impl(
     let surface_targets = cmd.build_flags.target.clone();
     let targets = lower_surface_targets(&surface_targets);
 
-    if single_file.is_some() || cmd.watch {
+    if cmd.watch {
         let mut ret_value = 0;
         for t in targets {
-            let x = run_check_internal(
+            let x = run_check_normal_internal(
                 cli,
                 cmd,
                 &dirs,
                 &watch_ignored_subtree,
-                single_file.as_deref(),
                 Some(t),
                 output,
                 json.as_deref_mut(),
@@ -473,41 +511,6 @@ fn run_check_impl(
     Ok(if result.ok { 0 } else { 1 })
 }
 
-#[instrument(skip_all)]
-#[allow(clippy::too_many_arguments)]
-fn run_check_internal(
-    cli: &UniversalFlags,
-    cmd: &CheckSubcommand,
-    dirs: &PackageDirs,
-    watch_ignored_subtree: &Path,
-    single_file: Option<&Path>,
-    selected_target_backend: Option<TargetBackend>,
-    output: &CommandOutput,
-    json: Option<&mut CheckJsonAccumulator>,
-) -> anyhow::Result<i32> {
-    if let Some(single_file_path) = single_file {
-        run_check_for_single_file_rr(
-            cli,
-            cmd,
-            single_file_path,
-            dirs,
-            selected_target_backend,
-            output,
-            json,
-        )
-    } else {
-        run_check_normal_internal(
-            cli,
-            cmd,
-            dirs,
-            watch_ignored_subtree,
-            selected_target_backend,
-            output,
-            json,
-        )
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 fn run_check_for_single_file_rr(
     cli: &UniversalFlags,
@@ -517,7 +520,7 @@ fn run_check_for_single_file_rr(
     selected_target_backend: Option<TargetBackend>,
     output: &CommandOutput,
     json: Option<&mut CheckJsonAccumulator>,
-) -> anyhow::Result<i32> {
+) -> anyhow::Result<(i32, TargetBackend)> {
     let user_log = output.user_log();
     let PackageDirs {
         source_dir,
@@ -553,9 +556,10 @@ fn run_check_for_single_file_rr(
         false,
         user_log,
     )?;
-    let selected_target_backend = selected_target_backend
-        .or(cmd.build_flags.resolve_single_target_backend()?)
-        .or(backend);
+    let selected_target_backend = match selected_target_backend {
+        Some(selected) => Some(selected),
+        None => cmd.build_flags.resolve_single_target_backend()?.or(backend),
+    };
 
     let preconfig = preconfig_compile(
         &cmd.auto_sync_flags,
@@ -584,6 +588,7 @@ fn run_check_for_single_file_rr(
         resolved,
     )
     .context("Failed to calculate build plan")?;
+    let target_backend = build_meta.target_backend();
 
     if cli.dry_run {
         output.write_result(|writer| {
@@ -595,7 +600,7 @@ fn run_check_for_single_file_rr(
                 target_dir,
             )
         })?;
-        return Ok(0);
+        return Ok((0, target_backend));
     }
 
     let _lock = lock_directory(target_dir, user_log).with_context(|| {
@@ -613,7 +618,6 @@ fn run_check_for_single_file_rr(
         .map(String::from);
     rr_build::generate_metadata(source_dir, &build_meta, &build_graph, filename.as_deref())?;
     rr_build::generate_metadata_selector(&build_meta, filename.as_deref())?;
-    rr_build::generate_metadata_index(std::iter::once(&build_meta))?;
 
     let mut cfg = BuildConfig::from_flags(
         &cmd.build_flags,
@@ -631,13 +635,13 @@ fn run_check_for_single_file_rr(
         )?;
         let successful = result.successful();
         json.append_build(result, user_log);
-        return Ok(if successful { 0 } else { 1 });
+        return Ok((if successful { 0 } else { 1 }, target_backend));
     }
 
     let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
     result.print_info(cli.quiet, "checking")?;
 
-    Ok(if result.successful() { 0 } else { 1 })
+    Ok((if result.successful() { 0 } else { 1 }, target_backend))
 }
 
 fn get_user_intents_single_file(
@@ -845,7 +849,10 @@ fn run_check_normal_rr_from_resolved(
                 .0;
             rr_build::generate_metadata_selector(selected, None)?;
             rr_build::generate_metadata_index(
-                planned_runs.iter().map(|(build_meta, _)| build_meta),
+                target_dir,
+                planned_runs
+                    .iter()
+                    .map(|(build_meta, _)| build_meta.target_backend()),
             )?;
         }
 

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -409,47 +409,23 @@ fn run_check_impl(
         dirs.mooncake_bin_dir = dirs.target_dir.join(moonutil::constants::MOON_BIN_DIR);
     }
 
+    let targets = if cmd.build_flags.target.is_empty() {
+        Vec::new()
+    } else {
+        lower_surface_targets(&cmd.build_flags.target)
+    };
+
     if let Some(single_file_path) = single_file.as_deref() {
-        let targets = if cmd.build_flags.target.is_empty() {
-            vec![None]
-        } else {
-            lower_surface_targets(&cmd.build_flags.target)
-                .into_iter()
-                .map(Some)
-                .collect()
+        let result =
+            run_check_for_single_file_rr(cli, cmd, single_file_path, &dirs, &targets, output, json);
+        return match targets.as_slice() {
+            [] => result,
+            [target] => result.context(format!("failed to run check for target {target:?}")),
+            _ => result.context(format!("failed to run check for targets {targets:?}")),
         };
-        let mut ret_value = 0;
-        let mut build_metas = Vec::with_capacity(targets.len());
-        for t in targets {
-            let result = run_check_for_single_file_rr(
-                cli,
-                cmd,
-                single_file_path,
-                &dirs,
-                t,
-                output,
-                json.as_deref_mut(),
-            );
-            let (x, build_meta) = match t {
-                Some(t) => result.context(format!("failed to run check for target {t:?}"))?,
-                None => result?,
-            };
-            ret_value = ret_value.max(x);
-            build_metas.push(build_meta);
-        }
-        if !cli.dry_run {
-            let _lock = lock_directory(&dirs.target_dir, user_log).with_context(|| {
-                format!(
-                    "failed to acquire build lock in target directory `{}`",
-                    dirs.target_dir.display()
-                )
-            })?;
-            rr_build::generate_metadata_index(&build_metas)?;
-        }
-        return Ok(ret_value);
     }
 
-    if cmd.build_flags.target.is_empty() {
+    if targets.is_empty() {
         return run_check_normal_internal(
             cli,
             cmd,
@@ -460,9 +436,6 @@ fn run_check_impl(
             json,
         );
     }
-
-    let surface_targets = cmd.build_flags.target.clone();
-    let targets = lower_surface_targets(&surface_targets);
 
     if cmd.watch {
         let mut ret_value = 0;
@@ -517,13 +490,12 @@ fn run_check_for_single_file_rr(
     cmd: &CheckSubcommand,
     single_file_path: &Path,
     dirs: &PackageDirs,
-    selected_target_backend: Option<TargetBackend>,
+    selected_target_backends: &[TargetBackend],
     output: &CommandOutput,
     json: Option<&mut CheckJsonAccumulator>,
-) -> anyhow::Result<(i32, rr_build::BuildMeta)> {
+) -> anyhow::Result<i32> {
     let user_log = output.user_log();
     let PackageDirs {
-        source_dir,
         target_dir,
         mooncake_bin_dir,
         ..
@@ -556,90 +528,57 @@ fn run_check_for_single_file_rr(
         false,
         user_log,
     )?;
-    let selected_target_backend = match selected_target_backend {
-        Some(selected) => Some(selected),
-        None => cmd.build_flags.resolve_single_target_backend()?.or(backend),
+    let target_backends = if selected_target_backends.is_empty() {
+        vec![cmd.build_flags.resolve_single_target_backend()?.or(backend)]
+    } else {
+        selected_target_backends.iter().copied().map(Some).collect()
     };
 
-    let preconfig = preconfig_compile(
-        &cmd.auto_sync_flags,
-        cli,
-        &cmd.build_flags,
-        selected_target_backend,
-        target_dir,
-        RunMode::Check,
-    );
-
-    let planning_context = rr_build::prepare_resolved_build(
-        &preconfig,
-        &cli.unstable_feature,
-        target_dir,
-        user_log,
-        &resolved,
-    )?;
-    let intent = get_user_intents_single_file(&resolved, planning_context.target_backend())?;
-    let (build_meta, build_graph) = rr_build::plan_resolved_build_from_intent(
-        preconfig,
-        &cli.unstable_feature,
-        user_log,
-        planning_context,
-        intent,
-        mooncake_bin_dir,
-        resolved,
-    )
-    .context("Failed to calculate build plan")?;
-    if cli.dry_run {
-        output.write_result(|writer| {
-            rr_build::write_dry_run(
-                writer,
-                &build_graph,
-                build_meta.artifacts.values(),
-                source_dir,
-                target_dir,
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(target_dir, user_log).with_context(|| {
+            format!(
+                "failed to acquire build lock in target directory `{}`",
+                target_dir.display()
             )
         })?;
-        return Ok((0, build_meta));
     }
 
-    let _lock = lock_directory(target_dir, user_log).with_context(|| {
-        format!(
-            "failed to acquire build lock in target directory `{}`",
-            target_dir.display()
-        )
-    })?;
-
-    // Generate all_pkgs.json for indirect dependency resolution
-    rr_build::generate_all_pkgs_json(&build_meta)?;
-    let filename = single_file_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(String::from);
-    rr_build::generate_metadata(source_dir, &build_meta, &build_graph, filename.as_deref())?;
-    rr_build::generate_metadata_selector(&build_meta, filename.as_deref())?;
-
-    let mut cfg = BuildConfig::from_flags(
-        &cmd.build_flags,
-        &cli.unstable_feature,
-        cli.verbose && json.is_none(),
-    );
-    cfg.patch_file = cmd.patch_file.clone();
-    cfg.explain_errors |= cmd.explain;
-
-    if let Some(json) = json {
-        let result = rr_build::execute_build_json(
-            &cfg.with_suppressed_progress(true),
-            build_graph,
+    let mut planned_runs = Vec::with_capacity(target_backends.len());
+    for target_backend in target_backends {
+        let preconfig = preconfig_compile(
+            &cmd.auto_sync_flags,
+            cli,
+            &cmd.build_flags,
+            target_backend,
             target_dir,
+            RunMode::Check,
+        );
+        let planning_context = rr_build::prepare_resolved_build(
+            &preconfig,
+            &cli.unstable_feature,
+            target_dir,
+            user_log,
+            &resolved,
         )?;
-        let successful = result.successful();
-        json.append_build(result, user_log);
-        return Ok((if successful { 0 } else { 1 }, build_meta));
+        let intent = get_user_intents_single_file(&resolved, planning_context.target_backend())?;
+        planned_runs.push(
+            rr_build::plan_resolved_build_from_intent(
+                preconfig,
+                &cli.unstable_feature,
+                user_log,
+                planning_context,
+                intent,
+                mooncake_bin_dir,
+                resolved.clone(),
+            )
+            .context("Failed to calculate build plan")?,
+        );
     }
 
-    let result = rr_build::execute_build(&cfg, build_graph, target_dir, user_log)?;
-    result.print_info(cli.quiet, "checking")?;
-
-    Ok((if result.successful() { 0 } else { 1 }, build_meta))
+    let filename = single_file_path.file_name().and_then(|name| name.to_str());
+    run_planned_checks(cli, cmd, dirs, planned_runs, true, filename, output, json)
+        .map(|ok| if ok { 0 } else { 1 })
 }
 
 fn get_user_intents_single_file(
@@ -799,15 +738,48 @@ fn run_check_normal_rr_from_resolved(
             .collect()
     };
 
+    let ok = run_planned_checks(
+        cli,
+        cmd,
+        dirs,
+        planned_runs,
+        cmd.package_path.is_none() && cmd.path.is_empty(),
+        None,
+        output,
+        json,
+    )?;
+
+    Ok(WatchOutput {
+        ok,
+        additional_ignored_paths: prebuild_list.ignored_paths,
+        additional_watched_paths: prebuild_list.watched_paths,
+    })
+}
+
+/// Finalizes metadata and executes checks that have already been planned.
+///
+/// The caller must hold the target-directory lock for a non-dry-run check.
+#[allow(clippy::too_many_arguments)]
+fn run_planned_checks(
+    cli: &UniversalFlags,
+    cmd: &CheckSubcommand,
+    dirs: &PackageDirs,
+    planned_runs: Vec<(rr_build::BuildMeta, rr_build::BuildInput)>,
+    publish_metadata: bool,
+    metadata_filename: Option<&str>,
+    output: &CommandOutput,
+    json: Option<&mut CheckJsonAccumulator>,
+) -> anyhow::Result<bool> {
     if planned_runs.is_empty() {
-        return Ok(WatchOutput {
-            ok: true,
-            additional_ignored_paths: prebuild_list.ignored_paths,
-            additional_watched_paths: prebuild_list.watched_paths,
-        });
+        return Ok(true);
     }
 
-    let ok = if cli.dry_run {
+    let PackageDirs {
+        source_dir,
+        target_dir,
+        ..
+    } = dirs;
+    if cli.dry_run {
         output.write_result(|writer| {
             let (build_metas, build_inputs): (Vec<_>, Vec<_>) = planned_runs.into_iter().unzip();
             let build_input =
@@ -821,59 +793,51 @@ fn run_check_normal_rr_from_resolved(
             )?;
             Ok::<_, std::io::Error>(())
         })?;
-        true
+        return Ok(true);
+    }
+
+    let mut cfg = BuildConfig::from_flags(
+        &cmd.build_flags,
+        &cli.unstable_feature,
+        cli.verbose && json.is_none(),
+    );
+    cfg.patch_file = cmd.patch_file.clone();
+    cfg.explain_errors |= cmd.explain;
+    for (build_meta, build_input) in &planned_runs {
+        // Generate all_pkgs.json for indirect dependency resolution
+        rr_build::generate_all_pkgs_json(build_meta)?;
+        if publish_metadata {
+            rr_build::generate_metadata(source_dir, build_meta, build_input, metadata_filename)?;
+        }
+    }
+    if publish_metadata {
+        // The compiler's universal format selects one active projection.
+        // Before the split, repeated publication made the final planned
+        // backend authoritative, so retain that deterministic behavior.
+        let selected = &planned_runs
+            .last()
+            .expect("non-empty planned runs were checked above")
+            .0;
+        rr_build::generate_metadata_selector(selected, metadata_filename)?;
+        rr_build::generate_metadata_index(planned_runs.iter().map(|(build_meta, _)| build_meta))?;
+    }
+
+    let build_inputs = planned_runs.into_iter().map(|(_, input)| input).collect();
+    let build_input = rr_build::compose_build_inputs(build_inputs)?;
+    if let Some(json) = json {
+        let result = rr_build::execute_build_json(
+            &cfg.with_suppressed_progress(true),
+            build_input,
+            target_dir,
+        )?;
+        let successful = result.successful();
+        json.append_build(result, output.user_log());
+        Ok(successful)
     } else {
-        let mut cfg = BuildConfig::from_flags(
-            &cmd.build_flags,
-            &cli.unstable_feature,
-            cli.verbose && json.is_none(),
-        );
-        cfg.patch_file = cmd.patch_file.clone();
-        cfg.explain_errors |= cmd.explain;
-        for (build_meta, build_input) in &planned_runs {
-            // Generate all_pkgs.json for indirect dependency resolution
-            rr_build::generate_all_pkgs_json(build_meta)?;
-            if cmd.package_path.is_none() && cmd.path.is_empty() {
-                rr_build::generate_metadata(source_dir, build_meta, build_input, None)?;
-            }
-        }
-        if cmd.package_path.is_none() && cmd.path.is_empty() {
-            // The compiler's universal format selects one active projection.
-            // Before the split, repeated publication made the final planned
-            // backend authoritative, so retain that deterministic behavior.
-            let selected = &planned_runs
-                .last()
-                .expect("non-empty planned runs were checked above")
-                .0;
-            rr_build::generate_metadata_selector(selected, None)?;
-            rr_build::generate_metadata_index(
-                planned_runs.iter().map(|(build_meta, _)| build_meta),
-            )?;
-        }
-
-        let build_inputs = planned_runs.into_iter().map(|(_, input)| input).collect();
-        let build_input = rr_build::compose_build_inputs(build_inputs)?;
-        if let Some(json) = json {
-            let result = rr_build::execute_build_json(
-                &cfg.with_suppressed_progress(true),
-                build_input,
-                target_dir,
-            )?;
-            let successful = result.successful();
-            json.append_build(result, user_log);
-            successful
-        } else {
-            let result = rr_build::execute_build(&cfg, build_input, target_dir, user_log)?;
-            result.print_info(cli.quiet, "checking")?;
-            result.successful()
-        }
-    };
-
-    Ok(WatchOutput {
-        ok,
-        additional_ignored_paths: prebuild_list.ignored_paths,
-        additional_watched_paths: prebuild_list.watched_paths,
-    })
+        let result = rr_build::execute_build(&cfg, build_input, target_dir, output.user_log())?;
+        result.print_info(cli.quiet, "checking")?;
+        Ok(result.successful())
+    }
 }
 
 fn sync_and_resolve_check_project(

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -921,6 +921,28 @@ pub fn generate_metadata_selector(
     write_metadata_if_changed(&metadata_file, &selector)
 }
 
+/// Generate the backend inventory for the package metadata published by one
+/// full Check invocation.
+pub fn generate_metadata_index<'a>(
+    build_metas: impl IntoIterator<Item = &'a BuildMeta>,
+) -> anyhow::Result<()> {
+    let mut build_metas = build_metas.into_iter();
+    let first = build_metas
+        .next()
+        .context("Cannot generate packages metadata index without a Check plan")?;
+    let metadata_file = first.artifact_paths.target_layout().packages_index_path();
+    let backends = std::iter::once(first)
+        .chain(build_metas)
+        .map(BuildMeta::target_backend)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(|backend| backend.to_string())
+        .collect::<Vec<_>>();
+    let index = serde_json::to_string_pretty(&backends)
+        .context("Failed to serialize packages metadata index")?;
+    write_metadata_if_changed(&metadata_file, &index)
+}
+
 fn write_metadata_if_changed(metadata_file: &Path, metadata: &str) -> anyhow::Result<()> {
     let orig_meta = std::fs::read_to_string(metadata_file);
     if !orig_meta.is_ok_and(|original| original == metadata) {

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -923,21 +923,21 @@ pub fn generate_metadata_selector(
 
 /// Generate the backend inventory for the package metadata published by one
 /// full Check invocation.
-pub fn generate_metadata_index(
-    target_dir: &Path,
-    target_backends: impl IntoIterator<Item = TargetBackend>,
+pub fn generate_metadata_index<'a>(
+    build_metas: impl IntoIterator<Item = &'a BuildMeta>,
 ) -> anyhow::Result<()> {
-    let backends = target_backends
-        .into_iter()
+    let mut build_metas = build_metas.into_iter();
+    let first = build_metas
+        .next()
+        .context("Cannot generate packages metadata index without a Check plan")?;
+    let metadata_file = first.artifact_paths.target_layout().packages_index_path();
+    let backends = std::iter::once(first)
+        .chain(build_metas)
+        .map(BuildMeta::target_backend)
         .collect::<BTreeSet<_>>()
         .into_iter()
         .map(|backend| backend.to_string())
         .collect::<Vec<_>>();
-    anyhow::ensure!(
-        !backends.is_empty(),
-        "Cannot generate packages metadata index without a Check plan"
-    );
-    let metadata_file = TargetLayout::packages_index_path_in(target_dir);
     let index = serde_json::to_string_pretty(&backends)
         .context("Failed to serialize packages metadata index")?;
     write_metadata_if_changed(&metadata_file, &index)

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -923,21 +923,21 @@ pub fn generate_metadata_selector(
 
 /// Generate the backend inventory for the package metadata published by one
 /// full Check invocation.
-pub fn generate_metadata_index<'a>(
-    build_metas: impl IntoIterator<Item = &'a BuildMeta>,
+pub fn generate_metadata_index(
+    target_dir: &Path,
+    target_backends: impl IntoIterator<Item = TargetBackend>,
 ) -> anyhow::Result<()> {
-    let mut build_metas = build_metas.into_iter();
-    let first = build_metas
-        .next()
-        .context("Cannot generate packages metadata index without a Check plan")?;
-    let metadata_file = first.artifact_paths.target_layout().packages_index_path();
-    let backends = std::iter::once(first)
-        .chain(build_metas)
-        .map(BuildMeta::target_backend)
+    let backends = target_backends
+        .into_iter()
         .collect::<BTreeSet<_>>()
         .into_iter()
         .map(|backend| backend.to_string())
         .collect::<Vec<_>>();
+    anyhow::ensure!(
+        !backends.is_empty(),
+        "Cannot generate packages metadata index without a Check plan"
+    );
+    let metadata_file = TargetLayout::packages_index_path_in(target_dir);
     let index = serde_json::to_string_pretty(&backends)
         .context("Failed to serialize packages metadata index")?;
     write_metadata_if_changed(&metadata_file, &index)

--- a/crates/moon/tests/mod.rs
+++ b/crates/moon/tests/mod.rs
@@ -56,6 +56,10 @@ fn packages_selector_path(dir: impl AsRef<Path>) -> PathBuf {
     dir.as_ref().join("_build/packages.json")
 }
 
+fn packages_index_path(dir: impl AsRef<Path>) -> PathBuf {
+    dir.as_ref().join("_build/index.json")
+}
+
 fn scoped_packages_json_path(dir: impl AsRef<Path>, backend: &str, profile: &str) -> PathBuf {
     dir.as_ref()
         .join(format!("_build/{backend}/{profile}/check/packages.json"))

--- a/crates/moon/tests/test_cases/build_workflow.rs
+++ b/crates/moon/tests/test_cases/build_workflow.rs
@@ -131,15 +131,18 @@ fn test_check_failed_should_write_pkg_json() {
 
     let pkg_json = packages_selector_path(&dir);
     assert!(pkg_json.exists());
+    assert!(packages_index_path(&dir).exists());
 }
 
 #[test]
 fn test_packages_json_full_check_and_focused_check_behavior() {
     let dir = TestDir::new("hello");
     let pkg_json = packages_selector_path(&dir);
+    let index_json = packages_index_path(&dir);
     let scoped_pkg_json = scoped_packages_json_path(&dir, "wasm-gc", "release");
     std::fs::create_dir_all(pkg_json.parent().unwrap()).unwrap();
     std::fs::write(&pkg_json, "existing metadata").unwrap();
+    std::fs::write(&index_json, "existing index").unwrap();
 
     moon_cmd(&dir)
         .args(["check", "--target", "wasm-gc", "--release"])
@@ -158,12 +161,16 @@ fn test_packages_json_full_check_and_focused_check_behavior() {
             "opt_level": "release"
         })
     );
+    let packages_index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&index_json).unwrap()).unwrap();
+    assert_eq!(packages_index, serde_json::json!(["wasm-gc"]));
     let scoped_metadata: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&scoped_pkg_json).unwrap()).unwrap();
     assert_eq!(scoped_metadata["backend"], serde_json::json!("wasm-gc"));
     assert_eq!(scoped_metadata["opt_level"], serde_json::json!("release"));
 
     std::fs::write(&pkg_json, "existing metadata").unwrap();
+    std::fs::write(&index_json, "existing index").unwrap();
     std::fs::write(&scoped_pkg_json, "existing scoped metadata").unwrap();
 
     moon_cmd(&dir)
@@ -173,6 +180,10 @@ fn test_packages_json_full_check_and_focused_check_behavior() {
     assert_eq!(
         std::fs::read_to_string(&pkg_json).unwrap(),
         "existing metadata"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&index_json).unwrap(),
+        "existing index"
     );
     assert_eq!(
         std::fs::read_to_string(&scoped_pkg_json).unwrap(),

--- a/crates/moon/tests/test_cases/indirect_dep/mod.rs
+++ b/crates/moon/tests/test_cases/indirect_dep/mod.rs
@@ -125,6 +125,7 @@ fn test_indirect_dep_bundle() {
     let _ = get_stdout(&dir, ["clean"]);
     std::fs::create_dir_all(dir.join("_build")).unwrap();
     std::fs::write(packages_selector_path(&dir), "existing check selector").unwrap();
+    std::fs::write(packages_index_path(&dir), "existing check index").unwrap();
     check(
         get_stderr(&dir, ["bundle", "--target", "wasm-gc"]),
         expect![[r#"
@@ -134,6 +135,10 @@ fn test_indirect_dep_bundle() {
     assert_eq!(
         std::fs::read_to_string(packages_selector_path(&dir)).unwrap(),
         "existing check selector"
+    );
+    assert_eq!(
+        std::fs::read_to_string(packages_index_path(&dir)).unwrap(),
+        "existing check index"
     );
     assert!(
         !dir.join("_build/wasm-gc/release/bundle/packages.json")

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -663,3 +663,30 @@ fn test_single_file_commands_work_with_workspace_disabled() {
         "#]],
     );
 }
+
+#[test]
+fn test_single_file_multi_target_metadata_index() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    std::fs::write(
+        dir.join("hello.mbt"),
+        r#"fn main {
+  println("hello")
+}
+"#,
+    )
+    .unwrap();
+
+    moon_cmd(&dir)
+        .env(MOON_WORK_ENV, "off")
+        .args(["check", "hello.mbt", "--target", "wasm-gc,js"])
+        .assert()
+        .success();
+
+    assert!(standalone_scoped_packages_json_path(dir, "wasm-gc", "debug", "hello.mbt").exists());
+    assert!(standalone_scoped_packages_json_path(dir, "js", "debug", "hello.mbt").exists());
+    let packages_index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(packages_index_path(dir)).unwrap()).unwrap();
+    assert_eq!(packages_index, serde_json::json!(["wasm-gc", "js"]));
+}

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -634,6 +634,9 @@ fn test_single_file_commands_work_with_workspace_disabled() {
             "opt_level": "debug"
         })
     );
+    let packages_index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(packages_index_path(dir)).unwrap()).unwrap();
+    assert_eq!(packages_index, serde_json::json!(["wasm-gc"]));
     let scoped_pkg_json: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(scoped_pkg_json).unwrap()).unwrap();
     assert_eq!(scoped_pkg_json["backend"], serde_json::json!("wasm-gc"));

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -789,6 +789,8 @@ fn test_check_publishes_backend_scoped_packages_json() {
     let packages_selector: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(packages_selector_path(&dir)).unwrap())
             .unwrap();
+    let packages_index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(packages_index_path(&dir)).unwrap()).unwrap();
     let js_packages_json: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(scoped_packages_json_path(&dir, "js", "debug")).unwrap(),
     )
@@ -805,6 +807,7 @@ fn test_check_publishes_backend_scoped_packages_json() {
             "opt_level": "debug"
         })
     );
+    assert_eq!(packages_index, serde_json::json!(["js", "native"]));
     assert_eq!(js_packages_json["backend"], serde_json::json!("js"));
     assert_eq!(native_packages_json["backend"], serde_json::json!("native"));
     assert_eq!(js_packages_json["opt_level"], serde_json::json!("debug"));

--- a/crates/moon/tests/test_cases/tool_commands.rs
+++ b/crates/moon/tests/test_cases/tool_commands.rs
@@ -36,11 +36,13 @@ fn test_moon_doc() {
     let dir = TestDir::new("moon_doc.in");
     std::fs::create_dir_all(dir.join("_build")).unwrap();
     std::fs::write(packages_selector_path(&dir), "existing check selector").unwrap();
+    std::fs::write(packages_index_path(&dir), "existing check index").unwrap();
     let _ = get_stderr(&dir, ["doc"]);
     assert_eq!(
         read(packages_selector_path(&dir)),
         "existing check selector"
     );
+    assert_eq!(read(packages_index_path(&dir)), "existing check index");
     check(
         read(dir.join("_build/doc/username/hello/lib/members.md")),
         expect![[r#"

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -51,6 +51,7 @@ const MI_EXTENSION: &str = ".mi";
 /// Implementation packages generate a dummy mi file so they are not rebuilt every time.
 const IMPL_MI_EXTENSION: &str = ".impl.mi";
 pub const GENERATED_TEST_DRIVER_PREFIX: &str = "__generated_driver_for";
+const PACKAGES_INDEX_JSON: &str = "index.json";
 const PACKAGES_JSON: &str = "packages.json";
 
 #[derive(Clone, Copy, Debug)]
@@ -633,6 +634,11 @@ impl TargetLayout {
     /// Returns the universal `packages.json` selector path.
     pub fn packages_selector_path(&self) -> PathBuf {
         packages_metadata_path(self.target_base_dir.clone(), None)
+    }
+
+    /// Returns the backend inventory path shared by package metadata consumers.
+    pub fn packages_index_path(&self) -> PathBuf {
+        self.target_base_dir.join(PACKAGES_INDEX_JSON)
     }
 
     /// Returns the universal metadata selector path for a standalone source
@@ -1810,6 +1816,10 @@ mod tests {
         assert_eq!(
             layout.packages_selector_path(),
             PathBuf::from("_build/packages.json")
+        );
+        assert_eq!(
+            layout.packages_index_path(),
+            PathBuf::from("_build/index.json")
         );
         assert_eq!(
             layout.standalone_packages_selector_path("main.mbt"),

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -638,12 +638,7 @@ impl TargetLayout {
 
     /// Returns the backend inventory path shared by package metadata consumers.
     pub fn packages_index_path(&self) -> PathBuf {
-        Self::packages_index_path_in(&self.target_base_dir)
-    }
-
-    /// Returns the backend inventory path under the given target directory.
-    pub fn packages_index_path_in(target_base_dir: &Path) -> PathBuf {
-        target_base_dir.join(PACKAGES_INDEX_JSON)
+        self.target_base_dir.join(PACKAGES_INDEX_JSON)
     }
 
     /// Returns the universal metadata selector path for a standalone source

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -638,7 +638,12 @@ impl TargetLayout {
 
     /// Returns the backend inventory path shared by package metadata consumers.
     pub fn packages_index_path(&self) -> PathBuf {
-        self.target_base_dir.join(PACKAGES_INDEX_JSON)
+        Self::packages_index_path_in(&self.target_base_dir)
+    }
+
+    /// Returns the backend inventory path under the given target directory.
+    pub fn packages_index_path_in(target_base_dir: &Path) -> PathBuf {
+        target_base_dir.join(PACKAGES_INDEX_JSON)
     }
 
     /// Returns the universal metadata selector path for a standalone source

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -598,9 +598,9 @@ vector. Physical outputs required only for execution, such as a companion dSYM
 directory, are not caller-requested results; the current n2 graph still executes
 their producer when the output is an unconsumed graph root.
 
-`packages.json` is metadata shared with IDE tooling. The universal file is a
-small selector containing the active Target Backend and build profile from the
-last full Check plan:
+Package metadata is shared with IDE tooling. The universal `packages.json` is
+an exact two-field selector containing the active Target Backend and build
+profile from the last full Check plan:
 
 ```json
 {
@@ -609,10 +609,26 @@ last full Check plan:
 }
 ```
 
-The selector identifies a configuration-scoped Check document:
+The companion `index.json` is a JSON array of every Target Backend for which
+that Check invocation planned and published package metadata:
+
+```json
+[
+  "js",
+  "native"
+]
+```
+
+This set comes directly from the already-planned Check runs, so explicit
+targets, module preferences, and package `supported_targets` filtering are
+reflected without an additional discovery or resolution pass. Entries are
+deduplicated and ordered by Target Backend.
+
+The selector and index identify configuration-scoped Check documents:
 
 ```text
 _build/packages.json
+_build/index.json
 _build/<backend>/<profile>/check/packages.json
 ```
 
@@ -622,14 +638,22 @@ and conditional metadata for all package files. This first migration step only
 relocates that document behind the selector; backend/profile projection and
 removal of redundant legacy fields are deferred to a follow-up change.
 
-Standalone-file checks similarly publish both
-`_build/<filename>.packages.json` and
-`_build/<backend>/<profile>/check/<filename>.packages.json`. Project checks
-without a package or path selector publish metadata; focused project checks
-leave it untouched. `moon bundle` does not publish either format. `moon doc`
-generates only its scoped Check document and passes that path directly to
-`moondoc`, without changing the universal selector used by the language server.
+Standalone-file checks similarly publish their selector and scoped document,
+and replace the shared backend index:
 
-Scoped documents are atomically replaced before the selector, so readers never
-follow a new selector to a partially written document. Byte-identical metadata
-is left untouched.
+```text
+_build/<filename>.packages.json
+_build/index.json
+_build/<backend>/<profile>/check/<filename>.packages.json
+```
+
+Project checks without a package or path selector publish metadata; focused
+project checks leave it untouched. `moon bundle` does not publish these files.
+`moon doc` generates only its scoped Check document and passes that path
+directly to `moondoc`, without changing the universal selector or backend index
+used by the language server.
+
+Scoped documents are atomically replaced before the selector, and the backend
+index is replaced last. Readers therefore never follow a newly published index
+to a partially written document or stale selector. Byte-identical metadata is
+left untouched.


### PR DESCRIPTION
## Why

Package metadata consumers can select one active scoped document through
`_build/packages.json`, but they cannot discover every backend published by a
multi-backend check. They need a small, authoritative backend inventory without
another project discovery or resolution pass.

## Why this is correct

- `_build/index.json` is derived from the exact check plans that publish the
  scoped metadata documents, so explicit targets, configured preferences, and
  supported-target filtering are already reflected.
- Shared check finalization publishes all scoped documents, then the selector,
  and finally one accumulated index. This covers project and standalone checks,
  including multi-target standalone invocations.
- Backend entries are deduplicated and deterministic. Focused checks and other
  commands that do not own this metadata leave the existing index untouched.

## Scope

This PR adds the index path, publication lifecycle, behavioral coverage, and
reference documentation. It does not change the scoped `packages.json` schema
or the universal selector's two-field shape.
