### PR TITLE
feat(cli): deprecate runwasm and moonx native target

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -118,6 +118,8 @@ pub(crate) enum MoonBuildSubcommands {
     Check(CheckSubcommand),
     Prove(ProveSubcommand),
     Run(RunSubcommand),
+    // TODO(2026-09-14): Remove `moon runwasm` after the two-week deprecation
+    // window; its replacements depend on whether the input is local or remote.
     #[clap(name = "runwasm")]
     RunWasm(RunWasmSubcommand),
     Test(TestSubcommand),

--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -23,10 +23,15 @@ use moonutil::user_log::UserLog;
 
 use super::registry_runner::{self, RegistryRunTarget};
 
+pub(crate) const NATIVE_TARGET_DEPRECATION_WARNING: &str =
+    "`moonx --target native` is deprecated and scheduled for removal after 2026-09-14.";
+
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
 pub(crate) enum MoonxTarget {
     #[default]
     Wasm,
+    // TODO(2026-09-14): Remove the native moonx target and its registry
+    // build/cache path after the two-week deprecation window.
     Native,
 }
 
@@ -43,7 +48,9 @@ Accepted package coordinate forms:
 
 Pinned coordinates use the requested version directly. `@latest` refreshes the
 registry index before resolving the latest version. Unpinned coordinates use
-the latest version already known to the local registry index."#,
+the latest version already known to the local registry index.
+
+The native target is deprecated and scheduled for removal after 2026-09-14."#,
     override_usage = "moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...",
     version
 )]

