### PR TITLE
refactor(moonrun): distribute policy to host domains

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -117,8 +117,10 @@ The Runtime-owned, backend-neutral implementation of moonrun's
 permission-backed filesystem operations. It owns filesystem authorization,
 Filesystem Job payloads, execution, and result interpretation. Wasm runtime
 adapters only convert values and expose imports; the thread pool only schedules
-Filesystem Jobs and delivers their Completions. WASI does not pass through the
-Host Filesystem.
+Filesystem Jobs and delivers their Completions. Other Host Domains may ask it
+to interpret and authorize filesystem intents without transferring their own
+domain semantics to the Host Filesystem. WASI does not pass through the Host
+Filesystem.
 _Avoid_: WASI filesystem, V8 filesystem
 
 **Host Network**:
@@ -248,7 +250,14 @@ The V8-facing `moonbitlang/sqlite` adapter that lowers SQLite-shaped calls into 
 _Avoid_: SQLite Host, SQLite wrapper SDK
 
 **SQLite Host**:
-The backend-neutral SQLite implementation owned by one Runtime. It owns SQLite policy and operations, uses the Runtime's shared Host Key namespace, and contains the Database and Statement pointer maps, teardown, and leak accounting. Wasm runtime adapters lower their own memory and scalar representations before crossing its interface.
+The backend-neutral SQLite implementation owned by one Runtime. It owns SQLite
+admission rules and operations, uses the Runtime's shared Host Key namespace,
+and contains the Database and Statement pointer maps, teardown, and leak
+accounting. File-backed admission currently asks the Host Filesystem to
+interpret and authorize its filesystem intents before SQLite's default VFS
+reinterprets the filename; SQLite flags, VFS selection, authorizer behavior,
+and FFI remain SQLite Host semantics. Wasm runtime adapters lower their own
+memory and scalar representations before crossing its interface.
 _Avoid_: SQLite API, Async Host, V8 SQLite
 
 **Async Sys**:

