### PR TITLE
refactor(moonrun): make stdio bindings Runtime State

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -94,13 +94,13 @@ after construction it is Runtime State. Ambient retains process-environment
 write-through for guest-reachable effects that do not yet cross Env.
 _Avoid_: Mutable policy, per-import environment map
 
-**Stdio Bindings**:
+**Runtime Stdio**:
 The standard-stream behavior selected once by Runtime Configuration and owned
 by one Runtime. The V8 I/O imports, WASI descriptors, reserved Async Host
 Resources, and Host Process defaults all consume this same Runtime State.
 The only current value is `Ambient`: it preserves the historical observation
 points for process standard streams and does not snapshot, own, or close their
-OS handles. Moonrun Policy neither selects nor authorizes Stdio Bindings.
+OS handles. Moonrun Policy neither selects nor authorizes Runtime Stdio.
 _Avoid_: process-global fallback, stdio policy, Host Stdio forwarding service
 
 **WASI Capability Surface**:
@@ -252,7 +252,7 @@ The V8-facing `moonbitlang/async` adapter that registers imports, decodes wasm A
 _Avoid_: Host state, native-stub implementation
 
 **Async Host**:
-Moonrun-owned async state for one `moonbitlang/async` host instance: Resources, host workers, completion queues, Jobs, and opaque host poll instances. It uses the Runtime's shared Host Key namespace, materializes its reserved standard-stream Resources from the Runtime Stdio Bindings, and contains no SQLite state.
+Moonrun-owned async state for one `moonbitlang/async` host instance: Resources, host workers, completion queues, Jobs, and opaque host poll instances. It uses the Runtime's shared Host Key namespace, materializes its reserved standard-stream Resources from the Runtime Stdio, and contains no SQLite state.
 _Avoid_: `moonbitlang/async` source mirror
 
 **SQLite API**:

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -94,6 +94,15 @@ after construction it is Runtime State. Ambient retains process-environment
 write-through for guest-reachable effects that do not yet cross Env.
 _Avoid_: Mutable policy, per-import environment map
 
+**Stdio Bindings**:
+The standard-stream behavior selected once by Runtime Configuration and owned
+by one Runtime. The V8 I/O imports, WASI descriptors, reserved Async Host
+Resources, and Host Process defaults all consume this same Runtime State.
+The only current value is `Ambient`: it preserves the historical observation
+points for process standard streams and does not snapshot, own, or close their
+OS handles. Moonrun Policy neither selects nor authorizes Stdio Bindings.
+_Avoid_: process-global fallback, stdio policy, Host Stdio forwarding service
+
 **WASI Capability Surface**:
 The files and directories reachable through WASI descriptors and preopens.
 WASI access is configured separately from Moonrun Policy, even when both
@@ -135,8 +144,9 @@ _Avoid_: V8 network, Async Host network
 **Host Process**:
 The Runtime-owned, backend-neutral implementation of moonrun's
 permission-backed process operations. It owns Process Job payloads,
-authorization and final configuration, result interpretation, and child-process
-authority. Native execution stays behind its private Ambient Process
+authorization and final configuration (including cwd and default stdio),
+result interpretation, and child-process authority. Native execution stays
+behind its private Ambient Process
 implementation. The Async Host owns guest Handles and worker lifecycle; the
 thread pool only schedules Process Jobs and delivers their Completions.
 _Avoid_: V8 process, thread-pool process
@@ -242,7 +252,7 @@ The V8-facing `moonbitlang/async` adapter that registers imports, decodes wasm A
 _Avoid_: Host state, native-stub implementation
 
 **Async Host**:
-Moonrun-owned async state for one `moonbitlang/async` host instance: Resources, host workers, completion queues, Jobs, and opaque host poll instances. It uses the Runtime's shared Host Key namespace and contains no SQLite state.
+Moonrun-owned async state for one `moonbitlang/async` host instance: Resources, host workers, completion queues, Jobs, and opaque host poll instances. It uses the Runtime's shared Host Key namespace, materializes its reserved standard-stream Resources from the Runtime Stdio Bindings, and contains no SQLite state.
 _Avoid_: `moonbitlang/async` source mirror
 
 **SQLite API**:

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -58,7 +58,7 @@ use crate::network::HostNetwork;
 use crate::process::HostProcess;
 use crate::resource::{Resource, ResourceClass, ResourcePublication, ResourceRef};
 pub(crate) use crate::runtime::HostKey as HandleKey;
-use crate::runtime::{Env, HostKeys, HostResourceKind as HandleKind};
+use crate::runtime::{Env, HostKeys, HostResourceKind as HandleKind, Stdio, StdioBindings};
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 compile_error!("moonrun async wasm host currently supports only Linux, macOS, and Windows hosts");
@@ -236,24 +236,6 @@ const STDIN_ID: i32 = 0;
 const STDOUT_ID: i32 = 1;
 const STDERR_ID: i32 = 2;
 
-#[cfg(windows)]
-const WINDOWS_STDIO_IDS: [u32; 3] = [
-    windows_sys::Win32::System::Console::STD_INPUT_HANDLE,
-    windows_sys::Win32::System::Console::STD_OUTPUT_HANDLE,
-    windows_sys::Win32::System::Console::STD_ERROR_HANDLE,
-];
-
-#[cfg(unix)]
-const STDIO_IDS: [i32; 3] = [STDIN_ID, STDOUT_ID, STDERR_ID];
-
-#[repr(usize)]
-#[derive(Clone, Copy)]
-enum Stdio {
-    Stdin,
-    Stdout,
-    Stderr,
-}
-
 fn handle_from_key(key: HandleKey) -> HostHandle {
     key.data().as_ffi()
 }
@@ -282,51 +264,31 @@ struct HandleTable {
     stdio_resources: [HandleKey; 3],
 }
 
