### PR TITLE
feat(moonrun): complete Wasmtime host adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,10 @@ jobs:
 
       - name: Clippy (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: |
+          cargo clippy --workspace --exclude moonrun --all-targets --all-features -- -D warnings
+          cargo clippy -p moonrun --all-targets -- -D warnings
+          cargo clippy -p moonrun --all-targets --no-default-features --features wasmtime -- -D warnings
 
       - name: Set built binary to PATH (Unix)
         if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/moonrun-conformance.yml
+++ b/.github/workflows/moonrun-conformance.yml
@@ -16,7 +16,7 @@
 #
 # For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-name: Moonrun async conformance
+name: Moonrun conformance
 
 on:
   push:
@@ -95,3 +95,38 @@ jobs:
 
       - name: Test Moonrun against upstream async
         run: cargo test -p moonrun --test test test_moonrun_against_upstream_async -- --ignored --exact
+
+  wasmtime:
+    name: wasmtime / ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git
+        run: git config --global core.autocrlf false
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.95.0
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s nightly
+          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+          echo "$GITHUB_WORKSPACE/target/debug" >> $GITHUB_PATH
+
+      - name: Build Moon
+        run: cargo build -p moon
+
+      - name: Bundle core
+        run: cargo run --bin moon -- -C ~/.moon/lib/core bundle --all
+
+      - name: Test Wasmtime backend conformance
+        run: |
+          cargo test -p moonrun --no-default-features --features wasmtime --locked
+          cargo test -p moonrun --test test --no-default-features --features wasmtime --locked test_moonrun_against_upstream_async -- --ignored --exact

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -26,13 +26,13 @@ cargo build -p moonrun --no-default-features --features wasmtime
 ```
 
 V8 remains selected when both engine features are enabled; select Wasmtime by
-disabling default features as shown above. Wasmtime supports both `wasm` and
-`wasm-gc`, including JS-string builtins with `_` imported string constants, the
-MoonBit test driver, and the same Moonrun-owned WASIp1 capability surface as
-V8. WASIp1 descriptors and preopens remain separate from Moonrun Policy; both
-engine adapters invoke the same shared WASIp1 host operations. The remaining
-Moonrun host-import adapters, including async and SQLite, will follow in a
-separate change.
+disabling default features as shown above. Both engines use the same Moonrun
+Host Domains for async operations, filesystem and environment access, SQLite,
+memory-sanitizer state, policy, and termination. Wasmtime supports both `wasm`
+and `wasm-gc`, including JS-string builtins with `_` imported string constants,
+the MoonBit test driver, and the same Moonrun-owned WASIp1 capability surface
+as V8. WASIp1 descriptors and preopens remain separate from Moonrun Policy;
+both engine adapters invoke the same shared WASIp1 host operations.
 
 ## Running
 
@@ -83,22 +83,24 @@ the stable program name used for guest arguments and diagnostics:
 let module = engine.compile("server.wasm", wasm_bytes).unwrap();
 ```
 
-The current implementation remains V8-backed and still inherits process stdio,
-environment, and working-directory behavior. The library does not install an
-operating-system signal handler. Callers may create a `signal_channel`, pass
-its receiver to `Engine::run_with_signal_receiver`, and send signals to that
-Run after its guest async handler is ready. This is cooperative delivery only:
-signals are not retained before registration and cannot yet forcibly interrupt
-guest execution. The `moonrun` CLI owns a process-lifetime adapter and forwards
-accepted signals directly through such a channel. On Unix it blocks its managed
-signals before creating the Engine and receives them on a `sigwait` thread;
-spawned guest processes retain the signal mask from before that block. Each
-Run's guest signal-wait Job is virtual: it receives forwarded signals through
-the Run channel rather than competing for process-wide signals. It supplies the
-same optional cancellation hook supported by the native Job model, recording
-cancellation before waking its blocking pipe read. Ordinary Unix Jobs retain
-the thread pool's `pthread_kill(SIGUSR2)` path. If the Run does not accept a
-signal, the adapter applies the process's existing signal behavior.
+The shipping configuration remains V8-backed; the Wasmtime feature provides
+the same library surface at compile time. Both configurations inherit process
+stdio, environment, and working-directory behavior. The library does not
+install an operating-system signal handler. Callers may create a
+`signal_channel`, pass its receiver to `Engine::run_with_signal_receiver`, and
+send signals to that Run after its guest async handler is ready. This is
+cooperative delivery only: signals are not retained before registration and
+cannot yet forcibly interrupt guest execution. The `moonrun` CLI owns a
+process-lifetime adapter and forwards accepted signals directly through such a
+channel. On Unix it blocks its managed signals before creating the Engine and
+receives them on a `sigwait` thread; spawned guest processes retain the signal
+mask from before that block. Each Run's guest signal-wait Job is virtual: it
+receives forwarded signals through the Run channel rather than competing for
+process-wide signals. It supplies the same optional cancellation hook supported
+by the native Job model, recording cancellation before waking its blocking pipe
+read. Ordinary Unix Jobs retain the thread pool's `pthread_kill(SIGUSR2)` path.
+If the Run does not accept a signal, the adapter applies the process's existing
+signal behavior.
 
 A Run can make its working-directory selection explicit with
 `WorkingDirectory::Ambient`, which is also the default and preserves the

--- a/crates/moonrun/docs/dev/README.md
+++ b/crates/moonrun/docs/dev/README.md
@@ -12,6 +12,7 @@
 ```bash
 cargo build
 cargo test
+cargo test -p moonrun --no-default-features --features wasmtime
 ```
 
 ## Before PR
@@ -23,7 +24,9 @@ It's recommended to run the following command before you submit a PR, which may 
 ```bash
 cargo fmt
 
-cargo clippy --all-targets --all-features -- -D warnings
+cargo clippy --workspace --exclude moonrun --all-targets --all-features -- -D warnings
+cargo clippy -p moonrun --all-targets -- -D warnings
+cargo clippy -p moonrun --all-targets --no-default-features --features wasmtime -- -D warnings
 
 cargo test
 ```

--- a/crates/moonrun/src/async_api/context.rs
+++ b/crates/moonrun/src/async_api/context.rs
@@ -16,13 +16,18 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::async_host::{AsyncHost, AsyncHostError, AsyncHostResult};
+#[cfg(feature = "v8")]
+use crate::async_host::AsyncHostError;
+use crate::async_host::{AsyncHost, AsyncHostResult};
 use crate::filesystem::HostFs;
 use crate::run_termination::{RunTermination, TerminationRequest};
+#[cfg(feature = "v8")]
 use crate::v8::context::{V8ImportError, V8MemoryBinding, V8RunContext};
 
+#[cfg(feature = "v8")]
 pub(super) use crate::v8::context::ImportArgs;
 
+#[cfg(feature = "v8")]
 pub(super) fn callback_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> &'s V8RunContext {
     // SAFETY: every async callback is registered with the pointer to the V8
     // run context retained by the V8 host imports for the complete run.
@@ -30,14 +35,21 @@ pub(super) fn callback_context<'s>(args: &v8::FunctionCallbackArguments<'s>) -> 
 }
 
 pub(super) struct ImportContext<'a, 'scope> {
+    #[cfg(feature = "v8")]
     pub(super) scope: &'a mut v8::HandleScope<'scope>,
     pub(super) host: &'a AsyncHost,
     filesystem: &'a HostFs,
+    #[cfg(feature = "v8")]
     memory_binding: &'a V8MemoryBinding,
+    #[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+    memory: &'a mut [u8],
     termination_request: &'a TerminationRequest,
+    #[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+    scope: std::marker::PhantomData<&'scope ()>,
 }
 
 impl<'a, 'scope> ImportContext<'a, 'scope> {
+    #[cfg(feature = "v8")]
     pub(super) fn new(scope: &'a mut v8::HandleScope<'scope>, context: &'a V8RunContext) -> Self {
         Self {
             scope,
@@ -50,9 +62,12 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
 
     pub(super) fn request_termination(&mut self, termination: RunTermination) {
         self.termination_request.request(termination);
-        // Termination cannot be caught by the guest's JavaScript glue. The run
-        // loop converts the recorded request into its runtime outcome.
-        self.scope.terminate_execution();
+        #[cfg(feature = "v8")]
+        {
+            // Termination cannot be caught by the guest's JavaScript glue. The run
+            // loop converts the recorded request into its runtime outcome.
+            self.scope.terminate_execution();
+        }
     }
 
     pub(super) fn filesystem(&self) -> &HostFs {
@@ -64,8 +79,15 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
         f: impl FnOnce(&AsyncHost, &mut [u8]) -> AsyncHostResult<T>,
     ) -> AsyncHostResult<T> {
         let host = self.host;
-        self.memory_binding
-            .with_memory_mut(self.scope, |memory| f(host, memory))
+        #[cfg(feature = "v8")]
+        {
+            self.memory_binding
+                .with_memory_mut(self.scope, |memory| f(host, memory))
+        }
+        #[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+        {
+            f(host, &mut *self.memory)
+        }
     }
 
     pub(super) fn with_memory_mut<T>(
@@ -76,6 +98,42 @@ impl<'a, 'scope> ImportContext<'a, 'scope> {
     }
 }
 
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+pub(crate) fn with_wasmtime_context<R>(
+    caller: &mut wasmtime::Caller<'_, crate::wasmtime::StoreData>,
+    f: impl FnOnce(&mut ImportContext<'_, '_>) -> R,
+) -> R {
+    let memory = caller
+        .get_export("memory")
+        .and_then(wasmtime::Extern::into_memory);
+    match memory {
+        Some(memory) => {
+            let (memory, data) = memory.data_and_store_mut(&mut *caller);
+            let mut context = ImportContext {
+                host: data.runtime().async_host(),
+                filesystem: data.runtime().filesystem(),
+                memory,
+                termination_request: data.termination_request(),
+                scope: std::marker::PhantomData,
+            };
+            f(&mut context)
+        }
+        None => {
+            let data = caller.data_mut();
+            let mut empty = [];
+            let mut context = ImportContext {
+                host: data.runtime().async_host(),
+                filesystem: data.runtime().filesystem(),
+                memory: &mut empty,
+                termination_request: data.termination_request(),
+                scope: std::marker::PhantomData,
+            };
+            f(&mut context)
+        }
+    }
+}
+
+#[cfg(feature = "v8")]
 impl From<V8ImportError> for AsyncHostError {
     fn from(error: V8ImportError) -> Self {
         match error {
@@ -85,6 +143,7 @@ impl From<V8ImportError> for AsyncHostError {
     }
 }
 
+#[cfg(feature = "v8")]
 pub(super) fn throw_import_error(
     scope: &mut v8::HandleScope,
     import_name: &str,
@@ -93,10 +152,12 @@ pub(super) fn throw_import_error(
     crate::v8::context::throw_import_error(scope, super::MOONBIT_ASYNC_MODULE, import_name, error);
 }
 
+#[cfg(feature = "v8")]
 pub(super) trait FinishVoid {
     fn finish_void(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str);
 }
 
+#[cfg(feature = "v8")]
 impl FinishVoid for () {
     fn finish_void(
         self,
@@ -108,6 +169,7 @@ impl FinishVoid for () {
     }
 }
 
+#[cfg(feature = "v8")]
 impl FinishVoid for AsyncHostResult<()> {
     fn finish_void(
         self,
@@ -122,10 +184,12 @@ impl FinishVoid for AsyncHostResult<()> {
     }
 }
 
+#[cfg(feature = "v8")]
 pub(super) trait FinishI32 {
     fn finish_i32(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str);
 }
 
+#[cfg(feature = "v8")]
 impl FinishI32 for i32 {
     fn finish_i32(
         self,
@@ -137,6 +201,7 @@ impl FinishI32 for i32 {
     }
 }
 
+#[cfg(feature = "v8")]
 impl FinishI32 for u32 {
     fn finish_i32(
         self,
@@ -148,6 +213,7 @@ impl FinishI32 for u32 {
     }
 }
 
+#[cfg(feature = "v8")]
 impl FinishI32 for AsyncHostResult<i32> {
     fn finish_i32(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str) {
         match self {
@@ -157,6 +223,7 @@ impl FinishI32 for AsyncHostResult<i32> {
     }
 }
 
+#[cfg(feature = "v8")]
 impl FinishI32 for AsyncHostResult<u32> {
     fn finish_i32(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str) {
         match self {
@@ -166,10 +233,12 @@ impl FinishI32 for AsyncHostResult<u32> {
     }
 }
 
+#[cfg(feature = "v8")]
 pub(super) trait FinishI64 {
     fn finish_i64(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str);
 }
 
+#[cfg(feature = "v8")]
 impl FinishI64 for i64 {
     fn finish_i64(
         self,
@@ -181,6 +250,7 @@ impl FinishI64 for i64 {
     }
 }
 
+#[cfg(feature = "v8")]
 impl FinishI64 for u64 {
     fn finish_i64(
         self,
@@ -192,6 +262,7 @@ impl FinishI64 for u64 {
     }
 }
 
+#[cfg(feature = "v8")]
 impl FinishI64 for AsyncHostResult<i64> {
     fn finish_i64(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str) {
         match self {
@@ -201,6 +272,7 @@ impl FinishI64 for AsyncHostResult<i64> {
     }
 }
 
+#[cfg(feature = "v8")]
 impl FinishI64 for AsyncHostResult<u64> {
     fn finish_i64(self, scope: &mut v8::HandleScope, ret: &mut v8::ReturnValue, import_name: &str) {
         match self {

--- a/crates/moonrun/src/async_api/mod.rs
+++ b/crates/moonrun/src/async_api/mod.rs
@@ -16,7 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-//! `moonbitlang/async` Wasm adapter.
+//! `moonbitlang/async` Wasm Adapter shared by the engine backends.
 //!
 //! This layer owns the canonical wasm import list, decodes wasm ABI values from
 //! callback arguments, acquires guest memory, sets return values, and reports
@@ -47,13 +47,17 @@ mod thread_pool;
 mod time;
 mod tls;
 
+#[cfg(feature = "v8")]
 use crate::v8::context::V8RunContext;
 
 pub(crate) use registry::MOONBIT_ASYNC_MODULE;
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+pub(crate) use registry::register_wasmtime_imports;
 
 /// # Safety
 ///
 /// `context` must remain valid whenever a registered callback can be invoked.
+#[cfg(feature = "v8")]
 pub(crate) unsafe fn init_env<'s>(
     obj: v8::Local<'s, v8::Object>,
     scope: &mut v8::HandleScope<'s>,

--- a/crates/moonrun/src/async_api/registry.rs
+++ b/crates/moonrun/src/async_api/registry.rs
@@ -16,9 +16,11 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+#[cfg(feature = "v8")]
+use super::context::ImportContext;
+#[cfg(feature = "v8")]
 use super::context::{
-    FinishI32, FinishI64, FinishVoid, ImportArgs, ImportContext, callback_context,
-    throw_import_error,
+    FinishI32, FinishI64, FinishVoid, ImportArgs, callback_context, throw_import_error,
 };
 #[cfg(test)]
 use super::provenance::{PortedImport, SourceLocation, SourceRoot};
@@ -101,6 +103,7 @@ macro_rules! wasm_result {
     };
 }
 
+#[cfg(feature = "v8")]
 macro_rules! decode_wasm_arg {
     ($args:ident, i32) => {
         $args.next_i32()
@@ -116,6 +119,7 @@ macro_rules! decode_wasm_arg {
     };
 }
 
+#[cfg(feature = "v8")]
 macro_rules! decode_wasm_args {
     ($scope:ident, $args:ident,) => {
         Ok(())
@@ -132,6 +136,7 @@ macro_rules! decode_wasm_args {
     }};
 }
 
+#[cfg(feature = "v8")]
 macro_rules! wasm_arg_count {
     () => {
         0_i32
@@ -141,6 +146,7 @@ macro_rules! wasm_arg_count {
     };
 }
 
+#[cfg(feature = "v8")]
 macro_rules! finish_wasm_import {
     ($scope:ident, $ret:ident, $name:expr, void, $result:expr) => {
         $result.finish_void($scope, &mut $ret, $name)
@@ -156,6 +162,171 @@ macro_rules! finish_wasm_import {
     };
     ($scope:ident, $ret:ident, $name:expr, u64, $result:expr) => {
         $result.finish_i64($scope, &mut $ret, $name)
+    };
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+trait FinishWasmtimeVoid {
+    fn finish(self, import_name: &str) -> wasmtime::Result<()>;
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+impl FinishWasmtimeVoid for () {
+    fn finish(self, _import_name: &str) -> wasmtime::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+impl FinishWasmtimeVoid for crate::async_host::AsyncHostResult<()> {
+    fn finish(self, import_name: &str) -> wasmtime::Result<()> {
+        self.map_err(|error| {
+            wasmtime::format_err!("{MOONBIT_ASYNC_MODULE}.{import_name} failed: {error:?}")
+        })
+    }
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+trait FinishWasmtimeI32 {
+    fn finish(self, import_name: &str) -> wasmtime::Result<i32>;
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+impl FinishWasmtimeI32 for i32 {
+    fn finish(self, _import_name: &str) -> wasmtime::Result<i32> {
+        Ok(self)
+    }
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+impl FinishWasmtimeI32 for u32 {
+    fn finish(self, _import_name: &str) -> wasmtime::Result<i32> {
+        Ok(self as i32)
+    }
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+impl FinishWasmtimeI32 for crate::async_host::AsyncHostResult<i32> {
+    fn finish(self, import_name: &str) -> wasmtime::Result<i32> {
+        self.map_err(|error| {
+            wasmtime::format_err!("{MOONBIT_ASYNC_MODULE}.{import_name} failed: {error:?}")
+        })
+    }
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+impl FinishWasmtimeI32 for crate::async_host::AsyncHostResult<u32> {
+    fn finish(self, import_name: &str) -> wasmtime::Result<i32> {
+        self.map(|value| value as i32).map_err(|error| {
+            wasmtime::format_err!("{MOONBIT_ASYNC_MODULE}.{import_name} failed: {error:?}")
+        })
+    }
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+trait FinishWasmtimeI64 {
+    fn finish(self, import_name: &str) -> wasmtime::Result<i64>;
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+impl FinishWasmtimeI64 for i64 {
+    fn finish(self, _import_name: &str) -> wasmtime::Result<i64> {
+        Ok(self)
+    }
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+impl FinishWasmtimeI64 for u64 {
+    fn finish(self, _import_name: &str) -> wasmtime::Result<i64> {
+        Ok(self as i64)
+    }
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+impl FinishWasmtimeI64 for crate::async_host::AsyncHostResult<i64> {
+    fn finish(self, import_name: &str) -> wasmtime::Result<i64> {
+        self.map_err(|error| {
+            wasmtime::format_err!("{MOONBIT_ASYNC_MODULE}.{import_name} failed: {error:?}")
+        })
+    }
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+impl FinishWasmtimeI64 for crate::async_host::AsyncHostResult<u64> {
+    fn finish(self, import_name: &str) -> wasmtime::Result<i64> {
+        self.map(|value| value as i64).map_err(|error| {
+            wasmtime::format_err!("{MOONBIT_ASYNC_MODULE}.{import_name} failed: {error:?}")
+        })
+    }
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+macro_rules! wasmtime_arg_type {
+    (i32) => {
+        i32
+    };
+    (u32) => {
+        i32
+    };
+    (i64) => {
+        i64
+    };
+    (u64) => {
+        i64
+    };
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+macro_rules! decode_wasmtime_arg {
+    ($arg:ident, i32) => {
+        $arg
+    };
+    ($arg:ident, u32) => {
+        $arg as u32
+    };
+    ($arg:ident, i64) => {
+        $arg
+    };
+    ($arg:ident, u64) => {
+        $arg as u64
+    };
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+macro_rules! wasmtime_return_type {
+    (void) => {
+        ()
+    };
+    (i32) => {
+        i32
+    };
+    (u32) => {
+        i32
+    };
+    (i64) => {
+        i64
+    };
+    (u64) => {
+        i64
+    };
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+macro_rules! finish_wasmtime_import {
+    ($name:expr, void, $result:expr) => {
+        FinishWasmtimeVoid::finish($result, $name)
+    };
+    ($name:expr, i32, $result:expr) => {
+        FinishWasmtimeI32::finish($result, $name)
+    };
+    ($name:expr, u32, $result:expr) => {
+        FinishWasmtimeI32::finish($result, $name)
+    };
+    ($name:expr, i64, $result:expr) => {
+        FinishWasmtimeI64::finish($result, $name)
+    };
+    ($name:expr, u64, $result:expr) => {
+        FinishWasmtimeI64::finish($result, $name)
     };
 }
 
@@ -181,6 +352,7 @@ macro_rules! declare_async_imports {
             )*
         ];
 
+        #[cfg(feature = "v8")]
         pub(super) fn register_imports<'s>(
             obj: v8::Local<'s, v8::Object>,
             scope: &mut v8::HandleScope<'s>,
@@ -200,9 +372,28 @@ macro_rules! declare_async_imports {
                 );
             )*
         }
+
+        #[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+        pub(crate) fn register_wasmtime_imports(
+            linker: &mut wasmtime::Linker<crate::wasmtime::StoreData>,
+        ) -> wasmtime::Result<()> {
+            $(
+                $(#[$meta])*
+                register_wasmtime_async_import!(
+                    $kind,
+                    linker,
+                    $wasm_symbol,
+                    $ret_ty,
+                    $module::$callback,
+                    ($($arg : $arg_ty),*)
+                );
+            )*
+            Ok(())
+        }
     };
 }
 
+#[cfg(feature = "v8")]
 macro_rules! register_async_import {
     (
         fake,
@@ -280,6 +471,62 @@ macro_rules! register_async_import {
             callback,
             $context_ptr,
         );
+    }};
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+macro_rules! register_wasmtime_async_import {
+    (
+        fake,
+        $linker:ident,
+        $wasm_symbol:literal,
+        $ret_ty:ident,
+        $module:ident::$callback:ident,
+        ($($arg:ident : $arg_ty:ident),* $(,)?)
+    ) => {{
+        $linker.func_wrap(
+            MOONBIT_ASYNC_MODULE,
+            $wasm_symbol,
+            |_: wasmtime::Caller<'_, crate::wasmtime::StoreData>
+                $(, $arg: wasmtime_arg_type!($arg_ty))*|
+                -> wasmtime::Result<wasmtime_return_type!($ret_ty)> {
+                let _ = ($($arg,)*);
+                Err(wasmtime::format_err!(
+                    "platform-inactive moonbitlang/async import `{}` was called",
+                    $wasm_symbol,
+                ))
+            },
+        )?;
+    }};
+    (
+        $kind:ident,
+        $linker:ident,
+        $wasm_symbol:literal,
+        $ret_ty:ident,
+        $module:ident::$callback:ident,
+        ($($arg:ident : $arg_ty:ident),* $(,)?)
+    ) => {{
+        $linker.func_wrap(
+            MOONBIT_ASYNC_MODULE,
+            $wasm_symbol,
+            |mut caller: wasmtime::Caller<'_, crate::wasmtime::StoreData>
+                $(, $arg: wasmtime_arg_type!($arg_ty))*|
+                -> wasmtime::Result<wasmtime_return_type!($ret_ty)> {
+                let result = super::context::with_wasmtime_context(
+                    &mut caller,
+                    |context| {
+                        $module::$callback(
+                            context,
+                            $(decode_wasmtime_arg!($arg, $arg_ty)),*
+                        )
+                    },
+                );
+                if caller.data().termination_request().is_requested() {
+                    return Err(wasmtime::format_err!("run termination requested"));
+                }
+                finish_wasmtime_import!($wasm_symbol, $ret_ty, result)
+            },
+        )?;
     }};
 }
 

--- a/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/poll/mod.rs
@@ -154,10 +154,10 @@ mod tests {
     fn event_list_get_rejects_missing_event() {
         let poll = poll_create().unwrap();
 
-        assert_eq!(
-            event_list_get(&poll, 0).copied(),
+        assert!(matches!(
+            event_list_get(&poll, 0),
             Err(AsyncHostError::Fault)
-        );
+        ));
     }
 
     #[test]

--- a/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
+++ b/crates/moonrun/src/async_sys/internal/event_loop/thread_pool/mod.rs
@@ -22,9 +22,9 @@ mod sleep;
 mod types;
 mod worker;
 
-#[cfg(any(feature = "v8", test))]
+#[cfg(any(feature = "v8", feature = "wasmtime", test))]
 pub(crate) use jobs::make_sleep_job;
-#[cfg(feature = "v8")]
+#[cfg(any(feature = "v8", feature = "wasmtime"))]
 pub(crate) use jobs::{errno_is_cancelled, get_platform};
 pub(crate) use jobs::{job_get_err, job_get_ret, make_failed_job};
 pub(crate) use runner::run_host_job;

--- a/crates/moonrun/src/filesystem/mod.rs
+++ b/crates/moonrun/src/filesystem/mod.rs
@@ -54,6 +54,8 @@ impl fmt::Display for HostFsError {
     }
 }
 
+impl std::error::Error for HostFsError {}
+
 impl HostFsError {
     fn permission_denied(path: &str) -> Self {
         Self {
@@ -144,16 +146,19 @@ impl HostFs {
             .map_err(|_| HostFsError::operation(format!("Failed to write file: {path}")))
     }
 
-    pub(crate) fn write_bytes_to_file(
+    pub(crate) fn write_bytes_to_file<E>(
         &self,
         path: &str,
-        contents: impl FnOnce() -> Vec<u8>,
-    ) -> Result<(), HostFsError> {
+        contents: impl FnOnce() -> Result<Vec<u8>, E>,
+    ) -> Result<(), E>
+    where
+        E: From<HostFsError>,
+    {
         self.ensure_write(path)?;
         // Decode guest-owned contents only after authorization, matching the
         // existing import's observable failure order for untrusted guests.
-        std::fs::write(path, contents())
-            .map_err(|_| HostFsError::operation(format!("Failed to write file: {path}")))
+        std::fs::write(path, contents()?)
+            .map_err(|_| HostFsError::operation(format!("Failed to write file: {path}")).into())
     }
 
     pub(crate) fn create_dir(&self, path: &str) -> Result<(), HostFsError> {
@@ -673,6 +678,16 @@ mod tests {
         let host = host_fs(policy, Arc::new(Env::ambient()));
         let mut results = FsOperationResults::default();
         let converted = Cell::new(false);
+
+        let error = host
+            .write_bytes_to_file("denied.bin", || {
+                converted.set(true);
+                Ok::<_, HostFsError>(Vec::new())
+            })
+            .unwrap_err();
+
+        assert!(!converted.get());
+        assert_eq!(error.to_string(), "Permission denied: denied.bin");
 
         let status = host.write_bytes_to_file_new(&mut results, "denied.bin", || {
             converted.set(true);

--- a/crates/moonrun/src/filesystem/v8/whole_file.rs
+++ b/crates/moonrun/src/filesystem/v8/whole_file.rs
@@ -18,7 +18,7 @@
 
 //! V8 adapter for the temporary whole-file filesystem imports.
 
-use crate::filesystem::{FsOperationResults, HostFs};
+use crate::filesystem::{FsOperationResults, HostFs, HostFsError};
 use crate::util::get_ref;
 use crate::v8::builder::{ArgsExt, ObjectExt, ScopeExt};
 use std::any::Any;
@@ -91,7 +91,7 @@ fn write_bytes_to_file(
         .filesystem
         .write_bytes_to_file(&path, || {
             let array = v8::Local::<v8::Uint8Array>::try_from(args.get(1)).unwrap();
-            copy_uint8_array(array)
+            Ok::<_, HostFsError>(copy_uint8_array(array))
         })
         .unwrap_or_else(|error| panic!("{error}"));
     ret.set_undefined();

--- a/crates/moonrun/src/lib.rs
+++ b/crates/moonrun/src/lib.rs
@@ -16,10 +16,6 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-// The core Wasmtime feature compiles shared Runtime domains before their
-// Wasmtime adapters become reachable in the follow-up adapter feature slice.
-#![cfg_attr(all(feature = "wasmtime", not(feature = "v8")), allow(dead_code))]
-
 //! Embeddable execution support for MoonBit Wasm programs.
 //!
 //! The interface is experimental. It separates guest termination from
@@ -28,7 +24,6 @@
 #[cfg(not(any(feature = "v8", feature = "wasmtime")))]
 compile_error!("moonrun requires an engine feature: `v8` or `wasmtime`");
 
-#[cfg(feature = "v8")]
 mod async_api;
 mod async_host;
 mod async_sys;
@@ -36,7 +31,6 @@ mod async_sys;
 mod engine;
 mod filesystem;
 mod guest_memory;
-#[cfg(feature = "v8")]
 mod memory_sanitizer;
 mod network;
 mod policy;

--- a/crates/moonrun/src/process/mod.rs
+++ b/crates/moonrun/src/process/mod.rs
@@ -38,7 +38,7 @@ use crate::resource::ResourceRef;
 use crate::runtime::{Stdio, WorkingDirectory};
 
 pub(crate) use job::Job;
-#[cfg(any(feature = "v8", test))]
+#[cfg(any(feature = "v8", feature = "wasmtime", test))]
 pub(crate) use job::SpawnOptions;
 
 /// Process operations and child ownership shared by guest and worker threads.

--- a/crates/moonrun/src/run_termination.rs
+++ b/crates/moonrun/src/run_termination.rs
@@ -38,6 +38,11 @@ impl TerminationRequest {
         }
     }
 
+    #[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+    pub(crate) fn is_requested(&self) -> bool {
+        self.0.get().is_some()
+    }
+
     pub(crate) fn take(&self) -> Option<RunTermination> {
         self.0.take()
     }

--- a/crates/moonrun/src/runtime/mod.rs
+++ b/crates/moonrun/src/runtime/mod.rs
@@ -42,9 +42,7 @@ use crate::sqlite::SqliteHost;
 
 pub(crate) use environment::Env;
 pub(crate) use environment_provisioning::EnvProvisioning;
-#[cfg(feature = "v8")]
-pub(crate) use stdio::Utf16Writer;
-pub(crate) use stdio::{Stdio, StdioStream};
+pub(crate) use stdio::{Stdio, StdioStream, Utf16Writer};
 pub use working_directory::WorkingDirectory;
 
 new_key_type! {

--- a/crates/moonrun/src/sqlite/mod.rs
+++ b/crates/moonrun/src/sqlite/mod.rs
@@ -18,7 +18,6 @@
 
 //! SQLite behavior, lifetime state, admission rules, and runtime adapters.
 
-#[cfg(feature = "v8")]
 pub(crate) mod wasm;
 
 mod bind;

--- a/crates/moonrun/src/sqlite/wasm/context.rs
+++ b/crates/moonrun/src/sqlite/wasm/context.rs
@@ -20,6 +20,7 @@ use std::ffi::CString;
 
 use crate::guest_memory::{GuestMemory, GuestMemoryError};
 use crate::sqlite::{SqliteHost, SqliteHostError};
+#[cfg(feature = "v8")]
 use crate::v8::context::{V8ImportError, V8RunContext};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -31,6 +32,7 @@ pub(super) enum SqliteError {
 
 pub(super) type SqliteResult<T> = Result<T, SqliteError>;
 
+#[cfg(feature = "v8")]
 pub(super) fn with_memory_context<T>(
     scope: &mut v8::HandleScope,
     context: &V8RunContext,
@@ -42,6 +44,33 @@ pub(super) fn with_memory_context<T>(
             memory,
         })
     })
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+pub(super) fn with_wasmtime_context<T>(
+    caller: &mut wasmtime::Caller<'_, crate::wasmtime::StoreData>,
+    f: impl FnOnce(&mut ImportContext<'_>) -> SqliteResult<T>,
+) -> SqliteResult<T> {
+    let memory = caller
+        .get_export("memory")
+        .and_then(wasmtime::Extern::into_memory);
+    match memory {
+        Some(memory) => {
+            let (memory, data) = memory.data_and_store_mut(&mut *caller);
+            f(&mut ImportContext {
+                host: data.runtime().sqlite(),
+                memory,
+            })
+        }
+        None => {
+            let data = caller.data_mut();
+            let mut empty = [];
+            f(&mut ImportContext {
+                host: data.runtime().sqlite(),
+                memory: &mut empty,
+            })
+        }
+    }
 }
 
 pub(super) struct ImportContext<'a> {
@@ -171,6 +200,7 @@ impl From<GuestMemoryError> for SqliteError {
     }
 }
 
+#[cfg(feature = "v8")]
 impl From<V8ImportError> for SqliteError {
     fn from(_error: V8ImportError) -> Self {
         Self::Fault

--- a/crates/moonrun/src/sqlite/wasm/mod.rs
+++ b/crates/moonrun/src/sqlite/wasm/mod.rs
@@ -45,13 +45,17 @@ mod registry;
 mod registry_macros;
 mod statement;
 
+#[cfg(feature = "v8")]
 use crate::v8::context::V8RunContext;
 
 pub(crate) use registry::MOONBIT_SQLITE_MODULE;
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+pub(crate) use registry::register_wasmtime_imports;
 
 /// # Safety
 ///
 /// `context` must remain valid whenever a registered callback can be invoked.
+#[cfg(feature = "v8")]
 pub(crate) unsafe fn init_env<'s>(
     obj: v8::Local<'s, v8::Object>,
     scope: &mut v8::HandleScope<'s>,

--- a/crates/moonrun/src/sqlite/wasm/registry.rs
+++ b/crates/moonrun/src/sqlite/wasm/registry.rs
@@ -16,17 +16,27 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use super::context::{SqliteError, with_memory_context};
+use super::context::SqliteError;
+#[cfg(feature = "v8")]
+use super::context::with_memory_context;
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+use super::context::with_wasmtime_context;
 use super::registry_macros::declare_sqlite_imports;
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+use super::registry_macros::{
+    decode_wasmtime_arg, finish_wasmtime_sqlite_import, invoke_wasmtime_sqlite_import,
+    wasmtime_arg_type, wasmtime_return_type,
+};
 use super::{bind, column, connection, statement};
+#[cfg(feature = "v8")]
 use crate::v8::context::{ImportArgs, V8ImportError, V8RunContext};
 
 pub(crate) const MOONBIT_SQLITE_MODULE: &str = "moonbitlang/sqlite";
 
-// This is the complete `moonbitlang/sqlite` ABI surface. The declaration keeps
-// callbacks and registration generated together, so adding a symbol cannot
-// update one without the other. Each entry names its implementation target;
-// the registry does not expose how the macro reaches that target.
+// This is the complete `moonbitlang/sqlite` ABI surface. The declaration
+// generates each engine's callbacks and registration, so adding a symbol
+// cannot update one without the other. Each entry names its implementation
+// target; the registry does not expose how the macro reaches that target.
 declare_sqlite_imports! {
     Runtime::null_handle() -> u64 => "sqlite3_null_handle";
 

--- a/crates/moonrun/src/sqlite/wasm/registry_macros.rs
+++ b/crates/moonrun/src/sqlite/wasm/registry_macros.rs
@@ -16,6 +16,7 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
+#[cfg(feature = "v8")]
 macro_rules! decode_wasm_arg {
     ($args:ident, i32) => {
         $args.next_i32()
@@ -34,6 +35,7 @@ macro_rules! decode_wasm_arg {
     };
 }
 
+#[cfg(feature = "v8")]
 macro_rules! wasm_arg_count {
     () => {
         0_i32
@@ -43,6 +45,7 @@ macro_rules! wasm_arg_count {
     };
 }
 
+#[cfg(feature = "v8")]
 macro_rules! decode_sqlite_args {
     ($scope:ident, $args:ident,) => {
         Ok::<(), V8ImportError>(())
@@ -61,6 +64,7 @@ macro_rules! decode_sqlite_args {
     }};
 }
 
+#[cfg(feature = "v8")]
 macro_rules! set_sqlite_import_return {
     ($scope:ident, $ret:ident, i32, $value:expr) => {
         $ret.set_int32($value)
@@ -84,6 +88,7 @@ macro_rules! set_sqlite_import_return {
     }};
 }
 
+#[cfg(feature = "v8")]
 macro_rules! finish_sqlite_import {
     ($scope:ident, $ret:ident, $name:expr, $ret_ty:ident, $result:expr) => {
         match $result {
@@ -97,6 +102,7 @@ macro_rules! finish_sqlite_import {
     };
 }
 
+#[cfg(feature = "v8")]
 macro_rules! invoke_sqlite_import {
     (
         $scope:ident,
@@ -142,6 +148,7 @@ macro_rules! invoke_sqlite_import {
     }};
 }
 
+#[cfg(feature = "v8")]
 macro_rules! register_sqlite_import {
     (
         $obj:ident,
@@ -199,6 +206,160 @@ macro_rules! register_sqlite_import {
     }};
 }
 
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+macro_rules! wasmtime_arg_type {
+    (i32) => {
+        i32
+    };
+    (u32) => {
+        i32
+    };
+    (i64) => {
+        i64
+    };
+    (u64) => {
+        i64
+    };
+    (f64) => {
+        f64
+    };
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+macro_rules! decode_wasmtime_arg {
+    ($arg:ident, i32) => {
+        $arg
+    };
+    ($arg:ident, u32) => {
+        $arg as u32
+    };
+    ($arg:ident, i64) => {
+        $arg
+    };
+    ($arg:ident, u64) => {
+        $arg as u64
+    };
+    ($arg:ident, f64) => {
+        $arg
+    };
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+macro_rules! wasmtime_return_type {
+    (void) => {
+        ()
+    };
+    (i32) => {
+        i32
+    };
+    (u32) => {
+        i32
+    };
+    (i64) => {
+        i64
+    };
+    (u64) => {
+        i64
+    };
+    (f64) => {
+        f64
+    };
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+macro_rules! finish_wasmtime_sqlite_import {
+    ($name:expr, void, $result:expr) => {
+        $result.map_err(|error| {
+            wasmtime::format_err!("{}.{} failed: {error:?}", MOONBIT_SQLITE_MODULE, $name)
+        })
+    };
+    ($name:expr, i32, $result:expr) => {
+        $result.map_err(|error| {
+            wasmtime::format_err!("{}.{} failed: {error:?}", MOONBIT_SQLITE_MODULE, $name)
+        })
+    };
+    ($name:expr, u32, $result:expr) => {
+        $result.map(|value| value as i32).map_err(|error| {
+            wasmtime::format_err!("{}.{} failed: {error:?}", MOONBIT_SQLITE_MODULE, $name)
+        })
+    };
+    ($name:expr, i64, $result:expr) => {
+        $result.map_err(|error| {
+            wasmtime::format_err!("{}.{} failed: {error:?}", MOONBIT_SQLITE_MODULE, $name)
+        })
+    };
+    ($name:expr, u64, $result:expr) => {
+        $result.map(|value| value as i64).map_err(|error| {
+            wasmtime::format_err!("{}.{} failed: {error:?}", MOONBIT_SQLITE_MODULE, $name)
+        })
+    };
+    ($name:expr, f64, $result:expr) => {
+        $result.map_err(|error| {
+            wasmtime::format_err!("{}.{} failed: {error:?}", MOONBIT_SQLITE_MODULE, $name)
+        })
+    };
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+macro_rules! invoke_wasmtime_sqlite_import {
+    (
+        $caller:ident,
+        Runtime::$callback:ident,
+        ($($arg:ident),*)
+    ) => {
+        Ok::<_, SqliteError>($caller.data().runtime().$callback($($arg),*))
+    };
+    (
+        $caller:ident,
+        SqliteHost::$callback:ident,
+        ($($arg:ident),*)
+    ) => {
+        $caller
+            .data()
+            .runtime()
+            .sqlite()
+            .$callback($($arg),*)
+            .map_err(SqliteError::from)
+    };
+    (
+        $caller:ident,
+        $module:ident::$callback:ident,
+        ($($arg:ident),*)
+    ) => {
+        with_wasmtime_context(&mut $caller, |context| {
+            $module::$callback(context, $($arg),*)
+        })
+    };
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+macro_rules! register_wasmtime_sqlite_import {
+    (
+        $linker:ident,
+        $module:ident::$callback:ident(
+            $($arg:ident : $arg_ty:ident),* $(,)?
+        ) -> $ret_ty:ident => $wasm_symbol:literal
+    ) => {{
+        $linker.func_wrap(
+            MOONBIT_SQLITE_MODULE,
+            $wasm_symbol,
+            |caller: wasmtime::Caller<'_, crate::wasmtime::StoreData>
+                $(, $arg: wasmtime_arg_type!($arg_ty))*|
+                -> wasmtime::Result<wasmtime_return_type!($ret_ty)> {
+                #[allow(unused_mut)]
+                let mut caller = caller;
+                $(let $arg = decode_wasmtime_arg!($arg, $arg_ty);)*
+                let result = invoke_wasmtime_sqlite_import!(
+                    caller,
+                    $module::$callback,
+                    ($($arg),*)
+                );
+                finish_wasmtime_sqlite_import!($wasm_symbol, $ret_ty, result)
+            },
+        )?;
+    }};
+}
+
 macro_rules! declare_sqlite_imports {
     ($(
         $(#[$meta:meta])*
@@ -212,6 +373,7 @@ macro_rules! declare_sqlite_imports {
         ///
         /// `context_ptr` must remain valid whenever a registered callback can
         /// be invoked.
+        #[cfg(feature = "v8")]
         pub(super) unsafe fn register_imports<'s>(
             obj: v8::Local<'s, v8::Object>,
             scope: &mut v8::HandleScope<'s>,
@@ -228,10 +390,31 @@ macro_rules! declare_sqlite_imports {
                 );
             )*
         }
+        #[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+        pub(crate) fn register_wasmtime_imports(
+            linker: &mut wasmtime::Linker<crate::wasmtime::StoreData>,
+        ) -> wasmtime::Result<()> {
+            $(
+                $(#[$meta])*
+                $crate::sqlite::wasm::registry_macros::register_wasmtime_sqlite_import!(
+                    linker,
+                    $module::$callback($($arg : $arg_ty),*)
+                        -> $ret_ty => $wasm_symbol
+                );
+            )*
+            Ok(())
+        }
     };
 }
 
+pub(super) use declare_sqlite_imports;
+#[cfg(feature = "v8")]
 pub(super) use {
-    declare_sqlite_imports, decode_sqlite_args, decode_wasm_arg, finish_sqlite_import,
-    invoke_sqlite_import, register_sqlite_import, set_sqlite_import_return, wasm_arg_count,
+    decode_sqlite_args, decode_wasm_arg, finish_sqlite_import, invoke_sqlite_import,
+    register_sqlite_import, set_sqlite_import_return, wasm_arg_count,
+};
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+pub(super) use {
+    decode_wasmtime_arg, finish_wasmtime_sqlite_import, invoke_wasmtime_sqlite_import,
+    register_wasmtime_sqlite_import, wasmtime_arg_type, wasmtime_return_type,
 };

--- a/crates/moonrun/src/wasmtime/host_imports.rs
+++ b/crates/moonrun/src/wasmtime/host_imports.rs
@@ -1,0 +1,1183 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+//! Wasmtime lowering for Moonrun's synchronous, JS-shaped Wasm imports.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use wasmtime::{AsContext, Caller, ExternRef, Linker, Memory, MemoryType, Rooted, Store};
+
+use super::{JsString, StoreData};
+use crate::filesystem::FsOperationResults;
+use crate::memory_sanitizer::{SanitizerStack, SanitizerStackFrame};
+
+const FS_MODULE: &str = "__moonbit_fs_unstable";
+const IO_MODULE: &str = "__moonbit_io_unstable";
+const RAND_MODULE: &str = "__moonbit_rand_unstable";
+const TIME_MODULE: &str = "__moonbit_time_unstable";
+
+pub(super) struct State {
+    arguments: Vec<String>,
+    filesystem_results: FsOperationResults,
+    ffi_bytes_memory: Option<Memory>,
+}
+
+impl State {
+    pub(super) fn new(module_name: &str, arguments: &[String]) -> Self {
+        Self {
+            arguments: std::iter::once(module_name.to_owned())
+                .chain(arguments.iter().cloned())
+                .collect(),
+            filesystem_results: FsOperationResults::default(),
+            ffi_bytes_memory: None,
+        }
+    }
+
+    fn ffi_bytes_memory(&self) -> wasmtime::Result<Memory> {
+        self.ffi_bytes_memory
+            .ok_or_else(|| wasmtime::format_err!("ffi-bytes.memory was not imported"))
+    }
+}
+
+#[derive(Debug)]
+struct JsBytes(Mutex<Vec<u8>>);
+
+#[derive(Clone, Debug)]
+struct JsStringArray(Vec<Vec<u16>>);
+
+#[derive(Debug, Default)]
+struct JsStringBuilder(Mutex<Vec<u16>>);
+
+#[derive(Debug)]
+struct JsStringReader {
+    units: Arc<[u16]>,
+    index: AtomicUsize,
+}
+
+#[derive(Debug, Default)]
+struct JsByteBuilder(Mutex<Vec<u8>>);
+
+#[derive(Debug)]
+struct JsByteReader {
+    bytes: Vec<u8>,
+    index: AtomicUsize,
+}
+
+#[derive(Debug)]
+struct JsStringArrayReader {
+    strings: Vec<Vec<u16>>,
+    index: AtomicUsize,
+}
+
+#[derive(Debug)]
+struct JsInstant(Instant);
+
+#[derive(Debug)]
+struct JsRng(Mutex<StdRng>);
+
+pub(super) fn define_import(
+    linker: &mut Linker<StoreData>,
+    namespace: &str,
+    name: &str,
+) -> wasmtime::Result<bool> {
+    match namespace {
+        FS_MODULE => define_filesystem_import(linker, name),
+        IO_MODULE => define_io_import(linker, namespace, name),
+        "spectest" if name == "read_char" => define_io_import(linker, namespace, name),
+        RAND_MODULE => define_random_import(linker, name),
+        TIME_MODULE => define_time_import(linker, name),
+        "ffi-bytes" => define_ffi_bytes_import(linker, name),
+        crate::memory_sanitizer::MEMORY_SANITIZER_MODULE => {
+            define_memory_sanitizer_import(linker, name)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn define_memory_sanitizer_import(
+    linker: &mut Linker<StoreData>,
+    name: &str,
+) -> wasmtime::Result<bool> {
+    match name {
+        "register-object-alloc" => {
+            linker.func_wrap(
+                crate::memory_sanitizer::MEMORY_SANITIZER_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, address: i32, size: i32| {
+                    caller
+                        .data()
+                        .memory_sanitizer
+                        .register_object_alloc(address as u32, size as u32, || {
+                            capture_memory_sanitizer_stack(&caller)
+                        })
+                        .map_err(|error| {
+                            wasmtime::format_err!(
+                                "{}.{} failed: {error}",
+                                crate::memory_sanitizer::MEMORY_SANITIZER_MODULE,
+                                "register-object-alloc",
+                            )
+                        })
+                },
+            )?;
+        }
+        "register-object-free" => {
+            linker.func_wrap(
+                crate::memory_sanitizer::MEMORY_SANITIZER_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, address: i32| {
+                    caller
+                        .data()
+                        .memory_sanitizer
+                        .register_object_free(address as u32)
+                        .map_err(|error| {
+                            wasmtime::format_err!(
+                                "{}.{} failed: {error}",
+                                crate::memory_sanitizer::MEMORY_SANITIZER_MODULE,
+                                "register-object-free",
+                            )
+                        })
+                },
+            )?;
+        }
+        "object-is-valid" => {
+            linker.func_wrap(
+                crate::memory_sanitizer::MEMORY_SANITIZER_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, address: i32| {
+                    i32::from(
+                        caller
+                            .data()
+                            .memory_sanitizer
+                            .object_is_valid(address as u32),
+                    )
+                },
+            )?;
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+pub(super) fn define_ffi_bytes_memory(
+    linker: &mut Linker<StoreData>,
+    store: &mut Store<StoreData>,
+) -> wasmtime::Result<()> {
+    let memory = Memory::new(&mut *store, MemoryType::new(1, None))?;
+    store.data_mut().host_imports.ffi_bytes_memory = Some(memory);
+    linker.define(&mut *store, "ffi-bytes", "memory", memory)?;
+    Ok(())
+}
+
+fn define_filesystem_import(linker: &mut Linker<StoreData>, name: &str) -> wasmtime::Result<bool> {
+    match name {
+        "begin_create_string" => {
+            linker.func_wrap(FS_MODULE, name, |mut caller: Caller<'_, StoreData>| {
+                Ok(Some(ExternRef::new(
+                    &mut caller,
+                    JsStringBuilder::default(),
+                )?))
+            })?;
+        }
+        "string_append_char" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, builder: Option<Rooted<ExternRef>>, value: i32| {
+                    with_extern_data::<JsStringBuilder, _>(&caller, builder.as_ref(), |builder| {
+                        builder
+                            .0
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .push(value as u16);
+                    })?;
+                    Ok(())
+                },
+            )?;
+        }
+        "finish_create_string" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |mut caller: Caller<'_, StoreData>, builder: Option<Rooted<ExternRef>>| {
+                    let units = with_extern_data::<JsStringBuilder, _>(
+                        &caller,
+                        builder.as_ref(),
+                        |builder| {
+                            builder
+                                .0
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                                .clone()
+                        },
+                    )?;
+                    Ok(Some(ExternRef::new(&mut caller, JsString(units.into()))?))
+                },
+            )?;
+        }
+        "begin_read_string" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |mut caller: Caller<'_, StoreData>, string: Option<Rooted<ExternRef>>| {
+                    let units =
+                        with_extern_data::<JsString, _>(&caller, string.as_ref(), |string| {
+                            Arc::clone(&string.0)
+                        })?;
+                    Ok(Some(ExternRef::new(
+                        &mut caller,
+                        JsStringReader {
+                            units,
+                            index: AtomicUsize::new(0),
+                        },
+                    )?))
+                },
+            )?;
+        }
+        "string_read_char" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, reader: Option<Rooted<ExternRef>>| {
+                    with_extern_data::<JsStringReader, _>(&caller, reader.as_ref(), |reader| {
+                        next(&reader.units, &reader.index).map_or(-1, i32::from)
+                    })
+                },
+            )?;
+        }
+        "finish_read_string" | "finish_read_byte_array" | "finish_read_string_array" => {
+            linker.func_wrap(FS_MODULE, name, |_value: Option<Rooted<ExternRef>>| {})?;
+        }
+        "begin_create_byte_array" => {
+            linker.func_wrap(FS_MODULE, name, |mut caller: Caller<'_, StoreData>| {
+                Ok(Some(ExternRef::new(&mut caller, JsByteBuilder::default())?))
+            })?;
+        }
+        "byte_array_append_byte" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, builder: Option<Rooted<ExternRef>>, value: i32| {
+                    with_extern_data::<JsByteBuilder, _>(&caller, builder.as_ref(), |builder| {
+                        builder
+                            .0
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .push(value as u8);
+                    })?;
+                    Ok(())
+                },
+            )?;
+        }
+        "finish_create_byte_array" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |mut caller: Caller<'_, StoreData>, builder: Option<Rooted<ExternRef>>| {
+                    let bytes = with_extern_data::<JsByteBuilder, _>(
+                        &caller,
+                        builder.as_ref(),
+                        |builder| {
+                            builder
+                                .0
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                                .clone()
+                        },
+                    )?;
+                    Ok(Some(ExternRef::new(
+                        &mut caller,
+                        JsBytes(Mutex::new(bytes)),
+                    )?))
+                },
+            )?;
+        }
+        "begin_read_byte_array" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |mut caller: Caller<'_, StoreData>, bytes: Option<Rooted<ExternRef>>| {
+                    let bytes = extern_bytes(&caller, bytes.as_ref())?;
+                    Ok(Some(ExternRef::new(
+                        &mut caller,
+                        JsByteReader {
+                            bytes,
+                            index: AtomicUsize::new(0),
+                        },
+                    )?))
+                },
+            )?;
+        }
+        "byte_array_read_byte" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, reader: Option<Rooted<ExternRef>>| {
+                    with_extern_data::<JsByteReader, _>(&caller, reader.as_ref(), |reader| {
+                        next(&reader.bytes, &reader.index).map_or(-1, i32::from)
+                    })
+                },
+            )?;
+        }
+        "begin_read_string_array" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |mut caller: Caller<'_, StoreData>, strings: Option<Rooted<ExternRef>>| {
+                    let strings =
+                        with_extern_data::<JsStringArray, _>(&caller, strings.as_ref(), |array| {
+                            array.0.clone()
+                        })?;
+                    Ok(Some(ExternRef::new(
+                        &mut caller,
+                        JsStringArrayReader {
+                            strings,
+                            index: AtomicUsize::new(0),
+                        },
+                    )?))
+                },
+            )?;
+        }
+        "string_array_read_string" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |mut caller: Caller<'_, StoreData>, reader: Option<Rooted<ExternRef>>| {
+                    let units = with_extern_data::<JsStringArrayReader, _>(
+                        &caller,
+                        reader.as_ref(),
+                        |reader| {
+                            let index = reader.index.load(Ordering::Relaxed);
+                            let value = reader.strings.get(index).cloned();
+                            if value.is_some() {
+                                reader.index.store(index + 1, Ordering::Relaxed);
+                            }
+                            value
+                        },
+                    )?
+                    .unwrap_or_else(|| "ffi_end_of_/string_array".encode_utf16().collect());
+                    Ok(Some(ExternRef::new(&mut caller, JsString(units.into()))?))
+                },
+            )?;
+        }
+        "array_len" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, array: Option<Rooted<ExternRef>>| {
+                    Ok(with_extern_data::<JsStringArray, _>(
+                        &caller,
+                        array.as_ref(),
+                        |array| i32::try_from(array.0.len()),
+                    )??)
+                },
+            )?;
+        }
+        "array_get" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |mut caller: Caller<'_, StoreData>,
+                 array: Option<Rooted<ExternRef>>,
+                 index: i32| {
+                    let index = usize::try_from(index)?;
+                    let units =
+                        with_extern_data::<JsStringArray, _>(&caller, array.as_ref(), |array| {
+                            array.0.get(index).cloned()
+                        })?
+                        .ok_or_else(|| wasmtime::format_err!("array index out of bounds"))?;
+                    Ok(Some(ExternRef::new(&mut caller, JsString(units.into()))?))
+                },
+            )?;
+        }
+        "jsvalue_is_string" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, value: Option<Rooted<ExternRef>>| {
+                    Ok(i32::from(is_extern_data::<JsString>(
+                        &caller,
+                        value.as_ref(),
+                    )?))
+                },
+            )?;
+        }
+        "args_get" => {
+            linker.func_wrap(FS_MODULE, name, |mut caller: Caller<'_, StoreData>| {
+                let values = caller
+                    .data()
+                    .host_imports
+                    .arguments
+                    .iter()
+                    .map(|value| value.encode_utf16().collect())
+                    .collect();
+                Ok(Some(ExternRef::new(&mut caller, JsStringArray(values))?))
+            })?;
+        }
+        "env_get_var" | "get_env_var" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |mut caller: Caller<'_, StoreData>, key: Option<Rooted<ExternRef>>| {
+                    let key = extern_string(&caller, key.as_ref())?;
+                    let value = caller
+                        .data()
+                        .runtime()
+                        .environment()
+                        .get(key.as_ref())
+                        .and_then(|value| value.into_string().ok())
+                        .unwrap_or_default();
+                    Ok(Some(new_string_value(&mut caller, &value)?))
+                },
+            )?;
+        }
+        "get_env_var_exists" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, key: Option<Rooted<ExternRef>>| {
+                    let key = extern_string(&caller, key.as_ref())?;
+                    Ok(i32::from(
+                        caller
+                            .data()
+                            .runtime()
+                            .environment()
+                            .get(key.as_ref())
+                            .is_some(),
+                    ))
+                },
+            )?;
+        }
+        "set_env_var" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>,
+                 key: Option<Rooted<ExternRef>>,
+                 value: Option<Rooted<ExternRef>>| {
+                    let key = extern_string(&caller, key.as_ref())?;
+                    let value = extern_string(&caller, value.as_ref())?;
+                    let _ = caller
+                        .data()
+                        .runtime()
+                        .environment()
+                        .set(key.into(), value.into());
+                    Ok(())
+                },
+            )?;
+        }
+        "unset_env_var" => {
+            linker.func_wrap(
+                FS_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, key: Option<Rooted<ExternRef>>| {
+                    let key = extern_string(&caller, key.as_ref())?;
+                    let _ = caller.data().runtime().environment().unset(key.as_ref());
+                    Ok(())
+                },
+            )?;
+        }
+        "get_env_vars" => {
+            linker.func_wrap(FS_MODULE, name, |mut caller: Caller<'_, StoreData>| {
+                let values = caller
+                    .data()
+                    .runtime()
+                    .environment()
+                    .entries()
+                    .into_iter()
+                    .filter_map(|(name, value)| {
+                        Some((name.into_string().ok()?, value.into_string().ok()?))
+                    })
+                    .flat_map(|(name, value)| [name, value])
+                    .map(|value| value.encode_utf16().collect())
+                    .collect();
+                Ok(Some(ExternRef::new(&mut caller, JsStringArray(values))?))
+            })?;
+        }
+        "read_file_to_string" => define_read_file_to_string(linker, name)?,
+        "write_string_to_file" => define_write_string_to_file(linker, name)?,
+        "write_bytes_to_file" => define_write_bytes_to_file(linker, name, false)?,
+        "create_dir" | "remove_file" | "remove_dir" => define_legacy_path_operation(linker, name)?,
+        "read_dir" => define_read_dir(linker, name)?,
+        "is_file" | "is_dir" | "path_exists" => define_path_predicate(linker, name)?,
+        "current_dir" => {
+            linker.func_wrap(FS_MODULE, name, |mut caller: Caller<'_, StoreData>| {
+                let directory = caller.data().runtime().filesystem().current_dir();
+                Ok(Some(new_string_value(&mut caller, &directory)?))
+            })?;
+        }
+        "read_file_to_bytes_new"
+        | "create_dir_new"
+        | "read_dir_new"
+        | "is_file_new"
+        | "is_dir_new"
+        | "remove_file_new"
+        | "remove_dir_new" => define_status_path_operation(linker, name)?,
+        "write_bytes_to_file_new" => define_write_bytes_to_file(linker, name, true)?,
+        "get_file_content" => {
+            linker.func_wrap(FS_MODULE, name, |mut caller: Caller<'_, StoreData>| {
+                let contents = caller
+                    .data()
+                    .host_imports
+                    .filesystem_results
+                    .file_content()
+                    .to_vec();
+                Ok(Some(ExternRef::new(
+                    &mut caller,
+                    JsBytes(Mutex::new(contents)),
+                )?))
+            })?;
+        }
+        "get_dir_files" => {
+            linker.func_wrap(FS_MODULE, name, |mut caller: Caller<'_, StoreData>| {
+                let files = caller
+                    .data()
+                    .host_imports
+                    .filesystem_results
+                    .dir_files()
+                    .iter()
+                    .map(|value| value.encode_utf16().collect())
+                    .collect();
+                Ok(Some(ExternRef::new(&mut caller, JsStringArray(files))?))
+            })?;
+        }
+        "get_error_message" => {
+            linker.func_wrap(FS_MODULE, name, |mut caller: Caller<'_, StoreData>| {
+                let message = caller
+                    .data()
+                    .host_imports
+                    .filesystem_results
+                    .error_message()
+                    .to_owned();
+                Ok(Some(new_string_value(&mut caller, &message)?))
+            })?;
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+fn define_io_import(
+    linker: &mut Linker<StoreData>,
+    namespace: &str,
+    name: &str,
+) -> wasmtime::Result<bool> {
+    match name {
+        "read_bytes_from_stdin" => {
+            linker.func_wrap(namespace, name, |mut caller: Caller<'_, StoreData>| {
+                let mut bytes = Vec::new();
+                caller
+                    .data()
+                    .runtime()
+                    .stdio()
+                    .with_stdin(|stdin| stdin.read_to_end(&mut bytes))?;
+                Ok(Some(ExternRef::new(
+                    &mut caller,
+                    JsBytes(Mutex::new(bytes)),
+                )?))
+            })?;
+        }
+        "read_char" => {
+            linker.func_wrap(namespace, name, |caller: Caller<'_, StoreData>| {
+                caller
+                    .data()
+                    .runtime()
+                    .stdio()
+                    .read_utf8_char()
+                    .ok()
+                    .flatten()
+                    .map_or(-1, |value| value as i32)
+            })?;
+        }
+        "write_char" => {
+            linker.func_wrap(
+                namespace,
+                name,
+                |caller: Caller<'_, StoreData>, fd: i32, value: i32| {
+                    let value = char::from_u32(value as u32)
+                        .ok_or_else(|| wasmtime::format_err!("invalid character"))?;
+                    let stdio = caller.data().runtime().stdio();
+                    match fd {
+                        1 => stdio.with_stdout(|stdout| write!(stdout, "{value}"))?,
+                        2 => stdio.with_stderr(|stderr| write!(stderr, "{value}"))?,
+                        _ => {}
+                    }
+                    Ok(())
+                },
+            )?;
+        }
+        "flush" => {
+            linker.func_wrap(namespace, name, |caller: Caller<'_, StoreData>, fd: i32| {
+                let stdio = caller.data().runtime().stdio();
+                match fd {
+                    1 => stdio.with_stdout(|stdout| stdout.flush())?,
+                    2 => stdio.with_stderr(|stderr| stderr.flush())?,
+                    _ => {}
+                }
+                Ok(())
+            })?;
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+fn define_random_import(linker: &mut Linker<StoreData>, name: &str) -> wasmtime::Result<bool> {
+    match name {
+        "stdrng_seed_from_u64" => {
+            linker.func_wrap(
+                RAND_MODULE,
+                name,
+                |mut caller: Caller<'_, StoreData>, seed: i32| {
+                    let rng = StdRng::seed_from_u64(seed as u64);
+                    Ok(Some(ExternRef::new(&mut caller, JsRng(Mutex::new(rng)))?))
+                },
+            )?;
+        }
+        "stdrng_gen_range" => {
+            linker.func_wrap(
+                RAND_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, rng: Option<Rooted<ExternRef>>, upper: i32| {
+                    if upper <= 0 {
+                        wasmtime::bail!("random range upper bound must be positive");
+                    }
+                    with_extern_data::<JsRng, _>(&caller, rng.as_ref(), |rng| {
+                        rng.0
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .gen_range(0..upper)
+                    })
+                },
+            )?;
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+fn define_time_import(linker: &mut Linker<StoreData>, name: &str) -> wasmtime::Result<bool> {
+    match name {
+        "instant_now" => {
+            linker.func_wrap(TIME_MODULE, name, |mut caller: Caller<'_, StoreData>| {
+                Ok(Some(ExternRef::new(
+                    &mut caller,
+                    JsInstant(Instant::now()),
+                )?))
+            })?;
+        }
+        "instant_elapsed_as_secs_f64" => {
+            linker.func_wrap(
+                TIME_MODULE,
+                name,
+                |caller: Caller<'_, StoreData>, instant: Option<Rooted<ExternRef>>| {
+                    with_extern_data::<JsInstant, _>(&caller, instant.as_ref(), |instant| {
+                        instant.0.elapsed().as_secs_f64()
+                    })
+                },
+            )?;
+        }
+        "now" => {
+            linker.func_wrap(TIME_MODULE, name, || {
+                let millis = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|_| wasmtime::format_err!("system time is before the Unix epoch"))?
+                    .as_millis();
+                Ok(u64::try_from(millis)? as i64)
+            })?;
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+fn define_ffi_bytes_import(linker: &mut Linker<StoreData>, name: &str) -> wasmtime::Result<bool> {
+    match name {
+        "from_memory" => {
+            linker.func_wrap(
+                "ffi-bytes",
+                name,
+                |mut caller: Caller<'_, StoreData>, offset: i32, length: i32| {
+                    let offset = usize::try_from(offset)?;
+                    let length = usize::try_from(length)?;
+                    let memory = caller.data().host_imports.ffi_bytes_memory()?;
+                    let end = offset
+                        .checked_add(length)
+                        .ok_or_else(|| wasmtime::format_err!("ffi-bytes range overflow"))?;
+                    let bytes = memory
+                        .data(&caller)
+                        .get(offset..end)
+                        .ok_or_else(|| wasmtime::format_err!("ffi-bytes range out of bounds"))?
+                        .to_vec();
+                    ExternRef::new(&mut caller, JsBytes(Mutex::new(bytes)))
+                },
+            )?;
+        }
+        "new" => {
+            linker.func_wrap(
+                "ffi-bytes",
+                name,
+                |mut caller: Caller<'_, StoreData>, length: i32| {
+                    let length = usize::try_from(length)?;
+                    ExternRef::new(&mut caller, JsBytes(Mutex::new(vec![0; length])))
+                },
+            )?;
+        }
+        "get" => {
+            linker.func_wrap(
+                "ffi-bytes",
+                name,
+                |caller: Caller<'_, StoreData>, bytes: Option<Rooted<ExternRef>>, index: i32| {
+                    let index = usize::try_from(index)?;
+                    let value = with_extern_data::<JsBytes, _>(&caller, bytes.as_ref(), |bytes| {
+                        bytes
+                            .0
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .get(index)
+                            .copied()
+                    })?
+                    .ok_or_else(|| wasmtime::format_err!("ffi-bytes index out of bounds"))?;
+                    Ok(i32::from(value))
+                },
+            )?;
+        }
+        "set" => {
+            linker.func_wrap(
+                "ffi-bytes",
+                name,
+                |caller: Caller<'_, StoreData>,
+                 bytes: Option<Rooted<ExternRef>>,
+                 index: i32,
+                 value: i32| {
+                    let index = usize::try_from(index)?;
+                    with_extern_data::<JsBytes, _>(&caller, bytes.as_ref(), |bytes| {
+                        let mut bytes = bytes
+                            .0
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        let output = bytes.get_mut(index).ok_or_else(|| {
+                            wasmtime::format_err!("ffi-bytes index out of bounds")
+                        })?;
+                        *output = value as u8;
+                        Ok::<(), wasmtime::Error>(())
+                    })??;
+                    Ok(())
+                },
+            )?;
+        }
+        "copy" => {
+            linker.func_wrap(
+                "ffi-bytes",
+                name,
+                |caller: Caller<'_, StoreData>,
+                 destination: Option<Rooted<ExternRef>>,
+                 destination_offset: i32,
+                 source: Option<Rooted<ExternRef>>,
+                 source_offset: i32,
+                 length: i32| {
+                    let destination_offset = usize::try_from(destination_offset)?;
+                    let source = extern_bytes(&caller, source.as_ref())?;
+                    let source_offset = usize::try_from(source_offset)?;
+                    let length = usize::try_from(length)?;
+                    let source_end = source_offset
+                        .checked_add(length)
+                        .ok_or_else(|| wasmtime::format_err!("ffi-bytes source range overflow"))?;
+                    let source = source.get(source_offset..source_end).ok_or_else(|| {
+                        wasmtime::format_err!("ffi-bytes source range out of bounds")
+                    })?;
+                    with_extern_data::<JsBytes, _>(
+                        &caller,
+                        destination.as_ref(),
+                        |destination| {
+                            let mut destination = destination
+                                .0
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner());
+                            let destination_end =
+                                destination_offset.checked_add(length).ok_or_else(|| {
+                                    wasmtime::format_err!("ffi-bytes destination range overflow")
+                                })?;
+                            let output = destination
+                                .get_mut(destination_offset..destination_end)
+                                .ok_or_else(|| {
+                                wasmtime::format_err!("ffi-bytes destination range out of bounds")
+                            })?;
+                            output.copy_from_slice(source);
+                            Ok::<(), wasmtime::Error>(())
+                        },
+                    )??;
+                    Ok(())
+                },
+            )?;
+        }
+        "fill" => {
+            linker.func_wrap(
+                "ffi-bytes",
+                name,
+                |caller: Caller<'_, StoreData>,
+                 bytes: Option<Rooted<ExternRef>>,
+                 start: i32,
+                 value: i32,
+                 length: i32| {
+                    let start = usize::try_from(start)?;
+                    let length = usize::try_from(length)?;
+                    let end = start
+                        .checked_add(length)
+                        .ok_or_else(|| wasmtime::format_err!("ffi-bytes range overflow"))?;
+                    with_extern_data::<JsBytes, _>(&caller, bytes.as_ref(), |bytes| {
+                        bytes
+                            .0
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .get_mut(start..end)
+                            .ok_or_else(|| wasmtime::format_err!("ffi-bytes range out of bounds"))?
+                            .fill(value as u8);
+                        Ok::<(), wasmtime::Error>(())
+                    })??;
+                    Ok(())
+                },
+            )?;
+        }
+        "length" => {
+            linker.func_wrap(
+                "ffi-bytes",
+                name,
+                |caller: Caller<'_, StoreData>,
+                 bytes: Option<Rooted<ExternRef>>|
+                 -> wasmtime::Result<i32> {
+                    Ok(with_extern_data::<JsBytes, _>(
+                        &caller,
+                        bytes.as_ref(),
+                        |bytes| {
+                            i32::try_from(
+                                bytes
+                                    .0
+                                    .lock()
+                                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                                    .len(),
+                            )
+                        },
+                    )??)
+                },
+            )?;
+        }
+        "equals" => {
+            linker.func_wrap(
+                "ffi-bytes",
+                name,
+                |caller: Caller<'_, StoreData>,
+                 left: Option<Rooted<ExternRef>>,
+                 right: Option<Rooted<ExternRef>>| {
+                    Ok(i32::from(
+                        extern_bytes(&caller, left.as_ref())?
+                            == extern_bytes(&caller, right.as_ref())?,
+                    ))
+                },
+            )?;
+        }
+        "asString" => {
+            linker.func_wrap(
+                "ffi-bytes",
+                name,
+                |mut caller: Caller<'_, StoreData>,
+                 bytes: Option<Rooted<ExternRef>>,
+                 start: i32,
+                 length: i32| {
+                    let bytes = extern_bytes(&caller, bytes.as_ref())?;
+                    let start = usize::try_from(start)?;
+                    let length = usize::try_from(length)?;
+                    let end = start
+                        .checked_add(length)
+                        .ok_or_else(|| wasmtime::format_err!("ffi-bytes range overflow"))?;
+                    let bytes = bytes
+                        .get(start..end)
+                        .ok_or_else(|| wasmtime::format_err!("ffi-bytes range out of bounds"))?;
+                    let units = bytes
+                        .chunks_exact(2)
+                        .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+                        .collect::<Vec<_>>();
+                    ExternRef::new(&mut caller, JsString(units.into()))
+                },
+            )?;
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+fn define_read_file_to_string(linker: &mut Linker<StoreData>, name: &str) -> wasmtime::Result<()> {
+    linker.func_wrap(
+        FS_MODULE,
+        name,
+        |mut caller: Caller<'_, StoreData>, path: Option<Rooted<ExternRef>>| {
+            let path = extern_string(&caller, path.as_ref())?;
+            let contents = caller
+                .data()
+                .runtime()
+                .filesystem()
+                .read_file_to_string(&path)
+                .map_err(|error| wasmtime::format_err!(error.to_string()))?;
+            Ok(Some(new_string_value(&mut caller, &contents)?))
+        },
+    )?;
+    Ok(())
+}
+
+fn define_write_string_to_file(linker: &mut Linker<StoreData>, name: &str) -> wasmtime::Result<()> {
+    linker.func_wrap(
+        FS_MODULE,
+        name,
+        |caller: Caller<'_, StoreData>,
+         path: Option<Rooted<ExternRef>>,
+         contents: Option<Rooted<ExternRef>>| {
+            let path = extern_string(&caller, path.as_ref())?;
+            let contents = extern_string(&caller, contents.as_ref())?;
+            caller
+                .data()
+                .runtime()
+                .filesystem()
+                .write_string_to_file(&path, &contents)
+                .map_err(|error| wasmtime::format_err!(error.to_string()))
+        },
+    )?;
+    Ok(())
+}
+
+fn define_write_bytes_to_file(
+    linker: &mut Linker<StoreData>,
+    name: &str,
+    status_result: bool,
+) -> wasmtime::Result<()> {
+    if status_result {
+        linker.func_wrap(
+            FS_MODULE,
+            name,
+            |mut caller: Caller<'_, StoreData>,
+             path: Option<Rooted<ExternRef>>,
+             contents: Option<Rooted<ExternRef>>|
+             -> wasmtime::Result<i32> {
+                let path = extern_string(&caller, path.as_ref())?;
+                let filesystem = caller.data().runtime().filesystem().clone();
+                let mut operation_results =
+                    std::mem::take(&mut caller.data_mut().host_imports.filesystem_results);
+                let status =
+                    filesystem.write_bytes_to_file_new(&mut operation_results, &path, || {
+                        extern_bytes(&caller, contents.as_ref()).map_err(|error| error.to_string())
+                    });
+                caller.data_mut().host_imports.filesystem_results = operation_results;
+                Ok(status)
+            },
+        )?;
+    } else {
+        linker.func_wrap(
+            FS_MODULE,
+            name,
+            |caller: Caller<'_, StoreData>,
+             path: Option<Rooted<ExternRef>>,
+             contents: Option<Rooted<ExternRef>>| {
+                let path = extern_string(&caller, path.as_ref())?;
+                let filesystem = caller.data().runtime().filesystem().clone();
+                filesystem.write_bytes_to_file(&path, || extern_bytes(&caller, contents.as_ref()))
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn define_legacy_path_operation(
+    linker: &mut Linker<StoreData>,
+    name: &str,
+) -> wasmtime::Result<()> {
+    let operation = name.to_owned();
+    linker.func_wrap(
+        FS_MODULE,
+        name,
+        move |caller: Caller<'_, StoreData>, path: Option<Rooted<ExternRef>>| {
+            let path = extern_string(&caller, path.as_ref())?;
+            let filesystem = caller.data().runtime().filesystem();
+            let result = match operation.as_str() {
+                "create_dir" => filesystem.create_dir(&path),
+                "remove_file" => filesystem.remove_file(&path),
+                "remove_dir" => filesystem.remove_dir(&path),
+                _ => unreachable!(),
+            };
+            result.map_err(|error| wasmtime::format_err!(error.to_string()))
+        },
+    )?;
+    Ok(())
+}
+
+fn define_read_dir(linker: &mut Linker<StoreData>, name: &str) -> wasmtime::Result<()> {
+    linker.func_wrap(
+        FS_MODULE,
+        name,
+        |mut caller: Caller<'_, StoreData>, path: Option<Rooted<ExternRef>>| {
+            let path = extern_string(&caller, path.as_ref())?;
+            let entries = caller
+                .data()
+                .runtime()
+                .filesystem()
+                .read_dir(&path)
+                .map_err(|error| wasmtime::format_err!(error.to_string()))?
+                .into_iter()
+                .map(|value| value.encode_utf16().collect())
+                .collect();
+            Ok(Some(ExternRef::new(&mut caller, JsStringArray(entries))?))
+        },
+    )?;
+    Ok(())
+}
+
+fn define_path_predicate(linker: &mut Linker<StoreData>, name: &str) -> wasmtime::Result<()> {
+    let operation = name.to_owned();
+    linker.func_wrap(
+        FS_MODULE,
+        name,
+        move |caller: Caller<'_, StoreData>, path: Option<Rooted<ExternRef>>| {
+            let path = extern_string(&caller, path.as_ref())?;
+            let filesystem = caller.data().runtime().filesystem();
+            let value = match operation.as_str() {
+                "is_file" => filesystem.is_file(&path),
+                "is_dir" => filesystem.is_dir(&path),
+                "path_exists" => filesystem.path_exists(&path),
+                _ => unreachable!(),
+            };
+            Ok(i32::from(value))
+        },
+    )?;
+    Ok(())
+}
+
+fn define_status_path_operation(
+    linker: &mut Linker<StoreData>,
+    name: &str,
+) -> wasmtime::Result<()> {
+    let operation = name.to_owned();
+    linker.func_wrap(
+        FS_MODULE,
+        name,
+        move |mut caller: Caller<'_, StoreData>, path: Option<Rooted<ExternRef>>| {
+            let path = extern_string(&caller, path.as_ref())?;
+            let filesystem = caller.data().runtime().filesystem().clone();
+            let state = &mut caller.data_mut().host_imports.filesystem_results;
+            let status = match operation.as_str() {
+                "read_file_to_bytes_new" => filesystem.read_file_to_bytes_new(state, &path),
+                "create_dir_new" => filesystem.create_dir_new(state, &path),
+                "read_dir_new" => filesystem.read_dir_new(state, &path),
+                "is_file_new" => filesystem.is_file_new(state, &path),
+                "is_dir_new" => filesystem.is_dir_new(state, &path),
+                "remove_file_new" => filesystem.remove_file_new(state, &path),
+                "remove_dir_new" => filesystem.remove_dir_new(state, &path),
+                _ => unreachable!(),
+            };
+            Ok(status)
+        },
+    )?;
+    Ok(())
+}
+
+fn capture_memory_sanitizer_stack(caller: &Caller<'_, StoreData>) -> SanitizerStack {
+    let frames = wasmtime::WasmBacktrace::capture(caller)
+        .frames()
+        .iter()
+        .map(|frame| {
+            SanitizerStackFrame::new(
+                frame
+                    .func_name()
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| format!("wasm-function[{}]", frame.func_index())),
+                true,
+            )
+        })
+        .collect();
+    SanitizerStack::new(frames)
+}
+
+fn with_extern_data<T: 'static, R>(
+    caller: &Caller<'_, StoreData>,
+    reference: Option<&Rooted<ExternRef>>,
+    f: impl FnOnce(&T) -> R,
+) -> wasmtime::Result<R> {
+    let reference = reference.ok_or_else(|| wasmtime::format_err!("host value received null"))?;
+    let data = reference
+        .data(caller.as_context())?
+        .ok_or_else(|| wasmtime::format_err!("externref has no host data"))?;
+    let value = data
+        .downcast_ref::<T>()
+        .ok_or_else(|| wasmtime::format_err!("unexpected externref host value"))?;
+    Ok(f(value))
+}
+
+fn is_extern_data<T: 'static>(
+    caller: &Caller<'_, StoreData>,
+    reference: Option<&Rooted<ExternRef>>,
+) -> wasmtime::Result<bool> {
+    let Some(reference) = reference else {
+        return Ok(false);
+    };
+    Ok(reference
+        .data(caller.as_context())?
+        .is_some_and(|value| value.is::<T>()))
+}
+
+fn extern_string(
+    caller: &Caller<'_, StoreData>,
+    value: Option<&Rooted<ExternRef>>,
+) -> wasmtime::Result<String> {
+    Ok(String::from_utf16_lossy(&with_extern_data::<JsString, _>(
+        caller,
+        value,
+        |string| Arc::clone(&string.0),
+    )?))
+}
+
+fn new_string_value(
+    caller: &mut Caller<'_, StoreData>,
+    value: &str,
+) -> wasmtime::Result<Rooted<ExternRef>> {
+    ExternRef::new(
+        caller,
+        JsString(value.encode_utf16().collect::<Vec<_>>().into()),
+    )
+}
+
+fn extern_bytes(
+    caller: &Caller<'_, StoreData>,
+    value: Option<&Rooted<ExternRef>>,
+) -> wasmtime::Result<Vec<u8>> {
+    with_extern_data::<JsBytes, _>(caller, value, |bytes| {
+        bytes
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    })
+}
+
+fn next<T: Copy>(values: &[T], index: &AtomicUsize) -> Option<T> {
+    let current = index.load(Ordering::Relaxed);
+    let value = values.get(current).copied();
+    if value.is_some() {
+        index.store(current + 1, Ordering::Relaxed);
+    }
+    value
+}

--- a/crates/moonrun/src/wasmtime/mod.rs
+++ b/crates/moonrun/src/wasmtime/mod.rs
@@ -18,16 +18,18 @@
 
 //! Wasmtime Engine Backend for Moonrun's Wasm execution surface.
 
+mod host_imports;
 mod wasi;
 
 use std::collections::HashSet;
 use std::fmt;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use ::wasmtime as wt;
 use ::wasmtime::{
-    AsContext, AsContextMut, Collector, ExnRef, ExnRefPre, ExnType, ExternRef, ExternType,
-    FuncType, Global, HeapType, Linker, Mutability, RefType, Store, Strategy, Tag, Val, ValType,
+    AsContext, AsContextMut, Caller, Collector, ExnRef, ExnRefPre, ExnType, ExternRef, ExternType,
+    FuncType, Global, GlobalType, HeapType, Linker, Mutability, RefType, Rooted, Store, Strategy,
+    Tag, TagType, Val, ValType,
 };
 use anyhow::Context;
 
@@ -36,7 +38,7 @@ use crate::engine::{
     run_test_driver,
 };
 use crate::run_termination::{RunTermination, TerminationRequest};
-use crate::runtime::Runtime;
+use crate::runtime::{Runtime, Utf16Writer};
 use crate::source_map::SourceMap;
 use crate::wasm_diagnostic::{self, DiagnosticLine};
 
@@ -44,28 +46,25 @@ use crate::wasm_diagnostic::{self, DiagnosticLine};
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct JsString(Arc<[u16]>);
 
-/// An independent UTF-16 cursor. Wasmtime requires externref host data to be
-/// thread-safe even though one Moonrun Store executes synchronously.
-#[derive(Debug)]
-struct JsStringReader {
-    units: Arc<[u16]>,
-    index: Mutex<usize>,
-}
-
-#[derive(Default)]
-struct PrintState {
-    dangling_high_half: Option<u32>,
-}
-
 pub(crate) struct StoreData {
     runtime: Runtime,
     termination_request: TerminationRequest,
-    print: PrintState,
+    print: Utf16Writer,
     exception_tag: Option<Tag>,
     wasi: crate::wasi::WasiContext,
+    host_imports: host_imports::State,
+    memory_sanitizer: crate::memory_sanitizer::MemorySanitizer,
 }
 
 impl StoreData {
+    pub(crate) fn runtime(&self) -> &Runtime {
+        &self.runtime
+    }
+
+    pub(crate) fn termination_request(&self) -> &TerminationRequest {
+        &self.termination_request
+    }
+
     pub(crate) fn wasi(&self) -> &crate::wasi::WasiContext {
         &self.wasi
     }
@@ -135,18 +134,22 @@ impl Engine {
             termination_request.clone(),
         );
         let stdio = Arc::clone(runtime.stdio());
+        let memory_sanitizer = crate::memory_sanitizer::MemorySanitizer::default();
         let mut store = Store::new(
             engine,
             StoreData {
                 runtime,
                 termination_request: termination_request.clone(),
-                print: PrintState::default(),
+                print: Utf16Writer::default(),
                 exception_tag: None,
                 wasi,
+                host_imports: host_imports::State::new(module_name, &options.args),
+                memory_sanitizer: memory_sanitizer.clone(),
             },
         );
         let linker = linker_for_module(engine, &mut store, &module.0)
-            .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+            .with_context(|| format!("failed to instantiate `{module_name}`"))?;
         let instance = match linker.instantiate(&mut store, &module.0) {
             Ok(instance) => instance,
             Err(error) => {
@@ -158,6 +161,13 @@ impl Engine {
                         source_map,
                         options.no_stack_trace,
                     ))
+                } else if error.downcast_ref::<wt::WasmBacktrace>().is_some() {
+                    return Err(anyhow::anyhow!(format_host_error(
+                        &error,
+                        source_map,
+                        options.no_stack_trace,
+                    )))
+                    .with_context(|| format!("failed to instantiate `{module_name}`"));
                 } else {
                     return Err(anyhow::Error::from(error)
                         .context(format!("failed to instantiate `{module_name}`")));
@@ -166,7 +176,7 @@ impl Engine {
             }
         };
 
-        if let Some(test_args) = test_args {
+        let result = if let Some(test_args) = test_args {
             let execute = instance
                 .get_func(&mut store, "moonbit_test_driver_internal_execute")
                 .context("test module does not export `moonbit_test_driver_internal_execute`")?;
@@ -199,7 +209,14 @@ impl Engine {
             complete_run_call(outcome, &stdio)
         } else {
             Ok(BackendRunOutcome::Completed)
+        };
+        drop(store);
+
+        let outcome = result?;
+        if matches!(outcome, BackendRunOutcome::Completed) {
+            memory_sanitizer.check_for_leaks()?;
         }
+        Ok(outcome)
     }
 }
 
@@ -220,6 +237,8 @@ fn linker_for_module(
 ) -> wt::Result<Linker<StoreData>> {
     let mut linker = Linker::new(engine);
     wasi::register_imports(&mut linker)?;
+    crate::async_api::register_wasmtime_imports(&mut linker)?;
+    crate::sqlite::wasm::register_wasmtime_imports(&mut linker)?;
     let mut defined = HashSet::new();
 
     for import in module.imports() {
@@ -229,119 +248,62 @@ fn linker_for_module(
         }
         match (import.module(), import.name(), import.ty()) {
             (wasi::WASI_SNAPSHOT_PREVIEW1_MODULE, _, ExternType::Func(_)) => {}
-            ("_", literal, ExternType::Global(ty)) => {
-                if ty.mutability() != Mutability::Const {
-                    wt::bail!("imported string constant `{literal}` is mutable");
-                }
-                validate_types(
-                    "imported string constant",
-                    [ty.content().clone()],
-                    [non_null_externref()],
-                )?;
+            (crate::async_api::MOONBIT_ASYNC_MODULE, _, ExternType::Func(_)) => {}
+            (crate::sqlite::wasm::MOONBIT_SQLITE_MODULE, _, ExternType::Func(_)) => {}
+            ("ffi-bytes", "memory", ExternType::Memory(_)) => {
+                host_imports::define_ffi_bytes_memory(&mut linker, store)?;
+            }
+            (namespace, name, ExternType::Func(_))
+                if host_imports::define_import(&mut linker, namespace, name)? => {}
+            ("_", literal, ExternType::Global(_)) => {
                 let value =
                     ExternRef::new(&mut *store, JsString(literal.encode_utf16().collect()))?;
+                let ty = GlobalType::new(non_null_externref(), Mutability::Const);
                 let global = Global::new(&mut *store, ty, Val::ExternRef(Some(value)))?;
                 linker.define(&mut *store, "_", literal, global)?;
             }
             ("wasm:js-string", name, ExternType::Func(ty)) => {
                 register_js_string_builtin(&mut linker, name, ty)?;
             }
-            ("__moonbit_fs_unstable", "begin_read_string", ExternType::Func(ty)) => {
-                validate_func(&ty, [ValType::EXTERNREF], [ValType::EXTERNREF])?;
-                linker.func_new(
-                    "__moonbit_fs_unstable",
-                    "begin_read_string",
-                    ty,
-                    |mut caller, params, results| {
-                        let units = Arc::clone(&require_string(caller.as_context(), &params[0])?.0);
-                        let reader = ExternRef::new(
-                            &mut caller,
-                            JsStringReader {
-                                units,
-                                index: Mutex::new(0),
-                            },
-                        )?;
-                        results[0] = Val::ExternRef(Some(reader));
+            ("console", "log", ExternType::Func(_)) => {
+                linker.func_wrap(
+                    "console",
+                    "log",
+                    |caller: Caller<'_, StoreData>, value: Rooted<ExternRef>| {
+                        let units = require_string(caller.as_context(), Some(&value))?;
+                        let value = String::from_utf16_lossy(&units.0);
+                        caller
+                            .data()
+                            .runtime
+                            .stdio()
+                            .with_stdout(|stdout| writeln!(stdout, "{value}"))?;
                         Ok(())
                     },
                 )?;
             }
-            ("__moonbit_fs_unstable", "string_read_char", ExternType::Func(ty)) => {
-                validate_func(&ty, [ValType::EXTERNREF], [ValType::I32])?;
-                linker.func_new(
-                    "__moonbit_fs_unstable",
-                    "string_read_char",
-                    ty,
-                    |caller, params, results| {
-                        let reference = params[0].unwrap_externref().ok_or_else(|| {
-                            wt::format_err!("string reader operation received null")
-                        })?;
-                        let data = reference
-                            .data(caller.as_context())?
-                            .ok_or_else(|| wt::format_err!("externref has no host reader data"))?;
-                        let reader = data
-                            .downcast_ref::<JsStringReader>()
-                            .ok_or_else(|| wt::format_err!("externref is not a string reader"))?;
-                        let mut index = reader
-                            .index
-                            .lock()
-                            .map_err(|_| wt::format_err!("string reader lock is poisoned"))?;
-                        results[0] = Val::I32(match reader.units.get(*index) {
-                            Some(unit) => {
-                                *index += 1;
-                                i32::from(*unit)
-                            }
-                            None => -1,
-                        });
-                        Ok(())
-                    },
-                )?;
-            }
-            ("__moonbit_fs_unstable", "finish_read_string", ExternType::Func(ty)) => {
-                validate_func(&ty, [ValType::EXTERNREF], [])?;
-                linker.func_new(
-                    "__moonbit_fs_unstable",
-                    "finish_read_string",
-                    ty,
-                    |_caller, _params, _results| Ok(()),
-                )?;
-            }
-            ("console", "log", ExternType::Func(ty)) => {
-                validate_func(&ty, [non_null_externref()], [])?;
-                linker.func_new("console", "log", ty, |caller, params, _results| {
-                    let units = require_string(caller.as_context(), &params[0])?;
-                    let value = String::from_utf16_lossy(&units.0);
-                    caller
-                        .data()
-                        .runtime
-                        .stdio()
-                        .with_stdout(|stdout| writeln!(stdout, "{value}"))?;
-                    Ok(())
-                })?;
-            }
-            ("spectest", "print_char", ExternType::Func(ty)) => {
-                validate_func(&ty, [ValType::I32], [])?;
-                linker.func_new(
+            ("spectest", "print_char", ExternType::Func(_)) => {
+                linker.func_wrap(
                     "spectest",
                     "print_char",
-                    ty,
-                    |mut caller, params, _results| {
-                        print_char(caller.data_mut(), params[0].unwrap_i32() as u32)?;
+                    |caller: Caller<'_, StoreData>, value: i32| {
+                        caller
+                            .data()
+                            .print
+                            .write_stdout(caller.data().runtime.stdio(), value as u32)?;
                         Ok(())
                     },
                 )?;
             }
-            ("exception", "tag", ExternType::Tag(ty)) => {
-                validate_func(ty.ty(), [], [])?;
+            ("exception", "tag", ExternType::Tag(_)) => {
+                let ty = TagType::new(FuncType::new(engine, [], []));
                 let tag = Tag::new(&mut *store, &ty)?;
                 if store.data_mut().exception_tag.replace(tag).is_some() {
                     wt::bail!("duplicate `exception.tag` import");
                 }
                 linker.define(&mut *store, "exception", "tag", tag)?;
             }
-            ("exception", "throw", ExternType::Func(ty)) => {
-                validate_func(&ty, [], [])?;
-                linker.func_new("exception", "throw", ty, |mut caller, _params, _results| {
+            ("exception", "throw", ExternType::Func(_)) => {
+                linker.func_wrap("exception", "throw", |mut caller: Caller<'_, StoreData>| {
                     let tag = caller
                         .data()
                         .exception_tag
@@ -349,32 +311,23 @@ fn linker_for_module(
                     let exception_type = ExnType::from_tag_type(&tag.ty(caller.as_context()))?;
                     let allocator = ExnRefPre::new(&mut caller, exception_type);
                     let exception = ExnRef::new(&mut caller, &allocator, &tag, &[])?;
-                    caller.as_context_mut().throw(exception)
+                    caller.as_context_mut().throw::<()>(exception)
                 })?;
             }
-            ("__moonbit_sys_unstable", "is_windows", ExternType::Func(ty)) => {
-                validate_func(&ty, [], [ValType::I32])?;
-                linker.func_new(
-                    "__moonbit_sys_unstable",
-                    "is_windows",
-                    ty,
-                    |_caller, _params, results| {
-                        results[0] = Val::I32(i32::from(cfg!(windows)));
-                        Ok(())
-                    },
-                )?;
+            ("__moonbit_sys_unstable", "is_windows", ExternType::Func(_)) => {
+                linker.func_wrap("__moonbit_sys_unstable", "is_windows", || {
+                    i32::from(cfg!(windows))
+                })?;
             }
-            ("__moonbit_sys_unstable", "exit", ExternType::Func(ty)) => {
-                validate_func(&ty, [ValType::I32], [])?;
-                linker.func_new(
+            ("__moonbit_sys_unstable", "exit", ExternType::Func(_)) => {
+                linker.func_wrap(
                     "__moonbit_sys_unstable",
                     "exit",
-                    ty,
-                    |caller, params, _results| {
+                    |caller: Caller<'_, StoreData>, code: i32| -> wt::Result<()> {
                         caller
                             .data()
                             .termination_request
-                            .request(RunTermination::Exit(params[0].unwrap_i32()));
+                            .request(RunTermination::Exit(code));
                         wt::bail!("run termination requested")
                     },
                 )?;
@@ -394,159 +347,173 @@ fn register_js_string_builtin(
 ) -> wt::Result<()> {
     match name {
         "cast" => {
-            validate_func(&ty, [ValType::EXTERNREF], [non_null_externref()])?;
-            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
-                require_builtin_string(caller.as_context(), &params[0])?;
-                results[0] = params[0];
-                Ok(())
-            })?;
+            linker.func_wrap(
+                "wasm:js-string",
+                name,
+                |caller: Caller<'_, StoreData>, value: Option<Rooted<ExternRef>>| {
+                    require_builtin_string(caller.as_context(), value.as_ref())?;
+                    value.ok_or_else(|| wt::Trap::UnreachableCodeReached.into())
+                },
+            )?;
         }
         "test" => {
-            validate_func(&ty, [ValType::EXTERNREF], [ValType::I32])?;
-            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
-                results[0] = Val::I32(i32::from(matches!(
-                    js_string_value(caller.as_context(), &params[0])?,
-                    JsStringValue::String(_)
-                )));
-                Ok(())
-            })?;
+            linker.func_wrap(
+                "wasm:js-string",
+                name,
+                |caller: Caller<'_, StoreData>, value: Option<Rooted<ExternRef>>| {
+                    Ok(i32::from(matches!(
+                        js_string_value(caller.as_context(), value.as_ref())?,
+                        JsStringValue::String(_)
+                    )))
+                },
+            )?;
         }
         "fromCharCode" => {
-            validate_func(&ty, [ValType::I32], [non_null_externref()])?;
-            linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
-                let value = ExternRef::new(
-                    &mut caller,
-                    JsString(vec![params[0].unwrap_i32() as u16].into()),
-                )?;
-                results[0] = Val::ExternRef(Some(value));
-                Ok(())
-            })?;
+            linker.func_wrap(
+                "wasm:js-string",
+                name,
+                |mut caller: Caller<'_, StoreData>, value: i32| {
+                    ExternRef::new(&mut caller, JsString(vec![value as u16].into()))
+                },
+            )?;
         }
         "fromCodePoint" => {
-            validate_func(&ty, [ValType::I32], [non_null_externref()])?;
-            linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
-                let code_point = params[0].unwrap_i32() as u32;
-                let units = match code_point {
-                    0..=0xffff => vec![code_point as u16],
-                    0x10000..=0x10ffff => {
-                        let value = code_point - 0x10000;
-                        vec![
-                            0xd800 | ((value >> 10) as u16),
-                            0xdc00 | ((value & 0x3ff) as u16),
-                        ]
-                    }
-                    _ => return js_string_trap(),
-                };
-                let value = ExternRef::new(&mut caller, JsString(units.into()))?;
-                results[0] = Val::ExternRef(Some(value));
-                Ok(())
-            })?;
+            linker.func_wrap(
+                "wasm:js-string",
+                name,
+                |mut caller: Caller<'_, StoreData>, code_point: i32| {
+                    let code_point = code_point as u32;
+                    let units = match code_point {
+                        0..=0xffff => vec![code_point as u16],
+                        0x10000..=0x10ffff => {
+                            let value = code_point - 0x10000;
+                            vec![
+                                0xd800 | ((value >> 10) as u16),
+                                0xdc00 | ((value & 0x3ff) as u16),
+                            ]
+                        }
+                        _ => return js_string_trap(),
+                    };
+                    ExternRef::new(&mut caller, JsString(units.into()))
+                },
+            )?;
         }
         "charCodeAt" => {
-            validate_func(&ty, [ValType::EXTERNREF, ValType::I32], [ValType::I32])?;
-            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
-                let units = require_builtin_string(caller.as_context(), &params[0])?;
-                let index = params[1].unwrap_i32() as u32;
-                let Some(code_unit) = units.0.get(index as usize) else {
-                    return js_string_trap();
-                };
-                results[0] = Val::I32(i32::from(*code_unit));
-                Ok(())
-            })?;
+            linker.func_wrap(
+                "wasm:js-string",
+                name,
+                |caller: Caller<'_, StoreData>, value: Option<Rooted<ExternRef>>, index: i32| {
+                    let units = require_builtin_string(caller.as_context(), value.as_ref())?;
+                    units
+                        .0
+                        .get(index as u32 as usize)
+                        .copied()
+                        .map(i32::from)
+                        .ok_or_else(|| wt::Trap::UnreachableCodeReached.into())
+                },
+            )?;
         }
         "codePointAt" => {
-            validate_func(&ty, [ValType::EXTERNREF, ValType::I32], [ValType::I32])?;
-            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
-                let units = require_builtin_string(caller.as_context(), &params[0])?;
-                let index = params[1].unwrap_i32() as u32 as usize;
-                let Some(&first) = units.0.get(index) else {
-                    return js_string_trap();
-                };
-                let code_point = match (first, units.0.get(index + 1).copied()) {
-                    (0xd800..=0xdbff, Some(second @ 0xdc00..=0xdfff)) => {
-                        0x10000 + ((u32::from(first) - 0xd800) << 10) + (u32::from(second) - 0xdc00)
-                    }
-                    _ => u32::from(first),
-                };
-                results[0] = Val::I32(code_point as i32);
-                Ok(())
-            })?;
+            linker.func_wrap(
+                "wasm:js-string",
+                name,
+                |caller: Caller<'_, StoreData>, value: Option<Rooted<ExternRef>>, index: i32| {
+                    let units = require_builtin_string(caller.as_context(), value.as_ref())?;
+                    let index = index as u32 as usize;
+                    let Some(&first) = units.0.get(index) else {
+                        return js_string_trap();
+                    };
+                    Ok(match (first, units.0.get(index + 1).copied()) {
+                        (0xd800..=0xdbff, Some(second @ 0xdc00..=0xdfff)) => {
+                            (0x10000
+                                + ((u32::from(first) - 0xd800) << 10)
+                                + (u32::from(second) - 0xdc00)) as i32
+                        }
+                        _ => i32::from(first),
+                    })
+                },
+            )?;
         }
         "length" => {
-            validate_func(&ty, [ValType::EXTERNREF], [ValType::I32])?;
-            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
-                let units = require_builtin_string(caller.as_context(), &params[0])?;
-                results[0] = Val::I32(i32::try_from(units.0.len())?);
-                Ok(())
-            })?;
+            linker.func_wrap(
+                "wasm:js-string",
+                name,
+                |caller: Caller<'_, StoreData>, value: Option<Rooted<ExternRef>>| {
+                    let units = require_builtin_string(caller.as_context(), value.as_ref())?;
+                    Ok(i32::try_from(units.0.len())?)
+                },
+            )?;
         }
         "concat" => {
-            validate_func(
-                &ty,
-                [ValType::EXTERNREF, ValType::EXTERNREF],
-                [non_null_externref()],
+            linker.func_wrap(
+                "wasm:js-string",
+                name,
+                |mut caller: Caller<'_, StoreData>,
+                 left: Option<Rooted<ExternRef>>,
+                 right: Option<Rooted<ExternRef>>| {
+                    let left = require_builtin_string(caller.as_context(), left.as_ref())?;
+                    let right = require_builtin_string(caller.as_context(), right.as_ref())?;
+                    let mut units = Vec::with_capacity(left.0.len() + right.0.len());
+                    units.extend_from_slice(&left.0);
+                    units.extend_from_slice(&right.0);
+                    ExternRef::new(&mut caller, JsString(units.into()))
+                },
             )?;
-            linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
-                let left = require_builtin_string(caller.as_context(), &params[0])?;
-                let right = require_builtin_string(caller.as_context(), &params[1])?;
-                let mut units = Vec::with_capacity(left.0.len() + right.0.len());
-                units.extend_from_slice(&left.0);
-                units.extend_from_slice(&right.0);
-                let value = ExternRef::new(&mut caller, JsString(units.into()))?;
-                results[0] = Val::ExternRef(Some(value));
-                Ok(())
-            })?;
         }
         "substring" => {
-            validate_func(
-                &ty,
-                [ValType::EXTERNREF, ValType::I32, ValType::I32],
-                [non_null_externref()],
+            linker.func_wrap(
+                "wasm:js-string",
+                name,
+                |mut caller: Caller<'_, StoreData>,
+                 value: Option<Rooted<ExternRef>>,
+                 start: i32,
+                 end: i32| {
+                    let units = require_builtin_string(caller.as_context(), value.as_ref())?;
+                    let start = start as u32 as usize;
+                    let end = end as u32 as usize;
+                    let substring = if start > end || start > units.0.len() {
+                        Vec::new()
+                    } else {
+                        units.0[start..end.min(units.0.len())].to_vec()
+                    };
+                    ExternRef::new(&mut caller, JsString(substring.into()))
+                },
             )?;
-            linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
-                let units = require_builtin_string(caller.as_context(), &params[0])?;
-                let start = params[1].unwrap_i32() as u32 as usize;
-                let end = params[2].unwrap_i32() as u32 as usize;
-                let substring = if start > end || start > units.0.len() {
-                    Vec::new()
-                } else {
-                    units.0[start..end.min(units.0.len())].to_vec()
-                };
-                let value = ExternRef::new(&mut caller, JsString(substring.into()))?;
-                results[0] = Val::ExternRef(Some(value));
-                Ok(())
-            })?;
         }
         "equals" => {
-            validate_func(
-                &ty,
-                [ValType::EXTERNREF, ValType::EXTERNREF],
-                [ValType::I32],
+            linker.func_wrap(
+                "wasm:js-string",
+                name,
+                |caller: Caller<'_, StoreData>,
+                 left: Option<Rooted<ExternRef>>,
+                 right: Option<Rooted<ExternRef>>| {
+                    let left = optional_builtin_string(caller.as_context(), left.as_ref())?;
+                    let right = optional_builtin_string(caller.as_context(), right.as_ref())?;
+                    Ok(i32::from(left == right))
+                },
             )?;
-            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
-                let left = optional_builtin_string(caller.as_context(), &params[0])?;
-                let right = optional_builtin_string(caller.as_context(), &params[1])?;
-                results[0] = Val::I32(i32::from(left == right));
-                Ok(())
-            })?;
         }
         "compare" => {
-            validate_func(
-                &ty,
-                [ValType::EXTERNREF, ValType::EXTERNREF],
-                [ValType::I32],
+            linker.func_wrap(
+                "wasm:js-string",
+                name,
+                |caller: Caller<'_, StoreData>,
+                 left: Option<Rooted<ExternRef>>,
+                 right: Option<Rooted<ExternRef>>| {
+                    let left = require_builtin_string(caller.as_context(), left.as_ref())?;
+                    let right = require_builtin_string(caller.as_context(), right.as_ref())?;
+                    Ok(match left.0.cmp(&right.0) {
+                        std::cmp::Ordering::Less => -1,
+                        std::cmp::Ordering::Equal => 0,
+                        std::cmp::Ordering::Greater => 1,
+                    })
+                },
             )?;
-            linker.func_new("wasm:js-string", name, ty, |caller, params, results| {
-                let left = require_builtin_string(caller.as_context(), &params[0])?;
-                let right = require_builtin_string(caller.as_context(), &params[1])?;
-                results[0] = Val::I32(match left.0.cmp(&right.0) {
-                    std::cmp::Ordering::Less => -1,
-                    std::cmp::Ordering::Equal => 0,
-                    std::cmp::Ordering::Greater => 1,
-                });
-                Ok(())
-            })?;
         }
+        // These imports name a concrete array type declared by the guest module. `func_wrap`
+        // can express only the abstract `(ref array)` type, which Wasmtime does not link as
+        // the same function parameter type. Preserve the concrete type after checking its
+        // mutable-i16 shape; all other callbacks above have statically declared host ABIs.
         "fromCharCodeArray" => {
             validate_from_char_code_array(&ty)?;
             linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
@@ -573,7 +540,9 @@ fn register_js_string_builtin(
         "intoCharCodeArray" => {
             validate_into_char_code_array(&ty)?;
             linker.func_new("wasm:js-string", name, ty, |mut caller, params, results| {
-                let units = Arc::clone(&require_builtin_string(caller.as_context(), &params[0])?.0);
+                let units = Arc::clone(
+                    &require_builtin_string(caller.as_context(), params[0].unwrap_externref())?.0,
+                );
                 let Some(reference) = params[1].unwrap_anyref() else {
                     return js_string_trap();
                 };
@@ -620,7 +589,11 @@ fn call_export(
         Err(error) if is_guest_failure(&error) => Ok(BackendCallOutcome::GuestFailure(
             format_wasm_error(&error, source_map, no_stack_trace),
         )),
-        Err(error) => Err(error.into()),
+        Err(error) => Err(anyhow::anyhow!(format_host_error(
+            &error,
+            source_map,
+            no_stack_trace,
+        ))),
     }
 }
 
@@ -642,6 +615,21 @@ fn format_wasm_error(
         format!("Error: {root}")
     };
     let mut lines = vec![DiagnosticLine::Text(message)];
+    append_wasm_backtrace(&mut lines, error);
+    wasm_diagnostic::render(lines, source_map, no_stack_trace)
+}
+
+fn format_host_error(
+    error: &wasmtime::Error,
+    source_map: Option<&SourceMap>,
+    no_stack_trace: bool,
+) -> String {
+    let mut lines = vec![DiagnosticLine::Text(error.root_cause().to_string())];
+    append_wasm_backtrace(&mut lines, error);
+    wasm_diagnostic::render(lines, source_map, no_stack_trace)
+}
+
+fn append_wasm_backtrace(lines: &mut Vec<DiagnosticLine>, error: &wasmtime::Error) {
     if let Some(backtrace) = error.downcast_ref::<wasmtime::WasmBacktrace>() {
         for frame in backtrace.frames() {
             let raw_name = frame
@@ -655,61 +643,6 @@ fn format_wasm_error(
             });
         }
     }
-    wasm_diagnostic::render(lines, source_map, no_stack_trace)
-}
-
-fn print_char(data: &mut StoreData, value: u32) -> wt::Result<()> {
-    let stdio = Arc::clone(data.runtime.stdio());
-    if (0xd800..=0xdbff).contains(&value) {
-        if data
-            .print
-            .dangling_high_half
-            .replace(value - 0xd800)
-            .is_some()
-        {
-            stdio.with_stdout(|stdout| write!(stdout, "\u{fffd}"))?;
-        }
-        return Ok(());
-    }
-
-    let value = if (0xdc00..=0xdfff).contains(&value) {
-        data.print
-            .dangling_high_half
-            .take()
-            .map_or(0xfffd, |high| 0x10000 + (high << 10) + (value - 0xdc00))
-    } else {
-        value
-    };
-    let value = char::from_u32(value).ok_or_else(|| wt::format_err!("invalid character"))?;
-    stdio.with_stdout(|stdout| write!(stdout, "{value}"))?;
-    Ok(())
-}
-
-pub(super) fn validate_func<const P: usize, const R: usize>(
-    ty: &FuncType,
-    params: [ValType; P],
-    results: [ValType; R],
-) -> wt::Result<()> {
-    validate_types("function parameters", ty.params(), params)?;
-    validate_types("function results", ty.results(), results)
-}
-
-pub(super) fn validate_types(
-    label: &str,
-    actual: impl IntoIterator<Item = ValType>,
-    expected: impl IntoIterator<Item = ValType>,
-) -> wt::Result<()> {
-    let actual = actual.into_iter().collect::<Vec<_>>();
-    let expected = expected.into_iter().collect::<Vec<_>>();
-    if actual.len() != expected.len()
-        || !actual
-            .iter()
-            .zip(&expected)
-            .all(|(actual, expected)| ValType::eq(actual, expected))
-    {
-        wt::bail!("invalid Wasmtime import {label}: expected {expected:?}, found {actual:?}");
-    }
-    Ok(())
 }
 
 fn validate_from_char_code_array(ty: &FuncType) -> wt::Result<()> {
@@ -758,7 +691,7 @@ fn non_null_externref() -> ValType {
 
 fn require_string<'a, T: 'static>(
     store: wt::StoreContext<'a, T>,
-    value: &Val,
+    value: Option<&Rooted<ExternRef>>,
 ) -> wt::Result<&'a JsString> {
     match js_string_value(store, value)? {
         JsStringValue::String(units) => Ok(units),
@@ -775,9 +708,9 @@ enum JsStringValue<'a> {
 
 fn js_string_value<'a, T: 'static>(
     store: wt::StoreContext<'a, T>,
-    value: &Val,
+    value: Option<&Rooted<ExternRef>>,
 ) -> wt::Result<JsStringValue<'a>> {
-    let Some(reference) = value.unwrap_externref() else {
+    let Some(reference) = value else {
         return Ok(JsStringValue::Null);
     };
     let Some(data) = reference.data(store)? else {
@@ -791,7 +724,7 @@ fn js_string_value<'a, T: 'static>(
 
 fn require_builtin_string<'a, T: 'static>(
     store: wt::StoreContext<'a, T>,
-    value: &Val,
+    value: Option<&Rooted<ExternRef>>,
 ) -> wt::Result<&'a JsString> {
     match js_string_value(store, value)? {
         JsStringValue::String(units) => Ok(units),
@@ -801,7 +734,7 @@ fn require_builtin_string<'a, T: 'static>(
 
 fn optional_builtin_string<'a, T: 'static>(
     store: wt::StoreContext<'a, T>,
-    value: &Val,
+    value: Option<&Rooted<ExternRef>>,
 ) -> wt::Result<Option<&'a JsString>> {
     match js_string_value(store, value)? {
         JsStringValue::Null => Ok(None),
@@ -825,13 +758,13 @@ mod tests {
             ),
             (
                 r#"(module (import "_" "value" (global (mut externref))))"#,
-                "imported string constant `value` is mutable",
+                "incompatible import type for `_::value`",
             ),
             (
                 r#"(module
                     (import "wasm:js-string" "length"
                         (func (param i32) (result i32))))"#,
-                "invalid Wasmtime import function parameters",
+                "incompatible import type for `wasm:js-string::length`",
             ),
         ] {
             let engine = crate::Engine::default();

--- a/crates/moonrun/tests/engine_backends.rs
+++ b/crates/moonrun/tests/engine_backends.rs
@@ -34,6 +34,40 @@ fn engine_backend_reuses_compiled_modules() {
 }
 
 #[test]
+fn engine_backends_support_legacy_spectest_read_char() {
+    let wasm = tempfile::Builder::new()
+        .prefix("spectest-read-char.")
+        .suffix(".wasm")
+        .tempfile()
+        .unwrap();
+    std::fs::write(
+        wasm.path(),
+        wat::parse_str(
+            r#"(module
+                (import "spectest" "read_char" (func $read_char (result i32)))
+                (import "spectest" "print_char" (func $print_char (param i32)))
+                (func (export "_start")
+                    call $read_char
+                    call $print_char
+                    call $read_char
+                    i32.const -1
+                    i32.ne
+                    if unreachable end))"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(wasm.path())
+        .stdin("λ")
+        .assert()
+        .success()
+        .stdout_eq("λ")
+        .stderr_eq("");
+}
+
+#[test]
 fn engine_backends_support_js_string_builtins() {
     let engine = moonrun::Engine::default();
     let js_strings = engine
@@ -258,26 +292,6 @@ fn engine_backends_support_test_driver_string_bridge() {
 }
 
 #[test]
-fn engine_backends_support_explicit_exit() {
-    let engine = moonrun::Engine::default();
-    let exit = engine
-        .compile(
-            "exit.wasm",
-            wat::parse_str(
-                r#"(module
-                    (import "__moonbit_sys_unstable" "exit" (func $exit (param i32)))
-                    (func (export "_start") i32.const 7 call $exit))"#,
-            )
-            .unwrap(),
-        )
-        .unwrap();
-    assert_eq!(
-        engine.run(&exit, moonrun::RunOptions::default()).unwrap(),
-        moonrun::RunOutcome::Exited(7)
-    );
-}
-
-#[test]
 fn engine_backends_support_repeated_imports() {
     let engine = moonrun::Engine::default();
     let module = engine
@@ -305,102 +319,6 @@ fn engine_backends_support_repeated_imports() {
     );
 }
 
-#[test]
-fn engine_backend_handles_start_section_traps_as_guest_failures() {
-    let engine = moonrun::Engine::default();
-    let module = engine
-        .compile(
-            "start-trap.wasm",
-            wat::parse_str(
-                r#"(module
-                    (func $module_start unreachable)
-                    (start $module_start))"#,
-            )
-            .unwrap(),
-        )
-        .unwrap();
-
-    assert_eq!(
-        engine.run(&module, moonrun::RunOptions::default()).unwrap(),
-        moonrun::RunOutcome::Exited(1)
-    );
-}
-
-#[test]
-fn engine_backend_handles_wasm_exceptions_as_guest_failures() {
-    let engine = moonrun::Engine::default();
-    let module = engine
-        .compile(
-            "exception.wasm",
-            wat::parse_str(
-                r#"(module
-                    (import "exception" "tag" (tag $tag))
-                    (import "exception" "throw" (func $throw))
-                    (func (export "_start") call $throw))"#,
-            )
-            .unwrap(),
-        )
-        .unwrap();
-
-    assert_eq!(
-        engine.run(&module, moonrun::RunOptions::default()).unwrap(),
-        moonrun::RunOutcome::Exited(1)
-    );
-}
-
-#[test]
-fn engine_backend_handles_js_string_builtin_traps_as_guest_failures() {
-    let engine = moonrun::Engine::default();
-    let module = engine
-        .compile(
-            "js-string-trap.wasm",
-            wat::parse_str(
-                r#"(module
-                    (import "wasm:js-string" "fromCodePoint"
-                        (func $from_code_point (param i32) (result (ref extern))))
-                    (func (export "_start")
-                        i32.const -1
-                        call $from_code_point
-                        drop))"#,
-            )
-            .unwrap(),
-        )
-        .unwrap();
-
-    assert_eq!(
-        engine.run(&module, moonrun::RunOptions::default()).unwrap(),
-        moonrun::RunOutcome::Exited(1)
-    );
-}
-
-#[test]
-fn engine_backend_handles_test_driver_finish_traps_as_guest_failures() {
-    let engine = moonrun::Engine::default();
-    let module = engine
-        .compile(
-            "finish-trap.wasm",
-            wat::parse_str(
-                r#"(module
-                    (func (export "moonbit_test_driver_internal_execute")
-                        (param externref i32))
-                    (func (export "moonbit_test_driver_finish") unreachable))"#,
-            )
-            .unwrap(),
-        )
-        .unwrap();
-
-    assert_eq!(
-        engine
-            .run(
-                &module,
-                moonrun::RunOptions::default()
-                    .with_test_args(r#"{"package":"moon/core","file_and_index":[]}"#),
-            )
-            .unwrap(),
-        moonrun::RunOutcome::Exited(1)
-    );
-}
-
 #[cfg(all(feature = "wasmtime", not(feature = "v8")))]
 #[test]
 fn wasmtime_rejects_unregistered_imports() {
@@ -422,6 +340,11 @@ fn wasmtime_rejects_unregistered_imports() {
             r#"(import "moonbit" "string_to_js_string" (func (param i32)))"#,
             "unsupported Wasmtime import `moonbit.string_to_js_string`",
         ),
+        (
+            "unsupported-console-elog.wasm",
+            r#"(import "console" "elog" (func (param externref)))"#,
+            "unsupported Wasmtime import `console.elog`",
+        ),
     ] {
         let module = engine
             .compile(name, wat::parse_str(format!("(module {import})")).unwrap())
@@ -436,7 +359,7 @@ fn wasmtime_rejects_unregistered_imports() {
 
 #[cfg(all(feature = "wasmtime", not(feature = "v8")))]
 #[test]
-fn wasmtime_preserves_instantiation_host_adapter_errors() {
+fn wasmtime_preserves_instantiation_context_for_start_host_errors() {
     let engine = moonrun::Engine::default();
     let module = engine
         .compile(
@@ -464,9 +387,89 @@ fn wasmtime_preserves_instantiation_host_adapter_errors() {
     let error = format!("{error:#}");
     assert!(
         error.contains("failed to instantiate `start-host-error.wasm`")
-            && error.contains("externref is not a JS string"),
+            && error.contains("externref is not a JS string")
+            && error.contains("at module_start"),
         "{error}"
     );
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+#[test]
+fn wasmtime_reports_invalid_byte_handles_as_host_errors() {
+    let directory = tempfile::tempdir().unwrap();
+    let output = directory.path().join("invalid-bytes.bin");
+    let path = output
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let engine = moonrun::Engine::default();
+    let module = engine
+        .compile(
+            "invalid-byte-handle.wasm",
+            wat::parse_str(format!(
+                r#"(module
+                    (import "_" "{path}" (global $path (ref extern)))
+                    (import "_" "not bytes" (global $not_bytes (ref extern)))
+                    (import "__moonbit_fs_unstable" "write_bytes_to_file"
+                        (func $write (param externref externref)))
+                    (func (export "_start")
+                        global.get $path
+                        global.get $not_bytes
+                        call $write))"#,
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+
+    let error = engine
+        .run(&module, moonrun::RunOptions::default())
+        .unwrap_err();
+    assert!(
+        format!("{error:#}").contains("unexpected externref host value"),
+        "{error:#}"
+    );
+    assert!(!output.exists());
+}
+
+#[cfg(all(feature = "wasmtime", not(feature = "v8")))]
+#[test]
+fn wasmtime_authorizes_before_reading_byte_handles() {
+    let directory = tempfile::tempdir().unwrap();
+    let policy = directory.path().join("policy.toml");
+    std::fs::write(&policy, "").unwrap();
+    let wasm = directory.path().join("denied-invalid-byte-handle.wasm");
+    std::fs::write(
+        &wasm,
+        wat::parse_str(
+            r#"(module
+                (import "_" "denied.bin" (global $path (ref extern)))
+                (import "_" "not bytes" (global $not_bytes (ref extern)))
+                (import "__moonbit_fs_unstable" "write_bytes_to_file_new"
+                    (func $write (param externref externref) (result i32)))
+                (import "__moonbit_fs_unstable" "get_error_message"
+                    (func $get_error_message (result externref)))
+                (import "console" "log" (func $log (param (ref extern))))
+                (func (export "_start")
+                    global.get $path
+                    global.get $not_bytes
+                    call $write
+                    drop
+                    call $get_error_message
+                    ref.as_non_null
+                    call $log))"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(&wasm)
+        .arg("--policy")
+        .arg(policy)
+        .assert()
+        .success()
+        .stdout_eq("Permission denied: denied.bin\n")
+        .stderr_eq("Sandbox policy blocked file write: \"denied.bin\"\n");
 }
 
 #[cfg(all(feature = "wasmtime", not(feature = "v8")))]

--- a/crates/moonrun/tests/engine_outcomes.rs
+++ b/crates/moonrun/tests/engine_outcomes.rs
@@ -16,8 +16,6 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-#![cfg(feature = "v8")]
-
 fn compile(name: &str, source: &str) -> (moonrun::Engine, moonrun::Module) {
     let engine = moonrun::Engine::default();
     let module = engine
@@ -27,7 +25,7 @@ fn compile(name: &str, source: &str) -> (moonrun::Engine, moonrun::Module) {
 }
 
 #[test]
-fn v8_classifies_uncaught_wasm_failures_as_guest_failures() {
+fn engine_backend_classifies_uncaught_wasm_failures_as_guest_failures() {
     let cases = [
         (
             "module-start-trap.wasm",
@@ -82,7 +80,7 @@ fn v8_classifies_uncaught_wasm_failures_as_guest_failures() {
 }
 
 #[test]
-fn v8_keeps_handled_test_failures_inside_the_test_driver() {
+fn engine_backend_keeps_handled_test_failures_inside_the_test_driver() {
     let (engine, module) = compile(
         "test-execute-trap.wasm",
         r#"(module
@@ -106,7 +104,7 @@ fn v8_keeps_handled_test_failures_inside_the_test_driver() {
 }
 
 #[test]
-fn v8_preserves_explicit_run_termination() {
+fn engine_backend_preserves_explicit_run_termination() {
     let (engine, module) = compile(
         "exit.wasm",
         r#"(module
@@ -121,7 +119,7 @@ fn v8_preserves_explicit_run_termination() {
 }
 
 #[test]
-fn v8_preserves_instantiation_link_errors() {
+fn engine_backend_preserves_instantiation_link_errors() {
     let (engine, module) = compile(
         "missing-import.wasm",
         r#"(module
@@ -134,13 +132,14 @@ fn v8_preserves_instantiation_link_errors() {
     let error = format!("{error:#}");
     assert!(
         error.contains("failed to instantiate `missing-import.wasm`")
-            && error.contains("LinkError"),
+            && error.contains("__moonbit_sys_unstable")
+            && error.contains("missing"),
         "{error}"
     );
 }
 
 #[test]
-fn v8_preserves_host_adapter_errors() {
+fn engine_backend_preserves_host_adapter_errors() {
     let cases = [
         (
             "module-start-host-error.wasm",

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -268,11 +268,24 @@ fn test_moonrun_wasm_stack_trace_in_test_blocks() {
     let redactions = moon_test_util::stack_trace::stack_trace_redactions(dir.as_ref());
     let assert = snapbox::Assert::new().redact_with(redactions);
 
-    moon_test_case(&dir, &["--filter", "stacktrace test abort closure"])
-        .with_assert(assert.clone())
-        .assert()
-        .failure()
-        .stdout_eq(snapbox::str![[r#"
+    let abort_closure_output = if cfg!(feature = "wasmtime") {
+        snapbox::str![[r#"
+[username/hello] test main/main.mbt:[..] ("stacktrace test abort closure") failed: Error
+    at @moonbitlang/core/abort.abort[Int] [..]/abort/abort.mbt[LINE_NUMBER]
+    at @username/hello/main.abort_via_closure.inner[stamp=[..]] [..]/main/main.mbt[LINE_NUMBER]
+    at @username/hello/main.abort_via_closure [..]/main/main.mbt[LINE_NUMBER]
+    at @username/hello/main.__test_6d61696e2e6d6274_2 [..]/main/main.mbt[LINE_NUMBER]
+    at @username/hello/main.__test_6d61696e2e6d6274_2.dyncall
+    at @username/hello/main.moonbit_test_driver_internal_catch_error [..]/main/__generated_driver_for_internal_test.mbt[LINE_NUMBER]
+    at impl @username/hello/main.MoonBit_Test_Driver for @username/hello/main.MoonBit_Test_Driver_Internal_No_Args with run_test [..]/main/__generated_driver_for_internal_test.mbt[LINE_NUMBER]
+    at @username/hello/main.moonbit_test_driver_internal_do_execute [..]/main/__generated_driver_for_internal_test.mbt[LINE_NUMBER]
+    at @username/hello/main.moonbit_test_driver_internal_execute [..]/main/__generated_driver_for_internal_test.mbt[LINE_NUMBER]
+    at @username/hello/main.moonbit_test_driver_internal_execute_wrapper/[..] [..]/main/__generated_driver_for_internal_test.mbt[LINE_NUMBER]
+Total tests: 1, passed: 0, failed: 1.
+
+"#]]
+    } else {
+        snapbox::str![[r#"
 [username/hello] test main/main.mbt:[..] ("stacktrace test abort closure") failed: Error
     at @moonbitlang/core/abort.abort[Int] [..]/abort/abort.mbt[LINE_NUMBER]
     at @username/hello/main.abort_via_closure.inner[stamp=[..]] [..]/main/main.mbt[LINE_NUMBER]
@@ -285,7 +298,13 @@ fn test_moonrun_wasm_stack_trace_in_test_blocks() {
     at @username/hello/main.moonbit_test_driver_internal_execute [..]/main/__generated_driver_for_internal_test.mbt[LINE_NUMBER]
 Total tests: 1, passed: 0, failed: 1.
 
-"#]]);
+"#]]
+    };
+    moon_test_case(&dir, &["--filter", "stacktrace test abort closure"])
+        .with_assert(assert.clone())
+        .assert()
+        .failure()
+        .stdout_eq(abort_closure_output);
 
     moon_test_case(&dir, &["main/main.mbt", "--index", "1"])
         .with_assert(assert.clone())
@@ -471,6 +490,257 @@ fn moonrun_library_compiles_modules_when_loading() {
         .unwrap_err();
 
     assert!(format!("{error:#}").contains("failed to compile"));
+}
+
+#[test]
+fn engine_backends_run_both_wasm_profiles_and_js_strings() {
+    let dir = TestDir::new("test_engine_backend.in");
+
+    for target in ["wasm", "wasm-gc"] {
+        moon_cmd()
+            .current_dir(&dir)
+            .args(["build", "--target", target])
+            .assert()
+            .success();
+    }
+    moon_cmd()
+        .current_dir(&dir)
+        .args(["test", "js_string", "--target", "wasm-gc", "--build-only"])
+        .assert()
+        .success();
+
+    let engine = moonrun::Engine::default();
+    let plain_wasm = dir.join("_build/wasm/debug/build/plain/plain.wasm");
+    let plain_module = engine.load_file(&plain_wasm).unwrap();
+    std::fs::remove_file(plain_wasm).unwrap();
+    assert_eq!(
+        engine
+            .run(&plain_module, moonrun::RunOptions::default())
+            .unwrap(),
+        moonrun::RunOutcome::Completed
+    );
+    assert_eq!(
+        engine
+            .run(&plain_module, moonrun::RunOptions::default())
+            .unwrap(),
+        moonrun::RunOutcome::Completed
+    );
+
+    let exit_wasm = dir.join("_build/wasm-gc/debug/build/exit/exit.wasm");
+    assert_eq!(
+        engine
+            .run_file(&exit_wasm, moonrun::RunOptions::default())
+            .unwrap(),
+        moonrun::RunOutcome::Exited(7)
+    );
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(dir.join("_build/wasm-gc/debug/build/js_string/js_string.wasm"))
+        .assert()
+        .success()
+        .stdout_eq("hello from imported constants\n11\nfalse\n")
+        .stderr_eq("");
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(dir.join("_build/wasm-gc/debug/build/time/time.wasm"))
+        .assert()
+        .success()
+        .stdout_eq("true\ntrue\n")
+        .stderr_eq("");
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg("--test-args")
+        .arg(
+            r#"{"package":"moon/engine_backend/js_string","file_and_index":[["main_wbtest.mbt",[{"start":0,"end":1}]]]}"#,
+        )
+        .arg(dir.join(
+            "_build/wasm-gc/debug/test/js_string/js_string.whitebox_test.wasm",
+        ))
+        .assert()
+        .success()
+        .stdout_eq(concat!(
+            "----- BEGIN MOON TEST RESULT -----\n",
+            r#"{"type":"start","file":"main_wbtest.mbt","index":0}"#,
+            "\n----- END MOON TEST RESULT -----\n",
+            "----- BEGIN MOON TEST RESULT -----\n",
+            r#"{"type":"result","file":"main_wbtest.mbt","index":0,"message":""}"#,
+            "\n----- END MOON TEST RESULT -----\n",
+        ))
+        .stderr_eq("");
+}
+
+#[test]
+fn engine_backends_run_compiler_generated_ffi_bytes() {
+    let dir = TestDir::new("test_engine_backend.in");
+
+    moon_cmd()
+        .current_dir(&dir)
+        .env("MOONC_INTERNAL_PARAMS", "use_ffi_bytes=1|")
+        .args(["build", "ffi_bytes", "--target", "wasm-gc"])
+        .assert()
+        .success();
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(dir.join("_build/wasm-gc/debug/build/ffi_bytes/ffi_bytes.wasm"))
+        .assert()
+        .success()
+        .stdout_eq("A\n")
+        .stderr_eq("");
+}
+
+#[test]
+fn engine_backends_share_the_sqlite_wasm_adapter() {
+    let wasm = wat::parse_str(
+        r#"(module
+            (import "moonbitlang/sqlite" "sqlite3_null_handle"
+                (func $null_handle (result i64)))
+            (import "moonbitlang/sqlite" "sqlite3_open_v2"
+                (func $open (param i32 i32 i32 i32 i64) (result i32)))
+            (import "moonbitlang/sqlite" "sqlite3_close"
+                (func $close (param i64) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 16) ":memory:")
+            (func (export "_start") (local $null i64)
+                call $null_handle
+                local.set $null
+                i32.const 16
+                i32.const 8
+                i32.const 8
+                i32.const 6
+                local.get $null
+                call $open
+                if unreachable end
+                i32.const 8
+                i64.load
+                call $close
+                if unreachable end))"#,
+    )
+    .unwrap();
+    let engine = moonrun::Engine::default();
+    let module = engine.compile("sqlite-adapter.wasm", wasm).unwrap();
+
+    assert_eq!(
+        engine.run(&module, moonrun::RunOptions::default()).unwrap(),
+        moonrun::RunOutcome::Completed
+    );
+}
+
+#[test]
+fn engine_backends_share_the_js_byte_adapter() {
+    let wasm = wat::parse_str(
+        r#"(module
+            (import "ffi-bytes" "memory" (memory 1))
+            (import "ffi-bytes" "new"
+                (func $new (param i32) (result (ref extern))))
+            (import "ffi-bytes" "set"
+                (func $set (param externref i32 i32)))
+            (import "ffi-bytes" "get"
+                (func $get (param externref i32) (result i32)))
+            (import "ffi-bytes" "length"
+                (func $length (param externref) (result i32)))
+            (import "ffi-bytes" "asString"
+                (func $as_string (param externref i32 i32) (result (ref extern))))
+            (func (export "_start") (local $bytes externref)
+                i32.const 4
+                call $new
+                local.set $bytes
+                local.get $bytes i32.const 0 i32.const 300 call $set
+                local.get $bytes i32.const 0 call $get
+                i32.const 44
+                i32.ne
+                if unreachable end
+                local.get $bytes i32.const 0 i32.const 65 call $set
+                local.get $bytes i32.const 1 i32.const 0 call $set
+                local.get $bytes i32.const 2 i32.const 66 call $set
+                local.get $bytes i32.const 3 i32.const 0 call $set
+                local.get $bytes
+                call $length
+                i32.const 4
+                i32.ne
+                if unreachable end
+                local.get $bytes
+                i32.const 0
+                i32.const 4
+                call $as_string
+                drop))"#,
+    )
+    .unwrap();
+    let wasm_file = tempfile::Builder::new()
+        .prefix("ffi-bytes.")
+        .suffix(".wasm")
+        .tempfile()
+        .unwrap();
+    std::fs::write(wasm_file.path(), wasm).unwrap();
+    let output = snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("moonrun"))
+        .arg(wasm_file.path())
+        .assert()
+        .success();
+
+    output.stdout_eq("");
+}
+
+#[test]
+fn engine_backends_share_the_memory_sanitizer_adapter() {
+    let wasm = wat::parse_str(
+        r#"(module
+            (import "moonbit:ffi/memory-sanitizer" "register-object-alloc"
+                (func $alloc (param i32 i32)))
+            (import "moonbit:ffi/memory-sanitizer" "register-object-free"
+                (func $free (param i32)))
+            (import "moonbit:ffi/memory-sanitizer" "object-is-valid"
+                (func $valid (param i32) (result i32)))
+            (func (export "_start")
+                i32.const 16
+                i32.const 32
+                call $alloc
+                i32.const 32
+                call $valid
+                i32.eqz
+                if unreachable end
+                i32.const 32
+                call $free
+                i32.const 32
+                call $valid
+                if unreachable end))"#,
+    )
+    .unwrap();
+    let engine = moonrun::Engine::default();
+    let module = engine
+        .compile("memory-sanitizer-adapter.wasm", wasm)
+        .unwrap();
+
+    assert_eq!(
+        engine.run(&module, moonrun::RunOptions::default()).unwrap(),
+        moonrun::RunOutcome::Completed
+    );
+}
+
+#[test]
+fn engine_backends_share_the_async_host_adapter() {
+    let wasm = wat::parse_str(
+        r#"(module
+            (import "moonbitlang/async" "time/get_ms_since_epoch"
+                (func $now (result i64)))
+            (import "moonbitlang/async" "random/fill"
+                (func $random_fill (param i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (func (export "_start")
+                call $now
+                i64.eqz
+                if unreachable end
+                i32.const 16
+                i32.const 32
+                call $random_fill
+                if unreachable end))"#,
+    )
+    .unwrap();
+    let engine = moonrun::Engine::default();
+    let module = engine.compile("async-adapter.wasm", wasm).unwrap();
+
+    assert_eq!(
+        engine.run(&module, moonrun::RunOptions::default()).unwrap(),
+        moonrun::RunOutcome::Completed
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/exit/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/exit/main.mbt
@@ -1,0 +1,23 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+fn exit_with_code(code : Int) = "__moonbit_sys_unstable" "exit"
+
+fn main {
+  exit_with_code(7)
+}

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/exit/moon.pkg.json
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/exit/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/ffi_bytes/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/ffi_bytes/main.mbt
@@ -1,0 +1,22 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+fn main {
+  let bytes = Bytes::from_array([65, 0, 66])
+  println(bytes.to_unchecked_string())
+}

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/ffi_bytes/moon.pkg.json
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/ffi_bytes/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/js_string/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/js_string/main.mbt
@@ -1,0 +1,25 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+fn main {
+  let left = "hello from "
+  let right = "imported constants"
+  println(left + right)
+  println(left.length())
+  println(left == right)
+}

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/js_string/main_wbtest.mbt
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/js_string/main_wbtest.mbt
@@ -1,0 +1,19 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+test "wasmtime test driver" {}

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/js_string/moon.pkg.json
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/js_string/moon.pkg.json
@@ -1,0 +1,9 @@
+{
+  "is-main": true,
+  "link": {
+    "wasm-gc": {
+      "use-js-builtin-string": true,
+      "imported-string-constants": "_"
+    }
+  }
+}

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/moon.mod.json
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/moon.mod.json
@@ -1,0 +1,3 @@
+{
+  "name": "moon/engine_backend"
+}

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/plain/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/plain/main.mbt
@@ -1,0 +1,19 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+fn main {}

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/plain/moon.pkg.json
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/plain/moon.pkg.json
@@ -1,0 +1,3 @@
+{
+  "is-main": true
+}

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/time/main.mbt
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/time/main.mbt
@@ -1,0 +1,23 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+fn main {
+  println(@env.now() > 0)
+  let start = @bench.monotonic_clock_start()
+  println(@bench.monotonic_clock_end(start) >= 0.0)
+}

--- a/crates/moonrun/tests/test_cases/test_engine_backend.in/time/moon.pkg.json
+++ b/crates/moonrun/tests/test_cases/test_engine_backend.in/time/moon.pkg.json
@@ -1,0 +1,7 @@
+{
+  "is-main": true,
+  "import": [
+    "moonbitlang/core/bench",
+    "moonbitlang/core/env"
+  ]
+}

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -9,12 +9,16 @@ This runs:
 - `cargo run --bin moon -- -C crates/moonbuild/template/test_driver_project check`
 - `cargo run --bin moon -- -C crates/moonbuild/template/test_driver_project fmt --check`
 - `cargo fmt -- --check`
-- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo clippy --workspace --exclude moonrun --all-targets --all-features -- -D warnings`
+- `cargo clippy -p moonrun --all-targets -- -D warnings`
+- `cargo clippy -p moonrun --all-targets --no-default-features --features wasmtime -- -D warnings`
 
 If any check fails, `xtask` prints plain copy-paste commands, for example:
 
 - `cargo run --bin moon -- -C crates/moonbuild/template/test_driver_project fmt`
-- `cargo clippy --fix --all-targets --all-features --allow-dirty --allow-staged`
+- `cargo clippy --fix --workspace --exclude moonrun --all-targets --all-features --allow-dirty --allow-staged`
+- `cargo clippy --fix -p moonrun --all-targets --allow-dirty --allow-staged`
+- `cargo clippy --fix -p moonrun --all-targets --no-default-features --features wasmtime --allow-dirty --allow-staged`
 - `cargo fmt`
 
 `xtask ci` does not fail fast; it runs all checks and reports all failures at the end.

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -66,11 +66,14 @@ pub(crate) fn run(_ci: &Ci) -> anyhow::Result<()> {
             fix_script: Some("cargo fmt"),
         },
         Check {
-            label: "cargo clippy --all-targets --all-features -- -D warnings",
+            label: "cargo clippy --workspace --exclude moonrun --all-targets --all-features -- -D warnings",
             command: Command {
                 program: "cargo",
                 args: &[
                     "clippy",
+                    "--workspace",
+                    "--exclude",
+                    "moonrun",
                     "--all-targets",
                     "--all-features",
                     "--",
@@ -79,7 +82,46 @@ pub(crate) fn run(_ci: &Ci) -> anyhow::Result<()> {
                 ],
             },
             fix_script: Some(
-                "cargo clippy --fix --all-targets --all-features --allow-dirty --allow-staged",
+                "cargo clippy --fix --workspace --exclude moonrun --all-targets --all-features --allow-dirty --allow-staged",
+            ),
+        },
+        Check {
+            label: "cargo clippy -p moonrun --all-targets -- -D warnings",
+            command: Command {
+                program: "cargo",
+                args: &[
+                    "clippy",
+                    "-p",
+                    "moonrun",
+                    "--all-targets",
+                    "--",
+                    "-D",
+                    "warnings",
+                ],
+            },
+            fix_script: Some(
+                "cargo clippy --fix -p moonrun --all-targets --allow-dirty --allow-staged",
+            ),
+        },
+        Check {
+            label: "cargo clippy -p moonrun --all-targets --no-default-features --features wasmtime -- -D warnings",
+            command: Command {
+                program: "cargo",
+                args: &[
+                    "clippy",
+                    "-p",
+                    "moonrun",
+                    "--all-targets",
+                    "--no-default-features",
+                    "--features",
+                    "wasmtime",
+                    "--",
+                    "-D",
+                    "warnings",
+                ],
+            },
+            fix_script: Some(
+                "cargo clippy --fix -p moonrun --all-targets --no-default-features --features wasmtime --allow-dirty --allow-staged",
             ),
         },
     ];


### PR DESCRIPTION
## Depends on

- #2152

## Why

The Wasmtime engine core can execute simple modules, but compiler-generated MoonBit programs depend on Moonrun host adapters for filesystem and environment access, I/O, random and time, ffi-bytes, async operations, SQLite, memory-sanitizer diagnostics, and the test driver.

## What

- Connect Wasmtime to the existing Runtime host domains and shared WASIp1 operations.
- Register the portable async and SQLite Wasm ABIs through typed Wasmtime functions.
- Preserve guest-failure, host-error, termination, source-map, and test-driver behavior.
- Run compiler-generated wasm and wasm-gc fixtures plus async, SQLite, byte, sanitizer, and termination coverage under both engines.
- Add dedicated feature-only Wasmtime CI while retaining V8 as the shipping default.

## Why this is correct

Wasmtime exercises the same host-domain implementations and fixed Wasm ABIs as V8. Guest traps and exceptions remain guest outcomes, explicit termination remains scoped to the run, and host-adapter failures retain direct diagnostics and guest Wasm frames.

## Scope

After #2152, this PR is one Wasmtime implementation commit. It introduces no runtime selector, does not change the default engine, and does not add wasmtime-wasi.