### PR TITLE
refactor(moonrun): classify V8 run failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
 dependencies = [
  "concolor",
- "unicode-width",
+ "unicode-width 0.1.13",
  "yansi",
 ]
 
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -437,7 +437,7 @@ dependencies = [
  "libc",
  "regex",
  "terminal_size",
- "unicode-width",
+ "unicode-width 0.1.13",
  "winapi",
  "winapi-util",
 ]
@@ -451,7 +451,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "unicode-width",
+ "unicode-width 0.1.13",
  "windows-sys 0.52.0",
 ]
 
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1343,13 +1343,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1473,6 +1474,12 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1701,7 +1708,7 @@ dependencies = [
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
- "unicode-width",
+ "unicode-width 0.1.13",
  "walkdir",
  "which 6.0.2",
  "windows-sys 0.59.0",
@@ -1867,6 +1874,7 @@ dependencies = [
  "toml",
  "v8",
  "vergen",
+ "wat",
  "windows-sys 0.59.0",
 ]
 
@@ -3337,6 +3345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3501,6 +3515,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e974fe6821a8cf64575d51ea2194e2c8f77e7b66e9afe7419ce8a97f9ee0d251"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,6 +3535,39 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
+dependencies = [
+ "bitflags 2.6.0",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wast"
+version = "258.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f7defc7ecca8b19ac7f824598eadd0c53985ee00c74060d65051e9da5b58a1"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width 0.2.2",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7555c008cca87f2ac58d9f83ccda7e7b44611093ce28eb28f052e7c78024b9bf"
+dependencies = [
+ "wast",
 ]
 
 [[package]]

--- a/crates/moonrun/CONTEXT.md
+++ b/crates/moonrun/CONTEXT.md
@@ -220,6 +220,14 @@ The observable behavior of `moonbitlang/async` native execution that moonrun sho
 For normal MoonBit async paths, moonrun should stay strictly native-shaped and avoid adding observable intermediate states. Extra validation exists at the async boundary to reject stale or unexpected calls from an Untrusted Guest before they can violate moonrun's Rust or OS ownership invariants.
 _Avoid_: Conceptual parity, best-effort compatibility
 
+**Guest Failure**:
+An uncaught Wasm trap or exception observed by an Engine Backend. The backend
+formats its engine-specific diagnostic, then the common Engine maps the failure
+to the public unsuccessful Run outcome. A Guest Failure is distinct from a Host
+Error raised by a Wasm Adapter and from Run Termination explicitly requested by
+guest code.
+_Avoid_: Run Termination, Host Error, implicit exit request
+
 **Run Termination**:
 A per-Wasm-run outcome requested by guest code, either an exit code or termination by signal. A runtime adapter records Run Termination and interrupts guest execution without terminating its embedding process; only the outer CLI adapter applies the outcome after guest and host state have been torn down.
 _Avoid_: Host exit, import-side exit, process-global termination state

--- a/crates/moonrun/Cargo.toml
+++ b/crates/moonrun/Cargo.toml
@@ -80,6 +80,7 @@ escargot.workspace = true
 moon-test-util = { path = "../moon-test-util" }
 snapbox.workspace = true
 tokio = { workspace = true, features = ["io-util", "net", "time"] }
+wat = "1.255.0"
 
 [[bin]]
 name = "moonrun"

--- a/crates/moonrun/src/engine.rs
+++ b/crates/moonrun/src/engine.rs
@@ -16,7 +16,8 @@
 //
 // For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
 
-use crate::runtime::{Runtime, WorkingDirectory};
+use crate::run_termination::RunTermination;
+use crate::runtime::{Runtime, Stdio, WorkingDirectory};
 use crate::{source_map, v8 as backend};
 use anyhow::Context;
 use std::fmt;
@@ -114,6 +115,88 @@ pub enum RunOutcome {
     Completed,
     Exited(i32),
     KilledBySignal(i32),
+}
+
+/// Backend result before the public runner applies Moonrun's common lifecycle
+/// policy. Guest failures are deliberately distinct from terminations requested
+/// by guest code.
+pub(crate) enum BackendRunOutcome {
+    Completed,
+    GuestFailure,
+    Terminated(RunTermination),
+}
+
+/// Result of one backend call into guest code. Guest diagnostics are formatted
+/// by the backend before common run or test-driver policy consumes them.
+pub(crate) enum BackendCallOutcome {
+    Completed,
+    GuestFailure(String),
+    Terminated(RunTermination),
+}
+
+#[derive(serde::Serialize)]
+struct TestFailure<'a> {
+    r#type: &'static str,
+    file: &'a str,
+    index: u32,
+    message: &'a str,
+}
+
+pub(crate) fn complete_run_call(
+    outcome: BackendCallOutcome,
+    stdio: &Stdio,
+) -> anyhow::Result<BackendRunOutcome> {
+    match outcome {
+        BackendCallOutcome::Completed => Ok(BackendRunOutcome::Completed),
+        BackendCallOutcome::GuestFailure(message) => {
+            stdio.with_stderr(|stderr| writeln!(stderr, "{message}"))?;
+            Ok(BackendRunOutcome::GuestFailure)
+        }
+        BackendCallOutcome::Terminated(termination) => {
+            Ok(BackendRunOutcome::Terminated(termination))
+        }
+    }
+}
+
+/// Run the backend-neutral MoonBit test-driver lifecycle. Backends provide
+/// only the representation-specific calls and formatted guest diagnostics.
+pub(crate) fn run_test_driver<D>(
+    driver: &mut D,
+    test_args: TestArgs,
+    stdio: &Stdio,
+    mut execute: impl FnMut(&mut D, &str, u32) -> anyhow::Result<BackendCallOutcome>,
+    finish: impl FnOnce(&mut D) -> anyhow::Result<BackendCallOutcome>,
+) -> anyhow::Result<BackendRunOutcome> {
+    let TestArgs {
+        package: _package,
+        file_and_index,
+    } = test_args;
+    for (file, ranges) in file_and_index {
+        for index in ranges.into_iter().flatten() {
+            match execute(driver, &file, index)? {
+                BackendCallOutcome::Completed => {}
+                BackendCallOutcome::GuestFailure(message) => {
+                    let result = TestFailure {
+                        r#type: "result",
+                        file: &file,
+                        index,
+                        message: &message,
+                    };
+                    stdio.with_stdout(|stdout| {
+                        writeln!(stdout, "----- BEGIN MOON TEST RESULT -----")?;
+                        serde_json::to_writer(&mut *stdout, &result)?;
+                        writeln!(stdout)?;
+                        writeln!(stdout, "----- END MOON TEST RESULT -----")?;
+                        Ok::<(), anyhow::Error>(())
+                    })?;
+                }
+                BackendCallOutcome::Terminated(termination) => {
+                    return Ok(BackendRunOutcome::Terminated(termination));
+                }
+            }
+        }
+    }
+    complete_run_call(finish(driver)?, stdio)
 }
 
 struct ModuleData {
@@ -223,13 +306,21 @@ impl Engine {
             options.inherited_policy.as_deref(),
             options.working_directory.clone(),
         )?;
-        self.backend.run(
+        let outcome = self.backend.run(
             module.name(),
             module.compiled(),
             module.source_map(),
             options,
             runtime,
-        )
+        )?;
+        Ok(match outcome {
+            BackendRunOutcome::Completed => RunOutcome::Completed,
+            BackendRunOutcome::GuestFailure => RunOutcome::Exited(1),
+            BackendRunOutcome::Terminated(RunTermination::Exit(code)) => RunOutcome::Exited(code),
+            BackendRunOutcome::Terminated(RunTermination::KilledBySignal(signal)) => {
+                RunOutcome::KilledBySignal(signal)
+            }
+        })
     }
 
     /// Load and synchronously execute one Wasm file.

--- a/crates/moonrun/src/template/js_glue.js
+++ b/crates/moonrun/src/template/js_glue.js
@@ -277,10 +277,23 @@ function formatStackLine(line) {
     return line;
 }
 
+function formatRunError(error) {
+    const stack = error && error.stack ? error.stack.toString() : String(error);
+    const lines = [];
+    for (const line of stack.split('\n')) {
+        if (!line.includes(BUILTIN_SCRIPT_ORIGIN_PREFIX)) {
+            lines.push(formatStackLine(line));
+        }
+        if (no_stack_trace) {
+            break;
+        }
+    }
+    return lines.join('\n');
+}
+
 // WASM instantiation + test harness.
 const tag = new WebAssembly.Tag({ parameters: [] });
 const console = {
-    elog: (x) => console_elog(x),
     log: (x) => console_log(x),
 };
 const ffiBytesMemory = new WebAssembly.Memory({ initial: 1 });
@@ -327,51 +340,5 @@ const spectest = {
     },
 };
 
