### PR TITLE
feat(moonrun): add Wasmtime engine core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +25,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -89,6 +104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +173,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,10 +213,10 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -206,9 +238,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake3"
@@ -248,6 +280,9 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "byteorder"
@@ -391,6 +426,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +532,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +557,152 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9903e767cc0a95a59950de099a6b1d61e1476f774be1cdfa06d7ccdc9bfae56f"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e777252ea3ec9daffa71408fbfe0793ab0a7b7bc3b2cf0f417dd0fa33964b8ef"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7828208a36e6627481cea61bd24c6234e31411d5c58b48e80ca094a1d593b944"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a58c8447cc59ef98c49096679f81392ad0acec2224cea2bef52011f5169f9d02"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce520e899df1de583e7b564eafd66760fbc147d72894d2278ddac57a1489fcc0"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.17.1",
+ "libm",
+ "log",
+ "postcard",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8ab23e63d78ea6bbda18ae1ed9c958bc1cb88d90fb5e95f5ba62e9c019474b"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24319a996b1ef40ebf8af69b39c868c790b35a42cfe38edacfd8c9deb75ea712"
+
+[[package]]
+name = "cranelift-control"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9856d68cc2cefb83229cb2c55b620dd38427555c2fe87d73f8a4421616f628"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ec225d6b79c5d61358cb5ea081a1384ec541dbf8c1a8c618d187875af326ad"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3a96a09bd9bd3cf6df2de2ea15d7418f493e946a8eaa1acfe39297a67ed3f3"
+dependencies = [
+ "cranelift-codegen",
+ "hashbrown 0.17.1",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd28f593c36afbdc9aa17305c0bb66c39ce0530e1caffcf389fbec053950083e"
+
+[[package]]
+name = "cranelift-native"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2987ca47affc261aa31ac643fb80dd7f8274cebf878003ba9f50cd6ff2c1055f"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.135.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7431dd8c9def94aca43b27915dee0d42103d9b13922cfb044febcd975547d68"
 
 [[package]]
 name = "crc32fast"
@@ -707,6 +906,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +1037,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,10 +1086,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.30"
+name = "futures"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -919,6 +1150,7 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -964,6 +1196,18 @@ dependencies = [
  "r-efi",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1026,14 +1270,25 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.20",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -1348,7 +1603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1401,6 +1656,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1483,9 +1747,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -1494,8 +1758,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1503,7 +1773,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "libc",
  "redox_syscall",
 ]
@@ -1536,6 +1806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,9 +1819,9 @@ checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "logos"
@@ -1588,6 +1864,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1883,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memfd"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57804b2c9b69967f1536a56f86297e367a33b19e98852ed624b84551cdbc0d90"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "mime"
@@ -1874,6 +2165,7 @@ dependencies = [
  "toml",
  "v8",
  "vergen",
+ "wasmtime",
  "wat",
  "windows-sys 0.59.0",
 ]
@@ -1940,7 +2232,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -1974,7 +2266,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -2046,6 +2338,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,7 +2367,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2129,7 +2433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.16",
+ "thiserror 2.0.20",
  "ucd-trie",
 ]
 