--- a/crates/moonrun/src/async_api/context.rs
+++ b/crates/moonrun/src/async_api/context.rs
@@ -41,7 +41,7 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
     pub(super) fn new(scope: &'a mut v8::HandleScope<'scope>, context: &'a V8RunContext) -> Self {
         Self {
             scope,
-            host: context.runtime().async_state(),
+            host: context.runtime().async_host(),
             filesystem: context.runtime().filesystem(),
             memory_binding: context.memory_binding(),
             termination_request: context.termination_request(),

--- a/crates/moonrun/src/async_api/process.rs
+++ b/crates/moonrun/src/async_api/process.rs
@@ -358,14 +358,11 @@ pub(super) fn get_process_result(
         let code = {
             let handle_id = handle_id.ok_or(AsyncHostError::Badf)?;
             let raw_handle = raw_handle.ok_or(AsyncHostError::Badf)?;
-            context.host.finish_process_handle(pid, handle_id, || {
-                if context.host.policy().has_process_policy()
-                    && process::process_id_from_handle(raw_handle)? != pid
-                {
-                    return Err(AsyncHostError::PermissionDenied);
-                }
-                process::get_process_result(Some(raw_handle), pid)
-            })?
+            context
+                .host
+                .finish_process_handle(pid, handle_id, raw_handle, || {
+                    process::get_process_result(Some(raw_handle), pid)
+                })?
         };
         context.with_memory_mut(|memory| Ok(memory.write_exact(out, &code.to_le_bytes())?))
     })();

--- a/crates/moonrun/src/async_api/thread_pool.rs
+++ b/crates/moonrun/src/async_api/thread_pool.rs
@@ -805,19 +805,7 @@ pub(super) fn make_wait_for_process_job(
     handle: u64,
     pid: i32,
 ) -> AsyncHostResult<u64> {
-    let tracked_pid = context.host.process_handle_pid(handle)?;
-    let handle = optional_resource(context, handle)?;
-    #[cfg(unix)]
-    let defer_reap = context.host.policy().has_process_policy();
-    context
-        .host
-        .insert_job(ProcessJob::wait_for_process(
-            handle,
-            tracked_pid,
-            pid,
-            #[cfg(unix)]
-            defer_reap,
-        )?)
+    context.host.make_wait_for_process_job(handle, pid)
 }
 
 #[ported(source = "src/internal/event_loop/thread_pool.c")]

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -52,13 +52,13 @@ use crate::async_sys::internal::event_loop::{
 };
 use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::async_sys::socket::RawSocket;
+use crate::filesystem::HostFs;
 use crate::guest_memory::{GuestMemory, GuestMemoryError};
 use crate::network::HostNetwork;
-use crate::policy::Policy;
 use crate::process::HostProcess;
 use crate::resource::{Resource, ResourceClass, ResourcePublication, ResourceRef};
 pub(crate) use crate::runtime::HostKey as HandleKey;
-use crate::runtime::{Env, HostKeys, HostResourceKind as HandleKind, WorkingDirectory};
+use crate::runtime::{Env, HostKeys, HostResourceKind as HandleKind};
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 compile_error!("moonrun async wasm host currently supports only Linux, macOS, and Windows hosts");
@@ -1198,7 +1198,7 @@ pub(crate) struct AsyncHost {
     // V8 enters this host synchronously on one thread. Cell and RefCell encode
     // that ownership; worker threads own their Jobs and return them through the
     // completion channel instead of sharing the host's tables.
-    policy: Arc<Policy>,
+    filesystem: Arc<HostFs>,
     environment: Arc<Env>,
     network: HostNetwork,
     errno: Cell<i32>,
@@ -1222,39 +1222,16 @@ pub(crate) struct AsyncHost {
     tls_error: RefCell<Option<String>>,
 }
 
-#[cfg(test)]
-impl Default for AsyncHost {
-    fn default() -> Self {
-        Self::new(Arc::new(Policy::allow_all()))
-    }
-}
-
 impl AsyncHost {
-    #[cfg(test)]
-    pub(crate) fn new(policy: Arc<Policy>) -> Self {
-        let environment = Arc::new(
-            policy
-                .realize_env()
-                .expect("construct test Host environment"),
-        );
-        Self::with_keys(
-            policy,
-            environment,
-            Rc::new(RefCell::new(HostKeys::default())),
-            WorkingDirectory::Ambient,
-        )
-    }
-
-    pub(crate) fn with_keys(
-        policy: Arc<Policy>,
+    pub(crate) fn new(
         environment: Arc<Env>,
+        filesystem: Arc<HostFs>,
+        network: HostNetwork,
+        process: HostProcess,
         keys: Rc<RefCell<HostKeys>>,
-        working_directory: WorkingDirectory,
     ) -> Self {
-        let process = HostProcess::new(Arc::clone(&policy), working_directory);
-        let network = HostNetwork::new(Arc::clone(&policy));
         Self {
-            policy,
+            filesystem,
             environment,
             network,
             errno: Cell::new(0),
@@ -2439,11 +2416,9 @@ impl AsyncHost {
             }
             ResourcePublication::Unpublished(resource) => resource,
         };
-        let process_pid = self.process.has_policy().then(|| job.ret() as i32);
+        let process_pid = job.ret() as i32;
         let fd = self.handles.borrow_mut().insert_resource(resource);
-        if let Some(pid) = process_pid {
-            self.process.track_process_handle(fd, pid);
-        }
+        self.process.track_process_handle(fd, process_pid);
         job.process_mut()?
             .set_spawn_result(ResourcePublication::Published(fd))?;
         Ok(fd)
@@ -2639,7 +2614,7 @@ impl AsyncHost {
 
         let kqueue = self.acquire_resource(kqueue_handle)?;
         let file = self.acquire_resource(file_handle)?;
-        Self::check_file_metadata_policy(&self.policy, Some(file.as_ref()))?;
+        Self::check_file_metadata_policy(&self.filesystem, Some(file.as_ref()))?;
         crate::async_sys::fs::watch_kqueue::add_file(
             kqueue.as_fd()?.as_raw_fd(),
             file.as_fd()?.as_raw_fd(),
@@ -2648,8 +2623,9 @@ impl AsyncHost {
         )
     }
 
-    pub(crate) fn policy(&self) -> &Policy {
-        &self.policy
+    #[cfg(all(test, unix))]
+    pub(crate) fn filesystem(&self) -> &HostFs {
+        &self.filesystem
     }
 
     pub(crate) fn environment(&self) -> &Env {
@@ -2684,16 +2660,33 @@ impl AsyncHost {
         &self,
         pid: i32,
         handle: HostHandle,
+        raw_handle: RawFd,
         f: impl FnOnce() -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
-        self.process.finish_process_handle(pid, handle, f)
+        self.process
+            .finish_process_handle(pid, handle, raw_handle, f)
     }
 
-    pub(crate) fn process_handle_pid(&self, handle: HostHandle) -> AsyncHostResult<Option<i32>> {
+    fn process_handle_pid(&self, handle: HostHandle) -> AsyncHostResult<Option<i32>> {
         if handle == INVALID_HOST_HANDLE || handle == self.invalid_fd() {
             return Ok(None);
         }
         self.process.process_handle_pid(handle)
+    }
+
+    pub(crate) fn make_wait_for_process_job(
+        &self,
+        handle: HostHandle,
+        pid: i32,
+    ) -> AsyncHostResult<HostHandle> {
+        let tracked_pid = self.process_handle_pid(handle)?;
+        let resource = if handle == INVALID_HOST_HANDLE || handle == self.invalid_fd() {
+            None
+        } else {
+            Some(self.acquire_resource(handle)?)
+        };
+        let job = self.process.wait_job(resource, tracked_pid, pid)?;
+        self.insert_job(job)
     }
 
     #[cfg(test)]
@@ -3640,7 +3633,7 @@ impl AsyncHost {
 
     pub(crate) fn try_lock_file(&self, handle: HostHandle, exclusive: bool) -> AsyncHostResult<()> {
         self.with_resource_of_class(handle, ResourceClass::File, |file| {
-            Self::check_file_lock_policy(&self.policy, Some(file), exclusive)?;
+            Self::check_file_lock_policy(&self.filesystem, Some(file), exclusive)?;
             crate::async_sys::fs::stub::try_lock_acquired_file(file, exclusive)
         })
     }
@@ -3654,12 +3647,12 @@ impl AsyncHost {
     pub(crate) fn run_job(&self, handle: u64) -> AsyncHostResult<()> {
         let key = self.handles.borrow().job(handle)?;
         let mut job = self.jobs.borrow_mut().take_ready_job(key)?;
-        Self::run_policy_checked_job(&self.policy, &self.process, &mut job);
+        Self::run_policy_checked_job(&self.filesystem, &self.process, &mut job);
         self.restore_job(key, job)
     }
 
-    fn run_policy_checked_job(policy: &Policy, process: &HostProcess, job: &mut Job) {
-        if let Err(error) = Self::check_job_policy(policy, process, job) {
+    fn run_policy_checked_job(filesystem: &HostFs, process: &HostProcess, job: &mut Job) {
+        if let Err(error) = Self::check_job_policy(filesystem, process, job) {
             job.set_err(error.errno());
             return;
         }
@@ -3675,9 +3668,13 @@ impl AsyncHost {
         }
     }
 
-    fn check_job_policy(policy: &Policy, process: &HostProcess, job: &Job) -> AsyncHostResult<()> {
+    fn check_job_policy(
+        filesystem: &HostFs,
+        process: &HostProcess,
+        job: &Job,
+    ) -> AsyncHostResult<()> {
         match job.payload() {
-            JobPayload::Filesystem(job) => job.check_policy(policy),
+            JobPayload::Filesystem(job) => job.check_policy(filesystem),
             JobPayload::Process(job) => process.check_job(job),
             _ => Ok(()),
         }
@@ -3691,18 +3688,21 @@ impl AsyncHost {
     }
 
     #[cfg(target_os = "macos")]
-    fn check_file_metadata_policy(policy: &Policy, file: Option<&Resource>) -> AsyncHostResult<()> {
+    fn check_file_metadata_policy(
+        filesystem: &HostFs,
+        file: Option<&Resource>,
+    ) -> AsyncHostResult<()> {
         let file = file.ok_or(AsyncHostError::Badf)?;
-        policy.stat_resource_path(file.policy_path())
+        filesystem.authorize_resource_metadata(file.canonical_path())
     }
 
     fn check_file_lock_policy(
-        policy: &Policy,
+        filesystem: &HostFs,
         file: Option<&Resource>,
         exclusive: bool,
     ) -> AsyncHostResult<()> {
         let file = file.ok_or(AsyncHostError::Badf)?;
-        policy.lock_resource_path(file.policy_path(), exclusive)
+        filesystem.authorize_resource_lock(file.canonical_path(), exclusive)
     }
 
     pub(crate) fn spawn_worker(&self, completion_id: i32, job_handle: u64) -> AsyncHostResult<u64> {
@@ -3981,7 +3981,10 @@ impl AsyncHost {
             ("TLS private key", private_key_file.as_path()),
             ("TLS certificate", certificate_file.as_path()),
         ] {
-            if let Err(error) = self.policy.open_path(path.as_os_str(), 0, 0, false) {
+            if let Err(error) = self
+                .filesystem
+                .authorize_open(path.as_os_str(), 0, 0, false)
+            {
                 return self.with_tls_pending_mut(handle, |pending| {
                     pending.set_error(format!("failed to access {label} file: {error:?}"))
                 });
@@ -4202,13 +4205,13 @@ impl AsyncHost {
         init_job: HostWorkerJob,
         complete_job: impl FnMut(WorkerCompletionId) + Send + 'static,
     ) -> AsyncHostResult<()> {
-        let policy = Arc::clone(&self.policy);
+        let filesystem = Arc::clone(&self.filesystem);
         let process_for_runner = self.process.clone();
         self.workers.spawn(
             worker,
             init_job,
             move |worker_job| {
-                Self::run_policy_checked_job(&policy, &process_for_runner, &mut worker_job.job);
+                Self::run_policy_checked_job(&filesystem, &process_for_runner, &mut worker_job.job);
             },
             complete_job,
         )
@@ -4376,7 +4379,9 @@ mod tests {
 
     use super::*;
     use crate::filesystem::Job as FilesystemJob;
+    use crate::policy::Policy;
     use crate::process::{Job as ProcessJob, SpawnOptions};
+    use crate::runtime::WorkingDirectory;
 
     #[repr(align(2))]
     struct AlignedBytes<const N: usize>([u8; N]);
@@ -4393,8 +4398,39 @@ mod tests {
         host.handles.borrow().resource_count_excluding_reserved()
     }
 
+    fn test_host(mut policy: Policy) -> AsyncHost {
+        let environment = Arc::new(
+            policy
+                .realize_env()
+                .expect("construct test Host environment"),
+        );
+        let working_directory = Arc::new(WorkingDirectory::Ambient);
+        let filesystem = Arc::new(HostFs::new(
+            policy.take_filesystem_policy(),
+            Arc::clone(&environment),
+            Arc::clone(&working_directory),
+        ));
+        let network = HostNetwork::new(policy.take_network_policy());
+        let process = HostProcess::new(
+            policy.take_process_policy(),
+            policy.take_policy_inheritance(),
+            working_directory,
+        );
+        AsyncHost::new(
+            environment,
+            filesystem,
+            network,
+            process,
+            Rc::new(RefCell::new(HostKeys::default())),
+        )
+    }
+
+    fn default_host() -> AsyncHost {
+        test_host(Policy::allow_all())
+    }
+
     fn host_with_policy(path: &std::path::Path) -> AsyncHost {
-        AsyncHost::new(Arc::new(Policy::from_file(path).unwrap()))
+        test_host(Policy::from_file(path).unwrap())
     }
 
     #[cfg(unix)]
@@ -4432,16 +4468,15 @@ mod tests {
     }
 
     #[test]
-    fn no_policy_does_not_allocate_child_ownership_tracking() {
-        let host = AsyncHost::default();
+    fn no_policy_leaves_unknown_child_access_unrestricted() {
+        let host = default_host();
 
-        assert!(!host.process.has_policy());
         host.check_owned_child_pid(i32::MAX).unwrap();
     }
 
     #[test]
     fn spawn_job_builder_only_mutates_ready_spawn_jobs() {
-        let host = AsyncHost::default();
+        let host = default_host();
         #[cfg(unix)]
         let spawn_job = successful_process_job();
         #[cfg(windows)]
@@ -4662,7 +4697,7 @@ mod tests {
 
     #[test]
     fn get_spawn_result_rejects_non_spawn_job() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
 
         assert_eq!(
@@ -4729,7 +4764,7 @@ mod tests {
 
     #[test]
     fn process_env_block_transfer_consumes_source() {
-        let host = AsyncHost::default();
+        let host = default_host();
         #[cfg(unix)]
         let src = host.insert_process_env(vec![Some(OsString::from("A=B"))]);
         #[cfg(windows)]
@@ -4771,7 +4806,7 @@ mod tests {
 
     #[test]
     fn process_env_block_transfer_consumes_source_on_failure() {
-        let host = AsyncHost::default();
+        let host = default_host();
         #[cfg(unix)]
         let src = host.insert_process_env(vec![Some(OsString::from("A=B"))]);
         #[cfg(windows)]
@@ -4791,7 +4826,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn legacy_process_spawn_inputs_use_inherited_count_to_build_environment() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let argv = host.insert_process_argv(2).unwrap();
         host.process_argv_add_entry(argv, 0, OsString::from("command"))
             .unwrap();
@@ -4820,7 +4855,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn legacy_process_spawn_inputs_apply_current_nul_handling() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let argv = host.insert_process_argv(1).unwrap();
         host.process_argv_add_entry(argv, 0, OsString::from("command"))
             .unwrap();
@@ -4848,7 +4883,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn invalid_legacy_process_spawn_inherited_count_does_not_consume_buffers() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let argv = host.insert_process_argv(1).unwrap();
         host.process_argv_add_entry(argv, 0, OsString::from("command"))
             .unwrap();
@@ -4865,7 +4900,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn invalid_process_spawn_buffers_are_not_partially_consumed() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let argv = host.insert_process_argv(1).unwrap();
         host.process_argv_add_entry(argv, 0, OsString::from("command"))
             .unwrap();
@@ -4882,7 +4917,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn process_spawn_abis_reject_the_other_environment_handle_kind() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let argv = host.insert_process_argv(1).unwrap();
         host.process_argv_add_entry(argv, 0, OsString::from("command"))
             .unwrap();
@@ -4907,7 +4942,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn process_spawn_environment_transfers_ownership() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let block = vec![b'A' as u16, b'=' as u16, b'B' as u16, 0, 0];
         let env = host.insert_process_env(block.clone());
 
@@ -4918,7 +4953,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn process_spawn_abis_reject_the_other_environment_handle_kind() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let builder = host.insert_process_env_builder(Vec::new());
         assert_eq!(host.take_process_env(builder), Err(AsyncHostError::Badf));
         assert!(host.handles.borrow().process_env_builder(builder).is_ok());
@@ -4999,7 +5034,7 @@ mod tests {
 
     #[test]
     fn resource_class_rejects_file_as_socket() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let [read, write] = host.pipe(true, true).unwrap();
 
         assert_eq!(
@@ -5018,7 +5053,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn pipe_applies_async_flags_to_nonblocking_state() {
-        let host = AsyncHost::default();
+        let host = default_host();
 
         for (read_is_async, write_is_async) in
             [(false, false), (true, false), (false, true), (true, true)]
@@ -5054,7 +5089,7 @@ mod tests {
         #[cfg(windows)]
         assert_eq!(crate::async_sys::internal::event_loop::io::init_wsa(), 0);
 
-        let host = AsyncHost::default();
+        let host = default_host();
         let tcp = host.make_tcp_socket(4).unwrap();
         let udp = host.make_udp_socket(4, false).unwrap();
 
@@ -5086,7 +5121,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn completion_source_is_resource_handle() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let completion_source = host.init_thread_pool(poll).unwrap();
         let raw_completion_fd = host
@@ -5121,7 +5156,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn fetch_completion_publishes_completion_id_without_copying_payload() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let job = FilesystemJob::read(Arc::new(Resource::invalid()), 3, -1);
@@ -5157,7 +5192,7 @@ mod tests {
 
     #[test]
     fn failed_stat_job_does_not_require_a_filesystem_payload() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let error = AsyncHostError::Inval.errno();
         let job = host
             .insert_job(thread_pool::make_failed_job(error))
@@ -5174,7 +5209,7 @@ mod tests {
 
     #[test]
     fn c_buffer_access_rejects_interior_raw_pointer() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let handle = host.insert_c_buffer(b"abcd".to_vec().into_boxed_slice());
         let interior_ptr = host
             .with_c_buffer(handle, |buffer| {
@@ -5197,7 +5232,7 @@ mod tests {
 
     #[test]
     fn readdir_job_exclusively_leases_and_restores_c_buffer() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let handle = host.insert_c_buffer(b"abcd".to_vec().into_boxed_slice());
         let key = host.handles.borrow().c_buffer(handle).unwrap();
         assert!(matches!(
@@ -5236,7 +5271,7 @@ mod tests {
 
     #[test]
     fn freeing_unrun_readdir_job_restores_c_buffer() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let handle = host.insert_c_buffer(b"abcd".to_vec().into_boxed_slice());
         let lease = host.lease_c_buffer(handle).unwrap();
         let job = FilesystemJob::readdir(Arc::new(Resource::invalid()), lease, 4, false);
@@ -5253,7 +5288,7 @@ mod tests {
 
     #[test]
     fn discarded_queued_readdir_job_restores_c_buffer() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let handle = host.insert_c_buffer(b"abcd".to_vec().into_boxed_slice());
         let lease = host.lease_c_buffer(handle).unwrap();
         let job = FilesystemJob::readdir(Arc::new(Resource::invalid()), lease, 4, false);
@@ -5278,7 +5313,7 @@ mod tests {
 
     #[test]
     fn freed_c_buffer_is_not_restored_by_its_readdir_job() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let handle = host.insert_c_buffer(b"old".to_vec().into_boxed_slice());
         let lease = host.lease_c_buffer(handle).unwrap();
         let job = FilesystemJob::readdir(Arc::new(Resource::invalid()), lease, 3, false);
@@ -5302,7 +5337,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn realpath_result_is_registered_c_buffer_cleaned_up_with_job() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let job_handle = host
             .insert_job(FilesystemJob::realpath(std::ffi::OsString::from(
                 "/tmp/example",
@@ -5335,7 +5370,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn fetch_completion_leaves_unfetched_completion_ids_in_os_source() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         {
@@ -5366,7 +5401,7 @@ mod tests {
 
     #[test]
     fn stale_job_handle_is_rejected_after_free() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
 
         host.free_job(job).unwrap();
@@ -5377,7 +5412,7 @@ mod tests {
 
     #[test]
     fn open_job_get_fd_publishes_opened_resource_once() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let path =
             std::env::temp_dir().join(format!("moonrun-published-open-job-{}", std::process::id()));
         let job = host
@@ -5538,8 +5573,8 @@ mod tests {
         std::fs::write(&policy_file, "[fs]\nread = [\"allowed\"]\n").unwrap();
         let host = host_with_policy(&policy_file);
 
-        host.policy()
-            .open_path(link.as_os_str(), 0, 0, false)
+        host.filesystem()
+            .authorize_open(link.as_os_str(), 0, 0, false)
             .unwrap();
         let job = host
             .insert_job(FilesystemJob::open_legacy(
@@ -5982,7 +6017,7 @@ mod tests {
 
     #[test]
     fn discarded_completed_open_job_drops_unpublished_resource() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let path =
             std::env::temp_dir().join(format!("moonrun-discarded-open-job-{}", std::process::id()));
         let job_handle = host
@@ -6018,9 +6053,8 @@ mod tests {
 
     #[test]
     fn drop_destroys_pool_even_when_worker_holds_state() {
-        let policy = Arc::new(Policy::allow_all());
-        let policy_weak = Arc::downgrade(&policy);
-        let host = AsyncHost::new(policy);
+        let host = default_host();
+        let filesystem_weak = Arc::downgrade(&host.filesystem);
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
@@ -6042,12 +6076,12 @@ mod tests {
 
         drop(host);
 
-        assert!(policy_weak.upgrade().is_none());
+        assert!(filesystem_weak.upgrade().is_none());
     }
 
     #[test]
     fn worker_result_is_available_after_completion_event() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let completion_source = host.init_thread_pool(poll).unwrap();
         let job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
@@ -6080,7 +6114,7 @@ mod tests {
 
     #[test]
     fn free_running_worker_job_detaches_its_result() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let first_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
         let first_key = job_key(&host, first_job);
         let (started_sender, started_receiver) = std::sync::mpsc::channel();
@@ -6126,7 +6160,7 @@ mod tests {
 
     #[test]
     fn free_queued_worker_job_detaches_without_cancelling_it() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let first_job = host.insert_job(thread_pool::make_sleep_job(0)).unwrap();
         let first_key = job_key(&host, first_job);
         let (started_sender, started_receiver) = std::sync::mpsc::channel();
@@ -6209,7 +6243,7 @@ mod tests {
 
     #[test]
     fn worker_handles_stay_stale_after_thread_pool_reinit() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let first_job = host
@@ -6254,7 +6288,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn native_order_completion_before_poll_destroy_remains_supported() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let completion = host.thread_pool_completion_target().unwrap();
@@ -6274,7 +6308,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn alternate_order_poll_destroy_before_completion_remains_safe() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
 
         host.init_thread_pool(poll).unwrap();
@@ -6290,7 +6324,7 @@ mod tests {
 
     #[test]
     fn stale_worker_handle_is_rejected_after_free() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let completion_notifier = host.init_thread_pool(poll).unwrap();
         let job = host
@@ -6319,7 +6353,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn acquired_resource_survives_guest_close() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let [read, write] = host.pipe(false, false).unwrap();
         let file = host.acquire_resource(read).unwrap();
 
@@ -6344,7 +6378,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn close_fd_unregisters_poll_when_job_still_holds_resource() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let [read, write] = host.pipe(true, true).unwrap();
         host.poll_register(poll, read, true).unwrap();
@@ -6403,7 +6437,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn read_dir_changes_io_result_leases_buffer_until_free() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let buffer = host.insert_windows_watcher_buffer();
         let result = host.make_read_dir_changes_io_result(buffer).unwrap();
 
@@ -6423,7 +6457,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn read_dir_changes_rejects_a_generic_c_buffer() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let buffer = host.insert_c_buffer(vec![1, 2, 3].into_boxed_slice());
 
         assert_eq!(
@@ -6484,7 +6518,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn io_result_write_creation_copies_guest_source() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let mut memory = b"zzzabc".to_vec();
 
         let result = host
@@ -6504,7 +6538,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn cancel_io_result_rejects_wrong_fd_without_clearing_pending() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let raw_read = {
@@ -6542,7 +6576,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn cancel_io_result_clears_pending_result_when_no_wait_is_needed() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         {
@@ -6574,7 +6608,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn cancel_io_result_keeps_pending_result_when_wait_is_needed() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let raw_read = {
@@ -6611,7 +6645,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn close_fd_rejects_pending_io_result() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let raw_read = {
@@ -6647,7 +6681,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn close_fd_rejects_extra_pending_close_guard() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         let (raw_read, raw_write) = {
@@ -6699,7 +6733,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn free_io_result_rejects_pending_result() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let [read, write] = host.pipe(true, true).unwrap();
         let result = host.make_file_read_io_result(0, 0).unwrap();
         {
@@ -6736,7 +6770,7 @@ mod tests {
     fn poll_event_io_result_marks_pending_result_delivered() {
         use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let completion_port = {
             let polls = host.polls.borrow();
@@ -6783,7 +6817,7 @@ mod tests {
     fn unregistered_iocp_completion_key_is_returned() {
         use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let completion_port = {
             let polls = host.polls.borrow();
@@ -6807,7 +6841,7 @@ mod tests {
     fn zero_iocp_completion_key_is_returned() {
         use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let completion_port = {
             let polls = host.polls.borrow();
@@ -6829,7 +6863,7 @@ mod tests {
     fn close_fd_preserves_polled_iocp_resource_handle() {
         use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let [read, write] = host.pipe(true, true).unwrap();
         host.poll_register(poll, read, true).unwrap();
@@ -6860,7 +6894,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn poll_reports_registered_pipe_readiness_as_guest_fd() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let [read, write] = host.pipe(true, true).unwrap();
         host.poll_register(poll, read, true).unwrap();
@@ -6891,7 +6925,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn close_fd_preserves_polled_resource_handle() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let poll = host.poll_create().unwrap();
         let [read, write] = host.pipe(true, true).unwrap();
         host.poll_register(poll, read, true).unwrap();
@@ -6917,7 +6951,7 @@ mod tests {
 
     #[test]
     fn stale_file_handle_is_rejected_after_close() {
-        let host = AsyncHost::default();
+        let host = default_host();
         let [read, write] = host.pipe(true, true).unwrap();
 
         host.close_fd(read).unwrap();

--- a/crates/moonrun/src/filesystem/job/mod.rs
+++ b/crates/moonrun/src/filesystem/job/mod.rs
@@ -25,8 +25,8 @@ use std::ffi::{OsStr, OsString};
 
 use crate::async_host::{AsyncHostError, AsyncHostResult, CBufferLease};
 use crate::async_sys::internal::fd_util;
+use crate::filesystem::HostFs;
 use crate::guest_memory::GuestMemory;
-use crate::policy::Policy;
 use crate::resource::{Resource, ResourcePublication, ResourceRef};
 
 use stat::{PackedStat, STAT_DEVICE_ID, STAT_FILE_ID, STAT_FILE_KIND, StatRequest};
@@ -420,7 +420,7 @@ impl Job {
         }
     }
 
-    pub(crate) fn check_policy(&self, policy: &Policy) -> AsyncHostResult<()> {
+    pub(crate) fn check_policy(&self, filesystem: &HostFs) -> AsyncHostResult<()> {
         match &self.kind {
             Kind::Open {
                 filename,
@@ -430,13 +430,13 @@ impl Job {
                 request,
                 ..
             } => {
-                policy.open_path(filename, *access, *create_mode, *append)?;
+                filesystem.authorize_open(filename, *access, *create_mode, *append)?;
                 if request.mask() & !STAT_OPEN_IDENTITY != 0 {
-                    policy.stat_path(filename)?;
+                    filesystem.authorize_metadata(filename)?;
                 }
                 Ok(())
             }
-            Kind::Fstatx { file, .. } => check_file_metadata_policy(policy, file.as_deref()),
+            Kind::Fstatx { file, .. } => check_file_metadata_policy(filesystem, file.as_deref()),
             Kind::Statx {
                 parent,
                 path,
@@ -447,30 +447,30 @@ impl Job {
                 parent,
                 path,
                 follow_symlink,
-            } => check_path_metadata_policy(policy, parent.as_deref(), path, *follow_symlink),
+            } => check_path_metadata_policy(filesystem, parent.as_deref(), path, *follow_symlink),
             Kind::FileSize { file, .. } | Kind::FileTime { file, .. } => {
-                check_file_metadata_policy(policy, file.as_deref())
+                check_file_metadata_policy(filesystem, file.as_deref())
             }
             Kind::FileTimeByPath {
                 path,
                 follow_symlink,
                 ..
-            } => check_path_metadata_policy(policy, None, path, *follow_symlink),
-            Kind::Realpath { path, .. } => policy.stat_path(path),
+            } => check_path_metadata_policy(filesystem, None, path, *follow_symlink),
+            Kind::Realpath { path, .. } => filesystem.authorize_metadata(path),
             #[cfg(target_os = "linux")]
-            Kind::InotifyAddWatch { path, .. } => policy.stat_path(path),
-            Kind::Access { path, access } => policy.access_path(path, *access),
-            Kind::Chmod { path, .. } => policy.chmod_path(path),
+            Kind::InotifyAddWatch { path, .. } => filesystem.authorize_metadata(path),
+            Kind::Access { path, access } => filesystem.authorize_access(path, *access),
+            Kind::Chmod { path, .. } => filesystem.authorize_write(path),
             Kind::Flock { file, exclusive } => {
-                check_file_lock_policy(policy, file.as_deref(), *exclusive)
+                check_file_lock_policy(filesystem, file.as_deref(), *exclusive)
             }
-            Kind::Remove { path } => policy.remove_path(path),
+            Kind::Remove { path } => filesystem.authorize_remove(path),
             Kind::Rename {
                 old_path, new_path, ..
-            } => policy.rename_path(old_path, new_path),
-            Kind::Symlink { path, .. } => policy.symlink_path(path),
-            Kind::Mkdir { path, .. } => policy.mkdir_path(path),
-            Kind::Rmdir { path } => policy.rmdir_path(path),
+            } => filesystem.authorize_rename(old_path, new_path),
+            Kind::Symlink { path, .. } | Kind::Mkdir { path, .. } | Kind::Rmdir { path } => {
+                filesystem.authorize_write_entry(path)
+            }
             Kind::Read { .. } | Kind::Write { .. } | Kind::Fsync { .. } | Kind::Readdir { .. } => {
                 Ok(())
             }
@@ -828,32 +828,34 @@ impl OpenJobResult {
     }
 }
 
-fn check_file_metadata_policy(policy: &Policy, file: Option<&Resource>) -> AsyncHostResult<()> {
+fn check_file_metadata_policy(filesystem: &HostFs, file: Option<&Resource>) -> AsyncHostResult<()> {
     let file = file.ok_or(AsyncHostError::Badf)?;
-    policy.stat_resource_path(file.policy_path())
+    filesystem.authorize_resource_metadata(file.canonical_path())
 }
 
 fn check_path_metadata_policy(
-    policy: &Policy,
+    filesystem: &HostFs,
     parent: Option<&Resource>,
     path: &OsStr,
     follow_symlink: bool,
 ) -> AsyncHostResult<()> {
     match (parent, follow_symlink) {
-        (None, true) => policy.stat_path(path),
-        (None, false) => policy.stat_entry_path(path),
-        (Some(parent), true) => policy.stat_path_at(parent.policy_path(), path),
-        (Some(parent), false) => policy.stat_entry_path_at(parent.policy_path(), path),
+        (None, true) => filesystem.authorize_metadata(path),
+        (None, false) => filesystem.authorize_entry_metadata(path),
+        (Some(parent), true) => filesystem.authorize_metadata_at(parent.canonical_path(), path),
+        (Some(parent), false) => {
+            filesystem.authorize_entry_metadata_at(parent.canonical_path(), path)
+        }
     }
 }
 
 fn check_file_lock_policy(
-    policy: &Policy,
+    filesystem: &HostFs,
     file: Option<&Resource>,
     exclusive: bool,
 ) -> AsyncHostResult<()> {
     let file = file.ok_or(AsyncHostError::Badf)?;
-    policy.lock_resource_path(file.policy_path(), exclusive)
+    filesystem.authorize_resource_lock(file.canonical_path(), exclusive)
 }
 
 #[cfg(test)]

--- a/crates/moonrun/src/filesystem/job/runner.rs
+++ b/crates/moonrun/src/filesystem/job/runner.rs
@@ -57,11 +57,11 @@ ported_fns! {
         mode: i32,
         request: StatRequest,
     ) -> AsyncHostResult<i64> {
-        let filename_for_policy = filename.clone();
+        let filename_for_provenance = filename.clone();
         let file = open_raw_native_file(filename, access, create_mode, append, sync, mode)?;
-        let resource = Resource::new_with_policy_path(
+        let resource = Resource::new_with_canonical_path(
             file,
-            std::fs::canonicalize(filename_for_policy).ok(),
+            std::fs::canonicalize(filename_for_provenance).ok(),
         );
         let mut stat = None;
         run_fstatx_job(&resource, request, &mut stat)?;

--- a/crates/moonrun/src/filesystem/mod.rs
+++ b/crates/moonrun/src/filesystem/mod.rs
@@ -34,12 +34,12 @@ pub(crate) use job::{STAT_OPEN_IDENTITY, compat_symbols};
 
 use std::ffi::{OsStr, OsString};
 use std::fmt;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
-use crate::async_host::AsyncHostResult;
+use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::fs::stub;
-use crate::policy::Policy;
+use crate::policy::{FsIntents, FsPolicy};
 use crate::runtime::{Env, WorkingDirectory};
 
 #[derive(Debug)]
@@ -90,16 +90,16 @@ impl FsOperationResults {
 /// Engine-neutral filesystem operations that enforce the runtime policy
 /// before accessing the operating system's filesystem.
 pub(crate) struct HostFs {
-    policy: Arc<Policy>,
+    policy: Option<FsPolicy>,
     environment: Arc<Env>,
-    working_directory: WorkingDirectory,
+    working_directory: Arc<WorkingDirectory>,
 }
 
 impl HostFs {
     pub(crate) fn new(
-        policy: Arc<Policy>,
+        policy: Option<FsPolicy>,
         environment: Arc<Env>,
-        working_directory: WorkingDirectory,
+        working_directory: Arc<WorkingDirectory>,
     ) -> Self {
         Self {
             policy,
@@ -308,29 +308,214 @@ impl HostFs {
         }
     }
 
+    pub(crate) fn authorize_open(
+        &self,
+        path: &OsStr,
+        access: i32,
+        create_mode: i32,
+        append: bool,
+    ) -> AsyncHostResult<()> {
+        self.authorize_path(path, FsIntents::for_open(access, create_mode, append))
+    }
+
+    fn authorize_metadata(&self, path: &OsStr) -> AsyncHostResult<()> {
+        self.authorize_read(path)
+    }
+
+    fn authorize_metadata_at(&self, base: Option<&Path>, path: &OsStr) -> AsyncHostResult<()> {
+        let Some(policy) = &self.policy else {
+            return Ok(());
+        };
+        let target = authorization_target_at(base, path);
+        let resolved = resolve_from_directory(base, Path::new(path))
+            .and_then(|path| canonicalize_existing_prefix(&path))
+            .ok();
+        policy.authorize(resolved.as_deref(), FsIntents::read(), &target)
+    }
+
+    pub(crate) fn authorize_resource_metadata(&self, path: Option<&Path>) -> AsyncHostResult<()> {
+        let Some(policy) = &self.policy else {
+            return Ok(());
+        };
+        match path {
+            Some(path) => policy.authorize(
+                Some(path),
+                FsIntents::read(),
+                &quote_os_str(path.as_os_str()),
+            ),
+            None => policy.authorize(None, FsIntents::read(), "\"<untracked resource>\""),
+        }
+    }
+
+    pub(crate) fn authorize_read(&self, path: &OsStr) -> AsyncHostResult<()> {
+        self.authorize_path(path, FsIntents::read())
+    }
+
+    pub(crate) fn authorize_write(&self, path: &OsStr) -> AsyncHostResult<()> {
+        self.authorize_path(path, FsIntents::write())
+    }
+
+    fn authorize_entry_metadata_at(
+        &self,
+        base: Option<&Path>,
+        path: &OsStr,
+    ) -> AsyncHostResult<()> {
+        let Some(policy) = &self.policy else {
+            return Ok(());
+        };
+        let target = authorization_target_at(base, path);
+        let resolved = resolve_from_directory(base, Path::new(path))
+            .and_then(|path| canonicalize_entry_path(&path))
+            .ok();
+        policy.authorize(resolved.as_deref(), FsIntents::read(), &target)
+    }
+
+    fn authorize_entry_metadata(&self, path: &OsStr) -> AsyncHostResult<()> {
+        self.authorize_entry(path, FsIntents::read())
+    }
+
+    fn authorize_access(&self, path: &OsStr, access: i32) -> AsyncHostResult<()> {
+        self.authorize_path(path, FsIntents::for_access_check(access))
+    }
+
+    fn authorize_remove(&self, path: &OsStr) -> AsyncHostResult<()> {
+        self.authorize_entry(path, FsIntents::write())
+    }
+
+    fn authorize_rename(&self, old_path: &OsStr, new_path: &OsStr) -> AsyncHostResult<()> {
+        self.authorize_entry(old_path, FsIntents::write())?;
+        self.authorize_entry(new_path, FsIntents::write())
+    }
+
+    pub(crate) fn authorize_resource_lock(
+        &self,
+        path: Option<&Path>,
+        exclusive: bool,
+    ) -> AsyncHostResult<()> {
+        if !exclusive {
+            return Ok(());
+        }
+        let Some(policy) = &self.policy else {
+            return Ok(());
+        };
+        match path {
+            Some(path) => policy.authorize(
+                Some(path),
+                FsIntents::write(),
+                &quote_os_str(path.as_os_str()),
+            ),
+            None => policy.authorize(None, FsIntents::write(), "\"<untracked resource>\""),
+        }
+    }
+
+    fn authorize_write_entry(&self, path: &OsStr) -> AsyncHostResult<()> {
+        self.authorize_entry(path, FsIntents::write())
+    }
+
+    fn authorize_path(&self, path: &OsStr, intents: FsIntents) -> AsyncHostResult<()> {
+        let Some(policy) = &self.policy else {
+            return Ok(());
+        };
+        let target = quote_os_str(path);
+        let resolved = self
+            .resolve_from_working_directory(Path::new(path))
+            .and_then(|path| canonicalize_existing_prefix(&path))
+            .ok();
+        policy.authorize(resolved.as_deref(), intents, &target)
+    }
+
+    fn authorize_entry(&self, path: &OsStr, intents: FsIntents) -> AsyncHostResult<()> {
+        let Some(policy) = &self.policy else {
+            return Ok(());
+        };
+        let target = quote_os_str(path);
+        let resolved = self
+            .resolve_from_working_directory(Path::new(path))
+            .and_then(|path| canonicalize_entry_path(&path))
+            .ok();
+        policy.authorize(resolved.as_deref(), intents, &target)
+    }
+
+    fn resolve_from_working_directory(&self, path: &Path) -> AsyncHostResult<PathBuf> {
+        if path.is_absolute() {
+            Ok(path.to_path_buf())
+        } else {
+            self.working_directory
+                .resolve(path)
+                .map_err(|_| AsyncHostError::PermissionDenied)
+        }
+    }
+
     fn ensure_read(&self, path: &str) -> Result<(), HostFsError> {
-        ensure_read_policy(&self.policy, path).map_err(|_| HostFsError::permission_denied(path))
+        self.authorize_metadata(OsStr::new(path))
+            .map_err(|_| HostFsError::permission_denied(path))
     }
 
     fn ensure_write(&self, path: &str) -> Result<(), HostFsError> {
-        ensure_write_policy(&self.policy, path).map_err(|_| HostFsError::permission_denied(path))
+        self.authorize_open(OsStr::new(path), 1, 1, false)
+            .map_err(|_| HostFsError::permission_denied(path))
     }
 
     fn ensure_remove(&self, path: &str) -> Result<(), HostFsError> {
-        ensure_remove_policy(&self.policy, path).map_err(|_| HostFsError::permission_denied(path))
+        self.authorize_remove(OsStr::new(path))
+            .map_err(|_| HostFsError::permission_denied(path))
     }
 }
 
-fn ensure_read_policy(policy: &Policy, path: &str) -> AsyncHostResult<()> {
-    policy.stat_path(OsStr::new(path))
+fn resolve_from_directory(base: Option<&Path>, path: &Path) -> AsyncHostResult<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        base.map(|base| base.join(path))
+            .ok_or(AsyncHostError::PermissionDenied)
+    }
 }
 
-fn ensure_write_policy(policy: &Policy, path: &str) -> AsyncHostResult<()> {
-    policy.open_path(OsStr::new(path), 1, 1, false)
+fn canonicalize_existing_prefix(path: &Path) -> AsyncHostResult<PathBuf> {
+    for ancestor in path.ancestors() {
+        if let Ok(prefix) = std::fs::canonicalize(ancestor) {
+            let suffix = path
+                .strip_prefix(ancestor)
+                .map_err(|_| AsyncHostError::PermissionDenied)?;
+            return Ok(normalize_path(prefix.join(suffix)));
+        }
+    }
+    Err(AsyncHostError::PermissionDenied)
 }
 
-fn ensure_remove_policy(policy: &Policy, path: &str) -> AsyncHostResult<()> {
-    policy.remove_path(OsStr::new(path))
+fn canonicalize_entry_path(path: &Path) -> AsyncHostResult<PathBuf> {
+    let parent = path.parent().ok_or(AsyncHostError::PermissionDenied)?;
+    let file_name = path.file_name().ok_or(AsyncHostError::PermissionDenied)?;
+    Ok(normalize_path(
+        canonicalize_existing_prefix(parent)?.join(file_name),
+    ))
+}
+
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    normalized
+}
+
+fn quote_os_str(value: &OsStr) -> String {
+    format!("{:?}", value.to_string_lossy())
+}
+
+fn authorization_target_at(base: Option<&Path>, path: &OsStr) -> String {
+    base.map_or_else(
+        || quote_os_str(OsStr::new("<untracked resource>")),
+        |_| quote_os_str(path),
+    )
 }
 
 fn read_dir_entries(path: &str) -> std::io::Result<Vec<String>> {
@@ -363,9 +548,14 @@ mod tests {
     use super::*;
     #[cfg(windows)]
     use crate::async_host::AsyncHostError;
+    use crate::policy::Policy;
 
-    fn host_fs(policy: Policy, environment: Arc<Env>) -> HostFs {
-        HostFs::new(Arc::new(policy), environment, WorkingDirectory::Ambient)
+    fn host_fs(mut policy: Policy, environment: Arc<Env>) -> HostFs {
+        HostFs::new(
+            policy.take_filesystem_policy(),
+            environment,
+            Arc::new(WorkingDirectory::Ambient),
+        )
     }
 
     #[test]
@@ -497,6 +687,39 @@ mod tests {
         assert_eq!(results.error_message(), "Permission denied: denied.bin");
     }
 
+    #[test]
+    fn relative_at_authorization_uses_the_open_directory_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let allowed = tmp.path().join("allowed");
+        std::fs::create_dir(&allowed).unwrap();
+        std::fs::write(allowed.join("input.txt"), "input").unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(&policy_file, "[fs]\nread = [\"allowed\"]\n").unwrap();
+        let host = host_fs(
+            Policy::from_file(&policy_file).unwrap(),
+            Arc::new(Env::ambient()),
+        );
+
+        host.authorize_metadata_at(Some(&allowed), OsStr::new("input.txt"))
+            .unwrap();
+        assert_eq!(
+            host.authorize_metadata_at(None, OsStr::new("input.txt")),
+            Err(AsyncHostError::PermissionDenied)
+        );
+    }
+
+    #[test]
+    fn relative_at_authorization_preserves_untracked_diagnostic_target() {
+        assert_eq!(
+            authorization_target_at(None, OsStr::new("input.txt")),
+            "\"<untracked resource>\""
+        );
+        assert_eq!(
+            authorization_target_at(Some(Path::new("base")), OsStr::new("input.txt")),
+            "\"input.txt\""
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn remove_policy_checks_link_path_not_target() {
@@ -513,10 +736,39 @@ mod tests {
         std::os::unix::fs::symlink(&allowed_file, &denied_link).unwrap();
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\nwrite = [\"allowed\"]\n").unwrap();
-        let policy = Policy::from_file(&policy_file).unwrap();
+        let host = host_fs(
+            Policy::from_file(&policy_file).unwrap(),
+            Arc::new(Env::ambient()),
+        );
 
         assert_eq!(
-            ensure_remove_policy(&policy, denied_link.to_str().unwrap()),
+            host.authorize_remove(denied_link.as_os_str()),
+            Err(AsyncHostError::PermissionDenied)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_policy_checks_link_entry_not_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let allowed = tmp.path().join("allowed");
+        let denied = tmp.path().join("denied");
+        std::fs::create_dir(&allowed).unwrap();
+        std::fs::create_dir(&denied).unwrap();
+        let denied_file = denied.join("target.txt");
+        let allowed_link = allowed.join("link.txt");
+        std::fs::write(&denied_file, "target").unwrap();
+        std::os::unix::fs::symlink(&denied_file, &allowed_link).unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(&policy_file, "[fs]\nwrite = [\"allowed\"]\n").unwrap();
+        let host = host_fs(
+            Policy::from_file(&policy_file).unwrap(),
+            Arc::new(Env::ambient()),
+        );
+
+        host.authorize_remove(allowed_link.as_os_str()).unwrap();
+        assert_eq!(
+            host.authorize_write(allowed_link.as_os_str()),
             Err(AsyncHostError::PermissionDenied)
         );
     }

--- a/crates/moonrun/src/filesystem/mod.rs
+++ b/crates/moonrun/src/filesystem/mod.rs
@@ -338,11 +338,11 @@ impl HostFs {
             return Ok(());
         };
         match path {
-            Some(path) => policy.authorize(
-                Some(path),
-                FsIntents::read(),
-                &quote_os_str(path.as_os_str()),
-            ),
+            Some(path) => {
+                let target = quote_os_str(path.as_os_str());
+                let resolved = canonicalize_existing_prefix(path).ok();
+                policy.authorize(resolved.as_deref(), FsIntents::read(), &target)
+            }
             None => policy.authorize(None, FsIntents::read(), "\"<untracked resource>\""),
         }
     }
@@ -399,11 +399,11 @@ impl HostFs {
             return Ok(());
         };
         match path {
-            Some(path) => policy.authorize(
-                Some(path),
-                FsIntents::write(),
-                &quote_os_str(path.as_os_str()),
-            ),
+            Some(path) => {
+                let target = quote_os_str(path.as_os_str());
+                let resolved = canonicalize_existing_prefix(path).ok();
+                policy.authorize(resolved.as_deref(), FsIntents::write(), &target)
+            }
             None => policy.authorize(None, FsIntents::write(), "\"<untracked resource>\""),
         }
     }
@@ -718,6 +718,39 @@ mod tests {
             authorization_target_at(Some(Path::new("base")), OsStr::new("input.txt")),
             "\"input.txt\""
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resource_authorization_rechecks_saved_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let allowed = tmp.path().join("allowed");
+        let denied = tmp.path().join("denied");
+        std::fs::create_dir(&allowed).unwrap();
+        std::fs::create_dir(&denied).unwrap();
+        let resource_path = allowed.join("resource.txt");
+        let denied_file = denied.join("target.txt");
+        std::fs::write(&resource_path, "allowed").unwrap();
+        std::fs::write(&denied_file, "denied").unwrap();
+        let saved_path = std::fs::canonicalize(&resource_path).unwrap();
+        let policy_file = tmp.path().join("policy.toml");
+        std::fs::write(
+            &policy_file,
+            "[fs]\nread = [\"allowed\"]\nwrite = [\"allowed\"]\n",
+        )
+        .unwrap();
+        let host = host_fs(
+            Policy::from_file(&policy_file).unwrap(),
+            Arc::new(Env::ambient()),
+        );
+
+        std::fs::remove_file(&resource_path).unwrap();
+        std::os::unix::fs::symlink(&denied_file, &resource_path).unwrap();
+
+        let metadata = host.authorize_resource_metadata(Some(&saved_path));
+        let lock = host.authorize_resource_lock(Some(&saved_path), true);
+        assert_eq!(metadata, Err(AsyncHostError::PermissionDenied));
+        assert_eq!(lock, Err(AsyncHostError::PermissionDenied));
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/network/mod.rs
+++ b/crates/moonrun/src/network/mod.rs
@@ -20,16 +20,16 @@
 
 mod job;
 
+use std::cell::RefCell;
 use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
-use std::sync::Arc;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::socket as sys;
-use crate::policy::Policy;
+use crate::policy::{NetOperation, NetPolicy, SocketRule};
 use crate::resource::{Resource, ResourceClass, ResourceRef};
 
 pub(crate) use job::Job;
@@ -42,12 +42,17 @@ pub(crate) use job::Job;
 /// its guest-memory representation.
 #[derive(Debug)]
 pub(crate) struct HostNetwork {
-    policy: Arc<Policy>,
+    policy: Option<NetPolicy>,
+    // DNS results are Runtime provenance, not part of the clonable policy.
+    resolved_connect: RefCell<Vec<SocketRule>>,
 }
 
 impl HostNetwork {
-    pub(crate) fn new(policy: Arc<Policy>) -> Self {
-        Self { policy }
+    pub(crate) fn new(policy: Option<NetPolicy>) -> Self {
+        Self {
+            policy,
+            resolved_connect: RefCell::new(Vec::new()),
+        }
     }
 
     pub(crate) fn make_tcp_socket(&self, family: i32) -> AsyncHostResult<Resource> {
@@ -143,20 +148,30 @@ impl HostNetwork {
 
     pub(crate) fn getaddrinfo_result(&self, job: &Job) -> AsyncHostResult<Vec<Box<[u8]>>> {
         let (host, addrs) = job.getaddrinfo_result()?;
-        self.policy.register_dns_result(host, addrs)?;
+        if let Some(policy) = &self.policy {
+            self.resolved_connect
+                .borrow_mut()
+                .extend(policy.resolved_connect_rules(host, addrs)?);
+        }
         Ok(addrs.to_vec())
     }
 
     fn check_bind(&self, addr: &[u8]) -> AsyncHostResult<()> {
-        self.policy.check_bind(addr)
+        self.policy.as_ref().map_or(Ok(()), |policy| {
+            policy.check_socket(NetOperation::Bind, addr, &self.resolved_connect.borrow())
+        })
     }
 
     pub(crate) fn check_connect(&self, addr: &[u8]) -> AsyncHostResult<()> {
-        self.policy.check_connect(addr)
+        self.policy.as_ref().map_or(Ok(()), |policy| {
+            policy.check_socket(NetOperation::Connect, addr, &self.resolved_connect.borrow())
+        })
     }
 
     fn check_dns(&self, host: &OsStr) -> AsyncHostResult<()> {
-        self.policy.check_dns(host)
+        self.policy
+            .as_ref()
+            .map_or(Ok(()), |policy| policy.check_dns(host))
     }
 }
 
@@ -284,6 +299,13 @@ fn socket_addr_port(addr: &[u8]) -> AsyncHostResult<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    use crate::policy::Policy;
+
+    fn network(mut policy: Policy) -> HostNetwork {
+        HostNetwork::new(policy.take_network_policy())
+    }
 
     #[test]
     fn socket_addr_port_reads_ipv4_port() {
@@ -299,7 +321,7 @@ mod tests {
         #[cfg(windows)]
         assert_eq!(crate::async_sys::internal::event_loop::io::init_wsa(), 0);
 
-        let network = HostNetwork::new(Arc::new(Policy::allow_all()));
+        let network = network(Policy::allow_all());
         let tcp = network.make_tcp_socket(4).unwrap();
         let udp = network.make_udp_socket(4, false).unwrap();
         let mut addr = vec![0; usize::try_from(sys::ipv4_addr_size()).unwrap()];
@@ -318,7 +340,7 @@ mod tests {
         #[cfg(windows)]
         assert_eq!(crate::async_sys::internal::event_loop::io::init_wsa(), 0);
 
-        let network = HostNetwork::new(Arc::new(Policy::allow_all()));
+        let network = network(Policy::allow_all());
         let first = network.make_tcp_socket(4).unwrap();
         let second = network.make_tcp_socket(4).unwrap();
         let mut addr = vec![0; usize::try_from(sys::ipv4_addr_size()).unwrap()];
@@ -341,7 +363,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let policy_file = dir.path().join("deny-all.toml");
         std::fs::write(&policy_file, "").unwrap();
-        let network = HostNetwork::new(Arc::new(Policy::from_file(&policy_file).unwrap()));
+        let network = network(Policy::from_file(&policy_file).unwrap());
         let socket = network.make_tcp_socket(4).unwrap();
 
         assert_eq!(
@@ -359,7 +381,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let policy_file = dir.path().join("deny-all.toml");
         std::fs::write(&policy_file, "").unwrap();
-        let network = HostNetwork::new(Arc::new(Policy::from_file(&policy_file).unwrap()));
+        let network = network(Policy::from_file(&policy_file).unwrap());
         let mut addr = vec![0; usize::try_from(sys::ipv4_addr_size()).unwrap()];
         sys::init_ip_addr(&mut addr, 0x7f000001, 1234).unwrap();
 
@@ -374,6 +396,38 @@ mod tests {
                 .make_getaddrinfo_job(OsString::from("localhost"))
                 .unwrap_err(),
             AsyncHostError::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn resolved_connect_authority_is_local_to_host_network() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy_file = dir.path().join("network.toml");
+        std::fs::write(&policy_file, "[net]\nconnect = [\"api.example.com:443\"]\n").unwrap();
+        let mut policy = Policy::from_file(&policy_file).unwrap();
+        let policy = policy.take_network_policy().unwrap();
+        let first = HostNetwork::new(Some(policy.clone()));
+        let second = HostNetwork::new(Some(policy));
+        let mut resolved_addr = vec![0; usize::try_from(sys::ipv4_addr_size()).unwrap()];
+        sys::init_ip_addr(&mut resolved_addr, 0x7f000001, 0).unwrap();
+        let mut connect_addr = vec![0; usize::try_from(sys::ipv4_addr_size()).unwrap()];
+        sys::init_ip_addr(&mut connect_addr, 0x7f000001, 443).unwrap();
+
+        let rules = first
+            .policy
+            .as_ref()
+            .unwrap()
+            .resolved_connect_rules(
+                OsStr::new("api.example.com"),
+                &[resolved_addr.into_boxed_slice()],
+            )
+            .unwrap();
+        first.resolved_connect.borrow_mut().extend(rules);
+
+        first.check_connect(&connect_addr).unwrap();
+        assert_eq!(
+            second.check_connect(&connect_addr),
+            Err(AsyncHostError::PermissionDenied)
         );
     }
 }

--- a/crates/moonrun/src/policy/fs.rs
+++ b/crates/moonrun/src/policy/fs.rs
@@ -17,21 +17,18 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use std::ffi::OsStr;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
-use crate::async_host::{AsyncHostError, AsyncHostResult};
-use crate::runtime::WorkingDirectory;
+use crate::async_host::AsyncHostResult;
 
 use super::{config::FsConfig, sandbox_denied};
 
 /// Restricts async filesystem operations to native host roots.
 ///
-/// This is not a virtual filesystem: relative runtime paths are resolved using
-/// the Runtime Working Directory, and configured roots are resolved using the host
-/// platform's path rules.
+/// This is not a virtual filesystem. `HostFs` resolves runtime paths before
+/// asking these immutable rules whether the resulting target is allowed.
 #[derive(Clone, Debug, Default)]
-pub(super) struct FsPolicy {
-    working_directory: WorkingDirectory,
+pub(crate) struct FsPolicy {
     read_roots: Vec<FsRoot>,
     write_roots: Vec<FsRoot>,
 }
@@ -43,81 +40,29 @@ enum FsRoot {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) struct FsIntents {
+pub(crate) struct FsIntents {
     read: bool,
     write: bool,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum RuntimePathBase<'a> {
-    WorkingDirectory,
-    PolicyPath(&'a Path),
-    Untracked,
 }
 
 impl FsPolicy {
     /// Construct runtime enforcement from roots canonicalized by `policy`.
     pub(super) fn from_canonical_config(config: FsConfig) -> Self {
         Self {
-            working_directory: WorkingDirectory::Ambient,
             read_roots: roots_from_config(config.read),
             write_roots: roots_from_config(config.write),
         }
     }
 
-    pub(super) fn with_working_directory(mut self, working_directory: WorkingDirectory) -> Self {
-        self.working_directory = working_directory;
-        self
-    }
-
-    pub(super) fn allows(
+    pub(crate) fn authorize(
         &self,
-        base: RuntimePathBase<'_>,
-        path: &OsStr,
-        intents: FsIntents,
-    ) -> AsyncHostResult<()> {
-        let target = sandbox_path_target(base, path);
-        let path = Path::new(path);
-        let path = match resolve_runtime_path(&self.working_directory, base, path)
-            .and_then(|path| canonicalize_existing_prefix(&path))
-        {
-            Ok(path) => path,
-            Err(AsyncHostError::PermissionDenied) => {
-                return sandbox_denied(intents.sandbox_action(), Some(&target));
-            }
-            Err(error) => return Err(error),
-        };
-
-        self.allows_resolved(&path, intents, &target)
-    }
-
-    pub(super) fn allows_entry(
-        &self,
-        base: RuntimePathBase<'_>,
-        path: &OsStr,
-        intents: FsIntents,
-    ) -> AsyncHostResult<()> {
-        let target = sandbox_path_target(base, path);
-        let path = Path::new(path);
-        let path = match resolve_runtime_path(&self.working_directory, base, path)
-            .and_then(|path| canonicalize_entry_path(&path))
-        {
-            Ok(path) => path,
-            Err(AsyncHostError::PermissionDenied) => {
-                return sandbox_denied(intents.sandbox_action(), Some(&target));
-            }
-            Err(error) => return Err(error),
-        };
-
-        self.allows_resolved(&path, intents, &target)
-    }
-
-    fn allows_resolved(
-        &self,
-        path: &Path,
+        resolved_path: Option<&Path>,
         intents: FsIntents,
         target: &str,
     ) -> AsyncHostResult<()> {
+        let Some(path) = resolved_path else {
+            return sandbox_denied(intents.sandbox_action(), Some(target));
+        };
         if intents.read && !self.allows_read(path) {
             return sandbox_denied("file read", Some(target));
         }
@@ -146,14 +91,14 @@ impl FsRoot {
 }
 
 impl FsIntents {
-    pub(super) fn read() -> Self {
+    pub(crate) fn read() -> Self {
         Self {
             read: true,
             write: false,
         }
     }
 
-    pub(super) fn write() -> Self {
+    pub(crate) fn write() -> Self {
         Self {
             read: false,
             write: true,
@@ -167,7 +112,7 @@ impl FsIntents {
         }
     }
 
-    pub(super) fn for_open(access: i32, create_mode: i32, append: bool) -> Self {
+    pub(crate) fn for_open(access: i32, create_mode: i32, append: bool) -> Self {
         let mut intents = match access {
             0 | 3 => Self::read(),
             1 => Self::write(),
@@ -180,7 +125,7 @@ impl FsIntents {
         intents
     }
 
-    pub(super) fn for_access_check(access: i32) -> Self {
+    pub(crate) fn for_access_check(access: i32) -> Self {
         if access == 2 {
             Self::write()
         } else {
@@ -210,79 +155,10 @@ fn roots_from_config(roots: Vec<PathBuf>) -> Vec<FsRoot> {
         .collect()
 }
 
-fn resolve_runtime_path(
-    working_directory: &WorkingDirectory,
-    base: RuntimePathBase<'_>,
-    path: &Path,
-) -> AsyncHostResult<PathBuf> {
-    if path.is_absolute() {
-        return Ok(path.to_path_buf());
-    }
-
-    match base {
-        RuntimePathBase::WorkingDirectory => working_directory
-            .resolve(path)
-            .map_err(|_| AsyncHostError::PermissionDenied),
-        RuntimePathBase::PolicyPath(base) => Ok(base.join(path)),
-        RuntimePathBase::Untracked => Err(AsyncHostError::PermissionDenied),
-    }
-}
-
-fn canonicalize_existing_prefix(path: &Path) -> AsyncHostResult<PathBuf> {
-    for ancestor in path.ancestors() {
-        if let Ok(prefix) = std::fs::canonicalize(ancestor) {
-            let suffix = path
-                .strip_prefix(ancestor)
-                .map_err(|_| AsyncHostError::PermissionDenied)?;
-            return Ok(normalize_path(prefix.join(suffix)));
-        }
-    }
-    Err(AsyncHostError::PermissionDenied)
-}
-
-fn canonicalize_entry_path(path: &Path) -> AsyncHostResult<PathBuf> {
-    let parent = path.parent().ok_or(AsyncHostError::PermissionDenied)?;
-    let file_name = path.file_name().ok_or(AsyncHostError::PermissionDenied)?;
-    Ok(normalize_path(
-        canonicalize_existing_prefix(parent)?.join(file_name),
-    ))
-}
-
-fn normalize_path(path: PathBuf) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
-                normalized.push(component.as_os_str());
-            }
-        }
-    }
-    normalized
-}
-
-fn sandbox_path_target(base: RuntimePathBase<'_>, path: &OsStr) -> String {
-    if matches!(base, RuntimePathBase::Untracked) {
-        quote_str("<untracked resource>")
-    } else {
-        quote_os_str(path)
-    }
-}
-
-fn quote_os_str(value: &OsStr) -> String {
-    quote_str(&value.to_string_lossy())
-}
-
-fn quote_str(value: &str) -> String {
-    format!("{value:?}")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::async_host::AsyncHostError;
 
     fn policy(read: Vec<PathBuf>, write: Vec<PathBuf>, config_dir: &Path) -> FsPolicy {
         let config = crate::policy::canonicalize(
@@ -296,6 +172,12 @@ mod tests {
         FsPolicy::from_canonical_config(config.fs.unwrap())
     }
 
+    fn authorize(policy: &FsPolicy, path: &Path, intents: FsIntents) -> AsyncHostResult<()> {
+        let parent = std::fs::canonicalize(path.parent().unwrap()).unwrap();
+        let resolved = parent.join(path.file_name().unwrap());
+        policy.authorize(Some(&resolved), intents, &format!("{:?}", path.as_os_str()))
+    }
+
     #[test]
     fn allows_missing_file_under_relative_root() {
         let tmp = tempfile::tempdir().unwrap();
@@ -303,17 +185,16 @@ mod tests {
         std::fs::create_dir(&allowed).unwrap();
         let policy = policy(Vec::new(), vec![PathBuf::from("allowed")], tmp.path());
 
-        policy
-            .allows(
-                RuntimePathBase::WorkingDirectory,
-                allowed.join("new.txt").as_os_str(),
-                FsIntents::for_open(1, 0, false),
-            )
-            .unwrap();
+        authorize(
+            &policy,
+            &allowed.join("new.txt"),
+            FsIntents::for_open(1, 0, false),
+        )
+        .unwrap();
     }
 
     #[test]
-    fn denies_paths_outside_roots_after_normalization() {
+    fn denies_paths_outside_roots() {
         let tmp = tempfile::tempdir().unwrap();
         let allowed = tmp.path().join("allowed");
         let denied = tmp.path().join("denied");
@@ -321,13 +202,7 @@ mod tests {
         std::fs::create_dir(&denied).unwrap();
         let policy = policy(Vec::new(), vec![allowed], tmp.path());
 
-        let error = policy
-            .allows(
-                RuntimePathBase::WorkingDirectory,
-                denied.join("new.txt").as_os_str(),
-                FsIntents::write(),
-            )
-            .unwrap_err();
+        let error = authorize(&policy, &denied.join("new.txt"), FsIntents::write()).unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }
 
@@ -339,20 +214,8 @@ mod tests {
         let policy = policy(vec![PathBuf::from("allowed")], Vec::new(), tmp.path());
         let path = allowed.join("new.txt");
 
-        policy
-            .allows(
-                RuntimePathBase::WorkingDirectory,
-                path.as_os_str(),
-                FsIntents::read(),
-            )
-            .unwrap();
-        let error = policy
-            .allows(
-                RuntimePathBase::WorkingDirectory,
-                path.as_os_str(),
-                FsIntents::write(),
-            )
-            .unwrap_err();
+        authorize(&policy, &path, FsIntents::read()).unwrap();
+        let error = authorize(&policy, &path, FsIntents::write()).unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }
 
@@ -363,13 +226,7 @@ mod tests {
         std::fs::create_dir(&allowed).unwrap();
         let policy = policy(Vec::new(), vec![PathBuf::from("allowed")], tmp.path());
 
-        let error = policy
-            .allows(
-                RuntimePathBase::WorkingDirectory,
-                allowed.join("new.txt").as_os_str(),
-                FsIntents::read(),
-            )
-            .unwrap_err();
+        let error = authorize(&policy, &allowed.join("new.txt"), FsIntents::read()).unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }
 
@@ -380,13 +237,12 @@ mod tests {
         std::fs::create_dir(&allowed).unwrap();
         let policy = policy(vec![PathBuf::from("allowed")], Vec::new(), tmp.path());
 
-        let error = policy
-            .allows(
-                RuntimePathBase::WorkingDirectory,
-                allowed.join("new.txt").as_os_str(),
-                FsIntents::for_open(0, 1, false),
-            )
-            .unwrap_err();
+        let error = authorize(
+            &policy,
+            &allowed.join("new.txt"),
+            FsIntents::for_open(0, 1, false),
+        )
+        .unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }
 
@@ -400,11 +256,7 @@ mod tests {
         );
 
         let error = policy
-            .allows(
-                RuntimePathBase::Untracked,
-                OsStr::new("file.txt"),
-                FsIntents::read(),
-            )
+            .authorize(None, FsIntents::read(), "\"<untracked resource>\"")
             .unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }
@@ -416,76 +268,6 @@ mod tests {
         std::fs::create_dir(&denied).unwrap();
         let policy = policy(Vec::new(), vec![PathBuf::from("*")], tmp.path());
 
-        policy
-            .allows(
-                RuntimePathBase::WorkingDirectory,
-                denied.join("new.txt").as_os_str(),
-                FsIntents::write(),
-            )
-            .unwrap();
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn entry_checks_use_link_path_not_symlink_target() {
-        let tmp = tempfile::tempdir().unwrap();
-        let allowed = tmp.path().join("allowed");
-        let denied = tmp.path().join("denied");
-        std::fs::create_dir(&allowed).unwrap();
-        std::fs::create_dir(&denied).unwrap();
-        let allowed_file = allowed.join("target.txt");
-        std::fs::write(&allowed_file, "target").unwrap();
-        let denied_link = denied.join("link.txt");
-        std::os::unix::fs::symlink(&allowed_file, &denied_link).unwrap();
-        let policy = policy(Vec::new(), vec![PathBuf::from("allowed")], tmp.path());
-
-        policy
-            .allows(
-                RuntimePathBase::WorkingDirectory,
-                denied_link.as_os_str(),
-                FsIntents::write(),
-            )
-            .unwrap();
-        let error = policy
-            .allows_entry(
-                RuntimePathBase::WorkingDirectory,
-                denied_link.as_os_str(),
-                FsIntents::write(),
-            )
-            .unwrap_err();
-
-        assert_eq!(error, AsyncHostError::PermissionDenied);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn entry_checks_allow_allowed_link_without_target_write() {
-        let tmp = tempfile::tempdir().unwrap();
-        let allowed = tmp.path().join("allowed");
-        let denied = tmp.path().join("denied");
-        std::fs::create_dir(&allowed).unwrap();
-        std::fs::create_dir(&denied).unwrap();
-        let denied_file = denied.join("target.txt");
-        std::fs::write(&denied_file, "target").unwrap();
-        let allowed_link = allowed.join("link.txt");
-        std::os::unix::fs::symlink(&denied_file, &allowed_link).unwrap();
-        let policy = policy(Vec::new(), vec![PathBuf::from("allowed")], tmp.path());
-
-        policy
-            .allows_entry(
-                RuntimePathBase::WorkingDirectory,
-                allowed_link.as_os_str(),
-                FsIntents::write(),
-            )
-            .unwrap();
-        let error = policy
-            .allows(
-                RuntimePathBase::WorkingDirectory,
-                allowed_link.as_os_str(),
-                FsIntents::write(),
-            )
-            .unwrap_err();
-
-        assert_eq!(error, AsyncHostError::PermissionDenied);
+        authorize(&policy, &denied.join("new.txt"), FsIntents::write()).unwrap();
     }
 }

--- a/crates/moonrun/src/policy/mod.rs
+++ b/crates/moonrun/src/policy/mod.rs
@@ -16,10 +16,12 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! Runtime-owned access policy for moonrun-owned wasm boundaries.
+//! Construction-time authorization input for moonrun-owned wasm boundaries.
 //!
 //! No policy file preserves existing moonrun behavior. Supplying a policy file
-//! switches the supported host surfaces to deny-by-default mode.
+//! switches the supported host surfaces to deny-by-default mode. Runtime
+//! construction consumes the resulting domain policies instead of retaining a
+//! global policy object in the Host domains.
 
 mod config;
 mod env;
@@ -29,21 +31,19 @@ mod policy_inheritance;
 mod process;
 
 use std::ffi::OsStr;
-#[cfg(unix)]
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
-use crate::runtime::{Env, WorkingDirectory};
+use crate::runtime::Env;
 
 use self::config::PolicyConfig;
 use self::env::EnvPolicy;
-use self::fs::{FsIntents, FsPolicy, RuntimePathBase};
-use self::net::{NetOperation, NetPolicy};
+pub(crate) use self::fs::{FsIntents, FsPolicy};
+pub(crate) use self::net::{NetOperation, NetPolicy, SocketRule};
 pub(crate) use self::policy_inheritance::PolicyInheritance;
-use self::process::ProcessPolicy;
+pub(crate) use self::process::ProcessPolicy;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Policy {
@@ -88,16 +88,6 @@ impl Policy {
         Self::from_config(config, Path::new("."))
     }
 
-    /// Bind runtime path authorization to the working directory selected for
-    /// this Runtime. Unrestricted policy remains a no-op and therefore does not
-    /// introduce an additional cwd observation.
-    pub(crate) fn with_working_directory(mut self, working_directory: WorkingDirectory) -> Self {
-        self.fs = self
-            .fs
-            .map(|fs| fs.with_working_directory(working_directory));
-        self
-    }
-
     fn from_config(config: PolicyConfig, config_dir: &Path) -> anyhow::Result<Self> {
         let config = canonicalize(config, config_dir)?;
         let policy_inheritance = PolicyInheritance::from_config(&config)?;
@@ -114,254 +104,26 @@ impl Policy {
         })
     }
 
-    pub(crate) fn policy_inheritance(&self) -> Option<PolicyInheritance> {
-        self.policy_inheritance.clone()
+    pub(crate) fn take_filesystem_policy(&mut self) -> Option<FsPolicy> {
+        self.fs.take()
     }
 
-    pub(crate) fn open_path(
-        &self,
-        path: &OsStr,
-        access: i32,
-        create_mode: i32,
-        append: bool,
-    ) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows(
-            RuntimePathBase::WorkingDirectory,
-            path,
-            FsIntents::for_open(access, create_mode, append),
-        )
+    pub(crate) fn take_network_policy(&mut self) -> Option<NetPolicy> {
+        self.net.take()
     }
 
-    pub(crate) fn stat_path(&self, path: &OsStr) -> AsyncHostResult<()> {
-        self.read_path(path)
+    pub(crate) fn realize_env(&mut self) -> anyhow::Result<Env> {
+        self.env
+            .take()
+            .map_or_else(|| Ok(Env::ambient()), |policy| policy.realize())
     }
 
-    pub(crate) fn stat_path_at(&self, base: Option<&Path>, path: &OsStr) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows(
-            base.map(RuntimePathBase::PolicyPath)
-                .unwrap_or(RuntimePathBase::Untracked),
-            path,
-            FsIntents::read(),
-        )
+    pub(crate) fn take_process_policy(&mut self) -> Option<ProcessPolicy> {
+        self.process.take()
     }
 
-    pub(crate) fn stat_resource_path(&self, path: Option<&Path>) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        match path {
-            Some(path) => fs.allows(
-                RuntimePathBase::WorkingDirectory,
-                path.as_os_str(),
-                FsIntents::read(),
-            ),
-            None => fs.allows(
-                RuntimePathBase::Untracked,
-                OsStr::new(""),
-                FsIntents::read(),
-            ),
-        }
-    }
-
-    pub(crate) fn read_path(&self, path: &OsStr) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows(RuntimePathBase::WorkingDirectory, path, FsIntents::read())
-    }
-
-    pub(crate) fn write_path(&self, path: &OsStr) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows(RuntimePathBase::WorkingDirectory, path, FsIntents::write())
-    }
-
-    pub(crate) fn stat_entry_path_at(
-        &self,
-        base: Option<&Path>,
-        path: &OsStr,
-    ) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows_entry(
-            base.map(RuntimePathBase::PolicyPath)
-                .unwrap_or(RuntimePathBase::Untracked),
-            path,
-            FsIntents::read(),
-        )
-    }
-
-    pub(crate) fn stat_entry_path(&self, path: &OsStr) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows_entry(RuntimePathBase::WorkingDirectory, path, FsIntents::read())
-    }
-
-    pub(crate) fn access_path(&self, path: &OsStr, access: i32) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows(
-            RuntimePathBase::WorkingDirectory,
-            path,
-            FsIntents::for_access_check(access),
-        )
-    }
-
-    pub(crate) fn chmod_path(&self, path: &OsStr) -> AsyncHostResult<()> {
-        self.write_path(path)
-    }
-
-    pub(crate) fn remove_path(&self, path: &OsStr) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows_entry(RuntimePathBase::WorkingDirectory, path, FsIntents::write())
-    }
-
-    pub(crate) fn rename_path(&self, old_path: &OsStr, new_path: &OsStr) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows_entry(
-            RuntimePathBase::WorkingDirectory,
-            old_path,
-            FsIntents::write(),
-        )?;
-        fs.allows_entry(
-            RuntimePathBase::WorkingDirectory,
-            new_path,
-            FsIntents::write(),
-        )
-    }
-
-    pub(crate) fn symlink_path(&self, path: &OsStr) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows_entry(RuntimePathBase::WorkingDirectory, path, FsIntents::write())
-    }
-
-    pub(crate) fn mkdir_path(&self, path: &OsStr) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows_entry(RuntimePathBase::WorkingDirectory, path, FsIntents::write())
-    }
-
-    pub(crate) fn rmdir_path(&self, path: &OsStr) -> AsyncHostResult<()> {
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        fs.allows_entry(RuntimePathBase::WorkingDirectory, path, FsIntents::write())
-    }
-
-    pub(crate) fn lock_resource_path(
-        &self,
-        path: Option<&Path>,
-        exclusive: bool,
-    ) -> AsyncHostResult<()> {
-        if !exclusive {
-            return Ok(());
-        }
-        let Some(fs) = self.fs_policy() else {
-            return Ok(());
-        };
-        match path {
-            Some(path) => fs.allows(
-                RuntimePathBase::WorkingDirectory,
-                path.as_os_str(),
-                FsIntents::write(),
-            ),
-            None => fs.allows(
-                RuntimePathBase::Untracked,
-                OsStr::new(""),
-                FsIntents::write(),
-            ),
-        }
-    }
-
-    pub(crate) fn check_dns(&self, host: &OsStr) -> AsyncHostResult<()> {
-        let Some(net) = self.net_policy() else {
-            return Ok(());
-        };
-        net.check_dns(host)
-    }
-
-    pub(crate) fn register_dns_result(
-        &self,
-        host: &OsStr,
-        addrs: &[Box<[u8]>],
-    ) -> AsyncHostResult<()> {
-        let Some(net) = self.net_policy() else {
-            return Ok(());
-        };
-        net.register_dns_result(host, addrs)
-    }
-
-    pub(crate) fn check_connect(&self, addr: &[u8]) -> AsyncHostResult<()> {
-        let Some(net) = self.net_policy() else {
-            return Ok(());
-        };
-        net.check_socket(NetOperation::Connect, addr)
-    }
-
-    pub(crate) fn check_bind(&self, addr: &[u8]) -> AsyncHostResult<()> {
-        let Some(net) = self.net_policy() else {
-            return Ok(());
-        };
-        net.check_socket(NetOperation::Bind, addr)
-    }
-
-    pub(crate) fn realize_env(&self) -> anyhow::Result<Env> {
-        self.env_policy()
-            .map_or_else(|| Ok(Env::ambient()), EnvPolicy::realize)
-    }
-
-    #[cfg(unix)]
-    pub(crate) fn spawn_process_unix(
-        &self,
-        program: &OsStr,
-        argv: &[OsString],
-    ) -> AsyncHostResult<()> {
-        self.process
-            .as_ref()
-            .map_or(Ok(()), |process| process.allows_unix(program, argv))
-    }
-
-    #[cfg(windows)]
-    pub(crate) fn spawn_process_windows(&self, command_line: &OsStr) -> AsyncHostResult<()> {
-        self.process
-            .as_ref()
-            .map_or(Ok(()), |process| process.allows_windows(command_line))
-    }
-
-    pub(crate) fn has_process_policy(&self) -> bool {
-        self.process.is_some()
-    }
-
-    #[inline]
-    fn fs_policy(&self) -> Option<&FsPolicy> {
-        self.fs.as_ref()
-    }
-
-    #[inline]
-    fn net_policy(&self) -> Option<&NetPolicy> {
-        self.net.as_ref()
-    }
-
-    #[inline]
-    fn env_policy(&self) -> Option<&EnvPolicy> {
-        self.env.as_ref()
+    pub(crate) fn take_policy_inheritance(&mut self) -> Option<PolicyInheritance> {
+        self.policy_inheritance.take()
     }
 }
 
@@ -404,6 +166,8 @@ fn canonicalize_roots(roots: Vec<PathBuf>, config_dir: &Path) -> anyhow::Result<
 mod tests {
     use std::collections::BTreeMap;
     use std::ffi::OsStr;
+    #[cfg(unix)]
+    use std::ffi::OsString;
     use std::net::Ipv4Addr;
     use std::path::PathBuf;
 
@@ -415,6 +179,46 @@ mod tests {
             fs: Some(config::FsConfig { read, write }),
             ..Default::default()
         }
+    }
+
+    fn check_ambient_open(
+        mut policy: Policy,
+        path: &OsStr,
+        access: i32,
+        create_mode: i32,
+        append: bool,
+    ) -> AsyncHostResult<()> {
+        policy.take_filesystem_policy().map_or(Ok(()), |policy| {
+            policy.authorize(
+                Some(Path::new(path)),
+                FsIntents::for_open(access, create_mode, append),
+                &format!("{:?}", path),
+            )
+        })
+    }
+
+    fn check_network_connect(mut policy: Policy, addr: &[u8]) -> AsyncHostResult<()> {
+        policy.take_network_policy().map_or(Ok(()), |policy| {
+            policy.check_socket(NetOperation::Connect, addr, &[])
+        })
+    }
+
+    #[cfg(unix)]
+    fn check_process_spawn(
+        mut policy: Policy,
+        program: &OsStr,
+        argv: &[OsString],
+    ) -> AsyncHostResult<()> {
+        policy
+            .take_process_policy()
+            .map_or(Ok(()), |policy| policy.allows_unix(program, argv))
+    }
+
+    #[cfg(windows)]
+    fn check_process_spawn(mut policy: Policy, command_line: &OsStr) -> AsyncHostResult<()> {
+        policy
+            .take_process_policy()
+            .map_or(Ok(()), |policy| policy.allows_windows(command_line))
     }
 
     #[test]
@@ -536,7 +340,7 @@ mod tests {
         let canonical_write = std::fs::canonicalize(&write).unwrap();
         let secret = "value-that-must-not-be-serialized";
 
-        let policy = Policy::from_config(
+        let mut policy = Policy::from_config(
             PolicyConfig {
                 fs: Some(config::FsConfig {
                     read: vec![PathBuf::from("read")],
@@ -561,7 +365,7 @@ mod tests {
         )
         .unwrap();
         let contents = policy
-            .policy_inheritance()
+            .take_policy_inheritance()
             .unwrap()
             .open_transfer()
             .unwrap()
@@ -586,9 +390,9 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let source = tmp.path().join("policy.json");
         std::fs::write(&source, r#"{"process":{"spawn":false}}"#).unwrap();
-        let parent = Policy::from_file(&source).unwrap();
+        let mut parent = Policy::from_file(&source).unwrap();
         let contents = parent
-            .policy_inheritance()
+            .take_policy_inheritance()
             .unwrap()
             .open_transfer()
             .unwrap()
@@ -600,12 +404,16 @@ mod tests {
 
         #[cfg(unix)]
         assert_eq!(
-            inherited.spawn_process_unix(OsStr::new("program"), &[OsString::from("program")]),
+            check_process_spawn(
+                inherited,
+                OsStr::new("program"),
+                &[OsString::from("program")]
+            ),
             Err(AsyncHostError::PermissionDenied)
         );
         #[cfg(windows)]
         assert_eq!(
-            inherited.spawn_process_windows(OsStr::new("program.exe")),
+            check_process_spawn(inherited, OsStr::new("program.exe")),
             Err(AsyncHostError::PermissionDenied)
         );
     }
@@ -614,9 +422,7 @@ mod tests {
     fn no_policy_leaves_fs_unrestricted() {
         let policy = Policy::allow_all();
 
-        policy
-            .open_path(OsStr::new("missing-parent/new.txt"), 1, 4, false)
-            .unwrap();
+        check_ambient_open(policy, OsStr::new("missing-parent/new.txt"), 1, 4, false).unwrap();
     }
 
     #[test]
@@ -633,8 +439,7 @@ mod tests {
         )
         .unwrap();
 
-        let error = policy
-            .open_path(OsStr::new("missing-parent/new.txt"), 1, 4, false)
+        let error = check_ambient_open(policy, OsStr::new("missing-parent/new.txt"), 1, 4, false)
             .unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }
@@ -654,9 +459,7 @@ mod tests {
         .unwrap();
         let denied = tmp.path().join("new.txt");
 
-        let error = policy
-            .open_path(denied.as_os_str(), 1, 4, false)
-            .unwrap_err();
+        let error = check_ambient_open(policy, denied.as_os_str(), 1, 4, false).unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }
 
@@ -664,9 +467,7 @@ mod tests {
     fn no_policy_leaves_net_unrestricted() {
         let policy = Policy::allow_all();
 
-        policy
-            .check_connect(&ipv4_addr(Ipv4Addr::LOCALHOST, 443))
-            .unwrap();
+        check_network_connect(policy, &ipv4_addr(Ipv4Addr::LOCALHOST, 443)).unwrap();
     }
 
     #[test]
@@ -688,9 +489,8 @@ mod tests {
         )
         .unwrap();
 
-        let error = policy
-            .check_connect(&ipv4_addr(Ipv4Addr::LOCALHOST, 443))
-            .unwrap_err();
+        let error =
+            check_network_connect(policy, &ipv4_addr(Ipv4Addr::LOCALHOST, 443)).unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }
 
@@ -708,16 +508,15 @@ mod tests {
         )
         .unwrap();
 
-        let error = policy
-            .check_connect(&ipv4_addr(Ipv4Addr::LOCALHOST, 443))
-            .unwrap_err();
+        let error =
+            check_network_connect(policy, &ipv4_addr(Ipv4Addr::LOCALHOST, 443)).unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }
 
     #[test]
     fn missing_env_section_uses_empty_env_in_policy_mode() {
         let tmp = tempfile::tempdir().unwrap();
-        let policy = Policy::from_config(
+        let mut policy = Policy::from_config(
             PolicyConfig {
                 fs: None,
                 net: None,
@@ -737,13 +536,9 @@ mod tests {
     fn no_policy_leaves_process_spawning_unrestricted() {
         let policy = Policy::allow_all();
         #[cfg(unix)]
-        policy
-            .spawn_process_unix(OsStr::new("program"), &[OsString::from("program")])
-            .unwrap();
+        check_process_spawn(policy, OsStr::new("program"), &[OsString::from("program")]).unwrap();
         #[cfg(windows)]
-        policy
-            .spawn_process_windows(OsStr::new("program.exe"))
-            .unwrap();
+        check_process_spawn(policy, OsStr::new("program.exe")).unwrap();
     }
 
     #[test]
@@ -755,11 +550,11 @@ mod tests {
             {
                 #[cfg(unix)]
                 {
-                    policy.spawn_process_unix(OsStr::new("program"), &[OsString::from("program")])
+                    check_process_spawn(policy, OsStr::new("program"), &[OsString::from("program")])
                 }
                 #[cfg(windows)]
                 {
-                    policy.spawn_process_windows(OsStr::new("program.exe"))
+                    check_process_spawn(policy, OsStr::new("program.exe"))
                 }
             },
             Err(AsyncHostError::PermissionDenied)
@@ -782,13 +577,9 @@ mod tests {
         .unwrap();
 
         #[cfg(unix)]
-        policy
-            .spawn_process_unix(OsStr::new("program"), &[OsString::from("program")])
-            .unwrap();
+        check_process_spawn(policy, OsStr::new("program"), &[OsString::from("program")]).unwrap();
         #[cfg(windows)]
-        policy
-            .spawn_process_windows(OsStr::new("program.exe"))
-            .unwrap();
+        check_process_spawn(policy, OsStr::new("program.exe")).unwrap();
     }
 
     fn ipv4_addr(ip: Ipv4Addr, port: u16) -> Box<[u8]> {

--- a/crates/moonrun/src/policy/net.rs
+++ b/crates/moonrun/src/policy/net.rs
@@ -18,7 +18,6 @@
 
 use std::ffi::OsStr;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
 
@@ -27,15 +26,14 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 use super::{config::NetConfig, sandbox_denied};
 
 #[derive(Clone, Debug)]
-pub(super) struct NetPolicy {
+pub(crate) struct NetPolicy {
     dns: Vec<DnsPattern>,
     connect: Vec<SocketRule>,
     bind: Vec<SocketRule>,
-    resolved_connect: Arc<Mutex<Vec<SocketRule>>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum NetOperation {
+pub(crate) enum NetOperation {
     Connect,
     Bind,
 }
@@ -48,7 +46,7 @@ enum DnsPattern {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct SocketRule {
+pub(crate) struct SocketRule {
     host: SocketHostRule,
     port: SocketPortRule,
 }
@@ -95,15 +93,10 @@ impl NetPolicy {
             }
         }
 
-        Ok(Self {
-            dns,
-            connect,
-            bind,
-            resolved_connect: Arc::default(),
-        })
+        Ok(Self { dns, connect, bind })
     }
 
-    pub(super) fn check_dns(&self, host: &OsStr) -> AsyncHostResult<()> {
+    pub(crate) fn check_dns(&self, host: &OsStr) -> AsyncHostResult<()> {
         let target = quote_os_str(host);
         let host = host.to_string_lossy();
         let host = normalize_dns_name(&host);
@@ -116,11 +109,11 @@ impl NetPolicy {
         }
     }
 
-    pub(super) fn register_dns_result(
+    pub(crate) fn resolved_connect_rules(
         &self,
         host: &OsStr,
         addrs: &[Box<[u8]>],
-    ) -> AsyncHostResult<()> {
+    ) -> AsyncHostResult<Vec<SocketRule>> {
         let host = host.to_string_lossy();
         let host = normalize_dns_name(&host);
         let rules = self
@@ -129,30 +122,38 @@ impl NetPolicy {
             .filter(|rule| rule.allows_resolved_name(&host))
             .collect::<Vec<_>>();
         if rules.is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
         }
 
-        let mut resolved_connect = self.resolved_connect.lock().unwrap();
-        for addr in addrs {
-            let addr = parse_socket_addr(addr)?;
-            for rule in &rules {
-                resolved_connect.push(SocketRule {
-                    host: SocketHostRule::Ip(addr.ip),
-                    port: rule.port,
-                });
-            }
-        }
-        Ok(())
+        addrs
+            .iter()
+            .map(|addr| parse_socket_addr(addr))
+            .collect::<AsyncHostResult<Vec<_>>>()
+            .map(|addrs| {
+                addrs
+                    .into_iter()
+                    .flat_map(|addr| {
+                        rules.iter().map(move |rule| SocketRule {
+                            host: SocketHostRule::Ip(addr.ip),
+                            port: rule.port,
+                        })
+                    })
+                    .collect()
+            })
     }
 
-    pub(super) fn check_socket(&self, operation: NetOperation, addr: &[u8]) -> AsyncHostResult<()> {
+    pub(crate) fn check_socket(
+        &self,
+        operation: NetOperation,
+        addr: &[u8],
+        resolved_connect: &[SocketRule],
+    ) -> AsyncHostResult<()> {
         let addr = parse_socket_addr(addr)?;
         let target = quote_str(&addr.describe());
         let rules = match operation {
             NetOperation::Connect => &self.connect,
             NetOperation::Bind => &self.bind,
         };
-        let resolved_connect = self.resolved_connect.lock().unwrap();
         if rules.iter().any(|rule| rule.matches(addr))
             || (operation == NetOperation::Connect
                 && resolved_connect.iter().any(|rule| rule.matches(addr)))
@@ -404,15 +405,15 @@ mod tests {
         let denied_addr = ipv4_addr(Ipv4Addr::LOCALHOST, 80);
 
         policy.check_dns(OsStr::new("API.DEEPSEEK.COM.")).unwrap();
-        policy
-            .register_dns_result(OsStr::new("api.deepseek.com"), &[resolved_addr])
+        let resolved_connect = policy
+            .resolved_connect_rules(OsStr::new("api.deepseek.com"), &[resolved_addr])
             .unwrap();
 
         policy
-            .check_socket(NetOperation::Connect, &allowed_addr)
+            .check_socket(NetOperation::Connect, &allowed_addr, &resolved_connect)
             .unwrap();
         let error = policy
-            .check_socket(NetOperation::Connect, &denied_addr)
+            .check_socket(NetOperation::Connect, &denied_addr, &resolved_connect)
             .unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }
@@ -429,7 +430,7 @@ mod tests {
 
         policy.check_dns(OsStr::new("api.deepseek.com")).unwrap();
         let error = policy
-            .check_socket(NetOperation::Connect, &addr)
+            .check_socket(NetOperation::Connect, &addr, &[])
             .unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }
@@ -449,11 +450,11 @@ mod tests {
         let error = policy.check_dns(OsStr::new("example.com")).unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
 
-        policy
-            .register_dns_result(OsStr::new("api.example.com"), &[resolved_addr])
+        let resolved_connect = policy
+            .resolved_connect_rules(OsStr::new("api.example.com"), &[resolved_addr])
             .unwrap();
         policy
-            .check_socket(NetOperation::Connect, &allowed_addr)
+            .check_socket(NetOperation::Connect, &allowed_addr, &resolved_connect)
             .unwrap();
     }
 
@@ -468,7 +469,9 @@ mod tests {
         let addr = ipv4_addr(Ipv4Addr::LOCALHOST, 443);
 
         policy.check_dns(OsStr::new("api.deepseek.com")).unwrap();
-        policy.check_socket(NetOperation::Connect, &addr).unwrap();
+        policy
+            .check_socket(NetOperation::Connect, &addr, &[])
+            .unwrap();
     }
 
     #[test]
@@ -481,9 +484,9 @@ mod tests {
         .unwrap();
         let addr = ipv4_addr(Ipv4Addr::LOCALHOST, 8080);
 
-        policy.check_socket(NetOperation::Bind, &addr).unwrap();
+        policy.check_socket(NetOperation::Bind, &addr, &[]).unwrap();
         let error = policy
-            .check_socket(NetOperation::Connect, &addr)
+            .check_socket(NetOperation::Connect, &addr, &[])
             .unwrap_err();
         assert_eq!(error, AsyncHostError::PermissionDenied);
     }

--- a/crates/moonrun/src/policy/process.rs
+++ b/crates/moonrun/src/policy/process.rs
@@ -30,13 +30,13 @@ use super::{
 };
 
 #[derive(Clone, Debug)]
-pub(super) enum ProcessPolicy {
+pub(crate) enum ProcessPolicy {
     AllowAll,
     Scoped(Vec<ProcessRule>),
 }
 
 #[derive(Clone, Debug)]
-pub(super) struct ProcessRule {
+pub(crate) struct ProcessRule {
     #[cfg(unix)]
     program: String,
     #[cfg(unix)]
@@ -67,7 +67,7 @@ impl ProcessPolicy {
     }
 
     #[cfg(unix)]
-    pub(super) fn allows_unix(&self, program: &OsStr, argv: &[OsString]) -> AsyncHostResult<()> {
+    pub(crate) fn allows_unix(&self, program: &OsStr, argv: &[OsString]) -> AsyncHostResult<()> {
         match self {
             Self::AllowAll => Ok(()),
             Self::Scoped(rules) if rules.iter().any(|rule| rule.matches_unix(program, argv)) => {
@@ -78,7 +78,7 @@ impl ProcessPolicy {
     }
 
     #[cfg(windows)]
-    pub(super) fn allows_windows(&self, command_line: &OsStr) -> AsyncHostResult<()> {
+    pub(crate) fn allows_windows(&self, command_line: &OsStr) -> AsyncHostResult<()> {
         use std::os::windows::ffi::OsStrExt;
 
         match self {

--- a/crates/moonrun/src/process/mod.rs
+++ b/crates/moonrun/src/process/mod.rs
@@ -31,7 +31,10 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
-use crate::policy::Policy;
+#[cfg(windows)]
+use crate::async_sys::internal::fd_util::stub::RawFd;
+use crate::policy::{PolicyInheritance, ProcessPolicy};
+use crate::resource::ResourceRef;
 use crate::runtime::WorkingDirectory;
 
 pub(crate) use job::{Job, SpawnOptions};
@@ -39,41 +42,65 @@ pub(crate) use job::{Job, SpawnOptions};
 /// Process operations and child ownership shared by guest and worker threads.
 #[derive(Clone)]
 pub(crate) struct HostProcess {
-    policy: Arc<Policy>,
-    working_directory: WorkingDirectory,
-    state: Option<Arc<ChildProcessTable>>,
+    policy: Option<ProcessPolicy>,
+    policy_inheritance: Option<PolicyInheritance>,
+    working_directory: Arc<WorkingDirectory>,
+    child_authority: Option<Arc<ChildAuthorityState>>,
 }
 
 #[derive(Default)]
-struct ChildProcessTable {
+struct ChildAuthorityState {
     // PID authority and stable-handle provenance must change atomically.
-    inner: Mutex<ChildProcessTableInner>,
+    inner: Mutex<ChildAuthorityStateInner>,
 }
 
 #[derive(Default)]
-struct ChildProcessTableInner {
+struct ChildAuthorityStateInner {
     owned_child_pids: HashSet<i32>,
     process_handle_pids: HashMap<u64, i32>,
 }
 
 impl HostProcess {
-    pub(crate) fn new(policy: Arc<Policy>, working_directory: WorkingDirectory) -> Self {
-        let state = policy
-            .has_process_policy()
-            .then(|| Arc::new(ChildProcessTable::default()));
+    pub(crate) fn new(
+        policy: Option<ProcessPolicy>,
+        policy_inheritance: Option<PolicyInheritance>,
+        working_directory: Arc<WorkingDirectory>,
+    ) -> Self {
+        // Enforced process policy needs child provenance to authorize later
+        // PID and handle operations. Ambient execution preserves direct OS
+        // behavior and therefore does not create authority state.
+        let child_authority = policy
+            .is_some()
+            .then(|| Arc::new(ChildAuthorityState::default()));
         Self {
             policy,
+            policy_inheritance,
             working_directory,
-            state,
+            child_authority,
         }
-    }
-
-    pub(crate) fn has_policy(&self) -> bool {
-        self.state.is_some()
     }
 
     pub(crate) fn check_job(&self, job: &Job) -> AsyncHostResult<()> {
         job.check_policy(self)
+    }
+
+    pub(crate) fn wait_job(
+        &self,
+        handle: Option<ResourceRef>,
+        tracked_pid: Option<i32>,
+        pid: i32,
+    ) -> AsyncHostResult<Job> {
+        // On Unix, enforced authorization must inspect this provenance before
+        // reaping, so the worker defers the final reap to HostProcess.
+        #[cfg(unix)]
+        let defer_reap_for_authorization = self.child_authority.is_some();
+        Job::wait_for_process(
+            handle,
+            tracked_pid,
+            pid,
+            #[cfg(unix)]
+            defer_reap_for_authorization,
+        )
     }
 
     /// Apply Runtime-owned configuration to an authorized process job.
@@ -89,7 +116,7 @@ impl HostProcess {
         // inheritance payload. Direct-moonx recognition, temporary-file I/O,
         // handle setup, and reserved env replacement stay in the spawn job;
         // this path only clones Arc-backed bytes.
-        job.set_policy_inheritance(self.policy.policy_inheritance());
+        job.set_policy_inheritance(self.policy_inheritance.clone());
         Ok(())
     }
 
@@ -106,7 +133,7 @@ impl HostProcess {
         pid: i32,
         f: impl FnOnce() -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
-        let Some(state) = self.state.as_deref() else {
+        let Some(state) = self.child_authority.as_deref() else {
             return f();
         };
         let state = state.inner.lock().unwrap();
@@ -123,7 +150,7 @@ impl HostProcess {
         handle: Option<u64>,
         f: impl FnOnce() -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
-        let Some(state) = self.state.as_deref() else {
+        let Some(state) = self.child_authority.as_deref() else {
             return f();
         };
         let mut state = state.inner.lock().unwrap();
@@ -142,13 +169,17 @@ impl HostProcess {
         &self,
         pid: i32,
         handle: u64,
+        raw_handle: RawFd,
         f: impl FnOnce() -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
-        let Some(state) = self.state.as_deref() else {
+        let Some(state) = self.child_authority.as_deref() else {
             return f();
         };
         let mut state = state.inner.lock().unwrap();
         if state.process_handle_pids.get(&handle) != Some(&pid) {
+            return Err(AsyncHostError::PermissionDenied);
+        }
+        if crate::async_sys::process::process_id_from_handle(raw_handle)? != pid {
             return Err(AsyncHostError::PermissionDenied);
         }
         let result = f()?;
@@ -157,7 +188,7 @@ impl HostProcess {
     }
 
     pub(crate) fn process_handle_pid(&self, handle: u64) -> AsyncHostResult<Option<i32>> {
-        let Some(state) = self.state.as_deref() else {
+        let Some(state) = self.child_authority.as_deref() else {
             return Ok(None);
         };
         state
@@ -172,7 +203,7 @@ impl HostProcess {
     }
 
     pub(crate) fn track_process_handle(&self, handle: u64, pid: i32) {
-        if let Some(state) = self.state.as_deref() {
+        if let Some(state) = self.child_authority.as_deref() {
             state
                 .inner
                 .lock()
@@ -183,7 +214,7 @@ impl HostProcess {
     }
 
     pub(crate) fn untrack_process_handle(&self, handle: u64) {
-        if let Some(state) = self.state.as_deref() {
+        if let Some(state) = self.child_authority.as_deref() {
             let mut state = state.inner.lock().unwrap();
             if let Some(pid) = state.process_handle_pids.remove(&handle)
                 && !state
@@ -203,7 +234,7 @@ impl HostProcess {
 
     #[cfg(test)]
     pub(crate) fn check_process_handle_pid(&self, handle: u64, pid: i32) -> AsyncHostResult<()> {
-        let Some(state) = self.state.as_deref() else {
+        let Some(state) = self.child_authority.as_deref() else {
             return Ok(());
         };
         if state.inner.lock().unwrap().process_handle_pids.get(&handle) == Some(&pid) {
@@ -224,12 +255,16 @@ impl HostProcess {
         program: &std::ffi::OsStr,
         argv: &[std::ffi::OsString],
     ) -> AsyncHostResult<()> {
-        self.policy.spawn_process_unix(program, argv)
+        self.policy
+            .as_ref()
+            .map_or(Ok(()), |policy| policy.allows_unix(program, argv))
     }
 
     #[cfg(windows)]
     fn check_spawn_windows(&self, command_line: &std::ffi::OsStr) -> AsyncHostResult<()> {
-        self.policy.spawn_process_windows(command_line)
+        self.policy
+            .as_ref()
+            .map_or(Ok(()), |policy| policy.allows_windows(command_line))
     }
 
     fn check_wait(
@@ -238,7 +273,7 @@ impl HostProcess {
         tracked_pid: Option<i32>,
         pid: i32,
     ) -> AsyncHostResult<()> {
-        if self.state.is_none() {
+        if self.child_authority.is_none() {
             return Ok(());
         }
         self.ensure_owned_child_pid(pid)?;
@@ -250,7 +285,7 @@ impl HostProcess {
     }
 
     fn ensure_owned_child_pid(&self, pid: i32) -> AsyncHostResult<()> {
-        let Some(state) = self.state.as_deref() else {
+        let Some(state) = self.child_authority.as_deref() else {
             return Ok(());
         };
         if state.inner.lock().unwrap().owned_child_pids.contains(&pid) {
@@ -261,13 +296,13 @@ impl HostProcess {
     }
 
     fn track_spawned_child(&self, pid: i32) {
-        if let Some(state) = self.state.as_deref() {
+        if let Some(state) = self.child_authority.as_deref() {
             state.inner.lock().unwrap().owned_child_pids.insert(pid);
         }
     }
 
     fn finish_waited_child(&self, pid: i32, #[cfg(unix)] defer_reap: bool) -> AsyncHostResult<()> {
-        let Some(state) = self.state.as_deref() else {
+        let Some(state) = self.child_authority.as_deref() else {
             #[cfg(unix)]
             if defer_reap {
                 crate::async_sys::process::reap_process(pid)?;
@@ -284,7 +319,7 @@ impl HostProcess {
     }
 
     fn revoke_child_if_unreferenced(&self, pid: i32) {
-        let Some(state) = self.state.as_deref() else {
+        let Some(state) = self.child_authority.as_deref() else {
             return;
         };
         let mut state = state.inner.lock().unwrap();

--- a/crates/moonrun/src/resource.rs
+++ b/crates/moonrun/src/resource.rs
@@ -116,7 +116,9 @@ enum ResourcePayload {
     Invalid,
     File {
         raw: OwnedRawFile,
-        policy_path: Option<PathBuf>,
+        // Best-effort pathname provenance for current filesystem authorization.
+        // This is not a stable identity for the opened Resource.
+        canonical_path: Option<PathBuf>,
     },
     // Reserved process stdio handle. The guest can use it, but does not own it.
     StdioFile(isize),
@@ -137,20 +139,20 @@ impl Resource {
         }
         Self::from_payload(ResourcePayload::File {
             raw: owned_raw_file(raw),
-            policy_path: None,
+            canonical_path: None,
         })
     }
 
-    pub(crate) fn new_with_policy_path(
+    pub(crate) fn new_with_canonical_path(
         raw: fd_util::stub::RawFd,
-        policy_path: Option<PathBuf>,
+        canonical_path: Option<PathBuf>,
     ) -> Self {
         if raw == invalid_raw_file() {
             return Self::invalid();
         }
         Self::from_payload(ResourcePayload::File {
             raw: owned_raw_file(raw),
-            policy_path,
+            canonical_path,
         })
     }
 
@@ -277,9 +279,9 @@ impl Resource {
         }
     }
 
-    pub(crate) fn policy_path(&self) -> Option<&Path> {
+    pub(crate) fn canonical_path(&self) -> Option<&Path> {
         match &self.payload {
-            ResourcePayload::File { policy_path, .. } => policy_path.as_deref(),
+            ResourcePayload::File { canonical_path, .. } => canonical_path.as_deref(),
             ResourcePayload::Invalid
             | ResourcePayload::StdioFile(_)
             | ResourcePayload::TcpSocket { .. }

--- a/crates/moonrun/src/runtime/mod.rs
+++ b/crates/moonrun/src/runtime/mod.rs
@@ -32,7 +32,9 @@ use slotmap::{KeyData, SlotMap, new_key_type};
 
 use crate::async_host::AsyncHost;
 use crate::filesystem::HostFs;
+use crate::network::HostNetwork;
 use crate::policy::Policy;
+use crate::process::HostProcess;
 use crate::sqlite::SqliteHost;
 
 pub(crate) use environment::Env;
@@ -100,13 +102,13 @@ impl HostKeys {
 /// Backend-neutral composition root for one Moonrun virtual environment.
 ///
 /// `RunOptions` selects the process-facing dependencies. `Runtime` realizes
-/// them once, binds filesystem policy to the same working-directory authority,
+/// them once, distributes domain policy together with shared Runtime State,
 /// wires host domain state to one key namespace, and owns it until teardown.
 pub(crate) struct Runtime {
     environment: Arc<Env>,
-    working_directory: WorkingDirectory,
+    working_directory: Arc<WorkingDirectory>,
     filesystem: Arc<HostFs>,
-    async_state: AsyncHost,
+    async_host: AsyncHost,
     sqlite: SqliteHost,
 }
 
@@ -116,7 +118,7 @@ impl Runtime {
         inherited_policy: Option<&[u8]>,
         working_directory: WorkingDirectory,
     ) -> anyhow::Result<Self> {
-        let policy = match (inherited_policy, policy_file) {
+        let mut policy = match (inherited_policy, policy_file) {
             (Some(contents), _) => Policy::from_inherited_json(contents).context(
                 "failed to load inherited sandbox policy (experimental)",
             )?,
@@ -124,32 +126,42 @@ impl Runtime {
                 "failed to load sandbox policy (experimental); run `moonrun --help` for policy format notes",
             )?,
             (None, None) => Policy::allow_all(),
-        }
-        .with_working_directory(working_directory.clone());
+        };
         let environment = Arc::new(
             policy
                 .realize_env()
                 .context("failed to construct the Runtime environment")?,
         );
-        let policy = Arc::new(policy);
+        let filesystem_policy = policy.take_filesystem_policy();
+        let network_policy = policy.take_network_policy();
+        let process_policy = policy.take_process_policy();
+        let policy_inheritance = policy.take_policy_inheritance();
+        let working_directory = Arc::new(working_directory);
         let keys = Rc::new(RefCell::new(HostKeys::default()));
         let filesystem = Arc::new(HostFs::new(
-            Arc::clone(&policy),
+            filesystem_policy,
             Arc::clone(&environment),
-            working_directory.clone(),
+            Arc::clone(&working_directory),
         ));
-        let async_state = AsyncHost::with_keys(
-            Arc::clone(&policy),
-            Arc::clone(&environment),
-            Rc::clone(&keys),
-            working_directory.clone(),
+        let network = HostNetwork::new(network_policy);
+        let process = HostProcess::new(
+            process_policy,
+            policy_inheritance,
+            Arc::clone(&working_directory),
         );
-        let sqlite = SqliteHost::with_keys(Arc::clone(&policy), keys);
+        let async_host = AsyncHost::new(
+            Arc::clone(&environment),
+            Arc::clone(&filesystem),
+            network,
+            process,
+            Rc::clone(&keys),
+        );
+        let sqlite = SqliteHost::new(Arc::clone(&filesystem), keys);
         Ok(Self {
             environment,
             working_directory,
             filesystem,
-            async_state,
+            async_host,
             sqlite,
         })
     }
@@ -166,8 +178,8 @@ impl Runtime {
         &self.working_directory
     }
 
-    pub(crate) fn async_state(&self) -> &AsyncHost {
-        &self.async_state
+    pub(crate) fn async_host(&self) -> &AsyncHost {
+        &self.async_host
     }
 
     pub(crate) fn null_handle(&self) -> u64 {
@@ -188,7 +200,7 @@ impl Drop for Runtime {
         }
 
         let mut leaks = Vec::new();
-        if let Some(summary) = self.async_state.leak_summary() {
+        if let Some(summary) = self.async_host.leak_summary() {
             leaks.push(format!("async({summary})"));
         }
         if let Some(summary) = self.sqlite.leak_summary() {

--- a/crates/moonrun/src/sqlite/connection.rs
+++ b/crates/moonrun/src/sqlite/connection.rs
@@ -64,7 +64,7 @@ pub(crate) struct OpenOutcome {
 impl SqliteHost {
     pub(crate) fn open_v2(&self, filename: &CStr, flags: i32, vfs: u64) -> OpenOutcome {
         let flags = ensure_open_flags(flags);
-        if let Err(code) = ensure_valid_database(&self.policy, filename, flags, vfs) {
+        if let Err(code) = ensure_valid_database(&self.filesystem, filename, flags, vfs) {
             return OpenOutcome {
                 code,
                 database: None,

--- a/crates/moonrun/src/sqlite/mod.rs
+++ b/crates/moonrun/src/sqlite/mod.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! SQLite behavior, lifetime state, policy, and runtime adapters.
+//! SQLite behavior, lifetime state, admission rules, and runtime adapters.
 
 pub(crate) mod v8;
 
@@ -33,7 +33,7 @@ use std::sync::Arc;
 use libsqlite3_sys as ffi;
 use slotmap::SecondaryMap;
 
-use crate::policy::Policy;
+use crate::filesystem::HostFs;
 use crate::runtime::{HostKey, HostKeys};
 
 use connection::Database;
@@ -56,22 +56,22 @@ pub(crate) enum SqliteHostError {
 
 pub(crate) type SqliteHostResult<T> = Result<T, SqliteHostError>;
 
-/// Per-run SQLite policy, operations, identity, and payload storage.
+/// Per-run SQLite admission, operations, identity, and payload storage.
 ///
 /// Wasm runtime adapters lower their own memory and scalar representations before
 /// crossing this interface. The shared Host Key table supplies identity, while
 /// SQLite-owned pointers remain private payloads of this module.
 pub(crate) struct SqliteHost {
-    policy: Arc<Policy>,
+    filesystem: Arc<HostFs>,
     keys: Rc<RefCell<HostKeys>>,
     databases: RefCell<SecondaryMap<HostKey, Database>>,
     statements: RefCell<SecondaryMap<HostKey, Statement>>,
 }
 
 impl SqliteHost {
-    pub(crate) fn with_keys(policy: Arc<Policy>, keys: Rc<RefCell<HostKeys>>) -> Self {
+    pub(crate) fn new(filesystem: Arc<HostFs>, keys: Rc<RefCell<HostKeys>>) -> Self {
         Self {
-            policy,
+            filesystem,
             keys,
             databases: RefCell::new(SecondaryMap::new()),
             statements: RefCell::new(SecondaryMap::new()),
@@ -108,10 +108,20 @@ impl Drop for SqliteHost {
 #[cfg(test)]
 pub(super) mod tests {
     use super::*;
+    use crate::policy::Policy;
+    use crate::runtime::{Env, WorkingDirectory};
+
+    pub(super) fn ambient_filesystem(mut policy: Policy) -> Arc<HostFs> {
+        Arc::new(HostFs::new(
+            policy.take_filesystem_policy(),
+            Arc::new(Env::ambient()),
+            Arc::new(WorkingDirectory::Ambient),
+        ))
+    }
 
     pub(super) fn host() -> SqliteHost {
-        SqliteHost::with_keys(
-            Arc::new(Policy::allow_all()),
+        SqliteHost::new(
+            ambient_filesystem(Policy::allow_all()),
             Rc::new(RefCell::new(HostKeys::default())),
         )
     }

--- a/crates/moonrun/src/sqlite/policy.rs
+++ b/crates/moonrun/src/sqlite/policy.rs
@@ -22,7 +22,7 @@ use std::ptr::{self, NonNull};
 
 use libsqlite3_sys as ffi;
 
-use crate::policy::Policy;
+use crate::filesystem::HostFs;
 use crate::runtime::null_handle;
 
 /// Ensure the requested database and VFS are available in the MVP.
@@ -30,9 +30,11 @@ use crate::runtime::null_handle;
 /// File-backed connections use SQLite's default VFS. The main database is
 /// authorized for reading together with its parent directory because SQLite
 /// may read journal, WAL, and shared-memory files beside it. Writable
-/// connections also require write access to that directory.
+/// connections also require write access to that directory. This is an
+/// admission check, not VFS mediation: SQLite still interprets the filename
+/// again when `sqlite3_open_v2` runs.
 pub(super) fn ensure_valid_database(
-    policy: &Policy,
+    filesystem: &HostFs,
     filename: &CStr,
     flags: i32,
     vfs: u64,
@@ -49,20 +51,20 @@ pub(super) fn ensure_valid_database(
         return Err(ffi::SQLITE_CANTOPEN);
     }
     let database = Path::new(filename);
-    policy
-        .read_path(database.as_os_str())
+    filesystem
+        .authorize_read(database.as_os_str())
         .map_err(|_| ffi::SQLITE_CANTOPEN)?;
     let parent = database
         .parent()
         .filter(|path| !path.as_os_str().is_empty());
     let parent = parent.unwrap_or_else(|| Path::new("."));
-    policy
-        .read_path(parent.as_os_str())
+    filesystem
+        .authorize_read(parent.as_os_str())
         .map_err(|_| ffi::SQLITE_CANTOPEN)?;
 
     if flags & (ffi::SQLITE_OPEN_READWRITE | ffi::SQLITE_OPEN_CREATE) != 0 {
-        policy
-            .write_path(parent.as_os_str())
+        filesystem
+            .authorize_write(parent.as_os_str())
             .map_err(|_| ffi::SQLITE_CANTOPEN)?;
     }
     Ok(())
@@ -114,6 +116,7 @@ unsafe extern "C" fn untrusted_authorizer(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::policy::Policy;
     use std::ffi::CString;
 
     fn c_path(path: &Path) -> CString {
@@ -121,12 +124,17 @@ mod tests {
     }
 
     fn ensure_valid_ambient_database(
-        policy: &Policy,
+        policy: &crate::policy::Policy,
         filename: &CStr,
         flags: i32,
         vfs: u64,
     ) -> Result<(), i32> {
-        ensure_valid_database(policy, filename, flags, vfs)
+        ensure_valid_database(
+            &crate::sqlite::tests::ambient_filesystem(policy.clone()),
+            filename,
+            flags,
+            vfs,
+        )
     }
 
     #[test]

--- a/crates/moonrun/src/sqlite/v8/context.rs
+++ b/crates/moonrun/src/sqlite/v8/context.rs
@@ -192,14 +192,13 @@ mod tests {
     use super::*;
     use std::cell::RefCell;
     use std::rc::Rc;
-    use std::sync::Arc;
 
     use crate::policy::Policy;
     use crate::runtime::HostKeys;
 
     fn host() -> SqliteHost {
-        SqliteHost::with_keys(
-            Arc::new(Policy::allow_all()),
+        SqliteHost::new(
+            crate::sqlite::tests::ambient_filesystem(Policy::allow_all()),
             Rc::new(RefCell::new(HostKeys::default())),
         )
     }


### PR DESCRIPTION
## Why

Moonrun retained a broad Policy after Runtime construction, copied Runtime Working Directory into filesystem policy, and let Async adapters query process-policy presence to choose child lifecycle behavior. That mixed Runtime semantics with authorization and left AsyncHost acting as the filesystem policy dispatcher. Mutable DNS-derived connect authority also lived inside the clonable NetPolicy profile.

## Why this is correct

Runtime now realizes Env once, shares one Working Directory value, and consumes the filesystem, network, process, and inheritance policy components when constructing their Host domains. Ambient policy remains represented by the absence of a domain policy, while configured policy keeps the same deny-by-default checks and execution-time ordering.

HostFs now interprets cwd-relative and opened-directory-relative requests and canonicalizes their targets before asking FsPolicy to authorize them. FsPolicy therefore contains only immutable root rules: it no longer sees WorkingDirectory or a synthetic PolicyPath base. Pure checks are named authorize_*, and best-effort pathname provenance on an opened Resource is named canonical_path rather than policy_path.

HostNetwork owns DNS-derived connect provenance per Runtime while NetPolicy contains only immutable rules. HostProcess explicitly owns ChildAuthorityState and the Unix deferred-reap decision required to authorize child completion. AsyncHost's policy-composing constructor and Default implementation were removed; tests assemble production dependencies in their own fixture instead of extending the production interface. The Unix-only filesystem test accessor is compiled only for Unix tests.

## Scope

This reuses the existing domain policy types and Host domains; it does not add an authority wrapper, Runtime context, forwarding layer, or test-only production API. Policy component extraction remains confined to construction, and the temporary broad SQLite HostFs dependency remains explicit. A single consuming policy distribution operation, a narrower SQLite admission interface, and handle-relative filesystem execution remain separate follow-ups.