-try {
-    if (!(module instanceof WebAssembly.Module)) {
-        throw new Error(`failed to load compiled wasm module: ${module_name}`);
-    }
-    let instance = new WebAssembly.Instance(module, spectest);
-    const memory = instance.exports.memory;
-    if (memory instanceof WebAssembly.Memory) {
-        __moonrun_v8_import.bind_memory(memory);
-    }
-    if (test_mode) {
-        for (param of testParams) {
-            try {
-                instance.exports.moonbit_test_driver_internal_execute(param[0], parseInt(param[1]));
-            } catch (e) {
-                const stack = e && e.stack ? e.stack.toString() : String(e);
-                const formatted = stack.split('\n').map(formatStackLine).join('\n');
-                console.log("----- BEGIN MOON TEST RESULT -----")
-                console.log(JSON.stringify({
-                    type: "result",
-                    file: param[0],
-                    index: parseInt(param[1]),
-                    message: formatted,
-                }));
-                console.log("----- END MOON TEST RESULT -----")
-            }
-        }
-        instance.exports.moonbit_test_driver_finish();
-    }
-    else {
-        if (instance.exports._start) {
-            instance.exports._start();
-        }
-    }
-}
-catch (e) {
-    const stack = e && e.stack ? e.stack.toString() : String(e);
-    for (const line of stack.split('\n')) {
-        const formatted = formatStackLine(line);
-        if (!line.includes(BUILTIN_SCRIPT_ORIGIN_PREFIX)) {
-            console.elog(formatted);
-        }
-        if (no_stack_trace) {
-            break;
-        }
-    }
-    __moonbit_sys_unstable.exit(1);
-
-}
+__moonrun_v8_import.format_run_error = formatRunError;
+__moonrun_v8_import.module_imports = spectest;

