### PR TITLE
fix: support standalone .mbtx in build and check

### DIFF
--- a/crates/moon/src/cli.rs
+++ b/crates/moon/src/cli.rs
@@ -90,6 +90,24 @@ pub(crate) use version::*;
 pub(crate) use whoami::*;
 pub(crate) use work::{WorkSubcommand, work_cli};
 
+fn standalone_mbtx_path<'a>(
+    paths: &'a [std::path::PathBuf],
+    command: &str,
+) -> anyhow::Result<Option<&'a std::path::Path>> {
+    let Some(path) = paths.iter().find(|path| {
+        path.extension()
+            .is_some_and(|extension| extension == "mbtx")
+    }) else {
+        return Ok(None);
+    };
+
+    anyhow::ensure!(
+        paths.len() == 1,
+        "standalone `.mbtx` `{command}` expects exactly one `PATH`"
+    );
+    Ok(Some(path))
+}
+
 #[derive(Debug, clap::Parser)]
 #[clap(
     name = "moon",

--- a/crates/moon/src/cli/build.rs
+++ b/crates/moon/src/cli/build.rs
@@ -20,6 +20,7 @@ use anyhow::Context;
 use moonbuild_rupes_recta::intent::UserIntent;
 use moonbuild_rupes_recta::model::PackageId;
 use moonutil::build_options::RunMode;
+use moonutil::cache::{CacheKind, resolve_cache_root};
 use moonutil::cli_support::AutoSyncFlags;
 use moonutil::command_output::CommandOutput;
 use moonutil::locks::lock_directory;
