### PR TITLE
refactor(moonrun): centralize filesystem host ownership

### DIFF
--- a/crates/moonrun/src/async_api/context.rs
+++ b/crates/moonrun/src/async_api/context.rs
@@ -17,6 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use crate::async_host::{AsyncHost, AsyncHostError, AsyncHostResult};
+use crate::filesystem::HostFs;
 use crate::run_termination::{RunTermination, TerminationRequest};
 use crate::v8::context::{V8ImportError, V8MemoryBinding, V8RunContext};
 
@@ -31,6 +32,7 @@ pub(super) fn callback_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> 
 pub(super) struct ImportContext<'a, 'scope> {
     pub(super) scope: &'a mut v8::HandleScope<'scope>,
     pub(super) host: &'a AsyncHost,
+    filesystem: &'a HostFs,
     memory_binding: &'a V8MemoryBinding,
     termination_request: &'a TerminationRequest,
 }
@@ -40,6 +42,7 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
         Self {
             scope,
             host: context.runtime().async_state(),
+            filesystem: context.runtime().filesystem(),
             memory_binding: context.memory_binding(),
             termination_request: context.termination_request(),
         }
@@ -50,6 +53,10 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
         // Termination cannot be caught by the guest's JavaScript glue. The run
         // loop converts the recorded request into its runtime outcome.
         self.scope.terminate_execution();
