### PR TITLE
feat(doc): add target selection

### DIFF
--- a/crates/moon/src/cli/doc.rs
+++ b/crates/moon/src/cli/doc.rs
@@ -25,6 +25,7 @@ use moonutil::command_output::CommandOutput;
 use moonutil::constants::MOON_MOD_JSON;
 use moonutil::project::PackageDirs;
 use moonutil::resolution::ModuleId;
+use moonutil::target::TargetBackend;
 use moonutil::{build_options::RunMode, locks::lock_directory, user_log::UserLog};
 use tracing::instrument;
 
@@ -36,6 +37,10 @@ use crate::rr_build::{self, BuildConfig, preconfig_compile};
 /// Generate documentation or searching documentation for a symbol.
 #[derive(Debug, clap::Parser)]
 pub(crate) struct DocSubcommand {
+    /// Select output target
+    #[clap(long, value_parser = TargetBackend::str_to_backend)]
+    pub target: Option<TargetBackend>,
+
     /// Start a web server to serve the documentation
     #[clap(long)]
     pub serve: bool,
@@ -130,7 +135,7 @@ pub(crate) fn run_doc_rr(
         &cmd.auto_sync_flags,
         &cli,
         &BuildFlags::default(),
-        None,
+        cmd.target,
         target_dir,
         RunMode::Check,
     );

--- a/crates/moon/tests/test_cases/tool_commands.rs
+++ b/crates/moon/tests/test_cases/tool_commands.rs
@@ -32,6 +32,19 @@ fn test_moon_doc_dry_run() {
 }
 
 #[test]
+fn test_moon_doc_dry_run_with_target() {
+    let dir = TestDir::new("moon_doc.in");
+    check(
+        get_stdout(&dir, ["doc", "--target", "js", "--dry-run"]),
+        expect![[r#"
+            moonc check ./src/lib/hello.mbt -o ./_build/js/debug/check/lib/lib.mi -pkg username/hello/lib -pkg-type library -std-path '$MOON_HOME/lib/core/_build/js/release/bundle' -i '$MOON_HOME/lib/core/_build/js/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/hello/lib:./src/lib -target js -workspace-path . -all-pkgs ./_build/js/debug/check/all_pkgs.json
+            moonc check ./src/main/main.mbt -o ./_build/js/debug/check/main/main.mi -pkg username/hello/main -pkg-type executable -std-path '$MOON_HOME/lib/core/_build/js/release/bundle' -i ./_build/js/debug/check/lib/lib.mi:lib -i '$MOON_HOME/lib/core/_build/js/release/bundle/prelude/prelude.mi:prelude' -pkg-sources username/hello/main:./src/main -target js -workspace-path . -all-pkgs ./_build/js/debug/check/all_pkgs.json
+            moondoc . -o ./_build/doc -std-path '$MOON_HOME/lib/core' -packages-json ./_build/js/debug/check/packages.json
+        "#]],
+    );
+}
+
+#[test]
 fn test_moon_doc() {
     let dir = TestDir::new("moon_doc.in");
     std::fs::create_dir_all(dir.join("_build")).unwrap();

--- a/crates/moon/tests/test_cases/windows_long_paths/mod.rs
+++ b/crates/moon/tests/test_cases/windows_long_paths/mod.rs
@@ -55,8 +55,8 @@ impl LongPathCase {
             "the source file must remain below the legacy path limit"
         );
 
-        // `moon doc` has no `--target`, so pin the fixture while passing the
-        // target explicitly to commands that support it.
+        // Pin the fixture while also passing the target explicitly to commands
+        // that support it.
         write_file(
             &root.join("moon.mod"),
             "name = \"test/long-path\"\npreferred_target = \"wasm-gc\"\n",
@@ -256,7 +256,12 @@ fn bundle_reports_its_long_output_directory() {
 // reveals exactly which boundary becomes reachable.
 #[test]
 fn doc_reports_its_long_check_directory() {
-    LongPathCase::new().assert_compiler_path_failure(&["doc"], "wasm-gc", "debug", "check");
+    LongPathCase::new().assert_compiler_path_failure(
+        &["doc", "--target", "wasm-gc"],
+        "wasm-gc",
+        "debug",
+        "check",
+    );
 }
 
 #[test]

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -395,6 +395,7 @@ Generate documentation or searching documentation for a symbol
 
 ###### **Options:**
 
+* `--target <TARGET>` — Select output target
 * `--serve` — Start a web server to serve the documentation
 * `-b`, `--bind <BIND>` — The address of the server
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -395,6 +395,7 @@ Generate documentation or searching documentation for a symbol
 
 ###### **Options:**
 
+* `--target <TARGET>` — Select output target
 * `--serve` — Start a web server to serve the documentation
 * `-b`, `--bind <BIND>` — The address of the server
 


### PR DESCRIPTION
## Summary

- add `--target <TARGET>` to `moon doc`
- pass the selected backend into the existing documentation check pipeline
- preserve the existing target resolution when `--target` is omitted
- cover explicit target selection in the dry-run and Windows long-path tests
- update the generated English and Chinese command references

This PR intentionally adds only `--target`; it does not expose the other build flags used by commands such as `moon check`.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p moon --test mod test_moon_doc_dry_run_with_target -- --nocapture`
- `cargo clippy -p moon --all-targets -- -D warnings`

## Related issue

The existing documentation build plan checks a different package set from `moon check` before the final `moondoc` invocation. That behavior is separate from adding target selection and is tracked in #2118.

Related to #2118.
