### PR TITLE
feat(moonx): support standalone mbtx scripts

### DIFF
--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -16,9 +16,10 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use std::{ffi::OsString, path::PathBuf};
+use std::{ffi::OsString, path::Path, path::PathBuf};
 
 use clap::{Parser, Subcommand, ValueEnum};
+use mooncake::registry::RegistryClient;
 use moonutil::user_log::UserLog;
 
 use super::registry_runner::{self, RegistryRunTarget};
@@ -38,20 +39,22 @@ pub(crate) enum MoonxTarget {
 #[derive(Debug, Parser)]
 #[command(
     name = "moonx",
-    about = "Run a package from the Mooncakes registry without installing it",
-    long_about = r#"Run a package from the Mooncakes registry without installing it.
+    about = "Run a .mbtx file or a package from the Mooncakes registry",
+    long_about = r#"Run a standalone .mbtx file or a package from the Mooncakes registry without installing it.
 
-Accepted package coordinate forms:
+Accepted input forms:
+  moonx script.mbtx
   moonx user/module/package
   moonx user/module/package@1.2.3
   moonx user/module/package@latest
 
-Pinned coordinates use the requested version directly. `@latest` refreshes the
+Standalone .mbtx files always use the linear-memory Wasm backend. Pinned
+package coordinates use the requested version directly. `@latest` refreshes the
 registry index before resolving the latest version. Unpinned coordinates use
 the latest version already known to the local registry index.
 
 The native target is deprecated and scheduled for removal after 2026-09-14."#,
-    override_usage = "moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...",
+    override_usage = "moonx [OPTIONS] <MBTX|PACKAGE> [PROGRAM_ARGS]...",
     version
 )]
 pub(crate) struct MoonxCli {
@@ -67,11 +70,11 @@ pub(crate) struct MoonxCli {
     pub verbose: bool,
 
     #[command(subcommand)]
-    package: MoonxPackage,
+    input: MoonxInput,
 }
 
 #[derive(Debug, Subcommand)]
-enum MoonxPackage {
+enum MoonxInput {
     #[command(external_subcommand)]
     External(Vec<String>),
 }
@@ -81,7 +84,7 @@ pub(crate) struct MoonxInvocation {
     pub(crate) target: MoonxTarget,
     pub(crate) experimental_policy: Option<PathBuf>,
     pub(crate) verbose: bool,
-    package: String,
+    input: String,
     args: Vec<String>,
 }
 
@@ -93,8 +96,8 @@ pub(crate) fn is_moonx_invocation(raw_args: &[OsString]) -> bool {
 
 pub(crate) fn parse_from(raw_args: &[OsString]) -> Result<MoonxInvocation, clap::Error> {
     let cli = MoonxCli::try_parse_from(raw_args)?;
-    let MoonxPackage::External(package_and_args) = cli.package;
-    let (package, args) = package_and_args
+    let MoonxInput::External(input_and_args) = cli.input;
+    let (input, args) = input_and_args
         .split_first()
         .expect("external subcommand always contains its name");
     // External subcommands preserve `--`; moonx treats one leading occurrence as a separator.
@@ -106,7 +109,7 @@ pub(crate) fn parse_from(raw_args: &[OsString]) -> Result<MoonxInvocation, clap:
         target: cli.target,
         experimental_policy: cli.experimental_policy,
         verbose: cli.verbose,
-        package: package.clone(),
+        input: input.clone(),
         args: args.to_vec(),
     })
 }
@@ -115,14 +118,38 @@ pub(crate) fn prepare(
     invocation: MoonxInvocation,
     user_log: &UserLog,
 ) -> anyhow::Result<super::process::ProcessAction> {
-    let quiet = !invocation.verbose;
-    let target = match invocation.target {
-        MoonxTarget::Wasm => RegistryRunTarget::Wasm {
-            experimental_policy: invocation.experimental_policy,
-            policy_relay: moonutil::policy_transport::PolicyTransfer::take_from_env()?
-                .map(moonutil::policy_transport::PolicyTransfer::into_relay),
-        },
-        MoonxTarget::Native if invocation.experimental_policy.is_some() => {
+    let MoonxInvocation {
+        target,
+        experimental_policy,
+        verbose,
+        input,
+        args,
+    } = invocation;
+    let quiet = !verbose;
+
+    match target {
+        MoonxTarget::Wasm => {
+            let policy_relay = moonutil::policy_transport::PolicyTransfer::take_from_env()?
+                .map(moonutil::policy_transport::PolicyTransfer::into_relay);
+            let wasm_path = if is_mbtx_input(&input) {
+                super::run::build_standalone_wasm(input, verbose)?
+            } else {
+                RegistryClient::configured().acquire_executable_wasm(&input, user_log)?
+            };
+
+            registry_runner::prepare_artifact(
+                crate::run::ExecutionMode::MoonRun,
+                &wasm_path,
+                experimental_policy.as_deref(),
+                policy_relay,
+                &args,
+                user_log,
+            )
+        }
+        MoonxTarget::Native if is_mbtx_input(&input) => {
+            anyhow::bail!("standalone `.mbtx` inputs only support `--target wasm`")
+        }
+        MoonxTarget::Native if experimental_policy.is_some() => {
             anyhow::bail!("--experimental-policy is only valid with `--target wasm`")
         }
         MoonxTarget::Native => {
@@ -130,17 +157,22 @@ pub(crate) fn prepare(
             // valid relay without letting an ambient malformed marker change
             // native behavior.
             moonutil::policy_transport::PolicyTransfer::discard_from_env();
-            RegistryRunTarget::Native
+            registry_runner::prepare(
+                input,
+                RegistryRunTarget::Native,
+                args,
+                quiet,
+                verbose,
+                user_log,
+            )
         }
-    };
-    registry_runner::prepare(
-        invocation.package,
-        target,
-        invocation.args,
-        quiet,
-        invocation.verbose,
-        user_log,
-    )
+    }
+}
+
+fn is_mbtx_input(input: &str) -> bool {
+    Path::new(input)
+        .extension()
+        .is_some_and(|extension| extension == "mbtx")
 }
 
 #[cfg(test)]
@@ -178,7 +210,7 @@ mod tests {
     }
 
     #[test]
-    fn requires_package() {
+    fn requires_input() {
         let error = MoonxCli::try_parse_from(["moonx"]).unwrap_err();
         assert_eq!(
             error.kind(),
@@ -187,11 +219,19 @@ mod tests {
     }
 
     #[test]
-    fn forwards_help_and_version_flags_after_package() {
+    fn recognizes_standalone_mbtx_inputs() {
+        assert!(is_mbtx_input("script.mbtx"));
+        assert!(is_mbtx_input("path/to/script.mbtx"));
+        assert!(!is_mbtx_input("user/module/package"));
+        assert!(!is_mbtx_input("script.mbt"));
+    }
+
+    #[test]
+    fn forwards_help_and_version_flags_after_input() {
         for flag in ["-h", "--help", "-V", "--version"] {
             let cli = MoonxCli::try_parse_from(["moonx", "user/module", flag]).unwrap();
-            let MoonxPackage::External(package_and_args) = cli.package;
-            assert_eq!(package_and_args, ["user/module", flag]);
+            let MoonxInput::External(input_and_args) = cli.input;
+            assert_eq!(input_and_args, ["user/module", flag]);
         }
     }
 }

--- a/crates/moon/src/cli/process.rs
+++ b/crates/moon/src/cli/process.rs
@@ -62,9 +62,9 @@ fn delegate_with_policy_relay(
     relay: moonutil::policy_transport::PolicyRelay,
 ) -> anyhow::Result<ExitStatus> {
     install_ctrl_c_passthrough_handler()?;
-    // Moonx reaches this point after registry acquisition and does not start
-    // other children. Keep Windows' process-wide inheritable-handle window to
-    // the CreateProcess call itself.
+    // Moonx reaches this point after registry acquisition or standalone build
+    // work and does not start other children. Keep Windows' process-wide
+    // inheritable-handle window to the CreateProcess call itself.
     let relay = relay.attach_to(cmd)?;
     let child = cmd.spawn();
     let isolation = relay.finish();

--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -140,7 +140,8 @@ fn cached_native_executable(
     })
 }
 
-fn prepare_artifact(
+/// Prepare one already-acquired or already-built artifact for final execution.
+pub(crate) fn prepare_artifact(
     mode: crate::run::ExecutionMode,
     artifact: &Path,
     experimental_policy: Option<&Path>,

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -31,14 +31,14 @@ use mooncake::pkg::sync::SyncOutputOptions;
 use moonutil::child_process::ChildOutputMode;
 use moonutil::cli_support::AutoSyncFlags;
 use moonutil::command_output::CommandOutput;
-use moonutil::project::{PackageDirs, ProjectProbe};
+use moonutil::project::{PackageDirs, ProjectProbe, SourceTargetDirs, WorkspaceEnv};
 use moonutil::{
     build_options::{RunMode, TestArtifacts},
     cache::{CacheKind, resolve_cache_root},
     constants::is_moon_pkg_exist,
     locks::lock_directory,
-    target::TargetBackend,
-    user_log::UserLog,
+    target::{SurfaceTarget, TargetBackend},
+    user_log::{UserLog, user_log_level},
 };
 use tracing::{Level, instrument};
 
@@ -442,6 +442,58 @@ pub(crate) fn build_run_executable(
 
     let selected_target_backend = cmd.build_flags.resolve_single_target_backend()?;
     build_package_executable(cli, cmd, selected_target_backend, options, output)
+}
+
+/// Build a persistent standalone source as linear-memory Wasm.
+///
+/// The returned artifact is ready for a caller-owned execution path; no build
+/// lock remains held after this function returns.
+pub(crate) fn build_standalone_wasm(input: String, verbose: bool) -> anyhow::Result<PathBuf> {
+    // TODO(moonx-standalone-build-interface): Remove this command-layer adapter
+    // once standalone build planning accepts explicit source, backend, sync,
+    // and output options without UniversalFlags and RunSubcommand.
+    let cli = UniversalFlags {
+        source_tgt_dir: SourceTargetDirs {
+            cwd: None,
+            target_dir: None,
+        },
+        workspace_env: WorkspaceEnv::default(),
+        quiet: !verbose,
+        verbose,
+        trace: false,
+        dry_run: false,
+        build_graph: false,
+        unstable_feature: ""
+            .parse()
+            .expect("empty unstable feature set must be valid"),
+    };
+    let cmd = RunSubcommand {
+        package_or_mbt_file: Some(input),
+        command: None,
+        build_flags: BuildFlags {
+            target: vec![SurfaceTarget::Wasm],
+            ..BuildFlags::default()
+        },
+        args: Vec::new(),
+        moonrun_policy: None,
+        auto_sync_flags: AutoSyncFlags { frozen: false },
+        build_only: false,
+        profile: false,
+    };
+    let output = CommandOutput::new(user_log_level(verbose, !verbose));
+    let mut built = build_run_executable(
+        &cli,
+        &cmd,
+        BuildRunExecutableOptions::for_run(&cli),
+        &output,
+    )?;
+    built.ensure_build_success()?;
+    anyhow::ensure!(
+        built.backend.target_backend() == TargetBackend::Wasm,
+        "standalone `.mbtx` build did not produce linear-memory Wasm"
+    );
+    built.release_lock();
+    Ok(built.executable)
 }
 
 #[instrument(skip_all)]

--- a/crates/moon/src/cli/runtime.rs
+++ b/crates/moon/src/cli/runtime.rs
@@ -97,7 +97,8 @@ fn prepare_delegate(invocation: DelegatedInvocation) -> anyhow::Result<Command> 
 
 fn run_moonx(invocation: super::moonx::MoonxInvocation) -> i32 {
     // moonx intentionally has no Moon tracing or workspace bootstrap. It owns
-    // registry preparation, then returns the final program as a process action.
+    // standalone or registry preparation, then returns the final program as a
+    // process action.
     if matches!(invocation.target, super::moonx::MoonxTarget::Native) {
         UserLog::new(log::LevelFilter::Warn).warn(super::moonx::NATIVE_TARGET_DEPRECATION_WARNING);
     }

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -116,20 +116,22 @@ fn test_moonx_uses_its_own_command_line_interface() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Run a package from the Mooncakes registry without installing it.
+Run a standalone .mbtx file or a package from the Mooncakes registry without installing it.
 
-Accepted package coordinate forms:
+Accepted input forms:
+  moonx script.mbtx
   moonx user/module/package
   moonx user/module/package@1.2.3
   moonx user/module/package@latest
 
-Pinned coordinates use the requested version directly. `@latest` refreshes the
+Standalone .mbtx files always use the linear-memory Wasm backend. Pinned
+package coordinates use the requested version directly. `@latest` refreshes the
 registry index before resolving the latest version. Unpinned coordinates use
 the latest version already known to the local registry index.
 
 The native target is deprecated and scheduled for removal after 2026-09-14.
 
-Usage: moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...
+Usage: moonx [OPTIONS] <MBTX|PACKAGE> [PROGRAM_ARGS]...
 
 Options:
       --target <TARGET>
@@ -149,6 +151,82 @@ Options:
           Print version
 
 "#]]);
+}
+
+#[test]
+fn test_moonx_runs_mbtx_as_linear_wasm_and_forwards_args() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");
+    let moonx = moonx_bin(&bin_dir);
+
+    snapbox::cmd::Command::new(&moonx)
+        .current_dir(&dir)
+        .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
+        .env("MOONRUN_OVERRIDE", moonrun_bin())
+        .args(["moonx_args.mbtx", "--help", "--target", "native", "-V"])
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+--help
+--target
+native
+-V
+
+"#]])
+        .stderr_eq("");
+
+    assert!(
+        dir.join("_build/wasm/debug/build/single/single.wasm")
+            .is_file()
+    );
+    assert!(!dir.join("_build/wasm-gc").exists());
+}
+
+#[test]
+fn test_moonx_rejects_native_for_mbtx() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");
+    let moonx = moonx_bin(&bin_dir);
+
+    snapbox::cmd::Command::new(&moonx)
+        .current_dir(&dir)
+        .args(["--target", "native", "moonx_args.mbtx"])
+        .assert()
+        .failure()
+        .stdout_eq("")
+        .stderr_eq(snapbox::str![[r#"
+Warning: `moonx --target native` is deprecated and scheduled for removal after 2026-09-14.
+Error: standalone `.mbtx` inputs only support `--target wasm`
+
+"#]]);
+
+    assert!(!dir.join("_build").exists());
+}
+
+#[test]
+fn test_moonx_forwards_experimental_policy_to_mbtx() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");
+    let moonx = moonx_bin(&bin_dir);
+
+    let output = std::process::Command::new(&moonx)
+        .current_dir(&dir)
+        .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
+        .env("MOONRUN_OVERRIDE", moonrun_bin())
+        .args([
+            "--experimental-policy",
+            "missing-policy.json",
+            "moonx_args.mbtx",
+        ])
+        .output()
+        .expect("failed to run moonx");
+    let stderr = String::from_utf8(output.stderr).expect("moonx stderr should be UTF-8");
+
+    assert!(!output.status.success());
+    assert!(
+        stderr.contains("failed to load sandbox policy"),
+        "expected moonx to forward its policy to moonrun:\n{stderr}"
+    );
 }
 
 #[test]

--- a/crates/moon/tests/test_cases/moon_test_single_file.in/moonx_args.mbtx
+++ b/crates/moon/tests/test_cases/moon_test_single_file.in/moonx_args.mbtx
@@ -1,0 +1,10 @@
+import {
+  "moonbitlang/core/env",
+}
+
+fn main {
+  let args = @env.args()
+  for i = 1; i < args.length(); i = i + 1 {
+    println(args[i])
+  }
+}

--- a/crates/moon/tests/test_cases/native_abort_trace/mod.rs
+++ b/crates/moon/tests/test_cases/native_abort_trace/mod.rs
@@ -13,9 +13,9 @@ fn test_native_abort_trace() {
     let expected_stderr = if exits_via_signal {
         snapbox::str![[r#"
 PanicError
-    at @moonbitlang/core/option.Option::unwrap[Int] ([CORE_PATH]/builtin/option.mbt:[..])
-    at @username/scratch/cmd/main.g ([..]/cmd/main/main.mbt:[..])
-    at @username/scratch/cmd/main.f ([..]/cmd/main/main.mbt:[..])
+    at [..]Option::unwrap[..]Int[..] ([CORE_PATH]/builtin/option.mbt:[..])
+    at [..]username/scratch/cmd/main.g ([..]/cmd/main/main.mbt:[..])
+    at [..]username/scratch/cmd/main.f ([..]/cmd/main/main.mbt:[..])
     at moonbit_main ([..]/cmd/main/main.mbt:[..])
     at main ([..]/cmd/main/main.mbt:[..])
 ...

--- a/docs/dev/reference/moonx.md
+++ b/docs/dev/reference/moonx.md
@@ -1,13 +1,13 @@
 # Behavior of `moonx`
 
-> This page specifies the behavior of the `moonx` executable package runner.
+> This page specifies the behavior of the `moonx` package and script runner.
 
 ## Scope
 
-`moonx` resolves and executes exactly one main package from the Mooncakes
-registry without installing it into the user's binary directory. Version 1
-supports registry packages only; local paths, Git URLs, and wildcard package
-selectors are out of scope.
+`moonx` executes either one standalone `.mbtx` file or exactly one main package
+from the Mooncakes registry without installing it into the user's binary
+directory. Other local paths, Git URLs, and wildcard package selectors are out
+of scope.
 
 `moonx` is another entrance to the `moon` executable, not a separately compiled
 binary. The process selects the `moonx` command-line parser when its invoked
@@ -16,48 +16,75 @@ executable name is `moonx` or `moonx.exe`.
 ## Command line
 
 ```text
-moonx [OPTIONS] <PACKAGE> [PROGRAM_ARGS]...
+moonx [OPTIONS] <MBTX|PACKAGE> [PROGRAM_ARGS]...
 ```
 
 The supported options are:
 
 ```text
---target <wasm|native>        # defaults to wasm; native is deprecated
+--target <wasm|native>        # defaults to wasm; native is deprecated and registry-only
 --experimental-policy <PATH> # wasm only
 -v, --verbose
 -h, --help
 -V, --version
 ```
 
-Everything after `PACKAGE`, including hyphen-prefixed values, is forwarded to
-the executed program. An explicit `--` separator is accepted but is not
-required. `moonx` options therefore precede the package coordinate.
+Everything after the `.mbtx` path or package coordinate, including
+hyphen-prefixed values, is forwarded to the executed program. An explicit `--`
+separator is accepted but is not required. `moonx` options therefore precede
+the input.
 
 The child process inherits the caller's working directory, environment,
 standard streams, and signal behavior. `moonx` returns the child's exit code.
+
+By default, `moonx` emits no informational output of its own. With `--verbose`,
+registry or script dependency acquisition, build progress, and execution
+details are written to stderr. Stdout remains reserved for the executed
+program, whose standard streams are inherited unchanged.
 
 When a policy-bearing `moonrun` directly spawns `moonx`, the host publishes the
 canonical policy representation through an inherited OS handle and replaces a
 reserved environment entry with the handle's process-local identifier. At
 process entry, `moonx` takes ownership of the handle, removes the entry from its
-ambient environment before registry work, and makes the handle inheritable
-again only for the final `moonrun` command. That `moonrun` reads and closes the
-handle before constructing the Run environment. Detached `moonx` processes
-therefore do not depend on the parent Run's lifetime, while registry
-subprocesses and processes spawned by the resolved program receive neither the
-marker nor the handle. No pathname crosses the process boundary: Unix removes
-the temporary name before spawning, while Windows keeps the delete-on-close
-file exclusively open. The guest therefore has no filesystem name it can
-replace or modify.
+ambient environment before registry or script dependency work, and makes the
+handle inheritable again only for the final `moonrun` command. That `moonrun`
+reads and closes the handle before constructing the Run environment. Detached
+`moonx` processes therefore do not depend on the parent Run's lifetime, while
+registry and build subprocesses and processes spawned by the resolved program
+receive neither the marker nor the handle. No pathname crosses the process
+boundary: Unix removes the temporary name before spawning, while Windows keeps
+the delete-on-close file exclusively open. The guest therefore has no
+filesystem name it can replace or modify.
 
 Policy publication and handle setup run as part of the direct `moonx` spawn
 job. If either fails, the job reports the corresponding OS error and no child
 process is created or registered.
 
 For the Wasm target, the inherited policy takes precedence over an explicit
-`--experimental-policy`; the child may not replace or widen it. Native
-execution does not pass through `moonrun`, so moonx closes an inherited policy
-relay before registry work and otherwise preserves native execution behavior.
+`--experimental-policy`; the child may not replace or widen it. This applies to
+both registry packages and standalone `.mbtx` files. Native execution does not
+pass through `moonrun`, so moonx closes an inherited policy relay before
+registry work and otherwise preserves native execution behavior.
+
+## Standalone `.mbtx`
+
+An input whose extension is `.mbtx` is treated as a persistent standalone
+script path. Moonx reuses the same synthesized-package dependency resolution,
+build planning, and incremental target directory as
+`moon run <PATH> --target wasm`. Imports declared by the `.mbtx` prelude are
+resolved and built before the synthesized script package. The resulting Wasm
+artifact then uses the same moonx execution path as a registry Wasm artifact.
+
+Standalone `.mbtx` execution supports only the linear-memory Wasm backend.
+`--target wasm` is the default; `--target native` is rejected before dependency
+acquisition or building. Program arguments are forwarded to the final
+`moonrun`, and `--experimental-policy` has the same meaning as for a registry
+Wasm artifact.
+
+Moonx consumes an inherited policy handle before resolving `.mbtx`
+dependencies and relays it only to the final `moonrun` process. Registry and
+build subprocesses therefore cannot observe the reserved marker or inherit the
+handle.
 
 ## Executable package coordinates
 
@@ -86,7 +113,7 @@ Unpinned coordinates resolve the latest version already known to the local
 registry index. The index is updated only when the module cannot be resolved
 locally, matching `moon runwasm`.
 
-## Wasm target
+## Registry package Wasm target
 
 The default `wasm` target means the linear-memory Wasm backend, not WasmGC.
 It reuses registry-backed `moon runwasm` behavior:
@@ -103,7 +130,7 @@ Registry-backed `moon runwasm` must use the linear Wasm backend consistently.
 Tests for its cached-asset mode must use linear-Wasm fixtures rather than
 WasmGC fixtures.
 
-## Native target
+## Registry package native target
 
 The `native` target is deprecated and scheduled for removal after September
 14, 2026. Until then, it retains its existing behavior and emits a deprecation
@@ -118,11 +145,6 @@ Registry source acquisition never executes the downloaded module's
 `scripts.postadd` hook. `moonx` stops after source acquisition and therefore
 does not opt into the legacy hook. Existing project sync, `moon fetch`, and
 binary-install paths retain an explicit postadd compatibility step.
-
-By default, `moonx` emits no informational output of its own. With `--verbose`,
-registry acquisition, build progress, and execution details are written to
-stderr. Stdout remains reserved for the delegated program, whose standard
-streams are inherited unchanged.
 
 The Cached Executable Artifact is keyed by the resolved module version, package
 path, and Target Backend. A cache hit executes it directly; Moon toolchain


### PR DESCRIPTION
## Why

`moonx` can execute registry packages but cannot run persistent standalone `.mbtx` scripts. Users therefore have to switch to `moon run` even though `moonx` already owns Wasm artifact execution and inherited-policy relay.

## What changed

- Accept a standalone `.mbtx` path as a `moonx` input and build it with the existing Rupes Recta standalone pipeline for linear-memory Wasm.
- Treat standalone building and registry acquisition as two ways to produce the same Wasm artifact, then use the shared moonrun preparation path.
- Forward program arguments and experimental policies to the resulting Wasm program, while rejecting the deprecated native target before dependency acquisition or building.
- Document the implemented behavior and cover argument forwarding, backend selection, native rejection, and policy forwarding.

## Why this is correct

The build step reuses the same synthesized-package dependency resolution, planning, incremental target directory, and artifact selection as `moon run <PATH> --target wasm`. Policy handles are consumed before build work and attached only to the final moonrun process, preserving the existing isolation boundary.

## Scope and follow-up

The change is limited to persistent `.mbtx` inputs and the Wasm backend. The standalone build entry currently adapts explicit inputs into `UniversalFlags` and `RunSubcommand` because the lower build pipeline has no command-independent entrance; a searchable source TODO records the condition for removing that adapter in a follow-up refactor.