@@ -62,7 +63,7 @@ impl ResolvedBuildSelection {
 /// Build the current package
 #[derive(Debug, clap::Parser, Clone)]
 pub(crate) struct BuildSubcommand {
-    /// Paths to the packages that should be built.
+    /// Paths to the packages that should be built, or one standalone `.mbtx` file.
     #[clap(name = "PATH", conflicts_with("package"))]
     pub path: Vec<PathBuf>,
 
@@ -87,6 +88,23 @@ pub(crate) fn run_build(
     cmd: BuildSubcommand,
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
+    let targets = lower_surface_targets(&cmd.build_flags.target);
+    if let Some(path) = super::standalone_mbtx_path(&cmd.path, "moon build")? {
+        anyhow::ensure!(
+            !cmd.watch,
+            "standalone `.mbtx` `moon build` does not support `--watch`"
+        );
+        let single_file = cli.source_tgt_dir.single_file_package_dirs(path)?;
+        return run_build_for_single_file_rr(
+            cli,
+            &cmd,
+            &single_file.file_path,
+            &single_file.package_dirs,
+            &targets,
+            output,
+        );
+    }
+
     let dirs = cli
         .source_tgt_dir
         .query(cli.workspace_env.clone())?
@@ -96,9 +114,6 @@ pub(crate) fn run_build(
     if cmd.build_flags.target.is_empty() {
         return run_build_internal(cli, &cmd, &dirs, None, output);
     }
-    let surface_targets = cmd.build_flags.target.clone();
-    let targets = lower_surface_targets(&surface_targets);
-
     // Watch reruns must synchronize and resolve fresh project state each time.
     if cmd.watch {
         let mut ret_value = 0;
@@ -122,6 +137,119 @@ pub(crate) fn run_build(
                 _ => format!("failed to run build for targets {targets:?}"),
             })?;
     Ok(if result.ok { 0 } else { 1 })
+}
+
+/// Resolve one standalone `.mbtx` input and build it for every selected Target Backend.
+#[allow(clippy::too_many_arguments)]
+fn run_build_for_single_file_rr(
+    cli: &UniversalFlags,
+    cmd: &BuildSubcommand,
+    single_file_path: &Path,
+    dirs: &PackageDirs,
+    selected_target_backends: &[TargetBackend],
+    output: &CommandOutput,
+) -> anyhow::Result<i32> {
+    let user_log = output.user_log();
+    let PackageDirs {
+        source_dir,
+        target_dir,
+        mooncake_bin_dir,
+        ..
+    } = dirs;
+    std::fs::create_dir_all(target_dir).context("failed to create target directory")?;
+
+    let resolve_config = moonbuild_rupes_recta::ResolveConfig::new(
+        cmd.auto_sync_flags.clone(),
+        !cmd.build_flags.std(),
+        cmd.build_flags.enable_coverage,
+        cli.workspace_env.clone(),
+    )
+    .with_dependency_source_cache(
+        resolve_cache_root(CacheKind::DependencySources)
+            .context("Failed to resolve the module dependency graph")?,
+    );
+    let (resolved, backend) = moonbuild_rupes_recta::resolve::resolve_single_file_project(
+        &resolve_config,
+        dirs,
+        single_file_path,
+        true,
+        user_log,
+    )?;
+    let target_backends = if selected_target_backends.is_empty() {
+        vec![cmd.build_flags.resolve_single_target_backend()?.or(backend)]
+    } else {
+        selected_target_backends.iter().copied().map(Some).collect()
+    };
+
+    let _lock;
+    if !cli.dry_run {
+        _lock = lock_directory(target_dir, user_log)?;
+    }
+
+    let package = rr_build::local_packages(&resolved)
+        .next()
+        .context("single-file project must resolve exactly one local package")?;
+    let mut planned_runs = Vec::with_capacity(target_backends.len());
+    for target_backend in target_backends {
+        let preconfig = preconfig_compile(
+            &cmd.auto_sync_flags,
+            cli,
+            &cmd.build_flags,
+            target_backend,
+            target_dir,
+            RunMode::Build,
+        );
+        let planning_context = rr_build::prepare_resolved_build(
+            &preconfig,
+            &cli.unstable_feature,
+            target_dir,
+            user_log,
+            &resolved,
+        )?;
+        planned_runs.push(rr_build::plan_resolved_standalone_build_from_intent(
+            preconfig,
+            &cli.unstable_feature,
+            user_log,
+            planning_context,
+            vec![UserIntent::Build(package)].into(),
+            package,
+            mooncake_bin_dir,
+            resolved.clone(),
+        )?);
+    }
+
+    let ok = if cli.dry_run {
+        output.write_result(|writer| {
+            let (build_metas, build_inputs): (Vec<_>, Vec<_>) = planned_runs.into_iter().unzip();
+            let build_input = rr_build::compose_standalone_build_inputs(build_inputs)
+                .map_err(std::io::Error::other)?;
+            rr_build::write_standalone_dry_run(
+                writer,
+                &build_input,
+                build_metas.iter().flat_map(|meta| meta.artifacts.values()),
+                source_dir,
+                target_dir,
+            )?;
+            Ok::<_, std::io::Error>(())
+        })?;
+        true
+    } else {
+        for (build_meta, _) in &planned_runs {
+            rr_build::generate_all_pkgs_json(build_meta)?;
+        }
+        let build_input = rr_build::compose_standalone_build_inputs(
+            planned_runs
+                .into_iter()
+                .map(|(_, build_input)| build_input)
+                .collect(),
+        )?;
+        let config = BuildConfig::from_flags(&cmd.build_flags, &cli.unstable_feature, cli.verbose);
+        let result =
+            rr_build::execute_standalone_build(&config, build_input, target_dir, user_log)?;
+        result.print_info(cli.quiet, "building")?;
+        result.successful()
+    };
+    Ok(if ok { 0 } else { 1 })
 }
 
 #[instrument(skip_all)]

--- a/crates/moon/src/cli/check.rs
+++ b/crates/moon/src/cli/check.rs
@@ -279,7 +279,7 @@ pub(crate) struct CheckSubcommand {
     #[clap(long)]
     pub explain: bool,
 
-    /// Filesystem path to a package directory or `.mbt` / `.mbt.md` file
+    /// Filesystem path to a package directory, `.mbt` / `.mbt.md` selector, or standalone `.mbtx` file
     #[clap(conflicts_with = "watch", name = "PATH", group = "package_selector")]
     pub path: Vec<PathBuf>,
 
@@ -415,16 +415,20 @@ fn run_check_impl(
         }
     }
 
-    // Check if we're running within a project
-    let query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
-    let (mut dirs, single_file) = match query.probe_project()? {
-        ProjectProbe::Found(_) => {
-            let dirs = query.select(user_log)?.package_dirs()?;
-            (dirs, None)
-        }
-        ProjectProbe::NotFound(not_found) => {
-            // Now we're talking about real single-file scenario.
-            match cmd.path.as_slice() {
+    let (mut dirs, single_file) = if let Some(path) =
+        super::standalone_mbtx_path(&cmd.path, "moon check")?
+    {
+        let single_file = cli.source_tgt_dir.single_file_package_dirs(path)?;
+        (single_file.package_dirs, Some(single_file.file_path))
+    } else {
+        // Check if we're running within a project.
+        let query = cli.source_tgt_dir.query(cli.workspace_env.clone())?;
+        match query.probe_project()? {
+            ProjectProbe::Found(_) => {
+                let dirs = query.select(user_log)?.package_dirs()?;
+                (dirs, None)
+            }
+            ProjectProbe::NotFound(not_found) => match cmd.path.as_slice() {
                 [path] => {
                     let single_file = cli.source_tgt_dir.single_file_package_dirs(path)?;
                     (single_file.package_dirs, Some(single_file.file_path))
@@ -433,7 +437,7 @@ fn run_check_impl(
                 _ => {
                     anyhow::bail!("standalone single-file `moon check` expects exactly one `PATH`");
                 }
-            }
+            },
         }
     };
     let watch_ignored_subtree = dirs.target_dir.clone();

--- a/crates/moon/src/rr_build/mod.rs
+++ b/crates/moon/src/rr_build/mod.rs
@@ -681,7 +681,7 @@ pub(crate) fn plan_resolved_build_from_intent(
 /// Plan dependency-package and synthesized script-package work independently.
 ///
 /// This entry point is intentionally used only by standalone `.mbt`/`.mbtx`
-/// execution. Normal workspace commands continue through
+/// builds. Normal workspace commands continue through
 /// [`plan_resolved_build_from_intent`].
 #[allow(clippy::too_many_arguments)]
 #[instrument(level = Level::DEBUG, skip_all)]
@@ -1071,7 +1071,7 @@ pub struct BuildInput {
     db_path: PathBuf,
 }
 
-/// Dependency-package and script-package inputs for standalone execution.
+/// Dependency-package and script-package inputs for a standalone build.
 ///
 /// Keeping this orchestration outside [`BuildInput`] lets ordinary workspace
 /// execution remain a single-graph operation.
@@ -1079,6 +1079,24 @@ pub struct BuildInput {
 pub struct StandaloneBuildInput {
     dependencies: Option<BuildInput>,
     script: BuildInput,
+}
+
+impl StandaloneBuildInput {
+    fn compose(inputs: Vec<Self>) -> anyhow::Result<Self> {
+        let mut dependencies = Vec::new();
+        let mut scripts = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            dependencies.extend(input.dependencies);
+            scripts.push(input.script);
+        }
+
+        Ok(Self {
+            dependencies: (!dependencies.is_empty())
+                .then(|| BuildInput::compose(dependencies))
+                .transpose()?,
+            script: BuildInput::compose(scripts)?,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -1173,6 +1191,12 @@ struct N2ExecutionInput {
 
 pub(crate) fn compose_build_inputs(inputs: Vec<BuildInput>) -> anyhow::Result<BuildInput> {
     BuildInput::compose(inputs)
+}
+
+pub(crate) fn compose_standalone_build_inputs(
+    inputs: Vec<StandaloneBuildInput>,
+) -> anyhow::Result<StandaloneBuildInput> {
+    StandaloneBuildInput::compose(inputs)
 }
 
 struct CapturedBuildExecution {

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -71,6 +71,79 @@ fn test_single_file_mbtx_check() {
 }
 
 #[test]
+fn test_single_file_mbtx_build() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let stdout = get_stdout(&dir, ["build", "moonx_args.mbtx", "--dry-run"]);
+
+    assert!(stdout.contains("moonx_args.mbtx"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("-ignore-import-declaration"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("moonc link-core"), "stdout: {stdout}");
+    assert!(stdout.contains("_build/wasm/"), "stdout: {stdout}");
+    assert!(!stdout.contains("moonrun"), "stdout: {stdout}");
+}
+
+#[test]
+fn test_single_file_mbtx_build_accepts_multiple_targets() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let _ = get_stdout(&dir, ["build", "moonx_args.mbtx", "--target", "wasm,js"]);
+
+    assert!(
+        dir.join("_build/wasm/debug/build/single/single.wasm")
+            .is_file()
+    );
+    assert!(dir.join("_build/js/debug/build/single/single.js").is_file());
+}
+
+#[test]
+fn test_project_mbtx_builds_standalone_input() {
+    let dir = TestDir::new("test_filter/test_filter");
+    fs::write(
+        dir.join("A/script.mbtx"),
+        r#"fn main {
+  println("hello")
+}
+"#,
+    )
+    .unwrap();
+
+    let stdout = get_stdout(
+        &dir,
+        ["build", "A/script.mbtx", "--target", "wasm", "--dry-run"],
+    );
+
+    assert!(stdout.contains("script.mbtx"), "stdout: {stdout}");
+    assert!(!stdout.contains("hello.mbt"), "stdout: {stdout}");
+}
+
+#[test]
+fn test_project_mbtx_check_uses_standalone_input() {
+    let dir = TestDir::new("test_filter/test_filter");
+    fs::write(
+        dir.join("A/script.mbtx"),
+        r#"fn main {
+  println("hello")
+}
+"#,
+    )
+    .unwrap();
+
+    moon_cmd(&dir)
+        .args(["check", "A/script.mbtx", "--target", "wasm"])
+        .assert()
+        .success();
+
+    let metadata =
+        standalone_scoped_packages_json_path(dir.join("A"), "wasm", "debug", "script.mbtx");
+    assert!(
+        metadata.is_file(),
+        "standalone check should publish file-scoped package metadata"
+    );
+}
+
+#[test]
 fn test_single_file_mbtx_run_does_not_warn_about_supported_targets() {
     let dir = TestDir::new("moon_test_single_file.in");
     let stderr = get_stderr(&dir, ["run", "import_ok.mbtx"]);

--- a/docs/dev/reference/arch.md
+++ b/docs/dev/reference/arch.md
@@ -311,6 +311,11 @@ The concrete declaration of the synthesized module/package is out of scope for t
 please consult the relevant code for the actual implementation.
 Subcommands that do not support single-file mode simply fails with an error.
 
+An explicit `.mbtx` path selects single-file mode for `moon build` and
+`moon check` even when the path is inside an ordinary package. The `.mbtx`
+file is therefore the synthetic package's source; it is not interpreted as a
+selector for the containing package.
+
 ## Module dependency management
 
 There are two types of dependencies in a module.

--- a/docs/dev/reference/build-plan-artifact-dependencies.md
+++ b/docs/dev/reference/build-plan-artifact-dependencies.md
@@ -332,13 +332,16 @@ consume `ExecutionPlan` directly: each input path resolves to its declared
 output and producer action, while requested artifacts and physical-only outputs
 retain the distinct root semantics that n2 otherwise flattens into file IDs.
 
-## Standalone script boundary
+## Standalone build boundary
 
-Standalone `.mbt` and `.mbtx` execution starts from one complete `BuildPlan`
-and lowers it once into one `ExecutionPlan`. Dependency preparation and script
-execution are two `ActionId` selections over that plan. Following artifact
+Standalone `.mbt` and `.mbtx` execution, and standalone `.mbtx` compilation
+through `moon build`, start from one complete `BuildPlan` per Target Backend
+and lower it once into one `ExecutionPlan`. Dependency preparation and script
+compilation are two `ActionId` selections over that plan. Following artifact
 providers to a fixed point includes package-less prerequisites such as the
-runtime library and runtime objects.
+runtime library and runtime objects. Multi-backend standalone builds compose
+dependency selections separately from script selections so the phase ordering
+remains explicit.
 
 The dependency graph executes first, followed by the script graph. Both use the
 target directory's `.moon_db`; n2 ignores records whose outputs do not belong

--- a/docs/dev/reference/build.md
+++ b/docs/dev/reference/build.md
@@ -33,6 +33,11 @@ original `.mbtx` input is kept as a regular, unconditional source file. Both
 when lowering that synthetic package. This does not make `.mbtx` a source
 extension discovered in ordinary packages.
 
+`moon build <file.mbtx>` and `moon check <file.mbtx>` always select this
+standalone representation, even when the file is located under an ordinary
+package root. Each command accepts one standalone `.mbtx` path and supports
+single- and multi-backend target selection; watch mode remains project-only.
+
 ### Build targets
 
 Source files may also be conditionally included into the build --

--- a/docs/manual-zh/src/commands.md
+++ b/docs/manual-zh/src/commands.md
@@ -108,7 +108,7 @@ Build the current package
 
 ###### **Arguments:**
 
-* `<PATH>` — Paths to the packages that should be built
+* `<PATH>` — Paths to the packages that should be built, or one standalone `.mbtx` file
 
 ###### **Options:**
 
@@ -148,7 +148,7 @@ Check the current package, but don't build object files
 
 ###### **Arguments:**
 
-* `<PATH>` — Filesystem path to a package directory or `.mbt` / `.mbt.md` file
+* `<PATH>` — Filesystem path to a package directory, `.mbt` / `.mbt.md` selector, or standalone `.mbtx` file
 
 ###### **Options:**
 

--- a/docs/manual/src/commands.md
+++ b/docs/manual/src/commands.md
@@ -108,7 +108,7 @@ Build the current package
 
 ###### **Arguments:**
 
-* `<PATH>` — Paths to the packages that should be built
+* `<PATH>` — Paths to the packages that should be built, or one standalone `.mbtx` file
 
 ###### **Options:**
 
@@ -148,7 +148,7 @@ Check the current package, but don't build object files
 
 ###### **Arguments:**
 
-* `<PATH>` — Filesystem path to a package directory or `.mbt` / `.mbt.md` file
+* `<PATH>` — Filesystem path to a package directory, `.mbt` / `.mbt.md` selector, or standalone `.mbtx` file
 
 ###### **Options:**
 


### PR DESCRIPTION
- Related issues: None
- PR kind: Bugfix

## Summary

`moon build <file.mbtx>` previously required project discovery and therefore could not build a standalone `.mbtx` outside a project. Inside a project, both `moon build` and `moon check` interpreted the file path as a selector for its containing package instead of checking or building the file itself.

This change gives both commands the same explicit `.mbtx` routing rule: one `.mbtx` path always resolves as a synthetic single-file package, regardless of whether it is under a Moon project. Standalone builds use the existing Rupes Recta dependency/script phase boundary and compose multi-backend plans without weakening dependency-before-script ordering.

The change is limited to command routing, standalone build orchestration, regression coverage, and the corresponding command/build references. The temporary `moonx` RunCommand adapter is intentionally left for a follow-up that can introduce a semantic standalone-build interface separately.

## Metadata

- [x] Tests added/updated for bug fixes or new features
- [x] Compatible with Windows/Linux/macOS