--- a/crates/moon/src/cli/runtime.rs
+++ b/crates/moon/src/cli/runtime.rs
@@ -98,6 +98,9 @@ fn prepare_delegate(invocation: DelegatedInvocation) -> anyhow::Result<Command> 
 fn run_moonx(invocation: super::moonx::MoonxInvocation) -> i32 {
     // moonx intentionally has no Moon tracing or workspace bootstrap. It owns
     // registry preparation, then returns the final program as a process action.
+    if matches!(invocation.target, super::moonx::MoonxTarget::Native) {
+        UserLog::new(log::LevelFilter::Warn).warn(super::moonx::NATIVE_TARGET_DEPRECATION_WARNING);
+    }
     let verbose = invocation.verbose;
     let user_log = UserLog::new(user_log_level(verbose, !verbose));
     let result = super::moonx::prepare(invocation, &user_log).and_then(process::execute);

--- a/crates/moon/src/cli/runwasm.rs
+++ b/crates/moon/src/cli/runwasm.rs
@@ -28,10 +28,13 @@ use tracing::instrument;
 use super::{BuildFlags, RunSubcommand};
 use crate::cli::process::ProcessAction;
 
-/// Run a local package as WebAssembly or a prebuilt WebAssembly binary
+/// Deprecated: use moon run --target wasm locally or moonx for registry packages
 #[derive(Debug, clap::Parser)]
-#[clap(
-    long_about = r#"Run a local package as WebAssembly or a prebuilt WebAssembly binary published as a Mooncakes asset.
+#[clap(long_about = r#"Deprecated:
+  Local packages: use `moon run <LOCAL_PACKAGE> --target wasm`.
+  Registry packages: use `moonx <PACKAGE[@VERSION]>`.
+
+Run a local package as WebAssembly or a prebuilt WebAssembly binary published as a Mooncakes asset.
 
 Local package inputs are handled like `moon run --target wasm`:
   moon runwasm main
@@ -49,8 +52,7 @@ Pinned coordinates use the given version directly. `@latest` refreshes the
 registry index before resolving the latest version. Unpinned coordinates use
 the latest version already in the local index, updating it only when the module
 is absent. Fetched wasm files are cached under $MOON_HOME/registry/cache/assets
-and reused on later runs."#
-)]
+and reused on later runs."#)]
 pub(crate) struct RunWasmSubcommand {
     /// Local package path or Mooncakes package coordinate of the prebuilt wasm binary
     #[clap(value_name = "LOCAL_PACKAGE|PACKAGE[@VERSION]")]
@@ -75,9 +77,16 @@ pub(crate) fn run_runwasm(
     output: &CommandOutput,
 ) -> anyhow::Result<ProcessAction> {
     if should_run_as_local_package(&cmd.package)? {
+        output.user_log().warn(
+            "`moon runwasm` is deprecated and scheduled for removal after 2026-09-14; use `moon run <PACKAGE> --target wasm` instead.",
+        );
         return super::run_run(cli, runwasm_as_run_subcommand(cmd), output)
             .map(ProcessAction::Exit);
     }
+
+    output.user_log().warn(
+        "`moon runwasm` is deprecated and scheduled for removal after 2026-09-14; use `moonx` instead.",
+    );
 
     if cli.dry_run {
         bail!("--dry-run is not supported for Mooncakes assets in `moon runwasm`");

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -53,7 +53,7 @@ fn test_moon_help() {
               check                  Check the current package, but don't build object files
               prove                  Prove the current package
               run                    Run a main package
-              runwasm                Run a local package as WebAssembly or a prebuilt WebAssembly binary
+              runwasm                Deprecated: use moon run --target wasm locally or moonx for registry packages
               test                   Test the current package
               clean                  Remove local build outputs or configured global caches
               fmt                    Format source code
@@ -127,6 +127,8 @@ Pinned coordinates use the requested version directly. `@latest` refreshes the
 registry index before resolving the latest version. Unpinned coordinates use
 the latest version already known to the local registry index.
 
+The native target is deprecated and scheduled for removal after 2026-09-14.
+
 Usage: moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...
 
 Options:
@@ -172,6 +174,7 @@ fn test_moonx_validates_native_options_before_discarding_an_inherited_marker() {
         .failure()
         .stdout_eq("")
         .stderr_eq(snapbox::str![[r#"
+Warning: `moonx --target native` is deprecated and scheduled for removal after 2026-09-14.
 Error: --experimental-policy is only valid with `--target wasm`
 
 "#]]);
@@ -277,6 +280,7 @@ fn test_moonx_native_output_and_cache_contract() {
         .failure()
         .stdout_eq("")
         .stderr_eq(snapbox::str![[r#"
+Warning: `moonx --target native` is deprecated and scheduled for removal after 2026-09-14.
 [..]Package `testuser/runner` not found or is not a main package (is-main: true required)
 
 "#]]);
@@ -290,6 +294,7 @@ fn test_moonx_native_output_and_cache_contract() {
         .failure()
         .stdout_eq("")
         .stderr_eq(snapbox::str![[r#"
+Warning: `moonx --target native` is deprecated and scheduled for removal after 2026-09-14.
 [..]Package `testuser/runner/lib` not found or is not a main package (is-main: true required)
 
 "#]]);
@@ -332,6 +337,7 @@ fn test_moonx_native_output_and_cache_contract() {
         .success()
         .stdout_eq("native runner\n--child-arg\n")
         .stderr_eq(snapbox::str![[r#"
+Warning: `moonx --target native` is deprecated and scheduled for removal after 2026-09-14.
 Using cached testuser/runner@1.2.3
 Using cached testuser/dependency@1.0.0
 Building `testuser/runner/tool`...
@@ -368,7 +374,9 @@ Finished. moon: ran 9 tasks, now up to date
         .assert()
         .success()
         .stdout_eq("native runner\n--inherited-native\n")
-        .stderr_eq("");
+        .stderr_eq(
+            "Warning: `moonx --target native` is deprecated and scheduled for removal after 2026-09-14.\n",
+        );
     relay.finish().unwrap();
 
     snapbox::cmd::Command::new(&moonx)
@@ -388,7 +396,9 @@ Finished. moon: ran 9 tasks, now up to date
         .assert()
         .success()
         .stdout_eq("native runner\n--malformed-inherited-marker\n")
-        .stderr_eq("");
+        .stderr_eq(
+            "Warning: `moonx --target native` is deprecated and scheduled for removal after 2026-09-14.\n",
+        );
 
     std::fs::remove_file(&zip_path).unwrap();
     std::fs::remove_file(&index_path).unwrap();
@@ -499,6 +509,14 @@ fn test_runwasm_help_marks_policy_as_experimental() {
     let dir = TestDir::new_empty();
     let help = get_stdout(&dir, ["runwasm", "--help"]);
     assert!(
+        help.contains("Local packages: use `moon run <LOCAL_PACKAGE> --target wasm`."),
+        "expected runwasm help to identify the local-package replacement, got:\n{help}"
+    );
+    assert!(
+        help.contains("Registry packages: use `moonx <PACKAGE[@VERSION]>`."),
+        "expected runwasm help to identify the registry-package replacement, got:\n{help}"
+    );
+    assert!(
         help.contains("--experimental-policy <PATH>"),
         "expected runwasm help to expose experimental policy flag, got:\n{help}"
     );
@@ -528,6 +546,12 @@ fn test_runwasm_local_package_forwards_experimental_policy() {
             "main",
         ],
         [("MOONRUN_OVERRIDE", moonrun_bin())],
+    );
+    assert!(
+        stderr.contains(
+            "`moon runwasm` is deprecated and scheduled for removal after 2026-09-14; use `moon run <PACKAGE> --target wasm` instead."
+        ),
+        "expected local runwasm deprecation guidance, got:\n{stderr}"
     );
     assert!(
         stderr.contains("failed to load sandbox policy"),
@@ -631,7 +655,9 @@ fn test_runwasm_cached_asset_exits_with_guest_exit_code() {
         .assert()
         .code(7)
         .stdout_eq("")
-        .stderr_eq("");
+        .stderr_eq(
+            "Warning: `moon runwasm` is deprecated and scheduled for removal after 2026-09-14; use `moonx` instead.\n",
+        );
 }
 
 #[test]
@@ -704,6 +730,12 @@ fn test_runwasm_cached_asset_forwards_experimental_policy() {
         envs,
     );
     assert!(
+        stderr.contains(
+            "`moon runwasm` is deprecated and scheduled for removal after 2026-09-14; use `moonx` instead."
+        ),
+        "expected registry runwasm deprecation guidance, got:\n{stderr}"
+    );
+    assert!(
         stderr.contains("failed to load sandbox policy"),
         "expected sandbox policy load error, got:\n{stderr}"
     );
@@ -744,7 +776,9 @@ fn test_runwasm_uses_cached_asset_and_forwards_args() {
 arg2
 
 "#]])
-        .stderr_eq("");
+        .stderr_eq(
+            "Warning: `moon runwasm` is deprecated and scheduled for removal after 2026-09-14; use `moonx` instead.\n",
+        );
 }
 
 #[test]

--- a/docs/dev/reference/moonx.md
+++ b/docs/dev/reference/moonx.md
@@ -22,7 +22,7 @@ moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...
 The supported options are:
 
 ```text
---target <wasm|native>        # defaults to wasm
+--target <wasm|native>        # defaults to wasm; native is deprecated
 --experimental-policy <PATH> # wasm only
 -v, --verbose
 -h, --help
@@ -104,6 +104,10 @@ Tests for its cached-asset mode must use linear-Wasm fixtures rather than
 WasmGC fixtures.
 
 ## Native target
+
+The `native` target is deprecated and scheduled for removal after September
+14, 2026. Until then, it retains its existing behavior and emits a deprecation
+warning on every invocation.
 
 The `native` target reuses the registry acquisition, exact main-package
 selection, and release build behavior of `moon install`, but publishes the

--- a/docs/dev/reference/runwasm.md
+++ b/docs/dev/reference/runwasm.md
@@ -3,7 +3,9 @@
 > This page documents registry-backed prebuilt wasm mode of `moon runwasm`.
 > Local package inputs are delegated to `moon run --target wasm`.
 >
-> Status: expected behavior in this branch as of June 10, 2026.
+> Status: deprecated and scheduled for removal after September 14, 2026. Use
+> `moon run <local-package> --target wasm` for local packages and `moonx` for
+> registry packages.
 
 ## Scope
 
@@ -16,6 +18,10 @@
    published for a registry module version.
 
 This document focuses on Mooncakes asset mode.
+
+Valid local-package invocations emit a deprecation warning directing users to
+`moon run <local-package> --target wasm`. Registry-package invocations instead
+direct users to `moonx`.
 
 ## Coordinate model
 

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -54,7 +54,7 @@ This document contains the help content for the `moon` command-line program.
 * `check` — Check the current package, but don't build object files
 * `prove` — Prove the current package
 * `run` — Run a main package
-* `runwasm` — Run a local package as WebAssembly or a prebuilt WebAssembly binary
+* `runwasm` — Deprecated: use moon run --target wasm locally or moonx for registry packages
 * `test` — Test the current package
 * `clean` — Remove local build outputs or configured global caches
 * `fmt` — Format source code
@@ -260,6 +260,10 @@ Run a main package
 
 
 ## `moon runwasm`
+
+Deprecated:
+  Local packages: use `moon run <LOCAL_PACKAGE> --target wasm`.
+  Registry packages: use `moonx <PACKAGE[@VERSION]>`.
 
 Run a local package as WebAssembly or a prebuilt WebAssembly binary published as a Mooncakes asset.
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -54,7 +54,7 @@ This document contains the help content for the `moon` command-line program.
 * `check` — Check the current package, but don't build object files
 * `prove` — Prove the current package
 * `run` — Run a main package
-* `runwasm` — Run a local package as WebAssembly or a prebuilt WebAssembly binary
+* `runwasm` — Deprecated: use moon run --target wasm locally or moonx for registry packages
 * `test` — Test the current package
 * `clean` — Remove local build outputs or configured global caches
 * `fmt` — Format source code
@@ -260,6 +260,10 @@ Run a main package
 
 
 ## `moon runwasm`
+
+Deprecated:
+  Local packages: use `moon run <LOCAL_PACKAGE> --target wasm`.
+  Registry packages: use `moonx <PACKAGE[@VERSION]>`.
 
 Run a local package as WebAssembly or a prebuilt WebAssembly binary published as a Mooncakes asset.
 


### PR DESCRIPTION
## Why

The CLI currently exposes two execution surfaces that are planned for removal: `moon runwasm` overlaps with `moon run --target wasm` and `moonx`, while the native `moonx` target conflicts with the direction toward portable Wasm tools. Removing either immediately would break existing workflows without migration guidance.

## What changed

- Deprecate `moon runwasm` with replacement guidance selected by input type: local packages point to `moon run <PACKAGE> --target wasm`, while registry packages point to `moonx`.
- Deprecate `moonx --target native` while preserving its existing build, cache, execution, policy, and signal behavior during the compatibility window.
- Mark both compatibility paths for removal after September 14, 2026.
- Update CLI help, generated manuals, implemented-behavior references, and focused coverage for the warnings.

## Why this is correct

The change keeps both existing execution paths intact and adds warnings at their established command boundaries. `moon runwasm` reuses its existing local-package classification to choose accurate guidance. The `moonx` warning is emitted at the executable entry point so it remains visible despite moonx intentionally using an error-only default log level.

## Scope

This PR is limited to deprecation and migration communication. Local file or project support in `moonx`, and the eventual removal of these compatibility paths, remain follow-up work.