### PR TITLE
refactor(native): isolate compiler toolchain policy

### DIFF
--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -27,9 +27,16 @@ use std::{
     process::Command,
 };
 
+mod gcc_like;
 mod msvc;
 mod tcc;
 
+#[cfg(all(test, target_os = "macos"))]
+use gcc_like::resolve_apple_libtool_path;
+use gcc_like::{
+    add_cc_common_libraries, add_cc_specific_flags as add_cc_gcc_like_specific_flags,
+    add_linker_common_libraries,
+};
 #[cfg(all(test, windows))]
 use msvc::windows_msvc_host_target_triple;
 pub use msvc::{
@@ -448,117 +455,6 @@ impl CC {
             cc_dir.join(tool).display().to_string()
         } else {
             tool.to_string()
-        }
-    }
-
-    fn probe_prog_name(cc_path: &Path, name: &str) -> Option<String> {
-        let output = Command::new(cc_path)
-            .arg(format!("-print-prog-name={name}"))
-            .output()
-            .ok()?;
-        if !output.status.success() {
-            return None;
-        }
-        let prog = String::from_utf8_lossy(&output.stdout);
-        let prog = prog.lines().next()?.trim();
-        (!prog.is_empty()).then(|| prog.to_string())
-    }
-
-    fn resolve_reported_prog_path(prog: &str) -> Option<String> {
-        let prog_path = Path::new(prog);
-        let has_non_empty_parent = prog_path
-            .parent()
-            .is_some_and(|parent| !parent.as_os_str().is_empty());
-
-        if prog_path.is_absolute() || has_non_empty_parent {
-            if prog_path.is_file() {
-                return Some(prog.to_string());
-            }
-
-            #[cfg(windows)]
-            if prog_path.extension().is_none() {
-                let exe_path = prog_path.with_extension("exe");
-                if exe_path.is_file() {
-                    return Some(exe_path.display().to_string());
-                }
-            }
-
-            return None;
-        }
-
-        which::which(prog)
-            .ok()
-            .map(|path| path.display().to_string())
-    }
-
-    fn probe_existing_prog_name(cc_path: &Path, name: &str) -> Option<String> {
-        let prog = CC::probe_prog_name(cc_path, name)?;
-        CC::resolve_reported_prog_path(&prog)
-    }
-
-    fn with_default_platform_archiver(mut self) -> Self {
-        #[cfg(target_os = "macos")]
-        if self.targets_apple_darwin()
-            && !self.is_tcc()
-            && let Some(libtool) = resolve_apple_libtool_path()
-        {
-            self.ar_kind = ARKind::AppleLibtool;
-            self.ar_path = libtool.display().to_string();
-            return self;
-        }
-
-        if matches!(self.cc_kind, CCKind::Clang)
-            && self.targets_msvc()
-            && let Some(llvm_lib) =
-                CC::probe_existing_prog_name(Path::new(&self.cc_path), "llvm-lib")
-        {
-            self.ar_kind = ARKind::MsvcLib;
-            self.ar_path = llvm_lib;
-        }
-
-        self
-    }
-
-    fn is_llvm_ar_name(ar_name_or_path: &str) -> bool {
-        let file_name = Path::new(ar_name_or_path)
-            .file_name()
-            .and_then(OsStr::to_str)
-            .unwrap_or(ar_name_or_path)
-            .to_ascii_lowercase();
-        CC::strip_exe_suffix(&file_name) == "llvm-ar"
-    }
-
-    fn is_msvc_librarian_name(ar_name_or_path: &str) -> bool {
-        let file_name = Path::new(ar_name_or_path)
-            .file_name()
-            .and_then(OsStr::to_str)
-            .unwrap_or(ar_name_or_path)
-            .to_ascii_lowercase();
-        matches!(CC::strip_exe_suffix(&file_name), "lib" | "llvm-lib")
-    }
-
-    fn is_apple_libtool_name(ar_name_or_path: &str) -> bool {
-        let file_name = Path::new(ar_name_or_path)
-            .file_name()
-            .and_then(OsStr::to_str)
-            .unwrap_or(ar_name_or_path)
-            .to_ascii_lowercase();
-        CC::strip_exe_suffix(&file_name) == "libtool"
-    }
-
-    fn classify_gcc_like_archiver(ar_name_or_path: &str, target_triple: Option<&str>) -> ARKind {
-        if target_triple.is_some_and(|target| target.contains("msvc"))
-            && CC::is_msvc_librarian_name(ar_name_or_path)
-        {
-            ARKind::MsvcLib
-        } else if target_triple.is_some_and(|target| target.contains("apple-darwin"))
-            && CC::is_apple_libtool_name(ar_name_or_path)
-        {
-            ARKind::AppleLibtool
-        } else if CC::is_llvm_ar_name(ar_name_or_path) {
-            ARKind::LlvmAr
-        } else {
-            ARKind::GnuAr
         }
     }
 
@@ -1092,22 +988,6 @@ fn add_linker_moonbitrun(
     }
 }
 
-fn add_linker_common_libraries<P: AsRef<Path>>(
-    cc: &CC,
-    buf: &mut Vec<String>,
-    config: &LinkerConfig<P>,
-) {
-    if cc.is_gcc_like() {
-        if cc.should_link_libm() {
-            buf.push("-lm".to_string());
-        }
-        if let Some(dyn_lib_path) = config.link_shared_runtime.as_ref() {
-            buf.push("-lruntime".to_string());
-            buf.push(format!("-Wl,-rpath,{}", dyn_lib_path.as_ref().display()));
-        }
-    }
-}
-
 pub fn make_linker_command<S, P>(
     cc: CC,
     user_cc: Option<CC>,
@@ -1194,21 +1074,6 @@ fn add_cc_output_flags(cc: &CC, buf: &mut Vec<String>, config: &CCConfig, dest: 
     }
 }
 
