### PR TITLE
test(moonrun): stabilize detached policy synchronization

### DIFF
--- a/crates/moonrun/tests/fixtures/detached_moonx_wrapper.rs
+++ b/crates/moonrun/tests/fixtures/detached_moonx_wrapper.rs
@@ -1,0 +1,50 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::process::Command;
+
+fn main() {
+    // Do not interpret the inherited-policy marker here. This intermediary
+    // deliberately treats it as an opaque piece of the process environment,
+    // so the black-box test remains valid for either an FD or HANDLE backend.
+    let server = std::env::var("MOON_TEST_DETACH_SERVER")
+        .expect("missing detached moonx synchronization server");
+    let real_moonx =
+        std::env::var_os("MOON_TEST_REAL_MOONX").expect("missing real moonx executable");
+    let mut server = TcpStream::connect(server).expect("connect to detached moonx test");
+    server.write_all(b"R").expect("announce detached moonx");
+
+    let mut release = [0];
+    server
+        .read_exact(&mut release)
+        .expect("wait for detached moonx release");
+    assert_eq!(release, [b'G'], "unexpected detached moonx release");
+
+    let status = Command::new(real_moonx)
+        .args(std::env::args_os().skip(1))
+        .status()
+        .expect("run real moonx");
+    server
+        .write_all(if status.success() { b"S" } else { b"F" })
+        .expect("report detached moonx result");
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -1064,7 +1064,6 @@ fn test_moon_run_policy_with_workspace_async_fs() {
     // test executable because a MoonBit test driver does nothing without
     // moonrun's --test-args selection.
     let env_marker_wasm = wasm_file("env_marker");
-    #[cfg(unix)]
     let detach_moonx_wasm = wasm_file("detach_moonx");
     let env_mutate_wasm = wasm_file("env_mutate");
     let listen_implicit_bind_wasm = wasm_file("listen_implicit_bind");
@@ -1250,34 +1249,43 @@ spawn = true
         .success()
         .stdout_eq("Total tests: 1, passed: 1, failed: 0.\n");
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     {
-        use std::os::unix::fs::PermissionsExt;
-
-        // The moonx-named wrapper stops itself before execing the real binary.
-        // Resuming it only after the parent moonrun exits makes the detached
-        // lifetime boundary deterministic. Exec preserves both environment and
-        // inherited OS handles, so this test also applies to a future FD transport.
+        // Each moonx-named wrapper announces itself over TCP and waits for the
+        // test to release it. The test does not send that release until the
+        // parent moonrun has exited, so the detached lifetime boundary is an
+        // event in the protocol rather than a filesystem timing assumption.
         let wrapper_dir =
             tempfile::TempDir::new().expect("create detached moonx wrapper directory");
-        let wrapper = wrapper_dir.path().join("moonx");
-        std::fs::write(
-            &wrapper,
-            r#"#!/bin/sh
-set -eu
-printf '%s' "$$" > "$MOON_TEST_DETACH_PID"
-kill -STOP "$$"
-exec "$MOON_TEST_REAL_MOONX" "$@"
-"#,
-        )
-        .unwrap();
-        std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let wrapper = wrapper_dir
+            .path()
+            .join(format!("moonx{}", std::env::consts::EXE_SUFFIX));
+        let wrapper_source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/detached_moonx_wrapper.rs");
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let status = std::process::Command::new(rustc)
+            .arg("--edition=2021")
+            .arg(wrapper_source)
+            .arg("-o")
+            .arg(&wrapper)
+            .status()
+            .expect("compile detached moonx wrapper");
+        assert!(status.success(), "failed to compile detached moonx wrapper");
+
+        let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .expect("bind detached moonx synchronization listener");
+        listener
+            .set_nonblocking(true)
+            .expect("make detached moonx listener nonblocking");
+        let server = listener
+            .local_addr()
+            .expect("read detached moonx listener address")
+            .to_string();
         let detached_path = std::env::join_paths(
             std::iter::once(wrapper_dir.path().to_path_buf()).chain(std::env::split_paths(&path)),
         )
         .expect("put detached moonx wrapper on PATH");
-        let marker = dir.path().join("detached-moonx-finished");
-        let pid_marker = dir.path().join("detached-moonx-pid");
+        let log = dir.path().join("detached-moonx");
 
         snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
             .current_dir(dir.path())
@@ -1286,8 +1294,8 @@ exec "$MOON_TEST_REAL_MOONX" "$@"
             .env("MOON_TOOLCHAIN_ROOT", moonutil::toolchain::toolchain_root())
             .env("MOONRUN_OVERRIDE", snapbox::cmd::cargo_bin!("moonrun"))
             .env("MOON_TEST_REAL_MOONX", &moonx)
-            .env("MOON_TEST_DETACH_MARKER", &marker)
-            .env("MOON_TEST_DETACH_PID", &pid_marker)
+            .env("MOON_TEST_DETACH_SERVER", server)
+            .env("MOON_TEST_DETACH_LOG", &log)
             .arg("--policy")
             .arg(&inherited_policy)
             .arg(&detach_moonx_wasm)
@@ -1296,56 +1304,69 @@ exec "$MOON_TEST_REAL_MOONX" "$@"
             .stdout_eq("")
             .stderr_eq("");
 
-        let pid_markers = [
-            pid_marker.with_file_name("detached-moonx-pid-0"),
-            pid_marker.with_file_name("detached-moonx-pid-1"),
-        ];
-        let markers = [
-            marker.with_file_name("detached-moonx-finished-0"),
-            marker.with_file_name("detached-moonx-finished-1"),
-        ];
-        let deadline = std::time::Instant::now() + Duration::from_secs(10);
-        while !pid_markers.iter().all(|path| path.exists()) {
-            if std::time::Instant::now() >= deadline {
-                for path in &pid_markers {
-                    if let Ok(pid) = std::fs::read_to_string(path)
-                        .and_then(|pid| pid.parse::<libc::pid_t>().map_err(std::io::Error::other))
-                    {
-                        unsafe {
-                            libc::kill(pid, libc::SIGKILL);
-                        }
+        let logs = || {
+            (0..2)
+                .map(|index| {
+                    let path = log.with_file_name(format!("detached-moonx-{index}.log"));
+                    let contents = std::fs::read_to_string(&path)
+                        .unwrap_or_else(|error| format!("<failed to read: {error}>"));
+                    format!("{}:\n{contents}", path.display())
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        // Time only bounds a broken test. Every successful transition below
+        // is driven by a byte received from the process on the other side.
+        let deadline = std::time::Instant::now() + Duration::from_secs(60);
+        let mut children = Vec::with_capacity(2);
+        while children.len() < 2 {
+            match listener.accept() {
+                Ok((stream, _)) => children.push(stream),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if std::time::Instant::now() >= deadline {
+                        panic!("detached moonx did not connect before timeout\n{}", logs());
                     }
+                    std::thread::sleep(Duration::from_millis(10));
                 }
-                panic!("detached moonx processes did not reach their synchronization point");
+                Err(error) => panic!("failed to accept detached moonx: {error}\n{}", logs()),
             }
-            std::thread::sleep(Duration::from_millis(50));
-        }
-        let pids = pid_markers.map(|path| {
-            std::fs::read_to_string(path)
-                .unwrap()
-                .parse::<libc::pid_t>()
-                .unwrap()
-        });
-        for pid in pids {
-            assert_eq!(unsafe { libc::kill(pid, libc::SIGCONT) }, 0);
         }
 
-        let completion_deadline = std::time::Instant::now() + Duration::from_secs(10);
-        while !markers.iter().all(|path| path.exists()) {
-            if std::time::Instant::now() >= completion_deadline {
-                for pid in pids {
-                    unsafe {
-                        libc::kill(pid, libc::SIGKILL);
-                    }
-                }
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(50));
+        for child in &mut children {
+            child
+                .set_nonblocking(false)
+                .expect("make detached moonx connection blocking");
+            child
+                .set_read_timeout(Some(Duration::from_secs(60)))
+                .expect("set detached moonx read timeout");
+            child
+                .set_write_timeout(Some(Duration::from_secs(60)))
+                .expect("set detached moonx write timeout");
+            let mut ready = [0];
+            std::io::Read::read_exact(child, &mut ready).unwrap_or_else(|error| {
+                panic!("detached moonx did not become ready: {error}\n{}", logs())
+            });
+            assert_eq!(ready, [b'R'], "unexpected detached moonx handshake");
         }
-        for marker in markers {
+
+        for child in &mut children {
+            std::io::Write::write_all(child, b"G").unwrap_or_else(|error| {
+                panic!("failed to release detached moonx: {error}\n{}", logs())
+            });
+        }
+        for child in &mut children {
+            let mut result = [0];
+            std::io::Read::read_exact(child, &mut result).unwrap_or_else(|error| {
+                panic!(
+                    "detached moonx did not report completion: {error}\n{}",
+                    logs()
+                )
+            });
             assert_eq!(
-                std::fs::read_to_string(marker).expect("detached moonx did not finish"),
-                "inherited policy active"
+                result,
+                [b'S'],
+                "detached moonx failed after its parent exited\n{}",
+                logs()
             );
         }
     }

--- a/crates/moonrun/tests/test_cases/test_policy_workspace.in/detach_moonx/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_policy_workspace.in/detach_moonx/main.mbt
@@ -18,21 +18,15 @@
 
 ///|
 async fn main {
-  let marker = match @env.get_env_var("MOON_TEST_DETACH_MARKER") {
-    Some(marker) => marker
-    None => abort("missing detach marker path")
-  }
-  let pid_marker = match @env.get_env_var("MOON_TEST_DETACH_PID") {
-    Some(marker) => marker
-    None => abort("missing detached pid path")
+  let log = match @env.get_env_var("MOON_TEST_DETACH_LOG") {
+    Some(log) => log
+    None => abort("missing detach log path")
   }
   for index = 0; index < 2; index = index + 1 {
-    let marker = marker + "-\{index}"
-    let output = @process.redirect_to_file(marker + ".log")
+    let output = @process.redirect_to_file(log + "-\{index}.log")
     let _ = @process.spawn_orphan(
       "moonx",
-      ["moonbitlang/parser/cmd/moonfmt@0.3.3", marker],
-      extra_env={ "MOON_TEST_DETACH_PID": pid_marker + "-\{index}" },
+      ["moonbitlang/parser/cmd/moonfmt@0.3.3"],
       stdout=output,
       stderr=output,
     )


### PR DESCRIPTION
## Why

The detached moonx policy test treated marker-file creation as process completion. An asynchronous writer can create the file before writing its contents, producing intermittent empty reads. The SIGSTOP-based wrapper also restricted the detached-lifetime coverage to Unix.

## What

- Replace PID and completion marker polling with a cross-platform moonx wrapper and TCP handshake.
- Require both detached wrappers to announce readiness, then release them only after the parent moonrun has exited.
- Run the real moonx and report its result over the same connection, so successful progress is event-driven; timeouts only guard against a broken test hanging CI.
- Run the same black-box path on Unix and Windows.

## Scope

This is a test-only change. It keeps the existing policy inheritance implementation and fixture coverage unchanged while making the detached-process assertion deterministic and cross-platform.