--- a/crates/moonrun/src/v8/host_imports.rs
+++ b/crates/moonrun/src/v8/host_imports.rs
@@ -144,19 +144,6 @@ fn print_char(
     ret.set_undefined()
 }
 
-fn console_elog(
-    scope: &mut v8::HandleScope,
-    args: v8::FunctionCallbackArguments,
-    mut _ret: v8::ReturnValue,
-) {
-    let arg = args.string_lossy(scope, 0);
-    run_context(&args)
-        .runtime()
-        .stdio()
-        .with_stderr(|stderr| writeln!(stderr, "{arg}"))
-        .unwrap();
-}
-
 fn console_log(
     scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
@@ -390,13 +377,6 @@ pub(crate) fn install(
             scope,
             "console_log",
             console_log,
-            v8_context_ptr,
-        );
-        context::register_func(
-            global_proxy,
-            scope,
-            "console_elog",
-            console_elog,
             v8_context_ptr,
         );
     }

--- a/crates/moonrun/src/v8/mod.rs
+++ b/crates/moonrun/src/v8/mod.rs
@@ -23,12 +23,15 @@ mod host_imports;
 mod memory_sanitizer;
 mod wasi;
 
-use crate::engine::{EngineConfig, RunOptions, RunOutcome};
-use crate::run_termination::RunTermination;
+use crate::engine::{
+    BackendCallOutcome, BackendRunOutcome, EngineConfig, RunOptions, complete_run_call,
+    run_test_driver,
+};
+use crate::run_termination::TerminationRequest;
 use crate::runtime::Runtime;
 use anyhow::Context;
 use builder::{ObjectExt, ScopeExt};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 const BUILTIN_SCRIPT_ORIGIN_PREFIX: &str = "__$moonrun_v8_builtin_script$__";
 const JS_GLUE: &str = include_str!(concat!(
@@ -37,6 +40,128 @@ const JS_GLUE: &str = include_str!(concat!(
 ));
 
 pub(crate) struct CompiledModule(v8::CompiledWasmModule);
+
+#[derive(Clone, Copy)]
+struct FailureContext<'s> {
+    runtime_error: v8::Local<'s, v8::Object>,
+    wasm_exception: v8::Local<'s, v8::Object>,
+    formatter: v8::Local<'s, v8::Function>,
+}
+
+enum CallOutcome<'s> {
+    Returned(v8::Local<'s, v8::Value>),
+    Stopped(BackendCallOutcome),
+}
+
+fn classify_exception<'s>(
+    scope: &mut v8::HandleScope<'s>,
+    exception: v8::Local<'s, v8::Value>,
+    failure: FailureContext<'s>,
+) -> anyhow::Result<BackendCallOutcome> {
+    let guest_failure = exception.instance_of(scope, failure.runtime_error).unwrap()
+        || exception
+            .instance_of(scope, failure.wasm_exception)
+            .unwrap();
+    let receiver = v8::undefined(scope).into();
+    let formatted = failure
+        .formatter
+        .call(scope, receiver, &[exception])
+        .and_then(|value| value.to_string(scope))
+        .context("Moonrun's V8 error formatter failed")?
+        .to_rust_string_lossy(scope);
+    if guest_failure {
+        Ok(BackendCallOutcome::GuestFailure(formatted))
+    } else {
+        // The outer anyhow reporter adds its own `Error:` label. V8 includes
+        // that label in a generic JavaScript Error stack, so avoid doubling it.
+        let formatted = formatted.strip_prefix("Error: ").unwrap_or(&formatted);
+        Err(anyhow::anyhow!("{formatted}"))
+    }
+}
+
+fn invoke<'s>(
+    scope: &mut v8::HandleScope<'s>,
+    termination_request: &TerminationRequest,
+    failure: FailureContext<'s>,
+    call: impl FnOnce(&mut v8::HandleScope<'s>) -> Option<v8::Local<'s, v8::Value>>,
+) -> anyhow::Result<CallOutcome<'s>> {
+    let scope = &mut v8::TryCatch::new(scope);
+    let result = call(scope);
+    if let Some(termination) = termination_request.take() {
+        return Ok(CallOutcome::Stopped(BackendCallOutcome::Terminated(
+            termination,
+        )));
+    }
+    if let Some(result) = result {
+        return Ok(CallOutcome::Returned(result));
+    }
+    if scope.has_terminated() {
+        anyhow::bail!("V8 execution terminated without a Moonrun termination request");
+    }
+
+    let exception = scope
+        .exception()
+        .context("V8 execution failed without an exception")?;
+    scope.reset();
+    Ok(CallOutcome::Stopped(classify_exception(
+        scope, exception, failure,
+    )?))
+}
+
+fn call_function<'s>(
+    scope: &mut v8::HandleScope<'s>,
+    function: v8::Local<'s, v8::Function>,
+    arguments: &[v8::Local<'s, v8::Value>],
+    termination_request: &TerminationRequest,
+    failure: FailureContext<'s>,
+) -> anyhow::Result<CallOutcome<'s>> {
+    invoke(scope, termination_request, failure, |scope| {
+        let receiver = v8::undefined(scope).into();
+        function.call(scope, receiver, arguments)
+    })
+}
+
+fn construct<'s>(
+    scope: &mut v8::HandleScope<'s>,
+    constructor: v8::Local<'s, v8::Function>,
+    arguments: &[v8::Local<'s, v8::Value>],
+    termination_request: &TerminationRequest,
+    failure: FailureContext<'s>,
+) -> anyhow::Result<CallOutcome<'s>> {
+    invoke(scope, termination_request, failure, |scope| {
+        constructor.new_instance(scope, arguments).map(Into::into)
+    })
+}
+
+fn call_export<'s>(
+    scope: &mut v8::HandleScope<'s>,
+    function: v8::Local<'s, v8::Function>,
+    arguments: &[v8::Local<'s, v8::Value>],
+    termination_request: &TerminationRequest,
+    failure: FailureContext<'s>,
+) -> anyhow::Result<BackendCallOutcome> {
+    Ok(
+        match call_function(scope, function, arguments, termination_request, failure)? {
+            CallOutcome::Returned(_) => BackendCallOutcome::Completed,
+            CallOutcome::Stopped(outcome) => outcome,
+        },
+    )
+}
+
+fn exported_function<'s>(
+    scope: &mut v8::HandleScope<'s>,
+    exports: v8::Local<'s, v8::Object>,
+    name: &str,
+) -> anyhow::Result<Option<v8::Local<'s, v8::Function>>> {
+    let key = scope.string(name);
+    let value = exports.get(scope, key.into()).unwrap();
+    if value.is_undefined() {
+        return Ok(None);
+    }
+    Ok(Some(v8::Local::<v8::Function>::try_from(value).map_err(
+        |_| anyhow::anyhow!("export `{name}` is not a function"),
+    )?))
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct Engine {
@@ -59,7 +184,7 @@ impl Engine {
         source_map: Option<&str>,
         options: RunOptions,
         runtime: Runtime,
-    ) -> anyhow::Result<RunOutcome> {
+    ) -> anyhow::Result<BackendRunOutcome> {
         run(
             &self.config,
             module_name,
@@ -161,8 +286,9 @@ pub(crate) fn run(
     source_map: Option<&str>,
     options: RunOptions,
     runtime: Runtime,
-) -> anyhow::Result<RunOutcome> {
+) -> anyhow::Result<BackendRunOutcome> {
     initialize(config)?;
+    let test_args = options.parsed_test_args()?;
 
     let isolate = &mut v8::Isolate::new(Default::default());
     let scope = &mut v8::HandleScope::new(isolate);
@@ -173,13 +299,35 @@ pub(crate) fn run(
         format!(r#"const BUILTIN_SCRIPT_ORIGIN_PREFIX = "{BUILTIN_SCRIPT_ORIGIN_PREFIX}";"#);
 
     let global_proxy = scope.get_current_context().global(scope);
+    let webassembly_key = scope.string("WebAssembly");
+    let webassembly =
+        v8::Local::<v8::Object>::try_from(global_proxy.get(scope, webassembly_key.into()).unwrap())
+            .unwrap();
+    let runtime_error_key = scope.string("RuntimeError");
+    let runtime_error = v8::Local::<v8::Object>::try_from(
+        webassembly.get(scope, runtime_error_key.into()).unwrap(),
+    )
+    .unwrap();
+    let exception_key = scope.string("Exception");
+    let wasm_exception =
+        v8::Local::<v8::Object>::try_from(webassembly.get(scope, exception_key.into()).unwrap())
+            .unwrap();
+    let instance_key = scope.string("Instance");
+    let instance_constructor =
+        v8::Local::<v8::Function>::try_from(webassembly.get(scope, instance_key.into()).unwrap())
+            .unwrap();
     let wasm_module = v8::WasmModuleObject::from_compiled_module(scope, &module.0)
         .context("failed to load compiled WebAssembly module into the run isolate")?;
     let memory_sanitizer = crate::memory_sanitizer::MemorySanitizer::default();
+    let stdio = Arc::clone(runtime.stdio());
 
     let mut dtors = Vec::new();
     let termination_request =
         host_imports::install(&mut dtors, scope, module_name, &options.args, runtime);
+    let v8_imports_key = scope.string("__moonrun_v8_import");
+    let v8_imports =
+        v8::Local::<v8::Object>::try_from(global_proxy.get(scope, v8_imports_key.into()).unwrap())
+            .unwrap();
 
     let memory_sanitizer_imports =
         global_proxy.child(scope, crate::memory_sanitizer::MEMORY_SANITIZER_MODULE);
@@ -190,27 +338,9 @@ pub(crate) fn run(
         &mut dtors,
     );
 
-    if let Some(test_args) = options.parsed_test_args()? {
-        let file_and_index = test_args.file_and_index;
-
-        let mut test_params: Vec<[String; 2]> = vec![];
-        for (file, index) in file_and_index {
-            for range in index {
-                for i in range {
-                    test_params.push([file.clone(), i.to_string()]);
-                }
-            }
-        }
-        entrypoint_source.push_str(&format!("const packageName = {:?};", test_args.package));
-        entrypoint_source.push_str(&format!("const testParams = {test_params:?};"));
-    }
     entrypoint_source.push_str(&format!(
         "const no_stack_trace = {};",
         options.no_stack_trace
-    ));
-    entrypoint_source.push_str(&format!(
-        "const test_mode = {};",
-        options.test_args.is_some()
     ));
     entrypoint_source.push_str(demangle::DEMANGLE_JS_TEMPLATE);
     entrypoint_source.push('\n');
@@ -219,38 +349,129 @@ pub(crate) fn run(
     let code = scope.string(&entrypoint_source);
     let script_origin = create_script_origin(scope, "wasm_mode_entry");
     let mut source = v8::script_compiler::Source::new(code, Some(&script_origin));
-    let module_argument = scope.string("module");
-    let module_name_argument = scope.string("module_name");
     let source_map_argument = scope.string("source_map");
     let entry = v8::script_compiler::compile_function(
         scope,
         &mut source,
-        &[module_argument, module_name_argument, source_map_argument],
+        &[source_map_argument],
         &[],
         v8::script_compiler::CompileOptions::NoCompileOptions,
         v8::script_compiler::NoCacheReason::BecauseCachingDisabled,
     )
     .context("failed to compile Moonrun's Wasm entrypoint")?;
-    let receiver = v8::undefined(scope).into();
-    let module_name = scope.string(module_name);
     let source_map = source_map
         .map(|source_map| scope.string(source_map).into())
         .unwrap_or_else(|| v8::undefined(scope).into());
-    entry.call(
-        scope,
-        receiver,
-        &[wasm_module.into(), module_name.into(), source_map],
-    );
-    let termination = termination_request.take();
-    drop(dtors);
-    if let Some(termination) = termination {
-        return Ok(match termination {
-            RunTermination::Exit(code) => RunOutcome::Exited(code),
-            RunTermination::KilledBySignal(signal) => RunOutcome::KilledBySignal(signal),
-        });
+    {
+        let scope = &mut v8::TryCatch::new(scope);
+        let receiver = v8::undefined(scope).into();
+        if entry.call(scope, receiver, &[source_map]).is_none() {
+            let error = scope
+                .stack_trace()
+                .or_else(|| scope.exception())
+                .context("Moonrun's V8 setup failed without an exception")?
+                .to_rust_string_lossy(scope);
+            anyhow::bail!("failed to initialize Moonrun's V8 adapter: {error}");
+        }
     }
-    memory_sanitizer.check_for_leaks()?;
-    Ok(RunOutcome::Completed)
+
+    let formatter_key = scope.string("format_run_error");
+    let formatter =
+        v8::Local::<v8::Function>::try_from(v8_imports.get(scope, formatter_key.into()).unwrap())
+            .unwrap();
+    let module_imports_key = scope.string("module_imports");
+    let module_imports = v8::Local::<v8::Object>::try_from(
+        v8_imports.get(scope, module_imports_key.into()).unwrap(),
+    )
+    .unwrap();
+    let failure = FailureContext {
+        runtime_error,
+        wasm_exception,
+        formatter,
+    };
+
+    let result = (|| -> anyhow::Result<BackendRunOutcome> {
+        let instance = match construct(
+            scope,
+            instance_constructor,
+            &[wasm_module.into(), module_imports.into()],
+            &termination_request,
+            failure,
+        )
+        .with_context(|| format!("failed to instantiate `{module_name}`"))?
+        {
+            CallOutcome::Returned(instance) => v8::Local::<v8::Object>::try_from(instance).unwrap(),
+            CallOutcome::Stopped(outcome) => return complete_run_call(outcome, &stdio),
+        };
+        let exports_key = scope.string("exports");
+        let exports =
+            v8::Local::<v8::Object>::try_from(instance.get(scope, exports_key.into()).unwrap())
+                .unwrap();
+
+        let memory_key = scope.string("memory");
+        let memory = exports.get(scope, memory_key.into()).unwrap();
+        if let Ok(memory) = v8::Local::<v8::WasmMemoryObject>::try_from(memory) {
+            let bind_memory_key = scope.string("bind_memory");
+            let bind_memory = v8::Local::<v8::Function>::try_from(
+                v8_imports.get(scope, bind_memory_key.into()).unwrap(),
+            )
+            .unwrap();
+            if let CallOutcome::Stopped(outcome) = call_function(
+                scope,
+                bind_memory,
+                &[memory.into()],
+                &termination_request,
+                failure,
+            )
+            .context("failed to bind the exported WebAssembly memory")?
+            {
+                return complete_run_call(outcome, &stdio);
+            }
+        }
+
+        if let Some(test_args) = test_args {
+            let execute =
+                exported_function(scope, exports, "moonbit_test_driver_internal_execute")?
+                    .context(
+                        "test module does not export `moonbit_test_driver_internal_execute`",
+                    )?;
+            let finish = exported_function(scope, exports, "moonbit_test_driver_finish")?
+                .context("test module does not export `moonbit_test_driver_finish`")?;
+            run_test_driver(
+                scope,
+                test_args,
+                &stdio,
+                |scope, file, index| {
+                    let file = scope.string(file).into();
+                    let index = v8::Integer::new_from_unsigned(scope, index).into();
+                    call_export(
+                        scope,
+                        execute,
+                        &[file, index],
+                        &termination_request,
+                        failure,
+                    )
+                    .context("failed to execute a MoonBit test")
+                },
+                |scope| {
+                    call_export(scope, finish, &[], &termination_request, failure)
+                        .context("failed to finish the MoonBit test driver")
+                },
+            )
+        } else if let Some(start) = exported_function(scope, exports, "_start")? {
+            let outcome = call_export(scope, start, &[], &termination_request, failure)?;
+            complete_run_call(outcome, &stdio)
+        } else {
+            Ok(BackendRunOutcome::Completed)
+        }
+    })();
+    drop(dtors);
+
+    let outcome = result?;
+    if matches!(outcome, BackendRunOutcome::Completed) {
+        memory_sanitizer.check_for_leaks()?;
+    }
+    Ok(outcome)
 }
 
 fn create_script_origin<'s>(scope: &mut v8::HandleScope<'s>, name: &str) -> v8::ScriptOrigin<'s> {

--- a/crates/moonrun/tests/engine_outcomes.rs
+++ b/crates/moonrun/tests/engine_outcomes.rs
@@ -1,0 +1,204 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+fn compile(name: &str, source: &str) -> (moonrun::Engine, moonrun::Module) {
+    let engine = moonrun::Engine::default();
+    let module = engine
+        .compile(name, wat::parse_str(source).unwrap())
+        .unwrap();
+    (engine, module)
+}
+
+#[test]
+fn v8_classifies_uncaught_wasm_failures_as_guest_failures() {
+    let cases = [
+        (
+            "module-start-trap.wasm",
+            r#"(module
+                (func $module_start unreachable)
+                (start $module_start))"#,
+            moonrun::RunOptions::default(),
+        ),
+        (
+            "exported-start-trap.wasm",
+            r#"(module (func (export "_start") unreachable))"#,
+            moonrun::RunOptions::default(),
+        ),
+        (
+            "wasm-exception.wasm",
+            r#"(module
+                (import "exception" "tag" (tag $tag))
+                (import "exception" "throw" (func $throw))
+                (func (export "_start") call $throw))"#,
+            moonrun::RunOptions::default(),
+        ),
+        (
+            "js-string-trap.wasm",
+            r#"(module
+                (import "wasm:js-string" "fromCodePoint"
+                    (func $from_code_point (param i32) (result (ref extern))))
+                (func (export "_start")
+                    i32.const -1
+                    call $from_code_point
+                    drop))"#,
+            moonrun::RunOptions::default(),
+        ),
+        (
+            "test-finish-trap.wasm",
+            r#"(module
+                (func (export "moonbit_test_driver_internal_execute")
+                    (param externref i32))
+                (func (export "moonbit_test_driver_finish") unreachable))"#,
+            moonrun::RunOptions::default()
+                .with_test_args(r#"{"package":"moon/core","file_and_index":[]}"#),
+        ),
+    ];
+
+    for (name, source, options) in cases {
+        let (engine, module) = compile(name, source);
+        assert_eq!(
+            engine.run(&module, options).unwrap(),
+            moonrun::RunOutcome::Exited(1),
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn v8_keeps_handled_test_failures_inside_the_test_driver() {
+    let (engine, module) = compile(
+        "test-execute-trap.wasm",
+        r#"(module
+            (func (export "moonbit_test_driver_internal_execute")
+                (param externref i32)
+                unreachable)
+            (func (export "moonbit_test_driver_finish")))"#,
+    );
+
+    assert_eq!(
+        engine
+            .run(
+                &module,
+                moonrun::RunOptions::default().with_test_args(
+                    r#"{"package":"moon/core","file_and_index":[["main_test.mbt",[{"start":0,"end":1}]]]}"#,
+                ),
+            )
+            .unwrap(),
+        moonrun::RunOutcome::Completed
+    );
+}
+
+#[test]
+fn v8_preserves_explicit_run_termination() {
+    let (engine, module) = compile(
+        "exit.wasm",
+        r#"(module
+            (import "__moonbit_sys_unstable" "exit" (func $exit (param i32)))
+            (func (export "_start") i32.const 7 call $exit))"#,
+    );
+
+    assert_eq!(
+        engine.run(&module, moonrun::RunOptions::default()).unwrap(),
+        moonrun::RunOutcome::Exited(7)
+    );
+}
+
+#[test]
+fn v8_preserves_instantiation_link_errors() {
+    let (engine, module) = compile(
+        "missing-import.wasm",
+        r#"(module
+            (import "__moonbit_sys_unstable" "missing" (func)))"#,
+    );
+
+    let error = engine
+        .run(&module, moonrun::RunOptions::default())
+        .unwrap_err();
+    let error = format!("{error:#}");
+    assert!(
+        error.contains("failed to instantiate `missing-import.wasm`")
+            && error.contains("LinkError"),
+        "{error}"
+    );
+}
+
+#[test]
+fn v8_preserves_host_adapter_errors() {
+    let cases = [
+        (
+            "module-start-host-error.wasm",
+            r#"(module
+                (import "moonbit:ffi/memory-sanitizer" "register-object-free"
+                    (func $free (param i32)))
+                (func $module_start i32.const 1 call $free)
+                (start $module_start))"#,
+            moonrun::RunOptions::default(),
+            Some("failed to instantiate"),
+        ),
+        (
+            "exported-start-host-error.wasm",
+            r#"(module
+                (import "moonbit:ffi/memory-sanitizer" "register-object-free"
+                    (func $free (param i32)))
+                (func (export "_start") i32.const 1 call $free))"#,
+            moonrun::RunOptions::default(),
+            None,
+        ),
+        (
+            "test-execute-host-error.wasm",
+            r#"(module
+                (import "moonbit:ffi/memory-sanitizer" "register-object-free"
+                    (func $free (param i32)))
+                (func (export "moonbit_test_driver_internal_execute")
+                    (param externref i32)
+                    i32.const 1
+                    call $free)
+                (func (export "moonbit_test_driver_finish")))"#,
+            moonrun::RunOptions::default().with_test_args(
+                r#"{"package":"moon/core","file_and_index":[["main_test.mbt",[{"start":0,"end":1}]]]}"#,
+            ),
+            Some("failed to execute a MoonBit test"),
+        ),
+        (
+            "test-finish-host-error.wasm",
+            r#"(module
+                (import "moonbit:ffi/memory-sanitizer" "register-object-free"
+                    (func $free (param i32)))
+                (func (export "moonbit_test_driver_internal_execute")
+                    (param externref i32))
+                (func (export "moonbit_test_driver_finish")
+                    i32.const 1
+                    call $free))"#,
+            moonrun::RunOptions::default()
+                .with_test_args(r#"{"package":"moon/core","file_and_index":[]}"#),
+            Some("failed to finish the MoonBit test driver"),
+        ),
+    ];
+
+    for (name, source, options, expected_context) in cases {
+        let (engine, module) = compile(name, source);
+        let error = engine.run(&module, options).unwrap_err();
+        let error = format!("{error:#}");
+        assert!(
+            expected_context.is_none_or(|context| error.contains(context))
+                && error.contains("register-object-free failed")
+                && error.contains("invalid object 1"),
+            "{error}"
+        );
+    }
+}

