### PR TITLE
feat: deprecate legacy packaging config

### DIFF
--- a/crates/moon/tests/test_cases/test_exclude_001.in/.gitignore
+++ b/crates/moon/tests/test_cases/test_exclude_001.in/.gitignore
@@ -2,3 +2,4 @@ target/
 .mooncakes/
 target
 _build/
+gitignored.txt

--- a/crates/moon/tests/test_cases/test_exclude_001.in/.moonignore
+++ b/crates/moon/tests/test_cases/test_exclude_001.in/.moonignore
@@ -1,0 +1,1 @@
+moonignored.txt

--- a/crates/moon/tests/test_cases/test_exclude_001.in/moon.test
+++ b/crates/moon/tests/test_cases/test_exclude_001.in/moon.test
@@ -1,6 +1,7 @@
   $ moon package --list
   
   Running moon check ...
+  Warning: `exclude` in `[WORK_DIR]/moon.mod.json` is deprecated; use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.
   Finished. moon: ran 4 tasks, now up to date
   Check passed
   README.md

--- a/crates/moon/tests/test_cases/test_exclude_001/mod.rs
+++ b/crates/moon/tests/test_cases/test_exclude_001/mod.rs
@@ -4,3 +4,20 @@ use super::*;
 fn test_exclude_001() {
     run_moon_cmdtest("test_exclude_001.in");
 }
+
+#[test]
+fn test_moonignore_overrides_gitignore() {
+    let dir = TestDir::new("test_exclude_001.in");
+    std::fs::write(dir.join("gitignored.txt"), "included by .moonignore\n").unwrap();
+    std::fs::write(dir.join("moonignored.txt"), "excluded by .moonignore\n").unwrap();
+
+    let stderr = get_stderr(&dir, ["package", "--list"]);
+    assert!(
+        stderr.lines().any(|line| line == "gitignored.txt"),
+        ".moonignore should override the sibling .gitignore, got:\n{stderr}"
+    );
+    assert!(
+        stderr.lines().all(|line| line != "moonignored.txt"),
+        ".moonignore should still exclude its own matches, got:\n{stderr}"
+    );
+}

--- a/crates/moon/tests/test_cases/test_exclude_002.in/moon.test
+++ b/crates/moon/tests/test_cases/test_exclude_002.in/moon.test
@@ -1,6 +1,7 @@
   $ moon package --list
   
   Running moon check ...
+  Warning: `exclude` in `[WORK_DIR]/moon.mod.json` is deprecated; use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.
   Finished. moon: ran 4 tasks, now up to date
   Check passed
   README.md

--- a/crates/moon/tests/test_cases/test_include_001.in/moon.test
+++ b/crates/moon/tests/test_cases/test_include_001.in/moon.test
@@ -1,6 +1,7 @@
   $ moon package --list
   
   Running moon check ...
+  Warning: `include` in `[WORK_DIR]/moon.mod.json` is deprecated; use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.
   Finished. moon: ran 4 tasks, now up to date
   Check passed
   moon.mod.json

--- a/crates/moon/tests/test_cases/test_include_001/mod.rs
+++ b/crates/moon/tests/test_cases/test_include_001/mod.rs
@@ -4,3 +4,27 @@ use super::*;
 fn test_include_001() {
     run_moon_cmdtest("test_include_001.in");
 }
