### PR TITLE
refactor(moonrun): separate environment provisioning from policy

### DIFF
--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -89,9 +89,10 @@ _Avoid_: Host Domain, Raw Operation, Runtime
 **Env**:
 The environment interface owned by one Runtime and shared by MoonBit
 environment imports, WASI environment calls, temporary-directory resolution,
-and child inheritance. Provisioning rules may determine its initial contents;
-after construction it is Runtime State. Ambient retains process-environment
-write-through for guest-reachable effects that do not yet cross Env.
+and child inheritance. Provisioning rules may determine its initial contents
+and are consumed during construction. The realized Env is then Runtime State.
+Ambient retains process-environment write-through for guest-reachable effects
+that do not yet cross Env.
 _Avoid_: Mutable policy, per-import environment map
 
 **Runtime Stdio**:

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -141,7 +141,7 @@ path syntax; Windows policies may use normal Windows paths such as `C:\work` or
 wildcard `"*"` allows every host path on every platform. List a root in both
 `read` and `write` to allow read-write filesystem access.
 
-The environment policy constructs the guest environment. Use `from_host` to copy
+The `env` section provisions the guest environment. Use `from_host` to copy
 selected host variables if present, `required_from_host` to require selected
 host variables, and `env.set` for literal values. `env.set` overrides values
 copied from the host. The realized environment is shared by MoonBit runtime