-#[cfg(target_os = "macos")]
-fn resolve_apple_libtool_path() -> Option<PathBuf> {
-    let output = Command::new("xcrun")
-        .args(["--find", "libtool"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let libtool = String::from_utf8_lossy(&output.stdout);
-    let libtool = PathBuf::from(libtool.lines().next()?.trim());
-    libtool.is_file().then_some(libtool)
-}
-
 fn add_cc_include_and_lib_paths(cc: &CC, buf: &mut Vec<String>, ipath: &str, lpath: &str) {
     if cc.is_msvc() {
         buf.push(format!("/I{ipath}"));
@@ -1261,20 +1126,6 @@ fn add_cc_compile_only_flags(cc: &CC, buf: &mut Vec<String>, config: &CCConfig) 
             buf.push("/c".to_string());
         } else if cc.is_gcc_like() {
             buf.push("-c".to_string());
-        }
-    }
-}
-
-fn add_cc_gcc_like_specific_flags(cc: &CC, buf: &mut Vec<String>) {
-    // the below flags are needed, ref: https://github.com/moonbitlang/core/issues/1594#issuecomment-2649652455
-    if cc.is_full_featured_gcc_like() {
-        buf.push("-fwrapv".to_string());
-        buf.push("-fno-strict-aliasing".to_string());
-        // Apple clang is usually detected as SystemCC on macOS.
-        if matches!(cc.cc_kind, CCKind::Clang)
-            || (cfg!(target_os = "macos") && matches!(cc.cc_kind, CCKind::SystemCC))
-        {
-            buf.push("-Wno-unused-value".to_string());
         }
     }
 }
@@ -1379,12 +1230,6 @@ fn add_cc_moonbitrun(cc: &CC, buf: &mut Vec<String>, config: &CCConfig, paths: &
         &paths.lib_path,
     ) {
         buf.push(object);
-    }
-}
-
-fn add_cc_common_libraries(cc: &CC, buf: &mut Vec<String>, config: &CCConfig) {
-    if cc.should_link_libm() && config.output_ty != OutputType::Object {
-        buf.push("-lm".to_string());
     }
 }
 

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -27,10 +27,12 @@ use std::{
     process::Command,
 };
 
+mod archiver;
 mod gcc_like;
 mod msvc;
 mod tcc;
 
+pub use archiver::{make_archiver_command, make_archiver_command_resolved};
 #[cfg(all(test, target_os = "macos"))]
 use gcc_like::resolve_apple_libtool_path;
 use gcc_like::{
@@ -823,30 +825,6 @@ impl CompilerPaths {
     }
 }
 
-// Helper functions for archiver command building
-fn add_archiver_flags(cc: &CC, buf: &mut Vec<String>, dest: &str) {
-    match cc.ar_kind {
-        ARKind::MsvcLib => {
-            buf.push("/nologo".to_string());
-            buf.push(format!("/Out:{dest}"));
-        }
-        ARKind::AppleLibtool => {
-            buf.push("-static".to_string());
-            buf.push("-o".to_string());
-            buf.push(dest.to_string());
-        }
-        ARKind::GnuAr | ARKind::LlvmAr => {
-            buf.push("-r".to_string());
-            buf.push("-c".to_string());
-            buf.push("-s".to_string());
-            buf.push(dest.to_string());
-        }
-        ARKind::TccAr => {
-            tcc::add_archiver_flags(buf, dest);
-        }
-    }
-}
-
 fn moonbitrun_object(
     cc: &CC,
     enabled: bool,
@@ -859,57 +837,6 @@ fn moonbitrun_object(
             .display()
             .to_string()
     })
-}
-
-// Archiver compiler-specific handling for moonbitrun
-fn add_archiver_moonbitrun(
-    cc: &CC,
-    buf: &mut Vec<String>,
-    config: &ArchiverConfig,
-    paths: &CompilerPaths,
-) {
-    if let Some(object) = moonbitrun_object(
-        cc,
-        config.archive_moonbitrun,
-        config.native_allocator,
-        &paths.lib_path,
-    ) {
-        buf.push(object);
-    }
-}
-
-pub fn make_archiver_command<S>(
-    cc: CC,
-    user_cc: Option<CC>,
-    config: ArchiverConfig,
-    src: &[S],
-    dest: &str,
-) -> Vec<String>
-where
-    S: AsRef<str>,
-{
-    let resolved_cc = resolve_cc(&cc, user_cc.as_ref());
-    let paths = CompilerPaths::from_moon_dirs();
-    make_archiver_command_resolved(resolved_cc, config, src, dest, &paths)
-}
-
-pub fn make_archiver_command_resolved<S>(
-    cc: CC,
-    config: ArchiverConfig,
-    src: &[S],
-    dest: &str,
-    paths: &CompilerPaths,
-) -> Vec<String>
-where
-    S: AsRef<str>,
-{
-    let mut buf = vec![cc.ar_path.clone()];
-
-    add_archiver_flags(&cc, &mut buf, dest);
-    add_archiver_moonbitrun(&cc, &mut buf, &config, paths);
-    buf.extend(src.iter().map(|s| s.as_ref().to_string()));
-
-    buf
 }
 
 // Helper functions for linker command building

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -28,6 +28,7 @@ use std::{
 };
 
 mod msvc;
+mod tcc;
 
 #[cfg(all(test, windows))]
 use msvc::windows_msvc_host_target_triple;