+
+#[test]
+fn test_deprecated_packaging_config_warns_during_check() {
+    let dir = TestDir::new("test_include_001.in");
+    let stderr = get_stderr(&dir, ["check"]);
+    let warning = "`include` in `$ROOT/moon.mod.json` is deprecated";
+    assert_eq!(
+        stderr.matches(warning).count(),
+        1,
+        "expected exactly one deprecation warning, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn test_deprecated_packaging_config_warns_during_fmt() {
+    let dir = TestDir::new("test_include_001.in");
+    let stderr = get_stderr(&dir, ["fmt", "--dry-run"]);
+    let warning = "`include` in `$ROOT/moon.mod.json` is deprecated";
+    assert_eq!(
+        stderr.matches(warning).count(),
+        1,
+        "expected exactly one deprecation warning, got:\n{stderr}"
+    );
+}

--- a/crates/moon/tests/test_cases/test_include_002.in/moon.test
+++ b/crates/moon/tests/test_cases/test_include_002.in/moon.test
@@ -1,6 +1,7 @@
   $ moon package --list
   
   Running moon check ...
+  Warning: `include` in `[WORK_DIR]/moon.mod.json` is deprecated; use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.
   Finished. moon: ran 4 tasks, now up to date
   Check passed
   moon.mod.json

--- a/crates/moon/tests/test_cases/test_include_003.in/moon.test
+++ b/crates/moon/tests/test_cases/test_include_003.in/moon.test
@@ -1,6 +1,7 @@
   $ moon package --list
   
   Running moon check ...
+  Warning: `include` and `exclude` in `[WORK_DIR]/moon.mod.json` are deprecated; use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.
   Finished. moon: ran 4 tasks, now up to date
   Check passed
   moon.mod.json

--- a/crates/moon/tests/test_cases/workspace_basic/mod.rs
+++ b/crates/moon/tests/test_cases/workspace_basic/mod.rs
@@ -37,6 +37,32 @@ fn write_file(path: &Path, content: &str) {
     std::fs::write(path, content).unwrap();
 }
 
+#[test]
+fn deprecated_packaging_config_reports_workspace_member_manifest() {
+    let dir = TestDir::new("workspace_basic.in");
+    write_file(
+        &dir.join("app/moon.mod.json"),
+        r#"{
+  "name": "alice/app",
+  "version": "0.1.0",
+  "source": "src",
+  "deps": {
+    "alice/liba": "0.1.0"
+  },
+  "include": ["src/**"]
+}
+"#,
+    );
+
+    let stderr = get_stderr(&dir, ["check"]);
+    let warning = "`include` in `$ROOT/app/moon.mod.json` is deprecated";
+    assert_eq!(
+        stderr.matches(warning).count(),
+        1,
+        "expected the warning to identify the workspace member manifest, got:\n{stderr}"
+    );
+}
+
 fn same_root_workspace_dir() -> TestDir {
     let dir = TestDir::new_empty();
 

--- a/crates/moonbuild-rupes-recta/src/discover/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/discover/mod.rs
@@ -56,7 +56,7 @@ use moonutil::{
     },
     manifest::{
         read_module_desc_file_in_dir, read_package_desc_file_from_path_with_supported_targets_decl,
-        warn_if_shadowed_manifest, warn_known_shadowed_manifest,
+        warn_known_shadowed_manifest, warn_module_manifest,
     },
     package::resolve_supported_targets,
     user_log::UserLog,
@@ -93,7 +93,7 @@ pub fn discover_packages(
 
         let dir = dirs.get(id).expect("Bad module ID to get directory");
         let location = format!("at module root '{}'", dir.display());
-        warn_if_shadowed_manifest(dir, MOON_MOD_JSON, MOON_MOD, &location, user_log);
+        warn_module_manifest(dir, &location, user_log);
         discover_packages_for_mod(&mut res, dir, id, env.resolved_module(id), user_log)?;
     }
 
@@ -135,10 +135,8 @@ pub fn discover_local_project(
     let mut pkg_dirs = DiscoverResult::default();
 
     for module_dir in module_dirs {
-        warn_if_shadowed_manifest(
+        warn_module_manifest(
             &module_dir,
-            MOON_MOD_JSON,
-            MOON_MOD,
             &format!("at module root '{}'", module_dir.display()),
             user_log,
         );

--- a/crates/moonbuild/template/mod.schema.json
+++ b/crates/moonbuild/template/mod.schema.json
@@ -42,7 +42,7 @@
       ]
     },
     "exclude": {
-      "description": "Files to exclude when publishing.",
+      "description": "Deprecated. Use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.",
       "type": [
         "array",
         "null"
@@ -52,7 +52,7 @@
       }
     },
     "include": {
-      "description": "Files to include when publishing.",
+      "description": "Deprecated. Use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.",
       "type": [
         "array",
         "null"

--- a/crates/mooncake/src/pkg/work.rs
+++ b/crates/mooncake/src/pkg/work.rs
@@ -27,8 +27,8 @@ use moonutil::{
     constants::{MOON_MOD, MOON_MOD_JSON, MOON_WORK, MOONBITLANG_CORE},
     dependency::SourceDependencyInfo,
     manifest::{
-        MoonMod, convert_module_to_mod_json, read_module_desc_file_in_dir,
-        warn_if_shadowed_manifest, write_module_json_to_file,
+        MoonMod, convert_module_to_mod_json, read_module_desc_file_in_dir, warn_module_manifest,
+        write_module_json_to_file,
     },
     moon_mod_patch::{MoonModPatch, patch_module_dsl_to_file},
     project::{
@@ -162,10 +162,8 @@ fn resolve_workspace_member(path: &Path, user_log: &UserLog) -> anyhow::Result<P
     if !member_dir.is_dir() {
         bail!("workspace member `{}` is not a directory", path.display());
     }
-    warn_if_shadowed_manifest(
+    warn_module_manifest(
         &member_dir,
-        MOON_MOD_JSON,
-        MOON_MOD,
         &format!("at module root '{}'", member_dir.display()),
         user_log,
     );
@@ -223,10 +221,8 @@ fn workspace_roots(
     let mut roots = ResolvedRootModules::with_key();
 
     for member_dir in member_dirs {
-        warn_if_shadowed_manifest(
+        warn_module_manifest(
             member_dir,
-            MOON_MOD_JSON,
-            MOON_MOD,
             &format!("at module root '{}'", member_dir.display()),
             user_log,
         );

--- a/crates/moonutil/src/manifest.rs
+++ b/crates/moonutil/src/manifest.rs
@@ -419,6 +419,41 @@ pub fn warn_if_shadowed_manifest(
     }
 }
 
+/// Emit user-facing warnings associated with the selected module manifest.
+pub fn warn_module_manifest(dir: &Path, location: &str, user_log: &UserLog) {
+    if !should_warn_manifest(dir) {
+        return;
+    }
+    warn_if_shadowed_manifest(dir, MOON_MOD_JSON, MOON_MOD, location, user_log);
+
+    let Some((manifest_path, format)) = preferred_manifest_in_dir(dir, MOON_MOD, MOON_MOD_JSON)
+    else {
+        return;
+    };
+    let module = match format {
+        ManifestFormat::New => read_module_from_dsl(&manifest_path),
+        ManifestFormat::Legacy => {
+            read_module_from_json(&manifest_path).map_err(anyhow::Error::from)
+        }
+    };
+    let Ok(module) = module else {
+        // The normal manifest read reports format and I/O errors.
+        return;
+    };
+    let deprecated_fields = match (module.include.is_some(), module.exclude.is_some()) {
+        (true, true) => Some(("`include` and `exclude`", "are")),
+        (true, false) => Some(("`include`", "is")),
+        (false, true) => Some(("`exclude`", "is")),
+        (false, false) => None,
+    };
+    if let Some((fields, verb)) = deprecated_fields {
+        user_log.warn(format!(
+            "{fields} in `{}` {verb} deprecated; use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.",
+            manifest_path.display()
+        ));
+    }
+}
+
 pub fn warn_known_shadowed_manifest(
     dir: &Path,
     legacy_manifest: &'static str,

--- a/crates/moonutil/src/module.rs
+++ b/crates/moonutil/src/module.rs
@@ -58,6 +58,8 @@ pub struct MoonMod {
     pub name: String,
     pub version: Option<Version>,
     pub deps: IndexMap<String, SourceDependencyInfo>,
+    /// Deprecated third-party binary dependencies. Publish portable Wasm tools
+    /// and run them with `moonx` instead.
     pub bin_deps: Option<IndexMap<String, BinaryDependencyInfo>>,
     pub readme: Option<String>,
     pub repository: Option<String>,
@@ -77,7 +79,13 @@ pub struct MoonMod {
 
     pub warn_list: Option<String>,
 
+    /// Deprecated. Use `.gitignore` or `.moonignore` to control which files
+    /// are packaged instead. `.moonignore` overrides `.gitignore` in the same
+    /// directory.
     pub include: Option<Vec<String>>,
+    /// Deprecated. Use `.gitignore` or `.moonignore` to control which files
+    /// are packaged instead. `.moonignore` overrides `.gitignore` in the same
+    /// directory.
     pub exclude: Option<Vec<String>>,
 
     pub preferred_target: Option<TargetBackend>,
@@ -194,11 +202,15 @@ pub struct MoonModJSON {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warn_list: Option<String>,
 
-    /// Files to include when publishing.
+    /// Deprecated. Use `.gitignore` or `.moonignore` to control which files
+    /// are packaged instead. `.moonignore` overrides `.gitignore` in the same
+    /// directory.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include: Option<Vec<String>>,
 
-    /// Files to exclude when publishing.
+    /// Deprecated. Use `.gitignore` or `.moonignore` to control which files
+    /// are packaged instead. `.moonignore` overrides `.gitignore` in the same
+    /// directory.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclude: Option<Vec<String>>,
 

--- a/crates/moonutil/tests/expect_moon_mod.rs
+++ b/crates/moonutil/tests/expect_moon_mod.rs
@@ -20,10 +20,12 @@ use std::path::PathBuf;
 
 use moonutil::manifest::{
     MoonMod, MoonModJSON, MoonModJSONRules, MoonModRule, convert_module_to_mod_json,
-    read_module_desc_file_in_dir, read_module_from_dsl, write_module_dsl_to_file,
+    read_module_desc_file_in_dir, read_module_from_dsl, warn_module_manifest,
+    write_module_dsl_to_file,
 };
 use moonutil::package::SupportedTargetsConfig;
 use moonutil::target::TargetBackend;
+use moonutil::user_log::UserLog;
 use semver::Version;
 
 fn fixture_dir(name: &str) -> PathBuf {
@@ -109,6 +111,71 @@ fn read_module_desc_prefers_dsl() {
     let dir = fixture_dir("module_both");
     let module = read_module_desc_file_in_dir(&dir).expect("read module descriptor");
     assert_eq!(module.name, "example/dsl_prefers");
+}
+
+#[test]
+fn warn_module_manifest_reports_deprecated_packaging_fields() {
+    let dir = temp_dir("deprecated-packaging-fields");
+    std::fs::write(
+        dir.join("moon.mod.json"),
+        r#"{
+  "name": "example/deprecated",
+  "include": ["src/**"],
+  "exclude": ["target/**"]
+}
+"#,
+    )
+    .unwrap();
+    let (user_log, capture) = UserLog::captured(log::LevelFilter::Warn);
+
+    warn_module_manifest(&dir, "at test module root", &user_log);
+
+    let entries = capture.take();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].message,
+        format!(
+            "`include` and `exclude` in `{}` are deprecated; use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.",
+            dir.join("moon.mod.json").display()
+        )
+    );
+}
+
+#[test]
+fn warn_module_manifest_uses_the_selected_manifest_path() {
+    let dir = temp_dir("selected-deprecated-packaging-fields");
+    std::fs::write(
+        dir.join("moon.mod"),
+        r#"name = "example/deprecated"
+
+options(
+  "include": ["src/**"],
+)
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("moon.mod.json"),
+        r#"{
+  "name": "example/deprecated",
+  "exclude": ["target/**"]
+}
+"#,
+    )
+    .unwrap();
+    let (user_log, capture) = UserLog::captured(log::LevelFilter::Warn);
+
+    warn_module_manifest(&dir, "at test module root", &user_log);
+
+    let entries = capture.take();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(
+        entries[1].message,
+        format!(
+            "`include` in `{}` is deprecated; use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.",
+            dir.join("moon.mod").display()
+        )
+    );
 }
 
 #[test]

--- a/docs/manual-zh/src/source/mod_json_schema.html
+++ b/docs/manual-zh/src/source/mod_json_schema.html
@@ -80,7 +80,7 @@
       ]
     },
     "exclude": {
-      "description": "Files to exclude when publishing.",
+      "description": "Deprecated. Use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.",
       "type": [
         "array",
         "null"
@@ -90,7 +90,7 @@
       }
     },
     "include": {
-      "description": "Files to include when publishing.",
+      "description": "Deprecated. Use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.",
       "type": [
         "array",
         "null"

--- a/docs/manual/src/source/mod_json_schema.html
+++ b/docs/manual/src/source/mod_json_schema.html
@@ -80,7 +80,7 @@
       ]
     },
     "exclude": {
-      "description": "Files to exclude when publishing.",
+      "description": "Deprecated. Use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.",
       "type": [
         "array",
         "null"
@@ -90,7 +90,7 @@
       }
     },
     "include": {
-      "description": "Files to include when publishing.",
+      "description": "Deprecated. Use `.gitignore` or `.moonignore` to control which files are packaged instead. `.moonignore` overrides `.gitignore` in the same directory.",
       "type": [
         "array",
         "null"


### PR DESCRIPTION
## Why

The legacy `include` and `exclude` module fields imply that they still control packaged files, while packaging now follows ignore files. Users need a clear migration path, including the precedence rule when both ignore formats are present. The existing `bin-deps` compatibility path also needs to consistently direct new tools toward published portable Wasm packages executed with `moonx`.

## What changed

- Emit one User Log warning from the existing module-manifest discovery boundary when the selected `moon.mod` or `moon.mod.json` uses `include` or `exclude`.
- Report the actual selected manifest path and explain that a sibling `.moonignore` overrides `.gitignore`.
- Keep parsing the deprecated fields for compatibility while documenting their replacements in generated schemas.
- Document `bin-deps` as deprecated in favor of published portable Wasm tools run with `moonx`.
- Cover ordinary commands, workspace members, manifest selection, and ignore-file precedence.

## Why this is correct and minimal

The warning extends the existing manifest-warning seam, so module parsing and unrelated resolver APIs remain unchanged. Manifest selection uses the same `moon.mod`-over-`moon.mod.json` preference as normal reads, cached dependency manifests remain quiet, and the deprecated fields are retained solely for backward compatibility.