-impl Default for HandleTable {
-    fn default() -> Self {
-        Self::with_keys(Rc::new(RefCell::new(HostKeys::default())))
-    }
-}
-
 impl HandleTable {
-    fn with_keys(keys: Rc<RefCell<HostKeys>>) -> Self {
+    fn with_keys(keys: Rc<RefCell<HostKeys>>, stdio: &StdioBindings) -> Self {
         let mut handles = keys.borrow_mut();
         let mut resources = SecondaryMap::new();
 
         let invalid_resource = handles.insert(HandleKind::Resource);
         resources.insert(invalid_resource, Arc::new(Resource::invalid()));
 
-        #[cfg(unix)]
-        let stdio_resources = STDIO_IDS.map(|id| {
-            let key = handles.insert(HandleKind::Resource);
-            resources.insert(key, Arc::new(Resource::stdio_file(id)));
-            key
-        });
-
-        #[cfg(windows)]
-        let stdio_resources = {
-            use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
-            use windows_sys::Win32::System::Console::GetStdHandle;
-
-            let mut keys = [invalid_resource; 3];
-            let mut raws = [0isize; 3];
-            for (index, id) in WINDOWS_STDIO_IDS.iter().enumerate() {
-                let handle = unsafe { GetStdHandle(*id) };
-                if handle.is_null() || handle == INVALID_HANDLE_VALUE {
-                    continue;
-                }
-                let raw = handle as isize;
-                if let Some(prev) = (0..index).find(|prev| raws[*prev] == raw) {
-                    keys[index] = keys[prev];
-                    continue;
-                }
+        let stdio_raw_handles = stdio.raw_handles();
+        let mut stdio_resources = [invalid_resource; 3];
+        for (index, raw) in stdio_raw_handles.iter().enumerate() {
+            let Some(raw) = raw else {
+                continue;
+            };
+            if let Some(previous) = stdio_raw_handles[..index]
+                .iter()
+                .position(|previous| previous.as_ref() == Some(raw))
+            {
+                stdio_resources[index] = stdio_resources[previous];
+            } else {
                 let key = handles.insert(HandleKind::Resource);
-                resources.insert(key, Arc::new(Resource::stdio_file(handle)));
-                keys[index] = key;
-                raws[index] = raw;
+                resources.insert(key, Arc::new(Resource::stdio_file(*raw)));
+                stdio_resources[index] = key;
             }
-            keys
-        };
+        }
 
         drop(handles);
         Self {
@@ -1225,6 +1187,7 @@ pub(crate) struct AsyncHost {
 impl AsyncHost {
     pub(crate) fn new(
         environment: Arc<Env>,
+        stdio: &StdioBindings,
         filesystem: Arc<HostFs>,
         network: HostNetwork,
         process: HostProcess,
@@ -1250,7 +1213,7 @@ impl AsyncHost {
             workers: InstanceWorkers::new(),
             polls: RefCell::new(PollTable::default()),
             thread_pool_completions: RefCell::new(ThreadPoolCompletions::default()),
-            handles: RefCell::new(HandleTable::with_keys(keys)),
+            handles: RefCell::new(HandleTable::with_keys(keys, stdio)),
             tls_connections: RefCell::new(SecondaryMap::new()),
             tls_error: RefCell::new(None),
         }
@@ -4411,13 +4374,16 @@ mod tests {
             Arc::clone(&working_directory),
         ));
         let network = HostNetwork::new(policy.take_network_policy());
+        let stdio = Arc::new(StdioBindings::Ambient);
         let process = HostProcess::new(
             policy.take_process_policy(),
             policy.take_policy_inheritance(),
             working_directory,
+            Arc::clone(&stdio),
         );
         AsyncHost::new(
             environment,
+            &stdio,
             filesystem,
             network,
             process,

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -58,7 +58,7 @@ use crate::network::HostNetwork;
 use crate::process::HostProcess;
 use crate::resource::{Resource, ResourceClass, ResourcePublication, ResourceRef};
 pub(crate) use crate::runtime::HostKey as HandleKey;
-use crate::runtime::{Env, HostKeys, HostResourceKind as HandleKind, Stdio, StdioBindings};
+use crate::runtime::{Env, HostKeys, HostResourceKind as HandleKind, Stdio, StdioStream};
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 compile_error!("moonrun async wasm host currently supports only Linux, macOS, and Windows hosts");
@@ -265,7 +265,7 @@ struct HandleTable {
 }
 
 impl HandleTable {
-    fn with_keys(keys: Rc<RefCell<HostKeys>>, stdio: &StdioBindings) -> Self {
+    fn with_keys(keys: Rc<RefCell<HostKeys>>, stdio: &Stdio) -> Self {
         let mut handles = keys.borrow_mut();
         let mut resources = SecondaryMap::new();
 
@@ -1187,7 +1187,7 @@ pub(crate) struct AsyncHost {
 impl AsyncHost {
     pub(crate) fn new(
         environment: Arc<Env>,
-        stdio: &StdioBindings,
+        stdio: &Stdio,
         filesystem: Arc<HostFs>,
         network: HostNetwork,
         process: HostProcess,
@@ -1225,9 +1225,9 @@ impl AsyncHost {
 
     pub(crate) fn std_handle(&self, id: i32) -> AsyncHostResult<HostHandle> {
         let stdio = match id {
-            STDIN_ID => Stdio::Stdin,
-            STDOUT_ID => Stdio::Stdout,
-            STDERR_ID => Stdio::Stderr,
+            STDIN_ID => StdioStream::Stdin,
+            STDOUT_ID => StdioStream::Stdout,
+            STDERR_ID => StdioStream::Stderr,
             _ => return Err(AsyncHostError::Inval),
         };
         let handles = self.handles.borrow();
@@ -4374,7 +4374,7 @@ mod tests {
             Arc::clone(&working_directory),
         ));
         let network = HostNetwork::new(policy.take_network_policy());
-        let stdio = Arc::new(StdioBindings::Ambient);
+        let stdio = Arc::new(Stdio::Ambient);
         let process = HostProcess::new(
             policy.take_process_policy(),
             policy.take_policy_inheritance(),

--- a/crates/moonrun/src/process/ambient.rs
+++ b/crates/moonrun/src/process/ambient.rs
@@ -476,10 +476,7 @@ fn spawn_process_windows(
     result: &mut Option<ResourcePublication>,
 ) -> AsyncHostResult<i64> {
     use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
-    use windows_sys::Win32::System::Console::{
-        GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
-    };
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
     use windows_sys::Win32::System::Threading::{
         CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT,
         CreateProcessW, DeleteProcThreadAttributeList, EXTENDED_STARTUPINFO_PRESENT,
@@ -509,21 +506,14 @@ fn spawn_process_windows(
         global_job_object()?
     };
 
-    let std_handles = [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE];
     let mut inherited_handles =
-        Vec::with_capacity(std_handles.len() + usize::from(policy_transfer.is_some()));
-    for (resource, std_handle) in stdio.iter().zip(std_handles) {
-        let raw_result = if let Some(resource) = resource {
-            spawn_stdio_handle(resource)
-        } else {
-            let raw = unsafe { GetStdHandle(std_handle) };
-            if raw.is_null() || raw == INVALID_HANDLE_VALUE {
-                Err(last_native_error())
-            } else {
-                Ok(raw)
-            }
-        };
-        let raw = match raw_result {
+        Vec::with_capacity(stdio.len() + usize::from(policy_transfer.is_some()));
+    for resource in &stdio {
+        let raw = match resource
+            .as_deref()
+            .ok_or(AsyncHostError::Badf)
+            .and_then(spawn_stdio_handle)
+        {
             Ok(raw) => raw,
             Err(error) => {
                 close_handles(&inherited_handles);

--- a/crates/moonrun/src/process/job/mod.rs
+++ b/crates/moonrun/src/process/job/mod.rs
@@ -21,11 +21,14 @@
 #[cfg(windows)]
 use std::ffi::OsStr;
 use std::ffi::OsString;
+#[cfg(windows)]
 use std::sync::Arc;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::resource::{ResourcePublication, ResourceRef};
-use crate::runtime::{ChildStdio, Stdio, StdioBindings, WorkingDirectory};
+#[cfg(windows)]
+use crate::runtime::StdioStream;
+use crate::runtime::{Stdio, WorkingDirectory};
 
 use super::{HostProcess, ambient};
 
@@ -56,7 +59,6 @@ enum Kind {
         env: Vec<OsString>,
         options: SpawnOptions,
         stdio: [Option<ResourceRef>; 3],
-        runtime_stdio: Option<Arc<StdioBindings>>,
         cwd: Option<OsString>,
         policy_inheritance: Option<crate::policy::PolicyInheritance>,
         result: Option<ResourcePublication>,
@@ -67,7 +69,6 @@ enum Kind {
         env: Vec<u16>,
         options: SpawnOptions,
         stdio: [Option<ResourceRef>; 3],
-        runtime_stdio: Option<Arc<StdioBindings>>,
         cwd: Option<OsString>,
         policy_inheritance: Option<crate::policy::PolicyInheritance>,
         result: Option<ResourcePublication>,
@@ -104,7 +105,6 @@ impl Job {
                 env,
                 options,
                 stdio: [stdin, stdout, stderr],
-                runtime_stdio: None,
                 cwd,
                 policy_inheritance: None,
                 result: None,
@@ -129,7 +129,6 @@ impl Job {
                 env,
                 options,
                 stdio: [stdin, stdout, stderr],
-                runtime_stdio: None,
                 cwd,
                 policy_inheritance: None,
                 result: None,
@@ -252,57 +251,45 @@ impl Job {
                 env,
                 options,
                 stdio,
-                runtime_stdio,
                 cwd,
                 policy_inheritance,
                 result,
-            } => {
-                if let Some(runtime_stdio) = runtime_stdio.take() {
-                    apply_runtime_stdio(&runtime_stdio, stdio)?;
-                }
-                ambient::run_spawn_job_unix(
-                    std::mem::take(path),
-                    std::mem::take(args),
-                    std::mem::take(env),
-                    std::mem::take(stdio),
-                    cwd.take(),
-                    *options,
-                    if invokes_moonx {
-                        policy_inheritance.take()
-                    } else {
-                        None
-                    },
-                    result,
-                )
-            }
+            } => ambient::run_spawn_job_unix(
+                std::mem::take(path),
+                std::mem::take(args),
+                std::mem::take(env),
+                std::mem::take(stdio),
+                cwd.take(),
+                *options,
+                if invokes_moonx {
+                    policy_inheritance.take()
+                } else {
+                    None
+                },
+                result,
+            ),
             #[cfg(windows)]
             Kind::SpawnWindows {
                 command_line,
                 env,
                 options,
                 stdio,
-                runtime_stdio,
                 cwd,
                 policy_inheritance,
                 result,
-            } => {
-                if let Some(runtime_stdio) = runtime_stdio.take() {
-                    apply_runtime_stdio(&runtime_stdio, stdio)?;
-                }
-                ambient::run_spawn_job_windows(
-                    std::mem::take(command_line),
-                    std::mem::take(env),
-                    std::mem::take(stdio),
-                    cwd.take(),
-                    *options,
-                    if invokes_moonx {
-                        policy_inheritance.take()
-                    } else {
-                        None
-                    },
-                    result,
-                )
-            }
+            } => ambient::run_spawn_job_windows(
+                std::mem::take(command_line),
+                std::mem::take(env),
+                std::mem::take(stdio),
+                cwd.take(),
+                *options,
+                if invokes_moonx {
+                    policy_inheritance.take()
+                } else {
+                    None
+                },
+                result,
+            ),
             Kind::WaitForProcess {
                 handle,
                 tracked_pid: _,
@@ -332,13 +319,31 @@ impl Job {
         }
     }
 
-    pub(super) fn set_stdio_bindings(&mut self, stdio: Arc<StdioBindings>) {
+    pub(super) fn configure_stdio(&mut self, runtime_stdio: &Stdio) -> AsyncHostResult<()> {
         match &mut self.kind {
             #[cfg(unix)]
-            Kind::SpawnUnix { runtime_stdio, .. } => *runtime_stdio = Some(stdio),
+            Kind::SpawnUnix { .. } => {
+                // An absent Unix file action preserves native descriptor
+                // inheritance, which is exactly the Ambient Runtime setting.
+                match runtime_stdio {
+                    Stdio::Ambient => Ok(()),
+                }
+            }
             #[cfg(windows)]
-            Kind::SpawnWindows { runtime_stdio, .. } => *runtime_stdio = Some(stdio),
-            Kind::WaitForProcess { .. } => {}
+            Kind::SpawnWindows { stdio, .. } => {
+                for (slot, stream) in stdio.iter_mut().zip(StdioStream::ALL) {
+                    if slot.is_none() {
+                        let raw = runtime_stdio.raw(stream).map_err(|error| {
+                            error
+                                .raw_os_error()
+                                .map_or(AsyncHostError::Io, AsyncHostError::Native)
+                        })?;
+                        *slot = Some(Arc::new(crate::resource::Resource::stdio_file(raw)));
+                    }
+                }
+                Ok(())
+            }
+            Kind::WaitForProcess { .. } => Ok(()),
         }
     }
 
@@ -447,30 +452,6 @@ impl Job {
     }
 }
 
-fn apply_runtime_stdio(
-    runtime_stdio: &StdioBindings,
-    slots: &mut [Option<ResourceRef>; 3],
-) -> AsyncHostResult<()> {
-    for (slot, stream) in slots.iter_mut().zip(Stdio::ALL) {
-        if slot.is_none() {
-            let child = runtime_stdio.child(stream).map_err(|error| {
-                error
-                    .raw_os_error()
-                    .map_or(AsyncHostError::Io, AsyncHostError::Native)
-            })?;
-            match child {
-                #[cfg(unix)]
-                ChildStdio::Inherit => {}
-                #[cfg(windows)]
-                ChildStdio::Handle(raw) => {
-                    *slot = Some(Arc::new(crate::resource::Resource::stdio_file(raw)));
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 fn ported_symbols() -> Vec<crate::async_sys::PortedSymbol> {
     ambient::PORTED_SYMBOLS.to_vec()
@@ -513,6 +494,47 @@ mod tests {
         let job = spawn_job("moon", vec!["KEEP=value".into()]);
 
         assert!(!job.invokes_moonx());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ambient_stdio_preserves_native_inheritance() {
+        let mut job = spawn_job("moon", Vec::new());
+
+        job.configure_stdio(&Stdio::Ambient).unwrap();
+
+        let Kind::SpawnUnix { stdio, .. } = &job.kind else {
+            unreachable!();
+        };
+        assert!(stdio.iter().all(Option::is_none));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn ambient_stdio_fills_missing_handles_without_replacing_guest_streams() {
+        let explicit_stdin = Arc::new(crate::resource::Resource::stdio_file(
+            Stdio::Ambient.raw(StdioStream::Stdin).unwrap(),
+        ));
+        let mut job = Job::spawn_windows(
+            OsString::from("cmd.exe /D /C exit 0"),
+            vec![0, 0],
+            Some(Arc::clone(&explicit_stdin)),
+            None,
+            None,
+            None,
+            SpawnOptions {
+                no_console_window: false,
+                is_orphan: false,
+            },
+        );
+
+        job.configure_stdio(&Stdio::Ambient).unwrap();
+
+        let Kind::SpawnWindows { stdio, .. } = &job.kind else {
+            unreachable!();
+        };
+        assert!(Arc::ptr_eq(stdio[0].as_ref().unwrap(), &explicit_stdin));
+        assert!(stdio[1..].iter().all(Option::is_some));
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/process/job/mod.rs
+++ b/crates/moonrun/src/process/job/mod.rs
@@ -21,12 +21,11 @@
 #[cfg(windows)]
 use std::ffi::OsStr;
 use std::ffi::OsString;
-#[cfg(windows)]
 use std::sync::Arc;
 
 use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::resource::{ResourcePublication, ResourceRef};
-use crate::runtime::WorkingDirectory;
+use crate::runtime::{ChildStdio, Stdio, StdioBindings, WorkingDirectory};
 
 use super::{HostProcess, ambient};
 
@@ -57,6 +56,7 @@ enum Kind {
         env: Vec<OsString>,
         options: SpawnOptions,
         stdio: [Option<ResourceRef>; 3],
+        runtime_stdio: Option<Arc<StdioBindings>>,
         cwd: Option<OsString>,
         policy_inheritance: Option<crate::policy::PolicyInheritance>,
         result: Option<ResourcePublication>,
@@ -67,6 +67,7 @@ enum Kind {
         env: Vec<u16>,
         options: SpawnOptions,
         stdio: [Option<ResourceRef>; 3],
+        runtime_stdio: Option<Arc<StdioBindings>>,
         cwd: Option<OsString>,
         policy_inheritance: Option<crate::policy::PolicyInheritance>,
         result: Option<ResourcePublication>,
@@ -103,6 +104,7 @@ impl Job {
                 env,
                 options,
                 stdio: [stdin, stdout, stderr],
+                runtime_stdio: None,
                 cwd,
                 policy_inheritance: None,
                 result: None,
@@ -127,6 +129,7 @@ impl Job {
                 env,
                 options,
                 stdio: [stdin, stdout, stderr],
+                runtime_stdio: None,
                 cwd,
                 policy_inheritance: None,
                 result: None,
@@ -249,45 +252,57 @@ impl Job {
                 env,
                 options,
                 stdio,
+                runtime_stdio,
                 cwd,
                 policy_inheritance,
                 result,
-            } => ambient::run_spawn_job_unix(
-                std::mem::take(path),
-                std::mem::take(args),
-                std::mem::take(env),
-                std::mem::take(stdio),
-                cwd.take(),
-                *options,
-                if invokes_moonx {
-                    policy_inheritance.take()
-                } else {
-                    None
-                },
-                result,
-            ),
+            } => {
+                if let Some(runtime_stdio) = runtime_stdio.take() {
+                    apply_runtime_stdio(&runtime_stdio, stdio)?;
+                }
+                ambient::run_spawn_job_unix(
+                    std::mem::take(path),
+                    std::mem::take(args),
+                    std::mem::take(env),
+                    std::mem::take(stdio),
+                    cwd.take(),
+                    *options,
+                    if invokes_moonx {
+                        policy_inheritance.take()
+                    } else {
+                        None
+                    },
+                    result,
+                )
+            }
             #[cfg(windows)]
             Kind::SpawnWindows {
                 command_line,
                 env,
                 options,
                 stdio,
+                runtime_stdio,
                 cwd,
                 policy_inheritance,
                 result,
-            } => ambient::run_spawn_job_windows(
-                std::mem::take(command_line),
-                std::mem::take(env),
-                std::mem::take(stdio),
-                cwd.take(),
-                *options,
-                if invokes_moonx {
-                    policy_inheritance.take()
-                } else {
-                    None
-                },
-                result,
-            ),
+            } => {
+                if let Some(runtime_stdio) = runtime_stdio.take() {
+                    apply_runtime_stdio(&runtime_stdio, stdio)?;
+                }
+                ambient::run_spawn_job_windows(
+                    std::mem::take(command_line),
+                    std::mem::take(env),
+                    std::mem::take(stdio),
+                    cwd.take(),
+                    *options,
+                    if invokes_moonx {
+                        policy_inheritance.take()
+                    } else {
+                        None
+                    },
+                    result,
+                )
+            }
             Kind::WaitForProcess {
                 handle,
                 tracked_pid: _,
@@ -313,6 +328,16 @@ impl Job {
             Kind::SpawnUnix { cwd, .. } => working_directory.configure_child_cwd(cwd),
             #[cfg(windows)]
             Kind::SpawnWindows { cwd, .. } => working_directory.configure_child_cwd(cwd),
+            Kind::WaitForProcess { .. } => {}
+        }
+    }
+
+    pub(super) fn set_stdio_bindings(&mut self, stdio: Arc<StdioBindings>) {
+        match &mut self.kind {
+            #[cfg(unix)]
+            Kind::SpawnUnix { runtime_stdio, .. } => *runtime_stdio = Some(stdio),
+            #[cfg(windows)]
+            Kind::SpawnWindows { runtime_stdio, .. } => *runtime_stdio = Some(stdio),
             Kind::WaitForProcess { .. } => {}
         }
     }
@@ -420,6 +445,30 @@ impl Job {
             process.revoke_child_if_unreferenced(ret as i32);
         }
     }
+}
+
+fn apply_runtime_stdio(
+    runtime_stdio: &StdioBindings,
+    slots: &mut [Option<ResourceRef>; 3],
+) -> AsyncHostResult<()> {
+    for (slot, stream) in slots.iter_mut().zip(Stdio::ALL) {
+        if slot.is_none() {
+            let child = runtime_stdio.child(stream).map_err(|error| {
+                error
+                    .raw_os_error()
+                    .map_or(AsyncHostError::Io, AsyncHostError::Native)
+            })?;
+            match child {
+                #[cfg(unix)]
+                ChildStdio::Inherit => {}
+                #[cfg(windows)]
+                ChildStdio::Handle(raw) => {
+                    *slot = Some(Arc::new(crate::resource::Resource::stdio_file(raw)));
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/moonrun/src/process/mod.rs
+++ b/crates/moonrun/src/process/mod.rs
@@ -35,7 +35,7 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::policy::{PolicyInheritance, ProcessPolicy};
 use crate::resource::ResourceRef;
-use crate::runtime::WorkingDirectory;
+use crate::runtime::{StdioBindings, WorkingDirectory};
 
 pub(crate) use job::{Job, SpawnOptions};
 
@@ -45,6 +45,7 @@ pub(crate) struct HostProcess {
     policy: Option<ProcessPolicy>,
     policy_inheritance: Option<PolicyInheritance>,
     working_directory: Arc<WorkingDirectory>,
+    stdio: Arc<StdioBindings>,
     child_authority: Option<Arc<ChildAuthorityState>>,
 }
 
@@ -65,6 +66,7 @@ impl HostProcess {
         policy: Option<ProcessPolicy>,
         policy_inheritance: Option<PolicyInheritance>,
         working_directory: Arc<WorkingDirectory>,
+        stdio: Arc<StdioBindings>,
     ) -> Self {
         // Enforced process policy needs child provenance to authorize later
         // PID and handle operations. Ambient execution preserves direct OS
@@ -76,6 +78,7 @@ impl HostProcess {
             policy,
             policy_inheritance,
             working_directory,
+            stdio,
             child_authority,
         }
     }
@@ -109,13 +112,16 @@ impl HostProcess {
     /// The Runtime Working Directory gets the final chance to adjust that
     /// value before worker execution. Ambient deliberately leaves it alone,
     /// including `None`, so the operating system observes its current
-    /// directory at spawn time.
+    /// directory at spawn time. Guest-supplied standard streams also remain
+    /// authoritative; the Runtime binding resolves only missing child streams
+    /// immediately before native execution.
     pub(crate) fn configure_job_for_execution(&self, job: &mut Job) -> AsyncHostResult<()> {
         job.configure_working_directory(&self.working_directory);
+        job.set_stdio_bindings(Arc::clone(&self.stdio));
         // Authorization is complete, so the job may retain the immutable
         // inheritance payload. Direct-moonx recognition, temporary-file I/O,
         // handle setup, and reserved env replacement stay in the spawn job;
-        // this path only clones Arc-backed bytes.
+        // this path only attaches Arc-backed Runtime State.
         job.set_policy_inheritance(self.policy_inheritance.clone());
         Ok(())
     }

--- a/crates/moonrun/src/process/mod.rs
+++ b/crates/moonrun/src/process/mod.rs
@@ -35,7 +35,7 @@ use crate::async_host::{AsyncHostError, AsyncHostResult};
 use crate::async_sys::internal::fd_util::stub::RawFd;
 use crate::policy::{PolicyInheritance, ProcessPolicy};
 use crate::resource::ResourceRef;
-use crate::runtime::{StdioBindings, WorkingDirectory};
+use crate::runtime::{Stdio, WorkingDirectory};
 
 pub(crate) use job::{Job, SpawnOptions};
 
@@ -45,7 +45,7 @@ pub(crate) struct HostProcess {
     policy: Option<ProcessPolicy>,
     policy_inheritance: Option<PolicyInheritance>,
     working_directory: Arc<WorkingDirectory>,
-    stdio: Arc<StdioBindings>,
+    stdio: Arc<Stdio>,
     child_authority: Option<Arc<ChildAuthorityState>>,
 }
 
@@ -66,7 +66,7 @@ impl HostProcess {
         policy: Option<ProcessPolicy>,
         policy_inheritance: Option<PolicyInheritance>,
         working_directory: Arc<WorkingDirectory>,
-        stdio: Arc<StdioBindings>,
+        stdio: Arc<Stdio>,
     ) -> Self {
         // Enforced process policy needs child provenance to authorize later
         // PID and handle operations. Ambient execution preserves direct OS
@@ -117,11 +117,11 @@ impl HostProcess {
     /// immediately before native execution.
     pub(crate) fn configure_job_for_execution(&self, job: &mut Job) -> AsyncHostResult<()> {
         job.configure_working_directory(&self.working_directory);
-        job.set_stdio_bindings(Arc::clone(&self.stdio));
+        job.configure_stdio(&self.stdio)?;
         // Authorization is complete, so the job may retain the immutable
         // inheritance payload. Direct-moonx recognition, temporary-file I/O,
-        // handle setup, and reserved env replacement stay in the spawn job;
-        // this path only attaches Arc-backed Runtime State.
+        // handle duplication, and reserved env replacement stay in the spawn
+        // job.
         job.set_policy_inheritance(self.policy_inheritance.clone());
         Ok(())
     }

--- a/crates/moonrun/src/runtime/mod.rs
+++ b/crates/moonrun/src/runtime/mod.rs
@@ -39,7 +39,7 @@ use crate::process::HostProcess;
 use crate::sqlite::SqliteHost;
 
 pub(crate) use environment::Env;
-pub(crate) use stdio::{ChildStdio, Stdio, StdioBindings};
+pub(crate) use stdio::{Stdio, StdioStream};
 pub use working_directory::WorkingDirectory;
 
 new_key_type! {
@@ -109,7 +109,7 @@ impl HostKeys {
 pub(crate) struct Runtime {
     environment: Arc<Env>,
     working_directory: Arc<WorkingDirectory>,
-    stdio: Arc<StdioBindings>,
+    stdio: Arc<Stdio>,
     filesystem: Arc<HostFs>,
     async_host: AsyncHost,
     sqlite: SqliteHost,
@@ -140,7 +140,7 @@ impl Runtime {
         let process_policy = policy.take_process_policy();
         let policy_inheritance = policy.take_policy_inheritance();
         let working_directory = Arc::new(working_directory);
-        let stdio = Arc::new(StdioBindings::Ambient);
+        let stdio = Arc::new(Stdio::Ambient);
         let keys = Rc::new(RefCell::new(HostKeys::default()));
         let filesystem = Arc::new(HostFs::new(
             filesystem_policy,
@@ -185,7 +185,7 @@ impl Runtime {
         &self.working_directory
     }
 
-    pub(crate) fn stdio(&self) -> &Arc<StdioBindings> {
+    pub(crate) fn stdio(&self) -> &Arc<Stdio> {
         &self.stdio
     }
 

--- a/crates/moonrun/src/runtime/mod.rs
+++ b/crates/moonrun/src/runtime/mod.rs
@@ -19,6 +19,7 @@
 //! Process-facing state selected for one Moonrun Runtime.
 
 mod environment;
+mod stdio;
 mod working_directory;
 
 use std::cell::RefCell;
@@ -38,6 +39,7 @@ use crate::process::HostProcess;
 use crate::sqlite::SqliteHost;
 
 pub(crate) use environment::Env;
+pub(crate) use stdio::{ChildStdio, Stdio, StdioBindings};
 pub use working_directory::WorkingDirectory;
 
 new_key_type! {
@@ -107,6 +109,7 @@ impl HostKeys {
 pub(crate) struct Runtime {
     environment: Arc<Env>,
     working_directory: Arc<WorkingDirectory>,
+    stdio: Arc<StdioBindings>,
     filesystem: Arc<HostFs>,
     async_host: AsyncHost,
     sqlite: SqliteHost,
@@ -137,6 +140,7 @@ impl Runtime {
         let process_policy = policy.take_process_policy();
         let policy_inheritance = policy.take_policy_inheritance();
         let working_directory = Arc::new(working_directory);
+        let stdio = Arc::new(StdioBindings::Ambient);
         let keys = Rc::new(RefCell::new(HostKeys::default()));
         let filesystem = Arc::new(HostFs::new(
             filesystem_policy,
@@ -148,9 +152,11 @@ impl Runtime {
             process_policy,
             policy_inheritance,
             Arc::clone(&working_directory),
+            Arc::clone(&stdio),
         );
         let async_host = AsyncHost::new(
             Arc::clone(&environment),
+            &stdio,
             Arc::clone(&filesystem),
             network,
             process,
@@ -160,6 +166,7 @@ impl Runtime {
         Ok(Self {
             environment,
             working_directory,
+            stdio,
             filesystem,
             async_host,
             sqlite,
@@ -176,6 +183,10 @@ impl Runtime {
 
     pub(crate) fn working_directory(&self) -> &WorkingDirectory {
         &self.working_directory
+    }
+
+    pub(crate) fn stdio(&self) -> &Arc<StdioBindings> {
+        &self.stdio
     }
 
     pub(crate) fn async_host(&self) -> &AsyncHost {

--- a/crates/moonrun/src/runtime/stdio.rs
+++ b/crates/moonrun/src/runtime/stdio.rs
@@ -19,7 +19,6 @@
 //! Standard-stream behavior selected for one Moonrun Runtime.
 
 use std::io::{self, Read, Write};
-use std::time::Duration;
 
 #[cfg(unix)]
 pub(crate) type RawStdio = std::os::fd::RawFd;
@@ -28,22 +27,14 @@ pub(crate) type RawStdio = std::os::windows::io::RawHandle;
 
 #[repr(usize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum Stdio {
+pub(crate) enum StdioStream {
     Stdin,
     Stdout,
     Stderr,
 }
 
-impl Stdio {
+impl StdioStream {
     pub(crate) const ALL: [Self; 3] = [Self::Stdin, Self::Stdout, Self::Stderr];
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum ChildStdio {
-    #[cfg(unix)]
-    Inherit,
-    #[cfg(windows)]
-    Handle(RawStdio),
 }
 
 /// Runtime-owned selection of the guest-visible standard streams.
@@ -52,14 +43,12 @@ pub(crate) enum ChildStdio {
 /// points as the historical callers: the Handle namespace snapshots them at
 /// construction, child defaults are resolved at spawn, and synchronous I/O
 /// observes them for each operation.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[non_exhaustive]
-pub(crate) enum StdioBindings {
-    #[default]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Stdio {
     Ambient,
 }
 
-impl StdioBindings {
+impl Stdio {
     pub(crate) fn with_stdin<T, E>(
         &self,
         f: impl FnOnce(&mut dyn Read) -> Result<T, E>,
@@ -88,99 +77,33 @@ impl StdioBindings {
     }
 
     /// Observe one ambient raw handle without taking ownership of it.
-    pub(crate) fn raw(&self, stream: Stdio) -> io::Result<RawStdio> {
+    pub(crate) fn raw(&self, stream: StdioStream) -> io::Result<RawStdio> {
         match self {
-            #[cfg(unix)]
-            Self::Ambient => Ok(stream as RawStdio),
-            #[cfg(windows)]
-            Self::Ambient => ambient_windows_raw(stream),
+            Self::Ambient => ambient_raw(stream),
         }
     }
 
     pub(crate) fn raw_handles(&self) -> [Option<RawStdio>; 3] {
-        Stdio::ALL.map(|stream| self.raw(stream).ok())
-    }
-
-    pub(crate) fn child(&self, stream: Stdio) -> io::Result<ChildStdio> {
-        match self {
-            // Unix historically leaves an absent spawn entry untouched so
-            // posix_spawn inherits the child's descriptor 0, 1, or 2.
-            #[cfg(unix)]
-            Self::Ambient => {
-                let _ = stream;
-                Ok(ChildStdio::Inherit)
-            }
-            // Windows requires concrete STARTUPINFO handles and historically
-            // observes them immediately before each spawn.
-            #[cfg(windows)]
-            Self::Ambient => self.raw(stream).map(ChildStdio::Handle),
-        }
-    }
-
-    #[cfg(unix)]
-    pub(crate) fn poll_stdin(&self, timeout: Option<Duration>) -> io::Result<bool> {
-        let timeout_ms = match timeout {
-            Some(duration) => i32::try_from(duration.as_millis().min(i32::MAX as u128))
-                .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?,
-            None => -1,
-        };
-        let mut pollfd = libc::pollfd {
-            fd: self.raw(Stdio::Stdin)?,
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        loop {
-            // SAFETY: `pollfd` is a valid single-element array for this call.
-            let ready_count = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
-            if ready_count >= 0 {
-                return Ok(ready_count > 0
-                    && (pollfd.revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR)) != 0);
-            }
-            let error = io::Error::last_os_error();
-            if error.kind() == io::ErrorKind::Interrupted {
-                continue;
-            }
-            // Sandbox profiles can reject poll while reads remain available.
-            if error.raw_os_error() == Some(libc::EPERM) {
-                return Ok(true);
-            }
-            return Err(error);
-        }
-    }
-
-    #[cfg(windows)]
-    pub(crate) fn poll_stdin(&self, timeout: Option<Duration>) -> io::Result<bool> {
-        use windows_sys::Win32::Foundation::{WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
-        use windows_sys::Win32::System::Threading::{INFINITE, WaitForSingleObject};
-
-        let timeout_ms = match timeout {
-            Some(duration) => u32::try_from(duration.as_millis().min(u32::MAX as u128))
-                .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?,
-            None => INFINITE,
-        };
-        let handle = self.raw(Stdio::Stdin)?;
-        // SAFETY: the Ambient binding just obtained this non-owning process
-        // handle from GetStdHandle and does not close it.
-        match unsafe { WaitForSingleObject(handle, timeout_ms) } {
-            WAIT_OBJECT_0 => Ok(true),
-            WAIT_TIMEOUT => Ok(false),
-            WAIT_FAILED => Err(io::Error::last_os_error()),
-            _ => Ok(true),
-        }
+        StdioStream::ALL.map(|stream| self.raw(stream).ok())
     }
 }
 
+#[cfg(unix)]
+fn ambient_raw(stream: StdioStream) -> io::Result<RawStdio> {
+    Ok(stream as RawStdio)
+}
+
 #[cfg(windows)]
-fn ambient_windows_raw(stream: Stdio) -> io::Result<RawStdio> {
+fn ambient_raw(stream: StdioStream) -> io::Result<RawStdio> {
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     use windows_sys::Win32::System::Console::{
         GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
     };
 
     let id = match stream {
-        Stdio::Stdin => STD_INPUT_HANDLE,
-        Stdio::Stdout => STD_OUTPUT_HANDLE,
-        Stdio::Stderr => STD_ERROR_HANDLE,
+        StdioStream::Stdin => STD_INPUT_HANDLE,
+        StdioStream::Stdout => STD_OUTPUT_HANDLE,
+        StdioStream::Stderr => STD_ERROR_HANDLE,
     };
     // SAFETY: this only observes a process standard handle; ownership remains
     // with the process.
@@ -191,23 +114,14 @@ fn ambient_windows_raw(stream: Stdio) -> io::Result<RawStdio> {
     Ok(raw)
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 
     #[test]
-    fn runtime_stdio_defaults_to_ambient() {
-        assert_eq!(StdioBindings::default(), StdioBindings::Ambient);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn ambient_child_stdio_preserves_native_inheritance() {
-        for stream in Stdio::ALL {
-            assert_eq!(
-                StdioBindings::Ambient.child(stream).unwrap(),
-                ChildStdio::Inherit
-            );
+    fn ambient_raw_handles_are_native_stdio_descriptors() {
+        for (stream, expected) in StdioStream::ALL.into_iter().zip([0, 1, 2]) {
+            assert_eq!(Stdio::Ambient.raw(stream).unwrap(), expected);
         }
     }
 }

--- a/crates/moonrun/src/runtime/stdio.rs
+++ b/crates/moonrun/src/runtime/stdio.rs
@@ -1,0 +1,213 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Standard-stream behavior selected for one Moonrun Runtime.
+
+use std::io::{self, Read, Write};
+use std::time::Duration;
+
+#[cfg(unix)]
+pub(crate) type RawStdio = std::os::fd::RawFd;
+#[cfg(windows)]
+pub(crate) type RawStdio = std::os::windows::io::RawHandle;
+
+#[repr(usize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Stdio {
+    Stdin,
+    Stdout,
+    Stderr,
+}
+
+impl Stdio {
+    pub(crate) const ALL: [Self; 3] = [Self::Stdin, Self::Stdout, Self::Stderr];
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ChildStdio {
+    #[cfg(unix)]
+    Inherit,
+    #[cfg(windows)]
+    Handle(RawStdio),
+}
+
+/// Runtime-owned selection of the guest-visible standard streams.
+///
+/// Ambient deliberately observes the process standard streams at the same
+/// points as the historical callers: the Handle namespace snapshots them at
+/// construction, child defaults are resolved at spawn, and synchronous I/O
+/// observes them for each operation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum StdioBindings {
+    #[default]
+    Ambient,
+}
+
+impl StdioBindings {
+    pub(crate) fn with_stdin<T, E>(
+        &self,
+        f: impl FnOnce(&mut dyn Read) -> Result<T, E>,
+    ) -> Result<T, E> {
+        match self {
+            Self::Ambient => f(&mut io::stdin().lock()),
+        }
+    }
+
+    pub(crate) fn with_stdout<T, E>(
+        &self,
+        f: impl FnOnce(&mut dyn Write) -> Result<T, E>,
+    ) -> Result<T, E> {
+        match self {
+            Self::Ambient => f(&mut io::stdout().lock()),
+        }
+    }
+
+    pub(crate) fn with_stderr<T, E>(
+        &self,
+        f: impl FnOnce(&mut dyn Write) -> Result<T, E>,
+    ) -> Result<T, E> {
+        match self {
+            Self::Ambient => f(&mut io::stderr().lock()),
+        }
+    }
+
+    /// Observe one ambient raw handle without taking ownership of it.
+    pub(crate) fn raw(&self, stream: Stdio) -> io::Result<RawStdio> {
+        match self {
+            #[cfg(unix)]
+            Self::Ambient => Ok(stream as RawStdio),
+            #[cfg(windows)]
+            Self::Ambient => ambient_windows_raw(stream),
+        }
+    }
+
+    pub(crate) fn raw_handles(&self) -> [Option<RawStdio>; 3] {
+        Stdio::ALL.map(|stream| self.raw(stream).ok())
+    }
+
+    pub(crate) fn child(&self, stream: Stdio) -> io::Result<ChildStdio> {
+        match self {
+            // Unix historically leaves an absent spawn entry untouched so
+            // posix_spawn inherits the child's descriptor 0, 1, or 2.
+            #[cfg(unix)]
+            Self::Ambient => {
+                let _ = stream;
+                Ok(ChildStdio::Inherit)
+            }
+            // Windows requires concrete STARTUPINFO handles and historically
+            // observes them immediately before each spawn.
+            #[cfg(windows)]
+            Self::Ambient => self.raw(stream).map(ChildStdio::Handle),
+        }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn poll_stdin(&self, timeout: Option<Duration>) -> io::Result<bool> {
+        let timeout_ms = match timeout {
+            Some(duration) => i32::try_from(duration.as_millis().min(i32::MAX as u128))
+                .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?,
+            None => -1,
+        };
+        let mut pollfd = libc::pollfd {
+            fd: self.raw(Stdio::Stdin)?,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        loop {
+            // SAFETY: `pollfd` is a valid single-element array for this call.
+            let ready_count = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+            if ready_count >= 0 {
+                return Ok(ready_count > 0
+                    && (pollfd.revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR)) != 0);
+            }
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            // Sandbox profiles can reject poll while reads remain available.
+            if error.raw_os_error() == Some(libc::EPERM) {
+                return Ok(true);
+            }
+            return Err(error);
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn poll_stdin(&self, timeout: Option<Duration>) -> io::Result<bool> {
+        use windows_sys::Win32::Foundation::{WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
+        use windows_sys::Win32::System::Threading::{INFINITE, WaitForSingleObject};
+
+        let timeout_ms = match timeout {
+            Some(duration) => u32::try_from(duration.as_millis().min(u32::MAX as u128))
+                .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?,
+            None => INFINITE,
+        };
+        let handle = self.raw(Stdio::Stdin)?;
+        // SAFETY: the Ambient binding just obtained this non-owning process
+        // handle from GetStdHandle and does not close it.
+        match unsafe { WaitForSingleObject(handle, timeout_ms) } {
+            WAIT_OBJECT_0 => Ok(true),
+            WAIT_TIMEOUT => Ok(false),
+            WAIT_FAILED => Err(io::Error::last_os_error()),
+            _ => Ok(true),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn ambient_windows_raw(stream: Stdio) -> io::Result<RawStdio> {
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::Console::{
+        GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+    };
+
+    let id = match stream {
+        Stdio::Stdin => STD_INPUT_HANDLE,
+        Stdio::Stdout => STD_OUTPUT_HANDLE,
+        Stdio::Stderr => STD_ERROR_HANDLE,
+    };
+    // SAFETY: this only observes a process standard handle; ownership remains
+    // with the process.
+    let raw = unsafe { GetStdHandle(id) };
+    if raw.is_null() || raw == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_stdio_defaults_to_ambient() {
+        assert_eq!(StdioBindings::default(), StdioBindings::Ambient);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ambient_child_stdio_preserves_native_inheritance() {
+        for stream in Stdio::ALL {
+            assert_eq!(
+                StdioBindings::Ambient.child(stream).unwrap(),
+                ChildStdio::Inherit
+            );
+        }
+    }
+}

--- a/crates/moonrun/src/v8/host_imports.rs
+++ b/crates/moonrun/src/v8/host_imports.rs
@@ -20,7 +20,7 @@
 
 use super::builder::{ArgsExt, ObjectExt, ScopeExt};
 use super::{context, wasi};
-use crate::runtime::StdioBindings;
+use crate::runtime::Stdio;
 use crate::{async_api, filesystem, run_termination, sqlite, util};
 use rand::Rng;
 use rand::SeedableRng;
@@ -33,7 +33,7 @@ use std::{cell::Cell, time::Instant};
 
 struct PrintEnv {
     dangling_high_half: Cell<Option<u32>>,
-    stdio: Arc<StdioBindings>,
+    stdio: Arc<Stdio>,
 }
 
 fn run_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s context::V8RunContext {
@@ -174,7 +174,7 @@ fn get_array_buffer_ptr(ab: v8::Local<v8::ArrayBuffer>) -> *mut u8 {
     unsafe { std::mem::transmute(ab.data()) }
 }
 
-fn read_utf8_char(stdio: &StdioBindings) -> io::Result<Option<char>> {
+fn read_utf8_char(stdio: &Stdio) -> io::Result<Option<char>> {
     let mut buffer = [0; 4];
     stdio.with_stdin(|stdin| {
         let size = stdin.read(&mut buffer[0..1])?;

--- a/crates/moonrun/src/v8/host_imports.rs
+++ b/crates/moonrun/src/v8/host_imports.rs
@@ -20,19 +20,26 @@
 
 use super::builder::{ArgsExt, ObjectExt, ScopeExt};
 use super::{context, wasi};
+use crate::runtime::StdioBindings;
 use crate::{async_api, filesystem, run_termination, sqlite, util};
 use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use std::any::Any;
-use std::io::{self, Write};
+use std::io;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::{cell::Cell, io::Read, time::Instant};
+use std::{cell::Cell, time::Instant};
 
-#[derive(Default)]
 struct PrintEnv {
     dangling_high_half: Cell<Option<u32>>,
+    stdio: Arc<StdioBindings>,
+}
+
+fn run_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s context::V8RunContext {
+    // SAFETY: install registers these callbacks with the retained
+    // V8RunContext pointer.
+    unsafe { context::callback_context(args) }
 }
 
 fn now(
@@ -109,7 +116,10 @@ fn print_char(
         let high = c - 0xd800;
         if print_env.dangling_high_half.get().is_some() {
             // Print previous char as invalid unicode
-            print!("{}", std::char::from_u32(0xfffd).unwrap());
+            print_env
+                .stdio
+                .with_stdout(|stdout| write!(stdout, "{}", std::char::from_u32(0xfffd).unwrap()))
+                .unwrap();
         }
         print_env.dangling_high_half.set(Some(high));
     } else {
@@ -126,7 +136,10 @@ fn print_char(
             }
         };
         let c = std::char::from_u32(c).unwrap();
-        print!("{c}");
+        print_env
+            .stdio
+            .with_stdout(|stdout| write!(stdout, "{c}"))
+            .unwrap();
     }
     ret.set_undefined()
 }
@@ -137,7 +150,11 @@ fn console_elog(
     mut _ret: v8::ReturnValue,
 ) {
     let arg = args.string_lossy(scope, 0);
-    eprintln!("{arg}");
+    run_context(&args)
+        .runtime()
+        .stdio()
+        .with_stderr(|stderr| writeln!(stderr, "{arg}"))
+        .unwrap();
 }
 
 fn console_log(
@@ -146,55 +163,58 @@ fn console_log(
     mut _ret: v8::ReturnValue,
 ) {
     let arg = args.string_lossy(scope, 0);
-    println!("{arg}");
+    run_context(&args)
+        .runtime()
+        .stdio()
+        .with_stdout(|stdout| writeln!(stdout, "{arg}"))
+        .unwrap();
 }
 
 fn get_array_buffer_ptr(ab: v8::Local<v8::ArrayBuffer>) -> *mut u8 {
     unsafe { std::mem::transmute(ab.data()) }
 }
 
-fn read_utf8_char() -> io::Result<Option<char>> {
+fn read_utf8_char(stdio: &StdioBindings) -> io::Result<Option<char>> {
     let mut buffer = [0; 4];
-    let stdin = io::stdin();
-    let mut handle = stdin.lock();
-
-    let size = handle.read(&mut buffer[0..1])?;
-    if size == 0 {
-        return Ok(None);
-    }
-
-    let num_bytes = match buffer[0] {
-        0..=0x7F => 1,
-        0xC0..=0xDF => 2,
-        0xE0..=0xEF => 3,
-        0xF0..=0xF7 => 4,
-        _ => {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "invalid UTF-8 first byte",
-            ));
+    stdio.with_stdin(|stdin| {
+        let size = stdin.read(&mut buffer[0..1])?;
+        if size == 0 {
+            return Ok(None);
         }
-    };
 
-    if num_bytes > 1 {
-        handle.read_exact(&mut buffer[1..num_bytes])?;
-    }
+        let num_bytes = match buffer[0] {
+            0..=0x7F => 1,
+            0xC0..=0xDF => 2,
+            0xE0..=0xEF => 3,
+            0xF0..=0xF7 => 4,
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid UTF-8 first byte",
+                ));
+            }
+        };
 
-    let char = std::str::from_utf8(&buffer[..num_bytes])
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
-        .chars()
-        .next()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no character found"))?;
+        if num_bytes > 1 {
+            stdin.read_exact(&mut buffer[1..num_bytes])?;
+        }
 
-    Ok(Some(char))
+        let char = std::str::from_utf8(&buffer[..num_bytes])
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+            .chars()
+            .next()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no character found"))?;
+
+        Ok(Some(char))
+    })
 }
 
 fn read_char(
     _scope: &mut v8::HandleScope,
-    _args: v8::FunctionCallbackArguments,
+    args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
-    let result = read_utf8_char();
+    let result = read_utf8_char(run_context(&args).runtime().stdio());
     match result {
         Ok(Some(c)) => {
             ret.set_int32(c as i32);
@@ -205,14 +225,15 @@ fn read_char(
 
 fn read_bytes_from_stdin(
     scope: &mut v8::HandleScope,
-    _args: v8::FunctionCallbackArguments,
+    args: v8::FunctionCallbackArguments,
     mut ret: v8::ReturnValue,
 ) {
     let mut buffer = Vec::new();
-    let stdin = io::stdin();
-    let mut handle = stdin.lock();
-
-    let size = handle.read_to_end(&mut buffer).unwrap();
+    let size = run_context(&args)
+        .runtime()
+        .stdio()
+        .with_stdin(|stdin| stdin.read_to_end(&mut buffer))
+        .unwrap();
 
     if size == 0 {
         let empty_array_buffer = v8::ArrayBuffer::new(scope, 0);
@@ -236,9 +257,10 @@ fn write_char(
     let fd = args.get(0).int32_value(scope).unwrap();
     let c = args.get(1).integer_value(scope).unwrap() as u32;
     let c = std::char::from_u32(c).unwrap();
+    let stdio = run_context(&args).runtime().stdio();
     match fd {
-        1 => print!("{c}"),
-        2 => eprint!("{c}"),
+        1 => stdio.with_stdout(|stdout| write!(stdout, "{c}")).unwrap(),
+        2 => stdio.with_stderr(|stderr| write!(stderr, "{c}")).unwrap(),
         _ => {}
     }
 }
@@ -249,9 +271,10 @@ fn flush(
     mut _ret: v8::ReturnValue,
 ) {
     let fd = args.get(0).int32_value(scope).unwrap();
+    let stdio = run_context(&args).runtime().stdio();
     match fd {
-        1 => std::io::stdout().flush().unwrap(),
-        2 => std::io::stderr().flush().unwrap(),
+        1 => stdio.with_stdout(|stdout| stdout.flush()).unwrap(),
+        2 => stdio.with_stderr(|stderr| stderr.flush()).unwrap(),
         _ => {}
     }
 }
@@ -347,7 +370,10 @@ pub(crate) fn install(
         )
     };
 
-    let print_env_box = Box::<PrintEnv>::default();
+    let print_env_box = Box::new(PrintEnv {
+        dangling_high_half: Cell::new(None),
+        stdio: Arc::clone(v8_context.runtime().stdio()),
+    });
     let identifier = scope.string("print");
     let print_env = &*print_env_box as *const PrintEnv;
     let print_env = v8::External::new(scope, print_env as *mut std::ffi::c_void);
@@ -359,8 +385,20 @@ pub(crate) fn install(
     dtors.push(print_env_box);
 
     {
-        global_proxy.set_func(scope, "console_log", console_log);
-        global_proxy.set_func(scope, "console_elog", console_elog);
+        context::register_func(
+            global_proxy,
+            scope,
+            "console_log",
+            console_log,
+            v8_context_ptr,
+        );
+        context::register_func(
+            global_proxy,
+            scope,
+            "console_elog",
+            console_elog,
+            v8_context_ptr,
+        );
     }
 
     {
@@ -418,10 +456,16 @@ pub(crate) fn install(
     }
     {
         let io = global_proxy.child(scope, "__moonbit_io_unstable");
-        io.set_func(scope, "read_bytes_from_stdin", read_bytes_from_stdin);
-        io.set_func(scope, "read_char", read_char);
-        io.set_func(scope, "write_char", write_char);
-        io.set_func(scope, "flush", flush);
+        context::register_func(
+            io,
+            scope,
+            "read_bytes_from_stdin",
+            read_bytes_from_stdin,
+            v8_context_ptr,
+        );
+        context::register_func(io, scope, "read_char", read_char, v8_context_ptr);
+        context::register_func(io, scope, "write_char", write_char, v8_context_ptr);
+        context::register_func(io, scope, "flush", flush, v8_context_ptr);
     }
 
     {

--- a/crates/moonrun/src/v8/wasi.rs
+++ b/crates/moonrun/src/v8/wasi.rs
@@ -19,7 +19,7 @@
 use super::builder::ScopeExt;
 use super::context::{self, V8ImportError, V8MemoryBinding, V8RunContext};
 use crate::run_termination::{RunTermination, TerminationRequest};
-use crate::runtime::Env;
+use crate::runtime::{Env, StdioBindings};
 use rand::{RngCore, rngs::OsRng};
 use std::any::Any;
 use std::collections::BTreeMap;
@@ -173,6 +173,7 @@ impl TryFrom<i32> for ClockId {
 struct WasiContext {
     argv: Vec<Vec<u8>>,
     environment: Arc<Env>,
+    stdio: Arc<StdioBindings>,
     preopen_dir_name: Vec<u8>,
     preopen_dir_host_path: PathBuf,
     preopen_dir_real_path: PathBuf,
@@ -1143,91 +1144,16 @@ fn normalize_poll_subscriptions(
     Ok(())
 }
 
-#[cfg(unix)]
-fn poll_stdin_with_timeout(timeout: Option<Duration>) -> WasiResult<bool> {
-    let timeout_ms = match timeout {
-        Some(duration) => {
-            let millis = duration.as_millis();
-            i32::try_from(millis.min(i32::MAX as u128)).map_err(|_| WASI_ERRNO_INVAL)?
-        }
-        None => -1,
-    };
-
-    let mut pollfd = libc::pollfd {
-        fd: libc::STDIN_FILENO,
-        events: libc::POLLIN,
-        revents: 0,
-    };
-    loop {
-        // SAFETY: `pollfd` points to a valid single-element array for the duration of the call.
-        let ready_count = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
-        if ready_count >= 0 {
-            return Ok(ready_count > 0
-                && (pollfd.revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR)) != 0);
-        }
-
-        let error = std::io::Error::last_os_error();
-        if error.kind() == ErrorKind::Interrupted {
-            continue;
-        }
-        if let Some(code) = error.raw_os_error()
-            && code == libc::EPERM
-        {
-            return Ok(true);
-        }
-        return Err(io_error_to_errno(&error));
-    }
-}
-
-#[cfg(windows)]
-fn poll_stdin_with_timeout(timeout: Option<Duration>) -> WasiResult<bool> {
-    use windows_sys::Win32::Foundation::{
-        INVALID_HANDLE_VALUE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
-    };
-    use windows_sys::Win32::System::Console::{GetStdHandle, STD_INPUT_HANDLE};
-    use windows_sys::Win32::System::Threading::{INFINITE, WaitForSingleObject};
-
-    let timeout_ms = match timeout {
-        Some(duration) => {
-            let millis = duration.as_millis();
-            u32::try_from(millis.min(u32::MAX as u128)).map_err(|_| WASI_ERRNO_INVAL)?
-        }
-        None => INFINITE,
-    };
-
-    // SAFETY: We only query the process standard-input handle; no ownership is transferred.
-    let stdin_handle = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
-    if stdin_handle.is_null() || stdin_handle == INVALID_HANDLE_VALUE {
-        return Err(WASI_ERRNO_IO);
-    }
-
-    // SAFETY: `stdin_handle` is a handle value obtained from `GetStdHandle`.
-    let wait_result = unsafe { WaitForSingleObject(stdin_handle, timeout_ms) };
-    match wait_result {
-        WAIT_OBJECT_0 => Ok(true),
-        WAIT_TIMEOUT => Ok(false),
-        WAIT_FAILED => {
-            let error = std::io::Error::last_os_error();
-            Err(io_error_to_errno(&error))
-        }
-        _ => Ok(true),
-    }
-}
-
-#[cfg(not(any(unix, windows)))]
-fn poll_stdin_with_timeout(timeout: Option<Duration>) -> WasiResult<bool> {
-    if let Some(duration) = timeout
-        && duration > Duration::ZERO
-    {
-        thread::sleep(duration);
-    }
-    Ok(true)
+fn poll_stdin_with_timeout(stdio: &StdioBindings, timeout: Option<Duration>) -> WasiResult<bool> {
+    stdio
+        .poll_stdin(timeout)
+        .map_err(|error| io_error_to_errno(&error))
 }
 
 fn poll_fd_read_state(context: &WasiContext, fd: i32) -> WasiResult<FdReadPollState> {
     match fd {
         WASI_FD_STDIN => {
-            if poll_stdin_with_timeout(Some(Duration::ZERO))? {
+            if poll_stdin_with_timeout(&context.stdio, Some(Duration::ZERO))? {
                 Ok(FdReadPollState::Ready(1))
             } else {
                 Ok(FdReadPollState::Pending)
@@ -1394,7 +1320,7 @@ fn poll_oneoff_impl(
         while events.is_empty() {
             if pending_stdin_read {
                 let timeout = min_remaining_ns.map(Duration::from_nanos);
-                let _ = poll_stdin_with_timeout(timeout)?;
+                let _ = poll_stdin_with_timeout(&context.stdio, timeout)?;
             } else if let Some(wait_ns) = min_remaining_ns {
                 if wait_ns > 0 {
                     thread::sleep(Duration::from_nanos(wait_ns));
@@ -1653,24 +1579,28 @@ fn fd_write(
 
             match fd {
                 WASI_FD_STDOUT => {
-                    let mut stdout = std::io::stdout();
-                    for index in 0..iovs_len {
-                        let (buf_offset, len) = iovec(memory, iovs_ptr, index)?;
-                        let bytes = checked_mut_range(memory, buf_offset, len)?;
-                        stdout.write_all(bytes).map_err(|_| WASI_ERRNO_IO)?;
-                        total_written = total_written.checked_add(len).ok_or(WASI_ERRNO_FAULT)?;
-                    }
-                    stdout.flush().map_err(|_| WASI_ERRNO_IO)?;
+                    context.stdio.with_stdout(|stdout| -> WasiResult<()> {
+                        for index in 0..iovs_len {
+                            let (buf_offset, len) = iovec(memory, iovs_ptr, index)?;
+                            let bytes = checked_mut_range(memory, buf_offset, len)?;
+                            stdout.write_all(bytes).map_err(|_| WASI_ERRNO_IO)?;
+                            total_written =
+                                total_written.checked_add(len).ok_or(WASI_ERRNO_FAULT)?;
+                        }
+                        stdout.flush().map_err(|_| WASI_ERRNO_IO)
+                    })?;
                 }
                 WASI_FD_STDERR => {
-                    let mut stderr = std::io::stderr();
-                    for index in 0..iovs_len {
-                        let (buf_offset, len) = iovec(memory, iovs_ptr, index)?;
-                        let bytes = checked_mut_range(memory, buf_offset, len)?;
-                        stderr.write_all(bytes).map_err(|_| WASI_ERRNO_IO)?;
-                        total_written = total_written.checked_add(len).ok_or(WASI_ERRNO_FAULT)?;
-                    }
-                    stderr.flush().map_err(|_| WASI_ERRNO_IO)?;
+                    context.stdio.with_stderr(|stderr| -> WasiResult<()> {
+                        for index in 0..iovs_len {
+                            let (buf_offset, len) = iovec(memory, iovs_ptr, index)?;
+                            let bytes = checked_mut_range(memory, buf_offset, len)?;
+                            stderr.write_all(bytes).map_err(|_| WASI_ERRNO_IO)?;
+                            total_written =
+                                total_written.checked_add(len).ok_or(WASI_ERRNO_FAULT)?;
+                        }
+                        stderr.flush().map_err(|_| WASI_ERRNO_IO)
+                    })?;
                 }
                 _ => {
                     let descriptor = descriptor.as_ref().ok_or(WASI_ERRNO_BADF)?;
@@ -1719,20 +1649,23 @@ fn fd_read(
             let mut total_read: usize = 0;
             match fd {
                 WASI_FD_STDIN => {
-                    let mut stdin = std::io::stdin().lock();
-                    for index in 0..iovs_len {
-                        let (buf_offset, len) = iovec(memory, iovs_ptr, index)?;
-                        if len == 0 {
-                            continue;
-                        }
-                        let buffer = checked_mut_range(memory, buf_offset, len)?;
-                        let read_len = stdin.read(buffer).map_err(|_| WASI_ERRNO_IO)?;
-                        total_read = total_read.checked_add(read_len).ok_or(WASI_ERRNO_FAULT)?;
+                    context.stdio.with_stdin(|stdin| -> WasiResult<()> {
+                        for index in 0..iovs_len {
+                            let (buf_offset, len) = iovec(memory, iovs_ptr, index)?;
+                            if len == 0 {
+                                continue;
+                            }
+                            let buffer = checked_mut_range(memory, buf_offset, len)?;
+                            let read_len = stdin.read(buffer).map_err(|_| WASI_ERRNO_IO)?;
+                            total_read =
+                                total_read.checked_add(read_len).ok_or(WASI_ERRNO_FAULT)?;
 
-                        if read_len < len {
-                            break;
+                            if read_len < len {
+                                break;
+                            }
                         }
-                    }
+                        Ok(())
+                    })?;
                 }
                 _ => {
                     let descriptor = descriptor.as_ref().ok_or(WASI_ERRNO_BADF)?;
@@ -1811,6 +1744,7 @@ pub(crate) fn init_env<'s>(
     let context = Box::new(WasiContext {
         argv: build_argv(wasm_file_name, args),
         environment,
+        stdio: Arc::clone(run_context.runtime().stdio()),
         preopen_dir_name: preopen_name(),
         preopen_dir_host_path,
         preopen_dir_real_path,
@@ -1850,6 +1784,7 @@ mod tests {
         WasiContext {
             argv: Vec::new(),
             environment: Arc::new(Env::owned([]).unwrap()),
+            stdio: Arc::new(StdioBindings::Ambient),
             preopen_dir_name: preopen_name(),
             preopen_dir_host_path: root.to_path_buf(),
             preopen_dir_real_path: fs::canonicalize(root).expect("canonicalize preopen root"),

--- a/crates/moonrun/src/v8/wasi.rs
+++ b/crates/moonrun/src/v8/wasi.rs
@@ -19,7 +19,7 @@
 use super::builder::ScopeExt;
 use super::context::{self, V8ImportError, V8MemoryBinding, V8RunContext};
 use crate::run_termination::{RunTermination, TerminationRequest};
-use crate::runtime::{Env, StdioBindings};
+use crate::runtime::{Env, Stdio, StdioStream};
 use rand::{RngCore, rngs::OsRng};
 use std::any::Any;
 use std::collections::BTreeMap;
@@ -173,7 +173,7 @@ impl TryFrom<i32> for ClockId {
 struct WasiContext {
     argv: Vec<Vec<u8>>,
     environment: Arc<Env>,
-    stdio: Arc<StdioBindings>,
+    stdio: Arc<Stdio>,
     preopen_dir_name: Vec<u8>,
     preopen_dir_host_path: PathBuf,
     preopen_dir_real_path: PathBuf,
@@ -1144,10 +1144,75 @@ fn normalize_poll_subscriptions(
     Ok(())
 }
 
-fn poll_stdin_with_timeout(stdio: &StdioBindings, timeout: Option<Duration>) -> WasiResult<bool> {
-    stdio
-        .poll_stdin(timeout)
-        .map_err(|error| io_error_to_errno(&error))
+#[cfg(unix)]
+fn poll_stdin_with_timeout(stdio: &Stdio, timeout: Option<Duration>) -> WasiResult<bool> {
+    let timeout_ms = match timeout {
+        Some(duration) => {
+            let millis = duration.as_millis();
+            i32::try_from(millis.min(i32::MAX as u128)).map_err(|_| WASI_ERRNO_INVAL)?
+        }
+        None => -1,
+    };
+    let mut pollfd = libc::pollfd {
+        fd: stdio
+            .raw(StdioStream::Stdin)
+            .map_err(|error| io_error_to_errno(&error))?,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    loop {
+        // SAFETY: `pollfd` points to a valid single-element array for the
+        // duration of the call.
+        let ready_count = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+        if ready_count >= 0 {
+            return Ok(ready_count > 0
+                && (pollfd.revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR)) != 0);
+        }
+
+        let error = std::io::Error::last_os_error();
+        if error.kind() == ErrorKind::Interrupted {
+            continue;
+        }
+        if error.raw_os_error() == Some(libc::EPERM) {
+            return Ok(true);
+        }
+        return Err(io_error_to_errno(&error));
+    }
+}
+
+#[cfg(windows)]
+fn poll_stdin_with_timeout(stdio: &Stdio, timeout: Option<Duration>) -> WasiResult<bool> {
+    use windows_sys::Win32::Foundation::{WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
+    use windows_sys::Win32::System::Threading::{INFINITE, WaitForSingleObject};
+
+    let timeout_ms = match timeout {
+        Some(duration) => {
+            let millis = duration.as_millis();
+            u32::try_from(millis.min(u32::MAX as u128)).map_err(|_| WASI_ERRNO_INVAL)?
+        }
+        None => INFINITE,
+    };
+    let stdin_handle = stdio
+        .raw(StdioStream::Stdin)
+        .map_err(|error| io_error_to_errno(&error))?;
+    // SAFETY: `stdin_handle` is a non-owning handle observed from the Runtime
+    // Stdio immediately before this wait.
+    match unsafe { WaitForSingleObject(stdin_handle, timeout_ms) } {
+        WAIT_OBJECT_0 => Ok(true),
+        WAIT_TIMEOUT => Ok(false),
+        WAIT_FAILED => Err(io_error_to_errno(&std::io::Error::last_os_error())),
+        _ => Ok(true),
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn poll_stdin_with_timeout(_stdio: &Stdio, timeout: Option<Duration>) -> WasiResult<bool> {
+    if let Some(duration) = timeout
+        && duration > Duration::ZERO
+    {
+        thread::sleep(duration);
+    }
+    Ok(true)
 }
 
 fn poll_fd_read_state(context: &WasiContext, fd: i32) -> WasiResult<FdReadPollState> {
@@ -1784,7 +1849,7 @@ mod tests {
         WasiContext {
             argv: Vec::new(),
             environment: Arc::new(Env::owned([]).unwrap()),
-            stdio: Arc::new(StdioBindings::Ambient),
+            stdio: Arc::new(Stdio::Ambient),
             preopen_dir_name: preopen_name(),
             preopen_dir_host_path: root.to_path_buf(),
             preopen_dir_real_path: fs::canonicalize(root).expect("canonicalize preopen root"),


### PR DESCRIPTION
## Why

Standard streams were reconstructed independently by Async Host, Host Process, V8 I/O, and WASI. That contradicted Runtime’s role as the composition root and left process-global fallback behavior scattered across domains.

## Why this is correct

Runtime now owns one `Stdio::Ambient` value and distributes it to every consumer. Ambient preserves the existing observation points: Async Host snapshots reserved Resources during construction, child defaults resolve immediately before spawn, and synchronous V8/WASI I/O observes the process streams per operation. Guest-provided child stdio still takes precedence, and policy remains unrelated to stdio selection.

Runtime Stdio exposes runtime semantics and raw standard-handle observation only. Async Host and Host Process still own Resource and host-error materialization at their domain boundaries. Process Jobs retain only the three effective stream slots; they do not carry a second copy of Runtime State. WASI-specific polling and errno mapping remain in WASI.

## Scope

This is intentionally limited to ownership and routing. It adds no public stdio configuration, captured mode, policy rule, or forwarding Host Stdio service.