@@ -47,6 +48,10 @@ use msvc::{
 use msvc::{discovered_windows_msvc_toolchain, resolve_msvc_toolchain_override};
 #[cfg(test)]
 use msvc::{ensure_windows_msvc_compatible, windows_msvc_toolchain_with_package_override};
+use tcc::{
+    add_cc_specific_flags as add_cc_tcc_specific_flags,
+    add_macos_sdk_library_path as add_tcc_macos_sdk_library_path,
+};
 
 const ENV_MOON_CC: &str = "MOON_CC";
 const ENV_MOON_AR: &str = "MOON_AR";
@@ -309,7 +314,7 @@ fn resolve_native_toolchain_executables_with(
         .to_string();
 
     if toolchain.cc.is_tcc() {
-        toolchain.cc.ar_path.clone_from(&toolchain.cc.cc_path);
+        tcc::resolve_archiver_path(&mut toolchain.cc);
         return Ok(toolchain);
     }
 
@@ -569,7 +574,7 @@ impl CC {
                 CC::classify_gcc_like_archiver(ar_name, target_triple.as_deref()),
                 CC::resolve_tool_path(cc_path, ar_name),
             ),
-            CCKind::Tcc => (ARKind::TccAr, cc_path.display().to_string()),
+            CCKind::Tcc => tcc::default_archiver(cc_path),
         };
         Ok(CC::new(
             cc_kind,
@@ -941,10 +946,7 @@ fn add_archiver_flags(cc: &CC, buf: &mut Vec<String>, dest: &str) {
             buf.push(dest.to_string());
         }
         ARKind::TccAr => {
-            // tcc doesn't have a separate archiver command.
-            buf.push("-ar".to_string());
-            buf.push("rcs".to_string());
-            buf.push(dest.to_string());
+            tcc::add_archiver_flags(buf, dest);
         }
     }
 }
@@ -1207,40 +1209,6 @@ fn resolve_apple_libtool_path() -> Option<PathBuf> {
     libtool.is_file().then_some(libtool)
 }
 
-#[cfg(target_os = "macos")]
-fn resolve_macos_sdk_lib_path() -> Option<PathBuf> {
-    let output = Command::new("xcrun")
-        .args(["--sdk", "macosx", "--show-sdk-path"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let sdk_root = String::from_utf8_lossy(&output.stdout);
-    let sdk_root = sdk_root.lines().next()?.trim();
-    if sdk_root.is_empty() {
-        return None;
-    }
-
-    let sdk_lib_path = Path::new(sdk_root).join("usr").join("lib");
-    sdk_lib_path.is_dir().then_some(sdk_lib_path)
-}
-
-#[cfg(target_os = "macos")]
-static MACOS_SDK_LIB_PATH: std::sync::LazyLock<Option<PathBuf>> =
-    std::sync::LazyLock::new(resolve_macos_sdk_lib_path);
-
-#[cfg(target_os = "macos")]
-fn add_tcc_macos_sdk_library_path(buf: &mut Vec<String>) {
-    if let Some(sdk_lib_path) = MACOS_SDK_LIB_PATH.as_ref() {
-        buf.push(format!("-L{}", sdk_lib_path.display()));
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-fn add_tcc_macos_sdk_library_path(_buf: &mut Vec<String>) {}
-
 fn add_cc_include_and_lib_paths(cc: &CC, buf: &mut Vec<String>, ipath: &str, lpath: &str) {
     if cc.is_msvc() {
         buf.push(format!("/I{ipath}"));
@@ -1308,21 +1276,6 @@ fn add_cc_gcc_like_specific_flags(cc: &CC, buf: &mut Vec<String>) {
         {
             buf.push("-Wno-unused-value".to_string());
         }
-    }
-}
-
-fn add_cc_tcc_specific_flags(cc: &CC, buf: &mut Vec<String>, config: &CCConfig) {
-    if !cc.is_tcc() {
-        return;
-    }
-
-    if config.no_sys_header {
-        buf.push("-DMOONBIT_NATIVE_NO_SYS_HEADER".to_string());
-    } else {
-        eprintln!(
-            "{}: Use tcc without set MOONBIT_NATIVE_NO_SYS_HEADER.",
-            "Warning".yellow().bold(),
-        );
     }
 }
 

--- a/crates/moonutil/src/compiler_flags.rs
+++ b/crates/moonutil/src/compiler_flags.rs
@@ -20,14 +20,33 @@ use crate::moon_dir::MOON_DIRS;
 use anyhow::Context;
 use colored::Colorize;
 use derive_builder::Builder;
-#[cfg(windows)]
-use std::sync::OnceLock;
 use std::{
     env,
     ffi::OsStr,
     path::{Path, PathBuf},
     process::Command,
 };
+
+mod msvc;
+
+#[cfg(all(test, windows))]
+use msvc::windows_msvc_host_target_triple;
+pub use msvc::{
+    WINDOWS_MSVC_C_STANDARD_FLAG, WINDOWS_MSVC_DEFAULT_LIBS, WINDOWS_MSVC_STATIC_RUNTIME_FLAG,
+    has_incompatible_windows_msvc_env_override, resolve_windows_msvc_toolchain,
+    windows_msvc_native_toolchain,
+};
+use msvc::{
+    add_cc_linker_flags as add_cc_msvc_linker_flags,
+    add_cc_runtime_flags as add_cc_msvc_runtime_flags,
+    add_cc_specific_flags as add_cc_msvc_specific_flags,
+    add_linker_runtime as add_linker_msvc_runtime,
+    add_linker_specific_flags as add_linker_msvc_specific_flags, default_librarian,
+};
+#[cfg(windows)]
+use msvc::{discovered_windows_msvc_toolchain, resolve_msvc_toolchain_override};
+#[cfg(test)]
+use msvc::{ensure_windows_msvc_compatible, windows_msvc_toolchain_with_package_override};
 
 const ENV_MOON_CC: &str = "MOON_CC";
 const ENV_MOON_AR: &str = "MOON_AR";
@@ -271,155 +290,6 @@ const CAN_USE_MOONBITRUN: bool = false;
 // backend still needs a no-stdlib runtime build there, plus an /MT vs /MD call.
 const CAN_USE_SIMDUTF: bool = cfg!(any(target_os = "linux", target_os = "macos"));
 
-pub const WINDOWS_MSVC_DEFAULT_LIBS: &[&str] = &[
-    "libcmt.lib",
-    "oldnames.lib",
-    "kernel32.lib",
-    "shell32.lib",
-    "user32.lib",
-    "dbghelp.lib",
-    "uuid.lib",
-];
-pub const WINDOWS_MSVC_STATIC_RUNTIME_FLAG: &str = "/MT";
-pub const WINDOWS_MSVC_C_STANDARD_FLAG: &str = "/std:c11";
-
-#[cfg(windows)]
-static WINDOWS_MSVC_TOOLCHAIN: OnceLock<Option<DiscoveredMsvcToolchain>> = OnceLock::new();
-
-#[derive(Clone, Debug)]
-struct DiscoveredMsvcToolchain {
-    cc: CC,
-    environment: MsvcEnvironment,
-}
-
-#[cfg(windows)]
-fn windows_msvc_host_target_triple() -> Option<String> {
-    let arch = env::consts::ARCH;
-    match arch {
-        "x86_64" | "aarch64" => Some(format!("{arch}-pc-windows-msvc")),
-        _ => None,
-    }
-}
-
-#[cfg(windows)]
-fn find_windows_msvc_toolchain(target: &str) -> Option<DiscoveredMsvcToolchain> {
-    let tool = find_msvc_tools::find_tool(target, "cl.exe")
-        .or_else(|| find_msvc_tools::find_tool(target, "clang-cl.exe"))?;
-    let cc = CC::try_from_path(&tool.path().display().to_string()).ok()?;
-    if !Path::new(&cc.ar_path).is_file() {
-        return None;
-    }
-    Some(DiscoveredMsvcToolchain {
-        cc,
-        environment: MsvcEnvironment {
-            command_env: tool
-                .env()
-                .into_iter()
-                .map(|(key, value)| {
-                    (
-                        key.to_string_lossy().into_owned(),
-                        value.to_string_lossy().into_owned(),
-                    )
-                })
-                .collect(),
-        },
-    })
-}
-
-fn resolve_windows_msvc_discovery() -> anyhow::Result<DiscoveredMsvcToolchain> {
-    #[cfg(not(windows))]
-    {
-        anyhow::bail!("Windows MSVC environment resolution is only supported on Windows")
-    }
-
-    #[cfg(windows)]
-    {
-        let target = windows_msvc_host_target_triple()
-            .context("Windows MSVC discovery currently supports 64-bit x64 and ARM64 hosts")?;
-
-        WINDOWS_MSVC_TOOLCHAIN
-            .get_or_init(|| find_windows_msvc_toolchain(&target))
-            .clone()
-            .with_context(|| {
-                "Windows native backend requires MSVC Build Tools with C++ tools and Windows SDK"
-            })
-    }
-}
-
-fn discovered_windows_msvc_toolchain() -> anyhow::Result<Toolchain> {
-    let discovered = resolve_windows_msvc_discovery()?;
-    Ok(Toolchain::from_path_probe(discovered.cc).with_msvc_environment(discovered.environment))
-}
-
-pub fn resolve_windows_msvc_toolchain() -> anyhow::Result<Toolchain> {
-    resolve_native_toolchain_executables(discovered_windows_msvc_toolchain()?)
-}
-
-fn ensure_windows_msvc_compatible(cc: &CC) -> anyhow::Result<()> {
-    if cc.is_msvc() {
-        Ok(())
-    } else {
-        anyhow::bail!(
-            "Windows native backend requires an MSVC cl-compatible compiler driver such as cl.exe or clang-cl.exe; found {}",
-            cc.cc_path
-        )
-    }
-}
-
-pub fn windows_msvc_native_toolchain(package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
-    if let Some(env_cc) = ENV_CC.as_ref().filter(|cc| cc.is_msvc()) {
-        let override_toolchain = Toolchain::from_env_override(env_cc.clone());
-        let resolved = if is_path_like_tool(&env_cc.cc_path) {
-            override_toolchain
-        } else {
-            let discovered = discovered_windows_msvc_toolchain()?;
-            resolve_msvc_toolchain_override(override_toolchain, &discovered)
-        };
-        return windows_msvc_toolchain_with_package_override(resolved, package_cc);
-    }
-
-    if let Some(package_cc) = package_cc {
-        ensure_windows_msvc_compatible(package_cc)?;
-    }
-
-    let resolved = discovered_windows_msvc_toolchain()?;
-    windows_msvc_toolchain_with_package_override(resolved, package_cc)
-}
-
-pub fn has_incompatible_windows_msvc_env_override() -> bool {
-    ENV_CC.as_ref().is_some_and(|cc| !cc.is_msvc())
-}
-
-fn windows_msvc_toolchain_with_package_override(
-    resolved: Toolchain,
-    package_cc: Option<&CC>,
-) -> anyhow::Result<Toolchain> {
-    let mut toolchain = resolved.with_package_override(package_cc);
-    ensure_windows_msvc_compatible(toolchain.cc())?;
-
-    if toolchain.source() == ToolchainSource::PackageOverride {
-        toolchain = resolve_msvc_toolchain_override(toolchain, &resolved);
-    }
-
-    resolve_native_toolchain_executables(toolchain)
-}
-
-// A bare override selects the discovered toolchain as a whole. Path-like overrides
-// remain self-contained so they cannot inherit an environment for another installation.
-fn resolve_msvc_toolchain_override(mut toolchain: Toolchain, resolved: &Toolchain) -> Toolchain {
-    if is_path_like_tool(&toolchain.cc.cc_path) {
-        return toolchain;
-    }
-
-    toolchain.cc.cc_path.clone_from(&resolved.cc.cc_path);
-    toolchain.cc.ar_path.clone_from(&resolved.cc.ar_path);
-
-    match resolved.msvc_environment() {
-        Some(environment) => toolchain.with_msvc_environment(environment.clone()),
-        None => toolchain,
-    }
-}
-
 fn is_path_like_tool(tool: &str) -> bool {
     let path = Path::new(tool);
     let has_parent = path
@@ -621,27 +491,6 @@ impl CC {
         CC::resolve_reported_prog_path(&prog)
     }
 
-    fn default_msvc_librarian(cc_path: &Path) -> String {
-        let lib = CC::resolve_tool_path(cc_path, "lib.exe");
-        if Path::new(&lib).is_file() {
-            return lib;
-        }
-
-        let compiler_name = cc_path
-            .file_name()
-            .and_then(OsStr::to_str)
-            .unwrap_or_default()
-            .to_ascii_lowercase();
-        if CC::strip_exe_suffix(&compiler_name).ends_with("clang-cl") {
-            let llvm_lib = CC::resolve_tool_path(cc_path, "llvm-lib.exe");
-            if Path::new(&llvm_lib).is_file() {
-                return llvm_lib;
-            }
-        }
-
-        lib
-    }
-
     fn with_default_platform_archiver(mut self) -> Self {
         #[cfg(target_os = "macos")]
         if self.targets_apple_darwin()
@@ -715,7 +564,7 @@ impl CC {
     ) -> anyhow::Result<Self> {
         let target_triple = CC::probe_target_triple(cc_path, cc_kind);
         let (ar_kind, ar_path) = match cc_kind {
-            CCKind::Msvc => (ARKind::MsvcLib, CC::default_msvc_librarian(cc_path)),
+            CCKind::Msvc => (ARKind::MsvcLib, default_librarian(cc_path)),
             CCKind::SystemCC | CCKind::Gcc | CCKind::Clang => (
                 CC::classify_gcc_like_archiver(ar_name, target_triple.as_deref()),
                 CC::resolve_tool_path(cc_path, ar_name),
@@ -1227,13 +1076,6 @@ fn add_linker_shared_lib_flags(
     }
 }
 
-// Linker compiler-specific flags
-fn add_linker_msvc_specific_flags(cc: &CC, buf: &mut Vec<String>) {
-    if cc.is_msvc() {
-        buf.push("/nologo".to_string());
-    }
-}
-
 // Linker compiler-specific handling for moonbitrun
 fn add_linker_moonbitrun(
     cc: &CC,
@@ -1261,27 +1103,6 @@ fn add_linker_common_libraries<P: AsRef<Path>>(
             buf.push("-lruntime".to_string());
             buf.push(format!("-Wl,-rpath,{}", dyn_lib_path.as_ref().display()));
         }
-    }
-}
-
-fn add_linker_msvc_runtime<P: AsRef<Path>>(
-    cc: &CC,
-    buf: &mut Vec<String>,
-    config: &LinkerConfig<P>,
-    lpath: &str,
-) {
-    if cc.is_msvc() {
-        if let Some(dyn_lib_path) = config.link_shared_runtime.as_ref() {
-            buf.push(
-                dyn_lib_path
-                    .as_ref()
-                    .join("libruntime.lib")
-                    .display()
-                    .to_string(),
-            );
-        }
-        buf.push("/link".to_string());
-        buf.push(format!("/LIBPATH:{lpath}"));
     }
 }
 
@@ -1476,30 +1297,6 @@ fn add_cc_compile_only_flags(cc: &CC, buf: &mut Vec<String>, config: &CCConfig) 
     }
 }
 
-// Compiler-specific flags grouped together
-fn add_cc_msvc_specific_flags(cc: &CC, buf: &mut Vec<String>, has_user_flags: bool) {
-    if !cc.is_msvc() {
-        return;
-    }
-
-    buf.push(WINDOWS_MSVC_C_STANDARD_FLAG.to_string());
-
-    // MSVC-specific misc options
-    if !has_user_flags {
-        buf.push("/utf-8".to_string());
-        buf.push("/wd4819".to_string());
-    }
-    buf.push("/nologo".to_string());
-}
-
-fn add_cc_msvc_runtime_flags(cc: &CC, toolchain: Option<&Toolchain>, buf: &mut Vec<String>) {
-    if cc.is_msvc()
-        && let Some(crt) = toolchain.and_then(Toolchain::msvc_crt_policy)
-    {
-        buf.push(crt.compiler_flag().to_string());
-    }
-}
-
 fn add_cc_gcc_like_specific_flags(cc: &CC, buf: &mut Vec<String>) {
     // the below flags are needed, ref: https://github.com/moonbitlang/core/issues/1594#issuecomment-2649652455
     if cc.is_full_featured_gcc_like() {
@@ -1635,13 +1432,6 @@ fn add_cc_moonbitrun(cc: &CC, buf: &mut Vec<String>, config: &CCConfig, paths: &
 fn add_cc_common_libraries(cc: &CC, buf: &mut Vec<String>, config: &CCConfig) {
     if cc.should_link_libm() && config.output_ty != OutputType::Object {
         buf.push("-lm".to_string());
-    }
-}
-
-fn add_cc_msvc_linker_flags(cc: &CC, buf: &mut Vec<String>, config: &CCConfig, lpath: &str) {
-    if cc.is_msvc() && config.output_ty != OutputType::Object {
-        buf.push("/link".to_string());
-        buf.push(format!("/LIBPATH:{lpath}"));
     }
 }
 

--- a/crates/moonutil/src/compiler_flags/archiver.rs
+++ b/crates/moonutil/src/compiler_flags/archiver.rs
@@ -1,0 +1,92 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use super::{ARKind, ArchiverConfig, CC, CompilerPaths, moonbitrun_object, resolve_cc, tcc};
+
+fn add_archiver_flags(cc: &CC, buf: &mut Vec<String>, dest: &str) {
+    match cc.ar_kind {
+        ARKind::MsvcLib => {
+            buf.push("/nologo".to_string());
+            buf.push(format!("/Out:{dest}"));
+        }
+        ARKind::AppleLibtool => {
+            buf.push("-static".to_string());
+            buf.push("-o".to_string());
+            buf.push(dest.to_string());
+        }
+        ARKind::GnuAr | ARKind::LlvmAr => {
+            buf.push("-r".to_string());
+            buf.push("-c".to_string());
+            buf.push("-s".to_string());
+            buf.push(dest.to_string());
+        }
+        ARKind::TccAr => {
+            tcc::add_archiver_flags(buf, dest);
+        }
+    }
+}
+
+fn add_archiver_moonbitrun(
+    cc: &CC,
+    buf: &mut Vec<String>,
+    config: &ArchiverConfig,
+    paths: &CompilerPaths,
+) {
+    if let Some(object) = moonbitrun_object(
+        cc,
+        config.archive_moonbitrun,
+        config.native_allocator,
+        &paths.lib_path,
+    ) {
+        buf.push(object);
+    }
+}
+
+pub fn make_archiver_command<S>(
+    cc: CC,
+    user_cc: Option<CC>,
+    config: ArchiverConfig,
+    src: &[S],
+    dest: &str,
+) -> Vec<String>
+where
+    S: AsRef<str>,
+{
+    let resolved_cc = resolve_cc(&cc, user_cc.as_ref());
+    let paths = CompilerPaths::from_moon_dirs();
+    make_archiver_command_resolved(resolved_cc, config, src, dest, &paths)
+}
+
+pub fn make_archiver_command_resolved<S>(
+    cc: CC,
+    config: ArchiverConfig,
+    src: &[S],
+    dest: &str,
+    paths: &CompilerPaths,
+) -> Vec<String>
+where
+    S: AsRef<str>,
+{
+    let mut buf = vec![cc.ar_path.clone()];
+
+    add_archiver_flags(&cc, &mut buf, dest);
+    add_archiver_moonbitrun(&cc, &mut buf, &config, paths);
+    buf.extend(src.iter().map(|s| s.as_ref().to_string()));
+
+    buf
+}

--- a/crates/moonutil/src/compiler_flags/gcc_like.rs
+++ b/crates/moonutil/src/compiler_flags/gcc_like.rs
@@ -1,0 +1,189 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::path::Path;
+
+use super::{ARKind, CC, CCConfig, CCKind, LinkerConfig, OutputType};
+
+impl CC {
+    fn probe_prog_name(cc_path: &Path, name: &str) -> Option<String> {
+        let output = std::process::Command::new(cc_path)
+            .arg(format!("-print-prog-name={name}"))
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let prog = String::from_utf8_lossy(&output.stdout);
+        let prog = prog.lines().next()?.trim();
+        (!prog.is_empty()).then(|| prog.to_string())
+    }
+
+    pub(super) fn resolve_reported_prog_path(prog: &str) -> Option<String> {
+        let prog_path = Path::new(prog);
+        let has_non_empty_parent = prog_path
+            .parent()
+            .is_some_and(|parent| !parent.as_os_str().is_empty());
+
+        if prog_path.is_absolute() || has_non_empty_parent {
+            if prog_path.is_file() {
+                return Some(prog.to_string());
+            }
+
+            #[cfg(windows)]
+            if prog_path.extension().is_none() {
+                let exe_path = prog_path.with_extension("exe");
+                if exe_path.is_file() {
+                    return Some(exe_path.display().to_string());
+                }
+            }
+
+            return None;
+        }
+
+        which::which(prog)
+            .ok()
+            .map(|path| path.display().to_string())
+    }
+
+    pub(super) fn probe_existing_prog_name(cc_path: &Path, name: &str) -> Option<String> {
+        let prog = CC::probe_prog_name(cc_path, name)?;
+        CC::resolve_reported_prog_path(&prog)
+    }
+
+    pub(super) fn with_default_platform_archiver(mut self) -> Self {
+        #[cfg(target_os = "macos")]
+        if self.targets_apple_darwin()
+            && !self.is_tcc()
+            && let Some(libtool) = resolve_apple_libtool_path()
+        {
+            self.ar_kind = ARKind::AppleLibtool;
+            self.ar_path = libtool.display().to_string();
+            return self;
+        }
+
+        if matches!(self.cc_kind, CCKind::Clang)
+            && self.targets_msvc()
+            && let Some(llvm_lib) =
+                CC::probe_existing_prog_name(Path::new(&self.cc_path), "llvm-lib")
+        {
+            self.ar_kind = ARKind::MsvcLib;
+            self.ar_path = llvm_lib;
+        }
+
+        self
+    }
+
+    fn is_llvm_ar_name(ar_name_or_path: &str) -> bool {
+        let file_name = Path::new(ar_name_or_path)
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or(ar_name_or_path)
+            .to_ascii_lowercase();
+        CC::strip_exe_suffix(&file_name) == "llvm-ar"
+    }
+
+    fn is_msvc_librarian_name(ar_name_or_path: &str) -> bool {
+        let file_name = Path::new(ar_name_or_path)
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or(ar_name_or_path)
+            .to_ascii_lowercase();
+        matches!(CC::strip_exe_suffix(&file_name), "lib" | "llvm-lib")
+    }
+
+    fn is_apple_libtool_name(ar_name_or_path: &str) -> bool {
+        let file_name = Path::new(ar_name_or_path)
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or(ar_name_or_path)
+            .to_ascii_lowercase();
+        CC::strip_exe_suffix(&file_name) == "libtool"
+    }
+
+    pub(super) fn classify_gcc_like_archiver(
+        ar_name_or_path: &str,
+        target_triple: Option<&str>,
+    ) -> ARKind {
+        if target_triple.is_some_and(|target| target.contains("msvc"))
+            && CC::is_msvc_librarian_name(ar_name_or_path)
+        {
+            ARKind::MsvcLib
+        } else if target_triple.is_some_and(|target| target.contains("apple-darwin"))
+            && CC::is_apple_libtool_name(ar_name_or_path)
+        {
+            ARKind::AppleLibtool
+        } else if CC::is_llvm_ar_name(ar_name_or_path) {
+            ARKind::LlvmAr
+        } else {
+            ARKind::GnuAr
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn resolve_apple_libtool_path() -> Option<std::path::PathBuf> {
+    let output = std::process::Command::new("xcrun")
+        .args(["--find", "libtool"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let libtool = String::from_utf8_lossy(&output.stdout);
+    let libtool = std::path::PathBuf::from(libtool.lines().next()?.trim());
+    libtool.is_file().then_some(libtool)
+}
+
+pub(super) fn add_cc_specific_flags(cc: &CC, buf: &mut Vec<String>) {
+    // The flags are required by the generated C runtime. See:
+    // https://github.com/moonbitlang/core/issues/1594#issuecomment-2649652455
+    if cc.is_full_featured_gcc_like() {
+        buf.push("-fwrapv".to_string());
+        buf.push("-fno-strict-aliasing".to_string());
+        // Apple clang is usually detected as SystemCC on macOS.
+        if matches!(cc.cc_kind, CCKind::Clang)
+            || (cfg!(target_os = "macos") && matches!(cc.cc_kind, CCKind::SystemCC))
+        {
+            buf.push("-Wno-unused-value".to_string());
+        }
+    }
+}
+
+pub(super) fn add_linker_common_libraries<P: AsRef<Path>>(
+    cc: &CC,
+    buf: &mut Vec<String>,
+    config: &LinkerConfig<P>,
+) {
+    if cc.is_gcc_like() {
+        if cc.should_link_libm() {
+            buf.push("-lm".to_string());
+        }
+        if let Some(dyn_lib_path) = config.link_shared_runtime.as_ref() {
+            buf.push("-lruntime".to_string());
+            buf.push(format!("-Wl,-rpath,{}", dyn_lib_path.as_ref().display()));
+        }
+    }
+}
+
+pub(super) fn add_cc_common_libraries(cc: &CC, buf: &mut Vec<String>, config: &CCConfig) {
+    if cc.should_link_libm() && config.output_ty != OutputType::Object {
+        buf.push("-lm".to_string());
+    }
+}

--- a/crates/moonutil/src/compiler_flags/msvc.rs
+++ b/crates/moonutil/src/compiler_flags/msvc.rs
@@ -1,0 +1,257 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::path::Path;
+
+#[cfg(windows)]
+use anyhow::Context;
+
+use super::{
+    CC, CCConfig, ENV_CC, LinkerConfig, MsvcEnvironment, OutputType, Toolchain, ToolchainSource,
+    is_path_like_tool, resolve_native_toolchain_executables,
+};
+
+pub const WINDOWS_MSVC_DEFAULT_LIBS: &[&str] = &[
+    "libcmt.lib",
+    "oldnames.lib",
+    "kernel32.lib",
+    "shell32.lib",
+    "user32.lib",
+    "dbghelp.lib",
+    "uuid.lib",
+];
+pub const WINDOWS_MSVC_STATIC_RUNTIME_FLAG: &str = "/MT";
+pub const WINDOWS_MSVC_C_STANDARD_FLAG: &str = "/std:c11";
+
+#[cfg(windows)]
+static WINDOWS_MSVC_TOOLCHAIN: std::sync::OnceLock<Option<DiscoveredMsvcToolchain>> =
+    std::sync::OnceLock::new();
+
+#[derive(Clone, Debug)]
+struct DiscoveredMsvcToolchain {
+    cc: CC,
+    environment: MsvcEnvironment,
+}
+
+#[cfg(windows)]
+pub(super) fn windows_msvc_host_target_triple() -> Option<String> {
+    let arch = std::env::consts::ARCH;
+    match arch {
+        "x86_64" | "aarch64" => Some(format!("{arch}-pc-windows-msvc")),
+        _ => None,
+    }
+}
+
+#[cfg(windows)]
+fn find_windows_msvc_toolchain(target: &str) -> Option<DiscoveredMsvcToolchain> {
+    let tool = find_msvc_tools::find_tool(target, "cl.exe")
+        .or_else(|| find_msvc_tools::find_tool(target, "clang-cl.exe"))?;
+    let cc = CC::try_from_path(&tool.path().display().to_string()).ok()?;
+    if !Path::new(&cc.ar_path).is_file() {
+        return None;
+    }
+    Some(DiscoveredMsvcToolchain {
+        cc,
+        environment: MsvcEnvironment {
+            command_env: tool
+                .env()
+                .into_iter()
+                .map(|(key, value)| {
+                    (
+                        key.to_string_lossy().into_owned(),
+                        value.to_string_lossy().into_owned(),
+                    )
+                })
+                .collect(),
+        },
+    })
+}
+
+fn resolve_windows_msvc_discovery() -> anyhow::Result<DiscoveredMsvcToolchain> {
+    #[cfg(not(windows))]
+    {
+        anyhow::bail!("Windows MSVC environment resolution is only supported on Windows")
+    }
+
+    #[cfg(windows)]
+    {
+        let target = windows_msvc_host_target_triple()
+            .context("Windows MSVC discovery currently supports 64-bit x64 and ARM64 hosts")?;
+
+        WINDOWS_MSVC_TOOLCHAIN
+            .get_or_init(|| find_windows_msvc_toolchain(&target))
+            .clone()
+            .with_context(|| {
+                "Windows native backend requires MSVC Build Tools with C++ tools and Windows SDK"
+            })
+    }
+}
+
+pub(super) fn discovered_windows_msvc_toolchain() -> anyhow::Result<Toolchain> {
+    let discovered = resolve_windows_msvc_discovery()?;
+    Ok(Toolchain::from_path_probe(discovered.cc).with_msvc_environment(discovered.environment))
+}
+
+pub fn resolve_windows_msvc_toolchain() -> anyhow::Result<Toolchain> {
+    resolve_native_toolchain_executables(discovered_windows_msvc_toolchain()?)
+}
+
+pub(super) fn ensure_windows_msvc_compatible(cc: &CC) -> anyhow::Result<()> {
+    if cc.is_msvc() {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "Windows native backend requires an MSVC cl-compatible compiler driver such as cl.exe or clang-cl.exe; found {}",
+            cc.cc_path
+        )
+    }
+}
+
+pub fn windows_msvc_native_toolchain(package_cc: Option<&CC>) -> anyhow::Result<Toolchain> {
+    if let Some(env_cc) = ENV_CC.as_ref().filter(|cc| cc.is_msvc()) {
+        let override_toolchain = Toolchain::from_env_override(env_cc.clone());
+        let resolved = if is_path_like_tool(&env_cc.cc_path) {
+            override_toolchain
+        } else {
+            let discovered = discovered_windows_msvc_toolchain()?;
+            resolve_msvc_toolchain_override(override_toolchain, &discovered)
+        };
+        return windows_msvc_toolchain_with_package_override(resolved, package_cc);
+    }
+
+    if let Some(package_cc) = package_cc {
+        ensure_windows_msvc_compatible(package_cc)?;
+    }
+
+    let resolved = discovered_windows_msvc_toolchain()?;
+    windows_msvc_toolchain_with_package_override(resolved, package_cc)
+}
+
+pub fn has_incompatible_windows_msvc_env_override() -> bool {
+    ENV_CC.as_ref().is_some_and(|cc| !cc.is_msvc())
+}
+
+pub(super) fn windows_msvc_toolchain_with_package_override(
+    resolved: Toolchain,
+    package_cc: Option<&CC>,
+) -> anyhow::Result<Toolchain> {
+    let mut toolchain = resolved.with_package_override(package_cc);
+    ensure_windows_msvc_compatible(toolchain.cc())?;
+
+    if toolchain.source() == ToolchainSource::PackageOverride {
+        toolchain = resolve_msvc_toolchain_override(toolchain, &resolved);
+    }
+
+    resolve_native_toolchain_executables(toolchain)
+}
+
+// A bare override selects the discovered toolchain as a whole. Path-like overrides
+// remain self-contained so they cannot inherit an environment for another installation.
+pub(super) fn resolve_msvc_toolchain_override(
+    mut toolchain: Toolchain,
+    resolved: &Toolchain,
+) -> Toolchain {
+    if is_path_like_tool(&toolchain.cc.cc_path) {
+        return toolchain;
+    }
+
+    toolchain.cc.cc_path.clone_from(&resolved.cc.cc_path);
+    toolchain.cc.ar_path.clone_from(&resolved.cc.ar_path);
+
+    match resolved.msvc_environment() {
+        Some(environment) => toolchain.with_msvc_environment(environment.clone()),
+        None => toolchain,
+    }
+}
+
+pub(super) fn default_librarian(cc_path: &Path) -> String {
+    let lib = CC::resolve_tool_path(cc_path, "lib.exe");
+    if Path::new(&lib).is_file() {
+        return lib;
+    }
+
+    let compiler_name = cc_path
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if CC::strip_exe_suffix(&compiler_name).ends_with("clang-cl") {
+        let llvm_lib = CC::resolve_tool_path(cc_path, "llvm-lib.exe");
+        if Path::new(&llvm_lib).is_file() {
+            return llvm_lib;
+        }
+    }
+
+    lib
+}
+
+pub(super) fn add_linker_specific_flags(cc: &CC, buf: &mut Vec<String>) {
+    if cc.is_msvc() {
+        buf.push("/nologo".to_string());
+    }
+}
+
+pub(super) fn add_linker_runtime<P: AsRef<Path>>(
+    cc: &CC,
+    buf: &mut Vec<String>,
+    config: &LinkerConfig<P>,
+    lpath: &str,
+) {
+    if cc.is_msvc() {
+        if let Some(dyn_lib_path) = config.link_shared_runtime.as_ref() {
+            buf.push(
+                dyn_lib_path
+                    .as_ref()
+                    .join("libruntime.lib")
+                    .display()
+                    .to_string(),
+            );
+        }
+        buf.push("/link".to_string());
+        buf.push(format!("/LIBPATH:{lpath}"));
+    }
+}
+
+pub(super) fn add_cc_specific_flags(cc: &CC, buf: &mut Vec<String>, has_user_flags: bool) {
+    if !cc.is_msvc() {
+        return;
+    }
+
+    buf.push(WINDOWS_MSVC_C_STANDARD_FLAG.to_string());
+
+    if !has_user_flags {
+        buf.push("/utf-8".to_string());
+        buf.push("/wd4819".to_string());
+    }
+    buf.push("/nologo".to_string());
+}
+
+pub(super) fn add_cc_runtime_flags(cc: &CC, toolchain: Option<&Toolchain>, buf: &mut Vec<String>) {
+    if cc.is_msvc()
+        && let Some(crt) = toolchain.and_then(Toolchain::msvc_crt_policy)
+    {
+        buf.push(crt.compiler_flag().to_string());
+    }
+}
+
+pub(super) fn add_cc_linker_flags(cc: &CC, buf: &mut Vec<String>, config: &CCConfig, lpath: &str) {
+    if cc.is_msvc() && config.output_ty != OutputType::Object {
+        buf.push("/link".to_string());
+        buf.push(format!("/LIBPATH:{lpath}"));
+    }
+}

--- a/crates/moonutil/src/compiler_flags/tcc.rs
+++ b/crates/moonutil/src/compiler_flags/tcc.rs
@@ -1,0 +1,86 @@
+// moon: The build system and package manager for MoonBit.
+// Copyright (C) 2024 International Digital Economy Academy
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// For inquiries, you can contact us via e-mail at jichuruanjian@idea.edu.cn.
+
+use std::path::Path;
+
+use colored::Colorize;
+
+use super::{ARKind, CC, CCConfig};
+
+pub(super) fn default_archiver(cc_path: &Path) -> (ARKind, String) {
+    (ARKind::TccAr, cc_path.display().to_string())
+}
+
+pub(super) fn resolve_archiver_path(cc: &mut CC) {
+    cc.ar_path.clone_from(&cc.cc_path);
+}
+
+pub(super) fn add_archiver_flags(buf: &mut Vec<String>, dest: &str) {
+    buf.push("-ar".to_string());
+    buf.push("rcs".to_string());
+    buf.push(dest.to_string());
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_macos_sdk_lib_path() -> Option<std::path::PathBuf> {
+    let output = std::process::Command::new("xcrun")
+        .args(["--sdk", "macosx", "--show-sdk-path"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let sdk_root = String::from_utf8_lossy(&output.stdout);
+    let sdk_root = sdk_root.lines().next()?.trim();
+    if sdk_root.is_empty() {
+        return None;
+    }
+
+    let sdk_lib_path = Path::new(sdk_root).join("usr").join("lib");
+    sdk_lib_path.is_dir().then_some(sdk_lib_path)
+}
+
+#[cfg(target_os = "macos")]
+static MACOS_SDK_LIB_PATH: std::sync::LazyLock<Option<std::path::PathBuf>> =
+    std::sync::LazyLock::new(resolve_macos_sdk_lib_path);
+
+#[cfg(target_os = "macos")]
+pub(super) fn add_macos_sdk_library_path(buf: &mut Vec<String>) {
+    if let Some(sdk_lib_path) = MACOS_SDK_LIB_PATH.as_ref() {
+        buf.push(format!("-L{}", sdk_lib_path.display()));
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(super) fn add_macos_sdk_library_path(_buf: &mut Vec<String>) {}
+
+pub(super) fn add_cc_specific_flags(cc: &CC, buf: &mut Vec<String>, config: &CCConfig) {
+    if !cc.is_tcc() {
+        return;
+    }
+
+    if config.no_sys_header {
+        buf.push("-DMOONBIT_NATIVE_NO_SYS_HEADER".to_string());
+    } else {
+        eprintln!(
+            "{}: Use tcc without set MOONBIT_NATIVE_NO_SYS_HEADER.",
+            "Warning".yellow().bold(),
+        );
+    }
+}


### PR DESCRIPTION
## Why

`compiler_flags` mixes its public native-toolchain model and command orchestration with compiler-family discovery and flag details. That makes family-specific work—especially deciding the future scope of explicit TCC support—require reasoning through one large implementation file.

## What

- Move MSVC and clang-cl discovery, compatibility, CRT, and flag policy into a private `msvc` module.
- Move explicit TCC compiler and archiver policy into a private `tcc` module.
- Move shared GCC/Clang probing and flag policy into a private `gcc_like` module.
- Move archive command construction into a private `archiver` module.

## Correctness and scope

The existing `moonutil::compiler_flags` types and command-building entry points remain at the same paths through private imports and public re-exports. Selection order, emitted flags, and command construction order are unchanged. The work is split into four compiler-family/operation commits and deliberately leaves the remaining shared model and orchestration in the parent module.