@@ -2189,6 +2493,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,6 +2548,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulley-interpreter"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f755d75e0809a4738a3e4880eeeb852fadbe1de5a437505b84f09c381657012a"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e69fa1c4a555946f82e7894a7df88b0e9ee03b4266829b4811467c616ce51d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,7 +2584,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2",
- "thiserror 2.0.16",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -2267,7 +2606,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2364,7 +2703,22 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757712e8e61590d6d4f5d563483755538b5aa13467837a3b41cd9832509a7f85"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.1",
+ "log",
+ "rustc-hash 2.1.1",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -2467,6 +2821,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,11 +2853,24 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2613,7 +2986,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2643,11 +3016,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2820,6 +3194,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snapbox"
@@ -2920,7 +3297,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2936,6 +3313,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,8 +3326,17 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "rustix",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2996,11 +3388,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3016,13 +3408,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3203,7 +3595,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -3392,7 +3784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a381badc47c6f15acb5fe0b5b40234162349ed9d4e4fd7c83a7f5547c0fc69c5"
 dependencies = [
  "bindgen",
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "fslock",
  "gzip-header",
  "home",
@@ -3516,12 +3908,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.254.0",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e974fe6821a8cf64575d51ea2194e2c8f77e7b66e9afe7419ce8a97f9ee0d251"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]
@@ -3539,13 +3941,207 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
+dependencies = [
+ "bitflags 2.13.1",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.13.1",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e3ba11e024f504698f87b629b2b66c22a1231758de7607754963f7d198be39"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.254.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd39f78fe9bc82cee4025ec9d52118269e9a1498016cc60119b14f2e1d86a8d"
+dependencies = [
+ "addr2line",
+ "async-trait",
+ "bitflags 2.13.1",
+ "bumpalo",
+ "cc",
+ "futures",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix 1.1.4",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser 0.254.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c1070d95484d048994ec109cd42c4932ac07e6ee3cc1886fb90c7a18ec29da"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0fe8292115fda08875f29064ae9f7f0b2c1ffbb323146eae538ae34b8a613f"
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821385794cf44baf2967fd2515368429ed2bff9b9b256f62d09a0f1301474fd8"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0238b4a52773457ad1b8a1a26be90486e0ca0108cf46b9be16cc1d8d8cabdfa1"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools 0.14.0",
+ "log",
+ "object",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.20",
+ "wasmparser 0.254.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "596f1d85e06cbf9c9add9c78ea135171c5753264ffe94a83dcc082a1ff49fc9b"
+dependencies = [
+ "cc",
+ "libc",
+ "rustix 1.1.4",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "365faed74827bb0116785bab5872372df1baaec9ec0003c83bc99ccdc595f689"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cce25afd9e7ac4957292a5c6a219951dd0f140b8417e7378a97f50b67c3b96f"
+dependencies = [
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fdea09d51e39c774984ca68a7d7486767e5b2935f5e686fa654aabcfc3c42d"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "object",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e48a5f514c38c2f74249724cb3501e45548d3311ca9e3881694859fd6ba116"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3558,7 +4154,7 @@ dependencies = [
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder",
+ "wasm-encoder 0.258.0",
 ]
 
 [[package]]
@@ -3608,7 +4204,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -3619,7 +4215,7 @@ checksum = "3d9c5ed668ee1f17edb3b627225343d210006a90bb1e3745ce1f30b1fb115075"
 dependencies = [
  "either",
  "home",
- "rustix",
+ "rustix 0.38.34",
  "winsafe",
 ]
 

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -23,6 +23,11 @@ edition.workspace = true
 readme = "README.md"
 rust-version.workspace = true
 
+[features]
+default = ["v8"]
+v8 = ["dep:v8"]
+wasmtime = ["dep:wasmtime"]
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
@@ -36,7 +41,13 @@ slotmap.workspace = true
 toml = { workspace = true, features = ["parse", "serde", "std"] }
 moonutil.workspace = true
 rand = "0.8.5"
-v8 = "0.106.0"
+v8 = { version = "0.106.0", optional = true }
+wasmtime = { version = "48.0.1", default-features = false, optional = true, features = [
+    "anyhow",
+    "runtime",
+    "cranelift",
+    "gc-copying",
+] }
 
 [target."cfg(not(windows))".dependencies]
 openssl.workspace = true

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -2,7 +2,8 @@
 
 # moonrun
 
-Moonrun is the WebAssembly runtime for MoonBit, utilizing V8 at its core to offer an efficient and flexible environment for executing WASM.
+Moonrun is the WebAssembly runtime for MoonBit. Shipping builds use V8, while a
+Wasmtime 48 backend is available as a compile-time development feature.
 
 ## Platform Support
 
@@ -17,6 +18,21 @@ To build the project, ensure that Rust and Cargo are installed. Then execute:
 ```
 cargo build
 ```
+
+The default `moonrun` build selects V8. To build the Wasmtime backend:
+
+```sh
+cargo build -p moonrun --no-default-features --features wasmtime
+```
+
+V8 remains selected when both engine features are enabled; select Wasmtime by
+disabling default features as shown above. Wasmtime supports both `wasm` and
+`wasm-gc`, including JS-string builtins with `_` imported string constants, the
+MoonBit test driver, and the same Moonrun-owned WASIp1 capability surface as
+V8. WASIp1 descriptors and preopens remain separate from Moonrun Policy; both
+engine adapters invoke the same shared WASIp1 host operations. The remaining
+Moonrun host-import adapters, including async and SQLite, will follow in a
+separate change.
 
 ## Running
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -22,9 +22,11 @@ mod sleep;
 mod types;
 mod worker;
 
-pub(crate) use jobs::{
-    errno_is_cancelled, get_platform, job_get_err, job_get_ret, make_failed_job, make_sleep_job,
-};
+#[cfg(any(feature = "v8", test))]
+pub(crate) use jobs::make_sleep_job;
+#[cfg(feature = "v8")]
+pub(crate) use jobs::{errno_is_cancelled, get_platform};
+pub(crate) use jobs::{job_get_err, job_get_ret, make_failed_job};
 pub(crate) use runner::run_host_job;
 pub(crate) use types::{HostHandle, Job, JobPayload, ResourceTable};
 #[cfg(unix)]

--- a/crates/moonrun/src/engine.rs
+++ b/crates/moonrun/src/engine.rs
@@ -19,16 +19,21 @@
 use crate::run_signal::{SignalReceiver, signal_channel};
 use crate::run_termination::RunTermination;
 use crate::runtime::{Runtime, Stdio, WorkingDirectory};
-use crate::{source_map, v8 as backend};
+use crate::source_map;
+#[cfg(feature = "v8")]
+use crate::v8 as backend;
+#[cfg(all(not(feature = "v8"), feature = "wasmtime"))]
+use crate::wasmtime as backend;
 use anyhow::Context;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-/// Process-wide configuration for the Engine Backend.
+/// Process-wide configuration for the selected Engine Backend.
 ///
 /// V8 flags are process-global and must be selected before the first run, so
 /// all V8-backed [`Engine`] values in one process need the same configuration.
+/// A Wasmtime-backed Engine owns its corresponding Wasmtime engine state.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct EngineConfig {
     pub(crate) stack_size: Option<usize>,

--- a/crates/moonrun/src/filesystem/mod.rs
+++ b/crates/moonrun/src/filesystem/mod.rs
@@ -23,6 +23,7 @@
 //! WASI has its own descriptor and preopen capability model and does not pass
 //! through this module.
 
+#[cfg(feature = "v8")]
 pub(crate) mod v8;
 
 mod job;

--- a/crates/moonrun/src/lib.rs
+++ b/crates/moonrun/src/lib.rs
@@ -16,18 +16,27 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+// The core Wasmtime feature compiles shared Runtime domains before their
+// Wasmtime adapters become reachable in the follow-up adapter feature slice.
+#![cfg_attr(all(feature = "wasmtime", not(feature = "v8")), allow(dead_code))]
+
 //! Embeddable execution support for MoonBit Wasm programs.
 //!
 //! The interface is experimental. It separates guest termination from
-//! host-process termination while retaining Moonrun's existing process-scoped
-//! host integrations.
+//! host-process termination and selects one Engine Backend at compile time.
 
+#[cfg(not(any(feature = "v8", feature = "wasmtime")))]
+compile_error!("moonrun requires an engine feature: `v8` or `wasmtime`");
+
+#[cfg(feature = "v8")]
 mod async_api;
 mod async_host;
 mod async_sys;
+#[cfg(any(feature = "v8", feature = "wasmtime"))]
 mod engine;
 mod filesystem;
 mod guest_memory;
+#[cfg(feature = "v8")]
 mod memory_sanitizer;
 mod network;
 mod policy;
@@ -38,11 +47,16 @@ mod run_termination;
 mod runtime;
 mod source_map;
 mod sqlite;
+#[cfg(feature = "v8")]
 mod util;
+#[cfg(feature = "v8")]
 mod v8;
 mod wasi;
 mod wasm_diagnostic;
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+mod wasmtime;
 
+#[cfg(any(feature = "v8", feature = "wasmtime"))]
 pub use engine::{Engine, EngineConfig, Module, RunOptions, RunOutcome};
 pub use run_signal::{SignalReceiver, SignalSendError, SignalSender, signal_channel};
 pub use runtime::WorkingDirectory;

--- a/crates/moonrun/src/process/mod.rs
+++ b/crates/moonrun/src/process/mod.rs
@@ -37,7 +37,9 @@ use crate::policy::{PolicyInheritance, ProcessPolicy};
 use crate::resource::ResourceRef;
 use crate::runtime::{Stdio, WorkingDirectory};
 
-pub(crate) use job::{Job, SpawnOptions};
+pub(crate) use job::Job;
+#[cfg(any(feature = "v8", test))]
+pub(crate) use job::SpawnOptions;
 
 /// Process operations and child ownership shared by guest and worker threads.
 #[derive(Clone)]

--- a/crates/moonrun/src/sqlite/mod.rs
+++ b/crates/moonrun/src/sqlite/mod.rs
@@ -18,6 +18,7 @@
 
 //! SQLite behavior, lifetime state, admission rules, and runtime adapters.
 
+#[cfg(feature = "v8")]
 pub(crate) mod v8;
 
 mod bind;

--- a/crates/moonrun/src/wasmtime/mod.rs
+++ b/crates/moonrun/src/wasmtime/mod.rs
@@ -1,0 +1,860 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Wasmtime Engine Backend for Moonrun's Wasm execution surface.
+
+mod wasi;
+
+use std::collections::HashSet;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use ::wasmtime as wt;
+use ::wasmtime::{
+    AsContext, AsContextMut, Collector, ExnRef, ExnRefPre, ExnType, ExternRef, ExternType,
+    FuncType, Global, HeapType, Linker, Mutability, RefType, Store, Strategy, Tag, Val, ValType,
+};
+use anyhow::Context;
+
+use crate::engine::{
+    BackendCallOutcome, BackendRunOutcome, EngineConfig, RunOptions, complete_run_call,
+    run_test_driver,
+};
+use crate::run_termination::{RunTermination, TerminationRequest};
+use crate::runtime::Runtime;
+use crate::source_map::SourceMap;
+use crate::wasm_diagnostic::{self, DiagnosticLine};
+
+/// Immutable UTF-16 storage shared by JS-string values and host readers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct JsString(Arc<[u16]>);
+
+/// An independent UTF-16 cursor. Wasmtime requires externref host data to be
+/// thread-safe even though one Moonrun Store executes synchronously.
+#[derive(Debug)]
+struct JsStringReader {
+    units: Arc<[u16]>,
+    index: Mutex<usize>,
+}
+
+#[derive(Default)]
+struct PrintState {
+    dangling_high_half: Option<u32>,
+}
+
+pub(crate) struct StoreData {
+    runtime: Runtime,
+    termination_request: TerminationRequest,
+    print: PrintState,
+    exception_tag: Option<Tag>,
+    wasi: crate::wasi::WasiContext,
+}
+
+impl StoreData {
+    pub(crate) fn wasi(&self) -> &crate::wasi::WasiContext {
+        &self.wasi
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Engine {
+    inner: Result<::wasmtime::Engine, Arc<str>>,
+}
+
+impl Engine {
+    pub(crate) fn new(config: EngineConfig) -> Self {
+        let mut wasmtime_config = ::wasmtime::Config::new();
+        wasmtime_config
+            .strategy(Strategy::Cranelift)
+            .gc_support(true)
+            .collector(Collector::Copying)
+            .wasm_reference_types(true)
+            .wasm_function_references(true)
+            .wasm_gc(true)
+            .wasm_exceptions(true);
+        let stack_size = config
+            .stack_size
+            .map(|size| {
+                size.checked_mul(1024)
+                    .ok_or_else(|| Arc::<str>::from("Wasmtime stack size overflows bytes"))
+            })
+            .transpose();
+        if let Ok(Some(stack_size)) = &stack_size {
+            wasmtime_config.max_wasm_stack(*stack_size);
+        }
+        Self {
+            inner: stack_size.and_then(|_| {
+                ::wasmtime::Engine::new(&wasmtime_config)
+                    .map_err(|error| Arc::<str>::from(error.to_string()))
+            }),
+        }
+    }
+
+    fn inner(&self) -> anyhow::Result<&::wasmtime::Engine> {
+        self.inner
+            .as_ref()
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+    }
+
+    pub(crate) fn compile(&self, bytes: &[u8]) -> anyhow::Result<CompiledModule> {
+        ::wasmtime::Module::new(self.inner()?, bytes)
+            .map(CompiledModule)
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+    }
+
+    pub(crate) fn run(
+        &self,
+        module_name: &str,
+        module: &CompiledModule,
+        source_map: Option<&SourceMap>,
+        options: RunOptions,
+        runtime: Runtime,
+    ) -> anyhow::Result<BackendRunOutcome> {
+        let test_args = options.parsed_test_args()?;
+        let engine = self.inner()?;
+        let termination_request = TerminationRequest::default();
+        let wasi = crate::wasi::WasiContext::new(
+            module_name,
+            &options.args,
+            &runtime,
+            termination_request.clone(),
+        );
+        let stdio = Arc::clone(runtime.stdio());
+        let mut store = Store::new(
+            engine,
+            StoreData {
+                runtime,
+                termination_request: termination_request.clone(),
+                print: PrintState::default(),
+                exception_tag: None,
+                wasi,
+            },
+        );
+        let linker = linker_for_module(engine, &mut store, &module.0)
+            .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+        let instance = match linker.instantiate(&mut store, &module.0) {
+            Ok(instance) => instance,
+            Err(error) => {
+                let outcome = if let Some(termination) = termination_request.take() {
+                    BackendCallOutcome::Terminated(termination)
+                } else if is_guest_failure(&error) {
+                    BackendCallOutcome::GuestFailure(format_wasm_error(
+                        &error,
+                        source_map,
+                        options.no_stack_trace,
+                    ))
+                } else {
+                    return Err(anyhow::Error::from(error)
+                        .context(format!("failed to instantiate `{module_name}`")));
+                };
+                return complete_run_call(outcome, &stdio);
+            }
+        };
+
+        if let Some(test_args) = test_args {
+            let execute = instance
+                .get_func(&mut store, "moonbit_test_driver_internal_execute")
+                .context("test module does not export `moonbit_test_driver_internal_execute`")?;
+            let finish = instance
+                .get_func(&mut store, "moonbit_test_driver_finish")
+                .context("test module does not export `moonbit_test_driver_finish`")?;
+            run_test_driver(
+                &mut store,
+                test_args,
+                &stdio,
+                |store, file, index| {
+                    let file =
+                        ExternRef::new(&mut *store, JsString(file.encode_utf16().collect()))?;
+                    call_export(
+                        store,
+                        &execute,
+                        &[Val::ExternRef(Some(file)), Val::I32(index as i32)],
+                        source_map,
+                        options.no_stack_trace,
+                    )
+                    .context("failed to execute a MoonBit test")
+                },
+                |store| {
+                    call_export(store, &finish, &[], source_map, options.no_stack_trace)
+                        .context("failed to finish the MoonBit test driver")
+                },
+            )
+        } else if let Some(start) = instance.get_func(&mut store, "_start") {
+            let outcome = call_export(&mut store, &start, &[], source_map, options.no_stack_trace)?;
+            complete_run_call(outcome, &stdio)
+        } else {
+            Ok(BackendRunOutcome::Completed)
+        }
+    }
+}
+
+impl fmt::Debug for Engine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WasmtimeEngine")
+            .field("initialized", &self.inner.is_ok())
+            .finish()
+    }
+}
+
+pub(crate) struct CompiledModule(::wasmtime::Module);
+
+fn linker_for_module(
+    engine: &::wasmtime::Engine,
+    store: &mut Store<StoreData>,
+    module: &::wasmtime::Module,
+) -> wt::Result<Linker<StoreData>> {
+    let mut linker = Linker::new(engine);
+    wasi::register_imports(&mut linker)?;
+    let mut defined = HashSet::new();
+
+    for import in module.imports() {
+        let key = (import.module().to_owned(), import.name().to_owned());
+        if !defined.insert(key) {
+            continue;
+        }
+        match (import.module(), import.name(), import.ty()) {
+            (wasi::WASI_SNAPSHOT_PREVIEW1_MODULE, _, ExternType::Func(_)) => {}
+            ("_", literal, ExternType::Global(ty)) => {
+                if ty.mutability() != Mutability::Const {
+                    wt::bail!("imported string constant `{literal}` is mutable");
+                }
+                validate_types(
+                    "imported string constant",
+                    [ty.content().clone()],
+                    [non_null_externref()],
+                )?;
+                let value =
+                    ExternRef::new(&mut *store, JsString(literal.encode_utf16().collect()))?;
+                let global = Global::new(&mut *store, ty, Val::ExternRef(Some(value)))?;
+                linker.define(&mut *store, "_", literal, global)?;
+            }
+            ("wasm:js-string", name, ExternType::Func(ty)) => {
+                register_js_string_builtin(&mut linker, name, ty)?;
+            }
+            ("__moonbit_fs_unstable", "begin_read_string", ExternType::Func(ty)) => {
+                validate_func(&ty, [ValType::EXTERNREF], [ValType::EXTERNREF])?;
+                linker.func_new(
+                    "__moonbit_fs_unstable",
+                    "begin_read_string",
+                    ty,
+                    |mut caller, params, results| {
+                        let units = Arc::clone(&require_string(caller.as_context(), &params[0])?.0);
+                        let reader = ExternRef::new(
+                            &mut caller,
+                            JsStringReader {
+                                units,
+                                index: Mutex::new(0),
+                            },
+                        )?;
+                        results[0] = Val::ExternRef(Some(reader));
+                        Ok(())
+                    },
+                )?;
+            }
+            ("__moonbit_fs_unstable", "string_read_char", ExternType::Func(ty)) => {
+                validate_func(&ty, [ValType::EXTERNREF], [ValType::I32])?;
+                linker.func_new(
+                    "__moonbit_fs_unstable",
+                    "string_read_char",
+                    ty,
+                    |caller, params, results| {
+                        let reference = params[0].unwrap_externref().ok_or_else(|| {
+                            wt::format_err!("string reader operation received null")
+                        })?;
+                        let data = reference
+                            .data(caller.as_context())?
+                            .ok_or_else(|| wt::format_err!("externref has no host reader data"))?;
+                        let reader = data
+                            .downcast_ref::<JsStringReader>()
+                            .ok_or_else(|| wt::format_err!("externref is not a string reader"))?;
+                        let mut index = reader
+                            .index
+                            .lock()
+                            .map_err(|_| wt::format_err!("string reader lock is poisoned"))?;
+                        results[0] = Val::I32(match reader.units.get(*index) {
+                            Some(unit) => {
+                                *index += 1;
+                                i32::from(*unit)
+                            }
+                            None => -1,
+                        });
+                        Ok(())
+                    },
+                )?;
+            }
+            ("__moonbit_fs_unstable", "finish_read_string", ExternType::Func(ty)) => {
+                validate_func(&ty, [ValType::EXTERNREF], [])?;
+                linker.func_new(
+                    "__moonbit_fs_unstable",
+                    "finish_read_string",
+                    ty,
+                    |_caller, _params, _results| Ok(()),
+                )?;
+            }
+            ("console", "log", ExternType::Func(ty)) => {
+                validate_func(&ty, [non_null_externref()], [])?;
+                linker.func_new("console", "log", ty, |caller, params, _results| {
+                    let units = require_string(caller.as_context(), &params[0])?;
+                    let value = String::from_utf16_lossy(&units.0);
+                    caller
+                        .data()
+                        .runtime
+                        .stdio()
+                        .with_stdout(|stdout| writeln!(stdout, "{value}"))?;
+                    Ok(())
+                })?;
+            }
+            ("spectest", "print_char", ExternType::Func(ty)) => {
+                validate_func(&ty, [ValType::I32], [])?;
+                linker.func_new(
+                    "spectest",
+                    "print_char",
+                    ty,
+                    |mut caller, params, _results| {
+                        print_char(caller.data_mut(), params[0].unwrap_i32() as u32)?;
+                        Ok(())
+                    },
+                )?;
+            }
+            ("exception", "tag", ExternType::Tag(ty)) => {
+                validate_func(ty.ty(), [], [])?;
+                let tag = Tag::new(&mut *store, &ty)?;
+                if store.data_mut().exception_tag.replace(tag).is_some() {
+                    wt::bail!("duplicate `exception.tag` import");
+                }
+                linker.define(&mut *store, "exception", "tag", tag)?;
+            }
+            ("exception", "throw", ExternType::Func(ty)) => {
+                validate_func(&ty, [], [])?;
+                linker.func_new("exception", "throw", ty, |mut caller, _params, _results| {
+                    let tag = caller
+                        .data()
+                        .exception_tag
+                        .ok_or_else(|| wt::format_err!("missing `exception.tag` import"))?;
+                    let exception_type = ExnType::from_tag_type(&tag.ty(caller.as_context()))?;
+                    let allocator = ExnRefPre::new(&mut caller, exception_type);
+                    let exception = ExnRef::new(&mut caller, &allocator, &tag, &[])?;
+                    caller.as_context_mut().throw(exception)
+                })?;
+            }
+            ("__moonbit_sys_unstable", "is_windows", ExternType::Func(ty)) => {
+                validate_func(&ty, [], [ValType::I32])?;
+                linker.func_new(
+                    "__moonbit_sys_unstable",
+                    "is_windows",
+                    ty,
+                    |_caller, _params, results| {
+                        results[0] = Val::I32(i32::from(cfg!(windows)));
+                        Ok(())
+                    },
+                )?;
+            }
+            ("__moonbit_sys_unstable", "exit", ExternType::Func(ty)) => {
+                validate_func(&ty, [ValType::I32], [])?;
+                linker.func_new(
+                    "__moonbit_sys_unstable",
+                    "exit",
+                    ty,
+                    |caller, params, _results| {
+                        caller
+                            .data()
+                            .termination_request
+                            .request(RunTermination::Exit(params[0].unwrap_i32()));
+                        wt::bail!("run termination requested")
+                    },
+                )?;
+            }
+            (namespace, name, ty) => {
+                wt::bail!("unsupported Wasmtime import `{namespace}.{name}`: {ty:?}");
+            }
+        }
+    }
+    Ok(linker)
+}
+
+fn register_js_string_builtin(
+    linker: &mut Linker<StoreData>,
+    name: &str,
+    ty: FuncType,
+) -> wt::Result<()> {
+    match name {
+        "cast" => {
+            validate_func(&ty, [ValType::EXTERNREF], [non_null_externref()])?;
+            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
+                require_builtin_string(caller.as_context(), &params[0])?;
+                results[0] = params[0];
+                Ok(())
+            })?;
+        }
+        "test" => {
+            validate_func(&ty, [ValType::EXTERNREF], [ValType::I32])?;
+            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
+                results[0] = Val::I32(i32::from(matches!(
+                    js_string_value(caller.as_context(), &params[0])?,
+                    JsStringValue::String(_)
+                )));
+                Ok(())
+            })?;
+        }
+        "fromCharCode" => {
+            validate_func(&ty, [ValType::I32], [non_null_externref()])?;
+            linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
+                let value = ExternRef::new(
+                    &mut caller,
+                    JsString(vec![params[0].unwrap_i32() as u16].into()),
+                )?;
+                results[0] = Val::ExternRef(Some(value));
+                Ok(())
+            })?;
+        }
+        "fromCodePoint" => {
+            validate_func(&ty, [ValType::I32], [non_null_externref()])?;
+            linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
+                let code_point = params[0].unwrap_i32() as u32;
+                let units = match code_point {
+                    0..=0xffff => vec![code_point as u16],
+                    0x10000..=0x10ffff => {
+                        let value = code_point - 0x10000;
+                        vec![
+                            0xd800 | ((value >> 10) as u16),
+                            0xdc00 | ((value & 0x3ff) as u16),
+                        ]
+                    }
+                    _ => return js_string_trap(),
+                };
+                let value = ExternRef::new(&mut caller, JsString(units.into()))?;
+                results[0] = Val::ExternRef(Some(value));
+                Ok(())
+            })?;
+        }
+        "charCodeAt" => {
+            validate_func(&ty, [ValType::EXTERNREF, ValType::I32], [ValType::I32])?;
+            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
+                let units = require_builtin_string(caller.as_context(), &params[0])?;
+                let index = params[1].unwrap_i32() as u32;
+                let Some(code_unit) = units.0.get(index as usize) else {
+                    return js_string_trap();
+                };
+                results[0] = Val::I32(i32::from(*code_unit));
+                Ok(())
+            })?;
+        }
+        "codePointAt" => {
+            validate_func(&ty, [ValType::EXTERNREF, ValType::I32], [ValType::I32])?;
+            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
+                let units = require_builtin_string(caller.as_context(), &params[0])?;
+                let index = params[1].unwrap_i32() as u32 as usize;
+                let Some(&first) = units.0.get(index) else {
+                    return js_string_trap();
+                };
+                let code_point = match (first, units.0.get(index + 1).copied()) {
+                    (0xd800..=0xdbff, Some(second @ 0xdc00..=0xdfff)) => {
+                        0x10000 + ((u32::from(first) - 0xd800) << 10) + (u32::from(second) - 0xdc00)
+                    }
+                    _ => u32::from(first),
+                };
+                results[0] = Val::I32(code_point as i32);
+                Ok(())
+            })?;
+        }
+        "length" => {
+            validate_func(&ty, [ValType::EXTERNREF], [ValType::I32])?;
+            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
+                let units = require_builtin_string(caller.as_context(), &params[0])?;
+                results[0] = Val::I32(i32::try_from(units.0.len())?);
+                Ok(())
+            })?;
+        }
+        "concat" => {
+            validate_func(
+                &ty,
+                [ValType::EXTERNREF, ValType::EXTERNREF],
+                [non_null_externref()],
+            )?;
+            linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
+                let left = require_builtin_string(caller.as_context(), &params[0])?;
+                let right = require_builtin_string(caller.as_context(), &params[1])?;
+                let mut units = Vec::with_capacity(left.0.len() + right.0.len());
+                units.extend_from_slice(&left.0);
+                units.extend_from_slice(&right.0);
+                let value = ExternRef::new(&mut caller, JsString(units.into()))?;
+                results[0] = Val::ExternRef(Some(value));
+                Ok(())
+            })?;
+        }
+        "substring" => {
+            validate_func(
+                &ty,
+                [ValType::EXTERNREF, ValType::I32, ValType::I32],
+                [non_null_externref()],
+            )?;
+            linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
+                let units = require_builtin_string(caller.as_context(), &params[0])?;
+                let start = params[1].unwrap_i32() as u32 as usize;
+                let end = params[2].unwrap_i32() as u32 as usize;
+                let substring = if start > end || start > units.0.len() {
+                    Vec::new()
+                } else {
+                    units.0[start..end.min(units.0.len())].to_vec()
+                };
+                let value = ExternRef::new(&mut caller, JsString(substring.into()))?;
+                results[0] = Val::ExternRef(Some(value));
+                Ok(())
+            })?;
+        }
+        "equals" => {
+            validate_func(
+                &ty,
+                [ValType::EXTERNREF, ValType::EXTERNREF],
+                [ValType::I32],
+            )?;
+            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
+                let left = optional_builtin_string(caller.as_context(), &params[0])?;
+                let right = optional_builtin_string(caller.as_context(), &params[1])?;
+                results[0] = Val::I32(i32::from(left == right));
+                Ok(())
+            })?;
+        }
+        "compare" => {
+            validate_func(
+                &ty,
+                [ValType::EXTERNREF, ValType::EXTERNREF],
+                [ValType::I32],
+            )?;
+            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
+                let left = require_builtin_string(caller.as_context(), &params[0])?;
+                let right = require_builtin_string(caller.as_context(), &params[1])?;
+                results[0] = Val::I32(match left.0.cmp(&right.0) {
+                    std::cmp::Ordering::Less => -1,
+                    std::cmp::Ordering::Equal => 0,
+                    std::cmp::Ordering::Greater => 1,
+                });
+                Ok(())
+            })?;
+        }
+        "fromCharCodeArray" => {
+            validate_from_char_code_array(&ty)?;
+            linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
+                let Some(reference) = params[0].unwrap_anyref() else {
+                    return js_string_trap();
+                };
+                let array = reference.unwrap_array(caller.as_context())?;
+                let start = params[1].unwrap_i32() as u32;
+                let end = params[2].unwrap_i32() as u32;
+                let len = array.len(caller.as_context())?;
+                if start > end || end > len {
+                    return js_string_trap();
+                }
+
+                let mut units = Vec::with_capacity((end - start) as usize);
+                for index in start..end {
+                    units.push(array.get(&mut caller, index)?.unwrap_i32() as u16);
+                }
+                let value = ExternRef::new(&mut caller, JsString(units.into()))?;
+                results[0] = Val::ExternRef(Some(value));
+                Ok(())
+            })?;
+        }
+        "intoCharCodeArray" => {
+            validate_into_char_code_array(&ty)?;
+            linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
+                let units = Arc::clone(&require_builtin_string(caller.as_context(), &params[0])?.0);
+                let Some(reference) = params[1].unwrap_anyref() else {
+                    return js_string_trap();
+                };
+                let array = reference.unwrap_array(caller.as_context())?;
+                let start = params[2].unwrap_i32() as u32;
+                let len = array.len(caller.as_context())?;
+                let unit_count = u32::try_from(units.len())?;
+                if start.checked_add(unit_count).is_none_or(|end| end > len) {
+                    return js_string_trap();
+                }
+                for (offset, unit) in units.iter().copied().enumerate() {
+                    array.set(
+                        &mut caller,
+                        start + offset as u32,
+                        Val::I32(i32::from(unit)),
+                    )?;
+                }
+                results[0] = Val::I32(unit_count as i32);
+                Ok(())
+            })?;
+        }
+        _ => wt::bail!("unsupported Wasmtime import `wasm:js-string.{name}`: {ty:?}"),
+    }
+    Ok(())
+}
+
+fn is_guest_failure(error: &wt::Error) -> bool {
+    error.root_cause().is::<wt::Trap>() || error.root_cause().is::<wt::ThrownException>()
+}
+
+fn call_export(
+    store: &mut Store<StoreData>,
+    function: &wt::Func,
+    arguments: &[Val],
+    source_map: Option<&SourceMap>,
+    no_stack_trace: bool,
+) -> anyhow::Result<BackendCallOutcome> {
+    let result = function.call(&mut *store, arguments, &mut []);
+    if let Some(termination) = store.data().termination_request.take() {
+        return Ok(BackendCallOutcome::Terminated(termination));
+    }
+    match result {
+        Ok(()) => Ok(BackendCallOutcome::Completed),
+        Err(error) if is_guest_failure(&error) => Ok(BackendCallOutcome::GuestFailure(
+            format_wasm_error(&error, source_map, no_stack_trace),
+        )),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn format_wasm_error(
+    error: &wasmtime::Error,
+    source_map: Option<&SourceMap>,
+    no_stack_trace: bool,
+) -> String {
+    let root = error.root_cause();
+    let thrown_exception = root.is::<wasmtime::ThrownException>();
+    let message = if matches!(
+        root.downcast_ref::<wasmtime::Trap>(),
+        Some(wasmtime::Trap::UnreachableCodeReached)
+    ) {
+        "RuntimeError: unreachable".to_owned()
+    } else if thrown_exception {
+        "Error".to_owned()
+    } else {
+        format!("Error: {root}")
+    };
+    let mut lines = vec![DiagnosticLine::Text(message)];
+    if thrown_exception {
+        lines.push(DiagnosticLine::Frame {
+            indentation: "    ".to_owned(),
+            function: "throw".to_owned(),
+            module_offset: None,
+        });
+    }
+    if let Some(backtrace) = error.downcast_ref::<wasmtime::WasmBacktrace>() {
+        for frame in backtrace.frames() {
+            let raw_name = frame
+                .func_name()
+                .map(str::to_owned)
+                .unwrap_or_else(|| format!("wasm-function[{}]", frame.func_index()));
+            if moonutil::demangle::demangle_mangled_function_name(&raw_name)
+                .contains(".moonbit_test_driver_internal_execute_wrapper/")
+            {
+                continue;
+            }
+            lines.push(DiagnosticLine::Frame {
+                indentation: "    ".to_owned(),
+                function: raw_name,
+                module_offset: frame.module_offset(),
+            });
+        }
+    }
+    wasm_diagnostic::render(lines, source_map, no_stack_trace)
+}
+
+fn print_char(data: &mut StoreData, value: u32) -> wt::Result<()> {
+    let stdio = Arc::clone(data.runtime.stdio());
+    if (0xd800..=0xdbff).contains(&value) {
+        if data
+            .print
+            .dangling_high_half
+            .replace(value - 0xd800)
+            .is_some()
+        {
+            stdio.with_stdout(|stdout| write!(stdout, "\u{fffd}"))?;
+        }
+        return Ok(());
+    }
+
+    let value = if (0xdc00..=0xdfff).contains(&value) {
+        data.print
+            .dangling_high_half
+            .take()
+            .map_or(0xfffd, |high| 0x10000 + (high << 10) + (value - 0xdc00))
+    } else {
+        value
+    };
+    let value = char::from_u32(value).ok_or_else(|| wt::format_err!("invalid character"))?;
+    stdio.with_stdout(|stdout| write!(stdout, "{value}"))?;
+    Ok(())
+}
+
+pub(super) fn validate_func<const P: usize, const R: usize>(
+    ty: &FuncType,
+    params: [ValType; P],
+    results: [ValType; R],
+) -> wt::Result<()> {
+    validate_types("function parameters", ty.params(), params)?;
+    validate_types("function results", ty.results(), results)
+}
+
+pub(super) fn validate_types(
+    label: &str,
+    actual: impl IntoIterator<Item = ValType>,
+    expected: impl IntoIterator<Item = ValType>,
+) -> wt::Result<()> {
+    let actual = actual.into_iter().collect::<Vec<_>>();
+    let expected = expected.into_iter().collect::<Vec<_>>();
+    if actual.len() != expected.len()
+        || !actual
+            .iter()
+            .zip(&expected)
+            .all(|(actual, expected)| ValType::eq(actual, expected))
+    {
+        wt::bail!("invalid Wasmtime import {label}: expected {expected:?}, found {actual:?}");
+    }
+    Ok(())
+}
+
+fn validate_from_char_code_array(ty: &FuncType) -> wt::Result<()> {
+    let params = ty.params().collect::<Vec<_>>();
+    let results = ty.results().collect::<Vec<_>>();
+    let valid_array = params.first().is_some_and(is_nullable_mutable_i16_array);
+    let valid_scalars = params.len() == 3
+        && ValType::eq(&params[1], &ValType::I32)
+        && ValType::eq(&params[2], &ValType::I32);
+    let valid_result = results.len() == 1 && ValType::eq(&results[0], &non_null_externref());
+    if !valid_array || !valid_scalars || !valid_result {
+        wt::bail!("invalid fromCharCodeArray signature: params {params:?}, results {results:?}");
+    }
+    Ok(())
+}
+
+fn validate_into_char_code_array(ty: &FuncType) -> wt::Result<()> {
+    let params = ty.params().collect::<Vec<_>>();
+    let results = ty.results().collect::<Vec<_>>();
+    let valid_params = params.len() == 3
+        && ValType::eq(&params[0], &ValType::EXTERNREF)
+        && is_nullable_mutable_i16_array(&params[1])
+        && ValType::eq(&params[2], &ValType::I32);
+    let valid_result = results.len() == 1 && ValType::eq(&results[0], &ValType::I32);
+    if !valid_params || !valid_result {
+        wt::bail!("invalid intoCharCodeArray signature: params {params:?}, results {results:?}");
+    }
+    Ok(())
+}
+
+fn is_nullable_mutable_i16_array(ty: &ValType) -> bool {
+    match ty {
+        ValType::Ref(reference) if reference.is_nullable() => match reference.heap_type() {
+            HeapType::ConcreteArray(array) => {
+                array.mutability() == Mutability::Var && array.element_type().is_i16()
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn non_null_externref() -> ValType {
+    RefType::new(false, HeapType::Extern).into()
+}
+
+fn require_string<'a, T: 'static>(
+    store: wt::StoreContext<'a, T>,
+    value: &Val,
+) -> wt::Result<&'a JsString> {
+    match js_string_value(store, value)? {
+        JsStringValue::String(units) => Ok(units),
+        JsStringValue::Null => wt::bail!("JS-string operation received null"),
+        JsStringValue::Other => wt::bail!("externref is not a JS string"),
+    }
+}
+
+enum JsStringValue<'a> {
+    Null,
+    String(&'a JsString),
+    Other,
+}
+
+fn js_string_value<'a, T: 'static>(
+    store: wt::StoreContext<'a, T>,
+    value: &Val,
+) -> wt::Result<JsStringValue<'a>> {
+    let Some(reference) = value.unwrap_externref() else {
+        return Ok(JsStringValue::Null);
+    };
+    let Some(data) = reference.data(store)? else {
+        return Ok(JsStringValue::Other);
+    };
+    Ok(match data.downcast_ref::<JsString>() {
+        Some(string) => JsStringValue::String(string),
+        None => JsStringValue::Other,
+    })
+}
+
+fn require_builtin_string<'a, T: 'static>(
+    store: wt::StoreContext<'a, T>,
+    value: &Val,
+) -> wt::Result<&'a JsString> {
+    match js_string_value(store, value)? {
+        JsStringValue::String(units) => Ok(units),
+        JsStringValue::Null | JsStringValue::Other => js_string_trap(),
+    }
+}
+
+fn optional_builtin_string<'a, T: 'static>(
+    store: wt::StoreContext<'a, T>,
+    value: &Val,
+) -> wt::Result<Option<&'a JsString>> {
+    match js_string_value(store, value)? {
+        JsStringValue::Null => Ok(None),
+        JsStringValue::String(units) => Ok(Some(units)),
+        JsStringValue::Other => js_string_trap(),
+    }
+}
+
+fn js_string_trap<T>() -> wt::Result<T> {
+    Err(wt::Trap::UnreachableCodeReached.into())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn rejects_unsupported_string_constant_namespaces_and_shapes() {
+        for (source, expected) in [
+            (
+                r#"(module (import "my_strings" "value" (global (ref extern))))"#,
+                "unsupported Wasmtime import `my_strings.value`",
+            ),
+            (
+                r#"(module (import "_" "value" (global (mut externref))))"#,
+                "imported string constant `value` is mutable",
+            ),
+            (
+                r#"(module
+                    (import "wasm:js-string" "length"
+                        (func (param i32) (result i32))))"#,
+                "invalid Wasmtime import function parameters",
+            ),
+        ] {
+            let engine = crate::Engine::default();
+            let module = engine.compile("invalid-import.wasm", wat::parse_str(source).unwrap());
+            let error = engine
+                .run(&module.unwrap(), crate::RunOptions::default())
+                .unwrap_err();
+            assert!(
+                format!("{error:#}").contains(expected),
+                "expected {expected:?} in {error:#}"
+            );
+        }
+    }
+}

--- a/crates/moonrun/src/wasmtime/wasi.rs
+++ b/crates/moonrun/src/wasmtime/wasi.rs
@@ -1,0 +1,330 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Wasmtime adapter for the shared WASIp1 Host state.
+
+use crate::wasi::{self, WasiContext, WasiResult};
+
+use super::StoreData;
+
+pub(super) const WASI_SNAPSHOT_PREVIEW1_MODULE: &str = "wasi_snapshot_preview1";
+
+fn with_memory(
+    caller: &mut wasmtime::Caller<'_, StoreData>,
+    f: impl FnOnce(&WasiContext, &mut [u8]) -> WasiResult<()>,
+) -> i32 {
+    let memory = caller
+        .get_export("memory")
+        .and_then(wasmtime::Extern::into_memory);
+    let result = match memory {
+        Some(memory) => {
+            let (memory, data) = memory.data_and_store_mut(&mut *caller);
+            f(data.wasi(), memory)
+        }
+        None => {
+            let mut empty = [];
+            f(caller.data().wasi(), &mut empty)
+        }
+    };
+    wasi::result_to_errno(result)
+}
+
+pub(super) fn register_imports(linker: &mut wasmtime::Linker<StoreData>) -> wasmtime::Result<()> {
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "args_get",
+        |mut caller: wasmtime::Caller<'_, StoreData>, argv_ptr: i32, argv_buf_ptr: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::args_get_impl(context, memory, argv_ptr as u32, argv_buf_ptr as u32)
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "args_sizes_get",
+        |mut caller: wasmtime::Caller<'_, StoreData>, argc_ptr: i32, argv_buf_size_ptr: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::args_sizes_get_impl(
+                    context,
+                    memory,
+                    argc_ptr as u32,
+                    argv_buf_size_ptr as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "environ_get",
+        |mut caller: wasmtime::Caller<'_, StoreData>, environ_ptr: i32, environ_buf_ptr: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::environ_get_impl(context, memory, environ_ptr as u32, environ_buf_ptr as u32)
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "environ_sizes_get",
+        |mut caller: wasmtime::Caller<'_, StoreData>,
+         environc_ptr: i32,
+         environ_buf_size_ptr: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::environ_sizes_get_impl(
+                    context,
+                    memory,
+                    environc_ptr as u32,
+                    environ_buf_size_ptr as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "random_get",
+        |mut caller: wasmtime::Caller<'_, StoreData>, buffer: i32, length: i32| {
+            with_memory(&mut caller, |_context, memory| {
+                wasi::random_get_impl(memory, buffer as u32, length as u32)
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "fd_read",
+        |mut caller: wasmtime::Caller<'_, StoreData>,
+         fd: i32,
+         iovs_ptr: i32,
+         iovs_len: i32,
+         nread_ptr: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::fd_read_impl(
+                    context,
+                    memory,
+                    fd,
+                    iovs_ptr as u32,
+                    iovs_len as u32,
+                    nread_ptr as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "fd_write",
+        |mut caller: wasmtime::Caller<'_, StoreData>,
+         fd: i32,
+         iovs_ptr: i32,
+         iovs_len: i32,
+         nwritten_ptr: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::fd_write_impl(
+                    context,
+                    memory,
+                    fd,
+                    iovs_ptr as u32,
+                    iovs_len as u32,
+                    nwritten_ptr as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "fd_close",
+        |caller: wasmtime::Caller<'_, StoreData>, fd: i32| {
+            wasi::result_to_errno(wasi::fd_close_impl(caller.data().wasi(), fd))
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "fd_prestat_get",
+        |mut caller: wasmtime::Caller<'_, StoreData>, fd: i32, prestat_ptr: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::fd_prestat_get_impl(context, memory, fd, prestat_ptr as u32)
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "fd_prestat_dir_name",
+        |mut caller: wasmtime::Caller<'_, StoreData>, fd: i32, path_ptr: i32, path_len: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::fd_prestat_dir_name_impl(
+                    context,
+                    memory,
+                    fd,
+                    path_ptr as u32,
+                    path_len as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "fd_readdir",
+        |mut caller: wasmtime::Caller<'_, StoreData>,
+         fd: i32,
+         buf_ptr: i32,
+         buf_len: i32,
+         cookie: i64,
+         buf_used_ptr: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::fd_readdir_impl(
+                    context,
+                    memory,
+                    fd,
+                    buf_ptr as u32,
+                    buf_len as u32,
+                    cookie as u64,
+                    buf_used_ptr as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "path_open",
+        |mut caller: wasmtime::Caller<'_, StoreData>,
+         dirfd: i32,
+         dirflags: i32,
+         path_ptr: i32,
+         path_len: i32,
+         oflags: i32,
+         rights_base: i64,
+         rights_inheriting: i64,
+         fdflags: i32,
+         opened_fd_ptr: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::path_open_impl(
+                    context,
+                    memory,
+                    dirfd,
+                    dirflags,
+                    path_ptr as u32,
+                    path_len as u32,
+                    oflags,
+                    rights_base as u64,
+                    rights_inheriting as u64,
+                    fdflags,
+                    opened_fd_ptr as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "path_readlink",
+        |mut caller: wasmtime::Caller<'_, StoreData>,
+         dirfd: i32,
+         path_ptr: i32,
+         path_len: i32,
+         buf_ptr: i32,
+         buf_len: i32,
+         buf_used_ptr: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::path_readlink_impl(
+                    context,
+                    memory,
+                    dirfd,
+                    path_ptr as u32,
+                    path_len as u32,
+                    buf_ptr as u32,
+                    buf_len as u32,
+                    buf_used_ptr as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "path_rename",
+        |mut caller: wasmtime::Caller<'_, StoreData>,
+         old_fd: i32,
+         old_path_ptr: i32,
+         old_path_len: i32,
+         new_fd: i32,
+         new_path_ptr: i32,
+         new_path_len: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::path_rename_impl(
+                    context,
+                    memory,
+                    old_fd,
+                    old_path_ptr as u32,
+                    old_path_len as u32,
+                    new_fd,
+                    new_path_ptr as u32,
+                    new_path_len as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "path_create_directory",
+        |mut caller: wasmtime::Caller<'_, StoreData>, dirfd: i32, path_ptr: i32, path_len: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::path_create_directory_impl(
+                    context,
+                    memory,
+                    dirfd,
+                    path_ptr as u32,
+                    path_len as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "path_remove_directory",
+        |mut caller: wasmtime::Caller<'_, StoreData>, dirfd: i32, path_ptr: i32, path_len: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::path_remove_directory_impl(
+                    context,
+                    memory,
+                    dirfd,
+                    path_ptr as u32,
+                    path_len as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "path_unlink_file",
+        |mut caller: wasmtime::Caller<'_, StoreData>, dirfd: i32, path_ptr: i32, path_len: i32| {
+            with_memory(&mut caller, |context, memory| {
+                wasi::path_unlink_file_impl(
+                    context,
+                    memory,
+                    dirfd,
+                    path_ptr as u32,
+                    path_len as u32,
+                )
+            })
+        },
+    )?;
+    linker.func_wrap(
+        WASI_SNAPSHOT_PREVIEW1_MODULE,
+        "proc_exit",
+        |caller: wasmtime::Caller<'_, StoreData>, code: i32| -> wasmtime::Result<()> {
+            wasi::proc_exit_impl(caller.data().wasi(), code as u32);
+            Err(wasmtime::format_err!("run termination requested"))
+        },
+    )?;
+    Ok(())
+}

--- a/crates/moonrun/tests/engine_backends.rs
+++ b/crates/moonrun/tests/engine_backends.rs
@@ -1,0 +1,693 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+#[test]
+fn engine_backend_reuses_compiled_modules() {
+    let engine = moonrun::Engine::default();
+    let plain = engine
+        .compile(
+            "plain.wasm",
+            wat::parse_str(r#"(module (func (export "_start")))"#).unwrap(),
+        )
+        .unwrap();
+    for _ in 0..2 {
+        assert_eq!(
+            engine.run(&plain, moonrun::RunOptions::default()).unwrap(),
+            moonrun::RunOutcome::Completed
+        );
+    }
+}
+
+#[test]
+fn engine_backends_support_js_string_builtins() {
+    let engine = moonrun::Engine::default();
+    let js_strings = engine
+        .compile(
+            "js-strings.wasm",
+            wat::parse_str(
+                r#"(module
+                    (type $chars (array (mut i16)))
+                    (import "_" "hello" (global $hello (ref extern)))
+                    (import "_" " world" (global $world (ref extern)))
+                    (import "_" "ell" (global $ell (ref extern)))
+                    (import "wasm:js-string" "cast"
+                        (func $cast (param externref) (result (ref extern))))
+                    (import "wasm:js-string" "test"
+                        (func $test (param externref) (result i32)))
+                    (import "wasm:js-string" "fromCharCode"
+                        (func $from_char_code (param i32) (result (ref extern))))
+                    (import "wasm:js-string" "fromCodePoint"
+                        (func $from_code_point (param i32) (result (ref extern))))
+                    (import "wasm:js-string" "length"
+                        (func $length (param externref) (result i32)))
+                    (import "wasm:js-string" "charCodeAt"
+                        (func $char_code_at (param externref i32) (result i32)))
+                    (import "wasm:js-string" "codePointAt"
+                        (func $code_point_at (param externref i32) (result i32)))
+                    (import "wasm:js-string" "equals"
+                        (func $equals (param externref externref) (result i32)))
+                    (import "wasm:js-string" "concat"
+                        (func $concat (param externref externref) (result (ref extern))))
+                    (import "wasm:js-string" "substring"
+                        (func $substring (param externref i32 i32) (result (ref extern))))
+                    (import "wasm:js-string" "compare"
+                        (func $compare (param externref externref) (result i32)))
+                    (import "wasm:js-string" "fromCharCodeArray"
+                        (func $from_chars
+                            (param (ref null $chars) i32 i32)
+                            (result (ref extern))))
+                    (import "wasm:js-string" "intoCharCodeArray"
+                        (func $into_chars
+                            (param externref (ref null $chars) i32)
+                            (result i32)))
+                    (func (export "_start")
+                        (local $array (ref $chars))
+                        (local $string externref)
+                        global.get $hello
+                        call $cast
+                        call $length
+                        i32.const 5
+                        i32.ne
+                        if unreachable end
+
+                        global.get $hello
+                        call $test
+                        i32.const 1
+                        i32.ne
+                        if unreachable end
+                        ref.null extern
+                        call $test
+                        if unreachable end
+
+                        i32.const 65
+                        call $from_char_code
+                        i32.const 0
+                        call $char_code_at
+                        i32.const 65
+                        i32.ne
+                        if unreachable end
+
+                        i32.const 128516
+                        call $from_code_point
+                        local.set $string
+                        local.get $string
+                        call $length
+                        i32.const 2
+                        i32.ne
+                        if unreachable end
+                        local.get $string
+                        i32.const 0
+                        call $code_point_at
+                        i32.const 128516
+                        i32.ne
+                        if unreachable end
+
+                        global.get $hello
+                        global.get $world
+                        call $concat
+                        call $length
+                        i32.const 11
+                        i32.ne
+                        if unreachable end
+
+                        global.get $hello
+                        i32.const 1
+                        call $char_code_at
+                        i32.const 101
+                        i32.ne
+                        if unreachable end
+
+                        global.get $hello
+                        i32.const 1
+                        i32.const 4
+                        call $substring
+                        global.get $ell
+                        call $equals
+                        i32.eqz
+                        if unreachable end
+
+                        global.get $hello
+                        ref.null extern
+                        call $equals
+                        if unreachable end
+                        ref.null extern
+                        ref.null extern
+                        call $equals
+                        i32.eqz
+                        if unreachable end
+
+                        global.get $hello
+                        global.get $world
+                        call $compare
+                        i32.const 1
+                        i32.ne
+                        if unreachable end
+
+                        i32.const 6
+                        array.new_default $chars
+                        local.set $array
+                        global.get $hello
+                        local.get $array
+                        i32.const 1
+                        call $into_chars
+                        i32.const 5
+                        i32.ne
+                        if unreachable end
+                        local.get $array
+                        i32.const 1
+                        i32.const 6
+                        call $from_chars
+                        global.get $hello
+                        call $equals
+                        i32.eqz
+                        if unreachable end))"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    assert_eq!(
+        engine
+            .run(&js_strings, moonrun::RunOptions::default())
+            .unwrap(),
+        moonrun::RunOutcome::Completed
+    );
+}
+
+#[test]
+fn engine_backends_support_test_driver_string_bridge() {
+    let engine = moonrun::Engine::default();
+    let driver = engine
+        .compile(
+            "test-driver.wasm",
+            wat::parse_str(
+                r#"(module
+                    (import "__moonbit_fs_unstable" "begin_read_string"
+                        (func $begin_read_string (param externref) (result externref)))
+                    (import "__moonbit_fs_unstable" "string_read_char"
+                        (func $string_read_char (param externref) (result i32)))
+                    (import "__moonbit_fs_unstable" "finish_read_string"
+                        (func $finish_read_string (param externref)))
+                    (func (export "moonbit_test_driver_internal_execute")
+                        (param $file externref) (param i32)
+                        (local $reader externref)
+                        (local $length i32)
+                        local.get $file
+                        call $begin_read_string
+                        local.set $reader
+
+                        local.get $reader
+                        call $string_read_char
+                        i32.const 109
+                        i32.ne
+                        if unreachable end
+                        i32.const 1
+                        local.set $length
+
+                        block $done
+                            loop $next
+                                local.get $reader
+                                call $string_read_char
+                                i32.const -1
+                                i32.eq
+                                br_if $done
+                                local.get $length
+                                i32.const 1
+                                i32.add
+                                local.set $length
+                                br $next
+                            end
+                        end
+                        local.get $reader
+                        call $finish_read_string
+
+                        local.get $length
+                        i32.const 13
+                        i32.ne
+                        if unreachable end)
+                    (func (export "moonbit_test_driver_finish")))"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    assert_eq!(
+        engine
+            .run(
+                &driver,
+                moonrun::RunOptions::default().with_test_args(
+                    r#"{"package":"moon/core","file_and_index":[["main_test.mbt",[{"start":0,"end":1}]]]}"#,
+                ),
+            )
+            .unwrap(),
+        moonrun::RunOutcome::Completed
+    );
+}
+
+#[test]
+fn engine_backends_support_explicit_exit() {
+    let engine = moonrun::Engine::default();
+    let exit = engine
+        .compile(
+            "exit.wasm",
+            wat::parse_str(
+                r#"(module
+                    (import "__moonbit_sys_unstable" "exit" (func $exit (param i32)))
+                    (func (export "_start") i32.const 7 call $exit))"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    assert_eq!(
+        engine.run(&exit, moonrun::RunOptions::default()).unwrap(),
+        moonrun::RunOutcome::Exited(7)
+    );
+}
+
+#[test]
+fn engine_backends_support_repeated_imports() {
+    let engine = moonrun::Engine::default();
+    let module = engine
+        .compile(
+            "repeated-imports.wasm",
+            wat::parse_str(
+                r#"(module
+                    (import "__moonbit_sys_unstable" "is_windows"
+                        (func $is_windows_a (result i32)))
+                    (import "__moonbit_sys_unstable" "is_windows"
+                        (func $is_windows_b (result i32)))
+                    (func (export "_start")
+                        call $is_windows_a
+                        call $is_windows_b
+                        i32.ne
+                        if unreachable end))"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        engine.run(&module, moonrun::RunOptions::default()).unwrap(),
+        moonrun::RunOutcome::Completed
+    );
+}
+
+#[test]
+fn engine_backend_handles_start_section_traps_as_guest_failures() {
+    let engine = moonrun::Engine::default();
+    let module = engine
+        .compile(
+            "start-trap.wasm",
+            wat::parse_str(
+                r#"(module
+                    (func $module_start unreachable)
+                    (start $module_start))"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        engine.run(&module, moonrun::RunOptions::default()).unwrap(),
+        moonrun::RunOutcome::Exited(1)
+    );
+}
+
+#[test]
+fn engine_backend_handles_wasm_exceptions_as_guest_failures() {
+    let engine = moonrun::Engine::default();
+    let module = engine
+        .compile(
+            "exception.wasm",
+            wat::parse_str(
+                r#"(module
+                    (import "exception" "tag" (tag $tag))
+                    (import "exception" "throw" (func $throw))
+                    (func (export "_start") call $throw))"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        engine.run(&module, moonrun::RunOptions::default()).unwrap(),
+        moonrun::RunOutcome::Exited(1)
+    );
+}
+
+#[test]
+fn engine_backend_handles_js_string_builtin_traps_as_guest_failures() {
+    let engine = moonrun::Engine::default();
+    let module = engine
+        .compile(
+            "js-string-trap.wasm",
+            wat::parse_str(
+                r#"(module
+                    (import "wasm:js-string" "fromCodePoint"
+                        (func $from_code_point (param i32) (result (ref extern))))
+                    (func (export "_start")
+                        i32.const -1
+                        call $from_code_point
+                        drop))"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        engine.run(&module, moonrun::RunOptions::default()).unwrap(),
+        moonrun::RunOutcome::Exited(1)
+    );
+}
+
+#[test]
+fn engine_backend_handles_test_driver_finish_traps_as_guest_failures() {
+    let engine = moonrun::Engine::default();
+    let module = engine
+        .compile(
+            "finish-trap.wasm",
+            wat::parse_str(
+                r#"(module
+                    (func (export "moonbit_test_driver_internal_execute")
+                        (param externref i32))
+                    (func (export "moonbit_test_driver_finish") unreachable))"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        engine
+            .run(
+                &module,
+                moonrun::RunOptions::default()
+                    .with_test_args(r#"{"package":"moon/core","file_and_index":[]}"#),
+            )
+            .unwrap(),
+        moonrun::RunOutcome::Exited(1)
+    );
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+#[test]
+fn wasmtime_rejects_unregistered_imports() {
+    let engine = moonrun::Engine::default();
+    for (name, import, expected) in [
+        (
+            "missing-wasi-import.wasm",
+            r#"(import "wasi_snapshot_preview1" "not_registered" (func))"#,
+            "unknown import: `wasi_snapshot_preview1::not_registered`",
+        ),
+        (
+            "unsupported-poll-oneoff.wasm",
+            r#"(import "wasi_snapshot_preview1" "poll_oneoff"
+                (func (param i32 i32 i32 i32) (result i32)))"#,
+            "unknown import: `wasi_snapshot_preview1::poll_oneoff`",
+        ),
+        (
+            "unsupported-legacy-string-hook.wasm",
+            r#"(import "moonbit" "string_to_js_string" (func (param i32)))"#,
+            "unsupported Wasmtime import `moonbit.string_to_js_string`",
+        ),
+    ] {
+        let module = engine
+            .compile(name, wat::parse_str(format!("(module {import})")).unwrap())
+            .unwrap();
+        let error = engine
+            .run(&module, moonrun::RunOptions::default())
+            .unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains(expected), "{name}: {error}");
+    }
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+#[test]
+fn wasmtime_preserves_instantiation_host_adapter_errors() {
+    let engine = moonrun::Engine::default();
+    let module = engine
+        .compile(
+            "start-host-error.wasm",
+            wat::parse_str(
+                r#"(module
+                    (import "_" "filename" (global $filename (ref extern)))
+                    (import "__moonbit_fs_unstable" "begin_read_string"
+                        (func $begin_read_string (param externref) (result externref)))
+                    (import "console" "log" (func $log (param (ref extern))))
+                    (func $module_start
+                        global.get $filename
+                        call $begin_read_string
+                        ref.as_non_null
+                        call $log)
+                    (start $module_start))"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    let error = engine
+        .run(&module, moonrun::RunOptions::default())
+        .unwrap_err();
+    let error = format!("{error:#}");
+    assert!(
+        error.contains("failed to instantiate `start-host-error.wasm`")
+            && error.contains("externref is not a JS string"),
+        "{error}"
+    );
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+#[test]
+fn wasmtime_preserves_host_adapter_errors_from_exported_calls() {
+    let engine = moonrun::Engine::default();
+    let cases = [
+        (
+            "run-host-error.wasm",
+            r#"(module
+                (import "_" "filename" (global $filename (ref extern)))
+                (import "__moonbit_fs_unstable" "begin_read_string"
+                    (func $begin_read_string (param externref) (result externref)))
+                (import "console" "log" (func $log (param (ref extern))))
+                (func (export "_start")
+                    global.get $filename
+                    call $begin_read_string
+                    ref.as_non_null
+                    call $log))"#,
+            moonrun::RunOptions::default(),
+            None,
+        ),
+        (
+            "test-execute-host-error.wasm",
+            r#"(module
+                (import "__moonbit_fs_unstable" "begin_read_string"
+                    (func $begin_read_string (param externref) (result externref)))
+                (import "console" "log" (func $log (param (ref extern))))
+                (func (export "moonbit_test_driver_internal_execute")
+                    (param $file externref) (param i32)
+                    local.get $file
+                    call $begin_read_string
+                    ref.as_non_null
+                    call $log)
+                (func (export "moonbit_test_driver_finish")))"#,
+            moonrun::RunOptions::default().with_test_args(
+                r#"{"package":"moon/core","file_and_index":[["main_test.mbt",[{"start":0,"end":1}]]]}"#,
+            ),
+            Some("failed to execute a MoonBit test"),
+        ),
+        (
+            "test-finish-host-error.wasm",
+            r#"(module
+                (import "_" "filename" (global $filename (ref extern)))
+                (import "__moonbit_fs_unstable" "begin_read_string"
+                    (func $begin_read_string (param externref) (result externref)))
+                (import "console" "log" (func $log (param (ref extern))))
+                (func (export "moonbit_test_driver_internal_execute")
+                    (param externref i32))
+                (func (export "moonbit_test_driver_finish")
+                    global.get $filename
+                    call $begin_read_string
+                    ref.as_non_null
+                    call $log))"#,
+            moonrun::RunOptions::default()
+                .with_test_args(r#"{"package":"moon/core","file_and_index":[]}"#),
+            Some("failed to finish the MoonBit test driver"),
+        ),
+    ];
+
+    for (name, source, options, expected) in cases {
+        let module = engine
+            .compile(name, wat::parse_str(source).unwrap())
+            .unwrap();
+        let error = engine.run(&module, options).unwrap_err();
+        let error = format!("{error:#}");
+        assert!(
+            expected.is_none_or(|context| error.contains(context))
+                && error.contains("externref is not a JS string"),
+            "{error}"
+        );
+    }
+}
+
+#[test]
+fn engine_backends_share_the_wasip1_adapter() {
+    let dir = tempfile::tempdir().unwrap();
+    let stdio_wasm = dir.path().join("stdio.wasm");
+    std::fs::write(
+        &stdio_wasm,
+        wat::parse_str(
+            r#"(module
+                (import "wasi_snapshot_preview1" "fd_read"
+                    (func $fd_read (param i32 i32 i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "fd_write"
+                    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+                (memory (export "memory") 1)
+                (func $ok (param $errno i32)
+                    local.get $errno
+                    if unreachable end)
+                (func (export "_start")
+                    i32.const 16 i32.const 32 i32.store
+                    i32.const 20 i32.const 64 i32.store
+                    i32.const 0 i32.const 16 i32.const 1 i32.const 24 call $fd_read call $ok
+                    i32.const 20 i32.const 24 i32.load i32.store
+                    i32.const 1 i32.const 16 i32.const 1 i32.const 28 call $fd_write call $ok))"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(&stdio_wasm)
+        .stdin("wasi stdio\n")
+        .assert()
+        .success()
+        .stdout_eq("wasi stdio\n")
+        .stderr_eq("");
+
+    let surface_wasm = dir.path().join("surface.wasm");
+    std::fs::write(
+        &surface_wasm,
+        wat::parse_str(
+            r#"(module
+                (import "wasi_snapshot_preview1" "args_get"
+                    (func $args_get (param i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "args_sizes_get"
+                    (func $args_sizes_get (param i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "environ_get"
+                    (func $environ_get (param i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "environ_sizes_get"
+                    (func $environ_sizes_get (param i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "random_get"
+                    (func $random_get (param i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "fd_close"
+                    (func $fd_close (param i32) (result i32)))
+                (import "wasi_snapshot_preview1" "fd_prestat_get"
+                    (func $fd_prestat_get (param i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "fd_prestat_dir_name"
+                    (func $fd_prestat_dir_name (param i32 i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "fd_readdir"
+                    (func $fd_readdir (param i32 i32 i32 i64 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "fd_write"
+                    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "path_open"
+                    (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "path_readlink"
+                    (func $path_readlink (param i32 i32 i32 i32 i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "path_rename"
+                    (func $path_rename (param i32 i32 i32 i32 i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "path_create_directory"
+                    (func $path_create_directory (param i32 i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "path_remove_directory"
+                    (func $path_remove_directory (param i32 i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "path_unlink_file"
+                    (func $path_unlink_file (param i32 i32 i32) (result i32)))
+                (import "wasi_snapshot_preview1" "proc_exit"
+                    (func $proc_exit (param i32)))
+                (memory (export "memory") 1)
+                (data (i32.const 16) "dir")
+                (data (i32.const 32) "dir/file.txt")
+                (data (i32.const 48) "dir/renamed.txt")
+                (data (i32.const 80) "payload")
+                (func $ok (param $errno i32)
+                    local.get $errno
+                    if unreachable end)
+                (func (export "_start")
+                    i32.const 200 i32.const 204 call $args_sizes_get call $ok
+                    i32.const 200 i32.load i32.const 2 i32.ne if unreachable end
+                    i32.const 208 i32.const 256 call $args_get call $ok
+                    i32.const 300 i32.const 304 call $environ_sizes_get call $ok
+                    i32.const 300 i32.load if unreachable end
+                    i32.const 8000 i32.const 12000 call $environ_get call $ok
+                    i32.const 4096 i32.const 16 call $random_get call $ok
+
+                    i32.const 3 i32.const 4200 call $fd_prestat_get call $ok
+                    i32.const 3 i32.const 4210 i32.const 64 call $fd_prestat_dir_name call $ok
+                    i32.const 3 i32.const 16 i32.const 3 call $path_create_directory call $ok
+
+                    i32.const 3 i32.const 0 i32.const 32 i32.const 12 i32.const 1
+                    i64.const 66 i64.const 0 i32.const 0 i32.const 140 call $path_open call $ok
+                    i32.const 128 i32.const 80 i32.store
+                    i32.const 132 i32.const 7 i32.store
+                    i32.const 140 i32.load i32.const 128 i32.const 1 i32.const 148
+                    call $fd_write call $ok
+                    i32.const 140 i32.load call $fd_close call $ok
+
+                    i32.const 3 i32.const 32 i32.const 12
+                    i32.const 3 i32.const 48 i32.const 15 call $path_rename call $ok
+                    i32.const 3 i32.const 0 i32.const 16 i32.const 3 i32.const 2
+                    i64.const 16384 i64.const 0 i32.const 0 i32.const 144 call $path_open call $ok
+                    i32.const 144 i32.load i32.const 5000 i32.const 1024 i64.const 0 i32.const 152
+                    call $fd_readdir call $ok
+                    i32.const 152 i32.load i32.eqz if unreachable end
+                    i32.const 144 i32.load call $fd_close call $ok
+
+                    i32.const 3 i32.const 48 i32.const 15 call $path_unlink_file call $ok
+                    i32.const 3 i32.const 16 i32.const 3 call $path_remove_directory call $ok))"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let policy = dir.path().join("policy.json");
+    std::fs::write(&policy, "{}").unwrap();
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .current_dir(dir.path())
+        .arg("--policy")
+        .arg(&policy)
+        .arg(&surface_wasm)
+        .arg("--")
+        .arg("alpha")
+        .assert()
+        .success()
+        .stdout_eq("")
+        .stderr_eq("");
+    assert!(!dir.path().join("dir").exists());
+
+    let exit_wasm = dir.path().join("exit.wasm");
+    std::fs::write(
+        &exit_wasm,
+        wat::parse_str(
+            r#"(module
+                (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
+                (func (export "_start") i32.const 7 call $proc_exit))"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(exit_wasm)
+        .assert()
+        .code(7)
+        .stdout_eq("")
+        .stderr_eq("");
+}

--- a/crates/moonrun/tests/engine_outcomes.rs
+++ b/crates/moonrun/tests/engine_outcomes.rs
@@ -16,6 +16,8 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+#![cfg(feature = "v8")]
+
 fn compile(name: &str, source: &str) -> (moonrun::Engine, moonrun::Module) {
     let engine = moonrun::Engine::default();
     let module = engine


### PR DESCRIPTION
## Why

Moonrun needs a second executor for Wasm and Wasm-GC without changing the V8-backed shipping path.

## What

- Add Wasmtime 48 as an optional compile-time backend using Cranelift and the copying GC collector.
- Keep V8 as the default and select Wasmtime explicitly with no default features.
- Support Wasm, Wasm-GC, exceptions, JS-string builtins, underscore-namespace string constants, source-map diagnostics, and the MoonBit test driver.
- Adapt the shared Moonrun-owned WASIp1 host operations through a Wasmtime-local adapter rather than adopting wasmtime-wasi policy or capability semantics.
- Exercise the runnable core and WASIp1 contract under both V8 and Wasmtime.

## Why this split

This PR introduces only the runnable executor core and WASIp1 adapter. The larger Moonrun host-import adapter surface and CI expansion remain in a follow-up PR.