--- a/crates/moonrun/src/async_host/mod.rs
+++ b/crates/moonrun/src/async_host/mod.rs
@@ -4342,7 +4342,7 @@ mod tests {
 
     use super::*;
     use crate::filesystem::Job as FilesystemJob;
-    use crate::policy::Policy;
+    use crate::policy::{self, Policy};
     use crate::process::{Job as ProcessJob, SpawnOptions};
     use crate::runtime::WorkingDirectory;
 
@@ -4361,12 +4361,8 @@ mod tests {
         host.handles.borrow().resource_count_excluding_reserved()
     }
 
-    fn test_host(mut policy: Policy) -> AsyncHost {
-        let environment = Arc::new(
-            policy
-                .realize_env()
-                .expect("construct test Host environment"),
-        );
+    fn test_host(mut policy: Policy, environment: Env) -> AsyncHost {
+        let environment = Arc::new(environment);
         let working_directory = Arc::new(WorkingDirectory::Ambient);
         let filesystem = Arc::new(HostFs::new(
             policy.take_filesystem_policy(),
@@ -4392,11 +4388,12 @@ mod tests {
     }
 
     fn default_host() -> AsyncHost {
-        test_host(Policy::allow_all())
+        test_host(Policy::allow_all(), Env::ambient())
     }
 
     fn host_with_policy(path: &std::path::Path) -> AsyncHost {
-        test_host(Policy::from_file(path).unwrap())
+        let (policy, env) = policy::load_file(path).unwrap();
+        test_host(policy, env.realize().unwrap())
     }
 
     #[cfg(unix)]

--- a/crates/moonrun/src/filesystem/mod.rs
+++ b/crates/moonrun/src/filesystem/mod.rs
@@ -548,7 +548,7 @@ mod tests {
     use super::*;
     #[cfg(windows)]
     use crate::async_host::AsyncHostError;
-    use crate::policy::Policy;
+    use crate::policy::{self, Policy};
 
     fn host_fs(mut policy: Policy, environment: Arc<Env>) -> HostFs {
         HostFs::new(
@@ -655,10 +655,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\n").unwrap();
-        let host = host_fs(
-            Policy::from_file(&policy_file).unwrap(),
-            Arc::new(Env::ambient()),
-        );
+        let (policy, _) = policy::load_file(&policy_file).unwrap();
+        let host = host_fs(policy, Arc::new(Env::ambient()));
         let mut results = FsOperationResults::default();
 
         assert_eq!(host.read_file_to_bytes_new(&mut results, "denied.bin"), -1);
@@ -670,10 +668,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\n").unwrap();
-        let host = host_fs(
-            Policy::from_file(&policy_file).unwrap(),
-            Arc::new(Env::ambient()),
-        );
+        let (policy, _) = policy::load_file(&policy_file).unwrap();
+        let host = host_fs(policy, Arc::new(Env::ambient()));
         let mut results = FsOperationResults::default();
         let converted = Cell::new(false);
 
@@ -695,10 +691,8 @@ mod tests {
         std::fs::write(allowed.join("input.txt"), "input").unwrap();
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\nread = [\"allowed\"]\n").unwrap();
-        let host = host_fs(
-            Policy::from_file(&policy_file).unwrap(),
-            Arc::new(Env::ambient()),
-        );
+        let (policy, _) = policy::load_file(&policy_file).unwrap();
+        let host = host_fs(policy, Arc::new(Env::ambient()));
 
         host.authorize_metadata_at(Some(&allowed), OsStr::new("input.txt"))
             .unwrap();
@@ -739,10 +733,8 @@ mod tests {
             "[fs]\nread = [\"allowed\"]\nwrite = [\"allowed\"]\n",
         )
         .unwrap();
-        let host = host_fs(
-            Policy::from_file(&policy_file).unwrap(),
-            Arc::new(Env::ambient()),
-        );
+        let (policy, _) = policy::load_file(&policy_file).unwrap();
+        let host = host_fs(policy, Arc::new(Env::ambient()));
 
         std::fs::remove_file(&resource_path).unwrap();
         std::os::unix::fs::symlink(&denied_file, &resource_path).unwrap();
@@ -769,10 +761,8 @@ mod tests {
         std::os::unix::fs::symlink(&allowed_file, &denied_link).unwrap();
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\nwrite = [\"allowed\"]\n").unwrap();
-        let host = host_fs(
-            Policy::from_file(&policy_file).unwrap(),
-            Arc::new(Env::ambient()),
-        );
+        let (policy, _) = policy::load_file(&policy_file).unwrap();
+        let host = host_fs(policy, Arc::new(Env::ambient()));
 
         assert_eq!(
             host.authorize_remove(denied_link.as_os_str()),
@@ -794,10 +784,8 @@ mod tests {
         std::os::unix::fs::symlink(&denied_file, &allowed_link).unwrap();
         let policy_file = tmp.path().join("policy.toml");
         std::fs::write(&policy_file, "[fs]\nwrite = [\"allowed\"]\n").unwrap();
-        let host = host_fs(
-            Policy::from_file(&policy_file).unwrap(),
-            Arc::new(Env::ambient()),
-        );
+        let (policy, _) = policy::load_file(&policy_file).unwrap();
+        let host = host_fs(policy, Arc::new(Env::ambient()));
 
         host.authorize_remove(allowed_link.as_os_str()).unwrap();
         assert_eq!(

--- a/crates/moonrun/src/network/mod.rs
+++ b/crates/moonrun/src/network/mod.rs
@@ -301,7 +301,7 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
-    use crate::policy::Policy;
+    use crate::policy::{self, Policy};
 
     fn network(mut policy: Policy) -> HostNetwork {
         HostNetwork::new(policy.take_network_policy())
@@ -363,7 +363,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let policy_file = dir.path().join("deny-all.toml");
         std::fs::write(&policy_file, "").unwrap();
-        let network = network(Policy::from_file(&policy_file).unwrap());
+        let (policy, _) = policy::load_file(&policy_file).unwrap();
+        let network = network(policy);
         let socket = network.make_tcp_socket(4).unwrap();
 
         assert_eq!(
@@ -381,7 +382,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let policy_file = dir.path().join("deny-all.toml");
         std::fs::write(&policy_file, "").unwrap();
-        let network = network(Policy::from_file(&policy_file).unwrap());
+        let (policy, _) = policy::load_file(&policy_file).unwrap();
+        let network = network(policy);
         let mut addr = vec![0; usize::try_from(sys::ipv4_addr_size()).unwrap()];
         sys::init_ip_addr(&mut addr, 0x7f000001, 1234).unwrap();
 
@@ -404,7 +406,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let policy_file = dir.path().join("network.toml");
         std::fs::write(&policy_file, "[net]\nconnect = [\"api.example.com:443\"]\n").unwrap();
-        let mut policy = Policy::from_file(&policy_file).unwrap();
+        let (mut policy, _) = policy::load_file(&policy_file).unwrap();
         let policy = policy.take_network_policy().unwrap();
         let first = HostNetwork::new(Some(policy.clone()));
         let second = HostNetwork::new(Some(policy));

--- a/crates/moonrun/src/policy/mod.rs
+++ b/crates/moonrun/src/policy/mod.rs
@@ -21,10 +21,10 @@
 //! No policy file preserves existing moonrun behavior. Supplying a policy file
 //! switches the supported host surfaces to deny-by-default mode. Runtime
 //! construction consumes the resulting domain policies instead of retaining a
-//! global policy object in the Host domains.
+//! global policy object in the Host domains. Environment provisioning is also
+//! consumed during construction and does not become a runtime policy check.
 
 mod config;
-mod env;
 mod fs;
 mod net;
 mod policy_inheritance;
@@ -35,21 +35,18 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 
-use crate::async_host::{AsyncHostError, AsyncHostResult};
-use crate::runtime::Env;
-
 use self::config::PolicyConfig;
-use self::env::EnvPolicy;
 pub(crate) use self::fs::{FsIntents, FsPolicy};
 pub(crate) use self::net::{NetOperation, NetPolicy, SocketRule};
 pub(crate) use self::policy_inheritance::PolicyInheritance;
 pub(crate) use self::process::ProcessPolicy;
+use crate::async_host::{AsyncHostError, AsyncHostResult};
+use crate::runtime::EnvProvisioning;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Policy {
     fs: Option<FsPolicy>,
     net: Option<NetPolicy>,
-    env: Option<EnvPolicy>,
     process: Option<ProcessPolicy>,
     policy_inheritance: Option<PolicyInheritance>,
 }
@@ -68,40 +65,9 @@ impl Policy {
         Self {
             fs: None,
             net: None,
-            env: None,
             process: None,
             policy_inheritance: None,
         }
-    }
-
-    pub(crate) fn from_file(path: &Path) -> anyhow::Result<Self> {
-        let config = PolicyConfig::from_file(path)?;
-        let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
-        Self::from_config(config, config_dir)
-    }
-
-    pub(crate) fn from_inherited_json(contents: &[u8]) -> anyhow::Result<Self> {
-        let config = serde_json::from_slice(contents)
-            .context("failed to parse inherited JSON Moonrun Policy")?;
-        // Inherited policies contain absolute filesystem roots. Running the
-        // same canonicalization confirms that those roots still resolve here.
-        Self::from_config(config, Path::new("."))
-    }
-
-    fn from_config(config: PolicyConfig, config_dir: &Path) -> anyhow::Result<Self> {
-        let config = canonicalize(config, config_dir)?;
-        let policy_inheritance = PolicyInheritance::from_config(&config)?;
-        Ok(Self {
-            fs: Some(FsPolicy::from_canonical_config(
-                config.fs.unwrap_or_default(),
-            )),
-            net: Some(NetPolicy::from_config(config.net.unwrap_or_default())?),
-            env: Some(EnvPolicy::from_config(config.env.unwrap_or_default())?),
-            process: Some(ProcessPolicy::from_config(
-                config.process.unwrap_or_default(),
-            )?),
-            policy_inheritance: Some(policy_inheritance),
-        })
     }
 
     pub(crate) fn take_filesystem_policy(&mut self) -> Option<FsPolicy> {
@@ -110,12 +76,6 @@ impl Policy {
 
     pub(crate) fn take_network_policy(&mut self) -> Option<NetPolicy> {
         self.net.take()
-    }
-
-    pub(crate) fn realize_env(&mut self) -> anyhow::Result<Env> {
-        self.env
-            .take()
-            .map_or_else(|| Ok(Env::ambient()), |policy| policy.realize())
     }
 
     pub(crate) fn take_process_policy(&mut self) -> Option<ProcessPolicy> {
@@ -127,11 +87,56 @@ impl Policy {
     }
 }
 
+/// Load the legacy policy document into its two construction-time outputs.
+///
+/// The source format still colocates environment provisioning with operational
+/// authorization. Splitting them here prevents that historical file layout
+/// from making provisioning part of the realized `Policy`.
+pub(crate) fn load_file(path: &Path) -> anyhow::Result<(Policy, EnvProvisioning)> {
+    let config = PolicyConfig::from_file(path)?;
+    let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    realize_config(config, config_dir)
+}
+
+pub(crate) fn load_inherited_json(contents: &[u8]) -> anyhow::Result<(Policy, EnvProvisioning)> {
+    let config = serde_json::from_slice(contents)
+        .context("failed to parse inherited JSON Moonrun Policy")?;
+    // Inherited policies contain absolute filesystem roots. Running the same
+    // canonicalization confirms that those roots still resolve here.
+    realize_config(config, Path::new("."))
+}
+
+fn realize_config(
+    config: PolicyConfig,
+    config_dir: &Path,
+) -> anyhow::Result<(Policy, EnvProvisioning)> {
+    let config = canonicalize(config, config_dir)?;
+    let policy_inheritance = PolicyInheritance::from_config(&config)?;
+    let fs = Some(FsPolicy::from_canonical_config(
+        config.fs.unwrap_or_default(),
+    ));
+    let net = Some(NetPolicy::from_config(config.net.unwrap_or_default())?);
+    let env = config.env.unwrap_or_default();
+    let env_provisioning = EnvProvisioning::new(env.from_host, env.required_from_host, env.set)?;
+    let process = Some(ProcessPolicy::from_config(
+        config.process.unwrap_or_default(),
+    )?);
+    Ok((
+        Policy {
+            fs,
+            net,
+            process,
+            policy_inheritance: Some(policy_inheritance),
+        },
+        env_provisioning,
+    ))
+}
+
 /// Resolve source-relative policy values into a transport-independent form.
 ///
-/// Environment materialization and runtime rule validation deliberately remain
-/// part of Policy construction; only filesystem roots depend on the policy
-/// source directory.
+/// Environment provisioning and runtime rule validation deliberately remain
+/// part of configuration realization; only filesystem roots depend on the
+/// policy source directory.
 fn canonicalize(mut config: PolicyConfig, config_dir: &Path) -> anyhow::Result<PolicyConfig> {
     if let Some(fs) = config.fs.as_mut() {
         fs.read = canonicalize_roots(std::mem::take(&mut fs.read), config_dir)?;
@@ -340,7 +345,7 @@ mod tests {
         let canonical_write = std::fs::canonicalize(&write).unwrap();
         let secret = "value-that-must-not-be-serialized";
 
-        let mut policy = Policy::from_config(
+        let (mut policy, _) = realize_config(
             PolicyConfig {
                 fs: Some(config::FsConfig {
                     read: vec![PathBuf::from("read")],
@@ -390,7 +395,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let source = tmp.path().join("policy.json");
         std::fs::write(&source, r#"{"process":{"spawn":false}}"#).unwrap();
-        let mut parent = Policy::from_file(&source).unwrap();
+        let (mut parent, _) = load_file(&source).unwrap();
         let contents = parent
             .take_policy_inheritance()
             .unwrap()
@@ -400,7 +405,7 @@ mod tests {
             .unwrap();
 
         std::fs::write(&source, r#"{"process":{"spawn":true}}"#).unwrap();
-        let inherited = Policy::from_inherited_json(&contents).unwrap();
+        let (inherited, _) = load_inherited_json(&contents).unwrap();
 
         #[cfg(unix)]
         assert_eq!(
@@ -428,7 +433,7 @@ mod tests {
     #[test]
     fn missing_fs_section_denies_fs_in_policy_mode() {
         let tmp = tempfile::tempdir().unwrap();
-        let policy = Policy::from_config(
+        let (policy, _) = realize_config(
             PolicyConfig {
                 fs: None,
                 net: Some(Default::default()),
@@ -447,7 +452,7 @@ mod tests {
     #[test]
     fn empty_fs_section_denies_fs() {
         let tmp = tempfile::tempdir().unwrap();
-        let policy = Policy::from_config(
+        let (policy, _) = realize_config(
             PolicyConfig {
                 fs: Some(Default::default()),
                 net: None,
@@ -475,7 +480,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let allowed = tmp.path().join("allowed");
         std::fs::create_dir(&allowed).unwrap();
-        let policy = Policy::from_config(
+        let (policy, _) = realize_config(
             PolicyConfig {
                 fs: Some(config::FsConfig {
                     read: vec![PathBuf::from("allowed")],
@@ -497,7 +502,7 @@ mod tests {
     #[test]
     fn empty_net_section_denies_net() {
         let tmp = tempfile::tempdir().unwrap();
-        let policy = Policy::from_config(
+        let (policy, _) = realize_config(
             PolicyConfig {
                 fs: None,
                 net: Some(Default::default()),
@@ -516,7 +521,7 @@ mod tests {
     #[test]
     fn missing_env_section_uses_empty_env_in_policy_mode() {
         let tmp = tempfile::tempdir().unwrap();
-        let mut policy = Policy::from_config(
+        let (_, provisioning) = realize_config(
             PolicyConfig {
                 fs: None,
                 net: None,
@@ -527,7 +532,7 @@ mod tests {
         )
         .unwrap();
 
-        let environment = policy.realize_env().unwrap();
+        let environment = provisioning.realize().unwrap();
         assert!(environment.entries().is_empty());
         assert!(environment.get("PATH".as_ref()).is_none());
     }
@@ -544,7 +549,7 @@ mod tests {
     #[test]
     fn missing_process_section_denies_spawning_in_policy_mode() {
         let tmp = tempfile::tempdir().unwrap();
-        let policy = Policy::from_config(PolicyConfig::default(), tmp.path()).unwrap();
+        let (policy, _) = realize_config(PolicyConfig::default(), tmp.path()).unwrap();
 
         assert_eq!(
             {
@@ -564,7 +569,7 @@ mod tests {
     #[test]
     fn process_section_can_allow_spawning() {
         let tmp = tempfile::tempdir().unwrap();
-        let policy = Policy::from_config(
+        let (policy, _) = realize_config(
             PolicyConfig {
                 process: Some(config::ProcessConfig {
                     spawn: true,

--- a/crates/moonrun/src/runtime/environment.rs
+++ b/crates/moonrun/src/runtime/environment.rs
@@ -19,8 +19,8 @@
 //! Environment state owned by one Runtime.
 //!
 //! Callers use one native-string interface regardless of whether the Run uses
-//! moonrun's legacy ambient environment or an owned environment realized from
-//! policy. The ambient backing deliberately preserves the existing write-
+//! moonrun's legacy ambient environment or an owned provisioned environment.
+//! The ambient backing deliberately preserves the existing write-
 //! through contract: native executable lookup and native libraries can observe
 //! the process environment without crossing this interface, so the embedder
 //! must serialize process-environment access. An isolated backing must audit

--- a/crates/moonrun/src/runtime/environment_provisioning.rs
+++ b/crates/moonrun/src/runtime/environment_provisioning.rs
@@ -16,41 +16,49 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::collections::BTreeSet;
+//! One-time construction input for a Runtime's owned environment.
+//!
+//! Host imports and configured values are resolved and normalized before the
+//! Runtime creates its Env. This input is not consulted by runtime Env access.
+
+use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 
-use super::config::EnvConfig;
-use crate::runtime::Env;
+use super::Env;
 
-#[derive(Clone, Debug)]
-pub(super) struct EnvPolicy {
-    initial: Vec<(OsString, OsString)>,
+#[derive(Debug)]
+pub(crate) struct EnvProvisioning {
+    entries: Vec<(OsString, OsString)>,
 }
 
-impl EnvPolicy {
-    pub(super) fn from_config(config: EnvConfig) -> anyhow::Result<Self> {
+impl EnvProvisioning {
+    pub(crate) fn new(
+        from_host: Vec<String>,
+        required_from_host: Vec<String>,
+        set: BTreeMap<String, String>,
+    ) -> anyhow::Result<Self> {
         let mut vars = Vec::new();
 
-        let copy_all = config.from_host.iter().any(|name| name == "*");
+        let copy_all = from_host.iter().any(|name| name == "*");
         if copy_all {
             vars.extend(std::env::vars_os());
         }
 
-        copy_host_names(&mut vars, &config.from_host, false)?;
-        copy_host_names(&mut vars, &config.required_from_host, true)?;
+        copy_host_names(&mut vars, &from_host, false)?;
+        copy_host_names(&mut vars, &required_from_host, true)?;
 
-        for (name, value) in config.set {
+        for (name, value) in set {
             vars.push((name.into(), value.into()));
         }
 
         let environment = Env::owned(vars)?;
         Ok(Self {
-            initial: environment.entries(),
+            entries: environment.entries(),
         })
     }
 
-    pub(super) fn realize(&self) -> anyhow::Result<Env> {
-        Ok(Env::owned(self.initial.clone())?)
+    pub(crate) fn realize(self) -> anyhow::Result<Env> {
+        Ok(Env::owned(self.entries)?)
     }
 }
 
@@ -83,23 +91,23 @@ fn copy_host_names(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
 
     #[test]
-    fn empty_env_config_starts_empty() {
-        let policy = EnvPolicy::from_config(EnvConfig::default()).unwrap();
+    fn empty_provisioning_starts_empty() {
+        let provisioning = EnvProvisioning::new(Vec::new(), Vec::new(), BTreeMap::new()).unwrap();
 
-        assert!(policy.realize().unwrap().entries().is_empty());
+        assert!(provisioning.realize().unwrap().entries().is_empty());
     }
 
     #[test]
     fn set_values_are_applied_to_the_realized_environment() {
-        let policy = EnvPolicy::from_config(EnvConfig {
-            set: BTreeMap::from([("APP_ENV".to_owned(), "test".to_owned())]),
-            ..EnvConfig::default()
-        })
+        let provisioning = EnvProvisioning::new(
+            Vec::new(),
+            Vec::new(),
+            BTreeMap::from([("APP_ENV".to_owned(), "test".to_owned())]),
+        )
         .unwrap();
-        let environment = policy.realize().unwrap();
+        let environment = provisioning.realize().unwrap();
 
         assert_eq!(environment.get("APP_ENV".as_ref()), Some("test".into()));
         environment.set("APP_ENV".into(), "dev".into()).unwrap();
@@ -109,44 +117,30 @@ mod tests {
     }
 
     #[test]
-    fn startup_policy_realizes_independent_environments() {
-        let policy = EnvPolicy::from_config(EnvConfig {
-            set: BTreeMap::from([("APP_ENV".to_owned(), "test".to_owned())]),
-            ..EnvConfig::default()
-        })
-        .unwrap();
-
-        let left = policy.realize().unwrap();
-        let right = policy.realize().unwrap();
-        left.set("APP_ENV".into(), "left".into()).unwrap();
-
-        assert_eq!(left.get("APP_ENV".as_ref()), Some("left".into()));
-        assert_eq!(right.get("APP_ENV".as_ref()), Some("test".into()));
-    }
-
-    #[test]
     fn vars_are_returned_in_stable_name_order() {
-        let policy = EnvPolicy::from_config(EnvConfig {
-            set: BTreeMap::from([
+        let provisioning = EnvProvisioning::new(
+            Vec::new(),
+            Vec::new(),
+            BTreeMap::from([
                 ("B".to_owned(), "2".to_owned()),
                 ("A".to_owned(), "1".to_owned()),
             ]),
-            ..EnvConfig::default()
-        })
+        )
         .unwrap();
 
         assert_eq!(
-            policy.realize().unwrap().entries(),
+            provisioning.realize().unwrap().entries(),
             vec![("A".into(), "1".into()), ("B".into(), "2".into())]
         );
     }
 
     #[test]
     fn duplicate_host_entries_are_an_error() {
-        let error = EnvPolicy::from_config(EnvConfig {
-            from_host: vec!["APP_ENV".to_owned(), "APP_ENV".to_owned()],
-            ..EnvConfig::default()
-        })
+        let error = EnvProvisioning::new(
+            vec!["APP_ENV".to_owned(), "APP_ENV".to_owned()],
+            Vec::new(),
+            BTreeMap::new(),
+        )
         .unwrap_err();
 
         assert!(
@@ -158,10 +152,11 @@ mod tests {
 
     #[test]
     fn missing_required_host_value_is_an_error() {
-        let error = EnvPolicy::from_config(EnvConfig {
-            required_from_host: vec!["MOONRUN_ENV_POLICY_TEST_MISSING".to_owned()],
-            ..EnvConfig::default()
-        })
+        let error = EnvProvisioning::new(
+            Vec::new(),
+            vec!["MOONRUN_ENV_POLICY_TEST_MISSING".to_owned()],
+            BTreeMap::new(),
+        )
         .unwrap_err();
 
         assert!(

--- a/crates/moonrun/src/runtime/mod.rs
+++ b/crates/moonrun/src/runtime/mod.rs
@@ -19,6 +19,7 @@
 //! Process-facing state selected for one Moonrun Runtime.
 
 mod environment;
+mod environment_provisioning;
 mod stdio;
 mod working_directory;
 
@@ -34,11 +35,12 @@ use slotmap::{KeyData, SlotMap, new_key_type};
 use crate::async_host::AsyncHost;
 use crate::filesystem::HostFs;
 use crate::network::HostNetwork;
-use crate::policy::Policy;
+use crate::policy::{self, Policy};
 use crate::process::HostProcess;
 use crate::sqlite::SqliteHost;
 
 pub(crate) use environment::Env;
+pub(crate) use environment_provisioning::EnvProvisioning;
 pub(crate) use stdio::{Stdio, StdioStream};
 pub use working_directory::WorkingDirectory;
 
@@ -121,18 +123,23 @@ impl Runtime {
         inherited_policy: Option<&[u8]>,
         working_directory: WorkingDirectory,
     ) -> anyhow::Result<Self> {
-        let mut policy = match (inherited_policy, policy_file) {
-            (Some(contents), _) => Policy::from_inherited_json(contents).context(
-                "failed to load inherited sandbox policy (experimental)",
-            )?,
-            (None, Some(path)) => Policy::from_file(path).context(
-                "failed to load sandbox policy (experimental); run `moonrun --help` for policy format notes",
-            )?,
-            (None, None) => Policy::allow_all(),
+        let (mut policy, env_provisioning) = match (inherited_policy, policy_file) {
+            (Some(contents), _) => {
+                let (policy, env) = policy::load_inherited_json(contents)
+                    .context("failed to load inherited sandbox policy (experimental)")?;
+                (policy, Some(env))
+            }
+            (None, Some(path)) => {
+                let (policy, env) = policy::load_file(path).context(
+                    "failed to load sandbox policy (experimental); run `moonrun --help` for policy format notes",
+                )?;
+                (policy, Some(env))
+            }
+            (None, None) => (Policy::allow_all(), None),
         };
         let environment = Arc::new(
-            policy
-                .realize_env()
+            env_provisioning
+                .map_or_else(|| Ok(Env::ambient()), EnvProvisioning::realize)
                 .context("failed to construct the Runtime environment")?,
         );
         let filesystem_policy = policy.take_filesystem_policy();

--- a/crates/moonrun/src/sqlite/policy.rs
+++ b/crates/moonrun/src/sqlite/policy.rs
@@ -116,7 +116,7 @@ unsafe extern "C" fn untrusted_authorizer(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::policy::Policy;
+    use crate::policy::{self, Policy};
     use std::ffi::CString;
 
     fn c_path(path: &Path) -> CString {
@@ -204,7 +204,7 @@ mod tests {
             "[fs]\nread = [\"allowed\"]\nwrite = [\"allowed\"]\n",
         )
         .unwrap();
-        let policy = Policy::from_file(&policy_file).unwrap();
+        let (policy, _) = policy::load_file(&policy_file).unwrap();
         let allowed_database = c_path(&allowed.join("database.sqlite"));
         let denied_database = c_path(&denied.join("database.sqlite"));
 
@@ -239,7 +239,7 @@ mod tests {
             "[fs]\nread = [\"database.sqlite\"]\nwrite = [\"database.sqlite\"]\n",
         )
         .unwrap();
-        let policy = Policy::from_file(&policy_file).unwrap();
+        let (policy, _) = policy::load_file(&policy_file).unwrap();
         let database = c_path(&database);
 
         assert_eq!(


### PR DESCRIPTION
## Why

The env section constructs Runtime state, but Policy retained that construction input alongside operational filesystem, network, and process authorities. That blurred the boundary between how a virtual environment runs and which host operations it may perform.

## What changed

- Move one-time environment provisioning into the Runtime module.
- Split the legacy policy document into operational Policy and EnvProvisioning outputs during loading.
- Let Runtime realize the canonical Ambient or Owned Env before distributing domain authorities.
- Update test construction and Moonrun ownership terminology to match the new boundary.

## Why this is correct and minimal

The existing policy-file schema, host-variable import rules, inherited from_host wildcard, validation order, and Ambient/Owned runtime behavior remain unchanged. The source format still colocates the two inputs for compatibility; only the realized ownership changes. This introduces no generic context or forwarding layer and leaves the operational Host Domain paths untouched.