### PR TITLE
feat: add experimental embedded Moonrun policies to .mbtx

### DIFF
--- a/crates/moon/src/cli/moonx.rs
+++ b/crates/moon/src/cli/moonx.rs
@@ -131,16 +131,25 @@ pub(crate) fn prepare(
         MoonxTarget::Wasm => {
             let policy_relay = moonutil::policy_transport::PolicyTransfer::take_from_env()?
                 .map(moonutil::policy_transport::PolicyTransfer::into_relay);
-            let wasm_path = if is_mbtx_input(&input) {
-                super::run::build_standalone_wasm(input, verbose)?
+            let (wasm_path, embedded_policy) = if is_mbtx_input(&input) {
+                let built = super::run::build_standalone_wasm(input, verbose)?;
+                (built.executable, built.embedded_mbtx_policy)
             } else {
-                RegistryClient::configured().acquire_executable_wasm(&input, user_log)?
+                (
+                    RegistryClient::configured().acquire_executable_wasm(&input, user_log)?,
+                    None,
+                )
             };
+            let (policy, policy_source_dir) = super::run::effective_moonrun_policy(
+                experimental_policy.as_deref(),
+                embedded_policy.as_ref(),
+            );
 
             registry_runner::prepare_artifact(
                 crate::run::ExecutionMode::MoonRun,
                 &wasm_path,
-                experimental_policy.as_deref(),
+                policy,
+                policy_source_dir,
                 policy_relay,
                 &args,
                 user_log,

--- a/crates/moon/src/cli/registry_runner.rs
+++ b/crates/moon/src/cli/registry_runner.rs
@@ -94,6 +94,7 @@ pub(crate) fn prepare(
                 crate::run::ExecutionMode::MoonRun,
                 &wasm_path,
                 experimental_policy.as_deref(),
+                None,
                 policy_relay,
                 &args,
                 user_log,
@@ -105,6 +106,7 @@ pub(crate) fn prepare(
             prepare_artifact(
                 crate::run::ExecutionMode::Native,
                 &executable,
+                None,
                 None,
                 None,
                 &args,
@@ -145,12 +147,18 @@ pub(crate) fn prepare_artifact(
     mode: crate::run::ExecutionMode,
     artifact: &Path,
     experimental_policy: Option<&Path>,
+    policy_source_dir: Option<&Path>,
     policy_relay: Option<moonutil::policy_transport::PolicyRelay>,
     args: &[String],
     user_log: &UserLog,
 ) -> anyhow::Result<super::process::ProcessAction> {
-    let mut run_cmd =
-        crate::run::command_for_with_moonrun_policy(mode, artifact, None, experimental_policy);
+    let mut run_cmd = crate::run::command_for_with_moonrun_policy_source_dir(
+        mode,
+        artifact,
+        None,
+        experimental_policy,
+        policy_source_dir,
+    );
     run_cmd.args(args);
 
     if user_log.is_enabled(log::Level::Info) {
@@ -184,6 +192,7 @@ mod tests {
         let action = prepare_artifact(
             crate::run::ExecutionMode::MoonRun,
             Path::new("artifact.wasm"),
+            None,
             None,
             None,
             &[],

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -154,6 +154,9 @@ pub(crate) struct BuildRunExecutableOptions {
     output: RunOutputVerbosity,
     /// Backend to use when neither CLI flags nor single-file metadata selects one.
     default_target_backend: TargetBackend,
+    /// Synthetic stdin and inline sources live in a temporary directory, but
+    /// relative embedded-policy paths retain the invocation directory.
+    embedded_policy_source_dir: Option<PathBuf>,
 }
 
 impl BuildRunExecutableOptions {
@@ -162,6 +165,7 @@ impl BuildRunExecutableOptions {
             print_dry_run_run_command: true,
             output: RunOutputVerbosity::from_flags(cli),
             default_target_backend: TargetBackend::default(),
+            embedded_policy_source_dir: None,
         }
     }
 
@@ -172,8 +176,14 @@ impl BuildRunExecutableOptions {
             print_dry_run_run_command: false,
             output: RunOutputVerbosity::from_flags(cli),
             default_target_backend: TargetBackend::default(),
+            embedded_policy_source_dir: None,
         }
     }
+}
+
+pub(crate) struct EmbeddedMbtxPolicy {
+    source: PathBuf,
+    source_dir_override: Option<PathBuf>,
 }
 
 /// A built executable plus the state needed to consume it.
@@ -189,6 +199,7 @@ pub(crate) struct RunExecutable {
     pub(crate) backend: BackendConfig,
     pub(crate) opt_level: moonutil::cond_expr::OptLevel,
     pub(crate) target_dir: PathBuf,
+    pub(crate) embedded_mbtx_policy: Option<EmbeddedMbtxPolicy>,
     source_dir: PathBuf,
     build_exit_code: Option<i32>,
     lock: Option<std::fs::File>,
@@ -197,6 +208,7 @@ pub(crate) struct RunExecutable {
 struct BuildExecutableFromPlanOptions {
     print_dry_run_run_command: bool,
     output: RunOutputVerbosity,
+    embedded_mbtx_policy: Option<EmbeddedMbtxPolicy>,
 }
 
 enum RunBuildInput {
@@ -268,9 +280,13 @@ fn run_source_as_single_file(
     source: String,
     temp_name: &str,
     source_name: &str,
-    options: BuildRunExecutableOptions,
+    mut options: BuildRunExecutableOptions,
     output: &CommandOutput,
 ) -> anyhow::Result<i32> {
+    options.embedded_policy_source_dir = Some(
+        std::env::current_dir()
+            .with_context(|| format!("failed to resolve {source_name} policy source directory"))?,
+    );
     let temp_dir = tempfile::TempDir::new()
         .with_context(|| format!("failed to create temporary directory for {source_name} run"))?;
     let input_path = temp_dir.path().join(temp_name);
@@ -353,6 +369,7 @@ fn build_wasm_file_executable_from_arg(
         backend: BackendConfig::WasmGc { use_wat: false },
         opt_level: moonutil::cond_expr::OptLevel::Debug,
         target_dir: print_dir.clone(),
+        embedded_mbtx_policy: None,
         source_dir: print_dir,
         build_exit_code: (!cli.dry_run).then_some(0),
         lock: None,
@@ -448,7 +465,10 @@ pub(crate) fn build_run_executable(
 ///
 /// The returned artifact is ready for a caller-owned execution path; no build
 /// lock remains held after this function returns.
-pub(crate) fn build_standalone_wasm(input: String, verbose: bool) -> anyhow::Result<PathBuf> {
+pub(crate) fn build_standalone_wasm(
+    input: String,
+    verbose: bool,
+) -> anyhow::Result<StandaloneWasm> {
     // TODO(moonx-standalone-build-interface): Remove this command-layer adapter
     // once standalone build planning accepts explicit source, backend, sync,
     // and output options without UniversalFlags and RunSubcommand.
@@ -493,7 +513,15 @@ pub(crate) fn build_standalone_wasm(input: String, verbose: bool) -> anyhow::Res
         "standalone `.mbtx` build did not produce linear-memory Wasm"
     );
     built.release_lock();
-    Ok(built.executable)
+    Ok(StandaloneWasm {
+        executable: built.executable,
+        embedded_mbtx_policy: built.embedded_mbtx_policy,
+    })
+}
+
+pub(crate) struct StandaloneWasm {
+    pub(crate) executable: PathBuf,
+    pub(crate) embedded_mbtx_policy: Option<EmbeddedMbtxPolicy>,
 }
 
 #[instrument(skip_all)]
@@ -553,6 +581,7 @@ fn build_package_executable(
         BuildExecutableFromPlanOptions {
             print_dry_run_run_command: options.print_dry_run_run_command,
             output: options.output,
+            embedded_mbtx_policy: None,
         },
         output,
     )
@@ -623,16 +652,32 @@ fn get_run_cmd(
     build_meta: &rr_build::BuildMeta,
     argv: &[String],
     moonrun_policy: Option<&Path>,
+    policy_source_dir: Option<&Path>,
 ) -> std::process::Command {
     let executable = get_run_executable(build_meta);
-    let mut cmd = crate::run::command_for_with_moonrun_policy(
+    let mut cmd = crate::run::command_for_with_moonrun_policy_source_dir(
         crate::run::ExecutionMode::from(&build_meta.backend),
         executable,
         None,
         moonrun_policy,
+        policy_source_dir,
     );
     cmd.args(argv);
     cmd
+}
+
+pub(crate) fn effective_moonrun_policy<'a>(
+    cli_policy: Option<&'a Path>,
+    embedded_policy: Option<&'a EmbeddedMbtxPolicy>,
+) -> (Option<&'a Path>, Option<&'a Path>) {
+    match (cli_policy, embedded_policy) {
+        (Some(policy), _) => (Some(policy), None),
+        (None, Some(policy)) => (
+            Some(policy.source.as_path()),
+            policy.source_dir_override.as_deref(),
+        ),
+        (None, None) => (None, None),
+    }
 }
 
 /// Extract the single executable artifact emitted for a `UserIntent::Run` plan.
@@ -691,6 +736,17 @@ fn build_single_file_executable(
     options: BuildRunExecutableOptions,
     output: &CommandOutput,
 ) -> anyhow::Result<RunExecutable> {
+    let embedded_mbtx_policy = if input_path.extension().is_some_and(|ext| ext == "mbtx")
+        && moonutil::front_matter::parse_mbtx_policy::<serde::de::IgnoredAny>(&input_path)?
+            .is_some()
+    {
+        Some(EmbeddedMbtxPolicy {
+            source: input_path.clone(),
+            source_dir_override: options.embedded_policy_source_dir.clone(),
+        })
+    } else {
+        None
+    };
     let user_log = output.user_log();
     let PackageDirs {
         source_dir,
@@ -772,6 +828,7 @@ fn build_single_file_executable(
         BuildExecutableFromPlanOptions {
             print_dry_run_run_command: options.print_dry_run_run_command,
             output: options.output,
+            embedded_mbtx_policy,
         },
         output,
     )
@@ -791,6 +848,10 @@ fn build_executable_from_plan(
     options: BuildExecutableFromPlanOptions,
     output: &CommandOutput,
 ) -> Result<RunExecutable, anyhow::Error> {
+    let (moonrun_policy, policy_source_dir) = effective_moonrun_policy(
+        cmd.moonrun_policy.as_deref(),
+        options.embedded_mbtx_policy.as_ref(),
+    );
     let user_log = output.user_log();
     if cli.dry_run {
         output.write_result(|writer| {
@@ -812,7 +873,7 @@ fn build_executable_from_plan(
             }
 
             if options.print_dry_run_run_command {
-                let run_cmd = get_run_cmd(build_meta, &cmd.args, cmd.moonrun_policy.as_deref());
+                let run_cmd = get_run_cmd(build_meta, &cmd.args, moonrun_policy, policy_source_dir);
                 writeln!(
                     writer,
                     "{}",
@@ -826,6 +887,7 @@ fn build_executable_from_plan(
             backend: build_meta.backend.clone(),
             opt_level: build_meta.opt_level,
             target_dir: target_dir.to_path_buf(),
+            embedded_mbtx_policy: options.embedded_mbtx_policy,
             source_dir: source_dir.to_path_buf(),
             build_exit_code: None,
             lock: None,
@@ -853,6 +915,7 @@ fn build_executable_from_plan(
         backend: build_meta.backend.clone(),
         opt_level: build_meta.opt_level,
         target_dir: target_dir.to_path_buf(),
+        embedded_mbtx_policy: options.embedded_mbtx_policy,
         source_dir: source_dir.to_path_buf(),
         build_exit_code: Some(build_result.return_code_for_success()),
         lock: Some(lock),
@@ -881,11 +944,16 @@ fn run_executable(
         return Ok(build_exit_code);
     }
 
-    let mut run_cmd = crate::run::command_for_with_moonrun_policy(
+    let (moonrun_policy, policy_source_dir) = effective_moonrun_policy(
+        cmd.moonrun_policy.as_deref(),
+        executable.embedded_mbtx_policy.as_ref(),
+    );
+    let mut run_cmd = crate::run::command_for_with_moonrun_policy_source_dir(
         crate::run::ExecutionMode::from(&executable.backend),
         executable.executable.as_path(),
         None,
-        cmd.moonrun_policy.as_deref(),
+        moonrun_policy,
+        policy_source_dir,
     );
     run_cmd.args(&cmd.args);
     let user_log = output.user_log();

--- a/crates/moon/src/cli/run.rs
+++ b/crates/moon/src/cli/run.rs
@@ -737,8 +737,7 @@ fn build_single_file_executable(
     output: &CommandOutput,
 ) -> anyhow::Result<RunExecutable> {
     let embedded_mbtx_policy = if input_path.extension().is_some_and(|ext| ext == "mbtx")
-        && moonutil::front_matter::parse_mbtx_policy::<serde::de::IgnoredAny>(&input_path)?
-            .is_some()
+        && moonutil::front_matter::has_mbtx_policy(&input_path)?
     {
         Some(EmbeddedMbtxPolicy {
             source: input_path.clone(),

--- a/crates/moon/src/run/mod.rs
+++ b/crates/moon/src/run/mod.rs
@@ -29,7 +29,10 @@ pub(crate) use runtest::{
     PackageFilter, TestFilter, TestIndex, TestOutlineEntry, collect_test_invocations,
     collect_test_outline, perform_promotion, run_tests,
 };
-pub(crate) use runtime::{ExecutionMode, command_for, command_for_with_moonrun_policy};
+pub(crate) use runtime::{
+    ExecutionMode, command_for, command_for_with_moonrun_policy,
+    command_for_with_moonrun_policy_source_dir,
+};
 
 use std::sync::OnceLock;
 

--- a/crates/moon/src/run/runtime.rs
+++ b/crates/moon/src/run/runtime.rs
@@ -74,6 +74,16 @@ pub(crate) fn command_for_with_moonrun_policy(
     test: Option<&TestArgs>,
     moonrun_policy: Option<&Path>,
 ) -> Command {
+    command_for_with_moonrun_policy_source_dir(mode, mbt_executable, test, moonrun_policy, None)
+}
+
+pub(crate) fn command_for_with_moonrun_policy_source_dir(
+    mode: ExecutionMode,
+    mbt_executable: &Path,
+    test: Option<&TestArgs>,
+    moonrun_policy: Option<&Path>,
+    policy_source_dir: Option<&Path>,
+) -> Command {
     match mode {
         ExecutionMode::MoonRun => {
             let mut cmd = Command::new(&*moonutil::toolchain::BINARIES.moonrun);
@@ -84,6 +94,11 @@ pub(crate) fn command_for_with_moonrun_policy(
             if let Some(policy) = moonrun_policy {
                 cmd.arg("--policy");
                 cmd.arg(policy);
+            }
+            if let Some(source_dir) = policy_source_dir {
+                debug_assert!(moonrun_policy.is_some());
+                cmd.arg("--policy-source-dir");
+                cmd.arg(source_dir);
             }
             cmd.arg(mbt_executable);
             cmd.arg("--");

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -230,6 +230,22 @@ fn test_moonx_forwards_experimental_policy_to_mbtx() {
 }
 
 #[test]
+fn test_moonx_uses_embedded_mbtx_policy() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");
+    let moonx = moonx_bin(&bin_dir);
+
+    snapbox::cmd::Command::new(&moonx)
+        .current_dir(&dir)
+        .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
+        .env("MOONRUN_OVERRIDE", moonrun_bin())
+        .arg("embedded_policy.mbtx")
+        .assert()
+        .success()
+        .stdout_eq("embedded\n");
+}
+
+#[test]
 fn test_moonx_validates_native_options_before_discarding_an_inherited_marker() {
     let dir = TestDir::new_empty();
     let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");

--- a/crates/moon/tests/test_cases/moon_commands/mod.rs
+++ b/crates/moon/tests/test_cases/moon_commands/mod.rs
@@ -246,6 +246,61 @@ fn test_moonx_uses_embedded_mbtx_policy() {
 }
 
 #[test]
+fn test_moonx_explicit_policy_skips_malformed_embedded_policy() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");
+    let moonx = moonx_bin(&bin_dir);
+    std::fs::write(
+        dir.join("explicit-policy.json"),
+        r#"{"env":{"set":{"MBTX_POLICY":"explicit"}}}"#,
+    )
+    .unwrap();
+
+    snapbox::cmd::Command::new(&moonx)
+        .current_dir(&dir)
+        .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
+        .env("MOONRUN_OVERRIDE", moonrun_bin())
+        .args([
+            "--experimental-policy",
+            "explicit-policy.json",
+            "malformed_embedded_policy.mbtx",
+        ])
+        .assert()
+        .success()
+        .stdout_eq("explicit\n");
+}
+
+#[test]
+fn test_moonx_inherited_policy_skips_malformed_embedded_policy() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");
+    let moonx = moonx_bin(&bin_dir);
+    let inherited_policy = dir.join("inherited-policy.json");
+    std::fs::write(
+        &inherited_policy,
+        r#"{"env":{"set":{"MBTX_POLICY":"inherited"}}}"#,
+    )
+    .unwrap();
+    let transfer = moonutil::policy_transport::PolicyTransfer::from_file(
+        std::fs::File::open(inherited_policy).unwrap(),
+    )
+    .unwrap();
+    let mut command = std::process::Command::new(&moonx);
+    command
+        .current_dir(&dir)
+        .env("MOON_TOOLCHAIN_ROOT", toolchain_root_for_tests())
+        .env("MOONRUN_OVERRIDE", moonrun_bin())
+        .arg("malformed_embedded_policy.mbtx");
+    let relay = transfer.into_relay().attach_to(&mut command).unwrap();
+
+    snapbox::cmd::Command::from_std(command)
+        .assert()
+        .success()
+        .stdout_eq("inherited\n");
+    relay.finish().unwrap();
+}
+
+#[test]
 fn test_moonx_validates_native_options_before_discarding_an_inherited_marker() {
     let dir = TestDir::new_empty();
     let bin_dir = tempfile::TempDir::new().expect("failed to create moonx bin directory");

--- a/crates/moon/tests/test_cases/moon_test_single_file.in/embedded_policy.mbtx
+++ b/crates/moon/tests/test_cases/moon_test_single_file.in/embedded_policy.mbtx
@@ -1,0 +1,12 @@
+// policy:
+//   env:
+//     set:
+//       MBTX_POLICY: embedded
+
+import {
+  "moonbitlang/core/env",
+}
+
+fn main {
+  println(@env.get_env_var("MBTX_POLICY").unwrap_or("missing"))
+}

--- a/crates/moon/tests/test_cases/moon_test_single_file.in/malformed_embedded_policy.mbtx
+++ b/crates/moon/tests/test_cases/moon_test_single_file.in/malformed_embedded_policy.mbtx
@@ -1,0 +1,10 @@
+// policy:
+//   env: [
+
+import {
+  "moonbitlang/core/env",
+}
+
+fn main {
+  println(@env.get_env_var("MBTX_POLICY").unwrap_or("missing"))
+}

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -160,6 +160,73 @@ fn test_single_file_mbtx_explicit_policy_overrides_embedded_policy() {
 }
 
 #[test]
+fn test_single_file_mbtx_explicit_policy_skips_malformed_embedded_policy() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    fs::write(
+        dir.join("explicit-policy.json"),
+        r#"{"env":{"set":{"MBTX_POLICY":"explicit"}}}"#,
+    )
+    .unwrap();
+
+    moon_cmd(&dir)
+        .args([
+            "run",
+            "malformed_embedded_policy.mbtx",
+            "--target",
+            "wasm",
+            "--wasm-policy",
+            "explicit-policy.json",
+        ])
+        .assert()
+        .success()
+        .stdout_eq("explicit\n");
+}
+
+#[test]
+fn test_single_file_mbtx_non_wasm_paths_skip_malformed_embedded_policy() {
+    let dir = TestDir::new("moon_test_single_file.in");
+
+    for target in ["js", "native"] {
+        moon_cmd(&dir)
+            .args([
+                "run",
+                "malformed_embedded_policy.mbtx",
+                "--target",
+                target,
+                "--dry-run",
+            ])
+            .assert()
+            .success();
+    }
+}
+
+#[test]
+fn test_single_file_mbtx_build_only_skips_malformed_embedded_policy() {
+    let dir = TestDir::new("moon_test_single_file.in");
+
+    moon_cmd(&dir)
+        .args([
+            "run",
+            "malformed_embedded_policy.mbtx",
+            "--target",
+            "wasm",
+            "--build-only",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_single_file_mbtx_rejects_effective_malformed_embedded_policy() {
+    let dir = TestDir::new("moon_test_single_file.in");
+
+    moon_cmd(&dir)
+        .args(["run", "malformed_embedded_policy.mbtx", "--target", "wasm"])
+        .assert()
+        .failure();
+}
+
+#[test]
 fn test_single_file_mbtx_check() {
     let dir = TestDir::new("moon_test_single_file.in");
     let _ = get_stdout(&dir, ["check", "import_ok.mbtx"]);

--- a/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
+++ b/crates/moon/tests/test_cases/single_file_front_matter/mod.rs
@@ -65,6 +65,101 @@ fn test_single_file_mbtx_run() {
 }
 
 #[test]
+fn test_single_file_mbtx_run_uses_embedded_yaml_policy() {
+    let dir = TestDir::new("moon_test_single_file.in");
+
+    moon_cmd(&dir)
+        .args(["run", "embedded_policy.mbtx", "--target", "wasm"])
+        .assert()
+        .success()
+        .stdout_eq("embedded\n");
+}
+
+#[test]
+fn test_single_file_mbtx_dry_run_forwards_embedded_policy() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    let stdout = get_stdout(
+        &dir,
+        [
+            "run",
+            "embedded_policy.mbtx",
+            "--target",
+            "wasm",
+            "--dry-run",
+        ],
+    );
+
+    assert!(
+        stdout.lines().last().is_some_and(|line| {
+            line.contains("--policy") && line.contains("embedded_policy.mbtx")
+        }),
+        "expected the script itself to be forwarded as the policy source:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_stdin_mbtx_uses_embedded_yaml_policy() {
+    let fixture_dir = TestDir::new("moon_test_single_file.in");
+    let dir = TestDir::new_empty();
+    let source = fs::read_to_string(fixture_dir.join("embedded_policy.mbtx")).unwrap();
+
+    moon_cmd(&dir)
+        .args(["run", "-", "--target", "wasm"])
+        .stdin(source)
+        .assert()
+        .success()
+        .stdout_eq("embedded\n");
+}
+
+#[test]
+fn test_stdin_mbtx_policy_keeps_the_invocation_directory() {
+    let fixture_dir = TestDir::new("moon_test_single_file.in");
+    let dir = TestDir::new_empty();
+    let source = fs::read_to_string(fixture_dir.join("embedded_policy.mbtx")).unwrap();
+    let output = moon_cmd(&dir)
+        .args(["run", "-", "--target", "wasm", "--dry-run"])
+        .stdin(source)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(output).unwrap();
+
+    assert!(
+        stdout.lines().last().is_some_and(|line| {
+            line.contains("--policy")
+                && line.contains("stdin.mbtx")
+                && line.contains("--policy-source-dir")
+        }),
+        "expected stdin to preserve the logical policy source directory:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_single_file_mbtx_explicit_policy_overrides_embedded_policy() {
+    let dir = TestDir::new("moon_test_single_file.in");
+    fs::write(
+        dir.join("explicit-policy.json"),
+        r#"{"env":{"set":{"MBTX_POLICY":"explicit"}}}"#,
+    )
+    .unwrap();
+
+    moon_cmd(&dir)
+        .args([
+            "run",
+            "embedded_policy.mbtx",
+            "--target",
+            "wasm",
+            "--wasm-policy",
+            "explicit-policy.json",
+        ])
+        .assert()
+        .success()
+        .stdout_eq("explicit\n");
+}
+
+#[test]
 fn test_single_file_mbtx_check() {
     let dir = TestDir::new("moon_test_single_file.in");
     let _ = get_stdout(&dir, ["check", "import_ok.mbtx"]);

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -183,7 +183,9 @@ policy inline as YAML; this format may change. Put a leading `// policy:` block
 at the start of the script and prefix every YAML line with `//`, without `---`
 delimiters. `moon run` and `moonx` detect this block and use the script itself
 as the policy source. Explicit command-line policy paths override the embedded
-policy; inherited policies cannot be replaced by either.
+policy; inherited policies cannot be replaced by either. An embedded block is
+parsed only when it is the effective policy for Wasm execution; overridden,
+non-Wasm, and build-only paths do not validate its YAML.
 For `moon run -` and `moon run -e`, relative filesystem roots resolve from the
 directory where Moon was invoked rather than the temporary source directory.
 

--- a/crates/moonrun/README.md
+++ b/crates/moonrun/README.md
@@ -178,6 +178,15 @@ MoonBit appends `.exe` unless the requested program already ends in `.exe` or
 Allowing a shell, interpreter, package runner, or extensible tool can permit much
 more than the visible argument prefix suggests.
 
+As an experimental feature, standalone `.mbtx` scripts can carry the same
+policy inline as YAML; this format may change. Put a leading `// policy:` block
+at the start of the script and prefix every YAML line with `//`, without `---`
+delimiters. `moon run` and `moonx` detect this block and use the script itself
+as the policy source. Explicit command-line policy paths override the embedded
+policy; inherited policies cannot be replaced by either.
+For `moon run -` and `moon run -e`, relative filesystem roots resolve from the
+directory where Moon was invoked rather than the temporary source directory.
+
 A native child receives the host user's ambient filesystem, network, and process
 access. The `fs` and `net` objects do not sandbox child processes. PID-based
 process operations are restricted to children spawned by the current moonrun

--- a/crates/moonrun/src/engine.rs
+++ b/crates/moonrun/src/engine.rs
@@ -48,6 +48,7 @@ pub struct RunOptions {
     pub(crate) no_stack_trace: bool,
     pub(crate) test_args: Option<String>,
     pub(crate) policy_file: Option<PathBuf>,
+    pub(crate) policy_source_dir: Option<PathBuf>,
     pub(crate) inherited_policy: Option<Vec<u8>>,
     pub(crate) working_directory: WorkingDirectory,
 }
@@ -88,6 +89,19 @@ impl RunOptions {
 
     pub fn with_policy_file(mut self, policy_file: impl Into<PathBuf>) -> Self {
         self.policy_file = Some(policy_file.into());
+        self.policy_source_dir = None;
+        self.inherited_policy = None;
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn with_policy_file_source_dir(
+        mut self,
+        policy_file: impl Into<PathBuf>,
+        source_dir: impl Into<PathBuf>,
+    ) -> Self {
+        self.policy_file = Some(policy_file.into());
+        self.policy_source_dir = Some(source_dir.into());
         self.inherited_policy = None;
         self
     }
@@ -95,6 +109,7 @@ impl RunOptions {
     #[doc(hidden)]
     pub fn with_inherited_policy(mut self, policy: Vec<u8>) -> Self {
         self.policy_file = None;
+        self.policy_source_dir = None;
         self.inherited_policy = Some(policy);
         self
     }
@@ -303,6 +318,7 @@ impl Engine {
     pub fn run(&self, module: &Module, options: RunOptions) -> anyhow::Result<RunOutcome> {
         let runtime = Runtime::new(
             options.policy_file.as_deref(),
+            options.policy_source_dir.as_deref(),
             options.inherited_policy.as_deref(),
             options.working_directory.clone(),
         )?;

--- a/crates/moonrun/src/main.rs
+++ b/crates/moonrun/src/main.rs
@@ -74,6 +74,10 @@ Process spawning is disabled by default. process.allow entries match the exact r
 Setting process.spawn to true grants child processes the host user's ambient filesystem, network, and process access; the other policy sections do not sandbox child processes. Scoped rules authorize the logical request, not the executable eventually selected through PATH or other OS lookup."#
     )]
     policy: Option<PathBuf>,
+
+    /// Override the directory used to resolve relative policy paths.
+    #[clap(long, value_name = "PATH", hide = true, requires = "policy")]
+    policy_source_dir: Option<PathBuf>,
 }
 
 fn get_moonrun_version() -> String {
@@ -106,7 +110,10 @@ fn main() -> anyhow::Result<()> {
     if let Some(policy) = inherited_policy {
         options = options.with_inherited_policy(policy);
     } else if let Some(policy) = matches.policy {
-        options = options.with_policy_file(policy);
+        options = match matches.policy_source_dir {
+            Some(source_dir) => options.with_policy_file_source_dir(policy, source_dir),
+            None => options.with_policy_file(policy),
+        };
     }
 
     match Engine::new(engine_config).run_file(matches.path, options)? {

--- a/crates/moonrun/src/policy/config.rs
+++ b/crates/moonrun/src/policy/config.rs
@@ -81,6 +81,18 @@ pub(super) struct ProcessRuleConfig {
 
 impl PolicyConfig {
     pub(super) fn from_file(path: &Path) -> anyhow::Result<Self> {
+        if path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("mbtx"))
+        {
+            return moonutil::front_matter::parse_mbtx_policy(path)?.with_context(|| {
+                format!(
+                    ".mbtx policy source {} has no `// policy:` front matter",
+                    path.display()
+                )
+            });
+        }
+
         let contents = std::fs::read_to_string(path)
             .with_context(|| format!("failed to read policy {}", path.display()))?;
         if path
@@ -165,6 +177,30 @@ spawn = true
             Some("test")
         );
         assert!(config.process.unwrap().spawn);
+    }
+
+    #[test]
+    fn parses_yaml_policy_from_mbtx_front_matter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let policy_file = tmp.path().join("script.mbtx");
+        std::fs::write(
+            &policy_file,
+            r#"// policy:
+//   env:
+//     set:
+//       APP_ENV: embedded
+
+fn main {}
+"#,
+        )
+        .unwrap();
+
+        let config = PolicyConfig::from_file(&policy_file).unwrap();
+
+        assert_eq!(
+            config.env.unwrap().set.get("APP_ENV").map(String::as_str),
+            Some("embedded")
+        );
     }
 
     #[test]

--- a/crates/moonrun/src/policy/mod.rs
+++ b/crates/moonrun/src/policy/mod.rs
@@ -87,14 +87,22 @@ impl Policy {
     }
 }
 
-/// Load the legacy policy document into its two construction-time outputs.
+/// Load a policy document into its two construction-time outputs.
 ///
 /// The source format still colocates environment provisioning with operational
 /// authorization. Splitting them here prevents that historical file layout
 /// from making provisioning part of the realized `Policy`.
+#[cfg(test)]
 pub(crate) fn load_file(path: &Path) -> anyhow::Result<(Policy, EnvProvisioning)> {
+    load_file_with_source_dir(path, None)
+}
+
+pub(crate) fn load_file_with_source_dir(
+    path: &Path,
+    source_dir: Option<&Path>,
+) -> anyhow::Result<(Policy, EnvProvisioning)> {
     let config = PolicyConfig::from_file(path)?;
-    let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let config_dir = source_dir.unwrap_or_else(|| path.parent().unwrap_or_else(|| Path::new(".")));
     realize_config(config, config_dir)
 }
 
@@ -265,6 +273,33 @@ mod tests {
         assert_eq!(config.net.unwrap().dns, ["example.com"]);
         assert_eq!(config.env.unwrap().from_host, ["PATH"]);
         assert!(config.process.unwrap().spawn);
+    }
+
+    #[test]
+    fn embedded_policy_can_resolve_roots_from_its_logical_source_directory() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let allowed = source_dir.path().join("allowed");
+        std::fs::create_dir(&allowed).unwrap();
+
+        let temporary_source_dir = tempfile::tempdir().unwrap();
+        let temporary_source = temporary_source_dir.path().join("stdin.mbtx");
+        std::fs::write(
+            &temporary_source,
+            r#"// policy:
+//   fs:
+//     read:
+//       - allowed
+
+fn main {}
+"#,
+        )
+        .unwrap();
+
+        let (policy, _) =
+            load_file_with_source_dir(&temporary_source, Some(source_dir.path())).unwrap();
+        let allowed = std::fs::canonicalize(allowed).unwrap();
+
+        check_ambient_open(policy, allowed.as_os_str(), 0, 0, false).unwrap();
     }
 
     #[test]

--- a/crates/moonrun/src/runtime/mod.rs
+++ b/crates/moonrun/src/runtime/mod.rs
@@ -120,6 +120,7 @@ pub(crate) struct Runtime {
 impl Runtime {
     pub(crate) fn new(
         policy_file: Option<&Path>,
+        policy_source_dir: Option<&Path>,
         inherited_policy: Option<&[u8]>,
         working_directory: WorkingDirectory,
     ) -> anyhow::Result<Self> {
@@ -130,7 +131,8 @@ impl Runtime {
                 (policy, Some(env))
             }
             (None, Some(path)) => {
-                let (policy, env) = policy::load_file(path).context(
+                let (policy, env) = policy::load_file_with_source_dir(path, policy_source_dir)
+                    .context(
                     "failed to load sandbox policy (experimental); run `moonrun --help` for policy format notes",
                 )?;
                 (policy, Some(env))

--- a/crates/moonutil/src/front_matter.rs
+++ b/crates/moonutil/src/front_matter.rs
@@ -86,6 +86,17 @@ pub fn parse_mbtx_policy<T: DeserializeOwned>(
     Ok(Some(front_matter.policy))
 }
 
+/// Detect an embedded `.mbtx` policy without validating its YAML contents.
+///
+/// Policy selection happens in the invoking command. Keeping detection
+/// separate from parsing lets an explicit or inherited policy override a
+/// malformed embedded block and avoids parsing policies on non-Wasm paths.
+pub fn has_mbtx_policy(single_file_path: &Path) -> anyhow::Result<bool> {
+    let content = std::fs::read_to_string(single_file_path)
+        .with_context(|| format!("failed to read .mbtx file `{}`", single_file_path.display()))?;
+    Ok(extract_mbtx_front_matter(&content).is_some())
+}
+
 fn extract_mbtx_front_matter(content: &str) -> Option<String> {
     let content = content.strip_prefix('\u{feff}').unwrap_or(content);
     let mut lines = content.lines().skip_while(|line| line.trim().is_empty());
@@ -184,6 +195,16 @@ fn main {}
             extract_mbtx_front_matter("// An ordinary comment.\nfn main {}\n"),
             None
         );
+    }
+
+    #[test]
+    fn detects_malformed_policy_without_parsing_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("malformed.mbtx");
+        std::fs::write(&source, "// policy:\n//   env: [\n\nfn main {}\n").unwrap();
+
+        assert!(super::has_mbtx_policy(&source).unwrap());
+        assert!(super::parse_mbtx_policy::<serde::de::IgnoredAny>(&source).is_err());
     }
 
     #[test]

--- a/crates/moonutil/src/front_matter.rs
+++ b/crates/moonutil/src/front_matter.rs
@@ -18,7 +18,9 @@
 
 use std::path::Path;
 
+use anyhow::Context;
 use indexmap::IndexMap;
+use serde::de::DeserializeOwned;
 
 use crate::constants::DOT_MBT_DOT_MD;
 
@@ -53,4 +55,142 @@ pub fn parse_front_matter_config(single_file_path: &Path) -> anyhow::Result<Opti
         None
     };
     Ok(front_matter_config)
+}
+
+/// Parse YAML policy embedded in the leading line comments of an `.mbtx` file.
+///
+/// Unlike Markdown front matter, the script form has no delimiter. It starts
+/// with `// policy:` and continues through the following indented `//` lines.
+/// A non-comment line, a MoonBit doc comment, or another unindented comment
+/// ends the front matter.
+pub fn parse_mbtx_policy<T: DeserializeOwned>(
+    single_file_path: &Path,
+) -> anyhow::Result<Option<T>> {
+    let content = std::fs::read_to_string(single_file_path)
+        .with_context(|| format!("failed to read .mbtx file `{}`", single_file_path.display()))?;
+    let Some(yaml) = extract_mbtx_front_matter(&content) else {
+        return Ok(None);
+    };
+
+    #[derive(serde::Deserialize)]
+    struct MbtxFrontMatter<T> {
+        policy: T,
+    }
+
+    let front_matter: MbtxFrontMatter<T> = serde_yaml::from_str(&yaml).with_context(|| {
+        format!(
+            "failed to parse YAML front matter in .mbtx file `{}`",
+            single_file_path.display()
+        )
+    })?;
+    Ok(Some(front_matter.policy))
+}
+
+fn extract_mbtx_front_matter(content: &str) -> Option<String> {
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+    let mut lines = content.lines().skip_while(|line| line.trim().is_empty());
+    let first = mbtx_comment_content(lines.next()?)?;
+    if !first.trim().starts_with("policy:") {
+        return None;
+    }
+
+    let mut yaml = String::from(first);
+    yaml.push('\n');
+    for line in lines {
+        let Some(comment) = mbtx_comment_content(line) else {
+            break;
+        };
+        if !comment.is_empty() && !comment.starts_with([' ', '\t']) {
+            break;
+        }
+        yaml.push_str(comment);
+        yaml.push('\n');
+    }
+    Some(yaml)
+}
+
+fn mbtx_comment_content(line: &str) -> Option<&str> {
+    let comment = line.trim_start().strip_prefix("//")?;
+    if !comment.is_empty() && !comment.starts_with([' ', '\t']) {
+        return None;
+    }
+    Some(comment.strip_prefix(' ').unwrap_or(comment))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use serde::Deserialize;
+
+    use super::extract_mbtx_front_matter;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Policy {
+        env: Env,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Env {
+        set: BTreeMap<String, String>,
+    }
+
+    #[derive(Deserialize)]
+    struct FrontMatter {
+        policy: Policy,
+    }
+
+    fn parse(source: &str) -> Option<Policy> {
+        let yaml = extract_mbtx_front_matter(source)?;
+        Some(serde_yaml::from_str::<FrontMatter>(&yaml).unwrap().policy)
+    }
+
+    #[test]
+    fn extracts_yaml_from_leading_line_comments() {
+        let source = r#"// policy:
+//   env:
+//     set:
+//       MODE: embedded
+
+///|
+fn main {}
+"#;
+
+        assert_eq!(
+            parse(source),
+            Some(Policy {
+                env: Env {
+                    set: BTreeMap::from([("MODE".into(), "embedded".into())]),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn stops_before_moonbit_and_ordinary_comments() {
+        assert_eq!(
+            extract_mbtx_front_matter("// policy: {}\n///|\nfn main {}\n").as_deref(),
+            Some("policy: {}\n")
+        );
+        assert_eq!(
+            extract_mbtx_front_matter("// policy: {}\n// explanation\nfn main {}\n").as_deref(),
+            Some("policy: {}\n")
+        );
+    }
+
+    #[test]
+    fn ignores_ordinary_leading_comments() {
+        assert_eq!(
+            extract_mbtx_front_matter("// An ordinary comment.\nfn main {}\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn supports_crlf_and_a_utf8_bom() {
+        assert_eq!(
+            extract_mbtx_front_matter("\u{feff}// policy: {}\r\nfn main {}\r\n").as_deref(),
+            Some("policy: {}\n")
+        );
+    }
 }

--- a/docs/dev/reference/moonx.md
+++ b/docs/dev/reference/moonx.md
@@ -81,6 +81,31 @@ acquisition or building. Program arguments are forwarded to the final
 `moonrun`, and `--experimental-policy` has the same meaning as for a registry
 Wasm artifact.
 
+As an experimental feature, a script may embed its Moonrun Policy as YAML in a
+leading line-comment front matter block. This format may change. The block
+starts with `// policy:` and ends at the first non-comment, MoonBit doc-comment,
+or unindented comment line. Each `//` prefix and one following space are removed
+before parsing. For example:
+
+```moonbit
+// policy:
+//   env:
+//     from_host: [PATH]
+//   fs:
+//     read: [.]
+
+fn main {
+  // ...
+}
+```
+
+The `.mbtx` path itself is passed to Moonrun as the policy source, so relative
+filesystem roots are resolved from the script's directory. For `moon run -`
+and `moon run -e`, Moon writes the source to a temporary `.mbtx` but retains the
+invocation directory as the logical policy source directory. An explicit
+`--experimental-policy` takes precedence over embedded policy. An inherited
+policy remains host-owned and takes precedence over both.
+
 Moonx consumes an inherited policy handle before resolving `.mbtx`
 dependencies and relays it only to the final `moonrun` process. Registry and
 build subprocesses therefore cannot observe the reserved marker or inherit the

--- a/docs/dev/reference/moonx.md
+++ b/docs/dev/reference/moonx.md
@@ -104,7 +104,9 @@ filesystem roots are resolved from the script's directory. For `moon run -`
 and `moon run -e`, Moon writes the source to a temporary `.mbtx` but retains the
 invocation directory as the logical policy source directory. An explicit
 `--experimental-policy` takes precedence over embedded policy. An inherited
-policy remains host-owned and takes precedence over both.
+policy remains host-owned and takes precedence over both. An embedded block is
+parsed only when it is the effective policy for Wasm execution; overridden,
+non-Wasm, and build-only paths do not validate its YAML.
 
 Moonx consumes an inherited policy handle before resolving `.mbtx`
 dependencies and relays it only to the final `moonrun` process. Registry and


### PR DESCRIPTION
## Why

Standalone `.mbtx` scripts currently need a separate file to configure Moonrun Policy. That makes a supposedly self-contained script depend on an adjacent policy artifact and gives stdin or inline execution no natural policy file.

## What changes

- Recognize an experimental YAML policy front matter beginning with `// policy:` in leading `.mbtx` line comments, without `---` delimiters.
- Use the `.mbtx` script itself as the Moonrun policy source for `moon run` and `moonx`.
- Preserve the invocation directory as the logical policy source directory for `moon run -` and `moon run -e`, whose source is materialized in a temporary `.mbtx` file.
- Keep policy precedence explicit: inherited policy takes priority over a command-line policy, which takes priority over embedded policy.
- Detect embedded policy presence without deserializing it in Moon, so overridden, non-Wasm, and build-only paths do not validate unused YAML.
- Document that this embedded format is experimental and may change.

## Why this is correct

Moonrun remains responsible for deserializing and realizing the effective policy. Moon only detects the embedded marker, applies precedence, and transports the selected script source across the existing process boundary. Relative filesystem roots therefore retain file-relative behavior for persistent scripts and invocation-relative behavior for stdin and inline scripts.

Regression coverage exercises comment extraction, YAML decoding, `moon run`, `moon run -`, `moonx`, relative filesystem roots, dry-run forwarding, command-line and inherited precedence, malformed overridden policies, non-Wasm paths, and build-only execution.

## Scope

The change is limited to standalone `.mbtx` Wasm execution and the internal Moon-to-Moonrun policy transport. Existing external policy files and policy-free execution keep their current behavior.
