### PR TITLE
feat(check): publish package metadata backend index

### DIFF
--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -27,7 +27,8 @@
 //!    ordered list of single-backend RR plans.
 //! 4. `plan_check_rr_from_resolved` still plans exactly one backend group.
 //! 5. The command layer composes those plans into one executor graph. Project
-//!    checks without a selector publish `packages.json`; focused checks leave
+//!    checks without a selector publish `packages.json` and `index.json`;
+//!    focused checks leave
 //!    it untouched.
 //!
 use anyhow::Context;
@@ -826,6 +827,7 @@ fn run_planned_checks(
             .expect("non-empty planned runs were checked above")
             .0;
         rr_build::generate_metadata_selector(selected, metadata_filename)?;
+        rr_build::generate_metadata_index(planned_runs.iter().map(|(build_meta, _)| build_meta))?;
     }
 
     let build_inputs = planned_runs.into_iter().map(|(_, input)| input).collect();

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -921,6 +921,28 @@ pub fn generate_metadata_selector(
     write_metadata_if_changed(&metadata_file, &selector)
 }
 
+/// Generate the backend inventory for the package metadata published by one
+/// full Check invocation.
+pub fn generate_metadata_index<'a>(
+    build_metas: impl IntoIterator<Item = &'a BuildMeta>,
+) -> anyhow::Result<()> {
+    let mut build_metas = build_metas.into_iter();
+    let first = build_metas
+        .next()
+        .context("Cannot generate packages metadata index without a Check plan")?;
+    let metadata_file = first.artifact_paths.target_layout().packages_index_path();
+    let backends = std::iter::once(first)
+        .chain(build_metas)
+        .map(BuildMeta::target_backend)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(|backend| backend.to_string())
+        .collect::<Vec<_>>();
+    let index = serde_json::to_string_pretty(&backends)
+        .context("Failed to serialize packages metadata index")?;
+    write_metadata_if_changed(&metadata_file, &index)
+}
+
 fn write_metadata_if_changed(metadata_file: &Path, metadata: &str) -> anyhow::Result<()> {
     let orig_meta = std::fs::read_to_string(metadata_file);
     if !orig_meta.is_ok_and(|original| original == metadata) {

--- a/crates/moon/tests/mod.rs
+++ b/crates/moon/tests/mod.rs
@@ -56,6 +56,10 @@ fn packages_selector_path(dir: impl AsRef<Path>) -> PathBuf {
     dir.as_ref().join("_build/packages.json")
 }
 
+fn packages_index_path(dir: impl AsRef<Path>) -> PathBuf {
+    dir.as_ref().join("_build/index.json")
+}
+
 fn scoped_packages_json_path(dir: impl AsRef<Path>, backend: &str, profile: &str) -> PathBuf {
     dir.as_ref()
         .join(format!("_build/{backend}/{profile}/check/packages.json"))

--- a/crates/moon/tests/test_cases/build_workflow.rs
+++ b/crates/moon/tests/test_cases/build_workflow.rs
@@ -131,15 +131,18 @@ fn test_check_failed_should_write_pkg_json() {
 
     let pkg_json = packages_selector_path(&dir);
     assert!(pkg_json.exists());
+    assert!(packages_index_path(&dir).exists());
 }
 
 #[test]
 fn test_packages_json_full_check_and_focused_check_behavior() {
     let dir = TestDir::new("hello");
     let pkg_json = packages_selector_path(&dir);
+    let index_json = packages_index_path(&dir);
     let scoped_pkg_json = scoped_packages_json_path(&dir, "wasm-gc", "release");
     std::fs::create_dir_all(pkg_json.parent().unwrap()).unwrap();
     std::fs::write(&pkg_json, "existing metadata").unwrap();
+    std::fs::write(&index_json, "existing index").unwrap();
 
     moon_cmd(&dir)
         .args(["check", "--target", "wasm-gc", "--release"])
@@ -158,12 +161,16 @@ fn test_packages_json_full_check_and_focused_check_behavior() {
             "opt_level": "release"
         })
     );
+    let packages_index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&index_json).unwrap()).unwrap();
+    assert_eq!(packages_index, serde_json::json!(["wasm-gc"]));
     let scoped_metadata: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&scoped_pkg_json).unwrap()).unwrap();
     assert_eq!(scoped_metadata["backend"], serde_json::json!("wasm-gc"));
     assert_eq!(scoped_metadata["opt_level"], serde_json::json!("release"));
 
     std::fs::write(&pkg_json, "existing metadata").unwrap();
+    std::fs::write(&index_json, "existing index").unwrap();
     std::fs::write(&scoped_pkg_json, "existing scoped metadata").unwrap();
 
     moon_cmd(&dir)