+    }
+
+    pub(super) fn filesystem(&self) -> &HostFs {
+        self.filesystem
     }
 
     pub(super) fn with_host_and_memory_mut<T>(

--- a/crates/moonrun/src/async_api/fs.rs
+++ b/crates/moonrun/src/async_api/fs.rs
@@ -33,7 +33,7 @@ use super::provenance::ported_imports;
 ported_imports! {
 pub(super) fn get_tmp_path_len(context: &mut ImportContext<'_, '_>) -> i32 {
     match context
-        .host
+        .filesystem()
         .temp_dir()
         .and_then(|path| encode_guest_units(&path))
         .and_then(|units| i32::try_from(units.len()).map_err(|_| AsyncHostError::Fault))
@@ -49,7 +49,7 @@ pub(super) fn get_tmp_path_len(context: &mut ImportContext<'_, '_>) -> i32 {
 #[ported(source = "src/fs/stub.c")]
 pub(super) fn get_tmp_path(context: &mut ImportContext<'_, '_>, ptr: u32, len: u32) -> i32 {
     let result = (|| {
-        let path = context.host.temp_dir()?;
+        let path = context.filesystem().temp_dir()?;
         let units = encode_guest_units(&path)?;
         let len = usize::try_from(len).map_err(|_| AsyncHostError::Fault)?;
         if len != units.len() {
@@ -61,7 +61,7 @@ pub(super) fn get_tmp_path(context: &mut ImportContext<'_, '_>, ptr: u32, len: u
 }
 
 pub(super) fn get_tmp_path_buffer(context: &mut ImportContext<'_, '_>) -> AsyncHostResult<u64> {
-    let path = context.host.temp_dir()?;
+    let path = context.filesystem().temp_dir()?;
     Ok(context
         .host
         .insert_c_buffer(stub::tmp_path_buffer(path.as_os_str())?))

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -2656,10 +2656,6 @@ impl AsyncHost {
         &self.environment
     }
 
-    pub(crate) fn temp_dir(&self) -> AsyncHostResult<OsString> {
-        self.environment.temp_dir()
-    }
-
     #[cfg(test)]
     pub(crate) fn check_owned_child_pid(&self, pid: i32) -> AsyncHostResult<()> {
         self.process.check_owned_child_pid(pid)

--- a/crates/moonrun/src/filesystem/mod.rs
+++ b/crates/moonrun/src/filesystem/mod.rs
@@ -32,14 +32,15 @@ pub(crate) use job::Job;
 #[cfg(test)]
 pub(crate) use job::{STAT_OPEN_IDENTITY, compat_symbols};
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::path::Path;
 use std::sync::Arc;
 
 use crate::async_host::AsyncHostResult;
+use crate::async_sys::fs::stub;
 use crate::policy::Policy;
-use crate::runtime::WorkingDirectory;
+use crate::runtime::{Env, WorkingDirectory};
 
 #[derive(Debug)]
 pub(crate) struct HostFsError {
@@ -90,14 +91,39 @@ impl FsOperationResults {
 /// before accessing the operating system's filesystem.
 pub(crate) struct HostFs {
     policy: Arc<Policy>,
+    environment: Arc<Env>,
     working_directory: WorkingDirectory,
 }
 
 impl HostFs {
-    pub(crate) fn new(policy: Arc<Policy>, working_directory: WorkingDirectory) -> Self {
+    pub(crate) fn new(
+        policy: Arc<Policy>,
+        environment: Arc<Env>,
+        working_directory: WorkingDirectory,
+    ) -> Self {
         Self {
             policy,
+            environment,
             working_directory,
+        }
+    }
+
+    pub(crate) fn temp_dir(&self) -> AsyncHostResult<OsString> {
+        // Native Windows selection has fallbacks beyond TMP and TEMP. Preserve
+        // those only for Ambient; an owned Env must never consult process state.
+        if self.environment.is_ambient() {
+            return stub::get_tmp_path();
+        }
+        #[cfg(unix)]
+        {
+            stub::get_tmp_path_from_env(self.environment.get("TMPDIR".as_ref()))
+        }
+        #[cfg(windows)]
+        {
+            stub::get_tmp_path_from_env(
+                self.environment.get("TMP".as_ref()),
+                self.environment.get("TEMP".as_ref()),
+            )
         }
     }
 
@@ -335,13 +361,94 @@ mod tests {
     use std::cell::Cell;
 
     use super::*;
+    #[cfg(windows)]
+    use crate::async_host::AsyncHostError;
+
+    fn host_fs(policy: Policy, environment: Arc<Env>) -> HostFs {
+        HostFs::new(Arc::new(policy), environment, WorkingDirectory::Ambient)
+    }
+
+    #[test]
+    fn ambient_temp_dir_uses_native_path() {
+        let host = host_fs(Policy::allow_all(), Arc::new(Env::ambient()));
+
+        assert_eq!(host.temp_dir().unwrap(), stub::get_tmp_path().unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owned_temp_dir_uses_runtime_environment() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let environment = Arc::new(Env::owned([("TMPDIR".into(), "/runtime/tmp".into())]).unwrap());
+        let host = host_fs(Policy::allow_all(), environment);
+
+        assert_eq!(host.temp_dir().unwrap().as_bytes(), b"/runtime/tmp/");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temp_dir_reflects_runtime_environment_changes() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let environment = Arc::new(Env::owned([("TMPDIR".into(), "/first".into())]).unwrap());
+        let host = host_fs(Policy::allow_all(), Arc::clone(&environment));
+
+        assert_eq!(host.temp_dir().unwrap().as_bytes(), b"/first/");
+        environment.set("TMPDIR".into(), "/second".into()).unwrap();
+        assert_eq!(host.temp_dir().unwrap().as_bytes(), b"/second/");
+        environment.unset("TMPDIR".as_ref()).unwrap();
+        assert_eq!(
+            host.temp_dir().unwrap(),
+            stub::get_tmp_path_from_env(None).unwrap()
+        );
+    }
+
+    #[cfg(all(unix, not(target_os = "android")))]
+    #[test]
+    fn empty_owned_environment_uses_default_temp_dir() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let environment = Arc::new(Env::owned(Vec::<(OsString, OsString)>::new()).unwrap());
+        let host = host_fs(Policy::allow_all(), environment);
+
+        assert_eq!(host.temp_dir().unwrap().as_bytes(), b"/tmp/");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn owned_temp_dir_requires_configured_windows_environment() {
+        let environment = Arc::new(Env::owned(Vec::<(OsString, OsString)>::new()).unwrap());
+        let host = host_fs(Policy::allow_all(), Arc::clone(&environment));
+
+        assert_eq!(host.temp_dir(), Err(AsyncHostError::PermissionDenied));
+        environment.set("TEMP".into(), "C:/Temp".into()).unwrap();
+        assert_eq!(host.temp_dir().unwrap().to_string_lossy(), "C:/Temp\\");
+        environment.unset("TEMP".as_ref()).unwrap();
+        assert_eq!(host.temp_dir(), Err(AsyncHostError::PermissionDenied));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn empty_tmp_falls_back_to_temp() {
+        let environment = Arc::new(
+            Env::owned([
+                ("TMP".into(), "".into()),
+                ("TEMP".into(), "C:/Fallback".into()),
+            ])
+            .unwrap(),
+        );
+        let host = host_fs(Policy::allow_all(), environment);
+
+        assert_eq!(host.temp_dir().unwrap().to_string_lossy(), "C:/Fallback\\");
+    }
 
     #[test]
     fn operation_results_belong_to_one_runtime() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("input.bin");
         std::fs::write(&path, [1, 2, 3]).unwrap();
-        let host = HostFs::new(Arc::new(Policy::allow_all()), WorkingDirectory::Ambient);
+        let host = host_fs(Policy::allow_all(), Arc::new(Env::ambient()));
         let mut first = FsOperationResults::default();
         let second = FsOperationResults::default();
 
@@ -358,9 +465,9 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\n").unwrap();
-        let host = HostFs::new(
-            Arc::new(Policy::from_file(&policy_file).unwrap()),
-            WorkingDirectory::Ambient,
+        let host = host_fs(
+            Policy::from_file(&policy_file).unwrap(),
+            Arc::new(Env::ambient()),
         );
         let mut results = FsOperationResults::default();
 
@@ -373,9 +480,9 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\n").unwrap();
-        let host = HostFs::new(
-            Arc::new(Policy::from_file(&policy_file).unwrap()),
-            WorkingDirectory::Ambient,
+        let host = host_fs(
+            Policy::from_file(&policy_file).unwrap(),
+            Arc::new(Env::ambient()),
         );
         let mut results = FsOperationResults::default();
         let converted = Cell::new(false);

--- a/crates/moonrun/src/filesystem/v8/mod.rs
+++ b/crates/moonrun/src/filesystem/v8/mod.rs
@@ -33,7 +33,7 @@ pub(crate) fn init_env<'s>(
     wasm_file_name: &str,
     args: &[String],
     environment: Arc<Env>,
-    filesystem: HostFs,
+    filesystem: Arc<HostFs>,
     dtors: &mut Vec<Box<dyn Any>>,
 ) {
     runtime::register(obj, scope, wasm_file_name, args, environment, dtors);

--- a/crates/moonrun/src/filesystem/v8/whole_file.rs
+++ b/crates/moonrun/src/filesystem/v8/whole_file.rs
@@ -23,9 +23,10 @@ use crate::util::get_ref;
 use crate::v8::builder::{ArgsExt, ObjectExt, ScopeExt};
 use std::any::Any;
 use std::cell::RefCell;
+use std::sync::Arc;
 
 struct FsImports {
-    filesystem: HostFs,
+    filesystem: Arc<HostFs>,
     // V8 invokes these imports synchronously on the isolate thread. Keep the
     // adapter's mutable protocol state local without imposing a threading
     // model on the engine-neutral FsOperationResults.
@@ -33,7 +34,7 @@ struct FsImports {
 }
 
 impl FsImports {
-    fn new(filesystem: HostFs) -> Self {
+    fn new(filesystem: Arc<HostFs>) -> Self {
         Self {
             filesystem,
             operation_results: RefCell::new(FsOperationResults::default()),
@@ -357,7 +358,7 @@ fn copy_uint8_array(array: v8::Local<'_, v8::Uint8Array>) -> Vec<u8> {
 pub(super) fn register<'s>(
     obj: v8::Local<'s, v8::Object>,
     scope: &mut v8::HandleScope<'s>,
-    filesystem: HostFs,
+    filesystem: Arc<HostFs>,
     dtors: &mut Vec<Box<dyn Any>>,
 ) {
     let imports = Box::new(FsImports::new(filesystem));

--- a/crates/moonrun/src/runtime/environment.rs
+++ b/crates/moonrun/src/runtime/environment.rs
@@ -32,8 +32,6 @@ use std::sync::RwLock;
 
 use thiserror::Error;
 
-use crate::async_host::AsyncHostResult;
-
 #[derive(Debug, Error)]
 pub(crate) enum EnvError {
     #[error("invalid environment variable name {0:?}")]
@@ -86,6 +84,12 @@ impl Env {
         Ok(Self {
             backing: EnvBacking::Owned(RwLock::new(normalized)),
         })
+    }
+
+    /// Whether domain operations should retain process-global environment
+    /// integration instead of using only this Runtime's owned entries.
+    pub(crate) fn is_ambient(&self) -> bool {
+        matches!(self.backing, EnvBacking::Ambient)
     }
 
     pub(crate) fn get(&self, name: &OsStr) -> Option<OsString> {
@@ -183,25 +187,6 @@ impl Env {
         match &self.backing {
             EnvBacking::Ambient => os::inherited_entries(),
             EnvBacking::Owned(_) => self.entries(),
-        }
-    }
-
-    pub(crate) fn temp_dir(&self) -> AsyncHostResult<OsString> {
-        match &self.backing {
-            EnvBacking::Ambient => crate::async_sys::fs::stub::get_tmp_path(),
-            EnvBacking::Owned(_) => {
-                #[cfg(unix)]
-                {
-                    crate::async_sys::fs::stub::get_tmp_path_from_env(self.get("TMPDIR".as_ref()))
-                }
-                #[cfg(windows)]
-                {
-                    crate::async_sys::fs::stub::get_tmp_path_from_env(
-                        self.get("TMP".as_ref()),
-                        self.get("TEMP".as_ref()),
-                    )
-                }
-            }
         }
     }
 }
@@ -375,92 +360,6 @@ mod os {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(windows)]
-    use crate::async_host::AsyncHostError;
-    use crate::async_sys::fs::stub;
-
-    #[test]
-    fn ambient_temp_dir_uses_native_path() {
-        let environment = Env::ambient();
-
-        assert_eq!(
-            environment.temp_dir().unwrap(),
-            stub::get_tmp_path().unwrap()
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn owned_temp_dir_uses_tmpdir() {
-        use std::os::unix::ffi::OsStrExt;
-
-        let environment = Env::owned([("TMPDIR".into(), "/runtime/tmp".into())]).unwrap();
-
-        assert_eq!(environment.temp_dir().unwrap().as_bytes(), b"/runtime/tmp/");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn temp_dir_reflects_owned_environment_changes() {
-        use std::os::unix::ffi::OsStrExt;
-
-        let environment = Env::owned([("TMPDIR".into(), "/first".into())]).unwrap();
-
-        assert_eq!(environment.temp_dir().unwrap().as_bytes(), b"/first/");
-        environment.set("TMPDIR".into(), "/second".into()).unwrap();
-        assert_eq!(environment.temp_dir().unwrap().as_bytes(), b"/second/");
-        environment.unset("TMPDIR".as_ref()).unwrap();
-        assert_eq!(
-            environment.temp_dir().unwrap(),
-            stub::get_tmp_path_from_env(None).unwrap()
-        );
-    }
-
-    #[cfg(all(unix, not(target_os = "android")))]
-    #[test]
-    fn empty_owned_environment_uses_default_temp_dir() {
-        use std::os::unix::ffi::OsStrExt;
-
-        let environment = Env::owned(Vec::<(OsString, OsString)>::new()).unwrap();
-
-        assert_eq!(environment.temp_dir().unwrap().as_bytes(), b"/tmp/");
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn owned_temp_dir_requires_configured_windows_temp_env() {
-        let environment = Env::owned(Vec::<(OsString, OsString)>::new()).unwrap();
-
-        assert_eq!(
-            environment.temp_dir(),
-            Err(AsyncHostError::PermissionDenied)
-        );
-        environment.set("TEMP".into(), "C:/Temp".into()).unwrap();
-        assert_eq!(
-            environment.temp_dir().unwrap().to_string_lossy(),
-            "C:/Temp\\"
-        );
-        environment.unset("TEMP".as_ref()).unwrap();
-        assert_eq!(
-            environment.temp_dir(),
-            Err(AsyncHostError::PermissionDenied)
-        );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn empty_tmp_falls_back_to_temp() {
-        let environment = Env::owned([
-            ("TMP".into(), "".into()),
-            ("TEMP".into(), "C:/Fallback".into()),
-        ])
-        .unwrap();
-
-        assert_eq!(
-            environment.temp_dir().unwrap().to_string_lossy(),
-            "C:/Fallback\\"
-        );
-    }
 
     #[test]
     fn owned_environment_applies_mutations_over_initial_values() {

--- a/crates/moonrun/src/runtime/mod.rs
+++ b/crates/moonrun/src/runtime/mod.rs
@@ -103,9 +103,9 @@ impl HostKeys {
 /// them once, binds filesystem policy to the same working-directory authority,
 /// wires host domain state to one key namespace, and owns it until teardown.
 pub(crate) struct Runtime {
-    policy: Arc<Policy>,
     environment: Arc<Env>,
     working_directory: WorkingDirectory,
+    filesystem: Arc<HostFs>,
     async_state: AsyncHost,
     sqlite: SqliteHost,
 }
@@ -133,6 +133,11 @@ impl Runtime {
         );
         let policy = Arc::new(policy);
         let keys = Rc::new(RefCell::new(HostKeys::default()));
+        let filesystem = Arc::new(HostFs::new(
+            Arc::clone(&policy),
+            Arc::clone(&environment),
+            working_directory.clone(),
+        ));
         let async_state = AsyncHost::with_keys(
             Arc::clone(&policy),
             Arc::clone(&environment),
@@ -141,9 +146,9 @@ impl Runtime {
         );
         let sqlite = SqliteHost::with_keys(Arc::clone(&policy), keys);
         Ok(Self {
-            policy,
             environment,
             working_directory,
+            filesystem,
             async_state,
             sqlite,
         })
@@ -153,8 +158,8 @@ impl Runtime {
         &self.environment
     }
 
-    pub(crate) fn filesystem(&self) -> HostFs {
-        HostFs::new(Arc::clone(&self.policy), self.working_directory.clone())
+    pub(crate) fn filesystem(&self) -> &Arc<HostFs> {
+        &self.filesystem
     }
 
     pub(crate) fn working_directory(&self) -> &WorkingDirectory {

--- a/crates/moonrun/src/v8/host_imports.rs
+++ b/crates/moonrun/src/v8/host_imports.rs
@@ -330,7 +330,7 @@ pub(crate) fn install(
     let global_proxy = scope.get_current_context().global(scope);
     let termination_request = run_termination::TerminationRequest::default();
     let environment = Arc::clone(runtime.environment());
-    let filesystem = runtime.filesystem();
+    let filesystem = Arc::clone(runtime.filesystem());
     let v8_context = Box::new(context::V8RunContext::new(
         runtime,
         termination_request.clone(),


### PR DESCRIPTION
## Why

PR #2110 removed the TempDir-to-Policy query, but resolving the path inside Env made Runtime State depend on the raw filesystem implementation. Runtime also constructed HostFs on demand for one adapter instead of owning a single filesystem semantic owner.

## What changed

- Make Runtime own one shared HostFs for the complete virtual environment.
- Give HostFs the canonical Env reference and move raw temporary-path resolution into the filesystem domain.
- Route the async temporary-path imports directly through HostFs instead of AsyncHost.
- Keep Env limited to environment state and its Ambient-or-Owned runtime semantics.
- Test temporary-path behavior through the HostFs interface.

## Why this is correct

Ambient environments continue to use the native platform temporary-path selection, including Windows fallbacks. Owned environments consult only their Runtime-owned TMPDIR, TMP, or TEMP entries and continue to observe guest mutations.

## Scope

This is the smallest filesystem ownership slice that corrects the dependency direction exposed by #2110. It does not change policy syntax, split FsPolicy from the broad Policy yet, or begin the handle-relative open/openat refactor.