### PR TITLE
fix(bench): run each benchmark in its own process

### DIFF
--- a/crates/moon/src/run/runtest.rs
+++ b/crates/moon/src/run/runtest.rs
@@ -212,6 +212,19 @@ pub(crate) fn run_tests(
     let invocations = collect_test_invocations(build_meta, filter, include_skipped, bench)?;
     debug!(count = invocations.len(), "collected test invocations");
 
+    // Benchmarks are timed, so they must not share a process; see
+    // [`isolate_invocations`].
+    let invocations = if bench {
+        let invocations = isolate_invocations(invocations);
+        debug!(
+            count = invocations.len(),
+            "isolated each benchmark into its own run"
+        );
+        invocations
+    } else {
+        invocations
+    };
+
     // Parallelism is opt-in: sequential by default, parallel only when -j is given
     let parallelism = if no_parallelize {
         1
@@ -775,6 +788,51 @@ pub(crate) fn collect_test_invocations(
     Ok(invocations)
 }
 
+/// Split each invocation into one invocation per selected case, so that every
+/// case gets a freshly started process.
+///
+/// A test executable runs every case it is given inside one long-lived
+/// runtime, which is fine for tests but not for benchmarks: a case that runs
+/// second is measured against a runtime that the first case has already
+/// warmed, grown and specialized. The effect is large enough to show up as a
+/// regression when an unrelated benchmark is added ahead of an existing one.
+fn isolate_invocations(invocations: Vec<TestInvocation>) -> Vec<TestInvocation> {
+    let mut isolated = Vec::with_capacity(invocations.len());
+    for invocation in invocations {
+        for case in split_cases(&invocation.args.file_and_index) {
+            isolated.push(TestInvocation {
+                target: invocation.target,
+                executable: invocation.executable.clone(),
+                args: TestArgs {
+                    package: invocation.args.package.clone(),
+                    file_and_index: vec![case],
+                },
+                meta: invocation.meta.clone(),
+            });
+        }
+    }
+    isolated
+}
+
+/// Expand a case filter into one single-case filter per selected case. Files
+/// with nothing selected drop out.
+// The one-element range vectors are the point here: each returned filter
+// selects exactly one case.
+#[allow(clippy::single_range_in_vec_init)]
+fn split_cases(
+    file_and_index: &[(String, Vec<std::ops::Range<u32>>)],
+) -> Vec<(String, Vec<std::ops::Range<u32>>)> {
+    let mut cases = Vec::new();
+    for (file, ranges) in file_and_index {
+        for range in ranges {
+            for index in range.clone() {
+                cases.push((file.clone(), vec![index..index + 1]));
+            }
+        }
+    }
+    cases
+}
+
 #[instrument(level = "debug", skip(ctx, test))]
 fn run_one_test_executable(
     ctx: &TestRunCtx<'_>,
@@ -1169,6 +1227,26 @@ mod tests {
                 );
             }
         });
+    }
+
+    #[test]
+    #[allow(clippy::single_range_in_vec_init)]
+    fn isolation_gives_every_selected_case_its_own_run() {
+        let selected = vec![
+            ("a.mbt".to_string(), vec![0..2, 5..6]),
+            ("b.mbt".to_string(), vec![]),
+            ("c.mbt".to_string(), vec![3..4]),
+        ];
+
+        assert_eq!(
+            super::split_cases(&selected),
+            vec![
+                ("a.mbt".to_string(), vec![0..1]),
+                ("a.mbt".to_string(), vec![1..2]),
+                ("a.mbt".to_string(), vec![5..6]),
+                ("c.mbt".to_string(), vec![3..4]),
+            ]
+        );
     }
 
     #[test]

--- a/crates/moon/tests/test_cases/bench_isolation.in/lib/a_bench.mbt
+++ b/crates/moon/tests/test_cases/bench_isolation.in/lib/a_bench.mbt
@@ -1,0 +1,19 @@
+// The two benchmarks below must not observe each other: `moon bench` gives
+// each one its own process, so the second always starts from a clean slate.
+
+///|
+let ran_before : Array[Int] = [0]
+
+///|
+test "leaves state behind" (it : @bench.T) {
+  ran_before[0] = ran_before[0] + 1
+  it.bench(fn() { () })
+}
+
+///|
+test "must start from a fresh process" (it : @bench.T) {
+  if ran_before[0] != 0 {
+    fail("another benchmark ran in this process first")
+  }
+  it.bench(fn() { () })
+}

--- a/crates/moon/tests/test_cases/bench_isolation.in/lib/moon.pkg
+++ b/crates/moon/tests/test_cases/bench_isolation.in/lib/moon.pkg
@@ -1,0 +1,3 @@
+import {
+  "moonbitlang/core/bench"
+}

--- a/crates/moon/tests/test_cases/bench_isolation.in/moon.mod
+++ b/crates/moon/tests/test_cases/bench_isolation.in/moon.mod
@@ -1,0 +1,1 @@
+name = "bench_isolation"

--- a/crates/moon/tests/test_cases/moon_bench/mod.rs
+++ b/crates/moon/tests/test_cases/moon_bench/mod.rs
@@ -46,6 +46,16 @@ fn test_bench_driver_build_native() {
 }
 
 #[test]