@@ -173,6 +180,10 @@ fn test_packages_json_full_check_and_focused_check_behavior() {
     assert_eq!(
         std::fs::read_to_string(&pkg_json).unwrap(),
         "existing metadata"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&index_json).unwrap(),
+        "existing index"
     );
     assert_eq!(
         std::fs::read_to_string(&scoped_pkg_json).unwrap(),

--- a/crates/moon/tests/test_cases/indirect_dep/mod.rs
+++ b/crates/moon/tests/test_cases/indirect_dep/mod.rs
@@ -125,6 +125,7 @@ fn test_indirect_dep_bundle() {
     let _ = get_stdout(&dir, ["clean"]);
     std::fs::create_dir_all(dir.join("_build")).unwrap();
     std::fs::write(packages_selector_path(&dir), "existing check selector").unwrap();
+    std::fs::write(packages_index_path(&dir), "existing check index").unwrap();
     check(
         get_stderr(&dir, ["bundle", "--target", "wasm-gc"]),
         expect![[r#"
@@ -134,6 +135,10 @@ fn test_indirect_dep_bundle() {
     assert_eq!(
         std::fs::read_to_string(packages_selector_path(&dir)).unwrap(),
         "existing check selector"
+    );
+    assert_eq!(
+        std::fs::read_to_string(packages_index_path(&dir)).unwrap(),
+        "existing check index"
     );
     assert!(
         !dir.join("_build/wasm-gc/release/bundle/packages.json")

--- a/crates/moon/tests/test_cases/single_file.rs
+++ b/crates/moon/tests/test_cases/single_file.rs
@@ -638,6 +638,9 @@ fn test_single_file_commands_work_with_workspace_disabled() {
         serde_json::from_str(&std::fs::read_to_string(scoped_pkg_json).unwrap()).unwrap();
     assert_eq!(scoped_pkg_json["backend"], serde_json::json!("wasm-gc"));
     assert_eq!(scoped_pkg_json["opt_level"], serde_json::json!("debug"));
+    let packages_index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(packages_index_path(dir)).unwrap()).unwrap();
+    assert_eq!(packages_index, serde_json::json!(["wasm-gc"]));
 
     check(
         get_stdout_with_envs(&dir, ["test", "test.mbt"], [(MOON_NO_WORKSPACE, "1")]),
@@ -683,6 +686,9 @@ fn test_single_file_check_accepts_multiple_targets() {
 
     assert!(standalone_scoped_packages_json_path(dir, "wasm-gc", "debug", "hello.mbt").exists());
     assert!(standalone_scoped_packages_json_path(dir, "js", "debug", "hello.mbt").exists());
+    let packages_index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(packages_index_path(dir)).unwrap()).unwrap();
+    assert_eq!(packages_index, serde_json::json!(["wasm-gc", "js"]));
     let selector: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(standalone_packages_selector_path(dir, "hello.mbt")).unwrap(),
     )

--- a/crates/moon/tests/test_cases/target_backend/mod.rs
+++ b/crates/moon/tests/test_cases/target_backend/mod.rs
@@ -789,6 +789,8 @@ fn test_check_publishes_backend_scoped_packages_json() {
     let packages_selector: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(packages_selector_path(&dir)).unwrap())
             .unwrap();
+    let packages_index: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(packages_index_path(&dir)).unwrap()).unwrap();
     let js_packages_json: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(scoped_packages_json_path(&dir, "js", "debug")).unwrap(),
     )
@@ -805,6 +807,7 @@ fn test_check_publishes_backend_scoped_packages_json() {
             "opt_level": "debug"
         })
     );
+    assert_eq!(packages_index, serde_json::json!(["js", "native"]));
     assert_eq!(js_packages_json["backend"], serde_json::json!("js"));
     assert_eq!(native_packages_json["backend"], serde_json::json!("native"));
     assert_eq!(js_packages_json["opt_level"], serde_json::json!("debug"));

--- a/crates/moon/tests/test_cases/tool_commands.rs
+++ b/crates/moon/tests/test_cases/tool_commands.rs
@@ -36,11 +36,13 @@ fn test_moon_doc() {
     let dir = TestDir::new("moon_doc.in");
     std::fs::create_dir_all(dir.join("_build")).unwrap();
     std::fs::write(packages_selector_path(&dir), "existing check selector").unwrap();
+    std::fs::write(packages_index_path(&dir), "existing check index").unwrap();
     let _ = get_stderr(&dir, ["doc"]);
     assert_eq!(
         read(packages_selector_path(&dir)),
         "existing check selector"
     );
+    assert_eq!(read(packages_index_path(&dir)), "existing check index");
     check(
         read(dir.join("_build/doc/username/hello/lib/members.md")),
         expect![[r#"

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -52,6 +52,7 @@ const MI_EXTENSION: &str = ".mi";
 const IMPL_MI_EXTENSION: &str = ".impl.mi";
 pub const GENERATED_TEST_DRIVER_PREFIX: &str = "__generated_driver_for";
 const PACKAGES_JSON: &str = "packages.json";
+const PACKAGES_INDEX_JSON: &str = "index.json";
 
 #[derive(Clone, Copy, Debug)]
 pub enum ExecutableArtifact {
@@ -633,6 +634,11 @@ impl TargetLayout {
     /// Returns the universal `packages.json` selector path.
     pub fn packages_selector_path(&self) -> PathBuf {
         packages_metadata_path(self.target_base_dir.clone(), None)
+    }
+
+    /// Returns the backend inventory path shared by package metadata consumers.
+    pub fn packages_index_path(&self) -> PathBuf {
+        self.target_base_dir.join(PACKAGES_INDEX_JSON)
     }
 
     /// Returns the universal metadata selector path for a standalone source
@@ -1810,6 +1816,10 @@ mod tests {
         assert_eq!(
             layout.packages_selector_path(),
             PathBuf::from("_build/packages.json")
+        );
+        assert_eq!(
+            layout.packages_index_path(),
+            PathBuf::from("_build/index.json")
         );
         assert_eq!(
             layout.standalone_packages_selector_path("main.mbt"),

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -92,7 +92,8 @@ In a broad sense, `moon` subcommands follows this order when executing project-b
    - Generate a concrete build graph containing the final commandlines to execute.
 3. Execute the build graph
    - Generate metadata files required by compiler actions. Full project checks
-     also publish `packages.json` for tooling compatibility during migration.
+     also publish `packages.json` and `index.json` for tooling compatibility
+     during migration.
    - For a multi-backend invocation, compose the independently lowered
      Execution Plans into one executor graph, sharing compatible physical
      providers such as package prebuild actions. JSON-formatted checks retain
@@ -598,9 +599,9 @@ vector. Physical outputs required only for execution, such as a companion dSYM
 directory, are not caller-requested results; the current n2 graph still executes
 their producer when the output is an unconsumed graph root.
 
-`packages.json` is metadata shared with IDE tooling. The universal file is a
-small selector containing the active Target Backend and build profile from the
-last full Check plan:
+Package metadata is shared with IDE tooling. The universal `packages.json` is
+an exact two-field selector containing the active Target Backend and build
+profile from the last full Check plan:
 
 ```json
 {
@@ -609,10 +610,26 @@ last full Check plan:
 }
 ```
 
-The selector identifies a configuration-scoped Check document:
+The companion `index.json` is a JSON array of every Target Backend for which
+that Check invocation planned and published package metadata:
+
+```json
+[
+  "js",
+  "native"
+]
+```
+
+This set comes directly from the already-planned Check runs, so explicit
+targets, module preferences, and package `supported_targets` filtering are
+reflected without an additional discovery or resolution pass. Entries are
+deduplicated and ordered by Target Backend.
+
+The selector and index identify configuration-scoped Check documents:
 
 ```text
 _build/packages.json
+_build/index.json
 _build/<backend>/<profile>/check/packages.json
 ```
 
@@ -622,14 +639,22 @@ and conditional metadata for all package files. This first migration step only
 relocates that document behind the selector; backend/profile projection and
 removal of redundant legacy fields are deferred to a follow-up change.
 
-Standalone-file checks similarly publish both
-`_build/<filename>.packages.json` and
-`_build/<backend>/<profile>/check/<filename>.packages.json`. Project checks
-without a package or path selector publish metadata; focused project checks
-leave it untouched. `moon bundle` does not publish either format. `moon doc`
-generates only its scoped Check document and passes that path directly to
-`moondoc`, without changing the universal selector used by the language server.
+Standalone-file checks similarly publish their selector and scoped document,
+and replace the shared backend index:
 
-Scoped documents are atomically replaced before the selector, so readers never
-follow a new selector to a partially written document. Byte-identical metadata
-is left untouched.
+```text
+_build/<filename>.packages.json
+_build/index.json
+_build/<backend>/<profile>/check/<filename>.packages.json
+```
+
+Project checks without a package or path selector publish metadata; focused
+project checks leave it untouched. `moon bundle` does not publish these files.
+`moon doc` generates only its scoped Check document and passes that path
+directly to `moondoc`, without changing the universal selector or backend index
+used by the language server.
+
+Scoped documents are atomically replaced before the selector, and the backend
+index is replaced last. Readers therefore never follow a newly published index
+to a partially written document or stale selector. Byte-identical metadata is
+left untouched.


### PR DESCRIPTION
## Why

Package metadata consumers can select one active scoped document through
`_build/packages.json`, but they cannot discover every backend published by a
multi-backend check. They need a small, authoritative backend inventory without
another project discovery or resolution pass.

## Why this is correct

- `_build/index.json` is derived from the exact check plans that publish the
  scoped metadata documents, so explicit targets, configured preferences, and
  supported-target filtering are already reflected.
- Shared check finalization publishes all scoped documents, then the selector,
  and finally one accumulated index. This covers project and standalone checks,
  including multi-target standalone invocations.
- Backend entries are deduplicated and deterministic. Focused checks and other
  commands that do not own this metadata leave the existing index untouched.

## Scope

This PR adds the index path, publication lifecycle, behavioral coverage, and
reference documentation. It does not change the scoped `packages.json` schema
or the universal selector's two-field shape.
