### PR TITLE
feat(tree): collapse repeated human subgraphs

### DIFF
--- a/crates/moon/src/cli/tree.rs
+++ b/crates/moon/src/cli/tree.rs
@@ -48,11 +48,22 @@ const PACKAGE_TREE_JSON_VERSION: u32 = 2;
 const TREE_JSON_ERROR_EXIT_CODE: i32 = -1;
 
 /// Display the dependency tree
+///
+/// Text output expands each dependency once per root. When another path
+/// reaches a dependency whose children were already displayed, the dependency
+/// remains visible with `(*)`, but its children are omitted. Use
+/// `--no-dedupe` to repeat those subgraphs. Cycles remain marked as `(cycle)`.
+/// JSON output represents shared dependencies once and preserves their
+/// relationships as edges.
 #[derive(Debug, clap::Parser)]
 pub(crate) struct TreeSubcommand {
     /// Output one complete JSON result to stdout
     #[clap(long)]
     pub json: bool,
+
+    /// Repeat dependency subgraphs instead of marking them with `(*)`
+    #[clap(long, conflicts_with = "json")]
+    pub no_dedupe: bool,
 
     /// Show the package-level dependency graph instead of the module-level tree
     ///
@@ -69,15 +80,16 @@ pub(crate) fn tree_cli(
     cmd: TreeSubcommand,
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
+    let dedupe = !cmd.no_dedupe;
     let rendered = if cmd.package {
         let (resolve_output, selected) =
             resolve_selected_package_graph(&cli, output.user_log(), ChildOutputMode::Inherit)?;
-        render_package_tree(&resolve_output, selected)
+        render_package_tree(&resolve_output, selected, dedupe)
     } else {
         let resolved = resolve_selected_tree(&cli, output.user_log())?;
         let workspace_members =
             (resolved.workspace_members.len() > 1).then_some(&resolved.workspace_members);
-        render_tree(&resolved.env, resolved.root, workspace_members)
+        render_tree(&resolved.env, resolved.root, workspace_members, dedupe)
     };
     output.write_result(|writer| -> anyhow::Result<()> {
         writer.write_all(rendered.as_bytes())?;
@@ -544,7 +556,11 @@ fn target_kind_str(kind: TargetKind) -> &'static str {
 ///
 /// Source targets form the roots; expansion follows all non-stdlib dependency
 /// edges, mirroring the module-level text tree's treatment of stdlib modules.
-fn render_package_tree(resolve_output: &ResolveOutput, selected_module: ModuleId) -> String {
+fn render_package_tree(
+    resolve_output: &ResolveOutput,
+    selected_module: ModuleId,
+    dedupe: bool,
+) -> String {
     let pkg_dirs = &resolve_output.pkg_dirs;
     let source_packages = selected_source_packages(resolve_output, selected_module);
     let sorted_children = |source| sorted_package_tree_children(resolve_output, source);
@@ -560,8 +576,17 @@ fn render_package_tree(resolve_output: &ResolveOutput, selected_module: ModuleId
 
         let mut stack = HashSet::new();
         stack.insert(target);
-        let direct_dep_count =
-            render_tree_children(target, "", &mut stack, &mut out, &sorted_children);
+        let mut expanded = HashSet::new();
+        expanded.insert(target);
+        let direct_dep_count = render_tree_children(
+            sorted_children(target),
+            "",
+            &mut stack,
+            &mut expanded,
+            dedupe,
+            &mut out,
+            &sorted_children,
+        );
         if direct_dep_count == 0 {
             out.push_str("  (no dependencies)\n");
         }
@@ -658,6 +683,7 @@ fn render_tree(
     resolved: &ResolvedEnv,
     root: ModuleId,
     workspace_members: Option<&HashSet<ModuleId>>,
+    dedupe: bool,
 ) -> String {
     let sorted_children = |source| sorted_module_tree_children(resolved, source, workspace_members);
     let mut out = String::new();
@@ -666,7 +692,17 @@ fn render_tree(
 
     let mut stack = HashSet::new();
     stack.insert(root);
-    let direct_dep_count = render_tree_children(root, "", &mut stack, &mut out, &sorted_children);
+    let mut expanded = HashSet::new();
+    expanded.insert(root);
+    let direct_dep_count = render_tree_children(
+        sorted_children(root),
+        "",
+        &mut stack,
+        &mut expanded,
+        dedupe,
+        &mut out,
+        &sorted_children,
+    );
 
     if direct_dep_count == 0 {
         out.push_str("  (no dependencies)\n");
@@ -707,9 +743,11 @@ struct TreeChild<Node> {
 }
 
 fn render_tree_children<Node, Children>(
-    source: Node,
+    children: Vec<TreeChild<Node>>,
     indent: &str,
     stack: &mut HashSet<Node>,
+    expanded: &mut HashSet<Node>,
+    dedupe: bool,
     out: &mut String,
     sorted_children: &Children,
 ) -> usize
@@ -717,24 +755,47 @@ where
     Node: Copy + Eq + Hash,
     Children: Fn(Node) -> Vec<TreeChild<Node>>,
 {
-    let children = sorted_children(source);
     for (idx, child) in children.iter().enumerate() {
         let is_last = idx + 1 == children.len();
+        let is_cycle = stack.contains(&child.node);
+        let already_expanded = !expanded.insert(child.node);
+        let descendants = if is_cycle {
+            Vec::new()
+        } else {
+            sorted_children(child.node)
+        };
+        let omit_descendants = dedupe && already_expanded;
+
         out.push_str(indent);
         out.push_str(if is_last { "└─" } else { "├─" });
         out.push(' ');
         out.push_str(&child.label);
+        if omit_descendants && !descendants.is_empty() {
+            out.push_str(" (*)");
+        }
         out.push('\n');
 
         let next_indent = format!("{indent}{}", if is_last { "   " } else { "│  " });
-        if stack.contains(&child.node) {
+        if is_cycle {
             out.push_str(&next_indent);
             out.push_str("└─ (cycle)\n");
             continue;
         }
 
+        if omit_descendants {
+            continue;
+        }
+
         stack.insert(child.node);
-        render_tree_children(child.node, &next_indent, stack, out, sorted_children);
+        render_tree_children(
+            descendants,
+            &next_indent,
+            stack,
+            expanded,
+            dedupe,
+            out,
+            sorted_children,
+        );
         stack.remove(&child.node);
     }
 
@@ -787,6 +848,49 @@ mod tests {
     }
 
     #[test]
+    fn no_dedupe_is_text_only() {
+        let command =
+            <TreeSubcommand as clap::Parser>::try_parse_from(["tree", "--no-dedupe"]).unwrap();
+        assert!(command.no_dedupe);
+        assert!(
+            <TreeSubcommand as clap::Parser>::try_parse_from(["tree", "--json", "--no-dedupe"])
+                .is_err()
+        );
+    }
+
+    fn shared_subgraph() -> (ResolvedEnv, ModuleId) {
+        let (roots, root) = ResolvedModule::only_one_module(
+            local_source("alice/root", "0.1.0", "/workspace/root"),
+            local_module("alice/root", "0.1.0"),
+        );
+        let mut env = ResolvedEnv::from_root_modules(roots);
+        let dep_a = env.add_module(
+            local_source("alice/a", "0.1.0", "/workspace/a"),
+            local_module("alice/a", "0.1.0"),
+        );
+        let dep_b = env.add_module(
+            local_source("alice/b", "0.1.0", "/workspace/b"),
+            local_module("alice/b", "0.1.0"),
+        );
+        let shared = env.add_module(
+            local_source("alice/shared", "0.1.0", "/workspace/shared"),
+            local_module("alice/shared", "0.1.0"),
+        );
+        let leaf = env.add_module(
+            local_source("alice/leaf", "0.1.0", "/workspace/leaf"),
+            local_module("alice/leaf", "0.1.0"),
+        );
+
+        env.add_dependency(root, dep_a, &regular_dep("alice/a"));
+        env.add_dependency(root, dep_b, &regular_dep("alice/b"));
+        env.add_dependency(dep_a, shared, &regular_dep("alice/shared"));
+        env.add_dependency(dep_b, shared, &regular_dep("alice/shared"));
+        env.add_dependency(shared, leaf, &regular_dep("alice/leaf"));
+        env.add_dependency(dep_b, leaf, &regular_dep("alice/leaf"));
+        (env, root)
+    }
+
+    #[test]
     fn tree_render_uses_three_column_unicode_indent() {
         let (roots, root_id) = ResolvedModule::only_one_module(
             local_source("alice/root", "0.1.0", "/workspace/root"),
@@ -811,7 +915,7 @@ mod tests {
         env.add_dependency(root_id, dep_b, &regular_dep("alice/b"));
         env.add_dependency(dep_a, dep_c, &regular_dep("alice/c"));
 
-        let rendered = render_tree(&env, root_id, None);
+        let rendered = render_tree(&env, root_id, None, true);
         expect![[r#"
             alice/root@0.1.0 (local /workspace/root):
             ├─ alice/a -> alice/a@0.1.0 (local /workspace/a)
@@ -834,12 +938,96 @@ mod tests {
         );
         env.add_dependency(root_id, dep_id, &regular_dep("just/hello004"));
 
-        let rendered = render_tree(&env, root_id, None);
+        let rendered = render_tree(&env, root_id, None, true);
         expect![[r#"
             username/hello@0.1.0 (local /workspace/hello):
             └─ just/hello004 -> just/hello004@0.1.0 (local /workspace/hello/deps/hello004)
         "#]]
         .assert_eq(&rendered);
+    }
+
+    #[test]
+    fn tree_render_expands_shared_subgraph_once() {
+        let (env, root) = shared_subgraph();
+
+        let rendered = render_tree(&env, root, None, true);
+        expect![[r#"
+            alice/root@0.1.0 (local /workspace/root):
+            ├─ alice/a -> alice/a@0.1.0 (local /workspace/a)
+            │  └─ alice/shared -> alice/shared@0.1.0 (local /workspace/shared)
+            │     └─ alice/leaf -> alice/leaf@0.1.0 (local /workspace/leaf)
+            └─ alice/b -> alice/b@0.1.0 (local /workspace/b)
+               ├─ alice/leaf -> alice/leaf@0.1.0 (local /workspace/leaf)
+               └─ alice/shared -> alice/shared@0.1.0 (local /workspace/shared) (*)
+        "#]]
+        .assert_eq(&rendered);
+    }
+
+    #[test]
+    fn tree_render_can_repeat_shared_subgraphs() {
+        let (env, root) = shared_subgraph();
+
+        let rendered = render_tree(&env, root, None, false);
+        expect![[r#"
+            alice/root@0.1.0 (local /workspace/root):
+            ├─ alice/a -> alice/a@0.1.0 (local /workspace/a)
+            │  └─ alice/shared -> alice/shared@0.1.0 (local /workspace/shared)
+            │     └─ alice/leaf -> alice/leaf@0.1.0 (local /workspace/leaf)
+            └─ alice/b -> alice/b@0.1.0 (local /workspace/b)
+               ├─ alice/leaf -> alice/leaf@0.1.0 (local /workspace/leaf)
+               └─ alice/shared -> alice/shared@0.1.0 (local /workspace/shared)
+                  └─ alice/leaf -> alice/leaf@0.1.0 (local /workspace/leaf)
+        "#]]
+        .assert_eq(&rendered);
+    }
+
+    #[test]
+    fn tree_render_stops_cycles_without_deduplication() {
+        let (roots, root) = ResolvedModule::only_one_module(
+            local_source("alice/root", "0.1.0", "/workspace/root"),
+            local_module("alice/root", "0.1.0"),
+        );
+        let mut env = ResolvedEnv::from_root_modules(roots);
+        let dep = env.add_module(
+            local_source("alice/dep", "0.1.0", "/workspace/dep"),
+            local_module("alice/dep", "0.1.0"),
+        );
+        env.add_dependency(root, dep, &regular_dep("alice/dep"));
+        env.add_dependency(dep, root, &regular_dep("alice/root"));
+
+        let rendered = render_tree(&env, root, None, false);
+        expect![[r#"
+            alice/root@0.1.0 (local /workspace/root):
+            └─ alice/dep -> alice/dep@0.1.0 (local /workspace/dep)
+               └─ alice/root -> alice/root@0.1.0 (local /workspace/root)
+                  └─ (cycle)
+        "#]]
+        .assert_eq(&rendered);
+    }
+
+    #[test]
+    fn tree_json_represents_shared_subgraph_once() {
+        let (env, root) = shared_subgraph();
+
+        let graph = render_graph_json(&env, root, &HashSet::new());
+        let shared = graph
+            .modules
+            .iter()
+            .position(|module| module.name == "alice/shared")
+            .unwrap();
+
+        assert_eq!(
+            graph
+                .modules
+                .iter()
+                .filter(|module| module.name == "alice/shared")
+                .count(),
+            1
+        );
+        assert_eq!(
+            graph.edges.iter().filter(|edge| edge.to == shared).count(),
+            2
+        );
     }
 
     #[test]
@@ -857,7 +1045,7 @@ mod tests {
         env.add_dependency(app, liba, &regular_dep("alice/liba"));
 
         let workspace_members = [app, liba].into_iter().collect();
-        let rendered = render_tree(&env, app, Some(&workspace_members));
+        let rendered = render_tree(&env, app, Some(&workspace_members), true);
         expect![[r#"
             alice/app@0.1.0 (local /workspace/app) [workspace member]:
             └─ alice/liba -> alice/liba@0.1.1 (local /workspace/liba) [workspace member]

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -54,6 +54,9 @@ path still uses it or compatibility is part of the requirement.
   reconsideration criteria.
 - [`docs/dev/reference`](reference/readme.md) owns descriptions of implemented
   MoonBuild behavior and must change with that behavior.
+- [`docs/dev/research`](research/) contains non-normative investigations that
+  inform design choices but do not define implemented behavior, including the
+  [dependency-tree deduplication comparison](research/dependency-tree-dedup-comparison.md).
 - [Command output migration](command-output-migration.md) owns the sequencing
   of that in-progress migration.
 - [`docs/manual`](../manual/) and [`docs/manual-zh`](../manual-zh/) own

--- a/docs/dev/research/dependency-tree-dedup-comparison.md
+++ b/docs/dev/research/dependency-tree-dedup-comparison.md
@@ -1,0 +1,158 @@
+# Dependency-tree deduplication in Cargo and Go
+
+Verified against current official documentation and first-party source on
+2026-08-27.
+
+## Recommendation
+
+Use Cargo's human-output policy as the precedent for `moon tree`:
+
+- Expand a dependency's children at its first displayed occurrence.
+- Keep every later parent-to-dependency occurrence visible, but omit the
+  already displayed children.
+- Put the omission marker on the repeated dependency line, rather than adding
+  a synthetic child such as `(already shown)`.
+- Do not mark a repeated leaf, because no subgraph was omitted.
+- Add `--no-dedupe` with the behavior change so users can recover the complete
+  path-expanded view. Do not call this flag `--duplicates`: Cargo uses
+  `--duplicates` for a different question, packages resolved at multiple
+  versions.
+- Keep Moon's explicit `(cycle)` marker distinct from ordinary deduplication.
+
+For the compact marker, Cargo's `(*)` is familiar and cheap. A more explicit
+`(already shown)` is also defensible, but it should be appended to the repeated
+dependency itself:
+
+```text
+alice/root:
+├─ alice/a
+│  └─ alice/shared
+│     └─ alice/leaf
+└─ alice/b
+   └─ alice/shared (*)
+```
+
+The Moon implementation follows this policy: it uses `(*)` on repeated
+non-leaves, leaves repeated leaves unmarked, and provides `--no-dedupe` for
+complete path expansion. Its per-root deduplication scope is a deliberate
+difference from Cargo.
+
+## Cargo
+
+`cargo tree` is a nested, human-oriented dependency view. By default, when a
+package's dependencies have already been shown, later occurrences still print
+the package under each parent, append `(*)`, and do not print its dependencies
+again. `--no-dedupe` restores repeated expansion. The Cargo Book both defines
+this behavior and shows it in the default output example. [Cargo tree
+description](https://doc.rust-lang.org/cargo/commands/cargo-tree.html#description),
+[Cargo tree options](https://doc.rust-lang.org/cargo/commands/cargo-tree.html#tree-options)
+
+Cargo's implementation makes the traversal scope precise. It creates one
+`visited_deps` set before iterating over all displayed roots; the first
+`insert(node)` succeeds and recursion proceeds, while a later occurrence
+returns before its dependencies are visited. Deduplication therefore spans the
+whole displayed forest, not only one root or one ancestor path. [Cargo tree
+implementation, traversal and visited
+set](https://doc.rust-lang.org/stable/nightly-rustc/src/cargo/ops/tree/mod.rs.html#266-363)
+
+Cargo suppresses `(*)` for a repeated node with no outgoing edges, explicitly
+because no dependency subtree was deduplicated and the marker would be noise.
+The leaf occurrence itself is still printed under every parent. [Cargo tree
+implementation, marker
+selection](https://doc.rust-lang.org/stable/nightly-rustc/src/cargo/ops/tree/mod.rs.html#343-356)
+
+With `--no-dedupe`, Cargo still uses a separate recursion stack to stop cycles;
+full repeated expansion does not imply infinite traversal. [Cargo tree
+implementation, cycle stack](https://doc.rust-lang.org/stable/nightly-rustc/src/cargo/ops/tree/mod.rs.html#266-363)
+
+Cargo's `-d` / `--duplicates` is unrelated to display deduplication. It selects
+packages present at multiple versions and implies `--invert`; with `-p`, it
+limits that search to a package subtree. [Cargo tree
+options](https://doc.rust-lang.org/cargo/commands/cargo-tree.html#tree-options)
+
+For programs, Cargo exposes a normalized graph through
+`cargo metadata --format-version=1`: `resolve.nodes` contains one entry per
+package, and dependencies are package-ID references. A shared package is thus
+one graph node reached by multiple references rather than a recursively nested
+object repeated at each path. [Cargo metadata JSON
+format](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html#json-format)
+
+## Go
+
+Go's relevant built-in commands do not provide a Cargo-like nested dependency
+tree, so Go does not establish a marker or `--no-dedupe` convention. This is an
+inference from the documented shapes of the built-in inspection commands:
+
+- `go mod graph` prints the module requirement graph as an edge list, one
+  `module dependency` pair per line. Shared modules naturally recur as edge
+  endpoints; no subtree is embedded or repeated. [Go Modules Reference: `go
+  mod graph`](https://go.dev/ref/mod#go-mod-graph)
+- `go mod why` answers a narrower question: for each requested package or
+  module, it prints one shortest package-import path from the main module. It
+  does not render the full graph as a tree. Even with `-m`, it queries the
+  package graph rather than the module graph from `go mod graph`. [Go Modules
+  Reference: `go mod why`](https://go.dev/ref/mod#go-mod-why)
+- `go list -deps` emits a flat depth-first post-order sequence of package
+  records. `-json` changes each record's representation, while the `Imports`
+  and `Deps` fields expose direct and recursive dependency names; neither form
+  introduces a nested-tree dedup marker. [Official `go list`
+  documentation](https://pkg.go.dev/cmd/go#hdr-List_packages_or_modules)
+- `go list -m all` lists the selected module build list, and
+  `go list -m -json all` provides flat module records for tools. Neither is a
+  dependency hierarchy. [Go Modules Reference: `go list
+  -m`](https://go.dev/ref/mod#go-list-m)
+
+The design lesson from Go is therefore about representation rather than tree
+formatting: when exact graph structure matters, expose edges or flat node
+records instead of path-expanded nested objects. It does not argue for or
+against Cargo's human-tree policy.
+
+## Implications for Moon
+
+Moon's JSON representation already follows the graph-oriented model. Module
+JSON builds one indexed `modules` array and a separate `edges` array; package
+JSON deduplicates nodes by `PackageId`, stores them once, and preserves shared
+relationships as edges. The regression test also checks that a shared
+module appears once while two edges point to it. [Moon module JSON
+renderer](../../../crates/moon/src/cli/tree.rs#L376), [Moon package JSON
+renderer](../../../crates/moon/src/cli/tree.rs#L462), [shared-subgraph JSON
+test](../../../crates/moon/src/cli/tree.rs#L1009)
+
+Consequently, `--no-dedupe` should affect text output only. Applying it to JSON
+would either be meaningless or would replace the graph schema with a lossy,
+path-expanded structure.
+
+The human renderer has two independent sets with distinct roles: a recursion
+`stack` for cycles and an `expanded` set for shared subgraphs. It keeps Moon's
+explicit `(cycle)` child while appending `(*)` to a repeated dependency whose
+children are omitted. [Moon human tree
+renderer](../../../crates/moon/src/cli/tree.rs#L745)
+
+Moon initializes `expanded` once for the single module root but once *per
+source-package root* in `moon tree --package`. Cargo instead shares
+one visited set across all roots. Per-root scope keeps every selected Moon
+package independently inspectable, while command-wide scope maximizes output
+reduction. Either can work, but the manual must state the choice; the current
+wording, “once per root,” is an intentional divergence from Cargo. [Moon
+package-tree roots](../../../crates/moon/src/cli/tree.rs#L559), [Cargo's shared
+visited set](https://doc.rust-lang.org/stable/nightly-rustc/src/cargo/ops/tree/mod.rs.html#266-295)
+
+One Moon-specific identity issue also needs an explicit choice. Package text
+tracks expansion by `BuildTarget`, while its visible label identifies only the
+package; package JSON instead deduplicates by `PackageId` and aggregates target
+kinds on edges. If two target kinds for one package have different outgoing
+edges, deduplicating them by visible package label would hide information, but
+keeping `BuildTarget` identity can show apparently repeated package subgraphs.
+The human output should either display target kind when it is identity-relevant
+or document that identical-looking package labels may denote different build
+targets. [Moon package text child
+identity](../../../crates/moon/src/cli/tree.rs#L606), [Moon package JSON edge
+aggregation](../../../crates/moon/src/cli/tree.rs#L462)
+
+## Scope boundary
+
+Default text deduplication, its marker behavior, leaf behavior, cycle behavior,
+and `--no-dedupe` belong together because they define one user-visible output
+policy and its escape hatch. A later change can alter the multi-root scope or
+redesign package-text identity; those choices need separate examples and
+compatibility discussion.

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -562,11 +562,14 @@ Install a binary package globally or install project dependencies (deprecated wi
 
 Display the dependency tree
 
+Text output expands each dependency once per root. When another path reaches a dependency whose children were already displayed, the dependency remains visible with `(*)`, but its children are omitted. Use `--no-dedupe` to repeat those subgraphs. Cycles remain marked as `(cycle)`. JSON output represents shared dependencies once and preserves their relationships as edges.
+
 **Usage:** `moon tree [OPTIONS]`
 
 ###### **Options:**
 
 * `--json` — Output one complete JSON result to stdout
+* `--no-dedupe` — Repeat dependency subgraphs instead of marking them with `(*)`
 * `--package` — Show the package-level dependency graph instead of the module-level tree
 
    Text output expands source imports from every package in the selected module. With `--json`, the result contains every non-standard-library package in the resolved project, all import target kinds, and the selected module's packages in `root`.

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -562,11 +562,14 @@ Install a binary package globally or install project dependencies (deprecated wi
 
 Display the dependency tree
 
+Text output expands each dependency once per root. When another path reaches a dependency whose children were already displayed, the dependency remains visible with `(*)`, but its children are omitted. Use `--no-dedupe` to repeat those subgraphs. Cycles remain marked as `(cycle)`. JSON output represents shared dependencies once and preserves their relationships as edges.
+
 **Usage:** `moon tree [OPTIONS]`
 
 ###### **Options:**
 
 * `--json` — Output one complete JSON result to stdout
+* `--no-dedupe` — Repeat dependency subgraphs instead of marking them with `(*)`
 * `--package` — Show the package-level dependency graph instead of the module-level tree
 
    Text output expands source imports from every package in the selected module. With `--json`, the result contains every non-standard-library package in the resolved project, all import target kinds, and the selected module's packages in `root`.


### PR DESCRIPTION
## Why

Human tree output recursively renders a shared dependency subgraph at every incoming path. Diamond-shaped dependency graphs can therefore become noisy and grow much larger than the underlying graph.

## What changed

- Expand each dependency subtree once per displayed root and mark later non-leaf occurrences with (*), following the cargo tree convention.
- Leave repeated leaves unmarked because no child output was omitted.
- Add --no-dedupe for callers that need full path expansion.
- Keep cycle detection independent and retain the existing (cycle) marker.
- Keep module and package JSON unchanged as normalized nodes plus edges.
- Document the Cargo and Go precedents using primary sources.

## Why this is correct and scoped

The shared module/package renderer owns the traversal policy, with one recursion stack for cycles and one expanded set for repeated subgraphs. Tests cover default deduplication, repeated leaves, full expansion, cycles, the text-only flag contract, and the unchanged shared-node JSON representation.

Deduplication remains per root, preserving independently readable package roots. Command-wide deduplication and the package BuildTarget versus visible-label distinction are documented as separate follow-up design choices rather than expanding this change.