### PR TITLE
feat(registry): split API and download endpoints

### DIFF
--- a/crates/mooncake/src/registry/client.rs
+++ b/crates/mooncake/src/registry/client.rs
@@ -54,9 +54,9 @@ struct RegistryIndexEntry {
 }
 
 struct RegistryEndpoints {
-    registry: String,
-    packages: String,
-    assets: String,
+    api: String,
+    download: String,
+    legacy_asset_urls: bool,
 }
 
 fn registry_http_client() -> anyhow::Result<reqwest::blocking::Client> {
@@ -68,16 +68,10 @@ fn registry_http_client() -> anyhow::Result<reqwest::blocking::Client> {
 
 impl RegistryEndpoints {
     fn from_config(config: &RegistryConfig) -> Self {
-        let registry = config.registry.trim_end_matches('/');
-        let packages = if registry == "https://mooncakes.io" {
-            "https://download.mooncakes.io/user".to_owned()
-        } else {
-            format!("{registry}/user")
-        };
         Self {
-            registry: registry.to_owned(),
-            packages,
-            assets: format!("{registry}/assets"),
+            api: config.api.trim_end_matches('/').to_owned(),
+            download: config.download.trim_end_matches('/').to_owned(),
+            legacy_asset_urls: config.legacy_asset_urls,
         }
     }
 
@@ -86,27 +80,66 @@ impl RegistryEndpoints {
             .append_pair("kw", keyword)
             .append_pair("limit", &limit.to_string())
             .finish();
-        format!("{}/api/v0/search?{query}", self.registry)
+        format!("{}/api/v0/search?{query}", self.api)
     }
 
     fn package_archive(&self, name: &ModuleName, version: &Version) -> String {
-        let path = form_urlencoded::Serializer::new(String::new())
-            .append_key_only(&format!("{}/{}/{}", name.username, name.unqual, version))
-            .finish();
-        format!("{}/{}.zip", self.packages, path)
+        if self.legacy_asset_urls {
+            let path = form_urlencoded::Serializer::new(String::new())
+                .append_key_only(&format!("{}/{}/{}", name.username, name.unqual, version))
+                .finish();
+            format!("{}/user/{path}.zip", self.download)
+        } else {
+            format!(
+                "{}/user/{}/{}/{}.zip",
+                self.download,
+                encode_path_segment(&name.username),
+                encode_path_segment(&name.unqual),
+                encode_path_segment(&version.to_string())
+            )
+        }
     }
 
     fn wasm_asset(&self, name: &ModuleName, version: &Version, package_path: &str) -> String {
         let artifact_name = wasm_artifact_name(name, package_path);
-        if package_path.is_empty() {
-            format!("{}/{}@{version}/{artifact_name}", self.assets, name)
+        if self.legacy_asset_urls {
+            if package_path.is_empty() {
+                format!("{}/assets/{}@{version}/{artifact_name}", self.api, name)
+            } else {
+                format!(
+                    "{}/assets/{}@{version}/{package_path}/{artifact_name}",
+                    self.api, name
+                )
+            }
+        } else if package_path.is_empty() {
+            format!(
+                "{}/prebuild/{}@{version}/{artifact_name}",
+                self.download, name
+            )
         } else {
             format!(
-                "{}/{}@{version}/{package_path}/{artifact_name}",
-                self.assets, name
+                "{}/prebuild/{}@{version}/{package_path}/{artifact_name}",
+                self.download, name
             )
         }
     }
+
+    fn wasm_checksum(&self, name: &ModuleName, version: &Version, package_path: &str) -> String {
+        format!("{}.sha256", self.wasm_asset(name, version, package_path))
+    }
+}
+
+/// Percent-encode one RFC 3986 path segment without treating `/` as data.
+fn encode_path_segment(segment: &str) -> String {
+    segment.bytes().fold(String::new(), |mut encoded, byte| {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+        encoded
+    })
 }
 
 /// One module returned by a Mooncakes registry search.
@@ -164,7 +197,7 @@ impl RegistryClient {
     }
 
     /// Search the configured registry for published modules.
-    #[tracing::instrument(skip(self), fields(registry = %self.config.registry))]
+    #[tracing::instrument(skip(self), fields(api = %self.config.api))]
     pub fn search(&self, keyword: &str, limit: u32) -> anyhow::Result<Vec<RegistrySearchResult>> {
         let url = self.endpoints.search(keyword, limit);
         let response = registry_http_client()?
@@ -201,9 +234,10 @@ impl RegistryClient {
         user_log: &UserLog,
         mut download: impl FnMut(&str) -> anyhow::Result<Vec<u8>>,
     ) -> anyhow::Result<std::path::PathBuf> {
+        validate_registry_module_name(name)?;
         validate_asset_package_path(name, package_path)?;
         let url = self.endpoints.wasm_asset(name, version, package_path);
-        let checksum_url = format!("{url}.sha256");
+        let checksum_url = self.endpoints.wasm_checksum(name, version, package_path);
         let cache_path = self.home.registry_executable_artifact_path(
             name,
             version,
@@ -279,6 +313,16 @@ fn validate_asset_package_path(name: &ModuleName, package_path: &str) -> anyhow:
         .context("invalid registry asset package path")?;
     if parsed.module != *name || parsed.package != package_path {
         bail!("invalid registry asset package path");
+    }
+    Ok(())
+}
+
+fn validate_registry_module_name(name: &ModuleName) -> anyhow::Result<()> {
+    if name
+        .segments()
+        .any(|component| component.contains(['#', '?', '%']))
+    {
+        bail!("registry module name cannot contain `#`, `?`, or `%`");
     }
     Ok(())
 }
@@ -563,6 +607,7 @@ impl RegistryClient {
         expected_checksum: &str,
         user_log: &UserLog,
     ) -> anyhow::Result<File> {
+        validate_registry_module_name(name)?;
         let pkg_index = self.home.registry_index_file(name);
         if !pkg_index.exists() {
             anyhow::bail!("Module {}@{} not found", name, version);
@@ -749,41 +794,94 @@ mod tests {
     }
 
     #[test]
-    fn official_registry_uses_download_service() {
+    fn split_registry_uses_configured_download_service() {
         let endpoints = RegistryEndpoints::from_config(&RegistryConfig {
-            registry: "https://mooncakes.io/".to_owned(),
+            api: "https://mooncakes.io/".to_owned(),
             index: String::new(),
+            download: "https://download.mooncakes.io/".to_owned(),
             symbols: None,
+            legacy_asset_urls: false,
         });
         assert_eq!(
             endpoints.package_archive(&"test/pkg".into(), &Version::new(1, 2, 3)),
-            "https://download.mooncakes.io/user/test%2Fpkg%2F1.2.3.zip"
+            "https://download.mooncakes.io/user/test/pkg/1.2.3.zip"
         );
     }
 
     #[test]
-    fn configured_registry_serves_package_downloads() {
+    fn split_registry_keeps_api_and_download_urls_independent() {
         let endpoints = RegistryEndpoints::from_config(&RegistryConfig {
-            registry: "https://registry.example.com/".to_owned(),
+            api: "https://api.example.com/".to_owned(),
             index: String::new(),
+            download: "https://download.example.com/".to_owned(),
             symbols: None,
+            legacy_asset_urls: false,
         });
         assert_eq!(
             endpoints.package_archive(&"test/pkg".into(), &Version::new(1, 2, 3)),
-            "https://registry.example.com/user/test%2Fpkg%2F1.2.3.zip"
+            "https://download.example.com/user/test/pkg/1.2.3.zip"
+        );
+        assert_eq!(
+            endpoints.search("json query", 7),
+            "https://api.example.com/api/v0/search?kw=json+query&limit=7"
+        );
+    }
+
+    #[test]
+    fn split_registry_rejects_reserved_archive_path_components() {
+        let endpoints = RegistryEndpoints::from_config(&RegistryConfig {
+            api: "https://api.example.com".to_owned(),
+            index: String::new(),
+            download: "https://download.example.com".to_owned(),
+            symbols: None,
+            legacy_asset_urls: false,
+        });
+        let name: ModuleName = "test#/pkg?".into();
+        assert!(validate_registry_module_name(&name).is_err());
+        assert_eq!(
+            endpoints.package_archive(&"test/pkg".into(), &Version::parse("1.2.3+build").unwrap()),
+            "https://download.example.com/user/test/pkg/1.2.3%2Bbuild.zip"
         );
     }
 
     #[test]
     fn registry_search_url_uses_configured_registry_and_encodes_query() {
         let endpoints = RegistryEndpoints::from_config(&RegistryConfig {
-            registry: "https://registry.example.com/".to_owned(),
+            api: "https://registry.example.com/".to_owned(),
             index: String::new(),
+            download: String::new(),
             symbols: None,
+            legacy_asset_urls: false,
         });
         assert_eq!(
             endpoints.search("json query", 7),
             "https://registry.example.com/api/v0/search?kw=json+query&limit=7"
+        );
+    }
+
+    #[test]
+    fn legacy_registry_config_keeps_existing_download_urls() {
+        let endpoints = RegistryEndpoints::from_config(&RegistryConfig {
+            api: "https://registry.example.com".to_owned(),
+            index: String::new(),
+            download: "https://registry.example.com".to_owned(),
+            symbols: None,
+            legacy_asset_urls: true,
+        });
+        let name: ModuleName = "test/pkg".into();
+        let version = Version::new(1, 2, 3);
+
+        assert_eq!(
+            endpoints.package_archive(&name, &version),
+            "https://registry.example.com/user/test%2Fpkg%2F1.2.3.zip"
+        );
+        assert_eq!(
+            endpoints.wasm_asset(&name, &version, "cmd/tool"),
+            "https://registry.example.com/assets/test/pkg@1.2.3/cmd/tool/tool.wasm"
+        );
+        assert_eq!(
+            endpoints.wasm_checksum(&name, &version, "cmd/tool"),
+            "https://registry.example.com/assets/test/pkg@1.2.3/cmd/tool/tool.wasm.sha256"
         );
     }
 
@@ -807,9 +905,11 @@ mod tests {
     fn asset_test_registry(sandbox: &tempfile::TempDir) -> RegistryClient {
         RegistryClient::with_home(
             RegistryConfig {
-                registry: "https://mooncakes.io".to_owned(),
+                api: "https://mooncakes.io".to_owned(),
                 index: String::new(),
+                download: "https://download.mooncakes.io".to_owned(),
                 symbols: None,
+                legacy_asset_urls: false,
             },
             MoonHomeLayout::new(sandbox.path().to_path_buf()),
         )
@@ -829,13 +929,13 @@ mod tests {
             registry
                 .endpoints
                 .wasm_asset(&parser_module(), &version, "cmd/moonfmt"),
-            "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm"
+            "https://download.mooncakes.io/prebuild/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm"
         );
         assert_eq!(
             registry
                 .endpoints
                 .wasm_asset(&parser_module(), &version, ""),
-            "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/parser.wasm"
+            "https://download.mooncakes.io/prebuild/moonbitlang/parser@0.3.3/parser.wasm"
         );
     }
 
@@ -865,7 +965,7 @@ mod tests {
                 &quiet_user_log(),
                 |url| {
                     urls.push(url.to_owned());
-                    if url.ends_with(".sha256") {
+                    if url.ends_with(".wasm.sha256") {
                         Ok(format!("{checksum}  moonfmt.wasm\n").into_bytes())
                     } else {
                         Ok(wasm.clone())
@@ -878,8 +978,8 @@ mod tests {
         assert_eq!(
             urls,
             [
-                "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm.sha256",
-                "https://mooncakes.io/assets/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm",
+                "https://download.mooncakes.io/prebuild/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm.sha256",
+                "https://download.mooncakes.io/prebuild/moonbitlang/parser@0.3.3/cmd/moonfmt/moonfmt.wasm",
             ]
         );
     }
@@ -922,9 +1022,11 @@ mod tests {
             .map(|_| {
                 let registry = RegistryClient::with_home(
                     RegistryConfig {
-                        registry: "https://mooncakes.io".to_owned(),
+                        api: "https://mooncakes.io".to_owned(),
                         index: String::new(),
+                        download: "https://download.mooncakes.io".to_owned(),
                         symbols: None,
+                        legacy_asset_urls: false,
                     },
                     home.clone(),
                 );
@@ -940,7 +1042,7 @@ mod tests {
                         "cmd/moonfmt",
                         &quiet_user_log(),
                         |url| {
-                            if url.ends_with(".sha256") {
+                            if url.ends_with(".wasm.sha256") {
                                 download_count.fetch_add(1, Ordering::SeqCst);
                                 std::thread::sleep(Duration::from_millis(50));
                                 Ok(format!("{checksum}  moonfmt.wasm\n").into_bytes())
@@ -973,7 +1075,7 @@ mod tests {
 
         let error = registry
             .acquire_wasm_asset_with(&name, &version, "cmd/moonfmt", &quiet_user_log(), |url| {
-                if url.ends_with(".sha256") {
+                if url.ends_with(".wasm.sha256") {
                     Ok(format!("{expected_checksum}\n").into_bytes())
                 } else {
                     Ok(b"different wasm".to_vec())
@@ -1026,7 +1128,7 @@ mod tests {
             let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
             let unavailable_address = listener.local_addr().unwrap();
             drop(listener);
-            registry.endpoints.packages = format!("http://{unavailable_address}");
+            registry.endpoints.download = format!("http://{unavailable_address}");
 
             registry
                 .acquire_source_to(
@@ -1130,9 +1232,11 @@ mod tests {
         (
             RegistryClient::with_home(
                 RegistryConfig {
-                    registry: String::new(),
+                    api: String::new(),
                     index: String::new(),
+                    download: String::new(),
                     symbols: None,
+                    legacy_asset_urls: false,
                 },
                 home,
             ),
@@ -1271,9 +1375,11 @@ mod tests {
                 std::thread::spawn(move || {
                     let registry = RegistryClient::with_home(
                         RegistryConfig {
-                            registry: url_base,
+                            api: url_base.clone(),
                             index: String::new(),
+                            download: url_base,
                             symbols: None,
+                            legacy_asset_urls: false,
                         },
                         home,
                     );
@@ -1402,9 +1508,11 @@ mod tests {
 
         let registry = RegistryClient::with_home(
             RegistryConfig {
-                registry: String::new(),
+                api: String::new(),
                 index: String::new(),
+                download: String::new(),
                 symbols: None,
+                legacy_asset_urls: false,
             },
             home.clone(),
         );

--- a/crates/mooncake/src/registry/path.rs
+++ b/crates/mooncake/src/registry/path.rs
@@ -62,6 +62,7 @@ fn parse_path_components(path: &str) -> anyhow::Result<Vec<&str>> {
             || *component == ".."
             || component.contains(':')
             || component.contains('\\')
+            || component.contains(['#', '?', '%'])
     }) {
         anyhow::bail!("path contains an invalid component");
     }
@@ -260,6 +261,9 @@ mod tests {
         for path in [
             "user/module/.",
             "user/module/..",
+            "user#/module/package",
+            "user/module?/package",
+            "user/module/package%",
             "C:/module/package",
             r"user/module/a\..\..\evil",
         ] {

--- a/crates/mooncake/src/update.rs
+++ b/crates/mooncake/src/update.rs
@@ -681,8 +681,8 @@ pub(crate) fn sync(
     std::fs::create_dir_all(&registry_dir)
         .with_context(|| format!("failed to create `{}`", registry_dir.display()))?;
     let observed = observe_registry_update_state(&home.registry_update_state_path());
-    let symbols_url = registry_config.symbols.as_deref().unwrap_or(SYMBOLS_URL);
-    let registry_identity = registry_identity(&registry_config.index, symbols_url);
+    let symbols_url = symbols_url(registry_config);
+    let registry_identity = registry_identity(&registry_config.index, &symbols_url);
 
     run_registry_update_locked(
         home,
@@ -694,7 +694,7 @@ pub(crate) fn sync(
             let (symbols_updated, symbols_etag) = match update_symbols_from_url(
                 &registry_dir,
                 &symbols_dir,
-                symbols_url,
+                &symbols_url,
                 previous_etag,
             ) {
                 Ok(etag) => (true, etag),
@@ -713,6 +713,19 @@ pub(crate) fn sync(
             ))
         },
     )
+}
+
+fn symbols_url(registry_config: &RegistryConfig) -> String {
+    if let Some(symbols) = &registry_config.symbols {
+        symbols.clone()
+    } else if registry_config.legacy_asset_urls {
+        SYMBOLS_URL.to_owned()
+    } else {
+        format!(
+            "{}/symbols.zip",
+            registry_config.download.trim_end_matches('/')
+        )
+    }
 }
 
 fn registry_identity(index_url: &str, symbols_url: &str) -> String {
@@ -789,9 +802,11 @@ mod tests {
         (
             base,
             RegistryConfig {
-                registry: index.clone(),
+                api: index.clone(),
                 index,
+                download: String::new(),
                 symbols: None,
+                legacy_asset_urls: false,
             },
         )
     }
@@ -868,9 +883,11 @@ mod tests {
         (
             base,
             RegistryConfig {
-                registry: index.clone(),
+                api: index.clone(),
                 index,
+                download: String::new(),
                 symbols: None,
+                legacy_asset_urls: false,
             },
         )
     }
@@ -893,6 +910,32 @@ mod tests {
             identity,
             registry_identity("https://registry.invalid/index", "https://b/symbols")
         );
+    }
+
+    #[test]
+    fn symbols_url_uses_the_split_download_endpoint() {
+        let config = RegistryConfig {
+            api: "https://api.example".to_owned(),
+            index: "https://index.example".to_owned(),
+            download: "https://download.example/".to_owned(),
+            symbols: None,
+            legacy_asset_urls: false,
+        };
+
+        assert_eq!(symbols_url(&config), "https://download.example/symbols.zip");
+    }
+
+    #[test]
+    fn symbols_url_preserves_legacy_overrides() {
+        let config = RegistryConfig {
+            api: "https://registry.example".to_owned(),
+            index: "https://index.example".to_owned(),
+            download: "https://registry.example".to_owned(),
+            symbols: Some("https://mirror.example/symbols.zip".to_owned()),
+            legacy_asset_urls: true,
+        };
+
+        assert_eq!(symbols_url(&config), "https://mirror.example/symbols.zip");
     }
 
     struct TestHttpResponse {

--- a/crates/moonutil/src/mooncakes.rs
+++ b/crates/moonutil/src/mooncakes.rs
@@ -599,12 +599,70 @@ pub struct Credentials {
     pub username: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub struct RegistryConfig {
-    pub registry: String,
+    pub api: String,
     pub index: String,
-    #[serde(default)]
+    pub download: String,
     pub symbols: Option<String>,
+    /// TODO: Remove after support for `registry`-format configurations is dropped.
+    /// Old configurations use the registry endpoint for prebuilt wasm assets.
+    pub legacy_asset_urls: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RegistryConfigFile {
+    Split {
+        api: String,
+        index: String,
+        download: String,
+        #[serde(default)]
+        symbols: Option<String>,
+    },
+    Legacy {
+        registry: String,
+        index: String,
+        #[serde(default)]
+        symbols: Option<String>,
+    },
+}
+
+impl From<RegistryConfigFile> for RegistryConfig {
+    fn from(config: RegistryConfigFile) -> Self {
+        match config {
+            RegistryConfigFile::Split {
+                api,
+                index,
+                download,
+                symbols,
+            } => Self {
+                api,
+                index,
+                download,
+                symbols,
+                legacy_asset_urls: false,
+            },
+            RegistryConfigFile::Legacy {
+                registry,
+                index,
+                symbols,
+            } => {
+                let download = if registry.trim_end_matches('/') == "https://mooncakes.io" {
+                    "https://download.mooncakes.io".to_owned()
+                } else {
+                    registry.clone()
+                };
+                Self {
+                    api: registry.clone(),
+                    index,
+                    download,
+                    symbols,
+                    legacy_asset_urls: true,
+                }
+            }
+        }
+    }
 }
 
 impl RegistryConfig {
@@ -613,13 +671,17 @@ impl RegistryConfig {
             RegistryConfig {
                 index: format!("{v}/git/index"),
                 symbols: Some(format!("{v}/symbols.zip")),
-                registry: v,
+                download: v.clone(),
+                api: v,
+                legacy_asset_urls: true,
             }
         } else {
             RegistryConfig {
-                registry: "https://mooncakes.io".into(),
+                api: "https://mooncakes.io".into(),
                 index: "https://mooncakes.io/git/index".into(),
+                download: "https://download.mooncakes.io".into(),
                 symbols: None,
+                legacy_asset_urls: false,
             }
         }
     }
@@ -631,14 +693,74 @@ impl RegistryConfig {
         }
         let file = File::open(config_path).unwrap();
         let reader = BufReader::new(file);
-        let config: RegistryConfig = serde_json_lenient::from_reader(reader).unwrap();
-        config
+        let config: RegistryConfigFile = serde_json_lenient::from_reader(reader).unwrap();
+        config.into()
     }
 }
 
 impl Default for RegistryConfig {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod registry_config_tests {
+    use super::RegistryConfigFile;
+
+    #[test]
+    fn split_registry_config_uses_independent_endpoints() {
+        let config: RegistryConfigFile = serde_json_lenient::from_str(
+            r#"{
+                "api": "https://api.example",
+                "index": "https://index.example",
+                "download": "https://download.example"
+            }"#,
+        )
+        .unwrap();
+        let config: super::RegistryConfig = config.into();
+
+        assert_eq!(config.api, "https://api.example");
+        assert_eq!(config.index, "https://index.example");
+        assert_eq!(config.download, "https://download.example");
+        assert!(!config.legacy_asset_urls);
+    }
+
+    #[test]
+    fn legacy_registry_config_preserves_its_endpoint_contract() {
+        let config: RegistryConfigFile = serde_json_lenient::from_str(
+            r#"{
+                "registry": "https://registry.example",
+                "index": "https://index.example",
+                "symbols": "https://registry.example/symbols.zip"
+            }"#,
+        )
+        .unwrap();
+        let config: super::RegistryConfig = config.into();
+
+        assert_eq!(config.api, "https://registry.example");
+        assert_eq!(config.download, "https://registry.example");
+        assert!(config.legacy_asset_urls);
+        assert_eq!(
+            config.symbols.as_deref(),
+            Some("https://registry.example/symbols.zip")
+        );
+    }
+
+    #[test]
+    fn legacy_official_registry_keeps_its_download_service() {
+        let config: RegistryConfigFile = serde_json_lenient::from_str(
+            r#"{
+                "registry": "https://mooncakes.io",
+                "index": "https://mooncakes.io/git/index"
+            }"#,
+        )
+        .unwrap();
+        let config: super::RegistryConfig = config.into();
+
+        assert_eq!(config.api, "https://mooncakes.io");
+        assert_eq!(config.download, "https://download.mooncakes.io");
+        assert!(config.legacy_asset_urls);
     }
 }
 

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -370,14 +370,17 @@ Current registry configuration behavior today is:
 - The public `Registry` trait contains only metadata queries used by resolution.
   Package source acquisition remains on `RegistryClient`; dependency-source
   tests replace it through a crate-private seam.
-- `RegistryConfig.index` controls how `moon update` populates the local
-  registry index over Git.
-- `RegistryClient` derives the search and package archive endpoints internally
-  from the loaded registry configuration; callers do not construct or depend
-  on its transport URLs.
-- The optional `RegistryConfig.symbols` URL overrides the default Mooncakes
-  symbols archive used by `moon update`. `MOONCAKES_REGISTRY` derives the
-  index and symbols URLs from the configured registry base.
+- `RegistryConfig.api` controls dynamic registry requests such as search.
+  `RegistryConfig.index` controls how `moon update` populates the local
+  registry index over Git. `RegistryConfig.download` controls immutable package
+  archives, prebuilt Wasm artifacts and checksums, and the default
+  `symbols.zip` archive.
+- `RegistryClient` constructs those URLs internally; callers do not construct
+  or depend on its transport URLs. The optional `RegistryConfig.symbols` URL
+  remains a compatibility override for `symbols.zip`.
+- Existing `registry`-format configurations and `MOONCAKES_REGISTRY` retain
+  their former combined endpoint layout while users migrate to the split
+  configuration.
 - MVS itself resolves against the local on-disk index and does not consume
   `RegistryConfig` directly.
 

--- a/docs/dev/reference/modules-packages.md
+++ b/docs/dev/reference/modules-packages.md
@@ -79,9 +79,11 @@ Currently, no ambiguity is allowed when resolving package names.
 If two packages resolves to the same full name when building,
 the build system should abort and return an error.
 
-Although technically module and package name components are allowed to contain any character execpt `/`,
+Although technically module and package name components are allowed to contain any character except `/`,
 we recommend and plan to restrict the character set to ASCII identifiers,
 to prevent causing issues on other parts of the toolchain and compiler.
+Registry module and package components additionally may not contain `#`, `?`,
+or `%`, because they have URL syntax meaning.
 
 ## Dependency resolving
 

--- a/docs/dev/reference/moon-home-layout.md
+++ b/docs/dev/reference/moon-home-layout.md
@@ -70,7 +70,12 @@ $MOON_HOME/
   `.registry-update-state.json` lets callers that waited for that lock reuse a
   concurrent update. Lock files remain in place after unlocking so all
   processes continue to lock the same filesystem object.
-- `config.json` stores registry configuration.
+- `config.json` stores registry configuration. New configurations use independent
+  `api`, `index`, and `download` URLs: dynamic registry operations use `api`,
+  the local Git checkout uses `index`, and immutable package archives,
+  prebuilt Wasm artifacts, checksums, and `symbols.zip` use `download`.
+  Existing configurations with `registry`, `index`, and optional `symbols`
+  remain supported with their original URL layout.
 - `credentials.json` stores Mooncakes login credentials.
 
 The layout deliberately records current behavior rather than claiming every


### PR DESCRIPTION
## Why

Registry API operations, the Git index, and immutable artifacts need independently configurable endpoints so read-only mirrors can serve the index and downloads without implementing Mooncakes dynamic APIs.

## What changed

- Add split api, index, and download registry configuration.
- Route source archives, symbols, prebuilt Wasm, and .wasm.sha256 checksums through download.
- Reject URL-reserved #, ?, and % characters in registry module and executable package components; SemVer + remains supported.
- Preserve legacy registry configurations and MOONCAKES_REGISTRY, including the official package download host and legacy executable asset URLs.
- Document the implemented endpoint ownership and compatibility behavior.

## Why this is correct

The new schema keeps dynamic API traffic separate from mirrorable immutable data. Legacy configurations retain their prior URL construction. Tests cover split routing, reserved registry components, legacy routing, symbols selection, and the official legacy download service.

## Scope

The change is limited to registry configuration, URL construction, synchronization, and their behavior references.