--- a/crates/moonrun/tests/test.rs
+++ b/crates/moonrun/tests/test.rs
@@ -274,7 +274,6 @@ fn test_moonrun_wasm_stack_trace_in_test_blocks() {
         .failure()
         .stdout_eq(snapbox::str![[r#"
 [username/hello] test main/main.mbt:[..] ("stacktrace test abort closure") failed: Error
-    at throw
     at @moonbitlang/core/abort.abort[Int] [..]/abort/abort.mbt[LINE_NUMBER]
     at @username/hello/main.abort_via_closure.inner[stamp=[..]] [..]/main/main.mbt[LINE_NUMBER]
     at @username/hello/main.abort_via_closure [..]/main/main.mbt[LINE_NUMBER]
@@ -294,7 +293,6 @@ Total tests: 1, passed: 0, failed: 1.
         .failure()
         .stdout_eq(snapbox::str![[r#"
 [username/hello] test main/main.mbt:[..] ("stacktrace test abort method") failed: Error
-    at throw
     at @moonbitlang/core/abort.abort[UInt] [..]/abort/abort.mbt[LINE_NUMBER]
     at @username/hello/main.CrashBox::abort_method [..]/main/main.mbt[LINE_NUMBER]
     at @username/hello/main.__test_6d61696e2e6d6274_1 [..]/main/main.mbt[LINE_NUMBER]
@@ -942,7 +940,6 @@ previous allocation stack:
     at @moonbit/ffi-memory-sanitizer-test/memory_sanitizer.register_object_alloc
     at @moonbit/ffi-memory-sanitizer-test/duplicate_alloc.allocate_once
     at @__moonbit_main
-    at <anonymous>
 ...
 "#]]);
 }
@@ -999,7 +996,6 @@ allocation stack:
     at @moonbit/ffi-memory-sanitizer-test/memory_sanitizer.register_object_alloc
     at @moonbit/ffi-memory-sanitizer-test/leak.leak_object
     at @__moonbit_main
-    at <anonymous>
 ...
 "#]]);
 }


### PR DESCRIPTION
## Why

Moonrun currently catches every V8 execution error in JavaScript and turns it into an exit request. That conflates uncaught Wasm failures, explicit guest termination, linker failures, and host-adapter errors, preventing additional execution backends from sharing a precise run-outcome contract.

## What

- Introduce backend call and run outcomes that distinguish completion, guest failure, and requested termination.
- Move module construction, exported-function invocation, and the MoonBit test-driver lifecycle into Rust.
- Classify the fixed V8 WebAssembly.RuntimeError and WebAssembly.Exception types directly under TryCatch.
- Keep V8-specific import construction and source-map-aware stack formatting in the JavaScript adapter.
- Preserve linker and host-adapter failures as errors while routing guest diagnostics through common Runtime stdio policy.
- Cover module-start, exported-start, test-execute, test-finish, linker, host-adapter, exit, and signal outcomes with focused tests.

## Why this split

This PR reshapes the existing V8 boundary and introduces the backend-neutral test-driver control flow that Wasmtime can reuse. It does not introduce Wasmtime or widen the shared host-adapter surface.