+fn test_bench_isolates_each_case_in_its_own_process() {
+    let dir = TestDir::new("bench_isolation.in");
+    let out = get_stdout(&dir, ["bench"]);
+    assert!(
+        out.contains("Total tests: 2, passed: 2, failed: 0."),
+        "benchmarks should not share a process:\n{out}"
+    );
+}
+
+#[test]
 #[cfg(not(windows))]
 fn test_bench_displays_nanoseconds() {
     let dir = TestDir::new("moon_bench");

--- a/docs/dev/reference/tests.md
+++ b/docs/dev/reference/tests.md
@@ -15,20 +15,28 @@ behavior can change.
    into one n2 graph. The entire graph must build successfully before any test
    executable starts. This invocation-wide barrier prevents tests for an early
    backend from running when a later backend fails to build.
-3. `run_tests` (in `runtest.rs`) calls `gather_tests`, which pairs those artifacts,
-   sorts them by executable path (to match legacy ordering), and then iterates over
-   each test binary.
-4. Every executable is launched through `run_one_test_executable`. The runner:
-   - Parses the metadata (`MooncGenTestInfo`) to know which files and indices exist.
-   - Applies the CLI filter to build a `TestArgs` payload that lists the test ranges
-     to execute.
+3. `run_tests` (in `runtest.rs`) calls `gather_tests`, which pairs those artifacts and
+   sorts them by executable path (to match legacy ordering). `collect_test_invocations`
+   then turns each pair into a `TestInvocation`: it parses the metadata
+   (`MooncGenTestInfo`) to know which files and indices exist, applies the CLI filter to
+   build the `TestArgs` payload listing the ranges to execute, and drops binaries for
+   which nothing is selected.
+4. Benchmarks are then isolated. When `bench` is true, `isolate_invocations` splits
+   every invocation into one invocation per selected case, so no benchmark shares a
+   process with another. Cases that share a process share a runtime that the earlier
+   ones have already warmed, grown and specialized, which makes a reported time depend
+   on how many cases ran before it — around 10% on wasm-gc. `moon test` keeps one
+   invocation per test binary.
+5. Every invocation is launched through `run_one_test_executable`, which therefore
+   starts a bench executable once per case. The runner:
    - Builds a backend-specific command (see below) and optionally prints it when
      `--verbose` is enabled.
    - Captures the test driver event stream between the
      `MOON_TEST_DELIMITER_{BEGIN,END}` markers. Coverage sections delimited by
      `MOON_COVERAGE_DELIMITER_*` are written to `_build/moonbit_coverage_<timestamp>_<rand>.txt`.
-5. The collected `TestCaseResult`s are merged per build target inside
-   `ReplaceableTestResults`. This structure keeps the latest result per
+6. The collected `TestCaseResult`s are merged per build target inside
+   `ReplaceableTestResults`, so the several invocations of an isolated benchmark run
+   land in one entry. This structure keeps the latest result per
    `(target, file, index)` pair so later reruns can overwrite earlier data. The
    final report is rendered either as compact text (default) or JSON lines (when
    `--test-failure-json` is on).
@@ -187,8 +195,10 @@ Filtering is handled by `TestFilter` (`runtest/filter.rs`). It stores allowed
 
 ### Benchmarks and skips
 
-- `moon bench` reuses the exact same plumbing but passes `bench = true` to the filter,
-  so only benchmark entries (`with_bench_args_tests`) are collected.
+- `moon bench` reuses the same filtering plumbing but passes `bench = true`, so only
+  benchmark entries (`with_bench_args_tests`) are collected. It also changes the process
+  model: every selected case is run in a process of its own (step 4 above) rather than
+  one process per test binary.
 - `--include-skipped` keeps skipped cases in the computed ranges. Without it, skipped
   tests are excluded unless their indices are explicitly listed.
 


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

## Summary

`moon bench` handed every selected case of a package to a single test executable, so all of them shared one long-lived runtime. Only the first case is measured against a fresh runtime; every later case runs against one the earlier cases have already warmed, grown and specialized.

Three benchmarks with identical bodies, one package, wasm-gc:

| | slot0 | slot1 | slot2 |
|---|---|---|---|
| before | 285.6 ns | 319.0 ns | 321.6 ns |
| before, after adding an unrelated `z_bench.mbt` | 321.4 ns | 319.8 ns | 321.2 ns |
| after | 284.3 ns | 286.7 ns | 285.1 ns |

The middle row is the practical failure: adding one trivial benchmark file pushes three untouched benchmarks up by ~12%, which reads as a regression on a benchmark dashboard. Run alone (`-p pkg -f file -i N`), each of them reports ~285 ns.

The cause is the harness's indirect call into the benchmark body. While that call site has seen only one closure it is speculatively inlined; the second distinct closure makes it polymorphic, and every case after that loses the inlining. Three cases that pass the *same* function value show no spread, and the native backend, which does not speculate, shows none either.

The fix splits each bench invocation into one invocation per case, reusing the existing case filter, so every benchmark starts from a fresh process. `moon test` is unaffected.

Cost is one extra process start plus module instantiation per benchmark, about 60 ms: 8.35s vs 7.93s over 13 benchmarks locally.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS
