### PR TITLE
enable `/std:c11` for MSVC

### DIFF
--- a/crates/moonbuild-rupes-recta/src/build_lower/compiler/msvc.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/compiler/msvc.rs
@@ -21,7 +21,8 @@
 use std::path::Path;
 
 use moonutil::compiler_flags::{
-    MsvcCrtPolicy, NativeAllocator, Toolchain, WINDOWS_MSVC_DEFAULT_LIBS,
+    MsvcCrtPolicy, NativeAllocator, Toolchain, WINDOWS_MSVC_C_STANDARD_FLAG,
+    WINDOWS_MSVC_DEFAULT_LIBS,
 };
 
 pub(crate) fn command_env(toolchain: &Toolchain) -> Vec<(String, String)> {
@@ -42,6 +43,7 @@ pub(crate) fn compile_runtime_command(
     let mut command = vec![
         toolchain.cc_command_path(),
         "/nologo".to_string(),
+        WINDOWS_MSVC_C_STANDARD_FLAG.to_string(),
         "/utf-8".to_string(),
         "/wd4819".to_string(),
         "/c".to_string(),
@@ -120,6 +122,11 @@ mod tests {
         );
 
         assert!(command.iter().any(|arg| arg == "/Imoon/include"));
+        assert!(
+            command
+                .iter()
+                .any(|arg| arg == WINDOWS_MSVC_C_STANDARD_FLAG)
+        );
         assert!(
             command
                 .iter()

--- a/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
+++ b/crates/moonbuild-rupes-recta/src/build_lower/mod.rs
@@ -1130,6 +1130,11 @@ mod tests {
             runtime_compile_command,
             "native/debug/build/runtime-runtime.obj"
         ));
+        assert!(
+            runtime_compile_command
+                .iter()
+                .any(|arg| arg == moonutil::compiler_flags::WINDOWS_MSVC_C_STANDARD_FLAG)
+        );
 
         let runtime_archive_command = lowered
             .command_args_by_output
@@ -1160,6 +1165,11 @@ mod tests {
             stub_compile_command
                 .iter()
                 .any(|arg| arg == moonutil::compiler_flags::WINDOWS_MSVC_STATIC_RUNTIME_FLAG)
+        );
+        assert!(
+            stub_compile_command
+                .iter()
+                .any(|arg| arg == moonutil::compiler_flags::WINDOWS_MSVC_C_STANDARD_FLAG)
         );
 
         let moonc_inputs = n2_input_paths_for_command(&lowered, |command| {

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -281,6 +281,7 @@ pub const WINDOWS_MSVC_DEFAULT_LIBS: &[&str] = &[
     "uuid.lib",
 ];
 pub const WINDOWS_MSVC_STATIC_RUNTIME_FLAG: &str = "/MT";
+pub const WINDOWS_MSVC_C_STANDARD_FLAG: &str = "/std:c11";
 
 #[cfg(windows)]
 static WINDOWS_MSVC_TOOLCHAIN: OnceLock<Option<DiscoveredMsvcToolchain>> = OnceLock::new();
@@ -1487,6 +1488,8 @@ fn add_cc_msvc_specific_flags(cc: &CC, buf: &mut Vec<String>, has_user_flags: bo
         return;
     }
 
+    buf.push(WINDOWS_MSVC_C_STANDARD_FLAG.to_string());
+
     // MSVC-specific misc options
     if !has_user_flags {
         buf.push("/utf-8".to_string());
@@ -2672,6 +2675,11 @@ mod tests {
         );
 
         assert!(command.iter().any(|flag| flag == "/nologo"));
+        assert!(
+            command
+                .iter()
+                .any(|flag| flag == WINDOWS_MSVC_C_STANDARD_FLAG)
+        );
         assert!(command.iter().any(|flag| flag == "/O2"));
         assert!(!command.iter().any(|flag| flag == "/utf-8"));
         assert!(!command.iter().any(|flag| flag == "/wd4819"));

--- a/docs/dev/reference/native-c-toolchain-resolution.md
+++ b/docs/dev/reference/native-c-toolchain-resolution.md
@@ -312,6 +312,7 @@ The `-lm` behavior belongs to this semantic layer, not just to executable lookup
 ### Compile
 
 `make_cc_command*` uses `cc_path` for compile steps (`-c` or `/c`) and backend-specific flags.
+MSVC-style compile commands pass `/std:c11`.
 For TCC on macOS, Moon also passes the active SDK `usr/lib` path reported by
 `xcrun --sdk macosx --show-sdk-path` when it resolves to an existing directory.
 If `xcrun` is missing or returns an unusable path, Moon omits the extra `-L` flag instead of


### PR DESCRIPTION
Currently, no `/std` flag is passed when using MSVC to compile things (runtime, stub, `moonc` generated C code). This correspond to C89 + MSVC extension according to Microsoft's doc. This PR pass `/std:c11` when compiling stuff using MSVC to enable several modern C features, such as `stdatomic.h`.