### PR TITLE
refactor(native): remove tcc run from build graph

### DIFF
--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -141,7 +141,7 @@ fn cached_native_executable(
 }
 
 fn prepare_artifact(
-    mode: crate::run::ExecutionMode<'_>,
+    mode: crate::run::ExecutionMode,
     artifact: &Path,
     experimental_policy: Option<&Path>,
     policy_relay: Option<moonutil::policy_transport::PolicyRelay>,

--- a/crates/moon/src/run/runtime.rs
+++ b/crates/moon/src/run/runtime.rs
@@ -22,26 +22,21 @@ use std::path::Path;
 use std::process::Command;
 
 use moonbuild::entry::TestArgs;
-use moonbuild_rupes_recta::model::{BackendConfig, NativeBackendMode, TccRunConfig};
+use moonbuild_rupes_recta::model::{BackendConfig, NativeBackendMode};
 
 /// The runtime mode used to execute one built artifact.
 #[derive(Clone, Copy)]
-pub(crate) enum ExecutionMode<'a> {
+pub(crate) enum ExecutionMode {
     MoonRun,
     Node,
     Native,
-    TccRun(&'a TccRunConfig),
 }
 
-impl<'a> From<&'a BackendConfig> for ExecutionMode<'a> {
-    fn from(backend: &'a BackendConfig) -> Self {
+impl From<&BackendConfig> for ExecutionMode {
+    fn from(backend: &BackendConfig) -> Self {
         match backend {
             BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } => Self::MoonRun,
             BackendConfig::Js => Self::Node,
-            BackendConfig::Native {
-                mode: NativeBackendMode::TccRun(config),
-                ..
-            } => Self::TccRun(config),
             BackendConfig::Native {
                 mode: NativeBackendMode::GeneratedC | NativeBackendMode::DirectObject(_),
                 ..
@@ -66,7 +61,7 @@ impl<'a> From<&'a BackendConfig> for ExecutionMode<'a> {
 /// ### Note
 ///
 pub(crate) fn command_for(
-    mode: ExecutionMode<'_>,
+    mode: ExecutionMode,
     mbt_executable: &Path,
     test: Option<&TestArgs>,
 ) -> Command {
@@ -74,7 +69,7 @@ pub(crate) fn command_for(
 }
 
 pub(crate) fn command_for_with_moonrun_policy(
-    mode: ExecutionMode<'_>,
+    mode: ExecutionMode,
     mbt_executable: &Path,
     test: Option<&TestArgs>,
     moonrun_policy: Option<&Path>,
@@ -100,15 +95,6 @@ pub(crate) fn command_for_with_moonrun_policy(
             cmd.arg(mbt_executable);
             if let Some(t) = test {
                 cmd.arg(serde_json::to_string(t).expect("Failed to serialize test args"));
-            }
-            cmd
-        }
-        ExecutionMode::TccRun(tcc_run) => {
-            let tcc = tcc_run.internal_tcc();
-            let mut cmd = Command::new(tcc.cc_path());
-            cmd.arg(format!("@{}", mbt_executable.display()));
-            if let Some(t) = test {
-                cmd.arg(t.to_cli_args_for_native());
             }
             cmd
         }

--- a/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/backend.rs
@@ -22,97 +22,30 @@
 //! backend branch for command shape and runtime/linking behavior. Concrete
 //! artifact paths are resolved by `target_layout`.
 
-use crate::model::{BackendConfig, NativeBackendMode};
+use crate::model::NativeBackendMode;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum CExecutableRealization {
     CompileAndLinkGeneratedC,
     LinkDirectObject,
-    WriteTccRunResponseFile,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum CRuntimeRealization {
-    StaticObject,
-    SharedLibraryForTccRun,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) enum CStubLibraryRealization {
-    StaticArchive,
-    SharedLibraryForTccRun,
-}
-
-impl BackendConfig {
-    pub(crate) fn c_stub_library_realization(&self) -> CStubLibraryRealization {
-        match self {
-            Self::Native { mode, .. } => mode.c_stub_library_realization(),
-            Self::Llvm { .. } => CStubLibraryRealization::StaticArchive,
-            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => {
-                unreachable!("C stubs are only realized for C or LLVM backends")
-            }
-        }
-    }
-
-    pub(crate) fn uses_shared_runtime(&self) -> bool {
-        match self {
-            Self::Native { mode, .. } => {
-                mode.runtime_realization() == CRuntimeRealization::SharedLibraryForTccRun
-            }
-            Self::Llvm { .. } => false,
-            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js => {
-                unreachable!("runtime artifacts are only realized for C or LLVM backends")
-            }
-        }
-    }
 }
 
 impl NativeBackendMode {
     pub(crate) fn executable_realization(&self) -> CExecutableRealization {
         match self {
             NativeBackendMode::GeneratedC => CExecutableRealization::CompileAndLinkGeneratedC,
-            NativeBackendMode::TccRun(_) => CExecutableRealization::WriteTccRunResponseFile,
             NativeBackendMode::DirectObject(_) => CExecutableRealization::LinkDirectObject,
-        }
-    }
-
-    fn runtime_realization(&self) -> CRuntimeRealization {
-        match self {
-            NativeBackendMode::TccRun(_) => CRuntimeRealization::SharedLibraryForTccRun,
-            NativeBackendMode::GeneratedC | NativeBackendMode::DirectObject(_) => {
-                CRuntimeRealization::StaticObject
-            }
-        }
-    }
-
-    pub(crate) fn c_stub_library_realization(&self) -> CStubLibraryRealization {
-        match self {
-            NativeBackendMode::TccRun(_) => CStubLibraryRealization::SharedLibraryForTccRun,
-            NativeBackendMode::GeneratedC | NativeBackendMode::DirectObject(_) => {
-                CStubLibraryRealization::StaticArchive
-            }
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use moonutil::compiler_flags::{ARKind, CC, CCKind, NativeAllocator};
+    use moonutil::compiler_flags::NativeAllocator;
 
-    use crate::model::{DirectNativeMode, TccRunConfig};
+    use crate::model::{BackendConfig, DirectNativeMode};
 
     use super::*;
-
-    fn fake_tcc_run() -> TccRunConfig {
-        TccRunConfig::new(CC {
-            cc_kind: CCKind::Tcc,
-            cc_path: "tcc".to_string(),
-            ar_kind: ARKind::TccAr,
-            ar_path: "tcc".to_string(),
-            target_triple: None,
-            is_env_override: false,
-        })
-    }
 
     #[test]
     fn wasm_backend_carries_wat_setting() {
@@ -122,30 +55,6 @@ mod tests {
         };
 
         assert!(matches!(backend, BackendConfig::Wasm { use_wat: true, .. }));
-    }
-
-    #[test]
-    fn c_tcc_run_realizes_shared_runtime_and_response_file() {
-        let backend = BackendConfig::Native {
-            mode: NativeBackendMode::TccRun(fake_tcc_run()),
-            allocator: NativeAllocator::Default,
-        };
-        let BackendConfig::Native {
-            mode: ref native_mode,
-            ..
-        } = backend
-        else {
-            panic!("native backend should select C lowering")
-        };
-        assert_eq!(
-            native_mode.executable_realization(),
-            CExecutableRealization::WriteTccRunResponseFile
-        );
-        assert_eq!(
-            backend.c_stub_library_realization(),
-            CStubLibraryRealization::SharedLibraryForTccRun
-        );
-        assert!(backend.uses_shared_runtime());
     }
 
     #[test]
@@ -168,11 +77,6 @@ mod tests {
             native_mode.executable_realization(),
             CExecutableRealization::LinkDirectObject
         );
-        assert_eq!(
-            backend.c_stub_library_realization(),
-            CStubLibraryRealization::StaticArchive
-        );
-        assert!(!backend.uses_shared_runtime());
     }
 
     #[test]
@@ -182,10 +86,5 @@ mod tests {
         };
 
         assert!(matches!(backend, BackendConfig::Llvm { .. }));
-        assert_eq!(
-            backend.c_stub_library_realization(),
-            CStubLibraryRealization::StaticArchive
-        );
-        assert!(!backend.uses_shared_runtime());
     }
 }

--- a/crates/moonbuild-rupes-recta/src/build_lower/context.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/context.rs
@@ -27,7 +27,7 @@ use moonutil::{
 use tracing::{Level, instrument};
 use walkdir::WalkDir;
 
-use super::{BuildOptions, CExecutableRealization, CStubLibraryRealization, LoweringError};
+use super::{BuildOptions, CExecutableRealization, LoweringError};
 use crate::{
     ResolveOutput,
     build_plan::{
@@ -541,9 +541,6 @@ impl<'a> LoweringContext<'a> {
             BuildAction::BuildCStub { .. } | BuildAction::BuildRuntimeObject { .. }
         ) || matches!(
             action,
-            BuildAction::BuildRuntimeLib { .. } if self.opt.backend.uses_shared_runtime()
-        ) || matches!(
-            action,
             BuildAction::MakeExecutable { .. }
                 if matches!(
                     &self.opt.backend,
@@ -599,11 +596,7 @@ impl<'a> LoweringContext<'a> {
                     .is_none_or(<[_]>::is_empty)
             }
             BuildAction::BuildCStub { info, .. } => info.cc_flags.is_empty(),
-            BuildAction::ArchiveOrLinkCStubs { info, .. } => {
-                self.opt.backend.c_stub_library_realization()
-                    == CStubLibraryRealization::StaticArchive
-                    || info.link_flags.is_empty()
-            }
+            BuildAction::ArchiveOrLinkCStubs { .. } => true,
             BuildAction::LinkCore { target, .. } => {
                 let package = self.get_package(target);
                 let package_link_flags =
@@ -635,7 +628,6 @@ impl<'a> LoweringContext<'a> {
                         info.c_flags.is_empty() && info.link_flags.is_empty()
                     }
                     CExecutableRealization::LinkDirectObject => info.link_flags.is_empty(),
-                    CExecutableRealization::WriteTccRunResponseFile => true,
                 },
                 BackendConfig::Llvm { .. } => info.c_flags.is_empty() && info.link_flags.is_empty(),
                 BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } | BackendConfig::Js => {

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_aux.rs
@@ -22,8 +22,8 @@ use std::path::Path;
 
 use moonutil::{
     compiler_flags::{
-        ArchiverConfigBuilder, CCConfigBuilder, NativeAllocator, OptLevel as CCOptLevel,
-        OutputType as CCOutputType, make_archiver_command_resolved, make_cc_command_resolved,
+        ArchiverConfigBuilder, CCConfigBuilder, OptLevel as CCOptLevel, OutputType as CCOutputType,
+        make_archiver_command_resolved, make_cc_command_resolved,
     },
     resolution::{ModuleId, ModuleSourceKind},
     test_metadata::DriverKind,
@@ -253,50 +253,6 @@ impl<'a> super::LoweringContext<'a> {
         let artifact_path = artifacts.single_output_path_matching(|artifact| {
             matches!(artifact, ArtifactKey::RuntimeLibrary)
         });
-
-        if self.opt.backend.uses_shared_runtime() {
-            let resolved_cc = info.effective_native_toolchain.cc().clone();
-            let sources = info
-                .source_files
-                .iter()
-                .map(|source| source.display().to_string())
-                .collect::<Vec<_>>();
-            let cc_cmd = make_cc_command_resolved(
-                resolved_cc,
-                CCConfigBuilder::default()
-                    .no_sys_header(true)
-                    .output_ty(CCOutputType::SharedLib)
-                    .opt_level(CCOptLevel::Speed)
-                    .debug_info(true)
-                    .allow_stacktrace(
-                        self.opt.debug_symbols && self.opt.os() != OperatingSystem::Windows,
-                    )
-                    .define_tinyc_macro(true)
-                    .preserve_frame_pointer(true)
-                    .link_moonbitrun(matches!(info.native_allocator, NativeAllocator::Mimalloc))
-                    .link_libbacktrace(true)
-                    .define_use_shared_runtime_macro(false)
-                    .native_allocator(info.native_allocator)
-                    .build()
-                    .expect("Failed to build CC configuration for shared runtime"),
-                &[] as &[&str],
-                &sources,
-                &self
-                    .artifact_paths
-                    .target_layout()
-                    .runtime_output_dir(self.opt.target_backend())
-                    .display()
-                    .to_string(),
-                Some(&artifact_path.display().to_string()),
-                self.opt.compiler_paths(),
-            );
-
-            return BuildCommand {
-                extra_inputs: info.source_files.clone(),
-                commandline: cc_cmd.into(),
-            }
-            .with_msvc_env(&info.effective_native_toolchain);
-        }
 
         let mut object_files = artifacts.dependency_paths_matching(|artifact| {
             matches!(artifact, ArtifactKey::RuntimeObject { .. })

--- a/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/lower_build.rs
@@ -26,10 +26,9 @@ use std::{
 use moonutil::{
     build_options::RunMode,
     compiler_flags::{
-        ArchiverConfigBuilder, CC, CCConfigBuilder, LinkerConfigBuilder, OptLevel as CCOptLevel,
+        ArchiverConfigBuilder, CCConfigBuilder, LinkerConfigBuilder, OptLevel as CCOptLevel,
         OutputType as CCOutputType, make_archiver_command_resolved,
-        make_cc_command_resolved_for_toolchain, make_cc_command_resolved_with_link_flags,
-        make_linker_command_resolved,
+        make_cc_command_resolved_for_toolchain, make_linker_command_resolved,
     },
     cond_expr::OptLevel,
     package::JsFormat,
@@ -42,7 +41,7 @@ use tracing::{Level, instrument};
 
 use crate::{
     build_lower::{
-        CExecutableRealization, CStubLibraryRealization, WarningCondition,
+        CExecutableRealization, WarningCondition,
         compiler::{
             BuildCommonConfig, BuildCommonInput, CmdlineAbstraction, ErrorFormat, JsConfig,
             MiDependency, PackageSource, WasmConfig,
@@ -894,16 +893,13 @@ impl<'a> LoweringContext<'a> {
             (false, true) => CCOptLevel::Debug,
             (false, false) => CCOptLevel::None,
         };
-        // `tcc run` uses shared runtime, others use static runtime
-        let use_shared_runtime = self.opt.backend.uses_shared_runtime();
-
         let config = CCConfigBuilder::default()
             .no_sys_header(true)
             .output_ty(CCOutputType::Object)
             .opt_level(opt_level)
             .debug_info(self.opt.debug_symbols)
-            .link_moonbitrun(!use_shared_runtime)
-            .define_use_shared_runtime_macro(use_shared_runtime)
+            .link_moonbitrun(true)
+            .define_use_shared_runtime_macro(false)
             .build()
             .expect("Failed to build CC configuration for C stub");
 
@@ -951,32 +947,14 @@ impl<'a> LoweringContext<'a> {
             matches!(artifact, ArtifactKey::CStubObject { .. })
         });
 
-        // There's two ways to handle this:
-        // - When not using `tcc -run`, this creates an archive of the C stubs.
-        // - When using `tcc -run`, this links the C stubs to an ELF .so, so tcc
-        //   can load it at runtime.
-        match self.opt.backend.c_stub_library_realization() {
-            CStubLibraryRealization::SharedLibraryForTccRun => {
-                let output = artifacts.single_output_path_matching(|artifact| {
-                    matches!(
-                        artifact,
-                        ArtifactKey::CStubLibrary { package }
-                            if *package == target
-                    )
-                });
-                self.lower_link_c_stubs(artifacts, info, &object_files, output)
-            }
-            CStubLibraryRealization::StaticArchive => {
-                let output = artifacts.single_output_path_matching(|artifact| {
-                    matches!(
-                        artifact,
-                        ArtifactKey::CStubLibrary { package }
-                            if *package == target
-                    )
-                });
-                self.lower_archive_c_stubs(info, &object_files, output)
-            }
-        }
+        let output = artifacts.single_output_path_matching(|artifact| {
+            matches!(
+                artifact,
+                ArtifactKey::CStubLibrary { package }
+                    if *package == target
+            )
+        });
+        self.lower_archive_c_stubs(info, &object_files, output)
     }
 
     fn lower_archive_c_stubs(
@@ -1004,64 +982,6 @@ impl<'a> LoweringContext<'a> {
         BuildCommand {
             extra_inputs: vec![],
             commandline: commandline.into(),
-        }
-        .with_msvc_env(&info.effective_native_toolchain)
-    }
-
-    fn lower_link_c_stubs(
-        &mut self,
-        artifacts: &ActionArtifacts,
-        info: &BuildCStubsInfo,
-        object_files: &[PathBuf],
-        dylib_out: PathBuf,
-    ) -> BuildCommand {
-        let dest_dir = dylib_out
-            .parent()
-            .expect("c stub dylib should have a parent directory")
-            .display()
-            .to_string();
-
-        // Track libruntime.{DYN_EXT} as a dependency but do not pass it as a direct linker src.
-        // Legacy adds runtime into build inputs then links via -lruntime using link_shared_runtime.
-        let runtime_dylib = artifacts.single_dependency_path_matching(|artifact| {
-            matches!(artifact, ArtifactKey::RuntimeLibrary)
-        });
-        let runtime_parent = runtime_dylib
-            .parent()
-            .expect("runtime dylib should have a parent directory");
-
-        // Use the effective toolchain (already resolved at planning time)
-        let cc = info.effective_native_toolchain.cc().clone();
-
-        // Build linker config: shared lib, no libmoonbitrun, and link shared runtime dir
-        let lcfg = LinkerConfigBuilder::<&Path>::default()
-            .link_moonbitrun(false) // this is only for tcc -run
-            .link_libbacktrace(true)
-            .output_ty(CCOutputType::SharedLib)
-            .link_shared_runtime(Some(runtime_parent))
-            .build()
-            .expect("Failed to build LinkerConfig for C stub dylib");
-
-        // Sources: only object files; runtime handled via link_shared_runtime (-lruntime + rpath)
-        let sources: Vec<String> = object_files
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect();
-
-        let cc_cmd = make_linker_command_resolved(
-            cc,
-            lcfg,
-            &info.link_flags,
-            &sources,
-            &dest_dir,
-            &dylib_out.display().to_string(),
-            &self.opt.compiler_paths().lib_path,
-        );
-
-        // Note: Runtime input is tracked in build plan, so no need to add here.
-        BuildCommand {
-            extra_inputs: vec![],
-            commandline: cc_cmd.into(),
         }
         .with_msvc_env(&info.effective_native_toolchain)
     }
@@ -1101,13 +1021,6 @@ impl<'a> LoweringContext<'a> {
                 unreachable!("non-native plans do not contain MakeExecutable actions")
             }
             BackendConfig::Native { mode, .. } => match mode.executable_realization() {
-                CExecutableRealization::WriteTccRunResponseFile => {
-                    let tcc_run = mode
-                        .tcc_run()
-                        .expect("tcc-run realization should carry tcc-run config");
-                    let internal_tcc = tcc_run.internal_tcc().clone();
-                    self.build_tcc_run_driver_command(artifacts, info, internal_tcc)
-                }
                 CExecutableRealization::LinkDirectObject => {
                     self.lower_link_new_native_exe(artifacts, target, info)
                 }
@@ -1146,22 +1059,14 @@ impl<'a> LoweringContext<'a> {
         &self,
         artifacts: &ActionArtifacts,
         info: &MakeExecutableInfo,
-        include_linked_core: bool,
     ) -> Vec<PathBuf> {
         let mut sources = Vec::new();
 
         // Runtime is a static archive for regular builds, so place it after the
         // linked core and C stub archives that may introduce runtime symbols.
-        // TCC-run uses a shared runtime and keeps the legacy runtime-first order.
-        if include_linked_core {
-            sources.extend(artifacts.dependency_paths_matching(|artifact| {
-                matches!(artifact, ArtifactKey::LinkedCore { .. })
-            }));
-        } else {
-            sources.extend(artifacts.dependency_paths_matching(|artifact| {
-                matches!(artifact, ArtifactKey::RuntimeLibrary)
-            }));
-        }
+        sources.extend(artifacts.dependency_paths_matching(|artifact| {
+            matches!(artifact, ArtifactKey::LinkedCore { .. })
+        }));
 
         for package in &info.link_c_stubs {
             sources.extend(artifacts.dependency_paths_matching(|artifact| {
@@ -1169,11 +1074,11 @@ impl<'a> LoweringContext<'a> {
             }));
         }
 
-        if include_linked_core {
-            sources.extend(artifacts.dependency_paths_matching(|artifact| {
+        sources.extend(
+            artifacts.dependency_paths_matching(|artifact| {
                 matches!(artifact, ArtifactKey::RuntimeLibrary)
-            }));
-        }
+            }),
+        );
 
         sources
     }
@@ -1190,7 +1095,7 @@ impl<'a> LoweringContext<'a> {
         // - compile the program (if needed)
         // - link with runtime library & artifacts of other C stubs
 
-        let sources = self.native_executable_dependency_paths(artifacts, info, true);
+        let sources = self.native_executable_dependency_paths(artifacts, info);
 
         let opt_level = match self.opt.opt_level {
             OptLevel::Release => CCOptLevel::Speed,
@@ -1243,7 +1148,7 @@ impl<'a> LoweringContext<'a> {
         target: BuildTarget,
         info: &MakeExecutableInfo,
     ) -> BuildCommand {
-        let sources = self.native_executable_dependency_paths(artifacts, info, true);
+        let sources = self.native_executable_dependency_paths(artifacts, info);
         let cc = info.effective_native_toolchain.cc().clone();
 
         let dest = artifacts.single_output_path().display().to_string();
@@ -1294,73 +1199,6 @@ impl<'a> LoweringContext<'a> {
             commandline,
         }
         .with_msvc_env(&info.effective_native_toolchain)
-    }
-
-    /// Build the command for `tcc -run` to execute when running, as well as
-    /// putting that into a response file.
-    fn build_tcc_run_driver_command(
-        &self,
-        artifacts: &ActionArtifacts,
-        info: &MakeExecutableInfo,
-        cc: CC,
-    ) -> BuildCommand {
-        let sources = self.native_executable_dependency_paths(artifacts, info, false);
-
-        let cfg = CCConfigBuilder::default()
-            .no_sys_header(true) // -DMOONBIT_NATIVE_NO_SYS_HEADER for TCC
-            .output_ty(CCOutputType::Executable) // base flags akin to "run"
-            .opt_level(match self.opt.opt_level {
-                OptLevel::Release => CCOptLevel::Speed,
-                OptLevel::Debug => CCOptLevel::Debug,
-            })
-            .debug_info(self.opt.debug_symbols)
-            .link_moonbitrun(false) // never link libmoonbitrun.o under tcc -run
-            .define_use_shared_runtime_macro(true) // -DMOONBIT_USE_SHARED_RUNTIME (+ -fPIC on gcc-like)
-            .build()
-            .expect("Failed to build CC configuration for tcc-run");
-
-        let mut cmdline = make_cc_command_resolved_with_link_flags(
-            cc,
-            cfg,
-            &[] as &[&str], // no user flags
-            &info.link_flags,
-            sources.iter().map(|x| x.to_string_lossy().into_owned()),
-            "", // TCC is not MSVC, no need to set special dest dir
-            None,
-            self.opt.compiler_paths(),
-        );
-
-        // The C file from moonc link-core
-        cmdline.push("-run".to_string());
-        let c_file = artifacts.single_dependency_path_matching(|artifact| {
-            matches!(artifact, ArtifactKey::LinkedCore { .. })
-        });
-        cmdline.push(c_file.display().to_string());
-
-        // Note: at this point, we have our TCC command.
-        // However, this command should be executed when the user runs the final
-        // executable, not in this build graph. Thus, we need to put them into
-        // a response file so that `tcc` will run it later.
-        //
-        // We have a tool for this: `moon tool write-tcc-rsp-file <out> <args...>`
-        let moonbuild = BINARIES
-            .moonbuild
-            .to_str()
-            .expect("moonbuild path is valid UTF-8");
-        let mut rsp_cmdline = vec![
-            moonbuild.to_string(),
-            "tool".to_string(),
-            "write-tcc-rsp-file".to_string(),
-        ];
-        let rsp_path = artifacts.single_output_path();
-
-        rsp_cmdline.push(rsp_path.display().to_string());
-        rsp_cmdline.extend(cmdline.into_iter().skip(1)); // skip original `tcc` command
-
-        BuildCommand {
-            extra_inputs: vec![],
-            commandline: rsp_cmdline.into(),
-        }
     }
 
     #[instrument(level = Level::DEBUG, skip(self, artifacts))]

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -56,7 +56,7 @@ pub use crate::execution_plan::{
 };
 pub use utils::{build_ins, build_n2_fileloc, build_outs};
 
-pub(crate) use backend::{CExecutableRealization, CStubLibraryRealization};
+pub(crate) use backend::CExecutableRealization;
 
 use command::BuildCommand;
 use context::LoweringContext;
@@ -151,11 +151,7 @@ impl BuildOptions {
             ),
             BackendConfig::Js => (ExecutableArtifact::Js, LinkedCoreArtifact::Js),
             BackendConfig::Native { mode, .. } => (
-                if mode.tcc_run().is_some() {
-                    ExecutableArtifact::TccRunResponseFile
-                } else {
-                    ExecutableArtifact::NativeExecutable
-                },
+                ExecutableArtifact::NativeExecutable,
                 if mode.direct_target().is_some() {
                     LinkedCoreArtifact::NativeObject { os }
                 } else {

--- a/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/builders.rs
@@ -118,10 +118,7 @@ impl<'a> BuildPlanConstructor<'a> {
             return compiler_flags::windows_msvc_native_toolchain(package_cc);
         }
 
-        compiler_flags::effective_native_toolchain(
-            package_cc,
-            self.build_env.tcc_run().map(|config| config.internal_tcc()),
-        )
+        compiler_flags::effective_native_toolchain(package_cc, None)
     }
 
     pub(super) fn warn_moon_cc_overrides(&self) {
@@ -938,11 +935,6 @@ impl<'a> BuildPlanConstructor<'a> {
             );
         }
 
-        // If we're tcc run, also depend on the runtime library
-        if self.build_env.tcc_run().is_some() {
-            self.require_artifact(node, ArtifactKey::RuntimeLibrary);
-        }
-
         // Populate C stub info
         let native_config = pkg.raw.link.as_ref().and_then(|x| x.native.as_ref());
 
@@ -993,11 +985,10 @@ impl<'a> BuildPlanConstructor<'a> {
             &mut link_flags,
         );
 
-        let static_archive_fingerprint = (self.build_env.tcc_run().is_none()
-            && effective_native_toolchain
-                .cc()
-                .archiver_updates_existing_archive())
-        .then(|| c_stub_archive_fingerprint(&pkg.c_stub_files));
+        let static_archive_fingerprint = effective_native_toolchain
+            .cc()
+            .archiver_updates_existing_archive()
+            .then(|| c_stub_archive_fingerprint(&pkg.c_stub_files));
 
         let c_info = BuildCStubsInfo {
             effective_native_toolchain,
@@ -1156,7 +1147,7 @@ impl<'a> BuildPlanConstructor<'a> {
                 &effective_native_toolchain,
             ),
             BackendConfig::Native {
-                mode: NativeBackendMode::GeneratedC | NativeBackendMode::TccRun(_),
+                mode: NativeBackendMode::GeneratedC,
                 ..
             } => false,
             BackendConfig::Wasm { .. } | BackendConfig::WasmGc { .. } | BackendConfig::Js => {
@@ -1567,9 +1558,7 @@ impl<'a> BuildPlanConstructor<'a> {
         })?;
         let source_files = toolchain::runtime_source_paths()
             .map_err(BuildPlanConstructError::FailedToFindRuntimeSources)?;
-        let builds_static_archive = self.build_env.tcc_run().is_none();
-        let simdutf_objects = if builds_static_archive
-            && self.build_env.opt_level == OptLevel::Release
+        let simdutf_objects = if self.build_env.opt_level == OptLevel::Release
             && effective_native_toolchain.cc().can_use_simdutf()
         {
             self.build_env
@@ -1582,11 +1571,10 @@ impl<'a> BuildPlanConstructor<'a> {
         } else {
             Vec::new()
         };
-        let static_archive_fingerprint = (builds_static_archive
-            && effective_native_toolchain
-                .cc()
-                .archiver_updates_existing_archive())
-        .then(|| runtime_archive_fingerprint(&source_files, &simdutf_objects));
+        let static_archive_fingerprint = effective_native_toolchain
+            .cc()
+            .archiver_updates_existing_archive()
+            .then(|| runtime_archive_fingerprint(&source_files, &simdutf_objects));
         let native_allocator = self
             .build_env
             .backend
@@ -1604,30 +1592,28 @@ impl<'a> BuildPlanConstructor<'a> {
             native_allocator,
         });
 
-        if builds_static_archive {
-            let source_count = self
+        let source_count = self
+            .res
+            .backend
+            .runtime_info
+            .as_ref()
+            .expect("runtime info was just populated")
+            .source_files
+            .len();
+        for index in 0..source_count {
+            let source = &self
                 .res
                 .backend
                 .runtime_info
                 .as_ref()
                 .expect("runtime info was just populated")
-                .source_files
-                .len();
-            for index in 0..source_count {
-                let source = &self
-                    .res
-                    .backend
-                    .runtime_info
-                    .as_ref()
-                    .expect("runtime info was just populated")
-                    .source_files[index];
-                self.require_artifact(
-                    node,
-                    ArtifactKey::RuntimeObject {
-                        source: runtime_source_key(source),
-                    },
-                );
-            }
+                .source_files[index];
+            self.require_artifact(
+                node,
+                ArtifactKey::RuntimeObject {
+                    source: runtime_source_key(source),
+                },
+            );
         }
 
         self.resolved_node(node);

--- a/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_plan/mod.rs
@@ -67,10 +67,7 @@ use tracing::instrument;
 
 use crate::{
     ResolveOutput,
-    model::{
-        BackendConfig, BuildPlanNode, BuildTarget, NativeTarget, OperatingSystem, PackageId,
-        TccRunConfig,
-    },
+    model::{BackendConfig, BuildPlanNode, BuildTarget, NativeTarget, OperatingSystem, PackageId},
     pkg_name::PackageFQNWithSource,
     prebuild::PrebuildOutput,
 };
@@ -471,7 +468,8 @@ pub struct BuildCStubsInfo {
     pub(crate) effective_native_toolchain: Toolchain,
     /// Additional flags to pass to the C compiler when compiling the C stubs
     pub(crate) cc_flags: Vec<String>,
-    /// Additional flags to pass to the linker (TCC only)
+    /// Legacy C-stub linker flags retained for manifest compatibility.
+    /// The current static-archive realization does not consume them.
     #[allow(unused)]
     pub(crate) link_flags: Vec<String>,
     /// Identity of the ordered static archive member list.
@@ -649,10 +647,6 @@ impl BuildEnvironment {
 
     pub(crate) fn direct_native_target(&self) -> Option<NativeTarget> {
         self.backend.direct_native_target()
-    }
-
-    pub(crate) fn tcc_run(&self) -> Option<&TccRunConfig> {
-        self.backend.tcc_run()
     }
 }
 

--- a/crates/moonbuild-rupes-recta/src/model.rs
+++ b/crates/moonbuild-rupes-recta/src/model.rs
@@ -17,7 +17,7 @@
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
 use moonutil::{
-    compiler_flags::{CC, NativeAllocator},
+    compiler_flags::NativeAllocator,
     resolution::{ModuleId, ResolvedEnv},
     target::TargetBackend,
 };
@@ -72,10 +72,6 @@ pub enum NativeTarget {
 pub enum NativeBackendMode {
     /// Legacy generated-C native path.
     GeneratedC,
-    /// Dormant native execution through `tcc -run`.
-    /// TODO: Remove after legacy TCC lowering and runtime-launch compatibility
-    /// are deleted.
-    TccRun(TccRunConfig),
     /// Experimental direct object-code native path.
     DirectObject(DirectNativeMode),
 }
@@ -135,14 +131,7 @@ impl NativeBackendMode {
     pub fn direct_native_mode(&self) -> Option<&DirectNativeMode> {
         match self {
             Self::DirectObject(mode) => Some(mode),
-            Self::GeneratedC | Self::TccRun(_) => None,
-        }
-    }
-
-    pub fn tcc_run(&self) -> Option<&TccRunConfig> {
-        match self {
-            Self::TccRun(config) => Some(config),
-            Self::GeneratedC | Self::DirectObject(_) => None,
+            Self::GeneratedC => None,
         }
     }
 }
@@ -161,13 +150,6 @@ impl BackendConfig {
     pub fn direct_native_target(&self) -> Option<NativeTarget> {
         match self {
             Self::Native { mode, .. } => mode.direct_target(),
-            Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js | Self::Llvm { .. } => None,
-        }
-    }
-
-    pub fn tcc_run(&self) -> Option<&TccRunConfig> {
-        match self {
-            Self::Native { mode, .. } => mode.tcc_run(),
             Self::Wasm { .. } | Self::WasmGc { .. } | Self::Js | Self::Llvm { .. } => None,
         }
     }
@@ -195,25 +177,6 @@ impl DirectNativeMode {
         match self {
             Self::Target(target) => *target,
         }
-    }
-}
-
-/// Configuration for the dormant legacy native `tcc -run` lowering.
-///
-/// Normal native execution, LLVM execution, and all non-native backends do not
-/// carry this value.
-#[derive(Clone, Debug)]
-pub struct TccRunConfig {
-    internal_tcc: CC,
-}
-
-impl TccRunConfig {
-    pub fn new(internal_tcc: CC) -> Self {
-        Self { internal_tcc }
-    }
-
-    pub fn internal_tcc(&self) -> &CC {
-        &self.internal_tcc
     }
 }
 
@@ -306,19 +269,7 @@ pub enum BuildPlanNode {
     /// Build the i-th C file in the C stub list.
     BuildCStub(PackageId, u32), // change into global artifact list if we need non-package ones
 
-    /// Build an archive or link all C stubs for the given package.
-    ///
-    /// Archive building is for non-TCC native targets, so they can be
-    /// referenced during linking.
-    ///
-    /// Linking is for native targets using TCC to compile. TCC can't link with
-    /// Mach-O objects, so in Linux and MacOS we directly link the C stubs into
-    /// a shared library (which is in ELF format) and load it in TCC at runtime.
-    ///
-    /// FIXME: This node is not split into two separate Archive and Link nodes
-    /// because the action is determined by the default C compiler used in this
-    /// build. In theory this should be separated for better clarity, and maybe
-    /// determined by the C compiler overrides for each build target.
+    /// Archive all C stubs for the given package.
     ArchiveOrLinkCStubs(PackageId),
 
     /// Link the `.core` file into an executable or library for the given target.
@@ -330,11 +281,6 @@ pub enum BuildPlanNode {
     /// from `LinkCore` is a C file or object file that needs further compilation
     /// and linking. Wasm and JavaScript `LinkCore` actions provide the final
     /// executable artifact directly.
-    ///
-    /// In TCC mode, since linking is done at the same time as running, this
-    /// step writes a response file containing the linking flags for TCC to use.
-    /// This is to avoid leaking and coupling linking logic into the runtime
-    /// execution logic.
     MakeExecutable(BuildTarget),
 
     /// Generate the macOS dSYM bundle for a linked executable.
@@ -359,7 +305,7 @@ pub enum BuildPlanNode {
     /// Build the i-th runtime C translation unit.
     BuildRuntimeObject(u32),
 
-    /// Archive the runtime objects, or realize the dormant legacy TCC-run runtime.
+    /// Archive the runtime objects into the native runtime library.
     BuildRuntimeLib,
 
     /// Build the virtual package's `.mbti` interface file to get an `.mi` file.

--- a/crates/moonbuild-rupes-recta/src/target_layout.rs
+++ b/crates/moonbuild-rupes-recta/src/target_layout.rs
@@ -60,6 +60,8 @@ pub enum ExecutableArtifact {
     WasmGC { use_wat: bool },
     Js,
     NativeExecutable,
+    // TODO(native): Remove this variant and its `uses_tcc_run` response-file and
+    // shared-library layout branches when `write-tcc-rsp-file` is removed.
     TccRunResponseFile,
     LlvmExecutable,
 }

--- a/crates/moonbuild/template/pkg.schema.json
+++ b/crates/moonbuild/template/pkg.schema.json
@@ -357,7 +357,7 @@
       ]
     },
     "NativeLinkConfig": {
-      "description": "Native C/C++ compilation and linking configuration for MoonBit packages.\n\nControls how C stub files and main executables are compiled and linked. The build system uses these flags differently depending on compilation mode: normal mode creates static libraries, while TCC mode creates dynamic libraries.",
+      "description": "Native C/C++ compilation and linking configuration for MoonBit packages.\n\nControls how C stub files and main executables are compiled and linked. C stub object files are collected into static archives.",
       "type": "object",
       "properties": {
         "cc": {
@@ -375,7 +375,7 @@
           ]
         },
         "cc-link-flags": {
-          "description": "Linker flags for main executable (also used for stub dynamic libraries in TCC mode)",
+          "description": "Linker flags for the main executable",
           "type": [
             "string",
             "null"
@@ -406,7 +406,7 @@
           ]
         },
         "stub-cc-link-flags": {
-          "description": "Linker flags for C stub linking (only used in TCC mode for dynamic libraries)",
+          "description": "Legacy linker flags for C stubs, retained for manifest compatibility",
           "type": [
             "string",
             "null"

--- a/crates/moonutil/src/package.rs
+++ b/crates/moonutil/src/package.rs
@@ -479,8 +479,7 @@ pub struct WasmLinkConfig {
 /// Native C/C++ compilation and linking configuration for MoonBit packages.
 ///
 /// Controls how C stub files and main executables are compiled and linked.
-/// The build system uses these flags differently depending on compilation mode:
-/// normal mode creates static libraries, while TCC mode creates dynamic libraries.
+/// C stub object files are collected into static archives.
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct NativeLinkConfig {
@@ -499,7 +498,7 @@ pub struct NativeLinkConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cc_flags: Option<String>,
 
-    /// Linker flags for main executable (also used for stub dynamic libraries in TCC mode)
+    /// Linker flags for the main executable
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cc_link_flags: Option<String>,
 
@@ -511,7 +510,7 @@ pub struct NativeLinkConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stub_cc_flags: Option<String>,
 
-    /// Linker flags for C stub linking (only used in TCC mode for dynamic libraries)
+    /// Legacy linker flags for C stubs, retained for manifest compatibility
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stub_cc_link_flags: Option<String>,
 

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -501,9 +501,8 @@ Here are some examples:
 - `BuildVirtual(PackageId)` builds the virtual package interface of the given package
   (build targets don't make sense on virtual packages).
 - `BuildRuntimeObject(u32)` compiles one shipped runtime C translation unit.
-- `BuildRuntimeLib` collects the runtime objects into the single runtime
-  library used globally by all consumers in the project. The dormant legacy
-  TCC-run lowering lowers this node directly from all runtime sources instead.
+- `BuildRuntimeLib` collects the runtime objects into the single static runtime
+  library used globally by all consumers in the project.
 
 The full list of backend build-plan nodes is available in
 [its module](/crates/moonbuild-rupes-recta/src/model.rs). Package prebuild keys

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -77,12 +77,9 @@ interchangeable compiler inputs even though they all currently use `.mi`.
 `ProofWhyml` artifacts; only `Prove` additionally provides `ProofReport`.
 Provider selection belongs to the invocation lifecycle, not artifact identity.
 
-Static archives and the dormant legacy TCC-run shared libraries are two
-physical realizations of the same logical C-stub or runtime library artifact.
-Lowering selects the realization from `BackendConfig`, just as it selects
-`.wasm` or `.wat` for a `LinkedCore` or `Executable` artifact. `RuntimeObject`
-exists only on the static-archive path; the legacy TCC shared-runtime action
-consumes runtime sources directly when that configuration is constructed.
+C-stub and runtime library artifacts are realized as static archives.
+`RuntimeObject` identifies each separately compiled runtime translation unit
+consumed by the runtime archive.
 
 `Executable { package, target_kind }` includes test executables: source,
 inline-test, whitebox-test, and blackbox-test targets have different

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -211,9 +211,7 @@ Compiling C stubs of a package involves 3 steps:
    directives. Dot-prefixed directories, ignored generated directories, and
    nested module or package roots are outside the Package File Set, so headers
    under those boundaries are not discovered automatically.
-2. `ArchiveOrLinkCStubs` -- All C stubs in a package is archived using AR.
-   The dormant [legacy TCC-run lowering](./tcc-run.md) instead links the C
-   stubs. This is out of scope of a regular compilation.
+2. `ArchiveOrLinkCStubs` -- All C stubs in a package are archived using AR.
 3. For every package that transitively depends on this package with C stubs,
    the archived compilation output is added to the input list of `MakeExecutable`.
 
@@ -231,10 +229,6 @@ which remain ordinary n2 inputs. Adding, removing, or renaming a runtime
 translation unit, or changing the selected SIMDUTF members, therefore uses a
 new archive path instead of letting an update-style archiver retain a removed
 member.
-
-The dormant legacy TCC-run lowering instead lowers `BuildRuntimeLib` to one
-compiler invocation that builds a shared runtime library directly from all
-runtime sources.
 
 ### Reading and writing MBTI interfaces
 

--- a/docs/dev/reference/native-c-toolchain-resolution.md
+++ b/docs/dev/reference/native-c-toolchain-resolution.md
@@ -68,11 +68,8 @@ For native backends, `LinkCore` emits:
 Package C stubs are handled separately:
 
 1. each `stub.c` is compiled to an object file
-2. usually, all stub object files in the package are archived together
+2. all stub object files in the package are archived together
 3. the final executable links against that per-package archive
-
-The dormant legacy `NativeTccRun` lowering instead links the stub objects into
-a shared library so `tcc -run` can load them at runtime.
 
 The runtime uses the same explicit multi-step shape for ordinary native builds:
 
@@ -96,13 +93,11 @@ The runtime uses the same explicit multi-step shape for ordinary native builds:
   `-DMOONBIT_ALLOCATOR=MOONBIT_ALLOCATOR_SYSTEM` and do not link `libmoonbitrun.o`
 
 The `MOONBIT_ALLOCATOR` macro is a runtime compile setting. Moon passes it only
-when compiling the shipped runtime sources or fused shared runtime, not when
-compiling package C stubs or the C file emitted by `moonc link-core`.
+when compiling the shipped runtime sources, not when compiling package C stubs
+or the C file emitted by `moonc link-core`.
 
 During the toolchain transition, Moon falls back to the legacy `lib/runtime.c`
-when the split runtime directory is absent. The dormant legacy `NativeTccRun`
-lowering remains a fused exception: one TCC invocation compiles all runtime
-translation units directly into the shared runtime library.
+when the split runtime directory is absent.
 
 This is why Moon needs both a compiler driver and an archiver.
 
@@ -122,9 +117,6 @@ When a native build step chooses its compiler, the current precedence is:
 2. package-level override (`link.native.cc` or `link.native.stub_cc`)
 3. detected default toolchain
 
-The build model still contains the legacy `NativeTccRun` lowering, but command
-planning no longer selects it.
-
 ## Global Environment Override
 
 - If `MOON_CC` is set, Moon uses it as the compiler for the regular native pipeline.
@@ -135,9 +127,7 @@ planning no longer selects it.
 - For `tcc`, Moon still uses `tcc -ar`, so `MOON_AR` is ignored.
 - `MOON_CC` takes precedence over package-level compiler overrides.
 
-This override is global to the current Moon invocation. The dormant legacy
-`NativeTccRun` lowering hard-codes the internal TCC when that configuration is
-constructed directly, but command planning no longer constructs it.
+This override is global to the current Moon invocation.
 
 ## Package-Level Override
 

--- a/docs/dev/reference/readme.md
+++ b/docs/dev/reference/readme.md
@@ -21,7 +21,7 @@ This is a reference documentation of the current MoonBuild behavior.
 * [Prebuild tasks](./prebuild.md)
 * [Conditional compilation](./cond-comp.md)
 * [Virtual packages](./virtual-pkg.md)
-* [Legacy `tcc -run` lowering](./tcc-run.md)
+* [Legacy `tcc -run` compatibility](./tcc-run.md)
 * [`moon bundle`](./bundle.md)
 * [`moon install` binary installer behavior](./moon-install-binary.md)
 * [`moon runwasm` behavior](./runwasm.md)

--- a/docs/dev/reference/tcc-run.md
+++ b/docs/dev/reference/tcc-run.md
@@ -1,4 +1,4 @@
-# Legacy TCC Run Lowering
+# Legacy TCC Run Compatibility
 
 > This document describes dormant compatibility code. TCC run mode is not
 > selectable behavior.
@@ -14,12 +14,14 @@ In particular, setting `MOONBIT_NEW_NATIVE=0` does not enable TCC. Native
 `run` and `test` actions produce ordinary executables through the generated-C
 pipeline.
 
-## Retained legacy lowering
+## Retained compatibility code
 
-The build model, lowering code, and runtime launcher still contain a
-`TccRun` representation while removal is staged. Current command planning does
-not construct that representation, so the flow described below is unreachable
-from the CLI.
+The build model, lowering code, and runtime launcher no longer contain a TCC-run
+mode. A hidden response-file writer and dormant response-file and shared-library
+layout helpers remain while their removal is staged separately. The CLI and
+build graph cannot reach that compatibility code. Explicitly selecting an
+external TCC as the regular C compiler remains supported and is independent of
+the removed mode.
 
 Historically, eligible Linux and macOS debug `run` and `test` invocations used
 the following realization:
@@ -34,6 +36,5 @@ the following realization:
 5. The runtime launcher invoked the bundled TCC with that response file and the
    program arguments.
 
-The response-file, shared-runtime, and shared-stub paths remain implementation
-details of the dormant lowering. They do not describe current native command
-behavior.
+The remaining response-file and shared-library helpers do not describe current
+native command behavior.

--- a/docs/manual-zh/src/source/pkg_json_schema.html
+++ b/docs/manual-zh/src/source/pkg_json_schema.html
@@ -395,7 +395,7 @@
       ]
     },
     "NativeLinkConfig": {
-      "description": "Native C/C++ compilation and linking configuration for MoonBit packages.\n\nControls how C stub files and main executables are compiled and linked. The build system uses these flags differently depending on compilation mode: normal mode creates static libraries, while TCC mode creates dynamic libraries.",
+      "description": "Native C/C++ compilation and linking configuration for MoonBit packages.\n\nControls how C stub files and main executables are compiled and linked. C stub object files are collected into static archives.",
       "type": "object",
       "properties": {
         "cc": {
@@ -413,7 +413,7 @@
           ]
         },
         "cc-link-flags": {
-          "description": "Linker flags for main executable (also used for stub dynamic libraries in TCC mode)",
+          "description": "Linker flags for the main executable",
           "type": [
             "string",
             "null"
@@ -444,7 +444,7 @@
           ]
         },
         "stub-cc-link-flags": {
-          "description": "Linker flags for C stub linking (only used in TCC mode for dynamic libraries)",
+          "description": "Legacy linker flags for C stubs, retained for manifest compatibility",
           "type": [
             "string",
             "null"

--- a/docs/manual/src/source/pkg_json_schema.html
+++ b/docs/manual/src/source/pkg_json_schema.html
@@ -395,7 +395,7 @@
       ]
     },
     "NativeLinkConfig": {
-      "description": "Native C/C++ compilation and linking configuration for MoonBit packages.\n\nControls how C stub files and main executables are compiled and linked. The build system uses these flags differently depending on compilation mode: normal mode creates static libraries, while TCC mode creates dynamic libraries.",
+      "description": "Native C/C++ compilation and linking configuration for MoonBit packages.\n\nControls how C stub files and main executables are compiled and linked. C stub object files are collected into static archives.",
       "type": "object",
       "properties": {
         "cc": {
@@ -413,7 +413,7 @@
           ]
         },
         "cc-link-flags": {
-          "description": "Linker flags for main executable (also used for stub dynamic libraries in TCC mode)",
+          "description": "Linker flags for the main executable",
           "type": [
             "string",
             "null"
@@ -444,7 +444,7 @@
           ]
         },
         "stub-cc-link-flags": {
-          "description": "Linker flags for C stub linking (only used in TCC mode for dynamic libraries)",
+          "description": "Legacy linker flags for C stubs, retained for manifest compatibility",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
## Why

#2128 made TCC-run unselectable, but the backend model, build graph, lowering, and runtime execution mode still described that unreachable path. Keeping both realizations made the native graph harder to reason about.

## Why this is correct

Generated-C and direct-object native builds already use the static C-stub/runtime archive path and produce ordinary executables. This change removes only the unreachable TCC-run branches and makes those existing choices unconditional. Explicitly selecting TCC as a regular external C compiler remains supported.

The behavioral references and generated package-schema descriptions now match the graph. `stub-cc-link-flags` remains accepted for manifest compatibility.

## Scope

This is intentionally limited to the graph and execution-mode boundary. The hidden `write-tcc-rsp-file` command, dormant response-file/layout helpers, compiler utilities, and existing fixtures are unchanged so their removal can happen as one separate step.